### PR TITLE
feat: Article Experience System Session 1 — ArticleLayout + TableOfContents

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -945,3 +945,81 @@ html.dark :where(
     }
   }
 }
+
+/* Article layout typography — scoped to .article-body, inside @layer components
+   so Tailwind utility classes (in @layer utilities) always take precedence. */
+@layer components {
+  .article-body {
+    font-size: 1rem;
+    line-height: 1.72;
+  }
+
+  .article-body p {
+    margin-top: 1.25em;
+    line-height: 1.72;
+  }
+
+  .article-body p:first-child {
+    margin-top: 0;
+  }
+
+  .article-body ul,
+  .article-body ol {
+    padding-left: 1.5em;
+    margin-top: 1em;
+    margin-bottom: 1em;
+  }
+
+  .article-body li + li {
+    margin-top: 0.375em;
+  }
+
+  .article-body blockquote {
+    border-left: 3px solid var(--color-brand-300);
+    padding-left: 1.25em;
+    margin: 1.5em 0;
+    font-style: italic;
+  }
+
+  .article-body pre {
+    overflow-x: auto;
+    border-radius: 0.75rem;
+    padding: 1rem;
+    margin: 1.5em 0;
+    background: var(--surface);
+  }
+
+  .article-body code:not(pre code) {
+    font-size: 0.875em;
+    background: var(--surface);
+    padding: 0.125em 0.35em;
+    border-radius: 0.25rem;
+  }
+
+  .article-body table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 1.5em 0;
+    font-size: 0.875rem;
+  }
+
+  .article-body th,
+  .article-body td {
+    padding: 0.5rem 0.75rem;
+    text-align: left;
+    border-bottom: 1px solid var(--border-soft);
+  }
+
+  .article-body th {
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  .article-body img {
+    border-radius: 0.75rem;
+    max-width: 100%;
+    height: auto;
+    margin: 1.5em auto;
+    display: block;
+  }
+}

--- a/app/guides/passionflower/page.tsx
+++ b/app/guides/passionflower/page.tsx
@@ -9,6 +9,8 @@ import SafetyBox from '@/components/SafetyBox'
 import MechanismBox from '@/components/MechanismBox'
 import AffiliateProductBox from '@/components/AffiliateProductBox'
 import { revenueProductSets } from '@/config/revenue-products'
+import { ArticleLayout, TableOfContents } from '@/components/articles'
+import type { Heading } from '@/components/articles'
 
 const SLUG = 'passionflower'
 const PAGE_URL = 'https://thehippiescientist.net/guides/passionflower'
@@ -24,6 +26,14 @@ export const metadata: Metadata = buildPageMetadata({
   path: `/guides/${SLUG}`,
   openGraphType: 'article',
 })
+
+const HEADINGS: Heading[] = [
+  { id: 'research', text: 'What the Research Shows', level: 2 },
+  { id: 'mechanism', text: 'How It Works', level: 2 },
+  { id: 'dosage', text: 'Dosage & Forms', level: 2 },
+  { id: 'safety', text: 'Safety & Precautions', level: 2 },
+  { id: 'faq', text: 'Common Questions', level: 2 },
+]
 
 const FAQS = [
   {
@@ -99,9 +109,10 @@ const MECHANISM_POINTS = [
 
 export default function PassionflowerGuidePage() {
   const passionflowerProducts = revenueProductSets['passionflower']
+  const toc = <TableOfContents headings={HEADINGS} />
 
   return (
-    <div className="mx-auto max-w-4xl space-y-8 px-4 py-8 sm:px-6 sm:py-10 lg:px-8">
+    <ArticleLayout toc={toc} zone="supplement">
       <StructuredData
         pageUrl={PAGE_URL}
         headline={TITLE}
@@ -115,6 +126,7 @@ export default function PassionflowerGuidePage() {
           { label: 'Passionflower', href: `/guides/${SLUG}` },
         ]}
       />
+      <div className="space-y-8">
 
       {/* Hero */}
       <section className="rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-10">
@@ -136,7 +148,7 @@ export default function PassionflowerGuidePage() {
       </section>
 
       {/* Evidence */}
-      <section className="space-y-4">
+      <section id="research" className="scroll-mt-20 space-y-4">
         <h2 className="text-2xl font-semibold tracking-tight text-ink">What the Research Shows</h2>
         <div className="grid gap-3 sm:grid-cols-2">
           <EvidenceSummaryBox
@@ -167,7 +179,7 @@ export default function PassionflowerGuidePage() {
       </section>
 
       {/* Mechanism */}
-      <section className="space-y-4">
+      <section id="mechanism" className="scroll-mt-20 space-y-4">
         <h2 className="text-2xl font-semibold tracking-tight text-ink">How It Works</h2>
         <MechanismBox
           summary="Passionflower is thought to exert anxiolytic effects primarily through modulation of the GABA system, supported by mild anti-inflammatory and antioxidant actions and possible effects on serotonin and dopamine. Human mechanistic data remain limited."
@@ -176,7 +188,7 @@ export default function PassionflowerGuidePage() {
       </section>
 
       {/* Dosage */}
-      <section className="space-y-4" id="dosage">
+      <section id="dosage" className="scroll-mt-20 space-y-4">
         <h2 className="text-2xl font-semibold tracking-tight text-ink">Dosage &amp; Forms</h2>
         <DosageBox
           rows={DOSAGE_ROWS}
@@ -185,7 +197,7 @@ export default function PassionflowerGuidePage() {
       </section>
 
       {/* Safety */}
-      <section className="space-y-4" id="safety">
+      <section id="safety" className="scroll-mt-20 space-y-4">
         <h2 className="text-2xl font-semibold tracking-tight text-ink">Safety &amp; Precautions</h2>
         <SafetyBox notes={SAFETY_NOTES} />
       </section>
@@ -200,7 +212,9 @@ export default function PassionflowerGuidePage() {
       )}
 
       {/* FAQ */}
-      <FAQAccordion faqs={FAQS} heading="Common Questions About Passionflower" />
+      <div id="faq" className="scroll-mt-20">
+        <FAQAccordion faqs={FAQS} heading="Common Questions About Passionflower" />
+      </div>
 
       {/* Related */}
       <section className="space-y-3">
@@ -229,6 +243,8 @@ export default function PassionflowerGuidePage() {
         <Link href="/guides" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">← All Guides</Link>
         <Link href="/herbs" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">Herb Library →</Link>
       </div>
-    </div>
+
+      </div>{/* end space-y-8 */}
+    </ArticleLayout>
   )
 }

--- a/components/articles/ArticleLayout.tsx
+++ b/components/articles/ArticleLayout.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from 'react'
+
+interface ArticleLayoutProps {
+  children: ReactNode;
+  toc?: ReactNode;
+  zone?: 'supplement' | 'harm-reduction';
+}
+
+export default function ArticleLayout({ children, toc, zone }: ArticleLayoutProps) {
+  return (
+    <div
+      className="mx-auto max-w-5xl px-4 py-8 sm:px-6 sm:py-10"
+      data-zone={zone}
+    >
+      {toc && (
+        <div className="mb-6 lg:hidden">
+          {toc}
+        </div>
+      )}
+      <div className={toc ? 'lg:grid lg:grid-cols-[minmax(0,1fr)_240px] lg:items-start lg:gap-10' : undefined}>
+        <article className="article-body min-w-0">
+          {children}
+        </article>
+        {toc && (
+          <aside aria-label="Page navigation" className="hidden lg:block">
+            <div className="sticky top-20 rounded-xl border border-brand-900/10 bg-white/90 p-4 shadow-sm">
+              {toc}
+            </div>
+          </aside>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/articles/TableOfContents.tsx
+++ b/components/articles/TableOfContents.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import type { Heading } from './extractHeadings'
+
+interface Props {
+  headings: Heading[];
+}
+
+export default function TableOfContents({ headings }: Props) {
+  const [activeId, setActiveId] = useState<string>('');
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const observer = useRef<IntersectionObserver | null>(null);
+
+  useEffect(() => {
+    observer.current = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter(e => e.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        if (visible.length > 0) {
+          setActiveId(visible[0].target.id);
+        }
+      },
+      { rootMargin: '-80px 0px -60% 0px', threshold: 0 }
+    );
+
+    headings.forEach(({ id }) => {
+      const el = document.getElementById(id);
+      if (el) observer.current?.observe(el);
+    });
+
+    return () => observer.current?.disconnect();
+  }, [headings]);
+
+  if (!headings.length) return null;
+
+  const links = (
+    <nav aria-label="Table of contents">
+      <ol className="space-y-0.5">
+        {headings.map(h => (
+          <li key={h.id} className={h.level === 3 ? 'pl-3' : ''}>
+            <a
+              href={`#${h.id}`}
+              onClick={() => setMobileOpen(false)}
+              className={[
+                'block rounded-lg px-2.5 py-1.5 leading-snug transition-colors',
+                h.level === 3 ? 'text-xs' : 'text-sm',
+                activeId === h.id
+                  ? 'bg-brand-50 font-semibold text-brand-800'
+                  : 'text-muted hover:bg-brand-50/60 hover:text-brand-800',
+              ].join(' ')}
+            >
+              {h.text}
+            </a>
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+
+  return (
+    <>
+      {/* Mobile collapsible */}
+      <div className="rounded-xl border border-brand-900/10 bg-white/90 shadow-sm lg:hidden">
+        <button
+          type="button"
+          aria-expanded={mobileOpen}
+          onClick={() => setMobileOpen(o => !o)}
+          className="flex w-full items-center justify-between px-4 py-3 text-sm font-semibold text-ink"
+        >
+          On this page
+          <svg
+            className={`size-4 transition-transform ${mobileOpen ? 'rotate-180' : ''}`}
+            viewBox="0 0 16 16"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            aria-hidden="true"
+          >
+            <path d="M4 6l4 4 4-4" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </button>
+        {mobileOpen && (
+          <div className="border-t border-brand-900/10 px-4 py-3">
+            {links}
+          </div>
+        )}
+      </div>
+
+      {/* Desktop always-visible */}
+      <div className="hidden lg:block">
+        <p className="mb-3 text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">
+          On this page
+        </p>
+        {links}
+      </div>
+    </>
+  );
+}

--- a/components/articles/extractHeadings.ts
+++ b/components/articles/extractHeadings.ts
@@ -1,0 +1,13 @@
+export interface Heading {
+  id: string;
+  text: string;
+  level: 2 | 3;
+}
+
+export function textToId(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-');
+}

--- a/components/articles/index.ts
+++ b/components/articles/index.ts
@@ -1,0 +1,4 @@
+export { default as ArticleLayout } from './ArticleLayout'
+export { default as TableOfContents } from './TableOfContents'
+export type { Heading } from './extractHeadings'
+export { textToId } from './extractHeadings'


### PR DESCRIPTION
## Summary

- Adds `ArticleLayout` component: two-column grid (article + sticky TOC sidebar on desktop, TOC above content on mobile)
- Adds `TableOfContents` component: IntersectionObserver active highlighting, collapsible on mobile
- Adds `extractHeadings.ts`: `Heading` type + `textToId()` utility
- Adds scoped `.article-body` typography in `@layer components` (Tailwind utilities remain authoritative)
- Wires passionflower guide page as the first integration with stable section IDs

## Test plan
- [ ] `npm run build` passes with zero errors
- [ ] `/guides/passionflower` renders with sticky TOC sidebar on desktop
- [ ] TOC collapses/expands on mobile
- [ ] TOC links scroll to correct sections with proper offset
- [ ] No homepage or non-guide pages changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012bGJCEQXdzfU1wh2GcB6rP

---
_Generated by [Claude Code](https://claude.ai/code/session_012bGJCEQXdzfU1wh2GcB6rP)_