### PR TITLE
Activate revenue foundation

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,10 +1,12 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
+import AffiliateDisclosure from '../../components/AffiliateDisclosure'
+import EmailCapture from '../../components/EmailCapture'
 
 export const metadata: Metadata = {
   title: { absolute: 'About The Hippie Scientist | Evidence-First Supplement Research' },
   description:
-    'Learn how The Hippie Scientist approaches herb and supplement research — plain English, science-first, with honest disclaimers and evidence context.',
+    'Learn how The Hippie Scientist approaches herbs, compounds, evidence quality, affiliate disclosure, and founder-led supplement research.',
   alternates: {
     canonical: '/about',
   },
@@ -14,19 +16,14 @@ export default function AboutPage() {
   return (
     <div className='mx-auto max-w-5xl space-y-8 px-4 py-8 sm:py-12'>
       <section className='rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-10'>
-        <p className='text-xs font-bold uppercase tracking-[0.18em] text-brand-700'>
-          About
-        </p>
+        <p className='text-xs font-bold uppercase tracking-[0.18em] text-brand-700'>About</p>
 
         <h1 className='mt-3 text-4xl font-bold tracking-tight text-ink sm:text-5xl'>
           About The Hippie Scientist
         </h1>
 
         <p className='mt-4 max-w-3xl text-base leading-7 text-muted sm:text-lg'>
-          The Hippie Scientist is a plain-English, science-first educational site
-          about herbs, compounds, and related research notes. The goal is to make
-          complicated topics easier to browse without pretending that internet
-          content replaces personal medical advice.
+          The Hippie Scientist is a founder-led research site for people who want clearer supplement information without hype. It organizes herbs, compounds, safety context, and evidence notes so readers can compare claims before they buy, try, or share anything.
         </p>
 
         <div className='mt-7 flex flex-wrap gap-3'>
@@ -45,137 +42,75 @@ export default function AboutPage() {
           </Link>
 
           <Link
-            href='/blog'
+            href='/goals'
             className='rounded-full border border-brand-900/20 px-5 py-3 text-sm font-semibold text-ink transition hover:border-brand-700 hover:bg-brand-50'
           >
-            Read the blog
+            Goal guides
           </Link>
         </div>
       </section>
 
-      <section className='grid gap-4 lg:grid-cols-3'>
-        <div className='rounded-[1.5rem] border border-brand-900/10 bg-white/85 p-6 shadow-sm'>
-          <p className='text-xs font-bold uppercase tracking-[0.18em] text-brand-700'>
-            What you will find
-          </p>
-
-          <h2 className='mt-3 text-xl font-semibold text-ink'>Structured profiles</h2>
-
-          <p className='mt-3 text-sm leading-6 text-muted'>
-            Herb and compound pages are easy to scan, with summaries,
-            mechanisms, safety notes, and related reading where available.
-          </p>
-        </div>
-
-        <div className='rounded-[1.5rem] border border-brand-900/10 bg-white/85 p-6 shadow-sm'>
-          <p className='text-xs font-bold uppercase tracking-[0.18em] text-brand-700'>
-            How to use it
-          </p>
-
-          <h2 className='mt-3 text-xl font-semibold text-ink'>Start broad, then narrow</h2>
-
-          <p className='mt-3 text-sm leading-6 text-muted'>
-            Use the libraries to explore a topic, then open specific detail pages
-            and blog posts for more context.
-          </p>
-        </div>
-
-        <div className='rounded-[1.5rem] border border-brand-900/10 bg-white/85 p-6 shadow-sm'>
-          <p className='text-xs font-bold uppercase tracking-[0.18em] text-brand-700'>
-            Important note
-          </p>
-
-          <h2 className='mt-3 text-xl font-semibold text-ink'>Educational only</h2>
-
-          <p className='mt-3 text-sm leading-6 text-muted'>
-            This site is for education and research context. It is not diagnosis,
-            treatment, or personal medical advice.
-          </p>
-        </div>
-      </section>
-
-      <section className='grid gap-6 lg:grid-cols-[1.2fr_0.8fr]'>
-        <div className='rounded-[1.5rem] border border-brand-900/10 bg-white/85 p-6 shadow-sm sm:p-8'>
-          <p className='text-xs font-bold uppercase tracking-[0.18em] text-brand-700'>
-            What the project is trying to do
-          </p>
-
-          <h2 className='mt-3 text-2xl font-semibold text-ink'>Readable science communication</h2>
-
+      <section className='grid gap-6 lg:grid-cols-[1.1fr_0.9fr]'>
+        <article className='rounded-[1.5rem] border border-brand-900/10 bg-white/85 p-6 shadow-sm sm:p-8'>
+          <p className='text-xs font-bold uppercase tracking-[0.18em] text-brand-700'>Founder story</p>
+          <h2 className='mt-3 text-2xl font-semibold text-ink'>Built for careful explorers</h2>
           <div className='mt-4 space-y-4 text-sm leading-7 text-muted sm:text-base'>
             <p>
-              A lot of herb and supplement information online is either too vague,
-              too salesy, or too technical to be useful for beginners.
+              The project started from a simple frustration: most supplement content is either sales copy, scattered forum advice, or dense research language that is hard to use in real decisions.
             </p>
-
             <p>
-              This project tries to sit in the middle: clear enough for normal
-              readers, but organized enough to still be useful for deeper study.
-            </p>
-
-            <p>
-              Over time, the site keeps improving with better summaries, better
-              navigation, and more complete profile pages.
+              The Hippie Scientist is built to sit between those extremes. It translates research context into plain English while keeping uncertainty, safety, and product-quality questions visible.
             </p>
           </div>
-        </div>
+        </article>
 
-        <aside className='rounded-[1.5rem] border border-brand-900/10 bg-white/85 p-6 shadow-sm h-fit'>
-          <p className='text-xs font-bold uppercase tracking-[0.18em] text-brand-700'>
-            Good starting points
+        <article className='rounded-[1.5rem] border border-brand-900/10 bg-white/85 p-6 shadow-sm sm:p-8'>
+          <p className='text-xs font-bold uppercase tracking-[0.18em] text-brand-700'>Evidence philosophy</p>
+          <h2 className='mt-3 text-2xl font-semibold text-ink'>Evidence before enthusiasm</h2>
+          <p className='mt-4 text-sm leading-7 text-muted sm:text-base'>
+            Human evidence, plausible mechanisms, traditional use, and safety signals are not the same thing. The site tries to separate those layers instead of flattening every interesting compound into a recommendation.
           </p>
-
-          <div className='mt-4 space-y-3'>
-            <Link
-              href='/herbs'
-              className='block rounded-2xl border border-brand-900/10 bg-white/80 px-4 py-4 transition hover:border-brand-700/20 hover:bg-white hover:-translate-y-0.5 shadow-sm'
-            >
-              <p className='text-sm font-semibold text-ink'>Herb library</p>
-              <p className='mt-1 text-sm leading-6 text-muted'>
-                Browse plant profiles and quick summaries.
-              </p>
-            </Link>
-
-            <Link
-              href='/compounds'
-              className='block rounded-2xl border border-brand-900/10 bg-white/80 px-4 py-4 transition hover:border-brand-700/20 hover:bg-white hover:-translate-y-0.5 shadow-sm'
-            >
-              <p className='text-sm font-semibold text-ink'>Compound library</p>
-              <p className='mt-1 text-sm leading-6 text-muted'>
-                Review constituents, classes, and concise notes.
-              </p>
-            </Link>
-
-            <Link
-              href='/blog'
-              className='block rounded-2xl border border-brand-900/10 bg-white/80 px-4 py-4 transition hover:border-brand-700/20 hover:bg-white hover:-translate-y-0.5 shadow-sm'
-            >
-              <p className='text-sm font-semibold text-ink'>Blog</p>
-              <p className='mt-1 text-sm leading-6 text-muted'>
-                Read explainers, comparisons, and practical notes.
-              </p>
-            </Link>
-
-            <Link
-              href='/goals'
-              className='block rounded-2xl border border-brand-900/10 bg-white/80 px-4 py-4 transition hover:border-brand-700/20 hover:bg-white hover:-translate-y-0.5 shadow-sm'
-            >
-              <p className='text-sm font-semibold text-ink'>Goal guides</p>
-              <p className='mt-1 text-sm leading-6 text-muted'>
-                Find options by what you are trying to support.
-              </p>
-            </Link>
-          </div>
-        </aside>
+        </article>
       </section>
 
+      <section className='rounded-[1.5rem] border border-brand-900/10 bg-white/85 p-6 shadow-sm sm:p-8'>
+        <p className='text-xs font-bold uppercase tracking-[0.18em] text-brand-700'>Methodology</p>
+        <h2 className='mt-3 text-2xl font-semibold text-ink'>How pages are built</h2>
+        <div className='mt-5 grid gap-4 md:grid-cols-3'>
+          {[
+            {
+              title: 'Start with structured data',
+              body: 'Profiles are organized from workbook-backed fields, generated JSON, and route-safe static pages.',
+            },
+            {
+              title: 'Keep safety visible',
+              body: 'Contraindications, medication context, and uncertainty are surfaced before buying or protocol decisions.',
+            },
+            {
+              title: 'Prefer conservative claims',
+              body: 'When evidence is limited, mixed, or mechanism-only, the language should say that plainly.',
+            },
+          ].map((item) => (
+            <article key={item.title} className='rounded-2xl border border-brand-900/10 bg-white/70 p-5'>
+              <h3 className='text-base font-semibold text-ink'>{item.title}</h3>
+              <p className='mt-3 text-sm leading-6 text-muted'>{item.body}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <AffiliateDisclosure />
+
+      <EmailCapture
+        headline='Follow the research as the library improves'
+        description='Get occasional updates when new evidence guides, comparison pages, and sourcing notes are published.'
+        location='about'
+      />
+
       <section className='rounded-2xl border border-amber-900/15 bg-amber-50/70 p-5 text-sm leading-6 text-amber-950'>
-        <p className='font-semibold'>Disclaimer</p>
+        <p className='font-semibold'>Medical disclaimer</p>
         <p className='mt-1'>
-          All content on this site is educational. It is not intended as medical
-          advice, diagnosis, or treatment. Always consult a qualified healthcare
-          professional before making decisions about supplements, medications, or
-          health interventions.
+          All content on this site is educational. It is not intended as medical advice, diagnosis, or treatment. Always consult a qualified healthcare professional before making decisions about supplements, medications, or health interventions.
         </p>
       </section>
     </div>

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -4,6 +4,8 @@ import posts from '../../../data/blog/posts.json'
 import { getAllCompounds, getAllHerbs } from '@/lib/server/runtime-data'
 import { ResearchContinuityBlock } from '@/components/scientific-discovery'
 import { findArticleEntities } from '@/lib/editorial-discovery'
+import EmailCapture from '../../../components/EmailCapture'
+import NewsletterCtaBlock from '../../../components/NewsletterCtaBlock'
 
 const allPosts = posts as any[]
 
@@ -193,6 +195,18 @@ export default async function BlogPostPage({ params }: BlogRouteProps) {
           items={relatedItems}
         />
       </section>
+
+      <EmailCapture
+        headline="Get future research notes by email"
+        description="Join for concise supplement safety, sourcing, and evidence updates tied to new articles."
+        location={`blog-${post.slug}`}
+      />
+
+      <NewsletterCtaBlock
+        title="Continue with the newsletter archive"
+        description="Read short notes built for cautious supplement decisions."
+        location={`blog-${post.slug}-newsletter`}
+      />
     </main>
   )
 }

--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -17,6 +17,8 @@ import { getValidComparisonSlug } from '@/lib/comparison-utils'
 import { getAffiliateShopLinks } from '@/lib/affiliate'
 import { SourcingCta } from '@/components/sourcing/SourcingCta'
 import { normalizeEvidenceLevel, normalizeSafetyLevel } from '@/lib/evidence-utils'
+import RecommendationSection from '../../../components/RecommendationSection'
+import { getRevenueProductSet } from '@/config/revenue-products'
 
 type PageProps = {
   params: Promise<{ slug: string }>
@@ -203,6 +205,7 @@ export default async function CompoundPage({ params }: PageProps) {
 
   const activeShopLinks = getAffiliateShopLinks(compound, displayName, 'compound')
   const affiliateCtaLink = activeShopLinks.find(link => link.url)
+  const revenueProducts = getRevenueProductSet(normalizedSlug)
 
   return (
     <>
@@ -337,6 +340,14 @@ export default async function CompoundPage({ params }: PageProps) {
             <p className="text-sm text-muted">Compare side-by-side tradeoffs or verify active marker guidelines.</p>
           </div>
           <SourcingCta record={compound} displayName={displayName} />
+
+          {revenueProducts ? (
+            <RecommendationSection
+              title={revenueProducts.title}
+              description={`Affiliate recommendations for ${displayName}. Review safety, dose, and product quality before buying.`}
+              products={revenueProducts.products}
+            />
+          ) : null}
 
           <div className="grid gap-4 sm:grid-cols-2 pt-2">
             {semanticRelated.length > 0 && (

--- a/app/goals/[goal]/GoalDecisionExperience.tsx
+++ b/app/goals/[goal]/GoalDecisionExperience.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import EvidenceClaimCard from '@/components/evidence-engine/EvidenceClaimCard'
+import EmailCapture from '../../../components/EmailCapture'
 import type { Goal } from '@/data/goals'
 import {
   type EvidenceEngineClaim,
@@ -190,6 +191,12 @@ export default function GoalDecisionExperience({
           ))}
         </div>
       </section>
+
+      <EmailCapture
+        headline={`Get ${goal.title.toLowerCase()} research updates`}
+        description="Join for practical safety notes, new guide announcements, and evidence-first supplement context."
+        location={`goal-${goal.slug}`}
+      />
 
       <footer className="rounded-2xl border border-brand-900/10 bg-brand-950/[0.02] p-5 text-xs leading-6 text-muted">
         Educational only. Not medical advice. Evidence varies by population, preparation, dose, timing, and study design.

--- a/app/goals/[goal]/page.tsx
+++ b/app/goals/[goal]/page.tsx
@@ -7,6 +7,7 @@ import { normalizeDecisionEvidence, normalizeDecisionSafety } from '@/lib/decisi
 import { faqPageJsonLd, breadcrumbJsonLd, collectionPageJsonLd, itemListJsonLd } from '@/lib/seo'
 import { rankEntitiesForGoal } from '@/lib/goal-matching-engine'
 import { getAffiliateShopLinks } from '@/lib/affiliate'
+import EmailCapture from '../../../components/EmailCapture'
 import GoalDecisionExperience from './GoalDecisionExperience'
 
 type GoalRouteParams = { goal: string }
@@ -515,6 +516,12 @@ export default async function GoalDecisionPage({
           })}
         </div>
       </section>
+
+      <EmailCapture
+        headline={`Get ${goal.title.toLowerCase()} updates`}
+        description="Join for new evidence notes, product-quality checklists, and conservative supplement decision guides."
+        location={`goal-${goal.slug}`}
+      />
 
       <footer className="rounded-2xl border border-brand-900/10 bg-brand-950/[0.02] p-5 text-xs leading-6 text-muted">
         Educational only. Not medical advice. Evidence varies by population, preparation, and study design.

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -20,6 +20,8 @@ import {
   deriveResearchStyle,
 } from '@/lib/research-intelligence'
 import { SourcingCta } from '@/components/sourcing/SourcingCta'
+import RecommendationSection from '../../../components/RecommendationSection'
+import { getRevenueProductSet } from '@/config/revenue-products'
 import { AshwagandhaStressClaim } from './AshwagandhaStressClaim'
 
 
@@ -239,6 +241,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
   const topUses = unique([...effects, ...traditionalUses, ...deriveResearchFocusAreas({ profile: herb })]).slice(0, 8)
   const safetyTone = getSafetyTone(safetySummary, avoidIf)
   const relatedHerbLinks = getRelatedLinks(relatedHerbs, 'herb')
+  const revenueProducts = getRevenueProductSet(normalizedSlug)
   const comparisonLinks = comparisonRecords
     .filter((record: any) => record?.slug)
     .map((record: any) => {
@@ -398,6 +401,14 @@ export default async function HerbDetailPage({ params }: PageProps) {
           <p className="text-sm text-muted">Compare side-by-side tradeoffs or verify active marker guidelines.</p>
         </div>
         <SourcingCta record={herb} displayName={displayName} />
+
+        {revenueProducts ? (
+          <RecommendationSection
+            title={revenueProducts.title}
+            description={`Affiliate recommendations for ${displayName}. Review safety, dose, and product quality before buying.`}
+            products={revenueProducts.products}
+          />
+        ) : null}
 
         <div className="grid gap-4 sm:grid-cols-2 pt-2">
           {relatedHerbLinks.length > 0 && (

--- a/app/newsletter/confirmed/page.tsx
+++ b/app/newsletter/confirmed/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+export const metadata: Metadata = {
+  title: 'Newsletter Signup Confirmed | The Hippie Scientist',
+  description: 'Newsletter signup confirmation page for The Hippie Scientist.',
+  alternates: { canonical: '/newsletter/confirmed' },
+}
+
+export default function NewsletterConfirmedPage() {
+  return (
+    <main className='mx-auto max-w-3xl space-y-6 px-4 py-16 sm:px-6 lg:px-8'>
+      <section className='rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-10'>
+        <p className='text-xs font-bold uppercase tracking-[0.18em] text-brand-700'>Confirmed</p>
+        <h1 className='mt-3 text-4xl font-bold tracking-tight text-ink'>You are on the list.</h1>
+        <p className='mt-4 text-base leading-8 text-muted'>
+          Thanks for joining The Hippie Scientist newsletter. Use the archive and safety checklist while the next note is prepared.
+        </p>
+        <div className='mt-7 flex flex-wrap gap-3'>
+          <Link href='/newsletter' className='rounded-full bg-brand-950 px-5 py-3 text-sm font-bold text-white transition hover:bg-brand-900'>
+            Open newsletter archive
+          </Link>
+          <Link href='/supplement-safety-checklist' className='rounded-full border border-brand-900/15 bg-white px-5 py-3 text-sm font-semibold text-brand-800 transition hover:bg-brand-50'>
+            View safety checklist
+          </Link>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/app/newsletter/page.tsx
+++ b/app/newsletter/page.tsx
@@ -1,0 +1,58 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import EmailCapture from '../../components/EmailCapture'
+
+export const metadata: Metadata = {
+  title: 'Newsletter Archive | The Hippie Scientist',
+  description: 'Static archive for The Hippie Scientist newsletter notes on supplement safety, evidence, and sourcing.',
+  alternates: { canonical: '/newsletter' },
+}
+
+const archiveItems = [
+  {
+    title: 'How to read supplement safety labels',
+    description: 'Medication context, dose transparency, and why product form matters before affiliate clicks.',
+  },
+  {
+    title: 'Evidence levels in plain English',
+    description: 'Separating human trials, mechanistic plausibility, traditional use, and marketing claims.',
+  },
+  {
+    title: 'What to check before buying magnesium',
+    description: 'Elemental dose, form, laxative effects, and kidney-disease caution.',
+  },
+]
+
+export default function NewsletterArchivePage() {
+  return (
+    <main className='mx-auto max-w-5xl space-y-8 px-4 py-10 sm:px-6 lg:px-8'>
+      <section className='rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-10'>
+        <p className='text-xs font-bold uppercase tracking-[0.18em] text-brand-700'>Newsletter archive</p>
+        <h1 className='mt-3 text-4xl font-bold tracking-tight text-ink sm:text-5xl'>Evidence-first supplement notes</h1>
+        <p className='mt-5 max-w-3xl text-base leading-8 text-muted'>
+          Short static notes for readers who want safety, sourcing, and evidence context without sales-first supplement rankings.
+        </p>
+      </section>
+
+      <div className='grid gap-4 md:grid-cols-3'>
+        {archiveItems.map((item) => (
+          <article key={item.title} className='rounded-2xl border border-brand-900/10 bg-white/85 p-5 shadow-sm'>
+            <h2 className='text-base font-semibold text-ink'>{item.title}</h2>
+            <p className='mt-3 text-sm leading-6 text-muted'>{item.description}</p>
+          </article>
+        ))}
+      </div>
+
+      <EmailCapture
+        headline='Get the next newsletter'
+        description='Join for concise research notes, product-quality reminders, and new safety-first guides.'
+        ctaLabel='Subscribe'
+        location='newsletter-archive'
+      />
+
+      <Link href='/supplement-safety-checklist' className='inline-flex rounded-full border border-brand-900/10 bg-white px-5 py-3 text-sm font-semibold text-brand-800 transition hover:bg-brand-50'>
+        Get the safety checklist
+      </Link>
+    </main>
+  )
+}

--- a/app/supplement-safety-checklist/page.tsx
+++ b/app/supplement-safety-checklist/page.tsx
@@ -1,0 +1,59 @@
+import type { Metadata } from 'next'
+import EmailCapture from '../../components/EmailCapture'
+import NewsletterCtaBlock from '../../components/NewsletterCtaBlock'
+
+export const metadata: Metadata = {
+  title: 'Supplement Safety Checklist | The Hippie Scientist',
+  description: 'Join the email list and preview a safety-first supplement checklist before buying or stacking products.',
+  alternates: { canonical: '/supplement-safety-checklist' },
+}
+
+export default function SupplementSafetyChecklistPage() {
+  return (
+    <main className='mx-auto max-w-5xl space-y-8 px-4 py-10 sm:px-6 lg:px-8'>
+      <section className='rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-10'>
+        <p className='text-xs font-bold uppercase tracking-[0.18em] text-brand-700'>Free checklist</p>
+        <h1 className='mt-3 max-w-4xl text-4xl font-bold tracking-tight text-ink sm:text-5xl'>
+          Check supplement safety before you buy, stack, or increase the dose.
+        </h1>
+        <p className='mt-5 max-w-3xl text-base leading-8 text-muted'>
+          Use a simple safety-first checklist to review medications, pregnancy and breastfeeding, chronic conditions, sedative or stimulant stacking, product form, and dose transparency before making a supplement decision.
+        </p>
+      </section>
+
+      <EmailCapture
+        headline='Get the supplement safety checklist'
+        description='Enter your email to join the list. PDF delivery can be connected later; this page establishes the lead magnet flow now.'
+        ctaLabel='Send me the checklist'
+        location='supplement-safety-checklist'
+      />
+
+      <section className='grid gap-4 md:grid-cols-3'>
+        {[
+          ['Medication review', 'Flag interaction-prone categories before adding a new product.'],
+          ['Dose and form check', 'Compare elemental dose, extract standardization, and serving size.'],
+          ['Stacking risk', 'Spot sedative, stimulant, liver, kidney, and blood-pressure concerns.'],
+        ].map(([title, body]) => (
+          <article key={title} className='rounded-2xl border border-brand-900/10 bg-white/85 p-5 shadow-sm'>
+            <h2 className='text-base font-semibold text-ink'>{title}</h2>
+            <p className='mt-3 text-sm leading-6 text-muted'>{body}</p>
+          </article>
+        ))}
+      </section>
+
+      <section className='rounded-[1.5rem] border border-brand-900/10 bg-white/85 p-6 shadow-sm sm:p-8'>
+        <p className='text-xs font-bold uppercase tracking-[0.18em] text-brand-700'>Why trust it</p>
+        <h2 className='mt-3 text-2xl font-semibold text-ink'>Built around caution, not conversion pressure</h2>
+        <p className='mt-3 max-w-3xl text-sm leading-7 text-muted'>
+          The checklist follows the same editorial rule as the main site: safety context comes before affiliate links, and uncertainty should stay visible when evidence is limited.
+        </p>
+      </section>
+
+      <NewsletterCtaBlock
+        title='Want the ongoing notes too?'
+        description='The newsletter archive collects short safety and sourcing updates.'
+        location='supplement-safety-checklist'
+      />
+    </main>
+  )
+}

--- a/components/AffiliateDisclosure.tsx
+++ b/components/AffiliateDisclosure.tsx
@@ -1,0 +1,23 @@
+type AffiliateDisclosureProps = {
+  variant?: 'compact' | 'full'
+  className?: string
+}
+
+export default function AffiliateDisclosure({ variant = 'full', className = '' }: AffiliateDisclosureProps) {
+  if (variant === 'compact') {
+    return (
+      <p className={`text-xs italic leading-6 text-muted ${className}`}>
+        Affiliate disclosure: we may earn a commission from qualifying links at no extra cost to you.
+      </p>
+    )
+  }
+
+  return (
+    <section className={`rounded-2xl border border-amber-900/15 bg-amber-50/70 p-5 text-sm leading-7 text-amber-950 ${className}`}>
+      <h2 className='text-base font-semibold text-amber-950'>Affiliate disclosure</h2>
+      <p className='mt-2'>
+        Some pages may include affiliate links. If you buy through those links, The Hippie Scientist may earn a commission at no additional cost to you. Affiliate relationships do not change evidence ratings, safety warnings, product-quality criteria, or editorial conclusions.
+      </p>
+    </section>
+  )
+}

--- a/components/AffiliateProductCard.tsx
+++ b/components/AffiliateProductCard.tsx
@@ -1,24 +1,74 @@
 'use client'
 
-type Product = {
-  name: string
-  brand: string
-  price: string
-  rating: number
-  link: string
+import { trackRevenueEvent } from '@/lib/revenue-tracking'
+
+export type AffiliateProduct = {
+  title?: string
+  name?: string
+  brand?: string
+  price?: string
+  rating?: number
+  imageUrl?: string
+  image?: string
+  rationale?: string
+  notes?: string
+  ctaLabel?: string
+  affiliateUrl?: string
+  url?: string
+  link?: string
+  trackingLocation?: string
 }
 
-export default function AffiliateProductCard({ product }: { product: Product }) {
+type AffiliateProductCardProps = {
+  product: AffiliateProduct
+  compact?: boolean
+}
+
+export default function AffiliateProductCard({ product, compact = false }: AffiliateProductCardProps) {
+  const title = product.title || product.name || 'Supplement option'
+  const imageUrl = product.imageUrl || product.image
+  const rationale = product.rationale || product.notes || 'Review the label, dose, third-party testing, and safety context before buying.'
+  const affiliateUrl = product.affiliateUrl || product.url || product.link || '#'
+  const ctaLabel = product.ctaLabel || 'Check current price'
+
   return (
-    <a
-      href={product.link}
-      target="_blank"
-      rel="noopener noreferrer nofollow sponsored"
-      className='block rounded-2xl border border-brand/20 bg-glass-standard p-4 space-y-2 transition hover:bg-glass-heavy active:scale-[0.99]'
-    >
-      <h4 className='font-bold text-[color:var(--text-primary)]'>{product.name}</h4>
-      <p className='text-sm text-[color:var(--text-secondary)]'>{product.brand}</p>
-      <p className='text-sm text-[color:var(--text-secondary)]'>{product.price} • ⭐ {product.rating}</p>
-    </a>
+    <article className={`flex h-full flex-col overflow-hidden rounded-2xl border border-brand-900/10 bg-white/85 shadow-sm ${compact ? 'p-4' : 'p-5'}`}>
+      {imageUrl ? (
+        <div className='mb-4 aspect-[4/3] overflow-hidden rounded-xl border border-brand-900/10 bg-brand-50'>
+          <img src={imageUrl} alt='' className='h-full w-full object-cover' loading='lazy' />
+        </div>
+      ) : null}
+
+      <div className='flex flex-1 flex-col'>
+        <div>
+          {product.brand ? (
+            <p className='text-xs font-bold uppercase tracking-[0.16em] text-brand-700'>{product.brand}</p>
+          ) : null}
+          <h3 className='mt-2 text-base font-semibold leading-6 text-ink'>{title}</h3>
+          <p className='mt-3 text-sm leading-6 text-muted'>{rationale}</p>
+        </div>
+
+        {(product.price || product.rating) ? (
+          <p className='mt-4 text-xs font-semibold text-muted'>
+            {[product.price, product.rating ? `${product.rating.toFixed(1)} rating` : ''].filter(Boolean).join(' / ')}
+          </p>
+        ) : null}
+
+        <a
+          href={affiliateUrl}
+          target='_blank'
+          rel='noopener noreferrer nofollow sponsored'
+          onClick={() => trackRevenueEvent({
+            kind: 'recommendation_click',
+            location: product.trackingLocation || 'recommendation-section',
+            label: title,
+            target: affiliateUrl,
+          })}
+          className='mt-5 inline-flex min-h-11 w-full items-center justify-center rounded-full bg-brand-950 px-4 py-2.5 text-sm font-bold text-white transition hover:bg-brand-900'
+        >
+          {ctaLabel}
+        </a>
+      </div>
+    </article>
   )
 }

--- a/components/EmailCapture.tsx
+++ b/components/EmailCapture.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import { trackRevenueEvent } from '@/lib/revenue-tracking'
+
+type EmailCaptureProps = {
+  headline?: string
+  description?: string
+  ctaLabel?: string
+  action?: string
+  className?: string
+  location?: string
+}
+
+export default function EmailCapture({
+  headline = 'Get the evidence-first supplement notes',
+  description = 'Occasional research updates, practical safety context, and new guide announcements. No diagnosis, treatment, or personal medical advice.',
+  ctaLabel = 'Join the list',
+  action = '/newsletter/confirmed',
+  className = '',
+  location = 'email-capture',
+}: EmailCaptureProps) {
+  return (
+    <section className={`rounded-[1.5rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8 ${className}`}>
+      <div className='grid gap-5 lg:grid-cols-[1fr_0.9fr] lg:items-center'>
+        <div>
+          <p className='text-xs font-bold uppercase tracking-[0.18em] text-brand-700'>Email updates</p>
+          <h2 className='mt-3 text-2xl font-semibold text-ink'>{headline}</h2>
+          <p className='mt-3 text-sm leading-7 text-muted'>{description}</p>
+        </div>
+
+        <form
+          action={action}
+          method='get'
+          onSubmit={() => trackRevenueEvent({
+            kind: 'email_signup_attempt',
+            location,
+            label: ctaLabel,
+            target: action,
+          })}
+          className='flex flex-col gap-3 sm:flex-row lg:flex-col xl:flex-row'
+        >
+          <label className='sr-only' htmlFor='email-capture-address'>Email address</label>
+          <input
+            id='email-capture-address'
+            name='email'
+            type='email'
+            required
+            placeholder='you@example.com'
+            className='min-h-11 flex-1 rounded-full border border-brand-900/15 bg-white px-4 text-sm text-ink outline-none transition placeholder:text-muted/70 focus:border-brand-700 focus:ring-2 focus:ring-brand-700/15'
+          />
+          <button
+            type='submit'
+            className='min-h-11 rounded-full bg-brand-950 px-5 py-2.5 text-sm font-bold text-white transition hover:bg-brand-900'
+          >
+            {ctaLabel}
+          </button>
+        </form>
+      </div>
+    </section>
+  )
+}

--- a/components/NewsletterCtaBlock.tsx
+++ b/components/NewsletterCtaBlock.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import Link from 'next/link'
+import { trackRevenueEvent } from '@/lib/revenue-tracking'
+
+type NewsletterCtaBlockProps = {
+  title?: string
+  description?: string
+  href?: string
+  ctaLabel?: string
+  location?: string
+}
+
+export default function NewsletterCtaBlock({
+  title = 'Read the newsletter archive',
+  description = 'Short evidence-first notes on supplement safety, sourcing, and research interpretation.',
+  href = '/newsletter',
+  ctaLabel = 'Open newsletter',
+  location = 'newsletter-cta',
+}: NewsletterCtaBlockProps) {
+  return (
+    <section className='rounded-[1.5rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8'>
+      <div className='flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between'>
+        <div>
+          <p className='text-xs font-bold uppercase tracking-[0.18em] text-brand-700'>Newsletter</p>
+          <h2 className='mt-2 text-2xl font-semibold text-ink'>{title}</h2>
+          <p className='mt-2 max-w-2xl text-sm leading-7 text-muted'>{description}</p>
+        </div>
+        <Link
+          href={href}
+          onClick={() => trackRevenueEvent({
+            kind: 'cta_click',
+            location,
+            label: ctaLabel,
+            target: href,
+          })}
+          className='inline-flex min-h-11 shrink-0 items-center justify-center rounded-full bg-brand-950 px-5 py-2.5 text-sm font-bold text-white transition hover:bg-brand-900'
+        >
+          {ctaLabel}
+        </Link>
+      </div>
+    </section>
+  )
+}

--- a/components/RecommendationSection.tsx
+++ b/components/RecommendationSection.tsx
@@ -1,0 +1,53 @@
+import AffiliateDisclosure from './AffiliateDisclosure'
+import AffiliateProductCard, { type AffiliateProduct } from './AffiliateProductCard'
+
+export type RecommendationSlot = 'budget' | 'overall' | 'premium'
+
+export type RecommendationProduct = AffiliateProduct & {
+  slot: RecommendationSlot
+}
+
+type RecommendationSectionProps = {
+  title?: string
+  description?: string
+  products: RecommendationProduct[]
+}
+
+const slotLabels: Record<RecommendationSlot, string> = {
+  budget: 'Budget pick',
+  overall: 'Best overall',
+  premium: 'Premium pick',
+}
+
+export default function RecommendationSection({
+  title = 'Product recommendations',
+  description = 'Use these as sourcing starting points, not medical recommendations. Product quality, dose, and fit still need review.',
+  products,
+}: RecommendationSectionProps) {
+  if (products.length === 0) return null
+
+  const ordered = ['budget', 'overall', 'premium'].flatMap((slot) =>
+    products.filter((product) => product.slot === slot)
+  )
+
+  return (
+    <section className='rounded-[1.5rem] border border-brand-900/10 bg-white/80 p-6 shadow-sm sm:p-8'>
+      <div className='max-w-3xl'>
+        <p className='text-xs font-bold uppercase tracking-[0.18em] text-brand-700'>Affiliate-ready sourcing</p>
+        <h2 className='mt-3 text-2xl font-semibold text-ink'>{title}</h2>
+        <p className='mt-3 text-sm leading-7 text-muted'>{description}</p>
+      </div>
+
+      <div className='mt-6 grid gap-4 md:grid-cols-3'>
+        {ordered.map((product) => (
+          <div key={`${product.slot}-${product.title || product.name}`} className='flex flex-col gap-2'>
+            <p className='text-xs font-bold uppercase tracking-[0.16em] text-brand-700'>{slotLabels[product.slot]}</p>
+            <AffiliateProductCard product={{ ...product, trackingLocation: 'recommendation-section' }} compact />
+          </div>
+        ))}
+      </div>
+
+      <AffiliateDisclosure variant='compact' className='mt-5' />
+    </section>
+  )
+}

--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link'
 import { cleanSummary, formatDisplayLabel, isClean } from '@/lib/display-utils'
 import { goals } from '@/data/goals'
+import EmailCapture from './EmailCapture'
+import NewsletterCtaBlock from './NewsletterCtaBlock'
 
 type RuntimeFeature = Record<string, unknown>
 type HomepageV2Props = { featuredHerbs?: RuntimeFeature[]; featuredCompounds?: RuntimeFeature[] }
@@ -386,6 +388,19 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
             </Link>
           </div>
         </section>
+
+        <EmailCapture
+          headline='Get the supplement safety checklist'
+          description='Join the list for safety-first supplement notes and the checklist landing page before you compare products.'
+          ctaLabel='Get the checklist'
+          location='homepage'
+        />
+
+        <NewsletterCtaBlock
+          title='Browse evidence-first newsletter notes'
+          description='Use the archive for concise supplement safety and sourcing updates.'
+          location='homepage-newsletter'
+        />
 
         {/* Popular Profiles */}
         <section className='space-y-2.5 sm:space-y-3'>

--- a/config/revenue-products.ts
+++ b/config/revenue-products.ts
@@ -1,0 +1,173 @@
+import { AFFILIATE_TAGS } from './affiliate'
+import type { RecommendationProduct } from '@/components/RecommendationSection'
+
+export type RevenueProductSet = {
+  slug: string
+  title: string
+  products: RecommendationProduct[]
+}
+
+function amazonUrl(query: string) {
+  return `https://www.amazon.com/s?k=${encodeURIComponent(query)}&tag=${AFFILIATE_TAGS.amazon}`
+}
+
+export const revenueProductSets: Record<string, RevenueProductSet> = {
+  ashwagandha: {
+    slug: 'ashwagandha',
+    title: 'Ashwagandha product picks',
+    products: [
+      {
+        slot: 'budget',
+        brand: 'NOW Foods',
+        title: 'NOW Ashwagandha 450 mg',
+        rationale: 'Budget pick for a simple ashwagandha capsule from a widely available supplement brand.',
+        affiliateUrl: amazonUrl('NOW Ashwagandha 450 mg capsules'),
+      },
+      {
+        slot: 'overall',
+        brand: 'Jarrow Formulas',
+        title: 'Jarrow KSM-66 Ashwagandha',
+        rationale: 'Best overall pick for users who want a clearly standardized KSM-66 ashwagandha extract.',
+        affiliateUrl: amazonUrl('Jarrow Formulas KSM-66 Ashwagandha'),
+      },
+      {
+        slot: 'premium',
+        brand: 'Thorne',
+        title: 'Thorne Stress Balance',
+        rationale: 'Premium pick for users who prioritize practitioner-style branding and broader stress-support context.',
+        affiliateUrl: amazonUrl('Thorne ashwagandha stress balance'),
+      },
+    ],
+  },
+  magnesium: {
+    slug: 'magnesium',
+    title: 'Magnesium product picks',
+    products: [
+      {
+        slot: 'budget',
+        brand: "Doctor's Best",
+        title: "Doctor's Best High Absorption Magnesium",
+        rationale: 'Budget pick for chelated magnesium with clear elemental magnesium labeling.',
+        affiliateUrl: amazonUrl("Doctor's Best High Absorption Magnesium lysinate glycinate"),
+      },
+      {
+        slot: 'overall',
+        brand: 'Pure Encapsulations',
+        title: 'Pure Encapsulations Magnesium Glycinate',
+        rationale: 'Best overall pick for a cleaner glycinate-style magnesium product.',
+        affiliateUrl: amazonUrl('Pure Encapsulations Magnesium Glycinate'),
+      },
+      {
+        slot: 'premium',
+        brand: 'Thorne',
+        title: 'Thorne Magnesium Bisglycinate',
+        rationale: 'Premium pick for users who prefer powder format and a practitioner-oriented brand.',
+        affiliateUrl: amazonUrl('Thorne Magnesium Bisglycinate powder'),
+      },
+    ],
+  },
+  'l-theanine': {
+    slug: 'l-theanine',
+    title: 'L-Theanine product picks',
+    products: [
+      {
+        slot: 'budget',
+        brand: 'NOW Foods',
+        title: 'NOW L-Theanine 200 mg',
+        rationale: 'Budget pick for plain L-theanine capsules without a complex calming blend.',
+        affiliateUrl: amazonUrl('NOW Foods L-Theanine 200 mg'),
+      },
+      {
+        slot: 'overall',
+        brand: 'Jarrow Formulas',
+        title: 'Jarrow Theanine 200 mg',
+        rationale: 'Best overall pick for a simple 200 mg L-theanine capsule format.',
+        affiliateUrl: amazonUrl('Jarrow Formulas Theanine 200 mg'),
+      },
+      {
+        slot: 'premium',
+        brand: 'Sports Research',
+        title: 'Sports Research Suntheanine L-Theanine',
+        rationale: 'Premium pick for users who want a Suntheanine-labeled theanine product.',
+        affiliateUrl: amazonUrl('Sports Research Suntheanine L-Theanine 200 mg'),
+      },
+    ],
+  },
+  rhodiola: {
+    slug: 'rhodiola',
+    title: 'Rhodiola product picks',
+    products: [
+      {
+        slot: 'budget',
+        brand: 'NOW Foods',
+        title: 'NOW Rhodiola 500 mg',
+        rationale: 'Budget pick for a common Rhodiola rosea capsule from a mainstream brand.',
+        affiliateUrl: amazonUrl('NOW Rhodiola 500 mg'),
+      },
+      {
+        slot: 'overall',
+        brand: 'Gaia Herbs',
+        title: 'Gaia Herbs Rhodiola Rosea',
+        rationale: 'Best overall pick for users who want a recognizable botanical brand and liquid phyto-caps format.',
+        affiliateUrl: amazonUrl('Gaia Herbs Rhodiola Rosea'),
+      },
+      {
+        slot: 'premium',
+        brand: 'Thorne',
+        title: 'Thorne Rhodiola',
+        rationale: 'Premium pick for users prioritizing brand quality signals and transparent standardized extract positioning.',
+        affiliateUrl: amazonUrl('Thorne Rhodiola'),
+      },
+    ],
+  },
+  'lions-mane': {
+    slug: 'lions-mane',
+    title: "Lion's Mane product picks",
+    products: [
+      {
+        slot: 'budget',
+        brand: 'NOW Foods',
+        title: "NOW Lion's Mane",
+        rationale: 'Budget pick for a widely available lion’s mane capsule.',
+        affiliateUrl: amazonUrl("NOW Lion's Mane mushroom supplement"),
+      },
+      {
+        slot: 'overall',
+        brand: 'Real Mushrooms',
+        title: "Real Mushrooms Lion's Mane",
+        rationale: 'Best overall pick for fruiting-body-forward labeling and mushroom-category transparency.',
+        affiliateUrl: amazonUrl("Real Mushrooms Lion's Mane"),
+      },
+      {
+        slot: 'premium',
+        brand: 'Host Defense',
+        title: "Host Defense Lion's Mane",
+        rationale: 'Premium pick for users who prefer a well-known mushroom-specialist brand.',
+        affiliateUrl: amazonUrl("Host Defense Lion's Mane capsules"),
+      },
+    ],
+  },
+}
+
+const revenueProductAliases: Record<string, string> = {
+  'ashwagandha-root': 'ashwagandha',
+  'magnesium-glycinate': 'magnesium',
+  'magnesium-citrate': 'magnesium',
+  'magnesium-threonate': 'magnesium',
+  theanine: 'l-theanine',
+  'l-theanine-sleep': 'l-theanine',
+  rhodiola: 'rhodiola',
+  'rhodiola-rosea': 'rhodiola',
+  'lions-mane': 'lions-mane',
+  'lion-s-mane': 'lions-mane',
+  lionmane: 'lions-mane',
+}
+
+export function getRevenueProductSet(slug: string): RevenueProductSet | null {
+  const normalized = slug.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-')
+  const key = revenueProductAliases[normalized] || normalized
+  return revenueProductSets[key] ?? null
+}
+
+export const revenueProductPlaceholders = revenueProductSets
+export const getRevenueProductPlaceholders = getRevenueProductSet

--- a/docs/revenue-activation-report.md
+++ b/docs/revenue-activation-report.md
@@ -1,0 +1,31 @@
+# Revenue Activation Report
+
+## Pages Updated
+- `/about`
+- `/`
+- `/goals/:goal`
+- `/blog/:slug`
+- `/herbs/:slug`
+- `/compounds/:slug`
+
+## Pages Added
+- `/supplement-safety-checklist`
+- `/newsletter`
+- `/newsletter/confirmed`
+
+## Components Added
+- `AffiliateDisclosure`
+- `EmailCapture`
+- `NewsletterCtaBlock`
+- `RecommendationSection`
+
+## Tracking Points Added
+- Recommendation clicks from `AffiliateProductCard`
+- Newsletter and lead-magnet CTA clicks from `NewsletterCtaBlock`
+- Email signup attempts from `EmailCapture`
+
+## Remaining Blockers Before First Affiliate Revenue
+- Replace Amazon search URLs with direct product URLs where program policy and product availability are confirmed.
+- Connect email forms to the chosen email service provider.
+- Add live product images only after sourcing rights and performance impact are reviewed.
+- Review affiliate placements after initial click data shows which pages receive qualified traffic.

--- a/docs/superpowers/plans/2026-05-31-revenue-foundation.md
+++ b/docs/superpowers/plans/2026-05-31-revenue-foundation.md
@@ -1,0 +1,53 @@
+# Revenue Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add reusable affiliate recommendation, disclosure, email capture, and founder-trust surfaces without changing site architecture.
+
+**Architecture:** Reuse the existing top-level `components/` convention for app-facing shared components. Keep product recommendation data as a small config module so herb and compound pages can import it later without data pipeline changes.
+
+**Tech Stack:** Next.js App Router, React server components, Tailwind utility classes, existing affiliate tag config.
+
+---
+
+### Task 1: Shared Monetization Components
+
+**Files:**
+- Modify: `components/AffiliateProductCard.tsx`
+- Create: `components/AffiliateDisclosure.tsx`
+- Create: `components/EmailCapture.tsx`
+- Create: `components/RecommendationSection.tsx`
+
+- [ ] Replace the existing affiliate card with a prop-driven card that supports image, title, rationale, CTA, and affiliate URL.
+- [ ] Add a reusable disclosure component with compact and full variants.
+- [ ] Add a static email capture form component that can post to a caller-provided action later.
+- [ ] Add a three-slot recommendation section for budget, best overall, and premium picks.
+
+### Task 2: Placeholder Product Config
+
+**Files:**
+- Create: `config/revenue-products.ts`
+
+- [ ] Add placeholder recommendation slots for `ashwagandha`, `magnesium`, `l-theanine`, `rhodiola`, and `lions-mane`.
+- [ ] Build Amazon search URLs using `AFFILIATE_TAGS.amazon`, not hardcoded tags.
+- [ ] Export a lookup helper for later herb and compound page integration.
+
+### Task 3: About Page Trust Update
+
+**Files:**
+- Modify: `app/about/page.tsx`
+
+- [ ] Preserve the existing `/about` route.
+- [ ] Add founder story, methodology, affiliate disclosure, and evidence philosophy sections.
+- [ ] Use existing warm light theme classes and avoid a visual redesign.
+- [ ] Add email capture as a trust-oriented subscriber surface.
+
+### Task 4: Validation
+
+**Files:**
+- No source edits.
+
+- [ ] Run `npm run lint`.
+- [ ] Run `npx tsc --noEmit --incremental false`.
+- [ ] Run `npm run validate:static-export`.
+- [ ] Run `npm run validate:route-seo`.

--- a/src/components/AffiliateDisclosure.tsx
+++ b/src/components/AffiliateDisclosure.tsx
@@ -1,7 +1,2 @@
-export function AffiliateDisclosure() {
-  return (
-    <p className="mt-3 text-xs italic leading-6 text-muted">
-      Affiliate disclosure: This section may contain affiliate links through which we may earn a commission at no additional cost to you. Editorial assessments remain evidence-driven and independent.
-    </p>
-  )
-}
+export { default } from '../../components/AffiliateDisclosure'
+export { default as AffiliateDisclosure } from '../../components/AffiliateDisclosure'

--- a/src/lib/__tests__/revenue-products.test.ts
+++ b/src/lib/__tests__/revenue-products.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { getRevenueProductSet, revenueProductSets } from '@/config/revenue-products'
+
+describe('revenue product recommendations', () => {
+  it('provides three real recommendation slots for priority ingredients', () => {
+    for (const slug of ['ashwagandha', 'magnesium', 'l-theanine', 'rhodiola', 'lions-mane']) {
+      const set = getRevenueProductSet(slug)
+
+      expect(set?.products.map(product => product.slot).sort()).toEqual(['budget', 'overall', 'premium'])
+      expect(set?.products).toHaveLength(3)
+      expect(set?.products.every(product => product.brand && product.title && product.affiliateUrl)).toBe(true)
+      expect(set?.products.some(product => /placeholder|search$/i.test(product.title || ''))).toBe(false)
+    }
+  })
+
+  it('supports common herb and compound slug aliases', () => {
+    expect(getRevenueProductSet('rhodiola-rosea')?.slug).toBe('rhodiola')
+    expect(getRevenueProductSet('theanine')?.slug).toBe('l-theanine')
+    expect(getRevenueProductSet('magnesium-glycinate')?.slug).toBe('magnesium')
+  })
+
+  it('keeps affiliate URLs centralized and tagged', () => {
+    const allProducts = Object.values(revenueProductSets).flatMap(set => set.products)
+
+    expect(allProducts.length).toBe(15)
+    for (const product of allProducts) {
+      expect(product.affiliateUrl).toContain('tag=')
+      expect(product.affiliateUrl).toMatch(/^https:\/\/www\.amazon\.com\//)
+    }
+  })
+})

--- a/src/lib/__tests__/revenue-tracking.test.ts
+++ b/src/lib/__tests__/revenue-tracking.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { buildRevenueEvent, normalizeRevenueEventKind } from '@/lib/revenue-tracking'
+
+describe('revenue tracking', () => {
+  it('normalizes supported revenue event kinds', () => {
+    expect(normalizeRevenueEventKind('recommendation_click')).toBe('recommendation_click')
+    expect(normalizeRevenueEventKind('cta_click')).toBe('cta_click')
+    expect(normalizeRevenueEventKind('email_signup_attempt')).toBe('email_signup_attempt')
+    expect(normalizeRevenueEventKind('other')).toBe('cta_click')
+  })
+
+  it('builds static-export compatible event payloads', () => {
+    const event = buildRevenueEvent({
+      kind: 'recommendation_click',
+      location: 'compound-page',
+      label: 'Best overall',
+      target: 'https://example.com/product',
+    })
+
+    expect(event).toMatchObject({
+      kind: 'recommendation_click',
+      location: 'compound-page',
+      label: 'Best overall',
+      target: 'https://example.com/product',
+    })
+    expect(event.occurredAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+})

--- a/src/lib/revenue-tracking.ts
+++ b/src/lib/revenue-tracking.ts
@@ -1,0 +1,57 @@
+export type RevenueEventKind = 'recommendation_click' | 'cta_click' | 'email_signup_attempt'
+
+export type RevenueEventInput = {
+  kind: string
+  location: string
+  label: string
+  target?: string
+}
+
+export type RevenueEvent = {
+  kind: RevenueEventKind
+  location: string
+  label: string
+  target: string
+  occurredAt: string
+}
+
+export function normalizeRevenueEventKind(kind: string): RevenueEventKind {
+  if (kind === 'recommendation_click' || kind === 'cta_click' || kind === 'email_signup_attempt') {
+    return kind
+  }
+  return 'cta_click'
+}
+
+export function buildRevenueEvent(input: RevenueEventInput): RevenueEvent {
+  return {
+    kind: normalizeRevenueEventKind(input.kind),
+    location: input.location,
+    label: input.label,
+    target: input.target || '',
+    occurredAt: new Date().toISOString(),
+  }
+}
+
+export function trackRevenueEvent(input: RevenueEventInput) {
+  if (typeof window === 'undefined') return
+
+  const event = buildRevenueEvent(input)
+  window.dispatchEvent(new CustomEvent('ths:revenue-event', { detail: event }))
+
+  const dataLayerTarget = window as Window & {
+    dataLayer?: RevenueEvent[]
+  }
+  dataLayerTarget.dataLayer = dataLayerTarget.dataLayer || []
+  dataLayerTarget.dataLayer.push(event)
+
+  try {
+    const existing = window.localStorage.getItem('ths_revenue_events')
+    const queue = existing ? JSON.parse(existing) : []
+    if (Array.isArray(queue)) {
+      queue.push(event)
+      window.localStorage.setItem('ths_revenue_events', JSON.stringify(queue.slice(-50)))
+    }
+  } catch {
+    // Local storage can be unavailable in privacy modes; event dispatch above still works.
+  }
+}


### PR DESCRIPTION
## Summary
- Adds centralized affiliate recommendation data for Ashwagandha, Magnesium, L-Theanine, Rhodiola, and Lion's Mane.
- Adds reusable affiliate, recommendation, email capture, newsletter CTA, and static tracking infrastructure.
- Adds static lead magnet, newsletter archive, and signup confirmation pages.
- Places email capture and recommendation insertion points across homepage, about, goal pages, blog articles, herb pages, and compound pages.

## Validation
- PASS: npx vitest run src/lib/__tests__/revenue-products.test.ts src/lib/__tests__/revenue-tracking.test.ts
- PASS: npm run lint
- PASS: npx tsc --noEmit --incremental false
- PASS: npm run validate:static-export
- PASS: npm run validate:route-seo
- NOTE: npm test currently fails on an unrelated Evidence Engine expectation: currently onboarded goals expected sleep/stress/anxiety but local data includes focus as well.
