### PR TITLE
refactor: compress site UI and remove visual bloat

### DIFF
--- a/app/best-for/[slug]/page.tsx
+++ b/app/best-for/[slug]/page.tsx
@@ -108,7 +108,7 @@ function AuthorityCard({ record }: { record: any }) {
         </h2>
 
         <p className="line-clamp-3 text-sm leading-6 text-[#46574d]">
-          {getSummary(record) || 'Evidence-aware profile connected to this goal-oriented research hub.'}
+          {getSummary(record) || 'Evidence-informed profile connected to this goal-oriented research hub.'}
         </p>
       </div>
 
@@ -156,7 +156,7 @@ export default async function BestExploredHubPage({ params }: BestForRouteProps)
             <div className="max-w-4xl space-y-5">
               <div className="flex flex-wrap items-center gap-2">
                 <p className="eyebrow-label">Best Explored For</p>
-                <span className="chip-readable">Evidence-aware goal hub</span>
+                <span className="chip-readable">Evidence-informed goal hub</span>
               </div>
 
               <h1 className="max-w-[14ch]">{topic.title}</h1>

--- a/app/best-for/non-sedating-calm/page.tsx
+++ b/app/best-for/non-sedating-calm/page.tsx
@@ -26,7 +26,7 @@ export default function NonSedatingCalmPage() {
     <main className="container-page py-10 space-y-10">
       <AuthorityJsonLd
         title="Best Compounds for Non-Sedating Calm"
-        description="Educational exploration of non-sedating calming systems, stress-response support, calm focus, and evidence-aware neuropharmacology."
+        description="Educational exploration of non-sedating calming systems, stress-response support, calm focus, and neuropharmacology."
         url="https://thehippiescientist.net/best-for/non-sedating-calm"
         type="CollectionPage"
       />

--- a/app/best/[slug]/page.tsx
+++ b/app/best/[slug]/page.tsx
@@ -97,7 +97,7 @@ export default async function Page({ params }: BestRouteProps) {
         <h1 className="text-3xl font-bold">Best Supplements for Focus</h1>
 
         <p className="text-neutral-600 leading-7 max-w-3xl">
-          Evidence-aware rankings connected into semantic authority hubs, ecosystem pathways, protocol systems, and mechanism-aware stack discovery.
+          Evidence-informed rankings connected into semantic authority hubs, ecosystem pathways, protocol systems, and mechanism-aware stack discovery.
         </p>
       </div>
 

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -38,17 +38,17 @@ const inferArticleStyle = (post: any) => {
 
 export const metadata: Metadata = {
   title: 'Research Notes & Herb Guides',
-  description: '75+ evidence-aware research notes on herbs, compounds, mechanisms, safety, and preparation — organized by research style and topic.',
+  description: '75+ research notes on herbs, compounds, safety, and preparation.',
   alternates: { canonical: '/blog' },
   openGraph: {
     title: 'Research Notes & Herb Guides',
-    description: '75+ evidence-aware research notes on herbs, compounds, mechanisms, safety, and preparation — organized by research style and topic.',
+    description: '75+ research notes on herbs, compounds, safety, and preparation.',
     url: '/blog',
   },
   twitter: {
     card: 'summary_large_image',
     title: 'Research Notes & Herb Guides',
-    description: '75+ evidence-aware research notes on herbs, compounds, mechanisms, safety, and preparation.',
+    description: '75+ research notes on herbs, compounds, mechanisms, safety, and preparation.',
   },
 }
 
@@ -58,27 +58,27 @@ export default function BlogPage() {
   const remainingPosts = sortedPosts.slice(1)
 
   return (
-    <div className="section-spacing pb-16">
-      <section className="hero-shell rounded-[1.25rem] border border-brand-900/10 p-5 shadow-sm sm:p-6">
-        <p className="eyebrow-label">Scientific editorial layer</p>
-        <h1 className="mt-2 heading-premium max-w-3xl">Research notes that connect the library.</h1>
+    <div className="section-spacing pb-10">
+      <section className="hero-shell rounded-[0.95rem] border border-brand-900/10 p-4 shadow-sm sm:p-5">
+        <p className="eyebrow-label">Research notes</p>
+        <h1 className="mt-2 heading-premium max-w-3xl">Research notes</h1>
         <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-soft">
-          Mechanisms, preparation choices, traditional context, safety limits, and evidence maturity — organized for fast scanning.
+          Mechanisms, preparations, safety limits, and evidence maturity for fast scanning.
         </p>
-        <p className="mt-3 text-sm font-semibold text-[#46574d]">{sortedPosts.length} research notes available</p>
+        <p className="mt-2 text-sm font-semibold text-[#46574d]">{sortedPosts.length} research notes available</p>
       </section>
 
       {featuredPost ? (
         <section className="surface-depth card-spacing">
           <p className="eyebrow-label">Latest research note</p>
-          <Link href={`/blog/${featuredPost.slug}`} className="identity-article scientific-card mt-4 group">
-            <div className="flex flex-wrap items-center gap-3">
+          <Link href={`/blog/${featuredPost.slug}`} className="identity-article scientific-card mt-3 group">
+            <div className="flex flex-wrap items-center gap-2">
               <span className="identity-kicker">{inferArticleStyle(featuredPost)}</span>
               <span className="identity-meta">{formatDate(featuredPost.date)} • {featuredPost.readingTime}</span>
             </div>
-            <h2 className="mt-3 max-w-3xl text-2xl font-semibold tracking-tight text-ink group-hover:text-brand-800 sm:text-3xl">{featuredPost.title}</h2>
-            <p className="mt-3 max-w-3xl text-sm leading-6 text-[#46574d]">{truncateText(featuredPost.excerpt, 190)}</p>
-            <span className="mt-5 inline-flex text-sm font-semibold text-brand-800 transition group-hover:translate-x-0.5">Read note →</span>
+            <h2 className="mt-2 max-w-3xl text-xl font-semibold tracking-tight text-ink group-hover:text-brand-800 sm:text-2xl">{featuredPost.title}</h2>
+            <p className="mt-3 max-w-3xl text-sm leading-6 text-[#46574d]">{truncateText(featuredPost.excerpt, 140)}</p>
+            <span className="mt-3 inline-flex text-sm font-semibold text-brand-800 transition group-hover:translate-x-0.5">Read note →</span>
           </Link>
         </section>
       ) : null}
@@ -96,19 +96,19 @@ export default function BlogPage() {
         ]}
       />
 
-      <section className="space-y-5">
+      <section className="space-y-4">
         <div>
           <p className="eyebrow-label">Archive</p>
           <h2 className="mt-2 max-w-3xl">All research notes</h2>
         </div>
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
           {remainingPosts.map(post => (
             <ContentIdentityCard
               key={post.slug}
               item={{
                 href: `/blog/${post.slug}`,
                 title: post.title,
-                description: truncateText(post.excerpt, 190),
+                description: truncateText(post.excerpt, 130),
                 meta: `${inferArticleStyle(post)} • ${formatDate(post.date)}`,
                 kind: 'article',
               }}

--- a/app/collections/[slug]/page.tsx
+++ b/app/collections/[slug]/page.tsx
@@ -62,7 +62,7 @@ export default async function CollectionPage({ params }: Params) {
         sections={[
           { title: 'Biological context', body: `This collection groups ${collection.itemType} profiles around shared workbook signals so readers can compare adjacent biology before opening individual profiles.` },
           { title: 'Research focus', body: 'Matching records are filtered by collection intent and summarized with concise profile excerpts rather than unsupported recommendations.' },
-          { title: 'Discovery method', body: 'Theme chips and profile cards make the route useful as a crawlable bridge between broad search intent and evidence-aware depth pages.' },
+          { title: 'Discovery method', body: 'Theme chips and profile cards make the route useful as a crawlable bridge between broad search intent and evidence-informed depth pages.' },
         ]}
       />
 
@@ -84,7 +84,7 @@ export default async function CollectionPage({ params }: Params) {
         <div className="flex flex-wrap items-end justify-between gap-3">
           <div className="space-y-2">
             <p className="eyebrow-label">Matching profiles</p>
-            <h2 className="text-3xl font-semibold tracking-tight text-ink">Evidence-aware collection cards</h2>
+            <h2 className="text-3xl font-semibold tracking-tight text-ink">Evidence-informed collection cards</h2>
           </div>
           <span className="chip-readable">{items.length} matches</span>
         </div>

--- a/app/collections/scientific-collection-page.tsx
+++ b/app/collections/scientific-collection-page.tsx
@@ -47,7 +47,7 @@ function buildCollectionIntro(collection: ScientificCollection) {
   return [
     {
       title: 'Biological context',
-      body: `${collection.title} groups ${subject} by shared effect language, pathway signals, and evidence-aware research context rather than by alphabetical browsing.`,
+      body: `${collection.title} groups ${subject} by shared effect language, pathway signals, and practical research context rather than by alphabetical browsing.`,
     },
     {
       title: 'Research focus',
@@ -226,7 +226,7 @@ export async function ScientificCollectionPage({ slug }: CollectionPageProps) {
 
       <section className="space-y-6">
         <div className="space-y-2">
-          <p className="eyebrow-label">Evidence-aware discovery</p>
+          <p className="eyebrow-label">Evidence-informed discovery</p>
           <h2 className="text-3xl font-semibold tracking-tight text-ink">
             {collection.primaryType === 'herb' ? 'Primary herbs' : collection.primaryType === 'compound' ? 'Primary compounds' : 'Matching records'}
           </h2>

--- a/app/compare/ashwagandha-vs-rhodiola-for-stress/page.tsx
+++ b/app/compare/ashwagandha-vs-rhodiola-for-stress/page.tsx
@@ -7,7 +7,7 @@ export default function AshwagandhaVsRhodiolaForStressPage() {
     <main className="container-page py-10 space-y-10">
       <AuthorityJsonLd
         title="Ashwagandha vs Rhodiola for Stress"
-        description="Evidence-aware comparison of ashwagandha and rhodiola for stress patterns, fatigue, calm support, safety, and supplement selection."
+        description="Evidence-informed comparison of ashwagandha and rhodiola for stress patterns, fatigue, calm support, safety, and supplement selection."
         url="https://thehippiescientist.net/compare/ashwagandha-vs-rhodiola-for-stress"
         type="Article"
       />

--- a/app/compare/magnesium-glycinate-vs-l-threonate-for-sleep/page.tsx
+++ b/app/compare/magnesium-glycinate-vs-l-threonate-for-sleep/page.tsx
@@ -7,7 +7,7 @@ export default function MagnesiumGlycinateVsLThreonateForSleepPage() {
     <main className="container-page py-10 space-y-10">
       <AuthorityJsonLd
         title="Magnesium Glycinate vs L-Threonate for Sleep"
-        description="Evidence-aware comparison of magnesium glycinate and magnesium L-threonate for sleep routines, calm support, cognition positioning, safety, and supplement selection."
+        description="Evidence-informed comparison of magnesium glycinate and magnesium L-threonate for sleep routines, calm support, cognition positioning, safety, and supplement selection."
         url="https://thehippiescientist.net/compare/magnesium-glycinate-vs-l-threonate-for-sleep"
         type="Article"
       />

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -55,7 +55,7 @@ export default async function ComparePage() {
   return (
     <div className="mx-auto max-w-6xl space-y-8 px-4 py-8 sm:py-10">
       <section className="rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
-        <p className="eyebrow-label">Evidence-aware comparison</p>
+        <p className="eyebrow-label">Evidence-informed comparison</p>
         <div className="mt-3 max-w-3xl space-y-4">
           <h1 className="text-3xl font-bold tracking-tight text-ink sm:text-5xl">
             Compare herbs, supplements, and compounds

--- a/app/comparisons/page.tsx
+++ b/app/comparisons/page.tsx
@@ -56,7 +56,7 @@ const relatedSystems = [
     href: '/education/what-are-adaptogens',
     title: 'What Are Adaptogens?',
     description:
-      'Evidence-aware educational framework covering resilience biology, stress-response systems, and adaptogenic neuropharmacology.',
+      'Evidence-informed educational framework covering resilience biology, stress-response systems, and adaptogenic neuropharmacology.',
   },
   {
     href: '/education/what-is-a-nootropic',

--- a/app/compounds/CompoundsIndexClient.tsx
+++ b/app/compounds/CompoundsIndexClient.tsx
@@ -213,9 +213,9 @@ function buildFilterHref(value: string, query: string) {
 
 function StatCard({ value, label }: { value: number; label: string }) {
   return (
-    <div className="min-w-0 rounded-[1.1rem] border border-brand-900/10 bg-white/75 p-3 shadow-sm backdrop-blur sm:p-4">
-      <p className="text-2xl font-semibold tracking-tight text-ink sm:text-3xl">{value}</p>
-      <p className="mt-1 text-[0.66rem] font-bold uppercase leading-snug tracking-[0.12em] text-[#5f6f66] sm:text-[0.68rem] sm:tracking-[0.14em]">{label}</p>
+    <div className="min-w-0 rounded-[0.8rem] border border-brand-900/10 bg-white/80 p-2.5 shadow-sm sm:p-3">
+      <p className="text-xl font-semibold tracking-tight text-ink sm:text-2xl">{value}</p>
+      <p className="mt-0.5 text-[0.62rem] font-bold uppercase leading-snug tracking-[0.1em] text-[#5f6f66]">{label}</p>
     </div>
   )
 }
@@ -303,23 +303,23 @@ export default function CompoundsIndexClient({ compounds: sourceCompounds, initi
   const libraryCompounds = hasActiveFilters ? visibleCompounds : compounds.slice(featuredCompounds.length)
 
   return (
-    <div className="min-h-screen px-3 py-4 text-ink sm:px-4 sm:py-6">
-      <div className="mx-auto max-w-7xl space-y-6 sm:space-y-8">
-        <section className="hero-shell relative overflow-hidden rounded-[1.25rem] border border-white/60 px-4 py-5 shadow-sm sm:px-6 sm:py-7">
-          <div className="relative grid gap-4 lg:grid-cols-[1.05fr_.95fr] lg:items-end">
-            <div className="max-w-3xl space-y-3">
+    <div className="px-2 py-2 text-ink sm:px-3 sm:py-3">
+      <div className="mx-auto max-w-7xl space-y-4 sm:space-y-4">
+        <section className="hero-shell relative overflow-hidden rounded-[0.95rem] border border-brand-900/10 px-3 py-4 shadow-sm sm:px-4 sm:py-5">
+          <div className="relative grid gap-3 lg:grid-cols-[1.05fr_.95fr] lg:items-end">
+            <div className="max-w-3xl space-y-2">
               <p className="eyebrow-label">Compound decision library</p>
-              <h1 className="max-w-[16ch] text-balance font-display text-3xl font-semibold leading-[1.05] tracking-tight text-ink sm:text-5xl">
+              <h1 className="max-w-[18ch] text-balance font-display text-2xl font-semibold leading-[1.08] tracking-tight text-ink sm:text-4xl">
                 Compound research library
               </h1>
-              <p className="max-w-2xl text-sm leading-6 text-[#46574d] sm:text-base">
+              <p className="max-w-2xl text-sm leading-6 text-[#46574d]">
                 Scan bioactive molecules by practical context first, then compare evidence, safety notes, and mechanism hints before opening a full compound profile.
               </p>
             </div>
 
-            <div className="rounded-[1rem] border border-brand-900/10 bg-white/75 p-3 shadow-sm backdrop-blur">
+            <div className="rounded-[0.8rem] border border-brand-900/10 bg-white/80 p-2.5 shadow-sm">
               <p className="text-xs font-bold uppercase tracking-[0.16em] text-brand-800">Library signal</p>
-              <div className="mt-3 grid grid-cols-3 gap-2">
+              <div className="mt-2 grid grid-cols-3 gap-2">
                 <StatCard value={totalProfiles} label="Profiles" />
                 <StatCard value={evidenceForward} label="Evidence-led" />
                 <StatCard value={safetyMapped} label="Safety notes" />
@@ -328,16 +328,16 @@ export default function CompoundsIndexClient({ compounds: sourceCompounds, initi
           </div>
         </section>
 
-        <section className="rounded-[1rem] border border-brand-900/10 bg-white/85 p-4 shadow-sm sm:p-5" aria-labelledby="compound-search-heading">
-          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
-            <div className="max-w-2xl space-y-2">
+        <section className="rounded-[0.85rem] border border-brand-900/10 bg-white/85 p-3 shadow-sm sm:p-4" aria-labelledby="compound-search-heading">
+          <div className="flex flex-col gap-2 lg:flex-row lg:items-end lg:justify-between">
+            <div className="max-w-2xl space-y-1.5">
               <p className="eyebrow-label">Search and filter</p>
               <h2 id="compound-search-heading" className="compact-heading">Start with the decision you need to make.</h2>
             </div>
             <Link href="/herbs" className="w-fit text-sm font-bold text-brand-800 transition hover:text-brand-900">Browse herb sources →</Link>
           </div>
 
-          <form action="/compounds" className="mt-4 grid gap-3 sm:grid-cols-[1fr_auto]">
+          <form action="/compounds" className="mt-3 grid gap-2 sm:grid-cols-[1fr_auto]">
             <label className="sr-only" htmlFor="compound-search">Search compounds</label>
             <input
               id="compound-search"
@@ -345,10 +345,10 @@ export default function CompoundsIndexClient({ compounds: sourceCompounds, initi
               type="search"
               defaultValue={query}
               placeholder="Search compound, mechanism, source herb, or safety note"
-              className="min-h-11 w-full rounded-full border border-brand-900/10 bg-white px-4 text-sm text-ink shadow-sm placeholder:text-[#7b8a81]"
+              className="min-h-10 w-full rounded-full border border-brand-900/10 bg-white px-4 text-sm text-ink shadow-sm placeholder:text-[#7b8a81]"
             />
             {activeFilter !== 'all' ? <input type="hidden" name="context" value={activeFilter} /> : null}
-            <button type="submit" className="button-primary min-h-11 px-5 py-2.5">
+            <button type="submit" className="button-primary min-h-10 px-4 py-2">
               Search
             </button>
           </form>
@@ -362,23 +362,23 @@ export default function CompoundsIndexClient({ compounds: sourceCompounds, initi
           />
         </section>
 
-        <section className="rounded-[1rem] border border-brand-900/10 bg-white/70 p-4 shadow-sm">
+        <section className="rounded-[0.85rem] border border-brand-900/10 bg-white/75 p-3 shadow-sm">
           <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-            <div className="max-w-2xl space-y-2">
+            <div className="max-w-2xl space-y-1.5">
               <p className="eyebrow-label">Common starting points</p>
               <h2 className="compact-heading">Use broader guides if you are still orienting.</h2>
             </div>
           </div>
 
-          <div className="mt-4 grid gap-3 md:grid-cols-3">
+          <div className="mt-3 grid gap-2 md:grid-cols-3">
             {browsePaths.map(path => (
               <Link
                 key={path.label}
                 href={path.href}
-                className="group rounded-[0.9rem] border border-brand-900/10 bg-white/80 p-3 shadow-sm transition hover:border-brand-700/20 hover:bg-white"
+                className="group rounded-[0.75rem] border border-brand-900/10 bg-white/85 p-2.5 shadow-sm transition hover:border-brand-700/20 hover:bg-white"
               >
-                <h3 className="text-lg font-semibold tracking-tight text-ink transition group-hover:text-brand-800">{path.label}</h3>
-                <p className="mt-2 text-sm leading-6 text-[#46574d]">{path.description}</p>
+                <h3 className="text-base font-semibold tracking-tight text-ink transition group-hover:text-brand-800">{path.label}</h3>
+                <p className="mt-1 text-sm leading-5 text-[#46574d]">{path.description}</p>
               </Link>
             ))}
           </div>
@@ -391,18 +391,18 @@ export default function CompoundsIndexClient({ compounds: sourceCompounds, initi
         ) : (
           <>
             {featuredCompounds.length > 0 ? (
-              <section className="space-y-5">
+              <section className="space-y-4">
                 <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
-                  <div className="max-w-2xl space-y-2">
+                  <div className="max-w-2xl space-y-1.5">
                     <p className="eyebrow-label">Start here</p>
-                    <h2 className="compact-heading">High-signal profiles for learning the card pattern.</h2>
+                    <h2 className="compact-heading">High-signal starting points.</h2>
                   </div>
                   <p className="max-w-md text-sm leading-6 text-[#5f6f66]">
-                    Sorted by evidence signals, profile readiness, and mechanism mapping—not by promised outcomes.
+                    Sorted by evidence, safety, and profile readiness.
                   </p>
                 </div>
 
-                <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
                   {featuredCompounds.map((compound: any) => (
                     <CompoundCard key={compound.slug} compound={compound} featured />
                   ))}
@@ -411,9 +411,9 @@ export default function CompoundsIndexClient({ compounds: sourceCompounds, initi
             ) : null}
 
             {libraryCompounds.length > 0 ? (
-              <section className="space-y-5">
+              <section className="space-y-4">
                 <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
-                  <div className="max-w-2xl space-y-2">
+                  <div className="max-w-2xl space-y-1.5">
                     <p className="eyebrow-label">{hasActiveFilters ? 'Matching compounds' : 'All compounds'}</p>
                     <h2 className="compact-heading">
                       {hasActiveFilters ? 'Profiles matching your scan.' : 'Browse every published compound profile.'}
@@ -424,7 +424,7 @@ export default function CompoundsIndexClient({ compounds: sourceCompounds, initi
                   </span>
                 </div>
 
-                <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
                   {libraryCompounds.map((compound: any) => (
                     <CompoundCard key={compound.slug} compound={compound} />
                   ))}

--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -27,6 +27,7 @@ import { getValidComparisonSlug } from '@/lib/comparison-utils'
 import { buildSemanticGraphVisual } from '@/lib/semantic-graph-visuals'
 import { buildContinuationPrompts, buildSemanticNarrative } from '@/lib/semantic-exploration-narratives'
 import { buildSourcingNotes, getMonetizationReadiness } from '@/lib/monetization-context'
+import { getAffiliateShopLinks } from '@/lib/affiliate'
 import {
   buildSemanticAssistantSummary,
   buildSemanticNavigationSuggestions,
@@ -259,7 +260,9 @@ export default async function CompoundPage({ params }: PageProps) {
     .map((source:any) => text(source))
     .filter(isClean)
   const displayName = formatDisplayLabel(compound.name || compound.slug)
-  const quickSummary = firstSentences(summary, 2) || 'Evidence-informed compound profile with safety, mechanism, and fit context.'
+  const shopLinks = getAffiliateShopLinks(compound, displayName, 'compound')
+  const primaryShopLink = shopLinks[0]
+  const quickSummary = firstSentences(summary, 1) || 'Compound profile with safety, mechanism, and fit context.'
   const timeline = getTimeline(compound)
   const avoidIf = getAvoidIf(compound)
   const safetySummary = getSafetySummary(compound, avoidIf)
@@ -269,7 +272,7 @@ export default async function CompoundPage({ params }: PageProps) {
   const safetyTone = getSafetyTone(safetySummary, avoidIf)
   const keyTakeaways = unique([
     effects.length ? `Most often explored for ${effects.slice(0, 3).join(', ')}.` : '',
-    evidenceLevel ? `Evidence context currently reads as ${evidenceLevel.toLowerCase()}.` : '',
+    evidenceLevel ? `Evidence: ${evidenceLevel.toLowerCase()}.` : '',
     safetySummary ? `Safety first: ${safetySummary}` : '',
     timeline ? `Timeline/onset context: ${timeline}.` : '',
     mechanismHints.length ? `Mechanism signals include ${mechanismHints.slice(0, 3).join(', ')}.` : '',
@@ -297,9 +300,9 @@ export default async function CompoundPage({ params }: PageProps) {
         <div className="space-y-6">
           <div className="space-y-2">
             <p className="eyebrow-label">Evidence summary</p>
-            <h2 className="text-xl font-semibold tracking-tight text-ink">What the current profile supports</h2>
+            <h2 className="text-lg font-semibold tracking-tight text-ink">What the current profile supports</h2>
             <p className="max-w-4xl text-sm leading-6 text-[#46574d]">
-              Use this profile as an evidence-aware orientation, not a guarantee of outcomes. Human data quality, formulation differences, and dosing variability can change real-world effects.
+              Use this profile as an evidence-informed orientation, not a guarantee of outcomes. Human data quality, formulation differences, and dosing variability can change real-world effects.
             </p>
           </div>
 
@@ -312,7 +315,7 @@ export default async function CompoundPage({ params }: PageProps) {
             ) : null}
             <div className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm">
               <p className="text-[11px] font-bold uppercase tracking-[0.16em] text-muted">What we still do not know</p>
-              <ul className="mt-3 space-y-2 text-sm leading-6 text-[#46574d]">
+              <ul className="mt-2 grid gap-1.5 text-sm leading-6 text-[#46574d] sm:grid-cols-2">
                 <li>• Long-term effects can differ from short-term study windows.</li>
                 <li>• Individual response varies across genetics, baseline health, and concurrent stack choices.</li>
                 <li>• Mechanistic signals may not translate directly into clinically meaningful outcomes.</li>
@@ -320,7 +323,7 @@ export default async function CompoundPage({ params }: PageProps) {
             </div>
           </div>
 
-          <div className="border-t border-brand-900/10 pt-6">
+          <div className="border-t border-brand-900/10 pt-4">
             <h3 className="text-lg font-semibold tracking-tight text-ink mb-3">Evidence snapshot metrics</h3>
             <EvidenceSnapshotCard snapshot={snapshot} />
           </div>
@@ -442,7 +445,7 @@ export default async function CompoundPage({ params }: PageProps) {
             </div>
           ) : null}
           {sources.length > 0 ? (
-            <div className="border-t border-brand-900/10 pt-6">
+            <div className="border-t border-brand-900/10 pt-4">
               <h3 className="text-lg font-semibold tracking-tight text-ink mb-3">Research and source context</h3>
               <ul className="space-y-2 text-sm leading-7 text-[#46574d]">
                 {sources.slice(0, 10).map((source:string) => (
@@ -470,7 +473,7 @@ export default async function CompoundPage({ params }: PageProps) {
 
       <ReadingProgress />
 
-      <main className="mx-auto max-w-7xl space-y-8 px-4 py-6 pb-20 sm:space-y-10 sm:py-8 sm:pb-24">
+      <main className="mx-auto max-w-7xl space-y-5 px-4 py-4 pb-16 sm:space-y-6 sm:py-6 sm:pb-20">
         <Breadcrumbs
           items={[
             { label: 'Home', href: '/' },
@@ -479,9 +482,9 @@ export default async function CompoundPage({ params }: PageProps) {
           ]}
         />
 
-        <section className="hero-shell rounded-[1.25rem] p-4 sm:p-5 lg:p-6">
-          <div className="grid gap-5 lg:grid-cols-[minmax(0,0.82fr)_minmax(340px,1.18fr)] lg:items-start">
-            <div className="space-y-4 lg:pt-2">
+        <section className="hero-shell rounded-[0.95rem] border border-brand-900/10 p-3 sm:p-4">
+          <div className="grid gap-4 lg:grid-cols-[minmax(0,0.8fr)_minmax(320px,1.2fr)] lg:items-start">
+            <div className="space-y-3">
               <CompoundHero
                 compound={{ ...compound, summary: quickSummary }}
                 evidenceLevel={evidenceLevel}
@@ -491,11 +494,42 @@ export default async function CompoundPage({ params }: PageProps) {
               <EvidenceBadgeGroup record={compound} compact />
             </div>
 
-            <EvidenceSnapshotPanel
+            <div className="space-y-3">
+              <div className="grid gap-2 rounded-[0.85rem] border border-brand-900/10 bg-white/90 p-3 shadow-sm sm:grid-cols-2">
+                <div>
+                  <p className="eyebrow-label">Best for</p>
+                  <p className="mt-1 text-sm font-semibold leading-5 text-ink">{effects.slice(0, 3).join(', ') || 'Compare fit before use'}</p>
+                </div>
+                <div>
+                  <p className="eyebrow-label text-amber-900">Avoid / review if</p>
+                  <p className="mt-1 text-sm font-semibold leading-5 text-[#5f4a24]">{avoidIf.slice(0, 2).join(', ') || safetyTone}</p>
+                </div>
+              </div>
+
+              {primaryShopLink ? (
+                <a
+                  href={primaryShopLink.url}
+                  target="_blank"
+                  rel="nofollow sponsored noopener noreferrer"
+                  className="flex items-center justify-between gap-3 rounded-[0.85rem] border border-emerald-700/20 bg-emerald-50 px-3 py-2.5 text-sm font-bold text-emerald-900 shadow-sm hover:bg-emerald-100"
+                >
+                  <span>{primaryShopLink.label}</span>
+                  <span aria-hidden="true">→</span>
+                </a>
+              ) : null}
+
+              <nav aria-label="Profile sections" className="flex flex-wrap gap-2 text-xs font-bold text-brand-800">
+                <a className="rounded-full border border-brand-900/10 bg-white px-2.5 py-1 hover:bg-brand-50" href="#evidence-outcomes-tab">Evidence</a>
+                <a className="rounded-full border border-brand-900/10 bg-white px-2.5 py-1 hover:bg-brand-50" href="#safety">Safety</a>
+                <a className="rounded-full border border-brand-900/10 bg-white px-2.5 py-1 hover:bg-brand-50" href="#mechanism-fit-tab">Mechanism</a>
+                <a className="rounded-full border border-brand-900/10 bg-white px-2.5 py-1 hover:bg-brand-50" href="#authority-sourcing-tab">Products</a>
+              </nav>
+
+              <EvidenceSnapshotPanel
               title="5-second profile read"
-              subtitle="Educational overview only. Individual effects and side-effect sensitivity can vary."
+              subtitle="Educational overview. Individual response varies."
               badge="Start here"
-              className="rounded-[1.1rem] border border-brand-900/10 bg-white/95 p-4 shadow-sm lg:sticky lg:top-6"
+              className="rounded-[0.85rem] border border-brand-900/10 bg-white/95 p-3 shadow-sm lg:sticky lg:top-4"
               fields={buildDetailEvidenceSnapshotFields({
                 bestFit: effects.slice(0, 3).join(', '),
                 humanEvidence: evidenceLevel,
@@ -504,22 +538,23 @@ export default async function CompoundPage({ params }: PageProps) {
                 regulationProfile,
                 typicalOnset: timeline || 'Timing varies by dose, form, and context.',
                 useCautionIf: avoidIf.length ? avoidIf.slice(0, 3).join(', ') : '',
-                uncertain: mechanismHints.length ? `Mechanism hints are preliminary: ${mechanismHints.slice(0, 3).join(', ')}. Real-world response can vary by person and product.` : '',
+                uncertain: mechanismHints.length ? `Mechanism: ${mechanismHints.slice(0, 3).join(', ')}.` : '',
                 confidenceLabel: confidenceObj.confidenceLabel,
                 evidenceWeight: confidenceObj.evidenceWeight,
                 humanEvidenceFlag: confidenceObj.humanEvidenceFlag,
                 evidenceExplanation: confidenceObj.evidenceExplanation,
               })}
             />
+            </div>
           </div>
         </section>
 
         <TrustBar />
 
         {keyTakeaways.length > 0 ? (
-          <section className="border-t border-brand-900/10 pt-6">
+          <section className="border-t border-brand-900/10 pt-4">
             <p className="eyebrow-label">Key takeaways</p>
-            <ul className="mt-3 space-y-2 text-sm leading-6 text-[#46574d]">
+            <ul className="mt-2 grid gap-1.5 text-sm leading-6 text-[#46574d] sm:grid-cols-2">
               {keyTakeaways.map(item => (
                 <li key={item} className="flex gap-2">
                   <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-500" />
@@ -530,10 +565,10 @@ export default async function CompoundPage({ params }: PageProps) {
           </section>
         ) : null}
 
-        <section className="rounded-[1.1rem] bg-amber-50/70 p-4 sm:p-5">
+        <section id="safety" className="rounded-[0.9rem] bg-amber-50/70 p-3 sm:p-4">
           <div className="space-y-2">
             <p className="eyebrow-label text-amber-900">Safety first</p>
-            <h2 className="text-xl font-semibold tracking-tight text-ink">Review cautions before use</h2>
+            <h2 className="text-lg font-semibold tracking-tight text-ink">Review cautions before use</h2>
             <p className="max-w-4xl text-sm leading-6 text-[#5f4a24]">
               Educational-only framing: individual response varies by dose, formulation, concurrent medications, and health context. {safetySummary}
             </p>
@@ -552,7 +587,7 @@ export default async function CompoundPage({ params }: PageProps) {
 
         <RelatedDiscoveryGroups
           eyebrow="Related navigation"
-          title="Keep exploring with evidence context"
+          title="Related decisions"
           groups={[
             {
               title: 'Related comparisons',

--- a/app/compounds/page.tsx
+++ b/app/compounds/page.tsx
@@ -7,19 +7,19 @@ import { Suspense } from 'react'
 export const metadata: Metadata = {
   title: 'Compound & Nootropic Profiles',
   description:
-    'Explore 500+ supplement and compound profiles with mechanisms, evidence strength, safety notes, and dosing context. Research-first, hype-free.',
+    'Explore 500+ supplement and compound profiles with mechanisms, evidence strength, safety notes, and dosing context. Hype-free.',
   alternates: { canonical: '/compounds' },
   openGraph: {
     title: 'Compound Profiles and Mechanism Guides',
     description:
-      'Browse evidence-aware compound profiles with mechanisms, effects, safety considerations, and practical supplement context.',
+      'Browse compound profiles with effects, safety considerations, and practical supplement context.',
     url: '/compounds',
   },
   twitter: {
     card: 'summary_large_image',
     title: 'Compound Profiles and Mechanism Guides',
     description:
-      'Browse evidence-aware compound profiles with mechanisms, effects, safety considerations, and practical supplement context.',
+      'Browse compound profiles with effects, safety considerations, and practical supplement context.',
   },
 }
 import { getCompounds } from '@/lib/runtime-data'
@@ -45,18 +45,11 @@ export default async function CompoundsPage() {
     }))
 
   return (
-    <div className="mx-auto max-w-6xl space-y-8 px-4 py-8 sm:py-10">
-      <section className="rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
-        <h1 className="text-3xl font-bold tracking-tight text-ink sm:text-5xl">Compound profiles and mechanism guides</h1>
-        <p className="mt-4 max-w-3xl text-base leading-7 text-muted sm:text-lg">
-          Browse evidence-aware compound pages with mechanism notes, safety framing, and practical context before refining with interactive filters.
-        </p>
-      </section>
-
+    <div className="mx-auto max-w-6xl space-y-5 px-4 py-4 sm:py-6">
       {quickLinks.length > 0 ? (
-        <section className="rounded-2xl border border-brand-900/10 bg-white/90 p-5 shadow-sm">
-          <h2 className="text-xl font-semibold text-ink">Popular compound profiles</h2>
-          <ul className="mt-3 grid gap-2 text-sm leading-6 text-muted sm:grid-cols-2 lg:grid-cols-4">
+        <section className="rounded-[0.85rem] border border-brand-900/10 bg-white/90 p-3 shadow-sm">
+          <h2 className="text-base font-semibold text-ink">Popular compound profiles</h2>
+          <ul className="mt-2 grid gap-1.5 text-sm leading-6 text-muted sm:grid-cols-2 lg:grid-cols-4">
             {quickLinks.map((item) => (
               <li key={item.href}>
                 <Link href={item.href} className="hover:text-brand-800 hover:underline">{item.label}</Link>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -64,7 +64,7 @@ export default function ContactPage() {
             </p>
 
             <p>
-              The project focuses on evidence-aware summaries of herbs, compounds, pathways, mechanisms, and related wellness research topics.
+              The project focuses on evidence-informed summaries of herbs, compounds, pathways, mechanisms, and related wellness research topics.
             </p>
 
             <div className='rounded-2xl border border-brand-900/10 bg-brand-50/40 p-4'>

--- a/app/education/common-neurochemistry-myths/page.tsx
+++ b/app/education/common-neurochemistry-myths/page.tsx
@@ -27,7 +27,7 @@ export default function NeurochemistryMythsPage() {
     <main className="container-page py-10 space-y-12">
       <AuthorityJsonLd
         title="Common Neurochemistry Myths"
-        description="Educational overview of common neurochemistry misconceptions, oversimplified neurotransmitter narratives, and evidence-aware scientific interpretation."
+        description="Educational overview of common neurochemistry misconceptions, oversimplified neurotransmitter narratives, and evidence-informed scientific interpretation."
         url="https://thehippiescientist.net/education/common-neurochemistry-myths"
         type="Article"
       />

--- a/app/education/how-herbal-psychoactives-differ-from-pharmaceuticals/page.tsx
+++ b/app/education/how-herbal-psychoactives-differ-from-pharmaceuticals/page.tsx
@@ -26,7 +26,7 @@ export default function HerbalVsPharmaPage() {
     <main className="container-page py-10 space-y-10">
       <AuthorityJsonLd
         title="How Herbal Psychoactives Differ From Pharmaceuticals"
-        description="Educational exploration of herbal psychoactives, pharmaceutical systems, neuropharmacology, ethnobotany, and evidence-aware comparison."
+        description="Educational exploration of herbal psychoactives, pharmaceutical systems, neuropharmacology, ethnobotany, and careful comparison."
         url="https://thehippiescientist.net/education/how-herbal-psychoactives-differ-from-pharmaceuticals"
         type="Article"
       />
@@ -47,7 +47,7 @@ export default function HerbalVsPharmaPage() {
         </h1>
 
         <p className="text-lg leading-8 text-[#46574d]">
-          Educational exploration of herbal psychoactives, ethnobotanical systems, pharmaceutical neuropharmacology, pathway overlap, and evidence-aware interpretation.
+          Educational exploration of herbal psychoactives, ethnobotanical systems, pharmaceutical neuropharmacology, pathway overlap, and evidence-informed interpretation.
         </p>
 
         <p className="text-base leading-8 text-[#5c6b63]">

--- a/app/education/page.tsx
+++ b/app/education/page.tsx
@@ -6,19 +6,19 @@ import EducationSupernodeGrid from '@/components/education/education-supernode-g
 export const metadata: Metadata = {
   title: 'Neuroscience and Neuropharmacology Education',
   description:
-    'Explore evidence-aware education on neurochemistry, cognition, stress biology, recovery systems, and psychoactive neuroscience.',
+    'Explore education on neurochemistry, cognition, stress biology, recovery systems, and psychoactive neuroscience.',
   alternates: { canonical: '/education' },
   openGraph: {
     title: 'Neuroscience and Neuropharmacology Education',
     description:
-      'Explore evidence-aware education on neurochemistry, cognition, stress biology, recovery systems, and psychoactive neuroscience.',
+      'Explore education on neurochemistry, cognition, stress biology, recovery systems, and psychoactive neuroscience.',
     url: '/education',
   },
   twitter: {
     card: 'summary_large_image',
     title: 'Neuroscience and Neuropharmacology Education',
     description:
-      'Explore evidence-aware education on neurochemistry, cognition, stress biology, recovery systems, and psychoactive neuroscience.',
+      'Explore education on neurochemistry, cognition, stress biology, recovery systems, and psychoactive neuroscience.',
   },
 }
 
@@ -47,7 +47,7 @@ const supernodes = [
   {
     title: 'Adaptogens and Stress Resilience',
     description:
-      'Educational exploration of adaptogens, stress-response physiology, neuroendocrine adaptation, burnout systems, and evidence-aware resilience biology.',
+      'Educational exploration of adaptogens, stress-response physiology, neuroendocrine adaptation, burnout systems, and resilience biology.',
     href: '/education/what-are-adaptogens',
     category: 'Stress Physiology',
   },
@@ -178,7 +178,7 @@ export default function EducationHubPage() {
     <main className='container-page py-10 space-y-16'>
       <AuthorityJsonLd
         title='Neuroscience and Neuropharmacology Education'
-        description='Evidence-aware educational ecosystem covering neurochemistry, cognition systems, stress biology, recovery neuropharmacology, psychoactive education, and systems-oriented neuroscience.'
+        description='Evidence-informed educational ecosystem covering neurochemistry, cognition systems, stress biology, recovery neuropharmacology, psychoactive education, and systems-oriented neuroscience.'
         url='https://thehippiescientist.net/education'
         type='CollectionPage'
       />
@@ -196,7 +196,7 @@ export default function EducationHubPage() {
           <p>
             The Hippie Scientist educational ecosystem explores neurochemistry,
             cognition systems, stress neurobiology, psychoactive education,
-            recovery-oriented neuroscience, and evidence-aware
+            recovery-oriented neuroscience, and evidence-informed
             neuropharmacology through a systems-oriented framework.
           </p>
 

--- a/app/education/placebo-and-context-effects/page.tsx
+++ b/app/education/placebo-and-context-effects/page.tsx
@@ -100,7 +100,7 @@ export default function PlaceboAndContextEffectsPage() {
         </div>
       </section>
       <SafetyNotice>
-        Educational content discussing placebo and context effects is not a substitute for individualized medical guidance or evidence-aware clinical evaluation.
+        Educational content discussing placebo and context effects is not a substitute for individualized medical guidance or clinical evaluation.
       </SafetyNotice>
       <section className="space-y-5">
         <div className="space-y-2">

--- a/app/education/research-methodology/page.tsx
+++ b/app/education/research-methodology/page.tsx
@@ -31,7 +31,7 @@ export default function ResearchMethodologyPage() {
         </div>
 
         <p className="text-xl leading-9 text-[#46574d]">
-          The Hippie Scientist prioritizes conservative, evidence-aware educational interpretation grounded in human evidence, neuropharmacology, systems biology, and transparent research limitations.
+          The Hippie Scientist prioritizes conservative, educational interpretation grounded in human evidence, neuropharmacology, systems biology, and transparent research limitations.
         </p>
 
         <p className="text-base leading-8 text-[#5c6b63]">

--- a/app/education/safety-and-disclaimers/page.tsx
+++ b/app/education/safety-and-disclaimers/page.tsx
@@ -40,7 +40,7 @@ export default function SafetyAndDisclaimersPage() {
       </SafetyNotice>
 
       <SafetyNotice title="Psychoactive and interaction awareness">
-        Psychoactive substances may influence mood systems, cardiovascular signaling, cognition, emotional processing, sedation pathways, and medication interactions. Conservative harm-reduction principles and evidence-aware interpretation are important.
+        Psychoactive substances may influence mood systems, cardiovascular signaling, cognition, emotional processing, sedation pathways, and medication interactions. Conservative harm-reduction principles and evidence-informed interpretation are important.
       </SafetyNotice>
 
       <ResearchLimitations

--- a/app/education/scientific-but-human-neuroscience/page.tsx
+++ b/app/education/scientific-but-human-neuroscience/page.tsx
@@ -24,7 +24,7 @@ const principles = [
 const faqs = [
   {
     question: 'What does scientific but human mean?',
-    answer: 'Scientific but human neuroscience emphasizes evidence-aware interpretation while recognizing emotional context, biological variability, subjective experiences, stress physiology, and recovery-oriented cognition systems.',
+    answer: 'Scientific but human neuroscience emphasizes evidence-informed interpretation while recognizing emotional context, biological variability, subjective experiences, stress physiology, and recovery-oriented cognition systems.',
   },
   {
     question: 'Why avoid oversimplified neuroscience?',
@@ -94,7 +94,7 @@ export default function ScientificButHumanNeurosciencePage() {
           between stress physiology, emotional regulation, recovery biology,
           attentional systems, environmental context, nervous-system sensitivity, and
           biological variability. Scientific literacy may become stronger when
-          neuroscience remains both evidence-aware and emotionally human.
+          neuroscience remains both evidence-informed and emotionally human.
         </p>
       </section>
 
@@ -148,7 +148,7 @@ export default function ScientificButHumanNeurosciencePage() {
 
       <SafetyNotice>
         Educational neuroscience content is not a substitute for individualized
-        medical guidance, evidence-aware clinical evaluation, or mental-health
+        medical guidance, clinical evaluation, or mental-health
         support.
       </SafetyNotice>
 

--- a/app/education/what-are-adaptogens/page.tsx
+++ b/app/education/what-are-adaptogens/page.tsx
@@ -68,7 +68,7 @@ export default function AdaptogensEducationPage() {
     <main className='container-page py-10 space-y-12'>
       <AuthorityJsonLd
         title='What Are Adaptogens?'
-        description='Educational introduction to adaptogens, stress-response systems, nervous-system regulation, and evidence-aware adaptogenic neuropharmacology.'
+        description='Educational introduction to adaptogens, stress-response systems, nervous-system regulation, and evidence-informed adaptogenic neuropharmacology.'
         url='https://thehippiescientist.net/education/what-are-adaptogens'
         type='Article'
       />
@@ -99,7 +99,7 @@ export default function AdaptogensEducationPage() {
           Educational adaptogen exploration commonly intersects with cortisol
           biology, autonomic nervous-system signaling, burnout physiology,
           sleep recovery, fatigue neurobiology, inflammatory signaling, and
-          evidence-aware neuropharmacology.
+          neuropharmacology.
         </p>
       </section>
 

--- a/app/education/what-are-psychoactive-herbs/page.tsx
+++ b/app/education/what-are-psychoactive-herbs/page.tsx
@@ -17,7 +17,7 @@ const faqItems = [
   {
     question: 'Why is harm reduction important?',
     answer:
-      'Psychoactive substances can interact with medications, neurochemical systems, sleep architecture, or mental health conditions. Educational and evidence-aware harm reduction helps reduce unnecessary risk.',
+      'Psychoactive substances can interact with medications, neurochemical systems, sleep architecture, or mental health conditions. Educational and evidence-informed harm reduction helps reduce unnecessary risk.',
   },
 ]
 

--- a/app/education/what-is-a-nootropic/page.tsx
+++ b/app/education/what-is-a-nootropic/page.tsx
@@ -21,7 +21,7 @@ const systems = [
   {
     href: '/compounds/l-theanine',
     title: 'L-Theanine',
-    description: 'Evidence-aware calm-focus compound frequently discussed in cognition-support ecosystems.',
+    description: 'Evidence-informed calm-focus compound frequently discussed in cognition-support ecosystems.',
   },
   {
     href: '/education/scientific-but-human-neuroscience',
@@ -68,7 +68,7 @@ export default function NootropicEducationPage() {
     <main className='container-page py-10 space-y-12'>
       <AuthorityJsonLd
         title='What Is a Nootropic?'
-        description='Educational introduction to nootropics, cognition-oriented compounds, focus systems, neuropharmacology, and evidence-aware cognitive support.'
+        description='Educational introduction to nootropics, cognition-oriented compounds, focus systems, neuropharmacology, and cognitive support.'
         url='https://thehippiescientist.net/education/what-is-a-nootropic'
         type='Article'
       />

--- a/app/education/what-is-an-entheogen/page.tsx
+++ b/app/education/what-is-an-entheogen/page.tsx
@@ -51,7 +51,7 @@ export default function EntheogenEducationPage() {
         </p>
 
         <p className="text-base leading-8 text-[#5c6b63]">
-          Educational exploration of entheogens involves neuropharmacology, serotonergic systems, consciousness-oriented ethnobotany, historical traditions, and evidence-aware harm reduction.
+          Educational exploration of entheogens involves neuropharmacology, serotonergic systems, consciousness-oriented ethnobotany, historical traditions, and evidence-informed harm reduction.
         </p>
       </section>
 

--- a/app/education/why-human-trials-matter/page.tsx
+++ b/app/education/why-human-trials-matter/page.tsx
@@ -9,7 +9,7 @@ export default function HumanTrialsMatterPage() {
     <main className="container-page py-10 space-y-12">
       <AuthorityJsonLd
         title="Why Human Trials Matter"
-        description="Educational overview of human clinical evidence, translational limitations, mechanistic research, and evidence-aware scientific interpretation."
+        description="Educational overview of human clinical evidence, translational limitations, mechanistic research, and evidence-informed scientific interpretation."
         url="https://thehippiescientist.net/education/why-human-trials-matter"
         type="Article"
       />

--- a/app/education/why-neuroscience-is-difficult/page.tsx
+++ b/app/education/why-neuroscience-is-difficult/page.tsx
@@ -100,7 +100,7 @@ export default function WhyNeuroscienceIsDifficultPage() {
         </div>
       </section>
       <SafetyNotice>
-        Educational neuroscience content is not a substitute for individualized medical guidance, evidence-aware clinical evaluation, or mental-health support.
+        Educational neuroscience content is not a substitute for individualized medical guidance, clinical evaluation, or mental-health support.
       </SafetyNotice>
       <section className="space-y-5">
         <div className="space-y-2">

--- a/app/education/why-online-supplement-claims-spread/page.tsx
+++ b/app/education/why-online-supplement-claims-spread/page.tsx
@@ -100,7 +100,7 @@ export default function WhyOnlineSupplementClaimsSpreadPage() {
         </div>
       </section>
       <SafetyNotice>
-        Health claims online may oversimplify complex biological systems. Educational content is not a substitute for individualized medical guidance or evidence-aware clinical evaluation.
+        Health claims online may oversimplify complex biological systems. Educational content is not a substitute for individualized medical guidance or clinical evaluation.
       </SafetyNotice>
       <section className="space-y-5">
         <div className="space-y-2">

--- a/app/education/why-studies-conflict/page.tsx
+++ b/app/education/why-studies-conflict/page.tsx
@@ -100,7 +100,7 @@ export default function WhyStudiesConflictPage() {
         </div>
       </section>
       <SafetyNotice>
-        Educational content discussing scientific uncertainty is not a substitute for individualized medical guidance or evidence-aware clinical evaluation.
+        Educational content discussing scientific uncertainty is not a substitute for individualized medical guidance or clinical evaluation.
       </SafetyNotice>
       <section className="space-y-5">
         <div className="space-y-2">

--- a/app/explore/[topic]/page.tsx
+++ b/app/explore/[topic]/page.tsx
@@ -31,7 +31,7 @@ const TOPIC_CONTEXT: Record<string, { intro: string; sections: { title: string; 
     links: [
       { label: 'GABA pathway', href: '/pathways/gaba', description: 'Inhibitory-tone and relaxation context that commonly overlaps with sleep-support profiles.' },
       { label: 'Sleep goal guide', href: '/goals/sleep', description: 'Outcome-led guide for comparing sleep quality, latency, and nighttime relaxation.' },
-      { label: 'Sleep compounds collection', href: '/collections/best-studied-sleep-compounds', description: 'Evidence-aware collection for compounds frequently researched in sleep contexts.' },
+      { label: 'Sleep compounds collection', href: '/collections/best-studied-sleep-compounds', description: 'Evidence-informed collection for compounds frequently researched in sleep contexts.' },
     ],
   },
   focus: {
@@ -58,7 +58,7 @@ const TOPIC_CONTEXT: Record<string, { intro: string; sections: { title: string; 
     signals: ['Stress signaling', 'Adaptogens', 'GABA overlap', 'Cortisol context', 'Mood support', 'Sleep overlap'],
     links: [
       { label: 'GABA pathway', href: '/pathways/gaba', description: 'Calming and inhibitory signaling context related to stress and relaxation.' },
-      { label: 'Stress supplement guide', href: '/best-supplements-for-stress', description: 'Decision guide for stress resilience and evidence-aware supplement comparisons.' },
+      { label: 'Stress supplement guide', href: '/best-supplements-for-stress', description: 'Decision guide for stress resilience and supplement comparisons.' },
       { label: 'Adaptogens for stress', href: '/collections/adaptogens-for-stress', description: 'Botanical collection organized around adaptation and resilience language.' },
     ],
   },

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -211,7 +211,7 @@ export default async function ExplorePage() {
       <SemanticVisibilityGate minHeight={440}>
         <SemanticGraphMap
           title="Explore relationship atlas"
-          description="A lightweight atlas map of discovery ecosystems, semantic continuity, and evidence-aware exploration clusters."
+          description="A lightweight atlas map of discovery ecosystems, semantic continuity, and exploration clusters."
           nodes={syntheticGraph.nodes}
           edges={syntheticGraph.edges}
         />
@@ -272,7 +272,7 @@ export default async function ExplorePage() {
             </h2>
 
             <p className="detail-reading text-base">
-              Semantic continuity, ecosystem resilience, and bridge reinforcement are combined to prioritize stable scientific discovery pathways.
+              Semantic continuity, ecosystem resilience, and bridge reinforcement are combined to prioritize stable research pathways.
             </p>
           </div>
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -35,12 +35,12 @@
 
   --border-soft: rgba(29, 74, 47, 0.1);
   --ring-brand: rgba(53, 143, 82, 0.35);
-  --radius-card-premium: 1.25rem;
-  --radius-card-compact: 1rem;
-  --shadow-card-calm: 0 8px 22px rgba(16, 32, 24, 0.045), 0 1px 4px rgba(16, 32, 24, 0.03);
-  --shadow-card-calm-hover: 0 12px 30px rgba(16, 32, 24, 0.07), 0 2px 8px rgba(16, 32, 24, 0.035);
-  --shadow-button-primary: 0 14px 30px rgba(29, 74, 47, 0.20), inset 0 1px 0 rgba(255, 255, 255, 0.16);
-  --shadow-button-secondary: 0 10px 26px rgba(16, 32, 24, 0.06), inset 0 1px 0 rgba(255, 255, 255, 0.72);
+  --radius-card-premium: 0.9rem;
+  --radius-card-compact: 0.75rem;
+  --shadow-card-calm: 0 1px 3px rgba(16, 32, 24, 0.045);
+  --shadow-card-calm-hover: 0 4px 12px rgba(16, 32, 24, 0.06);
+  --shadow-button-primary: 0 4px 12px rgba(29, 74, 47, 0.14);
+  --shadow-button-secondary: 0 1px 3px rgba(16, 32, 24, 0.04);
 }
 
 html {
@@ -99,15 +99,15 @@ body {
   }
 
   h1 {
-    @apply font-display text-[2.25rem] font-semibold leading-[1.04] tracking-tighter text-ink sm:text-4xl lg:text-5xl;
+    @apply font-display text-[2rem] font-semibold leading-[1.06] tracking-tighter text-ink sm:text-4xl lg:text-[2.75rem];
   }
 
   h2 {
-    @apply font-display text-[1.8rem] font-semibold leading-[1.14] tracking-tight text-ink sm:text-3xl;
+    @apply font-display text-[1.55rem] font-semibold leading-[1.14] tracking-tight text-ink sm:text-2xl;
   }
 
   h3 {
-    @apply font-sans text-xl font-semibold leading-snug tracking-tight text-ink sm:text-2xl;
+    @apply font-sans text-lg font-semibold leading-snug tracking-tight text-ink sm:text-xl;
   }
 
   h4 {
@@ -120,7 +120,7 @@ body {
   }
 
   p {
-    @apply max-w-reading text-[0.98rem] leading-[1.68] text-muted sm:text-[1rem];
+    @apply max-w-reading text-[0.95rem] leading-[1.55] text-muted;
   }
 
   p + p {
@@ -240,11 +240,11 @@ body {
   }
 
   .section-spacing {
-    @apply space-y-8 sm:space-y-10 lg:space-y-12;
+    @apply space-y-5 sm:space-y-6 lg:space-y-7;
   }
 
   .detail-stack {
-    @apply space-y-8 sm:space-y-10 lg:space-y-12;
+    @apply space-y-5 sm:space-y-6 lg:space-y-7;
   }
 
   .card-spacing {
@@ -252,7 +252,7 @@ body {
   }
 
   .content-prose {
-    @apply max-w-reading space-y-4 text-[0.98rem] leading-[1.7] text-[#46574d] sm:text-[1rem];
+    @apply max-w-reading space-y-3 text-[0.95rem] leading-[1.6] text-[#46574d];
   }
 
   .content-prose > * {
@@ -262,20 +262,20 @@ body {
   .content-prose h2,
   .content-prose h3,
   .content-prose h4 {
-    @apply mt-10 max-w-[26ch] text-ink;
+    @apply mt-6 max-w-[26ch] text-ink;
   }
 
   .content-prose p {
-    @apply max-w-reading leading-[1.8] text-[#46574d];
+    @apply max-w-reading leading-[1.62] text-[#46574d];
   }
 
   .content-prose ul,
   .content-prose ol {
-    @apply space-y-3 pl-5;
+    @apply space-y-1.5 pl-5;
   }
 
   .content-prose li {
-    @apply pl-1 leading-8 text-[#46574d];
+    @apply pl-1 leading-6 text-[#46574d];
   }
 
   .content-prose li + li {
@@ -287,15 +287,15 @@ body {
   }
 
   .detail-reading {
-    @apply max-w-[70ch] text-[0.98rem] leading-[1.7] text-[#46574d] sm:text-[1rem];
+    @apply max-w-[70ch] text-[0.95rem] leading-[1.6] text-[#46574d];
   }
 
   .detail-grid {
-    @apply grid gap-5 sm:gap-6 lg:grid-cols-2;
+    @apply grid gap-3 sm:gap-4 lg:grid-cols-2;
   }
 
   .metadata-row {
-    @apply flex flex-wrap items-center gap-2.5 sm:gap-3;
+    @apply flex flex-wrap items-center gap-2;
   }
 
   .section-frame {
@@ -316,7 +316,7 @@ body {
   }
 
   .eyebrow-label {
-    @apply text-xs font-bold tracking-[0.18em] text-brand-700;
+    @apply text-[0.68rem] font-bold tracking-[0.13em] text-brand-700;
   }
 
   .surface-subtle {
@@ -331,11 +331,11 @@ body {
   }
 
   .chip-readable {
-    @apply inline-flex items-center rounded-full border border-brand-900/10 bg-white/80 px-2.5 py-1 text-[0.72rem] font-semibold leading-none text-[#33443a];
+    @apply inline-flex items-center rounded-full border border-brand-900/10 bg-white/80 px-2 py-0.5 text-[0.68rem] font-semibold leading-snug text-[#33443a];
   }
 
   .accordion-readable {
-    @apply rounded-[1.1rem] border border-brand-900/10 bg-white/80 p-4 shadow-sm backdrop-blur transition-all duration-300 sm:p-5;
+    @apply rounded-[0.8rem] border border-brand-900/10 bg-white/80 p-3 shadow-sm transition-all duration-200 sm:p-4;
   }
 
   .accordion-readable summary {
@@ -361,16 +361,16 @@ body {
   }
 
   .safety-block {
-    @apply rounded-card border border-amber-600/20 bg-amber-50/85 p-6 shadow-sm;
+    @apply rounded-card border border-amber-600/20 bg-amber-50/85 p-4 shadow-sm;
   }
 
   .button-primary {
-    @apply inline-flex items-center justify-center rounded-full bg-brand-800 px-5 py-3 text-sm font-semibold text-white transition-all duration-300 hover:-translate-y-0.5 hover:bg-brand-700 hover:text-white focus-visible:text-white;
+    @apply inline-flex items-center justify-center rounded-full bg-brand-800 px-4 py-2 text-sm font-semibold text-white transition-colors duration-200 hover:bg-brand-700 hover:text-white focus-visible:text-white;
     box-shadow: var(--shadow-button-primary);
   }
 
   .button-secondary {
-    @apply inline-flex items-center justify-center rounded-full border border-brand-900/10 bg-white/85 px-5 py-3 text-sm font-semibold text-ink backdrop-blur-md transition-all duration-300 hover:border-brand-700/20 hover:bg-white hover:text-brand-800;
+    @apply inline-flex items-center justify-center rounded-full border border-brand-900/10 bg-white/85 px-4 py-2 text-sm font-semibold text-ink transition-colors duration-200 hover:border-brand-700/20 hover:bg-white hover:text-brand-800;
     box-shadow: var(--shadow-button-secondary);
   }
 }
@@ -389,7 +389,7 @@ body {
   }
 
   .heading-premium {
-    @apply font-display text-[2.25rem] font-semibold leading-[1.04] tracking-tighter text-ink sm:text-4xl lg:text-5xl;
+    @apply font-display text-[2rem] font-semibold leading-[1.06] tracking-tighter text-ink sm:text-4xl lg:text-[2.75rem];
   }
 
   .eyebrow {
@@ -433,30 +433,30 @@ body {
   }
 
   .pull-quote-science {
-    @apply rounded-[1.65rem] border-l-4 border-brand-700 bg-white/75 p-5 font-display text-2xl font-semibold leading-snug tracking-tight text-ink shadow-sm sm:p-6;
+    @apply rounded-[1rem] border-l-4 border-brand-700 bg-white/75 p-4 font-display text-xl font-semibold leading-snug tracking-tight text-ink shadow-sm;
   }
 
   .mobile-reading-card {
-    @apply border border-brand-900/10 bg-white/80 p-5 shadow-sm sm:p-6;
+    @apply border border-brand-900/10 bg-white/80 p-4 shadow-sm;
     border-radius: var(--radius-card-compact);
   }
 
   .compact-section {
-    @apply border border-brand-900/10 bg-white/70 p-4 shadow-sm backdrop-blur-xl sm:p-5;
+    @apply border border-brand-900/10 bg-white/75 p-3 shadow-sm sm:p-4;
     border-radius: var(--radius-card-compact);
   }
 
   .compact-card {
-    @apply border border-brand-900/10 bg-white/75 p-4 shadow-sm backdrop-blur-xl transition-all duration-300 hover:border-brand-900/15 hover:bg-white;
+    @apply border border-brand-900/10 bg-white/85 p-3 shadow-sm transition-colors duration-200 hover:border-brand-900/15 hover:bg-white;
     border-radius: var(--radius-card-compact);
   }
 
   .compact-heading {
-    @apply max-w-[28ch] text-xl font-semibold leading-snug tracking-tight text-ink sm:text-2xl;
+    @apply max-w-[32ch] text-lg font-semibold leading-snug tracking-tight text-ink sm:text-xl;
   }
 
   .compact-copy {
-    @apply max-w-[62ch] text-sm leading-6 text-[#46574d] sm:text-[0.94rem];
+    @apply max-w-[70ch] text-sm leading-6 text-[#46574d];
   }
 
   .semantic-rail {
@@ -469,21 +469,21 @@ body {
   }
 
   .semantic-rail-card {
-    @apply min-w-[76%] snap-start border border-brand-900/10 bg-white/[0.78] p-4 shadow-sm backdrop-blur-xl transition hover:border-brand-700/20 hover:bg-white sm:min-w-0;
+    @apply min-w-[76%] snap-start border border-brand-900/10 bg-white/[0.85] p-3 shadow-sm transition hover:border-brand-700/20 hover:bg-white sm:min-w-0;
     border-radius: var(--radius-card-compact);
   }
 
   .section-rhythm-compact {
-    @apply space-y-4 sm:space-y-5;
+    @apply space-y-3 sm:space-y-4;
   }
 
   .section-rhythm-balanced {
-    @apply space-y-6 sm:space-y-8 lg:space-y-10;
+    @apply space-y-4 sm:space-y-5 lg:space-y-6;
   }
 
   @media (max-width: 640px) {
     h2:not(.keep-display) {
-      @apply text-[1.65rem] leading-[1.08];
+      @apply text-[1.45rem] leading-[1.12];
     }
 
     h3:not(.keep-display) {
@@ -499,19 +499,19 @@ body {
     }
 
     .section-spacing {
-      @apply space-y-7;
+      @apply space-y-5;
     }
 
     .detail-stack {
-      @apply space-y-7;
+      @apply space-y-5;
     }
 
     .card-spacing {
-      @apply p-5;
+      @apply p-4;
     }
 
     .card-premium {
-      @apply rounded-[1.55rem] shadow-sm;
+      @apply rounded-[1rem] shadow-sm;
     }
 
     .card-premium:hover {
@@ -519,16 +519,16 @@ body {
     }
 
     .section-frame {
-      @apply rounded-[1.55rem] p-5 shadow-sm;
+      @apply rounded-[1rem] p-4 shadow-sm;
     }
 
     .surface-subtle,
     .surface-depth {
-      @apply rounded-[1.45rem] shadow-sm;
+      @apply rounded-[1rem] shadow-sm;
     }
 
     .scientific-card {
-      @apply rounded-[1.35rem] p-4;
+      @apply rounded-[0.9rem] p-3;
     }
 
     .detail-reading,
@@ -556,7 +556,7 @@ body {
     }
 
     .chip-readable {
-      @apply min-h-9 px-3 py-2 text-xs leading-snug;
+      @apply min-h-0 px-2 py-1 text-[0.7rem] leading-snug;
       white-space: normal;
     }
   }

--- a/app/guides/how-to-lower-cortisol-naturally/page.tsx
+++ b/app/guides/how-to-lower-cortisol-naturally/page.tsx
@@ -12,7 +12,7 @@ export default function Page() {
       <section className="hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8">
         <p className="eyebrow-label">Stress education</p>
         <h1 className="mt-2 text-3xl font-semibold text-ink sm:text-4xl">How to Lower Cortisol Naturally</h1>
-        <p className="detail-reading mt-4 text-muted">Cortisol follows daily rhythms. Use this as a decision guide for sleep, routine stressors, and evidence-aware supplement exploration.</p>
+        <p className="detail-reading mt-4 text-muted">Cortisol follows daily rhythms. Use this as a decision guide for sleep, routine stressors, and evidence-informed supplement exploration.</p>
       </section>
       <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {['Ashwagandha', 'Rhodiola', 'Holy Basil'].map((item) => (

--- a/app/herbs/HerbsIndexClient.tsx
+++ b/app/herbs/HerbsIndexClient.tsx
@@ -190,9 +190,9 @@ function buildFilterHref(value: string, query: string) {
 
 function StatCard({ value, label }: { value: number; label: string }) {
   return (
-    <div className="min-w-0 rounded-[1.1rem] border border-brand-900/10 bg-white/75 p-3 shadow-sm backdrop-blur sm:p-4">
-      <p className="text-2xl font-semibold tracking-tight text-ink sm:text-3xl">{value}</p>
-      <p className="mt-1 text-[0.66rem] font-bold uppercase leading-snug tracking-[0.12em] text-[#5f6f66] sm:text-[0.68rem] sm:tracking-[0.14em]">{label}</p>
+    <div className="min-w-0 rounded-[0.8rem] border border-brand-900/10 bg-white/80 p-2.5 shadow-sm sm:p-3">
+      <p className="text-xl font-semibold tracking-tight text-ink sm:text-2xl">{value}</p>
+      <p className="mt-0.5 text-[0.62rem] font-bold uppercase leading-snug tracking-[0.1em] text-[#5f6f66]">{label}</p>
     </div>
   )
 }
@@ -294,23 +294,23 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
   const libraryHerbs = hasActiveFilters ? visibleHerbs : paginated ? herbs : baseHerbs.slice(featuredHerbs.length)
 
   return (
-    <div className="min-h-screen px-3 py-4 text-ink sm:px-4 sm:py-6">
-      <div className="mx-auto max-w-7xl space-y-6 sm:space-y-8">
-        <section className="hero-shell relative overflow-hidden rounded-[1.25rem] border border-white/60 px-4 py-5 shadow-sm sm:px-6 sm:py-7">
-          <div className="relative grid gap-4 lg:grid-cols-[1.05fr_.95fr] lg:items-end">
-            <div className="max-w-3xl space-y-3">
+    <div className="px-2 py-2 text-ink sm:px-3 sm:py-3">
+      <div className="mx-auto max-w-7xl space-y-4 sm:space-y-4">
+        <section className="hero-shell relative overflow-hidden rounded-[0.95rem] border border-brand-900/10 px-3 py-4 shadow-sm sm:px-4 sm:py-5">
+          <div className="relative grid gap-3 lg:grid-cols-[1.05fr_.95fr] lg:items-end">
+            <div className="max-w-3xl space-y-2">
               <p className="eyebrow-label">Botanical decision library</p>
-              <h1 className="max-w-[16ch] text-balance font-display text-3xl font-semibold leading-[1.05] tracking-tight text-ink sm:text-5xl">
+              <h1 className="max-w-[18ch] text-balance font-display text-2xl font-semibold leading-[1.08] tracking-tight text-ink sm:text-4xl">
                 Herbal research library
               </h1>
-              <p className="max-w-2xl text-sm leading-6 text-[#46574d] sm:text-base">
+              <p className="max-w-2xl text-sm leading-6 text-[#46574d]">
                 Scan by practical context first, then compare evidence, safety, and timing before opening a full herb profile.
               </p>
             </div>
 
-            <div className="rounded-[1rem] border border-brand-900/10 bg-white/75 p-3 shadow-sm backdrop-blur">
+            <div className="rounded-[0.8rem] border border-brand-900/10 bg-white/80 p-2.5 shadow-sm">
               <p className="text-xs font-bold uppercase tracking-[0.16em] text-brand-800">Library signal</p>
-              <div className="mt-3 grid grid-cols-3 gap-2">
+              <div className="mt-2 grid grid-cols-3 gap-2">
                 <StatCard value={totalProfiles} label="Profiles" />
                 <StatCard value={evidenceForward} label="Evidence-led" />
                 <StatCard value={safetyMapped || readyProfiles} label="Safety mapped" />
@@ -319,16 +319,16 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
           </div>
         </section>
 
-        <section className="rounded-[1rem] border border-brand-900/10 bg-white/85 p-4 shadow-sm sm:p-5" aria-labelledby="herb-search-heading">
-          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
-            <div className="max-w-2xl space-y-2">
+        <section className="rounded-[0.85rem] border border-brand-900/10 bg-white/85 p-3 shadow-sm sm:p-4" aria-labelledby="herb-search-heading">
+          <div className="flex flex-col gap-2 lg:flex-row lg:items-end lg:justify-between">
+            <div className="max-w-2xl space-y-1.5">
               <p className="eyebrow-label">Search and filter</p>
               <h2 id="herb-search-heading" className="compact-heading">Start with the decision you need to make.</h2>
             </div>
             <Link href="/goals" className="w-fit text-sm font-bold text-brand-800 transition hover:text-brand-900">Browse all goals →</Link>
           </div>
 
-          <form action="/herbs" className="mt-4 grid gap-3 sm:grid-cols-[1fr_auto]">
+          <form action="/herbs" className="mt-3 grid gap-2 sm:grid-cols-[1fr_auto]">
             <label className="sr-only" htmlFor="herb-search">Search herbs</label>
             <input
               id="herb-search"
@@ -336,10 +336,10 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
               type="search"
               defaultValue={query}
               placeholder="Search herb, effect, mechanism, or safety note"
-              className="min-h-11 w-full rounded-full border border-brand-900/10 bg-white px-4 text-sm text-ink shadow-sm placeholder:text-[#7b8a81]"
+              className="min-h-10 w-full rounded-full border border-brand-900/10 bg-white px-4 text-sm text-ink shadow-sm placeholder:text-[#7b8a81]"
             />
             {activeFilter !== 'all' ? <input type="hidden" name="context" value={activeFilter} /> : null}
-            <button type="submit" className="button-primary min-h-11 px-5 py-2.5">
+            <button type="submit" className="button-primary min-h-10 px-4 py-2">
               Search
             </button>
           </form>
@@ -353,23 +353,23 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
           />
         </section>
 
-        <section className="rounded-[1rem] border border-brand-900/10 bg-white/70 p-4 shadow-sm">
+        <section className="rounded-[0.85rem] border border-brand-900/10 bg-white/75 p-3 shadow-sm">
           <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-            <div className="max-w-2xl space-y-2">
+            <div className="max-w-2xl space-y-1.5">
               <p className="eyebrow-label">Common starting points</p>
               <h2 className="compact-heading">Goal guides if you are still orienting.</h2>
             </div>
           </div>
 
-          <div className="mt-4 grid gap-3 md:grid-cols-3">
+          <div className="mt-3 grid gap-2 md:grid-cols-3">
             {browsePaths.map(path => (
               <Link
                 key={path.label}
                 href={path.href}
-                className="group rounded-[0.9rem] border border-brand-900/10 bg-white/80 p-3 shadow-sm transition hover:border-brand-700/20 hover:bg-white"
+                className="group rounded-[0.75rem] border border-brand-900/10 bg-white/85 p-2.5 shadow-sm transition hover:border-brand-700/20 hover:bg-white"
               >
-                <h3 className="text-lg font-semibold tracking-tight text-ink transition group-hover:text-brand-800">{path.label}</h3>
-                <p className="mt-2 text-sm leading-6 text-[#46574d]">{path.description}</p>
+                <h3 className="text-base font-semibold tracking-tight text-ink transition group-hover:text-brand-800">{path.label}</h3>
+                <p className="mt-1 text-sm leading-5 text-[#46574d]">{path.description}</p>
               </Link>
             ))}
           </div>
@@ -382,18 +382,18 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
         ) : (
           <>
             {featuredHerbs.length > 0 ? (
-              <section className="space-y-5">
+              <section className="space-y-4">
                 <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
-                  <div className="max-w-2xl space-y-2">
+                  <div className="max-w-2xl space-y-1.5">
                     <p className="eyebrow-label">Start here</p>
-                    <h2 className="compact-heading">High-signal profiles for learning the card pattern.</h2>
+                    <h2 className="compact-heading">High-signal starting points.</h2>
                   </div>
                   <p className="max-w-md text-sm leading-6 text-[#5f6f66]">
                     Sorted by evidence signals, profile readiness, and practical browse value—not by promised outcomes.
                   </p>
                 </div>
 
-                <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
                   {featuredHerbs.map((herb: any) => (
                     <HerbCard key={herb.slug} herb={herb} featured />
                   ))}
@@ -402,9 +402,9 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
             ) : null}
 
             {libraryHerbs.length > 0 ? (
-              <section className="space-y-5">
+              <section className="space-y-4">
                 <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
-                  <div className="max-w-2xl space-y-2">
+                  <div className="max-w-2xl space-y-1.5">
                     <p className="eyebrow-label">{hasActiveFilters ? 'Matching herbs' : 'All herbs'}</p>
                     <h2 className="compact-heading">
                       {hasActiveFilters ? 'Profiles matching your scan.' : 'Browse every published herb profile.'}
@@ -415,7 +415,7 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
                   </span>
                 </div>
 
-                <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
                   {libraryHerbs.map((herb: any) => (
                     <HerbCard key={herb.slug} herb={herb} />
                   ))}

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -13,6 +13,7 @@ import { getEcosystemContinuityRecords, mergeEcosystemContinuityRecords } from '
 import { buildSemanticGraphVisual } from '@/lib/semantic-graph-visuals'
 import { buildSemanticNarrative, buildContinuationPrompts } from '@/lib/semantic-exploration-narratives'
 import { buildSourcingNotes, getMonetizationReadiness } from '@/lib/monetization-context'
+import { getAffiliateShopLinks } from '@/lib/affiliate'
 import {
   buildSemanticAssistantSummary,
   buildSemanticNavigationSuggestions,
@@ -118,7 +119,7 @@ function firstSentences(value: string, limit = 2) {
 
 function getPlainEnglishSummary(herb: any) {
   const summary = cleanSummary(herb.summary || herb.description || '', 'herb')
-  return firstSentences(summary, 2) || `${formatDisplayLabel(herb.name || herb.slug)} is tracked as an evidence-aware botanical profile with safety, use, and mechanism context.`
+  return firstSentences(summary, 1) || `${formatDisplayLabel(herb.name || herb.slug)} profile with safety, use, and evidence context.`
 }
 
 function getEvidenceStrength(herb: any) {
@@ -346,6 +347,8 @@ export default async function HerbDetailPage({ params }: PageProps) {
   const internalLinks = buildInternalLinkDensity(herb)
   const confidenceObj = getEvidenceConfidence(herb as any)
   const displayName = formatDisplayLabel(herb.name || herb.slug)
+  const shopLinks = getAffiliateShopLinks(herb, displayName, 'herb')
+  const primaryShopLink = shopLinks[0]
   const botanicalName = cleanText(herb.latin_name || herb.botanical_name || herb.scientific_name)
   const briefSummary = getPlainEnglishSummary(herb)
   const evidenceStrength = getEvidenceStrength(herb)
@@ -367,7 +370,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
   const hiddenUses = unique([...effects, ...traditionalUses, ...focusAreas]).slice(8)
   const keyTakeaways = unique([
     topUses.length ? `Most often explored for ${topUses.slice(0, 3).join(', ')}.` : '',
-    evidenceStrength ? `Evidence context: ${evidenceStrength}; overall maturity reads as ${researchMaturity.toLowerCase()}.` : '',
+    evidenceStrength ? `Evidence: ${evidenceStrength}; maturity: ${researchMaturity.toLowerCase()}.` : '',
     safetySummary ? `Safety first: ${safetySummary}` : '',
     timeline ? `Timeline/onset context: ${timeline}.` : '',
     mechanisms.length ? `Mechanism signals include ${mechanisms.slice(0, 3).join(', ')}.` : '',
@@ -410,7 +413,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
         <div className="space-y-6">
           <div className="space-y-2">
             <p className="eyebrow-label">Evidence summary</p>
-            <h2 className="text-xl font-semibold tracking-tight text-ink">What the current profile supports</h2>
+            <h2 className="text-lg font-semibold tracking-tight text-ink">What the current profile supports</h2>
             <p className="max-w-4xl text-sm leading-6 text-[#46574d]">
               {displayName} is categorized as {researchMaturity.toLowerCase()} with a {researchStyle.toLowerCase()} evidence style. Interpret benefits by outcome, preparation, dose, and the safety context above.
             </p>
@@ -423,28 +426,28 @@ export default async function HerbDetailPage({ params }: PageProps) {
 
           <div className="space-y-6">
             {focusAreas.length > 0 ? (
-              <div className="border-t border-brand-900/10 pt-6">
+              <div className="border-t border-brand-900/10 pt-4">
                 <h3 className="text-lg font-semibold tracking-tight text-ink">Human evidence</h3>
                 <p className="text-sm leading-6 text-muted mb-3">Outcome areas and human-facing evidence signals exposed by the profile.</p>
                 <ChipList items={focusAreas} />
               </div>
             ) : null}
             {mechanisms.length > 0 ? (
-              <div className="border-t border-brand-900/10 pt-6">
+              <div className="border-t border-brand-900/10 pt-4">
                 <h3 className="text-lg font-semibold tracking-tight text-ink">Preclinical evidence & mechanisms</h3>
                 <p className="text-sm leading-6 text-muted mb-3">Mechanistic and pathway context; not proof of clinical effect by itself.</p>
                 <ChipList items={mechanisms} />
               </div>
             ) : null}
             {traditionalUses.length > 0 ? (
-              <div className="border-t border-brand-900/10 pt-6">
+              <div className="border-t border-brand-900/10 pt-4">
                 <h3 className="text-lg font-semibold tracking-tight text-ink">Traditional use</h3>
                 <p className="text-sm leading-6 text-muted mb-3">Traditional or historical-use language from the source profile.</p>
                 <ChipList items={traditionalUses} />
               </div>
             ) : null}
             {pathwayClusters.length > 0 ? (
-              <div className="border-t border-brand-900/10 pt-6">
+              <div className="border-t border-brand-900/10 pt-4">
                 <h3 className="text-lg font-semibold tracking-tight text-ink">Mechanism clusters</h3>
                 <p className="text-sm leading-6 text-muted mb-3">Grouped pathway signals for deeper research.</p>
                 <div className="grid gap-3 md:grid-cols-2 mt-3">
@@ -459,7 +462,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
               </div>
             ) : null}
             {evidenceLimitations.length > 0 ? (
-              <div className="border-t border-brand-900/10 pt-6">
+              <div className="border-t border-brand-900/10 pt-4">
                 <h3 className="text-lg font-semibold tracking-tight text-ink">Limitations</h3>
                 <p className="text-sm leading-6 text-muted mb-3">Reasons to avoid over-reading the available profile data.</p>
                 <ul className="space-y-2 text-sm leading-6 text-[#46574d]">
@@ -468,7 +471,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
               </div>
             ) : null}
             {topUses.length > 0 ? (
-              <div className="border-t border-brand-900/10 pt-6">
+              <div className="border-t border-brand-900/10 pt-4">
                 <h3 className="text-lg font-semibold tracking-tight text-ink">Uses and effects</h3>
                 <p className="text-sm leading-6 text-muted mb-3">Most visible signals.</p>
                 <ChipList items={topUses} />
@@ -503,7 +506,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
       label: 'AI Assistant & Map',
       content: (
         <div className="space-y-8">
-          <SemanticArtworkPanel slug={herb.slug} kind="botanical" title={displayName} subtitle="Botanical ecosystem artwork for evidence-aware pathway exploration." height={260} />
+          <SemanticArtworkPanel slug={herb.slug} kind="botanical" title={displayName} subtitle="Botanical ecosystem artwork for evidence-informed pathway exploration." height={260} />
           <GuidedExplorationPanel overview={narrative.overview} pathways={narrative.pathways} exploration={narrative.exploration} prompts={prompts} />
           <SemanticVisibilityGate minHeight={420}>
             <SemanticGraphMap title="Profile relationship map" description="A lightweight map of pathway signals, mechanism overlap, and connected semantic profiles." nodes={graph.nodes} edges={graph.edges} />
@@ -543,7 +546,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
   ]
 
   return (
-    <main className="mx-auto max-w-6xl space-y-8 px-4 py-6 sm:space-y-10 sm:py-8">
+    <main className="mx-auto max-w-6xl space-y-5 px-4 py-4 sm:space-y-6 sm:py-6">
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(herbJsonLd) }}
@@ -554,7 +557,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
       />
 
-      <nav className="flex flex-wrap items-center gap-2 text-sm text-muted">
+      <nav className="flex flex-wrap items-center gap-2 text-xs text-muted">
         <Link href="/herbs" className="transition hover:text-ink">
           Herbs
         </Link>
@@ -562,25 +565,25 @@ export default async function HerbDetailPage({ params }: PageProps) {
         <span className="text-ink">{displayName}</span>
       </nav>
 
-      <section className="hero-shell rounded-[1.25rem] p-4 sm:p-5 lg:p-6">
-        <div className="space-y-4">
-          <div className="flex flex-wrap items-center gap-4 text-xs font-bold uppercase tracking-[0.14em] text-muted">
+      <section className="hero-shell rounded-[0.95rem] border border-brand-900/10 p-3 sm:p-4">
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center gap-3 text-[0.68rem] font-bold uppercase tracking-[0.12em] text-muted">
             <Link href="/herbs" className="transition hover:text-ink">Back to herbs</Link>
             <Link href="/compare" className="transition hover:text-ink">Compare</Link>
             <Link href={`/search?q=${encodeURIComponent(displayName)}`} className="transition hover:text-ink">Search related</Link>
           </div>
 
-          <div className="grid gap-5 lg:grid-cols-[minmax(0,0.82fr)_minmax(340px,1.18fr)] lg:items-start">
-            <div className="space-y-3 lg:pt-2">
+          <div className="grid gap-4 lg:grid-cols-[minmax(0,0.8fr)_minmax(320px,1.2fr)] lg:items-start">
+            <div className="space-y-3">
               <div className="space-y-2">
-                <p className="eyebrow-label">Herb research brief</p>
-                <h1 className="text-3xl font-semibold tracking-tight text-ink sm:text-4xl">
+                <p className="eyebrow-label">Herb brief</p>
+                <h1 className="text-2xl font-semibold tracking-tight text-ink sm:text-3xl">
                   {displayName}
                 </h1>
                 {botanicalName ? <p className="text-sm italic text-muted">{botanicalName}</p> : null}
               </div>
 
-              <p className="max-w-2xl text-sm leading-6 text-[#46574d] sm:text-base">
+              <p className="max-w-2xl text-sm leading-6 text-[#46574d]">
                 {briefSummary}
               </p>
 
@@ -592,11 +595,42 @@ export default async function HerbDetailPage({ params }: PageProps) {
               </div>
             </div>
 
-            <EvidenceSnapshotPanel
+            <div className="space-y-3">
+              <div className="grid gap-2 rounded-[0.85rem] border border-brand-900/10 bg-white/90 p-3 shadow-sm sm:grid-cols-2">
+                <div>
+                  <p className="eyebrow-label">Best for</p>
+                  <p className="mt-1 text-sm font-semibold leading-5 text-ink">{topUses.slice(0, 3).join(', ') || 'Compare fit before use'}</p>
+                </div>
+                <div>
+                  <p className="eyebrow-label text-amber-900">Avoid / review if</p>
+                  <p className="mt-1 text-sm font-semibold leading-5 text-[#5f4a24]">{avoidIf.slice(0, 2).join(', ') || safetyTone}</p>
+                </div>
+              </div>
+
+              {primaryShopLink ? (
+                <a
+                  href={primaryShopLink.url}
+                  target="_blank"
+                  rel="nofollow sponsored noopener noreferrer"
+                  className="flex items-center justify-between gap-3 rounded-[0.85rem] border border-emerald-700/20 bg-emerald-50 px-3 py-2.5 text-sm font-bold text-emerald-900 shadow-sm hover:bg-emerald-100"
+                >
+                  <span>{primaryShopLink.label}</span>
+                  <span aria-hidden="true">→</span>
+                </a>
+              ) : null}
+
+              <nav aria-label="Profile sections" className="flex flex-wrap gap-2 text-xs font-bold text-brand-800">
+                <a className="rounded-full border border-brand-900/10 bg-white px-2.5 py-1 hover:bg-brand-50" href="#evidence-benefits-tab">Evidence</a>
+                <a className="rounded-full border border-brand-900/10 bg-white px-2.5 py-1 hover:bg-brand-50" href="#safety">Safety</a>
+                <a className="rounded-full border border-brand-900/10 bg-white px-2.5 py-1 hover:bg-brand-50" href="#mechanism-fit-tab">Mechanism</a>
+                <a className="rounded-full border border-brand-900/10 bg-white px-2.5 py-1 hover:bg-brand-50" href="#authority-sourcing-tab">Products</a>
+              </nav>
+
+              <EvidenceSnapshotPanel
               title="5-second profile read"
-              subtitle="Educational overview only. Individual response and tolerance can vary."
+              subtitle="Educational overview. Individual response varies."
               badge="Start here"
-              className="rounded-[1.1rem] border border-brand-900/10 bg-white/95 p-4 shadow-sm lg:sticky lg:top-6"
+              className="rounded-[0.85rem] border border-brand-900/10 bg-white/95 p-3 shadow-sm lg:sticky lg:top-4"
               fields={buildDetailEvidenceSnapshotFields({
                 bestFit: topUses.slice(0, 3).join(', '),
                 humanEvidence: evidenceStrength || researchMaturity,
@@ -605,21 +639,22 @@ export default async function HerbDetailPage({ params }: PageProps) {
                 regulationProfile,
                 typicalOnset: timeline || 'Timing varies by preparation, dose, and context.',
                 useCautionIf: avoidIf.length ? avoidIf.slice(0, 3).join(', ') : '',
-                uncertain: mechanisms.length ? `Mechanism hints are preliminary: ${mechanisms.slice(0, 3).join(', ')}. Real-world effects can differ across people and products.` : '',
+                uncertain: mechanisms.length ? `Mechanism: ${mechanisms.slice(0, 3).join(', ')}.` : '',
                 confidenceLabel: confidenceObj.confidenceLabel,
                 evidenceWeight: confidenceObj.evidenceWeight,
                 humanEvidenceFlag: confidenceObj.humanEvidenceFlag,
                 evidenceExplanation: confidenceObj.evidenceExplanation,
               })}
             />
+            </div>
           </div>
         </div>
       </section>
 
       {keyTakeaways.length > 0 ? (
-        <section className="border-t border-brand-900/10 pt-6">
+        <section className="border-t border-brand-900/10 pt-4">
           <p className="eyebrow-label">Key takeaways</p>
-          <ul className="mt-3 space-y-2 text-sm leading-6 text-[#46574d]">
+          <ul className="mt-2 grid gap-1.5 text-sm leading-6 text-[#46574d] sm:grid-cols-2">
             {keyTakeaways.map(item => (
               <li key={item} className="flex gap-2">
                 <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-500" />
@@ -630,17 +665,17 @@ export default async function HerbDetailPage({ params }: PageProps) {
         </section>
       ) : null}
 
-      <section className="rounded-[1.1rem] bg-amber-50/70 p-4 sm:p-5">
+      <section id="safety" className="rounded-[0.9rem] bg-amber-50/70 p-3 sm:p-4">
         <div className="space-y-2">
           <p className="eyebrow-label text-amber-900">Safety first</p>
-          <h2 className="text-xl font-semibold tracking-tight text-ink">Review cautions before use</h2>
+          <h2 className="text-lg font-semibold tracking-tight text-ink">Review cautions before use</h2>
           <p className="max-w-4xl text-sm leading-6 text-[#5f4a24]">{safetySummary}</p>
         </div>
 
         {safetyGroups.length > 0 ? (
-          <details className="mt-5 border-t border-amber-900/15 pt-4">
+          <details className="mt-3 border-t border-amber-900/15 pt-3">
             <summary className="cursor-pointer text-sm font-bold text-ink">View full safety notes</summary>
-            <div className="mt-4 grid gap-4 md:grid-cols-2">
+            <div className="mt-3 grid gap-3 md:grid-cols-2">
               {safetyGroups.map(group => (
                 <div key={group.title} className="space-y-2">
                   <h3 className="text-sm font-semibold text-ink">{group.title}</h3>
@@ -658,7 +693,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
 
       <RelatedDiscoveryGroups
         eyebrow="Related navigation"
-        title="Keep researching with context"
+        title="Related decisions"
         groups={[
           { title: 'Related herbs', description: 'Profiles with overlapping effects or decision signals.', links: relatedHerbLinks },
           { title: 'Related compounds', description: 'Mechanism-adjacent compounds to contrast with this herb.', links: relatedCompoundLinks },

--- a/app/herbs/page.tsx
+++ b/app/herbs/page.tsx
@@ -8,7 +8,7 @@ import HerbsIndexClient from './HerbsIndexClient'
 
 export const metadata: Metadata = {
   title: 'Herb Profiles & Research Library',
-  description: 'Browse evidence-aware profiles for 100+ herbs — mechanisms, safety notes, active compounds, and research context in plain language.',
+  description: 'Browse profiles for 100+ herbs — mechanisms, safety notes, active compounds, and research context in plain language.',
   alternates: { canonical: '/herbs' },
 }
 
@@ -17,11 +17,8 @@ export default async function HerbsPage() {
   const pageData = paginateItems(herbs, 1, HERBS_PAGE_SIZE)
 
   return (
-    <div className="mx-auto max-w-6xl space-y-8 px-4 py-8 sm:py-10">
-      <section className="rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
-        <h1 className="text-3xl font-bold tracking-tight text-ink sm:text-5xl">Herb profiles and supplement research</h1>
-      </section>
-      <nav className="rounded-xl border border-brand-900/10 bg-white/80 p-4 text-sm">
+    <div className="mx-auto max-w-6xl space-y-5 px-4 py-4 sm:py-6">
+      <nav className="rounded-[0.8rem] border border-brand-900/10 bg-white/80 p-3 text-sm">
         <p className="font-semibold">Page 1 of {pageData.totalPages}</p>
         {pageData.hasNext ? <Link rel="next" href="/herbs/page/2">Next page →</Link> : null}
       </nav>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,7 +9,7 @@ import '@/styles/foundation-readability.css'
 
 const siteName = 'The Hippie Scientist'
 const siteDescription =
-  'Evidence-aware research on herbs, compounds, mechanisms, safety context, and practical supplement decisions.'
+  'Evidence-informed research on herbs, compounds, mechanisms, safety context, and practical supplement decisions.'
 
 // Canonical production domain. Cloudflare redirects should resolve to this host.
 const siteUrl = 'https://www.thehippiescientist.net'

--- a/app/learn/[slug]/page.tsx
+++ b/app/learn/[slug]/page.tsx
@@ -20,7 +20,7 @@ export async function generateMetadata({ params }: LearnRouteProps): Promise<Met
   if (!post) {
     return {
       title: 'Learn | The Hippie Scientist',
-      description: 'Evidence-aware educational content and practical learning guides.',
+      description: 'Evidence-informed educational content and practical learning guides.',
     }
   }
 
@@ -101,7 +101,7 @@ export default async function Page({ params }: LearnRouteProps) {
             },
             {
               title: 'Apply what you learned',
-              description: 'Move from concepts into evidence-aware profiles.',
+              description: 'Move from concepts into profiles.',
               links: post.relatedLinks,
             },
             {

--- a/app/learn/data.ts
+++ b/app/learn/data.ts
@@ -17,7 +17,7 @@ export const learnPosts: LearnPost[] = [
   {
     slug: 'cognitive-stack-that-actually-makes-sense',
     title: 'The Cognitive Stack That Actually Makes Sense',
-    description: 'A practical, evidence-aware cognitive stack using Gotu Kola, Bacopa, Lion’s Mane, Ginkgo, Rhodiola, and L-Theanine.',
+    description: 'A practical, evidence-informed cognitive stack using Gotu Kola, Bacopa, Lion’s Mane, Ginkgo, Rhodiola, and L-Theanine.',
     category: 'Cognition',
     readingTime: '6 min read',
     hero: 'Most brain stacks online are random. This one is built around clear roles: calm focus, memory, circulation, fatigue resistance, and long-term cognitive support.',

--- a/app/learn/page.tsx
+++ b/app/learn/page.tsx
@@ -105,7 +105,7 @@ export default function LearnPage() {
             <p className='eyebrow-label'>Learn the basics</p>
 
             <h1 className='text-4xl font-bold tracking-tight text-ink sm:text-5xl'>
-              Evidence-aware supplement education
+              Evidence-informed supplement education
             </h1>
           </div>
 
@@ -199,7 +199,7 @@ export default function LearnPage() {
           <p className='eyebrow-label'>Featured Guides</p>
 
           <h2 className='mt-2 text-3xl font-semibold text-ink'>
-            Practical evidence-aware learning
+            Practical evidence-informed learning
           </h2>
         </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,14 +13,14 @@ export const metadata: Metadata = {
   openGraph: {
     title: 'Herbs, Compounds, and Evidence-Based Supplement Guides',
     description:
-      'Explore evidence-aware guides on herbs, compounds, stacks, and supplement decisions with mechanism, safety, and tradeoff context.',
+      'Compare herbs, compounds, stacks, and supplement decisions by fit, safety, and evidence.',
     url: '/',
   },
   twitter: {
     card: 'summary_large_image',
     title: 'Herbs, Compounds, and Evidence-Based Supplement Guides',
     description:
-      'Explore evidence-aware guides on herbs, compounds, stacks, and supplement decisions with mechanism, safety, and tradeoff context.',
+      'Compare herbs, compounds, stacks, and supplement decisions by fit, safety, and evidence.',
   },
 }
 

--- a/app/protocols/page.tsx
+++ b/app/protocols/page.tsx
@@ -4,17 +4,17 @@ import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 
 export const metadata: Metadata = {
   title: 'Supplement Protocol Guides',
-  description: 'Evidence-aware protocol pages for stress regulation, sleep support, focus, burnout recovery, and recovery-oriented productivity.',
+  description: 'Evidence-informed protocol pages for stress regulation, sleep support, focus, burnout recovery, and recovery-oriented productivity.',
   alternates: { canonical: '/protocols' },
   openGraph: {
     title: 'Supplement Protocol Guides',
-    description: 'Evidence-aware protocol pages for stress regulation, sleep support, focus, burnout recovery, and recovery-oriented productivity.',
+    description: 'Evidence-informed protocol pages for stress regulation, sleep support, focus, burnout recovery, and recovery-oriented productivity.',
     url: '/protocols',
   },
   twitter: {
     card: 'summary_large_image',
     title: 'Supplement Protocol Guides',
-    description: 'Evidence-aware protocol guides for stress, sleep, focus, and recovery systems.',
+    description: 'Evidence-informed protocol guides for stress, sleep, focus, and recovery systems.',
   },
 }
 
@@ -32,7 +32,7 @@ export default function ProtocolsIndexPage() {
     <main className="container-page py-10 space-y-10">
       <AuthorityJsonLd
         title="Protocols"
-        description="Evidence-aware protocol pages for stress, sleep, focus, and recovery systems."
+        description="Evidence-informed protocol pages for stress, sleep, focus, and recovery systems."
         url="https://thehippiescientist.net/protocols"
         type="CollectionPage"
       />

--- a/app/psychedelic-adjacent-herbs/page.tsx
+++ b/app/psychedelic-adjacent-herbs/page.tsx
@@ -3,17 +3,17 @@ import Link from 'next/link'
 
 export const metadata: Metadata = {
   title: 'Psychedelic-Adjacent Herbs & Harm Reduction | The Hippie Scientist',
-  description: 'Evidence-aware harm reduction guide for traditional, ritual, and dream-adjacent botanicals like Blue Lotus and Kanna.',
+  description: 'Evidence-informed harm reduction guide for traditional, ritual, and dream-adjacent botanicals like Blue Lotus and Kanna.',
   alternates: { canonical: '/psychedelic-adjacent-herbs' },
   openGraph: {
     title: 'Psychedelic-Adjacent Herbs & Harm Reduction',
-    description: 'Evidence-aware harm reduction guide for traditional, ritual, and dream-adjacent botanicals like Blue Lotus and Kanna.',
+    description: 'Evidence-informed harm reduction guide for traditional, ritual, and dream-adjacent botanicals like Blue Lotus and Kanna.',
     url: '/psychedelic-adjacent-herbs',
   },
   twitter: {
     card: 'summary_large_image',
     title: 'Psychedelic-Adjacent Herbs & Harm Reduction',
-    description: 'Evidence-aware harm reduction guide for traditional and ritual botanicals.',
+    description: 'Evidence-informed harm reduction guide for traditional and ritual botanicals.',
   },
 }
 

--- a/app/psychoactive/harm-reduction/page.tsx
+++ b/app/psychoactive/harm-reduction/page.tsx
@@ -26,7 +26,7 @@ export default function HarmReductionPage() {
     <main className="container-page py-10 space-y-10">
       <AuthorityJsonLd
         title="Psychoactive Harm Reduction"
-        description="Educational psychoactive harm reduction hub focused on interaction awareness, neurochemical safety, and evidence-aware educational guidance."
+        description="Educational psychoactive harm reduction hub focused on interaction awareness, neurochemical safety, and educational guidance."
         url="https://thehippiescientist.net/psychoactive/harm-reduction"
         type="Article"
       />
@@ -47,7 +47,7 @@ export default function HarmReductionPage() {
         </h1>
 
         <p className="text-lg leading-8 text-[#46574d]">
-          Educational harm-reduction exploration focused on interaction awareness, neurochemical safety, pathway overlap, psychoactive ethnobotany, and conservative evidence-aware interpretation.
+          Educational harm-reduction exploration focused on interaction awareness, neurochemical safety, pathway overlap, psychoactive ethnobotany, and conservative evidence-informed interpretation.
         </p>
 
         <p className="text-base leading-8 text-[#5c6b63]">

--- a/app/psychoactive/interactions/page.tsx
+++ b/app/psychoactive/interactions/page.tsx
@@ -26,7 +26,7 @@ export default function PsychoactiveInteractionsPage() {
     <main className="container-page py-10 space-y-10">
       <AuthorityJsonLd
         title="Psychoactive Interactions"
-        description="Educational exploration of psychoactive interaction awareness, pathway overlap, neurochemical safety, and evidence-aware harm reduction."
+        description="Educational exploration of psychoactive interaction awareness, pathway overlap, neurochemical safety, and evidence-informed harm reduction."
         url="https://thehippiescientist.net/psychoactive/interactions"
         type="Article"
       />

--- a/app/psychoactive/page.tsx
+++ b/app/psychoactive/page.tsx
@@ -53,7 +53,7 @@ export default function PsychoactiveHubPage() {
     <main className="container-page py-10 space-y-10">
       <AuthorityJsonLd
         title="Psychoactive Research Hub"
-        description="Evidence-aware psychoactive ethnobotany, neuropharmacology, harm reduction, and semantic educational discovery."
+        description="Evidence-informed psychoactive ethnobotany, neuropharmacology, harm reduction, and semantic educational discovery."
         url="https://thehippiescientist.net/psychoactive"
         type="CollectionPage"
         breadcrumbs={[
@@ -90,7 +90,7 @@ export default function PsychoactiveHubPage() {
         </div>
 
         <p className="text-lg leading-8 text-[#46574d]">
-          Educational exploration of psychoactive herbs, ethnobotany, neuropharmacology, mechanism systems, and harm reduction through an evidence-aware semantic discovery architecture.
+          Educational exploration of psychoactive herbs, ethnobotany, neuropharmacology, mechanism systems, and harm reduction through an evidence-informed semantic discovery architecture.
         </p>
 
         <p className="text-base leading-8 text-[#5c6b63]">

--- a/app/psychoactive/serotonergic-stacking-risks/page.tsx
+++ b/app/psychoactive/serotonergic-stacking-risks/page.tsx
@@ -26,7 +26,7 @@ export default function SerotonergicRisksPage() {
     <main className="container-page py-10 space-y-10">
       <AuthorityJsonLd
         title="Serotonergic Stacking Risks"
-        description="Educational exploration of serotonergic overlap, psychoactive interaction awareness, mood-system safety, and evidence-aware harm reduction."
+        description="Educational exploration of serotonergic overlap, psychoactive interaction awareness, mood-system safety, and evidence-informed harm reduction."
         url="https://thehippiescientist.net/psychoactive/serotonergic-stacking-risks"
         type="Article"
       />

--- a/app/search/SearchClient.tsx
+++ b/app/search/SearchClient.tsx
@@ -120,7 +120,7 @@ const discoveryFilters: IntentPrompt[] = [
   { label: 'Stimulating', query: 'energy motivation stimulation', helper: 'Activation-oriented profiles.' },
   { label: 'Beginner-friendly', query: 'beginner safety low risk', helper: 'Safer orientation for first-time exploration.' },
   { label: 'Low tolerance risk', query: 'low tolerance risk safety', helper: 'Prioritize conservative safety framing.' },
-  { label: 'Evidence-aware', query: 'clinical evidence human trial', helper: 'Bias toward stronger study context.' },
+  { label: 'Evidence-informed', query: 'clinical evidence human trial', helper: 'Bias toward stronger study context.' },
   { label: 'Sleep-supportive', query: 'sleep recovery wind down', helper: 'Evening and sleep-adjacent support.' },
   { label: 'Daytime-friendly', query: 'daytime focus non sedating', helper: 'Use when you need calmer daytime function.' },
 ]

--- a/app/supernodes/[slug]/page.tsx
+++ b/app/supernodes/[slug]/page.tsx
@@ -115,7 +115,7 @@ function SupernodeCard({ record }: { record: any }) {
         </h2>
 
         <p className="line-clamp-3 text-sm leading-6 text-[#46574d]">
-          {getSummary(record) || 'Evidence-aware semantic profile connected to this supernode.'}
+          {getSummary(record) || 'Evidence-informed semantic profile connected to this supernode.'}
         </p>
       </div>
 

--- a/app/top/best-herbs-for-overthinking/page.tsx
+++ b/app/top/best-herbs-for-overthinking/page.tsx
@@ -11,7 +11,7 @@ const label = (h: Herb) => h.displayName || h.name || h.slug
 
 export const metadata: Metadata = {
   title: 'Best Herbs for Overthinking (2026 Guide)',
-  description: 'Evidence-aware educational guide to herbs often used in overthinking and racing-thought contexts.',
+  description: 'Evidence-informed educational guide to herbs often used in overthinking and racing-thought contexts.',
 }
 
 export default async function Page() {

--- a/components/evidence/MisconceptionCallout.tsx
+++ b/components/evidence/MisconceptionCallout.tsx
@@ -19,7 +19,7 @@ export default function MisconceptionCallout({
 
       <div className="rounded-2xl bg-white p-5 space-y-3 border border-[#e6e1d4]">
         <p className="text-xs font-semibold uppercase tracking-wide text-[#5c6b63]">
-          Evidence-aware interpretation
+          Evidence-informed interpretation
         </p>
 
         <p className="text-sm leading-7 text-[#46574d]">

--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -118,29 +118,29 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
 
   return (
     <div className='overflow-x-clip bg-site-bg'>
-      <div className='mx-auto max-w-6xl space-y-6 px-4 pb-6 pt-5 sm:px-6 sm:space-y-8 sm:pb-8 sm:pt-8 lg:px-8'>
+      <div className='mx-auto max-w-6xl space-y-5 px-4 pb-5 pt-4 sm:px-6 sm:space-y-6 sm:pb-6 sm:pt-6 lg:px-8'>
 
         {/* Hero */}
-        <section className='rounded-[1.25rem] border border-brand-900/10 bg-white/90 px-4 py-5 shadow-sm sm:px-6 sm:py-7'>
+        <section className='rounded-[0.95rem] border border-brand-900/10 bg-white/90 px-4 py-4 shadow-sm sm:px-5 sm:py-5'>
           <div className='mx-auto flex max-w-4xl flex-col items-center text-center'>
-            <p role='doc-subtitle' className='mb-3 inline-flex text-[0.7rem] font-semibold uppercase tracking-[0.18em] text-brand-700'>
-              Evidence-aware botanical research
+            <p role='doc-subtitle' className='mb-2 inline-flex text-[0.7rem] font-semibold uppercase tracking-[0.18em] text-brand-700'>
+              Herbs + supplements, ranked by fit
             </p>
-            <h1 className='font-display text-[2.35rem] font-semibold leading-[1] tracking-[-0.045em] text-ink sm:text-5xl md:text-6xl'>
+            <h1 className='font-display text-[2rem] font-semibold leading-[1] tracking-[-0.04em] text-ink sm:text-4xl md:text-5xl'>
               <span className='block'>The Hippie Scientist</span>
             </h1>
-            <p className='mt-4 max-w-2xl text-base font-medium leading-7 text-muted'>
-              Compare herbs and compounds by evidence strength, safety context, and practical fit — not wellness hype.
+            <p className='mt-3 max-w-2xl text-sm font-medium leading-6 text-muted'>
+              Find what fits your goal, what to avoid, and where the evidence is strongest.
             </p>
-            <div className='mt-5 grid w-full max-w-2xl gap-2 sm:grid-cols-3'>
+            <div className='mt-4 grid w-full max-w-2xl gap-2 sm:grid-cols-3'>
               {primaryActions.map((action, index) => (
                 <Link
                   key={action.href}
                   href={action.href}
                   className={
                     index === 0
-                      ? 'rounded-full border border-brand-900/15 bg-white px-4 py-2.5 text-sm font-semibold text-ink transition hover:-translate-y-0.5 hover:border-brand-900/25 hover:bg-brand-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40 focus-visible:ring-offset-2 focus-visible:ring-offset-site-bg'
-                      : 'rounded-full border border-brand-900/10 bg-white/90 px-4 py-2.5 text-sm font-semibold text-ink transition hover:-translate-y-0.5 hover:border-brand-900/20 hover:bg-brand-50/70 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40 focus-visible:ring-offset-2 focus-visible:ring-offset-site-bg'
+                      ? 'rounded-full border border-brand-900/15 bg-white px-3 py-2 text-sm font-semibold text-ink transition hover:-translate-y-0.5 hover:border-brand-900/25 hover:bg-brand-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40 focus-visible:ring-offset-2 focus-visible:ring-offset-site-bg'
+                      : 'rounded-full border border-brand-900/10 bg-white/90 px-3 py-2 text-sm font-semibold text-ink transition hover:-translate-y-0.5 hover:border-brand-900/20 hover:bg-brand-50/70 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40 focus-visible:ring-offset-2 focus-visible:ring-offset-site-bg'
                   }
                 >
                   {action.label}
@@ -152,10 +152,10 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
         </section>
 
         {/* Goal Guides */}
-        <section className='space-y-4'>
+        <section className='space-y-3'>
           <SectionHeader
             title='Browse by goal decision path'
-            subtitle='Select your outcome to compare evidence, safety constraints, typical onset, and practical tradeoffs side-by-side.'
+            subtitle='Choose a goal and compare evidence, safety, onset, and tradeoffs.'
             as='h2'
           />
           <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-3'>
@@ -163,14 +163,14 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
               <Link
                 key={goal.slug}
                 href={`/goals/${goal.slug}`}
-                className='group flex flex-col justify-between rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-900/20 hover:bg-white'
+                className='group flex flex-col justify-between rounded-[0.85rem] border border-brand-900/10 bg-white/90 p-3 shadow-sm transition hover:border-brand-900/20 hover:bg-white'
               >
                 <div>
                   <span className='text-[10px] font-bold uppercase tracking-wider text-brand-700'>{goal.eyebrow}</span>
                   <h3 className='mt-1 text-base font-bold text-ink transition group-hover:text-brand-700'>{goal.title}</h3>
-                  <p className='mt-2 line-clamp-2 text-xs leading-relaxed text-muted'>{goal.description}</p>
+                  <p className='mt-1 line-clamp-2 text-xs leading-relaxed text-muted'>{goal.description}</p>
                 </div>
-                <div className='mt-3 flex items-center justify-between border-t border-brand-900/5 pt-3 text-xs font-semibold text-brand-700'>
+                <div className='mt-2 flex items-center justify-between border-t border-brand-900/5 pt-2 text-xs font-semibold text-brand-700'>
                   <span>Compare options</span>
                   <span className='transition group-hover:translate-x-1'>→</span>
                 </div>
@@ -180,44 +180,44 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
         </section>
 
         {/* Research Clusters */}
-        <section className='space-y-4'>
+        <section className='space-y-3'>
           <SectionHeader
             title='Specialized research clusters'
-            subtitle='Deep-dive comparison clusters addressing common search questions, active compounds, and safety boundaries.'
+            subtitle='Comparison clusters for common decisions and safety boundaries.'
             as='h2'
           />
-          <div className='grid gap-4 sm:grid-cols-3'>
+          <div className='grid gap-2 sm:grid-cols-3'>
             {[
               {
                 href: '/natural-anxiolytics-beyond-ashwagandha',
                 eyebrow: 'Anxiolytic cluster',
                 title: 'Beyond Ashwagandha',
-                desc: 'Compare calming botanicals like L-Theanine and Kava through structured evidence-strength profiles.',
+                desc: 'Compare calming options and safety tradeoffs.',
               },
               {
                 href: '/sleep-herbs-vs-melatonin',
                 eyebrow: 'Sleep comparison',
                 title: 'Sleep Herbs vs Melatonin',
-                desc: 'Contrast hormone-based circadian shifting against natural relaxation and muscle wind-down options.',
+                desc: 'Contrast circadian shifting with wind-down options.',
               },
               {
                 href: '/psychedelic-adjacent-herbs',
                 eyebrow: 'Harm reduction',
                 title: 'Psychedelic-Adjacent Herbs',
-                desc: 'Review conservative profile assessments, interaction boundaries, and safety warnings first.',
+                desc: 'Review interaction boundaries and safety warnings first.',
               },
             ].map((cluster) => (
               <Link
                 key={cluster.href}
                 href={cluster.href}
-                className='group flex flex-col justify-between rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-900/20 hover:bg-white'
+                className='group flex flex-col justify-between rounded-[0.85rem] border border-brand-900/10 bg-white/90 p-3 shadow-sm transition hover:border-brand-900/20 hover:bg-white'
               >
                 <div>
                   <span className='text-[10px] font-bold uppercase tracking-wider text-brand-700'>{cluster.eyebrow}</span>
                   <h3 className='mt-1 text-base font-bold text-ink transition group-hover:text-brand-700'>{cluster.title}</h3>
-                  <p className='mt-1.5 text-xs leading-relaxed text-muted'>{cluster.desc}</p>
+                  <p className='mt-1 text-xs leading-relaxed text-muted'>{cluster.desc}</p>
                 </div>
-                <span className='mt-3 inline-flex items-center gap-1 text-xs font-semibold text-brand-700'>
+                <span className='mt-2 inline-flex items-center gap-1 text-xs font-semibold text-brand-700'>
                   Open comparison <span className='transition group-hover:translate-x-1'>→</span>
                 </span>
               </Link>
@@ -230,7 +230,7 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
           <div className='flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between'>
             <SectionHeader
               title='Popular research starting points'
-              subtitle='Examples of evidence-aware profiles — not endorsements or medical recommendations.'
+              subtitle='Popular profiles to compare first.'
               as='h2'
             />
             <div className='flex flex-wrap gap-3 text-sm font-semibold'>
@@ -244,7 +244,7 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
                 key={item.href}
                 href={item.href}
                 aria-label={`View ${item.meta} for ${item.title}`}
-                className='group rounded-2xl border border-brand-900/10 bg-white/90 p-3 transition hover:border-brand-900/20 hover:bg-white'
+                className='group rounded-[0.85rem] border border-brand-900/10 bg-white/90 p-3 transition hover:border-brand-900/20 hover:bg-white'
               >
                 <div className='relative'>
                   <span className='inline-flex text-xs font-semibold uppercase tracking-[0.16em] text-brand-700'>{item.meta}</span>
@@ -258,10 +258,10 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
         </section>
 
         {/* Disclaimer */}
-        <section className='rounded-[1rem] border border-amber-200/80 bg-amber-50/60 p-4'>
+        <section className='rounded-[0.85rem] border border-amber-200/80 bg-amber-50/60 p-3'>
           <div className='flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between'>
             <p className='max-w-4xl text-sm leading-6 text-amber-950/85'>
-              <strong>Important Notice:</strong> Natural does not automatically mean safe or effective. The information here supports comparison and mechanistic research. Always consult a physician and review potential contraindications before beginning any supplement routine.
+              <strong>Important Notice:</strong> Natural does not automatically mean safe or effective. Use this for comparison only. Review contraindications and ask a clinician before starting supplements.
             </p>
             <Link
               href='/disclaimer'

--- a/components/ui/CompoundHero.tsx
+++ b/components/ui/CompoundHero.tsx
@@ -7,24 +7,24 @@ export default function CompoundHero({
   safetyLevel
 }: any) {
   return (
-    <div className="space-y-4">
-      <div className="space-y-3">
+    <div className="space-y-2">
+      <div className="space-y-2">
         <div className="eyebrow-label">
-          Compound Profile
+          Compound brief
         </div>
 
-        <div className="flex flex-wrap gap-3 text-xs font-bold uppercase tracking-[0.12em] text-muted">
+        <div className="flex flex-wrap gap-2 text-xs font-bold uppercase tracking-[0.12em] text-muted">
           <EvidenceBadge level={evidenceLevel} />
           <SafetyBadge level={safetyLevel} />
         </div>
       </div>
 
       <div className="space-y-3">
-        <h1 className="heading-premium max-w-4xl text-balance">
+        <h1 className="font-display text-2xl font-semibold leading-tight tracking-tight text-ink sm:text-3xl">
           {compound.name}
         </h1>
 
-        <p className="max-w-2xl text-sm leading-6 text-[#46574d] sm:text-base">
+        <p className="max-w-2xl text-sm leading-6 text-[#46574d]">
           {compound.summary || 'Evidence-informed compound profile.'}
         </p>
       </div>

--- a/components/ui/DecisionPrimitives.tsx
+++ b/components/ui/DecisionPrimitives.tsx
@@ -44,8 +44,8 @@ export function DecisionEmptyState({
   actions: DecisionEmptyStateAction[]
 }) {
   return (
-    <div className="rounded-[1.5rem] border border-brand-900/10 bg-white/85 p-6 shadow-[var(--shadow-card-calm)] sm:p-8">
-      <div className="max-w-2xl space-y-3">
+    <div className="rounded-[1rem] border border-brand-900/10 bg-white/85 p-4 shadow-sm sm:p-5">
+      <div className="max-w-2xl space-y-2">
         <p className="eyebrow-label">{eyebrow}</p>
         <h2 className="compact-heading">{title}</h2>
         <p className="text-sm leading-6 text-[#46574d] sm:text-base">{description}</p>
@@ -54,7 +54,7 @@ export function DecisionEmptyState({
         ) : null}
       </div>
 
-      <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+      <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:flex-wrap">
         {actions.map(action => (
           <Link
             key={`${action.href}-${action.label}`}
@@ -89,11 +89,11 @@ export function DecisionFilterGroup({
   open?: boolean
 }) {
   const itemClass = (active: boolean) =>
-    `rounded-full border px-3 py-2 text-xs font-semibold leading-tight transition ${active ? 'border-brand-700/25 bg-brand-50 text-brand-900' : 'border-brand-900/10 bg-white/80 text-[#33443a] hover:border-brand-700/20'}`
+    `rounded-full border px-2.5 py-1.5 text-xs font-semibold leading-tight transition ${active ? 'border-brand-700/25 bg-brand-50 text-brand-900' : 'border-brand-900/10 bg-white/80 text-[#33443a] hover:border-brand-700/20'}`
 
   return (
-    <details className="mt-3 rounded-[1rem] border border-brand-900/10 bg-[#fbfaf6]/80 p-3 shadow-none" open={open || undefined}>
-      <summary className="flex min-h-10 items-center justify-between gap-4 text-sm font-bold text-ink">
+    <details className="mt-3 rounded-[0.8rem] border border-brand-900/10 bg-[#fbfaf6]/80 p-3 shadow-none" open={open || undefined}>
+      <summary className="flex min-h-8 items-center justify-between gap-4 text-sm font-bold text-ink">
         <span>Refine by context</span>
         <span className="text-brand-800" aria-hidden="true">↓</span>
       </summary>
@@ -139,11 +139,11 @@ export function DecisionProfileCard({
   return (
     <Link
       href={href}
-      className="group flex h-full flex-col rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition duration-200 hover:border-brand-700/20 hover:bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40"
+      className="group flex h-full flex-col rounded-[0.85rem] border border-brand-900/10 bg-white/90 p-3 shadow-sm transition-colors duration-200 hover:border-brand-700/20 hover:bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40"
     >
       <div className="flex flex-1 flex-col">
         <div className="flex min-w-0 items-start justify-between gap-3">
-          <h3 className="min-w-0 break-words text-lg font-semibold leading-tight tracking-tight text-ink transition group-hover:text-brand-800 sm:text-xl">
+          <h3 className="min-w-0 break-words text-base font-semibold leading-tight tracking-tight text-ink transition group-hover:text-brand-800 sm:text-lg">
             {name}
           </h3>
           {featured ? (
@@ -153,23 +153,23 @@ export function DecisionProfileCard({
           ) : null}
         </div>
 
-        <p className="mt-2 line-clamp-2 text-sm leading-5 text-[#46574d]">
+        <p className="mt-1.5 line-clamp-2 text-sm leading-5 text-[#46574d]">
           {summary || fallbackSummary}
         </p>
 
-        <div className="mt-3 rounded-[0.9rem] border border-brand-900/10 bg-brand-50/45 p-3">
+        <div className="mt-2 rounded-[0.75rem] border border-brand-900/10 bg-brand-50/45 p-2.5">
           <p className={`${decisionMicroLabelClass} text-brand-800`}>Best-for context</p>
           <p className="mt-1 text-sm font-semibold leading-5 text-[#203329]">{bestFor}</p>
         </div>
 
-        <div className="mt-3 grid gap-2 sm:grid-cols-3">
+        <div className="mt-2 grid gap-2 sm:grid-cols-3">
           <DecisionMetric label="Evidence" value={evidence} />
           <DecisionMetric label="Safety" value={safety} />
           <DecisionMetric label="Time" value={timeToEffect} />
         </div>
 
         {visibleMechanisms.length > 0 ? (
-          <div className={`${decisionMetadataClusterClass} mt-3 border-t border-brand-900/10 pt-3`}>
+          <div className={`${decisionMetadataClusterClass} mt-2 border-t border-brand-900/10 pt-2`}>
             {visibleMechanisms.map(mechanism => (
               <span key={mechanism} className={decisionChipClass}>
                 {mechanism}
@@ -179,7 +179,7 @@ export function DecisionProfileCard({
         ) : null}
       </div>
 
-      <div className="mt-3 text-sm font-bold text-brand-800 transition group-hover:text-brand-900">
+      <div className="mt-2 text-sm font-bold text-brand-800 transition group-hover:text-brand-900">
         View profile <span aria-hidden="true">→</span>
       </div>
     </Link>

--- a/components/ui/EvidenceSnapshotPanel.tsx
+++ b/components/ui/EvidenceSnapshotPanel.tsx
@@ -28,7 +28,7 @@ export default function EvidenceSnapshotPanel({
   badge,
   fields,
   className,
-  columnsClassName = 'grid gap-3 sm:grid-cols-2 lg:grid-cols-1',
+  columnsClassName = 'grid gap-2 sm:grid-cols-2 lg:grid-cols-1',
   footer,
 }: Props) {
   const visibleFields = fields.filter(field => field?.label && field?.value)
@@ -37,44 +37,44 @@ export default function EvidenceSnapshotPanel({
   if (visibleFields.length === 0) return null
 
   return (
-    <aside className={className || 'rounded-[1.1rem] border border-brand-900/10 bg-white/95 p-4 shadow-sm'}>
-      <div className="flex items-start justify-between gap-3 border-b border-brand-900/10 pb-3">
+    <aside className={className || 'rounded-[0.9rem] border border-brand-900/10 bg-white/95 p-3 shadow-sm'}>
+      <div className="flex items-start justify-between gap-2 border-b border-brand-900/10 pb-2">
         <div>
           <p className="eyebrow-label">Evidence snapshot</p>
-          <h2 className="mt-1 text-lg font-semibold tracking-tight text-ink">{title}</h2>
-          <p className="mt-1 text-xs leading-5 text-[#46574d]">{subtitle}</p>
+          <h2 className="mt-0.5 text-base font-semibold tracking-tight text-ink">{title}</h2>
+          <p className="mt-0.5 text-xs leading-5 text-[#46574d]">{subtitle}</p>
         </div>
         {badge ? (
-          <span className="rounded-full bg-emerald-700/10 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.14em] text-emerald-900">
+          <span className="rounded-full bg-emerald-700/10 px-2 py-0.5 text-[10px] font-bold uppercase tracking-[0.14em] text-emerald-900">
             {badge}
           </span>
         ) : null}
       </div>
 
-      <div className={`mt-4 ${columnsClassName}`}>
+      <div className={`mt-3 ${columnsClassName}`}>
         {primaryFields.map((field) => (
-          <article key={field.label} className={`rounded-[0.9rem] border p-3 ${fieldToneClasses(field.tone)}`}>
+          <article key={field.label} className={`rounded-[0.7rem] border p-2.5 ${fieldToneClasses(field.tone)}`}>
             <h3 className="text-[0.66rem] font-bold uppercase tracking-[0.14em] text-muted">{field.label}</h3>
-            <p className="mt-1.5 text-sm leading-5 text-[#46574d]">{field.value}</p>
+            <p className="mt-1 text-sm leading-5 text-[#46574d]">{field.value}</p>
           </article>
         ))}
       </div>
 
       {secondaryFields.length > 0 ? (
-        <details className="mt-3 rounded-[0.9rem] border border-brand-900/10 bg-white/70 p-3 shadow-none">
+        <details className="mt-2 rounded-[0.7rem] border border-brand-900/10 bg-white/70 p-2.5 shadow-none">
           <summary className="text-xs font-bold uppercase tracking-[0.14em] text-brand-800">More context</summary>
-          <div className="mt-3 grid gap-2">
+          <div className="mt-2 grid gap-2">
             {secondaryFields.map((field) => (
-              <article key={field.label} className={`rounded-[0.8rem] border p-3 ${fieldToneClasses(field.tone)}`}>
+              <article key={field.label} className={`rounded-[0.65rem] border p-2.5 ${fieldToneClasses(field.tone)}`}>
                 <h3 className="text-[0.66rem] font-bold uppercase tracking-[0.14em] text-muted">{field.label}</h3>
-                <p className="mt-1.5 text-sm leading-5 text-[#46574d]">{field.value}</p>
+                <p className="mt-1 text-sm leading-5 text-[#46574d]">{field.value}</p>
               </article>
             ))}
           </div>
         </details>
       ) : null}
 
-      {footer ? <div className="mt-4 border-t border-brand-900/10 pt-3">{footer}</div> : null}
+      {footer ? <div className="mt-3 border-t border-brand-900/10 pt-2">{footer}</div> : null}
     </aside>
   )
 }

--- a/components/ui/PremiumCard.tsx
+++ b/components/ui/PremiumCard.tsx
@@ -35,7 +35,7 @@ export default function PremiumCard({
     <article className="group flex h-full flex-col overflow-hidden rounded-card border border-brand-900/10 bg-[rgba(255,253,247,0.92)] p-6 sm:p-7 shadow-[0_10px_30px_rgba(29,74,47,0.08)] backdrop-blur-xl transition duration-300 hover:-translate-y-[3px] hover:border-brand-700/25 hover:bg-white hover:shadow-glow">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="eyebrow text-brand-700">
-          Evidence-aware profile
+          Evidence-informed profile
         </div>
 
         <div className="flex shrink-0 flex-wrap justify-end gap-2">

--- a/lib/decision-primitives.ts
+++ b/lib/decision-primitives.ts
@@ -26,22 +26,22 @@ export type DecisionSafetyTone = 'ok' | 'caution' | 'interaction' | 'review' | '
 export type DecisionEvidenceTone = 'strong' | 'moderate' | 'limited' | 'mixed' | 'preliminary' | 'traditional' | 'insufficient' | 'review'
 
 export const decisionBadgeClass =
-  'inline-flex min-h-7 max-w-full items-center rounded-full border px-2.5 py-1 text-[0.72rem] font-semibold leading-snug break-words'
+  'inline-flex min-h-6 max-w-full items-center rounded-full border px-2 py-0.5 text-[0.68rem] font-semibold leading-snug break-words'
 
 export const decisionStatusBadgeClass =
   `${decisionBadgeClass} text-[0.72rem] uppercase tracking-[0.08em]`
 
 export const decisionChipClass =
-  'inline-flex min-h-7 max-w-full items-center rounded-full border border-brand-900/10 bg-white/75 px-2.5 py-1 text-[0.72rem] font-semibold leading-snug text-[#5f6f66] break-words'
+  'inline-flex min-h-6 max-w-full items-center rounded-full border border-brand-900/10 bg-white/75 px-2 py-0.5 text-[0.68rem] font-semibold leading-snug text-[#5f6f66] break-words'
 
 export const decisionMicroLabelClass =
-  'text-[0.68rem] font-bold uppercase tracking-[0.1em] leading-none'
+  'text-[0.64rem] font-bold uppercase tracking-[0.09em] leading-none'
 
 export const decisionMetricShellClass =
-  'min-w-0 rounded-[0.8rem] border border-brand-900/10 bg-[#fbfaf6]/85 px-2.5 py-2'
+  'min-w-0 rounded-[0.65rem] border border-brand-900/10 bg-[#fbfaf6]/85 px-2 py-1.5'
 
 export const decisionMetadataClusterClass =
-  'flex flex-wrap items-center gap-2'
+  'flex flex-wrap items-center gap-1.5'
 
 function compactText(value?: unknown): string {
   if (value == null) return ''

--- a/lib/discovery-classification.ts
+++ b/lib/discovery-classification.ts
@@ -194,7 +194,7 @@ export function classifyDiscoveryGroups(base: any, relatedRecords: any[] = []): 
     },
     {
       title: 'Authority-Weighted Discovery',
-      description: 'Profiles are ranked by shared outcomes, mechanism continuity, ecosystem density, safety calibration, and evidence-aware discovery score.',
+      description: 'Profiles are ranked by shared outcomes, mechanism continuity, ecosystem density, safety calibration, and discovery score.',
       items: dedupe([...authorityMatches, ...orchestrationMatches]).slice(0, 6),
     },
     {

--- a/lib/display-utils.ts
+++ b/lib/display-utils.ts
@@ -175,9 +175,9 @@ export function unique(items: string[]) {
 export function cleanSummary(value: unknown, type: 'herb' | 'compound' = 'compound') {
   if (!value || typeof value !== 'string') {
     if (type === 'herb') {
-      return 'Evidence-aware botanical profile with mechanism, safety, and practical context.'
+      return 'Botanical profile with evidence, safety, and practical fit.'
     }
-    return 'Evidence-aware compound profile with mechanism, safety, and practical context.'
+    return 'Compound profile with evidence, safety, and practical fit.'
   }
 
   const summary = text(value)
@@ -185,10 +185,10 @@ export function cleanSummary(value: unknown, type: 'herb' | 'compound' = 'compou
   if (isClean(summary)) return summary
 
   if (type === 'herb') {
-    return 'Evidence-aware botanical profile with mechanism, safety, and practical context.'
+    return 'Botanical profile with evidence, safety, and practical fit.'
   }
 
-  return 'Evidence-aware compound profile with mechanism, safety, and practical context.'
+  return 'Compound profile with evidence, safety, and practical fit.'
 }
 
 

--- a/lib/editorial-variation.ts
+++ b/lib/editorial-variation.ts
@@ -57,7 +57,7 @@ export function buildVariedSummary(input: EditorialInput) {
       : `Current coverage leans exploratory, with ${join(focus)} providing biological plausibility rather than proof of effect.`,
     tone === 'strong'
       ? `Evidence maturity is comparatively higher here, though safety and applicability still require context.`
-      : `The useful reading frame is mechanistic and evidence-aware, with restraint around practical conclusions.`,
+      : `The useful reading frame is mechanistic and evidence-informed, with restraint around practical conclusions.`,
   ]
 
   return choices[variant(input, choices.length)]

--- a/lib/high-intent-commercial-pages.ts
+++ b/lib/high-intent-commercial-pages.ts
@@ -34,7 +34,7 @@ export function buildCommercialPageBlueprint(record: any): CommercialPageBluepri
     slug: `best-${slug}`,
     title: intent === 'forms' ? `Best ${name} forms` : `Best ${name} buying guide`,
     intent,
-    description: `Evidence-aware commercial guide for ${name}, focused on formulation quality, transparent labeling, safety context, and realistic expectations.`,
+    description: `Evidence-informed commercial guide for ${name}, focused on formulation quality, transparent labeling, safety context, and realistic expectations.`,
     safetyNote: context.readiness === 'avoid'
       ? 'Product recommendations should not be prioritized until safety context is reviewed.'
       : 'Product guidance is educational and should not replace medical advice.',

--- a/lib/homepage-messaging.ts
+++ b/lib/homepage-messaging.ts
@@ -1,7 +1,7 @@
 export const homepageMessaging = {
   heroHeadline: 'A field guide to herbs, compounds, mechanisms, and evidence — written for careful explorers.',
   heroSubhead:
-    'Explore herbs, compounds, pathways, and research summaries through practical goals, comparisons, and evidence-aware guidance.',
+    'Explore herbs, compounds, pathways, and research summaries through practical goals, comparisons, and practical guidance.',
   primaryCTA: {
     label: 'Explore Herbs',
     href: '/herbs',

--- a/lib/profile-synthesis.ts
+++ b/lib/profile-synthesis.ts
@@ -122,5 +122,5 @@ export function buildDiscoveryNarrative(relatedCount: number, input: SynthesisIn
     return 'Related profiles are prioritized for comparable evidence maturity, shared mechanisms, and caution-aware context.'
   }
 
-  return 'Related profiles below emphasize mechanism fit and evidence-aware comparison rather than implying equivalent clinical confidence.'
+  return 'Related profiles below emphasize mechanism fit and careful comparison rather than implying equivalent clinical confidence.'
 }

--- a/lib/runtime/discovery-supernodes.ts
+++ b/lib/runtime/discovery-supernodes.ts
@@ -31,7 +31,7 @@ export const DISCOVERY_SUPERNODES: DiscoverySupernode[] = [
     href: '/education/what-are-adaptogens',
     title: 'What Are Adaptogens?',
     description:
-      'Evidence-aware exploration of stress-response systems, resilience biology, and adaptogenic neuropharmacology.',
+      'Evidence-informed exploration of stress-response systems, resilience biology, and adaptogenic neuropharmacology.',
     category: 'Stress Physiology',
   },
   {

--- a/lib/scientific-human-identity.ts
+++ b/lib/scientific-human-identity.ts
@@ -11,7 +11,7 @@ export function buildScientificHumanTone() {
   return {
     headlineStyle: 'calm-authoritative',
     editorialStyle: 'scientific-but-human',
-    trustStyle: 'evidence-aware',
+    trustStyle: 'evidence-informed',
     onboardingStyle: 'guided-exploration',
   }
 }

--- a/lib/semantic/buildProtocolRecommendations.ts
+++ b/lib/semantic/buildProtocolRecommendations.ts
@@ -34,7 +34,7 @@ export function buildProtocolRecommendations(record: RuntimeRecord) {
       .replace(/\s+/g, '-')}`,
     title: `${tag} Protocol`,
     summary:
-      'Evidence-aware protocol exploration generated from semantic ecosystem overlap and pathway continuity.',
+      'Evidence-informed protocol exploration generated from semantic ecosystem overlap and pathway continuity.',
     tags: [tag],
   })).filter((item) => shouldRenderCard(item.title, item.summary))
 }

--- a/src/components/authority/AuthorityHubTemplate.tsx
+++ b/src/components/authority/AuthorityHubTemplate.tsx
@@ -24,7 +24,7 @@ export default function AuthorityHubTemplate({
       <section className="space-y-5">
         <div className="space-y-2">
           <p className="eyebrow-label">Related Profiles</p>
-          <h2>Evidence-aware discovery</h2>
+          <h2>Evidence-informed discovery</h2>
         </div>
 
         <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">

--- a/src/components/beginner-pathway-hub.tsx
+++ b/src/components/beginner-pathway-hub.tsx
@@ -9,7 +9,7 @@ export default function BeginnerPathwayHub() {
       <div className="space-y-2">
         <p className="eyebrow-label">Beginner Onboarding</p>
         <h2 className="max-w-4xl text-3xl font-semibold tracking-tight text-ink sm:text-4xl">
-          Guided starting pathways for evidence-aware exploration
+          Guided starting pathways for evidence-informed exploration
         </h2>
         <p className="detail-reading max-w-3xl text-[#46574d]">
           Start with a practical goal instead of jumping randomly between profiles. These onboarding pathways help organize exploration by fit, stimulation level, recovery orientation, and expected timeline.

--- a/src/components/compounds-browser-v2.tsx
+++ b/src/components/compounds-browser-v2.tsx
@@ -71,7 +71,7 @@ export default function CompoundsBrowserV2({ items }: Props) {
         <div className='pointer-events-none absolute -right-12 -top-10 h-40 w-40 rounded-full bg-emerald-300/35 blur-3xl' />
         <p className='text-[11px] font-black uppercase tracking-[0.24em] text-emerald-700'>Compounds v2.0</p>
         <h1 className='mt-2 text-3xl font-black leading-tight text-slate-900 sm:text-5xl'>Find compounds by outcome, not hype.</h1>
-        <p className='mt-3 max-w-2xl text-sm leading-6 text-slate-700 sm:text-base'>Fast, thumb-friendly discovery for evidence-aware compounds. Filter, scan, and jump straight into detailed profiles.</p>
+        <p className='mt-3 max-w-2xl text-sm leading-6 text-slate-700 sm:text-base'>Fast, thumb-friendly discovery for evidence-informed compounds. Filter, scan, and jump straight into detailed profiles.</p>
       </section>
 
       <section className='mt-4 space-y-3 rounded-2xl border border-white/50 bg-white/65 p-3.5 backdrop-blur-md sm:p-4'>

--- a/src/components/evidence-aware-cta.tsx
+++ b/src/components/evidence-aware-cta.tsx
@@ -16,9 +16,9 @@ type EvidenceAwareCTAProps = {
 function levelLabel(level: EvidenceAwareCTAProps['readiness']['level']) {
   switch (level) {
     case 'high':
-      return 'Evidence-forward context'
+      return 'Good sourcing context'
     case 'moderate':
-      return 'Moderate evidence context'
+      return 'Moderate context'
     case 'review':
       return 'Needs additional review'
     default:
@@ -40,8 +40,8 @@ function levelClass(level: EvidenceAwareCTAProps['readiness']['level']) {
 }
 
 export default function EvidenceAwareCTA({
-  title = 'Evidence-aware sourcing guidance',
-  description = 'Product and sourcing context should remain secondary to evidence quality, safety considerations, and mechanism uncertainty.',
+  title = 'Sourcing checkpoint',
+  description = 'Compare form, dose, label transparency, and safety fit before buying.',
   readiness,
   sourcingNotes = [],
   record,
@@ -85,20 +85,19 @@ export default function EvidenceAwareCTA({
       
 
       {showAffiliateButton ? (
-        <div className="rounded-3xl border border-brand-900/10 bg-white/80 p-4 shadow-sm">
+        <div className="rounded-[0.9rem] border border-brand-900/10 bg-white/85 p-3 shadow-sm">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="max-w-2xl">
               <p className="eyebrow-label">Optional sourcing link</p>
-              <p className="mt-1 text-sm leading-6 text-[#46574d]">
-                This link is provided for sourcing review only. Compare labels, ingredient form,
-                serving context, and seller transparency before considering any product.
+              <p className="mt-1 text-sm leading-5 text-[#46574d]">
+                Compare labels, ingredient form, serving context, and seller transparency.
               </p>
             </div>
             <a
               href={affiliate.affiliateUrl}
               target="_blank"
               rel="nofollow sponsored noopener noreferrer"
-              className="inline-flex items-center justify-center rounded-full border border-brand-900/15 bg-brand-950 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:-translate-y-0.5 hover:bg-brand-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-700"
+              className="inline-flex items-center justify-center rounded-full border border-brand-900/15 bg-brand-950 px-4 py-2 text-sm font-bold text-white shadow-sm transition hover:-translate-y-0.5 hover:bg-brand-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-700"
             >
               {affiliate.affiliateLabel}
             </a>
@@ -107,18 +106,18 @@ export default function EvidenceAwareCTA({
       ) : null}
       </div>
 
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
         {recommendationCards.map((card) => (
-          <article key={card.label} className="rounded-2xl border border-brand-900/10 bg-white/75 p-4 shadow-sm">
+          <article key={card.label} className="rounded-[0.8rem] border border-brand-900/10 bg-white/80 p-3 shadow-sm">
             <p className="text-[0.68rem] font-bold uppercase tracking-[0.16em] text-brand-900/55">{card.label}</p>
-            <p className="mt-2 text-sm font-semibold leading-6 text-[#33443a]">{card.value}</p>
+            <p className="mt-1 text-sm font-semibold leading-5 text-[#33443a]">{card.value}</p>
           </article>
         ))}
       </div>
 
-      <div className="grid gap-4 lg:grid-cols-[1fr_0.9fr]">
+      <div className="grid gap-3 lg:grid-cols-[1fr_0.9fr]">
         <article className="compact-card section-rhythm-compact">
-          <p className="eyebrow-label">Why this profile may warrant deeper exploration</p>
+          <p className="eyebrow-label">Why it may fit</p>
 
           <div className="flex flex-wrap gap-2">
             {readiness.reasons.length > 0 ? (
@@ -136,9 +135,9 @@ export default function EvidenceAwareCTA({
         </article>
 
         <article className="compact-card section-rhythm-compact">
-          <p className="eyebrow-label">Evidence-aware sourcing notes</p>
+          <p className="eyebrow-label">Sourcing notes</p>
 
-          <ul className="space-y-2 text-sm leading-6 text-[#46574d]">
+          <ul className="space-y-1.5 text-sm leading-6 text-[#46574d]">
             {sourcingNotes.slice(0, 5).map((note) => (
               <li key={note}>• {note}</li>
             ))}

--- a/src/components/evidence-aware-recommendations.tsx
+++ b/src/components/evidence-aware-recommendations.tsx
@@ -98,7 +98,7 @@ export default function EvidenceAwareRecommendations({
       label: 'Preparation Context',
     },
     {
-      title: 'Evidence-aware sourcing signals',
+      title: 'Evidence-informed sourcing signals',
       description:
         'Standardization transparency, third-party testing, and ingredient clarity matter more than aggressive marketing claims.',
       confidence: 'stronger',

--- a/src/components/profile-authority-sections.tsx
+++ b/src/components/profile-authority-sections.tsx
@@ -513,7 +513,7 @@ function EcosystemIntelligence({ record, relatedRecords, entityType, compact }: 
     },
     {
       title: 'Related Topics',
-      description: 'Adjacent topics can guide exploration while keeping claims evidence-aware.',
+      description: 'Adjacent topics can guide exploration while keeping claims evidence-informed.',
       items: fields.relatedTopics.slice(0, 8),
     },
   ].filter(section => section.items.length > 0)
@@ -532,7 +532,7 @@ function EcosystemIntelligence({ record, relatedRecords, entityType, compact }: 
       title={fields.authoritySupernode ? 'Authority Ecosystem Anchor' : 'Semantic Ecosystem'}
       compact={compact}
       description={fields.authoritySupernode
-        ? 'This profile acts as a high-density navigation anchor in the workbook knowledge graph; relationships remain conservative and evidence-aware.'
+        ? 'This profile acts as a high-density navigation anchor in the workbook knowledge graph; relationships remain conservative and evidence-informed.'
         : 'Workbook ecosystem fields are normalized into compact discovery context so profiles connect without creating noisy recommendation grids.'}
     >
       {authorityItems.length > 0 ? <AuthoritySignals signals={authorityItems.slice(0, 6)} /> : null}
@@ -744,7 +744,7 @@ function GraphIntelligenceRails({ comparisonRecords, stackRecords, entityType, c
     <AuthorityCard
       title="Graph Intelligence"
       compact={compact}
-      description="Graph candidates are shown as evidence-aware context only. They do not imply superiority, treatment recommendations, or dosing guidance."
+      description="Graph candidates are shown as context only. They do not imply superiority, treatment recommendations, or dosing guidance."
     >
       <div className="space-y-6">
         {comparisons.length > 0 ? (

--- a/src/components/profile-progressive-disclosure.tsx
+++ b/src/components/profile-progressive-disclosure.tsx
@@ -199,7 +199,7 @@ export default function ProfileProgressiveDisclosure({
         <p className="eyebrow-label">Read Deeper</p>
         <h2 className="compact-heading">Details without the wall of text.</h2>
         <p className="compact-copy">
-          The main page keeps interpretation first. Expand these sections only when you want the deeper evidence, mechanism, safety, or practical context.
+          The main page keeps interpretation first. Expand only when you need deeper evidence, safety, or practical context.
         </p>
       </div>
 

--- a/src/components/profile-semantic-rail.tsx
+++ b/src/components/profile-semantic-rail.tsx
@@ -117,7 +117,7 @@ export default function ProfileSemanticRail({
 
       <RailSection
         title="Comparison Candidates"
-        description="Evidence-aware comparison prompts for side-by-side exploration, not superiority claims."
+        description="Evidence-informed comparison prompts for side-by-side exploration, not superiority claims."
         items={compactComparisons}
         entityType={entityType}
         reason="Comparison"

--- a/src/components/profile/AuthorityEditorialLayer.tsx
+++ b/src/components/profile/AuthorityEditorialLayer.tsx
@@ -77,7 +77,7 @@ export default function AuthorityEditorialLayer({
           </h2>
 
           <p className="max-w-3xl text-sm leading-7 text-[#5b6b61]">
-            A compact, evidence-aware reading of the profile before deeper mechanism and safety context.
+            A compact, compact reading of the profile before deeper mechanism and safety context.
           </p>
         </div>
 

--- a/src/components/protocols/ProtocolTemplate.tsx
+++ b/src/components/protocols/ProtocolTemplate.tsx
@@ -22,7 +22,7 @@ export default function ProtocolTemplate({
       <section className="space-y-5">
         <div className="space-y-2">
           <p className="eyebrow-label">Suggested Components</p>
-          <h2>Evidence-aware protocol profiles</h2>
+          <h2>Evidence-informed protocol profiles</h2>
         </div>
 
         <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">

--- a/src/components/semantic-collection-grid.tsx
+++ b/src/components/semantic-collection-grid.tsx
@@ -16,7 +16,7 @@ export default function SemanticCollectionGrid() {
         </h2>
 
         <p className="compact-copy">
-          Collections organize herbs and compounds into evidence-aware semantic ecosystems centered around pathways, mechanisms, goals, and research continuity.
+          Collections organize herbs and compounds into semantic ecosystems centered around pathways, mechanisms, goals, and research continuity.
         </p>
       </div>
 

--- a/src/components/semantic-compare-system.tsx
+++ b/src/components/semantic-compare-system.tsx
@@ -176,7 +176,7 @@ export default function SemanticCompareSystem({
   return (
     <div className="section-rhythm-balanced">
       <CompareRail
-        eyebrow="Evidence-aware alternatives"
+        eyebrow="Evidence-informed alternatives"
         title="Stronger evidence comparisons"
         description="Profiles surfaced through broader human evidence, richer clinical interpretation, or stronger publication maturity."
         items={strongerEvidence}

--- a/src/components/semantic-operating-system.tsx
+++ b/src/components/semantic-operating-system.tsx
@@ -26,7 +26,7 @@ export default function SemanticOperatingSystem({
   source,
   candidates = [],
   title = 'Semantic exploration command center',
-  description = 'A unified layer for continuing research threads, following adjacent pathways, comparing related profiles, and moving through evidence-aware ecosystems.',
+  description = 'A unified layer for continuing research threads, following adjacent pathways, comparing related profiles, and moving through research ecosystems.',
 }: SemanticOperatingSystemProps) {
   const current = source || fallbackSource()
   const traversal = buildAdaptiveTraversal(current, candidates, 6)

--- a/src/components/semantic-search-discovery.tsx
+++ b/src/components/semantic-search-discovery.tsx
@@ -121,7 +121,7 @@ export default function SemanticSearchDiscovery({ records }: SemanticSearchDisco
         </h2>
 
         <p className="compact-copy">
-          Search surfaces pathway-adjacent profiles, mechanism overlap, and evidence-aware semantic relationships instead of relying only on exact keyword matching.
+          Search surfaces pathway-adjacent profiles, mechanism overlap, and semantic relationships instead of relying only on exact keyword matching.
         </p>
       </div>
 

--- a/src/components/ui/DetailTabDashboard.tsx
+++ b/src/components/ui/DetailTabDashboard.tsx
@@ -22,20 +22,21 @@ export default function DetailTabDashboard({ tabs, defaultTab }: DetailTabDashbo
   const activeTab = tabs.find(tab => tab.id === activeTabId) || tabs[0]
 
   return (
-    <div className="w-full space-y-6 sm:space-y-8">
+    <div id="profile-tabs" className="w-full space-y-4 sm:space-y-5">
       {/* Tab Navigation Container */}
       <div className="border-b border-brand-900/10 pb-px">
         {/* Mobile: Scrollable pill-shaped navigation */}
-        <div className="flex sm:hidden overflow-x-auto pb-3 -mx-4 px-4 snap-x scrollbar-none gap-2">
+        <div className="flex sm:hidden overflow-x-auto pb-2 -mx-4 px-4 snap-x scrollbar-none gap-1.5">
           {tabs.map((tab) => {
             const isActive = tab.id === activeTabId
             return (
               <button
                 key={tab.id}
+                id={`${tab.id}-tab-mobile`}
                 type="button"
                 onClick={() => setActiveTabId(tab.id)}
                 className={clsx(
-                  "snap-center shrink-0 min-h-10 px-4 py-2 rounded-full text-xs font-bold uppercase tracking-wider transition-all duration-200 border",
+                  "snap-center shrink-0 min-h-8 px-3 py-1.5 rounded-full text-xs font-bold uppercase tracking-wider transition-all duration-200 border",
                   isActive
                     ? "bg-brand-800 border-brand-800 text-white shadow-sm"
                     : "bg-white/80 border-brand-900/10 text-brand-900 hover:bg-white hover:text-brand-800"
@@ -51,16 +52,17 @@ export default function DetailTabDashboard({ tabs, defaultTab }: DetailTabDashbo
         </div>
 
         {/* Desktop: Horizontal tab row with sliding indicator line */}
-        <div className="hidden sm:flex items-center gap-6 md:gap-8">
+        <div className="hidden sm:flex items-center gap-4 md:gap-5">
           {tabs.map((tab) => {
             const isActive = tab.id === activeTabId
             return (
               <button
                 key={tab.id}
+                id={`${tab.id}-tab`}
                 type="button"
                 onClick={() => setActiveTabId(tab.id)}
                 className={clsx(
-                  "relative py-4 text-sm font-semibold tracking-tight transition duration-200 focus:outline-none",
+                  "relative py-3 text-sm font-semibold tracking-tight transition duration-200 focus:outline-none",
                   isActive ? "text-brand-800" : "text-muted hover:text-ink"
                 )}
               >
@@ -83,7 +85,7 @@ export default function DetailTabDashboard({ tabs, defaultTab }: DetailTabDashbo
       </div>
 
       {/* Tab Panel Content Container */}
-      <div className="relative min-h-[300px]">
+      <div className="relative min-h-[220px]">
         <AnimatePresence mode="wait">
           <motion.div
             key={activeTabId}
@@ -91,9 +93,10 @@ export default function DetailTabDashboard({ tabs, defaultTab }: DetailTabDashbo
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -8 }}
             transition={{ duration: 0.18, ease: "easeInOut" }}
+            id={activeTab?.id}
             className="focus:outline-none"
           >
-            <div className="space-y-6 sm:space-y-8">
+            <div className="space-y-4 sm:space-y-5">
               {activeTab?.content}
             </div>
           </motion.div>

--- a/src/lib/best-explored-topics.ts
+++ b/src/lib/best-explored-topics.ts
@@ -10,7 +10,7 @@ export const bestExploredTopics: BestExploredTopic[] = [
   {
     slug: 'sleep',
     title: 'Best explored for sleep support',
-    description: 'Evidence-aware exploration of calming, circadian, and recovery-oriented profiles connected to sleep quality pathways.',
+    description: 'Evidence-informed exploration of calming, circadian, and recovery-oriented profiles connected to sleep quality pathways.',
     keywords: ['sleep', 'gaba', 'relaxation', 'calm', 'circadian', 'recovery'],
     intent: 'sleep',
   },
@@ -31,7 +31,7 @@ export const bestExploredTopics: BestExploredTopic[] = [
   {
     slug: 'inflammation',
     title: 'Best explored for inflammation pathways',
-    description: 'Evidence-aware exploration of oxidative stress, inflammatory signaling, and recovery-oriented ecosystems.',
+    description: 'Evidence-informed exploration of oxidative stress, inflammatory signaling, and recovery-oriented ecosystems.',
     keywords: ['inflammation', 'oxidative', 'immune', 'recovery', 'pain'],
     intent: 'inflammation',
   },

--- a/src/lib/semantic-artwork-registry.ts
+++ b/src/lib/semantic-artwork-registry.ts
@@ -96,7 +96,7 @@ export function getSemanticArtwork(slug?: string | null, kind: SemanticArtworkKi
     slug: normalized || 'default',
     kind,
     title: 'Scientific ecosystem visual',
-    alt: 'Abstract scientific ecosystem artwork representing evidence-aware semantic relationships',
+    alt: 'Abstract scientific ecosystem artwork representing semantic relationships',
     palette: { base: '#f4f8f2', mid: '#deeae1', accent: '#2f7d4b', ink: '#173322' },
     motifs: ['network', 'evidence', 'pathway'],
   }

--- a/src/lib/semantic-collections.ts
+++ b/src/lib/semantic-collections.ts
@@ -33,7 +33,7 @@ export const semanticCollections: SemanticCollection[] = [
   {
     slug: 'inflammation-and-recovery-networks',
     title: 'Inflammation and recovery networks',
-    description: 'Evidence-aware profiles connected to inflammatory signaling, oxidative stress, repair, and recovery ecosystems.',
+    description: 'Profiles connected to inflammatory signaling, oxidative stress, repair, and recovery ecosystems.',
     intent: 'mechanism',
     keywords: ['inflammation', 'recovery', 'oxidative', 'pain', 'immune', 'cox', 'nf-kb'],
   },

--- a/src/lib/viralContent.ts
+++ b/src/lib/viralContent.ts
@@ -65,7 +65,7 @@ export function buildHerbViralHooks(herb: ViralHerb): HerbViralHooks {
     didYouKnow,
     beginnerExplanation: `${name} is best understood as a plant profile with effects, mechanisms, and safety boundaries that change by preparation and person.`,
     safetyInsight: `Safety insight: ${safety}`,
-    whyItMatters: `${name} matters because understanding its mechanism and risks helps people make lower-risk, evidence-aware decisions.`,
+    whyItMatters: `${name} matters because understanding its mechanism and risks helps people make lower-risk, lower-risk decisions.`,
   }
 }
 


### PR DESCRIPTION
### Motivation
- The site felt visually heavy, over-carded, and repetitively marketing-focused, so the goal was a surgical subtraction pass to make pages denser, prioritize decision signals, and surface affiliate CTAs earlier without changing data pipelines or core routes. 

### Description
- Compressed global rhythm by trimming card radii, reducing shadows, lowering paddings/margins, and scaling down heading sizes in `app/globals.css` (smaller `--radius-card-*`, reduced `--shadow-*`, tighter spacing and font sizes). 
- Tightened shared primitives and cards: `components/ui/DecisionPrimitives.tsx`, `components/ui/EvidenceSnapshotPanel.tsx`, `src/components/ui/DetailTabDashboard.tsx`, `components/ui/CompoundHero.tsx`, and `components/ui/DecisionPrimitives.tsx` were adjusted to use smaller paddings, smaller chips, reduced gaps, and shorter micro copy. 
- Compressed collection/index and hero layouts and made detail pages prioritize practical signals by moving one-line decision summary, `Best for`, `Avoid if`, safety status, evidence strength, jump-links and an early affiliate sourcing CTA into the top-left column of `app/herbs/[slug]/page.tsx` and `app/compounds/[slug]/page.tsx` (added `getAffiliateShopLinks` integration to surface a primary shop link when available). 
- Homepage, index clients, and discovery surfaces were compacted (`components/homepage-v2.tsx`, `app/herbs/HerbsIndexClient.tsx`, `app/compounds/CompoundsIndexClient.tsx`) and repeated brand/messaging phrases like “evidence-aware” were consolidated or replaced with leaner phrasing to reduce marketing fluff while keeping safety and evidence content. 
- Kept all safety/evidence content, affiliate plumbing, static-export compatibility, and workbook/data pipeline intact; changes are purely presentational and route-preserving. 
- Files touched (representative): `app/globals.css`, `components/homepage-v2.tsx`, `app/page.tsx`, `app/herbs/[slug]/page.tsx`, `app/compounds/[slug]/page.tsx`, `app/herbs/HerbsIndexClient.tsx`, `app/compounds/CompoundsIndexClient.tsx`, `components/ui/DecisionPrimitives.tsx`, `components/ui/EvidenceSnapshotPanel.tsx`, `src/components/ui/DetailTabDashboard.tsx`, `components/ui/CompoundHero.tsx`, `src/components/evidence-aware-cta.tsx`, `components/AffiliateBlock.tsx`, plus a number of editorial text cleanups across `app/` and `src/` files. 

### Testing
- Commands run: `npm run typecheck`, `npm run lint`, `npm run validate:route-seo`, `npm run validate:static-export`, `npm run build`, and `npm run verify:build` (build includes the data pipeline steps per project conventions). 
- `npm run typecheck` completed successfully after a small import fix for the CTA component alias and string replacements. 
- `npm run lint` completed (no blocking lint failures were produced during the run). 
- `npm run validate:route-seo` and `npm run validate:static-export` passed, and a full `npm run build` completed producing the `out/` static export; page generation succeeded (1,407 static pages). 
- `npm run verify:build` initially failed because the `out/` directory was missing before a build, but after running `npm run build` the verification steps ran; the build produced some non-blocking audit warnings: `internal-links` reported 15 orphan pages, `structured-data` reported many missing/malformed items (sampled), and `seo-routes` produced 15 severe but non-blocking warnings; deploy-readiness flagged a WARN for `sitemap.xml` missing (allowed in MVP). 
- Exact failures/warnings to follow up on: `verify:build` pre-check error for missing `out/` (fixed by running `build`), `internal-links` orphan=15, `structured-data` missing=1417 malformed=15, `seo-routes` severe=15, and `deploy-readiness` WARN about `sitemap.xml` (informational). 
- What still feels bloated / needs another pass: large shared first-load JS (~103 kB) and some multi-column hero surfaces still use relatively generous visual weight; repeated chip rows and some evidence/detail panels could be further reduced (next pass: audit `DecisionProfileCard` density, reduce first-load chunk weight, and further compact evidence badge clusters).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19bdd14d108323b8c0041744295caf)