### PR TITLE
docs: add reusable expansion blueprint + Magnificent 10 specs (Mission 008)

### DIFF
--- a/docs/expansion-blueprint.md
+++ b/docs/expansion-blueprint.md
@@ -1,0 +1,256 @@
+# Expansion Blueprint
+
+> **Mission 008 — Expansion Executor**
+> Purpose: a **reusable expansion blueprint** that defines the canonical section order, the
+> done-criteria, and the real components/schema each section uses — so **any** Magnificent 10
+> page (and any future page) can be expanded the same way without re-inventing the structure.
+>
+> **Scope rules (enforced):** This is a **blueprint and specification artifact only**. It does
+> **not** create page content, redesign anything, create pages, or build new systems/workflows.
+> It standardizes the *shape* of an expanded page and points at components that already exist in
+> the repo.
+>
+> Companions:
+> [`magnificent-10.md`](./magnificent-10.md) (what to expand) ·
+> [`expansion-order.md`](./expansion-order.md) (in what order) ·
+> [`content-expansion-playbook.md`](./content-expansion-playbook.md) (the assembly line) ·
+> per-page specs in [`page-expansion-specs/`](./page-expansion-specs/).
+>
+> Generated: 2026-06-16 · Branch: `claude/magnificent-10-expansion-blueprint-l0rf8t`
+
+---
+
+## How to use this blueprint
+
+1. Open the page's spec in [`page-expansion-specs/`](./page-expansion-specs/) — it tells you the
+   current state, the missing sections, the target word count, and the suggested
+   citations/links/affiliate placements **for that page**.
+2. Open this blueprint — it tells you the **section order** and **what "done" means** for each
+   section, identically for every page.
+3. Build the page in the app using the existing components named below. **Do not design anything
+   new** — every building block already exists (see the
+   [components table](./content-expansion-playbook.md#3-build--expand-the-page-in-the-app)).
+4. Not every section applies to every archetype. Use the **applicability** note on each section;
+   skip sections that don't fit and record the skip in the page's checklist.
+
+The 15 sections below are the full menu. A typical page renders them top-to-bottom in this order;
+herb/compound hubs lean on §4–§7, money/guide pages lean on §3, §5, §8.
+
+---
+
+## The 15 sections
+
+### 1. Search intent
+
+- **Purpose:** State, in one or two lines, the dominant query intent the page must satisfy
+  (commercial-investigational, informational→commercial, decision/comparison, etc.) and the head
+  term + cluster it owns. Everything else on the page serves this intent.
+- **What to capture:** Primary keyword cluster · searcher's job-to-be-done · whether they are
+  comparing, buying, or learning · the single question the page must answer above the fold.
+- **Applies to:** every page.
+- **Done when:** the intent is named in the spec and the H1 + intro answer it in the first 100
+  words.
+
+### 2. Who this page is for
+
+- **Purpose:** Name the reader segment(s) so tone, examples, and selection guidance are
+  calibrated (e.g. adults vs. kids, beginners vs. experienced, deficiency-driven vs. adjunct
+  users).
+- **What to capture:** audience segments · their constraints (budget, medication context,
+  sensitivity) · what would make the page *not* for them (route those readers elsewhere via §11).
+- **Applies to:** every page; especially YMYL pages (ADHD, anxiety, blood pressure, fat loss).
+- **Done when:** at least one explicit "this is for / this is not for" framing exists, and YMYL
+  readers are routed to `/disclaimer` where relevant.
+
+### 3. Evidence summary
+
+- **Purpose:** Up-front, scannable verdict on how strong the evidence is for each option — the
+  page's authority spine.
+- **What to capture:** per-option evidence tier (high / moderate / low / preliminary) ·
+  deficiency-context caveats · what the trials actually measured.
+- **Components:** `EvidenceSummaryBox`, `EvidenceMeter`, `EvidenceLegend` (`components/`).
+- **Applies to:** every commercial, guide, and hub page.
+- **Done when:** every ranked/listed item carries an evidence tier, and tiers are backed by §10
+  references.
+
+### 4. How it works
+
+- **Purpose:** The mechanism primer — why the option plausibly does anything (receptor/pathway,
+  cortisol axis, NGF, bioavailability, etc.).
+- **What to capture:** plain-language mechanism · the active constituent/compound · the
+  physiological target.
+- **Components:** `MechanismBox` (`components/`); link constituents to `/compounds/[slug]`.
+- **Applies to:** herb/compound hubs (primary), money/guide pages (brief primer).
+- **Done when:** mechanism is stated without overclaiming and links to the relevant compound
+  depth page.
+
+### 5. Best options
+
+- **Purpose:** The ranked/curated list the searcher came for ("best X for Y") — the conversion
+  core of a money page.
+- **What to capture:** ranked items with a one-line "why it's here" · the selection criteria
+  ("how we ranked these") · per-item form/standardization notes.
+- **Components:** affiliate cards via `RecommendedProduct` / `AffiliateProductCard`; `ItemList`
+  schema via `buildClusterItemListNode` (`lib/schema.ts`).
+- **Applies to:** money pages and guides (primary); hubs use a lighter "how to choose a product"
+  variant.
+- **Done when:** the list is ranked with transparent criteria and each item ties to an evidence
+  tier (§3) and a §12 placement.
+
+### 6. Dosing
+
+- **Purpose:** Actionable dose, form, and timing guidance.
+- **What to capture:** typical dose range · form/standardization (e.g. KSM-66, glycinate,
+  fruiting-body) · timing · titration/tolerance notes.
+- **Components:** `DosageBox` (`components/`); a dosing table where multiple options are compared.
+- **Applies to:** every page that recommends an intake.
+- **Done when:** doses are sourced (§10), ranges (not single numbers) are given, and YMYL dosing
+  carries a clinician caveat.
+
+### 7. Safety
+
+- **Purpose:** Contraindications, interactions, and side effects — non-negotiable on YMYL pages.
+- **What to capture:** common side effects · drug/condition interactions (SSRIs, blood thinners,
+  thyroid, pregnancy) · "who should avoid" · when to see a clinician.
+- **Components:** `SafetyBox` (`components/`); route to `/disclaimer` and relevant
+  `/psychoactive/*` interaction pages.
+- **Applies to:** every page; mandatory and expanded on YMYL pages.
+- **Done when:** interactions are explicit, never advises discontinuing prescribed medication, and
+  links to `/disclaimer`.
+
+### 8. Comparisons
+
+- **Purpose:** Resolve the "X vs Y" decision the searcher is weighing without sending them away
+  prematurely.
+- **What to capture:** head-to-head of the top alternatives (form vs form, herb vs herb,
+  supplement vs medication framing) · a "which to try first" decision aid.
+- **Components:** `ComparisonTable` / `compare-table-client` (`components/`);
+  `buildFAQPageFromComparisonRows` (`lib/schema.ts`); link to dedicated `/compare/*` pages.
+- **Applies to:** money pages, guides, hubs; the spine of `/compare/*` pages.
+- **Done when:** the comparison is a real table and funnels to the deeper `/compare/*` page rather
+  than duplicating it.
+
+### 9. FAQs
+
+- **Purpose:** Capture long-tail question intent and earn `FAQPage` rich results.
+- **What to capture:** 5–12 real questions (dose, timing, safety, "vs", "how long until it
+  works") drawn from the spec's FAQ list.
+- **Components:** `FAQAccordion`, `FaqJsonLd` (`components/`, `components/seo/`).
+- **Applies to:** every page.
+- **Done when:** questions render in an accordion and emit valid `FAQPage` JSON-LD.
+
+### 10. References
+
+- **Purpose:** The citation backbone behind every evidence and dosing claim — the E-E-A-T floor.
+- **What to capture:** PubMed/DOI/NIH-linked sources for each graded claim; meta-analyses
+  preferred over single trials.
+- **Markers:** `pubmed | doi | ncbi | nih.gov | et al | pmid` (the signal the scoreboard counts).
+- **Applies to:** every page; density scales with YMYL risk.
+- **Done when:** every evidence tier (§3) and dose (§6) has at least one citation; no uncited
+  efficacy claims remain.
+
+### 11. Internal links
+
+- **Purpose:** Distribute link equity and route the funnel — the portfolio multiplier.
+- **What to capture:** links following the dependency direction in
+  [`expansion-order.md`](./expansion-order.md): money pages link *down* into hubs; hubs/guides
+  funnel *up* into money pages. Use the spec's suggested list as the floor.
+- **Components:** `SeeAlsoCluster`, `SeeAlsoInCluster`, `Breadcrumbs` + `BreadcrumbSchema`.
+- **Applies to:** every page.
+- **Done when:** the page links to its money-page anchor and at least the spec's suggested links,
+  with breadcrumbs present.
+
+### 12. Affiliate opportunities
+
+- **Purpose:** Monetize without degrading trust.
+- **What to capture:** the specific placements from the spec (forms/brands) · disclosure before
+  the first link · consolidation over over-linking.
+- **Components:** `RecommendedProduct` / `AffiliateProductCard`; `AffiliateDisclosure`
+  (`components/AffiliateDisclosure.tsx`); **always** `AFFILIATE_TAGS.amazon` (`config/affiliate.ts`).
+- **Hygiene:** never hardcode an affiliate string; disclosure precedes the first affiliate link.
+- **Applies to:** money pages and hubs (primary); guides (secondary).
+- **Done when:** every link uses `AFFILIATE_TAGS.amazon`, disclosure renders first, and placements
+  map to ranked items in §5.
+
+### 13. Schema opportunities
+
+- **Purpose:** Make the page machine-readable for rich results and entity graph.
+- **What to capture:** the JSON-LD types the page earns — typically `BreadcrumbList`, `FAQPage`,
+  `ItemList` (ranked pages), `Article` (article routes), plus `buildWorkbookEntitySchema` for
+  herb/compound hubs.
+- **Builders:** `buildClusterItemListNode`, `buildFAQPageFromComparisonRows`,
+  `buildWorkbookEntitySchema` (`lib/schema.ts`); `GuideData` (`lib/schemas/guide-schemas.ts`).
+- **Static-export note:** all schema must be emitted at build time — no `force-dynamic`,
+  `cookies()`, or `headers()` (see `CLAUDE.md`).
+- **Applies to:** every page.
+- **Done when:** the page emits at least `BreadcrumbList` + `FAQPage`, plus `ItemList`/`Article`
+  where applicable, and validates.
+
+### 14. EEAT opportunities
+
+- **Purpose:** Signal Experience, Expertise, Authoritativeness, and Trust — the durable moat the
+  Mission 007 re-weighting rewards.
+- **What to capture:** author/reviewer attribution (`/author`) · "last reviewed" date ·
+  methodology transparency ("how we ranked / how we score evidence") · conservative YMYL framing ·
+  citation density (§10) · disclosure (§12) · linking to first-hand testing or original data
+  where it exists.
+- **Applies to:** every page; weighted heaviest on authority hubs and YMYL money pages.
+- **Done when:** the page shows author + review date, states its methodology, and meets the §10
+  citation floor.
+
+### 15. Completion checklist
+
+- **Purpose:** The single definition-of-done gate. A page is expanded only when every applicable
+  box passes. Copy this into the page's tracking issue/PR.
+
+```
+- [ ] 1. Search intent — H1 + intro answer the named intent
+- [ ] 2. Who this page is for — audience + "not for" framing (YMYL → /disclaimer)
+- [ ] 3. Evidence summary — every option carries an evidence tier
+- [ ] 4. How it works — mechanism stated, linked to compound depth
+- [ ] 5. Best options — ranked list with transparent criteria
+- [ ] 6. Dosing — sourced ranges, form/timing, clinician caveat where YMYL
+- [ ] 7. Safety — interactions explicit, links to /disclaimer
+- [ ] 8. Comparisons — real table, funnels to /compare/*
+- [ ] 9. FAQs — accordion + valid FAQPage JSON-LD
+- [ ] 10. References — every tier/dose cited
+- [ ] 11. Internal links — money-page anchor + spec floor, breadcrumbs present
+- [ ] 12. Affiliate opportunities — AFFILIATE_TAGS.amazon only, disclosure first
+- [ ] 13. Schema opportunities — BreadcrumbList + FAQPage (+ ItemList/Article)
+- [ ] 14. EEAT opportunities — author + review date + methodology + citation floor
+- [ ] Target word count reached (see page spec)
+- [ ] Quality gate: npm run lint && npm run typecheck && npm run check
+```
+
+---
+
+## Archetype → section emphasis
+
+Not every page weights the 15 sections equally. Use this to know where to spend effort.
+
+| Archetype | Heaviest sections | Lighter / optional |
+|-----------|-------------------|--------------------|
+| Money / commercial landing (`/best-supplements-for-*`, `/articles/best-*`) | §1, §3, §5, §6, §12, §13 | §4 (brief primer) |
+| Guide (`/guides/*`) | §1, §2, §3, §5, §8, §9 | §12 (secondary) |
+| Herb / compound authority hub (`/herbs/*`, `/compounds/*`) | §3, §4, §6, §7, §10, §14 | §8 (link out, don't duplicate) |
+| Comparison (`/compare/*`) | §1, §8, §3, §9 | §5 (light) |
+
+---
+
+## Guardrails (carried from Missions 006–007)
+
+1. **No new pages, no redesign, no new systems.** This blueprint specifies how to expand
+   existing routes with existing components only.
+2. **Build the pattern once.** Schema block, affiliate convention, and citation style established
+   on the first money page are reused on every later page.
+3. **Internal-link flow is the multiplier.** Every guide/herb/compare page funnels to a money
+   page; money pages link down into hubs.
+4. **YMYL discipline.** Conservative, citation-backed claims; route to `/disclaimer`; never
+   advise discontinuing prescribed medication.
+5. **Affiliate hygiene.** `AFFILIATE_TAGS.amazon` only; disclosure before the first link;
+   consolidate rather than over-link.
+6. **Static-export safe.** All data and schema available at build time (see `CLAUDE.md`).
+
+> **Reminder:** this blueprint *prepares the shape* of expansion work. Content creation,
+> rewriting, redesign, new pages, and new systems are explicitly out of scope per Mission 008
+> rules.

--- a/docs/page-expansion-specs/01-best-supplements-for-sleep.md
+++ b/docs/page-expansion-specs/01-best-supplements-for-sleep.md
@@ -1,0 +1,56 @@
+# Expansion Spec — `/best-supplements-for-sleep`
+
+> Mission 008 · Magnificent 10 rank **#1** · build order **1** (Wave A — money pages).
+> Plan only — applies the [Expansion Blueprint](../expansion-blueprint.md). Contains **no** content.
+
+## Current state
+
+- Rendered via `SeoEntryPage` (`app/seo-entry-pages.tsx`); ~580 body words.
+- High commercial intent, thin body. `ItemList`/`FAQPage` schema and citations not yet built to target.
+- The flagship money page and anchor of the sleep cluster.
+
+## Missing sections
+
+- "How we ranked these" methodology box
+- Per-supplement breakdown: melatonin, magnesium glycinate, glycine, L-theanine, valerian, apigenin
+- Dosing & timing table
+- Safety / interaction notes + "who should avoid"
+- Buyer's checklist (form, dose, third-party testing)
+
+## Target state
+
+- Pattern-setter for Wave A: establishes the reusable `ItemList` + `FAQPage` schema block and affiliate-card convention.
+- Full blueprint section set: evidence summary, best options, dosing, safety, comparisons, FAQs, references, schema, EEAT.
+
+## Suggested word count
+
+- **~2,400** (Δ ~+1,820)
+
+## Suggested citations
+
+- Melatonin dose/efficacy for sleep onset
+- Magnesium glycinate and sleep quality
+- Glycine pre-sleep evidence
+- L-theanine relaxation evidence
+- Valerian meta-analysis
+
+## Suggested internal links
+
+- [`/articles/best-herbs-for-sleep`](/articles/best-herbs-for-sleep)
+- [`/articles/magnesium-types-for-sleep`](/articles/magnesium-types-for-sleep)
+- [`/compare/sleep-herbs-vs-melatonin`](/compare/sleep-herbs-vs-melatonin)
+- [`/guides/magnesium-vs-melatonin`](/guides/magnesium-vs-melatonin)
+- [`/herbs/valerian`](/herbs/valerian)
+- [`/compounds/melatonin`](/compounds/melatonin)
+- [`/compounds/l-theanine`](/compounds/l-theanine)
+- [`/articles/sleep-stack-guide`](/articles/sleep-stack-guide)
+
+## Suggested affiliate opportunities
+
+> `AFFILIATE_TAGS.amazon` only, via `RecommendedProduct` / `AffiliateProductCard`.
+
+- magnesium glycinate
+- melatonin
+- L-theanine
+- glycine
+- valerian

--- a/docs/page-expansion-specs/02-articles-best-supplements-for-adhd.md
+++ b/docs/page-expansion-specs/02-articles-best-supplements-for-adhd.md
@@ -1,0 +1,56 @@
+# Expansion Spec — `/articles/best-supplements-for-adhd`
+
+> Mission 008 · Magnificent 10 rank **#2** · build order **2** (Wave A — money pages).
+> Plan only — applies the [Expansion Blueprint](../expansion-blueprint.md). Contains **no** content.
+
+## Current state
+
+- Component-driven (`FocusAdhdArticlePage` / `lib/focus-adhd-articles.ts`); ~1,557 body words.
+- Monetized via `AdhdMonetizationWidgets`. Largest commercial cluster.
+- **YMYL:** must frame supplements as adjuncts, never as replacements for prescribed medication.
+
+## Missing sections
+
+- Evidence tiers per nutrient: omega-3, zinc, iron/ferritin, magnesium, L-theanine, saffron, bacopa
+- "Deficiency-driven vs. adjunct" framing
+- Kids vs. adults section
+- "What the trials actually show"
+- Stack-building section + when to see a clinician
+
+## Target state
+
+- Reuses the Wave A pattern from order 1: `ItemList` over ranked nutrients, `FAQPage`, evidence tiers.
+- Authority + money page: deep evidence framing with conservative YMYL caveats and `/disclaimer` routing.
+
+## Suggested word count
+
+- **~2,500** (Δ ~+943)
+
+## Suggested citations
+
+- Omega-3 (EPA/DHA) ADHD RCT / meta-analysis
+- Zinc supplementation in ADHD
+- Iron/ferritin and ADHD symptom severity
+- Magnesium and ADHD
+- Saffron vs methylphenidate trial
+
+## Suggested internal links
+
+- [`/articles/omega-3-and-adhd`](/articles/omega-3-and-adhd)
+- [`/articles/zinc-and-adhd`](/articles/zinc-and-adhd)
+- [`/articles/iron-ferritin-and-adhd`](/articles/iron-ferritin-and-adhd)
+- [`/articles/magnesium-for-adhd`](/articles/magnesium-for-adhd)
+- [`/articles/l-theanine-for-adhd`](/articles/l-theanine-for-adhd)
+- [`/articles/best-magnesium-supplement-for-adhd`](/articles/best-magnesium-supplement-for-adhd)
+- [`/articles/adhd-stack-guide`](/articles/adhd-stack-guide)
+- [`/guides/adhd-supplements`](/guides/adhd-supplements)
+
+## Suggested affiliate opportunities
+
+> `AFFILIATE_TAGS.amazon` only, via `RecommendedProduct` / `AffiliateProductCard`.
+
+- omega-3
+- zinc
+- magnesium glycinate
+- iron
+- saffron

--- a/docs/page-expansion-specs/03-articles-best-magnesium-supplement-for-adhd.md
+++ b/docs/page-expansion-specs/03-articles-best-magnesium-supplement-for-adhd.md
@@ -1,0 +1,51 @@
+# Expansion Spec — `/articles/best-magnesium-supplement-for-adhd`
+
+> Mission 008 · Magnificent 10 rank **#6** · build order **3** (Wave A — money pages).
+> Plan only — applies the [Expansion Blueprint](../expansion-blueprint.md). Contains **no** content.
+
+## Current state
+
+- Strongest existing base in the set: ~1,852 body words, 10 FAQ, 4 schema blocks, 22 affiliate markers.
+- Highest monetization fit (95). Lowest incremental cost to push to elite.
+- **YMYL:** dosing for children needs a clinician caveat; deficiency-context framing required.
+
+## Missing sections
+
+- Form-by-form bioavailability table: glycinate, L-threonate, citrate, malate, oxide
+- "Magnesium + ADHD evidence" synthesis
+- Dosing by age/weight
+- GI tolerance + timing guidance
+- "Signs of deficiency"
+
+## Target state
+
+- Fastest money-page win: keep the existing FAQ/schema base, add `ItemList` over the form comparison.
+- Form-comparison depth becomes the canonical reference for magnesium-form selection in ADHD.
+
+## Suggested word count
+
+- **~2,600** (Δ ~+748)
+
+## Suggested citations
+
+- Magnesium status in ADHD children
+- L-threonate brain bioavailability
+- Form-by-form absorption data
+
+## Suggested internal links
+
+- [`/articles/magnesium-glycinate-vs-citrate-for-adhd`](/articles/magnesium-glycinate-vs-citrate-for-adhd)
+- [`/articles/magnesium-for-adhd`](/articles/magnesium-for-adhd)
+- [`/compare/magnesium-glycinate-vs-l-threonate-for-sleep`](/compare/magnesium-glycinate-vs-l-threonate-for-sleep)
+- [`/compounds/magnesium`](/compounds/magnesium)
+- [`/articles/l-theanine-magnesium-adhd-stack`](/articles/l-theanine-magnesium-adhd-stack)
+- [`/articles/best-supplements-for-adhd`](/articles/best-supplements-for-adhd)
+
+## Suggested affiliate opportunities
+
+> `AFFILIATE_TAGS.amazon` only, via `RecommendedProduct` / `AffiliateProductCard`.
+
+- glycinate
+- L-threonate
+- citrate
+- malate

--- a/docs/page-expansion-specs/04-best-supplements-for-stress.md
+++ b/docs/page-expansion-specs/04-best-supplements-for-stress.md
@@ -1,0 +1,54 @@
+# Expansion Spec — `/best-supplements-for-stress`
+
+> Mission 008 · Magnificent 10 rank **#3** · build order **4** (Wave A — money pages).
+> Plan only — applies the [Expansion Blueprint](../expansion-blueprint.md). Contains **no** content.
+
+## Current state
+
+- Rendered via `SeoEntryPage`; ~580 body words.
+- High commercial intent (monetization 92), thin body. Anchors the stress/adaptogen cluster.
+- Feeds the ashwagandha hub built next in the sequence (build order 6).
+
+## Missing sections
+
+- Adaptogen breakdown: ashwagandha, rhodiola, holy basil
+- Cortisol mechanism primer
+- Magnesium + L-theanine for acute stress
+- Dosing table
+- Safety section + "acute vs chronic stress" selection guide
+
+## Target state
+
+- Reuses the Wave A pattern: `ItemList`, `FAQPage`, per-adaptogen evidence tiers.
+- Links *down* into `/herbs/ashwagandha` and `/herbs/rhodiola` (link targets exist before hubs are expanded).
+
+## Suggested word count
+
+- **~2,200** (Δ ~+1,620)
+
+## Suggested citations
+
+- Ashwagandha cortisol reduction RCT
+- Rhodiola fatigue/stress trials
+- L-theanine acute stress
+- Magnesium and perceived stress
+
+## Suggested internal links
+
+- [`/guides/best-adaptogens-for-stress`](/guides/best-adaptogens-for-stress)
+- [`/guides/how-to-lower-cortisol-naturally`](/guides/how-to-lower-cortisol-naturally)
+- [`/herbs/ashwagandha`](/herbs/ashwagandha)
+- [`/herbs/rhodiola`](/herbs/rhodiola)
+- [`/compounds/l-theanine`](/compounds/l-theanine)
+- [`/articles/natural-anxiety-relief`](/articles/natural-anxiety-relief)
+- [`/compare/rhodiola-vs-ashwagandha`](/compare/rhodiola-vs-ashwagandha)
+- [`/guides/best-supplements-for-overthinking`](/guides/best-supplements-for-overthinking)
+
+## Suggested affiliate opportunities
+
+> `AFFILIATE_TAGS.amazon` only, via `RecommendedProduct` / `AffiliateProductCard`.
+
+- ashwagandha (KSM-66)
+- rhodiola
+- magnesium
+- L-theanine

--- a/docs/page-expansion-specs/05-best-supplements-for-focus.md
+++ b/docs/page-expansion-specs/05-best-supplements-for-focus.md
@@ -1,0 +1,54 @@
+# Expansion Spec — `/best-supplements-for-focus`
+
+> Mission 008 · Magnificent 10 rank **#5** · build order **5** (Wave A — money pages).
+> Plan only — applies the [Expansion Blueprint](../expansion-blueprint.md). Contains **no** content.
+
+## Current state
+
+- Rendered via `SeoEntryPage`; ~580 body words.
+- Anchors the focus/nootropic cluster (monetization 90), thin body. Complements — does not duplicate — the ADHD pages.
+- Feeds the lion's mane hub built next (build order 7).
+
+## Missing sections
+
+- Nootropic breakdown: L-theanine + caffeine, citicoline, alpha-GPC, bacopa, rhodiola, lion's mane
+- "Stimulant vs calm-focus" framing
+- Dosing/timing table
+- Tolerance / cycling notes
+- Safety section
+
+## Target state
+
+- Reuses the Wave A pattern: `ItemList`, `FAQPage`, evidence tiers separating stimulant vs calm-focus mechanisms.
+- Links *down* into `/herbs/lions-mane`; funnels laterally to the ADHD money page.
+
+## Suggested word count
+
+- **~2,200** (Δ ~+1,620)
+
+## Suggested citations
+
+- L-theanine + caffeine attention studies
+- Citicoline cognition trials
+- Bacopa memory meta-analysis
+
+## Suggested internal links
+
+- [`/guides/best-nootropics-for-focus`](/guides/best-nootropics-for-focus)
+- [`/articles/l-theanine-vs-caffeine-for-focus`](/articles/l-theanine-vs-caffeine-for-focus)
+- [`/articles/citicoline-vs-alpha-gpc`](/articles/citicoline-vs-alpha-gpc)
+- [`/herbs/lions-mane`](/herbs/lions-mane)
+- [`/compounds/l-theanine`](/compounds/l-theanine)
+- [`/guides/focus-without-caffeine-crash`](/guides/focus-without-caffeine-crash)
+- [`/compare/caffeine-vs-l-theanine-vs-bacopa-for-focus`](/compare/caffeine-vs-l-theanine-vs-bacopa-for-focus)
+- [`/articles/best-supplements-for-adhd`](/articles/best-supplements-for-adhd)
+
+## Suggested affiliate opportunities
+
+> `AFFILIATE_TAGS.amazon` only, via `RecommendedProduct` / `AffiliateProductCard`.
+
+- L-theanine
+- citicoline
+- alpha-GPC
+- lion's mane
+- bacopa

--- a/docs/page-expansion-specs/06-herbs-ashwagandha.md
+++ b/docs/page-expansion-specs/06-herbs-ashwagandha.md
@@ -1,0 +1,55 @@
+# Expansion Spec — `/herbs/ashwagandha`
+
+> Mission 008 · Magnificent 10 rank **#4** · build order **6** (Wave B — authority hubs).
+> Plan only — applies the [Expansion Blueprint](../expansion-blueprint.md). Contains **no** content.
+
+## Current state
+
+- ~200 body words around structured data + herb template scaffolding; thin body.
+- Highest-authority herb hub on the site (Authority 78) — the top link magnet.
+- Receives equity from the stress money page (build order 4); funnels *up* into it.
+- **YMYL:** thyroid-medication and pregnancy contraindications required.
+
+## Missing sections
+
+- Expanded mechanism (cortisol axis / GABAergic)
+- Benefit-by-goal (stress, sleep, testosterone, anxiety)
+- KSM-66 vs Sensoril
+- Dosing / timing
+- Side effects & contraindications (thyroid, pregnancy)
+- "How to choose a product"
+
+## Target state
+
+- Applies the Wave A pattern to the top authority hub: ensure `FAQPage` renders on the template, add benefit-by-goal evidence tiers.
+- Canonical, citation-backed ashwagandha reference that distributes link equity across clusters.
+
+## Suggested word count
+
+- **~1,800** (Δ ~+1,600), built around the existing structured template.
+
+## Suggested citations
+
+- Cortisol RCT
+- Sleep trial
+- Anxiety trial
+- Testosterone study
+
+## Suggested internal links
+
+- [`/best-supplements-for-stress`](/best-supplements-for-stress)
+- [`/guides/best-adaptogens-for-stress`](/guides/best-adaptogens-for-stress)
+- [`/compare/rhodiola-vs-ashwagandha`](/compare/rhodiola-vs-ashwagandha)
+- [`/articles/ashwagandha-for-anxiety`](/articles/ashwagandha-for-anxiety)
+- [`/articles/ashwagandha-for-sleep`](/articles/ashwagandha-for-sleep)
+- [`/articles/ashwagandha-for-adhd`](/articles/ashwagandha-for-adhd)
+- [`/compounds/withanolides`](/compounds/withanolides)
+- [`/guides/how-to-lower-cortisol-naturally`](/guides/how-to-lower-cortisol-naturally)
+
+## Suggested affiliate opportunities
+
+> `AFFILIATE_TAGS.amazon` only, via `RecommendedProduct` / `AffiliateProductCard`.
+
+- KSM-66
+- Sensoril
+- gummies

--- a/docs/page-expansion-specs/07-herbs-lions-mane.md
+++ b/docs/page-expansion-specs/07-herbs-lions-mane.md
@@ -1,0 +1,51 @@
+# Expansion Spec — `/herbs/lions-mane`
+
+> Mission 008 · Magnificent 10 rank **#7** · build order **7** (Wave B — authority hubs).
+> Plan only — applies the [Expansion Blueprint](../expansion-blueprint.md). Contains **no** content.
+
+## Current state
+
+- ~177 body words + herb template scaffolding; thin body.
+- High-authority hub (74) with rising branded demand; anchors the cognition/focus depth layer.
+- Receives equity from the focus money page (build order 5); funnels *up* into it.
+
+## Missing sections
+
+- Hericenones / erinacines & NGF mechanism
+- Cognition / focus / mood evidence
+- Fruiting body vs mycelium
+- Dosing
+- Safety
+- Product-selection (beta-glucan %)
+
+## Target state
+
+- Applies the Wave B pattern: `FAQPage` + `BreadcrumbList`, cognition evidence tier, fruiting-body-vs-mycelium quality framing.
+- Canonical lion's mane reference earning links from the focus cluster.
+
+## Suggested word count
+
+- **~1,700** (Δ ~+1,523), built around the existing template.
+
+## Suggested citations
+
+- NGF mechanism
+- Cognition trial
+- Mood trial
+
+## Suggested internal links
+
+- [`/best-supplements-for-focus`](/best-supplements-for-focus)
+- [`/guides/best-nootropics-for-focus`](/guides/best-nootropics-for-focus)
+- [`/guides/supplements-for-brain-fog-and-fatigue`](/guides/supplements-for-brain-fog-and-fatigue)
+- [`/compounds/hericenones`](/compounds/hericenones)
+- [`/education/how-learning-affects-neuroplasticity`](/education/how-learning-affects-neuroplasticity)
+- [`/articles/best-supplements-for-adhd`](/articles/best-supplements-for-adhd)
+- [`/herbs/rhodiola`](/herbs/rhodiola)
+
+## Suggested affiliate opportunities
+
+> `AFFILIATE_TAGS.amazon` only, via `RecommendedProduct` / `AffiliateProductCard`.
+
+- fruiting-body extract
+- dual-extract capsules

--- a/docs/page-expansion-specs/08-herbs-turmeric.md
+++ b/docs/page-expansion-specs/08-herbs-turmeric.md
@@ -1,0 +1,51 @@
+# Expansion Spec — `/herbs/turmeric`
+
+> Mission 008 · Magnificent 10 rank **#8** · build order **8** (Wave B — authority hubs).
+> Plan only — applies the [Expansion Blueprint](../expansion-blueprint.md). Contains **no** content.
+
+## Current state
+
+- ~183 body words + herb template scaffolding; thin body.
+- High-authority hub (76) spanning joint, inflammation, and gut clusters; broad evergreen demand.
+- **YMYL:** blood-thinner and gallbladder contraindications required.
+
+## Missing sections
+
+- Curcumin bioavailability (piperine / phytosome / liposomal)
+- Joint & inflammation evidence
+- Dosing
+- "With or without black pepper"
+- Safety (blood thinners, gallbladder)
+- Product-selection guide
+
+## Target state
+
+- Applies the Wave B pattern: `FAQPage` + `BreadcrumbList`, bioavailability-by-form ranking, joint evidence tier.
+- Canonical curcumin/turmeric reference distributing equity across joint, inflammation, and gut clusters.
+
+## Suggested word count
+
+- **~1,700** (Δ ~+1,517), built around the existing template.
+
+## Suggested citations
+
+- Curcumin bioavailability
+- OA / joint trials
+- Piperine absorption
+
+## Suggested internal links
+
+- [`/guides/turmeric-curcumin`](/guides/turmeric-curcumin)
+- [`/best-supplements-for-joint-support`](/best-supplements-for-joint-support)
+- [`/compare/curcumin-vs-boswellia-vs-omega-3`](/compare/curcumin-vs-boswellia-vs-omega-3)
+- [`/compounds/curcumin`](/compounds/curcumin)
+- [`/education/inflammation`](/education/inflammation)
+- [`/education/what-is-neuroinflammation`](/education/what-is-neuroinflammation)
+- [`/best-supplements-for-gut-health`](/best-supplements-for-gut-health)
+
+## Suggested affiliate opportunities
+
+> `AFFILIATE_TAGS.amazon` only, via `RecommendedProduct` / `AffiliateProductCard`.
+
+- curcumin phytosome (Meriva)
+- curcumin + piperine

--- a/docs/page-expansion-specs/09-guides-adhd-supplements.md
+++ b/docs/page-expansion-specs/09-guides-adhd-supplements.md
@@ -1,0 +1,52 @@
+# Expansion Spec — `/guides/adhd-supplements`
+
+> Mission 008 · Magnificent 10 rank **#10** · build order **9** (Wave C — cluster guides).
+> Plan only — applies the [Expansion Blueprint](../expansion-blueprint.md). Contains **no** content.
+
+## Current state
+
+- ~795 body words; already ships 12 FAQ markers + 10 schema markers (strong schema base, thin body).
+- Lowest-cost guide lift in the set. Key discovery hub funneling into the ADHD depth cluster.
+- **YMYL:** frame as adjunct, not medication replacement; route to `/disclaimer`.
+
+## Missing sections
+
+- Evidence-graded nutrient cards (omega-3, zinc, iron, magnesium, L-theanine, saffron, bacopa)
+- "Adjunct vs deficiency" framing
+- Kids vs adults
+- Stack examples
+- "What not to expect"
+
+## Target state
+
+- Keeps the existing `FAQPage`/schema base; adds `ItemList` over the ranked nutrients and per-nutrient evidence grades.
+- Funnels *up* into the ADHD money pages built in Wave A.
+
+## Suggested word count
+
+- **~2,000** (Δ ~+1,205)
+
+## Suggested citations
+
+- Omega-3 ADHD
+- Zinc / iron ADHD
+- Saffron trial
+
+## Suggested internal links
+
+- [`/articles/best-supplements-for-adhd`](/articles/best-supplements-for-adhd)
+- [`/articles/omega-3-and-adhd`](/articles/omega-3-and-adhd)
+- [`/articles/zinc-and-adhd`](/articles/zinc-and-adhd)
+- [`/articles/iron-ferritin-and-adhd`](/articles/iron-ferritin-and-adhd)
+- [`/articles/best-magnesium-supplement-for-adhd`](/articles/best-magnesium-supplement-for-adhd)
+- [`/articles/adhd-stack-guide`](/articles/adhd-stack-guide)
+- [`/best-magnesium-supplements-for-adhd`](/best-magnesium-supplements-for-adhd)
+
+## Suggested affiliate opportunities
+
+> `AFFILIATE_TAGS.amazon` only, via `RecommendedProduct` / `AffiliateProductCard`.
+
+- omega-3
+- zinc
+- magnesium
+- saffron

--- a/docs/page-expansion-specs/10-guides-best-herbs-for-anxiety.md
+++ b/docs/page-expansion-specs/10-guides-best-herbs-for-anxiety.md
@@ -1,0 +1,52 @@
+# Expansion Spec — `/guides/best-herbs-for-anxiety`
+
+> Mission 008 · Magnificent 10 rank **#9** · build order **10** (Wave C — cluster guides).
+> Plan only — applies the [Expansion Blueprint](../expansion-blueprint.md). Contains **no** content.
+
+## Current state
+
+- ~998 body words, 5 internal links, **0** FAQ / **0** schema / **0** citations.
+- Sole dedicated anxiety-cluster anchor in the priority tier; closes anxiety coverage.
+- **YMYL:** serotonergic-interaction (SSRI) safety required; never advise discontinuing prescribed medication.
+
+## Missing sections
+
+- Per-herb evidence cards (ashwagandha, kava, passionflower, lemon balm, chamomile, lavender/silexan)
+- "Fast-acting vs daily"
+- Dosing table
+- Serotonergic-interaction safety
+- "Which to try first"
+
+## Target state
+
+- Adds the full pattern from scratch: `FAQPage` schema, citations (currently none), per-herb evidence tiers.
+- Funnels *up* into the ashwagandha and other hubs already built in Wave B.
+
+## Suggested word count
+
+- **~2,000** (Δ ~+1,002)
+
+## Suggested citations
+
+- Kava meta-analysis
+- Lavender / silexan trials
+- Passionflower anxiety
+
+## Suggested internal links
+
+- [`/herbs/kava`](/herbs/kava)
+- [`/herbs/passionflower`](/herbs/passionflower)
+- [`/herbs/ashwagandha`](/herbs/ashwagandha)
+- [`/articles/natural-anxiety-relief`](/articles/natural-anxiety-relief)
+- [`/articles/l-theanine-for-anxiety`](/articles/l-theanine-for-anxiety)
+- [`/guides/natural-alternatives-to-anxiety-medication`](/guides/natural-alternatives-to-anxiety-medication)
+- [`/psychoactive/serotonergic-stacking-risks`](/psychoactive/serotonergic-stacking-risks)
+
+## Suggested affiliate opportunities
+
+> `AFFILIATE_TAGS.amazon` only, via `RecommendedProduct` / `AffiliateProductCard`.
+
+- ashwagandha
+- kava
+- passionflower
+- lemon balm

--- a/docs/page-expansion-specs/README.md
+++ b/docs/page-expansion-specs/README.md
@@ -1,0 +1,45 @@
+# Page Expansion Specs — Magnificent 10
+
+> **Mission 008 — Expansion Executor.** One expansion spec per Magnificent 10 page, generated
+> against the reusable [Expansion Blueprint](../expansion-blueprint.md).
+>
+> **Scope (enforced):** Specs only. Each file lists *what* to expand — it contains **no** page
+> content and modifies **no** production page. Sources:
+> [`magnificent-10.md`](../magnificent-10.md) (ranking) ·
+> [`expansion-order.md`](../expansion-order.md) (build order) ·
+> [`content-priority-scoreboard.md`](../content-priority-scoreboard.md) (measured signals).
+>
+> Generated: 2026-06-16 · Branch: `claude/magnificent-10-expansion-blueprint-l0rf8t`
+
+## What each spec contains
+
+Per mission rules, each spec carries **only** these fields:
+
+- **Current state** — measured signals today (words, FAQ/schema, architecture)
+- **Missing sections** — body sections to add
+- **Target state** — what the expanded page becomes
+- **Suggested word count** — target body length
+- **Suggested citations** — claims that need sourcing
+- **Suggested internal links** — funnel direction per `expansion-order.md`
+- **Suggested affiliate opportunities** — placements (always `AFFILIATE_TAGS.amazon`)
+
+The section order, done-criteria, and which components/schema each section uses are defined once
+in the [Expansion Blueprint](../expansion-blueprint.md) and apply to every page below.
+
+## Specs (in build order)
+
+| Order | Wave | Rank | Page | Spec |
+|:---:|:---:|:---:|------|------|
+| 1 | A | #1 | `/best-supplements-for-sleep` | [01](./01-best-supplements-for-sleep.md) |
+| 2 | A | #2 | `/articles/best-supplements-for-adhd` | [02](./02-articles-best-supplements-for-adhd.md) |
+| 3 | A | #6 | `/articles/best-magnesium-supplement-for-adhd` | [03](./03-articles-best-magnesium-supplement-for-adhd.md) |
+| 4 | A | #3 | `/best-supplements-for-stress` | [04](./04-best-supplements-for-stress.md) |
+| 5 | A | #5 | `/best-supplements-for-focus` | [05](./05-best-supplements-for-focus.md) |
+| 6 | B | #4 | `/herbs/ashwagandha` | [06](./06-herbs-ashwagandha.md) |
+| 7 | B | #7 | `/herbs/lions-mane` | [07](./07-herbs-lions-mane.md) |
+| 8 | B | #8 | `/herbs/turmeric` | [08](./08-herbs-turmeric.md) |
+| 9 | C | #10 | `/guides/adhd-supplements` | [09](./09-guides-adhd-supplements.md) |
+| 10 | C | #9 | `/guides/best-herbs-for-anxiety` | [10](./10-guides-best-herbs-for-anxiety.md) |
+
+> **Reminder:** these specs *prepare* expansion. Content creation, rewriting, redesign, new
+> pages, and new systems are out of scope per Mission 008 rules.


### PR DESCRIPTION
Add docs/expansion-blueprint.md — a reusable 15-section expansion
blueprint (search intent, audience, evidence, mechanism, best options,
dosing, safety, comparisons, FAQs, references, internal links, affiliate,
schema, EEAT, completion checklist) that works for any future page and
points at existing components/schema only.

Add docs/page-expansion-specs/ — one spec per Magnificent 10 page (in
build order), each containing only: current state, missing sections,
target state, suggested word count, citations, internal links, and
affiliate opportunities. Specs prepare expansion only; no content is
written and no production page is modified.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X48KArPohywQmYHQY7MePQ