### PR TITLE
feat(publishing): add content page generator and governance docs

### DIFF
--- a/docs/MASTER_CONTENT_MAP.md
+++ b/docs/MASTER_CONTENT_MAP.md
@@ -1,0 +1,202 @@
+# Master Content Map
+
+> Source of truth for content types, ownership, and routing governance.  
+> Last updated: 2026-06-17
+
+---
+
+## Content Architecture Overview
+
+The site uses a two-layer model:
+
+**Discovery layer** — broad search intent, funnels to depth:
+- `/goals/:slug` — evidence hubs by health goal
+- `/guides/:slug` — long-form how-to / roundup guides
+- `/articles/:slug` — Q&A, deep dives, comparisons
+- `/best-supplements-for-*` — entry pages
+
+**Depth layer** — authoritative profiles driven by the workbook:
+- `/herbs/:slug` — herb monographs (workbook-only)
+- `/compounds/:slug` — compound profiles (workbook-only)
+- `/stacks/:slug` — curated stacks (workbook-only)
+- `/compare/:slug` — head-to-head comparisons
+
+---
+
+## Content Types
+
+### `/herbs/:slug` — Herb Monographs
+
+| Property | Value |
+|----------|-------|
+| Source of truth | `data-sources/herb_monograph_master.xlsx` |
+| Data pipeline | `npm run data:build` → `public/data/` |
+| Route file | `app/herbs/[slug]/page.tsx` (dynamic catch-all) |
+| Edit workflow | Edit workbook → `npm run data:build` |
+| Static params | Generated from `public/data/herbs.json` |
+| Owner | Workbook only — **never edit `public/data` directly for herb content** |
+
+Do not create manual `app/herbs/<slug>/page.tsx` files. All herb pages are rendered by the dynamic route from workbook-generated JSON.
+
+---
+
+### `/compounds/:slug` — Compound Profiles
+
+| Property | Value |
+|----------|-------|
+| Source of truth | `data-sources/herb_monograph_master.xlsx` |
+| Data pipeline | `npm run data:build` → `public/data/` |
+| Route file | `app/compounds/[slug]/page.tsx` (dynamic catch-all) |
+| Edit workflow | Edit workbook → `npm run data:build` |
+| Static params | Generated from `public/data/compounds.json` |
+| Owner | Workbook only — **never edit `public/data` directly for compound content** |
+
+Same rule as herbs: no manual static compound pages.
+
+---
+
+### `/guides/:slug` — Long-Form Guides
+
+| Property | Value |
+|----------|-------|
+| Source of truth | Static TSX files in `app/guides/<slug>/page.tsx` |
+| Data pipeline | None (static) |
+| Route file | `app/guides/[slug]/page.tsx` (catch-all handles legacy slugs via `getGuideBySlug`) |
+| Create workflow | `npm run create:page` → type: guide |
+| Owner | Engineering / Editorial |
+
+**Purpose:** Long-form roundup guides, best-of lists, how-to content. These target high-volume "best supplements for X" and "how to Y" queries.
+
+**Static guide pages (current):**
+- adhd-supplements
+- best-adaptogens-for-stress
+- best-herbs-for-anxiety
+- best-herbs-for-stress-and-anxiety-at-night
+- best-natural-sleep-aids-that-work
+- best-nootropics-for-focus
+- best-supplements-for-focus
+- best-supplements-for-overthinking
+- best-supplements-for-sleep
+- best-supplements-for-stress
+- elderberry
+- focus-without-caffeine-crash
+- how-to-lower-cortisol-naturally
+- kava
+- kratom-7oh-withdrawal-management
+- magnesium-for-sleep
+- magnesium-vs-melatonin
+- natural-alternatives-to-anxiety-medication
+- natural-anxiolytics-beyond-ashwagandha
+- passionflower
+- psychedelic-adjacent-herbs
+- rhodiola-complete-guide / rhodiola-energy / rhodiola-extract-vs-powder / rhodiola-sleep-stack
+- sleep-herbs-vs-melatonin
+- supplements-for-brain-fog-and-fatigue
+- turmeric-curcumin
+
+**Note:** The `[slug]` catch-all serves `ashwagandha` and `lions-mane` from the legacy guide system (`getGuideBySlug`). All new guides use static per-page files.
+
+---
+
+### `/articles/:slug` — Deep-Dive Articles
+
+| Property | Value |
+|----------|-------|
+| Source of truth | Static TSX files in `app/articles/<slug>/page.tsx` AND `data/articles/articles.json` (for JSON-driven articles) |
+| Data pipeline | `npm run articles:build` regenerates the `[slug]` catch-all index |
+| Route file | `app/articles/[slug]/page.tsx` (catch-all handles both JSON and static pages) |
+| Create workflow | `npm run create:page` → type: article |
+| Owner | Engineering / Editorial |
+
+**Purpose:** Q&A articles, condition-specific deep dives, ingredient spotlights. These target long-tail queries like "L-theanine for anxiety dosage" and "ashwagandha vs magnesium for sleep."
+
+**Two rendering paths:**
+1. **Static page** (`app/articles/<slug>/page.tsx`) — full editorial control, rich components. Preferred for flagship articles.
+2. **JSON-driven** (`data/articles/articles.json`) — markdown-content articles rendered by the `[slug]` catch-all. Used for bulk/agent-enriched content.
+
+**Static article pages (current):**
+- adhd-blood-tests, adhd-stack-guide, anxiety-stack-guide
+- ashwagandha-for-adhd, ashwagandha-for-anxiety, ashwagandha-for-sleep, ashwagandha-vs-magnesium-for-sleep
+- best-herbs-for-sleep, best-magnesium-for-sleep, best-magnesium-supplement-for-adhd, best-supplements-for-adhd
+- cbd-vs-ashwagandha-for-anxiety, citicoline-vs-alpha-gpc
+- iron-ferritin-and-adhd
+- l-theanine-for-adhd, l-theanine-for-anxiety, l-theanine-for-calm, l-theanine-for-sleep
+- l-theanine-magnesium-adhd-stack, l-theanine-vs-caffeine-for-focus, l-theanine-without-caffeine
+- magnesium-for-adhd, magnesium-for-sleep, magnesium-glycinate-vs-citrate-for-adhd, magnesium-types-for-sleep
+- melatonin-for-adhd-sleep, melatonin-vs-valerian
+- natural-anxiety-relief, nutrient-deficiencies-and-adhd
+- omega-3-and-adhd, sleep-and-adhd, sleep-best-supplements, sleep-stack-guide, sleep-stack-magnesium-melatonin
+- vitamin-d-and-adhd, zinc-and-adhd
+
+**JSON-driven articles (current):**
+- adaptogenic-natural-compounds
+- ashwagandha (bacopa-monnieri, elderberry, ginkgo-biloba, kava, l-theanine, lions-mane, magnesium-glycinate, nac, passionflower, peptides-research-guide, rhodiola-rosea, valerian-root)
+- entourage-effect-herbal-supplements
+- lions-mane-mushroom-benefits-mechanisms-dosage-evidence-guide
+- natural-compounds-research-clusters
+
+---
+
+### `/compare/:slug` — Head-to-Head Comparisons
+
+| Property | Value |
+|----------|-------|
+| Source of truth | Static TSX files in `app/compare/<slug>/page.tsx` AND `src/data/comparisons.ts` (for dynamic comparisons) |
+| Data pipeline | None for static pages |
+| Route file | `app/compare/[slug]/page.tsx` (catch-all handles dynamic comparisons from supplement data) |
+| Create workflow | `npm run create:page` → type: compare |
+| Owner | Engineering / Editorial |
+
+**Purpose:** Head-to-head comparisons of supplements, compounds, or approaches. Targets "[A] vs [B]" queries with high commercial intent.
+
+**Slug convention:** Use `a-vs-b` or `a-vs-b-vs-c` format. The generator auto-suggests component names from the slug.
+
+**Static compare pages (current):**
+- ashwagandha-vs-l-theanine-vs-magnesium
+- berberine-vs-metformin
+- caffeine-vs-l-theanine-vs-bacopa-for-focus
+- curcumin-vs-boswellia-vs-omega-3
+- kanna-vs-ssris
+- kava-vs-alcohol
+- l-theanine-vs-magnesium
+- magnesium-glycinate-vs-l-threonate-for-sleep
+- magnesium-glycinate-vs-magnesium-oxide
+- melatonin-vs-valerian-vs-magnesium-for-sleep
+- mitragynine-vs-7-hydroxymitragynine
+- rhodiola-vs-ashwagandha
+- sleep-herbs-vs-melatonin
+
+---
+
+## Route Ownership Summary
+
+| Route pattern | Owned by | Edit via |
+|---------------|----------|----------|
+| `/herbs/:slug` | Workbook | Edit xlsx → `npm run data:build` |
+| `/compounds/:slug` | Workbook | Edit xlsx → `npm run data:build` |
+| `/stacks/:slug` | Workbook | Edit xlsx → `npm run data:build` |
+| `/goals/:slug` | Workbook | Edit xlsx → `npm run data:build` |
+| `/guides/:slug` | Static TSX | `npm run create:page` |
+| `/articles/:slug` (flagship) | Static TSX | `npm run create:page` |
+| `/articles/:slug` (bulk) | `data/articles/articles.json` | Edit JSON + `npm run articles:build` |
+| `/compare/:slug` (static) | Static TSX | `npm run create:page` |
+| `/compare/:slug` (dynamic) | `src/data/comparisons.ts` | Edit data file |
+
+---
+
+## Slug Governance
+
+- Slugs must be lowercase letters, numbers, and hyphens only.
+- No leading or trailing hyphens.
+- Must be unique across the type's route namespace (the generator enforces this).
+- Stable once published — add a redirect in `public/_redirects` before changing a live slug.
+- Compare slugs use `-vs-` as the separator.
+
+---
+
+## What NOT to Do
+
+- Do not create `app/herbs/<slug>/page.tsx` or `app/compounds/<slug>/page.tsx` — those routes are owned by the workbook.
+- Do not edit `public/data/*.json` directly for herb/compound content — changes will be overwritten by `npm run data:build`.
+- Do not add `force-dynamic`, `export const revalidate`, `cookies()`, `headers()`, or `next/headers` — this is a static export and these will break the build.
+- Do not hardcode affiliate strings — always use `AFFILIATE_TAGS.amazon` from `config/affiliate.ts`.

--- a/docs/PUBLISHING_WORKFLOW.md
+++ b/docs/PUBLISHING_WORKFLOW.md
@@ -1,0 +1,153 @@
+# Publishing Workflow
+
+> How to go from idea to live page. One-page reference.
+
+---
+
+## Quick Start
+
+```
+npm run create:page
+```
+
+The generator prompts for type → title → slug → description and writes the scaffolded `page.tsx`.  
+Fill in the TODO sections, validate, commit, push — done.
+
+---
+
+## Full Workflow Diagram
+
+```
+idea
+  │
+  ▼
+npm run create:page
+  │
+  ├── Type?  ─────────────────────────────────────────────────────────────────
+  │            article    →   app/articles/<slug>/page.tsx
+  │            guide      →   app/guides/<slug>/page.tsx
+  │            compare    →   app/compare/<slug>/page.tsx
+  │
+  ├── Title   (free text)
+  │
+  ├── Slug    (lowercase, hyphens; auto-suggested from title)
+  │            └─ generator aborts if slug already exists
+  │
+  └── Description  (1–2 sentence meta description)
+         │
+         ▼
+    page.tsx scaffold created with:
+      - metadata export (buildPageMetadata)
+      - breadcrumb + article JSON-LD
+      - FAQ JSON-LD
+      - H1, intro, evidence, safety, FAQ, related sections
+      - TODO comments marking every section to fill in
+         │
+         ▼
+    Fill in content
+      - Replace all TODO comments
+      - Add EvidenceSummaryCard values
+      - Add FAQs (2–6 Q&A pairs)
+      - Add related links
+      - Wire affiliate links via AFFILIATE_TAGS.amazon if needed
+         │
+         ▼
+    Validate
+      npm run lint && npm run typecheck
+         │
+         ▼
+    Build
+      npm run build
+         │
+         ├── Build passes?
+         │     YES → continue
+         │     NO  → fix errors, re-run build
+         │
+         ▼
+    Commit
+      git add app/<type>/<slug>/page.tsx
+      git commit -m "content(<type>): add <slug> page"
+         │
+         ▼
+    Push
+      git push origin <branch>
+         │
+         ▼
+    PR + merge → Cloudflare Pages deploys automatically
+         │
+         ▼
+    LIVE
+```
+
+---
+
+## Type Decision Guide
+
+| If you're writing… | Use |
+|--------------------|-----|
+| "What is X?", "X for Y condition", research deep-dive | `article` |
+| "Best X for Y", roundup, how-to guide, buyer guide | `guide` |
+| "X vs Y", head-to-head ingredient comparison | `compare` |
+| New herb or compound profile | Edit workbook → `npm run data:build` (not this generator) |
+
+---
+
+## Validation Checklist
+
+Before committing:
+
+- [ ] All TODO comments replaced with real content
+- [ ] Title is specific and includes the primary keyword
+- [ ] Description is 120–160 characters, unique, includes primary keyword
+- [ ] H1 matches or closely mirrors the `<title>`
+- [ ] FAQs have real questions and hedged, balanced answers (no clinical claims)
+- [ ] EvidenceSummaryCard fields filled in accurately
+- [ ] `AFFILIATE_TAGS.amazon` used (not hardcoded strings) if affiliate links present
+- [ ] No `force-dynamic`, `revalidate`, `cookies()`, `headers()` (breaks static export)
+- [ ] `npm run lint` passes (zero warnings)
+- [ ] `npm run typecheck` passes
+- [ ] `npm run build` passes
+
+---
+
+## Slug Rules
+
+- Lowercase letters, numbers, and hyphens only
+- No leading or trailing hyphens
+- Must be unique in the route namespace (generator checks automatically)
+- Once live: stable forever — add redirect to `public/_redirects` before renaming
+- Compare slugs: use `-vs-` separator (e.g. `rhodiola-vs-ashwagandha`)
+
+---
+
+## File Locations
+
+| Type | Output path |
+|------|-------------|
+| article | `app/articles/<slug>/page.tsx` |
+| guide | `app/guides/<slug>/page.tsx` |
+| compare | `app/compare/<slug>/page.tsx` |
+
+---
+
+## For Herb / Compound / Stack Content
+
+The generator does **not** handle these — they are workbook-owned:
+
+```
+Edit data-sources/herb_monograph_master.xlsx
+  → npm run data:build
+  → npm run data:validate
+  → commit public/data changes
+```
+
+See `docs/workbook-only-data-contract.md` for the full workbook edit policy.
+
+---
+
+## See Also
+
+- `docs/MASTER_CONTENT_MAP.md` — route ownership and full slug inventory
+- `docs/workbook-only-data-contract.md` — herb/compound data pipeline rules
+- `config/affiliate.ts` — affiliate tag constants
+- `scripts/create-content-page.mjs` — the generator source

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "node": ">=20 <23"
   },
   "scripts": {
+    "create:page": "node scripts/create-content-page.mjs",
     "dev": "next dev --turbo",
     "dev:watch": "nodemon --watch . --exec \"npm run dev\"",
     "start": "next start",

--- a/scripts/create-content-page.mjs
+++ b/scripts/create-content-page.mjs
@@ -1,0 +1,659 @@
+#!/usr/bin/env node
+/**
+ * create-content-page.mjs
+ *
+ * Interactive scaffold for new static content pages.
+ * Usage: node scripts/create-content-page.mjs
+ *   or:  npm run create:page
+ *
+ * Generates to:
+ *   article → app/articles/<slug>/page.tsx
+ *   guide   → app/guides/<slug>/page.tsx
+ *   compare → app/compare/<slug>/page.tsx
+ */
+
+import fs from 'fs'
+import path from 'path'
+import readline from 'readline'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const ROOT = path.resolve(__dirname, '..')
+const TODAY = new Date().toISOString().slice(0, 10)
+
+// ─── Slug helpers ────────────────────────────────────────────────────────────
+
+function slugify(text) {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .trim()
+    .replace(/[\s_]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+}
+
+function isValidSlug(slug) {
+  return /^[a-z0-9][a-z0-9-]*[a-z0-9]$/.test(slug) || /^[a-z0-9]$/.test(slug)
+}
+
+function checkSlugUniqueness(type, slug) {
+  const typeMap = { article: 'articles', guide: 'guides', compare: 'compare' }
+  const dir = path.join(ROOT, 'app', typeMap[type], slug)
+  if (fs.existsSync(dir)) {
+    return { taken: true, conflict: `app/${typeMap[type]}/${slug}/ already exists` }
+  }
+  // For articles also check the JSON data source
+  if (type === 'article') {
+    const jsonPath = path.join(ROOT, 'data', 'articles', 'articles.json')
+    if (fs.existsSync(jsonPath)) {
+      const articles = JSON.parse(fs.readFileSync(jsonPath, 'utf-8'))
+      if (articles.some((a) => a.slug === slug)) {
+        return { taken: true, conflict: `Slug "${slug}" is already in data/articles/articles.json` }
+      }
+    }
+  }
+  return { taken: false }
+}
+
+// ─── readline prompt helper ──────────────────────────────────────────────────
+
+function prompt(rl, question) {
+  return new Promise((resolve) => rl.question(question, (answer) => resolve(answer.trim())))
+}
+
+// ─── Page templates ──────────────────────────────────────────────────────────
+
+function articleTemplate(slug, title, description) {
+  const functionName = slug
+    .split('-')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join('')
+
+  return `import Link from 'next/link'
+import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd } from '@/lib/seo'
+import EvidenceSummaryCard from '@/components/evidence/EvidenceSummaryCard'
+import SafetyNotice from '@/components/evidence/SafetyNotice'
+import LastUpdatedBadge from '@/components/editorial/LastUpdatedBadge'
+import { AFFILIATE_TAGS } from '@/config/affiliate'
+
+const SLUG = '${slug}'
+const TITLE = '${title}'
+const DESCRIPTION =
+  '${description}'
+const DATE = '${TODAY}'
+
+export const metadata = buildPageMetadata({
+  title: TITLE,
+  description: DESCRIPTION,
+  path: \`/articles/\${SLUG}\`,
+  openGraphType: 'article',
+})
+
+const FAQS = [
+  {
+    question: 'TODO: Add a relevant question here?',
+    answer:
+      'TODO: Add a well-sourced, balanced answer. Avoid clinical claims. Use hedged language (may, has been studied for, some research suggests).',
+  },
+  {
+    question: 'TODO: Another common question?',
+    answer: 'TODO: Answer here.',
+  },
+]
+
+export default function ${functionName}Page() {
+  void AFFILIATE_TAGS.amazon // used via RecommendationSection when products are added
+
+  const pageBreadcrumb = breadcrumbJsonLd([
+    { name: 'Home', url: 'https://thehippiescientist.net' },
+    { name: 'Articles', url: 'https://thehippiescientist.net/articles' },
+    { name: TITLE, url: \`https://thehippiescientist.net/articles/\${SLUG}\` },
+  ])
+
+  const articleLd = blogJsonLd(
+    { title: TITLE, slug: SLUG, date: DATE, description: DESCRIPTION },
+    \`/articles/\${SLUG}\`,
+  )
+
+  const faqLd = faqPageJsonLd({ pagePath: \`/articles/\${SLUG}\`, questions: FAQS })
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(pageBreadcrumb) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
+      />
+
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        <nav className="mb-6 flex items-center gap-2 text-sm text-muted" aria-label="Breadcrumb">
+          <Link href="/articles" className="transition hover:text-ink">Articles</Link>
+          <span>/</span>
+          <span className="text-ink line-clamp-1">{TITLE}</span>
+        </nav>
+
+        <div className="mb-8">
+          <LastUpdatedBadge date={DATE} />
+          <h1 className="text-4xl font-bold tracking-tight mt-4 mb-4">{TITLE}</h1>
+          <p className="text-xl text-muted-foreground">{DESCRIPTION}</p>
+        </div>
+
+        {/* TODO: Quick Verdict */}
+        <div className="mb-10 p-6 border rounded-xl bg-card">
+          <h2 className="text-2xl font-semibold mb-4">Quick Verdict</h2>
+          <ul className="space-y-2 text-muted-foreground">
+            <li>• TODO: Key takeaway 1.</li>
+            <li>• TODO: Key takeaway 2.</li>
+            <li>• TODO: Key takeaway 3.</li>
+            <li>• Not a replacement for professional medical advice.</li>
+          </ul>
+        </div>
+
+        {/* TODO: Introduction */}
+        <section className="mb-12">
+          <h2 className="text-3xl font-semibold mb-6">TODO: What Is [Topic]?</h2>
+          <div className="prose prose-lg max-w-none">
+            <p>TODO: 2–3 paragraphs introducing the subject. Cover origin, mechanism overview, and why this topic matters.</p>
+          </div>
+        </section>
+
+        {/* TODO: Evidence Summary */}
+        <section className="mb-12">
+          <h2 className="text-3xl font-semibold mb-6">Evidence Summary</h2>
+          <EvidenceSummaryCard
+            title="TODO: [Topic] — Evidence Summary"
+            evidenceLevel="TODO: Strong | Moderate | Limited | Insufficient"
+            humanEvidence="TODO: Describe human trial evidence — number of studies, population, outcomes."
+            mechanisticEvidence="TODO: Describe proposed mechanisms and preclinical evidence."
+            safetyProfile="TODO: Known safety signals, drug interactions, populations to caution."
+          />
+        </section>
+
+        {/* TODO: Dosage */}
+        <section className="mb-12">
+          <h2 className="text-3xl font-semibold mb-6">Dosage and Timing</h2>
+          <div className="prose prose-lg max-w-none">
+            <p>TODO: Typical supplemental dose ranges from research. Timing considerations. Individual variation note.</p>
+          </div>
+        </section>
+
+        {/* TODO: Safety */}
+        <section className="mb-12">
+          <h2 className="text-3xl font-semibold mb-6">Safety Considerations</h2>
+          <SafetyNotice>
+            <p>TODO: Describe contraindications, drug interactions, and populations requiring extra caution. Always recommend consulting a licensed clinician.</p>
+          </SafetyNotice>
+        </section>
+
+        {/* FAQ */}
+        <section className="mb-12">
+          <h2 className="text-3xl font-semibold mb-6">Frequently Asked Questions</h2>
+          <div className="space-y-6">
+            {FAQS.map((faq, i) => (
+              <div key={i} className="border rounded-lg p-5">
+                <h3 className="font-semibold text-lg mb-2">{faq.question}</h3>
+                <p className="text-muted-foreground">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Related */}
+        <section className="mb-12">
+          <h2 className="text-2xl font-semibold mb-4">Related Articles</h2>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {/* TODO: Add 2–4 related links */}
+            <Link href="/articles" className="block p-4 border rounded-lg hover:border-brand-700 transition">
+              ← All Articles
+            </Link>
+            <Link href="/herbs" className="block p-4 border rounded-lg hover:border-brand-700 transition">
+              Herb Profiles →
+            </Link>
+          </div>
+        </section>
+
+        <div className="mt-8">
+          <Link href="/articles" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
+            ← Back to Articles
+          </Link>
+        </div>
+      </div>
+    </>
+  )
+}
+`
+}
+
+function guideTemplate(slug, title, description) {
+  const functionName = slug
+    .split('-')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join('')
+
+  return `import Link from 'next/link'
+import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd } from '@/lib/seo'
+import EvidenceSummaryCard from '@/components/evidence/EvidenceSummaryCard'
+import SafetyNotice from '@/components/evidence/SafetyNotice'
+import LastUpdatedBadge from '@/components/editorial/LastUpdatedBadge'
+import { AFFILIATE_TAGS } from '@/config/affiliate'
+
+const SLUG = '${slug}'
+const TITLE = '${title}'
+const DESCRIPTION =
+  '${description}'
+const DATE = '${TODAY}'
+
+export const metadata = buildPageMetadata({
+  title: TITLE,
+  description: DESCRIPTION,
+  path: \`/guides/\${SLUG}\`,
+})
+
+const FAQS = [
+  {
+    question: 'TODO: Common question about this topic?',
+    answer: 'TODO: Balanced, hedged answer. No clinical claims.',
+  },
+  {
+    question: 'TODO: Another question?',
+    answer: 'TODO: Answer here.',
+  },
+]
+
+export default function ${functionName}Page() {
+  void AFFILIATE_TAGS.amazon // used via RecommendationSection when products are added
+
+  const pageBreadcrumb = breadcrumbJsonLd([
+    { name: 'Home', url: 'https://thehippiescientist.net' },
+    { name: 'Guides', url: 'https://thehippiescientist.net/guides' },
+    { name: TITLE, url: \`https://thehippiescientist.net/guides/\${SLUG}\` },
+  ])
+
+  const guideLd = blogJsonLd(
+    { title: TITLE, slug: SLUG, date: DATE, description: DESCRIPTION },
+    \`/guides/\${SLUG}\`,
+  )
+
+  const faqLd = faqPageJsonLd({ pagePath: \`/guides/\${SLUG}\`, questions: FAQS })
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(guideLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(pageBreadcrumb) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
+      />
+
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        <nav className="mb-6 flex items-center gap-2 text-sm text-muted" aria-label="Breadcrumb">
+          <Link href="/guides" className="transition hover:text-ink">Guides</Link>
+          <span>/</span>
+          <span className="text-ink line-clamp-1">{TITLE}</span>
+        </nav>
+
+        <div className="mb-8">
+          <LastUpdatedBadge date={DATE} />
+          <h1 className="text-4xl font-bold tracking-tight mt-4 mb-4">{TITLE}</h1>
+          <p className="text-xl text-muted-foreground">{DESCRIPTION}</p>
+        </div>
+
+        {/* TODO: Overview — what this guide covers */}
+        <div className="mb-10 p-6 border rounded-xl bg-card">
+          <h2 className="text-2xl font-semibold mb-4">What This Guide Covers</h2>
+          <ul className="space-y-2 text-muted-foreground">
+            <li>• TODO: Bullet 1 — key topic coverage.</li>
+            <li>• TODO: Bullet 2 — evidence summary.</li>
+            <li>• TODO: Bullet 3 — practical guidance.</li>
+            <li>• TODO: Bullet 4 — safety.</li>
+          </ul>
+        </div>
+
+        {/* TODO: Background */}
+        <section className="mb-12">
+          <h2 className="text-3xl font-semibold mb-6">TODO: Background</h2>
+          <div className="prose prose-lg max-w-none">
+            <p>TODO: Introduce the topic — what it is, why it matters, who it is relevant for.</p>
+          </div>
+        </section>
+
+        {/* TODO: Evidence */}
+        <section className="mb-12">
+          <h2 className="text-3xl font-semibold mb-6">Evidence Review</h2>
+          <EvidenceSummaryCard
+            title="TODO: [Topic] Evidence"
+            evidenceLevel="TODO: Strong | Moderate | Limited | Insufficient"
+            humanEvidence="TODO: Describe human evidence."
+            mechanisticEvidence="TODO: Describe mechanisms."
+            safetyProfile="TODO: Safety considerations."
+          />
+        </section>
+
+        {/* TODO: Best Options */}
+        <section className="mb-12">
+          <h2 className="text-3xl font-semibold mb-6">TODO: Top Options</h2>
+          <div className="prose prose-lg max-w-none">
+            <p>TODO: Cover the primary options/compounds relevant to this guide with brief comparisons.</p>
+          </div>
+        </section>
+
+        {/* TODO: Dosage */}
+        <section className="mb-12">
+          <h2 className="text-3xl font-semibold mb-6">Dosage Guidance</h2>
+          <div className="prose prose-lg max-w-none">
+            <p>TODO: Typical dose ranges. Timing. Important individual variation note.</p>
+          </div>
+        </section>
+
+        {/* TODO: Safety */}
+        <section className="mb-12">
+          <h2 className="text-3xl font-semibold mb-6">Safety & Interactions</h2>
+          <SafetyNotice>
+            <p>TODO: Drug interactions, contraindications, and populations requiring extra caution.</p>
+          </SafetyNotice>
+        </section>
+
+        {/* FAQ */}
+        <section className="mb-12">
+          <h2 className="text-3xl font-semibold mb-6">Frequently Asked Questions</h2>
+          <div className="space-y-6">
+            {FAQS.map((faq, i) => (
+              <div key={i} className="border rounded-lg p-5">
+                <h3 className="font-semibold text-lg mb-2">{faq.question}</h3>
+                <p className="text-muted-foreground">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Related */}
+        <section className="mb-12">
+          <h2 className="text-2xl font-semibold mb-4">Related Guides</h2>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {/* TODO: Add 2–4 related links */}
+            <Link href="/guides" className="block p-4 border rounded-lg hover:border-brand-700 transition">
+              ← All Guides
+            </Link>
+            <Link href="/herbs" className="block p-4 border rounded-lg hover:border-brand-700 transition">
+              Herb Profiles →
+            </Link>
+          </div>
+        </section>
+
+        <div className="mt-8">
+          <Link href="/guides" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
+            ← Back to Guides
+          </Link>
+        </div>
+      </div>
+    </>
+  )
+}
+`
+}
+
+function compareTemplate(slug, title, description) {
+  const functionName = slug
+    .split('-')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join('')
+
+  // Derive subject A and B from slug (e.g. "a-vs-b" → ["a", "b"])
+  const vsParts = slug.split('-vs-')
+  const subjectA = vsParts[0]
+    ? vsParts[0].replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+    : 'Option A'
+  const subjectB = vsParts[1]
+    ? vsParts[1].replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+    : 'Option B'
+
+  return `import type { Metadata } from 'next'
+import Link from 'next/link'
+import { buildPageMetadata } from '@/lib/seo'
+import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
+import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
+import AffiliateDisclosure from '@/components/AffiliateDisclosure'
+import LastUpdatedBadge from '@/components/editorial/LastUpdatedBadge'
+
+const SLUG = '${slug}'
+const TITLE = '${title}'
+const DESCRIPTION =
+  '${description}'
+const DATE = '${TODAY}'
+const SITE = 'https://thehippiescientist.net'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: TITLE,
+  description: DESCRIPTION,
+  path: \`/compare/\${SLUG}/\`,
+})
+
+export default function ${functionName}Page() {
+  return (
+    <div className="container-page py-10 space-y-10">
+      <AuthorityJsonLd
+        title={TITLE}
+        description={DESCRIPTION}
+        url={\`\${SITE}/compare/\${SLUG}\`}
+        type="Article"
+      />
+
+      <AuthorityBreadcrumbs
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Compare', href: '/compare' },
+          { label: '${subjectA} vs ${subjectB}' },
+        ]}
+      />
+
+      <LastUpdatedBadge date={DATE} />
+      <AffiliateDisclosure />
+
+      {/* Hero */}
+      <section className="space-y-5 max-w-4xl">
+        <p className="eyebrow-label">Educational Comparison</p>
+        <h1 className="text-5xl font-bold tracking-tight text-ink">{TITLE}</h1>
+        <p className="text-lg leading-8 text-[#46574d]">{DESCRIPTION}</p>
+
+        {/* TODO: Add evidence-grade badges */}
+        <div className="flex flex-wrap gap-3 pt-1">
+          <span className="inline-flex items-center gap-1.5 rounded-full bg-green-50 border border-green-200 px-3 py-1 text-xs font-semibold text-green-800">
+            TODO: ${subjectA} — Evidence Grade: ?
+          </span>
+          <span className="inline-flex items-center gap-1.5 rounded-full bg-green-50 border border-green-200 px-3 py-1 text-xs font-semibold text-green-800">
+            TODO: ${subjectB} — Evidence Grade: ?
+          </span>
+        </div>
+      </section>
+
+      {/* Side-by-side overview */}
+      <section className="grid gap-6 lg:grid-cols-2">
+        <div className="card-premium p-6 space-y-4">
+          <p className="eyebrow-label">TODO: Category / Mechanism type</p>
+          <h2 className="text-3xl font-semibold tracking-tight text-ink">${subjectA}</h2>
+          <p className="text-sm leading-7 text-[#46574d]">
+            TODO: 3–4 sentences on mechanism, onset, primary use cases, and who benefits most.
+          </p>
+          {/* TODO: Add link to compound/herb profile if it exists */}
+          {/* <Link href="/compounds/TODO" className="chip-readable">Explore ${subjectA}</Link> */}
+        </div>
+
+        <div className="card-premium p-6 space-y-4">
+          <p className="eyebrow-label">TODO: Category / Mechanism type</p>
+          <h2 className="text-3xl font-semibold tracking-tight text-ink">${subjectB}</h2>
+          <p className="text-sm leading-7 text-[#46574d]">
+            TODO: 3–4 sentences on mechanism, onset, primary use cases, and who benefits most.
+          </p>
+          {/* <Link href="/compounds/TODO" className="chip-readable">Explore ${subjectB}</Link> */}
+        </div>
+      </section>
+
+      {/* TODO: Head-to-head comparison table */}
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Head-to-Head</h2>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm border-collapse">
+            <thead>
+              <tr className="border-b border-brand-900/10">
+                <th className="pb-2 pr-6 text-left text-xs font-bold uppercase tracking-wider text-muted">Dimension</th>
+                <th className="pb-2 pr-6 text-left text-xs font-bold uppercase tracking-wider text-muted">${subjectA}</th>
+                <th className="pb-2 text-left text-xs font-bold uppercase tracking-wider text-muted">${subjectB}</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-brand-900/5">
+              {[
+                ['Onset', 'TODO', 'TODO'],
+                ['Duration', 'TODO', 'TODO'],
+                ['Primary target', 'TODO', 'TODO'],
+                ['Evidence grade', 'TODO', 'TODO'],
+                ['Best for', 'TODO', 'TODO'],
+                ['Stack well with', 'TODO', 'TODO'],
+              ].map(([dimension, a, b]) => (
+                <tr key={dimension} className="align-top">
+                  <td className="py-3 pr-6 font-medium text-ink">{dimension}</td>
+                  <td className="py-3 pr-6 text-[#46574d]">{a}</td>
+                  <td className="py-3 text-[#46574d]">{b}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* TODO: When to choose A */}
+      <section className="space-y-3 max-w-4xl">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">When to Choose ${subjectA}</h2>
+        <p className="text-[#46574d] leading-7">TODO: Describe the use cases where ${subjectA} wins — timing, goals, populations.</p>
+      </section>
+
+      {/* TODO: When to choose B */}
+      <section className="space-y-3 max-w-4xl">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">When to Choose ${subjectB}</h2>
+        <p className="text-[#46574d] leading-7">TODO: Describe the use cases where ${subjectB} wins — timing, goals, populations.</p>
+      </section>
+
+      {/* TODO: Can you combine them? */}
+      <section className="space-y-3 max-w-4xl">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Can You Combine Them?</h2>
+        <p className="text-[#46574d] leading-7">TODO: Discuss stacking considerations — safety, rationale, when it makes sense.</p>
+      </section>
+
+      {/* TODO: Safety */}
+      <section className="rounded-xl border border-amber-700/20 bg-amber-50/80 p-5 text-sm leading-6 text-[#5b4a2c] max-w-4xl">
+        <p className="font-semibold mb-1">Safety Reminder</p>
+        <p>
+          This page is for educational purposes only. It is not medical advice, a diagnosis, or a recommendation
+          to use any substance. Discuss all supplement use with a licensed clinician, especially if you take
+          medications or have a health condition.
+        </p>
+      </section>
+
+      {/* Related comparisons */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold tracking-tight text-ink">Related Comparisons</h2>
+        <div className="flex flex-wrap gap-3">
+          {/* TODO: Add 3–5 related compare links */}
+          <Link href="/compare" className="chip-readable">All Comparisons →</Link>
+        </div>
+      </section>
+    </div>
+  )
+}
+`
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+
+  console.log('\n── The Hippie Scientist: Content Page Generator ──\n')
+
+  // 1. Type
+  let type = ''
+  while (!['article', 'guide', 'compare'].includes(type)) {
+    type = (await prompt(rl, 'Type (article | guide | compare): ')).toLowerCase()
+    if (!['article', 'guide', 'compare'].includes(type)) {
+      console.log('  Please enter article, guide, or compare.')
+    }
+  }
+
+  // 2. Title
+  let title = ''
+  while (!title) {
+    title = await prompt(rl, 'Title: ')
+    if (!title) console.log('  Title is required.')
+  }
+
+  // 3. Slug
+  const suggestedSlug = slugify(title)
+  let slug = ''
+  while (true) {
+    const raw = await prompt(rl, `Slug [${suggestedSlug}]: `)
+    slug = raw || suggestedSlug
+
+    if (!isValidSlug(slug)) {
+      console.log('  Slug must be lowercase letters, numbers, and hyphens only (no leading/trailing hyphens).')
+      slug = ''
+      continue
+    }
+
+    const { taken, conflict } = checkSlugUniqueness(type, slug)
+    if (taken) {
+      console.log(`  Conflict: ${conflict}`)
+      console.log('  Choose a different slug.')
+      slug = ''
+      continue
+    }
+
+    break
+  }
+
+  // 4. Description
+  let description = ''
+  while (!description) {
+    description = await prompt(rl, 'Meta description (1–2 sentences): ')
+    if (!description) console.log('  Description is required.')
+  }
+
+  rl.close()
+
+  // 5. Generate
+  const typeToDir = { article: 'articles', guide: 'guides', compare: 'compare' }
+  const targetDir = path.join(ROOT, 'app', typeToDir[type], slug)
+  const targetFile = path.join(targetDir, 'page.tsx')
+
+  const templateFns = { article: articleTemplate, guide: guideTemplate, compare: compareTemplate }
+  const content = templateFns[type](slug, title, description)
+
+  fs.mkdirSync(targetDir, { recursive: true })
+  fs.writeFileSync(targetFile, content, 'utf-8')
+
+  console.log('\n✓ Created:')
+  console.log(`  ${path.relative(ROOT, targetFile)}`)
+  console.log(`\n  Route: /${typeToDir[type]}/${slug}`)
+  console.log('\nNext steps:')
+  console.log('  1. Fill in all TODO sections in the generated file.')
+  console.log('  2. Run: npm run lint && npm run typecheck')
+  console.log('  3. Run: npm run build')
+  console.log('  4. Commit and push to deploy.\n')
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

- **`scripts/create-content-page.mjs`** — Interactive scaffold (`npm run create:page`). Prompts for type/title/slug/description, validates slug uniqueness, generates a `page.tsx` for articles, guides, and compare routes with full metadata, JSON-LD (article + breadcrumb + FAQ), EvidenceSummaryCard, SafetyNotice, FAQ section, and related links. All TODO-marked for editorial completion.
- **`docs/MASTER_CONTENT_MAP.md`** — Route ownership map: what's workbook-owned vs static TSX vs JSON-driven, full slug inventories for each type, governance rules (no manual herb/compound pages, no force-dynamic, etc.).
- **`docs/PUBLISHING_WORKFLOW.md`** — End-to-end publishing diagram from idea → generator → content → validate → build → commit → deploy. Includes type decision guide and pre-commit checklist.
- **`package.json`** — Added `create:page` script entry.

## Test plan

- [x] `npm run typecheck` — PASS
- [x] `npm run lint` — PASS (zero warnings)
- [x] `npm run check` (full 26-step build pipeline) — PASS
- [x] Template TSX validated: article template with EvidenceSummaryCard + SafetyNotice typechecks clean
- [x] Slug uniqueness check verified against existing dirs and articles.json
- [x] No route additions, no static-export regressions, no SEO regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)