### PR TITLE
Compress public UI surfaces

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -58,26 +58,26 @@ export default function BlogPage() {
   const remainingPosts = sortedPosts.slice(1)
 
   return (
-    <div className="section-spacing pb-20">
-      <section className="hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8 lg:p-10">
+    <div className="section-spacing pb-16">
+      <section className="hero-shell rounded-[1.25rem] border border-brand-900/10 p-5 shadow-sm sm:p-6">
         <p className="eyebrow-label">Scientific editorial layer</p>
-        <h1 className="mt-3 heading-premium max-w-4xl">Research notes that connect the library.</h1>
-        <p className="mt-5 text-reading max-w-3xl text-muted-soft">
-          Articles are not separate from the database — they are the interpretive layer that explains mechanisms, preparation choices, traditional context, safety limits, and evidence maturity.
+        <h1 className="mt-2 heading-premium max-w-3xl">Research notes that connect the library.</h1>
+        <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-soft">
+          Mechanisms, preparation choices, traditional context, safety limits, and evidence maturity — organized for fast scanning.
         </p>
-        <p className="mt-4 text-sm font-semibold text-[#46574d]">{sortedPosts.length} research notes available</p>
+        <p className="mt-3 text-sm font-semibold text-[#46574d]">{sortedPosts.length} research notes available</p>
       </section>
 
       {featuredPost ? (
         <section className="surface-depth card-spacing">
           <p className="eyebrow-label">Latest research note</p>
-          <Link href={`/blog/${featuredPost.slug}`} className="identity-article scientific-card mt-5 group">
+          <Link href={`/blog/${featuredPost.slug}`} className="identity-article scientific-card mt-4 group">
             <div className="flex flex-wrap items-center gap-3">
               <span className="identity-kicker">{inferArticleStyle(featuredPost)}</span>
               <span className="identity-meta">{formatDate(featuredPost.date)} • {featuredPost.readingTime}</span>
             </div>
-            <h2 className="mt-4 max-w-3xl text-3xl font-semibold tracking-tight text-ink group-hover:text-brand-800">{featuredPost.title}</h2>
-            <p className="mt-4 max-w-3xl text-sm leading-7 text-[#46574d] sm:text-base">{truncateText(featuredPost.excerpt, 280)}</p>
+            <h2 className="mt-3 max-w-3xl text-2xl font-semibold tracking-tight text-ink group-hover:text-brand-800 sm:text-3xl">{featuredPost.title}</h2>
+            <p className="mt-3 max-w-3xl text-sm leading-6 text-[#46574d]">{truncateText(featuredPost.excerpt, 190)}</p>
             <span className="mt-5 inline-flex text-sm font-semibold text-brand-800 transition group-hover:translate-x-0.5">Read note →</span>
           </Link>
         </section>
@@ -85,7 +85,7 @@ export default function BlogPage() {
 
       <SemanticBrowseModule
         eyebrow="Browse articles by research style"
-        title="Choose the kind of scientific context you need."
+        title="Choose the context you need."
         groups={[
           { title: 'Research digests', description: 'Evidence summaries with limitations and cautious interpretation.', href: '/blog', meta: 'Evidence' },
           { title: 'Pharmacology basics', description: 'Mechanism-first explainers for pathways, compounds, and receptor context.', href: '/blog', meta: 'Mechanism' },

--- a/app/compounds/CompoundsIndexClient.tsx
+++ b/app/compounds/CompoundsIndexClient.tsx
@@ -303,23 +303,21 @@ export default function CompoundsIndexClient({ compounds: sourceCompounds, initi
   const libraryCompounds = hasActiveFilters ? visibleCompounds : compounds.slice(featuredCompounds.length)
 
   return (
-    <div className="min-h-screen px-3 py-5 text-ink sm:px-4 sm:py-8">
-      <div className="mx-auto max-w-7xl space-y-8 sm:space-y-12">
-        <section className="hero-shell relative overflow-hidden rounded-[1.7rem] border border-white/50 px-5 py-7 shadow-sm sm:rounded-[2.2rem] sm:px-8 sm:py-10 lg:px-12">
-          <div className="!absolute right-[-8rem] top-[-8rem] h-72 w-72 rounded-full bg-emerald-200/25 blur-3xl" />
-
-          <div className="relative grid gap-6 lg:grid-cols-[1.05fr_.95fr] lg:items-end">
-            <div className="max-w-3xl space-y-4">
+    <div className="min-h-screen px-3 py-4 text-ink sm:px-4 sm:py-6">
+      <div className="mx-auto max-w-7xl space-y-6 sm:space-y-8">
+        <section className="hero-shell relative overflow-hidden rounded-[1.25rem] border border-white/60 px-4 py-5 shadow-sm sm:px-6 sm:py-7">
+          <div className="relative grid gap-4 lg:grid-cols-[1.05fr_.95fr] lg:items-end">
+            <div className="max-w-3xl space-y-3">
               <p className="eyebrow-label">Compound decision library</p>
-              <h1 className="max-w-[13ch] text-balance font-display text-4xl font-semibold leading-[1.04] tracking-tight text-ink sm:text-6xl lg:text-7xl">
+              <h1 className="max-w-[16ch] text-balance font-display text-3xl font-semibold leading-[1.05] tracking-tight text-ink sm:text-5xl">
                 Compound research library
               </h1>
-              <p className="max-w-2xl text-base leading-7 text-[#46574d] sm:text-lg sm:leading-8">
+              <p className="max-w-2xl text-sm leading-6 text-[#46574d] sm:text-base">
                 Scan bioactive molecules by practical context first, then compare evidence, safety notes, and mechanism hints before opening a full compound profile.
               </p>
             </div>
 
-            <div className="rounded-[1.35rem] border border-brand-900/10 bg-white/75 p-3 shadow-sm backdrop-blur sm:p-4">
+            <div className="rounded-[1rem] border border-brand-900/10 bg-white/75 p-3 shadow-sm backdrop-blur">
               <p className="text-xs font-bold uppercase tracking-[0.16em] text-brand-800">Library signal</p>
               <div className="mt-3 grid grid-cols-3 gap-2">
                 <StatCard value={totalProfiles} label="Profiles" />
@@ -330,7 +328,7 @@ export default function CompoundsIndexClient({ compounds: sourceCompounds, initi
           </div>
         </section>
 
-        <section className="rounded-[1.5rem] border border-brand-900/10 bg-white/85 p-4 shadow-[var(--shadow-card-calm)] sm:p-6" aria-labelledby="compound-search-heading">
+        <section className="rounded-[1rem] border border-brand-900/10 bg-white/85 p-4 shadow-sm sm:p-5" aria-labelledby="compound-search-heading">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
             <div className="max-w-2xl space-y-2">
               <p className="eyebrow-label">Search and filter</p>
@@ -339,7 +337,7 @@ export default function CompoundsIndexClient({ compounds: sourceCompounds, initi
             <Link href="/herbs" className="w-fit text-sm font-bold text-brand-800 transition hover:text-brand-900">Browse herb sources →</Link>
           </div>
 
-          <form action="/compounds" className="mt-5 grid gap-3 sm:grid-cols-[1fr_auto]">
+          <form action="/compounds" className="mt-4 grid gap-3 sm:grid-cols-[1fr_auto]">
             <label className="sr-only" htmlFor="compound-search">Search compounds</label>
             <input
               id="compound-search"
@@ -347,10 +345,10 @@ export default function CompoundsIndexClient({ compounds: sourceCompounds, initi
               type="search"
               defaultValue={query}
               placeholder="Search compound, mechanism, source herb, or safety note"
-              className="min-h-12 w-full rounded-full border border-brand-900/10 bg-white px-4 text-base text-ink shadow-sm placeholder:text-[#7b8a81]"
+              className="min-h-11 w-full rounded-full border border-brand-900/10 bg-white px-4 text-sm text-ink shadow-sm placeholder:text-[#7b8a81]"
             />
             {activeFilter !== 'all' ? <input type="hidden" name="context" value={activeFilter} /> : null}
-            <button type="submit" className="button-primary min-h-12 px-6 py-3">
+            <button type="submit" className="button-primary min-h-11 px-5 py-2.5">
               Search
             </button>
           </form>
@@ -364,7 +362,7 @@ export default function CompoundsIndexClient({ compounds: sourceCompounds, initi
           />
         </section>
 
-        <section className="rounded-[1.5rem] border border-brand-900/10 bg-white/70 p-4 shadow-sm sm:p-5">
+        <section className="rounded-[1rem] border border-brand-900/10 bg-white/70 p-4 shadow-sm">
           <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
             <div className="max-w-2xl space-y-2">
               <p className="eyebrow-label">Common starting points</p>
@@ -377,7 +375,7 @@ export default function CompoundsIndexClient({ compounds: sourceCompounds, initi
               <Link
                 key={path.label}
                 href={path.href}
-                className="group rounded-[1.1rem] border border-brand-900/10 bg-white/80 p-4 shadow-sm transition hover:-translate-y-0.5 hover:border-brand-700/20 hover:bg-white"
+                className="group rounded-[0.9rem] border border-brand-900/10 bg-white/80 p-3 shadow-sm transition hover:border-brand-700/20 hover:bg-white"
               >
                 <h3 className="text-lg font-semibold tracking-tight text-ink transition group-hover:text-brand-800">{path.label}</h3>
                 <p className="mt-2 text-sm leading-6 text-[#46574d]">{path.description}</p>
@@ -404,7 +402,7 @@ export default function CompoundsIndexClient({ compounds: sourceCompounds, initi
                   </p>
                 </div>
 
-                <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
                   {featuredCompounds.map((compound: any) => (
                     <CompoundCard key={compound.slug} compound={compound} featured />
                   ))}
@@ -426,7 +424,7 @@ export default function CompoundsIndexClient({ compounds: sourceCompounds, initi
                   </span>
                 </div>
 
-                <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
                   {libraryCompounds.map((compound: any) => (
                     <CompoundCard key={compound.slug} compound={compound} />
                   ))}

--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -297,7 +297,7 @@ export default async function CompoundPage({ params }: PageProps) {
         <div className="space-y-6">
           <div className="space-y-2">
             <p className="eyebrow-label">Evidence summary</p>
-            <h2 className="text-2xl font-semibold tracking-tight text-ink">What the current profile supports</h2>
+            <h2 className="text-xl font-semibold tracking-tight text-ink">What the current profile supports</h2>
             <p className="max-w-4xl text-sm leading-6 text-[#46574d]">
               Use this profile as an evidence-aware orientation, not a guarantee of outcomes. Human data quality, formulation differences, and dosing variability can change real-world effects.
             </p>
@@ -470,7 +470,7 @@ export default async function CompoundPage({ params }: PageProps) {
 
       <ReadingProgress />
 
-      <main className="mx-auto max-w-7xl space-y-12 px-4 py-8 pb-24 sm:space-y-16 sm:py-10 sm:pb-32">
+      <main className="mx-auto max-w-7xl space-y-8 px-4 py-6 pb-20 sm:space-y-10 sm:py-8 sm:pb-24">
         <Breadcrumbs
           items={[
             { label: 'Home', href: '/' },
@@ -479,7 +479,7 @@ export default async function CompoundPage({ params }: PageProps) {
           ]}
         />
 
-        <section className="hero-shell rounded-[2rem] p-4 sm:p-6 lg:p-8">
+        <section className="hero-shell rounded-[1.25rem] p-4 sm:p-5 lg:p-6">
           <div className="grid gap-5 lg:grid-cols-[minmax(0,0.82fr)_minmax(340px,1.18fr)] lg:items-start">
             <div className="space-y-4 lg:pt-2">
               <CompoundHero
@@ -495,7 +495,7 @@ export default async function CompoundPage({ params }: PageProps) {
               title="5-second profile read"
               subtitle="Educational overview only. Individual effects and side-effect sensitivity can vary."
               badge="Start here"
-              className="rounded-[1.65rem] border border-brand-900/10 bg-white/95 p-4 shadow-[0_18px_45px_rgba(47,64,52,0.12)] sm:p-5 lg:sticky lg:top-6"
+              className="rounded-[1.1rem] border border-brand-900/10 bg-white/95 p-4 shadow-sm lg:sticky lg:top-6"
               fields={buildDetailEvidenceSnapshotFields({
                 bestFit: effects.slice(0, 3).join(', '),
                 humanEvidence: evidenceLevel,
@@ -530,10 +530,10 @@ export default async function CompoundPage({ params }: PageProps) {
           </section>
         ) : null}
 
-        <section className="rounded-3xl bg-amber-50/70 p-5 sm:p-6">
+        <section className="rounded-[1.1rem] bg-amber-50/70 p-4 sm:p-5">
           <div className="space-y-2">
             <p className="eyebrow-label text-amber-900">Safety first</p>
-            <h2 className="text-2xl font-semibold tracking-tight text-ink">Review cautions before use</h2>
+            <h2 className="text-xl font-semibold tracking-tight text-ink">Review cautions before use</h2>
             <p className="max-w-4xl text-sm leading-6 text-[#5f4a24]">
               Educational-only framing: individual response varies by dose, formulation, concurrent medications, and health context. {safetySummary}
             </p>

--- a/app/globals.css
+++ b/app/globals.css
@@ -35,10 +35,10 @@
 
   --border-soft: rgba(29, 74, 47, 0.1);
   --ring-brand: rgba(53, 143, 82, 0.35);
-  --radius-card-premium: 1.65rem;
-  --radius-card-compact: 1.35rem;
-  --shadow-card-calm: 0 14px 42px rgba(16, 32, 24, 0.07), 0 2px 8px rgba(16, 32, 24, 0.035);
-  --shadow-card-calm-hover: 0 20px 56px rgba(16, 32, 24, 0.10), 0 4px 14px rgba(16, 32, 24, 0.045);
+  --radius-card-premium: 1.25rem;
+  --radius-card-compact: 1rem;
+  --shadow-card-calm: 0 8px 22px rgba(16, 32, 24, 0.045), 0 1px 4px rgba(16, 32, 24, 0.03);
+  --shadow-card-calm-hover: 0 12px 30px rgba(16, 32, 24, 0.07), 0 2px 8px rgba(16, 32, 24, 0.035);
   --shadow-button-primary: 0 14px 30px rgba(29, 74, 47, 0.20), inset 0 1px 0 rgba(255, 255, 255, 0.16);
   --shadow-button-secondary: 0 10px 26px rgba(16, 32, 24, 0.06), inset 0 1px 0 rgba(255, 255, 255, 0.72);
 }
@@ -99,11 +99,11 @@ body {
   }
 
   h1 {
-    @apply font-display text-[2.55rem] font-semibold leading-[1.02] tracking-tighter text-ink sm:text-5xl lg:text-6xl;
+    @apply font-display text-[2.25rem] font-semibold leading-[1.04] tracking-tighter text-ink sm:text-4xl lg:text-5xl;
   }
 
   h2 {
-    @apply font-display text-[2rem] font-semibold leading-[1.12] tracking-tight text-ink sm:text-4xl;
+    @apply font-display text-[1.8rem] font-semibold leading-[1.14] tracking-tight text-ink sm:text-3xl;
   }
 
   h3 {
@@ -120,7 +120,7 @@ body {
   }
 
   p {
-    @apply max-w-reading text-[1rem] leading-[1.78] text-muted sm:text-[1.035rem];
+    @apply max-w-reading text-[0.98rem] leading-[1.68] text-muted sm:text-[1rem];
   }
 
   p + p {
@@ -169,7 +169,7 @@ body {
   }
 
   details {
-    @apply border border-brand-900/10 bg-white/75 p-5 shadow-sm backdrop-blur-xl transition-all duration-300 sm:p-6;
+    @apply border border-brand-900/10 bg-white/75 p-4 shadow-sm backdrop-blur transition-all duration-300 sm:p-5;
     border-radius: var(--radius-card-premium);
   }
 
@@ -240,19 +240,19 @@ body {
   }
 
   .section-spacing {
-    @apply space-y-11 sm:space-y-14 lg:space-y-20;
+    @apply space-y-8 sm:space-y-10 lg:space-y-12;
   }
 
   .detail-stack {
-    @apply space-y-12 sm:space-y-14 lg:space-y-16;
+    @apply space-y-8 sm:space-y-10 lg:space-y-12;
   }
 
   .card-spacing {
-    @apply p-5 sm:p-7 lg:p-8;
+    @apply p-4 sm:p-5 lg:p-6;
   }
 
   .content-prose {
-    @apply max-w-reading space-y-5 text-[1rem] leading-[1.8] text-[#46574d] sm:text-[1.045rem];
+    @apply max-w-reading space-y-4 text-[0.98rem] leading-[1.7] text-[#46574d] sm:text-[1rem];
   }
 
   .content-prose > * {
@@ -287,7 +287,7 @@ body {
   }
 
   .detail-reading {
-    @apply max-w-[74ch] text-[1rem] leading-[1.82] text-[#46574d] sm:text-[1.045rem];
+    @apply max-w-[70ch] text-[0.98rem] leading-[1.7] text-[#46574d] sm:text-[1rem];
   }
 
   .detail-grid {
@@ -299,7 +299,7 @@ body {
   }
 
   .section-frame {
-    @apply border border-brand-900/10 bg-white/80 p-6 backdrop-blur-xl sm:p-8;
+    @apply border border-brand-900/10 bg-white/80 p-4 backdrop-blur sm:p-5;
     border-radius: var(--radius-card-premium);
     box-shadow: var(--shadow-card-calm);
   }
@@ -331,11 +331,11 @@ body {
   }
 
   .chip-readable {
-    @apply inline-flex items-center rounded-full border border-brand-900/10 bg-white/80 px-3.5 py-1.5 text-xs font-semibold leading-none text-[#33443a] shadow-sm;
+    @apply inline-flex items-center rounded-full border border-brand-900/10 bg-white/80 px-2.5 py-1 text-[0.72rem] font-semibold leading-none text-[#33443a];
   }
 
   .accordion-readable {
-    @apply rounded-3xl border border-brand-900/10 bg-white/80 p-5 shadow-sm backdrop-blur-xl transition-all duration-300 sm:p-6;
+    @apply rounded-[1.1rem] border border-brand-900/10 bg-white/80 p-4 shadow-sm backdrop-blur transition-all duration-300 sm:p-5;
   }
 
   .accordion-readable summary {
@@ -389,7 +389,7 @@ body {
   }
 
   .heading-premium {
-    @apply font-display text-[2.55rem] font-semibold leading-[1.02] tracking-tighter text-ink sm:text-5xl lg:text-6xl;
+    @apply font-display text-[2.25rem] font-semibold leading-[1.04] tracking-tighter text-ink sm:text-4xl lg:text-5xl;
   }
 
   .eyebrow {
@@ -399,7 +399,7 @@ body {
 
 @layer components {
   .scientific-card {
-    @apply block border border-brand-900/10 bg-white/75 p-5 backdrop-blur-xl transition-all duration-300 hover:border-brand-900/15 hover:bg-white;
+    @apply block border border-brand-900/10 bg-white/80 p-4 backdrop-blur transition-all duration-200 hover:border-brand-900/15 hover:bg-white;
     border-radius: var(--radius-card-compact);
     box-shadow: var(--shadow-card-calm);
   }
@@ -425,7 +425,7 @@ body {
   }
 
   .identity-kicker {
-    @apply rounded-full border border-brand-900/10 bg-white/75 px-3 py-1 text-xs font-bold tracking-[0.18em] text-brand-800;
+    @apply rounded-full border border-brand-900/10 bg-white/75 px-2.5 py-1 text-[0.68rem] font-bold tracking-[0.14em] text-brand-800;
   }
 
   .identity-meta {
@@ -456,7 +456,7 @@ body {
   }
 
   .compact-copy {
-    @apply max-w-[62ch] text-sm leading-7 text-[#46574d] sm:text-[0.95rem];
+    @apply max-w-[62ch] text-sm leading-6 text-[#46574d] sm:text-[0.94rem];
   }
 
   .semantic-rail {

--- a/app/herbs/HerbsIndexClient.tsx
+++ b/app/herbs/HerbsIndexClient.tsx
@@ -294,23 +294,21 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
   const libraryHerbs = hasActiveFilters ? visibleHerbs : paginated ? herbs : baseHerbs.slice(featuredHerbs.length)
 
   return (
-    <div className="min-h-screen px-3 py-5 text-ink sm:px-4 sm:py-8">
-      <div className="mx-auto max-w-7xl space-y-8 sm:space-y-12">
-        <section className="hero-shell relative overflow-hidden rounded-[1.7rem] border border-white/50 px-5 py-7 shadow-sm sm:rounded-[2.2rem] sm:px-8 sm:py-10 lg:px-12">
-          <div className="!absolute right-[-8rem] top-[-8rem] h-72 w-72 rounded-full bg-emerald-200/25 blur-3xl" />
-
-          <div className="relative grid gap-6 lg:grid-cols-[1.05fr_.95fr] lg:items-end">
-            <div className="max-w-3xl space-y-4">
+    <div className="min-h-screen px-3 py-4 text-ink sm:px-4 sm:py-6">
+      <div className="mx-auto max-w-7xl space-y-6 sm:space-y-8">
+        <section className="hero-shell relative overflow-hidden rounded-[1.25rem] border border-white/60 px-4 py-5 shadow-sm sm:px-6 sm:py-7">
+          <div className="relative grid gap-4 lg:grid-cols-[1.05fr_.95fr] lg:items-end">
+            <div className="max-w-3xl space-y-3">
               <p className="eyebrow-label">Botanical decision library</p>
-              <h1 className="max-w-[13ch] text-balance font-display text-4xl font-semibold leading-[1.04] tracking-tight text-ink sm:text-6xl lg:text-7xl">
+              <h1 className="max-w-[16ch] text-balance font-display text-3xl font-semibold leading-[1.05] tracking-tight text-ink sm:text-5xl">
                 Herbal research library
               </h1>
-              <p className="max-w-2xl text-base leading-7 text-[#46574d] sm:text-lg sm:leading-8">
+              <p className="max-w-2xl text-sm leading-6 text-[#46574d] sm:text-base">
                 Scan by practical context first, then compare evidence, safety, and timing before opening a full herb profile.
               </p>
             </div>
 
-            <div className="rounded-[1.35rem] border border-brand-900/10 bg-white/75 p-3 shadow-sm backdrop-blur sm:p-4">
+            <div className="rounded-[1rem] border border-brand-900/10 bg-white/75 p-3 shadow-sm backdrop-blur">
               <p className="text-xs font-bold uppercase tracking-[0.16em] text-brand-800">Library signal</p>
               <div className="mt-3 grid grid-cols-3 gap-2">
                 <StatCard value={totalProfiles} label="Profiles" />
@@ -321,7 +319,7 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
           </div>
         </section>
 
-        <section className="rounded-[1.5rem] border border-brand-900/10 bg-white/85 p-4 shadow-[var(--shadow-card-calm)] sm:p-6" aria-labelledby="herb-search-heading">
+        <section className="rounded-[1rem] border border-brand-900/10 bg-white/85 p-4 shadow-sm sm:p-5" aria-labelledby="herb-search-heading">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
             <div className="max-w-2xl space-y-2">
               <p className="eyebrow-label">Search and filter</p>
@@ -330,7 +328,7 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
             <Link href="/goals" className="w-fit text-sm font-bold text-brand-800 transition hover:text-brand-900">Browse all goals →</Link>
           </div>
 
-          <form action="/herbs" className="mt-5 grid gap-3 sm:grid-cols-[1fr_auto]">
+          <form action="/herbs" className="mt-4 grid gap-3 sm:grid-cols-[1fr_auto]">
             <label className="sr-only" htmlFor="herb-search">Search herbs</label>
             <input
               id="herb-search"
@@ -338,10 +336,10 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
               type="search"
               defaultValue={query}
               placeholder="Search herb, effect, mechanism, or safety note"
-              className="min-h-12 w-full rounded-full border border-brand-900/10 bg-white px-4 text-base text-ink shadow-sm placeholder:text-[#7b8a81]"
+              className="min-h-11 w-full rounded-full border border-brand-900/10 bg-white px-4 text-sm text-ink shadow-sm placeholder:text-[#7b8a81]"
             />
             {activeFilter !== 'all' ? <input type="hidden" name="context" value={activeFilter} /> : null}
-            <button type="submit" className="button-primary min-h-12 px-6 py-3">
+            <button type="submit" className="button-primary min-h-11 px-5 py-2.5">
               Search
             </button>
           </form>
@@ -355,7 +353,7 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
           />
         </section>
 
-        <section className="rounded-[1.5rem] border border-brand-900/10 bg-white/70 p-4 shadow-sm sm:p-5">
+        <section className="rounded-[1rem] border border-brand-900/10 bg-white/70 p-4 shadow-sm">
           <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
             <div className="max-w-2xl space-y-2">
               <p className="eyebrow-label">Common starting points</p>
@@ -368,7 +366,7 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
               <Link
                 key={path.label}
                 href={path.href}
-                className="group rounded-[1.1rem] border border-brand-900/10 bg-white/80 p-4 shadow-sm transition hover:-translate-y-0.5 hover:border-brand-700/20 hover:bg-white"
+                className="group rounded-[0.9rem] border border-brand-900/10 bg-white/80 p-3 shadow-sm transition hover:border-brand-700/20 hover:bg-white"
               >
                 <h3 className="text-lg font-semibold tracking-tight text-ink transition group-hover:text-brand-800">{path.label}</h3>
                 <p className="mt-2 text-sm leading-6 text-[#46574d]">{path.description}</p>
@@ -395,7 +393,7 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
                   </p>
                 </div>
 
-                <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
                   {featuredHerbs.map((herb: any) => (
                     <HerbCard key={herb.slug} herb={herb} featured />
                   ))}
@@ -417,7 +415,7 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
                   </span>
                 </div>
 
-                <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
                   {libraryHerbs.map((herb: any) => (
                     <HerbCard key={herb.slug} herb={herb} />
                   ))}

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -410,7 +410,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
         <div className="space-y-6">
           <div className="space-y-2">
             <p className="eyebrow-label">Evidence summary</p>
-            <h2 className="text-2xl font-semibold tracking-tight text-ink">What the current profile supports</h2>
+            <h2 className="text-xl font-semibold tracking-tight text-ink">What the current profile supports</h2>
             <p className="max-w-4xl text-sm leading-6 text-[#46574d]">
               {displayName} is categorized as {researchMaturity.toLowerCase()} with a {researchStyle.toLowerCase()} evidence style. Interpret benefits by outcome, preparation, dose, and the safety context above.
             </p>
@@ -543,7 +543,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
   ]
 
   return (
-    <main className="mx-auto max-w-6xl space-y-12 px-4 py-8 sm:space-y-16 sm:py-10">
+    <main className="mx-auto max-w-6xl space-y-8 px-4 py-6 sm:space-y-10 sm:py-8">
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(herbJsonLd) }}
@@ -562,7 +562,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
         <span className="text-ink">{displayName}</span>
       </nav>
 
-      <section className="hero-shell rounded-[1.75rem] p-4 sm:p-6 lg:p-8">
+      <section className="hero-shell rounded-[1.25rem] p-4 sm:p-5 lg:p-6">
         <div className="space-y-4">
           <div className="flex flex-wrap items-center gap-4 text-xs font-bold uppercase tracking-[0.14em] text-muted">
             <Link href="/herbs" className="transition hover:text-ink">Back to herbs</Link>
@@ -574,7 +574,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
             <div className="space-y-3 lg:pt-2">
               <div className="space-y-2">
                 <p className="eyebrow-label">Herb research brief</p>
-                <h1 className="text-4xl font-semibold tracking-tight text-ink sm:text-5xl">
+                <h1 className="text-3xl font-semibold tracking-tight text-ink sm:text-4xl">
                   {displayName}
                 </h1>
                 {botanicalName ? <p className="text-sm italic text-muted">{botanicalName}</p> : null}
@@ -596,7 +596,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
               title="5-second profile read"
               subtitle="Educational overview only. Individual response and tolerance can vary."
               badge="Start here"
-              className="rounded-[1.65rem] border border-brand-900/10 bg-white/95 p-4 shadow-[0_18px_45px_rgba(47,64,52,0.12)] sm:p-5 lg:sticky lg:top-6"
+              className="rounded-[1.1rem] border border-brand-900/10 bg-white/95 p-4 shadow-sm lg:sticky lg:top-6"
               fields={buildDetailEvidenceSnapshotFields({
                 bestFit: topUses.slice(0, 3).join(', '),
                 humanEvidence: evidenceStrength || researchMaturity,
@@ -630,10 +630,10 @@ export default async function HerbDetailPage({ params }: PageProps) {
         </section>
       ) : null}
 
-      <section className="rounded-3xl bg-amber-50/70 p-5 sm:p-6">
+      <section className="rounded-[1.1rem] bg-amber-50/70 p-4 sm:p-5">
         <div className="space-y-2">
           <p className="eyebrow-label text-amber-900">Safety first</p>
-          <h2 className="text-2xl font-semibold tracking-tight text-ink">Review cautions before use</h2>
+          <h2 className="text-xl font-semibold tracking-tight text-ink">Review cautions before use</h2>
           <p className="max-w-4xl text-sm leading-6 text-[#5f4a24]">{safetySummary}</p>
         </div>
 

--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -118,22 +118,19 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
 
   return (
     <div className='overflow-x-clip bg-site-bg'>
-      <div className='mx-auto max-w-6xl space-y-8 px-4 pb-6 pt-7 sm:px-6 sm:space-y-10 sm:pb-8 sm:pt-10 lg:px-8'>
+      <div className='mx-auto max-w-6xl space-y-6 px-4 pb-6 pt-5 sm:px-6 sm:space-y-8 sm:pb-8 sm:pt-8 lg:px-8'>
 
         {/* Hero */}
-        <section className='rounded-[2rem] border border-brand-900/10 bg-white/90 px-4 py-6 shadow-sm sm:px-7 sm:py-8 lg:py-10'>
+        <section className='rounded-[1.25rem] border border-brand-900/10 bg-white/90 px-4 py-5 shadow-sm sm:px-6 sm:py-7'>
           <div className='mx-auto flex max-w-4xl flex-col items-center text-center'>
-            <p role='doc-subtitle' className='mb-4 inline-flex text-xs font-semibold uppercase tracking-[0.2em] text-brand-700'>
+            <p role='doc-subtitle' className='mb-3 inline-flex text-[0.7rem] font-semibold uppercase tracking-[0.18em] text-brand-700'>
               Evidence-aware botanical research
             </p>
-            <h1 className='font-display text-[2.65rem] font-semibold leading-[0.96] tracking-[-0.055em] text-ink sm:text-6xl md:text-7xl'>
+            <h1 className='font-display text-[2.35rem] font-semibold leading-[1] tracking-[-0.045em] text-ink sm:text-5xl md:text-6xl'>
               <span className='block'>The Hippie Scientist</span>
             </h1>
-            <p className='mt-5 max-w-2xl text-base leading-7 text-muted sm:text-lg font-medium'>
-              Compare herbs and compounds using evidence, safety context, and practical decision filters — not wellness hype.
-            </p>
-            <p className='mt-2 max-w-2xl text-sm leading-6 text-muted'>
-              Use these profiles to orient decisions thoughtfully based on clinical data. Individual response varies.
+            <p className='mt-4 max-w-2xl text-base font-medium leading-7 text-muted'>
+              Compare herbs and compounds by evidence strength, safety context, and practical fit — not wellness hype.
             </p>
             <div className='mt-5 grid w-full max-w-2xl gap-2 sm:grid-cols-3'>
               {primaryActions.map((action, index) => (
@@ -150,9 +147,7 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
                 </Link>
               ))}
             </div>
-            <p className='mt-5 max-w-2xl rounded-full border border-brand-900/10 bg-white/85 px-4 py-2 text-xs leading-5 text-muted sm:text-sm'>
-              Evidence strength, safety context, and uncertainty are kept visible so comparisons stay cautious.
-            </p>
+
           </div>
         </section>
 
@@ -168,7 +163,7 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
               <Link
                 key={goal.slug}
                 href={`/goals/${goal.slug}`}
-                className='group flex flex-col justify-between rounded-2xl border border-brand-900/10 bg-white/90 p-5 shadow-sm transition hover:border-brand-900/20 hover:bg-white'
+                className='group flex flex-col justify-between rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-900/20 hover:bg-white'
               >
                 <div>
                   <span className='text-[10px] font-bold uppercase tracking-wider text-brand-700'>{goal.eyebrow}</span>
@@ -215,7 +210,7 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
               <Link
                 key={cluster.href}
                 href={cluster.href}
-                className='group flex flex-col justify-between rounded-2xl border border-brand-900/10 bg-white/90 p-5 shadow-sm transition hover:border-brand-900/20 hover:bg-white'
+                className='group flex flex-col justify-between rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-900/20 hover:bg-white'
               >
                 <div>
                   <span className='text-[10px] font-bold uppercase tracking-wider text-brand-700'>{cluster.eyebrow}</span>
@@ -263,7 +258,7 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
         </section>
 
         {/* Disclaimer */}
-        <section className='rounded-2xl border border-amber-200/80 bg-amber-50/60 p-4 sm:p-5'>
+        <section className='rounded-[1rem] border border-amber-200/80 bg-amber-50/60 p-4'>
           <div className='flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between'>
             <p className='max-w-4xl text-sm leading-6 text-amber-950/85'>
               <strong>Important Notice:</strong> Natural does not automatically mean safe or effective. The information here supports comparison and mechanistic research. Always consult a physician and review potential contraindications before beginning any supplement routine.

--- a/components/ui/DecisionPrimitives.tsx
+++ b/components/ui/DecisionPrimitives.tsx
@@ -89,23 +89,21 @@ export function DecisionFilterGroup({
   open?: boolean
 }) {
   const itemClass = (active: boolean) =>
-    `min-h-12 rounded-[1rem] border px-3 py-3 text-sm font-semibold leading-snug transition ${active ? 'border-brand-700/25 bg-brand-50 text-brand-900' : 'border-brand-900/10 bg-white/80 text-[#33443a] hover:border-brand-700/20'}`
+    `rounded-full border px-3 py-2 text-xs font-semibold leading-tight transition ${active ? 'border-brand-700/25 bg-brand-50 text-brand-900' : 'border-brand-900/10 bg-white/80 text-[#33443a] hover:border-brand-700/20'}`
 
   return (
-    <details className="mt-4 rounded-[1.2rem] border border-brand-900/10 bg-[#fbfaf6]/80 p-3 shadow-none sm:p-4" open={open || undefined}>
-      <summary className="flex min-h-12 items-center justify-between gap-4 text-sm font-bold text-ink">
+    <details className="mt-3 rounded-[1rem] border border-brand-900/10 bg-[#fbfaf6]/80 p-3 shadow-none" open={open || undefined}>
+      <summary className="flex min-h-10 items-center justify-between gap-4 text-sm font-bold text-ink">
         <span>Refine by context</span>
         <span className="text-brand-800" aria-hidden="true">↓</span>
       </summary>
-      <div className="mt-3 grid gap-2 sm:mt-4 sm:grid-cols-2 lg:grid-cols-5">
+      <div className="mt-3 flex flex-wrap gap-2">
         <Link href={buildHref('all', query)} className={itemClass(activeFilter === 'all')}>
           All contexts
-          <span className="mt-1 block text-xs font-medium leading-5 text-[#64746a]">Keep the scan broad.</span>
         </Link>
         {options.map(option => (
           <Link key={option.value} href={buildHref(option.value, query)} className={itemClass(activeFilter === option.value)}>
             {option.label}
-            <span className="mt-1 block text-xs font-medium leading-5 text-[#64746a]">{option.hint}</span>
           </Link>
         ))}
       </div>
@@ -141,11 +139,11 @@ export function DecisionProfileCard({
   return (
     <Link
       href={href}
-      className="group flex h-full min-h-[15rem] flex-col rounded-[1.3rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition duration-300 hover:-translate-y-0.5 hover:border-brand-700/20 hover:bg-white hover:shadow-[var(--shadow-card-calm)] focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40 sm:min-h-[16rem] sm:p-5"
+      className="group flex h-full flex-col rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition duration-200 hover:border-brand-700/20 hover:bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40"
     >
       <div className="flex flex-1 flex-col">
         <div className="flex min-w-0 items-start justify-between gap-3">
-          <h3 className="min-w-0 break-words text-[1.3rem] font-semibold leading-tight tracking-tight text-ink transition group-hover:text-brand-800 sm:text-2xl">
+          <h3 className="min-w-0 break-words text-lg font-semibold leading-tight tracking-tight text-ink transition group-hover:text-brand-800 sm:text-xl">
             {name}
           </h3>
           {featured ? (
@@ -155,16 +153,16 @@ export function DecisionProfileCard({
           ) : null}
         </div>
 
-        <p className="mt-3 line-clamp-2 text-[0.95rem] leading-6 text-[#46574d]">
+        <p className="mt-2 line-clamp-2 text-sm leading-5 text-[#46574d]">
           {summary || fallbackSummary}
         </p>
 
-        <div className="mt-4 rounded-[1.1rem] border border-brand-900/10 bg-brand-50/45 p-3">
+        <div className="mt-3 rounded-[0.9rem] border border-brand-900/10 bg-brand-50/45 p-3">
           <p className={`${decisionMicroLabelClass} text-brand-800`}>Best-for context</p>
-          <p className="mt-1.5 text-base font-semibold leading-6 text-[#203329]">{bestFor}</p>
+          <p className="mt-1 text-sm font-semibold leading-5 text-[#203329]">{bestFor}</p>
         </div>
 
-        <div className="mt-3 grid gap-2 sm:grid-cols-2">
+        <div className="mt-3 grid gap-2 sm:grid-cols-3">
           <DecisionMetric label="Evidence" value={evidence} />
           <DecisionMetric label="Safety" value={safety} />
           <DecisionMetric label="Time" value={timeToEffect} />
@@ -181,8 +179,8 @@ export function DecisionProfileCard({
         ) : null}
       </div>
 
-      <div className="mt-4 flex min-h-11 items-center justify-center rounded-full bg-brand-800 px-4 py-3 text-sm font-bold text-white transition group-hover:bg-brand-900 group-focus-visible:bg-brand-900">
-        View profile <span className="ml-2 transition group-hover:translate-x-0.5" aria-hidden="true">→</span>
+      <div className="mt-3 text-sm font-bold text-brand-800 transition group-hover:text-brand-900">
+        View profile <span aria-hidden="true">→</span>
       </div>
     </Link>
   )

--- a/components/ui/EvidenceSnapshotPanel.tsx
+++ b/components/ui/EvidenceSnapshotPanel.tsx
@@ -32,15 +32,17 @@ export default function EvidenceSnapshotPanel({
   footer,
 }: Props) {
   const visibleFields = fields.filter(field => field?.label && field?.value)
+  const primaryFields = visibleFields.slice(0, 6)
+  const secondaryFields = visibleFields.slice(6)
   if (visibleFields.length === 0) return null
 
   return (
-    <aside className={className || 'rounded-[1.65rem] border border-brand-900/10 bg-white/95 p-4 shadow-[0_18px_45px_rgba(47,64,52,0.12)] sm:p-5'}>
+    <aside className={className || 'rounded-[1.1rem] border border-brand-900/10 bg-white/95 p-4 shadow-sm'}>
       <div className="flex items-start justify-between gap-3 border-b border-brand-900/10 pb-3">
         <div>
           <p className="eyebrow-label">Evidence snapshot</p>
-          <h2 className="mt-1 text-xl font-semibold tracking-tight text-ink">{title}</h2>
-          <p className="mt-1 text-sm leading-6 text-[#46574d]">{subtitle}</p>
+          <h2 className="mt-1 text-lg font-semibold tracking-tight text-ink">{title}</h2>
+          <p className="mt-1 text-xs leading-5 text-[#46574d]">{subtitle}</p>
         </div>
         {badge ? (
           <span className="rounded-full bg-emerald-700/10 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.14em] text-emerald-900">
@@ -50,13 +52,27 @@ export default function EvidenceSnapshotPanel({
       </div>
 
       <div className={`mt-4 ${columnsClassName}`}>
-        {visibleFields.map((field) => (
-          <article key={field.label} className={`rounded-2xl border p-4 shadow-sm ${fieldToneClasses(field.tone)}`}>
-            <h3 className="text-[0.68rem] font-bold uppercase tracking-[0.16em] text-muted">{field.label}</h3>
-            <p className="mt-2 text-sm leading-6 text-[#46574d]">{field.value}</p>
+        {primaryFields.map((field) => (
+          <article key={field.label} className={`rounded-[0.9rem] border p-3 ${fieldToneClasses(field.tone)}`}>
+            <h3 className="text-[0.66rem] font-bold uppercase tracking-[0.14em] text-muted">{field.label}</h3>
+            <p className="mt-1.5 text-sm leading-5 text-[#46574d]">{field.value}</p>
           </article>
         ))}
       </div>
+
+      {secondaryFields.length > 0 ? (
+        <details className="mt-3 rounded-[0.9rem] border border-brand-900/10 bg-white/70 p-3 shadow-none">
+          <summary className="text-xs font-bold uppercase tracking-[0.14em] text-brand-800">More context</summary>
+          <div className="mt-3 grid gap-2">
+            {secondaryFields.map((field) => (
+              <article key={field.label} className={`rounded-[0.8rem] border p-3 ${fieldToneClasses(field.tone)}`}>
+                <h3 className="text-[0.66rem] font-bold uppercase tracking-[0.14em] text-muted">{field.label}</h3>
+                <p className="mt-1.5 text-sm leading-5 text-[#46574d]">{field.value}</p>
+              </article>
+            ))}
+          </div>
+        </details>
+      ) : null}
 
       {footer ? <div className="mt-4 border-t border-brand-900/10 pt-3">{footer}</div> : null}
     </aside>

--- a/lib/decision-primitives.ts
+++ b/lib/decision-primitives.ts
@@ -26,22 +26,22 @@ export type DecisionSafetyTone = 'ok' | 'caution' | 'interaction' | 'review' | '
 export type DecisionEvidenceTone = 'strong' | 'moderate' | 'limited' | 'mixed' | 'preliminary' | 'traditional' | 'insufficient' | 'review'
 
 export const decisionBadgeClass =
-  'inline-flex min-h-8 max-w-full items-center rounded-full border px-3 py-1 text-xs font-semibold leading-snug break-words shadow-sm'
+  'inline-flex min-h-7 max-w-full items-center rounded-full border px-2.5 py-1 text-[0.72rem] font-semibold leading-snug break-words'
 
 export const decisionStatusBadgeClass =
   `${decisionBadgeClass} text-[0.72rem] uppercase tracking-[0.08em]`
 
 export const decisionChipClass =
-  'inline-flex min-h-8 max-w-full items-center rounded-full border border-brand-900/10 bg-white/75 px-3 py-1 text-xs font-semibold leading-snug text-[#5f6f66] break-words'
+  'inline-flex min-h-7 max-w-full items-center rounded-full border border-brand-900/10 bg-white/75 px-2.5 py-1 text-[0.72rem] font-semibold leading-snug text-[#5f6f66] break-words'
 
 export const decisionMicroLabelClass =
-  'text-xs font-bold uppercase tracking-[0.1em] leading-none'
+  'text-[0.68rem] font-bold uppercase tracking-[0.1em] leading-none'
 
 export const decisionMetricShellClass =
-  'min-w-0 rounded-[1rem] border border-brand-900/10 bg-[#fbfaf6]/85 px-3 py-2.5'
+  'min-w-0 rounded-[0.8rem] border border-brand-900/10 bg-[#fbfaf6]/85 px-2.5 py-2'
 
 export const decisionMetadataClusterClass =
-  'flex flex-wrap items-center gap-2.5 sm:gap-3'
+  'flex flex-wrap items-center gap-2'
 
 function compactText(value?: unknown): string {
   if (value == null) return ''

--- a/src/components/profile-decision-layer.tsx
+++ b/src/components/profile-decision-layer.tsx
@@ -158,10 +158,10 @@ function DecisionCard({ item }: { item: DecisionItem }) {
   if (!shouldRenderCard(label, value)) return null
 
   return (
-    <div className={`rounded-2xl border p-4 ${decisionCardClass(item.tone)}`}>
+    <div className={`rounded-[0.9rem] border p-3 ${decisionCardClass(item.tone)}`}>
       <p className="text-[0.68rem] font-bold uppercase tracking-[0.16em] opacity-65">{label}</p>
       {isDuplicateTitleBody(label, value) ? null : (
-        <p className="mt-2 text-sm font-semibold leading-6">{value}</p>
+        <p className="mt-1.5 text-sm font-semibold leading-5">{value}</p>
       )}
     </div>
   )
@@ -219,34 +219,34 @@ export function ProfileDecisionLayer({
     .slice(0, 3)
 
   return (
-    <section className="card-premium overflow-hidden p-0">
-      <div className="grid gap-0 lg:grid-cols-[1.1fr_0.9fr]">
-        <div className="space-y-6 p-5 sm:p-7 lg:p-8">
-          <div className="space-y-3">
+    <section className="card-premium overflow-hidden p-0 shadow-sm">
+      <div className="grid gap-0 lg:grid-cols-[1fr_0.7fr]">
+        <div className="space-y-4 p-4 sm:p-5 lg:p-6">
+          <div className="space-y-2">
             <p className="eyebrow-label">Decision Layer</p>
-            <h2 className="max-w-2xl text-3xl font-semibold tracking-tight text-ink sm:text-4xl">
-              {name ? `${name}: quick interpretation` : 'Quick interpretation'}
+            <h2 className="max-w-2xl text-2xl font-semibold tracking-tight text-ink sm:text-3xl">
+              {name ? `${name}: quick read` : 'Quick read'}
             </h2>
             {isRenderableText(quickTake) ? (
-              <p className="detail-reading max-w-3xl text-[#46574d]">
+              <p className="max-w-3xl text-sm leading-6 text-[#46574d]">
                 {quickTake}
               </p>
             ) : null}
           </div>
 
-          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
             {decisionItems.map((item) => (
               <DecisionCard key={item.label} item={item} />
             ))}
           </div>
         </div>
 
-        <aside className="border-t border-brand-900/10 bg-brand-50/50 p-5 sm:p-7 lg:border-l lg:border-t-0 lg:p-8">
-          <div className="space-y-5">
+        <aside className="border-t border-brand-900/10 bg-brand-50/40 p-4 sm:p-5 lg:border-l lg:border-t-0 lg:p-6">
+          <div className="space-y-4">
             <div className="space-y-2">
               <p className="eyebrow-label">Guided Next Step</p>
-              <p className="text-sm leading-7 text-[#46574d]">
-                Use this profile as a decision starting point, then compare nearby profiles before interpreting mechanisms or research depth.
+              <p className="text-sm leading-6 text-[#46574d]">
+                Compare nearby profiles before acting on mechanisms or research depth.
               </p>
             </div>
 
@@ -264,7 +264,7 @@ export function ProfileDecisionLayer({
                       <Link
                         key={slug}
                         href={getRelatedHref(targetType, slug)}
-                        className="block rounded-2xl border border-brand-900/10 bg-white/70 px-4 py-3 text-sm font-semibold text-[#33443a] transition hover:border-brand-700/25 hover:bg-white hover:text-brand-800"
+                        className="block rounded-[0.85rem] border border-brand-900/10 bg-white/70 px-3 py-2 text-sm font-semibold text-[#33443a] transition hover:border-brand-700/25 hover:bg-white hover:text-brand-800"
                       >
                         {label}
                       </Link>


### PR DESCRIPTION
### Motivation
- Reduce visual bulk across shared surfaces so pages feel faster, calmer, and more editorial while preserving existing routing and data-driven rendering.
- Prefer small, surgical changes to shared layout and card primitives so the density improvement applies site-wide rather than per-page.
- Surface practical decision signals earlier on detail pages and make library/index pages and mobile scans require less vertical scrolling.

### Description
- Toned down global surface tokens and typography in `app/globals.css` by reducing card radii, shadows, heading scale, and section spacing to make cards and heroes visually lighter and denser. (`app/globals.css`)
- Compressed homepage hero and cards in `components/homepage-v2.tsx` by shortening hero copy and reducing padding, radii, and prominence of decorative elements. (`components/homepage-v2.tsx`)
- Tightened library index pages by shrinking hero shells, removing oversized decorative blobs, reducing search/filter control heights, and making cards denser on `app/herbs/HerbsIndexClient.tsx` and `app/compounds/CompoundsIndexClient.tsx`.
- Made decision and profile surfaces more compact by adjusting filter chips, card min-heights, headings, metric shells, and chip sizing in `components/ui/DecisionPrimitives.tsx`, `components/ui/EvidenceSnapshotPanel.tsx`, and `lib/decision-primitives.ts` so the decision layer is quicker to scan.
- Shortened evidence snapshot UX to show primary fields immediately and move lower-priority fields behind progressive disclosure in `components/ui/EvidenceSnapshotPanel.tsx` so the 5-second read is denser.
- Reduced top-section heights and kept practical decision information earlier on detail pages by tightening `app/herbs/[slug]/page.tsx` and `app/compounds/[slug]/page.tsx` and compressing the `ProfileDecisionLayer` in `src/components/profile-decision-layer.tsx`.
- Minor blog hero compression for faster scanning in `app/blog/page.tsx`.

Changed files: `app/globals.css`, `components/homepage-v2.tsx`, `components/ui/DecisionPrimitives.tsx`, `components/ui/EvidenceSnapshotPanel.tsx`, `lib/decision-primitives.ts`, `src/components/profile-decision-layer.tsx`, `app/herbs/HerbsIndexClient.tsx`, `app/compounds/CompoundsIndexClient.tsx`, `app/herbs/[slug]/page.tsx`, `app/compounds/[slug]/page.tsx`, `app/blog/page.tsx`.

### Testing
- Ran `npm run typecheck` and it passed with no type errors. (PASS)
- Ran `npm run lint` and it passed with no lint warnings. (PASS)
- Ran `npm run validate:static-export && npm run validate:route-seo` and both validators passed. (PASS)
- Ran full `npm run build` which completed successfully; build-time governance and semantic checks passed, though the build logs include non-blocking SEO/structured-data audit findings that should be reviewed separately (audit warnings reported). (PASS with audit warnings)
- Attempted automated visual checks with Playwright screenshots: browser install and screenshot capture succeeded (temporary screenshots produced and validated), but an auxiliary `file`-based verification step failed in one environment due to a missing `file` binary; screenshots themselves were generated successfully for manual review. (partial: screenshots produced, small environment verification step failed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19b738a258832392125654e67db699)