### PR TITLE
refactor(seo): remove Product JSON-LD from informational herb profiles

### DIFF
--- a/src/components/herb-profile/SchemaGenerator.tsx
+++ b/src/components/herb-profile/SchemaGenerator.tsx
@@ -1,7 +1,4 @@
-import {
-  buildHerbProductSchema,
-  buildHerbArticleSchema,
-} from '@/lib/schema-injector'
+import { buildHerbArticleSchema } from '@/lib/schema-injector'
 import JsonLd from '@/components/seo/JsonLd'
 
 export type HerbSchemaGeneratorProps = {
@@ -19,50 +16,28 @@ export type HerbSchemaGeneratorProps = {
   dateReviewed?: string
   /** Evidence grade string, e.g. "B — Moderate" */
   evidenceGrade?: string
-  /** Product category label, defaults to "Herbal Supplement" */
-  category?: string
-  /** Optional affiliate/purchase offer to include in the Product node */
-  offer?: {
-    price: number
-    priceCurrency: string
-    availability?: string
-    offerUrl?: string
-  }
 }
 
 /**
- * Renders supplementary Product and Article JSON-LD script tags for a herb
- * profile page. These nodes are additive — they sit alongside the existing
- * MedicalWebPage/@graph emitted by SchemaGraphScript and do not replace it.
+ * Renders a supplementary Article JSON-LD script tag for a herb profile page.
+ * This node is additive — it sits alongside the existing MedicalWebPage/@graph
+ * emitted by SchemaGraphScript and does not replace it.
  *
- * Product schema is emitted only when a real offer is supplied. Educational
- * herb profiles without offers should not advertise Product rich-result data.
- * Article schema remains eligible for article rich results.
+ * Informational herb profiles are educational references, not commercial
+ * product listings, so no Product JSON-LD is emitted here. Article schema
+ * remains eligible for article rich results.
  *
- * The component is a pure server component: it emits only static <script>
- * tags and performs no client-side work, so it has zero hydration cost.
+ * The component is a pure server component: it emits only a static <script>
+ * tag and performs no client-side work, so it has zero hydration cost.
  */
 export default function HerbSchemaGenerator({
   name,
-  slug,
   description,
   url,
   image,
   dateReviewed,
   evidenceGrade,
-  category = 'Herbal Supplement',
-  offer,
 }: HerbSchemaGeneratorProps) {
-  const productSchema = buildHerbProductSchema({
-    name,
-    description,
-    url,
-    image,
-    sku: slug,
-    category,
-    ...(offer ? { offers: offer } : {}),
-  })
-
   const articleSchema = buildHerbArticleSchema({
     headline: `${name} Benefits, Dosage & Safety`,
     description,
@@ -73,10 +48,5 @@ export default function HerbSchemaGenerator({
     evidenceGrade,
   })
 
-  return (
-    <>
-      {offer ? <JsonLd schema={productSchema} /> : null}
-      <JsonLd schema={articleSchema} />
-    </>
-  )
+  return <JsonLd schema={articleSchema} />
 }

--- a/src/components/herb-profile/__tests__/SchemaGenerator.test.tsx
+++ b/src/components/herb-profile/__tests__/SchemaGenerator.test.tsx
@@ -22,7 +22,7 @@ function getScripts(c: HTMLElement): { product?: Record<string, unknown>; articl
 }
 
 describe('HerbSchemaGenerator', () => {
-  it('renders Article JSON-LD by default', () => {
+  it('renders only Article JSON-LD and never a Product node', () => {
     const { container: c } = render(<HerbSchemaGenerator {...BASE_PROPS} />)
     const scripts = c.querySelectorAll('script[type="application/ld+json"]')
     expect(scripts.length).toBe(1)
@@ -31,71 +31,10 @@ describe('HerbSchemaGenerator', () => {
     expect(product).toBeUndefined()
   })
 
-  // ----- Product schema -----
-
-  it('Product node has correct @context and @type', () => {
-    const { container: c } = render(<HerbSchemaGenerator {...BASE_PROPS} offer={{ price: 19.99, priceCurrency: 'USD' }} />)
-    const { product } = getScripts(c)
-    expect(product?.['@context']).toBe('https://schema.org')
-    expect(product?.['@type']).toBe('Product')
-  })
-
-  it('Product node contains the herb name', () => {
-    const { container: c } = render(<HerbSchemaGenerator {...BASE_PROPS} offer={{ price: 19.99, priceCurrency: 'USD' }} />)
-    const { product } = getScripts(c)
-    expect(product?.name).toBe('Ashwagandha')
-  })
-
-  it('Product node contains the description', () => {
-    const { container: c } = render(<HerbSchemaGenerator {...BASE_PROPS} offer={{ price: 19.99, priceCurrency: 'USD' }} />)
-    const { product } = getScripts(c)
-    expect(product?.description).toBe(BASE_PROPS.description)
-  })
-
-  it('Product node uses slug as sku', () => {
-    const { container: c } = render(<HerbSchemaGenerator {...BASE_PROPS} offer={{ price: 19.99, priceCurrency: 'USD' }} />)
-    const { product } = getScripts(c)
-    expect(product?.sku).toBe('ashwagandha')
-  })
-
-  it('Product node defaults category to Herbal Supplement', () => {
-    const { container: c } = render(<HerbSchemaGenerator {...BASE_PROPS} offer={{ price: 19.99, priceCurrency: 'USD' }} />)
-    const { product } = getScripts(c)
-    expect(product?.category).toBe('Herbal Supplement')
-  })
-
-  it('Product node accepts a custom category', () => {
-    const { container: c } = render(<HerbSchemaGenerator {...BASE_PROPS} category="Adaptogen" offer={{ price: 19.99, priceCurrency: 'USD' }} />)
-    const { product } = getScripts(c)
-    expect(product?.category).toBe('Adaptogen')
-  })
-
-  it('Product node brand is The Hippie Scientist', () => {
-    const { container: c } = render(<HerbSchemaGenerator {...BASE_PROPS} offer={{ price: 19.99, priceCurrency: 'USD' }} />)
-    const { product } = getScripts(c)
-    const brand = product?.brand as Record<string, unknown>
-    expect(brand.name).toBe('The Hippie Scientist')
-  })
-
-  it('Product node is omitted when no offer prop is given', () => {
+  it('emits no Product node for an informational herb profile', () => {
     const { container: c } = render(<HerbSchemaGenerator {...BASE_PROPS} />)
     const { product } = getScripts(c)
     expect(product).toBeUndefined()
-  })
-
-  it('Product node includes offers when offer prop is provided', () => {
-    const { container: c } = render(
-      <HerbSchemaGenerator
-        {...BASE_PROPS}
-        offer={{ price: 19.99, priceCurrency: 'USD' }}
-      />
-    )
-    const { product } = getScripts(c)
-    const offers = product?.offers as Record<string, unknown>
-    expect(offers['@type']).toBe('Offer')
-    expect(offers.price).toBe(19.99)
-    expect(offers.priceCurrency).toBe('USD')
-    expect(offers.availability).toBe('https://schema.org/InStock')
   })
 
   // ----- Article schema -----

--- a/src/lib/__tests__/schema-injector.test.ts
+++ b/src/lib/__tests__/schema-injector.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
   serializeJsonLd,
-  buildHerbProductSchema,
   buildHerbArticleSchema,
 } from '../schema-injector'
 
@@ -11,7 +10,7 @@ import {
 
 describe('serializeJsonLd', () => {
   it('produces valid JSON', () => {
-    const result = serializeJsonLd({ '@type': 'Product', name: 'Ashwagandha' })
+    const result = serializeJsonLd({ '@type': 'Article', name: 'Ashwagandha' })
     expect(() => JSON.parse(result)).not.toThrow()
   })
 
@@ -40,112 +39,6 @@ describe('serializeJsonLd', () => {
     const parsed = JSON.parse(serialized)
     expect(parsed['@type']).toBe('Article')
     expect(parsed.headline).toBe('A & B < C > D')
-  })
-})
-
-// ---------------------------------------------------------------------------
-// buildHerbProductSchema — Google Rich Results compliance
-// ---------------------------------------------------------------------------
-
-describe('buildHerbProductSchema', () => {
-  const base = {
-    name: 'Ashwagandha',
-    description: 'An adaptogenic herb used to reduce stress and anxiety.',
-    url: 'https://thehippiescientist.net/herbs/ashwagandha/',
-  }
-
-  it('emits required @context and @type', () => {
-    const schema = buildHerbProductSchema(base)
-    expect(schema['@context']).toBe('https://schema.org')
-    expect(schema['@type']).toBe('Product')
-  })
-
-  it('includes the required name field (Google Rich Results)', () => {
-    const schema = buildHerbProductSchema(base)
-    expect(schema.name).toBe('Ashwagandha')
-  })
-
-  it('includes description as a qualifying additional property', () => {
-    const schema = buildHerbProductSchema(base)
-    expect(schema.description).toBe(base.description)
-  })
-
-  it('includes url', () => {
-    const schema = buildHerbProductSchema(base)
-    expect(schema.url).toBe(base.url)
-  })
-
-  it('defaults brand to The Hippie Scientist', () => {
-    const schema = buildHerbProductSchema(base)
-    expect(schema.brand).toEqual({ '@type': 'Brand', name: 'The Hippie Scientist' })
-  })
-
-  it('accepts a custom brand name', () => {
-    const schema = buildHerbProductSchema({ ...base, brand: 'Custom Brand' })
-    const brand = schema.brand as Record<string, unknown>
-    expect(brand.name).toBe('Custom Brand')
-  })
-
-  it('omits image when not provided', () => {
-    const schema = buildHerbProductSchema(base)
-    expect(schema.image).toBeUndefined()
-  })
-
-  it('includes image when provided', () => {
-    const schema = buildHerbProductSchema({ ...base, image: 'https://thehippiescientist.net/og-ashwagandha.jpg' })
-    expect(schema.image).toBe('https://thehippiescientist.net/og-ashwagandha.jpg')
-  })
-
-  it('includes sku when provided', () => {
-    const schema = buildHerbProductSchema({ ...base, sku: 'ashwagandha' })
-    expect(schema.sku).toBe('ashwagandha')
-  })
-
-  it('includes category when provided', () => {
-    const schema = buildHerbProductSchema({ ...base, category: 'Herbal Supplement' })
-    expect(schema.category).toBe('Herbal Supplement')
-  })
-
-  it('omits offers node when no price is supplied', () => {
-    const schema = buildHerbProductSchema(base)
-    expect(schema.offers).toBeUndefined()
-  })
-
-  it('emits a valid Offer node when price is supplied', () => {
-    const schema = buildHerbProductSchema({
-      ...base,
-      offers: { price: 19.99, priceCurrency: 'USD' },
-    })
-    const offers = schema.offers as Record<string, unknown>
-    expect(offers['@type']).toBe('Offer')
-    expect(offers.price).toBe(19.99)
-    expect(offers.priceCurrency).toBe('USD')
-    expect(offers.availability).toBe('https://schema.org/InStock')
-    expect(offers.url).toBe(base.url)
-  })
-
-  it('uses custom offerUrl when supplied in offers', () => {
-    const schema = buildHerbProductSchema({
-      ...base,
-      offers: { price: 24.99, priceCurrency: 'USD', offerUrl: 'https://amazon.com/dp/B000X' },
-    })
-    const offers = schema.offers as Record<string, unknown>
-    expect(offers.url).toBe('https://amazon.com/dp/B000X')
-  })
-
-  it('uses custom availability when supplied', () => {
-    const schema = buildHerbProductSchema({
-      ...base,
-      offers: { price: 24.99, priceCurrency: 'USD', availability: 'https://schema.org/OnlineOnly' },
-    })
-    const offers = schema.offers as Record<string, unknown>
-    expect(offers.availability).toBe('https://schema.org/OnlineOnly')
-  })
-
-  it('serializes without XSS vectors', () => {
-    const schema = buildHerbProductSchema({ ...base, description: '<script>alert(1)</script>' })
-    const serialized = serializeJsonLd(schema)
-    expect(serialized).not.toContain('<script>')
   })
 })
 

--- a/src/lib/__tests__/seo.test.ts
+++ b/src/lib/__tests__/seo.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { generateDetailMetadata, herbJsonLd, compoundJsonLd, isMeaningfulFaqAnswer, productJsonLd, shouldIndexRoute } from '../seo'
+import { generateDetailMetadata, herbJsonLd, compoundJsonLd, isMeaningfulFaqAnswer, shouldIndexRoute } from '../seo'
 
 describe('SEO Metadata & JSON-LD Utilities', () => {
   const mockHerb = {
@@ -167,53 +167,6 @@ describe('SEO Metadata & JSON-LD Utilities', () => {
           'Ashwagandha is typically dosed at 300 to 600 mg of a standardized root extract once or twice daily with food.',
         ),
       ).toBe(true)
-    })
-  })
-
-  describe('productJsonLd', () => {
-    it('returns null if price or priceCurrency is missing or invalid', () => {
-      expect(
-        productJsonLd({
-          name: 'Ashwagandha Extract',
-          description: 'A premium extract.',
-          url: 'https://thehippiescientist.net/herbs/ashwagandha/',
-        })
-      ).toBeNull()
-
-      expect(
-        productJsonLd({
-          name: 'Ashwagandha Extract',
-          description: 'A premium extract.',
-          url: 'https://thehippiescientist.net/herbs/ashwagandha/',
-          price: 'invalid-price',
-          priceCurrency: 'USD',
-        })
-      ).toBeNull()
-
-      expect(
-        productJsonLd({
-          name: 'Ashwagandha Extract',
-          description: 'A premium extract.',
-          url: 'https://thehippiescientist.net/herbs/ashwagandha/',
-          price: 15.99,
-        })
-      ).toBeNull()
-    })
-
-    it('returns valid Product JSON-LD if valid price and priceCurrency are provided', () => {
-      const jsonLd = productJsonLd({
-        name: 'Ashwagandha Extract',
-        description: 'A premium extract.',
-        url: 'https://thehippiescientist.net/herbs/ashwagandha/',
-        price: 15.99,
-        priceCurrency: 'USD',
-      })
-
-      expect(jsonLd).not.toBeNull()
-      expect(jsonLd?.['@type']).toBe('Product')
-      expect(jsonLd?.offers?.['@type']).toBe('Offer')
-      expect(jsonLd?.offers?.price).toBe(15.99)
-      expect(jsonLd?.offers?.priceCurrency).toBe('USD')
     })
   })
 })

--- a/src/lib/schema-injector.ts
+++ b/src/lib/schema-injector.ts
@@ -1,10 +1,13 @@
 /**
- * JSON-LD injection utilities for Product and Article schema types.
+ * JSON-LD injection utilities for Article schema.
  *
- * These builders complement the MedicalWebPage/@graph system in schema-graph.ts
- * by producing standalone Product and Article nodes suitable for Google Rich Results.
- * They are deliberately separate from the @graph to avoid type conflicts with
+ * This builder complements the MedicalWebPage/@graph system in schema-graph.ts
+ * by producing a standalone Article node suitable for Google Rich Results.
+ * It is deliberately separate from the @graph to avoid type conflicts with
  * MedicalWebPage nodes and to allow per-section injection.
+ *
+ * Informational herb profiles are not commercial product listings, so no
+ * Product node is emitted here — Product schema was intentionally removed.
  *
  * Serialization: serializeJsonLd() centralises the HTML-safe escaping used when
  * writing JSON-LD script payloads.
@@ -26,78 +29,6 @@ export function serializeJsonLd(node: JsonLdNode): string {
     .replace(/</g, '\\u003c')
     .replace(/>/g, '\\u003e')
     .replace(/&/g, '\\u0026')
-}
-
-// ---------------------------------------------------------------------------
-// Product schema
-// ---------------------------------------------------------------------------
-
-export type HerbProductSchemaArgs = {
-  /** Common display name, e.g. "Ashwagandha" */
-  name: string
-  /** One-sentence description used as schema description */
-  description: string
-  /** Absolute canonical URL for the profile page */
-  url: string
-  /** Absolute URL of the representative image (OG image is fine) */
-  image?: string
-  /** Brand name; defaults to site name */
-  brand?: string
-  /** Value used as schema `sku` — the herb slug works well */
-  sku?: string
-  /** Product category label, e.g. "Herbal Supplement" */
-  category?: string
-  /** Optional pricing information for Offer node */
-  offers?: {
-    price: number
-    priceCurrency: string
-    /** Defaults to https://schema.org/InStock */
-    availability?: string
-    /** Defaults to `url` */
-    offerUrl?: string
-  }
-}
-
-/**
- * Builds a Schema.org Product node for a herb supplement profile.
- *
- * Unlike the existing productJsonLd() in src/lib/seo.ts, this function does
- * not require a price: it emits a valid Product node that satisfies Google's
- * minimum requirements for basic product appearance (name + description +
- * brand). An Offer sub-node is added only when price data is supplied.
- *
- * Google Rich Results minimum required fields satisfied here:
- *   - name (required)
- *   - description (one of the qualifying additional properties)
- */
-export function buildHerbProductSchema(args: HerbProductSchemaArgs): JsonLdNode {
-  const node: JsonLdNode = {
-    '@context': 'https://schema.org',
-    '@type': 'Product',
-    name: args.name,
-    description: args.description,
-    url: args.url,
-    brand: {
-      '@type': 'Brand',
-      name: args.brand ?? 'The Hippie Scientist',
-    },
-  }
-
-  if (args.image) node.image = args.image
-  if (args.sku) node.sku = args.sku
-  if (args.category) node.category = args.category
-
-  if (args.offers) {
-    node.offers = {
-      '@type': 'Offer',
-      price: args.offers.price,
-      priceCurrency: args.offers.priceCurrency,
-      availability: args.offers.availability ?? 'https://schema.org/InStock',
-      url: args.offers.offerUrl ?? args.url,
-    }
-  }
-
-  return node
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -349,35 +349,6 @@ export function routePriority(path: string, pageData?: Record<string, unknown> |
   return shouldIndexRoute(path, pageData).priority
 }
 
-export function productJsonLd(args: {
-  name: string
-  description: string
-  url: string
-  price?: number | string
-  priceCurrency?: string
-}) {
-  const priceNum = typeof args.price === 'string' ? parseFloat(args.price) : args.price
-
-  if (typeof priceNum !== 'number' || isNaN(priceNum) || priceNum <= 0 || !args.priceCurrency) {
-    return null
-  }
-
-  return {
-    '@context': 'https://schema.org',
-    '@type': 'Product',
-    name: args.name,
-    description: args.description,
-    url: args.url,
-    offers: {
-      '@type': 'Offer',
-      price: priceNum,
-      priceCurrency: args.priceCurrency,
-      url: args.url,
-      availability: 'https://schema.org/OnlineOnly',
-    },
-  }
-}
-
 export function buildMeta({
   title = DEFAULT_TITLE,
   description = DEFAULT_DESCRIPTION,


### PR DESCRIPTION
## Summary

Herb profiles are educational references, not commercial product listings, so emitting `Product` JSON-LD risks Google structured-data violations. This removes all Product JSON-LD generation across source and tests.

This re-applies an audit that a prior Codex session completed but lost before it could commit (it hit a usage limit at the "Commit push and merge" step).

## Changes (6 files, +21 / −364)

- **`src/lib/schema-injector.ts`** — drop `buildHerbProductSchema` and `HerbProductSchemaArgs` entirely; the module now only builds Article nodes
- **`src/components/herb-profile/SchemaGenerator.tsx`** — now emits only Article JSON-LD alongside the existing `MedicalWebPage` @graph; removed the Product `offer`/`category` props and Product emission
- **`src/lib/seo.ts`** — remove the unused `productJsonLd` helper
- **Tests** (`schema-injector.test.ts`, `SchemaGenerator.test.tsx`, `seo.test.ts`) — updated to assert no Product node is emitted for informational herb profiles

## Route impact

No route changes. The `MedicalWebPage`/`WebPage` @graph, breadcrumbs, FAQ, and Article schema are all unaffected — only the standalone `Product` node is removed.

## Verification

- ✅ `tsc --noEmit` clean
- ✅ `eslint .` (zero warnings) clean
- ✅ 41 unit tests pass across the three affected files
- ✅ full 26-step `npm run build` passed
- ✅ `audit:structured-data` passed
- ✅ zero `"@type":"Product"` literals in the built `out/` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012aoss14Be2FCxyymWBEAfP

---
_Generated by [Claude Code](https://claude.ai/code/session_012aoss14Be2FCxyymWBEAfP)_