### PR TITLE
fix(seo): gate /compare link generators against the built page set

### DIFF
--- a/app/__tests__/compare-link-integrity.test.ts
+++ b/app/__tests__/compare-link-integrity.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+
+import { isBuiltComparisonSlug } from '@/lib/comparison-utils'
+import { buildComparisonRecommendations } from '@/lib/semantic/buildComparisonRecommendations'
+import { getComparisonCandidates } from '@/lib/semantic-runtime'
+import { buildCompareCTA } from '@/lib/conversion-aware-layouts'
+
+/**
+ * Guards against the regression that produced a large "Not found (404)" cluster
+ * in Google Search Console: dynamic generators emitting `/compare/<slug>` links
+ * for comparison pages that are never built. Under static export those links
+ * 404 the moment a crawler follows them.
+ *
+ * Every generator that can build a `/compare/...` href must only emit slugs that
+ * are actually built (`isBuiltComparisonSlug`). These tests feed each generator
+ * the exact shapes that historically leaked phantoms and assert nothing unbuilt
+ * escapes.
+ */
+
+function compareSlug(href: string): string {
+  return href.replace(/^\/compare\//, '').replace(/\/$/, '')
+}
+
+describe('compare link integrity', () => {
+  it('isBuiltComparisonSlug accepts a known built pair and rejects phantoms', () => {
+    // `aescin-vs-ajoene` is part of the generated/adjacent comparison set that
+    // `app/compare/[slug]/page.tsx` builds via generateStaticParams.
+    expect(isBuiltComparisonSlug('aescin-vs-ajoene')).toBe(true)
+    // Mechanism / signal "comparisons" and arbitrary pairs are not built pages.
+    expect(isBuiltComparisonSlug('garcinia-indica-vs-nf-b-inhibition')).toBe(false)
+    expect(isBuiltComparisonSlug('citicoline-vs-neuroprotective-activity')).toBe(false)
+    expect(isBuiltComparisonSlug('alpha-gpc')).toBe(false)
+  })
+
+  it('buildComparisonRecommendations never emits an unbuilt /compare/ slug', () => {
+    // Mechanisms/pathways/effects are NOT comparison pages — the historical leak.
+    const record = {
+      name: 'Garcinia Indica',
+      slug: 'garcinia-indica',
+      primary_effects: ['NF-B inhibition', 'HAT inhibition'],
+      mechanisms: ['JAK-STAT modulation', 'neuroprotective activity'],
+      pathways: ['inflammatory signaling modulation'],
+    }
+
+    const items = buildComparisonRecommendations(record)
+    for (const item of items) {
+      expect(isBuiltComparisonSlug(compareSlug(item.href))).toBe(true)
+    }
+  })
+
+  it('getComparisonCandidates only links to built comparison pages', () => {
+    const compound = {
+      name: 'Cordyceps',
+      slug: 'cordyceps',
+      effects: ['energy', 'endurance'],
+      mechanisms: ['atp production'],
+    }
+
+    const candidates = getComparisonCandidates(compound, 8)
+    for (const candidate of candidates) {
+      expect(candidate.href.startsWith('/compare/')).toBe(true)
+      expect(isBuiltComparisonSlug(compareSlug(candidate.href))).toBe(true)
+    }
+  })
+
+  it('buildCompareCTA falls back to the /compare hub for unbuilt topics', () => {
+    const cta = buildCompareCTA({ name: 'Sleep Herbs', slug: 'sleep-herbs' })
+    // Either the comparison hub, or a genuinely built comparison page.
+    if (cta.href !== '/compare') {
+      expect(isBuiltComparisonSlug(compareSlug(cta.href))).toBe(true)
+    } else {
+      expect(cta.href).toBe('/compare')
+    }
+  })
+})

--- a/components/authority/ComparisonRecommendations.tsx
+++ b/components/authority/ComparisonRecommendations.tsx
@@ -1,5 +1,15 @@
 import Link from 'next/link'
 import { cleanEditorialText, dedupeEditorialItems, isDuplicateTitleBody, isRenderableText, shouldRenderCard } from '@/lib/editorial-rendering'
+import { isBuiltComparisonSlug } from '@/lib/comparison-utils'
+
+// A href is safe to render only if it is a non-compare link, or a /compare/
+// link whose target page is actually built. This prevents the component from
+// ever emitting a phantom comparison URL that 404s the moment it is crawled.
+function isRenderableHref(href: string): boolean {
+  if (!href) return false
+  if (!href.startsWith('/compare/')) return true
+  return isBuiltComparisonSlug(href.replace(/^\/compare\//, '').replace(/\/$/, ''))
+}
 
 type DiscoveryItem = {
   href: string
@@ -30,7 +40,7 @@ export default function ComparisonRecommendations({
         overlap: dedupeEditorialItems(item.overlap || [], 4),
       }
     })
-    .filter((item) => item.href && shouldRenderCard(item.title, item.rationale))
+    .filter((item) => isRenderableHref(item.href) && shouldRenderCard(item.title, item.rationale))
 
   if (!renderableItems.length) {
     return null

--- a/docs/seo/coverage-diagnosis-2026-06-17.md
+++ b/docs/seo/coverage-diagnosis-2026-06-17.md
@@ -1,0 +1,146 @@
+# Search Console Coverage Diagnosis — 2026-06-17
+
+Source: Google Search Console "Page indexing" exports for `thehippiescientist.net`
+(coverage summary, sitemap-scoped coverage, and two issue drilldowns — "Discovered –
+currently not indexed" and "Not found (404)").
+
+This document records the diagnosis, the root cause of the largest issue cluster, the code
+hardening shipped alongside it, and the operator action items that must be done in GSC /
+Cloudflare (they cannot be fixed in the repo).
+
+---
+
+## 1. Headline
+
+The site is **not** being deindexed. The "All known pages" property holds steady at
+**~1,050 indexed**. The problem is **crawl-budget waste**: a large backlog of `404` and
+`redirect` URLs is consuming Googlebot's attention so that legitimate, in-sitemap pages sit
+"Discovered – currently not indexed" and never get fetched.
+
+| Reason | Pages | Read |
+|---|---|---|
+| **Not found (404)** | **1,806** | Historical phantom `/compare/*` URLs (see §3). Self-healing. |
+| Page with redirect | 678 | Intentional 301s being re-crawled. Wasted budget, not errors. |
+| Excluded by `noindex` | 186 | Audit intent; mostly deliberate. |
+| **Discovered – not indexed** | **188** | Real pages, **never crawled** (last-crawled epoch `1969-12-31`). |
+| Crawled – not indexed | 43 | Thin/low-authority; quality threshold. |
+| Redirect error | 15 | Broken redirect chains — worth a spot check. |
+
+The causal chain: **1,806 (404) + 678 (redirect) ≈ 2,484 junk fetch targets** crowd out the
+**188** legitimate pages. Clearing the junk is the lever that gets the 188 crawled and indexed.
+
+---
+
+## 2. Canonicalization (verified clean)
+
+Everything resolves to non-www `https://thehippiescientist.net`:
+
+- `src/lib/site.ts` strips `www.` if it appears in `NEXT_PUBLIC_SITE_URL`.
+- `app/sitemap.ts`, `app/robots.ts`, and all canonical tags emit non-www.
+- Trailing slash is enforced (`next.config.mjs` `trailingSlash: true`).
+
+⚠️ **Operator action — verify in GSC, not in repo:** the sitemap was submitted to GSC as
+`https://www.thehippiescientist.net/sitemap.xml` (the **www** host) while content
+canonicalizes to **non-www**, and there is no www→non-www redirect in `public/_redirects`.
+Confirm the Cloudflare custom-domain setup 301-redirects `www` → apex, and that the GSC
+property / submitted sitemap uses the non-www host (or a Domain property). A host split here
+manufactures duplicate URLs.
+
+---
+
+## 3. Root cause of the 1,806 `404`s — and why it is self-healing
+
+**99% of the sampled 404s are `/compare/*` URLs** that look combinatorial and invalid:
+
+```
+/compare/garcinia-indica-vs-nf-b-inhibition      (herb vs a mechanism)
+/compare/citicoline-vs-neuroprotective-activity  (compound vs an activity)
+/compare/cordyceps-vs-bicarbonate                (arbitrary pair)
+/compare/alpha-gpc                               (no "-vs-" at all)
+```
+
+Under static export, the only `/compare/*` pages that exist are the ~79 returned by
+`generateStaticParams` in `app/compare/[slug]/page.tsx` (`generatedComparisons` +
+`supplementComparisons` + an adjacent-pair list + the hand-authored `app/compare/*`
+directories). Any other `/compare/*` slug is a hard 404.
+
+Several internal-link generators historically emitted `/compare/{slug}-vs-{signal}` pairs
+where `signal` is a **mechanism / pathway / effect** (e.g. "NF-κB inhibition" →
+`nf-b-inhibition`) — these are not comparison pages, so every one 404s. The signature in the
+404 export (`-vs-{mechanism}`) matches `lib/semantic/buildComparisonRecommendations.ts`
+exactly.
+
+### Ground truth: the live build is already clean
+
+A full `next build` was run and the emitted HTML was crawled:
+
+- **37** unique `/compare/*` links appear across the entire site; **all 37 resolve to a built
+  page** (the single exception, `/compare/ashwagandha-vs-rhodiola-for-stress`, is a `301`
+  redirect source, not a 404).
+- **Zero** of the GSC phantom patterns (`-vs-nf-b-inhibition`, `-vs-neuroprotective-activity`,
+  bare `/compare/alpha-gpc`, etc.) appear in any built page.
+
+So the **current deployment does not emit these links**. The 1,806 are historical artifacts
+from a previous site version; Google re-validates known 404s for weeks/months, which is why
+the count is still drifting up (1,655 → 1,806) as it works through its own discovery backlog.
+**They will fall out of the index on their own** as Google re-crawls and confirms the 404.
+The correct response is `404` (not a mass 301 to unrelated pages, which Google treats as
+soft-404/manipulation).
+
+---
+
+## 4. Hardening shipped (so it cannot recur)
+
+The dead generators that produced the phantoms still exist and could be reactivated by a
+refactor. They are now gated through a single source of truth.
+
+- `lib/comparison-utils.ts` — added `isBuiltComparisonSlug(slug)`, the one guard every
+  dynamic `/compare/...` generator must pass a candidate through.
+- `lib/semantic/buildComparisonRecommendations.ts` — drops `{slug}-vs-{signal}` links unless
+  the slug is built (kills the exact pattern in the 404 export).
+- `lib/semantic-runtime.ts` `getComparisonCandidates` — validates each pair via
+  `getValidComparisonSlug`; emits only built comparisons.
+- `lib/conversion-aware-layouts.ts` `buildCompareCTA` — falls back to the `/compare` hub when
+  a topic has no built comparison page.
+- `lib/semantic-internal-linking.ts` — drops `compare`-type suggestions whose page is not built.
+- `components/authority/ComparisonRecommendations.tsx` — render-time guard filters any raw
+  `/compare/*` href that is not built (defense in depth).
+- `app/__tests__/compare-link-integrity.test.ts` — regression test feeding each generator the
+  shapes that historically leaked phantoms and asserting nothing unbuilt escapes.
+
+These are additive guards on code paths that are not currently rendered, so live behavior is
+unchanged; the build remains green and still emits zero phantom compare links.
+
+---
+
+## 5. Sitemap & redirect hygiene (verified)
+
+- `app/sitemap.ts` already excludes redirect sources (`readRedirectSources`), `noindex`
+  routes (`shouldIndexRoute`), and includes only **built** compare slugs — it is **not** a
+  source of the phantom 404s.
+- Minor: `public/_redirects` lists `/compare/ashwagandha-vs-rhodiola-for-stress` twice
+  (a benign duplicate). Left as-is; harmless under Cloudflare first-match semantics.
+
+---
+
+## 6. The 188 "Discovered – currently not indexed"
+
+These are real, in-sitemap pages (`/articles/*`, `/herbs/*`, `/compare/*`, `/guides/*`,
+`/learn/*`, plus index/utility pages) that have **never been crawled**. This is crawl-budget +
+authority, not a sitemap bug (verified: all are emitted by `app/sitemap.ts`). Levers, in order:
+
+1. **Clear the junk** (§3/§4) so Googlebot stops spending budget on 404/redirect URLs.
+2. **Internal linking** — per `expansionblueprint.md` §11, link these pages from higher-authority
+   money/hub pages so they accrue PageRank and crawl priority.
+3. **Request indexing / re-submit sitemap** in GSC for the highest-value pages.
+
+---
+
+## 7. Operator checklist (cannot be done in-repo)
+
+- [ ] Confirm Cloudflare 301-redirects `www.thehippiescientist.net` → apex.
+- [ ] Confirm the GSC property + submitted sitemap use the **non-www** host (or a Domain property).
+- [ ] In GSC, **Validate Fix** on "Not found (404)" and "Page with redirect" once this deploy is live.
+- [ ] Spot-check the 15 "Redirect error" URLs for broken 301 chains in `public/_redirects`.
+- [ ] Re-submit `sitemap.xml`; request indexing for top "Discovered – not indexed" pages.
+- [ ] Monitor: the 404 count should plateau then fall over the following weeks.

--- a/lib/comparison-utils.ts
+++ b/lib/comparison-utils.ts
@@ -41,3 +41,18 @@ export function getValidComparisonSlug(a: string, b: string): string | undefined
   if (validSlugs.has(slug2)) return slug2
   return undefined
 }
+
+/**
+ * Returns true only when `slug` resolves to a comparison page that is actually
+ * built (i.e. emitted by `generateStaticParams` in `app/compare/[slug]/page.tsx`).
+ *
+ * This is the single guard every dynamic `/compare/...` link generator must pass
+ * its candidate slug through. Under static export, linking to a `/compare/...`
+ * slug that is NOT built produces a hard 404 the moment Google crawls it — the
+ * root cause of the large "Not found (404)" cluster in Search Console. Validating
+ * here keeps internal links honest and prevents that class of phantom URL from
+ * ever being emitted again.
+ */
+export function isBuiltComparisonSlug(slug: string): boolean {
+  return typeof slug === 'string' && validSlugs.has(slug)
+}

--- a/lib/conversion-aware-layouts.ts
+++ b/lib/conversion-aware-layouts.ts
@@ -1,4 +1,5 @@
 import { text } from '@/lib/display-utils'
+import { isBuiltComparisonSlug } from '@/lib/comparison-utils'
 import { buildMonetizationOpportunity } from '@/lib/monetization-intelligence-layer'
 import { buildSemanticIntelligenceReport } from '@/lib/semantic-intelligence-layer'
 
@@ -45,10 +46,15 @@ export function buildPrimaryCTA(record: Record<string, unknown>): ConversionCTA 
 
 export function buildCompareCTA(record: Record<string, unknown>): ConversionCTA {
   const topic = title(record?.displayName || record?.name || record?.slug)
+  const topicSlug = slug(topic)
+
+  // A topic name is not a comparison slug, so only deep-link when a built page
+  // exists; otherwise route to the comparison hub instead of a 404.
+  const href = isBuiltComparisonSlug(topicSlug) ? `/compare/${topicSlug}` : '/compare'
 
   return {
     label: `Compare ${topic} alternatives`,
-    href: `/compare/${slug(topic)}`,
+    href,
     description: 'Review adjacent compounds, mechanisms, and evidence context side-by-side.',
     tone: 'compare',
   }

--- a/lib/semantic-internal-linking.ts
+++ b/lib/semantic-internal-linking.ts
@@ -1,4 +1,5 @@
 import { text, unique } from '@/lib/display-utils'
+import { isBuiltComparisonSlug } from '@/lib/comparison-utils'
 
 export type SemanticLinkSuggestion = {
   label: string
@@ -66,6 +67,9 @@ export function buildSemanticLinkSuggestions(source: Record<string, unknown>, ca
       }
     })
     .filter((item) => item.score > 0)
+    // Never surface a comparison link unless that comparison page is built;
+    // an unbuilt /compare/ slug 404s under static export.
+    .filter((item) => item.type !== 'compare' || isBuiltComparisonSlug(text(item.href).replace(/^\/compare\//, '')))
     .sort((a, b) => b.score - a.score || a.label.localeCompare(b.label))
     .slice(0, limit)
     .map(({ score: _score, ...item }) => item)

--- a/lib/semantic-runtime.ts
+++ b/lib/semantic-runtime.ts
@@ -1,5 +1,6 @@
 import compoundsData from '../public/data/compounds.json'
 import { cleanSummary, formatDisplayLabel, isClean, list as cleanList } from './display-utils'
+import { getValidComparisonSlug } from './comparison-utils'
 
 export type RuntimeCompoundInput = {
   slug?: string
@@ -228,11 +229,20 @@ export function getStackCandidates(compound: RuntimeCompoundInput, limit = 4) {
 export function getComparisonCandidates(compound: RuntimeCompoundInput, limit = 4) {
   const normalized = normalizeCompound(compound)
 
-  return getRelatedCompounds(normalized, limit).map((candidate) => ({
-    slug: `${normalized.slug}-vs-${candidate.slug}`,
-    href: `/compare/${normalized.slug}-vs-${candidate.slug}`,
-    label: `${normalized.name} vs ${candidate.name}`,
-  }))
+  return getRelatedCompounds(normalized, limit)
+    .map((candidate) => {
+      // Only emit links to comparison pages that are actually built; an
+      // arbitrary related-compound pair is usually not a real /compare/ route
+      // and would 404 under static export.
+      const validSlug = getValidComparisonSlug(normalized.slug, candidate.slug)
+      if (!validSlug) return null
+      return {
+        slug: validSlug,
+        href: `/compare/${validSlug}`,
+        label: `${normalized.name} vs ${candidate.name}`,
+      }
+    })
+    .filter((item): item is { slug: string; href: string; label: string } => item !== null)
 }
 
 export function getEvidenceSnapshot(compound: RuntimeCompoundInput) {

--- a/lib/semantic/buildComparisonRecommendations.ts
+++ b/lib/semantic/buildComparisonRecommendations.ts
@@ -1,4 +1,5 @@
 import { cleanEditorialText, dedupeEditorialItems, isRenderableText, shouldRenderCard } from '@/lib/editorial-rendering'
+import { isBuiltComparisonSlug } from '@/lib/comparison-utils'
 type RuntimeRecord = Record<string, unknown>
 
 function asList(value: unknown): string[] {
@@ -32,12 +33,21 @@ export function buildComparisonRecommendations(record: RuntimeRecord) {
 
   if (!isRenderableText(name) || !isRenderableText(slug)) return []
 
-  return signals.slice(0, 6).map((signal) => ({
-    href: `/compare/${slug}-vs-${signal
-      .toLowerCase()
-      .replace(/\s+/g, '-')}`,
-    title: cleanEditorialText(`${name} vs ${signal}`),
-    rationale: cleanEditorialText(`Semantic comparison generated through overlap in ${signal}.`),
-    overlap: [signal],
-  })).filter((item) => shouldRenderCard(item.title, item.rationale))
+  return signals
+    .slice(0, 6)
+    .map((signal) => {
+      const comparisonSlug = `${slug}-vs-${signal.toLowerCase().replace(/\s+/g, '-')}`
+      return {
+        comparisonSlug,
+        href: `/compare/${comparisonSlug}`,
+        title: cleanEditorialText(`${name} vs ${signal}`),
+        rationale: cleanEditorialText(`Semantic comparison generated through overlap in ${signal}.`),
+        overlap: [signal],
+      }
+    })
+    // Only surface comparisons that are actually built. Signals (mechanisms,
+    // pathways, effects) are not comparison pages, so these would 404 — the
+    // historical source of the "/compare/*" not-found cluster in Search Console.
+    .filter((item) => isBuiltComparisonSlug(item.comparisonSlug))
+    .filter((item) => shouldRenderCard(item.title, item.rationale))
 }


### PR DESCRIPTION
Google Search Console reported ~1,806 "Not found (404)" URLs, ~99% of them
combinatorial /compare/* links (e.g. herb-vs-mechanism such as
/compare/garcinia-indica-vs-nf-b-inhibition). Under static export only the
~79 slugs from generateStaticParams in app/compare/[slug]/page.tsx exist; any
other /compare slug is a hard 404.

A full build + HTML crawl confirms the live deployment no longer emits these
links (37 unique compare hrefs, all built; the GSC phantoms appear nowhere),
so the 404 backlog is historical and self-healing. But the dead generators
that produced them still exist and could be reactivated by a refactor.

Gate every dynamic /compare link generator through a single source of truth:

- lib/comparison-utils.ts: add isBuiltComparisonSlug(slug)
- buildComparisonRecommendations: drop {slug}-vs-{signal} unless built
- semantic-runtime getComparisonCandidates: validate each pair
- conversion-aware-layouts buildCompareCTA: fall back to /compare hub
- semantic-internal-linking: drop unbuilt compare suggestions
- ComparisonRecommendations.tsx: render-time guard on raw hrefs
- add app/__tests__/compare-link-integrity.test.ts regression test

Additive guards on non-rendered paths; build stays green and still emits zero
phantom compare links. Full diagnosis + operator action items (www/non-www
property verification, GSC validate-fix, the 188 discovered-not-indexed pages)
in docs/seo/coverage-diagnosis-2026-06-17.md.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A2QgUQRjE8XE25NfGkESAT