### PR TITLE
fix: resolve technical debt audit findings (Sprint 001)

### DIFF
--- a/docs/sprint-001-technical-health.md
+++ b/docs/sprint-001-technical-health.md
@@ -1,0 +1,137 @@
+# Sprint 001 — Technical Health: Findings & Inventory
+
+**Branch:** `claude/sprint-001-technical-health`
+**Date:** 2026-06-18
+**Scope:** Reduce technical debt only. No new content, no redesign, no architecture changes.
+
+## Phase 0 — Baseline (before any changes)
+
+Commands run: `npm run audit:content`, `npm run audit:links`, `npm run build` (all pass / exit 0).
+
+### `audit:content` summary (BEFORE)
+
+| Metric | Count |
+|---|---|
+| Pages audited | 78 |
+| Duplicate slugs | 2 |
+| Missing metadata | 5 |
+| Thin pages (<500w) | 35 *(explicitly OUT OF SCOPE)* |
+| Orphaned pages | 1 |
+| Broken internal links | 11 |
+| Hardcoded affiliate tags | 0 |
+
+`audit:links` is advisory (linking opportunities); exits 0 with no errors.
+`build` passes (26/26 pipeline steps; 367 sitemap URLs).
+
+---
+
+## Root-cause analysis
+
+Every actionable finding was investigated against **ground truth** (the built `out/**/index.html`
+and rendered `<title>`/`<meta>`/`<link rel=canonical>`). Result: the findings are **false positives
+caused by blind spots in `scripts/content-audit.mjs`**, not real defects in the site. Changing the
+flagged pages/links would have *removed working behavior and risked SEO*, violating the sprint's
+decision hierarchy (Stability → SEO → Maintainability). The real technical debt is the audit's
+accuracy. Fixes below target the audit, not the content. **Zero URLs, redirects, metadata values,
+or page content were changed.**
+
+### Broken internal links (11) — FALSE POSITIVES (valid dynamic routes)
+
+The audit's `buildKnownRouteSet()` only enumerates **static** `app/**` directories; it cannot see
+dynamically-generated `[slug]` routes. All 11 targets build and render real pages (verified in `out/`):
+
+| Source page | Linked target | Status (built?) |
+|---|---|---|
+| guides/best-natural-sleep-aids-that-work | /compare/magnesium-vs-melatonin | REAL |
+| guides/magnesium-vs-melatonin | /compare/magnesium-vs-melatonin | REAL |
+| guides/focus-without-caffeine-crash | /compare/caffeine-vs-l-theanine | REAL |
+| guides/kava | /guides/ashwagandha | REAL |
+| guides/kratom-7oh-withdrawal-management | /articles/mitragynine, /articles/7-hydroxymitragynine | REAL |
+| guides/supplements-for-brain-fog-and-fatigue | /compare/creatine-vs-caffeine | REAL |
+| compare/berberine-vs-metformin | /compare/berberine-vs-inositol, /compare/berberine-vs-psyllium | REAL |
+| compare/mitragynine-vs-7-hydroxymitragynine | /articles/mitragynine, /articles/7-hydroxymitragynine | REAL |
+
+**Fix:** `buildKnownRouteSet()` now unions in the actual built routes from `out/` when present, so
+real dynamic routes are recognized while genuinely-missing routes are still flagged.
+
+### Missing metadata (5) — FALSE POSITIVES (helper/variable metadata)
+
+The audit's `checkMetadata()` only matched **string-literal** `title:`/`description:`. The flagged
+pages supply metadata via a spread helper or a variable, and the rendered HTML has correct
+title/description/canonical:
+
+| Page | Mechanism | Rendered `<title>` present? |
+|---|---|---|
+| articles/anxiety-stack-guide | `buildPageMetadata({ title: articleTitle, ... })` | Yes |
+| guides/magnesium-for-sleep | `{ ...generateSeoEntryMetadata(route) }` | Yes |
+| guides/magnesium-vs-melatonin | `{ ...generateSeoEntryMetadata(route) }` | Yes |
+
+**Fix:** `checkMetadata()` now recognizes metadata produced via `buildPageMetadata`, a spread of a
+`*Metadata()` helper, or identifier (non-quoted) `title`/`description` values.
+
+### Orphaned page (1) — FALSE POSITIVE (object-property link)
+
+`/guides/elderberry` **is** linked from `app/guides/page.tsx:76` via `href: '/guides/elderberry'`
+(an object property). The audit's `buildBacklinkSet()` only matched JSX `href="..."` (with `=`) and
+double-quoted strings, missing single-quoted object-property hrefs.
+
+**Fix:** `buildBacklinkSet()` now also captures `href: '/path'` / `href: "/path"` object-property links.
+
+### Duplicate slugs (2) — REAL signal, intentional architecture → MANUAL REVIEW
+
+These are genuine cross-family static pages, each with a **distinct self-canonical** (no
+duplicate-URL/canonical penalty), reflecting the site's documented two-layer content model
+(discovery vs depth families):
+
+- `magnesium-for-sleep` → `/articles/magnesium-for-sleep` **and** `/guides/magnesium-for-sleep`
+- `sleep-herbs-vs-melatonin` → `/guides/sleep-herbs-vs-melatonin` **and** `/compare/sleep-herbs-vs-melatonin`
+  (note: bare `/sleep-herbs-vs-melatonin` already 301s to the guide in `public/_redirects`)
+
+Consolidating these requires a **content/SEO decision** about which page wins (potential keyword
+cannibalization), which is explicitly out of scope for a no-content-change technical-debt sprint and
+risks harming a ranking page. **Left untouched and escalated to MANUAL REVIEW.** The audit check is
+correct to surface them, so it was not modified.
+
+---
+
+## Validation (after fixes)
+
+| Audit metric | BEFORE | AFTER |
+|---|---:|---:|
+| Broken internal links | 11 | **0** |
+| Missing metadata | 5 | **0** |
+| Orphaned pages | 1 | **0** |
+| Duplicate slugs | 2 | 2 *(manual review — see below)* |
+| Thin pages (<500w) | 35 | 35 *(out of scope)* |
+| **Total issues** | 54 | **37** |
+
+- `npm run audit:content` — passes (exit 0); real defects eliminated.
+- `npm run audit:links` — passes (exit 0; advisory).
+- `npm run build` — passes (26/26 pipeline steps; 367 sitemap URLs).
+- **Regression guard:** verified the broken-link check still flags a genuinely
+  non-existent route after the accuracy fix (no false-negatives introduced).
+- **No URLs, redirects, page content, or metadata values were changed.**
+
+## Files modified
+
+| File | Change |
+|---|---|
+| `scripts/content-audit.mjs` | Audit accuracy fixes (no behavior change to the site): (1) `buildKnownRouteSet` now unions real built routes from `out/` so dynamic `[slug]` routes are recognized; (2) `checkMetadata` recognizes `buildPageMetadata`, spread `*Metadata()` helpers, and identifier title/description values; (3) `buildBacklinkSet` now captures `href: '/path'` object-property links. |
+| `docs/sprint-001-technical-health.md` | This findings/inventory/validation report (new). |
+
+## Manual review (human attention required)
+
+1. **Duplicate slugs (2) — content/SEO decision, intentionally NOT auto-resolved.**
+   - `magnesium-for-sleep`: `/articles/magnesium-for-sleep` + `/guides/magnesium-for-sleep`
+   - `sleep-herbs-vs-melatonin`: `/guides/sleep-herbs-vs-melatonin` + `/compare/sleep-herbs-vs-melatonin`
+     (bare `/sleep-herbs-vs-melatonin` already 301s to the guide)
+
+   Each page has a distinct self-canonical, so there is no duplicate-URL penalty today, but the
+   pairs may compete for the same query (cannibalization). Choosing a winner and adding a
+   cross-canonical or 301 is a content/SEO decision that needs an operator and is out of scope for a
+   no-content-change technical-debt sprint. Recommended follow-up: pick the stronger page per pair,
+   point the weaker page's canonical at it (preserving both URLs), and prefer keeping the older URL.
+
+2. **Reversed-comparison duplicate (pre-existing, noted in prior work):** `/compare/magnesium-vs-melatonin`
+   (dynamic) and `/compare/melatonin-vs-magnesium` (static) both exist. Consider a 301 from the
+   former to the latter to consolidate. Out of scope here; tracked for a future content sprint.

--- a/scripts/content-audit.mjs
+++ b/scripts/content-audit.mjs
@@ -116,8 +116,16 @@ function checkMetadata(source, route) {
     return issues
   }
 
-  // Check title presence (inside buildPageMetadata call or metadata object)
-  const titleMatch = /title\s*:\s*(['"`]|TITLE|[A-Z_]+)/.test(source)
+  // Metadata supplied by a helper provides title + description for us.
+  // Recognize both `buildPageMetadata({...})` and a spread of any `*Metadata()`
+  // generator (e.g. `{ ...generateSeoEntryMetadata(route) }`). When present, the
+  // literal title/description sub-checks below would false-positive, so skip them.
+  const hasSpreadMetadataHelper = /\.\.\.\s*[A-Za-z_$][\w$]*[Mm]etadata\w*\s*\(/.test(source)
+  if (hasBuildPageMetadata || hasSpreadMetadataHelper) return issues
+
+  // For inline plain-object metadata, accept any non-empty value (quoted string,
+  // template literal, or an identifier/variable like `title: articleTitle`).
+  const titleMatch = /title\s*:\s*['"`A-Za-z_$]/.test(source)
   if (!titleMatch) {
     issues.push({
       type: 'missing_metadata',
@@ -127,8 +135,7 @@ function checkMetadata(source, route) {
     })
   }
 
-  // Check description presence
-  const descMatch = /description\s*:\s*(['"`]|DESCRIPTION|[A-Z_]+)/.test(source)
+  const descMatch = /description\s*:\s*['"`A-Za-z_$]/.test(source)
   if (!descMatch) {
     issues.push({
       type: 'missing_metadata',
@@ -196,12 +203,45 @@ function checkAffiliateHardcoding(source, route) {
 
 // ─── Build route set ─────────────────────────────────────────────────────────
 
+/**
+ * Collect the actual built routes from a static-export `out/` directory.
+ * Each `out/<path>/index.html` corresponds to the route `/<path>`.
+ *
+ * This is the authoritative source of truth for which routes exist, including
+ * dynamically-generated `[slug]` routes (compare/guides/articles) that cannot be
+ * enumerated from `app/**` source alone. It is additive and gated on `out/`
+ * existing, so pre-build runs keep their previous (source-only) behavior.
+ */
+function collectBuiltRoutes() {
+  const routes = new Set()
+  const outDir = path.join(ROOT, 'out')
+  if (!fs.existsSync(outDir)) return routes
+
+  function walk(dir, prefix) {
+    let entries
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }) } catch { return }
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (entry.name === '_next') continue
+        walk(path.join(dir, entry.name), `${prefix}/${entry.name}`)
+      } else if (entry.name === 'index.html') {
+        routes.add(prefix || '/')
+      }
+    }
+  }
+  walk(outDir, '')
+  return routes
+}
+
 function buildKnownRouteSet(pages) {
   // Static routes from app/ directory structure
   const routes = new Set()
 
   // Add our audited pages
   for (const p of pages) routes.add(p.route)
+
+  // Union in real built routes (recognizes dynamic [slug] routes when out/ exists)
+  for (const r of collectBuiltRoutes()) routes.add(r)
 
   // Scan all app/ directories for additional routes
   function walkApp(dir, prefix) {
@@ -295,10 +335,16 @@ function buildBacklinkSet() {
       let src
       try { src = fs.readFileSync(filePath, 'utf-8') } catch { continue }
 
-      // href="/..." patterns
+      // href="/..." JSX attribute patterns
       const hrefPattern = /href=["'](\/[^"'#\s?]+)["']/g
       let m
       while ((m = hrefPattern.exec(src)) !== null) {
+        links.add(m[1].replace(/\/$/, '') || '/')
+      }
+      // href: '/...' object-property patterns (link data in arrays/config, e.g.
+      // `{ href: '/guides/elderberry', title: '...' }`) — single or double quoted.
+      const hrefPropPattern = /href\s*:\s*["'](\/[^"'#\s?]+)["']/g
+      while ((m = hrefPropPattern.exec(src)) !== null) {
         links.add(m[1].replace(/\/$/, '') || '/')
       }
       // Markdown link patterns [text](/path)


### PR DESCRIPTION
## Sprint 001 — Technical Health

Reduce technical debt only. No new content, no redesign, no architecture changes.

## What I found
Investigating each `npm run audit:content` finding against **ground truth** (the built `out/**/index.html` and rendered `<title>`/`<meta>`/`<link rel=canonical>`) showed the actionable findings were **false positives from blind spots in `scripts/content-audit.mjs`** — not real site defects:

- **Broken internal links (11):** all targets build and render real pages. The audit only enumerated static `app/**` dirs and couldn't see dynamic `[slug]` routes.
- **Missing metadata (5):** pages supply metadata via `buildPageMetadata({ title: articleTitle })` or `{ ...generateSeoEntryMetadata(route) }`; rendered HTML has correct title/description/canonical. The audit only matched string-literal `title:`/`description:`.
- **Orphaned page (1):** `/guides/elderberry` is linked from `app/guides/page.tsx` via `href: '/guides/elderberry'` (object property); the backlink scan only matched JSX `href="..."`.

Changing the flagged links/metadata/pages would have removed working behavior and risked SEO, violating the decision hierarchy (Stability → SEO → Maintainability). The real debt is the audit's accuracy, so the fixes target the audit — **zero URLs, redirects, metadata values, or page content changed.**

## Changes (`scripts/content-audit.mjs`)
1. `buildKnownRouteSet` unions real built routes from `out/` (recognizes dynamic routes; still flags genuinely-missing ones).
2. `checkMetadata` recognizes `buildPageMetadata`, spread `*Metadata()` helpers, and identifier title/description values.
3. `buildBacklinkSet` also captures `href: '/path'` object-property links.

## Results (BEFORE → AFTER)
| Metric | Before | After |
|---|---:|---:|
| Broken internal links | 11 | **0** |
| Missing metadata | 5 | **0** |
| Orphaned pages | 1 | **0** |
| Duplicate slugs | 2 | 2 *(manual review)* |
| Thin pages | 35 | 35 *(out of scope)* |
| **Total** | 54 | **37** |

- `npm run audit:content`, `npm run audit:links`, `npm run build` all pass.
- **Regression guard:** verified the broken-link check still flags a genuinely non-existent route after the fix (no false-negatives).

## Manual review (not auto-resolved)
- **Duplicate slugs (2):** `magnesium-for-sleep` (articles+guides) and `sleep-herbs-vs-melatonin` (guides+compare). Real cross-family pages with distinct self-canonicals; consolidating is a content/SEO decision (cannibalization) that's out of scope and risks a ranking page. Recommended follow-up documented.
- **Pre-existing reversed duplicate:** `/compare/magnesium-vs-melatonin` vs `/compare/melatonin-vs-magnesium` — consider a 301 in a future content sprint.

Full report: `docs/sprint-001-technical-health.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiCEvKvfzBhc2YY5zEnsk9)_