### PR TITLE
feat(phase-3a): pathway diagram component, evidence legend, 4 ADHD/focus cluster pages

### DIFF
--- a/app/articles/best-magnesium-supplement-for-adhd/page.tsx
+++ b/app/articles/best-magnesium-supplement-for-adhd/page.tsx
@@ -1,0 +1,473 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd } from '@/lib/seo'
+import LastUpdatedBadge from '@/components/editorial/LastUpdatedBadge'
+import ResponsiveTable from '@/components/ui/ResponsiveTable'
+import SafetyNotice from '@/components/evidence/SafetyNotice'
+import EmailCapture from '@/components/EmailCapture'
+import NewsletterCtaBlock from '@/components/NewsletterCtaBlock'
+import PathwayDiagram from '@/components/PathwayDiagram'
+import EvidenceLegend from '@/components/EvidenceLegend'
+import { pathwayDiagrams } from '@/lib/pathway-data'
+import { AFFILIATE_TAGS } from '@/config/affiliate'
+
+const SLUG = 'best-magnesium-supplement-for-adhd'
+const TITLE = 'Best Magnesium Supplement for ADHD: Which Form, What Dose, and What to Look For'
+const DESCRIPTION =
+  'Practical buying guide to magnesium supplements for ADHD. Covers the best forms (glycinate, citrate, threonate), what to ignore (oxide), how to read labels, dose ranges, and what to expect.'
+const DATE = '2026-06-12'
+const AUTHOR = 'Will'
+const READING_TIME = '9 min read'
+const TAGS = ['magnesium', 'ADHD', 'buying guide', 'sleep', 'supplements']
+const CATEGORY = 'Buying Guide'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: TITLE,
+  description: DESCRIPTION,
+  path: `/articles/${SLUG}`,
+  openGraphType: 'article',
+})
+
+const FAQS = [
+  {
+    question: 'What is the best magnesium supplement for ADHD?',
+    answer:
+      'Magnesium glycinate is the most recommended form for ADHD-related use. It combines good bioavailability with gentle GI tolerability and the mild calming effect of glycine — making it suitable for evening use to support sleep and reduce hyperactivation. It is more expensive than citrate but worth it as a starting point. For budget-conscious buyers, magnesium citrate is a reasonable second choice at lower doses.',
+  },
+  {
+    question: 'How much magnesium should I take for ADHD?',
+    answer:
+      'Most research in ADHD populations uses 200–400 mg of elemental magnesium daily. For adults starting glycinate, 200 mg elemental magnesium before bed is a reasonable starting dose. Elemental magnesium content is not the same as the product weight on the label — a product labeled "400 mg magnesium glycinate" typically contains only 60–80 mg of elemental magnesium. Always check the "Supplement Facts" label for elemental magnesium per serving.',
+  },
+  {
+    question: 'Should I take magnesium with food or without for ADHD?',
+    answer:
+      'Taking magnesium with a small meal or snack is generally recommended — this reduces the chance of nausea (which is uncommon but possible) and may improve absorption compared to a completely empty stomach. Magnesium glycinate is tolerant to be taken with or without food, unlike some other mineral supplements.',
+  },
+  {
+    question: 'Is magnesium threonate worth the extra cost for ADHD?',
+    answer:
+      'Magnesium threonate has been promoted as superior for brain health due to animal studies suggesting greater brain penetration. Human ADHD-specific trials comparing threonate to glycinate are very limited. At 3–4x the cost of glycinate and with no convincing comparative ADHD evidence, threonate is not the best starting choice. Try glycinate for 4–6 weeks first. If well-tolerated but insufficient, threonate may be worth exploring.',
+  },
+  {
+    question: 'Can my child with ADHD take magnesium?',
+    answer:
+      'Magnesium supplementation in children with ADHD has been studied, and several trials in pediatric populations show improvements in hyperactivity, emotional dysregulation, and sleep — particularly in children with confirmed low magnesium levels. However, pediatric dosing is different from adult dosing (typically 100–200 mg elemental depending on age and weight), and supplementation in children should be discussed with a pediatrician before starting.',
+  },
+  {
+    question: 'How long before bed should I take magnesium for ADHD?',
+    answer:
+      'Taking magnesium 30–60 minutes before bed is a commonly used timing for sleep and evening calm support. This allows time for absorption before the intended sleep-support effects are most useful. Some people prefer taking it earlier in the evening as part of a wind-down routine — this is also fine for most forms including glycinate.',
+  },
+]
+
+export default function BestMagnesiumForAdhdPage() {
+  const breadcrumbLd = breadcrumbJsonLd([
+    { name: 'Articles', url: 'https://thehippiescientist.net/articles' },
+    { name: TITLE, url: `https://thehippiescientist.net/articles/${SLUG}` },
+  ])
+  const articleLd = blogJsonLd(
+    { title: TITLE, slug: SLUG, date: DATE, description: DESCRIPTION },
+    `/articles/${SLUG}`,
+  )
+  const faqLd = faqPageJsonLd({ pagePath: `/articles/${SLUG}`, questions: FAQS })
+
+  return (
+    <article className="mx-auto max-w-5xl space-y-0 px-4 pb-20 pt-6 sm:px-6 lg:px-8">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }} />
+      {faqLd && <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />}
+
+      <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
+        <Link href="/articles" className="transition hover:text-ink">Articles</Link>
+        <span>/</span>
+        <span className="text-ink line-clamp-1">{TITLE}</span>
+      </nav>
+
+      <section className="rounded-[1.5rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8 lg:p-10">
+        <div className="flex flex-wrap items-center gap-2 text-xs">
+          <span className="rounded-full border border-brand-900/10 bg-brand-50 px-2.5 py-0.5 font-bold uppercase tracking-wider text-brand-800">
+            {CATEGORY}
+          </span>
+          {TAGS.slice(0, 3).map((tag) => (
+            <span key={tag} className="rounded-full border border-brand-900/10 bg-white px-2.5 py-0.5 font-semibold text-muted capitalize">
+              {tag}
+            </span>
+          ))}
+          <span className="text-muted">June 12, 2026</span>
+          <span className="text-muted">·</span>
+          <span className="text-muted">{READING_TIME}</span>
+        </div>
+        <h1 className="mt-4 font-display text-3xl font-bold leading-tight tracking-tight text-ink sm:text-4xl lg:text-5xl">
+          {TITLE}
+        </h1>
+        <p className="mt-2 text-sm text-muted">
+          By{' '}
+          <Link href="/about" rel="author" className="font-medium text-ink hover:underline">
+            {AUTHOR}
+          </Link>
+        </p>
+        <div className="mt-3">
+          <LastUpdatedBadge date={DATE} label="Last updated" />
+        </div>
+        <p className="mt-4 max-w-3xl text-base leading-7 text-[#46574d]">{DESCRIPTION}</p>
+      </section>
+
+      <div className="mt-4 rounded-[1rem] border border-brand-900/10 bg-brand-50/60 px-5 py-3 text-xs leading-6 text-muted">
+        <strong className="text-ink">Affiliate disclosure:</strong> This article contains affiliate
+        links. Purchases may earn us a commission at no additional cost to you. All recommendations
+        are based on evidence and dose ranges reviewed on this page.
+      </div>
+
+      <div className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1fr)_240px]">
+        <div className="space-y-6">
+
+          {/* Top Pick Box */}
+          <section className="rounded-[1rem] border border-emerald-200 bg-emerald-50/60 p-6 shadow-sm sm:p-8">
+            <p className="text-[10px] font-bold uppercase tracking-wider text-emerald-700">Top Pick for ADHD</p>
+            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
+              Magnesium Glycinate — The Best First Choice
+            </h2>
+            <p className="mt-3 text-[1.01rem] leading-[1.85] text-[#46574d]">
+              For most adults and children with ADHD, <strong>magnesium glycinate</strong> is the best
+              starting point. It has high bioavailability, excellent GI tolerability, and the glycine
+              component adds mild calming support that aligns well with ADHD-related sleep difficulty and
+              evening hyperactivation.
+            </p>
+            <ul className="mt-3 ml-5 space-y-1 list-disc text-[1.01rem] leading-[1.85] text-[#46574d]">
+              <li><strong>Target dose:</strong> 200–300 mg elemental magnesium before bed</li>
+              <li><strong>When to take it:</strong> 30–60 minutes before sleep</li>
+              <li><strong>What to look for on the label:</strong> &ldquo;Magnesium glycinate&rdquo; or &ldquo;magnesium bisglycinate&rdquo;; elemental magnesium listed in Supplement Facts</li>
+              <li><strong>What to avoid:</strong> Magnesium oxide — poor absorption (~4% bioavailability)</li>
+            </ul>
+            <a
+              href={`https://www.amazon.com/s?k=magnesium+glycinate+adhd+sleep&tag=${AFFILIATE_TAGS.amazon}`}
+              target="_blank"
+              rel="noopener noreferrer sponsored"
+              className="mt-4 inline-flex items-center gap-1.5 rounded-full bg-emerald-700 px-5 py-2 text-sm font-bold text-white transition hover:bg-emerald-800"
+            >
+              Find Magnesium Glycinate on Amazon →
+            </a>
+          </section>
+
+          <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8 space-y-8">
+
+            <div id="how-magnesium-works">
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
+                Why Magnesium for ADHD?
+              </h2>
+              <PathwayDiagram data={pathwayDiagrams['magnesium-adhd']} />
+              <p className="mt-4 text-[1.01rem] leading-[1.85] text-[#46574d]">
+                Magnesium plays a key role in regulating neural excitability via NMDA receptor blockade.
+                In ADHD, neural over-excitation contributes to hyperactivity, impulsivity, and difficulty
+                with emotional regulation. Magnesium deficiency — more common in ADHD than the general
+                population — may exacerbate these symptoms. Correcting it is one of the more
+                evidence-backed reasons to use magnesium in ADHD.
+              </p>
+              <EvidenceLegend highlightTier="moderate" className="mt-4" />
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            {/* Form Rankings */}
+            <div id="form-rankings">
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
+                Magnesium Forms Ranked for ADHD
+              </h2>
+              <div className="space-y-3">
+                {[
+                  {
+                    rank: '1',
+                    name: 'Magnesium Glycinate (Bisglycinate)',
+                    verdict: 'Best Choice',
+                    verdictClass: 'bg-emerald-50 border-emerald-200 text-emerald-800',
+                    desc: 'High absorption, gentle GI profile, glycine adds calming co-benefit. Best for sleep and evening calm support in ADHD.',
+                    query: 'magnesium+glycinate+bisglycinate+sleep',
+                  },
+                  {
+                    rank: '2',
+                    name: 'Magnesium Citrate',
+                    verdict: 'Good Alternative',
+                    verdictClass: 'bg-blue-50 border-blue-200 text-blue-800',
+                    desc: 'Good absorption, widely available, lower cost. Laxative effect at higher doses — start at 150–200 mg elemental.',
+                    query: 'magnesium+citrate+supplement+sleep',
+                  },
+                  {
+                    rank: '3',
+                    name: 'Magnesium L-Threonate',
+                    verdict: 'Premium / Unproven for ADHD',
+                    verdictClass: 'bg-amber-50 border-amber-200 text-amber-800',
+                    desc: 'Marketed for brain penetration. Animal data is interesting but human ADHD trials vs glycinate are limited. 3–4x the cost. Try glycinate first.',
+                    query: 'magnesium+threonate+cognitive',
+                  },
+                  {
+                    rank: '4',
+                    name: 'Magnesium Malate',
+                    verdict: 'Decent Option',
+                    verdictClass: 'bg-slate-50 border-slate-200 text-slate-700',
+                    desc: 'Good tolerance, reasonable absorption. Often used for energy and fatigue. Less calming co-benefit than glycinate. Valid choice if glycinate is unavailable.',
+                    query: 'magnesium+malate+supplement',
+                  },
+                  {
+                    rank: '✕',
+                    name: 'Magnesium Oxide',
+                    verdict: 'Avoid',
+                    verdictClass: 'bg-red-50 border-red-200 text-red-800',
+                    desc: '~4% bioavailability. Almost entirely passes through as a laxative. Very common in cheap supplements — check your label and avoid this form for ADHD use.',
+                    query: 'magnesium+glycinate+not+oxide',
+                  },
+                ].map(({ rank, name, verdict, verdictClass, desc, query }) => (
+                  <div key={name} className="flex gap-4 rounded-[1rem] border border-brand-900/10 bg-brand-50/20 p-4">
+                    <span className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-brand-900 text-xs font-bold text-white">
+                      {rank}
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="font-semibold text-ink">{name}</p>
+                        <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-bold ${verdictClass}`}>
+                          {verdict}
+                        </span>
+                      </div>
+                      <p className="mt-1 text-sm leading-6 text-[#46574d]">{desc}</p>
+                      {rank !== '✕' && (
+                        <a
+                          href={`https://www.amazon.com/s?k=${query}&tag=${AFFILIATE_TAGS.amazon}`}
+                          target="_blank"
+                          rel="noopener noreferrer sponsored"
+                          className="mt-2 inline-flex items-center gap-1 text-xs font-semibold text-brand-700 hover:text-brand-800 hover:underline"
+                        >
+                          View on Amazon →
+                        </a>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            {/* Label Reading Guide */}
+            <div id="label-guide">
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
+                How to Read a Magnesium Label
+              </h2>
+              <div className="rounded-[1rem] border border-brand-900/10 bg-brand-50/60 p-5">
+                <p className="font-semibold text-ink">The most common labeling confusion:</p>
+                <p className="mt-2 text-sm leading-6 text-[#46574d]">
+                  A product labeled &ldquo;Magnesium Glycinate 400mg&rdquo; does NOT mean you are getting
+                  400mg of elemental magnesium. The 400mg is the weight of the entire compound (magnesium
+                  + glycine). The actual elemental magnesium is typically <strong>60–80mg per tablet</strong>.
+                </p>
+                <p className="mt-3 text-sm leading-6 text-[#46574d]">
+                  Always look at the <strong>Supplement Facts panel</strong> for the line that reads:
+                  &ldquo;Magnesium [as magnesium glycinate] — Xmg&rdquo;. That &ldquo;Xmg&rdquo; is the
+                  elemental dose. If you want 200mg elemental magnesium per day, you may need 3–4 tablets
+                  of a standard glycinate product.
+                </p>
+              </div>
+              <ResponsiveTable label="Magnesium form comparison by elemental content" className="mt-4">
+                <table className="min-w-[520px] w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-brand-900/10">
+                      {['Form', 'Typical Elemental %', 'Dose to Hit 200mg Elemental', 'GI Risk'].map((h) => (
+                        <th key={h} className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">{h}</th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-brand-900/5">
+                    {[
+                      ['Glycinate', '~14–18%', '2–4 standard capsules', 'Very low'],
+                      ['Citrate', '~16%', '2–3 capsules', 'Moderate at high doses'],
+                      ['Threonate', '~8%', '3–4 capsules', 'Low'],
+                      ['Oxide', '~60%', '1 capsule (but ~4% absorbed)', 'High laxative effect'],
+                    ].map(([form, pct, dose, gi]) => (
+                      <tr key={form as string} className="align-top">
+                        <td className="py-3 pr-4 font-medium text-ink">{form}</td>
+                        <td className="py-3 pr-4 text-[#46574d]">{pct}</td>
+                        <td className="py-3 pr-4 text-[#46574d]">{dose}</td>
+                        <td className="py-3 text-[#46574d]">{gi}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </ResponsiveTable>
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            {/* Products */}
+            <div id="products">
+              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">Recommended Products</h2>
+              <p className="mb-4 text-[1.01rem] leading-[1.85] text-[#46574d]">
+                These searches reflect the forms and dose ranges most consistent with the ADHD evidence
+                reviewed on this page. Prices and availability vary.
+              </p>
+              <div className="grid gap-4 sm:grid-cols-2">
+                {[
+                  {
+                    eyebrow: '#1 Pick — Sleep + Calm',
+                    name: 'Magnesium Glycinate (200–400mg elemental)',
+                    desc: 'Best first purchase. Look for products listing 100–200mg elemental magnesium per serving in the Supplement Facts panel.',
+                    query: 'magnesium+glycinate+200mg+elemental+adhd+sleep',
+                    cta: 'Find on Amazon →',
+                  },
+                  {
+                    eyebrow: 'Budget Pick',
+                    name: 'Magnesium Citrate',
+                    desc: 'Solid absorption at lower cost. Stay at 150–200mg elemental per dose to minimize loose-stool effect.',
+                    query: 'magnesium+citrate+150mg+200mg+sleep',
+                    cta: 'Find on Amazon →',
+                  },
+                  {
+                    eyebrow: 'For Combining',
+                    name: 'L-Theanine + Magnesium Stack',
+                    desc: 'For adults who want both mental and physical calm support. Verify dose amounts on the label.',
+                    query: 'l-theanine+magnesium+glycinate+sleep+calm+adhd',
+                    cta: 'View combo options →',
+                  },
+                  {
+                    eyebrow: 'Kids ADHD (consult doctor first)',
+                    name: 'Magnesium Glycinate — Pediatric Dose',
+                    desc: 'Lower-dose options for children. Pediatric dosing should be guided by a clinician — do not use adult doses in children.',
+                    query: 'magnesium+glycinate+kids+children+100mg',
+                    cta: 'View options →',
+                  },
+                ].map(({ eyebrow, name, desc, query, cta }) => (
+                  <div key={name} className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
+                    <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">{eyebrow}</p>
+                    <p className="font-semibold text-ink">{name}</p>
+                    <p className="mt-1 text-xs leading-5 text-[#46574d]">{desc}</p>
+                    <a
+                      href={`https://www.amazon.com/s?k=${query}&tag=${AFFILIATE_TAGS.amazon}`}
+                      target="_blank"
+                      rel="noopener noreferrer sponsored"
+                      className="mt-3 inline-flex items-center gap-1 rounded-full bg-brand-950 px-4 py-1.5 text-xs font-bold text-white transition hover:bg-brand-900"
+                    >
+                      {cta}
+                    </a>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            <div id="safety">
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Safety Checklist</h2>
+              <SafetyNotice title="Magnesium Safety — ADHD Use">
+                <ul className="ml-5 space-y-1.5 list-disc">
+                  {[
+                    ['Upper limit for supplements: 350 mg/day elemental', 'This applies to supplemental magnesium only. Food-derived magnesium is not counted. Do not routinely exceed 350 mg supplemental without medical advice.'],
+                    ['Kidney disease: Do not supplement without guidance', 'Magnesium is cleared by the kidneys. Impaired clearance can lead to toxicity. Always consult your nephrologist or GP first.'],
+                    ['ADHD medications: No established interaction', 'No known interaction with methylphenidate, amphetamine salts, or atomoxetine. Inform your prescriber you are supplementing.'],
+                    ['Children: Get pediatric dosing advice', 'Research in children exists, but adult doses are not appropriate for children. Discuss with a pediatrician before supplementing.'],
+                    ['Do not use oxide', 'Magnesium oxide is mainly a laxative and delivers very little bioavailable magnesium. Check your labels carefully.'],
+                    ['Drug interactions', 'Magnesium can reduce absorption of some antibiotics, bisphosphonates, and may interact with blood pressure medications. Take 2+ hours apart from these.'],
+                  ].map(([bold, text]) => (
+                    <li key={bold as string}><strong>{bold as string}.</strong> {text as string}</li>
+                  ))}
+                </ul>
+              </SafetyNotice>
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            <div id="faq">
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Frequently Asked Questions</h2>
+              <div className="space-y-4">
+                {FAQS.map((faq, i) => (
+                  <div key={i} className="rounded-[0.75rem] border border-brand-900/10 bg-brand-50/40 p-4">
+                    <h3 className="font-semibold text-ink">{faq.question}</h3>
+                    <p className="mt-2 text-sm leading-7 text-[#46574d]">{faq.answer}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            <div id="related">
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Related Articles</h2>
+              <div className="grid gap-3 sm:grid-cols-2">
+                {[
+                  ['/articles/magnesium-for-adhd', 'ADHD Cluster', 'Magnesium for ADHD', 'Full evidence review.'],
+                  ['/articles/best-supplements-for-adhd', 'Cornerstone', 'Best Supplements for ADHD', 'Evidence-ranked guide.'],
+                  ['/articles/magnesium-glycinate-vs-citrate-for-adhd', 'ADHD Cluster', 'Glycinate vs Citrate for ADHD', 'Form comparison.'],
+                  ['/articles/l-theanine-magnesium-adhd-stack', 'Stack Guide', 'L-Theanine + Magnesium Stack', 'How to combine the two.'],
+                  ['/articles/sleep-and-adhd', 'Sleep + ADHD', 'Sleep and ADHD', 'Why sleep is critical in ADHD.'],
+                  ['/articles/adhd-stack-guide', 'ADHD Cluster', 'ADHD Stack Guide', 'Full supplement stacking guide.'],
+                ].map(([href, eyebrow, label, desc]) => (
+                  <Link key={href as string} href={href as string}
+                    className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30">
+                    <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">{eyebrow}</p>
+                    <p className="font-semibold text-ink transition group-hover:text-brand-700">{label}</p>
+                    <p className="mt-1 text-xs text-muted">{desc}</p>
+                  </Link>
+                ))}
+              </div>
+            </div>
+
+          </section>
+
+          <EmailCapture
+            headline="Get the ADHD supplement checklist"
+            description="Evidence-first supplement updates, buying guides, and ADHD research notes."
+            ctaLabel="Get Checklist"
+            location={`article-${SLUG}`}
+          />
+          <NewsletterCtaBlock
+            title="Continue with the newsletter archive"
+            description="Short notes built for cautious supplement decisions."
+            location={`article-${SLUG}-newsletter`}
+          />
+        </div>
+
+        {/* Sidebar */}
+        <aside className="space-y-4 lg:sticky lg:top-24 lg:self-start">
+          <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
+            <p className="text-[10px] font-bold uppercase tracking-wider text-muted">In this article</p>
+            <nav className="mt-3 space-y-1.5" aria-label="Article sections">
+              {[
+                ['#how-magnesium-works', 'Why Magnesium?'],
+                ['#form-rankings', 'Form Rankings'],
+                ['#label-guide', 'Reading Labels'],
+                ['#products', 'Product Picks'],
+                ['#safety', 'Safety Checklist'],
+                ['#faq', 'FAQ'],
+              ].map(([href, label]) => (
+                <a key={href} href={href as string}
+                  className="block text-sm text-brand-700 hover:text-brand-800 hover:underline">
+                  {label}
+                </a>
+              ))}
+            </nav>
+          </div>
+          <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
+            <p className="text-[10px] font-bold uppercase tracking-wider text-muted">ADHD cluster</p>
+            <div className="mt-3 space-y-2">
+              {[
+                ['/articles/best-supplements-for-adhd', 'Best supplements for ADHD →'],
+                ['/articles/magnesium-for-adhd', 'Magnesium for ADHD →'],
+                ['/articles/l-theanine-magnesium-adhd-stack', 'L-Theanine + Magnesium Stack →'],
+                ['/articles/adhd-stack-guide', 'ADHD stack guide →'],
+                ['/goals/focus', 'Focus goal hub →'],
+              ].map(([href, label]) => (
+                <Link key={href as string} href={href as string}
+                  className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline">
+                  {label}
+                </Link>
+              ))}
+            </div>
+          </div>
+        </aside>
+      </div>
+
+      <div className="mt-8">
+        <Link href="/articles" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
+          ← Back to Articles
+        </Link>
+      </div>
+    </article>
+  )
+}

--- a/app/articles/l-theanine-magnesium-adhd-stack/page.tsx
+++ b/app/articles/l-theanine-magnesium-adhd-stack/page.tsx
@@ -1,0 +1,474 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd } from '@/lib/seo'
+import LastUpdatedBadge from '@/components/editorial/LastUpdatedBadge'
+import ResponsiveTable from '@/components/ui/ResponsiveTable'
+import SafetyNotice from '@/components/evidence/SafetyNotice'
+import EmailCapture from '@/components/EmailCapture'
+import NewsletterCtaBlock from '@/components/NewsletterCtaBlock'
+import PathwayDiagram from '@/components/PathwayDiagram'
+import EvidenceLegend from '@/components/EvidenceLegend'
+import { pathwayDiagrams } from '@/lib/pathway-data'
+import { AFFILIATE_TAGS } from '@/config/affiliate'
+
+const SLUG = 'l-theanine-magnesium-adhd-stack'
+const TITLE = 'L-Theanine and Magnesium for ADHD: How to Stack Them Safely'
+const DESCRIPTION =
+  'Evidence-based guide to combining L-theanine and magnesium for ADHD. Covers mechanisms, synergy, safety, dosing order, timing, and drug interactions — including ADHD medication compatibility.'
+const DATE = '2026-06-12'
+const AUTHOR = 'Will'
+const READING_TIME = '10 min read'
+const TAGS = ['L-theanine', 'magnesium', 'ADHD', 'stacks', 'sleep']
+const CATEGORY = 'ADHD Stacks'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: TITLE,
+  description: DESCRIPTION,
+  path: `/articles/${SLUG}`,
+  openGraphType: 'article',
+})
+
+const FAQS = [
+  {
+    question: 'Can I take L-theanine and magnesium together for ADHD?',
+    answer:
+      'For most healthy adults and children without relevant medical conditions, yes — combining L-theanine and magnesium is considered reasonable. They act through different mechanisms (L-theanine via alpha-wave induction and glutamate modulation; magnesium via NMDA blockade and GABA support), which means they are complementary rather than duplicative. No significant adverse interaction between the two has been established in available literature. Introduce one at a time before combining to identify which is producing which effect.',
+  },
+  {
+    question: 'Does L-theanine make magnesium work better for ADHD?',
+    answer:
+      'Not through a direct pharmacological interaction — they do not amplify each other\'s absorption or binding. Rather, they address complementary aspects of ADHD-related difficulty: L-theanine works on mental calm and alpha-wave activity, while magnesium works on neural over-excitability and GABA pathways. Using both means broader coverage of the neurobiological targets relevant to ADHD hyperactivation and sleep difficulty.',
+  },
+  {
+    question: 'When should I take L-theanine and magnesium for ADHD?',
+    answer:
+      'Evening use is the most common pattern for both. L-theanine (100–200 mg) and magnesium glycinate (200–400 mg elemental) taken 30–60 minutes before bed supports ADHD-related sleep onset difficulties and evening hyperactivation. For daytime calm focus, L-theanine can also be taken in the morning or with a focus session — magnesium is typically reserved for evening because it may increase sedation when combined with other sleep cues.',
+  },
+  {
+    question: 'Is this stack safe with ADHD medications?',
+    answer:
+      'No established adverse interaction between supplemental L-theanine or magnesium and common ADHD stimulants (methylphenidate, amphetamine salts) has been documented. Some practitioners use magnesium to support side-effect management in stimulant users. However, you should inform your prescribing clinician that you are using these supplements, particularly if you observe changes in medication response. Do not adjust medication timing or dose based on supplement use without medical guidance.',
+  },
+  {
+    question: 'How long does it take to notice effects from this stack?',
+    answer:
+      'L-theanine effects (if they occur) are often noticeable within the same day or evening — particularly the alpha-wave calming effect. Magnesium effects on sleep quality and neural excitability are more gradual: most users report noticing changes within 1–2 weeks of consistent daily use, with fuller effects developing at 4–6 weeks. If neither supplement produces any noticeable effect after 4–6 weeks of consistent use, reassess with a clinician — blood testing for magnesium status may be informative.',
+  },
+  {
+    question: 'Should I start both supplements on the same day?',
+    answer:
+      'Starting them separately is strongly preferred. Begin one supplement, assess your response over 7–14 days, then add the second. If you start both simultaneously and experience an effect (positive or negative), you cannot determine which supplement is responsible. This makes it harder to optimise or troubleshoot. Starting separately also means smaller initial supplement burden and cleaner attribution of any side effects.',
+  },
+]
+
+export default function LTheanineMagnesiumAdhdStackPage() {
+  const breadcrumbLd = breadcrumbJsonLd([
+    { name: 'Articles', url: 'https://thehippiescientist.net/articles' },
+    { name: TITLE, url: `https://thehippiescientist.net/articles/${SLUG}` },
+  ])
+  const articleLd = blogJsonLd(
+    { title: TITLE, slug: SLUG, date: DATE, description: DESCRIPTION },
+    `/articles/${SLUG}`,
+  )
+  const faqLd = faqPageJsonLd({ pagePath: `/articles/${SLUG}`, questions: FAQS })
+
+  return (
+    <article className="mx-auto max-w-5xl space-y-0 px-4 pb-20 pt-6 sm:px-6 lg:px-8">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }} />
+      {faqLd && <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />}
+
+      {/* Breadcrumb */}
+      <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
+        <Link href="/articles" className="transition hover:text-ink">Articles</Link>
+        <span>/</span>
+        <span className="text-ink line-clamp-1">{TITLE}</span>
+      </nav>
+
+      {/* Hero */}
+      <section className="rounded-[1.5rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8 lg:p-10">
+        <div className="flex flex-wrap items-center gap-2 text-xs">
+          <span className="rounded-full border border-brand-900/10 bg-brand-50 px-2.5 py-0.5 font-bold uppercase tracking-wider text-brand-800">
+            {CATEGORY}
+          </span>
+          {TAGS.slice(0, 3).map((tag) => (
+            <span key={tag} className="rounded-full border border-brand-900/10 bg-white px-2.5 py-0.5 font-semibold text-muted capitalize">
+              {tag}
+            </span>
+          ))}
+          <span className="text-muted">June 12, 2026</span>
+          <span className="text-muted">·</span>
+          <span className="text-muted">{READING_TIME}</span>
+        </div>
+        <h1 className="mt-4 font-display text-3xl font-bold leading-tight tracking-tight text-ink sm:text-4xl lg:text-5xl">
+          {TITLE}
+        </h1>
+        <p className="mt-2 text-sm text-muted">
+          By{' '}
+          <Link href="/about" rel="author" className="font-medium text-ink hover:underline">
+            {AUTHOR}
+          </Link>
+        </p>
+        <div className="mt-3">
+          <LastUpdatedBadge date={DATE} label="Last updated" />
+        </div>
+        <p className="mt-4 max-w-3xl text-base leading-7 text-[#46574d]">{DESCRIPTION}</p>
+      </section>
+
+      {/* Disclosure */}
+      <div className="mt-4 rounded-[1rem] border border-brand-900/10 bg-brand-50/60 px-5 py-3 text-xs leading-6 text-muted">
+        <strong className="text-ink">Affiliate disclosure:</strong> This article contains affiliate
+        links. We may earn a commission at no additional cost to you. We only link to products
+        consistent with the evidence and dose ranges reviewed on this page.
+      </div>
+
+      <div className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1fr)_240px]">
+        <div className="space-y-6">
+
+          {/* Quick Verdict */}
+          <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+            <p className="eyebrow-label">Quick Verdict</p>
+            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
+              Is This Stack Worth Trying for ADHD?
+            </h2>
+            <ul className="mt-4 space-y-2">
+              {[
+                ['Safe to combine for most healthy adults', 'No established adverse interaction. Both are well-tolerated at supplemental doses.'],
+                ['Complementary mechanisms — not duplicative', 'L-theanine targets mental arousal and alpha waves; magnesium targets neural over-excitability and GABA. They cover different ground.'],
+                ['Best evidence is for individual components', 'Direct combination trials in ADHD are limited. Individual evidence for each compound is more robust.'],
+                ['Start one at a time — always', 'Introduce supplements separately over 1–2 weeks each to identify what works and attribute any effects correctly.'],
+              ].map(([bold, rest]) => (
+                <li key={bold as string} className="flex gap-2 text-[1.01rem] leading-[1.85] text-[#46574d]">
+                  <span className="mt-1 flex-shrink-0 text-brand-700">▸</span>
+                  <span><strong>{bold as string}.</strong> {rest as string}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8 space-y-8">
+
+            <div id="why-combine">
+              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">
+                Why Combine These Two for ADHD?
+              </h2>
+              <p className="text-[1.01rem] leading-[1.85] text-[#46574d]">
+                ADHD often involves hyperactivation across multiple dimensions: mental (racing thoughts,
+                difficulty quieting the mind), physical (motor restlessness), and neurochemical (imbalanced
+                excitatory/inhibitory signaling). A single supplement is unlikely to address all of these.
+              </p>
+              <p className="mt-3 text-[1.01rem] leading-[1.85] text-[#46574d]">
+                L-theanine and magnesium together cover more of this territory than either alone:
+              </p>
+              <ul className="mt-3 ml-5 space-y-1 list-disc text-[1.01rem] leading-[1.85] text-[#46574d]">
+                <li>L-theanine for mental calm, alpha-wave induction, and reducing stress-driven mental arousal</li>
+                <li>Magnesium for neural excitability regulation (NMDA), muscle relaxation, GABA support, and sleep architecture</li>
+                <li>Both are non-stimulant, non-sedative at typical doses — appropriate for use alongside ADHD medication</li>
+              </ul>
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            {/* Two mechanism diagrams */}
+            <div id="mechanisms">
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
+                How Each Works — Separate Pathways
+              </h2>
+              <p className="mb-4 text-[1.01rem] leading-[1.85] text-[#46574d]">
+                These two pathways are distinct — they don&apos;t share primary receptors or neurotransmitters,
+                which is why combining them is additive rather than redundant.
+              </p>
+              <div className="space-y-4">
+                <div>
+                  <p className="mb-2 text-sm font-semibold text-ink">L-Theanine Pathway:</p>
+                  <PathwayDiagram data={pathwayDiagrams['l-theanine-focus']} />
+                </div>
+                <div>
+                  <p className="mb-2 text-sm font-semibold text-ink">Magnesium Pathway:</p>
+                  <PathwayDiagram data={pathwayDiagrams['magnesium-adhd']} />
+                </div>
+              </div>
+              <EvidenceLegend highlightTier="limited" className="mt-4" />
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            {/* Synergy table */}
+            <div id="synergy">
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
+                Synergy Overview
+              </h2>
+              <ResponsiveTable label="L-theanine and magnesium synergy for ADHD">
+                <table className="min-w-[580px] w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-brand-900/10">
+                      {['ADHD Challenge', 'L-Theanine Contribution', 'Magnesium Contribution'].map((h) => (
+                        <th key={h} className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">{h}</th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-brand-900/5">
+                    {[
+                      ['Sleep onset', 'Mental quiet, reduced racing thoughts', 'NMDA calm, muscle relaxation, GABA support'],
+                      ['Evening hyperactivation', 'Alpha-wave induction, mental de-arousal', 'Neural excitability regulation'],
+                      ['Emotional dysregulation', 'Mild GABA modulation, stress attenuation', 'GABA support, potential cortisol-adjacent effects'],
+                      ['Daytime focus (L-theanine only)', '↑ Alpha, calm alertness without sedation', '(Not typically used in daytime)'],
+                      ['Physical restlessness', 'Limited direct effect', 'Muscle relaxation, magnesium\'s role in motor nerve conduction'],
+                    ].map(([challenge, lt, mg]) => (
+                      <tr key={challenge as string} className="align-top">
+                        <td className="py-3 pr-4 font-medium text-ink">{challenge}</td>
+                        <td className="py-3 pr-4 text-[#46574d]">{lt}</td>
+                        <td className="py-3 text-[#46574d]">{mg}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </ResponsiveTable>
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            {/* How to Stack */}
+            <div id="how-to-stack">
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
+                How to Stack Them: A Practical Protocol
+              </h2>
+              <div className="space-y-4">
+                {[
+                  {
+                    step: '1',
+                    title: 'Start with magnesium glycinate alone',
+                    body: 'Week 1–2: Take 200 mg elemental magnesium glycinate 30–60 minutes before bed. Assess sleep quality and evening calm. Magnesium deficiency is common in ADHD, so this may produce noticeable results quickly.',
+                  },
+                  {
+                    step: '2',
+                    title: 'Evaluate and add L-theanine',
+                    body: 'If magnesium is producing benefit but you still notice mental racing or stress-driven arousal at bedtime, add L-theanine 100–200 mg at the same time (30–60 min before bed). Start at 100 mg.',
+                  },
+                  {
+                    step: '3',
+                    title: 'For daytime calm focus',
+                    body: 'L-theanine can also be used alone during the day (100–200 mg, standalone, caffeine-free) for calm alertness. Magnesium is typically not added to daytime stacks unless deficiency correction is the primary goal.',
+                  },
+                  {
+                    step: '4',
+                    title: 'Monitor and adjust',
+                    body: 'After 4–6 weeks on the full stack, assess whether both supplements are contributing. If results are good, continue. If sleep worsened or any side effects emerged, step back to one supplement and reassess.',
+                  },
+                ].map(({ step, title, body }) => (
+                  <div key={step} className="flex gap-4 rounded-[1rem] border border-brand-900/10 bg-brand-50/40 p-4">
+                    <span className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-brand-700 text-xs font-bold text-white">
+                      {step}
+                    </span>
+                    <div>
+                      <p className="font-semibold text-ink">{title}</p>
+                      <p className="mt-1 text-sm leading-6 text-[#46574d]">{body}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              <div className="mt-4 rounded-[1rem] border border-brand-900/10 bg-white/90 p-5 shadow-sm">
+                <p className="mb-3 text-[10px] font-bold uppercase tracking-wider text-muted">
+                  Stack Reference — Evening Protocol
+                </p>
+                <ResponsiveTable label="L-theanine magnesium stack dosage">
+                  <table className="min-w-[500px] w-full text-sm">
+                    <thead>
+                      <tr className="border-b border-brand-900/10">
+                        {['Supplement', 'Dose', 'Timing', 'Notes'].map((h) => (
+                          <th key={h} className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">{h}</th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-brand-900/5">
+                      {[
+                        ['Magnesium Glycinate', '200–300 mg elemental', '30–60 min before bed', 'Introduce first; confirm tolerance'],
+                        ['L-Theanine', '100–200 mg', 'Same time as magnesium', 'Add after 1–2 weeks on Mg alone'],
+                      ].map(([supp, dose, timing, notes]) => (
+                        <tr key={supp as string} className="align-top">
+                          <td className="py-3 pr-4 font-medium text-ink">{supp}</td>
+                          <td className="py-3 pr-4 text-[#46574d]">{dose}</td>
+                          <td className="py-3 pr-4 text-[#46574d]">{timing}</td>
+                          <td className="py-3 text-[#46574d]">{notes}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </ResponsiveTable>
+              </div>
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            {/* Products */}
+            <div id="products">
+              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">Product Options</h2>
+              <div className="grid gap-4 sm:grid-cols-2">
+                {[
+                  {
+                    eyebrow: 'Magnesium Glycinate',
+                    name: 'Magnesium Glycinate 400mg',
+                    desc: 'Best form for the stack. Check the elemental magnesium per serving on the label.',
+                    query: 'magnesium+glycinate+sleep+calm',
+                    cta: 'View on Amazon →',
+                  },
+                  {
+                    eyebrow: 'L-Theanine (Caffeine-Free)',
+                    name: 'L-Theanine 100–200mg',
+                    desc: 'Choose a standalone product without added caffeine. Look for "caffeine-free" clearly stated.',
+                    query: 'l-theanine+200mg+caffeine+free+sleep',
+                    cta: 'View on Amazon →',
+                  },
+                  {
+                    eyebrow: 'Combined Stack',
+                    name: 'L-Theanine + Magnesium Combo',
+                    desc: 'Pre-combined sleep stack products. Verify dose amounts match the ranges on this page.',
+                    query: 'l-theanine+magnesium+glycinate+sleep+stack',
+                    cta: 'View combo products →',
+                  },
+                ].map(({ eyebrow, name, desc, query, cta }) => (
+                  <div key={name} className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
+                    <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">{eyebrow}</p>
+                    <p className="font-semibold text-ink">{name}</p>
+                    <p className="mt-1 text-xs leading-5 text-[#46574d]">{desc}</p>
+                    <a
+                      href={`https://www.amazon.com/s?k=${query}&tag=${AFFILIATE_TAGS.amazon}`}
+                      target="_blank"
+                      rel="noopener noreferrer sponsored"
+                      className="mt-3 inline-flex items-center gap-1 rounded-full bg-brand-950 px-4 py-1.5 text-xs font-bold text-white transition hover:bg-brand-900"
+                    >
+                      {cta}
+                    </a>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            {/* Safety */}
+            <div id="safety">
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Safety and Interactions</h2>
+              <SafetyNotice title="Stack Safety — L-Theanine + Magnesium for ADHD">
+                <ul className="ml-5 space-y-1.5 list-disc">
+                  {[
+                    ['No established adverse L-theanine + magnesium interaction', 'No pharmacokinetic or pharmacodynamic interaction has been identified between supplemental L-theanine and magnesium in available literature.'],
+                    ['ADHD stimulant medications', 'No established interaction with methylphenidate or amphetamine salts. Inform your prescriber that you are supplementing; do not adjust medication dose based on supplement use.'],
+                    ['Sedative medications', 'Both L-theanine and magnesium have mild CNS-calming properties. Use caution when combining with benzodiazepines, z-drugs, or other sedative medications.'],
+                    ['Kidney disease', 'Magnesium is renally cleared. Do not supplement without clinician guidance if you have kidney impairment.'],
+                    ['Tolerable upper level for magnesium', 'Do not exceed 350 mg supplemental magnesium per day without medical oversight. This does not include dietary magnesium.'],
+                    ['Pregnancy and breastfeeding', 'Insufficient safety data for supplemental L-theanine. Supplemental magnesium may be appropriate in some cases — consult a clinician.'],
+                  ].map(([bold, text]) => (
+                    <li key={bold as string}>
+                      <strong>{bold as string}.</strong> {text as string}
+                    </li>
+                  ))}
+                </ul>
+              </SafetyNotice>
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            {/* FAQ */}
+            <div id="faq">
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Frequently Asked Questions</h2>
+              <div className="space-y-4">
+                {FAQS.map((faq, i) => (
+                  <div key={i} className="rounded-[0.75rem] border border-brand-900/10 bg-brand-50/40 p-4">
+                    <h3 className="font-semibold text-ink">{faq.question}</h3>
+                    <p className="mt-2 text-sm leading-7 text-[#46574d]">{faq.answer}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            <div id="related">
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Related Articles</h2>
+              <div className="grid gap-3 sm:grid-cols-2">
+                {[
+                  ['/articles/best-supplements-for-adhd', 'Cornerstone', 'Best Supplements for ADHD', 'Full evidence-ranked guide.'],
+                  ['/articles/magnesium-for-adhd', 'ADHD Cluster', 'Magnesium for ADHD', 'Evidence review of magnesium for ADHD.'],
+                  ['/articles/l-theanine-for-adhd', 'ADHD Cluster', 'L-Theanine for ADHD', 'Evidence review of L-theanine for ADHD.'],
+                  ['/articles/magnesium-glycinate-vs-citrate-for-adhd', 'ADHD Cluster', 'Glycinate vs Citrate for ADHD', 'Which magnesium form works best.'],
+                  ['/articles/best-magnesium-supplement-for-adhd', 'Buying Guide', 'Best Magnesium for ADHD', 'Which product to buy first.'],
+                  ['/articles/adhd-stack-guide', 'Stack Guide', 'ADHD Stack Guide', 'Full supplement stacking guide for ADHD.'],
+                  ['/articles/sleep-and-adhd', 'Sleep + ADHD', 'Sleep and ADHD', 'Why sleep matters so much in ADHD.'],
+                  ['/goals/focus', 'Goal Hub', 'Focus Goal Hub', 'Compare all focus supplements.'],
+                ].map(([href, eyebrow, label, desc]) => (
+                  <Link key={href as string} href={href as string}
+                    className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30">
+                    <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">{eyebrow}</p>
+                    <p className="font-semibold text-ink transition group-hover:text-brand-700">{label}</p>
+                    <p className="mt-1 text-xs text-muted">{desc}</p>
+                  </Link>
+                ))}
+              </div>
+            </div>
+
+          </section>
+
+          <EmailCapture
+            headline="Get the ADHD supplement checklist"
+            description="Evidence-first supplement updates, stack guides, and ADHD research notes. No diagnosis or personal medical advice."
+            ctaLabel="Get Checklist"
+            location={`article-${SLUG}`}
+          />
+          <NewsletterCtaBlock
+            title="Continue with the newsletter archive"
+            description="Short notes built for cautious supplement decisions."
+            location={`article-${SLUG}-newsletter`}
+          />
+        </div>
+
+        {/* Sidebar */}
+        <aside className="space-y-4 lg:sticky lg:top-24 lg:self-start">
+          <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
+            <p className="text-[10px] font-bold uppercase tracking-wider text-muted">In this article</p>
+            <nav className="mt-3 space-y-1.5" aria-label="Article sections">
+              {[
+                ['#why-combine', 'Why Combine?'],
+                ['#mechanisms', 'Mechanisms'],
+                ['#synergy', 'Synergy Table'],
+                ['#how-to-stack', 'How to Stack'],
+                ['#products', 'Products'],
+                ['#safety', 'Safety'],
+                ['#faq', 'FAQ'],
+              ].map(([href, label]) => (
+                <a key={href} href={href as string}
+                  className="block text-sm text-brand-700 hover:text-brand-800 hover:underline">
+                  {label}
+                </a>
+              ))}
+            </nav>
+          </div>
+          <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
+            <p className="text-[10px] font-bold uppercase tracking-wider text-muted">ADHD cluster</p>
+            <div className="mt-3 space-y-2">
+              {[
+                ['/articles/best-supplements-for-adhd', 'Best supplements for ADHD →'],
+                ['/articles/magnesium-for-adhd', 'Magnesium for ADHD →'],
+                ['/articles/l-theanine-for-adhd', 'L-Theanine for ADHD →'],
+                ['/articles/adhd-stack-guide', 'ADHD stack guide →'],
+                ['/guides/adhd-supplements', 'ADHD supplements guide →'],
+              ].map(([href, label]) => (
+                <Link key={href as string} href={href as string}
+                  className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline">
+                  {label}
+                </Link>
+              ))}
+            </div>
+          </div>
+        </aside>
+      </div>
+
+      <div className="mt-8">
+        <Link href="/articles" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
+          ← Back to Articles
+        </Link>
+      </div>
+    </article>
+  )
+}

--- a/app/articles/l-theanine-without-caffeine/page.tsx
+++ b/app/articles/l-theanine-without-caffeine/page.tsx
@@ -1,0 +1,535 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd } from '@/lib/seo'
+import LastUpdatedBadge from '@/components/editorial/LastUpdatedBadge'
+import ResponsiveTable from '@/components/ui/ResponsiveTable'
+import SafetyNotice from '@/components/evidence/SafetyNotice'
+import EvidenceSummaryCard from '@/components/evidence/EvidenceSummaryCard'
+import EmailCapture from '@/components/EmailCapture'
+import NewsletterCtaBlock from '@/components/NewsletterCtaBlock'
+import PathwayDiagram from '@/components/PathwayDiagram'
+import EvidenceLegend from '@/components/EvidenceLegend'
+import { pathwayDiagrams } from '@/lib/pathway-data'
+import { AFFILIATE_TAGS } from '@/config/affiliate'
+
+const SLUG = 'l-theanine-without-caffeine'
+const TITLE = 'L-Theanine Without Caffeine for ADHD: Calm Focus Without the Jitters'
+const DESCRIPTION =
+  'Evidence guide to using L-theanine alone for ADHD — without caffeine. Covers how it produces calm alertness, alpha-wave effects, who benefits most, dosage, safety, and how it compares to the caffeine combination.'
+const DATE = '2026-06-12'
+const AUTHOR = 'Will'
+const READING_TIME = '10 min read'
+const TAGS = ['L-theanine', 'ADHD', 'focus', 'caffeine-free', 'calm']
+const CATEGORY = 'Focus'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: TITLE,
+  description: DESCRIPTION,
+  path: `/articles/${SLUG}`,
+  openGraphType: 'article',
+})
+
+const FAQS = [
+  {
+    question: 'Does L-theanine work for ADHD without caffeine?',
+    answer:
+      'L-theanine without caffeine can support a state of calm alertness by increasing alpha-wave brain activity, which may help with the mentally overactivated pattern common in ADHD. It is not a stimulant and does not increase dopamine or norepinephrine in the way ADHD medications do — so expectations should be calibrated accordingly. It is most likely to be noticeable for people whose ADHD presentation includes anxiety, stress-driven mental noise, or difficulty settling the mind for focused work. For primarily inattentive ADHD without high mental arousal, the benefit may be more subtle.',
+  },
+  {
+    question: 'Is L-theanine plus caffeine better than L-theanine alone for ADHD?',
+    answer:
+      'The L-theanine + caffeine combination has more published clinical evidence for cognitive outcomes than L-theanine alone. Caffeine provides direct alerting effects (adenosine antagonism), and L-theanine blunts caffeine\'s jitteriness while preserving its attentional benefits. For adults with ADHD who tolerate caffeine well, the combination is supported by stronger evidence. L-theanine alone is more appropriate for those who cannot tolerate caffeine, experience anxiety or sleep problems with caffeine, or prefer a stimulant-free approach.',
+  },
+  {
+    question: 'What dose of L-theanine for daytime focus without caffeine?',
+    answer:
+      'Studies on daytime calm focus and attention typically use 100–200 mg of L-theanine. Starting at 100 mg and assessing response before increasing to 200 mg is a reasonable approach. L-theanine at these doses does not typically cause sedation in the daytime — the alpha-wave effect is described as relaxed wakefulness, not drowsiness. If you notice sedation at 200 mg, reduce to 100 mg.',
+  },
+  {
+    question: 'When should I take L-theanine without caffeine for ADHD?',
+    answer:
+      'For daytime focus use, taking L-theanine 30–60 minutes before a planned focus session or work period is a common approach. It can also be taken in the morning as part of a routine. Because it does not contain caffeine, it can also be taken later in the day without affecting sleep — unlike caffeinated focus supplements.',
+  },
+  {
+    question: 'Can L-theanine be taken alongside ADHD medication?',
+    answer:
+      'No established adverse interaction between supplemental L-theanine and common ADHD medications (methylphenidate, amphetamine salts, atomoxetine) has been identified. Some adults with ADHD use L-theanine during stimulant off-periods or on weekends when not taking medication. Inform your prescribing clinician about supplements you are taking; they can advise in the context of your specific medication regimen.',
+  },
+  {
+    question: 'How is L-theanine different from ashwagandha for ADHD focus?',
+    answer:
+      'L-theanine works faster — effects may be noticeable within 30–60 minutes — and is more suitable for acute mental calm and daytime focus support. Ashwagandha works over weeks by reducing chronic HPA axis activation and cortisol, making it better suited for stress-driven ADHD difficulties over a longer time horizon. L-theanine is caffeine-free and can be taken as needed; ashwagandha is typically taken daily for weeks to months. Both are reasonable for ADHD; the choice depends on whether you need acute calm focus (L-theanine) or chronic stress management (ashwagandha).',
+  },
+]
+
+export default function LTheanineWithoutCaffeinePage() {
+  const breadcrumbLd = breadcrumbJsonLd([
+    { name: 'Articles', url: 'https://thehippiescientist.net/articles' },
+    { name: TITLE, url: `https://thehippiescientist.net/articles/${SLUG}` },
+  ])
+  const articleLd = blogJsonLd(
+    { title: TITLE, slug: SLUG, date: DATE, description: DESCRIPTION },
+    `/articles/${SLUG}`,
+  )
+  const faqLd = faqPageJsonLd({ pagePath: `/articles/${SLUG}`, questions: FAQS })
+
+  return (
+    <article className="mx-auto max-w-5xl space-y-0 px-4 pb-20 pt-6 sm:px-6 lg:px-8">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }} />
+      {faqLd && <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />}
+
+      <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
+        <Link href="/articles" className="transition hover:text-ink">Articles</Link>
+        <span>/</span>
+        <span className="text-ink line-clamp-1">{TITLE}</span>
+      </nav>
+
+      <section className="rounded-[1.5rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8 lg:p-10">
+        <div className="flex flex-wrap items-center gap-2 text-xs">
+          <span className="rounded-full border border-brand-900/10 bg-brand-50 px-2.5 py-0.5 font-bold uppercase tracking-wider text-brand-800">
+            {CATEGORY}
+          </span>
+          {TAGS.slice(0, 3).map((tag) => (
+            <span key={tag} className="rounded-full border border-brand-900/10 bg-white px-2.5 py-0.5 font-semibold text-muted capitalize">
+              {tag}
+            </span>
+          ))}
+          <span className="text-muted">June 12, 2026</span>
+          <span className="text-muted">·</span>
+          <span className="text-muted">{READING_TIME}</span>
+        </div>
+        <h1 className="mt-4 font-display text-3xl font-bold leading-tight tracking-tight text-ink sm:text-4xl lg:text-5xl">
+          {TITLE}
+        </h1>
+        <p className="mt-2 text-sm text-muted">
+          By{' '}
+          <Link href="/about" rel="author" className="font-medium text-ink hover:underline">
+            {AUTHOR}
+          </Link>
+        </p>
+        <div className="mt-3">
+          <LastUpdatedBadge date={DATE} label="Last updated" />
+        </div>
+        <p className="mt-4 max-w-3xl text-base leading-7 text-[#46574d]">{DESCRIPTION}</p>
+      </section>
+
+      <div className="mt-4 rounded-[1rem] border border-brand-900/10 bg-brand-50/60 px-5 py-3 text-xs leading-6 text-muted">
+        <strong className="text-ink">Affiliate disclosure:</strong> This article contains affiliate
+        links. Purchases may earn us a commission at no additional cost to you.
+      </div>
+
+      <div className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1fr)_240px]">
+        <div className="space-y-6">
+
+          {/* Quick Verdict */}
+          <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+            <p className="eyebrow-label">Quick Verdict</p>
+            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
+              Can L-Theanine Support ADHD Focus Without Caffeine?
+            </h2>
+            <ul className="mt-4 space-y-2">
+              {[
+                ['Yes — but the effect is calm alertness, not stimulation', 'L-theanine increases alpha-wave activity, producing a state of relaxed wakefulness. This is different from how caffeine or ADHD medications work.'],
+                ['Most useful when mental noise is the problem', 'If ADHD manifests as a busy, anxious mind that can\'t settle for focused work, L-theanine may help reduce that barrier.'],
+                ['Less effective for pure inattention without hyperactivation', 'If the main challenge is low dopamine / norepinephrine rather than mental hyperactivation, L-theanine\'s mechanism is a poor fit.'],
+                ['No crash, no sleep disruption', 'Unlike caffeine, L-theanine can be taken later in the day without disrupting sleep — and is also useful as a pre-sleep calm support.'],
+              ].map(([bold, rest]) => (
+                <li key={bold as string} className="flex gap-2 text-[1.01rem] leading-[1.85] text-[#46574d]">
+                  <span className="mt-1 flex-shrink-0 text-brand-700">▸</span>
+                  <span><strong>{bold as string}.</strong> {rest as string}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8 space-y-8">
+
+            <div id="what-is-l-theanine">
+              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">
+                What Is L-Theanine and Why Does It Matter for ADHD?
+              </h2>
+              <p className="text-[1.01rem] leading-[1.85] text-[#46574d]">
+                L-theanine is a non-protein amino acid found in tea leaves (<em>Camellia sinensis</em>).
+                It is the compound responsible for the calming quality of green tea that offsets green
+                tea&apos;s caffeine content — a natural calm + alertness combination that has been observed
+                for centuries.
+              </p>
+              <p className="mt-3 text-[1.01rem] leading-[1.85] text-[#46574d]">
+                In the context of ADHD, L-theanine is interesting precisely because many people with
+                ADHD experience <strong>hyperactivation</strong> — a mental state of over-arousal that
+                paradoxically makes focus harder, not easier. The hyperactivated brain generates too much
+                &ldquo;noise&rdquo; (racing thoughts, anxiety, mental restlessness) to sustain a single
+                attentional thread. L-theanine&apos;s alpha-wave induction directly addresses this pattern.
+              </p>
+              <p className="mt-3 text-[1.01rem] leading-[1.85] text-[#46574d]">
+                Importantly, this article focuses on <strong>L-theanine alone, without caffeine</strong>.
+                The caffeine+L-theanine combination is separately studied and has stronger evidence for
+                cognitive outcomes — but is not appropriate for people who cannot tolerate caffeine,
+                experience anxiety with stimulants, or want a truly stimulant-free option.
+              </p>
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            {/* Mechanism */}
+            <div id="mechanism">
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
+                How L-Theanine Produces Calm Focus
+              </h2>
+              <PathwayDiagram data={pathwayDiagrams['l-theanine-focus']} />
+              <div className="mt-4 space-y-3">
+                <div className="rounded-[1rem] border border-brand-900/10 bg-brand-50/60 p-4">
+                  <p className="font-semibold text-ink">Alpha Waves: The &ldquo;Calm Focus&rdquo; Brainwave</p>
+                  <p className="mt-1 text-sm leading-6 text-[#46574d]">
+                    Alpha waves (8–12 Hz) are the neural oscillation pattern associated with calm, relaxed
+                    wakefulness — the &ldquo;flow state&rdquo; precursor. L-theanine consistently increases
+                    alpha-wave power in EEG studies within 30–60 minutes of ingestion, making it one of the
+                    more mechanistically well-characterized supplements for this purpose.
+                  </p>
+                </div>
+                <div className="rounded-[1rem] border border-brand-900/10 bg-brand-50/60 p-4">
+                  <p className="font-semibold text-ink">Glutamate / GABA Modulation</p>
+                  <p className="mt-1 text-sm leading-6 text-[#46574d]">
+                    L-theanine has structural similarity to glutamate and may modulate AMPA, NMDA, and
+                    kainate receptors to reduce excitatory tone. It also appears to support GABA activity,
+                    the brain&apos;s primary inhibitory neurotransmitter. The net effect is a reduction in
+                    neural hyperactivation without producing strong sedation.
+                  </p>
+                </div>
+                <div className="rounded-[1rem] border border-brand-900/10 bg-brand-50/60 p-4">
+                  <p className="font-semibold text-ink">What L-Theanine Does NOT Do</p>
+                  <p className="mt-1 text-sm leading-6 text-[#46574d]">
+                    L-theanine does not meaningfully increase dopamine or norepinephrine — the
+                    catecholamines central to stimulant ADHD medication efficacy. It is not a stimulant.
+                    It does not block adenosine receptors (caffeine does this). Its mechanism is calming
+                    and inhibitory-supportive, not activating.
+                  </p>
+                </div>
+              </div>
+              <EvidenceLegend highlightTier="moderate" className="mt-4" />
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            {/* Evidence */}
+            <div id="evidence">
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Evidence Summary</h2>
+              <EvidenceSummaryCard
+                title="L-Theanine (No Caffeine) — Calm Focus &amp; ADHD"
+                evidenceLevel="Moderate"
+                humanEvidence="EEG studies consistently show alpha-wave induction within 30–60 minutes. Human trials on attention and focus with standalone L-theanine (no caffeine) show modest but consistent positive effects — particularly in populations with anxiety, stress, or high baseline mental arousal. Direct ADHD-specific trials without caffeine co-administration are limited but suggest potential benefit for hyperactivation-associated presentation."
+                mechanisticEvidence="Alpha-wave induction is the most replicated finding. Glutamate modulation and GABA support are plausible based on preclinical data and L-theanine's structural similarity to glutamate. Mechanism is coherent with the hyperactivation phenotype common in ADHD."
+                safetyProfile="Well-tolerated. No significant drug interactions with ADHD medications established. No crash or post-dose rebound. Safe for most evening use without sleep disruption. Insufficient data for pregnancy/breastfeeding. Caution with sedative medications."
+              />
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            {/* With vs Without Caffeine */}
+            <div id="with-vs-without-caffeine">
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
+                With Caffeine vs Without: Which Is Better for ADHD?
+              </h2>
+              <ResponsiveTable label="L-theanine with caffeine vs without caffeine for ADHD">
+                <table className="min-w-[580px] w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-brand-900/10">
+                      {['Factor', 'L-Theanine Alone', 'L-Theanine + Caffeine'].map((h) => (
+                        <th key={h} className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">{h}</th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-brand-900/5">
+                    {[
+                      ['Evidence base', 'Moderate (alpha-wave; limited ADHD-specific)', 'Strong (cognitive outcomes, attention, arousal)'],
+                      ['Mechanism', 'Alpha-wave induction, glutamate/GABA modulation', 'Adenosine block (caffeine) + alpha-wave balance (theanine)'],
+                      ['Effect quality', 'Calm alertness, reduced mental noise', 'Alert focus, improved reaction time, reduced jitteriness'],
+                      ['Sleep impact', 'None — can take any time of day', 'Caffeine disrupts sleep if taken too late'],
+                      ['Suitable for caffeine-sensitive', '★★★ Yes', '✕ No'],
+                      ['Suitable for anxiety-prone ADHD', '★★★ Yes — calming', '★★ Mixed — caffeine may worsen anxiety'],
+                      ['Use with ADHD meds', 'Generally fine (no interaction)', 'Discuss with prescriber — caffeine + stimulants'],
+                      ['Evening / sleep use', '★★★ Yes — also good for sleep', '✕ No — caffeine too late disrupts sleep'],
+                    ].map(([factor, solo, combo]) => (
+                      <tr key={factor as string} className="align-top">
+                        <td className="py-3 pr-4 font-medium text-ink">{factor}</td>
+                        <td className="py-3 pr-4 text-[#46574d]">{solo}</td>
+                        <td className="py-3 text-[#46574d]">{combo}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </ResponsiveTable>
+              <p className="mt-4 text-[1.01rem] leading-[1.85] text-[#46574d]">
+                <strong>Use L-theanine alone if:</strong> you are caffeine-sensitive, prone to anxiety,
+                want a stimulant-free approach, need evening/late-day use, or are already on ADHD
+                stimulant medication.
+              </p>
+              <p className="mt-3 text-sm text-muted">
+                For the full comparison, see{' '}
+                <Link href="/articles/l-theanine-vs-caffeine-for-focus"
+                  className="font-semibold text-brand-700 hover:underline">
+                  L-Theanine vs Caffeine for Focus
+                </Link>.
+              </p>
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            {/* Dosage */}
+            <div id="dosage">
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Dosage for Daytime ADHD Focus</h2>
+              <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-5 shadow-sm">
+                <p className="mb-3 text-[10px] font-bold uppercase tracking-wider text-muted">Dosage Reference — Stimulant-Free Focus</p>
+                <ResponsiveTable label="L-theanine dosage for ADHD focus without caffeine">
+                  <table className="min-w-[520px] w-full text-sm">
+                    <thead>
+                      <tr className="border-b border-brand-900/10">
+                        {['Use Case', 'Dose', 'Timing', 'Notes'].map((h) => (
+                          <th key={h} className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">{h}</th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-brand-900/5">
+                      {[
+                        ['Daytime calm focus', '100–200 mg', '30–60 min before work session', 'Caffeine-free only'],
+                        ['Morning routine', '100 mg', 'With breakfast', 'Good starting dose for first trial'],
+                        ['Evening / pre-sleep', '100–200 mg', '30–60 min before bed', 'No caffeine effect on sleep'],
+                        ['Anxiety-dominant ADHD', '200 mg', 'Before high-stress periods', 'May reduce both anxiety and hyperactivation'],
+                      ].map(([use, dose, timing, notes]) => (
+                        <tr key={use as string} className="align-top">
+                          <td className="py-3 pr-4 font-medium text-ink">{use}</td>
+                          <td className="py-3 pr-4 text-[#46574d]">{dose}</td>
+                          <td className="py-3 pr-4 text-[#46574d]">{timing}</td>
+                          <td className="py-3 text-[#46574d]">{notes}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </ResponsiveTable>
+              </div>
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            {/* Products */}
+            <div id="products">
+              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">Caffeine-Free L-Theanine Products</h2>
+              <p className="mb-4 text-[1.01rem] leading-[1.85] text-[#46574d]">
+                The key is choosing a <strong>standalone, caffeine-free</strong> product. Many &ldquo;focus
+                blend&rdquo; products combine L-theanine with caffeine — these are for daytime use only and
+                not appropriate if you want a stimulant-free approach.
+              </p>
+              <div className="grid gap-4 sm:grid-cols-2">
+                {[
+                  {
+                    eyebrow: 'Best Starting Dose',
+                    name: 'L-Theanine 100mg (Caffeine-Free)',
+                    desc: 'Conservative starting dose. Good for first-timers and those sensitive to supplements. Confirm "caffeine free" on the label.',
+                    query: 'l-theanine+100mg+caffeine+free',
+                    cta: 'View on Amazon →',
+                  },
+                  {
+                    eyebrow: 'Standard Focus Dose',
+                    name: 'L-Theanine 200mg (Caffeine-Free)',
+                    desc: 'The dose most studied for calm alertness. Standalone product only — avoid combo products for stimulant-free use.',
+                    query: 'l-theanine+200mg+standalone+caffeine+free',
+                    cta: 'View on Amazon →',
+                  },
+                  {
+                    eyebrow: 'Evening + Focus Combo',
+                    name: 'L-Theanine + Magnesium (No Caffeine)',
+                    desc: 'For dual mental calm (L-theanine) and neural excitability (magnesium) support. Good for ADHD with sleep difficulties.',
+                    query: 'l-theanine+magnesium+glycinate+no+caffeine',
+                    cta: 'View combo →',
+                  },
+                ].map(({ eyebrow, name, desc, query, cta }) => (
+                  <div key={name} className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
+                    <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">{eyebrow}</p>
+                    <p className="font-semibold text-ink">{name}</p>
+                    <p className="mt-1 text-xs leading-5 text-[#46574d]">{desc}</p>
+                    <a
+                      href={`https://www.amazon.com/s?k=${query}&tag=${AFFILIATE_TAGS.amazon}`}
+                      target="_blank"
+                      rel="noopener noreferrer sponsored"
+                      className="mt-3 inline-flex items-center gap-1 rounded-full bg-brand-950 px-4 py-1.5 text-xs font-bold text-white transition hover:bg-brand-900"
+                    >
+                      {cta}
+                    </a>
+                  </div>
+                ))}
+              </div>
+
+              <div className="mt-4 rounded-[1rem] border border-amber-200 bg-amber-50/60 p-4">
+                <p className="font-semibold text-amber-900">What to avoid when buying caffeine-free L-theanine:</p>
+                <ul className="mt-2 ml-5 space-y-1 list-disc text-sm text-amber-800">
+                  <li>Products labeled &ldquo;Focus Blend&rdquo; or &ldquo;Energy + Focus&rdquo; — these almost always contain caffeine</li>
+                  <li>Green tea extracts — these contain caffeine unless specifically decaffeinated</li>
+                  <li>Nootropic stacks without full ingredient disclosure</li>
+                </ul>
+              </div>
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            {/* Who Benefits Most */}
+            <div id="who-benefits">
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Who Benefits Most From Solo L-Theanine?</h2>
+              <div className="space-y-3">
+                {[
+                  {
+                    label: 'Strong candidate',
+                    color: 'border-emerald-200 bg-emerald-50/60',
+                    items: [
+                      'ADHD with high baseline anxiety or mental hyperactivation',
+                      'Caffeine-sensitive or caffeine-intolerant individuals',
+                      'People on ADHD stimulant medication wanting a calm complement (check with prescriber)',
+                      'Evening or late-day focus need (no sleep disruption from caffeine)',
+                    ],
+                  },
+                  {
+                    label: 'Weaker candidate',
+                    color: 'border-amber-200 bg-amber-50/60',
+                    items: [
+                      'Primarily inattentive ADHD without hyperactivation or anxiety',
+                      'Expecting stimulant-level alertness or dopamine-driven motivation',
+                      'Severe ADHD where evidence-based medical treatment has not been optimized',
+                    ],
+                  },
+                ].map(({ label, color, items }) => (
+                  <div key={label} className={`rounded-[1rem] border p-4 ${color}`}>
+                    <p className="text-[10px] font-bold uppercase tracking-wider text-muted">{label}</p>
+                    <ul className="mt-2 ml-5 space-y-1 list-disc text-sm leading-6 text-[#46574d]">
+                      {items.map((item) => <li key={item}>{item}</li>)}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            <div id="safety">
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Safety</h2>
+              <SafetyNotice title="Safety Summary — L-Theanine Without Caffeine">
+                <ul className="ml-5 space-y-1.5 list-disc">
+                  {[
+                    ['Generally well-tolerated', 'L-theanine has a good safety profile at typical supplemental doses (100–400 mg/day) based on available evidence and its long history in tea consumption.'],
+                    ['No crash or withdrawal', 'Unlike caffeine, L-theanine does not produce dependence, tolerance, or withdrawal effects at supplemental doses.'],
+                    ['Sedative medications', 'L-theanine has mild calming properties. Combining with benzodiazepines, z-drugs, or other CNS depressants requires medical supervision.'],
+                    ['ADHD medications', 'No established adverse interaction, but inform your prescriber you are supplementing.'],
+                    ['Blood pressure', 'Some evidence for mild blood pressure-lowering effects. Caution if you take antihypertensives.'],
+                    ['Pregnancy and breastfeeding', 'Insufficient safety data for supplemental doses. Consult a clinician before use.'],
+                    ['Product labeling warning', 'Always verify the product is caffeine-free. Green tea and many focus blends contain both L-theanine and caffeine.'],
+                  ].map(([bold, text]) => (
+                    <li key={bold as string}><strong>{bold as string}.</strong> {text as string}</li>
+                  ))}
+                </ul>
+              </SafetyNotice>
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            <div id="faq">
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Frequently Asked Questions</h2>
+              <div className="space-y-4">
+                {FAQS.map((faq, i) => (
+                  <div key={i} className="rounded-[0.75rem] border border-brand-900/10 bg-brand-50/40 p-4">
+                    <h3 className="font-semibold text-ink">{faq.question}</h3>
+                    <p className="mt-2 text-sm leading-7 text-[#46574d]">{faq.answer}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            <div id="related">
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Related Articles</h2>
+              <div className="grid gap-3 sm:grid-cols-2">
+                {[
+                  ['/articles/best-supplements-for-adhd', 'Cornerstone', 'Best Supplements for ADHD', 'Full evidence-ranked guide.'],
+                  ['/articles/l-theanine-for-adhd', 'ADHD Cluster', 'L-Theanine for ADHD', 'Full evidence review including sleep.'],
+                  ['/articles/l-theanine-vs-caffeine-for-focus', 'ADHD Cluster', 'L-Theanine vs Caffeine', 'Direct comparison for focus.'],
+                  ['/articles/l-theanine-magnesium-adhd-stack', 'Stack Guide', 'L-Theanine + Magnesium Stack', 'Combine for broader ADHD support.'],
+                  ['/articles/l-theanine-for-sleep', 'Sleep Cluster', 'L-Theanine for Sleep', 'Nighttime calm without caffeine.'],
+                  ['/articles/adhd-stack-guide', 'ADHD Cluster', 'ADHD Stack Guide', 'Building a safe ADHD supplement stack.'],
+                  ['/articles/ashwagandha-for-adhd', 'ADHD Cluster', 'Ashwagandha for ADHD', 'Chronic stress and focus support.'],
+                  ['/goals/focus', 'Goal Hub', 'Focus Goal Hub', 'Compare all focus supplements.'],
+                ].map(([href, eyebrow, label, desc]) => (
+                  <Link key={href as string} href={href as string}
+                    className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30">
+                    <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">{eyebrow}</p>
+                    <p className="font-semibold text-ink transition group-hover:text-brand-700">{label}</p>
+                    <p className="mt-1 text-xs text-muted">{desc}</p>
+                  </Link>
+                ))}
+              </div>
+            </div>
+
+          </section>
+
+          <EmailCapture
+            headline="Get the ADHD supplement checklist"
+            description="Evidence-first supplement guides, safety context, and ADHD research notes. No diagnosis or personal medical advice."
+            ctaLabel="Get Checklist"
+            location={`article-${SLUG}`}
+          />
+          <NewsletterCtaBlock
+            title="Continue with the newsletter archive"
+            description="Short notes built for cautious supplement decisions."
+            location={`article-${SLUG}-newsletter`}
+          />
+        </div>
+
+        {/* Sidebar */}
+        <aside className="space-y-4 lg:sticky lg:top-24 lg:self-start">
+          <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
+            <p className="text-[10px] font-bold uppercase tracking-wider text-muted">In this article</p>
+            <nav className="mt-3 space-y-1.5" aria-label="Article sections">
+              {[
+                ['#what-is-l-theanine', 'What Is L-Theanine?'],
+                ['#mechanism', 'How It Works'],
+                ['#evidence', 'Evidence Summary'],
+                ['#with-vs-without-caffeine', 'With vs Without Caffeine'],
+                ['#dosage', 'Dosage Guide'],
+                ['#products', 'Caffeine-Free Products'],
+                ['#who-benefits', 'Who Benefits?'],
+                ['#safety', 'Safety'],
+                ['#faq', 'FAQ'],
+              ].map(([href, label]) => (
+                <a key={href} href={href as string}
+                  className="block text-sm text-brand-700 hover:text-brand-800 hover:underline">
+                  {label}
+                </a>
+              ))}
+            </nav>
+          </div>
+          <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
+            <p className="text-[10px] font-bold uppercase tracking-wider text-muted">Focus + ADHD cluster</p>
+            <div className="mt-3 space-y-2">
+              {[
+                ['/articles/best-supplements-for-adhd', 'Best supplements for ADHD →'],
+                ['/articles/l-theanine-for-adhd', 'L-Theanine for ADHD →'],
+                ['/articles/l-theanine-vs-caffeine-for-focus', 'L-Theanine vs Caffeine →'],
+                ['/articles/adhd-stack-guide', 'ADHD stack guide →'],
+                ['/articles/l-theanine-for-sleep', 'L-Theanine for sleep →'],
+              ].map(([href, label]) => (
+                <Link key={href as string} href={href as string}
+                  className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline">
+                  {label}
+                </Link>
+              ))}
+            </div>
+          </div>
+        </aside>
+      </div>
+
+      <div className="mt-8">
+        <Link href="/articles" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
+          ← Back to Articles
+        </Link>
+      </div>
+    </article>
+  )
+}

--- a/app/articles/magnesium-glycinate-vs-citrate-for-adhd/page.tsx
+++ b/app/articles/magnesium-glycinate-vs-citrate-for-adhd/page.tsx
@@ -1,0 +1,497 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd } from '@/lib/seo'
+import LastUpdatedBadge from '@/components/editorial/LastUpdatedBadge'
+import ResponsiveTable from '@/components/ui/ResponsiveTable'
+import SafetyNotice from '@/components/evidence/SafetyNotice'
+import EvidenceSummaryCard from '@/components/evidence/EvidenceSummaryCard'
+import EmailCapture from '@/components/EmailCapture'
+import NewsletterCtaBlock from '@/components/NewsletterCtaBlock'
+import PathwayDiagram from '@/components/PathwayDiagram'
+import EvidenceLegend from '@/components/EvidenceLegend'
+import { pathwayDiagrams } from '@/lib/pathway-data'
+import { AFFILIATE_TAGS } from '@/config/affiliate'
+
+const SLUG = 'magnesium-glycinate-vs-citrate-for-adhd'
+const TITLE = 'Magnesium Glycinate vs Citrate for ADHD: Which Form Works Better?'
+const DESCRIPTION =
+  'Evidence-based comparison of magnesium glycinate and citrate for ADHD. Covers absorption, sleep support, calming effects, GI tolerability, dosage, and practical product guidance.'
+const DATE = '2026-06-12'
+const AUTHOR = 'Will'
+const READING_TIME = '11 min read'
+const TAGS = ['magnesium', 'ADHD', 'focus', 'sleep', 'minerals']
+const CATEGORY = 'Supplement Evidence'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: TITLE,
+  description: DESCRIPTION,
+  path: `/articles/${SLUG}`,
+  openGraphType: 'article',
+})
+
+const FAQS = [
+  {
+    question: 'Is magnesium glycinate or citrate better for ADHD?',
+    answer:
+      'Magnesium glycinate is generally considered the better first choice for ADHD-related use. The glycine component adds mild calming support, it is gentler on the digestive system, and it is well-absorbed. Citrate is a reasonable alternative with good absorption at a lower price point, but it has a stronger laxative effect at higher doses. For sleep support, glycinate is typically preferred. For general magnesium repletion at a lower cost, citrate is acceptable.',
+  },
+  {
+    question: 'Can magnesium help ADHD symptoms directly?',
+    answer:
+      'The evidence for magnesium improving core ADHD symptoms (inattention, hyperactivity) is primarily in populations with documented magnesium deficiency — which is more common in ADHD than the general population. Correcting a deficiency may improve symptoms by normalizing nervous system excitability. Using magnesium as a primary ADHD treatment in a non-deficient person has weaker supporting evidence. Testing serum magnesium levels before supplementing is reasonable.',
+  },
+  {
+    question: 'What dose of magnesium glycinate for ADHD?',
+    answer:
+      'Common supplemental doses are 200–400 mg elemental magnesium daily. For ADHD specifically, many practitioners use 200–300 mg elemental magnesium glycinate taken in the evening. Start at the lower end and increase gradually. Note that "magnesium glycinate 400 mg" on a label refers to the total salt weight, not elemental magnesium — check the label for elemental magnesium content, which is typically 60–75 mg per 400 mg serving of the chelate.',
+  },
+  {
+    question: 'Can I take magnesium glycinate every night for ADHD?',
+    answer:
+      'Daily evening use is a common pattern and is generally considered reasonable for healthy adults within typical supplemental dose ranges. Long-term formal safety data for high-dose supplementation is limited, but magnesium at physiological doses has a good safety record. Avoid exceeding the tolerable upper intake level of 350 mg supplemental magnesium per day from supplements (dietary magnesium is not counted in this limit). If you have kidney disease or take medications, consult a clinician first.',
+  },
+  {
+    question: 'Does magnesium citrate have a laxative effect at ADHD doses?',
+    answer:
+      'At typical ADHD supplemental doses (150–200 mg elemental magnesium), GI effects are mild for most people. Magnesium citrate has a stronger osmotic laxative effect than glycinate at equal elemental doses, particularly above 200–300 mg. If loose stools occur with citrate, switching to glycinate or reducing the dose usually resolves the issue. Some people find citrate useful for constipation as a side benefit; for others it is a reason to use glycinate instead.',
+  },
+  {
+    question: 'Is magnesium threonate better than glycinate for ADHD?',
+    answer:
+      'Magnesium threonate (L-threonate) is marketed for brain health due to animal data suggesting greater brain penetration. Human trial data for threonate vs glycinate in ADHD specifically is very limited. It is substantially more expensive than glycinate. For most people starting magnesium supplementation for ADHD, glycinate is the most practical first choice: better evidence, better cost, and a strong safety profile. Threonate may be worth exploring if glycinate does not produce results after a fair trial.',
+  },
+]
+
+export default function MagnesiumGlycinateCitrateAdhdPage() {
+  const breadcrumbLd = breadcrumbJsonLd([
+    { name: 'Articles', url: 'https://thehippiescientist.net/articles' },
+    { name: TITLE, url: `https://thehippiescientist.net/articles/${SLUG}` },
+  ])
+  const articleLd = blogJsonLd(
+    { title: TITLE, slug: SLUG, date: DATE, description: DESCRIPTION },
+    `/articles/${SLUG}`,
+  )
+  const faqLd = faqPageJsonLd({ pagePath: `/articles/${SLUG}`, questions: FAQS })
+
+  return (
+    <article className="mx-auto max-w-5xl space-y-0 px-4 pb-20 pt-6 sm:px-6 lg:px-8">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }} />
+      {faqLd && <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />}
+
+      {/* Breadcrumb */}
+      <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
+        <Link href="/articles" className="transition hover:text-ink">Articles</Link>
+        <span>/</span>
+        <span className="text-ink line-clamp-1">{TITLE}</span>
+      </nav>
+
+      {/* Hero */}
+      <section className="rounded-[1.5rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8 lg:p-10">
+        <div className="flex flex-wrap items-center gap-2 text-xs">
+          <span className="rounded-full border border-brand-900/10 bg-brand-50 px-2.5 py-0.5 font-bold uppercase tracking-wider text-brand-800">
+            {CATEGORY}
+          </span>
+          {TAGS.slice(0, 3).map((tag) => (
+            <span key={tag} className="rounded-full border border-brand-900/10 bg-white px-2.5 py-0.5 font-semibold text-muted capitalize">
+              {tag}
+            </span>
+          ))}
+          <span className="text-muted">June 12, 2026</span>
+          <span className="text-muted">·</span>
+          <span className="text-muted">{READING_TIME}</span>
+        </div>
+
+        <h1 className="mt-4 font-display text-3xl font-bold leading-tight tracking-tight text-ink sm:text-4xl lg:text-5xl">
+          {TITLE}
+        </h1>
+        <p className="mt-2 text-sm text-muted">
+          By{' '}
+          <Link href="/about" rel="author" className="font-medium text-ink hover:underline">
+            {AUTHOR}
+          </Link>
+        </p>
+        <div className="mt-3">
+          <LastUpdatedBadge date={DATE} label="Last updated" />
+        </div>
+        <p className="mt-4 max-w-3xl text-base leading-7 text-[#46574d]">{DESCRIPTION}</p>
+      </section>
+
+      {/* Disclosure */}
+      <div className="mt-4 rounded-[1rem] border border-brand-900/10 bg-brand-50/60 px-5 py-3 text-xs leading-6 text-muted">
+        <strong className="text-ink">Affiliate disclosure:</strong> This article contains affiliate
+        links. If you purchase through these links, we may earn a commission at no additional cost to
+        you. We only link to forms and dose ranges consistent with the research reviewed on this page.
+      </div>
+
+      {/* Body + sidebar */}
+      <div className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1fr)_240px]">
+        <div className="space-y-6">
+
+          {/* Quick Verdict */}
+          <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+            <p className="eyebrow-label">Quick Verdict</p>
+            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
+              Glycinate or Citrate — Which Wins for ADHD?
+            </h2>
+            <ul className="mt-4 space-y-2">
+              {[
+                ['Glycinate is the better first choice for ADHD', 'The glycine component adds mild calming support, GI tolerance is better, and it\'s well-suited for evening use.'],
+                ['Citrate is a reasonable budget alternative', 'Similar elemental absorption at lower cost, but more laxative potential at higher doses.'],
+                ['Both forms help correct magnesium deficiency', 'Deficiency is more common in ADHD and correcting it may reduce hyperactivation and support sleep.'],
+                ['Neither is a primary ADHD treatment', 'Evidence for direct ADHD symptom improvement is strongest in deficient populations — not as a standalone stimulant replacement.'],
+              ].map(([bold, rest]) => (
+                <li key={bold as string} className="flex gap-2 text-[1.01rem] leading-[1.85] text-[#46574d]">
+                  <span className="mt-1 flex-shrink-0 text-brand-700">▸</span>
+                  <span><strong>{bold as string}.</strong> {rest as string}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          {/* Main content */}
+          <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8 space-y-8">
+
+            <div id="why-form-matters">
+              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">
+                Why the Form of Magnesium Matters for ADHD
+              </h2>
+              <p className="text-[1.01rem] leading-[1.85] text-[#46574d]">
+                Not all magnesium supplements deliver the same amount of usable magnesium to your cells.
+                Bioavailability — how much is absorbed in the gut and reaches tissues — varies significantly
+                by form. For ADHD specifically, additional factors matter: whether the chelating agent has
+                its own neurological effect (glycine does), how the supplement affects digestion, and
+                whether the timing suits sleep support.
+              </p>
+              <p className="mt-3 text-[1.01rem] leading-[1.85] text-[#46574d]">
+                <strong>Magnesium glycinate</strong> is magnesium chelated to glycine, an amino acid that
+                acts as an inhibitory neurotransmitter in the central nervous system. Glycine itself has
+                evidence for sleep quality support and may add a calming effect beyond what magnesium alone
+                provides — making glycinate a natural fit for ADHD-related sleep difficulties and evening
+                calming support.
+              </p>
+              <p className="mt-3 text-[1.01rem] leading-[1.85] text-[#46574d]">
+                <strong>Magnesium citrate</strong> is magnesium bound to citric acid. It has good
+                bioavailability and is substantially cheaper than glycinate, but the citrate form has
+                a stronger osmotic effect in the gut — meaning it draws water into the intestines, which
+                can cause loose stools at higher doses. At typical supplemental doses for ADHD (150–200 mg
+                elemental), this is usually mild, but it is a meaningful difference for sensitive users.
+              </p>
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            {/* Mechanism */}
+            <div id="mechanism">
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
+                How Magnesium Works in the Brain
+              </h2>
+              <PathwayDiagram data={pathwayDiagrams['magnesium-adhd']} />
+              <p className="mt-4 text-[1.01rem] leading-[1.85] text-[#46574d]">
+                Magnesium&apos;s primary role in neural excitability is as a voltage-dependent blocker of
+                NMDA receptors — the &ldquo;volume knob&rdquo; for excitatory signaling in the brain. When
+                magnesium levels are adequate, NMDA receptors require stronger signals to activate, which
+                reduces neural hyperactivation. This is particularly relevant for ADHD, where
+                hyperactivation and sensory overload are common presentations.
+              </p>
+              <p className="mt-3 text-[1.01rem] leading-[1.85] text-[#46574d]">
+                Magnesium also supports GABA activity (the brain&apos;s primary inhibitory
+                neurotransmitter), which contributes to its calming and sleep-supporting properties. GABA
+                dysregulation is implicated in anxiety and sleep problems commonly co-occurring with ADHD.
+              </p>
+              <EvidenceLegend highlightTier="moderate" className="mt-4" />
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            {/* Evidence */}
+            <div id="evidence">
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
+                Evidence Summary
+              </h2>
+              <EvidenceSummaryCard
+                title="Magnesium &amp; ADHD Symptoms"
+                evidenceLevel="Moderate"
+                humanEvidence="Several controlled trials show improvements in ADHD-related hyperactivity, emotional dysregulation, and sleep — particularly in children and adults with confirmed low magnesium status. Effects are most consistent in deficient populations; evidence in magnesium-replete individuals is weaker. Form comparison trials (glycinate vs citrate specifically for ADHD) are limited."
+                mechanisticEvidence="NMDA receptor blockade by magnesium is well-established in preclinical literature. The connection to ADHD is biologically plausible: NMDA hyperactivation is proposed to contribute to impulsivity and executive dysfunction. GABA support via magnesium provides additional rationale for sleep and calming effects."
+                safetyProfile="Well-tolerated at supplemental doses. Main risks: laxative effect (dose-dependent, stronger with citrate), hypotension at very high doses, contraindication in severe kidney disease. Avoid magnesium oxide — poor bioavailability and significant GI effects."
+              />
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            {/* Comparison Table */}
+            <div id="comparison">
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
+                Glycinate vs Citrate: Side-by-Side
+              </h2>
+              <ResponsiveTable label="Magnesium glycinate vs citrate comparison for ADHD">
+                <table className="min-w-[600px] w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-brand-900/10">
+                      {['Factor', 'Glycinate', 'Citrate'].map((h) => (
+                        <th key={h} className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">{h}</th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-brand-900/5">
+                    {[
+                      ['Absorption', 'High — chelated form bypasses some GI barriers', 'Good — soluble salt, solid bioavailability'],
+                      ['GI tolerance', 'Excellent — rarely causes loose stools', 'Moderate — laxative effect above ~200 mg elemental'],
+                      ['Glycine co-factor', 'Yes — glycine adds mild calming + sleep support', 'No — citrate is neutral, no added CNS effect'],
+                      ['Cost', '$$–$$$ — premium form', '$ — widely available, lower cost'],
+                      ['Best for ADHD sleep', '★★★ First choice', '★★ Acceptable alternative'],
+                      ['Best for ADHD calm focus', '★★★ First choice', '★★ Good if tolerated'],
+                      ['Best for deficiency correction', '★★★', '★★★ (both equally effective)'],
+                      ['Avoid at high doses?', 'No special concern', 'Yes — GI effects above 300 mg elemental/day'],
+                    ].map(([factor, glycinate, citrate]) => (
+                      <tr key={factor as string} className="align-top">
+                        <td className="py-3 pr-4 font-medium text-ink">{factor}</td>
+                        <td className="py-3 pr-4 text-[#46574d]">{glycinate}</td>
+                        <td className="py-3 text-[#46574d]">{citrate}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </ResponsiveTable>
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            {/* Dosage */}
+            <div id="dosage">
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
+                Dosage Guide for ADHD
+              </h2>
+              <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-5 shadow-sm">
+                <p className="mb-3 text-[10px] font-bold uppercase tracking-wider text-muted">
+                  Magnesium Dosage Reference — ADHD Use
+                </p>
+                <ResponsiveTable label="Magnesium dosage for ADHD">
+                  <table className="min-w-[520px] w-full text-sm">
+                    <thead>
+                      <tr className="border-b border-brand-900/10">
+                        {['Use Case', 'Form', 'Elemental Dose', 'Timing'].map((h) => (
+                          <th key={h} className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">{h}</th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-brand-900/5">
+                      {[
+                        ['Sleep + calm support', 'Glycinate', '200–300 mg', '30–60 min before bed'],
+                        ['General repletion', 'Glycinate or Citrate', '200–400 mg', 'Evening, with food'],
+                        ['Budget option', 'Citrate', '150–250 mg', 'Evening — start low'],
+                        ['Deficiency correction', 'Either', '200–400 mg', 'As directed by clinician'],
+                      ].map(([use, form, dose, timing]) => (
+                        <tr key={use as string} className="align-top">
+                          <td className="py-3 pr-4 font-medium text-ink">{use}</td>
+                          <td className="py-3 pr-4 text-[#46574d]">{form}</td>
+                          <td className="py-3 pr-4 text-[#46574d]">{dose}</td>
+                          <td className="py-3 text-[#46574d]">{timing}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </ResponsiveTable>
+                <p className="mt-3 text-xs text-muted">
+                  Check product labels for elemental magnesium content — the chelate weight shown on the
+                  label is not the same as elemental magnesium. A product showing &ldquo;400 mg magnesium
+                  glycinate&rdquo; typically provides 60–80 mg of elemental magnesium per tablet.
+                </p>
+              </div>
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            {/* Products */}
+            <div id="products">
+              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">
+                Product Recommendations
+              </h2>
+              <p className="text-[1.01rem] leading-[1.85] text-[#46574d]">
+                These links reflect forms and dose ranges consistent with the evidence reviewed.
+                Affiliate links support this site at no additional cost to you.
+              </p>
+              <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                {[
+                  {
+                    eyebrow: 'Top Pick — Sleep & Calm',
+                    name: 'Magnesium Glycinate 400mg',
+                    desc: 'The most recommended form for ADHD-related sleep and calm support. Check the elemental magnesium per serving before purchasing.',
+                    query: 'magnesium+glycinate+400mg+sleep',
+                    cta: 'View Glycinate on Amazon →',
+                  },
+                  {
+                    eyebrow: 'Budget Option',
+                    name: 'Magnesium Citrate',
+                    desc: 'Good absorption at lower cost. Best used at evening doses of 150–200 mg elemental to minimize GI effects.',
+                    query: 'magnesium+citrate+supplement',
+                    cta: 'View Citrate on Amazon →',
+                  },
+                  {
+                    eyebrow: 'High-Absorption Premium',
+                    name: 'Magnesium Bisglycinate (chelate)',
+                    desc: 'Bisglycinate is another term for glycinate chelate — identical mechanism. Look for 200–400 mg elemental per serving.',
+                    query: 'magnesium+bisglycinate+chelate',
+                    cta: 'View Bisglycinate on Amazon →',
+                  },
+                  {
+                    eyebrow: 'Avoid for ADHD',
+                    name: 'Magnesium Oxide — Skip This',
+                    desc: 'Very poor bioavailability (~4%). Almost entirely passes through the gut as a laxative. Not appropriate for ADHD use.',
+                    query: 'magnesium+glycinate+adhd',
+                    cta: 'See better options →',
+                  },
+                ].map(({ eyebrow, name, desc, query, cta }) => (
+                  <div key={name} className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
+                    <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">{eyebrow}</p>
+                    <p className="font-semibold text-ink">{name}</p>
+                    <p className="mt-1 text-xs leading-5 text-[#46574d]">{desc}</p>
+                    <a
+                      href={`https://www.amazon.com/s?k=${query}&tag=${AFFILIATE_TAGS.amazon}`}
+                      target="_blank"
+                      rel="noopener noreferrer sponsored"
+                      className="mt-3 inline-flex items-center gap-1 rounded-full bg-brand-950 px-4 py-1.5 text-xs font-bold text-white transition hover:bg-brand-900"
+                    >
+                      {cta}
+                    </a>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            {/* Safety */}
+            <div id="safety">
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Safety</h2>
+              <SafetyNotice title="Safety Summary — Magnesium for ADHD">
+                <ul className="ml-5 space-y-1.5 list-disc">
+                  {[
+                    ['Generally safe at supplemental doses', 'Magnesium from food and supplements at physiological amounts is well-tolerated in healthy adults and children.'],
+                    ['Tolerable upper level: 350 mg/day supplemental', 'This limit applies to magnesium from supplements only. Dietary magnesium from food is not counted. Exceeding this level increases risk of adverse effects including diarrhea.'],
+                    ['Kidney disease caution', 'Magnesium is renally cleared. Impaired kidney function can lead to magnesium accumulation. Do not supplement without clinician guidance if you have chronic kidney disease.'],
+                    ['Drug interactions', 'Magnesium can reduce absorption of tetracycline and quinolone antibiotics, some bisphosphonates, and may interact with blood pressure medications. Take at least 2 hours apart from these drugs.'],
+                    ['ADHD medications', 'No established interaction between supplemental magnesium and stimulant ADHD medications. Some practitioners use magnesium alongside methylphenidate to potentially reduce side effects — discuss with your prescribing clinician.'],
+                    ['Avoid oxide form', 'Magnesium oxide is poorly absorbed and acts primarily as a laxative. It is not appropriate for ADHD-related supplementation goals.'],
+                  ].map(([bold, text]) => (
+                    <li key={bold as string}>
+                      <strong>{bold as string}.</strong> {text as string}
+                    </li>
+                  ))}
+                </ul>
+              </SafetyNotice>
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            {/* FAQ */}
+            <div id="faq">
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
+                Frequently Asked Questions
+              </h2>
+              <div className="space-y-4">
+                {FAQS.map((faq, i) => (
+                  <div key={i} className="rounded-[0.75rem] border border-brand-900/10 bg-brand-50/40 p-4">
+                    <h3 className="font-semibold text-ink">{faq.question}</h3>
+                    <p className="mt-2 text-sm leading-7 text-[#46574d]">{faq.answer}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            {/* Related */}
+            <div id="related">
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Related Articles</h2>
+              <div className="grid gap-3 sm:grid-cols-2">
+                {[
+                  ['/articles/magnesium-for-adhd', 'ADHD Cluster', 'Magnesium for ADHD', 'Evidence review, forms, sleep, and practical use.'],
+                  ['/articles/best-supplements-for-adhd', 'ADHD Cornerstone', 'Best Supplements for ADHD', 'Evidence-ranked guide covering all key ADHD supplements.'],
+                  ['/articles/l-theanine-magnesium-adhd-stack', 'ADHD Cluster', 'L-Theanine + Magnesium Stack', 'How to combine L-theanine and magnesium for ADHD.'],
+                  ['/articles/best-magnesium-supplement-for-adhd', 'Buying Guide', 'Best Magnesium Supplement for ADHD', 'Which product to buy first — form, dose, and practical guidance.'],
+                  ['/articles/adhd-stack-guide', 'ADHD Cluster', 'ADHD Stack Guide', 'How to build a safe, evidence-based ADHD supplement stack.'],
+                  ['/articles/l-theanine-for-adhd', 'ADHD Cluster', 'L-Theanine for ADHD', 'Evidence on attention, sleep, and emotional regulation.'],
+                  ['/articles/sleep-and-adhd', 'Sleep + ADHD', 'Sleep and ADHD', 'Why sleep issues are common in ADHD and how to address them.'],
+                  ['/goals/focus', 'Goal Hub', 'Focus Goal Hub', 'Compare all focus supplements side by side.'],
+                ].map(([href, eyebrow, label, desc]) => (
+                  <Link key={href as string} href={href as string}
+                    className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30">
+                    <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">{eyebrow}</p>
+                    <p className="font-semibold text-ink transition group-hover:text-brand-700">{label}</p>
+                    <p className="mt-1 text-xs text-muted">{desc}</p>
+                  </Link>
+                ))}
+              </div>
+            </div>
+
+          </section>
+
+          <EmailCapture
+            headline="Get the ADHD supplement checklist"
+            description="Evidence-first supplement updates, safety context, and ADHD research notes. No diagnosis or personal medical advice."
+            ctaLabel="Get Checklist"
+            location={`article-${SLUG}`}
+          />
+
+          <NewsletterCtaBlock
+            title="Continue with the newsletter archive"
+            description="Short notes built for cautious supplement decisions."
+            location={`article-${SLUG}-newsletter`}
+          />
+        </div>
+
+        {/* Sidebar */}
+        <aside className="space-y-4 lg:sticky lg:top-24 lg:self-start">
+          <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
+            <p className="text-[10px] font-bold uppercase tracking-wider text-muted">In this article</p>
+            <nav className="mt-3 space-y-1.5" aria-label="Article sections">
+              {[
+                ['#why-form-matters', 'Why Form Matters'],
+                ['#mechanism', 'How Magnesium Works'],
+                ['#evidence', 'Evidence Summary'],
+                ['#comparison', 'Glycinate vs Citrate'],
+                ['#dosage', 'Dosage Guide'],
+                ['#products', 'Product Picks'],
+                ['#safety', 'Safety'],
+                ['#faq', 'FAQ'],
+                ['#related', 'Related Articles'],
+              ].map(([href, label]) => (
+                <a key={href} href={href as string}
+                  className="block text-sm text-brand-700 hover:text-brand-800 hover:underline">
+                  {label}
+                </a>
+              ))}
+            </nav>
+          </div>
+
+          <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
+            <p className="text-[10px] font-bold uppercase tracking-wider text-muted">ADHD cluster</p>
+            <div className="mt-3 space-y-2">
+              {[
+                ['/articles/best-supplements-for-adhd', 'Best supplements for ADHD →'],
+                ['/articles/magnesium-for-adhd', 'Magnesium for ADHD →'],
+                ['/articles/l-theanine-for-adhd', 'L-Theanine for ADHD →'],
+                ['/articles/adhd-stack-guide', 'ADHD stack guide →'],
+                ['/articles/sleep-and-adhd', 'Sleep and ADHD →'],
+                ['/goals/focus', 'Focus goal hub →'],
+              ].map(([href, label]) => (
+                <Link key={href as string} href={href as string}
+                  className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline">
+                  {label}
+                </Link>
+              ))}
+            </div>
+          </div>
+        </aside>
+      </div>
+
+      <div className="mt-8">
+        <Link href="/articles" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
+          ← Back to Articles
+        </Link>
+      </div>
+    </article>
+  )
+}

--- a/components/EvidenceLegend.tsx
+++ b/components/EvidenceLegend.tsx
@@ -1,0 +1,172 @@
+import type { EvidenceStrengthTier } from '@/lib/evidence-strength'
+
+type TierRow = {
+  tier: EvidenceStrengthTier
+  grade: 'A' | 'B' | 'C' | 'D'
+  label: string
+  what: string
+  human: string
+  barClass: string
+  badgeClass: string
+  score: number
+}
+
+const TIERS: TierRow[] = [
+  {
+    tier: 'strong',
+    grade: 'A',
+    label: 'Strong Human Evidence',
+    what: 'Multiple RCTs or a meta-analysis with consistent positive results across independent labs.',
+    human: 'Yes — robust human clinical data',
+    barClass: 'bg-emerald-600',
+    badgeClass: 'bg-emerald-50 border-emerald-200 text-emerald-800',
+    score: 90,
+  },
+  {
+    tier: 'moderate',
+    grade: 'B',
+    label: 'Moderate Evidence',
+    what: 'Human trials showing generally positive outcomes, though study scale or consistency may vary.',
+    human: 'Yes — at least some quality human trials',
+    barClass: 'bg-blue-600',
+    badgeClass: 'bg-blue-50 border-blue-200 text-blue-800',
+    score: 70,
+  },
+  {
+    tier: 'limited',
+    grade: 'C',
+    label: 'Limited Evidence',
+    what: 'Small-scale human studies or preliminary trials exist, but better-controlled or larger trials are lacking.',
+    human: 'Some — early or small human data',
+    barClass: 'bg-amber-500',
+    badgeClass: 'bg-amber-50 border-amber-200 text-amber-800',
+    score: 45,
+  },
+  {
+    tier: 'preliminary',
+    grade: 'D',
+    label: 'Preliminary / Mechanistic',
+    what: 'Evidence comes mainly from animal studies, cell cultures, or proposed mechanisms — not validated in human trials.',
+    human: 'No — animal or theoretical only',
+    barClass: 'bg-amber-400',
+    badgeClass: 'bg-amber-50 border-amber-200 text-amber-700',
+    score: 28,
+  },
+  {
+    tier: 'traditional',
+    grade: 'D',
+    label: 'Traditional Use Only',
+    what: 'Long historical or ethnobotanical use; modern clinical validation is minimal or absent.',
+    human: 'No — traditional use record only',
+    barClass: 'bg-slate-400',
+    badgeClass: 'bg-slate-50 border-slate-200 text-slate-700',
+    score: 18,
+  },
+]
+
+type Props = {
+  /** Visually highlight one tier (matches current compound) */
+  highlightTier?: EvidenceStrengthTier
+  /** Extra Tailwind classes on the outer wrapper */
+  className?: string
+  /** Start expanded (default false) */
+  defaultOpen?: boolean
+}
+
+export default function EvidenceLegend({
+  highlightTier,
+  className = '',
+  defaultOpen = false,
+}: Props) {
+  return (
+    <details
+      className={`group rounded-[1rem] border border-brand-900/10 bg-white/90 shadow-sm ${className}`}
+      open={defaultOpen || undefined}
+    >
+      <summary className="flex cursor-pointer select-none list-none items-center gap-2 px-5 py-3 text-xs font-semibold text-brand-700 hover:text-brand-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40 [&::-webkit-details-marker]:hidden">
+        <span
+          className="transition-transform duration-200 group-open:rotate-90"
+          aria-hidden="true"
+        >
+          ▶
+        </span>
+        <span className="group-open:hidden">What do these evidence levels mean?</span>
+        <span className="hidden group-open:inline">Hide evidence level guide</span>
+      </summary>
+
+      <div className="border-t border-brand-900/10 px-5 pb-5 pt-4">
+        <p className="text-[10px] font-bold uppercase tracking-wider text-muted">
+          Evidence Strength Scale — How We Rate Research
+        </p>
+        <p className="mt-1.5 text-xs leading-5 text-[#5f6f66]">
+          Each rating reflects the quality, quantity, and human relevance of available clinical
+          research. Ratings are assigned to specific outcomes (e.g., &ldquo;sleep quality&rdquo;)
+          — not compounds overall.
+        </p>
+
+        <div className="mt-4 space-y-3">
+          {TIERS.map((row) => {
+            const isHighlighted = row.tier === highlightTier
+            return (
+              <div
+                key={row.tier}
+                className={`rounded-[0.75rem] border p-3 transition-colors ${
+                  isHighlighted
+                    ? 'border-brand-700/30 bg-brand-50/80 ring-1 ring-brand-700/20'
+                    : 'border-brand-900/10 bg-brand-50/20'
+                }`}
+                aria-current={isHighlighted ? 'true' : undefined}
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  <span
+                    className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-bold ${row.badgeClass}`}
+                  >
+                    {row.grade} · {row.label}
+                  </span>
+                  {isHighlighted && (
+                    <span className="text-[10px] font-bold uppercase tracking-wider text-brand-700">
+                      ← current
+                    </span>
+                  )}
+                </div>
+
+                {/* Mini progress bar */}
+                <div
+                  className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-neutral-200/80"
+                  role="meter"
+                  aria-valuenow={row.score}
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  aria-label={`${row.label} confidence score: ${row.score} out of 100`}
+                >
+                  <div
+                    className={`h-full rounded-full ${row.barClass}`}
+                    style={{ width: `${row.score}%` }}
+                  />
+                </div>
+
+                <div className="mt-2 grid gap-1 text-[11px] text-[#46574d] sm:grid-cols-2">
+                  <p>
+                    <span className="font-semibold text-ink">What it means: </span>
+                    {row.what}
+                  </p>
+                  <p>
+                    <span className="font-semibold text-ink">Human trials: </span>
+                    {row.human}
+                  </p>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+
+        <p className="mt-4 text-[10px] leading-5 text-muted">
+          Ratings reflect what the scientific literature currently supports — not marketing claims.
+          Effect sizes, study quality, and population context all influence the final grade.
+          &ldquo;Moderate&rdquo; evidence is meaningful; most supplements in widespread use sit at
+          &ldquo;Limited&rdquo; or below.
+        </p>
+      </div>
+    </details>
+  )
+}

--- a/components/PathwayDiagram.tsx
+++ b/components/PathwayDiagram.tsx
@@ -1,0 +1,223 @@
+import type { PathwayDiagramData, PathwayNodeRole } from '@/lib/pathway-data'
+
+// ─── Layout constants ─────────────────────────────────────────────────────────
+const NODE_W = 130
+const NODE_H = 52
+const COL_GAP = 66   // horizontal gap between node right edge and next node left edge
+const ROW_GAP = 52   // vertical gap between node bottom edge and next node top edge
+const COL_STEP = NODE_W + COL_GAP
+const ROW_STEP = NODE_H + ROW_GAP
+const PAD = 16
+
+function nodeX(col: number) { return PAD + col * COL_STEP }
+function nodeY(row: number) { return PAD + row * ROW_STEP }
+function nodeCx(col: number) { return nodeX(col) + NODE_W / 2 }
+function nodeCy(row: number) { return nodeY(row) + NODE_H / 2 }
+
+// ─── Colors by role ───────────────────────────────────────────────────────────
+function roleColors(role: PathwayNodeRole) {
+  switch (role) {
+    case 'compound':
+      return { fill: '#f1f5f9', stroke: '#94a3b8', text: '#1e293b' }
+    case 'target':
+      return { fill: '#eff6ff', stroke: '#93c5fd', text: '#1e40af' }
+    case 'mechanism':
+      return { fill: '#f0fdf4', stroke: '#86efac', text: '#166534' }
+    case 'effect':
+      return { fill: '#fff7ed', stroke: '#fed7aa', text: '#9a3412' }
+    default:
+      return { fill: '#f9fafb', stroke: '#e5e7eb', text: '#374151' }
+  }
+}
+
+// ─── Arrow path between two grid positions ────────────────────────────────────
+function arrowPath(
+  fromCol: number, fromRow: number,
+  toCol: number, toRow: number,
+): { x1: number; y1: number; x2: number; y2: number } {
+  const horizontal = fromRow === toRow && toCol === fromCol + 1
+  const vertical = fromCol === toCol && toRow === fromRow + 1
+
+  if (horizontal) {
+    return {
+      x1: nodeX(fromCol) + NODE_W,
+      y1: nodeCy(fromRow),
+      x2: nodeX(toCol) - 2,
+      y2: nodeCy(toRow),
+    }
+  }
+  if (vertical) {
+    return {
+      x1: nodeCx(fromCol),
+      y1: nodeY(fromRow) + NODE_H,
+      x2: nodeCx(toCol),
+      y2: nodeY(toRow) - 2,
+    }
+  }
+  // Fallback: center-to-center (skipped edges — diagonal)
+  return {
+    x1: nodeCx(fromCol),
+    y1: nodeCy(fromRow),
+    x2: nodeCx(toCol),
+    y2: nodeCy(toRow),
+  }
+}
+
+type Props = {
+  data: PathwayDiagramData
+  className?: string
+}
+
+export default function PathwayDiagram({ data, className = '' }: Props) {
+  // Compute SVG viewport from max col and row across all nodes
+  const maxCol = Math.max(...data.nodes.map((n) => n.col))
+  const maxRow = Math.max(...data.nodes.map((n) => n.row))
+  const svgW = PAD + maxCol * COL_STEP + NODE_W + PAD
+  const svgH = PAD + maxRow * ROW_STEP + NODE_H + PAD
+
+  const nodeMap = Object.fromEntries(data.nodes.map((n) => [n.id, n]))
+  const markerId = `arrow-${data.id}`
+
+  return (
+    <figure
+      className={`overflow-hidden rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm ${className}`}
+      aria-label={data.summary}
+    >
+      <p className="mb-3 text-[10px] font-bold uppercase tracking-wider text-muted">
+        Mechanism Pathway — {data.title}
+      </p>
+
+      <div className="overflow-x-auto">
+        <svg
+          viewBox={`0 0 ${svgW} ${svgH}`}
+          width={svgW}
+          height={svgH}
+          role="img"
+          aria-label={data.summary}
+          style={{ maxWidth: '100%', height: 'auto' }}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <title>{data.title}</title>
+          <desc>{data.summary}</desc>
+
+          <defs>
+            <marker
+              id={markerId}
+              viewBox="0 0 10 10"
+              refX="9"
+              refY="5"
+              markerUnits="userSpaceOnUse"
+              markerWidth="10"
+              markerHeight="10"
+              orient="auto-start-reverse"
+            >
+              <path d="M 0 1 L 10 5 L 0 9 z" fill="#94a3b8" />
+            </marker>
+          </defs>
+
+          {/* ── Edges (arrows) ── */}
+          {data.edges.map((edge, i) => {
+            const from = nodeMap[edge.from]
+            const to = nodeMap[edge.to]
+            if (!from || !to) return null
+            const { x1, y1, x2, y2 } = arrowPath(from.col, from.row, to.col, to.row)
+            const midX = (x1 + x2) / 2
+            const midY = (y1 + y2) / 2
+            return (
+              <g key={i}>
+                <line
+                  x1={x1} y1={y1} x2={x2} y2={y2}
+                  stroke="#94a3b8"
+                  strokeWidth="2"
+                  markerEnd={`url(#${markerId})`}
+                />
+                {edge.label && (
+                  <text
+                    x={midX}
+                    y={midY - 6}
+                    textAnchor="middle"
+                    fontSize="9"
+                    fill="#94a3b8"
+                    fontFamily="system-ui, sans-serif"
+                  >
+                    {edge.label}
+                  </text>
+                )}
+              </g>
+            )
+          })}
+
+          {/* ── Nodes ── */}
+          {data.nodes.map((node) => {
+            const colors = roleColors(node.role)
+            const nx = nodeX(node.col)
+            const ny = nodeY(node.row)
+            const ncx = nodeCx(node.col)
+            const ncy = nodeCy(node.row)
+            const hasSubLabel = Boolean(node.sublabel)
+            const mainLabelY = hasSubLabel ? ncy - 8 : ncy
+
+            return (
+              <g key={node.id}>
+                <rect
+                  x={nx}
+                  y={ny}
+                  width={NODE_W}
+                  height={NODE_H}
+                  rx="8"
+                  ry="8"
+                  fill={colors.fill}
+                  stroke={colors.stroke}
+                  strokeWidth="1.5"
+                />
+                <text
+                  x={ncx}
+                  y={mainLabelY}
+                  textAnchor="middle"
+                  dominantBaseline="middle"
+                  fontSize="12"
+                  fontWeight="600"
+                  fill={colors.text}
+                  fontFamily="system-ui, sans-serif"
+                >
+                  {node.label}
+                </text>
+                {node.sublabel && (
+                  <text
+                    x={ncx}
+                    y={ncy + 11}
+                    textAnchor="middle"
+                    dominantBaseline="middle"
+                    fontSize="9.5"
+                    fill={colors.text}
+                    opacity="0.7"
+                    fontFamily="system-ui, sans-serif"
+                  >
+                    {node.sublabel}
+                  </text>
+                )}
+              </g>
+            )
+          })}
+        </svg>
+      </div>
+
+      {/* Color legend key */}
+      <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1">
+        {(
+          [
+            ['compound', 'bg-slate-100 border-slate-300', 'Compound'],
+            ['target', 'bg-blue-50 border-blue-200', 'Target / Receptor'],
+            ['mechanism', 'bg-emerald-50 border-emerald-200', 'Mechanism'],
+            ['effect', 'bg-orange-50 border-orange-200', 'Effect / Outcome'],
+          ] as const
+        ).map(([, cls, label]) => (
+          <span key={label} className="flex items-center gap-1.5 text-[10px] text-muted">
+            <span className={`inline-block h-3 w-6 rounded border ${cls}`} aria-hidden="true" />
+            {label}
+          </span>
+        ))}
+      </div>
+    </figure>
+  )
+}

--- a/components/articles/FocusAdhdArticlePage.tsx
+++ b/components/articles/FocusAdhdArticlePage.tsx
@@ -103,6 +103,9 @@ function getRelatedFocusAdhdLinks(slug: string): RelatedLink[] {
       articleLink('zinc-and-adhd', 'Zinc and ADHD', 'Mineral guide'),
       articleLink('magnesium-for-adhd', 'Magnesium for ADHD', 'Mineral guide'),
       articleLink('omega-3-and-adhd', 'Omega-3 and ADHD', 'Fatty acids'),
+      // Phase 3a: magnesium form guidance
+      articleLink('magnesium-glycinate-vs-citrate-for-adhd', 'Glycinate vs Citrate for ADHD', 'Form guide'),
+      articleLink('best-magnesium-supplement-for-adhd', 'Best Magnesium for ADHD', 'Buying guide'),
     )
   } else if (sleepCalmArticleSlugs.has(slug)) {
     addRelatedLinks(
@@ -111,6 +114,9 @@ function getRelatedFocusAdhdLinks(slug: string): RelatedLink[] {
       articleLink('melatonin-for-adhd-sleep', 'Melatonin for ADHD Sleep', 'Sleep timing'),
       articleLink('l-theanine-for-adhd', 'L-Theanine for ADHD', 'Calm focus'),
       articleLink('magnesium-for-adhd', 'Magnesium for ADHD', 'Calm support'),
+      // Phase 3a: new stack + form pages
+      articleLink('l-theanine-magnesium-adhd-stack', 'L-Theanine + Magnesium Stack', 'Stack guide'),
+      articleLink('l-theanine-without-caffeine', 'L-Theanine Without Caffeine', 'Caffeine-free focus'),
       routeLink('/articles/l-theanine-for-sleep/', 'L-Theanine for Sleep', 'Sleep guide'),
       routeLink('/articles/magnesium-types-for-sleep/', 'Magnesium Types for Sleep', 'Sleep guide'),
       routeLink('/articles/best-herbs-for-sleep/', 'Best Herbs for Sleep', 'Sleep guide'),
@@ -124,6 +130,8 @@ function getRelatedFocusAdhdLinks(slug: string): RelatedLink[] {
       articleLink('l-theanine-vs-caffeine-for-focus', 'L-Theanine vs Caffeine for Focus', 'Focus comparison'),
       articleLink('l-theanine-for-adhd', 'L-Theanine for ADHD', 'Calm focus'),
       articleLink('omega-3-and-adhd', 'Omega-3 and ADHD', 'Fatty acids'),
+      // Phase 3a: caffeine-free focus option
+      articleLink('l-theanine-without-caffeine', 'L-Theanine Without Caffeine', 'Caffeine-free focus'),
     )
   }
 

--- a/lib/focus-adhd-articles.ts
+++ b/lib/focus-adhd-articles.ts
@@ -180,6 +180,47 @@ export const focusAdhdArticles: FocusAdhdArticle[] = [
     date: '2026-06-10',
     readingTime: '9 min read',
   },
+  // Phase 3a standalone pages — registered here for cross-linking; content lives in dedicated page.tsx files
+  {
+    slug: 'magnesium-glycinate-vs-citrate-for-adhd',
+    title: 'Magnesium Glycinate vs Citrate for ADHD: Which Form Works Better?',
+    seoTitle: 'Magnesium Glycinate vs Citrate for ADHD: Which Form Works Better?',
+    description: 'Evidence-based comparison of magnesium glycinate and citrate for ADHD. Covers absorption, sleep support, calming effects, GI tolerability, dosage, and practical product guidance.',
+    category: 'Supplement Evidence',
+    tags: ['Focus', 'ADHD', 'Nutrient Deficiencies', 'Supplement Evidence'],
+    date: '2026-06-12',
+    readingTime: '11 min read',
+  },
+  {
+    slug: 'l-theanine-magnesium-adhd-stack',
+    title: 'L-Theanine and Magnesium for ADHD: How to Stack Them Safely',
+    seoTitle: 'L-Theanine and Magnesium for ADHD: How to Stack Them Safely',
+    description: 'Evidence-based guide to combining L-theanine and magnesium for ADHD. Covers mechanisms, synergy, safety, dosing order, timing, and drug interactions.',
+    category: 'Focus',
+    tags: ['Focus', 'ADHD', 'Sleep', 'Supplement Evidence'],
+    date: '2026-06-12',
+    readingTime: '10 min read',
+  },
+  {
+    slug: 'best-magnesium-supplement-for-adhd',
+    title: 'Best Magnesium Supplement for ADHD: Which Form, What Dose, and What to Look For',
+    seoTitle: 'Best Magnesium Supplement for ADHD: Which Form, What Dose, and What to Look For',
+    description: 'Practical buying guide to magnesium supplements for ADHD. Covers the best forms, what to ignore, how to read labels, dose ranges, and what to expect.',
+    category: 'Supplement Evidence',
+    tags: ['Focus', 'ADHD', 'Nutrient Deficiencies', 'Supplement Evidence'],
+    date: '2026-06-12',
+    readingTime: '9 min read',
+  },
+  {
+    slug: 'l-theanine-without-caffeine',
+    title: 'L-Theanine Without Caffeine for ADHD: Calm Focus Without the Jitters',
+    seoTitle: 'L-Theanine Without Caffeine for ADHD: Calm Focus Without the Jitters',
+    description: 'Evidence guide to using L-theanine alone for ADHD — without caffeine. Covers alpha-wave effects, who benefits most, dosage, safety, and comparison to the caffeine combination.',
+    category: 'Focus',
+    tags: ['Focus', 'ADHD', 'Supplement Evidence'],
+    date: '2026-06-12',
+    readingTime: '10 min read',
+  },
 ]
 
 export const focusAdhdArticleSummaries = focusAdhdArticles.map((article) => ({

--- a/lib/pathway-data.ts
+++ b/lib/pathway-data.ts
@@ -1,0 +1,222 @@
+// Mechanism visualization data for PathwayDiagram component.
+// Each diagram describes how a compound produces its physiological effects.
+// Nodes are positioned on a (col, row) grid; edges define arrow connections.
+
+export type PathwayNodeRole =
+  | 'compound'   // The input supplement (slate)
+  | 'target'     // Receptor or neurotransmitter target (blue)
+  | 'mechanism'  // Biological process triggered (emerald)
+  | 'effect'     // Observable outcome (amber/orange)
+
+export type PathwayNode = {
+  id: string
+  label: string
+  /** Optional second line of text inside the node */
+  sublabel?: string
+  role: PathwayNodeRole
+  /** 0-indexed horizontal position */
+  col: number
+  /** 0-indexed vertical position (0 = top row) */
+  row: number
+}
+
+export type PathwayEdge = {
+  from: string  // node id
+  to: string    // node id
+  /** Short label drawn above horizontal arrows */
+  label?: string
+}
+
+export type PathwayDiagramData = {
+  id: string
+  /** Short display title shown above the diagram */
+  title: string
+  /** Accessible description (used in <desc> and aria-label) */
+  summary: string
+  nodes: PathwayNode[]
+  edges: PathwayEdge[]
+}
+
+export const pathwayDiagrams: Record<string, PathwayDiagramData> = {
+  'l-theanine-relaxation': {
+    id: 'l-theanine-relaxation',
+    title: 'How L-Theanine Promotes Relaxation',
+    summary:
+      'L-theanine modulates GABA and glutamate receptors, increasing alpha-wave brain activity, which produces calm alertness and reduces mental arousal.',
+    nodes: [
+      { id: 'a', label: 'L-Theanine', sublabel: '100–200 mg', role: 'compound', col: 0, row: 0 },
+      { id: 'b', label: 'GABA & Glutamate', sublabel: 'Receptor modulation', role: 'target', col: 1, row: 0 },
+      { id: 'c', label: '↑ Alpha Waves', sublabel: 'EEG activity', role: 'mechanism', col: 2, row: 0 },
+      { id: 'd', label: 'Calm Alertness', sublabel: '↓ Mental arousal', role: 'effect', col: 3, row: 0 },
+    ],
+    edges: [
+      { from: 'a', to: 'b' },
+      { from: 'b', to: 'c' },
+      { from: 'c', to: 'd' },
+    ],
+  },
+
+  'l-theanine-focus': {
+    id: 'l-theanine-focus',
+    title: 'L-Theanine for Daytime Calm Focus',
+    summary:
+      'Without caffeine, L-theanine increases alpha-wave activity via glutamate and GABA modulation, producing calm alertness that supports sustained attention without stimulant effects.',
+    nodes: [
+      { id: 'a', label: 'L-Theanine', sublabel: '100–200 mg', role: 'compound', col: 0, row: 0 },
+      { id: 'b', label: 'Glutamate Inhibition', sublabel: '+ GABA support', role: 'target', col: 1, row: 0 },
+      { id: 'c', label: '↑ Alpha Activity', sublabel: 'Relaxed wakefulness', role: 'mechanism', col: 2, row: 0 },
+      { id: 'd', label: 'Calm Focus', sublabel: 'No jitter or crash', role: 'effect', col: 3, row: 0 },
+    ],
+    edges: [
+      { from: 'a', to: 'b' },
+      { from: 'b', to: 'c' },
+      { from: 'c', to: 'd' },
+    ],
+  },
+
+  'magnesium-adhd': {
+    id: 'magnesium-adhd',
+    title: 'How Magnesium Supports Neural Calm',
+    summary:
+      'Magnesium blocks NMDA receptors to reduce neural over-excitation, while also supporting GABA activity — together these reduce hyperactivation and support calm focus.',
+    nodes: [
+      { id: 'a', label: 'Magnesium', sublabel: 'Glycinate / Citrate', role: 'compound', col: 0, row: 0 },
+      { id: 'b', label: 'NMDA Block', sublabel: 'Voltage-gated channel', role: 'target', col: 1, row: 0 },
+      { id: 'c', label: '↓ Excitability', sublabel: 'Reduced over-firing', role: 'mechanism', col: 2, row: 0 },
+      { id: 'd', label: 'Calm + Sleep', sublabel: 'ADHD symptom support', role: 'effect', col: 3, row: 0 },
+      { id: 'e', label: 'GABA Support', sublabel: 'Inhibitory boost', role: 'mechanism', col: 1, row: 1 },
+    ],
+    edges: [
+      { from: 'a', to: 'b' },
+      { from: 'b', to: 'c' },
+      { from: 'c', to: 'd' },
+      { from: 'b', to: 'e' },
+    ],
+  },
+
+  'magnesium-sleep': {
+    id: 'magnesium-sleep',
+    title: 'How Magnesium Supports Sleep',
+    summary:
+      'Magnesium regulates NMDA receptors and supports GABA signaling, reducing physical tension and neural hyperactivation to support sleep quality and sleep onset.',
+    nodes: [
+      { id: 'a', label: 'Magnesium', sublabel: 'Glycinate preferred', role: 'compound', col: 0, row: 0 },
+      { id: 'b', label: 'NMDA + GABA', sublabel: 'Dual pathway', role: 'target', col: 1, row: 0 },
+      { id: 'c', label: 'Muscle Relaxation', sublabel: 'Physical calm', role: 'mechanism', col: 2, row: 0 },
+      { id: 'd', label: 'Sleep Quality ↑', sublabel: 'Onset + maintenance', role: 'effect', col: 3, row: 0 },
+    ],
+    edges: [
+      { from: 'a', to: 'b' },
+      { from: 'b', to: 'c' },
+      { from: 'c', to: 'd' },
+    ],
+  },
+
+  'citicoline-focus': {
+    id: 'citicoline-focus',
+    title: 'How Citicoline Supports Focus',
+    summary:
+      'Citicoline provides a choline precursor (CDP-choline) that raises acetylcholine levels, supporting attention, working memory, and executive function.',
+    nodes: [
+      { id: 'a', label: 'Citicoline', sublabel: '250–500 mg', role: 'compound', col: 0, row: 0 },
+      { id: 'b', label: 'CDP-Choline', sublabel: 'Choline precursor', role: 'target', col: 1, row: 0 },
+      { id: 'c', label: '↑ Acetylcholine', sublabel: 'Cholinergic pathway', role: 'mechanism', col: 2, row: 0 },
+      { id: 'd', label: 'Focus + Memory', sublabel: 'Cognitive performance', role: 'effect', col: 3, row: 0 },
+    ],
+    edges: [
+      { from: 'a', to: 'b' },
+      { from: 'b', to: 'c' },
+      { from: 'c', to: 'd' },
+    ],
+  },
+
+  'alpha-gpc-focus': {
+    id: 'alpha-gpc-focus',
+    title: 'How Alpha-GPC Supports Focus',
+    summary:
+      'Alpha-GPC directly donates choline for acetylcholine synthesis, supporting attention, working memory, and cholinergic signaling — especially relevant for focus and ADHD-adjacent symptoms.',
+    nodes: [
+      { id: 'a', label: 'Alpha-GPC', sublabel: '300–600 mg', role: 'compound', col: 0, row: 0 },
+      { id: 'b', label: 'Choline Release', sublabel: 'High bioavailability', role: 'target', col: 1, row: 0 },
+      { id: 'c', label: '↑ Acetylcholine', sublabel: 'Cholinergic synthesis', role: 'mechanism', col: 2, row: 0 },
+      { id: 'd', label: 'Attention + Memory', sublabel: 'Cognitive support', role: 'effect', col: 3, row: 0 },
+    ],
+    edges: [
+      { from: 'a', to: 'b' },
+      { from: 'b', to: 'c' },
+      { from: 'c', to: 'd' },
+    ],
+  },
+
+  'l-tyrosine-focus': {
+    id: 'l-tyrosine-focus',
+    title: 'How L-Tyrosine Supports Alertness',
+    summary:
+      'L-tyrosine is a precursor for dopamine and norepinephrine synthesis. Under cognitive demand or stress, it may help replenish catecholamine pools, supporting alertness and mental stamina.',
+    nodes: [
+      { id: 'a', label: 'L-Tyrosine', sublabel: 'Amino acid precursor', role: 'compound', col: 0, row: 0 },
+      { id: 'b', label: 'Dopamine Pathway', sublabel: 'Catecholamine synthesis', role: 'target', col: 1, row: 0 },
+      { id: 'c', label: 'Dopamine + NE ↑', sublabel: 'Under demand conditions', role: 'mechanism', col: 2, row: 0 },
+      { id: 'd', label: 'Alertness + Focus', sublabel: 'Stress resilience', role: 'effect', col: 3, row: 0 },
+    ],
+    edges: [
+      { from: 'a', to: 'b' },
+      { from: 'b', to: 'c' },
+      { from: 'c', to: 'd' },
+    ],
+  },
+
+  'ashwagandha-stress': {
+    id: 'ashwagandha-stress',
+    title: 'How Ashwagandha Reduces Stress',
+    summary:
+      'Ashwagandha modulates the HPA axis to reduce cortisol output, blunting the chronic stress response and improving perceived stress, sleep quality, and focus over several weeks.',
+    nodes: [
+      { id: 'a', label: 'Ashwagandha', sublabel: 'KSM-66 / Sensoril', role: 'compound', col: 0, row: 0 },
+      { id: 'b', label: 'HPA Axis', sublabel: 'Stress-response axis', role: 'target', col: 1, row: 0 },
+      { id: 'c', label: '↓ Cortisol', sublabel: 'Chronic stress reduction', role: 'mechanism', col: 2, row: 0 },
+      { id: 'd', label: 'Stress Resilience', sublabel: 'Sleep + focus support', role: 'effect', col: 3, row: 0 },
+    ],
+    edges: [
+      { from: 'a', to: 'b' },
+      { from: 'b', to: 'c' },
+      { from: 'c', to: 'd' },
+    ],
+  },
+
+  'rhodiola-stamina': {
+    id: 'rhodiola-stamina',
+    title: 'How Rhodiola Supports Mental Stamina',
+    summary:
+      'Rhodiola modulates monoamine neurotransmitters (serotonin, dopamine) and stress-response pathways, supporting mental stamina, reducing fatigue, and improving cognitive performance under stress.',
+    nodes: [
+      { id: 'a', label: 'Rhodiola Rosea', sublabel: 'Salidroside / Rosavins', role: 'compound', col: 0, row: 0 },
+      { id: 'b', label: 'Monoamine System', sublabel: 'Serotonin + Dopamine', role: 'target', col: 1, row: 0 },
+      { id: 'c', label: '↓ Mental Fatigue', sublabel: 'Stress adaptation', role: 'mechanism', col: 2, row: 0 },
+      { id: 'd', label: 'Mental Stamina', sublabel: 'Focus under pressure', role: 'effect', col: 3, row: 0 },
+    ],
+    edges: [
+      { from: 'a', to: 'b' },
+      { from: 'b', to: 'c' },
+      { from: 'c', to: 'd' },
+    ],
+  },
+
+  'bacopa-memory': {
+    id: 'bacopa-memory',
+    title: 'How Bacopa Supports Memory',
+    summary:
+      'Bacopa monnieri promotes dendritic branching and synaptic plasticity via antioxidant activity and modulation of serotonin and acetylcholine systems, supporting long-term memory consolidation.',
+    nodes: [
+      { id: 'a', label: 'Bacopa Monnieri', sublabel: 'Bacosides A & B', role: 'compound', col: 0, row: 0 },
+      { id: 'b', label: 'Synaptic Plasticity', sublabel: 'Antioxidant + cholinergic', role: 'target', col: 1, row: 0 },
+      { id: 'c', label: 'Dendritic Growth', sublabel: 'Neural adaptation', role: 'mechanism', col: 2, row: 0 },
+      { id: 'd', label: 'Memory + Learning', sublabel: 'Over 8–12 weeks', role: 'effect', col: 3, row: 0 },
+    ],
+    edges: [
+      { from: 'a', to: 'b' },
+      { from: 'b', to: 'c' },
+      { from: 'c', to: 'd' },
+    ],
+  },
+}


### PR DESCRIPTION
Add reusable SVG PathwayDiagram and EvidenceLegend components plus four new
standalone article pages for the ADHD/Focus cluster, completing Phase 3a.

New components:
- lib/pathway-data.ts — 10 compound pathway definitions (grid-based node/edge data)
- components/PathwayDiagram.tsx — accessible SVG diagram with role-based color coding,
  arrowheads, sublabels, and a color-key legend; static-export compatible
- components/EvidenceLegend.tsx — expandable tier legend using native <details>/<summary>
  for zero-JS keyboard accessibility; highlights the current article's evidence tier

New article pages (standalone TSX, Schema.org FAQPage + BreadcrumbList, affiliate links):
- app/articles/magnesium-glycinate-vs-citrate-for-adhd/ — form comparison with dosage table
- app/articles/best-magnesium-supplement-for-adhd/ — ranked buyer's guide (5 forms)
- app/articles/l-theanine-magnesium-adhd-stack/ — combination protocol + synergy table
- app/articles/l-theanine-without-caffeine/ — daytime calm-focus angle (distinct from sleep article)

Cross-linking updates:
- lib/focus-adhd-articles.ts — register 4 new slugs so articleLink() resolves them
- components/articles/FocusAdhdArticlePage.tsx — link new pages in deficiency, sleep/calm,
  and cognitive-focus sidebar sections

https://claude.ai/code/session_015pKUCfMyTUPejBpYf9RSEH