### PR TITLE
Nav restructure: Learn → Guides, Blog → Articles taxonomy migration

### DIFF
--- a/app/__tests__/blog-index.test.ts
+++ b/app/__tests__/blog-index.test.ts
@@ -9,10 +9,10 @@ describe('blog index model', () => {
     expect(hrefs).toEqual([
       '/articles/style/research-digests',
       '/articles/style/pharmacology-basics',
-      '/articles/style/traditional-use',
-      '/articles/style/extraction-preparation',
       '/articles/style/safety-set-setting',
-      '/articles/style/field-notes',
+      '/articles/style/traditional-use',
+      '/articles/style/nootropics',
+      '/articles/style/extraction-preparation',
     ])
     expect(hrefs).not.toContain('/articles')
   })

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -169,6 +169,7 @@ export default async function BlogPage({
       if (category === 'traditional-use') return corpus.includes('traditional')
       if (category === 'extraction-preparation') return corpus.includes('extraction') || corpus.includes('preparation') || corpus.includes('formulation')
       if (category === 'safety-set-setting') return corpus.includes('safety') || corpus.includes('set setting')
+      if (category === 'nootropics') return corpus.includes('nootropic') || corpus.includes('cognitive') || corpus.includes('brain') || corpus.includes('focus')
       if (category === 'field-notes') return corpus.includes('field note') || corpus.includes('bioassay')
       return true
     })
@@ -200,16 +201,16 @@ export default async function BlogPage({
       {/* Hero */}
       <section className="hero-shell rounded-[0.95rem] border border-brand-900/10 p-4 shadow-sm sm:p-5">
           <p className="eyebrow-label">Articles</p>
-          <h1 className="mt-2 max-w-3xl font-display text-3xl font-semibold tracking-tight text-ink sm:text-5xl">Guides &amp; research notes</h1>
+          <h1 className="mt-2 max-w-3xl font-display text-3xl font-semibold tracking-tight text-ink sm:text-5xl">Educational &amp; research articles</h1>
         <p className="mt-2 max-w-2xl text-sm leading-6 text-[#46574d]">
-          Mechanisms, preparations, safety limits, and evidence maturity for fast scanning.
+          Pharmacology, mechanisms, historical medicine, safety discussions, and compound deep dives. Citation-heavy, less commercial, supporting topical authority.
         </p>
         <p className="mt-1 text-sm font-semibold text-[#46574d]">{count} articles available</p>
       </section>
 
       {/* Category filter (static links) */}
       <div>
-        <p className="mb-2 text-xs font-bold uppercase tracking-[0.12em] text-[#5f6f66]">Filter by style</p>
+        <p className="mb-2 text-xs font-bold uppercase tracking-[0.12em] text-[#5f6f66]">Filter by category</p>
         <CategoryFilterBar active={category} />
       </div>
 

--- a/app/compare/[slug]/page.tsx
+++ b/app/compare/[slug]/page.tsx
@@ -420,7 +420,7 @@ export default async function Page({ params }: Params) {
             description: 'Start with practical overviews before advanced stacking.',
             links: [
               { href: `/${winner.entityType === 'herb' ? 'herbs' : 'compounds'}/${winner.slug}`, label: `${displayName(winner)} profile` },
-              { href: '/learn', label: 'Learn evidence basics' },
+              { href: '/guides', label: 'Browse supplement guides' },
             ],
           },
           {

--- a/app/guides/page.tsx
+++ b/app/guides/page.tsx
@@ -1,108 +1,298 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
-import { indexableGuidePages } from '../seo-entry-pages'
+import { learnPosts } from '../learn/data'
+import { SITE_URL } from '@/lib/navigation-config'
 
 export const metadata: Metadata = {
-  title: 'Supplement Guides',
+  title: 'Supplement Guides — Problem-Solving Evidence-Informed Content',
   description:
-    'Evidence-aware supplement guides for sleep, stress, focus, anxiety, gut health, joint support, and product-quality decisions.',
+    'Evidence-aware guides for sleep, stress, anxiety, focus, ADHD, depression, and cognitive performance. Comparisons, dosing context, and safety tradeoffs included.',
   alternates: { canonical: '/guides' },
+  openGraph: {
+    title: 'Supplement Guides — The Hippie Scientist',
+    description:
+      'Problem-solving supplement guides for anxiety, sleep, focus, stress, ADHD, and cognitive performance. Long-form, search-intent focused, evidence-graded.',
+    url: '/guides',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Supplement Guides — The Hippie Scientist',
+    description:
+      'Evidence-informed guides for sleep, anxiety, focus, stress, ADHD, and cognitive performance.',
+  },
 }
 
-const priorityRoutes = new Set([
-  'guides/best-supplements-for-sleep',
-  'guides/best-supplements-for-stress',
-  'guides/best-herbs-for-anxiety',
-  'guides/best-nootropics-for-focus',
-  'guides/best-supplements-for-gut-health',
-  'guides/best-supplements-for-joint-support',
-  'guides/best-supplements-for-blood-pressure-support',
-  'guides/natural-testosterone-boosters',
-  'guides/focus-without-caffeine-crash',
-  'guides/supplements-for-brain-fog-and-fatigue',
-])
-
-const featuredGuides = indexableGuidePages
-  .filter((page) => priorityRoutes.has(page.route))
-  .sort((a, b) => a.h1.localeCompare(b.h1))
-
-const curatedStaticGuides = [
+const CONDITIONS = [
   {
-    href: '/guides/magnesium-vs-melatonin',
-    title: 'Magnesium vs Melatonin',
-    intro: 'Compare relaxation support against sleep-timing support before choosing a nighttime option.',
+    label: 'Anxiety',
+    slug: 'anxiety',
+    guides: [
+      { href: '/guides/best-herbs-for-anxiety', title: 'Best Herbs for Anxiety', readingTime: '8 min', evidenceStrength: 'Moderate–Strong' },
+      { href: '/guides/natural-anxiolytics-beyond-ashwagandha', title: 'Natural Anxiolytics Beyond Ashwagandha', readingTime: '7 min', evidenceStrength: 'Moderate' },
+      { href: '/guides/natural-alternatives-to-anxiety-medication', title: 'Natural Alternatives to Anxiety Medication', readingTime: '9 min', evidenceStrength: 'Moderate' },
+      { href: '/guides/best-supplements-for-overthinking', title: 'Best Supplements for Overthinking', readingTime: '6 min', evidenceStrength: 'Emerging' },
+    ],
   },
   {
-    href: '/guides/focus-without-caffeine-crash',
-    title: 'Focus Without the Caffeine Crash',
-    intro: 'A practical guide for cleaner attention support without piling on more stimulants.',
+    label: 'Sleep',
+    slug: 'sleep',
+    guides: [
+      { href: '/guides/best-supplements-for-sleep', title: 'Best Supplements for Sleep', readingTime: '10 min', evidenceStrength: 'Strong' },
+      { href: '/guides/best-natural-sleep-aids-that-work', title: 'Best Natural Sleep Aids That Work', readingTime: '8 min', evidenceStrength: 'Moderate–Strong' },
+      { href: '/guides/sleep-herbs-vs-melatonin', title: 'Sleep Herbs vs Melatonin', readingTime: '7 min', evidenceStrength: 'Moderate' },
+      { href: '/guides/magnesium-vs-melatonin', title: 'Magnesium vs Melatonin', readingTime: '6 min', evidenceStrength: 'Moderate' },
+      { href: '/guides/best-herbs-for-stress-and-anxiety-at-night', title: 'Best Herbs for Stress and Anxiety at Night', readingTime: '7 min', evidenceStrength: 'Moderate' },
+    ],
   },
   {
-    href: '/guides/supplements-for-brain-fog-and-fatigue',
-    title: 'Supplements for Brain Fog and Fatigue',
-    intro: 'A skeptical decision guide for fatigue, mental clarity, and recovery-related support.',
+    label: 'Focus & Cognition',
+    slug: 'focus',
+    guides: [
+      { href: '/guides/best-nootropics-for-focus', title: 'Best Nootropics for Focus', readingTime: '9 min', evidenceStrength: 'Moderate' },
+      { href: '/guides/best-supplements-for-focus', title: 'Best Supplements for Focus', readingTime: '8 min', evidenceStrength: 'Moderate' },
+      { href: '/guides/focus-without-caffeine-crash', title: 'Focus Without the Caffeine Crash', readingTime: '7 min', evidenceStrength: 'Moderate' },
+      { href: '/guides/supplements-for-brain-fog-and-fatigue', title: 'Supplements for Brain Fog and Fatigue', readingTime: '8 min', evidenceStrength: 'Emerging–Moderate' },
+    ],
   },
   {
-    href: '/guides/best-natural-sleep-aids-that-work',
-    title: 'Best Natural Sleep Aids That Work',
-    intro: 'A sleep-support guide that keeps evidence strength, timing, and safety tradeoffs visible.',
+    label: 'Stress',
+    slug: 'stress',
+    guides: [
+      { href: '/guides/best-supplements-for-stress', title: 'Best Supplements for Stress', readingTime: '9 min', evidenceStrength: 'Strong' },
+      { href: '/guides/best-adaptogens-for-stress', title: 'Best Adaptogens for Stress', readingTime: '8 min', evidenceStrength: 'Moderate–Strong' },
+      { href: '/guides/how-to-lower-cortisol-naturally', title: 'How to Lower Cortisol Naturally', readingTime: '8 min', evidenceStrength: 'Moderate' },
+    ],
   },
   {
-    href: '/guides/kratom-7oh-withdrawal-management',
-    title: 'Kratom 7-OH Withdrawal Management',
-    intro: 'Evidence-informed strategies for 7-hydroxymitragynine (7-OH) withdrawal, including symptom timeline, tapering approaches, harm reduction context, and when to seek medical support.',
+    label: 'Cognitive Performance',
+    slug: 'cognition',
+    guides: [
+      { href: '/guides/best-supplements-for-fat-loss', title: 'Best Supplements for Fat Loss', readingTime: '9 min', evidenceStrength: 'Moderate' },
+      { href: '/guides/natural-testosterone-boosters', title: 'Natural Testosterone Boosters', readingTime: '9 min', evidenceStrength: 'Moderate' },
+    ],
   },
 ]
 
+const COMPARISONS = [
+  { href: '/guides/magnesium-vs-melatonin', title: 'Magnesium vs Melatonin', subtitle: 'Relaxation support vs sleep-timing support' },
+  { href: '/guides/sleep-herbs-vs-melatonin', title: 'Sleep Herbs vs Melatonin', subtitle: 'Herbals vs hormone for sleep onset' },
+  { href: '/compare/rhodiola-vs-ashwagandha', title: 'Rhodiola vs Ashwagandha', subtitle: 'Performance adaptogen vs recovery adaptogen' },
+  { href: '/compare', title: 'Browse All Comparisons', subtitle: 'Full side-by-side comparison index' },
+]
+
+const STACK_GUIDES = learnPosts.map((post) => ({
+  href: `/learn/${post.slug}`,
+  title: post.title,
+  description: post.description,
+  category: post.category,
+  readingTime: post.readingTime,
+}))
+
+function GuidesCollectionJsonLd() {
+  const allGuideLinks = CONDITIONS.flatMap((c) => c.guides)
+  const graph = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'CollectionPage',
+        '@id': `${SITE_URL}/guides/#webpage`,
+        name: 'Supplement Guides',
+        headline: 'Problem-solving supplement guides',
+        description:
+          'Evidence-aware guides for sleep, anxiety, focus, stress, ADHD, and cognitive performance. Includes comparisons, dosing context, and safety tradeoffs.',
+        url: `${SITE_URL}/guides/`,
+        isPartOf: { '@type': 'WebSite', name: 'The Hippie Scientist', url: SITE_URL },
+        mainEntity: { '@id': `${SITE_URL}/guides/#item-list` },
+      },
+      {
+        '@type': 'ItemList',
+        '@id': `${SITE_URL}/guides/#item-list`,
+        name: 'The Hippie Scientist supplement guides',
+        itemListElement: allGuideLinks.map((g, i) => ({
+          '@type': 'ListItem',
+          position: i + 1,
+          url: `${SITE_URL}${g.href}`,
+          name: g.title,
+        })),
+      },
+    ],
+  }
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(graph) }}
+    />
+  )
+}
+
 export default function GuidesPage() {
   return (
-    <div className="mx-auto max-w-6xl space-y-8 px-4 py-8 sm:px-6 sm:py-10 lg:px-8">
-      <section className="rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+    <div className="mx-auto max-w-6xl space-y-12 px-4 py-8 sm:px-6 sm:py-12 lg:px-8">
+      <GuidesCollectionJsonLd />
+
+      {/* Hero */}
+      <section className="rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-10">
         <p className="eyebrow-label">Supplement guide library</p>
         <h1 className="mt-3 text-3xl font-bold tracking-tight text-ink sm:text-5xl">
           Practical supplement guides, consolidated.
         </h1>
         <p className="mt-4 max-w-3xl text-sm leading-7 text-muted sm:text-base">
-          Start with a guide when you know the problem you are trying to solve, then move into
-          goal pages, comparisons, safety context, and ingredient profiles before buying.
+          Start with a guide when you know the problem you are trying to solve. Every guide covers evidence strength,
+          safety tradeoffs, dosing context, and related herbs before pointing toward buying decisions.
         </p>
+        <div className="mt-6 flex flex-wrap gap-3">
+          <Link
+            href="/goals"
+            className="rounded-full border border-brand-900/15 px-4 py-2 text-sm font-medium text-ink transition hover:bg-ink hover:text-white"
+          >
+            Browse goal-based decision pages
+          </Link>
+          <Link
+            href="/compare"
+            className="rounded-full border border-brand-900/15 px-4 py-2 text-sm font-medium text-ink transition hover:bg-ink hover:text-white"
+          >
+            Head-to-head comparisons
+          </Link>
+        </div>
       </section>
 
-      <section className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-        {featuredGuides.map((guide) => (
+      {/* By condition */}
+      {CONDITIONS.map((condition) => (
+        <section key={condition.slug} className="space-y-4">
+          <div className="flex items-baseline justify-between">
+            <div>
+              <p className="eyebrow-label">{condition.label}</p>
+              <h2 className="mt-1 text-2xl font-semibold tracking-tight text-ink">
+                Guides for {condition.label}
+              </h2>
+            </div>
+            <Link
+              href={`/goals/${condition.slug}`}
+              className="hidden text-sm font-medium text-brand-700 hover:underline sm:block"
+            >
+              Goal page →
+            </Link>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {condition.guides.map((guide) => (
+              <Link
+                key={guide.href}
+                href={guide.href}
+                className="group rounded-2xl border border-brand-900/10 bg-white/90 p-5 shadow-sm transition hover:border-brand-700/20 hover:bg-white"
+              >
+                <div className="flex items-center justify-between">
+                  <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">
+                    Guide
+                  </p>
+                  <span className="rounded-full bg-brand-50 px-2 py-0.5 text-[10px] font-semibold text-brand-800">
+                    {guide.evidenceStrength}
+                  </span>
+                </div>
+                <h3 className="mt-2 text-lg font-semibold tracking-tight text-ink group-hover:text-brand-800">
+                  {guide.title}
+                </h3>
+                <p className="mt-1 text-xs text-muted">{guide.readingTime} read</p>
+              </Link>
+            ))}
+          </div>
+        </section>
+      ))}
+
+      {/* Comparisons */}
+      <section className="space-y-4">
+        <div>
+          <p className="eyebrow-label">Comparisons</p>
+          <h2 className="mt-1 text-2xl font-semibold tracking-tight text-ink">
+            Head-to-head guides
+          </h2>
+          <p className="mt-2 text-sm text-muted">
+            Compare two options before choosing. Covers mechanisms, evidence, dosing, and tradeoffs side-by-side.
+          </p>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {COMPARISONS.map((c) => (
+            <Link
+              key={c.href}
+              href={c.href}
+              className="rounded-2xl border border-brand-900/10 bg-white/90 p-5 shadow-sm transition hover:border-brand-700/20 hover:bg-white"
+            >
+              <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">
+                Compare
+              </p>
+              <h3 className="mt-2 text-base font-semibold tracking-tight text-ink">{c.title}</h3>
+              <p className="mt-1 text-xs text-muted">{c.subtitle}</p>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      {/* Stack & education guides (from learn section) */}
+      <section className="space-y-4">
+        <div>
+          <p className="eyebrow-label">Stack guides</p>
+          <h2 className="mt-1 text-2xl font-semibold tracking-tight text-ink">
+            Practical supplement stack guides
+          </h2>
+          <p className="mt-2 text-sm text-muted">
+            Long-form guides covering specific herb combinations with dosing context, timing, buying criteria, and safety notes.
+          </p>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {STACK_GUIDES.map((guide) => (
+            <Link
+              key={guide.href}
+              href={guide.href}
+              className="rounded-2xl border border-brand-900/10 bg-white/90 p-5 shadow-sm transition hover:border-brand-700/20 hover:bg-white"
+            >
+              <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">
+                {guide.category} · {guide.readingTime}
+              </p>
+              <h3 className="mt-2 text-base font-semibold tracking-tight text-ink">{guide.title}</h3>
+              <p className="mt-2 line-clamp-2 text-sm text-muted">{guide.description}</p>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      {/* Harm reduction */}
+      <section className="space-y-4">
+        <div>
+          <p className="eyebrow-label">Safety & harm reduction</p>
+          <h2 className="mt-1 text-2xl font-semibold tracking-tight text-ink">
+            Safety-first guides
+          </h2>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2">
           <Link
-            key={guide.route}
-            href={`/${guide.route}`}
+            href="/guides/psychedelic-adjacent-herbs"
             className="rounded-2xl border border-brand-900/10 bg-white/90 p-5 shadow-sm transition hover:border-brand-700/20 hover:bg-white"
           >
             <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">
-              Guide
+              Safety · 10 min
             </p>
-            <h2 className="mt-2 text-lg font-semibold tracking-tight text-ink">
-              {guide.h1}
-            </h2>
-            <p className="mt-2 line-clamp-3 text-sm leading-6 text-muted">
-              {guide.intro}
+            <h3 className="mt-2 text-base font-semibold tracking-tight text-ink">
+              Psychedelic-Adjacent Herbs
+            </h3>
+            <p className="mt-1 text-sm text-muted">
+              Education on altered states, perception, and safety context without romanticizing risky use.
             </p>
           </Link>
-        ))}
-        {curatedStaticGuides.map((guide) => (
           <Link
-            key={guide.href}
-            href={guide.href}
+            href="/guides/kratom-7oh-withdrawal-management"
             className="rounded-2xl border border-brand-900/10 bg-white/90 p-5 shadow-sm transition hover:border-brand-700/20 hover:bg-white"
           >
             <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">
-              Curated guide
+              Harm Reduction · 12 min
             </p>
-            <h2 className="mt-2 text-lg font-semibold tracking-tight text-ink">
-              {guide.title}
-            </h2>
-            <p className="mt-2 line-clamp-3 text-sm leading-6 text-muted">
-              {guide.intro}
+            <h3 className="mt-2 text-base font-semibold tracking-tight text-ink">
+              Kratom 7-OH Withdrawal Management
+            </h3>
+            <p className="mt-1 text-sm text-muted">
+              Evidence-informed strategies for 7-OH withdrawal with symptom timeline and tapering approaches.
             </p>
           </Link>
-        ))}
+        </div>
       </section>
     </div>
   )

--- a/app/learn/[slug]/page.tsx
+++ b/app/learn/[slug]/page.tsx
@@ -26,8 +26,9 @@ export async function generateMetadata({ params }: LearnRouteProps): Promise<Met
   }
 
   return {
-    title: `${post.title} | Learn`,
+    title: `${post.title} | Guides`,
     description: post.description,
+    alternates: { canonical: `/learn/${post.slug}` },
   }
 }
 
@@ -45,7 +46,7 @@ export default async function Page({ params }: LearnRouteProps) {
         <Breadcrumbs
           items={[
             { label: 'Home', href: '/' },
-            { label: 'Learn', href: '/learn' },
+            { label: 'Guides', href: '/guides' },
             { label: post.title },
           ]}
         />
@@ -118,7 +119,7 @@ export default async function Page({ params }: LearnRouteProps) {
               links: [
                 { href: '/guides/sleep-herbs-vs-melatonin', label: 'Sleep herbs vs melatonin' },
                 { href: '/guides/psychedelic-adjacent-herbs', label: 'Psychedelic-adjacent herbs' },
-                { href: '/learn', label: 'Browse all learn guides' },
+                { href: '/guides', label: 'Browse all guides' },
               ],
             },
           ]}

--- a/app/learn/page.tsx
+++ b/app/learn/page.tsx
@@ -2,21 +2,21 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 
 export const metadata: Metadata = {
-  title: 'Supplement Education Hub',
+  title: 'Supplement Guides — Stack Guides and Education',
   description:
-    'No hype, no marketing. Learn how to read supplement claims, evaluate evidence, compare adaptogens, nootropics, and herbs, and build safer stacks.',
-  alternates: { canonical: '/learn' },
+    'No hype, no marketing. Practical supplement stack guides for cognition, stress, sleep, and inflammation. Evidence-informed, safety-first.',
+  alternates: { canonical: '/guides' },
   openGraph: {
-    title: 'Learn Supplement Science and Safety Basics',
+    title: 'Supplement Stack Guides — The Hippie Scientist',
     description:
-      'Read plain-English education on supplement science, evidence quality, safety context, and decision-making tradeoffs.',
-    url: '/learn',
+      'Practical supplement stack guides covering evidence, safety, dosing, and buying criteria for cognition, stress, sleep, and more.',
+    url: '/guides',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Learn Supplement Science and Safety Basics',
+    title: 'Supplement Stack Guides — The Hippie Scientist',
     description:
-      'Read plain-English education on supplement science, evidence quality, safety context, and decision-making tradeoffs.',
+      'Practical supplement stack guides: cognition, stress, sleep, inflammation. Evidence-informed, safety-first.',
   },
 }
 
@@ -105,7 +105,7 @@ export default function LearnPage() {
             <p className='eyebrow-label'>Learn the basics</p>
 
             <h1 className='text-4xl font-bold tracking-tight text-ink sm:text-5xl'>
-              Evidence-informed supplement education
+              Supplement stack guides
             </h1>
           </div>
 
@@ -128,10 +128,10 @@ export default function LearnPage() {
             </Link>
 
             <Link
-              href='/learn/product-quality'
+              href='/guides'
               className='rounded-full border border-brand-900/15 px-4 py-2 text-sm font-medium text-ink transition hover:bg-ink hover:text-white'
             >
-              Product Quality Guide
+              Browse all guides
             </Link>
           </div>
         </div>
@@ -207,7 +207,7 @@ export default function LearnPage() {
           {learnPosts.map(post => (
             <Link
               key={post.slug}
-              href={`/education/${post.slug}`}
+              href={`/learn/${post.slug}`}
               className='rounded-2xl border border-brand-900/10 bg-white/90 p-5 transition hover:shadow-sm'
             >
               <p className='text-xs uppercase tracking-[0.16em] text-muted'>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { MetadataRoute } from 'next';
 
 import { SITE_URL } from '@/lib/site';
+import { learnPosts } from './learn/data';
 
 type SitemapSourceItem = {
   slug?: string;
@@ -82,7 +83,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
     route(`${SITE_URL}/about/`, currentDate, 'yearly', 0.6),
     route(`${SITE_URL}/contact/`, currentDate, 'yearly', 0.5),
     route(`${SITE_URL}/faq/`, currentDate, 'monthly', 0.7),
-    route(`${SITE_URL}/learn/`, currentDate, 'monthly', 0.7),
     route(`${SITE_URL}/methodology/`, currentDate, 'yearly', 0.6),
     route(`${SITE_URL}/safety-checker/`, currentDate, 'monthly', 0.8),
     route(`${SITE_URL}/herbs/`, currentDate, 'weekly', 0.9),
@@ -90,7 +90,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     route(`${SITE_URL}/articles/`, currentDate, 'daily', 0.8),
     route(`${SITE_URL}/goals/`, currentDate, 'monthly', 0.8),
     route(`${SITE_URL}/stacks/`, currentDate, 'monthly', 0.7),
-    route(`${SITE_URL}/guides/`, currentDate, 'monthly', 0.7),
+    route(`${SITE_URL}/guides/`, currentDate, 'monthly', 0.85),
     route(`${SITE_URL}/compare/`, currentDate, 'monthly', 0.7),
     route(`${SITE_URL}/tools/`, currentDate, 'monthly', 0.6),
     route(`${SITE_URL}/dosing/`, currentDate, 'monthly', 0.6),
@@ -170,6 +170,10 @@ export default function sitemap(): MetadataRoute.Sitemap {
     if (!guide.slug) return;
 
     sitemapEntries.push(route(`${SITE_URL}/guides/${guide.slug}/`, currentDate, 'monthly', 0.65));
+  });
+
+  learnPosts.forEach((post) => {
+    sitemapEntries.push(route(`${SITE_URL}/learn/${post.slug}/`, currentDate, 'monthly', 0.7));
   });
 
   // Add compare detail routes (data-driven, for task requirement to cover /compare/:slug)

--- a/app/start-here/page.tsx
+++ b/app/start-here/page.tsx
@@ -111,8 +111,8 @@ export default function StartHerePage() {
             <Link href='/herbs' className='rounded-full border border-brand-900/10 bg-white/90 px-4 py-2 text-sm font-medium text-ink transition hover:bg-white'>
               Browse herbs
             </Link>
-            <Link href='/learn' className='rounded-full border border-brand-900/10 bg-white/90 px-4 py-2 text-sm font-medium text-ink transition hover:bg-white'>
-              Learn the basics
+            <Link href='/guides' className='rounded-full border border-brand-900/10 bg-white/90 px-4 py-2 text-sm font-medium text-ink transition hover:bg-white'>
+              Browse guides
             </Link>
           </div>
         </div>

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -8,11 +8,11 @@ import { SearchModal } from './SearchModal'
 
 const desktopLinks = [
   { href: '/', label: 'Home' },
-  { href: '/guides', label: 'Guides & Articles' },
+  { href: '/herbs', label: 'Database' },
+  { href: '/compounds', label: 'Compounds' },
+  { href: '/guides', label: 'Guides' },
   { href: '/articles', label: 'Articles' },
-  { href: '/compare', label: 'Comparisons' },
-  { href: '/goals', label: 'Goal Guides' },
-  { href: '/about', label: 'About' },
+  { href: '/safety-checker', label: 'Safety' },
 ]
 
 function openPagefindSearch() {
@@ -55,6 +55,7 @@ export function Navigation() {
   const isActive = (href: string) => {
     if (href === '/') return pathname === '/'
     if (href === '/articles') return pathname === '/articles' || pathname.startsWith('/articles/') || pathname === '/research-notes' || pathname.startsWith('/research-notes/') || pathname === '/blog' || pathname.startsWith('/blog/')
+    if (href === '/guides') return pathname === '/guides' || pathname.startsWith('/guides/') || pathname === '/learn' || pathname.startsWith('/learn/')
     return pathname === href || pathname.startsWith(href + '/')
   }
 

--- a/lib/blog-index.ts
+++ b/lib/blog-index.ts
@@ -16,45 +16,45 @@ export type BlogStyleGroup = {
 export const BLOG_STYLE_GROUPS: BlogStyleGroup[] = [
   {
     slug: 'research-digests',
-    title: 'Research digests',
+    title: 'Research',
     description: 'Evidence summaries with limitations and cautious interpretation.',
     href: '/articles/style/research-digests',
     meta: 'Evidence',
   },
   {
     slug: 'pharmacology-basics',
-    title: 'Pharmacology basics',
+    title: 'Mechanisms',
     description: 'Mechanism-first explainers for pathways, compounds, and receptor context.',
     href: '/articles/style/pharmacology-basics',
     meta: 'Mechanism',
   },
   {
-    slug: 'traditional-use',
-    title: 'Traditional use',
-    description: 'Historical context kept separate from modern efficacy claims.',
-    href: '/articles/style/traditional-use',
-    meta: 'Tradition',
-  },
-  {
-    slug: 'extraction-preparation',
-    title: 'Extraction & preparation',
-    description: 'Form, solvent, dose visibility, and practical preparation notes.',
-    href: '/articles/style/extraction-preparation',
-    meta: 'Methods',
-  },
-  {
     slug: 'safety-set-setting',
-    title: 'Safety / set / setting',
+    title: 'Safety',
     description: 'Conservative reading for uncertainty, cautions, and context of use.',
     href: '/articles/style/safety-set-setting',
     meta: 'Safety',
   },
   {
-    slug: 'field-notes',
-    title: 'Field notes',
-    description: 'Editorial observations that help turn profiles into memorable learning.',
-    href: '/articles/style/field-notes',
-    meta: 'Notes',
+    slug: 'traditional-use',
+    title: 'Herbal Medicine',
+    description: 'Historical context kept separate from modern efficacy claims.',
+    href: '/articles/style/traditional-use',
+    meta: 'Tradition',
+  },
+  {
+    slug: 'nootropics',
+    title: 'Nootropics',
+    description: 'Cognitive enhancers, smart drugs, and evidence-graded nootropic profiles.',
+    href: '/articles/style/nootropics',
+    meta: 'Nootropics',
+  },
+  {
+    slug: 'extraction-preparation',
+    title: 'Supplement Science',
+    description: 'Form, solvent, dose visibility, bioavailability, and preparation notes.',
+    href: '/articles/style/extraction-preparation',
+    meta: 'Science',
   },
 ]
 
@@ -138,6 +138,8 @@ export const getPostsForStyle = (sourcePosts: BlogPost[], styleSlug: string): Bl
         return text.includes('extraction') || text.includes('preparation') || text.includes('formulation')
       case 'safety-set-setting':
         return text.includes('safety') || text.includes('set setting') || text.includes('set / setting')
+      case 'nootropics':
+        return text.includes('nootropic') || text.includes('cognitive') || text.includes('brain') || text.includes('focus')
       case 'field-notes':
         return text.includes('field notes') || text.includes('bioassay') || text.includes('notes')
       default:

--- a/lib/navigation-config.ts
+++ b/lib/navigation-config.ts
@@ -73,29 +73,29 @@ export const mainNavigation: NavigationItem[] = [
     description: 'The Hippie Scientist – evidence-first supplement research',
   },
   {
-    label: 'Guides & Articles',
+    label: 'Database',
+    href: '/herbs',
+    description: 'Browse the full herb database with evidence-graded profiles',
+  },
+  {
+    label: 'Compounds',
+    href: '/compounds',
+    description: 'Active compounds, mechanisms, and evidence summaries',
+  },
+  {
+    label: 'Guides',
     href: '/guides',
-    description: 'Goal-oriented guides, comparisons, and practical supplement decision pages',
+    description: 'Problem-solving, high-intent, evergreen supplement guides with internal linking and evidence summaries',
   },
   {
     label: 'Articles',
     href: '/articles',
-    description: 'Research notes, evidence reviews, regulatory updates, and editorial deep dives',
+    description: 'Educational and research content: pharmacology, mechanisms, historical medicine, safety discussions',
   },
   {
-    label: 'Comparisons',
-    href: '/compare',
-    description: 'Side-by-side herb and compound comparisons',
-  },
-  {
-    label: 'Goal Guides',
-    href: '/goals',
-    description: 'Goal-based decision guides with evidence-graded herbs and compounds',
-  },
-  {
-    label: 'About',
-    href: '/about',
-    description: 'About The Hippie Scientist',
+    label: 'Safety',
+    href: '/safety-checker',
+    description: 'Interaction checker and safety context for herbs and supplements',
   },
 ]
 
@@ -203,15 +203,26 @@ export const routeLabels: Record<string, RouteMetadata> = {
     parent: '/articles',
     isDynamic: true,
   },
+  '/guides': {
+    label: 'Guides',
+    description: 'Problem-solving supplement guides for sleep, anxiety, focus, stress, and more',
+    parent: '/',
+  },
+  '/guides/[slug]': {
+    label: 'Guide',
+    description: 'Evidence-informed supplement guide',
+    parent: '/guides',
+    isDynamic: true,
+  },
   '/learn': {
-    label: 'Learn',
-    description: 'Educational guides and deep dives',
+    label: 'Guides',
+    description: 'Educational guides (migrated to /guides)',
     parent: '/',
   },
   '/learn/[slug]': {
     label: 'Guide',
-    description: 'Educational guide',
-    parent: '/learn',
+    description: 'Supplement guide',
+    parent: '/guides',
     isDynamic: true,
   },
   '/tools': {
@@ -220,14 +231,14 @@ export const routeLabels: Record<string, RouteMetadata> = {
     parent: '/',
   },
   '/education': {
-    label: 'Education',
-    description: 'Educational resources (redirects to /learn)',
+    label: 'Guides',
+    description: 'Educational resources (redirects to /guides)',
     parent: '/',
   },
   '/education/[slug]': {
-    label: 'Education Guide',
-    description: 'Educational guide (redirects to /learn/[slug])',
-    parent: '/education',
+    label: 'Guide',
+    description: 'Supplement guide (redirects to /guides/[slug])',
+    parent: '/guides',
     isDynamic: true,
   },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -721,6 +721,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1584,6 +1585,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1606,6 +1608,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1628,6 +1631,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1644,6 +1648,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1660,6 +1665,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1676,6 +1682,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1692,6 +1699,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1708,6 +1716,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1724,6 +1733,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1740,6 +1750,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1756,6 +1767,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1772,6 +1784,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1788,6 +1801,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1810,6 +1824,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1832,6 +1847,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1854,6 +1870,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1876,6 +1893,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1898,6 +1916,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1920,6 +1939,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1942,6 +1962,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1964,6 +1985,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -1983,6 +2005,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2002,6 +2025,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2021,6 +2045,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,4 +1,10 @@
 /atom.xml /feed.xml 301
+# CONTENT TAXONOMY MIGRATION: Learn → Guides (June 2026)
+/learn /guides 301
+/learn/ /guides/ 301
+# Articles style category legacy redirect (field-notes → nootropics)
+/articles/style/field-notes /articles/style/nootropics 301
+/articles/style/field-notes/ /articles/style/nootropics/ 301
 /best-herbs-for-anxiety /guides/best-herbs-for-anxiety 301
 /herbs-for-sleep /guides/herbs-for-sleep 301
 /best-nootropics-for-focus /guides/best-nootropics-for-focus 301


### PR DESCRIPTION
- Navigation: replace Learn/Blog/Community with Database/Compounds/Guides/Articles/Safety
- Guides index: full revamp with condition sections (Anxiety, Sleep, Focus, Stress),
  comparison guides, stack guides from learn posts, safety/harm-reduction section, JSON-LD schema
- Articles index: update categories to Research/Mechanisms/Safety/Herbal Medicine/Nootropics/Supplement Science
- blog-index: rename style groups to new taxonomy (field-notes slug → nootropics)
- navigation-config: update mainNavigation and routeLabels for new structure
- learn pages: breadcrumbs updated to show Guides, canonicals updated, internal links updated
- Redirects: /learn → /guides, /articles/style/field-notes → /articles/style/nootropics
- Sitemap: remove /learn/ index entry, keep /learn/[slug] entries, raise /guides/ priority to 0.85
- Update stray /learn links in compare and start-here pages
- Tests: update blog-index test to match new category order

https://claude.ai/code/session_01WvDhSz7kjhHzFbhrsikthJ