### PR TITLE
Phase 1: affiliate ASINs, GA4 helpers, author bylines

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -33,7 +33,7 @@ export async function generateMetadata({ params }: BlogRouteProps) {
   return {
     title: post.title,
     description: post.excerpt,
-    authors: [{ name: 'The Hippie Scientist', url: 'https://thehippiescientist.net/about' }],
+    authors: [{ name: 'Will', url: 'https://thehippiescientist.net/about' }],
     alternates: { canonical: `/blog/${resolvedParams.slug}` },
     openGraph: {
       title: post.title,
@@ -91,7 +91,7 @@ export default async function BlogPostPage({ params }: BlogRouteProps) {
     description: post.excerpt,
     author: {
       '@type': 'Person',
-      name: 'The Hippie Scientist',
+      name: 'Will',
       url: 'https://thehippiescientist.net/about',
     },
     publisher: {
@@ -158,7 +158,7 @@ export default async function BlogPostPage({ params }: BlogRouteProps) {
         <p className="mt-3 text-sm text-muted">
           By{' '}
           <a href="/about" rel="author" className="font-medium text-ink hover:underline">
-            The Hippie Scientist
+            Will
           </a>
         </p>
         <p className="mt-3 text-reading max-w-3xl text-muted-soft">{post.excerpt}</p>

--- a/config/revenue-products.ts
+++ b/config/revenue-products.ts
@@ -36,7 +36,7 @@ export const revenueProductSets: Record<string, RevenueProductSet> = {
         brand: 'Jarrow Formulas',
         title: 'Jarrow KSM-66 Ashwagandha',
         rationale: 'Best overall pick for users who want a clearly standardized KSM-66 ashwagandha extract.',
-        affiliateUrl: amazonProductUrl({ query: 'Jarrow Formulas KSM-66 Ashwagandha' }),
+        affiliateUrl: amazonProductUrl({ asin: 'B07LFMM7N1', query: 'Jarrow Formulas KSM-66 Ashwagandha' }),
       },
       {
         slot: 'premium',
@@ -63,7 +63,7 @@ export const revenueProductSets: Record<string, RevenueProductSet> = {
         brand: 'Pure Encapsulations',
         title: 'Pure Encapsulations Magnesium Glycinate',
         rationale: 'Best overall pick for a cleaner glycinate-style magnesium product.',
-        affiliateUrl: amazonProductUrl({ query: 'Pure Encapsulations Magnesium Glycinate' }),
+        affiliateUrl: amazonProductUrl({ asin: 'B07F7NWYD8', query: 'Pure Encapsulations Magnesium Glycinate' }),
       },
       {
         slot: 'premium',
@@ -90,7 +90,7 @@ export const revenueProductSets: Record<string, RevenueProductSet> = {
         brand: 'Jarrow Formulas',
         title: 'Jarrow Theanine 200 mg',
         rationale: 'Best overall pick for a simple 200 mg L-theanine capsule format.',
-        affiliateUrl: amazonProductUrl({ query: 'Jarrow Formulas Theanine 200 mg' }),
+        affiliateUrl: amazonProductUrl({ asin: 'B01GAOCB56', query: 'Jarrow Formulas Theanine 200 mg' }),
       },
       {
         slot: 'premium',
@@ -117,7 +117,7 @@ export const revenueProductSets: Record<string, RevenueProductSet> = {
         brand: 'Gaia Herbs',
         title: 'Gaia Herbs Rhodiola Rosea',
         rationale: 'Best overall pick for users who want a recognizable botanical brand and liquid phyto-caps format.',
-        affiliateUrl: amazonProductUrl({ query: 'Gaia Herbs Rhodiola Rosea' }),
+        affiliateUrl: amazonProductUrl({ asin: 'B00E4HSMQE', query: 'Gaia Herbs Rhodiola Rosea' }),
       },
       {
         slot: 'premium',
@@ -144,7 +144,7 @@ export const revenueProductSets: Record<string, RevenueProductSet> = {
         brand: 'Real Mushrooms',
         title: "Real Mushrooms Lion's Mane",
         rationale: 'Best overall pick for fruiting-body-forward labeling and mushroom-category transparency.',
-        affiliateUrl: amazonProductUrl({ query: "Real Mushrooms Lion's Mane" }),
+        affiliateUrl: amazonProductUrl({ asin: 'B07YJN369J', query: "Real Mushrooms Lion's Mane" }),
       },
       {
         slot: 'premium',

--- a/src/lib/revenue-tracking.ts
+++ b/src/lib/revenue-tracking.ts
@@ -32,6 +32,34 @@ export function buildRevenueEvent(input: RevenueEventInput): RevenueEvent {
   }
 }
 
+export function trackAffiliateClick(productName: string) {
+  if (typeof window !== 'undefined' && window.gtag) {
+    window.gtag('event', 'affiliate_click', {
+      product_name: productName,
+      value: 1,
+      currency: 'USD',
+    })
+  }
+}
+
+export function trackEmailCapture(source: string) {
+  if (typeof window !== 'undefined' && window.gtag) {
+    window.gtag('event', 'email_signup', {
+      signup_source: source,
+      value: 1,
+    })
+  }
+}
+
+export function trackProfileView(profileName: string, profileType: string) {
+  if (typeof window !== 'undefined' && window.gtag) {
+    window.gtag('event', 'profile_view', {
+      profile_name: profileName,
+      profile_type: profileType,
+    })
+  }
+}
+
 export function trackRevenueEvent(input: RevenueEventInput) {
   if (typeof window === 'undefined') return
 


### PR DESCRIPTION
- Wire 5 ASIN-direct affiliate URLs to overall product slots (razzleberry02-20 tag)
- Add trackAffiliateClick, trackEmailCapture, trackProfileView GA4 helpers
- Update blog post author to Will in byline, metadata, and Article JSON-LD
- .env.local created locally with Mailchimp action URL and GA4 placeholder

https://claude.ai/code/session_01EPzFh16iZydvBMtHNxrScz