### PR TITLE
Expand /best-nootropics-for-focus (Builder→Gatekeeper→Publish)

### DIFF
--- a/docs/merge-report-best-nootropics-for-focus.md
+++ b/docs/merge-report-best-nootropics-for-focus.md
@@ -1,0 +1,55 @@
+# Merge Report: Best Nootropics for Focus (best-nootropics-for-focus)
+
+**Status:** MERGE READY
+
+**Date:** 2026-06-17
+
+**Route:** `/best-nootropics-for-focus`
+
+**Pipeline:** Refined Builder v2 → Gatekeeper v2 → Publish v2 (one page only)
+
+---
+
+## Summary of Changes
+
+- **Files modified (1):**
+  - `lib/curated-expansions.ts` — added the `best-nootropics-for-focus` `CuratedExpansion` to `seoEntryExpansions` (intent, ranking methodology, 8-row evidence/dose/safety table, "which to try first" comparison, safety notes, buyer checklist, 4 verified PubMed/PMC references).
+- **No new files, routes, components, or systems.** Renders through the existing `SeoEntryPage` path; affiliate placements (`l-theanine`, `lions-mane`) were already wired in `revenueProductSlugs`; schema (`BreadcrumbList` + `FAQPage`) auto-emitted.
+
+### Builder
+
+- Expanded the focus-cluster nootropics page with a deliberately distinct angle from `/best-supplements-for-focus`: three explicit "jobs" (same-day stimulation, calm-focus, weeks-long cognitive support) plus tolerance/cycling and sleep/anxiety tradeoffs.
+- Evidence graded conservatively: caffeine+L-theanine (moderate, acute), L-theanine alone (preliminary–moderate), citicoline (preliminary–moderate), alpha-GPC (preliminary), bacopa (moderate for memory, slow), lion's mane (preliminary), rhodiola (preliminary–moderate, activating), L-tyrosine (situational).
+
+### Gatekeeper
+
+- **Verdict:** Production Ready With Revisions. Scores — Search Intent 8, E-E-A-T 8, Overall 8.
+- No production blockers. Confirmed no cannibalization with `/best-supplements-for-focus`, explicit sleep/anxiety/stimulant-stacking cautions, and small-effect framing.
+
+### Publisher
+
+- References web-verified to real PubMed/PMC URLs (not guessed PMIDs):
+  - L-theanine + caffeine on cognition/sleep/mood — systematic review & meta-analysis (PMC12422004).
+  - Cognitive effects of Bacopa monnieri — meta-analysis of RCTs (PubMed 24252493).
+  - Citicoline and memory in healthy older adults — RCT (PMC8349115).
+  - Lion's mane neurotrophic review (PubMed 37958943).
+- Internal-link targets verified against the dataset; citicoline routed to `/articles/citicoline-vs-alpha-gpc` because `/compounds/citicoline` does not exist.
+
+---
+
+## Verification
+
+- **Production Blockers resolved:** Yes (none present).
+- **High Priority items addressed:** Yes — distinct angle, conservative effect sizes, stimulant/sleep cautions.
+- **Internal links:** all evidence-row hrefs verified to exist.
+- **Affiliate hygiene:** `revenueProductSlugs` → `getRevenueProductSet` → `AFFILIATE_TAGS.amazon`; disclosure renders before product cards. No hardcoded strings.
+- **Schema:** `BreadcrumbList` + `FAQPage` emitted at build time (static-export safe).
+- **Quality gate:** `npm run check` — passed (26 steps, exit 0).
+- **Scores:** improved over the prior thin SEO-entry baseline; no regression.
+
+## Remaining Low-Priority Items
+
+- Add a `/compounds/citicoline` profile later so the citicoline row can link to the compound directly.
+- Consider a dedicated tolerance/cycling callout component for nootropic pages.
+
+**Recommendation:** Safe to merge after static-export validation; production gate passes locally.

--- a/lib/curated-expansions.ts
+++ b/lib/curated-expansions.ts
@@ -259,6 +259,48 @@ export const seoEntryExpansions: Record<string, CuratedExpansion> = {
       { label: 'NIH ODS — Omega-3 fatty acids fact sheet (health professional)', href: 'https://ods.od.nih.gov/factsheets/Omega3FattyAcids-HealthProfessional/' },
     ],
   },
+  'best-nootropics-for-focus': {
+    intent: 'Commercial investigation: choose a focus nootropic by separating fast stimulant effects from calm-focus and slow cognitive-support options, weighing evidence strength, tolerance/cycling, and sleep and anxiety tradeoffs.',
+    methodology: [
+      'Sort options into three jobs — same-day stimulation, calm-focus, and weeks-long cognitive support — instead of treating "nootropic" as one category.',
+      'Prefer ingredients with human attention or memory outcomes over broad neuro-hype, and read effect sizes as small.',
+      'Penalize proprietary blends that hide caffeine, stack multiple cholinergics, or ignore anxiety and sleep cost.',
+    ],
+    evidenceRows: [
+      { name: 'Caffeine + L-theanine', tier: 'Moderate for acute attention', bestFor: 'Fast, same-day focus with fewer jitters than caffeine alone', dose: '50-100 mg caffeine + 100-200 mg L-theanine', safety: 'Avoid late-day dosing; caution with anxiety, blood pressure, and other stimulants.', href: '/articles/l-theanine-vs-caffeine-for-focus' },
+      { name: 'L-theanine (alone)', tier: 'Preliminary to moderate', bestFor: 'Calm-focus and taking the edge off caffeine or stress', dose: '100-200 mg as needed', safety: 'Usually gentle; can add to sedating effects in sensitive users.', href: '/compounds/l-theanine' },
+      { name: 'Citicoline (CDP-choline)', tier: 'Preliminary to moderate', bestFor: 'Choline support, attention, and mental effort', dose: '250-500 mg/day', safety: 'Headache or GI effects in some users; do not stack multiple cholinergics aggressively.', href: '/articles/citicoline-vs-alpha-gpc' },
+      { name: 'Alpha-GPC', tier: 'Preliminary', bestFor: 'Choline-focused stacks and effort-based tasks', dose: '300-600 mg/day', safety: 'Avoid combining several high-dose choline sources at once.', href: '/compounds/alpha-gpc' },
+      { name: 'Bacopa monnieri', tier: 'Moderate for memory, not acute focus', bestFor: 'Memory and speed-of-attention over 8-12 weeks', dose: '300 mg/day standardized bacosides', safety: 'GI upset and mild sedation are common deal-breakers; effects build slowly.' },
+      { name: "Lion's mane", tier: 'Preliminary', bestFor: 'Longer-horizon cognition experiments, not acute stimulation', dose: '500-1,000 mg extract/day or label-standardized equivalent', safety: 'Mushroom allergy and product quality matter; expect subtle effects.', href: '/herbs/lions-mane' },
+      { name: 'Rhodiola', tier: 'Preliminary to moderate', bestFor: 'Stress-fatigue and mental endurance rather than raw focus', dose: '200-400 mg/day standardized extract, earlier in the day', safety: 'Activating; caution with bipolar history and stimulants.', href: '/herbs/rhodiola' },
+      { name: 'L-tyrosine', tier: 'Situational', bestFor: 'Acute stress, sleep loss, or multitasking demands, not everyday focus', dose: 'Study doses vary widely; commonly grams before a stressor', safety: 'Caution with thyroid conditions, MAOIs, and stimulant medication.', href: '/compounds/l-tyrosine' },
+    ],
+    comparisonRows: [
+      { scenario: 'Need focus in the next hour', firstChoice: 'Caffeine + L-theanine', why: 'Most reliable same-day option, but it has a sleep cost if taken late.' },
+      { scenario: 'Caffeine-sensitive or anxious', firstChoice: 'L-theanine or citicoline', why: 'Less likely to add jitter, racing heart, or anxiety.' },
+      { scenario: 'Brain fog from stress fatigue', firstChoice: 'Rhodiola', why: 'Targets fatigue and endurance more than acute stimulation.' },
+      { scenario: 'Long-term memory and learning', firstChoice: "Bacopa or lion's mane", why: 'Evaluate over weeks; these are not acute nootropics.' },
+    ],
+    safetyNotes: [
+      'Nootropics can worsen insomnia, anxiety, blood pressure, or stimulant side effects — do not use them to paper over poor sleep.',
+      'Avoid stacking multiple stimulants or multiple cholinergics (citicoline + Alpha-GPC + high-dose choline) without a clear reason.',
+      'New, severe, or worsening focus problems — especially with low mood, sleep apnea, anemia, thyroid symptoms, or medication changes — deserve evaluation, not just a bigger stack.',
+      'Be cautious with ADHD or psychiatric medication, pregnancy, and heart-rhythm or blood-pressure conditions; check interactions before combining.',
+    ],
+    buyerChecklist: [
+      'Decide which job you are buying for: same-day stimulation, calm-focus, or weeks-long cognitive support.',
+      'Check the caffeine amount per serving and across the day before adding any stimulant nootropic.',
+      'Prefer single-ingredient products with disclosed doses over proprietary "focus" or "smart" blends.',
+      'Track sleep, anxiety, heart rate, and timing — not just perceived focus — and trial one ingredient at a time.',
+    ],
+    references: [
+      { label: 'L-theanine + caffeine on cognition, sleep, and mood: systematic review and meta-analysis (PMC)', href: 'https://pmc.ncbi.nlm.nih.gov/articles/PMC12422004/' },
+      { label: 'Cognitive effects of Bacopa monnieri: meta-analysis of RCTs (PubMed)', href: 'https://pubmed.ncbi.nlm.nih.gov/24252493/' },
+      { label: 'Citicoline and memory function in healthy older adults: RCT (PMC)', href: 'https://pmc.ncbi.nlm.nih.gov/articles/PMC8349115/' },
+      { label: "Lion's mane (Hericium erinaceus) neurotrophic review (PubMed)", href: 'https://pubmed.ncbi.nlm.nih.gov/37958943/' },
+    ],
+  },
 }
 
 export const herbProfileExpansions: Record<string, CuratedExpansion> = {


### PR DESCRIPTION
## Summary

Third article from the v2 content-expansion pipeline (**Builder → Gatekeeper → Publish**). The first two (`/best-supplements-for-blood-pressure`, `/herbs/rhodiola`) already merged via #1830; this PR carries the remaining page.

Target: `/best-nootropics-for-focus` — focus cluster, roadmap #17 (score 82 → target 90).

## Stage 1 — Builder
- Added the `best-nootropics-for-focus` `CuratedExpansion` to `lib/curated-expansions.ts`: intent, ranking methodology, an 8-row evidence/dose/safety table (caffeine+L-theanine, L-theanine, citicoline, alpha-GPC, bacopa, lion's mane, rhodiola, L-tyrosine), a "which to try first" decision aid, safety notes, buyer checklist, and 4 verified PubMed/PMC references.
- Deliberately distinct angle from `/best-supplements-for-focus`: three "jobs" (same-day stimulation, calm-focus, weeks-long cognitive support) plus tolerance/cycling and sleep/anxiety tradeoffs. Effect sizes framed as small.

## Stage 2 — Gatekeeper
- **Verdict: Production Ready With Revisions** — Search Intent 8 / E-E-A-T 8 / Overall 8.
- No production blockers; no cannibalization with the sibling focus page; explicit sleep/anxiety/stimulant-stacking cautions.

## Stage 3 — Publish
- References web-verified to real PubMed/PMC URLs (PMC12422004, PubMed 24252493, PMC8349115, PubMed 37958943).
- Citicoline routed to `/articles/citicoline-vs-alpha-gpc` because `/compounds/citicoline` does not exist; all other hrefs verified.
- Affiliate placements (`l-theanine`, `lions-mane`) already wired via `revenueProductSlugs` → `AFFILIATE_TAGS.amazon`; schema (`BreadcrumbList` + `FAQPage`) auto-emitted, static-export safe.

## Verification
- `npm run check` (typecheck + eslint `--max-warnings=0` + article-quality + blog/articles build + orchestrate-build, 26 steps) — **passed, exit 0**.
- Surgical diff: `lib/curated-expansions.ts` (+42) plus the merge report. No route changes, no new systems, no generated artifacts committed.

## Files
- `lib/curated-expansions.ts`
- `docs/merge-report-best-nootropics-for-focus.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2eSNEz3PQedR2Gw3cDssU

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2eSNEz3PQedR2Gw3cDssU)_