### PR TITLE
feat: add /tools hub page, LegacyProfileBanner for dual herb profiles, enhance /compounds, confirm /blog SSR

### DIFF
--- a/app/compounds/page.tsx
+++ b/app/compounds/page.tsx
@@ -45,6 +45,7 @@ type FilterState = {
   category: string
   evidence: string
   safety: string
+  sort: string
 }
 
 const CATEGORY_FILTERS = [
@@ -105,6 +106,19 @@ function getSafetyLabel(c: Compound): string {
   )
 }
 
+function getBestFor(c: Compound): string {
+  const primary = list(c.primary_effects || c.effects)
+    .map(formatDisplayLabel)
+    .filter(Boolean)
+    .slice(0, 3)
+  if (primary.length > 0) return primary.join(' • ')
+  const mech = list(c.mechanisms || c.mechanism_categories)
+    .map(formatDisplayLabel)
+    .filter(Boolean)
+    .slice(0, 2)
+  return mech.length > 0 ? mech.join(' • ') : 'Research context'
+}
+
 function getSearchCorpus(c: Compound): string {
   return [
     getName(c),
@@ -161,6 +175,7 @@ function buildFilterUrl(base: string, next: Partial<FilterState>, page?: number)
   if (next.category && next.category !== 'all') p.set('category', next.category)
   if (next.evidence && next.evidence !== 'all') p.set('evidence', next.evidence)
   if (next.safety && next.safety !== 'all') p.set('safety', next.safety)
+  if (next.sort && next.sort !== 'alpha') p.set('sort', next.sort)
   if (page && page > 1) p.set('page', String(page))
   const qs = p.toString()
   return qs ? `${base}?${qs}` : base
@@ -186,6 +201,7 @@ function CompoundCard({ c }: { c: Compound }) {
   const cat = getCategory(c)
   const desc = getBrief(c)
   const ev = getEvidenceLabel(c)
+  const best = getBestFor(c)
   const slug = c.slug || ''
   const href = `/compounds/${slug}`
 
@@ -200,6 +216,9 @@ function CompoundCard({ c }: { c: Compound }) {
       </div>
       <div className="mt-0.5 text-[11px] font-medium uppercase tracking-[0.08em] text-[#5f6f66]">{cat}</div>
       <p className="mt-2 line-clamp-3 text-sm leading-6 text-[#46574d]">{desc || 'Compound profile with mechanism, evidence, and safety context.'}</p>
+      {best && best !== 'Research context' && (
+        <div className="mt-2 text-[11px] text-[#5f6f66] line-clamp-1">Best for: {best}</div>
+      )}
       <span className="mt-auto pt-3 text-xs font-semibold text-brand-800 group-hover:underline">View profile →</span>
     </Link>
   )
@@ -217,6 +236,7 @@ export default async function CompoundsPage({
     category: text(Array.isArray(sp.category) ? sp.category[0] : sp.category) || 'all',
     evidence: text(Array.isArray(sp.evidence) ? sp.evidence[0] : sp.evidence) || 'all',
     safety: text(Array.isArray(sp.safety) ? sp.safety[0] : sp.safety) || 'all',
+    sort: text(Array.isArray(sp.sort) ? sp.sort[0] : sp.sort) || 'alpha',
   }
 
   const page = clampPositiveInt(Array.isArray(sp.page) ? sp.page[0] : sp.page, 1)
@@ -225,7 +245,22 @@ export default async function CompoundsPage({
   const allCompounds: Compound[] = raw.filter((c: any) => c?.slug && getRuntimeVisibility(c).canRender)
 
   const filtered = filterCompounds(allCompounds, f)
-  const paged = paginateItems(filtered, page, COMPOUNDS_PAGE_SIZE)
+
+  // Apply sort (default alpha by name; evidence strength secondary)
+  let sorted = [...filtered]
+  if (f.sort === 'evidence') {
+    sorted.sort((a, b) => {
+      const ea = getEvidenceLabel(a)
+      const eb = getEvidenceLabel(b)
+      const rank = (s: string) => /strong/i.test(s) ? 3 : /moderate/i.test(s) ? 2 : 1
+      const r = rank(eb) - rank(ea)
+      return r !== 0 ? r : getName(a).localeCompare(getName(b))
+    })
+  } else {
+    sorted.sort((a, b) => getName(a).localeCompare(getName(b)))
+  }
+
+  const paged = paginateItems(sorted, page, COMPOUNDS_PAGE_SIZE)
 
   const total = filtered.length
   const showingFrom = paged.pageItems.length > 0 ? (paged.currentPage - 1) * paged.pageSize + 1 : 0
@@ -328,8 +363,31 @@ export default async function CompoundsPage({
             </div>
           </div>
 
+          {/* Sort options (server-driven) */}
+          <div>
+            <div className="mb-1 text-xs font-bold uppercase tracking-[0.12em] text-[#5f6f66]">Sort</div>
+            <div className="flex flex-wrap gap-2">
+              {[
+                { label: 'A–Z', value: 'alpha' },
+                { label: 'Evidence strength', value: 'evidence' },
+              ].map((opt) => {
+                const href = buildFilterUrl(basePath, { ...f, sort: opt.value }, 1)
+                const active = (f.sort || 'alpha') === opt.value
+                return (
+                  <Link
+                    key={opt.value}
+                    href={href}
+                    className={`rounded-full border px-2.5 py-1 text-xs font-semibold transition ${active ? 'border-brand-700/25 bg-brand-50 text-brand-900' : 'border-brand-900/10 bg-white/80 text-[#33443a] hover:border-brand-700/20'}`}
+                  >
+                    {opt.label}
+                  </Link>
+                )
+              })}
+            </div>
+          </div>
+
           {/* Active filters reset */}
-          {(f.q || f.category !== 'all' || f.evidence !== 'all' || f.safety !== 'all') && (
+          {(f.q || f.category !== 'all' || f.evidence !== 'all' || f.safety !== 'all' || (f.sort && f.sort !== 'alpha')) && (
             <div className="pt-1">
               <Link href={basePath} className="text-xs font-semibold text-brand-800 underline-offset-2 hover:underline">
                 Clear all filters

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -34,6 +34,7 @@ import { getRevenueProductSet } from '@/config/revenue-products'
 import { getStackRecommendations } from '@/lib/recommendation-engine'
 import { AshwagandhaStressClaim } from './AshwagandhaStressClaim'
 import { isRestrictedRecord } from '@/lib/restricted-ingredients'
+import LegacyProfileBanner from '@/components/LegacyProfileBanner'
 
 
 type PageProps = {
@@ -260,6 +261,13 @@ export default async function HerbDetailPage({ params }: PageProps) {
     redirect(`/herbs/${normalizedSlug}/`)
   }
 
+  // Legacy / old-system slug detection for migration banner (new scientific-name slugs are canonical)
+  const legacyToNewMap = Object.fromEntries(
+    Object.entries(HERB_CANONICAL_SOURCE_ALIASES).map(([newS, oldS]) => [oldS, newS])
+  )
+  const isLegacySlug = !!legacyToNewMap[normalizedSlug]
+  const newSlugForBanner = isLegacySlug ? `/herbs/${legacyToNewMap[normalizedSlug]}/` : null
+
   const suppressAffiliate = shouldSuppressAffiliate(herb)
 
   const {
@@ -379,6 +387,9 @@ export default async function HerbDetailPage({ params }: PageProps) {
 
   return (
     <div className="mx-auto max-w-4xl space-y-8 px-4 py-6">
+      {isLegacySlug && newSlugForBanner && (
+        <LegacyProfileBanner newSlug={newSlugForBanner} herbName={displayName} />
+      )}
       <ScrollEngagementPrompt storageKey={`herb-prompt-${normalizedSlug}`} />
       <SchemaGraphScript graph={schemaGraph} />
 

--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -1,0 +1,153 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { Shield, GitCompare, Target, Search, Calculator, AlertTriangle, BookOpen } from 'lucide-react'
+import { buildPageMetadata } from '@/lib/seo'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Research Tools',
+  description: 'Interactive tools for navigating herb and compound evidence: safety checker, comparisons, goal guides, and site search.',
+  path: '/tools',
+})
+
+type ToolCard = {
+  href: string
+  title: string
+  description: string
+  icon: React.ComponentType<{ className?: string }>
+  available: boolean
+}
+
+const tools: ToolCard[] = [
+  {
+    href: '/safety-checker',
+    title: 'Safety Checker',
+    description: 'Check interactions, contraindications, and cautions for herbs and compounds against your medications or conditions.',
+    icon: Shield,
+    available: true,
+  },
+  {
+    href: '/compare',
+    title: 'Herb & Compound Comparison',
+    description: 'Side-by-side evidence, mechanisms, and safety comparison of two or more profiles.',
+    icon: GitCompare,
+    available: true,
+  },
+  {
+    href: '/goals',
+    title: 'Goal-Based Decision Guides',
+    description: 'Browse by practical goal (sleep, focus, stress) with evidence-ranked recommendations and context.',
+    icon: Target,
+    available: true,
+  },
+  {
+    href: '/search',
+    title: 'Site Search',
+    description: 'Full-text search across all herb, compound, and research note profiles powered by Pagefind.',
+    icon: Search,
+    available: true,
+  },
+]
+
+const comingSoon: ToolCard[] = [
+  {
+    href: '#',
+    title: 'Dosing Calculator',
+    description: 'Evidence-informed starting ranges and titration guidance (with safety guardrails).',
+    icon: Calculator,
+    available: false,
+  },
+  {
+    href: '#',
+    title: 'Interaction Checker',
+    description: 'Deeper medication + supplement interaction matrix with references.',
+    icon: AlertTriangle,
+    available: false,
+  },
+  {
+    href: '#',
+    title: 'Evidence Tracker',
+    description: 'Track updates to specific profiles and new human trials in your areas of interest.',
+    icon: BookOpen,
+    available: false,
+  },
+]
+
+export default function ToolsPage() {
+  return (
+    <div className="mx-auto max-w-6xl space-y-8 px-4 py-6 sm:py-8">
+      {/* Hero */}
+      <section className="hero-shell rounded-[0.95rem] border border-brand-900/10 p-4 shadow-sm sm:p-5">
+        <p className="eyebrow-label">Interactive research tools</p>
+        <h1 className="mt-2 max-w-3xl font-display text-3xl font-semibold tracking-tight text-ink sm:text-5xl">
+          Research Tools
+        </h1>
+        <p className="mt-2 max-w-2xl text-sm leading-6 text-[#46574d]">
+          Interactive tools for navigating herb and compound evidence without the guesswork.
+        </p>
+      </section>
+
+      {/* Available tools */}
+      <section className="space-y-4">
+        <div>
+          <p className="eyebrow-label">Available now</p>
+          <h2 className="compact-heading">Use these tools to make better decisions.</h2>
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          {tools.map((tool) => {
+            const Icon = tool.icon
+            return (
+              <Link
+                key={tool.href}
+                href={tool.href}
+                className="group flex h-full flex-col rounded-[0.85rem] border border-brand-900/10 bg-white/80 p-4 shadow-sm transition hover:border-brand-700/30 hover:bg-white"
+              >
+                <div className="flex items-center gap-3">
+                  <span className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-brand-900/10 bg-white text-brand-800">
+                    <Icon className="h-4 w-4" />
+                  </span>
+                  <h3 className="text-base font-semibold tracking-tight text-ink group-hover:text-brand-800">{tool.title}</h3>
+                </div>
+                <p className="mt-2 flex-1 text-sm leading-6 text-[#46574d]">{tool.description}</p>
+                <span className="mt-3 inline-flex text-xs font-semibold text-brand-800 group-hover:underline">Open tool →</span>
+              </Link>
+            )
+          })}
+        </div>
+      </section>
+
+      {/* Coming soon */}
+      <section className="space-y-4">
+        <div>
+          <p className="eyebrow-label">Planned</p>
+          <h2 className="compact-heading">More tools are in development.</h2>
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          {comingSoon.map((tool) => {
+            const Icon = tool.icon
+            return (
+              <div
+                key={tool.title}
+                className="flex h-full flex-col rounded-[0.85rem] border border-brand-900/10 bg-white/60 p-4 opacity-80"
+              >
+                <div className="flex items-center gap-3">
+                  <span className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-brand-900/10 bg-white text-[#5f6f66]">
+                    <Icon className="h-4 w-4" />
+                  </span>
+                  <h3 className="text-base font-semibold tracking-tight text-ink">{tool.title}</h3>
+                </div>
+                <p className="mt-2 flex-1 text-sm leading-6 text-[#46574d]">{tool.description}</p>
+                <span className="mt-3 inline-flex text-xs font-semibold text-[#5f6f66]">Coming soon</span>
+              </div>
+            )
+          })}
+        </div>
+      </section>
+
+      <p className="text-center text-xs text-[#5f6f66]">
+        All tools are evidence-first and include conservative safety framing. Not medical advice.
+      </p>
+    </div>
+  )
+}

--- a/components/LegacyProfileBanner.tsx
+++ b/components/LegacyProfileBanner.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+
+interface LegacyProfileBannerProps {
+  newSlug: string
+  herbName: string
+}
+
+export default function LegacyProfileBanner({ newSlug, herbName }: LegacyProfileBannerProps) {
+  const storageKey = `dismissed-legacy-banner-${newSlug.replace(/[^a-z0-9-]/gi, '')}`
+
+  const [isDismissed, setIsDismissed] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false
+    try {
+      return window.localStorage.getItem(storageKey) === 'true'
+    } catch {
+      return false
+    }
+  })
+
+  if (isDismissed) return null
+
+  const handleDismiss = () => {
+    setIsDismissed(true)
+    try {
+      window.localStorage.setItem(storageKey, 'true')
+    } catch {
+      // ignore storage errors (private mode etc)
+    }
+  }
+
+  return (
+    <div
+      role="alert"
+      className="mb-4 rounded-[0.75rem] border border-brand-700/20 bg-brand-50/70 px-4 py-3 text-sm text-ink shadow-sm"
+    >
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <p className="leading-snug">
+          This profile has been updated. View the new evidence-based profile for{' '}
+          <span className="font-semibold">{herbName}</span> with citations, safety context, and sourcing guidance.
+        </p>
+        <div className="flex items-center gap-2 sm:ml-4">
+          <Link
+            href={newSlug}
+            className="inline-flex items-center rounded-full bg-brand-700 px-3 py-1 text-xs font-bold text-white transition hover:bg-brand-800"
+          >
+            View updated profile →
+          </Link>
+          <button
+            type="button"
+            onClick={handleDismiss}
+            aria-label="Dismiss this banner"
+            className="rounded p-1 text-brand-800/70 hover:bg-white/60 hover:text-brand-900"
+          >
+            ✕
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
This PR implements the four tasks from the re-audit:

**TASK 1 — Fix /blog (static SSR)**
- Inspected app/blog/page.tsx: already a pure async Server Component.
- Static build-time data load via `import rawPosts from '@/data/blog/posts.json'` (sourced from content/blog/ MDX).
- All article titles, links, cards, Latest section, grid, pagination, and sr-only crawlable index are in the initial HTML.
- Category filter bar uses static <Link> (URL params) — no client JS required for the list.
- No 'use client', no useEffect/fetch, no loading state for core content. Confirmed data sources and lib/blog-index.
- No code changes needed (already compliant).

**TASK 2 — Build /compounds page**
- Inspected public/data/compounds.json (594 entries): schema includes slug, name, summary, description, effects, primary_effects, mechanisms, mechanism_categories, evidence_tier/evidenceLevel, etc.
- Inspected app/herbs/page.tsx as exact reference (summary load, visibility filter, pagination, sr-only links, client grid for UX).
- app/compounds/page.tsx is async Server Component using getAllCompounds + visibility (build-time data).
- Server-rendered cards: name, category badge, evidence badge, first 120 chars of description, best_for tags (derived from primary_effects), "View profile →".
- Added sort support (default alphabetical by name; "Evidence strength" option with server sort + UI chips).
- Filters (category, evidence, safety) + search via server params (local filter on loaded data, consistent with herbs form pattern).
- sr-only index + full list in static HTML. Zero client fetching for content.
- Verified first entries and schema via direct read.

**TASK 3 — Build /tools page**
- Confirmed no prior app/tools route.
- Verified target routes exist: /safety-checker, /compare, /goals, /search ( /build missing so not linked).
- New pure async Server Component app/tools/page.tsx.
- Hero: "Research Tools" + spec description.
- Tool cards for live tools (Safety Checker, Herb & Compound Comparison, Goal-Based Decision Guides, Site Search) using Lucide icons (project already depends on lucide-react).
- Coming Soon section for Dosing Calculator, Interaction Checker, Evidence Tracker.
- Consistent styling with other new-system pages (hero-shell, cards, etc.).

**TASK 4 — Dual-profile migration component**
- Created components/LegacyProfileBanner.tsx ('use client' for localStorage + useState).
- Props: newSlug, herbName.
- Renders dismissible gentle info banner (role="alert", accessible close button with aria-label, localStorage key per slug).
- Text: "This profile has been updated. View the new evidence-based profile for [herbName] with citations, safety context, and sourcing guidance." + CTA link.
- Integrated into app/herbs/[slug]/page.tsx (the page handling both old short slugs like /herbs/ashwagandha and new /herbs/ashwagandha-withania-somnifera).
- Derives legacy status + newSlug by reversing existing HERB_CANONICAL_SOURCE_ALIASES map (inspected the dual-slug logic, generateStaticParams, redirects, displayName computation).
- Banner renders early in content for old-system profiles during transition (redirects handled by separate agent).

All per constraints: Tailwind 4 only, strict TS (no new any), no new npm deps, match existing patterns (inspected adjacent files first), static export only, preserve /herbs/:slug etc. routes. Static export guard passed after changes. No data pipeline, redirect, or nav edits.

Files: app/tools/page.tsx (new), components/LegacyProfileBanner.tsx (new), app/compounds/page.tsx (enhanced), app/herbs/[slug]/page.tsx (integration).