### PR TITLE
UX refinement: remove CTA overlays, fix dark mode, simplify nav

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -745,6 +745,20 @@ html.dark :where(.button-primary, [class~="bg-brand-700"], [class~="bg-brand-800
   color: #07150c;
 }
 
+html.dark :where(
+  [class~="text-emerald-800"],
+  [class~="text-emerald-900"]
+) {
+  color: #6ee7b7;
+}
+
+html.dark :where(
+  [class~="text-amber-900"],
+  [class~="text-amber-950"]
+) {
+  color: #fcd34d;
+}
+
 @layer utilities {
   .text-display {
     @apply font-display font-semibold leading-display tracking-tighter text-ink;

--- a/app/goals/[goal]/GoalDecisionExperience.tsx
+++ b/app/goals/[goal]/GoalDecisionExperience.tsx
@@ -3,7 +3,6 @@ import Link from 'next/link'
 import EvidenceClaimCard from '@/components/evidence-engine/EvidenceClaimCard'
 import type { Goal } from '@/data/goals'
 import SafetyChecklistPromo from '@/components/monetization/SafetyChecklistPromo'
-import StickyChecklistBar from '@/components/monetization/StickyChecklistBar'
 import GoalTopAffiliatePicks from '@/components/monetization/GoalTopAffiliatePicks'
 import LastUpdatedBadge from '@/components/editorial/LastUpdatedBadge'
 import { getGoalFreshness } from '@/lib/freshness'
@@ -119,7 +118,6 @@ export default function GoalDecisionExperience({
   return (
     <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6 sm:py-10 lg:px-8 space-y-8">
       {structuredData}
-      <StickyChecklistBar storageKey={`goal-engine-sticky-${goal.slug}`} />
       <Breadcrumbs
         items={[
           { label: 'Home', href: '/' },
@@ -291,8 +289,6 @@ export default function GoalDecisionExperience({
           seoEntry={hubLinks.seoEntry}
         />
       ) : null}
-
-      <SafetyChecklistPromo goal={captureGoal} variant="compact" />
 
       <AuthorCredentials />
 

--- a/app/goals/[goal]/page.tsx
+++ b/app/goals/[goal]/page.tsx
@@ -15,7 +15,6 @@ import { rankEntitiesForGoal } from '@/lib/goal-matching-engine'
 import { getAffiliateShopLinks } from '@/lib/affiliate'
 import { getRevenueProductSet } from '@/config/revenue-products'
 import SafetyChecklistPromo from '@/components/monetization/SafetyChecklistPromo'
-import StickyChecklistBar from '@/components/monetization/StickyChecklistBar'
 import GoalTopAffiliatePicks from '@/components/monetization/GoalTopAffiliatePicks'
 import ProductTrustAffiliate from '@/components/monetization/ProductTrustAffiliate'
 import Breadcrumbs from '@/components/ui/Breadcrumbs'
@@ -319,7 +318,6 @@ export default async function GoalDecisionPage({
   return (
     <div className="mx-auto max-w-6xl px-4 py-10 sm:px-6 lg:px-8 space-y-8">
       {structuredData}
-      <StickyChecklistBar storageKey={`goal-sticky-${goal.slug}`} />
       <Breadcrumbs
         items={[
           { label: 'Home', href: '/' },
@@ -660,8 +658,6 @@ export default async function GoalDecisionPage({
           })}
         </div>
       </section>
-
-      <SafetyChecklistPromo goal={goalCaptureGoal(goal.slug)} variant="compact" />
 
       <AuthorCredentials />
 

--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -5,10 +5,7 @@ import { HERB_COUNT, COMPOUND_COUNT } from '@/lib/profile-counts'
 import { goals } from '@/data/goals'
 import { getRevenueProductSet } from '@/config/revenue-products'
 import { focusAdhdArticles } from '@/lib/focus-adhd-articles'
-import NewsletterCtaBlock from './NewsletterCtaBlock'
 import SafetyChecklistPromo from '@/components/monetization/SafetyChecklistPromo'
-import StickyChecklistBar from '@/components/monetization/StickyChecklistBar'
-import ExitIntentModal from '@/components/ExitIntentModal'
 import { getHomepageFreshness } from '@/lib/freshness'
 
 type RuntimeFeature = Record<string, unknown>
@@ -218,8 +215,6 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
 
   return (
     <div className='overflow-x-clip bg-site-bg'>
-      <StickyChecklistBar storageKey='homepage-sticky-checklist' />
-      <ExitIntentModal />
       <div className='mx-auto max-w-6xl space-y-8 px-4 pb-12 pt-4 sm:px-6 sm:space-y-10 sm:pb-16 sm:pt-6 lg:px-8'>
 
         {/* ── Hero ─────────────────────────────────────────────── */}
@@ -532,12 +527,6 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
         </section>
 
         <SafetyChecklistPromo goal='default' variant='hero' />
-
-        <NewsletterCtaBlock
-          title='Browse evidence-first newsletter notes'
-          description='Use the archive for concise supplement safety and sourcing updates.'
-          location='homepage-newsletter'
-        />
 
         {/* ── Disclaimer ───────────────────────────────────────── */}
         <section className='rounded-[0.85rem] border border-amber-200/80 bg-amber-50/50 p-4'>

--- a/components/monetization/SafetyChecklistPromo.tsx
+++ b/components/monetization/SafetyChecklistPromo.tsx
@@ -22,9 +22,9 @@ export default function SafetyChecklistPromo({
   if (variant === 'compact') {
     return (
       <section
-        className={`rounded-[1.25rem] border-2 border-emerald-700/25 bg-gradient-to-br from-emerald-50/90 to-white p-5 shadow-sm sm:p-6 ${className}`}
+        className={`rounded-[1.25rem] border-2 border-emerald-700/25 dark:border-emerald-700/15 bg-gradient-to-br from-emerald-50/90 to-white dark:from-brand-900/30 dark:to-brand-950/20 p-5 shadow-sm sm:p-6 ${className}`}
       >
-        <p className='text-xs font-bold uppercase tracking-[0.18em] text-emerald-800'>Free checklist</p>
+        <p className='text-xs font-bold uppercase tracking-[0.18em] text-emerald-800 dark:text-emerald-400'>Free checklist</p>
         <h2 className='mt-2 text-lg font-semibold text-ink sm:text-xl'>
           Avoid costly supplement mistakes before you buy
         </h2>
@@ -43,11 +43,11 @@ export default function SafetyChecklistPromo({
 
   return (
     <section
-      className={`rounded-[1.5rem] border-2 border-emerald-700/30 bg-gradient-to-br from-emerald-50 via-white to-brand-50/40 p-6 shadow-md sm:p-8 lg:p-10 ${className}`}
+      className={`rounded-[1.5rem] border-2 border-emerald-700/30 dark:border-emerald-700/15 bg-gradient-to-br from-emerald-50 via-white to-brand-50/40 dark:from-brand-900/30 dark:via-brand-950/10 dark:to-brand-900/20 p-6 shadow-md sm:p-8 lg:p-10 ${className}`}
     >
       <div className='grid gap-8 lg:grid-cols-[1fr_1.05fr] lg:items-start'>
         <div>
-          <p className='inline-flex rounded-full bg-emerald-100 px-3 py-1 text-xs font-bold uppercase tracking-[0.16em] text-emerald-900'>
+          <p className='inline-flex rounded-full bg-emerald-100 px-3 py-1 text-xs font-bold uppercase tracking-[0.16em] text-emerald-900 dark:text-emerald-300'>
             Free · Evidence-based
           </p>
           <h2 className='mt-4 text-2xl font-bold tracking-tight text-ink sm:text-3xl'>

--- a/lib/navigation-config.ts
+++ b/lib/navigation-config.ts
@@ -88,16 +88,6 @@ export const mainNavigation: NavigationItem[] = [
     description: 'Problem-solving, high-intent, evergreen supplement guides with internal linking and evidence summaries',
   },
   {
-    label: 'Compare',
-    href: '/compare',
-    description: 'Side-by-side supplement comparisons by evidence, safety, and practical fit',
-  },
-  {
-    label: 'Stacks',
-    href: '/stacks',
-    description: 'Curated supplement stacks by goal, timing, and safety context',
-  },
-  {
     label: 'Safety',
     href: '/safety-checker',
     description: 'Interaction checker and safety context for herbs and supplements',


### PR DESCRIPTION
## Summary
- **Remove StickyChecklistBar** from homepage, goal pages, and decision engine (fixed bottom bar covered content on mobile)
- **Remove ExitIntentModal** from homepage (disruptive scroll/mouse-leave trigger)
- **Remove duplicate NewsletterCtaBlock** from homepage — SafetyChecklistPromo is the single conversion CTA
- **Remove duplicate compact SafetyChecklistPromo** from goal page and decision engine — one per page max
- **Dark mode fixes** — SafetyChecklistPromo gradient replaced with dark-aware brand tones; globals.css adds patches for `text-emerald-800/900` and `text-amber-900/950` which had no dark override
- **Navigation simplified** — Compare and Stacks removed from main nav (7 → 5 items); pages remain intact and reachable via internal links

All 26 build pipeline steps pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATZU8vmhnZEXWDiJkyWRwr)_