### PR TITLE
[codex] Clarify goal guide navigation

### DIFF
--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -10,7 +10,7 @@ const desktopLinks = [
   { href: '/', label: 'Home' },
   { href: '/blog', label: 'Articles' },
   { href: '/compare', label: 'Comparisons' },
-  { href: '/goals', label: 'Evidence Reviews' },
+  { href: '/goals', label: 'Goal Guides' },
   { href: '/about', label: 'About' },
 ]
 

--- a/lib/navigation-config.ts
+++ b/lib/navigation-config.ts
@@ -83,9 +83,9 @@ export const mainNavigation: NavigationItem[] = [
     description: 'Side-by-side herb and compound comparisons',
   },
   {
-    label: 'Evidence Reviews',
+    label: 'Goal Guides',
     href: '/goals',
-    description: 'Health pathway guides with evidence-graded candidate compounds',
+    description: 'Goal-based decision guides with evidence-graded herbs and compounds',
   },
   {
     label: 'About',


### PR DESCRIPTION
## Summary
- Renames the primary `/goals` navigation entry from "Evidence Reviews" to "Goal Guides"
- Updates shared navigation metadata so the goal layer is described as goal-based decision guidance

## Issue context
- Partially addresses #1747 by making goal pages more prominent and explicit in primary navigation
- I also verified the previously reported workbook gap audit blocker from #1744 is resolved on current `main`: `npm run data:audit` scans 290 herbs and 617 compounds and writes the gap reports

## Validation
- `npm run check:ui` passed
- `npm run data:audit` passed
