### PR TITLE
fix(audit): address June 2026 deep audit — newsletter, herbs filtering, compound descriptions

### DIFF
--- a/app/compounds/page.tsx
+++ b/app/compounds/page.tsx
@@ -93,7 +93,33 @@ function getCategory(c: Compound): string {
 function getBrief(c: Compound): string {
   const raw = c.summary || c.description || c.short_earthy_summary || ''
   const cleaned = cleanSummary(raw, 'compound')
-  return (cleaned || '').slice(0, 120)
+  const genericFallback = 'Compound profile with evidence, safety, and practical fit.'
+  if (cleaned && cleaned !== genericFallback) return cleaned.slice(0, 130)
+
+  // Build a synthetic description from structured data when no prose summary exists
+  const name = getName(c)
+  const effects = list(c.primary_effects || c.effects)
+    .map(formatDisplayLabel)
+    .filter(Boolean)
+    .slice(0, 2)
+  const ev = getEvidenceLabel(c)
+
+  if (effects.length > 0) {
+    const effText = effects.map(e => e.toLowerCase()).join(' and ')
+    const evTone = /strong/i.test(ev) ? 'Human-trial evidence.' : /moderate/i.test(ev) ? 'Moderate evidence base.' : ''
+    return [`${name} studied for ${effText}.`, evTone].filter(Boolean).join(' ')
+  }
+
+  const mechs = list(c.mechanisms || c.mechanism_categories)
+    .map(formatDisplayLabel)
+    .filter(Boolean)
+    .slice(0, 2)
+
+  if (mechs.length > 0) {
+    return `${name} acts via ${mechs.map(m => m.toLowerCase()).join(' and ')} pathways.`
+  }
+
+  return `${name} — mechanism, evidence, and safety context. Profile data in progress.`
 }
 
 function getEvidenceLabel(c: Compound): string {

--- a/app/herbs/HerbsIndexClient.tsx
+++ b/app/herbs/HerbsIndexClient.tsx
@@ -279,13 +279,13 @@ export function EmptyLibraryState() {
 function EmptyFilteredState({ query, context, evidence }: { query: string; context: string; evidence: string }) {
   const activeContext = filterOptions.find(option => option.value === context)?.label
   const activeEvLabel = EVIDENCE_FILTER_OPTIONS.find(o => o.value === evidence && evidence !== 'all')?.label
-  const currentScan = [query ? `”${query}”` : '', activeContext || '', activeEvLabel || ''].filter(Boolean).join(' + ')
+  const currentScan = [query ? `"${query}"` : '', activeContext || '', activeEvLabel || ''].filter(Boolean).join(' + ')
 
   return (
     <DecisionEmptyState
-      eyebrow=”No matching profiles”
-      title=”No herbs matched this scan.”
-      description=”Try a broader herb name, mechanism, or goal. Evidence and safety labels stay conservative when source data is incomplete.”
+      eyebrow="No matching profiles"
+      title="No herbs matched this scan."
+      description="Try a broader herb name, mechanism, or goal. Evidence and safety labels stay conservative when source data is incomplete."
       currentScan={currentScan || undefined}
       actions={[
         { href: '/herbs', label: 'Reset filters', variant: 'primary' },

--- a/app/herbs/HerbsIndexClient.tsx
+++ b/app/herbs/HerbsIndexClient.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Link from 'next/link'
+import { useSearchParams } from 'next/navigation'
 import { cleanSummary, formatDisplayLabel, isClean, labelize, list, text, unique } from '@/lib/display-utils'
 import { normalizeDecisionEvidence, normalizeDecisionSafety } from '@/lib/decision-primitives'
 import { DecisionEmptyState, DecisionFilterGroup, DecisionProfileCard } from '@/components/ui/DecisionPrimitives'
@@ -200,7 +201,23 @@ function getSearchCorpus(item: RuntimeRecord) {
     .join(' ')
 }
 
-function filterHerbs(herbs: RuntimeRecord[], query: string, context: string) {
+const EVIDENCE_FILTER_OPTIONS = [
+  { label: 'Any evidence', value: 'all' },
+  { label: 'Strong', value: 'strong' },
+  { label: 'Moderate', value: 'moderate' },
+  { label: 'Limited / prelim', value: 'limited' },
+]
+
+function matchesEvidence(herb: RuntimeRecord, evidenceValue: string): boolean {
+  if (evidenceValue === 'all') return true
+  const ev = getEvidence(herb).toLowerCase()
+  if (evidenceValue === 'strong') return ev.includes('strong')
+  if (evidenceValue === 'moderate') return ev.includes('moderate')
+  if (evidenceValue === 'limited') return ev.includes('limited') || ev.includes('prelim') || ev.includes('traditional') || ev.includes('insufficient')
+  return true
+}
+
+function filterHerbs(herbs: RuntimeRecord[], query: string, context: string, evidenceFilter: string) {
   const normalizedQuery = query.trim().toLowerCase()
   const option = filterOptions.find(item => item.value === context)
 
@@ -208,15 +225,27 @@ function filterHerbs(herbs: RuntimeRecord[], query: string, context: string) {
     const corpus = getSearchCorpus(herb)
     const queryMatches = !normalizedQuery || normalizedQuery.split(/\s+/).every(term => corpus.includes(term))
     const contextMatches = !option || option.terms.some(term => corpus.includes(term))
+    const evMatches = matchesEvidence(herb, evidenceFilter)
 
-    return queryMatches && contextMatches
+    return queryMatches && contextMatches && evMatches
   })
 }
 
-function buildFilterHref(value: string, query: string) {
+function buildFilterHref(value: string, query: string, evidence?: string) {
   const params = new URLSearchParams()
   if (query.trim()) params.set('q', query.trim())
   if (value !== 'all') params.set('context', value)
+  if (evidence && evidence !== 'all') params.set('evidence', evidence)
+
+  const suffix = params.toString()
+  return suffix ? `/herbs?${suffix}` : '/herbs'
+}
+
+function buildEvidenceHref(evidenceValue: string, query: string, context: string) {
+  const params = new URLSearchParams()
+  if (query.trim()) params.set('q', query.trim())
+  if (context !== 'all') params.set('context', context)
+  if (evidenceValue !== 'all') params.set('evidence', evidenceValue)
 
   const suffix = params.toString()
   return suffix ? `/herbs?${suffix}` : '/herbs'
@@ -247,15 +276,16 @@ export function EmptyLibraryState() {
   )
 }
 
-function EmptyFilteredState({ query, context }: { query: string; context: string }) {
+function EmptyFilteredState({ query, context, evidence }: { query: string; context: string; evidence: string }) {
   const activeContext = filterOptions.find(option => option.value === context)?.label
-  const currentScan = [query ? `“${query}”` : '', activeContext || ''].filter(Boolean).join(' + ')
+  const activeEvLabel = EVIDENCE_FILTER_OPTIONS.find(o => o.value === evidence && evidence !== 'all')?.label
+  const currentScan = [query ? `”${query}”` : '', activeContext || '', activeEvLabel || ''].filter(Boolean).join(' + ')
 
   return (
     <DecisionEmptyState
-      eyebrow="No matching profiles"
-      title="No herbs matched this scan."
-      description="Try a broader herb name, mechanism, or goal. Evidence and safety labels stay conservative when source data is incomplete."
+      eyebrow=”No matching profiles”
+      title=”No herbs matched this scan.”
+      description=”Try a broader herb name, mechanism, or goal. Evidence and safety labels stay conservative when source data is incomplete.”
       currentScan={currentScan || undefined}
       actions={[
         { href: '/herbs', label: 'Reset filters', variant: 'primary' },
@@ -301,15 +331,18 @@ const browsePaths = [
 ]
 
 export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initialQuery = '', initialContext = '', paginated = false, page = 1, totalPages = 1}: { herbs: RuntimeRecord[]; allHerbs?: RuntimeRecord[]; initialQuery?: string; initialContext?: string; paginated?: boolean; page?: number; totalPages?: number }) {
-  const query = firstParam(initialQuery)
-  const context = firstParam(initialContext)
+  const urlParams = useSearchParams()
+  const query = urlParams?.get('q') || firstParam(initialQuery)
+  const context = urlParams?.get('context') || firstParam(initialContext)
+  const evidenceFilter = urlParams?.get('evidence') || 'all'
   const activeFilter = filterOptions.some(option => option.value === context) ? context : 'all'
+  const activeEvidence = EVIDENCE_FILTER_OPTIONS.some(o => o.value === evidenceFilter) ? evidenceFilter : 'all'
 
   const baseHerbs = [...(allHerbs || sourceHerbs)].sort((a: RuntimeRecord, b: RuntimeRecord) => scoreHerb(b) - scoreHerb(a))
   const herbs = [...sourceHerbs].sort((a: RuntimeRecord, b: RuntimeRecord) => scoreHerb(b) - scoreHerb(a))
 
-  const visibleHerbs = filterHerbs(baseHerbs, query, activeFilter)
-  const hasActiveFilters = Boolean(query.trim()) || activeFilter !== 'all'
+  const visibleHerbs = filterHerbs(baseHerbs, query, activeFilter, activeEvidence)
+  const hasActiveFilters = Boolean(query.trim()) || activeFilter !== 'all' || activeEvidence !== 'all'
   const totalProfiles = baseHerbs.length
 
   const pageSize = 36
@@ -383,6 +416,7 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
               className="min-h-10 w-full rounded-full border border-brand-900/10 bg-white px-4 text-sm text-ink shadow-sm placeholder:text-[#7b8a81]"
             />
             {activeFilter !== 'all' ? <input type="hidden" name="context" value={activeFilter} /> : null}
+            {activeEvidence !== 'all' ? <input type="hidden" name="evidence" value={activeEvidence} /> : null}
             <button type="submit" className="button-primary min-h-10 px-4 py-2">
               Search
             </button>
@@ -392,9 +426,36 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
             options={filterOptions}
             activeFilter={activeFilter}
             query={query}
-            buildHref={buildFilterHref}
+            buildHref={(value, q) => buildFilterHref(value, q, activeEvidence)}
             open={hasActiveFilters}
           />
+
+          <div className="mt-2">
+            <div className="mb-1.5 text-xs font-bold uppercase tracking-[0.12em] text-[#5f6f66]">Evidence level</div>
+            <div className="flex flex-wrap gap-2">
+              {EVIDENCE_FILTER_OPTIONS.map(opt => {
+                const href = buildEvidenceHref(opt.value, query, activeFilter)
+                const active = activeEvidence === opt.value
+                return (
+                  <Link
+                    key={opt.value}
+                    href={href}
+                    className={`rounded-full border px-2.5 py-1 text-xs font-semibold transition ${active ? 'border-brand-700/25 bg-brand-50 text-brand-900' : 'border-brand-900/10 bg-white/80 text-[#33443a] hover:border-brand-700/20'}`}
+                  >
+                    {opt.label}
+                  </Link>
+                )
+              })}
+            </div>
+          </div>
+
+          {hasActiveFilters && (
+            <div className="pt-1">
+              <Link href="/herbs" className="text-xs font-semibold text-brand-800 underline-offset-2 hover:underline">
+                Clear all filters
+              </Link>
+            </div>
+          )}
         </section>
 
         <section className="rounded-[0.85rem] border border-brand-900/10 bg-white/75 p-3 shadow-sm">
@@ -422,7 +483,7 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
         {herbs.length === 0 ? (
           <EmptyLibraryState />
         ) : visibleHerbs.length === 0 ? (
-          <EmptyFilteredState query={query} context={activeFilter} />
+          <EmptyFilteredState query={query} context={activeFilter} evidence={activeEvidence} />
         ) : (
           <>
             {featuredHerbs.length > 0 ? (

--- a/app/herbs/page.tsx
+++ b/app/herbs/page.tsx
@@ -14,6 +14,22 @@ export const metadata: Metadata = buildPageMetadata({
   path: '/herbs',
 })
 
+function HerbsLoadingSkeleton() {
+  return (
+    <div className="px-2 py-2 sm:px-3 sm:py-3">
+      <div className="mx-auto max-w-7xl space-y-4">
+        <div className="hero-shell animate-pulse rounded-[0.95rem] border border-brand-900/10 px-3 py-4 shadow-sm sm:px-4 sm:py-5 h-32" />
+        <div className="animate-pulse rounded-[0.85rem] border border-brand-900/10 bg-white/85 p-3 shadow-sm h-24" />
+        <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="animate-pulse rounded-[0.85rem] border border-brand-900/10 bg-white/60 p-4 shadow-sm h-36" />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export default async function HerbsPage() {
   const herbs = ((await getHerbSummaryIndex()) as RuntimeRecord[]).filter((h) => getRuntimeVisibility(h).canRender)
   const pageData = paginateItems(herbs, 1, HERBS_PAGE_SIZE)
@@ -39,7 +55,7 @@ export default async function HerbsPage() {
           ))}
         </ul>
       </nav>
-      <Suspense fallback={null}>
+      <Suspense fallback={<HerbsLoadingSkeleton />}>
         <HerbsIndexClient herbs={pageData.pageItems} allHerbs={herbs} paginated page={1} totalPages={pageData.totalPages} />
       </Suspense>
     </div>

--- a/app/herbs/page/[page]/page.tsx
+++ b/app/herbs/page/[page]/page.tsx
@@ -10,6 +10,17 @@ import type { RuntimeRecord } from '@/types/content'
 type P={params:Promise<{page:string}>}
 export async function generateStaticParams(){ const herbs=((await getHerbSummaryIndex()) as RuntimeRecord[]).filter((h)=>getRuntimeVisibility(h).canRender); const total=Math.max(1,Math.ceil(herbs.length/HERBS_PAGE_SIZE)); return Array.from({length:Math.max(total-1,0)},(_,i)=>({page:String(i+2)})) }
 export async function generateMetadata({params}:P):Promise<Metadata>{const n=clampPositiveInt((await params).page,2);return{title:`Herb Profiles & Research Library — Page ${n}`,alternates:{canonical:`/herbs/page/${n}`}}}
+
+function HerbsPageSkeleton() {
+  return (
+    <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <div key={i} className="animate-pulse rounded-[0.85rem] border border-brand-900/10 bg-white/60 p-4 shadow-sm h-36" />
+      ))}
+    </div>
+  )
+}
+
 export default async function HerbsPageN({params}:P){
   const n=clampPositiveInt((await params).page,2);
   const herbs=((await getHerbSummaryIndex()) as RuntimeRecord[]).filter((h)=>getRuntimeVisibility(h).canRender);
@@ -28,7 +39,7 @@ export default async function HerbsPageN({params}:P){
           {p.hasNext ? <Link rel="next" href={`/herbs/page/${p.currentPage+1}`}>Next page →</Link> : null}
         </div>
       </nav>
-      <Suspense fallback={null}>
+      <Suspense fallback={<HerbsPageSkeleton />}>
         <HerbsIndexClient herbs={p.pageItems as RuntimeRecord[]} allHerbs={herbs} paginated page={p.currentPage} totalPages={p.totalPages} />
       </Suspense>
     </div>

--- a/components/NewsletterSignup.tsx
+++ b/components/NewsletterSignup.tsx
@@ -88,11 +88,6 @@ export default function NewsletterSignup({
               {ctaLabel}
             </button>
           </div>
-          {!mailchimpSignupConfig.isMailchimpAction ? (
-            <p className={`text-xs leading-5 ${mutedColor}`}>
-              Signup uses the static checklist fallback until the Mailchimp list-manage URL is configured.
-            </p>
-          ) : null}
         </form>
       </div>
     </section>


### PR DESCRIPTION
Critical fixes:
- Remove visible developer warning from NewsletterSignup ("static checklist fallback until
  Mailchimp list-manage URL is configured") — form already routes to /newsletter/confirmed
  gracefully when unconfigured; the warning text was user-facing jargon

Herbs library parity with /compounds:
- Add useSearchParams to HerbsIndexClient so URL-based filter links (context=, evidence=)
  actually filter content after hydration in static export
- Add evidence-level filter chips (Any / Strong / Moderate / Limited/prelim) matching
  the pattern on the /compounds page; chips preserve existing query + context state
- Clear-all-filters link appears whenever any filter is active
- Hidden form inputs preserve active filters on search submit
- Replace Suspense fallback={null} with an animated skeleton so the page shows content
  structure before JS loads rather than a blank section
- Same skeleton treatment on paginated /herbs/page/[page] routes

Compound card descriptions:
- getBrief() now synthesises a useful sentence from primary_effects + evidence label when
  no prose summary exists in the workbook, instead of returning the generic
  "Compound profile with evidence, safety, and practical fit." placeholder

All changes:
- Pass static-export-compat validator (no force-dynamic, no server-only APIs in client code)
- Pass data contract guard (no public/data edits)
- Pass data structural validation
- No new TypeScript semantic errors in modified files