### PR TITLE
Add product vision strategy

### DIFF
--- a/docs/product/product-vision.md
+++ b/docs/product/product-vision.md
@@ -1,0 +1,618 @@
+# Product Vision for The Hippie Scientist
+
+Date: 2026-05-30
+Scope: product strategy, user experience, trust systems, recommendation strategy, comparison strategy, safety strategy, retention, and affiliate monetization. No code or route changes are proposed here.
+
+## Executive vision
+
+The ideal future version of The Hippie Scientist is the decision layer between supplement curiosity and supplement purchase.
+
+Users should visit because they have a real-life problem — poor sleep, stress, anxiety, brain fog, fatigue, inflammation, gut discomfort, focus, recovery, or a specific herb they heard about — and they do not know what is worth trying, what is unsafe, what is overhyped, or what to buy.
+
+Users should return because the site remembers the deeper job they are trying to solve: comparing options, avoiding bad fits, tracking a shortlist, learning how ingredients differ, and checking new products against a consistent evidence-and-safety standard.
+
+Users should trust recommendations because The Hippie Scientist does not behave like a generic affiliate blog. It should be visibly evidence-aware, safety-first, transparent about uncertainty, cautious about medical claims, clear about conflicts of interest, and specific about product-quality signals.
+
+Users should click affiliate links because the site earns the right to make a buying suggestion only after helping them answer four questions:
+
+1. Is this ingredient relevant to my goal?
+2. Is it a safe fit for my context?
+3. What form, preparation, or standardization should I look for?
+4. Which product options pass basic quality checks?
+
+The product should become the place where a skeptical, health-conscious buyer goes before opening Amazon, iHerb, a brand site, Reddit, TikTok, or Google.
+
+## 1. Core Value Proposition
+
+### Short version
+
+**Evidence-first supplement decisions for people who want benefits without hype, unsafe shortcuts, or low-quality products.**
+
+### Expanded version
+
+The Hippie Scientist helps users choose herbs, compounds, and supplement stacks by translating a complex research database into practical decision support:
+
+- what an ingredient may help with,
+- how strong or limited the evidence appears,
+- which mechanisms plausibly explain the effect,
+- which safety cautions matter,
+- how it compares with alternatives,
+- what product-quality signals to inspect before buying,
+- and when the safest recommendation is not to buy.
+
+The brand promise is not “we found the magic supplement.” The brand promise is:
+
+> “We help you decide what is worth considering, what to avoid, and what to look for if you buy.”
+
+### Product wedge
+
+The initial wedge should be high-intent supplement decisions where users already expect to spend money and where confusion creates demand for trusted guidance:
+
+- sleep,
+- stress and calm,
+- anxiety-adjacent support,
+- focus and brain fog,
+- fatigue and energy,
+- inflammation and recovery,
+- gut health,
+- joint support,
+- blood pressure support,
+- hormone and testosterone-adjacent support.
+
+The long-term wedge is broader: a structured, source-aware, safety-aware recommendation system for natural products that can out-trust both generic affiliate sites and unstructured social media advice.
+
+## 2. Primary User Types
+
+### 2.1 The skeptical buyer
+
+**Mindset:** “I am willing to buy a supplement, but I do not trust supplement marketing.”
+
+**Jobs to be done:**
+
+- Find which ingredients are plausible for a goal.
+- Avoid wasting money on weak or mismatched products.
+- Understand which form or standardization matters.
+- See why a product is recommended before clicking out.
+
+**What wins them:**
+
+- concise comparisons,
+- transparent evidence strength,
+- explicit tradeoffs,
+- third-party-testing and quality signals,
+- clear disclosure that affiliate revenue does not determine evidence conclusions.
+
+### 2.2 The symptom-led researcher
+
+**Mindset:** “I have a problem — sleep, stress, anxiety, fatigue, focus — and I need a safe starting point.”
+
+**Jobs to be done:**
+
+- Start from a goal, not an ingredient.
+- Narrow from many possible supplements to a few reasonable options.
+- Understand cautions before being pushed to buy.
+- Compare natural options with familiar defaults, such as melatonin for sleep.
+
+**What wins them:**
+
+- goal pages that explain option categories,
+- decision trees,
+- safety triage,
+- “best fit if / avoid if” framing,
+- simple next steps.
+
+### 2.3 The ingredient-led researcher
+
+**Mindset:** “I heard about ashwagandha, kava, magnesium, berberine, lion's mane, or another ingredient. Should I care?”
+
+**Jobs to be done:**
+
+- Validate a specific herb or compound.
+- Learn benefits, mechanisms, risks, and common uses.
+- See alternatives and comparisons.
+- Determine whether the ingredient is commerce-ready and what to buy if it is.
+
+**What wins them:**
+
+- deep profiles,
+- concise decision snapshots,
+- related comparisons,
+- quality checklist by ingredient,
+- clear “not a fit” warnings.
+
+### 2.4 The safety-sensitive user
+
+**Mindset:** “I may be pregnant, medicated, managing a condition, sensitive to side effects, or buying for someone vulnerable.”
+
+**Jobs to be done:**
+
+- Identify contraindications and interaction risks early.
+- Understand when to consult a clinician.
+- Avoid ingredients that are inappropriate for their context.
+- Find lower-risk alternatives or non-purchase guidance.
+
+**What wins them:**
+
+- above-the-fold safety notices,
+- interaction and population cautions,
+- no pressure to buy,
+- consistent language across route families,
+- clear educational boundaries.
+
+### 2.5 The optimizer and stack builder
+
+**Mindset:** “I already use supplements and want to compare, combine, or upgrade them intelligently.”
+
+**Jobs to be done:**
+
+- Compare ingredients by mechanism and goal fit.
+- Avoid redundant or risky combinations.
+- Build a shortlist.
+- Upgrade from generic products to better forms or sourcing.
+
+**What wins them:**
+
+- stack logic,
+- comparison tables,
+- mechanism clustering,
+- “do not combine casually” warnings,
+- product-quality filters.
+
+## 3. User Journeys
+
+### 3.1 Goal-first journey: “I need help sleeping”
+
+1. User lands on a sleep discovery, goal, top, comparison, or SEO entry page.
+2. Page states the decision frame: sleep onset, sleep maintenance, stress-driven sleep, circadian rhythm, next-day grogginess, safety context.
+3. User sees a small set of candidate options with evidence strength, safety flags, and best-fit notes.
+4. User chooses a comparison, such as magnesium vs melatonin or sleep herbs vs melatonin.
+5. The comparison explains tradeoffs and redirects to ingredient profiles for depth.
+6. If fit is reasonable, user sees a product-selection module with form, quality signals, and curated affiliate options.
+7. User clicks only after understanding why that product type is relevant.
+8. After purchase or research, user returns to save, compare, or check another option.
+
+**Success metric:** qualified affiliate click-through from a high-intent goal or comparison page after evidence and safety engagement.
+
+### 3.2 Ingredient-first journey: “Should I take ashwagandha?”
+
+1. User lands on an herb or compound profile.
+2. Page answers “what it is,” “what it may help with,” “evidence strength,” “how it works,” and “who should be cautious.”
+3. User sees a decision snapshot: best fit, poor fit, interaction cautions, alternatives.
+4. User compares it against nearby options for the same goal.
+5. If ingredient quality matters, the page explains form, extract ratio, standardization, testing, and sourcing.
+6. Affiliate CTAs appear as “compare verified product options,” not as generic buy buttons.
+7. User exits to a product because the profile has reduced perceived purchase risk.
+
+**Success metric:** profile-to-comparison engagement, then affiliate click-through on commerce-ready ingredients.
+
+### 3.3 Safety-first journey: “Can I take this with my context?”
+
+1. User arrives from search with a safety concern, medication concern, pregnancy concern, condition concern, or adverse-effect query.
+2. Page surfaces safety context before product CTAs.
+3. User receives conservative guidance and links to relevant ingredient profiles or alternatives.
+4. If the risk context is high, the site deliberately withholds commercial CTAs or moves them below stronger disclaimers.
+5. User trusts the brand more because the site is willing to reduce monetization when safety risk is high.
+
+**Success metric:** safety page engagement, return visits, and downstream trust-assisted conversions rather than immediate clicks.
+
+### 3.4 Comparison-first journey: “Which is better?”
+
+1. User lands on a comparison page from a “vs” query or internal link.
+2. Page clarifies that “better” depends on goal, onset speed, side-effect tolerance, contraindications, evidence strength, and product quality.
+3. User sees side-by-side decision criteria rather than a single universal winner.
+4. Page suggests a best-fit branch: choose A if, choose B if, avoid both if, consider alternatives if.
+5. Affiliate modules appear only where a branch is commerce-ready and safety-appropriate.
+
+**Success metric:** comparison pages become high-converting bridges from informational uncertainty to product-qualified clicks.
+
+### 3.5 Return journey: “Help me keep deciding”
+
+1. User saves a shortlist of ingredients, goals, or comparisons.
+2. User receives a reason to return: a saved decision board, safety reminders, new evidence updates, product-quality updates, or a personalized checklist.
+3. User reopens the site before buying, changing products, or stacking supplements.
+4. The site becomes a supplement decision companion rather than a one-time article.
+
+**Success metric:** repeat sessions, saved items, email signups, shortlist revisits, and assisted affiliate conversions.
+
+## 4. Recommendation Engine Concept
+
+### Product goal
+
+The recommendation engine should convert a large scientific content library into a small set of context-aware recommendations that feel useful, conservative, and explainable.
+
+### Recommendation philosophy
+
+Recommendations should be:
+
+- **goal-aware:** tied to a specific user outcome, not a generic ranking,
+- **evidence-aware:** weighted by signal quality and uncertainty,
+- **safety-aware:** filtered or downgraded by contraindications and interaction concerns,
+- **commerce-aware:** only monetized when product-quality guidance is strong enough,
+- **explainable:** every recommendation should answer “why this,” “why not that,” and “what to watch out for.”
+
+### Inputs
+
+The future engine should use structured inputs such as:
+
+- goal fit,
+- evidence strength,
+- mechanism relevance,
+- onset and duration expectations,
+- common user intent,
+- safety flags,
+- population cautions,
+- interaction risk,
+- preparation and standardization requirements,
+- product-quality availability,
+- affiliate readiness,
+- editorial review status.
+
+### Outputs
+
+The user-facing output should avoid black-box scores. Instead, it should produce:
+
+- “Best starting points for this goal,”
+- “Worth considering if...,”
+- “Avoid or use extra caution if...,”
+- “More evidence, more risk,”
+- “Lower risk, less direct evidence,”
+- “Most product-quality-sensitive,”
+- “Not enough confidence to recommend buying.”
+
+### Founder-level product insight
+
+The key is not to recommend more things. The key is to reduce the user's option set while increasing confidence.
+
+A good recommendation page should make the user feel:
+
+> “I understand why these three options made the shortlist, why others did not, and what would make me choose one over another.”
+
+## 5. Comparison Engine Concept
+
+### Product goal
+
+The comparison engine should own the moment when users are closest to purchase but still uncertain.
+
+Most supplement buyers do not only ask “what is good for sleep?” They ask:
+
+- magnesium vs melatonin,
+- ashwagandha vs rhodiola,
+- kava vs passionflower,
+- berberine vs cinnamon,
+- lion's mane vs bacopa,
+- turmeric vs boswellia,
+- L-theanine vs GABA.
+
+These “versus” moments are commercially valuable because the user has narrowed the category but needs a final decision framework.
+
+### Comparison dimensions
+
+Each comparison should standardize around practical axes:
+
+- primary goal fit,
+- evidence strength,
+- mechanism difference,
+- onset and use case,
+- side-effect profile,
+- medication and condition cautions,
+- population cautions,
+- product-quality complexity,
+- cost and availability,
+- best-fit user profile,
+- avoid-if user profile.
+
+### Output format
+
+The ideal comparison should end with decision branches, not a winner-take-all claim:
+
+- **Choose A if...**
+- **Choose B if...**
+- **Avoid both if...**
+- **Compare alternatives if...**
+- **If buying, check these product-quality signals...**
+
+### Monetization role
+
+The comparison engine should be the highest-intent affiliate bridge. It can support:
+
+- side-by-side product modules,
+- “best form for this use case” recommendations,
+- price and quality tradeoff explanations,
+- ingredient-specific product checklists,
+- outbound links that reflect the user's selected branch.
+
+### Trust guardrail
+
+Comparison pages must never imply clinical superiority from weak or heuristic data. They should frame ranking as decision support and route users to safety details before purchase when risk is non-trivial.
+
+## 6. Safety Engine Concept
+
+### Product goal
+
+The safety engine should become a visible reason users trust the brand and a hidden reason recommendations are better.
+
+In the supplement market, safety is not a legal footnote. It is part of product-market fit.
+
+### Safety engine principles
+
+1. **Safety before conversion:** Product CTAs should be delayed, softened, or suppressed when risk context is high.
+2. **Context changes recommendations:** An ingredient can be reasonable for one user and inappropriate for another.
+3. **Warnings should be specific:** “Use caution” is weaker than naming medication classes, pregnancy, liver concerns, sedation, blood pressure, bleeding risk, or stimulant sensitivity where relevant.
+4. **Uncertainty is a feature:** Clear uncertainty increases trust when users know the site is not exaggerating certainty.
+5. **Consistency matters:** Safety language should not vary meaningfully just because a user entered through a top page instead of a goal page.
+
+### Safety inputs
+
+The safety engine should eventually consider:
+
+- pregnancy and lactation cautions,
+- medication interaction categories,
+- condition-specific cautions,
+- age or vulnerable-population flags,
+- sedation and impairment risk,
+- blood pressure and blood sugar effects,
+- bleeding and surgery considerations,
+- liver and kidney concerns,
+- stimulant or psychiatric cautions,
+- allergy and sensitivity notes,
+- combination and stacking risk.
+
+### Safety outputs
+
+The user-facing product should include:
+
+- above-the-fold safety summaries,
+- “not a fit if...” warnings,
+- “ask a clinician first if...” prompts,
+- “avoid combining casually with...” notes,
+- safer alternative paths,
+- product CTA suppression rules for high-risk contexts,
+- a visible rationale when a recommendation is withheld.
+
+### Trust outcome
+
+A user should leave with the impression that The Hippie Scientist is willing to say:
+
+> “Do not buy this yet.”
+
+That sentence may reduce one click today, but it creates the long-term trust required for repeat visits and higher-quality affiliate clicks.
+
+## 7. Affiliate Monetization Strategy
+
+### Monetization thesis
+
+Affiliate revenue should come from qualified decision moments, not scattered generic links.
+
+The site should monetize when the user has passed through a trustworthy sequence:
+
+1. understand the evidence,
+2. check personal fit and safety,
+3. compare alternatives,
+4. inspect product-quality criteria,
+5. choose a vetted outbound option.
+
+### Product registry strategy
+
+The most important commerce upgrade is a curated product registry for a small set of high-value ingredients and goals before broad scaling.
+
+Each product or product category should store:
+
+- ingredient identity,
+- form or preparation,
+- standardization details when relevant,
+- third-party testing or COA status when available,
+- contaminant and purity signals,
+- allergen or excipient notes when available,
+- price and serving economics where appropriate,
+- merchant and affiliate URL,
+- editorial review status,
+- last reviewed date.
+
+### Initial monetization focus
+
+Prioritize high-intent, repeat-purchase, high-confusion categories:
+
+1. sleep support,
+2. stress and calm,
+3. focus and brain fog,
+4. fatigue and energy,
+5. inflammation and joint support,
+6. gut health,
+7. blood sugar and metabolic support,
+8. hormone-adjacent support.
+
+### CTA strategy
+
+Replace generic commercial language with high-trust conversion language:
+
+- “Compare quality-checked options,”
+- “See what to look for before buying,”
+- “Check third-party-tested options,”
+- “Compare forms and sourcing,”
+- “View product options for this use case.”
+
+Avoid overly aggressive language:
+
+- “Buy now,”
+- “Best supplement guaranteed,”
+- “Works for everyone,”
+- “Doctor recommended” unless substantiated,
+- “Clinically proven” unless source-backed and precise.
+
+### Affiliate disclosure strategy
+
+Affiliate disclosure should be plain, visible, and confidence-building:
+
+- The site may earn commissions from outbound product links.
+- Affiliate status does not determine evidence ratings or safety cautions.
+- Some recommendations intentionally do not include buy links when evidence, safety, or product-quality confidence is insufficient.
+
+### Funnel instrumentation
+
+Every monetized surface should be measurable by:
+
+- route,
+- goal,
+- ingredient,
+- comparison pair,
+- CTA label,
+- product module,
+- merchant,
+- affiliate readiness status,
+- safety-warning exposure,
+- click position.
+
+The business question should be answerable weekly:
+
+> “Which trustworthy decision moments create the most qualified outbound clicks?”
+
+## 8. Retention Features
+
+### Retention thesis
+
+The site should not rely only on one-time SEO traffic. It should create return behavior around ongoing supplement decisions.
+
+Users return when the product helps them maintain a living decision system.
+
+### 8.1 Saved shortlist
+
+Allow users to save herbs, compounds, stacks, goals, and comparisons into a personal shortlist.
+
+Return trigger:
+
+- “I was considering magnesium, glycine, and lemon balm. What did I decide?”
+
+Business value:
+
+- More return visits before purchase,
+- stronger assisted affiliate attribution,
+- clearer signals about commercial intent.
+
+### 8.2 Decision checklist
+
+For each goal or ingredient, provide a checklist:
+
+- evidence fit reviewed,
+- safety context reviewed,
+- interactions checked,
+- product form selected,
+- quality signals checked,
+- shortlist compared,
+- ready to buy or not ready.
+
+Return trigger:
+
+- “I want to finish my decision later.”
+
+### 8.3 Evidence and product-quality updates
+
+Let users follow ingredients, comparisons, or goals for updates:
+
+- new evidence summary,
+- safety-note change,
+- product-quality review update,
+- new comparison added,
+- product no longer recommended.
+
+Return trigger:
+
+- “Something changed about an ingredient I care about.”
+
+### 8.4 Personalized goal dashboard
+
+A lightweight dashboard could organize saved research by goal:
+
+- sleep shortlist,
+- stress shortlist,
+- focus shortlist,
+- avoid list,
+- products to compare,
+- questions to ask a clinician.
+
+Return trigger:
+
+- “I am managing multiple supplement decisions and need one place to track them.”
+
+### 8.5 Email course or guided decision series
+
+Offer non-hype email sequences around major jobs:
+
+- “Build a safer sleep supplement shortlist,”
+- “Compare calming herbs without overdoing sedation,”
+- “How to evaluate supplement labels,”
+- “What third-party testing really means.”
+
+Return trigger:
+
+- educational follow-up with direct links back to relevant decision pages.
+
+### 8.6 Post-click support
+
+After a user clicks out, the site can invite them to return for:
+
+- label review checklist,
+- interaction checklist,
+- side-effect watchlist,
+- comparison against alternatives,
+- reorder or upgrade guidance.
+
+Return trigger:
+
+- “Before I actually use this product, I want to sanity-check it.”
+
+## 9. Competitive Advantages
+
+### 9.1 Trust-first affiliate model
+
+Most supplement affiliate sites start with monetization and wrap it in thin content. The Hippie Scientist should start with evidence, safety, and decision quality, then monetize only when appropriate.
+
+This creates a brand advantage: users can believe recommendations because the site is visibly willing to withhold them.
+
+### 9.2 Two-layer content architecture
+
+The site can use discovery pages to capture broad intent and depth pages to provide scientific credibility. Discovery surfaces answer “where do I start?” Depth surfaces answer “why should I trust this?”
+
+The advantage is compounding internal linking: goal pages, comparison pages, herb profiles, compound profiles, stack pages, and educational guides can reinforce each other without changing route contracts.
+
+### 9.3 Structured safety moat
+
+Safety is hard to fake at scale. A consistent safety engine creates defensibility because it requires structured data, editorial judgment, conservative language, and clear UX placement.
+
+If executed well, safety becomes more than compliance. It becomes the reason users return.
+
+### 9.4 Explainable recommendations
+
+Black-box “best supplement” rankings are easy to copy and easy to distrust. Explainable recommendation branches are harder to copy because they connect evidence, mechanism, safety, goal fit, and product quality.
+
+The moat is not a score. The moat is the explanation.
+
+### 9.5 Product-quality specificity
+
+A generic affiliate link says “buy ashwagandha.” A trusted decision engine says:
+
+- what extract type matters,
+- what standardization means,
+- what testing signals to look for,
+- what claims are suspicious,
+- what user context changes the decision,
+- and which products pass the quality screen.
+
+That specificity is where affiliate clicks become higher intent.
+
+### 9.6 Static, indexable, scalable knowledge base
+
+The site's static architecture can support scalable SEO while preserving fast pages and stable route contracts. The future product should build smarter decision layers on top of that foundation rather than replacing it with a heavier dynamic application too early.
+
+### 9.7 Editorial independence as a growth loop
+
+Every cautious recommendation, safety warning, and “do not buy yet” moment reinforces brand memory. Users who feel protected are more likely to return, share, subscribe, and click when the site eventually does recommend a product.
+
+### 9.8 Founder-level north star
+
+The Hippie Scientist should be measured by its ability to create confident, safe, high-intent supplement decisions.
+
+The north-star metric should not be raw pageviews. It should be:
+
+> **Qualified decision completions:** sessions where a user reaches an evidence-informed, safety-aware next step — save, compare, avoid, ask a clinician, or click a product option.
+
+Affiliate revenue is the monetization output. Trustworthy decisions are the product.


### PR DESCRIPTION
### Motivation
- Capture a single, actionable product vision that turns the existing research database into an evidence-first decision engine aligned with the revenue-priority plan and trust audits. 
- Provide clear guidance for recommendation, comparison, and safety engines plus retention and affiliate monetization without touching runtime code, routes, or generated data. 
- Keep changes surgical and documentation-only to preserve route contracts and the static-export architecture.

### Description
- Add `docs/product/product-vision.md` containing the Core Value Proposition, Primary User Types, User Journeys, Recommendation Engine Concept, Comparison Engine Concept, Safety Engine Concept, Affiliate Monetization Strategy, Retention Features, and Competitive Advantages. 
- Ground the guidance in the repository audits and the revenue-priority plan, emphasizing explainable, safety-aware, evidence-weighted recommendations and a curated product-registry approach for initial monetization. 
- This is a docs-only change with no code, route, public/data, or workbook edits and is intended to steer small, reviewable implementation work.

### Testing
- Ran `git diff --cached --check` to validate staged changes and the check passed successfully. 
- No build, runtime, or workbook-dependent automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ad48f905c8323835e2b8f0a0a111b)