### PR TITLE
[codex] address june audit critical fixes

### DIFF
--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -570,6 +570,9 @@ export default async function CompoundPage({ params }: PageProps) {
     ],
     workbookRecord: { ...compound, slug: normalizedSlug },
     seeAlsoEntries: clusterSeeAlso,
+    reviewedAt: freshness.lastReviewed,
+    modifiedAt: freshness.lastReviewed,
+    citationCount: freshness.citationCount,
   })
 
   const faqSchema = faqPageJsonLd({

--- a/app/herbs/HerbsIndexClient.tsx
+++ b/app/herbs/HerbsIndexClient.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Link from 'next/link'
+import { useSearchParams } from 'next/navigation'
 import { cleanSummary, formatDisplayLabel, isClean, labelize, list, text, unique } from '@/lib/display-utils'
 import { normalizeDecisionEvidence, normalizeDecisionSafety } from '@/lib/decision-primitives'
 import { DecisionEmptyState, DecisionFilterGroup, DecisionProfileCard } from '@/components/ui/DecisionPrimitives'
@@ -301,8 +302,9 @@ const browsePaths = [
 ]
 
 export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initialQuery = '', initialContext = '', paginated = false, page = 1, totalPages = 1}: { herbs: RuntimeRecord[]; allHerbs?: RuntimeRecord[]; initialQuery?: string; initialContext?: string; paginated?: boolean; page?: number; totalPages?: number }) {
-  const query = firstParam(initialQuery)
-  const context = firstParam(initialContext)
+  const searchParams = useSearchParams()
+  const query = searchParams.get('q') || firstParam(initialQuery)
+  const context = searchParams.get('context') || firstParam(initialContext)
   const activeFilter = filterOptions.some(option => option.value === context) ? context : 'all'
 
   const baseHerbs = [...(allHerbs || sourceHerbs)].sort((a: RuntimeRecord, b: RuntimeRecord) => scoreHerb(b) - scoreHerb(a))

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -414,6 +414,9 @@ export default async function HerbDetailPage({ params }: PageProps) {
     ],
     workbookRecord: { ...herb, slug: normalizedSlug } as Record<string, unknown>,
     seeAlsoEntries: clusterSeeAlso,
+    reviewedAt: freshness.lastReviewed,
+    modifiedAt: freshness.lastReviewed,
+    citationCount: freshness.citationCount,
   })
 
   const faqSchema = faqPageJsonLd({

--- a/app/herbs/page.tsx
+++ b/app/herbs/page.tsx
@@ -2,11 +2,12 @@ import type { Metadata } from 'next'
 import type { RuntimeRecord } from '@/types/content'
 import Link from 'next/link'
 import { Suspense } from 'react'
+
 import { getHerbSummaryIndex } from '@/lib/runtime-summary-indexes'
 import { getRuntimeVisibility } from '@/lib/runtime-visibility'
 import { HERBS_PAGE_SIZE, paginateItems } from '@/lib/pagination'
-import HerbsIndexClient from './HerbsIndexClient'
 import { buildPageMetadata } from '@/lib/seo'
+import HerbsIndexClient from './HerbsIndexClient'
 
 export const metadata: Metadata = buildPageMetadata({
   title: 'Herb Profiles & Research Library',
@@ -14,8 +15,12 @@ export const metadata: Metadata = buildPageMetadata({
   path: '/herbs',
 })
 
+export const dynamic = 'force-static'
+
 export default async function HerbsPage() {
-  const herbs = ((await getHerbSummaryIndex()) as RuntimeRecord[]).filter((h) => getRuntimeVisibility(h).canRender)
+  const herbs = ((await getHerbSummaryIndex()) as RuntimeRecord[])
+    .filter((herb) => herb.slug && getRuntimeVisibility(herb).canRender)
+    .sort((a, b) => String(a.displayName || a.name || a.slug).localeCompare(String(b.displayName || b.name || b.slug)))
   const pageData = paginateItems(herbs, 1, HERBS_PAGE_SIZE)
 
   return (
@@ -23,13 +28,16 @@ export default async function HerbsPage() {
       <div className="space-y-1 pb-1">
         <p className="eyebrow-label">Botanical Research Library</p>
         <h1 className="text-3xl font-bold tracking-tight text-ink sm:text-4xl">Herb Profiles</h1>
-        <p className="text-sm text-muted">Mechanisms, safety notes, active compounds, and research context for {herbs.length} herbs — plain language, conservative claims.</p>
+        <p className="text-sm text-muted">
+          Mechanisms, safety notes, active compounds, and research context for {herbs.length} herbs — plain language, conservative claims.
+        </p>
       </div>
-      <nav className="rounded-[0.8rem] border border-brand-900/10 bg-white/80 p-3 text-sm">
+
+      <nav className="rounded-[0.8rem] border border-brand-900/10 bg-white/80 p-3 text-sm" aria-label="Herb pagination">
         <p className="font-semibold">Page 1 of {pageData.totalPages}</p>
         {pageData.hasNext ? <Link rel="next" href="/herbs/page/2">Next page →</Link> : null}
       </nav>
-      {/* Server-rendered link index for SEO crawlability — the interactive card grid is rendered by HerbsIndexClient below */}
+
       <nav aria-label="Herb profiles index" className="sr-only">
         <ul>
           {herbs.map((herb) => (
@@ -39,6 +47,24 @@ export default async function HerbsPage() {
           ))}
         </ul>
       </nav>
+
+      <noscript>
+        <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-3" aria-label="Herb profiles">
+          {pageData.pageItems.map((herb) => (
+            <Link
+              key={herb.slug}
+              href={`/herbs/${herb.slug}`}
+              className="block rounded-[0.85rem] border border-brand-900/10 bg-white/80 p-4 shadow-sm"
+            >
+              <h2 className="text-base font-semibold tracking-tight text-ink">{herb.displayName || herb.name || herb.slug}</h2>
+              <p className="mt-2 text-sm leading-6 text-[#46574d]">
+                {String(herb.summary || herb.description || 'Herb profile with evidence, mechanism, and safety context.')}
+              </p>
+            </Link>
+          ))}
+        </section>
+      </noscript>
+
       <Suspense fallback={null}>
         <HerbsIndexClient herbs={pageData.pageItems} allHerbs={herbs} paginated page={1} totalPages={pageData.totalPages} />
       </Suspense>

--- a/components/NewsletterSignup.tsx
+++ b/components/NewsletterSignup.tsx
@@ -1,4 +1,7 @@
+'use client'
+
 import Link from 'next/link'
+import { type FormEvent, useId, useState } from 'react'
 import { safetyChecklistLeadMagnet } from '@/lib/lead-magnet'
 import { mailchimpSignupConfig } from '@/lib/mailchimp-integration'
 
@@ -35,6 +38,47 @@ export default function NewsletterSignup({
   const buttonClass = isFooter
     ? 'min-h-11 rounded-full bg-emerald-600 px-5 text-sm font-semibold text-white transition hover:bg-emerald-500'
     : 'min-h-11 rounded-full bg-brand-950 px-5 py-2.5 text-sm font-bold text-white transition hover:bg-brand-900'
+  const emailId = useId()
+  const honeypotId = useId()
+  const statusId = useId()
+  const [email, setEmail] = useState('')
+  const [confirmEmail, setConfirmEmail] = useState('')
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle')
+  const [message, setMessage] = useState('')
+  const usesMailchimpForm = mailchimpSignupConfig.isMailchimpAction
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    if (usesMailchimpForm) return
+
+    event.preventDefault()
+    setStatus('submitting')
+    setMessage('')
+
+    try {
+      const response = await fetch('/api/subscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email,
+          firstName: '',
+          magnet: safetyChecklistLeadMagnet.slug,
+          confirmEmail,
+          source: location,
+        }),
+      })
+      const payload = (await response.json().catch(() => null)) as { ok?: boolean; error?: string } | null
+
+      if (!response.ok || !payload?.ok) {
+        throw new Error(payload?.error || 'Could not subscribe this email right now.')
+      }
+
+      setStatus('success')
+      setMessage('You are subscribed. Open the safety checklist while the next evidence note is prepared.')
+    } catch (error) {
+      setStatus('error')
+      setMessage(error instanceof Error ? error.message : 'Could not subscribe this email right now.')
+    }
+  }
 
   return (
     <section className={`${variantClasses[variant]} ${className}`} data-signup-location={location}>
@@ -57,25 +101,28 @@ export default function NewsletterSignup({
         <form
           action={mailchimpSignupConfig.action}
           method={mailchimpSignupConfig.method}
+          onSubmit={handleSubmit}
           className='flex flex-col gap-3'
         >
           <input type='hidden' name='SOURCE' value={location} />
           <input type='hidden' name='LEAD_MAGNET' value={safetyChecklistLeadMagnet.slug} />
           <div aria-hidden='true' className='absolute left-[-5000px]'>
-            <label htmlFor={`newsletter-honeypot-${location}`}>Leave this field empty</label>
+            <label htmlFor={honeypotId}>Leave this field empty</label>
             <input
-              id={`newsletter-honeypot-${location}`}
+              id={honeypotId}
               name={mailchimpSignupConfig.honeypotName}
               tabIndex={-1}
               autoComplete='off'
+              value={confirmEmail}
+              onChange={(event) => setConfirmEmail(event.target.value)}
             />
           </div>
           <div className='flex flex-col gap-3 sm:flex-row lg:flex-col xl:flex-row'>
-            <label className='sr-only' htmlFor={`newsletter-email-${location}`}>
+            <label className='sr-only' htmlFor={emailId}>
               Email address
             </label>
             <input
-              id={`newsletter-email-${location}`}
+              id={emailId}
               name={mailchimpSignupConfig.emailFieldName}
               type='email'
               required
@@ -83,14 +130,27 @@ export default function NewsletterSignup({
               autoComplete='email'
               placeholder='you@example.com'
               className={inputClass}
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              aria-describedby={message ? statusId : undefined}
             />
-            <button type='submit' className={buttonClass}>
-              {ctaLabel}
+            <button type='submit' className={buttonClass} disabled={status === 'submitting'}>
+              {status === 'submitting' ? 'Sending...' : ctaLabel}
             </button>
           </div>
-          {!mailchimpSignupConfig.isMailchimpAction ? (
-            <p className={`text-xs leading-5 ${mutedColor}`}>
-              Signup uses the static checklist fallback until the Mailchimp list-manage URL is configured.
+          {message ? (
+            <p
+              id={statusId}
+              className={`text-xs leading-5 ${status === 'error' ? 'text-red-700' : mutedColor}`}
+              role={status === 'error' ? 'alert' : 'status'}
+              aria-live='polite'
+            >
+              {message}{' '}
+              {status === 'success' ? (
+                <Link href='/supplement-safety-checklist' className={isFooter ? 'text-emerald-300 hover:underline' : 'text-brand-800 hover:underline'}>
+                  Open checklist
+                </Link>
+              ) : null}
             </p>
           ) : null}
         </form>

--- a/src/lib/schema-graph.ts
+++ b/src/lib/schema-graph.ts
@@ -47,6 +47,9 @@ export type ProfileSchemaGraphArgs = {
   compound?: CompoundJsonLdArgs
   breadcrumbs: Array<{ name: string; url: string }>
   workbookRecord?: WorkbookLinkedProfile
+  reviewedAt?: string
+  modifiedAt?: string
+  citationCount?: number
 }
 
 export function buildProfileSchemaGraph(args: ProfileSchemaGraphArgs) {
@@ -69,6 +72,20 @@ export function buildProfileSchemaGraph(args: ProfileSchemaGraphArgs) {
         url: canonical,
         mainEntityOfPage: canonical,
         mainEntity: { '@id': `${canonical}#entity` },
+        ...(args.modifiedAt ? { dateModified: args.modifiedAt } : {}),
+        ...(args.reviewedAt ? { dateReviewed: args.reviewedAt } : {}),
+        reviewedBy: { '@type': 'Organization', name: 'The Hippie Scientist', url: SITE_URL },
+        author: { '@type': 'Organization', name: 'The Hippie Scientist', url: SITE_URL },
+        publisher: { '@type': 'Organization', name: 'The Hippie Scientist', url: SITE_URL },
+        ...(typeof args.citationCount === 'number'
+          ? {
+              additionalProperty: {
+                '@type': 'PropertyValue',
+                propertyID: 'citation count',
+                value: args.citationCount,
+              },
+            }
+          : {}),
       }
     : null
 


### PR DESCRIPTION
## Summary
- Replace visible Mailchimp fallback copy with the existing Cloudflare `/api/subscribe` fallback and accessible status messaging.
- Improve `/herbs` surfacing with crawlable links, no-script cards, static-export-safe query filtering, and stable metadata.
- Harden herb and compound profile JSON-LD with review dates, modified dates, publisher/reviewer identity, and citation counts.

## Validation
- npm run audit:content-gaps
- npm run audit:safety
- npm run audit:best-for
- npm run audit:leaked-text
- npm run typecheck
- npm run lint
- npm run test:a11y
- npm run validate:static-export
- npm run data:validate
- npm run guard:source-of-truth
- npm run verify:build

Notes: `verify:build` passed after stopping the local dev server. Existing route-link warnings and the main JS bundle warning remain diagnostic, not blocking.
