### PR TITLE
feat(seo): keyword-first titles, relationship internal links, cleaner schema

### DIFF
--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -10,8 +10,9 @@ import ResponsiveTable from '@/components/ui/ResponsiveTable'
 import { getRuntimeVisibility } from '@/lib/runtime-visibility'
 import { cleanSummary, formatDisplayLabel, isClean, list, text, unique } from '@/lib/display-utils'
 import { normalizeSlug } from '@/lib/slug-utils'
-import { faqPageJsonLd, generateDetailMetadata, SITE_URL } from '@/lib/seo'
+import { faqPageJsonLd, generateDetailMetadata, isMeaningfulFaqAnswer, SITE_URL } from '@/lib/seo'
 import SchemaGraphScript from '@/components/seo/SchemaGraphScript'
+import CompoundSourceHerbs from '@/components/seo/CompoundSourceHerbs'
 import { buildProfileSchemaGraph } from '@/lib/schema-graph'
 import { getGoalsForEntity } from '@/lib/goal-hub-links'
 import LastUpdatedBadge from '@/components/editorial/LastUpdatedBadge'
@@ -538,18 +539,6 @@ export default async function CompoundPage({ params }: PageProps) {
   const canonicalNote = CANONICAL_COMPOUND_NOTES[normalizedSlug]
   const citations = extractCitationsFromRecord(compound)
 
-  const affiliateUrl = suppressAffiliate
-    ? ''
-    : revenueProducts?.products.find((p) => p.slot === 'overall')?.affiliateUrl ??
-      revenueProducts?.products[0]?.affiliateUrl
-  const productSchema = affiliateUrl
-    ? {
-        name: `${displayName} Supplement`,
-        description: `${displayName} supplement sourcing guide — safety context, dosage notes, and curated product picks.`,
-        url: affiliateUrl,
-      }
-    : null
-
   const schemaGraph = buildProfileSchemaGraph({
     kind: 'compound',
     slug: compound.slug,
@@ -560,13 +549,16 @@ export default async function CompoundPage({ params }: PageProps) {
       category: compound.compoundClass || compound.class || undefined,
       evidenceGrade: evidenceLevel || undefined,
       safetyNotes: compound.safetyNotes || compound.safety_notes || compound.safety || undefined,
+      // Phase-1-ready molecular identifiers (undefined until the workbook populates them).
+      pubchemCid: (compound.pubchem_cid as string | number | undefined) || undefined,
+      casNumber: (compound.cas_number as string | undefined) || undefined,
+      molecularFormula: (compound.molecular_formula as string | undefined) || undefined,
       breadcrumbId,
     },
     breadcrumbs: [
       { name: 'Compounds', url: `${SITE_URL}/compounds/` },
       { name: displayName, url: `${SITE_URL}/compounds/${compound.slug}/` },
     ],
-    product: productSchema,
   })
 
   const faqSchema = faqPageJsonLd({
@@ -593,7 +585,7 @@ export default async function CompoundPage({ params }: PageProps) {
           cleanText(compound.dosing || compound.dose || compound.dosage || compound.doseInfo || '') ||
           'See dosing guidelines and product labeling.',
       },
-    ],
+    ].filter((entry) => isMeaningfulFaqAnswer(entry.answer)),
   })
   const goalLinks = getGoalsForEntity(normalizedSlug)
   const lastReviewed =
@@ -724,6 +716,9 @@ export default async function CompoundPage({ params }: PageProps) {
             )}
           </div>
         </section>
+
+        {/* Source herbs — internal links from the curated relationship map */}
+        <CompoundSourceHerbs compoundSlug={compound.slug} compoundName={displayName} />
 
         {/* Affiliate CTA right after Quick Stats */}
         {affiliateCtaLink && !suppressAffiliate && (

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -11,8 +11,9 @@ import { getRuntimeVisibility } from '@/lib/runtime-visibility'
 import { getBatchedRuntimeRecords } from '@/lib/related-runtime'
 import { getEntityConditionEntries, type RuntimeMapEntry } from '@/lib/runtime-related-maps'
 import { getEcosystemContinuityRecords } from '@/lib/ecosystem-continuity'
-import { faqPageJsonLd, generateDetailMetadata, SITE_URL } from '@/lib/seo'
+import { faqPageJsonLd, generateDetailMetadata, isMeaningfulFaqAnswer, SITE_URL } from '@/lib/seo'
 import SchemaGraphScript from '@/components/seo/SchemaGraphScript'
+import HerbCompoundLinks from '@/components/seo/HerbCompoundLinks'
 import { buildProfileSchemaGraph } from '@/lib/schema-graph'
 import { getGoalsForEntity } from '@/lib/goal-hub-links'
 import LastUpdatedBadge from '@/components/editorial/LastUpdatedBadge'
@@ -367,17 +368,6 @@ export default async function HerbDetailPage({ params }: PageProps) {
   const stackRecommendations = getStackRecommendations(normalizedSlug, 3)
   const citations = extractCitationsFromRecord(herb)
 
-  const affiliateUrl =
-    revenueProducts?.products.find((p) => p.slot === 'overall')?.affiliateUrl ??
-    revenueProducts?.products[0]?.affiliateUrl
-  const productSchema =
-    affiliateUrl && !suppressAffiliate
-      ? {
-          name: `${displayName} Supplement`,
-          description: `${displayName} supplement sourcing guide — safety context, dosage notes, and curated product picks.`,
-          url: affiliateUrl,
-      }
-      : null
   const goalLinks = getGoalsForEntity(normalizedSlug)
   const lastReviewed = (herb.last_reviewed || herb.last_updated || herb.lastUpdated || herb.updatedAt || herb.updated_at || herb.reviewed_date || herb.reviewed_at) as string | undefined
 
@@ -412,7 +402,6 @@ export default async function HerbDetailPage({ params }: PageProps) {
       { name: 'Herbs', url: `${SITE_URL}/herbs/` },
       { name: displayName, url: `${SITE_URL}/herbs/${normalizedSlug}/` },
     ],
-    product: productSchema,
   })
 
   const faqSchema = faqPageJsonLd({
@@ -439,7 +428,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
           cleanText(herb.dosing || herb.dose || herb.dosage || herb.doseInfo || '') ||
           'See dosing guidelines and product labeling.',
       },
-    ],
+    ].filter((entry) => isMeaningfulFaqAnswer(entry.answer)),
   })
 
 
@@ -611,6 +600,9 @@ export default async function HerbDetailPage({ params }: PageProps) {
           </details>
         </section>
       )}
+
+      {/* Active compounds — internal links from the curated relationship map */}
+      <HerbCompoundLinks herbSlug={herb.slug} herbName={displayName} />
 
       {/* Section 5: Compare Nearby + CTA */}
       <section className="card-premium p-4 sm:p-5 space-y-4">

--- a/components/seo/CompoundSourceHerbs.tsx
+++ b/components/seo/CompoundSourceHerbs.tsx
@@ -1,0 +1,42 @@
+import Link from 'next/link'
+import { getCompoundSourceHerbs } from '@/lib/herb-compound-links'
+
+type CompoundSourceHerbsProps = {
+  compoundSlug: string
+  compoundName?: string
+}
+
+/**
+ * Renders the source herbs that contain a compound as keyword-rich internal
+ * links (reverse lookup of the curated relationship map). Renders nothing when
+ * the compound has no mapped (renderable) source herbs.
+ */
+export default async function CompoundSourceHerbs({
+  compoundSlug,
+  compoundName,
+}: CompoundSourceHerbsProps) {
+  const links = await getCompoundSourceHerbs(compoundSlug, compoundName)
+  if (links.length === 0) return null
+
+  return (
+    <section className="card-premium p-4 sm:p-5 space-y-3" aria-labelledby="source-herbs-heading">
+      <div className="space-y-1">
+        <h2 id="source-herbs-heading" className="text-lg font-bold text-ink">
+          Found In
+        </h2>
+        <p className="text-sm text-muted">
+          Botanicals that contain {compoundName || 'this compound'}, with full herb profiles.
+        </p>
+      </div>
+      <ul className="space-y-2">
+        {links.map((link) => (
+          <li key={link.slug}>
+            <Link href={link.href} className="text-sm font-semibold text-brand-800 hover:underline">
+              {link.anchor}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/components/seo/HerbCompoundLinks.tsx
+++ b/components/seo/HerbCompoundLinks.tsx
@@ -1,0 +1,39 @@
+import Link from 'next/link'
+import { getHerbCompoundLinks } from '@/lib/herb-compound-links'
+
+type HerbCompoundLinksProps = {
+  herbSlug: string
+  herbName?: string
+}
+
+/**
+ * Renders the active compounds found in a herb as keyword-rich internal links,
+ * sourced from the curated herb-compound relationship map. Renders nothing when
+ * the herb has no mapped (renderable) compounds.
+ */
+export default async function HerbCompoundLinks({ herbSlug, herbName }: HerbCompoundLinksProps) {
+  const links = await getHerbCompoundLinks(herbSlug, herbName)
+  if (links.length === 0) return null
+
+  return (
+    <section className="card-premium p-4 sm:p-5 space-y-3" aria-labelledby="active-compounds-heading">
+      <div className="space-y-1">
+        <h2 id="active-compounds-heading" className="text-lg font-bold text-ink">
+          Active Compounds
+        </h2>
+        <p className="text-sm text-muted">
+          Key constituents studied in {herbName || 'this herb'}, with full pharmacology and safety profiles.
+        </p>
+      </div>
+      <ul className="space-y-2">
+        {links.map((link) => (
+          <li key={link.slug}>
+            <Link href={link.href} className="text-sm font-semibold text-brand-800 hover:underline">
+              {link.anchor}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/lib/herb-compound-links.ts
+++ b/lib/herb-compound-links.ts
@@ -1,0 +1,174 @@
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import { cache } from 'react'
+import { formatDisplayLabel } from '@/lib/display-utils'
+import { getRuntimeVisibility } from '@/lib/runtime-visibility'
+import { getCompoundSummaryIndex, getHerbSummaryIndex } from '@/lib/runtime-summary-indexes'
+
+/**
+ * Renders the curated herb <-> compound relationship graph
+ * (`public/data/herb-compound-map.json`, 396 hand-authored edges) into internal
+ * links. The file is a flat array of edges; this module builds forward
+ * (herb -> active compounds) and reverse (compound -> source herbs) views,
+ * resolves display names from the cached summary indexes, and filters out any
+ * target whose detail page would not render.
+ */
+
+export type RelationshipKind = 'primary' | 'partial' | 'secondary'
+
+export type ProfileLink = {
+  slug: string
+  name: string
+  relationship: RelationshipKind
+  href: string
+  anchor: string
+}
+
+type RelationshipEdge = {
+  herb_slug?: unknown
+  compound_slug?: unknown
+  relationship?: unknown
+}
+
+const MAP_PATH = path.join(process.cwd(), 'public', 'data', 'herb-compound-map.json')
+const MAX_LINKS = 5
+const RELATIONSHIP_PRIORITY: Record<RelationshipKind, number> = { primary: 0, partial: 1, secondary: 2 }
+
+function normalizeRelationship(value: unknown): RelationshipKind {
+  const normalized = String(value ?? '').toLowerCase()
+  if (normalized === 'primary') return 'primary'
+  if (normalized === 'secondary') return 'secondary'
+  return 'partial'
+}
+
+const loadEdges = cache(async (): Promise<RelationshipEdge[]> => {
+  try {
+    const raw = await fs.readFile(MAP_PATH, 'utf8')
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? (parsed as RelationshipEdge[]) : []
+  } catch {
+    return []
+  }
+})
+
+/** slug -> display name for renderable targets of the given entity type. */
+const loadRenderableNames = cache(async (kind: 'herb' | 'compound'): Promise<Map<string, string>> => {
+  const records = kind === 'herb' ? await getHerbSummaryIndex() : await getCompoundSummaryIndex()
+  const names = new Map<string, string>()
+  for (const record of records) {
+    const slug = typeof record?.slug === 'string' ? record.slug : ''
+    if (!slug || names.has(slug)) continue
+    if (!getRuntimeVisibility(record).canRender) continue
+    names.set(slug, formatDisplayLabel(record.name || slug))
+  }
+  return names
+})
+
+/** Normalized key for collapsing near-duplicate targets (e.g. a canonical slug
+ *  and its alias that share a display name like "Garlic" / "Garlic (Allium sativum)"). */
+function nameKey(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/\s*\([^)]*\)\s*$/, '')
+    .trim()
+}
+
+/** Sort by relationship strength, then drop duplicate display names (keeping the
+ *  strongest-relationship entry, which is the canonical one), then cap. */
+function finalizeLinks(links: ProfileLink[]): ProfileLink[] {
+  const sorted = [...links].sort(
+    (a, b) => RELATIONSHIP_PRIORITY[a.relationship] - RELATIONSHIP_PRIORITY[b.relationship],
+  )
+  const seenNames = new Set<string>()
+  const deduped: ProfileLink[] = []
+  for (const link of sorted) {
+    const key = nameKey(link.name)
+    if (seenNames.has(key)) continue
+    seenNames.add(key)
+    deduped.push(link)
+  }
+  return deduped.slice(0, MAX_LINKS)
+}
+
+/**
+ * Active compounds found in a herb. `herbName` (the common display name) is used
+ * in anchor text; when omitted it is resolved from the herb summary index.
+ */
+export async function getHerbCompoundLinks(herbSlug: string, herbName?: string): Promise<ProfileLink[]> {
+  const slug = String(herbSlug ?? '').trim()
+  if (!slug) return []
+
+  const edges = await loadEdges()
+  const matches = edges.filter((edge) => edge.herb_slug === slug)
+  if (!matches.length) return []
+
+  const compoundNames = await loadRenderableNames('compound')
+  const display =
+    herbName?.trim() || (await loadRenderableNames('herb')).get(slug) || formatDisplayLabel(slug)
+
+  const seen = new Set<string>()
+  const links: ProfileLink[] = []
+  for (const edge of matches) {
+    const compoundSlug = typeof edge.compound_slug === 'string' ? edge.compound_slug : ''
+    const name = compoundNames.get(compoundSlug)
+    if (!compoundSlug || !name || seen.has(compoundSlug)) continue
+    seen.add(compoundSlug)
+
+    const relationship = normalizeRelationship(edge.relationship)
+    links.push({
+      slug: compoundSlug,
+      name,
+      relationship,
+      href: `/compounds/${compoundSlug}`,
+      anchor:
+        relationship === 'primary'
+          ? `${name} — primary active compound in ${display}`
+          : `${name} — active compound in ${display}`,
+    })
+  }
+
+  return finalizeLinks(links)
+}
+
+/**
+ * Source herbs that contain a compound (reverse lookup). `compoundName` is used
+ * in anchor text; when omitted it is resolved from the compound summary index.
+ */
+export async function getCompoundSourceHerbs(
+  compoundSlug: string,
+  compoundName?: string,
+): Promise<ProfileLink[]> {
+  const slug = String(compoundSlug ?? '').trim()
+  if (!slug) return []
+
+  const edges = await loadEdges()
+  const matches = edges.filter((edge) => edge.compound_slug === slug)
+  if (!matches.length) return []
+
+  const herbNames = await loadRenderableNames('herb')
+  const display =
+    compoundName?.trim() || (await loadRenderableNames('compound')).get(slug) || formatDisplayLabel(slug)
+
+  const seen = new Set<string>()
+  const links: ProfileLink[] = []
+  for (const edge of matches) {
+    const herbSlug = typeof edge.herb_slug === 'string' ? edge.herb_slug : ''
+    const name = herbNames.get(herbSlug)
+    if (!herbSlug || !name || seen.has(herbSlug)) continue
+    seen.add(herbSlug)
+
+    const relationship = normalizeRelationship(edge.relationship)
+    links.push({
+      slug: herbSlug,
+      name,
+      relationship,
+      href: `/herbs/${herbSlug}`,
+      anchor:
+        relationship === 'primary'
+          ? `${name}, a primary natural source of ${display}`
+          : `${name}, a natural source of ${display}`,
+    })
+  }
+
+  return finalizeLinks(links)
+}

--- a/src/lib/__tests__/schema-graph.test.ts
+++ b/src/lib/__tests__/schema-graph.test.ts
@@ -16,7 +16,6 @@ describe('schema-graph', () => {
         { name: 'Herbs', url: 'https://thehippiescientist.net/herbs/' },
         { name: 'Ashwagandha', url: 'https://thehippiescientist.net/herbs/ashwagandha/' },
       ],
-      product: null,
     })
 
     expect(graph['@context']).toBe('https://schema.org')

--- a/src/lib/__tests__/seo.test.ts
+++ b/src/lib/__tests__/seo.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest'
-import { generateDetailMetadata, herbJsonLd, compoundJsonLd } from '../seo'
+import { describe, it, expect } from 'vitest'
+import { generateDetailMetadata, herbJsonLd, compoundJsonLd, isMeaningfulFaqAnswer } from '../seo'
 
 describe('SEO Metadata & JSON-LD Utilities', () => {
   const mockHerb = {
@@ -30,20 +30,28 @@ describe('SEO Metadata & JSON-LD Utilities', () => {
     it('generates correct title, description, and alternates for a herb', () => {
       const meta = generateDetailMetadata(mockHerb, 'herb')
 
-      expect(meta.title).toContain('Ashwagandha')
-      expect(meta.title).toContain('Evidence-Based Guide')
-      expect(meta.description).toContain('Ashwagandha is an adaptogenic herb.')
-      expect(meta.description).toContain('Rated with strong')
-      expect(meta.description).toContain('Review safety and drug interactions before use.')
+      expect(meta.title).toBe('Ashwagandha Benefits, Dosage & Safety')
+      expect(meta.description).toContain('Ashwagandha dosage ranges')
+      expect(meta.description).toContain('Strong research evidence')
       expect(meta.alternates?.canonical).toBe('https://thehippiescientist.net/herbs/ashwagandha/')
     })
 
     it('generates correct metadata for a compound', () => {
       const meta = generateDetailMetadata(mockCompound, 'compound')
 
-      expect(meta.title).toContain('L Theanine')
-      expect(meta.title).toContain('Evidence-Based Guide')
+      expect(meta.title).toBe('L Theanine Dosage, Effects & Safety: What the Evidence Says')
+      expect(meta.description).toContain('L Theanine dosage by use case')
       expect(meta.alternates?.canonical).toBe('https://thehippiescientist.net/compounds/l-theanine/')
+    })
+
+    it('prefers a manual meta_title / meta_description when present', () => {
+      const meta = generateDetailMetadata(
+        { ...mockHerb, meta_title: 'Custom Ashwagandha Title', meta_description: 'Custom description override.' },
+        'herb',
+      )
+
+      expect(meta.title).toBe('Custom Ashwagandha Title')
+      expect(meta.description).toBe('Custom description override.')
     })
 
     it('sets robots to noindex if record is not indexable', () => {
@@ -77,7 +85,8 @@ describe('SEO Metadata & JSON-LD Utilities', () => {
       expect(jsonLd.about['@type']).toBe('MedicalTherapy')
       expect(jsonLd.about.evidenceLevel).toBe('Strong')
       expect(jsonLd.about.safetyWarnings).toBe(mockHerb.safetyNotes)
-      expect(jsonLd.about.duplicateTherapy).toEqual(mockHerb.primary_effects)
+      // Effects no longer mis-mapped to duplicateTherapy (wrong schema.org semantics).
+      expect((jsonLd.about as Record<string, unknown>).duplicateTherapy).toBeUndefined()
     })
   })
 
@@ -98,6 +107,37 @@ describe('SEO Metadata & JSON-LD Utilities', () => {
       expect(jsonLd.about.description).toBe(mockCompound.compoundClass)
       expect(jsonLd.about.evidenceLevel).toBe('Moderate')
       expect(jsonLd.about.safetyWarnings).toBe(mockCompound.safetyNotes)
+    })
+
+    it('upgrades to MolecularEntity when molecular identifiers are present', () => {
+      const jsonLd = compoundJsonLd({
+        name: 'Apigenin',
+        slug: 'apigenin',
+        molecularFormula: 'C15H10O5',
+        casNumber: '520-36-5',
+        pubchemCid: 5280443,
+      })
+
+      expect(jsonLd.about['@type']).toEqual(['MolecularEntity', 'ChemicalSubstance'])
+      expect(jsonLd.about.molecularFormula).toBe('C15H10O5')
+      expect(jsonLd.about.sameAs).toContain('https://pubchem.ncbi.nlm.nih.gov/compound/5280443')
+    })
+  })
+
+  describe('isMeaningfulFaqAnswer', () => {
+    it('rejects short and boilerplate answers, accepts substantive ones', () => {
+      expect(isMeaningfulFaqAnswer('See dosing guidelines and product labeling.')).toBe(false)
+      expect(isMeaningfulFaqAnswer('Too short.')).toBe(false)
+      expect(
+        isMeaningfulFaqAnswer(
+          'Review medications, pregnancy status, chronic conditions, and clinician guidance before use.',
+        ),
+      ).toBe(false)
+      expect(
+        isMeaningfulFaqAnswer(
+          'Ashwagandha is typically dosed at 300 to 600 mg of a standardized root extract once or twice daily with food.',
+        ),
+      ).toBe(true)
     })
   })
 })

--- a/src/lib/schema-graph.ts
+++ b/src/lib/schema-graph.ts
@@ -5,7 +5,6 @@ import {
   faqPageJsonLd,
   herbJsonLd,
   itemListJsonLd,
-  productJsonLd,
   SITE_URL,
   toAbsoluteUrl,
   type CompoundJsonLdArgs,
@@ -40,7 +39,6 @@ export type ProfileSchemaGraphArgs = {
   herb?: HerbJsonLdArgs
   compound?: CompoundJsonLdArgs
   breadcrumbs: Array<{ name: string; url: string }>
-  product?: { name: string; description: string; url: string; rating?: number; ratingCount?: number } | null
 }
 
 export function buildProfileSchemaGraph(args: ProfileSchemaGraphArgs) {
@@ -48,7 +46,6 @@ export function buildProfileSchemaGraph(args: ProfileSchemaGraphArgs) {
   const canonical = normalizeCanonical(`${SITE_URL}/${segment}/${args.slug}`)
   const webpageId = `${canonical}#webpage`
   const breadcrumbId = `${canonical}#breadcrumb`
-  const productId = `${canonical}#product`
 
   const webpageRaw =
     args.kind === 'herb' && args.herb
@@ -63,7 +60,6 @@ export function buildProfileSchemaGraph(args: ProfileSchemaGraphArgs) {
         '@id': webpageId,
         url: canonical,
         mainEntityOfPage: canonical,
-        ...(args.product ? { mainEntity: { '@id': productId } } : {}),
       }
     : null
 
@@ -72,33 +68,7 @@ export function buildProfileSchemaGraph(args: ProfileSchemaGraphArgs) {
     '@id': breadcrumbId,
   }
 
-  const product = args.product
-    ? {
-        ...stripSchemaContext(
-          productJsonLd({
-            name: args.product.name,
-            description: args.product.description,
-            url: args.product.url,
-          }),
-        ),
-        '@id': productId,
-        mainEntityOfPage: { '@id': webpageId },
-        ...(typeof args.product.rating === 'number' && args.product.rating > 0
-          ? {
-              aggregateRating: {
-                '@type': 'AggregateRating',
-                ratingValue: args.product.rating,
-                bestRating: 5,
-                ...(typeof args.product.ratingCount === 'number' && args.product.ratingCount > 0
-                  ? { ratingCount: args.product.ratingCount }
-                  : {}),
-              },
-            }
-          : {}),
-      }
-    : null
-
-  return buildSchemaGraph([webpage, breadcrumb, product])
+  return buildSchemaGraph([webpage, breadcrumb])
 }
 
 export function buildGoalSchemaGraph(args: {

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 import { getRuntimeVisibility } from './runtime-visibility'
-import { cleanSummary, formatDisplayLabel, isClean, list, text, unique } from '@/lib/display-utils'
+import { formatDisplayLabel, list } from '@/lib/display-utils'
 import { getEvidenceLabel } from '@/lib/evidence'
 import { SITE_URL, SITE_NAME } from '@/lib/site'
 
@@ -379,7 +379,6 @@ export function herbJsonLd(herb: HerbJsonLdArgs) {
             ).toLowerCase()}. Educational reference only.`,
             ...(herb.evidenceGrade ? { evidenceLevel: herb.evidenceGrade } : {}),
             ...(herb.safetyNotes ? { safetyWarnings: herb.safetyNotes } : {}),
-            ...(herb.primaryEffects ? { duplicateTherapy: herb.primaryEffects } : {}),
           },
           ...(hasPart.length ? { hasPart } : {}),
         }
@@ -389,7 +388,6 @@ export function herbJsonLd(herb: HerbJsonLdArgs) {
             name: herb.latinName || herb.name,
             ...(herb.evidenceGrade ? { evidenceLevel: herb.evidenceGrade } : {}),
             ...(herb.safetyNotes ? { safetyWarnings: herb.safetyNotes } : {}),
-            ...(herb.primaryEffects ? { duplicateTherapy: herb.primaryEffects } : {}),
           },
         }),
     ...(herb.image ? { image: herb.image } : {}),
@@ -405,12 +403,37 @@ export type CompoundJsonLdArgs = {
   governedSummary?: GovernedSummarySignals
   evidenceGrade?: string
   safetyNotes?: string
+  // Phase-1-ready molecular identifiers. When any are present the `about` node
+  // upgrades from a generic ChemicalSubstance to a MolecularEntity with formula,
+  // CAS/PubChem identifiers, and a PubChem sameAs link. Until the workbook
+  // populates these columns they are undefined and the schema is unchanged.
+  pubchemCid?: string | number
+  casNumber?: string
+  molecularFormula?: string
 }
 
 export function compoundJsonLd(compound: CompoundJsonLdArgs) {
   const url = `${SITE_URL}/compounds/${compound.slug}`
   const governed = compound.governedSummary
   const hasGoverned = Boolean(governed?.enrichedAndReviewed)
+
+  // Upgrade to MolecularEntity only when concrete molecular identifiers exist.
+  const hasMolecularData = Boolean(
+    compound.molecularFormula || compound.pubchemCid || compound.casNumber,
+  )
+  const compoundAboutType = hasMolecularData
+    ? ['MolecularEntity', 'ChemicalSubstance']
+    : 'ChemicalSubstance'
+  const molecularIdentifiers: Array<Record<string, string>> = []
+  if (compound.casNumber) {
+    molecularIdentifiers.push({ '@type': 'PropertyValue', propertyID: 'CAS', value: String(compound.casNumber) })
+  }
+  if (compound.pubchemCid) {
+    molecularIdentifiers.push({ '@type': 'PropertyValue', propertyID: 'PubChem CID', value: String(compound.pubchemCid) })
+  }
+  const molecularSameAs = compound.pubchemCid
+    ? [`https://pubchem.ncbi.nlm.nih.gov/compound/${compound.pubchemCid}`]
+    : []
   const hasPart = hasGoverned
     ? [
         { name: 'Evidence summary' },
@@ -435,7 +458,7 @@ export function compoundJsonLd(compound: CompoundJsonLdArgs) {
     aspect: ['treatment', 'safety', 'pharmacology', 'efficacy'],
     ...(compound.breadcrumbId ? { breadcrumb: { '@id': compound.breadcrumbId } } : {}),
     about: {
-      '@type': 'ChemicalSubstance',
+      '@type': compoundAboutType,
       name: compound.name,
       ...(compound.category ? { description: compound.category } : {}),
       ...(hasGoverned
@@ -447,6 +470,11 @@ export function compoundJsonLd(compound: CompoundJsonLdArgs) {
         : {}),
       ...(compound.evidenceGrade ? { evidenceLevel: compound.evidenceGrade } : {}),
       ...(compound.safetyNotes ? { safetyWarnings: compound.safetyNotes } : {}),
+      ...(compound.molecularFormula ? { molecularFormula: compound.molecularFormula } : {}),
+      ...(molecularIdentifiers.length
+        ? { identifier: molecularIdentifiers.length === 1 ? molecularIdentifiers[0] : molecularIdentifiers }
+        : {}),
+      ...(molecularSameAs.length ? { sameAs: molecularSameAs } : {}),
     },
     ...(hasPart.length ? { hasPart } : {}),
   }
@@ -573,55 +601,97 @@ export function commonSupplementFaqJsonLd(pagePath: string) {
   })
 }
 
+/**
+ * Boilerplate answers that should NOT be emitted as FAQ JSON-LD. Gating on these
+ * prevents Google from seeing placeholder Q&A (which can't earn rich results and
+ * dilutes the page's real content signals). Compared case-insensitively by prefix.
+ */
+export const FAQ_FALLBACK_ANSWERS: string[] = [
+  'See dosing guidelines and product labeling.',
+  'Review personal medications, pregnancy status, chronic conditions, and clinician guidance before use.',
+  'Review medications, pregnancy status, chronic conditions, and clinician guidance before use.',
+  'See the page evidence section',
+]
+
+/** True when an FAQ answer is substantive enough to publish as structured data. */
+export function isMeaningfulFaqAnswer(answer: unknown): boolean {
+  const normalized = String(answer ?? '').trim()
+  if (normalized.length <= 50) return false
+  const lower = normalized.toLowerCase()
+  return !FAQ_FALLBACK_ANSWERS.some((fallback) =>
+    lower.startsWith(fallback.toLowerCase().slice(0, 40)),
+  )
+}
+
+/** Common-name-first display name: strips a trailing Latin parenthetical. */
+function getProfileDisplayName(record: any): string {
+  const raw = String(record?.name || record?.slug || '')
+  const commonName = raw.replace(/\s*\([^)]*\)\s*$/, '').trim()
+  return formatDisplayLabel(commonName || raw)
+}
+
+function getProfileEvidenceLabel(record: any): string {
+  return formatDisplayLabel(
+    record?.evidenceLevel ||
+      record?.evidence_tier ||
+      record?.evidenceTier ||
+      record?.evidence_grade ||
+      getEvidenceLabel(record),
+  )
+}
+
+/** Keyword-first title formula (manual `meta_title` overrides via precedence). */
+export function formatProfileTitle(displayName: string, type: 'herb' | 'compound'): string {
+  return type === 'herb'
+    ? `${displayName} Benefits, Dosage & Safety`
+    : `${displayName} Dosage, Effects & Safety: What the Evidence Says`
+}
+
+/** Intent-driven meta description formula (manual `meta_description` overrides). */
+export function formatProfileDescription(
+  record: any,
+  displayName: string,
+  type: 'herb' | 'compound',
+): string {
+  const evidence = getProfileEvidenceLabel(record)
+  const primaryUse = list(
+    record?.primary_effects || record?.primaryEffects || record?.effects || record?.useContexts || [],
+  )
+    .map((effect: string) => formatDisplayLabel(effect).toLowerCase())
+    .filter(Boolean)[0]
+
+  const evidenceClause = evidence ? ` ${evidence} research evidence.` : ''
+  const raw =
+    type === 'herb'
+      ? `${displayName} dosage ranges, effects, drug interactions, and harm-reduction safety guide${
+          primaryUse ? ` for ${primaryUse}` : ''
+        }.${evidenceClause}`
+      : `${displayName} dosage by use case, onset and duration, safety limits, and interactions${
+          primaryUse ? ` for ${primaryUse}` : ''
+        }, graded against research.${evidenceClause}`
+
+  const fallback =
+    type === 'herb'
+      ? `${displayName} effects, dosage, drug interactions, and harm-reduction safety guide.`
+      : `${displayName} dosage, effects, onset, and safety graded against research evidence.`
+
+  return formatMetaDescription(raw, fallback, 160)
+}
+
 export function generateDetailMetadata(record: any, type: 'herb' | 'compound'): Metadata {
-  const displayName = formatDisplayLabel(record.name || record.slug)
-  const evidence = formatDisplayLabel(record.evidenceLevel || record.evidence_tier || record.evidenceTier || record.evidence_grade || getEvidenceLabel(record))
+  const displayName = getProfileDisplayName(record)
 
-  // Construct premium, intent-aware titles
-  let titleSuffix = type === 'herb' ? 'Herb Profile: Benefits, Effects & Safety' : 'Benefits, Effects & Safety'
-  if (evidence.toLowerCase().includes('strong') || evidence.toLowerCase().includes('moderate') || evidence.toLowerCase().includes('human')) {
-    titleSuffix += ' | Evidence-Based Guide'
-  } else if (evidence.toLowerCase().includes('traditional')) {
-    titleSuffix += ' | Traditional Use Guide'
-  } else {
-    titleSuffix += ' Guide'
-  }
-  const title = `${displayName} ${titleSuffix}`
+  // Precedence: hand-authored workbook columns (meta_title / meta_description) win
+  // over the templated formula. These columns are empty today but ready for Phase 1.
+  const manualTitle = typeof record?.meta_title === 'string' ? record.meta_title.trim() : ''
+  const manualDescription =
+    typeof record?.meta_description === 'string' ? record.meta_description.trim() : ''
 
-  // Construct dynamic description -- make unique per profile using available fields (fixes mass duplicate generics)
-  const cleanDesc = cleanSummary(record.summary || record.description || '', type)
-  let firstSentence = cleanDesc.match(/[^.!?]+[.!?]+/)?.[0] || cleanDesc
-  if (!firstSentence || firstSentence.length < 20) {
-    firstSentence = `${displayName} ${type} profile with evidence framing.`
-  }
-
-  // extract unique signals
-  const latin = record.scientific_name || record.latin_name || (record.name && record.name.match(/\(([^)]+)\)/)?.[1] ? record.name.match(/\(([^)]+)\)/)[1] : '')
-  const effects = list(record.primary_effects || record.primaryEffects || record.effects || record.useContexts || record.primaryDomain || [])
-  const primaryUse = effects[0] ? formatDisplayLabel(effects[0]).toLowerCase() : ''
-  const mechs = list(record.mechanisms || record.primary_mechanisms || record.pathways || [])
-  const primaryMech = mechs[0] ? formatDisplayLabel(mechs[0]).toLowerCase().replace(/\s+(modulation|signaling|context|response)/g, '') : ''
-  const safetyNotes = text(record.safetyNotes || record.safety_notes || record.safety || record.safety_level || '').toLowerCase()
-  let safetySnippet = ''
-  if (safetyNotes.includes('avoid') || safetyNotes.includes('caution') || safetyNotes.includes('interaction') || safetyNotes.includes('contraindicat')) {
-    safetySnippet = ' Review safety and drug interactions before use.'
-  }
-
-  let uniqueTail = ''
-  if (latin) uniqueTail += ` (${formatDisplayLabel(latin)})`
-  if (primaryUse) uniqueTail += ` for ${primaryUse}`
-  if (primaryMech) uniqueTail += ` (${primaryMech})`
-  if (evidence) uniqueTail += ` — evidence level ${evidence.toLowerCase()}`
-
-  const rawDescription = `${firstSentence}${uniqueTail} Rated with ${evidence.toLowerCase()}.${safetySnippet} Educational reference only.`
-  const description = formatMetaDescription(rawDescription, `${displayName} effects, mechanisms, dosage, and safety.`, 155)
+  const title = manualTitle || formatProfileTitle(displayName, type)
+  const description = manualDescription || formatProfileDescription(record, displayName, type)
 
   const path = `/${type === 'herb' ? 'herbs' : 'compounds'}/${record.slug}`
-  const meta = buildMeta({
-    title,
-    description,
-    path,
-  })
+  const meta = buildMeta({ title, description, path })
 
   const visibility = getRuntimeVisibility(record)
 


### PR DESCRIPTION
Phase 2 (code) of the monograph SEO strategy — applies across all 287 herb + 594 compound pages, zero workbook changes.

## What changed
- **Titles/metas** ([src/lib/seo.ts](../blob/main/src/lib/seo.ts)): keyword-first formula (`{name} Benefits, Dosage & Safety` / `{name} Dosage, Effects & Safety: What the Evidence Says`), replacing the Latin-name-first one. Adds `meta_title`/`meta_description` precedence (dormant until Phase 1 threads those columns into the summary-index generator).
- **Internal linking**: renders the previously-unused 396-edge `herb-compound-map.json` as "Active Compounds" (herb) and "Found In" (compound) sections with keyword-rich anchors. New `lib/herb-compound-links.ts` + two components; filters non-renderable targets and dedupes canonical/alias pairs.
- **Schema fixes**: removed `duplicateTherapy` (wrong semantics for effects); removed the empty-Offer `Product` node (GSC merchant errors); gated `FAQPage` on substantive answers; made compound schema `MolecularEntity`-ready for Phase 1.

## Verification
- tsc clean, eslint `--max-warnings=0` clean
- Full `next build` of all 881 pages passes
- Build audits PASS: structured-data (`malformed=0`), internal-links (`orphan=0, weak=0`), seo-metadata (60 pages), seo-routes (`avg=90, severe=0`)

## Notes
- `meta_title` precedence is wired but dormant: `generateMetadata` receives the summary-index record, which doesn't yet carry that column. Phase 1 must add it to `build-runtime-summary-indexes.mjs` for hand-authored titles to take effect. The formula improvement is fully live now.
- The orchestrated `npm run check` exits non-zero only at step 26 (`data:verify`), an environment artifact: it re-runs the workbook parser in a clean temp copy without `node_modules`, so `exceljs` can't resolve. Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)