### PR TITLE
feat: Schema.org cluster system + ADHD/Focus interlinking (Weeks 1-3 audit)

### DIFF
--- a/app/goals/[goal]/page.tsx
+++ b/app/goals/[goal]/page.tsx
@@ -7,6 +7,7 @@ import { normalizeDecisionEvidence, normalizeDecisionSafety } from '@/lib/decisi
 import { SITE_URL, SEO_YEAR } from '@/lib/seo'
 import SchemaGraphScript from '@/components/seo/SchemaGraphScript'
 import { buildGoalSchemaGraph } from '@/lib/schema-graph'
+import { buildGoalClusterGraph } from '@/lib/cluster-linking'
 import { buildGoalPageMetadata } from '@/lib/goal-seo'
 import { getGoalHubLinks } from '@/lib/goal-hub-links'
 import { getGoalContentExtension, getGoalFaqItems } from '@/data/goal-content'
@@ -247,7 +248,13 @@ export default async function GoalDecisionPage({
     },
   })
 
-  const structuredData = <SchemaGraphScript graph={schemaGraph} />
+  const clusterGraph = buildGoalClusterGraph(goal.slug)
+  const structuredData = (
+    <>
+      <SchemaGraphScript graph={schemaGraph} />
+      {clusterGraph ? <SchemaGraphScript graph={clusterGraph} /> : null}
+    </>
+  )
 
   const hubLinks = getGoalHubLinks(goal.slug)
   const goalEvidence = await getGoalEvidenceEngine(goal.slug)

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -15,6 +15,8 @@ import { faqPageJsonLd, generateDetailMetadata, isMeaningfulFaqAnswer, SITE_URL 
 import SchemaGraphScript from '@/components/seo/SchemaGraphScript'
 import HerbCompoundLinks from '@/components/seo/HerbCompoundLinks'
 import { buildProfileSchemaGraph } from '@/lib/schema-graph'
+import { getClusterSeeAlso, buildProfileSchemaGraphWithCluster } from '@/lib/cluster-linking'
+import SeeAlsoCluster from '@/components/SeeAlsoCluster'
 import { getGoalsForEntity } from '@/lib/goal-hub-links'
 import LastUpdatedBadge from '@/components/editorial/LastUpdatedBadge'
 import ScrollEngagementPrompt from '@/components/monetization/ScrollEngagementPrompt'
@@ -385,7 +387,8 @@ export default async function HerbDetailPage({ params }: PageProps) {
     .slice(0, 4)
 
   const breadcrumbId = `${SITE_URL}/herbs/${normalizedSlug}/#breadcrumb`
-  const schemaGraph = buildProfileSchemaGraph({
+  const clusterSeeAlso = getClusterSeeAlso(normalizedSlug, 'herb', 8)
+  const schemaGraph = buildProfileSchemaGraphWithCluster({
     kind: 'herb',
     slug: normalizedSlug,
     herb: {
@@ -402,6 +405,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
       { name: 'Herbs', url: `${SITE_URL}/herbs/` },
       { name: displayName, url: `${SITE_URL}/herbs/${normalizedSlug}/` },
     ],
+    seeAlsoEntries: clusterSeeAlso,
   })
 
   const faqSchema = faqPageJsonLd({
@@ -502,6 +506,8 @@ export default async function HerbDetailPage({ params }: PageProps) {
           </div>
         </section>
       ) : null}
+
+      <SeeAlsoCluster slug={normalizedSlug} kind="herb" limit={6} />
 
       {/* Section 1: Quick Stats */}
       <section className="hero-shell rounded-2xl border border-brand-900/10 p-4 sm:p-5 space-y-4">

--- a/components/SchemaOrg.tsx
+++ b/components/SchemaOrg.tsx
@@ -1,0 +1,52 @@
+/**
+ * SchemaOrg — flexible JSON-LD <script> renderer.
+ *
+ * Accepts either:
+ *  - `graph`  — a pre-built @graph object (from buildProfileSchemaGraph etc.)
+ *  - `schema` — a flat JSON-LD object (from herbJsonLd, faqPageJsonLd etc.)
+ *
+ * Both render as <script type="application/ld+json"> in the document.
+ * Null-safe: renders nothing when the schema is empty or malformed.
+ *
+ * Relationship to existing components:
+ *  - components/seo/SchemaGraphScript.tsx handles @graph objects only.
+ *  - This component is a superset: use it when you need to render either kind
+ *    or want a named, stable import path.
+ */
+
+type SchemaOrgProps = {
+  /** Pre-built @graph object (e.g. from buildProfileSchemaGraph). */
+  graph?: Record<string, unknown> | null
+  /** Flat JSON-LD object (e.g. from faqPageJsonLd, herbJsonLd). */
+  schema?: Record<string, unknown> | null
+}
+
+export default function SchemaOrg({ graph, schema }: SchemaOrgProps) {
+  if (graph) {
+    const graphArray = graph['@graph']
+    const hasNodes =
+      Array.isArray(graphArray) && graphArray.length > 0
+    if (!hasNodes) return null
+
+    return (
+      <script
+        type='application/ld+json'
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(graph) }}
+      />
+    )
+  }
+
+  if (schema) {
+    const type = schema['@type']
+    if (!type) return null
+
+    return (
+      <script
+        type='application/ld+json'
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+      />
+    )
+  }
+
+  return null
+}

--- a/components/SeeAlsoCluster.tsx
+++ b/components/SeeAlsoCluster.tsx
@@ -1,0 +1,110 @@
+/**
+ * SeeAlsoCluster — "See also in cluster" module.
+ *
+ * Renders chip-style links to related herbs/compounds in the same semantic
+ * cluster(s) as the current profile. Groups by cluster and links to the
+ * relevant goal page for the full cluster context.
+ *
+ * Server component — no client state, no side effects.
+ *
+ * Usage (herb page):
+ *   <SeeAlsoCluster slug={normalizedSlug} kind="herb" />
+ *
+ * Usage (compound page):
+ *   <SeeAlsoCluster slug={slug} kind="compound" limit={8} />
+ */
+
+import Link from 'next/link'
+import { getClusterSeeAlso, getEntityClusters } from '@/lib/cluster-linking'
+import type { EntityKind } from '@/lib/schema'
+
+type SeeAlsoClusterProps = {
+  slug: string
+  kind: EntityKind
+  /** Max number of "see also" entries to render (default 6). */
+  limit?: number
+  className?: string
+}
+
+export default function SeeAlsoCluster({
+  slug,
+  kind,
+  limit = 6,
+  className,
+}: SeeAlsoClusterProps) {
+  const seeAlso = getClusterSeeAlso(slug, kind, limit)
+  const clusters = getEntityClusters(slug, kind)
+
+  if (!seeAlso.length || !clusters.length) return null
+
+  // Group entries by cluster for display
+  type GroupedEntry = {
+    clusterId: string
+    clusterLabel: string
+    clusterGoalHref: string
+    entries: typeof seeAlso
+  }
+
+  const grouped: GroupedEntry[] = clusters.map((cluster) => ({
+    clusterId: cluster.id,
+    clusterLabel: cluster.label,
+    clusterGoalHref: `/goals/${cluster.goalSlug}`,
+    entries: seeAlso.filter((e) => e.cluster === cluster.id),
+  })).filter((g) => g.entries.length > 0)
+
+  if (!grouped.length) return null
+
+  return (
+    <section
+      className={`rounded-2xl border border-brand-900/10 bg-white/80 p-4 sm:p-5 space-y-4 ${className ?? ''}`}
+      aria-labelledby='see-also-cluster-heading'
+    >
+      <div className='flex items-center justify-between gap-2 flex-wrap'>
+        <p
+          id='see-also-cluster-heading'
+          className='text-[10px] font-bold uppercase tracking-wider text-brand-700'
+        >
+          Also in this cluster
+        </p>
+        {grouped.length === 1 && (
+          <Link
+            href={grouped[0].clusterGoalHref}
+            className='text-[10px] font-semibold text-brand-600 hover:text-brand-800 hover:underline transition'
+          >
+            {grouped[0].clusterLabel} guide →
+          </Link>
+        )}
+      </div>
+
+      {grouped.map((group) => (
+        <div key={group.clusterId} className='space-y-2'>
+          {grouped.length > 1 && (
+            <div className='flex items-center justify-between gap-2'>
+              <p className='text-[10px] font-semibold uppercase tracking-wider text-muted'>
+                {group.clusterLabel}
+              </p>
+              <Link
+                href={group.clusterGoalHref}
+                className='text-[10px] font-semibold text-brand-600 hover:text-brand-800 hover:underline transition'
+              >
+                Full guide →
+              </Link>
+            </div>
+          )}
+          <div className='flex flex-wrap gap-2'>
+            {group.entries.map((entry) => (
+              <Link
+                key={`${entry.kind}:${entry.slug}`}
+                href={entry.href}
+                title={entry.reason}
+                className='rounded-full border border-brand-900/10 bg-brand-50/50 px-3 py-1.5 text-xs font-semibold capitalize text-brand-800 hover:bg-brand-50 transition'
+              >
+                {entry.label}
+              </Link>
+            ))}
+          </div>
+        </div>
+      ))}
+    </section>
+  )
+}

--- a/lib/cluster-linking.ts
+++ b/lib/cluster-linking.ts
@@ -1,0 +1,559 @@
+/**
+ * ADHD / Focus cluster graph and interlinking system.
+ *
+ * Defines five semantic clusters (ADHD-Focus, Sleep, Stress-Anxiety, Energy,
+ * Neuroprotection) as static data — no runtime reads, fully tree-shakeable,
+ * safe for static export.
+ *
+ * Public API:
+ *  getEntityClusters(slug, kind)   — which clusters does this entity belong to?
+ *  getClusterSeeAlso(slug, kind)   — up to N "see also" entries for cluster peers
+ *  getGoalClusters(goalSlug)       — clusters anchored to a specific goal page
+ *  buildProfileRelatedLinks(slug, kind) — relatedLink[] URLs for schema embedding
+ *  buildProfileSchemaGraphWithCluster() — extends buildProfileSchemaGraph with relatedLink
+ */
+
+import { SITE_URL } from '@/lib/site'
+import type { ClusterDefinition, ClusterId, EntityKind, SeeAlsoEntry } from '@/lib/schema'
+import { buildRelatedLinksSchema } from '@/lib/schema'
+import { buildProfileSchemaGraph, buildSchemaGraph, stripSchemaContext } from '@/lib/schema-graph'
+import type { ProfileSchemaGraphArgs } from '@/lib/schema-graph'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Static cluster definitions
+// All slugs verified against public/data/herbs-summary.json + compounds-summary.json
+// ─────────────────────────────────────────────────────────────────────────────
+
+const CLUSTERS: Record<ClusterId, ClusterDefinition> = {
+  'adhd-focus': {
+    id: 'adhd-focus',
+    label: 'ADHD & Focus Support',
+    goalSlug: 'focus',
+    description:
+      'Herbs and compounds studied for attention, cognitive clarity, and ADHD-adjacent support.',
+    members: [
+      {
+        slug: 'bacopa',
+        kind: 'herb',
+        label: 'Bacopa',
+        primaryRoles: ['memory consolidation', 'attention', 'learning speed'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'lions-mane',
+        kind: 'herb',
+        label: "Lion's Mane",
+        primaryRoles: ['NGF synthesis', 'neuroplasticity', 'cognitive support'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'ashwagandha',
+        kind: 'herb',
+        label: 'Ashwagandha',
+        primaryRoles: ['stress-driven cognitive fatigue', 'adaptogen', 'working memory'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'rhodiola',
+        kind: 'herb',
+        label: 'Rhodiola',
+        primaryRoles: ['cognitive fatigue', 'mental endurance', 'stress resilience'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'ginkgo-biloba',
+        kind: 'herb',
+        label: 'Ginkgo Biloba',
+        primaryRoles: ['cerebral circulation', 'memory', 'attention'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'panax-ginseng',
+        kind: 'herb',
+        label: 'Panax Ginseng',
+        primaryRoles: ['mental performance', 'working memory', 'reaction time'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'gotu-kola',
+        kind: 'herb',
+        label: 'Gotu Kola',
+        primaryRoles: ['cognitive support', 'anxiety-adjacent focus'],
+        evidenceTier: 'low',
+      },
+      {
+        slug: 'l-theanine',
+        kind: 'compound',
+        label: 'L-Theanine',
+        primaryRoles: ['alpha-wave activity', 'calm focus', 'attention quality'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'phosphatidylserine',
+        kind: 'compound',
+        label: 'Phosphatidylserine',
+        primaryRoles: ['ADHD support', 'memory', 'cognitive aging'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'alpha-gpc',
+        kind: 'compound',
+        label: 'Alpha-GPC',
+        primaryRoles: ['cholinergic', 'memory', 'focus'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'l-tyrosine',
+        kind: 'compound',
+        label: 'L-Tyrosine',
+        primaryRoles: ['dopamine precursor', 'working memory under stress', 'cognitive load'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'magnesium',
+        kind: 'compound',
+        label: 'Magnesium',
+        primaryRoles: ['NMDA modulation', 'stress-related cognition', 'sleep quality'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'caffeine',
+        kind: 'compound',
+        label: 'Caffeine',
+        primaryRoles: ['adenosine antagonism', 'alertness', 'reaction speed'],
+        evidenceTier: 'high',
+      },
+    ],
+  },
+
+  sleep: {
+    id: 'sleep',
+    label: 'Sleep & Recovery',
+    goalSlug: 'sleep',
+    description:
+      'Herbs and compounds studied for sleep onset, sleep quality, and overnight recovery support.',
+    members: [
+      {
+        slug: 'valerian',
+        kind: 'herb',
+        label: 'Valerian',
+        primaryRoles: ['sleep latency', 'GABA modulation', 'sleep quality'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'piper-methysticum',
+        kind: 'herb',
+        label: 'Kava',
+        primaryRoles: ['relaxation', 'sleep onset', 'anxiolysis'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'ashwagandha',
+        kind: 'herb',
+        label: 'Ashwagandha',
+        primaryRoles: ['stress-driven sleep disruption', 'cortisol reduction'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'bacopa',
+        kind: 'herb',
+        label: 'Bacopa',
+        primaryRoles: ['stress reduction', 'sleep quality'],
+        evidenceTier: 'low',
+      },
+      {
+        slug: 'gotu-kola',
+        kind: 'herb',
+        label: 'Gotu Kola',
+        primaryRoles: ['mild sedation', 'anxiety reduction'],
+        evidenceTier: 'low',
+      },
+      {
+        slug: 'glycine',
+        kind: 'compound',
+        label: 'Glycine',
+        primaryRoles: ['sleep quality', 'core body temperature', 'REM sleep'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'magnesium',
+        kind: 'compound',
+        label: 'Magnesium',
+        primaryRoles: ['sleep onset', 'NMDA modulation', 'muscle relaxation'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'magnesium-glycinate',
+        kind: 'compound',
+        label: 'Magnesium Glycinate',
+        primaryRoles: ['sleep', 'bioavailable magnesium form'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'gaba',
+        kind: 'compound',
+        label: 'GABA',
+        primaryRoles: ['inhibitory neurotransmitter', 'relaxation', 'sleep onset'],
+        evidenceTier: 'low',
+      },
+      {
+        slug: '5-htp',
+        kind: 'compound',
+        label: '5-HTP',
+        primaryRoles: ['serotonin precursor', 'sleep onset', 'mood'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'l-theanine',
+        kind: 'compound',
+        label: 'L-Theanine',
+        primaryRoles: ['alpha-wave activity', 'relaxation', 'sleep quality'],
+        evidenceTier: 'moderate',
+      },
+    ],
+  },
+
+  'stress-anxiety': {
+    id: 'stress-anxiety',
+    label: 'Stress & Anxiety Support',
+    goalSlug: 'stress',
+    description:
+      'Herbs and compounds studied for stress resilience, anxiety reduction, and HPA axis regulation.',
+    members: [
+      {
+        slug: 'ashwagandha',
+        kind: 'herb',
+        label: 'Ashwagandha',
+        primaryRoles: ['cortisol reduction', 'HPA axis regulation', 'adaptogen'],
+        evidenceTier: 'high',
+      },
+      {
+        slug: 'rhodiola',
+        kind: 'herb',
+        label: 'Rhodiola',
+        primaryRoles: ['stress resilience', 'fatigue reduction', 'adaptogen'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'bacopa',
+        kind: 'herb',
+        label: 'Bacopa',
+        primaryRoles: ['anxiety reduction', 'cognitive stress buffering'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'gotu-kola',
+        kind: 'herb',
+        label: 'Gotu Kola',
+        primaryRoles: ['anxiolytic', 'GABAergic support'],
+        evidenceTier: 'low',
+      },
+      {
+        slug: 'piper-methysticum',
+        kind: 'herb',
+        label: 'Kava',
+        primaryRoles: ['GABAergic anxiolytic', 'social anxiety'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'panax-ginseng',
+        kind: 'herb',
+        label: 'Panax Ginseng',
+        primaryRoles: ['stress resilience', 'HPA axis support'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'l-theanine',
+        kind: 'compound',
+        label: 'L-Theanine',
+        primaryRoles: ['cortisol buffering', 'alpha-wave activity', 'calm focus'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'magnesium',
+        kind: 'compound',
+        label: 'Magnesium',
+        primaryRoles: ['HPA axis regulation', 'stress resilience'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'glycine',
+        kind: 'compound',
+        label: 'Glycine',
+        primaryRoles: ['inhibitory neurotransmitter', 'calm', 'sleep quality'],
+        evidenceTier: 'low',
+      },
+      {
+        slug: 'gaba',
+        kind: 'compound',
+        label: 'GABA',
+        primaryRoles: ['inhibitory neurotransmitter', 'anxiety reduction'],
+        evidenceTier: 'low',
+      },
+      {
+        slug: '5-htp',
+        kind: 'compound',
+        label: '5-HTP',
+        primaryRoles: ['serotonin precursor', 'mood support', 'anxiety'],
+        evidenceTier: 'moderate',
+      },
+    ],
+  },
+
+  energy: {
+    id: 'energy',
+    label: 'Energy & Fatigue',
+    goalSlug: 'energy',
+    description:
+      'Herbs and compounds studied for energy metabolism, mitochondrial function, and fatigue resilience.',
+    members: [
+      {
+        slug: 'rhodiola',
+        kind: 'herb',
+        label: 'Rhodiola',
+        primaryRoles: ['fatigue reduction', 'physical endurance', 'adaptogen'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'panax-ginseng',
+        kind: 'herb',
+        label: 'Panax Ginseng',
+        primaryRoles: ['energy metabolism', 'fatigue', 'cognitive performance'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'ashwagandha',
+        kind: 'herb',
+        label: 'Ashwagandha',
+        primaryRoles: ['adrenal support', 'fatigue resilience', 'VO2 max'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'caffeine',
+        kind: 'compound',
+        label: 'Caffeine',
+        primaryRoles: ['adenosine antagonism', 'energy', 'alertness'],
+        evidenceTier: 'high',
+      },
+      {
+        slug: 'l-tyrosine',
+        kind: 'compound',
+        label: 'L-Tyrosine',
+        primaryRoles: ['dopamine precursor', 'motivation', 'cognitive energy'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'magnesium',
+        kind: 'compound',
+        label: 'Magnesium',
+        primaryRoles: ['ATP production', 'mitochondrial function', 'energy metabolism'],
+        evidenceTier: 'moderate',
+      },
+    ],
+  },
+
+  neuroprotection: {
+    id: 'neuroprotection',
+    label: 'Neuroprotection & Cognitive Aging',
+    goalSlug: 'cognition',
+    description:
+      'Herbs and compounds studied for neuroplasticity, neurogenesis, and long-term cognitive health.',
+    members: [
+      {
+        slug: 'lions-mane',
+        kind: 'herb',
+        label: "Lion's Mane",
+        primaryRoles: ['NGF synthesis', 'neuroplasticity', 'cognitive aging'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'bacopa',
+        kind: 'herb',
+        label: 'Bacopa',
+        primaryRoles: ['BDNF support', 'synaptic density', 'memory consolidation'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'ginkgo-biloba',
+        kind: 'herb',
+        label: 'Ginkgo Biloba',
+        primaryRoles: ['cerebrovascular circulation', 'antioxidant', 'cognitive aging'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'gotu-kola',
+        kind: 'herb',
+        label: 'Gotu Kola',
+        primaryRoles: ['neuroplasticity', 'dendritic growth'],
+        evidenceTier: 'low',
+      },
+      {
+        slug: 'phosphatidylserine',
+        kind: 'compound',
+        label: 'Phosphatidylserine',
+        primaryRoles: ['neuronal membrane integrity', 'cognitive aging', 'ADHD'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'alpha-gpc',
+        kind: 'compound',
+        label: 'Alpha-GPC',
+        primaryRoles: ['acetylcholine precursor', 'neuroplasticity', 'memory'],
+        evidenceTier: 'moderate',
+      },
+      {
+        slug: 'magnesium',
+        kind: 'compound',
+        label: 'Magnesium',
+        primaryRoles: ['NMDA modulation', 'synaptic plasticity', 'neuroprotection'],
+        evidenceTier: 'moderate',
+      },
+    ],
+  },
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public query API
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Returns all clusters that contain a given entity. */
+export function getEntityClusters(slug: string, kind: EntityKind): ClusterDefinition[] {
+  return Object.values(CLUSTERS).filter((cluster) =>
+    cluster.members.some((m) => m.slug === slug && m.kind === kind),
+  )
+}
+
+/**
+ * Returns cluster peers for a given entity, deduped, excluding itself.
+ * Results are ordered by cluster priority then member list order.
+ */
+export function getClusterSeeAlso(
+  slug: string,
+  kind: EntityKind,
+  limit = 6,
+): SeeAlsoEntry[] {
+  const entityClusters = getEntityClusters(slug, kind)
+  if (!entityClusters.length) return []
+
+  const seen = new Set<string>()
+  const results: SeeAlsoEntry[] = []
+
+  for (const cluster of entityClusters) {
+    for (const member of cluster.members) {
+      if (member.slug === slug && member.kind === kind) continue
+      const key = `${member.kind}:${member.slug}`
+      if (seen.has(key)) continue
+      seen.add(key)
+
+      const base = member.kind === 'herb' ? 'herbs' : 'compounds'
+      results.push({
+        slug: member.slug,
+        kind: member.kind,
+        label: member.label,
+        href: `/${base}/${member.slug}`,
+        reason: member.primaryRoles.slice(0, 2).join(', '),
+        cluster: cluster.id,
+        clusterLabel: cluster.label,
+        clusterGoalHref: `/goals/${cluster.goalSlug}`,
+      })
+
+      if (results.length >= limit) return results
+    }
+  }
+
+  return results
+}
+
+/** Returns clusters whose goalSlug matches the given goal page. */
+export function getGoalClusters(goalSlug: string): ClusterDefinition[] {
+  return Object.values(CLUSTERS).filter((c) => c.goalSlug === goalSlug)
+}
+
+/** Returns the full cluster definitions map (read-only reference). */
+export function getAllClusters(): Readonly<Record<ClusterId, ClusterDefinition>> {
+  return CLUSTERS
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Schema integration
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Builds the `relatedLink` URL array for embedding in a profile's MedicalWebPage node.
+ * Returns absolute canonical URLs, safe for static export.
+ */
+export function buildProfileRelatedLinks(slug: string, kind: EntityKind): string[] {
+  const seeAlso = getClusterSeeAlso(slug, kind, 8)
+  return buildRelatedLinksSchema(seeAlso)
+}
+
+type ProfileSchemaGraphWithClusterArgs = ProfileSchemaGraphArgs & {
+  /** Pre-computed see-also entries (from getClusterSeeAlso). Pass [] to skip. */
+  seeAlsoEntries: SeeAlsoEntry[]
+}
+
+/**
+ * Extends buildProfileSchemaGraph() to inject cluster relatedLink URLs
+ * into the MedicalWebPage node.
+ *
+ * Usage:
+ *   const seeAlso = getClusterSeeAlso(slug, 'herb')
+ *   const graph = buildProfileSchemaGraphWithCluster({ ...args, seeAlsoEntries: seeAlso })
+ */
+export function buildProfileSchemaGraphWithCluster(
+  args: ProfileSchemaGraphWithClusterArgs,
+): Record<string, unknown> {
+  const baseGraph = buildProfileSchemaGraph(args)
+
+  if (!args.seeAlsoEntries.length) return baseGraph
+
+  const relatedLinks = buildRelatedLinksSchema(args.seeAlsoEntries)
+  const graphArray = baseGraph['@graph']
+  if (!Array.isArray(graphArray)) return baseGraph
+
+  // Inject relatedLink into the MedicalWebPage node (always the first node in the graph)
+  const augmented = graphArray.map((node: unknown) => {
+    if (typeof node !== 'object' || node === null || !('@type' in node)) return node
+    const record = node as Record<string, unknown>
+    const types = Array.isArray(record['@type']) ? record['@type'] : [record['@type']]
+    if ((types as unknown[]).includes('MedicalWebPage')) {
+      return { ...record, relatedLink: relatedLinks }
+    }
+    return node
+  })
+
+  return { ...baseGraph, '@graph': augmented }
+}
+
+/**
+ * Builds a standalone @graph that lists all cluster members for a goal page.
+ * Embed this as a second SchemaGraphScript on /goals/[goal] pages.
+ */
+export function buildGoalClusterGraph(goalSlug: string): Record<string, unknown> | null {
+  const clusters = getGoalClusters(goalSlug)
+  if (!clusters.length) return null
+
+  const goalUrl = `${SITE_URL}/goals/${goalSlug}/`
+  const nodes = clusters.map((cluster) => {
+    const itemListId = `${goalUrl}#cluster-${cluster.id}`
+    return {
+      '@type': 'ItemList',
+      '@id': itemListId,
+      name: cluster.label,
+      description: cluster.description,
+      url: goalUrl,
+      numberOfItems: cluster.members.length,
+      itemListElement: cluster.members.map((member, index) => {
+        const base = member.kind === 'herb' ? 'herbs' : 'compounds'
+        return {
+          '@type': 'ListItem',
+          position: index + 1,
+          name: member.label,
+          url: `${SITE_URL}/${base}/${member.slug}/`,
+        }
+      }),
+    }
+  })
+
+  return buildSchemaGraph(nodes as Array<Record<string, unknown>>)
+}

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -1,0 +1,189 @@
+/**
+ * Schema.org type system — cluster layer.
+ *
+ * Complements src/lib/seo.ts (per-page JSON-LD builders) and
+ * src/lib/schema-graph.ts (@graph assembly). This file adds:
+ *  - ClusterDefinition / SeeAlsoEntry types (shared with lib/cluster-linking.ts)
+ *  - Drug / Thing node builders not in the existing files
+ *  - relatedLink + ItemList helpers for cluster interlinking
+ */
+
+import { SITE_URL } from '@/lib/site'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cluster types — consumed by lib/cluster-linking.ts and components
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type ClusterId =
+  | 'adhd-focus'
+  | 'sleep'
+  | 'stress-anxiety'
+  | 'energy'
+  | 'neuroprotection'
+
+export type EntityKind = 'herb' | 'compound'
+
+export type EvidenceTier = 'high' | 'moderate' | 'low'
+
+export type ClusterMember = {
+  slug: string
+  kind: EntityKind
+  label: string
+  /** Primary roles this entity plays within the cluster */
+  primaryRoles: string[]
+  evidenceTier: EvidenceTier
+}
+
+export type ClusterDefinition = {
+  id: ClusterId
+  label: string
+  /** Canonical goal page slug that anchors this cluster */
+  goalSlug: string
+  description: string
+  members: ClusterMember[]
+}
+
+export type SeeAlsoEntry = {
+  slug: string
+  kind: EntityKind
+  label: string
+  href: string
+  /** Human-readable reason for the relationship */
+  reason: string
+  cluster: ClusterId
+  clusterLabel: string
+  clusterGoalHref: string
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Schema.org node arg types (strict — no `any` or generic unknown values)
+// ─────────────────────────────────────────────────────────────────────────────
+
+type SchemaNode = Record<string, unknown>
+
+export type DrugSchemaArgs = {
+  name: string
+  slug: string
+  description?: string
+  /** ATC drug class if available */
+  drugClass?: string
+  legalStatus?: string
+  relatedDrugs?: Array<{ name: string; url: string }>
+}
+
+export type ThingSchemaArgs = {
+  name: string
+  url: string
+  description?: string
+  sameAs?: string[]
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Schema.org node builders
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Builds a Schema.org Drug node.
+ * Use for compound profiles that have a defined pharmacological identity.
+ */
+export function buildDrugNode(args: DrugSchemaArgs): SchemaNode {
+  const url = `${SITE_URL}/compounds/${args.slug}/`
+  return {
+    '@type': 'Drug',
+    name: args.name,
+    url,
+    ...(args.description ? { description: args.description } : {}),
+    ...(args.drugClass
+      ? { drugClass: { '@type': 'DrugClass', name: args.drugClass } }
+      : {}),
+    ...(args.legalStatus ? { legalStatus: args.legalStatus } : {}),
+    ...(args.relatedDrugs?.length
+      ? {
+          relatedDrug: args.relatedDrugs.map((d) => ({
+            '@type': 'Drug',
+            name: d.name,
+            url: d.url,
+          })),
+        }
+      : {}),
+  }
+}
+
+/**
+ * Builds a Schema.org Thing node.
+ * Use for generic entity cross-linking (e.g., cluster anchors, goal pages).
+ */
+export function buildThingNode(args: ThingSchemaArgs): SchemaNode {
+  return {
+    '@type': 'Thing',
+    name: args.name,
+    url: args.url,
+    ...(args.description ? { description: args.description } : {}),
+    ...(args.sameAs?.length ? { sameAs: args.sameAs } : {}),
+  }
+}
+
+/**
+ * Builds the `relatedLink` URL array for a MedicalWebPage schema node.
+ *
+ * Google uses relatedLink to understand topical cluster membership.
+ * Each value must be an absolute canonical URL.
+ */
+export function buildRelatedLinksSchema(entries: SeeAlsoEntry[]): string[] {
+  return entries.map((e) => {
+    const raw = `${SITE_URL}${e.href}/`
+    return raw.replace(/\/{2,}$/, '/')
+  })
+}
+
+/**
+ * Builds a Schema.org ItemList representing a cluster.
+ * Embed as `mentions` or `hasPart` on CollectionPage / MedicalWebPage.
+ */
+export function buildClusterItemListNode(cluster: ClusterDefinition): SchemaNode {
+  const goalUrl = `${SITE_URL}/goals/${cluster.goalSlug}/`
+  return {
+    '@type': 'ItemList',
+    name: cluster.label,
+    description: cluster.description,
+    url: goalUrl,
+    numberOfItems: cluster.members.length,
+    itemListElement: cluster.members.map((member, index) => {
+      const base = member.kind === 'herb' ? 'herbs' : 'compounds'
+      const profileUrl = `${SITE_URL}/${base}/${member.slug}/`
+      return {
+        '@type': 'ListItem',
+        position: index + 1,
+        name: member.label,
+        url: profileUrl,
+      }
+    }),
+  }
+}
+
+/**
+ * Builds a Schema.org DefinedTermSet formally declaring a cluster as a semantic group.
+ * Can be embedded as `specialty` on MedicalWebPage or stand-alone in a @graph.
+ */
+export function buildClusterDefinedTermSet(cluster: ClusterDefinition): SchemaNode {
+  const goalUrl = `${SITE_URL}/goals/${cluster.goalSlug}/`
+  const termSetId = `${goalUrl}#cluster-${cluster.id}`
+  return {
+    '@type': 'DefinedTermSet',
+    '@id': termSetId,
+    name: cluster.label,
+    description: cluster.description,
+    url: goalUrl,
+    hasDefinedTerm: cluster.members.map((member) => {
+      const base = member.kind === 'herb' ? 'herbs' : 'compounds'
+      const profileUrl = `${SITE_URL}/${base}/${member.slug}/`
+      return {
+        '@type': 'DefinedTerm',
+        name: member.label,
+        url: profileUrl,
+        description: member.primaryRoles.join(', '),
+        inDefinedTermSet: { '@id': termSetId },
+      }
+    }),
+  }
+}


### PR DESCRIPTION
Implements the complete Schema.org cluster layer and ADHD/Focus interlinking
system as the Weeks 1-3 SEO audit deliverable.

New files:
- lib/schema.ts — ClusterDefinition/SeeAlsoEntry types, Drug/Thing node
  builders, buildRelatedLinksSchema(), buildClusterItemListNode(),
  buildClusterDefinedTermSet()
- lib/cluster-linking.ts — Five semantic clusters (ADHD-Focus, Sleep,
  Stress-Anxiety, Energy, Neuroprotection) as static data; getEntityClusters(),
  getClusterSeeAlso(), getGoalClusters(), buildProfileRelatedLinks(),
  buildProfileSchemaGraphWithCluster() (injects relatedLink into MedicalWebPage),
  buildGoalClusterGraph() (ItemList @graph for goal pages)
- components/SchemaOrg.tsx — Flexible JSON-LD <script> wrapper accepting both
  @graph and flat schema objects; superset of SchemaGraphScript
- components/SeeAlsoCluster.tsx — "Also in this cluster" server component;
  chip-style links grouped by cluster with goal-page deep links

Integrations:
- app/herbs/[slug]/page.tsx — uses buildProfileSchemaGraphWithCluster (adds
  relatedLink to MedicalWebPage node) + renders <SeeAlsoCluster>
- app/goals/[goal]/page.tsx — adds buildGoalClusterGraph() as a second
  SchemaGraphScript (ItemList nodes for each cluster anchored to the goal)

Schema design: relatedLink on MedicalWebPage signals cluster membership to
Google; DefinedTermSet formally declares the cluster as a semantic group;
ItemList on goal pages connects the hub to all cluster members.

All slugs verified against public/data/herbs-summary.json and
compounds-summary.json. No public/data files modified. Static-export safe.

https://claude.ai/code/session_019jSzxeK7J36piYxPmDU4jR