### PR TITLE
fix(ci): route JSON-LD through JsonLd component to fix html-injection gate

### DIFF
--- a/app/best-magnesium-supplements-for-adhd/page.tsx
+++ b/app/best-magnesium-supplements-for-adhd/page.tsx
@@ -5,6 +5,7 @@ import NewsletterSignup from '../../components/NewsletterSignup'
 import RecommendedProduct from '@/components/RecommendedProduct'
 import { getRevenueProductSet } from '@/config/revenue-products'
 import { buildPageMetadata, faqPageJsonLd } from '@/lib/seo'
+import JsonLd from '@/components/seo/JsonLd'
 
 export const metadata: Metadata = buildPageMetadata({
   title: 'Best Magnesium Supplements for ADHD: Forms, Dose, and Buying Guide',
@@ -108,8 +109,8 @@ export default function BestMagnesiumSupplementsForAdhdPage() {
 
   return (
     <div className='mx-auto max-w-6xl space-y-8 px-4 py-10 sm:px-6 lg:px-8'>
-      {faqLd && <script type='application/ld+json' dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />}
-      <script type='application/ld+json' dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListLd) }} />
+      <JsonLd schema={faqLd} />
+      <JsonLd schema={itemListLd} />
 
       <section className='rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-10'>
         <p className='text-xs font-bold uppercase tracking-[0.18em] text-brand-700'>Buying guide</p>

--- a/app/guides/best-herbs-for-anxiety/page.tsx
+++ b/app/guides/best-herbs-for-anxiety/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import StructuredData from '@/components/StructuredData'
+import JsonLd from '@/components/seo/JsonLd'
 import { SITE_URL } from '@/lib/navigation-config'
 
 const PAGE_URL = `${SITE_URL}/guides/best-herbs-for-anxiety`
@@ -150,10 +151,7 @@ export default function BestHerbsForAnxietyPage() {
           { label: 'Best Herbs for Anxiety', href: '/guides/best-herbs-for-anxiety' },
         ]}
       />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
-      />
+      <JsonLd schema={faqSchema} />
 
       <div className="mx-auto max-w-4xl space-y-14 px-4 pb-16 pt-8 sm:px-6 lg:px-8">
 


### PR DESCRIPTION
## Summary

Fixes the **pre-existing** CI failure on `main`. The `CI → quality-gate → Verify build output` step was failing at `validate-html-injection` (unrelated to recent content work — it was already red on commits before the article expansions).

Two pages emitted JSON-LD via raw `dangerouslySetInnerHTML` instead of the approved, XSS-escaping `components/seo/JsonLd.tsx` component:

- `app/best-magnesium-supplements-for-adhd/page.tsx` — FAQ + ItemList JSON-LD
- `app/guides/best-herbs-for-anxiety/page.tsx` — FAQ JSON-LD

## Change
- Replaced the inline `<script type="application/ld+json" dangerouslySetInnerHTML=...>` blocks with `<JsonLd schema={...} />`.
- `JsonLd` returns `null` for falsy schema, so the `faqLd &&` null-guard is dropped.
- No behavioral change to the emitted structured data; the component additionally escapes `<` to `<` (safer).

## Verification
- `node scripts/ci/validate-dangerously-set-inner-html.mjs` → **PASS: No unapproved dangerouslySetInnerHTML usages found.**
- Full **`npm run verify:build`** (verify:prebuild + production build + verify:postbuild) — **exit 0**, including the previously-failing `validate-html-injection` step.
- Surgical 2-file diff; no generated artifacts committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2eSNEz3PQedR2Gw3cDssU

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2eSNEz3PQedR2Gw3cDssU)_