### PR TITLE
feat(seo): launch Evidence Digest + strengthen evidence E-E-A-T (Week 1)

### DIFF
--- a/app/evidence-digest/page.tsx
+++ b/app/evidence-digest/page.tsx
@@ -1,0 +1,183 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { buildPageMetadata, SEO_YEAR } from '@/lib/seo'
+import type { StandardEvidenceLabel } from '@/lib/decision-primitives'
+import Breadcrumbs from '@/components/ui/Breadcrumbs'
+import LastUpdatedBadge from '@/components/editorial/LastUpdatedBadge'
+import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
+import NewsletterCtaBlock from '@/components/NewsletterCtaBlock'
+import {
+  evidenceDigestIssues,
+  evidenceDigestEntryCount,
+  evidenceDigestLatestDate,
+  type DigestEntry,
+} from '@/data/evidence-digest'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: `Evidence Digest ${SEO_YEAR} — Human-Trial Summaries by Goal`,
+  description:
+    'A conservative, recurring digest of what controlled human research actually supports — graded honestly and linked to goal pathways and full profiles. No hype.',
+  path: '/evidence-digest',
+  openGraphType: 'website',
+})
+
+const GRADE_STYLES: Partial<Record<StandardEvidenceLabel, string>> = {
+  'Strong evidence': 'bg-emerald-100 text-emerald-900 border-emerald-300',
+  'Moderate evidence': 'bg-emerald-50 text-emerald-800 border-emerald-200',
+  'Limited evidence': 'bg-amber-50 text-amber-800 border-amber-200',
+  'Preliminary evidence': 'bg-amber-50 text-amber-900 border-amber-200',
+  'Insufficient evidence': 'bg-rose-50 text-rose-800 border-rose-200',
+}
+
+function GradePill({ grade }: { grade: StandardEvidenceLabel }) {
+  const cls = GRADE_STYLES[grade] ?? 'bg-brand-50 text-brand-900 border-brand-900/10'
+  return (
+    <span className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold ${cls}`}>
+      {grade}
+    </span>
+  )
+}
+
+function EntryCard({ entry }: { entry: DigestEntry }) {
+  return (
+    <article className="card-premium p-5 sm:p-6">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <h3 className="text-lg font-semibold text-ink">{entry.title}</h3>
+        <GradePill grade={entry.grade} />
+      </div>
+
+      <p className="mt-3 text-sm font-medium leading-7 text-ink/90">{entry.takeaway}</p>
+
+      <dl className="mt-4 grid gap-3 text-sm leading-6 sm:grid-cols-2">
+        <div>
+          <dt className="text-[10px] font-bold uppercase tracking-[0.14em] text-brand-700">Study type</dt>
+          <dd className="mt-0.5 text-muted">{entry.studyType}</dd>
+        </div>
+        <div>
+          <dt className="text-[10px] font-bold uppercase tracking-[0.14em] text-brand-700">Population</dt>
+          <dd className="mt-0.5 text-muted">{entry.population}</dd>
+        </div>
+      </dl>
+
+      <div className="mt-4 space-y-2 text-sm leading-7">
+        <p className="text-muted">
+          <span className="font-semibold text-ink">What the evidence shows: </span>
+          {entry.finding}
+        </p>
+        <p className="rounded-xl border border-amber-600/10 bg-amber-50/50 px-3 py-2 text-amber-950">
+          <span className="font-semibold">Honest limitation: </span>
+          {entry.limitation}
+        </p>
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-center gap-3 border-t border-brand-900/5 pt-4 text-xs font-semibold">
+        <Link
+          href={`/goals/${entry.goalSlug}`}
+          className="inline-flex items-center rounded-full bg-brand-50 px-3 py-1 text-brand-800 transition hover:bg-brand-100"
+        >
+          Goal: {entry.goalLabel} →
+        </Link>
+        {entry.profileHref ? (
+          <Link href={entry.profileHref} className="text-emerald-700 hover:underline">
+            Full profile & citations →
+          </Link>
+        ) : null}
+        {entry.sources.map((source) => (
+          <a
+            key={source.href}
+            href={source.href}
+            target={source.href.startsWith('http') ? '_blank' : undefined}
+            rel={source.href.startsWith('http') ? 'noopener noreferrer' : undefined}
+            className="text-muted hover:text-ink hover:underline"
+          >
+            {source.label} ↗
+          </a>
+        ))}
+      </div>
+    </article>
+  )
+}
+
+export default function EvidenceDigestPage() {
+  return (
+    <div className="container-page space-y-10 py-10">
+      <AuthorityJsonLd
+        title="Evidence Digest"
+        description="A recurring, conservatively graded digest of human-trial evidence summaries, organized by health goal."
+        url="https://thehippiescientist.net/evidence-digest"
+        type="CollectionPage"
+      />
+
+      <Breadcrumbs
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Evidence Digest' },
+        ]}
+      />
+
+      <section className="hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8">
+        <p className="eyebrow-label">Compounding evidence log</p>
+        <h1 className="mt-2 text-3xl font-semibold text-ink sm:text-4xl">The Evidence Digest</h1>
+        <p className="mt-4 max-w-3xl text-muted">
+          A running log of what controlled human research actually supports — graded conservatively,
+          connected to the goal pathways, and pointed at the full profiles that carry the citations.
+          We summarize the <em>state of the evidence</em>, not marketing claims. Interesting does not
+          mean recommended.
+        </p>
+        <div className="mt-5 flex flex-wrap items-center gap-3">
+          <LastUpdatedBadge date={evidenceDigestLatestDate} />
+          <span className="inline-flex items-center gap-2 rounded-full border border-brand-900/10 bg-white/80 px-3 py-1 text-xs font-semibold text-muted">
+            <span className="h-1.5 w-1.5 rounded-full bg-emerald-600" aria-hidden="true" />
+            {evidenceDigestEntryCount} human-evidence summaries
+          </span>
+          <Link href="/methodology" className="text-xs font-semibold text-emerald-700 hover:underline">
+            How we grade evidence →
+          </Link>
+        </div>
+      </section>
+
+      {evidenceDigestIssues.map((issue) => (
+        <section key={issue.number} id={`issue-${issue.number}`} className="scroll-mt-24 space-y-5">
+          <div className="flex flex-col gap-2 border-b border-brand-900/10 pb-4">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <h2 className="text-2xl font-semibold tracking-tight text-ink">{issue.title}</h2>
+              <LastUpdatedBadge date={issue.date} label="Reviewed" />
+            </div>
+            <p className="max-w-3xl text-sm leading-7 text-muted">{issue.intro}</p>
+          </div>
+
+          <div className="grid gap-4 lg:grid-cols-2">
+            {issue.entries.map((entry) => (
+              <EntryCard key={entry.title} entry={entry} />
+            ))}
+          </div>
+        </section>
+      ))}
+
+      <section className="card-premium p-6 sm:p-8">
+        <h2 className="text-xl font-semibold text-ink">How to use the digest</h2>
+        <p className="mt-3 max-w-3xl text-sm leading-7 text-muted">
+          Treat each summary as a triage note, not a prescription. Start from the grade, read the honest
+          limitation, then open the full profile before deciding anything. Always review medications,
+          health conditions, and pregnancy status with a qualified clinician.
+        </p>
+        <div className="mt-4 flex flex-wrap gap-4 text-sm font-semibold">
+          <Link href="/methodology" className="text-emerald-700 hover:underline">Evidence grading methodology →</Link>
+          <Link href="/safety-checker" className="text-emerald-700 hover:underline">Run the safety checker →</Link>
+          <Link href="/goals" className="text-emerald-700 hover:underline">Browse goal pathways →</Link>
+        </div>
+      </section>
+
+      <NewsletterCtaBlock
+        title="Get each new Evidence Digest"
+        description="Concise, conservatively graded human-evidence summaries — no hype, unsubscribe anytime."
+        location="evidence-digest"
+      />
+
+      <footer className="rounded-2xl border border-brand-900/10 bg-brand-950/[0.02] p-5 text-xs leading-6 text-muted">
+        Educational only. Not medical advice. Evidence grades reflect the strength and consistency of
+        controlled human research at the time of review and can change as new trials are published.
+      </footer>
+    </div>
+  )
+}

--- a/app/methodology/page.tsx
+++ b/app/methodology/page.tsx
@@ -2,13 +2,53 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { SafetyDisclaimerBox } from '@/components/monetization/SafetyDisclaimerBox'
 import { TrustMethodologyCallout } from '@/components/monetization/TrustMethodologyCallout'
+import LastUpdatedBadge from '@/components/editorial/LastUpdatedBadge'
+import { SEO_YEAR } from '@/lib/seo'
 
 export const metadata: Metadata = {
-  title: 'Methodology',
+  title: 'How We Grade Evidence — Methodology',
   description:
-    'How The Hippie Scientist weighs human evidence, safety, practical usefulness, and uncertainty for supplement decision support.',
+    'How The Hippie Scientist weighs human evidence, safety, practical usefulness, and uncertainty for supplement decision support. See the exact grade definitions.',
   alternates: { canonical: '/methodology' },
 }
+
+const GRADE_ROWS: { grade: string; meaning: string; evidence: string; treatment: string; cls: string }[] = [
+  {
+    grade: 'Strong evidence',
+    meaning: 'Consistent benefit for a defined use.',
+    evidence: 'Multiple well-designed RCTs and/or meta-analyses that broadly agree.',
+    treatment: 'Stated confidently, with dose, timing, and safety boundaries.',
+    cls: 'bg-emerald-100 text-emerald-900 border-emerald-300',
+  },
+  {
+    grade: 'Moderate evidence',
+    meaning: 'Real but qualified support.',
+    evidence: 'Several RCTs with smaller samples, some heterogeneity, or short duration.',
+    treatment: 'Presented as reasonable to try, with the qualifiers made explicit.',
+    cls: 'bg-emerald-50 text-emerald-800 border-emerald-200',
+  },
+  {
+    grade: 'Limited evidence',
+    meaning: 'Promising but unsettled.',
+    evidence: 'Few or small human trials, mixed results, or strong dependence on baseline status.',
+    treatment: 'Framed as "may help some people," never as a recommendation.',
+    cls: 'bg-amber-50 text-amber-800 border-amber-200',
+  },
+  {
+    grade: 'Preliminary evidence',
+    meaning: 'Mechanism-led, not yet human-proven.',
+    evidence: 'Mostly preclinical, animal, in-vitro, or mechanistic plausibility.',
+    treatment: 'Clearly labeled as early; interesting does not mean effective.',
+    cls: 'bg-amber-50 text-amber-900 border-amber-200',
+  },
+  {
+    grade: 'Insufficient evidence',
+    meaning: 'Not established.',
+    evidence: 'No credible human data, or evidence too weak to interpret.',
+    treatment: 'No efficacy claims are made; safety context only.',
+    cls: 'bg-rose-50 text-rose-800 border-rose-200',
+  },
+]
 
 export default function MethodologyPage() {
   return (
@@ -19,9 +59,54 @@ export default function MethodologyPage() {
         <p className='mt-4 max-w-3xl text-muted'>
           Rankings are designed as transparent decision support. They are not medical advice and do not guarantee that a supplement is right for a specific person.
         </p>
+        <div className='mt-5'>
+          <LastUpdatedBadge date={`${SEO_YEAR}-06-01`} />
+        </div>
       </section>
 
       <TrustMethodologyCallout />
+
+      <section className='card-premium p-6 sm:p-8'>
+        <h2 className='text-xl font-semibold text-ink'>How we grade the evidence</h2>
+        <p className='mt-2 max-w-3xl text-sm leading-7 text-muted'>
+          Every profile and digest entry is graded against the same five-level scale. The grade reflects
+          the strength and consistency of <strong>controlled human research</strong>, not popularity,
+          tradition, or marketing. Grades can change as new trials are published.
+        </p>
+        <div className='mt-6 overflow-x-auto'>
+          <table className='min-w-full border-collapse text-left text-sm'>
+            <thead>
+              <tr className='border-b border-brand-900/10'>
+                <th className='py-3 pr-4 text-xs font-bold uppercase tracking-wider text-ink'>Grade</th>
+                <th className='py-3 pr-4 text-xs font-bold uppercase tracking-wider text-ink'>What it means</th>
+                <th className='py-3 pr-4 text-xs font-bold uppercase tracking-wider text-ink'>Typical evidence behind it</th>
+                <th className='py-3 text-xs font-bold uppercase tracking-wider text-ink'>How we treat it</th>
+              </tr>
+            </thead>
+            <tbody>
+              {GRADE_ROWS.map((row) => (
+                <tr key={row.grade} className='border-b border-brand-900/5 align-top last:border-0'>
+                  <td className='py-3 pr-4'>
+                    <span className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold ${row.cls}`}>
+                      {row.grade}
+                    </span>
+                  </td>
+                  <td className='py-3 pr-4 font-medium text-ink'>{row.meaning}</td>
+                  <td className='py-3 pr-4 text-muted'>{row.evidence}</td>
+                  <td className='py-3 text-muted'>{row.treatment}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <p className='mt-5 text-sm text-muted'>
+          See the grades applied in practice in the{' '}
+          <Link href='/evidence-digest' className='font-medium text-emerald-700 hover:underline'>Evidence Digest</Link>, or read
+          the deeper{' '}
+          <Link href='/education/research-methodology' className='font-medium text-emerald-700 hover:underline'>research methodology</Link> and{' '}
+          <Link href='/education/evidence-hierarchy' className='font-medium text-emerald-700 hover:underline'>evidence hierarchy</Link>.
+        </p>
+      </section>
 
       <section className='grid gap-4 md:grid-cols-2'>
         {[

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -178,6 +178,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     route(`${SITE_URL}/contact/`, currentDate, 'yearly', 0.5),
     route(`${SITE_URL}/faq/`, currentDate, 'monthly', 0.7),
     route(`${SITE_URL}/methodology/`, currentDate, 'yearly', 0.6),
+    route(`${SITE_URL}/evidence-digest/`, currentDate, 'weekly', 0.8),
     route(`${SITE_URL}/safety-checker/`, currentDate, 'monthly', 0.8),
     route(`${SITE_URL}/herbs/`, currentDate, 'weekly', 0.9),
     route(`${SITE_URL}/compounds/`, currentDate, 'weekly', 0.9),

--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -9,6 +9,12 @@ import NewsletterCtaBlock from './NewsletterCtaBlock'
 import SafetyChecklistPromo from '@/components/monetization/SafetyChecklistPromo'
 import StickyChecklistBar from '@/components/monetization/StickyChecklistBar'
 import ExitIntentModal from '@/components/ExitIntentModal'
+import { evidenceDigestEntryCount, evidenceDigestLatestDate } from '@/data/evidence-digest'
+
+const lastReviewedDisplay = new Date(`${evidenceDigestLatestDate}T00:00:00`).toLocaleDateString('en-US', {
+  year: 'numeric',
+  month: 'long',
+})
 
 type RuntimeFeature = Record<string, unknown>
 type HomepageV2Props = { featuredHerbs?: RuntimeFeature[]; featuredCompounds?: RuntimeFeature[] }
@@ -244,6 +250,14 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
                   </span>
                 ))}
               </div>
+              <p className='mt-4 inline-flex flex-wrap items-center gap-2 text-xs font-semibold text-muted'>
+                <span className='h-1.5 w-1.5 rounded-full bg-emerald-600' aria-hidden='true' />
+                <span>Last reviewed {lastReviewedDisplay}</span>
+                <span aria-hidden='true' className='text-brand-900/30'>•</span>
+                <Link href='/evidence-digest' className='text-emerald-700 hover:underline'>
+                  {evidenceDigestEntryCount} human-trial summaries in the Evidence Digest →
+                </Link>
+              </p>
             </div>
 
             {/* Hero image */}
@@ -492,9 +506,14 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
                 </li>
               ))}
             </ul>
-            <Link href='/education/research-methodology' className='mt-4 inline-flex text-sm font-bold text-brand-700 hover:text-brand-800'>
-              Research Methodology →
-            </Link>
+            <div className='mt-4 flex flex-wrap gap-4'>
+              <Link href='/methodology' className='inline-flex text-sm font-bold text-brand-700 hover:text-brand-800'>
+                How We Grade Evidence →
+              </Link>
+              <Link href='/evidence-digest' className='inline-flex text-sm font-bold text-brand-700 hover:text-brand-800'>
+                Evidence Digest →
+              </Link>
+            </div>
           </div>
           <div className='rounded-[1.25rem] border border-amber-200/80 bg-amber-50/50 p-4 shadow-sm sm:p-5'>
             <SectionHeader

--- a/data/evidence-digest.ts
+++ b/data/evidence-digest.ts
@@ -1,0 +1,239 @@
+/**
+ * Evidence Digest — a recurring, append-only log of human-evidence summaries.
+ *
+ * Each issue collects 3–5 goal-linked summaries of what controlled human research
+ * currently supports, written conservatively. Entries deliberately summarize the
+ * *state of the human evidence* and link out to the full on-site profile (which
+ * carries the underlying citations) plus a PubMed query — rather than asserting a
+ * single trial's metadata we cannot verify here. This keeps the digest aligned with
+ * the site's evidence-grading discipline: interesting does not mean recommended.
+ *
+ * To publish a new issue: prepend an object to `evidenceDigestIssues`. Keep the
+ * newest issue first. Grades must use the StandardEvidenceLabel vocabulary.
+ */
+
+import type { StandardEvidenceLabel } from '@/lib/decision-primitives'
+
+export type DigestSource = {
+  label: string
+  href: string
+}
+
+export type DigestEntry = {
+  /** Headline for the summary, e.g. "Ashwagandha for chronic stress". */
+  title: string
+  /** One-line, decision-useful takeaway. No hype. */
+  takeaway: string
+  /** Conservative evidence grade using the site-standard vocabulary. */
+  grade: StandardEvidenceLabel
+  /** Dominant human study design behind the grade. */
+  studyType: string
+  /** Who was studied (population framing). */
+  population: string
+  /** What the controlled human evidence shows. */
+  finding: string
+  /** The honest limitation that holds the grade back. */
+  limitation: string
+  /** Goal pathway this connects to. */
+  goalSlug: string
+  goalLabel: string
+  /** Canonical on-site profile that carries the full citations. */
+  profileHref?: string
+  /** External evidence pointers (PubMed queries, registries). */
+  sources: DigestSource[]
+}
+
+export type DigestIssue = {
+  /** URL-safe issue number, used as an anchor. */
+  number: number
+  /** Display title. */
+  title: string
+  /** ISO date (YYYY-MM-DD) the issue was reviewed/published. */
+  date: string
+  /** Short editorial framing for the issue. */
+  intro: string
+  entries: DigestEntry[]
+}
+
+const PUBMED = (query: string) =>
+  `https://pubmed.ncbi.nlm.nih.gov/?term=${encodeURIComponent(query)}`
+
+export const evidenceDigestIssues: DigestIssue[] = [
+  {
+    number: 2,
+    title: 'Issue #2 — Calm without sedation: daytime anxiety & stress',
+    date: '2026-06-13',
+    intro:
+      'This issue looks at options people reach for during the day, when the goal is a quieter nervous system without blunting alertness. The pattern across the controlled evidence: real but modest effects, with the strongest signals in standardized extracts and acute-stress settings.',
+    entries: [
+      {
+        title: 'L-Theanine for acute stress and attention',
+        takeaway:
+          'A reasonable daytime option for taking the edge off acute stress — effects are real but subtle, and best documented short-term.',
+        grade: 'Moderate evidence',
+        studyType: 'Randomized, placebo-controlled human trials (mostly acute/short-term)',
+        population: 'Healthy adults under induced or everyday stress',
+        finding:
+          'Controlled trials report reductions in subjective stress and improvements in attention/relaxation measures, often most clearly when paired with caffeine.',
+        limitation:
+          'Effect sizes are small, many studies are single-dose, and long-term anxiety outcomes are thin.',
+        goalSlug: 'anxiety',
+        goalLabel: 'Anxiety & calm',
+        profileHref: '/compounds/l-theanine',
+        sources: [
+          { label: 'PubMed: L-theanine stress RCT', href: PUBMED('l-theanine stress anxiety randomized') },
+          { label: 'Methodology', href: '/methodology' },
+        ],
+      },
+      {
+        title: 'Ashwagandha (standardized root extract) for chronic stress',
+        takeaway:
+          'One of the better-supported botanicals for subjective stress — but it is a multi-week commitment, not an acute fix.',
+        grade: 'Moderate evidence',
+        studyType: 'Multiple randomized, placebo-controlled trials',
+        population: 'Adults with self-reported chronic stress or elevated anxiety',
+        finding:
+          'Standardized root extracts (e.g. KSM-66, Shoden) reduced perceived-stress and anxiety scale scores versus placebo over 6–8 weeks, often alongside lower cortisol.',
+        limitation:
+          'Many trials are small, industry-funded, and short; thyroid, pregnancy, and autoimmune cautions apply.',
+        goalSlug: 'stress',
+        goalLabel: 'Stress resilience',
+        profileHref: '/herbs/ashwagandha',
+        sources: [
+          { label: 'PubMed: ashwagandha stress RCT', href: PUBMED('ashwagandha stress anxiety randomized controlled') },
+          { label: 'Compare: Rhodiola vs Ashwagandha', href: '/compare/rhodiola-vs-ashwagandha' },
+        ],
+      },
+      {
+        title: 'Rhodiola rosea for stress-related fatigue',
+        takeaway:
+          'Worth considering when stress shows up as mental fatigue rather than as racing anxiety; evidence is mixed.',
+        grade: 'Limited evidence',
+        studyType: 'Randomized trials with heterogeneous designs',
+        population: 'Adults with stress-related or burnout-type fatigue',
+        finding:
+          'Some controlled trials show improvements in fatigue and stress symptoms; results vary by extract and endpoint.',
+        limitation:
+          'Trial quality and standardization are inconsistent; can feel overstimulating in sensitive users.',
+        goalSlug: 'stress',
+        goalLabel: 'Stress resilience',
+        profileHref: '/herbs/rhodiola',
+        sources: [
+          { label: 'PubMed: Rhodiola fatigue RCT', href: PUBMED('rhodiola rosea fatigue stress randomized') },
+        ],
+      },
+      {
+        title: 'Kava for generalized anxiety',
+        takeaway:
+          'Among the stronger anxiety signals for a botanical — but liver-safety caution makes it a careful, short-term choice.',
+        grade: 'Moderate evidence',
+        studyType: 'Randomized, placebo-controlled trials and meta-analyses',
+        population: 'Adults with generalized or non-clinical anxiety',
+        finding:
+          'Aqueous and standardized kavalactone preparations reduced anxiety scores versus placebo in pooled analyses.',
+        limitation:
+          'Rare but serious hepatotoxicity reports; avoid with alcohol, liver disease, or other hepatically-cleared drugs.',
+        goalSlug: 'anxiety',
+        goalLabel: 'Anxiety & calm',
+        profileHref: '/compare/kava-vs-alcohol',
+        sources: [
+          { label: 'PubMed: kava anxiety meta-analysis', href: PUBMED('kava anxiety meta-analysis randomized') },
+        ],
+      },
+    ],
+  },
+  {
+    number: 1,
+    title: 'Issue #1 — What actually helps with sleep onset',
+    date: '2026-06-06',
+    intro:
+      'The inaugural issue tackles the most-searched goal on the site: falling asleep. The honest summary is that the strongest human evidence is narrow and timing-specific, while several popular options sit at "limited but reasonable to try."',
+    entries: [
+      {
+        title: 'Melatonin for sleep-onset and circadian timing',
+        takeaway:
+          'Best-supported for shifting sleep timing (jet lag, delayed phase); a smaller, lower-dose effect for general sleep onset.',
+        grade: 'Strong evidence',
+        studyType: 'Randomized trials and meta-analyses',
+        population: 'Adults with circadian disruption or difficulty initiating sleep',
+        finding:
+          'Meta-analyses support reduced sleep-onset latency, with the clearest benefit for circadian-timing problems at low doses taken at the right time.',
+        limitation:
+          'General-insomnia effect sizes are modest; timing and dose matter more than amount; possible morning grogginess.',
+        goalSlug: 'sleep',
+        goalLabel: 'Sleep support',
+        profileHref: '/compounds/melatonin',
+        sources: [
+          { label: 'PubMed: melatonin sleep onset meta-analysis', href: PUBMED('melatonin sleep onset latency meta-analysis') },
+          { label: 'Compare: sleep herbs vs melatonin', href: '/compare/sleep-herbs-vs-melatonin' },
+        ],
+      },
+      {
+        title: 'Magnesium for sleep quality',
+        takeaway:
+          'Reasonable to try, especially if intake is low — but the human evidence is thinner than the popularity suggests.',
+        grade: 'Limited evidence',
+        studyType: 'Small randomized trials and observational data',
+        population: 'Older adults and people with low magnesium status',
+        finding:
+          'Some controlled trials report modest improvements in subjective sleep, strongest where baseline magnesium is inadequate.',
+        limitation:
+          'Trials are small and mixed; benefit in magnesium-replete people is unclear; loose stools at higher doses.',
+        goalSlug: 'sleep',
+        goalLabel: 'Sleep support',
+        profileHref: '/compounds/magnesium-glycinate',
+        sources: [
+          { label: 'PubMed: magnesium sleep RCT', href: PUBMED('magnesium supplementation sleep randomized') },
+        ],
+      },
+      {
+        title: 'L-Theanine for pre-sleep cognitive quieting',
+        takeaway:
+          'Helpful for a busy mind at bedtime rather than for severe insomnia; gentle and low-risk.',
+        grade: 'Limited evidence',
+        studyType: 'Small randomized and combination-product trials',
+        population: 'Adults with stress-linked restlessness at night',
+        finding:
+          'Controlled studies suggest improved relaxation and some sleep-quality measures, often within combination products.',
+        limitation:
+          'Isolated long-term sleep data are limited; effect can be too subtle for clinical insomnia.',
+        goalSlug: 'sleep',
+        goalLabel: 'Sleep support',
+        profileHref: '/compounds/l-theanine',
+        sources: [
+          { label: 'PubMed: L-theanine sleep RCT', href: PUBMED('l-theanine sleep quality randomized') },
+        ],
+      },
+      {
+        title: 'Curcumin for inflammation-linked discomfort',
+        takeaway:
+          'A useful adjacent option when poor sleep tracks with inflammatory joint discomfort; works on a days-to-weeks timeline.',
+        grade: 'Moderate evidence',
+        studyType: 'Randomized trials in osteoarthritis-adjacent pain',
+        population: 'Adults with inflammatory joint discomfort',
+        finding:
+          'Bioavailability-enhanced curcumin reduced pain and function scores versus placebo in several controlled trials.',
+        limitation:
+          'Absorption varies widely by formulation; anticoagulant and gallbladder cautions apply.',
+        goalSlug: 'inflammation',
+        goalLabel: 'Inflammation support',
+        profileHref: '/herbs/turmeric',
+        sources: [
+          { label: 'PubMed: curcumin osteoarthritis RCT', href: PUBMED('curcumin osteoarthritis pain randomized') },
+        ],
+      },
+    ],
+  },
+]
+
+/** Total human-evidence summaries published across all issues. */
+export const evidenceDigestEntryCount = evidenceDigestIssues.reduce(
+  (total, issue) => total + issue.entries.length,
+  0,
+)
+
+/** Most recent issue date (ISO), for freshness signals. */
+export const evidenceDigestLatestDate = evidenceDigestIssues
+  .map((issue) => issue.date)
+  .sort()
+  .at(-1) as string

--- a/lib/navigation-config.ts
+++ b/lib/navigation-config.ts
@@ -197,6 +197,11 @@ export const routeLabels: Record<string, RouteMetadata> = {
     description: 'Research notes, evidence reviews, regulatory updates, and editorial deep dives',
     parent: '/',
   },
+  '/evidence-digest': {
+    label: 'Evidence Digest',
+    description: 'Recurring, conservatively graded human-trial evidence summaries by goal',
+    parent: '/',
+  },
   '/articles/[slug]': {
     label: 'Article',
     description: 'Research note or evidence review',

--- a/scripts/shared-route-manifest.mjs
+++ b/scripts/shared-route-manifest.mjs
@@ -15,6 +15,7 @@ const CORE_STATIC_ROUTES = [
   '/methodology',
   '/contact',
   '/learning',
+  '/evidence-digest',
   '/herbs',
   '/compounds',
   '/downloads',
@@ -49,6 +50,7 @@ const CORE_ROUTE_META = new Map([
   ['/methodology', { title: 'Methodology | The Hippie Scientist', description: 'How evidence is selected, summarized, and scored for confidence.' }],
   ['/contact', { title: 'Contact | The Hippie Scientist', description: 'Contact the editorial team and submit corrections or sources.' }],
   ['/learning', { title: 'Learning Paths | The Hippie Scientist', description: 'Structured paths across herbs, compounds, and safety context.' }],
+  ['/evidence-digest', { title: 'Evidence Digest | The Hippie Scientist', description: 'A conservatively graded, recurring digest of human-trial evidence summaries organized by health goal.' }],
   ['/herbs', { title: 'Herb Database | The Hippie Scientist', description: 'Browse herb profiles, mechanisms, and safety notes.' }],
   ['/compounds', { title: 'Compound Database | The Hippie Scientist', description: 'Browse active compounds, pharmacology, and related herbs.' }],
   ['/downloads', { title: 'Downloads | The Hippie Scientist', description: 'Download practical guides, checklists, and educational resources.' }],
@@ -94,6 +96,7 @@ const ENTRY_ROUTES = [
 
 const CORE_SITEMAP_META = new Map([
   ['/', { priority: 1.0, changefreq: 'weekly' }],
+  ['/evidence-digest', { priority: 0.8, changefreq: 'weekly' }],
   ['/articles', { priority: 0.8, changefreq: 'daily' }],
   ['/herbs', { priority: 0.9, changefreq: 'weekly' }],
   ['/compounds', { priority: 0.9, changefreq: 'weekly' }],


### PR DESCRIPTION
@
## Week 1 Foundations — Growth/SEO

Compounding evidence assets + freshness/E-E-A-T signals, all within the static-export contract (no server features, workbook untouched — Digest is editorial content in a typed data module).

### What shipped
- **Evidence Digest** — new `/evidence-digest` route + append-only data module (`data/evidence-digest.ts`) with 2 issues / 8 conservatively graded, goal-linked human-evidence summaries. Each entry summarizes the *state of the evidence* and links to the full on-site profile (which carries citations) plus a PubMed query, rather than asserting unverifiable trial metadata. Designed to grow: prepend a new issue to publish.
- **Methodology** (`/methodology`) — explicit five-level "How we grade evidence" criteria table, freshness badge, and a link to the Digest.
- **Homepage** — "Last reviewed • N human-trial summaries" freshness signal in the hero; surfaces the Digest + the grading page.
- **Plumbing** — registered `/evidence-digest` in the shared route manifest (approved + sitemap), `sitemap.ts` core list, and nav `routeLabels`.

### Verification
- `tsc --noEmit` clean
- `eslint . --max-warnings=0` clean
- Vitest: route-integrity, route-consolidation, a11y, rendering, seo — **23 passing**
- Full `next build` → **1243 static pages**, `/evidence-digest` + homepage + methodology export with expected content (note: local build needs ~8GB heap; the 4GB default OOMs on this machine — unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@