### PR TITLE
feat(seo): structured data expansion + route SEO polish

### DIFF
--- a/app/education/cognitive-resilience-systems/page.tsx
+++ b/app/education/cognitive-resilience-systems/page.tsx
@@ -46,7 +46,7 @@ const relatedSystems = [
     title: 'Recovery-Oriented Cognition Systems',
   },
   {
-    href: '/protocols/non-stimulant-focus',
+    href: '/goals/focus',
     title: 'Non-Stimulant Focus Stabilization',
   },
   {
@@ -54,7 +54,7 @@ const relatedSystems = [
     title: 'Scientific But Human Neuroscience',
   },
   {
-    href: '/protocols/burnout-recovery',
+    href: '/goals/stress',
     title: 'Burnout Recovery',
   },
 ]

--- a/app/education/how-emotional-regulation-works/page.tsx
+++ b/app/education/how-emotional-regulation-works/page.tsx
@@ -24,15 +24,15 @@ const systems = [
 
 const related = [
   {
-    href: '/pathways/serotonin',
+    href: '/education/serotonin',
     title: 'Serotonin Pathway',
   },
   {
-    href: '/pathways/gaba',
+    href: '/education/gaba',
     title: 'GABA Pathway',
   },
   {
-    href: '/protocols/stress-regulation',
+    href: '/goals/stress',
     title: 'Stress Regulation',
   },
   {

--- a/app/education/how-focus-and-motivation-work/page.tsx
+++ b/app/education/how-focus-and-motivation-work/page.tsx
@@ -24,11 +24,11 @@ const systems = [
 
 const related = [
   {
-    href: '/pathways/dopamine',
+    href: '/education/dopamine',
     title: 'Dopamine Pathway',
   },
   {
-    href: '/protocols/non-stimulant-focus',
+    href: '/goals/focus',
     title: 'Non-Stimulant Focus',
   },
   {

--- a/app/education/how-herbal-psychoactives-differ-from-pharmaceuticals/page.tsx
+++ b/app/education/how-herbal-psychoactives-differ-from-pharmaceuticals/page.tsx
@@ -16,7 +16,7 @@ const systems = [
     title: 'Kanna vs SSRIs',
   },
   {
-    href: '/pathways/serotonin',
+    href: '/education/serotonin',
     title: 'Serotonin Pathway',
   },
 ]

--- a/app/education/how-learning-affects-neuroplasticity/page.tsx
+++ b/app/education/how-learning-affects-neuroplasticity/page.tsx
@@ -36,7 +36,7 @@ const relatedSystems = [
     title: 'Sleep Neurochemistry',
   },
   {
-    href: '/pathways/glutamate',
+    href: '/education/glutamate',
     title: 'Glutamate Pathway',
   },
 ]
@@ -67,6 +67,7 @@ export default function NeuroplasticityEducationPage() {
         description="Educational exploration of neuroplasticity, learning systems, cognition continuity, recovery biology, and adaptive nervous-system signaling."
         url="https://thehippiescientist.net/education/how-learning-affects-neuroplasticity"
         type="Article"
+        faqItems={faqItems}
       />
 
       <AuthorityBreadcrumbs

--- a/app/education/how-memory-formation-works/page.tsx
+++ b/app/education/how-memory-formation-works/page.tsx
@@ -32,11 +32,11 @@ const relatedSystems = [
     title: 'Focus and Motivation',
   },
   {
-    href: '/pathways/glutamate',
+    href: '/education/glutamate',
     title: 'Glutamate Pathway',
   },
   {
-    href: '/pathways/cholinergic-system',
+    href: '/education/cholinergic-system',
     title: 'Cholinergic System',
   },
 ]
@@ -67,6 +67,7 @@ export default function MemoryFormationEducationPage() {
         description="Educational exploration of memory formation, cognition continuity, sleep-dependent consolidation, emotional salience, and neuropharmacology."
         url="https://thehippiescientist.net/education/how-memory-formation-works"
         type="Article"
+        faqItems={faqItems}
       />
 
       <AuthorityBreadcrumbs

--- a/app/education/how-neurotransmitters-work/page.tsx
+++ b/app/education/how-neurotransmitters-work/page.tsx
@@ -8,22 +8,22 @@ import MisconceptionCallout from '@/components/evidence/MisconceptionCallout'
 
 const pathways = [
   {
-    href: '/pathways/serotonin',
+    href: '/education/serotonin',
     title: 'Serotonin Pathway',
     description: 'Mood-related signaling systems associated with emotional regulation, stress adaptation, appetite, sleep continuity, and psychoactive neuropharmacology.',
   },
   {
-    href: '/pathways/dopamine',
+    href: '/education/dopamine',
     title: 'Dopamine Pathway',
     description: 'Motivation and cognition-oriented systems associated with reward signaling, behavioral reinforcement, novelty processing, and attention continuity.',
   },
   {
-    href: '/pathways/gaba',
+    href: '/education/gaba',
     title: 'GABA Pathway',
     description: 'Calming inhibitory signaling systems associated with nervous-system downregulation, relaxation, sedation pathways, and sleep continuity.',
   },
   {
-    href: '/pathways/glutamate',
+    href: '/education/glutamate',
     title: 'Glutamate Pathway',
     description: 'Excitatory signaling systems associated with learning, neuroplasticity, cognition, memory formation, and altered-state neuropharmacology.',
   },

--- a/app/education/how-psychoactive-plants-affect-the-brain/page.tsx
+++ b/app/education/how-psychoactive-plants-affect-the-brain/page.tsx
@@ -5,19 +5,19 @@ import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
 const systems = [
   {
     title: 'GABAergic Systems',
-    href: '/pathways/gaba',
+    href: '/education/gaba',
   },
   {
     title: 'Serotonergic Systems',
-    href: '/pathways/serotonin',
+    href: '/education/serotonin',
   },
   {
     title: 'Dopaminergic Systems',
-    href: '/pathways/dopamine',
+    href: '/education/dopamine',
   },
   {
     title: 'Cholinergic Systems',
-    href: '/pathways/cholinergic-system',
+    href: '/education/cholinergic-system',
   },
 ]
 

--- a/app/education/how-sleep-affects-neurochemistry/page.tsx
+++ b/app/education/how-sleep-affects-neurochemistry/page.tsx
@@ -24,11 +24,11 @@ const sections = [
 
 const related = [
   {
-    href: '/pathways/cholinergic-system',
+    href: '/education/cholinergic-system',
     title: 'Cholinergic System',
   },
   {
-    href: '/pathways/gaba',
+    href: '/education/gaba',
     title: 'GABA Pathway',
   },
   {

--- a/app/education/how-stress-affects-the-brain/page.tsx
+++ b/app/education/how-stress-affects-the-brain/page.tsx
@@ -24,11 +24,11 @@ const mechanisms = [
 
 const related = [
   {
-    href: '/protocols/stress-regulation',
+    href: '/goals/stress',
     title: 'Stress Regulation',
   },
   {
-    href: '/protocols/burnout-recovery',
+    href: '/goals/stress',
     title: 'Burnout Recovery',
   },
   {

--- a/app/education/how-the-brain-recovers-from-fatigue/page.tsx
+++ b/app/education/how-the-brain-recovers-from-fatigue/page.tsx
@@ -24,7 +24,7 @@ const systems = [
 
 const related = [
   {
-    href: '/protocols/burnout-recovery',
+    href: '/goals/stress',
     title: 'Burnout Recovery',
   },
   {

--- a/app/education/stress-and-cognition-continuity/page.tsx
+++ b/app/education/stress-and-cognition-continuity/page.tsx
@@ -38,11 +38,11 @@ const faqs = [
 
 const relatedSystems = [
   {
-    href: '/protocols/burnout-recovery',
+    href: '/goals/stress',
     title: 'Burnout Recovery',
   },
   {
-    href: '/protocols/recovery-oriented-productivity',
+    href: '/goals/stress',
     title: 'Recovery-Oriented Productivity',
   },
   {

--- a/app/education/understanding-altered-states/page.tsx
+++ b/app/education/understanding-altered-states/page.tsx
@@ -67,6 +67,7 @@ export default function AlteredStatesEducationPage() {
         description="Educational exploration of altered states, perception-oriented neurobiology, emotional processing, psychoactive context, and systems-oriented neuroscience."
         url="https://thehippiescientist.net/education/understanding-altered-states"
         type="Article"
+        faqItems={faqItems}
       />
 
       <AuthorityBreadcrumbs

--- a/app/education/what-are-adaptogens/page.tsx
+++ b/app/education/what-are-adaptogens/page.tsx
@@ -9,12 +9,12 @@ import RelatedEducationSystems from '@/components/education/related-education-sy
 
 const systems = [
   {
-    href: '/protocols/stress-regulation',
+    href: '/goals/stress',
     title: 'Stress Regulation',
     description: 'Educational exploration of stress-response continuity, nervous-system resilience, and recovery biology.',
   },
   {
-    href: '/protocols/burnout-recovery',
+    href: '/goals/stress',
     title: 'Burnout Recovery',
     description: 'Recovery-oriented protocol ecosystem focused on fatigue, emotional regulation, and resilience.',
   },

--- a/app/education/what-is-a-nootropic/page.tsx
+++ b/app/education/what-is-a-nootropic/page.tsx
@@ -9,12 +9,12 @@ import RelatedEducationSystems from '@/components/education/related-education-sy
 
 const systems = [
   {
-    href: '/protocols/non-stimulant-focus',
+    href: '/goals/focus',
     title: 'Non-Stimulant Focus',
     description: 'Recovery-oriented focus systems emphasizing attentional continuity and calm cognition.',
   },
   {
-    href: '/pathways/dopamine',
+    href: '/education/dopamine',
     title: 'Dopamine Pathway',
     description: 'Educational exploration of motivational signaling, salience systems, and neuropharmacology.',
   },
@@ -71,6 +71,7 @@ export default function NootropicEducationPage() {
         description='Educational introduction to nootropics, cognition-oriented compounds, focus systems, neuropharmacology, and cognitive support.'
         url='https://thehippiescientist.net/education/what-is-a-nootropic'
         type='Article'
+        faqItems={faqItems}
       />
 
       <AuthorityBreadcrumbs

--- a/app/education/what-is-an-entheogen/page.tsx
+++ b/app/education/what-is-an-entheogen/page.tsx
@@ -8,7 +8,7 @@ const related = [
     title: 'Entheogens',
   },
   {
-    href: '/pathways/serotonin',
+    href: '/education/serotonin',
     title: 'Serotonin Pathway',
   },
   {

--- a/app/education/what-is-anxiety-neurochemistry/page.tsx
+++ b/app/education/what-is-anxiety-neurochemistry/page.tsx
@@ -4,17 +4,17 @@ import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
 
 const systems = [
   {
-    href: '/pathways/gaba',
+    href: '/education/gaba',
     title: 'GABA Pathway',
     description: 'Calming inhibitory signaling systems associated with nervous-system regulation and relaxation.',
   },
   {
-    href: '/pathways/serotonin',
+    href: '/education/serotonin',
     title: 'Serotonin Pathway',
     description: 'Mood-regulation systems associated with emotional processing and stress-related neuropharmacology.',
   },
   {
-    href: '/protocols/stress-regulation',
+    href: '/goals/stress',
     title: 'Stress Regulation',
     description: 'Recovery-oriented educational protocol focused on stress systems and nervous-system stabilization.',
   },

--- a/app/education/what-is-neuroinflammation/page.tsx
+++ b/app/education/what-is-neuroinflammation/page.tsx
@@ -24,11 +24,11 @@ const sections = [
 
 const relatedSystems = [
   {
-    href: '/protocols/burnout-recovery',
+    href: '/goals/stress',
     title: 'Burnout Recovery',
   },
   {
-    href: '/protocols/stress-regulation',
+    href: '/goals/stress',
     title: 'Stress Regulation',
   },
   {
@@ -36,7 +36,7 @@ const relatedSystems = [
     title: 'Adaptogens',
   },
   {
-    href: '/pathways/glutamate',
+    href: '/education/glutamate',
     title: 'Glutamate Pathway',
   },
 ]

--- a/app/education/what-is-neuropharmacology/page.tsx
+++ b/app/education/what-is-neuropharmacology/page.tsx
@@ -4,19 +4,19 @@ import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
 
 const systems = [
   {
-    href: '/pathways/serotonin',
+    href: '/education/serotonin',
     title: 'Serotonin Pathway',
   },
   {
-    href: '/pathways/dopamine',
+    href: '/education/dopamine',
     title: 'Dopamine Pathway',
   },
   {
-    href: '/pathways/gaba',
+    href: '/education/gaba',
     title: 'GABA Pathway',
   },
   {
-    href: '/pathways/glutamate',
+    href: '/education/glutamate',
     title: 'Glutamate Pathway',
   },
 ]

--- a/app/education/why-burnout-affects-cognition/page.tsx
+++ b/app/education/why-burnout-affects-cognition/page.tsx
@@ -22,7 +22,7 @@ const systems = [
 ]
 
 const relatedSystems = [
-  { href: '/protocols/burnout-recovery', title: 'Burnout Recovery' },
+  { href: '/goals/stress', title: 'Burnout Recovery' },
   { href: '/education/how-the-brain-recovers-from-fatigue', title: 'Fatigue Recovery' },
   { href: '/education/how-sleep-affects-neurochemistry', title: 'Sleep and Neurochemistry' },
   { href: '/education/why-fatigue-is-biologically-complex', title: 'Fatigue Complexity' },

--- a/app/education/why-calm-focus-differs-from-stimulation/page.tsx
+++ b/app/education/why-calm-focus-differs-from-stimulation/page.tsx
@@ -38,7 +38,7 @@ const faqs = [
 
 const relatedSystems = [
   { href: '/compare/rhodiola-vs-ashwagandha', title: 'Rhodiola vs Ashwagandha' },
-  { href: '/protocols/non-stimulant-focus', title: 'Non-Stimulant Focus' },
+  { href: '/goals/focus', title: 'Non-Stimulant Focus' },
   { href: '/education/why-overstimulation-impairs-focus', title: 'Overstimulation and Focus' },
   { href: '/education/how-focus-and-motivation-work', title: 'Focus and Motivation' },
 ]

--- a/app/education/why-fatigue-is-biologically-complex/page.tsx
+++ b/app/education/why-fatigue-is-biologically-complex/page.tsx
@@ -39,7 +39,7 @@ const faqs = [
 const relatedSystems = [
   { href: '/education/how-the-brain-recovers-from-fatigue', title: 'Fatigue Recovery' },
   { href: '/education/why-burnout-affects-cognition', title: 'Burnout and Cognition' },
-  { href: '/protocols/burnout-recovery', title: 'Burnout Recovery' },
+  { href: '/goals/stress', title: 'Burnout Recovery' },
   { href: '/education/how-sleep-affects-neurochemistry', title: 'Sleep and Neurochemistry' },
 ]
 
@@ -51,6 +51,7 @@ export default function WhyFatigueIsBiologicallyComplexPage() {
         description="Educational exploration of fatigue systems, recovery biology, stress physiology, burnout-oriented neurobiology, and cognition sustainability."
         url="https://thehippiescientist.net/education/why-fatigue-is-biologically-complex"
         type="Article"
+        faqItems={faqs}
       />
       <AuthorityBreadcrumbs
         items={[

--- a/app/education/why-overstimulation-impairs-focus/page.tsx
+++ b/app/education/why-overstimulation-impairs-focus/page.tsx
@@ -38,7 +38,7 @@ const faqs = [
 
 const relatedSystems = [
   { href: '/compare/rhodiola-vs-ashwagandha', title: 'Rhodiola vs Ashwagandha' },
-  { href: '/protocols/non-stimulant-focus', title: 'Non-Stimulant Focus' },
+  { href: '/goals/focus', title: 'Non-Stimulant Focus' },
   { href: '/education/how-focus-and-motivation-work', title: 'Focus and Motivation' },
   { href: '/education/why-burnout-affects-cognition', title: 'Burnout and Cognition' },
 ]

--- a/app/education/why-set-and-setting-matter/page.tsx
+++ b/app/education/why-set-and-setting-matter/page.tsx
@@ -51,6 +51,7 @@ export default function WhySetAndSettingMatterPage() {
         description="Educational exploration of set and setting, contextual neurobiology, emotional regulation, environmental influence, and subjective experiences."
         url="https://thehippiescientist.net/education/why-set-and-setting-matter"
         type="Article"
+        faqItems={faqs}
       />
       <AuthorityBreadcrumbs
         items={[

--- a/app/education/why-sleep-changes-emotional-regulation/page.tsx
+++ b/app/education/why-sleep-changes-emotional-regulation/page.tsx
@@ -40,7 +40,7 @@ const relatedSystems = [
   { href: '/education/how-sleep-affects-neurochemistry', title: 'Sleep and Neurochemistry' },
   { href: '/education/why-burnout-affects-cognition', title: 'Burnout and Cognition' },
   { href: '/education/how-emotional-regulation-works', title: 'Emotional Regulation' },
-  { href: '/protocols/burnout-recovery', title: 'Burnout Recovery' },
+  { href: '/goals/stress', title: 'Burnout Recovery' },
 ]
 
 export default function WhySleepChangesEmotionalRegulationPage() {

--- a/app/education/why-studies-conflict/page.tsx
+++ b/app/education/why-studies-conflict/page.tsx
@@ -51,6 +51,7 @@ export default function WhyStudiesConflictPage() {
         description="Educational exploration of scientific uncertainty, human variability, study design differences, and biological complexity in neuroscience and health research."
         url="https://thehippiescientist.net/education/why-studies-conflict"
         type="Article"
+        faqItems={faqs}
       />
       <AuthorityBreadcrumbs
         items={[

--- a/app/psychoactive/dissociative-mechanisms/page.tsx
+++ b/app/psychoactive/dissociative-mechanisms/page.tsx
@@ -4,7 +4,7 @@ import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
 
 const systems = [
   {
-    href: '/pathways/glutamate',
+    href: '/education/glutamate',
     title: 'Glutamate Pathway',
   },
   {

--- a/app/psychoactive/interactions/page.tsx
+++ b/app/psychoactive/interactions/page.tsx
@@ -12,11 +12,11 @@ const systems = [
     title: 'Serotonergic Risks',
   },
   {
-    href: '/pathways/serotonin',
+    href: '/education/serotonin',
     title: 'Serotonin Pathway',
   },
   {
-    href: '/pathways/gaba',
+    href: '/education/gaba',
     title: 'GABA Pathway',
   },
 ]

--- a/app/psychoactive/serotonergic-stacking-risks/page.tsx
+++ b/app/psychoactive/serotonergic-stacking-risks/page.tsx
@@ -4,7 +4,7 @@ import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
 
 const systems = [
   {
-    href: '/pathways/serotonin',
+    href: '/education/serotonin',
     title: 'Serotonin Pathway',
   },
   {

--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -440,10 +440,10 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
               as='h2'
             />
             <div className='mt-6 flex flex-wrap gap-2.5'>
-              <Link href='/start-here/quiz' className='rounded-full bg-brand-700 px-5 py-3 text-sm font-bold text-white transition hover:bg-brand-800'>
+              <Link href='/goals/' className='rounded-full bg-brand-700 px-5 py-3 text-sm font-bold text-white transition hover:bg-brand-800'>
                 Start safety intake →
               </Link>
-              <Link href='/start-here' className='rounded-full border border-brand-900/10 bg-white px-5 py-3 text-sm font-bold text-ink transition hover:bg-brand-50'>
+              <Link href='/guides/' className='rounded-full border border-brand-900/10 bg-white px-5 py-3 text-sm font-bold text-ink transition hover:bg-brand-50'>
                 Intake Guidelines
               </Link>
             </div>

--- a/components/seo/AuthorityJsonLd.tsx
+++ b/components/seo/AuthorityJsonLd.tsx
@@ -1,6 +1,8 @@
 import { buildSchemaGraph } from '@/lib/schema-graph'
 import { SITE_URL } from '@/lib/seo'
 
+type FaqItem = { question: string; answer: string }
+
 type AuthorityJsonLdProps = {
   title: string
   description: string
@@ -10,6 +12,7 @@ type AuthorityJsonLdProps = {
     name: string
     url: string
   }>
+  faqItems?: FaqItem[]
 }
 
 export default function AuthorityJsonLd({
@@ -18,11 +21,13 @@ export default function AuthorityJsonLd({
   url,
   type = 'CollectionPage',
   breadcrumbs = [],
+  faqItems,
 }: AuthorityJsonLdProps) {
   const normalizedUrl = url.replace('https://thehippiescientist.net', SITE_URL)
   const canonical = normalizedUrl.endsWith('/') ? normalizedUrl : `${normalizedUrl}/`
   const webpageId = `${canonical}#webpage`
   const breadcrumbId = `${canonical}#breadcrumb`
+  const faqId = `${canonical}#faq`
 
   const webpage = {
     '@type': type === 'MedicalWebPage' ? ['MedicalWebPage', 'WebPage'] : type,
@@ -33,6 +38,7 @@ export default function AuthorityJsonLd({
     url: canonical,
     isPartOf: { '@type': 'WebSite', name: 'The Hippie Scientist', url: SITE_URL },
     ...(breadcrumbs.length ? { breadcrumb: { '@id': breadcrumbId } } : {}),
+    ...(faqItems?.length ? { hasPart: { '@id': faqId } } : {}),
   }
 
   const breadcrumb = breadcrumbs.length
@@ -48,13 +54,28 @@ export default function AuthorityJsonLd({
       }
     : null
 
-  const graph = buildSchemaGraph([webpage, breadcrumb])
+  const faq =
+    faqItems && faqItems.length > 0
+      ? {
+          '@type': 'FAQPage',
+          '@id': faqId,
+          url: canonical,
+          isPartOf: { '@id': webpageId },
+          mainEntity: faqItems.map((item) => ({
+            '@type': 'Question',
+            name: item.question,
+            acceptedAnswer: { '@type': 'Answer', text: item.answer },
+          })),
+        }
+      : null
+
+  const graph = buildSchemaGraph([webpage, breadcrumb, faq])
 
   return (
     <script
       type="application/ld+json"
       dangerouslySetInnerHTML={{
-        __html: JSON.stringify(graph),
+        __html: JSON.stringify(graph).replace(/</g, '\\u003c'),
       }}
     />
   )

--- a/lib/ecosystem-context.ts
+++ b/lib/ecosystem-context.ts
@@ -77,7 +77,7 @@ export const topicClusters: TopicCluster[] = [
   {
     slug: 'neurobiology',
     label: 'Neurobiology',
-    href: '/pathways/dopamine',
+    href: '/education/dopamine',
     description: 'Neurotransmitter systems, mood-adjacent signals, cognition, calm, and arousal regulation.',
     systems: ['Dopamine', 'GABA', 'Arousal'],
     keywords: ['neuro', 'dopamine', 'gaba', 'serotonin', 'brain', 'mood'],

--- a/lib/runtime/discovery-supernodes.ts
+++ b/lib/runtime/discovery-supernodes.ts
@@ -49,17 +49,17 @@ export const DISCOVERY_SUPERNODES: DiscoverySupernode[] = [
     category: 'Adaptogen Comparisons',
   },
   {
-    href: '/protocols/burnout-recovery',
-    title: 'Burnout Recovery',
+    href: '/goals/stress',
+    title: 'Stress & Burnout Recovery',
     description:
-      'Recovery-oriented protocol ecosystem focused on stress overload, fatigue systems, and nervous-system restoration.',
-    category: 'Recovery Protocols',
+      'Goal-oriented stress support exploring fatigue systems, nervous-system restoration, and recovery-aware supplementation.',
+    category: 'Recovery Support',
   },
   {
-    href: '/protocols/non-stimulant-focus',
-    title: 'Non-Stimulant Focus',
+    href: '/goals/focus',
+    title: 'Calm Focus Support',
     description:
-      'Calm-focus protocol systems emphasizing attentional continuity and sustainable cognition.',
-    category: 'Focus Systems',
+      'Goal-oriented focus support emphasizing attentional continuity, sustainable cognition, and non-stimulant strategies.',
+    category: 'Focus Support',
   },
 ]

--- a/lib/semantic/buildProtocolRecommendations.ts
+++ b/lib/semantic/buildProtocolRecommendations.ts
@@ -1,6 +1,13 @@
 import { dedupeEditorialItems, isRenderableText, shouldRenderCard } from '@/lib/editorial-rendering'
 type RuntimeRecord = Record<string, any>
 
+type ProtocolItem = {
+  href: string
+  title: string
+  summary: string
+  tags: string[]
+}
+
 function asList(value: unknown): string[] {
   if (Array.isArray(value)) {
     return dedupeEditorialItems(value)
@@ -25,16 +32,65 @@ function buildTags(record: RuntimeRecord) {
   ])
 }
 
+// Maps tag keywords to valid /goals/:slug routes. Only tags that resolve to a
+// known goal slug produce a card; all others are silently dropped so we never
+// render a dead link.
+const TAG_TO_GOAL: Record<string, string> = {
+  sleep: 'sleep',
+  insomnia: 'sleep',
+  'sleep quality': 'sleep',
+  stress: 'stress',
+  anxiety: 'anxiety',
+  cortisol: 'stress',
+  burnout: 'stress',
+  'stress resilience': 'stress',
+  focus: 'focus',
+  cognition: 'cognition',
+  'cognitive function': 'cognition',
+  attention: 'focus',
+  memory: 'cognition',
+  energy: 'energy',
+  fatigue: 'energy',
+  inflammation: 'inflammation',
+  'anti-inflammatory': 'inflammation',
+  pain: 'pain',
+  longevity: 'longevity',
+  'gut health': 'gut-health',
+  digestion: 'gut-health',
+  'joint support': 'joint-support',
+  recovery: 'recovery',
+  testosterone: 'testosterone-support',
+  'blood pressure': 'blood-pressure',
+  'fat loss': 'fat-loss',
+  weight: 'fat-loss',
+}
+
+function tagToGoalSlug(tag: string): string | null {
+  const normalised = tag.trim().toLowerCase()
+  return TAG_TO_GOAL[normalised] || null
+}
+
 export function buildProtocolRecommendations(record: RuntimeRecord) {
   const tags = buildTags(record)
+  const seen = new Set<string>()
 
-  return tags.slice(0, 6).filter(isRenderableText).map((tag) => ({
-    href: `/protocols/${tag
-      .toLowerCase()
-      .replace(/\s+/g, '-')}`,
-    title: `${tag} Protocol`,
-    summary:
-      'Evidence-informed protocol exploration generated from semantic ecosystem overlap and pathway continuity.',
-    tags: [tag],
-  })).filter((item) => shouldRenderCard(item.title, item.summary))
+  const items = tags
+    .filter(isRenderableText)
+    .reduce<ProtocolItem[]>((acc, tag: string) => {
+      const goalSlug = tagToGoalSlug(tag)
+      if (!goalSlug || seen.has(goalSlug)) return acc
+      seen.add(goalSlug)
+      acc.push({
+        href: `/goals/${goalSlug}`,
+        title: `${tag.charAt(0).toUpperCase() + tag.slice(1)} Goal Guide`,
+        summary:
+          'Evidence-informed goal exploration generated from semantic ecosystem overlap and pathway continuity.',
+        tags: [tag],
+      })
+      return acc
+    }, [])
+
+  return items
+    .filter((item: ProtocolItem) => shouldRenderCard(item.title, item.summary))
+    .slice(0, 4)
 }

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -372,6 +372,7 @@ export function herbJsonLd(herb: HerbJsonLdArgs) {
     '@context': 'https://schema.org',
     '@type': ['MedicalWebPage', 'WebPage'],
     name: `${herb.name} Herb Guide`,
+    headline: `${herb.name} Herb Guide`,
     description:
       herb.description || `${herb.name} herb profile — effects, safety, and pharmacology.`,
     url,
@@ -460,6 +461,7 @@ export function compoundJsonLd(compound: CompoundJsonLdArgs) {
     '@context': 'https://schema.org',
     '@type': ['MedicalWebPage', 'WebPage'],
     name: `${compound.name} Compound Guide`,
+    headline: `${compound.name} Compound Guide`,
     description:
       compound.description || `${compound.name} pharmacology, effects, and safety profile.`,
     url,


### PR DESCRIPTION
Route SEO (validate:route-seo: 53 warnings → 0):
- Fix all /pathways/* hrefs → /education/* (serotonin, dopamine, gaba,
  glutamate, cholinergic-system) across 17 education/psychoactive pages
  and lib/ecosystem-context.ts. These content pages already existed at
  /education/; the links just pointed to the wrong prefix.
- Fix all /protocols/* hrefs → /goals/* (non-stimulant-focus → /goals/focus,
  burnout-recovery/stress-regulation/recovery-oriented-productivity →
  /goals/stress) across 15 education pages and discovery-supernodes.ts.
  No /protocols/* routes exist; /goals/* are the correct destinations.
- Fix /start-here/quiz → /goals/ and /start-here → /guides/ in homepage.
- Refactor buildProtocolRecommendations.ts to map tag keywords to valid
  /goals/:slug routes instead of generating dead /protocols/* links.

Structured data:
- Add `headline` property to herbJsonLd() and compoundJsonLd() in
  src/lib/seo.ts. Google uses `headline` for rich results display; these
  nodes already had `name` but omitted the more specific `headline` field.
- Extend AuthorityJsonLd component to accept optional `faqItems` prop.
  When provided, a FAQPage node is added to the schema @graph with a
  hasPart link from the parent WebPage. Also adds XSS-safe escaping
  (\\u003c) which was missing from the inline script output.
- Wire FAQPage JSON-LD into 7 education pages that had FAQ content
  rendered as HTML but no structured data:
  what-is-a-nootropic, how-learning-affects-neuroplasticity,
  how-memory-formation-works, why-fatigue-is-biologically-complex,
  why-studies-conflict, why-set-and-setting-matter,
  understanding-altered-states.

https://claude.ai/code/session_01B1NYzLcU3jVTmL4YTEAQSp