### PR TITLE
Generalize Evidence Engine infrastructure

### DIFF
--- a/app/goals/[goal]/SleepDecisionExperience.tsx
+++ b/app/goals/[goal]/SleepDecisionExperience.tsx
@@ -4,11 +4,12 @@ import type { Goal } from '@/data/goals'
 import {
   type EvidenceEngineClaim,
   formatEvidenceLabel,
+  getClaimProblemKey,
   getSafetySeverityTone,
   groupClaimsByDecisionGroup,
   groupSafetyNotesByIngredient,
 } from '@/lib/evidence-engine'
-import type { SleepEvidenceClaim, SleepEvidenceEnginePayload } from '@/lib/runtime-data'
+import type { SleepEvidenceEnginePayload } from '@/lib/runtime-data'
 
 type SleepOption = {
   option: {
@@ -34,34 +35,11 @@ type SleepDecisionExperienceProps = {
   structuredData?: ReactNode
 }
 
-const sleepProblemLabels: Record<string, { title: string; description: string }> = {
-  sleep_onset: {
-    title: 'Sleep onset',
-    description: 'Trouble getting sleepy or shifting into bedtime.',
-  },
-  sleep_quality: {
-    title: 'Sleep quality',
-    description: 'Light, unrefreshing, or inconsistent sleep.',
-  },
-  night_waking: {
-    title: 'Night waking',
-    description: 'Waking during the night or struggling to return to sleep.',
-  },
-  racing_mind: {
-    title: 'Racing mind',
-    description: 'Mental noise, tension, or bedtime rumination.',
-  },
-  relaxation: {
-    title: 'Relaxation',
-    description: 'A gentler wind-down target before stronger sedating approaches.',
-  },
-}
-
 function getProblemKey(claim: EvidenceEngineClaim): string {
-  return claim.sleep_problem || claim.problem || ''
+  return getClaimProblemKey(claim, 'sleep_problem')
 }
 
-function profileHrefFor(claim: SleepEvidenceClaim, enrichedOptions: SleepOption[]) {
+function profileHrefFor(claim: EvidenceEngineClaim, enrichedOptions: SleepOption[]) {
   const option = enrichedOptions.find((item) => item.option.slug === claim.ingredient_slug)
   return option?.profileHref || `/compounds/${claim.ingredient_slug}`
 }
@@ -72,10 +50,7 @@ export default function SleepDecisionExperience({
   structuredData,
 }: SleepDecisionExperienceProps) {
   const claims = sleepEvidence.claims
-  const problemLabels = {
-    ...sleepProblemLabels,
-    ...(sleepEvidence.problemLabels || {}),
-  }
+  const problemLabels = sleepEvidence.problemLabels
   const claimGroups = groupClaimsByDecisionGroup(claims)
   const safetyGroups = groupSafetyNotesByIngredient(sleepEvidence.safetyNotes)
   const hasEvidence = claims.length > 0

--- a/src/lib/evidence-engine.ts
+++ b/src/lib/evidence-engine.ts
@@ -97,7 +97,7 @@ export const confidenceDisplays: Record<EvidenceConfidenceTier, EvidenceConfiden
   insufficient: {
     label: 'Insufficient evidence',
     tone: 'bg-zinc-50 text-zinc-700 ring-zinc-200',
-    description: 'Not enough reliable evidence for a confident sleep decision.',
+    description: 'Not enough reliable evidence to support a confident decision.',
   },
 }
 
@@ -142,4 +142,9 @@ export function groupSafetyNotesByIngredient<Note extends EvidenceEngineSafetyNo
     groups[note.ingredient_slug].push(note)
     return groups
   }, {})
+}
+
+export function getClaimProblemKey(claim: EvidenceEngineClaim, problemField: string): string {
+  const value = (claim as Record<string, unknown>)[problemField]
+  return typeof value === 'string' ? value : (claim.problem || '')
 }

--- a/src/lib/runtime-data.ts
+++ b/src/lib/runtime-data.ts
@@ -13,7 +13,6 @@ import { getRuntimeVisibility } from '@/lib/runtime-visibility'
 const dataDir = path.join(process.cwd(), 'public', 'data')
 
 type RuntimeRecord = Record<string, any>
-type GoalEvidenceSlug = 'sleep' | 'stress' | 'anxiety'
 
 export type SleepEvidenceClaim = EvidenceEngineClaim & { sleep_problem: string }
 export type SleepEvidenceSource = EvidenceEngineSource
@@ -75,7 +74,7 @@ function normalizeEvidenceSourcesByClaim(value: unknown): Record<string, Evidenc
   )
 }
 
-function normalizeEvidenceEnginePayload<GoalSlug extends GoalEvidenceSlug>(
+function normalizeEvidenceEnginePayload<GoalSlug extends string>(
   goalSlug: GoalSlug,
   payload: EvidenceEnginePayload | null
 ): EvidenceEnginePayload<GoalSlug> {


### PR DESCRIPTION
## Summary

- Remove hardcoded `sleepProblemLabels` from `SleepDecisionExperience`; problem labels are now owned entirely by the JSON payload
- Add `getClaimProblemKey(claim, problemField)` shared helper to `evidence-engine.ts` so all goal components resolve problem keys generically
- Fix sleep-specific copy in `insufficient` confidence tier description ("confident sleep decision" → "confident decision")
- Remove `GoalEvidenceSlug` private union from `runtime-data.ts`; `normalizeEvidenceEnginePayload` now accepts any string goal slug — no file changes needed when onboarding a new goal

## Test plan

- [ ] `validate:static-export` passes
- [ ] `validate:route-seo` passes
- [ ] `validate-sleep-evidence-engine` passes (sleep 5 claims, stress 0, anxiety 0)
- [ ] Sleep Evidence Engine page renders correctly (problem labels still driven by `sleep.json`)
- [ ] No TypeScript errors beyond the pre-existing `baseUrl` deprecation warning

https://claude.ai/code/session_01T2HCbXBiT3k47C2Q1XFSpR

---
_Generated by [Claude Code](https://claude.ai/code/session_01T2HCbXBiT3k47C2Q1XFSpR)_