### PR TITLE
[codex] Generalize Evidence Engine renderer config

### DIFF
--- a/app/goals/[goal]/GoalDecisionExperience.tsx
+++ b/app/goals/[goal]/GoalDecisionExperience.tsx
@@ -53,7 +53,7 @@ export default function GoalDecisionExperience({
   const safetyGroups = groupSafetyNotesByIngredient(evidence.safetyNotes)
   const hasEvidence = claims.length > 0
 
-  const problemField = `${goal.slug}_problem`
+  const problemField = config.problemField ?? `${goal.slug}_problem`
   const orientationId = `${goal.slug}-orientation`
   const heroHeadline = config.heroHeadline ?? `${goal.title}: What does the evidence actually support?`
   const heroDescription = `A workbook-backed ${goal.slug} decision page that separates claim, evidence, limitation, source, and safety context before you decide what to research next.`

--- a/public/data/evidence-engine/anxiety.json
+++ b/public/data/evidence-engine/anxiety.json
@@ -2,6 +2,7 @@
   "goal": "anxiety",
   "updatedAt": "2026-05-31T12:56:57.243Z",
   "config": {
+    "problemField": "anxiety_problem",
     "heroHeadline": "I want calmer anxiety support. What does the evidence actually support?",
     "heroCta": "Start with the anxiety pattern",
     "orientationHeading": "Start by naming the anxiety pattern",

--- a/public/data/evidence-engine/sleep.json
+++ b/public/data/evidence-engine/sleep.json
@@ -2,6 +2,7 @@
   "goal": "sleep",
   "updatedAt": "2026-05-31T12:56:57.241Z",
   "config": {
+    "problemField": "sleep_problem",
     "heroHeadline": "I want better sleep. What does the evidence actually support?",
     "heroCta": "Start with the sleep problem",
     "orientationHeading": "Start by naming the sleep problem",

--- a/public/data/evidence-engine/stress.json
+++ b/public/data/evidence-engine/stress.json
@@ -2,6 +2,7 @@
   "goal": "stress",
   "updatedAt": "2026-05-31T15:26:06.024Z",
   "config": {
+    "problemField": "stress_problem",
     "heroHeadline": "I want calmer stress response. What does the evidence actually support?",
     "heroCta": "Start with the stress pattern",
     "orientationHeading": "Start by naming the stress pattern",

--- a/scripts/data/build-runtime-from-workbook.mjs
+++ b/scripts/data/build-runtime-from-workbook.mjs
@@ -445,7 +445,10 @@ function buildEvidenceEngine(config, problemRows, claimRows, sourceRows, safetyR
   const payload = {
     goal: config.goal,
     updatedAt: new Date().toISOString(),
-    ...(config.config ? { config: config.config } : {}),
+    config: {
+      problemField: config.problemField,
+      ...(config.config || {}),
+    },
     problemLabels,
     claims: publishedClaims,
     safetyNotes: publishedSafetyNotes,

--- a/src/lib/evidence-engine.ts
+++ b/src/lib/evidence-engine.ts
@@ -30,6 +30,7 @@ export type EvidenceEngineClaim = {
 }
 
 export type EvidenceEngineConfig = {
+  problemField?: string
   heroHeadline?: string
   heroCta?: string
   orientationHeading?: string

--- a/src/lib/runtime-data.ts
+++ b/src/lib/runtime-data.ts
@@ -15,31 +15,6 @@ const dataDir = path.join(process.cwd(), 'public', 'data')
 
 type RuntimeRecord = Record<string, any>
 
-export type SleepEvidenceClaim = EvidenceEngineClaim & { sleep_problem: string }
-export type SleepEvidenceSource = EvidenceEngineSource
-export type SleepSafetyNote = EvidenceEngineSafetyNote
-export type SleepEvidenceEnginePayload = EvidenceEnginePayload<'sleep'> & {
-  claims: SleepEvidenceClaim[]
-  safetyNotes: SleepSafetyNote[]
-  sourcesByClaim: Record<string, SleepEvidenceSource[]>
-}
-export type StressEvidenceClaim = EvidenceEngineClaim & { stress_problem: string }
-export type StressEvidenceSource = EvidenceEngineSource
-export type StressSafetyNote = EvidenceEngineSafetyNote
-export type StressEvidenceEnginePayload = EvidenceEnginePayload<'stress'> & {
-  claims: StressEvidenceClaim[]
-  safetyNotes: StressSafetyNote[]
-  sourcesByClaim: Record<string, StressEvidenceSource[]>
-}
-export type AnxietyEvidenceClaim = EvidenceEngineClaim & { anxiety_problem: string }
-export type AnxietyEvidenceSource = EvidenceEngineSource
-export type AnxietySafetyNote = EvidenceEngineSafetyNote
-export type AnxietyEvidenceEnginePayload = EvidenceEnginePayload<'anxiety'> & {
-  claims: AnxietyEvidenceClaim[]
-  safetyNotes: AnxietySafetyNote[]
-  sourcesByClaim: Record<string, AnxietyEvidenceSource[]>
-}
-
 const fileCache = new Map<string, unknown>()
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -52,7 +27,7 @@ function cleanString(value: unknown): string {
 
 function normalizeConfig(value: unknown): EvidenceEngineConfig | undefined {
   if (!isRecord(value)) return undefined
-  const fields = ['heroHeadline', 'heroCta', 'orientationHeading', 'orientationSubtext', 'safetyHeading', 'safetyBody'] as const
+  const fields = ['problemField', 'heroHeadline', 'heroCta', 'orientationHeading', 'orientationSubtext', 'safetyHeading', 'safetyBody'] as const
   const config: Partial<EvidenceEngineConfig> = {}
   for (const field of fields) {
     if (typeof value[field] === 'string') config[field] = value[field] as string
@@ -83,29 +58,6 @@ function normalizeEvidenceSourcesByClaim(value: unknown): Record<string, Evidenc
       return [[claimId, sources.filter(isRecord) as EvidenceEngineSource[]]]
     })
   )
-}
-
-function normalizeEvidenceEnginePayload<GoalSlug extends string>(
-  goalSlug: GoalSlug,
-  payload: EvidenceEnginePayload | null
-): EvidenceEnginePayload<GoalSlug> {
-  if (!isRecord(payload)) {
-    return { goal: goalSlug, updatedAt: '', problemLabels: {}, claims: [], safetyNotes: [], sourcesByClaim: {} }
-  }
-
-  const normalized: EvidenceEnginePayload<GoalSlug> = {
-    goal: goalSlug,
-    updatedAt: cleanString(payload.updatedAt),
-    problemLabels: normalizeProblemLabels(payload.problemLabels),
-    claims: Array.isArray(payload.claims) ? payload.claims.filter(isRecord) as EvidenceEngineClaim[] : [],
-    safetyNotes: Array.isArray(payload.safetyNotes) ? payload.safetyNotes.filter(isRecord) as EvidenceEngineSafetyNote[] : [],
-    sourcesByClaim: normalizeEvidenceSourcesByClaim(payload.sourcesByClaim),
-  }
-
-  const config = normalizeConfig(payload.config)
-  if (config) normalized.config = config
-
-  return normalized
 }
 
 async function readJsonFile(fileName: string): Promise<unknown> {
@@ -209,21 +161,6 @@ export const getStacks = cache(async (): Promise<RuntimeRecord[]> => {
 export const getClaims = cache(async (): Promise<RuntimeRecord[]> => {
   const claims = await readJsonFile('claims.json')
   return Array.isArray(claims) ? claims : []
-})
-
-export const getSleepEvidenceEngine = cache(async (): Promise<SleepEvidenceEnginePayload> => {
-  const payload = await getGoalEvidenceEngine('sleep')
-  return normalizeEvidenceEnginePayload('sleep', payload) as SleepEvidenceEnginePayload
-})
-
-export const getStressEvidenceEngine = cache(async (): Promise<StressEvidenceEnginePayload> => {
-  const payload = await getGoalEvidenceEngine('stress')
-  return normalizeEvidenceEnginePayload('stress', payload) as StressEvidenceEnginePayload
-})
-
-export const getAnxietyEvidenceEngine = cache(async (): Promise<AnxietyEvidenceEnginePayload> => {
-  const payload = await getGoalEvidenceEngine('anxiety')
-  return normalizeEvidenceEnginePayload('anxiety', payload) as AnxietyEvidenceEnginePayload
 })
 
 export const getGoalEvidenceEngine = cache(async (goalSlug: string): Promise<EvidenceEnginePayload | null> => {


### PR DESCRIPTION
## Summary
- Move Evidence Engine claim problem field selection into payload config.
- Preserve backwards-compatible renderer fallback for older payloads.
- Remove unused Sleep/Stress/Anxiety-specific runtime-data helpers.

## Validation
- npm run lint
- npx tsc --noEmit --incremental false
- npm run validate:static-export
- npm run validate:route-seo