### PR TITLE
feat(guides): publish Rhodiola hub + kava/elderberry/passionflower rich guides

### DIFF
--- a/app/guides/[slug]/page.tsx
+++ b/app/guides/[slug]/page.tsx
@@ -9,16 +9,14 @@ interface Props {
   params: Promise<{ slug: string }>;
 }
 
+// NOTE: kava, elderberry, passionflower, and the rhodiola hub (complete-guide,
+// extract-vs-powder, energy, sleep-stack) were migrated to dedicated rich component
+// pages under app/guides/<slug>/page.tsx (Phase 2). They are removed here to avoid
+// static-export route collisions. ashwagandha and lions-mane remain on this legacy
+// renderer until they are upgraded to the dedicated pattern.
 const GUIDE_SLUGS = [
   "ashwagandha",
-  "kava",
-  "elderberry",
-  "passionflower",
   "lions-mane",
-  "rhodiola-complete-guide",
-  "rhodiola-extract-vs-powder",
-  "rhodiola-energy",
-  "rhodiola-sleep-stack",
 ];
 
 const SITE_URL = "https://thehippiescientist.net";

--- a/app/guides/elderberry/page.tsx
+++ b/app/guides/elderberry/page.tsx
@@ -1,0 +1,245 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { buildPageMetadata } from '@/lib/seo'
+import StructuredData from '@/components/StructuredData'
+import FAQAccordion from '@/components/FAQAccordion'
+import EvidenceSummaryBox from '@/components/EvidenceSummaryBox'
+import DosageBox from '@/components/DosageBox'
+import SafetyBox from '@/components/SafetyBox'
+import MechanismBox from '@/components/MechanismBox'
+import AffiliateProductBox from '@/components/AffiliateProductBox'
+import { revenueProductSets } from '@/config/revenue-products'
+
+const SLUG = 'elderberry'
+const PAGE_URL = 'https://thehippiescientist.net/guides/elderberry'
+const TITLE = 'Elderberry for Colds and Flu: Clinical Evidence and Practical Guidance'
+const DESCRIPTION =
+  'Evidence-based review of elderberry (Sambucus nigra) for upper respiratory infections: meta-analyses, mechanisms, the cyanogenic-glycoside safety issue, quality, and dosing.'
+const DATE_PUBLISHED = '2024-06-09'
+const DATE_MODIFIED = '2026-06-14'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: TITLE,
+  description: DESCRIPTION,
+  path: `/guides/${SLUG}`,
+  openGraphType: 'article',
+})
+
+const FAQS = [
+  {
+    question: 'Does elderberry actually shorten colds and flu?',
+    answer:
+      'Moderate evidence suggests elderberry can modestly reduce the duration and severity of upper respiratory symptoms when started at symptom onset. A 2019 meta-analysis (Hawkins et al.) found a significant reduction versus placebo, with effects more pronounced for influenza than the common cold. It is supportive, not a cure.',
+  },
+  {
+    question: 'Can elderberry prevent getting sick?',
+    answer:
+      'Evidence for prevention is weak and limited to very few trials. Most of the benefit shown in the literature is for treatment started early in an illness, not for stopping infections from occurring. Do not rely on it in place of vaccination.',
+  },
+  {
+    question: 'Why are raw elderberries dangerous?',
+    answer:
+      'Raw or unripe elderberries — along with the leaves, stems, and bark — contain cyanogenic glycosides that can release cyanide and cause nausea, vomiting, and more serious toxicity. Only properly cooked or processed commercial products (syrups, standardized extracts, lozenges) should be used; avoid homemade preparations from fresh plant material.',
+  },
+  {
+    question: 'When should I start taking it and for how long?',
+    answer:
+      'Begin at the first sign of symptoms — most clinical studies showing benefit started treatment early. It is typically used short-term (about 5–7 days or until symptoms resolve). Higher-than-recommended doses have not been shown to help more and may increase side-effect risk.',
+  },
+  {
+    question: 'Who should be cautious with elderberry?',
+    answer:
+      'People with autoimmune conditions should use caution, since elderberry may stimulate immune activity. It is generally best avoided in pregnancy and breastfeeding due to insufficient safety data, and children should only use products specifically formulated and dosed for pediatric use. Check with a pharmacist if you take immune-modulating medications.',
+  },
+]
+
+const DOSAGE_ROWS = [
+  { form: 'Standardized syrup (e.g., Sambucol-type)', range: 'Per label, at symptom onset', notes: 'Most clinically studied format; begin early in illness' },
+  { form: 'Lozenges', range: 'Per label', notes: 'Used in some influenza trials' },
+  { form: 'Capsules / extract', range: 'Per label', notes: 'Look for stated anthocyanin standardization' },
+  { form: 'Duration of use', range: '~5–7 days', notes: 'Short-term during acute illness; limited data on long-term daily use' },
+]
+
+const SAFETY_NOTES = [
+  {
+    severity: 'warning' as const,
+    text: 'Raw or unripe elderberries and the leaves, stems, and bark contain cyanogenic glycosides that can release cyanide. Use only properly cooked or processed commercial products — never homemade preparations from fresh plant material.',
+  },
+  {
+    severity: 'caution' as const,
+    text: 'Because elderberry may stimulate immune activity, people with autoimmune conditions should consult a healthcare provider before use.',
+  },
+  {
+    severity: 'caution' as const,
+    text: 'Insufficient safety data in pregnancy and breastfeeding — generally best avoided unless advised by a provider. Children should only use products specifically formulated for pediatric use.',
+  },
+  {
+    severity: 'info' as const,
+    text: 'Mild gastrointestinal upset (nausea, diarrhea) is occasionally reported. Elderberry should not replace proven medical care, including antiviral medication when indicated or annual influenza vaccination.',
+  },
+]
+
+const MECHANISM_POINTS = [
+  {
+    label: 'Anthocyanins',
+    description:
+      'High levels of anthocyanins (notably cyanidin-3-sambubioside and cyanidin-3-glucoside) provide antioxidant activity and have shown antiviral effects against influenza viruses in vitro.',
+  },
+  {
+    label: 'Possible Viral Entry Inhibition',
+    description:
+      'Laboratory studies suggest elderberry flavonoids may inhibit viral entry into host cells or reduce viral replication, though human mechanistic data remain limited.',
+  },
+  {
+    label: 'Immune Modulation',
+    description:
+      'Extracts may influence cytokine production and temper excessive inflammation, so clinical benefit likely reflects mild antiviral plus immune-modulating effects rather than direct pathogen eradication.',
+  },
+]
+
+export default function ElderberryGuidePage() {
+  const elderberryProducts = revenueProductSets['elderberry']
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-8 px-4 py-8 sm:px-6 sm:py-10 lg:px-8">
+      <StructuredData
+        pageUrl={PAGE_URL}
+        headline={TITLE}
+        description={DESCRIPTION}
+        datePublished={DATE_PUBLISHED}
+        dateModified={DATE_MODIFIED}
+        faqs={FAQS}
+        breadcrumbs={[
+          { label: 'Home', href: '/' },
+          { label: 'Guides', href: '/guides' },
+          { label: 'Elderberry', href: `/guides/${SLUG}` },
+        ]}
+      />
+
+      {/* Hero */}
+      <section className="rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-10">
+        <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">
+          Evidence Guide
+        </p>
+        <h1 className="mt-3 text-3xl font-black leading-tight text-ink sm:text-5xl">
+          Elderberry (<em>Sambucus nigra</em>)
+        </h1>
+        <p className="mt-1 text-base font-medium text-brand-700">
+          Clinical Evidence for Colds and Flu, Plus the Safety You Need to Know
+        </p>
+        <p className="mt-4 max-w-3xl text-sm leading-7 text-muted sm:text-base">
+          Meta-analyses of randomized trials suggest elderberry can reduce the duration and severity of upper
+          respiratory symptoms — most consistently when supplementation begins at symptom onset. It is generally
+          well tolerated when properly prepared, but raw or unripe berries and other plant parts can be toxic.
+          This is not medical advice.
+        </p>
+      </section>
+
+      {/* Evidence */}
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">What the Research Shows</h2>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <EvidenceSummaryBox
+            level="moderate"
+            outcome="Duration & severity of URI symptoms"
+            takeaway="Hawkins et al. (2019), a meta-analysis of RCTs, found elderberry significantly reduced duration and severity of upper respiratory symptoms versus placebo — more pronounced for influenza than the common cold."
+            citationCount={3}
+          />
+          <EvidenceSummaryBox
+            level="moderate"
+            outcome="Influenza-type symptoms"
+            takeaway="Harnett et al. (2020) concluded mono-herbal elderberry may reduce influenza-type symptoms (fever, headache, congestion), with overall evidence quality rated moderate."
+            citationCount={1}
+          />
+          <EvidenceSummaryBox
+            level="moderate"
+            outcome="Treatment (symptom onset)"
+            takeaway="Wieland et al. (2021) identified several trials showing reduced symptom duration when treatment began early in the illness course."
+            citationCount={1}
+          />
+          <EvidenceSummaryBox
+            level="limited"
+            outcome="Prevention of infection"
+            takeaway="Evidence for preventing colds or flu is weak and limited to one trial. Elderberry should not be relied on as a preventive and is no substitute for vaccination."
+            citationCount={1}
+          />
+        </div>
+      </section>
+
+      {/* Mechanism */}
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">How It Works</h2>
+        <MechanismBox
+          summary="Elderberry's proposed benefits are attributed to its high anthocyanin and flavonoid content, which show antioxidant and immunomodulatory properties in laboratory studies. Human mechanistic data remain limited, and most clinical benefit is thought to come from mild antiviral plus immune-modulating effects."
+          points={MECHANISM_POINTS}
+        />
+      </section>
+
+      {/* Dosage */}
+      <section className="space-y-4" id="dosage">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Dosage &amp; Forms</h2>
+        <DosageBox
+          rows={DOSAGE_ROWS}
+          disclaimer="Follow product label instructions and begin at the first sign of symptoms. Higher doses are not proven more effective. General guidance, not medical advice."
+        />
+      </section>
+
+      {/* Quality callout */}
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Quality Matters</h2>
+        <p className="text-sm leading-6 text-muted">
+          Elderberry is sold as a dietary supplement and is not subject to pre-market drug approval, so quality
+          varies widely. Look for clear sourcing and processing information, standardization of anthocyanin
+          content where stated, and third-party testing when available. Be aware that many products add other
+          ingredients (echinacea, zinc, vitamin C) that can affect results.
+        </p>
+      </section>
+
+      {/* Safety */}
+      <section className="space-y-4" id="safety">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Safety &amp; Precautions</h2>
+        <SafetyBox notes={SAFETY_NOTES} />
+      </section>
+
+      {/* Products */}
+      {elderberryProducts && (
+        <AffiliateProductBox
+          slug="elderberry"
+          products={elderberryProducts.products}
+          heading="Elderberry Product Picks"
+        />
+      )}
+
+      {/* FAQ */}
+      <FAQAccordion faqs={FAQS} heading="Common Questions About Elderberry" />
+
+      {/* Related */}
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold text-ink">Related Guides</h2>
+        <div className="grid gap-3 sm:grid-cols-3">
+          <Link href="/guides/turmeric-curcumin" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+            <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Guide</p>
+            <p className="mt-1 text-sm font-semibold text-ink">Turmeric &amp; Curcumin</p>
+            <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Anti-inflammatory evidence, bioavailability, and form comparison.</p>
+          </Link>
+          <Link href="/guides/passionflower" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+            <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Guide</p>
+            <p className="mt-1 text-sm font-semibold text-ink">Passionflower</p>
+            <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Evidence for anxiety and sleep, with safety and dosing context.</p>
+          </Link>
+          <Link href="/herbs" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+            <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Library</p>
+            <p className="mt-1 text-sm font-semibold text-ink">Herb Library</p>
+            <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Browse full herb profiles with mechanism maps and safety data.</p>
+          </Link>
+        </div>
+      </section>
+
+      {/* Bottom nav */}
+      <div className="flex flex-wrap gap-4 border-t border-brand-900/10 pt-6 text-sm">
+        <Link href="/guides" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">← All Guides</Link>
+        <Link href="/herbs" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">Herb Library →</Link>
+      </div>
+    </div>
+  )
+}

--- a/app/guides/kava/page.tsx
+++ b/app/guides/kava/page.tsx
@@ -1,0 +1,244 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { buildPageMetadata } from '@/lib/seo'
+import StructuredData from '@/components/StructuredData'
+import FAQAccordion from '@/components/FAQAccordion'
+import EvidenceSummaryBox from '@/components/EvidenceSummaryBox'
+import SafetyBox from '@/components/SafetyBox'
+import MechanismBox from '@/components/MechanismBox'
+
+// NOTE: This is intentionally a HARM-REDUCTION / educational guide, not a supplement
+// recommendation. The source content explicitly does not recommend or endorse kava use
+// and documents serious hepatotoxicity risk. Per the project's two-zone architecture,
+// NO AffiliateProductBox is added here even though a revenue-products set technically exists.
+
+const SLUG = 'kava'
+const PAGE_URL = 'https://thehippiescientist.net/guides/kava'
+const TITLE = 'Kava: Clinical Evidence for Anxiety, Hepatotoxicity Risk, and Harm Reduction'
+const DESCRIPTION =
+  'Evidence review of kava (Piper methysticum) for anxiety: kavalactones, GABA mechanism, the serious liver-injury risk, noble vs tudei cultivars, and harm-reduction guidance.'
+const DATE_PUBLISHED = '2024-06-09'
+const DATE_MODIFIED = '2026-06-14'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: TITLE,
+  description: DESCRIPTION,
+  path: `/guides/${SLUG}`,
+  openGraphType: 'article',
+})
+
+const FAQS = [
+  {
+    question: 'Does kava actually work for anxiety?',
+    answer:
+      'Moderate-quality evidence supports short-term anxiolytic effects in generalized anxiety disorder over 4–8 weeks, with effect sizes generally in the moderate range in positive trials. However, not all trials are positive, and results are more consistent with standardized extracts delivering roughly 120–280 mg kavalactones daily. Longer-term data are lacking.',
+  },
+  {
+    question: 'Why is kava considered dangerous?',
+    answer:
+      'Kava carries a well-documented risk of serious liver injury, ranging from mild enzyme elevations to severe hepatitis and acute liver failure requiring transplantation or resulting in death. The FDA issued a consumer advisory in 2002 and a 2020 scientific memorandum concluding kava is not safe as a recreational or relaxation beverage. This is why the substance is treated as harm-reduction content rather than a casual supplement.',
+  },
+  {
+    question: 'Are noble cultivars and water extracts safer?',
+    answer:
+      'The risk appears meaningfully lower with traditional water-based extracts of noble cultivars than with many commercial solvent (acetone/ethanol) extracts — but it is not eliminated. Tudei varieties contain higher levels of certain compounds and are generally avoided in traditional contexts. Cultivar and extraction method are among the most important variables for both efficacy and safety.',
+  },
+  {
+    question: 'What monitoring is recommended if someone uses kava anyway?',
+    answer:
+      'Anyone considering kava should do so only under medical supervision, with baseline liver function testing and periodic monitoring — especially with extended use. Discontinue immediately and seek medical attention at any sign of liver injury: jaundice, dark urine, pale stools, unusual fatigue, or abdominal pain.',
+  },
+  {
+    question: 'Who should absolutely avoid kava?',
+    answer:
+      'Kava should be avoided by anyone with a history of liver disease, regular alcohol consumers, pregnant or breastfeeding individuals, and those taking medications with significant hepatic metabolism or narrow therapeutic windows. Combining kava with other sedating substances increases the risk of excessive sedation.',
+  },
+]
+
+const SAFETY_NOTES = [
+  {
+    severity: 'warning' as const,
+    text: 'Kava has been associated with severe hepatotoxicity, including liver failure requiring transplantation or resulting in death. The FDA concluded (2020) that kava is not safe for use as a recreational or relaxation beverage. This article reviews the literature but does not recommend or endorse kava use.',
+  },
+  {
+    severity: 'warning' as const,
+    text: 'Avoid entirely if you have any history of liver disease, drink alcohol regularly, are pregnant or breastfeeding, or take medications with significant hepatic metabolism or narrow therapeutic indices.',
+  },
+  {
+    severity: 'caution' as const,
+    text: 'Kavalactones inhibit several cytochrome P450 enzymes (CYP2C9, CYP2C19, CYP3A4), creating potential for clinically relevant drug interactions. Combining kava with other sedatives increases sedation risk.',
+  },
+  {
+    severity: 'caution' as const,
+    text: 'If kava is used despite the risks, it should only be under medical supervision with baseline and periodic liver function testing. Stop immediately and seek care at any sign of liver injury (jaundice, dark urine, pale stools, fatigue, abdominal pain).',
+  },
+  {
+    severity: 'info' as const,
+    text: 'For most individuals, safer and better-studied alternatives exist for managing anxiety. Traditional ceremonial use of water-based noble kava has a very different risk profile from daily use of concentrated commercial extracts — the two should not be conflated.',
+  },
+]
+
+const MECHANISM_POINTS = [
+  {
+    label: 'GABA-A Modulation',
+    description:
+      'Kavalactones act primarily as positive allosteric modulators of GABA-A receptors, with affinity for subtypes associated with anxiolysis rather than heavy sedation.',
+  },
+  {
+    label: 'Additional Targets',
+    description:
+      'Proposed secondary mechanisms include inhibition of voltage-gated sodium channels, weak monoamine oxidase inhibition, and modulation of dopaminergic and noradrenergic signaling.',
+  },
+  {
+    label: 'Pharmacokinetics',
+    description:
+      'Kavalactones are absorbed relatively rapidly (peak 1–3 hours), metabolized by CYP enzymes, and eliminated via renal and fecal routes. Dividing the daily dose may produce more stable plasma levels.',
+  },
+]
+
+export default function KavaGuidePage() {
+  return (
+    <div className="mx-auto max-w-4xl space-y-8 px-4 py-8 sm:px-6 sm:py-10 lg:px-8">
+      <StructuredData
+        pageUrl={PAGE_URL}
+        headline={TITLE}
+        description={DESCRIPTION}
+        datePublished={DATE_PUBLISHED}
+        dateModified={DATE_MODIFIED}
+        faqs={FAQS}
+        breadcrumbs={[
+          { label: 'Home', href: '/' },
+          { label: 'Guides', href: '/guides' },
+          { label: 'Kava', href: `/guides/${SLUG}` },
+        ]}
+      />
+
+      {/* Hero */}
+      <section className="rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-10">
+        <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">
+          Harm-Reduction Guide
+        </p>
+        <h1 className="mt-3 text-3xl font-black leading-tight text-ink sm:text-5xl">
+          Kava (<em>Piper methysticum</em>)
+        </h1>
+        <p className="mt-1 text-base font-medium text-brand-700">
+          Clinical Evidence for Anxiety, Hepatotoxicity Risk &amp; Practical Harm Reduction
+        </p>
+        <p className="mt-4 max-w-3xl text-sm leading-7 text-muted sm:text-base">
+          Multiple randomized controlled trials suggest kava can produce moderate reductions in generalized
+          anxiety over 4–8 weeks. But kava also carries a well-established risk of serious liver injury. This is
+          an educational, harm-reduction review of the evidence — it is not medical advice and does not recommend
+          or endorse kava use.
+        </p>
+      </section>
+
+      {/* Strong disclaimer up front */}
+      <div className="rounded-2xl border border-red-200/60 bg-red-50/70 p-5 text-sm leading-6 text-red-950">
+        <p className="font-bold uppercase tracking-[0.12em] text-red-800">Important safety notice</p>
+        <p className="mt-2">
+          Kava has been linked to numerous reports of liver toxicity, ranging from mild enzyme elevations to
+          severe hepatitis, cirrhosis, and acute liver failure requiring transplantation or resulting in death.
+          Risk factors may include preparation method, cultivar, dose, duration, genetic susceptibility,
+          pre-existing liver conditions, and concurrent alcohol or medication use. Professional medical guidance
+          and monitoring are strongly recommended for anyone considering its use.
+        </p>
+      </div>
+
+      {/* Evidence */}
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Clinical Evidence</h2>
+        <p className="text-sm leading-6 text-muted">
+          Kava is one of the more extensively researched herbal options for anxiety, but the evidence is mixed
+          and must be weighed against a serious safety signal.
+        </p>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <EvidenceSummaryBox
+            level="moderate"
+            outcome="Generalized anxiety disorder (short-term)"
+            takeaway="The 2015 K-GAD RCT (75 participants) found a significant reduction in HAM-A scores versus placebo with a moderate effect size, strongest in those with higher baseline anxiety. Several other well-designed trials were null."
+            citationCount={7}
+          />
+          <EvidenceSummaryBox
+            level="moderate"
+            outcome="Pooled meta-analytic anxiety effect"
+            takeaway="Smith & Leiras (2018) found kava superior to placebo in 3 of 7 RCTs, with pooled responder rates favoring kava. Ooi et al. (2018) concluded a moderate anxiolytic effect, noting few high-quality trials."
+            citationCount={2}
+          />
+          <EvidenceSummaryBox
+            level="limited"
+            outcome="Sleep & secondary outcomes"
+            takeaway="Evidence for primary sleep benefit is weak and largely secondary to anxiety reduction. Some older trials reported improved sleep latency, but direct studies in primary insomnia are limited."
+            citationCount={2}
+          />
+          <EvidenceSummaryBox
+            level="limited"
+            outcome="Long-term efficacy & safety"
+            takeaway="Most positive data come from 4–8 week trials using 120–280 mg kavalactones daily. Longer-term efficacy and safety data are lacking, and the hepatotoxicity risk grows more uncertain with extended use."
+            citationCount={1}
+          />
+        </div>
+      </section>
+
+      {/* Mechanism */}
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Mechanisms &amp; Pharmacokinetics</h2>
+        <MechanismBox
+          summary="The six major kavalactones — kavain, dihydrokavain, methysticin, dihydromethysticin, yangonin, and desmethoxyyangonin — are concentrated in the root and lower stem and drive most of kava's pharmacology. Quality and preparation method are among the most important variables affecting both efficacy and safety."
+          points={MECHANISM_POINTS}
+        />
+      </section>
+
+      {/* Risk factors */}
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Factors That Influence Liver Risk</h2>
+        <ul className="space-y-2 text-sm leading-6 text-muted">
+          <li><strong className="text-ink">Preparation method:</strong> traditional water-based extracts of noble cultivars appear lower-risk than many commercial acetone/ethanol extracts.</li>
+          <li><strong className="text-ink">Cultivar type:</strong> noble varieties have a long history of traditional use; tudei varieties contain higher levels of certain compounds and are generally avoided.</li>
+          <li><strong className="text-ink">Dose &amp; duration:</strong> positive trials used 120–280 mg kavalactones daily for 4–8 weeks; higher doses and longer use have less safety data.</li>
+          <li><strong className="text-ink">Individual factors:</strong> pre-existing liver disease, CYP enzyme variation, alcohol use, and certain medications increase susceptibility.</li>
+          <li><strong className="text-ink">Product quality:</strong> adulteration, contamination, and poor standardization remain ongoing concerns in the commercial market.</li>
+        </ul>
+      </section>
+
+      {/* Safety */}
+      <section className="space-y-4" id="safety">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Safety &amp; Harm Reduction</h2>
+        <SafetyBox notes={SAFETY_NOTES} />
+      </section>
+
+      {/* FAQ */}
+      <FAQAccordion faqs={FAQS} heading="Common Questions About Kava" />
+
+      {/* Related — safer alternatives, no affiliate */}
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold text-ink">Better-Studied, Lower-Risk Alternatives</h2>
+        <p className="text-sm text-muted">
+          For most people managing anxiety, the options below have more favorable risk profiles than kava.
+        </p>
+        <div className="grid gap-3 sm:grid-cols-3">
+          <Link href="/guides/passionflower" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+            <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Guide</p>
+            <p className="mt-1 text-sm font-semibold text-ink">Passionflower</p>
+            <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Modest anxiety reduction with a more favorable safety profile.</p>
+          </Link>
+          <Link href="/guides/ashwagandha" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+            <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Guide</p>
+            <p className="mt-1 text-sm font-semibold text-ink">Ashwagandha</p>
+            <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Adaptogen with the strongest stress/anxiety evidence base.</p>
+          </Link>
+          <Link href="/guides/natural-anxiolytics-beyond-ashwagandha" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+            <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Guide</p>
+            <p className="mt-1 text-sm font-semibold text-ink">Natural Anxiolytics</p>
+            <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Evidence-ranked anxiolytic options beyond the usual picks.</p>
+          </Link>
+        </div>
+      </section>
+
+      {/* Bottom nav */}
+      <div className="flex flex-wrap gap-4 border-t border-brand-900/10 pt-6 text-sm">
+        <Link href="/guides" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">← All Guides</Link>
+        <Link href="/herbs" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">Herb Library →</Link>
+      </div>
+    </div>
+  )
+}

--- a/app/guides/page.tsx
+++ b/app/guides/page.tsx
@@ -75,6 +75,17 @@ const CONDITIONS = [
   },
 ]
 
+const SINGLE_HERB_GUIDES = [
+  { href: '/guides/rhodiola-complete-guide', title: 'Complete Rhodiola Guide', subtitle: 'Forms, benefits, dosing & evidence — pillar of the Rhodiola hub' },
+  { href: '/guides/rhodiola-energy', title: 'Rhodiola for Energy', subtitle: 'Sustained energy without the stimulant crash' },
+  { href: '/guides/rhodiola-extract-vs-powder', title: 'Rhodiola: Extract vs Powder', subtitle: 'Which form actually works — absorption, cost & evidence' },
+  { href: '/guides/rhodiola-sleep-stack', title: 'Rhodiola + Magnesium for Sleep', subtitle: 'The adaptogen stack for the "wired but tired" cycle' },
+  { href: '/guides/turmeric-curcumin', title: 'Turmeric & Curcumin', subtitle: 'Bioavailability, anti-inflammatory evidence & forms' },
+  { href: '/guides/elderberry', title: 'Elderberry for Colds & Flu', subtitle: 'Meta-analysis evidence, safety, and quality' },
+  { href: '/guides/passionflower', title: 'Passionflower', subtitle: 'Evidence for anxiety and sleep, with honest limits' },
+  { href: '/guides/kava', title: 'Kava (Harm Reduction)', subtitle: 'Anxiety evidence weighed against serious liver risk' },
+]
+
 const COMPARISONS = [
   { href: '/guides/magnesium-vs-melatonin', title: 'Magnesium vs Melatonin', subtitle: 'Relaxation support vs sleep-timing support' },
   { href: '/guides/sleep-herbs-vs-melatonin', title: 'Sleep Herbs vs Melatonin', subtitle: 'Herbals vs hormone for sleep onset' },
@@ -199,6 +210,35 @@ export default function GuidesPage() {
           </div>
         </section>
       ))}
+
+      {/* Single-herb evidence guides */}
+      <section className="space-y-4">
+        <div>
+          <p className="eyebrow-label">Single-herb evidence guides</p>
+          <h2 className="mt-1 text-2xl font-semibold tracking-tight text-ink">
+            Herb &amp; compound deep-dives
+          </h2>
+          <p className="mt-2 text-sm text-muted">
+            Long-form, evidence-graded profiles for individual herbs — mechanism, dosing, safety, and product
+            context. Includes the Rhodiola hub (pillar plus three focused angles).
+          </p>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {SINGLE_HERB_GUIDES.map((g) => (
+            <Link
+              key={g.href}
+              href={g.href}
+              className="rounded-2xl border border-brand-900/10 bg-white/90 p-5 shadow-sm transition hover:border-brand-700/20 hover:bg-white"
+            >
+              <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">
+                Guide
+              </p>
+              <h3 className="mt-2 text-base font-semibold tracking-tight text-ink">{g.title}</h3>
+              <p className="mt-1 text-xs text-muted">{g.subtitle}</p>
+            </Link>
+          ))}
+        </div>
+      </section>
 
       {/* Comparisons */}
       <section className="space-y-4">

--- a/app/guides/passionflower/page.tsx
+++ b/app/guides/passionflower/page.tsx
@@ -1,0 +1,234 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { buildPageMetadata } from '@/lib/seo'
+import StructuredData from '@/components/StructuredData'
+import FAQAccordion from '@/components/FAQAccordion'
+import EvidenceSummaryBox from '@/components/EvidenceSummaryBox'
+import DosageBox from '@/components/DosageBox'
+import SafetyBox from '@/components/SafetyBox'
+import MechanismBox from '@/components/MechanismBox'
+import AffiliateProductBox from '@/components/AffiliateProductBox'
+import { revenueProductSets } from '@/config/revenue-products'
+
+const SLUG = 'passionflower'
+const PAGE_URL = 'https://thehippiescientist.net/guides/passionflower'
+const TITLE = 'Passionflower for Anxiety and Sleep: Clinical Evidence and Guidance'
+const DESCRIPTION =
+  'Evidence-based review of passionflower (Passiflora incarnata) for anxiety and sleep: GABA mechanism, clinical trials, safety, drug interactions, and dosing.'
+const DATE_PUBLISHED = '2024-06-09'
+const DATE_MODIFIED = '2026-06-14'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: TITLE,
+  description: DESCRIPTION,
+  path: `/guides/${SLUG}`,
+  openGraphType: 'article',
+})
+
+const FAQS = [
+  {
+    question: 'Does passionflower help with anxiety?',
+    answer:
+      'Moderate evidence supports modest reductions in anxiety symptoms. A 2020 systematic review (Janda et al.) found most studies reported reduced anxiety, though overall quality was rated moderate due to methodological limitations. Effects are milder than pharmaceutical anxiolytics but with a better short-term side-effect profile, and results are more consistent with standardized extracts.',
+  },
+  {
+    question: 'Is passionflower effective for sleep?',
+    answer:
+      'The evidence for sleep is weaker and less consistent than for anxiety. Some studies show improvements in subjective sleep quality and time to fall asleep, but objective measures (polysomnography) often show little difference from placebo. It may help most when anxiety is contributing to poor sleep.',
+  },
+  {
+    question: 'How much passionflower should I take?',
+    answer:
+      'Clinical studies typically used roughly 0.5–2 grams of dried herb prepared as tea, or equivalent amounts in extract form — often around 200–500 mg of a standardized extract. Always follow the specific dosing on your product label, and because it can cause drowsiness, take it in the evening.',
+  },
+  {
+    question: 'Can I combine passionflower with other sedatives?',
+    answer:
+      'Not without medical supervision. Passionflower may increase the sedative effects of CNS depressants including benzodiazepines, opioids, alcohol, and certain antihistamines. Combining sedating herbs (valerian, hops, lemon balm) also raises the risk of excessive sedation, so start with lower doses.',
+  },
+  {
+    question: 'Who should avoid passionflower?',
+    answer:
+      'Avoid during pregnancy, as it may stimulate uterine contractions. There is insufficient data for breastfeeding, and limited data for children. Older adults may be more sensitive to sedation. Discontinue at least two weeks before scheduled surgery, since it can enhance anesthesia and sedatives.',
+  },
+]
+
+const DOSAGE_ROWS = [
+  { form: 'Dried herb (tea)', range: '~0.5–2 g', notes: 'Brewed as tea; traditional preparation' },
+  { form: 'Standardized extract', range: '~200–500 mg', notes: 'More consistent than non-standardized forms' },
+  { form: 'Tincture / liquid extract', range: 'Per label', notes: 'Allows flexible dose titration' },
+  { form: 'Timing & duration', range: 'Evening; short-term', notes: 'Best for occasional use; most trials ran a few days to 8 weeks' },
+]
+
+const SAFETY_NOTES = [
+  {
+    severity: 'warning' as const,
+    text: 'Avoid during pregnancy — passionflower may stimulate uterine contractions. Discontinue at least two weeks before scheduled surgery, as it can enhance the effects of anesthesia and sedatives.',
+  },
+  {
+    severity: 'caution' as const,
+    text: 'Passionflower can increase the sedative effects of CNS depressants (benzodiazepines, opioids, alcohol, some antihistamines) and may interact with drugs metabolized by CYP3A4 and CYP2C9. Consult a provider or pharmacist if you take prescription medication.',
+  },
+  {
+    severity: 'caution' as const,
+    text: 'Because it commonly causes drowsiness and dizziness, do not drive or operate machinery until you know how it affects you. Older adults may be more sensitive and often need lower doses.',
+  },
+  {
+    severity: 'info' as const,
+    text: 'Generally well tolerated at typical doses for short-term use. It is best used as a short-term supportive tool; if anxiety or sleep problems persist beyond a few weeks, consult a healthcare provider.',
+  },
+]
+
+const MECHANISM_POINTS = [
+  {
+    label: 'GABA Modulation',
+    description:
+      'Passionflower is thought to act primarily through the GABA system. Flavonoids such as chrysin have shown benzodiazepine-receptor binding in animal studies, though with far weaker affinity than pharmaceutical benzodiazepines.',
+  },
+  {
+    label: 'Key Constituents',
+    description:
+      'The aerial parts contain flavonoids including vitexin, isovitexin, and chrysin, plus alkaloids and other phenolics believed to contribute to its calming effects.',
+  },
+  {
+    label: 'Mild, Not Sedating',
+    description:
+      'Most clinical benefit is attributed to mild GABAergic activity and general calming rather than strong sedation — consistent with its modest effect sizes.',
+  },
+]
+
+export default function PassionflowerGuidePage() {
+  const passionflowerProducts = revenueProductSets['passionflower']
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-8 px-4 py-8 sm:px-6 sm:py-10 lg:px-8">
+      <StructuredData
+        pageUrl={PAGE_URL}
+        headline={TITLE}
+        description={DESCRIPTION}
+        datePublished={DATE_PUBLISHED}
+        dateModified={DATE_MODIFIED}
+        faqs={FAQS}
+        breadcrumbs={[
+          { label: 'Home', href: '/' },
+          { label: 'Guides', href: '/guides' },
+          { label: 'Passionflower', href: `/guides/${SLUG}` },
+        ]}
+      />
+
+      {/* Hero */}
+      <section className="rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-10">
+        <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">
+          Evidence Guide
+        </p>
+        <h1 className="mt-3 text-3xl font-black leading-tight text-ink sm:text-5xl">
+          Passionflower (<em>Passiflora incarnata</em>)
+        </h1>
+        <p className="mt-1 text-base font-medium text-brand-700">
+          Clinical Evidence for Anxiety and Sleep, With Honest Limits
+        </p>
+        <p className="mt-4 max-w-3xl text-sm leading-7 text-muted sm:text-base">
+          Several clinical studies and systematic reviews suggest passionflower can provide modest reductions in
+          anxiety symptoms. The evidence for improving sleep is weaker and less consistent. The plant is generally
+          well tolerated at typical doses, with drowsiness and dizziness the most common side effects. This is not
+          medical advice — use caution when driving or operating machinery.
+        </p>
+      </section>
+
+      {/* Evidence */}
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">What the Research Shows</h2>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <EvidenceSummaryBox
+            level="moderate"
+            outcome="Anxiety symptoms"
+            takeaway="Janda et al. (2020) found most studies reported reduced anxiety with passionflower preparations; quality was rated moderate. Effects are milder than pharmaceutical anxiolytics but with a better short-term tolerability profile."
+            citationCount={4}
+          />
+          <EvidenceSummaryBox
+            level="moderate"
+            outcome="Stress & sleep (recent RCT)"
+            takeaway="A 2024 randomized, double-blind, placebo-controlled trial (Harit et al.) found passionflower extract improved stress and sleep quality in adults with stress-related complaints — one of the better-designed recent studies."
+            citationCount={2}
+          />
+          <EvidenceSummaryBox
+            level="limited"
+            outcome="Objective sleep architecture"
+            takeaway="Some trials show improved subjective sleep and reduced sleep latency, but objective measures (polysomnography) often show minimal difference from placebo. Benefit is clearest when anxiety drives poor sleep."
+            citationCount={2}
+          />
+          <EvidenceSummaryBox
+            level="limited"
+            outcome="Older / lower-quality trials"
+            takeaway="Miroddi et al. (2013) noted many human studies suffer from small samples, poor reporting, and inconsistent standardization — directionally positive but limited in power."
+            citationCount={1}
+          />
+        </div>
+      </section>
+
+      {/* Mechanism */}
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">How It Works</h2>
+        <MechanismBox
+          summary="Passionflower is thought to exert anxiolytic effects primarily through modulation of the GABA system, supported by mild anti-inflammatory and antioxidant actions and possible effects on serotonin and dopamine. Human mechanistic data remain limited."
+          points={MECHANISM_POINTS}
+        />
+      </section>
+
+      {/* Dosage */}
+      <section className="space-y-4" id="dosage">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Dosage &amp; Forms</h2>
+        <DosageBox
+          rows={DOSAGE_ROWS}
+          disclaimer="Take in the evening because of drowsiness, and follow your product label. Standardized extracts offer more consistency than teas or non-standardized tinctures. General guidance, not medical advice."
+        />
+      </section>
+
+      {/* Safety */}
+      <section className="space-y-4" id="safety">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Safety &amp; Precautions</h2>
+        <SafetyBox notes={SAFETY_NOTES} />
+      </section>
+
+      {/* Products */}
+      {passionflowerProducts && (
+        <AffiliateProductBox
+          slug="passionflower"
+          products={passionflowerProducts.products}
+          heading="Passionflower Product Picks"
+        />
+      )}
+
+      {/* FAQ */}
+      <FAQAccordion faqs={FAQS} heading="Common Questions About Passionflower" />
+
+      {/* Related */}
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold text-ink">Related Guides</h2>
+        <div className="grid gap-3 sm:grid-cols-3">
+          <Link href="/guides/magnesium-for-sleep" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+            <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Guide</p>
+            <p className="mt-1 text-sm font-semibold text-ink">Magnesium for Sleep</p>
+            <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Forms, dosage, and evidence for magnesium as a sleep and anxiety support.</p>
+          </Link>
+          <Link href="/guides/natural-anxiolytics-beyond-ashwagandha" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+            <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Guide</p>
+            <p className="mt-1 text-sm font-semibold text-ink">Natural Anxiolytics</p>
+            <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Evidence-ranked anxiolytic options beyond the usual picks.</p>
+          </Link>
+          <Link href="/articles/best-herbs-for-sleep" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+            <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Pillar</p>
+            <p className="mt-1 text-sm font-semibold text-ink">Best Herbs for Sleep</p>
+            <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Evidence-ranked guide to the most-studied natural sleep options.</p>
+          </Link>
+        </div>
+      </section>
+
+      {/* Bottom nav */}
+      <div className="flex flex-wrap gap-4 border-t border-brand-900/10 pt-6 text-sm">
+        <Link href="/guides" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">← All Guides</Link>
+        <Link href="/herbs" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">Herb Library →</Link>
+      </div>
+    </div>
+  )
+}

--- a/app/guides/rhodiola-complete-guide/page.tsx
+++ b/app/guides/rhodiola-complete-guide/page.tsx
@@ -1,0 +1,284 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { buildPageMetadata } from '@/lib/seo'
+import StructuredData from '@/components/StructuredData'
+import FAQAccordion from '@/components/FAQAccordion'
+import EvidenceSummaryBox from '@/components/EvidenceSummaryBox'
+import DosageBox from '@/components/DosageBox'
+import SafetyBox from '@/components/SafetyBox'
+import MechanismBox from '@/components/MechanismBox'
+import ComparisonTable from '@/components/ComparisonTable'
+import AffiliateProductBox from '@/components/AffiliateProductBox'
+import { revenueProductSets } from '@/config/revenue-products'
+
+const SLUG = 'rhodiola-complete-guide'
+const PAGE_URL = 'https://thehippiescientist.net/guides/rhodiola-complete-guide'
+const TITLE = 'Rhodiola: Complete Science-Backed Guide to Forms, Benefits & Dosing'
+const DESCRIPTION =
+  'Evidence-based guide to Rhodiola rosea: forms compared, what the research shows for fatigue and stress, correct dosing, safety, and how to choose a product.'
+const DATE_PUBLISHED = '2024-06-09'
+const DATE_MODIFIED = '2026-06-14'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: TITLE,
+  description: DESCRIPTION,
+  path: `/guides/${SLUG}`,
+  openGraphType: 'article',
+})
+
+const FAQS = [
+  {
+    question: 'Which form of rhodiola should I start with?',
+    answer:
+      'A standardized extract capsule (SHR-5) is the best starting point — it is the most studied form, the most convenient, and has consistent potency. Switch to root powder only if cost is a barrier, understanding that powder has minimal direct clinical evidence and variable potency.',
+  },
+  {
+    question: 'When should I take rhodiola?',
+    answer:
+      'Morning or early afternoon — not before bed. Rhodiola has mild stimulating properties and can interfere with sleep in sensitive individuals when taken late in the day.',
+  },
+  {
+    question: 'How long until I notice effects?',
+    answer:
+      'Typically 2–3 weeks of consistent use. Rhodiola is not an acute remedy like caffeine; benefits accumulate gradually. A realistic outcome is a 20–30% reduction in fatigue symptoms — meaningful but not a dramatic transformation.',
+  },
+  {
+    question: 'Can I take rhodiola long term?',
+    answer:
+      'Yes. No tolerance is consistently documented in the literature, and studies have used doses up to 1,500 mg/day without serious toxicity. No long-term harm has been established in the available research.',
+  },
+  {
+    question: 'Can I take rhodiola with antidepressants?',
+    answer:
+      'Probably safe, but ask your doctor first. There is a theoretical (not documented) serotonin-related interaction with SSRIs/SNRIs. People with bipolar disorder, active psychosis, or severe anxiety disorders should also consult a clinician, as rhodiola may worsen these conditions in some cases.',
+  },
+  {
+    question: 'Will I build tolerance?',
+    answer:
+      'Tolerance is not documented in the available research. Most people can use rhodiola continuously, though it is sensible to periodically reassess whether it is still providing benefit.',
+  },
+]
+
+const QUICK_HEADERS = ['Goal', 'Best Form', 'Dose', 'Timeline']
+const QUICK_ROWS = [
+  { attribute: 'Mental fatigue / burnout', values: ['SHR-5 extract', '300–400 mg/day', '2–3 weeks'] },
+  { attribute: 'Budget / whole herb', values: ['Root powder', '1–2 g/day', '2–3 weeks'] },
+  { attribute: 'Fast absorption needed', values: ['Tincture', '1–2 mL/day', '2–3 weeks'] },
+  { attribute: 'General use', values: ['Standardized capsule', '300 mg/day', '2–3 weeks'] },
+]
+
+const DOSAGE_ROWS = [
+  { form: 'Starting dose', range: '200 mg/day', notes: 'Standardized extract, morning' },
+  { form: 'Standard maintenance', range: '300–400 mg/day', notes: 'Morning; most common effective range' },
+  { form: 'High-stress periods', range: 'up to 600 mg/day', notes: 'Morning / early afternoon' },
+  { form: 'Studied upper range', range: 'up to 1,500 mg/day', notes: 'No serious toxicity reported; no established upper limit' },
+]
+
+const SAFETY_NOTES = [
+  {
+    severity: 'info' as const,
+    text: 'Rhodiola has an excellent safety record in clinical trials. Side effects are rare (<3%) and mild — occasional headache, dry mouth, or agitation in sensitive individuals.',
+  },
+  {
+    severity: 'caution' as const,
+    text: 'Theoretical serotonin-related interaction with SSRIs/SNRIs (no documented cases). Additive effects possible with stimulants — reduce caffeine if combining. Consult a clinician about anticoagulants, where interaction data is absent.',
+  },
+  {
+    severity: 'warning' as const,
+    text: 'Avoid if pregnant or nursing (insufficient safety data). Use caution with active psychosis (may worsen), bipolar disorder (theoretical mania risk), and severe anxiety disorder (may worsen in some).',
+  },
+]
+
+const MECHANISM_POINTS = [
+  {
+    label: 'HPA Axis Modulation',
+    description:
+      'Rhodiola appears to modulate the hypothalamic-pituitary-adrenal axis — the system governing cortisol release and stress response — acting like a thermostat for the stress system rather than a gas pedal.',
+  },
+  {
+    label: 'Rosavins & Salidroside',
+    description:
+      'The primary active markers are rosavins (1–3%) and salidroside (0.5–1%), alongside various flavonoids and organic acids. Standardization to these compounds is what distinguishes a verifiable product.',
+  },
+  {
+    label: 'Not Stimulation',
+    description:
+      'Unlike caffeine, which blocks adenosine receptors to mask fatigue, rhodiola appears to work on the underlying stress physiology — which is why effects are gradual rather than acute.',
+  },
+]
+
+export default function RhodiolaCompleteGuidePage() {
+  const rhodiolaProducts = revenueProductSets['rhodiola']
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-8 px-4 py-8 sm:px-6 sm:py-10 lg:px-8">
+      <StructuredData
+        pageUrl={PAGE_URL}
+        headline={TITLE}
+        description={DESCRIPTION}
+        datePublished={DATE_PUBLISHED}
+        dateModified={DATE_MODIFIED}
+        faqs={FAQS}
+        breadcrumbs={[
+          { label: 'Home', href: '/' },
+          { label: 'Guides', href: '/guides' },
+          { label: 'Complete Rhodiola Guide', href: `/guides/${SLUG}` },
+        ]}
+      />
+
+      {/* Hero */}
+      <section className="rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-10">
+        <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">
+          Pillar Guide · Rhodiola Hub
+        </p>
+        <h1 className="mt-3 text-3xl font-black leading-tight text-ink sm:text-5xl">
+          Rhodiola: The Complete Guide
+        </h1>
+        <p className="mt-1 text-base font-medium text-brand-700">
+          Forms, Benefits, Dosing &amp; What the Research Actually Shows
+        </p>
+        <p className="mt-4 max-w-3xl text-sm leading-7 text-muted sm:text-base">
+          72% of American adults report experiencing fatigue regularly, and most reach for stimulants. Rhodiola
+          offers a fundamentally different approach: as an adaptogen, it helps the body adapt to stress rather
+          than simply stimulating or sedating. This guide covers what rhodiola is, why form matters more than for
+          most herbs, what the evidence supports, and how to dose it correctly — no hype, no filler.
+        </p>
+        <div className="mt-6 flex flex-wrap gap-4 text-xs font-semibold uppercase tracking-[0.14em]">
+          <Link href="/herbs/rhodiola" className="text-brand-700 hover:text-brand-800 hover:underline">
+            Rhodiola Herb Profile →
+          </Link>
+          <Link href="/compounds/salidroside" className="text-brand-700 hover:text-brand-800 hover:underline">
+            Salidroside Compound →
+          </Link>
+        </div>
+      </section>
+
+      {/* Quick summary */}
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Quick Summary</h2>
+        <ComparisonTable headers={QUICK_HEADERS} rows={QUICK_ROWS} caption="Match the form and dose to your goal. All timelines assume consistent daily use." />
+      </section>
+
+      {/* Evidence */}
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">The Evidence by Outcome</h2>
+        <p className="text-sm leading-6 text-muted">
+          Evidence quality varies by outcome. The strongest support is for stress-related fatigue; benefits are
+          real but modest, and they accumulate over 2–3 weeks rather than acting acutely.
+        </p>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <EvidenceSummaryBox
+            level="strong"
+            outcome="Stress-related fatigue"
+            takeaway="3+ RCTs with consistent findings (Darbinyan 2000, Spasov 2000, Sharpley 2000). Significant reductions in fatigue and improved work/exam performance versus placebo."
+            citationCount={3}
+          />
+          <EvidenceSummaryBox
+            level="moderate"
+            outcome="Burnout symptoms"
+            takeaway="Olsson (2009): SHR-5 at 576 mg/day for 12 weeks improved fatigue, concentration, and burnout symptoms in stress-related exhaustion. Benefits accumulated gradually."
+            citationCount={2}
+          />
+          <EvidenceSummaryBox
+            level="moderate"
+            outcome="Anxiety in stressed populations"
+            takeaway="Kasper (2010) found reduced cortisol response to stress and improved self-reported anxiety. Best for chronic stress rather than as a replacement for anxiety-disorder treatment."
+            citationCount={2}
+          />
+          <EvidenceSummaryBox
+            level="limited"
+            outcome="Athletic performance"
+            takeaway="Mixed results: some studies show 3–5% endurance improvement, others none. Effect sizes are small and may reflect recovery rather than direct performance enhancement."
+            citationCount={2}
+          />
+        </div>
+      </section>
+
+      {/* What it is / mechanism */}
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">What Is Rhodiola &amp; How It Works</h2>
+        <p className="text-sm leading-6 text-muted">
+          Rhodiola rosea is a perennial plant native to Siberia and Scandinavia, used in traditional medicine for
+          over 1,300 years and studied extensively by Soviet researchers from the 1950s–1990s. It is classified as
+          an adaptogen — a substance believed to help the body adapt to stress.
+        </p>
+        <MechanismBox
+          summary="Rhodiola's effects are attributed to rosavins and salidroside acting on stress physiology rather than on alertness pathways. This is the key difference from stimulants and the reason its benefits are cumulative."
+          points={MECHANISM_POINTS}
+        />
+      </section>
+
+      {/* Forms summary + satellite links */}
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Forms of Rhodiola</h2>
+        <p className="text-sm leading-6 text-muted">
+          Form matters significantly for rhodiola — more than for many herbs. The <strong>SHR-5 standardized
+          extract</strong> (min 1% salidroside, 3% rosavins) is the form used in most clinical trials and the best
+          default. <strong>Root powder</strong> is cheaper but has variable potency and minimal direct research.
+          <strong> Tinctures</strong> absorb fastest (15–30 min) but often contain alcohol. <strong>Generic
+          standardized capsules</strong> are convenient but vary widely by brand.
+        </p>
+        <div className="rounded-xl border border-brand-900/10 bg-brand-50/40 px-4 py-3 text-sm text-muted">
+          <strong className="font-semibold text-ink">Go deeper: </strong>
+          the full extract-vs-powder breakdown — absorption, cost, and how to verify standardization — is in the
+          dedicated satellite guide linked below.
+        </div>
+      </section>
+
+      {/* Dosage */}
+      <section className="space-y-4" id="dosage">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Dosage &amp; Timing</h2>
+        <DosageBox
+          rows={DOSAGE_ROWS}
+          disclaimer="Take in the morning or early afternoon. No loading phase is needed — benefits accumulate gradually. General ranges, not medical advice."
+        />
+      </section>
+
+      {/* Safety */}
+      <section className="space-y-4" id="safety">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Safety &amp; Who Should Avoid It</h2>
+        <SafetyBox notes={SAFETY_NOTES} />
+      </section>
+
+      {/* Products */}
+      {rhodiolaProducts && (
+        <AffiliateProductBox
+          slug="rhodiola"
+          products={rhodiolaProducts.products}
+          heading="Rhodiola Product Picks"
+        />
+      )}
+
+      {/* FAQ */}
+      <FAQAccordion faqs={FAQS} heading="Common Questions About Rhodiola" />
+
+      {/* Hub: links to all 3 satellites */}
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold text-ink">Explore the Rhodiola Hub</h2>
+        <div className="grid gap-3 sm:grid-cols-3">
+          <Link href="/guides/rhodiola-energy" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+            <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Guide</p>
+            <p className="mt-1 text-sm font-semibold text-ink">Rhodiola for Energy</p>
+            <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Sustained energy without the stimulant crash — and how it compares to caffeine.</p>
+          </Link>
+          <Link href="/guides/rhodiola-extract-vs-powder" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+            <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Guide</p>
+            <p className="mt-1 text-sm font-semibold text-ink">Extract vs Powder</p>
+            <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Which form actually works — absorption, cost, and evidence compared.</p>
+          </Link>
+          <Link href="/guides/rhodiola-sleep-stack" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+            <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Stack Guide</p>
+            <p className="mt-1 text-sm font-semibold text-ink">Rhodiola + Magnesium for Sleep</p>
+            <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">The adaptogen stack for the &quot;wired but tired&quot; cycle.</p>
+          </Link>
+        </div>
+      </section>
+
+      {/* Bottom nav */}
+      <div className="flex flex-wrap gap-4 border-t border-brand-900/10 pt-6 text-sm">
+        <Link href="/guides" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">← All Guides</Link>
+        <Link href="/herbs" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">Herb Library →</Link>
+      </div>
+    </div>
+  )
+}

--- a/app/guides/rhodiola-energy/page.tsx
+++ b/app/guides/rhodiola-energy/page.tsx
@@ -1,0 +1,271 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { buildPageMetadata } from '@/lib/seo'
+import StructuredData from '@/components/StructuredData'
+import FAQAccordion from '@/components/FAQAccordion'
+import EvidenceSummaryBox from '@/components/EvidenceSummaryBox'
+import DosageBox from '@/components/DosageBox'
+import SafetyBox from '@/components/SafetyBox'
+import MechanismBox from '@/components/MechanismBox'
+import ComparisonTable from '@/components/ComparisonTable'
+import AffiliateProductBox from '@/components/AffiliateProductBox'
+import { revenueProductSets } from '@/config/revenue-products'
+
+const SLUG = 'rhodiola-energy'
+const PAGE_URL = 'https://thehippiescientist.net/guides/rhodiola-energy'
+const TITLE = 'Rhodiola for Energy: Science-Backed Energy Without the Crash'
+const DESCRIPTION =
+  'How rhodiola supports sustained energy without a stimulant crash. Research, dosing, and a comparison to caffeine, ginseng, and ashwagandha.'
+const DATE_PUBLISHED = '2024-06-09'
+const DATE_MODIFIED = '2026-06-14'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: TITLE,
+  description: DESCRIPTION,
+  path: `/guides/${SLUG}`,
+  openGraphType: 'article',
+})
+
+const FAQS = [
+  {
+    question: 'Does rhodiola work immediately for energy?',
+    answer:
+      'Usually not. Unlike caffeine, rhodiola is not an acute stimulant. Benefits emerge gradually — most responders notice improvements in stress-related fatigue after 2–3 weeks of consistent daily use. Week 1 typically produces no noticeable change.',
+  },
+  {
+    question: 'Can rhodiola replace coffee?',
+    answer:
+      'No — they serve different purposes. Coffee wins for immediate alertness by blocking adenosine receptors. Rhodiola does not provide that acute boost; instead it may help address the chronic, stress-related fatigue patterns that drive the caffeine-crash cycle in the first place. Many people reduce (rather than eliminate) caffeine when starting rhodiola.',
+  },
+  {
+    question: 'Is rhodiola good for burnout?',
+    answer:
+      'The evidence is most supportive here. Trials in people with stress-related exhaustion (e.g., Olsson et al. 2009) show gradual improvements in fatigue, concentration, and burnout symptoms. It is best viewed as resilience support rather than a cure for burnout, and it does not replace addressing workload, sleep, and recovery.',
+  },
+  {
+    question: 'Can rhodiola cause anxiety or overstimulation?',
+    answer:
+      'Rarely. Some people report mild agitation or alertness, particularly at higher doses or when taken late in the day. Taking it in the morning and starting at 200 mg minimizes this. People with severe anxiety disorders, bipolar disorder, or active psychosis should consult a clinician first.',
+  },
+  {
+    question: 'Will I build tolerance to rhodiola?',
+    answer:
+      'Tolerance is not consistently documented in the available literature, and no long-term toxicity has been established in clinical trials. It can generally be used continuously, though periodic reassessment of whether it is still helping is sensible.',
+  },
+]
+
+const DOSAGE_ROWS = [
+  { form: 'Starting dose', range: '200 mg/day', notes: 'Standardized extract, taken in the morning' },
+  { form: 'Standard maintenance', range: '300–400 mg/day', notes: 'Morning; most common effective range' },
+  { form: 'Higher-stress periods', range: 'up to 600 mg/day', notes: 'Morning or early afternoon; avoid late evening' },
+]
+
+const SAFETY_NOTES = [
+  {
+    severity: 'info' as const,
+    text: 'Take rhodiola in the morning. Some users report alertness that interferes with sleep when it is taken late in the day.',
+  },
+  {
+    severity: 'caution' as const,
+    text: 'Higher doses do not reliably produce better results and may increase the chance of overstimulation or mild agitation in sensitive individuals. Start at 200 mg and increase only if needed.',
+  },
+  {
+    severity: 'caution' as const,
+    text: 'If you take SSRIs/SNRIs, stimulants, or other psychiatric medication, consult a clinician first. A theoretical serotonin-related interaction with antidepressants exists, though documented cases are absent.',
+  },
+  {
+    severity: 'warning' as const,
+    text: 'Avoid during pregnancy or breastfeeding (insufficient safety data), and use caution with bipolar disorder or active psychosis, where overstimulation could be harmful.',
+  },
+]
+
+const MECHANISM_POINTS = [
+  {
+    label: 'HPA Axis Modulation',
+    description:
+      'Rhodiola appears to support the hypothalamic-pituitary-adrenal axis, which governs cortisol release and energy allocation under stress — acting more like a thermostat than a gas pedal.',
+  },
+  {
+    label: 'Mental Fatigue, Not Sedation',
+    description:
+      'Most positive studies measure mental fatigue and concentration rather than physical exhaustion. Reported benefits include better focus and stress tolerance, especially under chronic stress.',
+  },
+  {
+    label: 'Not Adenosine Blockade',
+    description:
+      'Unlike caffeine, rhodiola does not mask fatigue by blocking adenosine receptors. This is why it lacks an acute "hit" but also why it avoids the rebound crash and tolerance spiral.',
+  },
+]
+
+const COMPARISON_HEADERS = ['Feature', 'Rhodiola', 'Caffeine', 'Ginseng', 'Ashwagandha']
+const COMPARISON_ROWS = [
+  { attribute: 'Immediate boost', values: ['Low', 'High', 'Moderate', 'Low'] },
+  { attribute: 'Crash potential', values: ['Low', 'High', 'Low–Moderate', 'Very low'] },
+  { attribute: 'Stress resilience', values: ['High', 'Low', 'Moderate', 'High'] },
+  { attribute: 'Mental fatigue support', values: ['Moderate–High', 'Moderate', 'Moderate', 'Moderate'] },
+  { attribute: 'Sleep disruption risk', values: ['Low–Moderate', 'High', 'Moderate', 'Low'] },
+]
+
+export default function RhodiolaEnergyGuidePage() {
+  const rhodiolaProducts = revenueProductSets['rhodiola']
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-8 px-4 py-8 sm:px-6 sm:py-10 lg:px-8">
+      <StructuredData
+        pageUrl={PAGE_URL}
+        headline={TITLE}
+        description={DESCRIPTION}
+        datePublished={DATE_PUBLISHED}
+        dateModified={DATE_MODIFIED}
+        faqs={FAQS}
+        breadcrumbs={[
+          { label: 'Home', href: '/' },
+          { label: 'Guides', href: '/guides' },
+          { label: 'Rhodiola for Energy', href: `/guides/${SLUG}` },
+        ]}
+      />
+
+      {/* Hero */}
+      <section className="rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-10">
+        <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">
+          Evidence Guide · Rhodiola Hub
+        </p>
+        <h1 className="mt-3 text-3xl font-black leading-tight text-ink sm:text-5xl">
+          Rhodiola for Energy
+        </h1>
+        <p className="mt-1 text-base font-medium text-brand-700">
+          Sustained Energy Without the Stimulant Crash
+        </p>
+        <p className="mt-4 max-w-3xl text-sm leading-7 text-muted sm:text-base">
+          Americans spend billions on energy drinks and stimulants that mostly override fatigue signals rather
+          than fixing what causes low energy: morning caffeine → midday crash → more caffeine → poor sleep →
+          repeat. Rhodiola is an adaptogen — it helps you tolerate stress-related fatigue rather than masking it.
+          This is not an acute stimulant, and that is the point.
+        </p>
+        <div className="mt-6 flex flex-wrap gap-4 text-xs font-semibold uppercase tracking-[0.14em]">
+          <Link href="/guides/rhodiola-complete-guide" className="text-brand-700 hover:text-brand-800 hover:underline">
+            Complete Rhodiola Guide →
+          </Link>
+          <Link href="/herbs/rhodiola" className="text-brand-700 hover:text-brand-800 hover:underline">
+            Rhodiola Herb Profile →
+          </Link>
+        </div>
+      </section>
+
+      {/* Evidence */}
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">What the Research Shows</h2>
+        <p className="text-sm leading-6 text-muted">
+          The strongest signal is for stress-related (mental) fatigue. Benefits are modest — roughly a 20–30%
+          improvement in fatigue measures — accumulate over weeks, and not everyone responds.
+        </p>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <EvidenceSummaryBox
+            level="strong"
+            outcome="Stress-related mental fatigue"
+            takeaway="Darbinyan (2000) and Spasov (2000) found significant reductions in fatigue and improved work/exam performance versus placebo with standardized extract. Consistent across multiple RCTs."
+            citationCount={3}
+          />
+          <EvidenceSummaryBox
+            level="moderate"
+            outcome="Burnout / stress-related exhaustion"
+            takeaway="Olsson (2009) showed gradual improvements in fatigue, concentration, and burnout symptoms over several weeks of SHR-5 use. Effects were cumulative, not immediate."
+            citationCount={2}
+          />
+          <EvidenceSummaryBox
+            level="moderate"
+            outcome="Concentration under stress"
+            takeaway="Modest but consistent improvements in focus and stress tolerance, most relevant for high-demand work where cognition under sustained stress matters."
+            citationCount={3}
+          />
+          <EvidenceSummaryBox
+            level="limited"
+            outcome="Physical / athletic energy"
+            takeaway="Mixed results. Some studies show 3–5% endurance improvement; others none. Benefits may reflect recovery and fatigue resistance rather than direct performance enhancement."
+            citationCount={2}
+          />
+        </div>
+      </section>
+
+      {/* Mechanism */}
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">How Rhodiola Supports Energy</h2>
+        <MechanismBox
+          summary="Many forms of fatigue are stress-driven — burnout, overtraining, chronic stress, poor recovery. When fatigue is stress-driven, more stimulation masks symptoms while worsening the root cause. Rhodiola operates through a different mechanism: supporting the body's stress-response physiology rather than blocking fatigue signals."
+          points={MECHANISM_POINTS}
+        />
+      </section>
+
+      {/* Comparison */}
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Rhodiola vs Other Options</h2>
+        <p className="text-sm leading-6 text-muted">
+          Coffee wins for immediate energy; rhodiola wins for addressing chronic fatigue patterns. Ginseng feels
+          more stimulating, while rhodiola is preferred for mental fatigue and burnout. Ashwagandha excels for
+          anxiety and sleep; rhodiola performs better for mental fatigue and productivity — many people use both.
+        </p>
+        <ComparisonTable headers={COMPARISON_HEADERS} rows={COMPARISON_ROWS} />
+      </section>
+
+      {/* Dosage */}
+      <section className="space-y-4" id="dosage">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Dosing Protocol</h2>
+        <DosageBox
+          rows={DOSAGE_ROWS}
+          disclaimer="No loading phase is needed — benefits accumulate gradually with consistent use. Use a standardized extract listing rosavin and salidroside content."
+        />
+        <div className="rounded-xl border border-amber-200/50 bg-amber-50/60 px-4 py-3 text-sm text-amber-950">
+          <strong className="font-semibold">Common mistakes: </strong>
+          taking too much (higher doses don&apos;t produce better outcomes), expecting immediate results,
+          ignoring sleep, and buying unstandardized products without rosavin/salidroside content listed.
+        </div>
+      </section>
+
+      {/* Safety */}
+      <section className="space-y-4" id="safety">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Safety &amp; Precautions</h2>
+        <SafetyBox notes={SAFETY_NOTES} />
+      </section>
+
+      {/* Products */}
+      {rhodiolaProducts && (
+        <AffiliateProductBox
+          slug="rhodiola"
+          products={rhodiolaProducts.products}
+          heading="Rhodiola Product Picks"
+        />
+      )}
+
+      {/* FAQ */}
+      <FAQAccordion faqs={FAQS} heading="Common Questions About Rhodiola for Energy" />
+
+      {/* Related (hub) */}
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold text-ink">More in the Rhodiola Hub</h2>
+        <div className="grid gap-3 sm:grid-cols-3">
+          <Link href="/guides/rhodiola-complete-guide" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+            <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Pillar Guide</p>
+            <p className="mt-1 text-sm font-semibold text-ink">Complete Rhodiola Guide</p>
+            <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Forms, benefits, dosing, and the full evidence base in one place.</p>
+          </Link>
+          <Link href="/guides/rhodiola-extract-vs-powder" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+            <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Guide</p>
+            <p className="mt-1 text-sm font-semibold text-ink">Extract vs Powder</p>
+            <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Which form actually works — absorption, dosing, and evidence compared.</p>
+          </Link>
+          <Link href="/guides/rhodiola-sleep-stack" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+            <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Stack Guide</p>
+            <p className="mt-1 text-sm font-semibold text-ink">Rhodiola + Magnesium for Sleep</p>
+            <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">The adaptogen stack for the &quot;wired but tired&quot; cycle.</p>
+          </Link>
+        </div>
+      </section>
+
+      {/* Bottom nav */}
+      <div className="flex flex-wrap gap-4 border-t border-brand-900/10 pt-6 text-sm">
+        <Link href="/guides" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">← All Guides</Link>
+        <Link href="/herbs" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">Herb Library →</Link>
+      </div>
+    </div>
+  )
+}

--- a/app/guides/rhodiola-extract-vs-powder/page.tsx
+++ b/app/guides/rhodiola-extract-vs-powder/page.tsx
@@ -1,0 +1,213 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { buildPageMetadata } from '@/lib/seo'
+import StructuredData from '@/components/StructuredData'
+import FAQAccordion from '@/components/FAQAccordion'
+import EvidenceSummaryBox from '@/components/EvidenceSummaryBox'
+import DosageBox from '@/components/DosageBox'
+import ComparisonTable from '@/components/ComparisonTable'
+import AffiliateProductBox from '@/components/AffiliateProductBox'
+import { revenueProductSets } from '@/config/revenue-products'
+
+const SLUG = 'rhodiola-extract-vs-powder'
+const PAGE_URL = 'https://thehippiescientist.net/guides/rhodiola-extract-vs-powder'
+const TITLE = 'Rhodiola Extract vs Powder: Which Form Actually Works?'
+const DESCRIPTION =
+  'Compare rhodiola extract vs powder: absorption rates, dosing, cost, and which form performs better for energy, stress, and fatigue based on the clinical evidence.'
+const DATE_PUBLISHED = '2024-06-09'
+const DATE_MODIFIED = '2026-06-14'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: TITLE,
+  description: DESCRIPTION,
+  path: `/guides/${SLUG}`,
+  openGraphType: 'article',
+})
+
+const FAQS = [
+  {
+    question: 'Can I mix rhodiola extract and powder?',
+    answer:
+      'Technically yes, but there is no real advantage. You would simply add a variable-potency dose (powder) on top of a consistent one (extract), which makes it harder to evaluate what is actually working.',
+  },
+  {
+    question: 'Is a generic rhodiola capsule the same as SHR-5?',
+    answer:
+      'Not necessarily. SHR-5 is a specific standardized extract used in most clinical trials. Generic capsules may or may not meet the same specifications. Check the label for "standardized to 3% rosavins, 1% salidroside" — if those numbers are absent, you cannot assume equivalence.',
+  },
+  {
+    question: 'Why does powder have so little research?',
+    answer:
+      'Clinical trials require consistency to produce meaningful results. Raw root powder varies batch to batch depending on harvest location, season, altitude, and storage, which makes controlled studies impractical. Researchers therefore use standardized extracts almost exclusively.',
+  },
+  {
+    question: 'Can I trust cheap extracts?',
+    answer:
+      'Not all cheap extracts are bad, but many are diluted or not genuinely standardized. Third-party testing (NSF, USP, Informed Sport) is the only reliable verification. Treat "rhodiola extract 500 mg" with no standardization percentages as effectively unverified.',
+  },
+  {
+    question: 'Does the whole herb have benefits that extracts miss?',
+    answer:
+      'It is theoretically possible — root powder retains minor plant compounds that may have synergistic effects. But there is currently no clinical evidence that this matters for outcomes, so it remains a philosophical rather than evidence-based reason to choose powder.',
+  },
+]
+
+const COMPARISON_HEADERS = ['Feature', 'Standardized Extract', 'Root Powder']
+const COMPARISON_ROWS = [
+  { attribute: 'Potency consistency', values: ['High', 'Low / variable'] },
+  { attribute: 'Absorption speed', values: ['30–90 min', '1–3 hours'] },
+  { attribute: 'Dose required', values: ['200–400 mg', '1–2 g'] },
+  { attribute: 'Clinical evidence', values: ['Strong (10+ trials)', 'Minimal / essentially absent'] },
+  { attribute: 'Approx. cost / month', values: ['$15–25', '$8–12'] },
+  { attribute: 'Best for', values: ['Efficacy & reliability', 'Budget / whole-herb preference'] },
+]
+
+const DOSAGE_ROWS = [
+  { form: 'SHR-5 standardized extract', range: '200–400 mg/day', notes: 'Min 3% rosavins / 1% salidroside; form used in the trials' },
+  { form: 'Standardized capsule (generic)', range: '300–600 mg/day', notes: 'Verify standardization percentages on the label' },
+  { form: 'Root powder', range: '1–2 g/day', notes: '3–5× more by weight; potency varies by batch' },
+]
+
+export default function RhodiolaExtractVsPowderGuidePage() {
+  const rhodiolaProducts = revenueProductSets['rhodiola']
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-8 px-4 py-8 sm:px-6 sm:py-10 lg:px-8">
+      <StructuredData
+        pageUrl={PAGE_URL}
+        headline={TITLE}
+        description={DESCRIPTION}
+        datePublished={DATE_PUBLISHED}
+        dateModified={DATE_MODIFIED}
+        faqs={FAQS}
+        breadcrumbs={[
+          { label: 'Home', href: '/' },
+          { label: 'Guides', href: '/guides' },
+          { label: 'Rhodiola Extract vs Powder', href: `/guides/${SLUG}` },
+        ]}
+      />
+
+      {/* Hero */}
+      <section className="rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-10">
+        <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">
+          Evidence Guide · Rhodiola Hub
+        </p>
+        <h1 className="mt-3 text-3xl font-black leading-tight text-ink sm:text-5xl">
+          Rhodiola Extract vs Powder
+        </h1>
+        <p className="mt-1 text-base font-medium text-brand-700">
+          Which Form Actually Works — and Why Form Matters More Here
+        </p>
+        <p className="mt-4 max-w-3xl text-sm leading-7 text-muted sm:text-base">
+          Walk into any supplement store and you&apos;ll find rhodiola in a dozen forms — standardized extracts,
+          root powders, tinctures, generic capsules — with no explanation of the difference. The form matters
+          more with rhodiola than most herbs. Here is why, and which one to buy.
+        </p>
+        <div className="mt-6 flex flex-wrap gap-4 text-xs font-semibold uppercase tracking-[0.14em]">
+          <Link href="/guides/rhodiola-complete-guide" className="text-brand-700 hover:text-brand-800 hover:underline">
+            Complete Rhodiola Guide →
+          </Link>
+          <Link href="/herbs/rhodiola" className="text-brand-700 hover:text-brand-800 hover:underline">
+            Rhodiola Herb Profile →
+          </Link>
+        </div>
+      </section>
+
+      {/* Quick comparison */}
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Quick Comparison</h2>
+        <ComparisonTable headers={COMPARISON_HEADERS} rows={COMPARISON_ROWS} />
+      </section>
+
+      {/* Evidence */}
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">What the Research Actually Used</h2>
+        <p className="text-sm leading-6 text-muted">
+          This is the critical point most buying guides miss. Every major positive trial used SHR-5 or a similar
+          standardized extract — not generic root powder. If you take powder and see no result, you cannot tell
+          whether rhodiola &quot;doesn&apos;t work for you&quot; or whether you simply got a weak batch.
+        </p>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <EvidenceSummaryBox
+            level="strong"
+            outcome="Standardized extract (SHR-5)"
+            takeaway="Darbinyan (2000) used 200 mg SHR-5; Spasov (2000) used 150 mg three times daily; Olsson (2009) used 576 mg/day. All showed positive results with characterized, predictable absorption."
+            citationCount={10}
+          />
+          <EvidenceSummaryBox
+            level="limited"
+            outcome="Raw root powder"
+            takeaway="Direct clinical evidence for whole rhodiola powder is essentially absent in the peer-reviewed literature. No published bioavailability studies exist for raw powder."
+            citationCount={0}
+          />
+        </div>
+      </section>
+
+      {/* Dosage */}
+      <section className="space-y-4" id="dosage">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Dosing by Form</h2>
+        <DosageBox
+          rows={DOSAGE_ROWS}
+          disclaimer="Because powder is far less concentrated than extract, typical doses are 3–5× higher by weight. All doses are general ranges, not medical advice."
+        />
+      </section>
+
+      {/* How to verify */}
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">How to Verify Extract Quality</h2>
+        <ul className="space-y-2 text-sm leading-6 text-muted">
+          <li><strong className="text-ink">Check the label</strong> — it should list &quot;standardized to 3% rosavins, 1% salidroside.&quot;</li>
+          <li><strong className="text-ink">Look for third-party testing</strong> — NSF, USP, or Informed Sport certification.</li>
+          <li><strong className="text-ink">Avoid proprietary blends</strong> — if the rosavin percentage isn&apos;t listed, assume it is low.</li>
+          <li><strong className="text-ink">Check the form description</strong> — &quot;rhodiola extract 500 mg&quot; without standardization specs is effectively meaningless.</li>
+        </ul>
+        <div className="rounded-xl border border-emerald-200/50 bg-emerald-50/60 px-4 py-3 text-sm text-emerald-950">
+          <strong className="font-semibold">Verdict: </strong>
+          For most people, start with standardized extract — the evidence base exists for it, potency is
+          consistent, and you can actually evaluate whether it works for you. Choose powder only if cost is the
+          primary constraint or you specifically prefer whole herbs, accepting more variability in results.
+        </div>
+      </section>
+
+      {/* Products */}
+      {rhodiolaProducts && (
+        <AffiliateProductBox
+          slug="rhodiola"
+          products={rhodiolaProducts.products}
+          heading="Rhodiola Product Picks"
+        />
+      )}
+
+      {/* FAQ */}
+      <FAQAccordion faqs={FAQS} heading="Common Questions About Rhodiola Forms" />
+
+      {/* Related (hub) */}
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold text-ink">More in the Rhodiola Hub</h2>
+        <div className="grid gap-3 sm:grid-cols-3">
+          <Link href="/guides/rhodiola-complete-guide" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+            <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Pillar Guide</p>
+            <p className="mt-1 text-sm font-semibold text-ink">Complete Rhodiola Guide</p>
+            <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Forms, benefits, dosing, and the full evidence base in one place.</p>
+          </Link>
+          <Link href="/guides/rhodiola-energy" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+            <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Guide</p>
+            <p className="mt-1 text-sm font-semibold text-ink">Rhodiola for Energy</p>
+            <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Sustained energy without the stimulant crash — research and dosing.</p>
+          </Link>
+          <Link href="/guides/rhodiola-sleep-stack" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+            <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Stack Guide</p>
+            <p className="mt-1 text-sm font-semibold text-ink">Rhodiola + Magnesium for Sleep</p>
+            <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">The adaptogen stack for the &quot;wired but tired&quot; cycle.</p>
+          </Link>
+        </div>
+      </section>
+
+      {/* Bottom nav */}
+      <div className="flex flex-wrap gap-4 border-t border-brand-900/10 pt-6 text-sm">
+        <Link href="/guides" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">← All Guides</Link>
+        <Link href="/herbs" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">Herb Library →</Link>
+      </div>
+    </div>
+  )
+}

--- a/app/guides/rhodiola-sleep-stack/page.tsx
+++ b/app/guides/rhodiola-sleep-stack/page.tsx
@@ -1,0 +1,267 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { buildPageMetadata } from '@/lib/seo'
+import StructuredData from '@/components/StructuredData'
+import FAQAccordion from '@/components/FAQAccordion'
+import EvidenceSummaryBox from '@/components/EvidenceSummaryBox'
+import DosageBox from '@/components/DosageBox'
+import SafetyBox from '@/components/SafetyBox'
+import MechanismBox from '@/components/MechanismBox'
+import AffiliateProductBox from '@/components/AffiliateProductBox'
+import { revenueProductSets } from '@/config/revenue-products'
+
+const SLUG = 'rhodiola-sleep-stack'
+const PAGE_URL = 'https://thehippiescientist.net/guides/rhodiola-sleep-stack'
+const TITLE = 'Rhodiola + Magnesium for Sleep: The Adaptogen Stack That Works'
+const DESCRIPTION =
+  'The rhodiola-magnesium sleep stack explained: complementary mechanisms, dosing and timing protocols, realistic expectations, and who should avoid it.'
+const DATE_PUBLISHED = '2024-06-09'
+const DATE_MODIFIED = '2026-06-14'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: TITLE,
+  description: DESCRIPTION,
+  path: `/guides/${SLUG}`,
+  openGraphType: 'article',
+})
+
+const FAQS = [
+  {
+    question: 'Can I take rhodiola and magnesium together?',
+    answer:
+      'Yes — but split the timing rather than taking them at the same moment. Rhodiola goes in the morning because it can cause alertness; magnesium goes 1–3 hours before bed. They target different problems (daytime stress resilience vs nighttime relaxation), which is what makes the pairing rational.',
+  },
+  {
+    question: 'Can rhodiola cause insomnia?',
+    answer:
+      'In some people, yes. Rhodiola has mild alerting properties, so taking it late in the day can interfere with sleep. Always take it in the morning. If you still notice evening alertness, lower the dose.',
+  },
+  {
+    question: 'Which magnesium is best for sleep?',
+    answer:
+      'Magnesium glycinate is the safest starting point for sleep — it is well absorbed and well tolerated. Threonate adds cognitive positioning at higher cost, citrate is fine for general use but can loosen stools at higher doses, and oxide is best avoided due to poor absorption.',
+  },
+  {
+    question: 'Can I add melatonin to this stack?',
+    answer:
+      'Possibly, but evaluate the rhodiola-magnesium stack on its own first so you know what is actually helping. Melatonin influences sleep timing rather than relaxation, so it addresses a different problem; layering everything at once makes it hard to attribute effects.',
+  },
+  {
+    question: 'Is this stack safe long term?',
+    answer:
+      'Both rhodiola and magnesium are generally well tolerated in healthy adults for long-term use. There is no strong evidence the combination is superior to either alone, and no RCT has studied the pair directly — so treat synergy claims as theoretical, not proven.',
+  },
+]
+
+const DOSAGE_ROWS = [
+  { form: 'Beginner — Rhodiola (AM)', range: '200–300 mg', notes: 'Standardized extract, morning only' },
+  { form: 'Beginner — Magnesium (PM)', range: '200 mg glycinate', notes: '1–3 hours before bed' },
+  { form: 'Standard — Rhodiola (AM)', range: '300–400 mg', notes: 'Morning only' },
+  { form: 'Standard — Magnesium (PM)', range: '300–400 mg glycinate', notes: '1–3 hours before bed' },
+]
+
+const SAFETY_NOTES = [
+  {
+    severity: 'info' as const,
+    text: 'Timing is the whole point: rhodiola in the morning (it can cause alertness), magnesium 1–3 hours before bed. Give the stack a minimum of 3–4 weeks before judging it.',
+  },
+  {
+    severity: 'caution' as const,
+    text: 'This is not a sleeping pill. Do not expect instant sedation or overnight transformation — think of it as a recovery-support system that works alongside consistent sleep habits.',
+  },
+  {
+    severity: 'caution' as const,
+    text: 'Magnesium can cause loose stools at higher doses (especially citrate/oxide). Glycinate is the gentlest. People with impaired kidney function should consult a clinician before supplementing magnesium.',
+  },
+  {
+    severity: 'warning' as const,
+    text: 'Consult a healthcare professional first if you are pregnant or nursing, have bipolar disorder or active psychosis, or take psychiatric, sleep, or mood medications.',
+  },
+]
+
+const MECHANISM_POINTS = [
+  {
+    label: 'Rhodiola → Resilience',
+    description:
+      'Rhodiola is not a sedative. It may improve resilience to the chronic stress that disrupts sleep — under chronic stress, cortisol does not drop normally through the evening, leaving people "wired but tired."',
+  },
+  {
+    label: 'Magnesium → Relaxation',
+    description:
+      'Magnesium has the stronger direct sleep evidence. It supports nerve signaling, muscle relaxation, and neurotransmitter function; low intake may contribute to tension, restlessness, and poor sleep quality.',
+  },
+  {
+    label: 'Non-Overlapping Pathways',
+    description:
+      'Most stacks fail because they target identical pathways. Here, rhodiola reduces daytime stress loading while magnesium helps the body wind down at night — complementary rather than redundant.',
+  },
+]
+
+export default function RhodiolaSleepStackGuidePage() {
+  const rhodiolaProducts = revenueProductSets['rhodiola']
+  const magnesiumProducts = revenueProductSets['magnesium']
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-8 px-4 py-8 sm:px-6 sm:py-10 lg:px-8">
+      <StructuredData
+        pageUrl={PAGE_URL}
+        headline={TITLE}
+        description={DESCRIPTION}
+        datePublished={DATE_PUBLISHED}
+        dateModified={DATE_MODIFIED}
+        faqs={FAQS}
+        breadcrumbs={[
+          { label: 'Home', href: '/' },
+          { label: 'Guides', href: '/guides' },
+          { label: 'Rhodiola + Magnesium for Sleep', href: `/guides/${SLUG}` },
+        ]}
+      />
+
+      {/* Hero */}
+      <section className="rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-10">
+        <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">
+          Stack Guide · Rhodiola Hub
+        </p>
+        <h1 className="mt-3 text-3xl font-black leading-tight text-ink sm:text-5xl">
+          Rhodiola + Magnesium for Sleep
+        </h1>
+        <p className="mt-1 text-base font-medium text-brand-700">
+          The Adaptogen Stack for the &quot;Wired But Tired&quot; Cycle
+        </p>
+        <p className="mt-4 max-w-3xl text-sm leading-7 text-muted sm:text-base">
+          Most sleep supplements force sedation — melatonin shifts timing, antihistamines create drowsiness,
+          prescriptions suppress wakefulness. Rhodiola and magnesium take a different approach: addressing the
+          underlying contributors to poor sleep rather than forcing unconsciousness. The goal is better sleep
+          quality, better recovery, and improved stress resilience.
+        </p>
+        <div className="mt-6 flex flex-wrap gap-4 text-xs font-semibold uppercase tracking-[0.14em]">
+          <Link href="/guides/rhodiola-complete-guide" className="text-brand-700 hover:text-brand-800 hover:underline">
+            Complete Rhodiola Guide →
+          </Link>
+          <Link href="/guides/magnesium-for-sleep" className="text-brand-700 hover:text-brand-800 hover:underline">
+            Magnesium for Sleep Guide →
+          </Link>
+        </div>
+      </section>
+
+      {/* The problem */}
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">The Root Problem: Wired But Tired</h2>
+        <p className="text-sm leading-6 text-muted">
+          The most common complaint is &quot;I&apos;m exhausted but can&apos;t fall asleep&quot; — racing thoughts,
+          elevated stress, mental hyperactivity, physical tension. The body is fatigued but the nervous system is
+          still activated. Under chronic stress, cortisol doesn&apos;t drop normally through the evening, producing
+          difficulty winding down and restless sleep. Traditional sleep aids mask this without fixing it.
+        </p>
+      </section>
+
+      {/* Evidence */}
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">What the Evidence Supports</h2>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <EvidenceSummaryBox
+            level="moderate"
+            outcome="Magnesium for sleep quality"
+            takeaway="Magnesium has the stronger direct sleep evidence of the two — involved in nerve signaling, muscle relaxation, and stress regulation, with trials linking adequate intake to better subjective sleep."
+            citationCount={4}
+          />
+          <EvidenceSummaryBox
+            level="moderate"
+            outcome="Rhodiola for stress resilience"
+            takeaway="Olsson (2009) and related burnout trials show improved fatigue and stress tolerance. Better daytime resilience may translate to better nighttime recovery — an indirect, secondary sleep benefit."
+            citationCount={2}
+          />
+          <EvidenceSummaryBox
+            level="limited"
+            outcome="Rhodiola for sleep (direct)"
+            takeaway="Direct evidence that rhodiola itself improves sleep is limited. Sleep benefits should be considered secondary to its stress-resilience effects, not a primary indication."
+            citationCount={1}
+          />
+          <EvidenceSummaryBox
+            level="limited"
+            outcome="The combination specifically"
+            takeaway="No randomized controlled trial has directly studied the rhodiola + magnesium pairing. Synergy is theoretical — what we can say is that both mechanisms are real, complementary, and generally safe."
+            citationCount={0}
+          />
+        </div>
+      </section>
+
+      {/* Mechanism */}
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Why the Combination Makes Sense</h2>
+        <MechanismBox
+          summary="These two supplements target different problems. Rhodiola reduces the stress loading your system during the day; magnesium helps your nervous system relax at night. Because the mechanisms do not overlap, the pairing is more rational than stacks that double up on the same pathway."
+          points={MECHANISM_POINTS}
+        />
+      </section>
+
+      {/* Dosage */}
+      <section className="space-y-4" id="dosage">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Dosing &amp; Timing Protocol</h2>
+        <DosageBox
+          rows={DOSAGE_ROWS}
+          disclaimer="Run the protocol for a minimum of 3–4 weeks. Rhodiola = morning only (can cause alertness); magnesium = 1–3 hours before bed. General ranges, not medical advice."
+        />
+        <div className="rounded-xl border border-brand-900/10 bg-brand-50/40 px-4 py-3 text-sm text-muted">
+          <strong className="font-semibold text-ink">What to expect: </strong>
+          Week 1 usually no change (some report reduced tension); weeks 2–3 easier recovery and better evening
+          wind-down; week 4+ better sleep quality and more stable energy. This is a recovery-support system, not a
+          sleeping pill.
+        </div>
+      </section>
+
+      {/* Safety */}
+      <section className="space-y-4" id="safety">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Safety &amp; Who Should Avoid It</h2>
+        <SafetyBox notes={SAFETY_NOTES} />
+      </section>
+
+      {/* Products */}
+      {rhodiolaProducts && (
+        <AffiliateProductBox
+          slug="rhodiola"
+          products={rhodiolaProducts.products}
+          heading="Rhodiola Product Picks"
+        />
+      )}
+      {magnesiumProducts && (
+        <AffiliateProductBox
+          slug="magnesium"
+          products={magnesiumProducts.products}
+          heading="Magnesium Product Picks"
+        />
+      )}
+
+      {/* FAQ */}
+      <FAQAccordion faqs={FAQS} heading="Common Questions About the Rhodiola + Magnesium Stack" />
+
+      {/* Related */}
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold text-ink">Related Reading</h2>
+        <div className="grid gap-3 sm:grid-cols-3">
+          <Link href="/guides/rhodiola-complete-guide" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+            <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Pillar Guide</p>
+            <p className="mt-1 text-sm font-semibold text-ink">Complete Rhodiola Guide</p>
+            <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Forms, benefits, dosing, and the full evidence base in one place.</p>
+          </Link>
+          <Link href="/guides/magnesium-for-sleep" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+            <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Guide</p>
+            <p className="mt-1 text-sm font-semibold text-ink">Magnesium for Sleep</p>
+            <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Forms, dosage, and evidence for magnesium as a sleep and anxiety support.</p>
+          </Link>
+          <Link href="/articles/best-herbs-for-sleep" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+            <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Pillar</p>
+            <p className="mt-1 text-sm font-semibold text-ink">Best Herbs for Sleep</p>
+            <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Evidence-ranked guide to the most-studied natural sleep options.</p>
+          </Link>
+        </div>
+      </section>
+
+      {/* Bottom nav */}
+      <div className="flex flex-wrap gap-4 border-t border-brand-900/10 pt-6 text-sm">
+        <Link href="/guides" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">← All Guides</Link>
+        <Link href="/herbs" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">Herb Library →</Link>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## What changed

Phase 2 content-hub integration. Seven cleaned MDX articles are now published as **dedicated, rich, component-driven guide pages** (matching the existing `turmeric-curcumin` pattern) instead of the plain-paragraph `[slug]` renderer.

### New routes (7)
**Rhodiola hub** (satellite-first; pillar links to all 3 satellites, satellites link back):
- `/guides/rhodiola-complete-guide` — pillar
- `/guides/rhodiola-energy`
- `/guides/rhodiola-extract-vs-powder`
- `/guides/rhodiola-sleep-stack`

**Standalone:**
- `/guides/elderberry` — affiliate box
- `/guides/passionflower` — affiliate box
- `/guides/kava` — **no affiliate** (see below)

Live rich-guide count goes from ~5 → ~12.

### Components applied
`StructuredData` (MedicalWebPage + FAQPage + BreadcrumbList), `EvidenceSummaryBox`, `MechanismBox`, `DosageBox`, `SafetyBox`, `FAQAccordion`, `ComparisonTable`, `AffiliateProductBox`. All shared from `/components` — no temp stubs.

### Reviewer notes
- **Kava is harm-reduction content** and deliberately has **no `AffiliateProductBox`**, despite a `revenue-products` set existing for it. The source content documents serious hepatotoxicity risk and does not endorse use — this respects the two-zone (monetized vs. harm-reduction) architecture.
- **Route collision avoided:** migrated slugs were removed from `app/guides/[slug]` `GUIDE_SLUGS`. `ashwagandha` and `lions-mane` remain on the legacy renderer (still live; can be upgraded later).
- **Affiliate gating:** boxes render `revenueProductSets[slug]` (rhodiola, magnesium, elderberry, passionflower) exactly as `turmeric-curcumin` does.
- **Phase 4 (sleep pillar):** already live at `/articles/best-herbs-for-sleep` — not duplicated; the rhodiola/passionflower guides cross-link to it.
- **indexable-herbs.json:** intentionally untouched — it's a generated artifact with a source-of-truth CI guard and no existing `guideUrl` field, so the prompt's additive-link condition didn't apply.
- **sitemap.ts not modified** (owned elsewhere) — reviewer should confirm whether it auto-discovers the new `/guides/*` routes or needs a manual entry.
- Citations preserved from source MDX; `npm run typecheck` passes.