### PR TITLE
Fix mobile herb cards and article formatting polish

### DIFF
--- a/app/__tests__/a11y.test.tsx
+++ b/app/__tests__/a11y.test.tsx
@@ -36,9 +36,6 @@ describe('a11y (axe-core)', () => {
         name="Ashwagandha"
         summary="Evidence summary for stress."
         bestFor="Stress support"
-        evidence="Strong evidence"
-        safety="Generally well tolerated"
-        timeToEffect="2-4 weeks"
         mechanisms={['GABA', 'Cortisol']}
         fallbackSummary="Ashwagandha profile summarizing available evidence, mechanisms, safety context, and practical research notes."
       />
@@ -50,22 +47,17 @@ describe('a11y (axe-core)', () => {
     await checkA11y(container)
   })
 
-  it('Safety pending in profile card context does not hide status (visible label)', async () => {
+  it('Profile card renders without evidence/safety boxes', async () => {
     const { container } = render(
       <DecisionProfileCard
         href="/herbs/unknown"
         name="Unknown Herb"
         summary="Profile summary."
         bestFor="General"
-        evidence="Limited evidence"
-        safety="Safety review pending"
-        timeToEffect="—"
         mechanisms={[]}
         fallbackSummary="Unknown Herb profile summarizing available evidence, mechanisms, safety context, and practical research notes."
       />
     )
-    // Now visible per publicSafetyLabel change + metric render
-    // (the metric itself may be present with value)
     await checkA11y(container)
   })
 

--- a/app/articles/[slug]/page.tsx
+++ b/app/articles/[slug]/page.tsx
@@ -144,7 +144,7 @@ function MdxArticlePage({ article }: { article: (typeof mdxArticles)[number] }) 
           <span className="rounded-full border border-brand-900/10 bg-brand-50 px-2.5 py-0.5 font-bold uppercase tracking-wider text-brand-800">
             {article.category}
           </span>
-          <span className="rounded-full border border-brand-900/10 bg-white px-2.5 py-0.5 font-semibold text-muted">
+          <span className="rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-2.5 py-0.5 font-semibold text-muted">
             Evidence: {article.evidenceGrade}
           </span>
           <time dateTime={article.lastUpdated} className="text-muted">
@@ -564,7 +564,7 @@ export default async function ArticlePage({ params }: { params: ArticleRoutePara
             Deep Dive
           </span>
           {article.tags.slice(0, 3).map((tag) => (
-            <span key={tag} className="rounded-full border border-brand-900/10 bg-white px-2.5 py-0.5 font-semibold text-muted capitalize">
+            <span key={tag} className="rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-2.5 py-0.5 font-semibold text-muted capitalize">
               {tag}
             </span>
           ))}

--- a/app/articles/[slug]/page.tsx
+++ b/app/articles/[slug]/page.tsx
@@ -173,7 +173,7 @@ function MdxArticlePage({ article }: { article: (typeof mdxArticles)[number] }) 
         ) : null}
       </header>
 
-      <div className="mt-6 rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+      <div className="mt-6 rounded-[1rem] border border-brand-900/10 bg-[var(--surface-card)] p-6 shadow-sm sm:p-8">
         <div className="content-prose max-w-none [&>*]:max-w-reading [&_blockquote]:max-w-reading [&_blockquote]:rounded-r-lg [&_blockquote]:border-l-4 [&_blockquote]:border-brand-700/40 [&_blockquote]:bg-brand-50/60 [&_blockquote]:py-3 [&_blockquote]:pl-5 [&_blockquote]:pr-4 [&_h2]:mt-10 [&_h2]:text-2xl [&_h3]:mt-7 [&_h3]:text-xl [&_ol]:list-decimal [&_table]:w-full [&_table]:text-sm [&_td]:border-t [&_td]:border-brand-900/10 [&_td]:py-3 [&_td]:pr-4 [&_th]:border-b [&_th]:border-brand-900/10 [&_th]:pb-2 [&_th]:pr-4 [&_th]:text-left [&_ul]:list-disc">
           <ArticleMdx code={article.body} />
         </div>
@@ -422,7 +422,7 @@ function ReferencesTable({ refs }: { refs: ArticleReference[] }) {
   if (!refs.length) return null
 
   return (
-    <section className="mt-10 rounded-[1rem] border border-brand-900/10 bg-white/90 p-5 shadow-sm sm:p-6">
+    <section className="mt-10 rounded-[1rem] border border-brand-900/10 bg-[var(--surface-card)] p-5 shadow-sm sm:p-6">
       <h2 className="mb-4 text-lg font-semibold tracking-tight text-ink">References</h2>
       <ResponsiveTable label="Article references table" className="article-table">
         <table className="min-w-[760px] w-full text-sm">
@@ -615,7 +615,7 @@ export default async function ArticlePage({ params }: { params: ArticleRoutePara
 
       {/* Body + sidebar */}
       <div className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1fr)_240px]">
-        <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+        <section className="rounded-[1rem] border border-brand-900/10 bg-[var(--surface-card)] p-6 shadow-sm sm:p-8">
           <ArticleBody content={article.content} />
           <ReferencesTable refs={article.references} />
         </section>
@@ -623,13 +623,13 @@ export default async function ArticlePage({ params }: { params: ArticleRoutePara
         {/* Sidebar */}
         <aside className="space-y-4 lg:sticky lg:top-24 lg:self-start">
           {headings.length > 0 && (
-            <div className="hidden rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm lg:block">
+            <div className="hidden rounded-[1rem] border border-brand-900/10 bg-[var(--surface-card)] p-4 shadow-sm lg:block">
               <TableOfContents headings={headings} />
             </div>
           )}
 
           {article.references.length > 0 && (
-            <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
+            <div className="rounded-[1rem] border border-brand-900/10 bg-[var(--surface-card)] p-4 shadow-sm">
               <p className="text-[10px] font-bold uppercase tracking-wider text-muted">
                 {article.references.length} reference{article.references.length !== 1 ? 's' : ''}
               </p>
@@ -656,7 +656,7 @@ export default async function ArticlePage({ params }: { params: ArticleRoutePara
             </div>
           )}
 
-          <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
+          <div className="rounded-[1rem] border border-brand-900/10 bg-[var(--surface-card)] p-4 shadow-sm">
             <p className="text-[10px] font-bold uppercase tracking-wider text-muted">Explore more</p>
             <div className="mt-3 space-y-2">
               <Link href="/safety-checker" className="block text-sm font-medium text-brand-700 hover:text-brand-800">

--- a/app/compounds/CompoundsIndexClient.tsx
+++ b/app/compounds/CompoundsIndexClient.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { cleanSummary, formatDisplayLabel, isClean, labelize, list, text, unique } from '@/lib/display-utils'
+import { cleanSummary, formatDisplayLabel, isClean, list, text, unique } from '@/lib/display-utils'
 import { normalizeDecisionEvidence, normalizeDecisionSafety } from '@/lib/decision-primitives'
 import { DecisionEmptyState, DecisionFilterGroup, DecisionProfileCard } from '@/components/ui/DecisionPrimitives'
 import '@/styles/premium-cards.css'
@@ -138,19 +138,6 @@ function getBestFor(item: RuntimeRecord) {
   return 'Research context'
 }
 
-function getTimeToEffect(item: RuntimeRecord) {
-  const value = labelize(
-    item?.time_to_effect ||
-      item?.timeToEffect ||
-      item?.onset ||
-      (item?.practical as Record<string, unknown>)?.timeToEffect ||
-      item?.timeline,
-    ''
-  )
-
-  return value && isClean(value) ? value : ''
-}
-
 function scoreCompound(item: RuntimeRecord) {
   let score = 0
   const profile = text(item?.profile_status || item?.summary_quality || item?.status).toLowerCase()
@@ -261,9 +248,6 @@ function CompoundCard({ compound, featured = false }: { compound: RuntimeRecord;
       name={getName(compound)}
       summary={getSummary(compound)}
       bestFor={getBestFor(compound)}
-      evidence={getEvidence(compound)}
-      safety={getSafety(compound)}
-      timeToEffect={getTimeToEffect(compound)}
       mechanisms={getMechanismSignals(compound)}
       featured={featured}
       fallbackSummary="A conservative compound profile with mechanism, evidence, and safety context."

--- a/app/globals.css
+++ b/app/globals.css
@@ -489,7 +489,7 @@ html.dark ::selection {
   }
 
   .content-prose .article-table {
-    @apply my-6 max-w-full bg-white/90;
+    @apply my-6 max-w-full bg-[var(--surface-card)];
   }
 
   .detail-reading {
@@ -585,6 +585,31 @@ html.dark ::selection {
     @apply inline-flex items-center justify-center rounded-full border border-brand-900/10 bg-white/85 px-4 py-2 text-sm font-semibold text-ink transition-colors duration-200 hover:border-brand-700/20 hover:bg-white hover:text-brand-800;
     box-shadow: var(--shadow-button-secondary);
   }
+}
+
+/* Dark mode overrides for hardcoded light-mode text colors in prose/content components */
+html.dark .content-prose {
+  color: var(--text-primary);
+}
+
+html.dark .content-prose p,
+html.dark .content-prose li,
+html.dark .content-prose td {
+  color: var(--text-muted);
+}
+
+html.dark .content-prose th {
+  color: var(--text-primary);
+  background-color: rgba(36, 61, 50, 0.8);
+}
+
+html.dark .content-prose tbody tr:nth-child(even) {
+  background-color: rgba(36, 61, 50, 0.4);
+}
+
+html.dark .content-prose blockquote {
+  background-color: rgba(36, 61, 50, 0.6);
+  color: var(--text-primary);
 }
 
 /* Legacy emerald utility compatibility: keep older components from reading mint/neon. */

--- a/app/goals/[goal]/page.tsx
+++ b/app/goals/[goal]/page.tsx
@@ -220,7 +220,7 @@ function SleepClusterLinks() {
           <Link
             key={article.slug}
             href={`/articles/${article.slug}/`}
-            className="rounded-2xl border border-brand-900/10 bg-white/75 p-4 text-sm transition hover:border-brand-700/20 hover:bg-white"
+            className="rounded-2xl border border-brand-900/10 bg-[var(--surface-card)] p-4 text-sm transition hover:border-brand-700/20 hover:bg-[var(--surface-card-strong)]"
           >
             <span className="text-[10px] font-bold uppercase tracking-[0.14em] text-brand-700">
               {article.kind.replace('-', ' ')}
@@ -530,13 +530,13 @@ export default async function GoalDecisionPage({
               <Link
                 key={`${option.slug}-profile-link`}
                 href={profileHref}
-                className="rounded-2xl border border-brand-900/10 bg-white/60 p-5 text-sm text-muted transition hover:border-brand-700/20 hover:bg-white hover:shadow-sm"
+                className="rounded-2xl border border-brand-900/10 bg-[var(--surface-card)] p-5 text-sm text-muted transition hover:border-brand-700/20 hover:bg-[var(--surface-card-strong)] hover:shadow-sm"
               >
                 <span className="block font-semibold text-ink">{option.name}</span>
                 <span className="mt-2 block text-xs leading-relaxed">Open the profile for sourcing, safety context, and mechanism notes →</span>
               </Link>
             ) : (
-              <article key={`${option.slug}-profile-pending`} className="rounded-2xl border border-brand-900/10 bg-white/60 p-5 text-sm text-muted">
+              <article key={`${option.slug}-profile-pending`} className="rounded-2xl border border-brand-900/10 bg-[var(--surface-card)] p-5 text-sm text-muted">
                 <span className="block font-semibold text-ink">{option.name}</span>
                 <span className="mt-2 block text-xs leading-relaxed">Canonical profile pending; no profile link is shown until a static route exists.</span>
               </article>
@@ -664,7 +664,7 @@ export default async function GoalDecisionPage({
               <Link
                 key={related.slug}
                 href={`/goals/${related.slug}`}
-                className="rounded-full border border-brand-900/10 bg-white px-4 py-2 text-xs font-semibold text-brand-800 transition hover:border-brand-700/20 hover:bg-brand-50/50"
+                className="rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-xs font-semibold text-brand-800 transition hover:border-brand-700/20 hover:bg-brand-50/50"
               >
                 {related.title}
               </Link>

--- a/app/herbs/HerbsIndexClient.tsx
+++ b/app/herbs/HerbsIndexClient.tsx
@@ -240,9 +240,9 @@ function buildEvidenceHref(evidenceValue: string, query: string, context: string
 
 function StatCard({ value, label }: { value: number; label: string }) {
   return (
-    <div className="min-w-0 rounded-[0.8rem] border border-brand-900/10 bg-white/80 p-2.5 shadow-sm sm:p-3">
+    <div className="min-w-0 rounded-[0.8rem] border border-brand-900/10 bg-[var(--surface-card)] p-2.5 shadow-sm sm:p-3">
       <p className="text-xl font-semibold tracking-tight text-ink sm:text-2xl">{value}</p>
-      <p className="mt-0.5 text-[0.62rem] font-bold uppercase leading-snug tracking-[0.1em] text-[#5f6f66]">{label}</p>
+      <p className="mt-0.5 text-[0.62rem] font-bold uppercase leading-snug tracking-[0.1em] text-[var(--text-muted)]">{label}</p>
     </div>
   )
 }
@@ -369,7 +369,7 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
               </p>
             </div>
 
-            <div className="rounded-[0.8rem] border border-brand-900/10 bg-white/80 p-2.5 shadow-sm">
+            <div className="rounded-[0.8rem] border border-brand-900/10 bg-[var(--surface-card)] p-2.5 shadow-sm">
               <p className="text-xs font-bold uppercase tracking-[0.16em] text-brand-800">Library signal</p>
               <div className="mt-2 grid grid-cols-3 gap-2">
                 <StatCard value={totalProfiles} label="Profiles" />
@@ -380,7 +380,7 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
           </div>
         </section>
 
-        <section className="rounded-[0.85rem] border border-brand-900/10 bg-white/85 p-3 shadow-sm sm:p-4" aria-labelledby="herb-search-heading">
+        <section className="rounded-[0.85rem] border border-brand-900/10 bg-[var(--surface-card)] p-3 shadow-sm sm:p-4" aria-labelledby="herb-search-heading">
           <div className="flex flex-col gap-2 lg:flex-row lg:items-end lg:justify-between">
             <div className="max-w-2xl space-y-1.5">
               <p className="eyebrow-label">Search and filter</p>
@@ -397,7 +397,7 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
               type="search"
               defaultValue={query}
               placeholder="Search herb, effect, mechanism, or safety note"
-              className="min-h-10 w-full rounded-full border border-brand-900/10 bg-white px-4 text-sm text-ink shadow-sm placeholder:text-[#7b8a81]"
+              className="min-h-10 w-full rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 text-sm text-ink shadow-sm placeholder:text-[#7b8a81]"
             />
             {activeFilter !== 'all' ? <input type="hidden" name="context" value={activeFilter} /> : null}
             {activeEvidence !== 'all' ? <input type="hidden" name="evidence" value={activeEvidence} /> : null}
@@ -424,7 +424,7 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
                   <Link
                     key={opt.value}
                     href={href}
-                    className={`rounded-full border px-2.5 py-1 text-xs font-semibold transition ${active ? 'border-brand-700/25 bg-brand-50 text-brand-900' : 'border-brand-900/10 bg-white/80 text-[#33443a] hover:border-brand-700/20'}`}
+                    className={`rounded-full border px-2.5 py-1 text-xs font-semibold transition ${active ? 'border-brand-700/25 bg-brand-50 text-brand-900' : 'border-brand-900/10 bg-[var(--surface-card)] text-[#33443a] hover:border-brand-700/20'}`}
                   >
                     {opt.label}
                   </Link>
@@ -442,7 +442,7 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
           )}
         </section>
 
-        <section className="rounded-[0.85rem] border border-brand-900/10 bg-white/75 p-3 shadow-sm">
+        <section className="rounded-[0.85rem] border border-brand-900/10 bg-[var(--surface-card)] p-3 shadow-sm">
           <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
             <div className="max-w-2xl space-y-1.5">
               <p className="eyebrow-label">Common starting points</p>
@@ -455,7 +455,7 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
               <Link
                 key={path.label}
                 href={path.href}
-                className="group rounded-[0.75rem] border border-brand-900/10 bg-white/85 p-2.5 shadow-sm transition hover:border-brand-700/20 hover:bg-white"
+                className="group rounded-[0.75rem] border border-brand-900/10 bg-[var(--surface-card)] p-2.5 shadow-sm transition hover:border-brand-700/20 hover:bg-[var(--surface-card-strong)]"
               >
                 <h3 className="text-base font-semibold tracking-tight text-ink transition group-hover:text-brand-800">{path.label}</h3>
                 <p className="mt-1 text-sm leading-5 text-[#46574d]">{path.description}</p>
@@ -499,7 +499,7 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
                       {hasActiveFilters ? 'Profiles matching your scan.' : 'Browse every published herb profile.'}
                     </h2>
                   </div>
-                  <span className="inline-flex w-fit rounded-full border border-brand-900/10 bg-white/70 px-4 py-2 text-xs font-bold uppercase tracking-[0.16em] text-[#5f6f66]">
+                  <span className="inline-flex w-fit rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-xs font-bold uppercase tracking-[0.16em] text-[var(--text-muted)]">
                     {countLabel} profiles
                   </span>
                 </div>

--- a/app/herbs/HerbsIndexClient.tsx
+++ b/app/herbs/HerbsIndexClient.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
-import { cleanSummary, formatDisplayLabel, isClean, labelize, list, text, unique } from '@/lib/display-utils'
+import { cleanSummary, formatDisplayLabel, isClean, list, text, unique } from '@/lib/display-utils'
 import { normalizeDecisionEvidence, normalizeDecisionSafety } from '@/lib/decision-primitives'
 import { DecisionEmptyState, DecisionFilterGroup, DecisionProfileCard } from '@/components/ui/DecisionPrimitives'
 import '@/styles/premium-cards.css'
@@ -150,19 +150,6 @@ function getBestFor(item: RuntimeRecord) {
   return traditionalUses.length > 0 ? text(traditionalUses.join(' • ')) : 'Research context'
 }
 
-function getTimeToEffect(item: RuntimeRecord) {
-  const value = labelize(
-    item?.time_to_effect ||
-      item?.timeToEffect ||
-      item?.onset ||
-      (item?.practical as Record<string, unknown>)?.timeToEffect ||
-      item?.timeline,
-    ''
-  )
-
-  return value && isClean(value) ? value : ''
-}
-
 function scoreHerb(item: RuntimeRecord) {
   let score = 0
 
@@ -302,9 +289,6 @@ function HerbCard({ herb, featured = false }: { herb: RuntimeRecord; featured?: 
       name={getName(herb)}
       summary={getSummary(herb)}
       bestFor={getBestFor(herb)}
-      evidence={getEvidence(herb)}
-      safety={getSafety(herb)}
-      timeToEffect={getTimeToEffect(herb)}
       mechanisms={getMechanisms(herb)}
       featured={featured}
       fallbackSummary={`${getName(herb)} profile summarizing available evidence, mechanisms, safety context, and practical research notes.`}
@@ -371,7 +355,7 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
   const libraryHerbs = hasActiveFilters ? visibleHerbs : paginated ? herbs : baseHerbs.slice(featuredHerbs.length)
 
   return (
-    <div className="px-2 py-2 text-ink sm:px-3 sm:py-3">
+    <div className="px-2 pb-28 pt-2 text-ink sm:px-3 sm:pt-3">
       <div className="mx-auto max-w-7xl space-y-4 sm:space-y-4">
         <section className="hero-shell relative overflow-hidden rounded-[0.95rem] border border-brand-900/10 px-3 py-4 shadow-sm sm:px-4 sm:py-5">
           <div className="relative grid gap-3 lg:grid-cols-[1.05fr_.95fr] lg:items-end">

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -515,7 +515,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
           <a
             key={href}
             href={href}
-            className="rounded-full border border-brand-900/10 bg-white/70 px-3 py-1.5 text-xs font-semibold text-brand-800 transition-colors hover:bg-brand-50"
+            className="rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-3 py-1.5 text-xs font-semibold text-brand-800 transition-colors hover:bg-brand-50"
           >
             {label}
           </a>
@@ -526,28 +526,28 @@ export default async function HerbDetailPage({ params }: PageProps) {
       <section id="quick-stats" className="hero-shell rounded-2xl border border-brand-900/10 p-5 sm:p-6 space-y-4">
         <h2 className="text-lg font-bold text-ink">Quick Stats</h2>
         <div className="grid gap-3 sm:grid-cols-3">
-          <div className="rounded-xl border border-brand-900/10 bg-white/90 p-3">
+          <div className="rounded-xl border border-brand-900/10 bg-[var(--surface-card)] p-3">
             <p className="text-[10px] font-bold uppercase tracking-wider text-muted">Evidence level</p>
             <p className="mt-1 text-sm font-semibold text-ink">{evidenceStrength || 'Mixed or uncertain'}</p>
           </div>
-          <div className="rounded-xl border border-brand-900/10 bg-white/90 p-3">
+          <div className="rounded-xl border border-brand-900/10 bg-[var(--surface-card)] p-3">
             <p className="text-[10px] font-bold uppercase tracking-wider text-muted">Typical onset</p>
             <p className="mt-1 text-sm font-semibold text-ink">{timeline || 'Varies by prep'}</p>
           </div>
-          <div className="rounded-xl border border-brand-900/10 bg-white/90 p-3">
+          <div className="rounded-xl border border-brand-900/10 bg-[var(--surface-card)] p-3">
             <p className="text-[10px] font-bold uppercase tracking-wider text-muted">Safety rating</p>
             <p className="mt-1 text-sm font-semibold text-ink">{safetyTone}: {formatDisplayLabel(safetySensitivity)} caution</p>
           </div>
         </div>
         <div className="grid gap-3 sm:grid-cols-2">
           {topUses.length > 0 && (
-            <div className="rounded-xl border border-brand-900/10 bg-white/90 p-3">
+            <div className="rounded-xl border border-brand-900/10 bg-[var(--surface-card)] p-3">
               <p className="text-[10px] font-bold uppercase tracking-wider text-muted font-semibold">Best for</p>
               <p className="mt-1 text-sm text-ink">{topUses.slice(0, 3).join(', ')}</p>
             </div>
           )}
           {avoidIf.length > 0 && (
-            <div className="rounded-xl border border-brand-900/10 bg-white/90 p-3">
+            <div className="rounded-xl border border-brand-900/10 bg-[var(--surface-card)] p-3">
               <p className="text-[10px] font-bold uppercase tracking-wider text-amber-900 font-semibold">Avoid / review if</p>
               <p className="mt-1 text-sm text-amber-900">{avoidIf.slice(0, 3).join(', ')}</p>
             </div>
@@ -566,10 +566,10 @@ export default async function HerbDetailPage({ params }: PageProps) {
           </div>
           <div className="grid gap-3 md:grid-cols-3">
             {expansion.methodology.map((item) => (
-              <div key={item} className="rounded-xl border border-brand-900/10 bg-white/90 p-3 text-xs leading-5 text-muted">{item}</div>
+              <div key={item} className="rounded-xl border border-brand-900/10 bg-[var(--surface-card)] p-3 text-xs leading-5 text-muted">{item}</div>
             ))}
           </div>
-          <div className="overflow-x-auto rounded-2xl border border-brand-900/10 bg-white">
+          <div className="overflow-x-auto rounded-2xl border border-brand-900/10 bg-[var(--surface-card)]">
             <table className="min-w-[760px] w-full text-left text-sm">
               <thead className="bg-brand-50/60 text-xs font-bold uppercase tracking-wider text-muted">
                 <tr>
@@ -594,7 +594,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
             </table>
           </div>
           <div className="grid gap-4 lg:grid-cols-2">
-            <div className="rounded-2xl border border-brand-900/10 bg-white/90 p-4">
+            <div className="rounded-2xl border border-brand-900/10 bg-[var(--surface-card)] p-4">
               <h3 className="font-bold text-ink">Product and form choices</h3>
               <div className="mt-3 space-y-3">
                 {expansion.comparisonRows.map((row) => (
@@ -614,13 +614,13 @@ export default async function HerbDetailPage({ params }: PageProps) {
             </div>
           </div>
           <div className="grid gap-4 lg:grid-cols-2">
-            <div className="rounded-2xl border border-brand-900/10 bg-white/90 p-4">
+            <div className="rounded-2xl border border-brand-900/10 bg-[var(--surface-card)] p-4">
               <h3 className="font-bold text-ink">How to choose a product</h3>
               <ul className="mt-3 list-disc space-y-2 pl-5 text-xs leading-5 text-muted">
                 {expansion.buyerChecklist.map((item) => <li key={item}>{item}</li>)}
               </ul>
             </div>
-            <div className="rounded-2xl border border-brand-900/10 bg-white/90 p-4">
+            <div className="rounded-2xl border border-brand-900/10 bg-[var(--surface-card)] p-4">
               <h3 className="font-bold text-ink">References</h3>
               <ul className="mt-3 space-y-2 text-xs leading-5">
                 {expansion.references.map((ref) => (
@@ -732,7 +732,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
       <HerbCompoundLinks herbSlug={herb.slug} herbName={displayName} />
 
       {goalLinks.length > 0 ? (
-        <section className="rounded-2xl border border-brand-900/10 bg-white/80 p-4 sm:p-5">
+        <section className="rounded-2xl border border-brand-900/10 bg-[var(--surface-card)] p-4 sm:p-5">
           <p className="text-[10px] font-bold uppercase tracking-wider text-brand-700">Goal guides</p>
           <div className="mt-3 flex flex-wrap gap-2">
             {goalLinks.map((link) => (
@@ -749,14 +749,14 @@ export default async function HerbDetailPage({ params }: PageProps) {
       ) : null}
 
       {conditionLinks.length > 0 ? (
-        <section className="rounded-2xl border border-brand-900/10 bg-white/80 p-4 sm:p-5">
+        <section className="rounded-2xl border border-brand-900/10 bg-[var(--surface-card)] p-4 sm:p-5">
           <p className="text-[10px] font-bold uppercase tracking-wider text-brand-700">Condition guides</p>
           <div className="mt-3 flex flex-wrap gap-2">
             {conditionLinks.slice(0, 5).map((link: RuntimeMapEntry) => (
               <Link
                 key={link.slug}
                 href={link.href || `/goals/${link.slug}`}
-                className="rounded-full border border-brand-900/10 bg-white px-3 py-1.5 text-xs font-semibold text-brand-800 hover:bg-brand-50"
+                className="rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-3 py-1.5 text-xs font-semibold text-brand-800 hover:bg-brand-50"
               >
                 {link.label || formatDisplayLabel(link.slug)}
               </Link>
@@ -799,7 +799,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
               description={`Affiliate recommendations for ${displayName}. Review safety, dose, and product quality before buying.`}
               products={revenueProducts.products}
             />
-            <div className="rounded-2xl border border-brand-900/10 bg-white/85 p-5 space-y-3 shadow-sm">
+            <div className="rounded-2xl border border-brand-900/10 bg-[var(--surface-card)] p-5 space-y-3 shadow-sm">
               <h4 className="text-sm font-bold text-ink uppercase tracking-wider">Product Form &amp; Quality Guidelines</h4>
               <p className="text-xs leading-relaxed text-muted">
                 When sourcing {displayName}, verify the label for:
@@ -854,7 +854,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
       <AuthorCredentials />
 
       <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between">
-        <Link href="/herbs" className="inline-flex rounded-full border border-brand-900/10 bg-white px-4 py-2 text-sm font-bold text-ink transition hover:bg-sand-50">
+        <Link href="/herbs" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">
           ← Back to herbs library
         </Link>
         <Link href="/safety-checker" className="text-sm font-bold text-brand-800 hover:underline">

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -459,7 +459,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
 
 
   return (
-    <div className="mx-auto max-w-4xl space-y-10 px-4 py-6">
+    <div className="mx-auto max-w-4xl space-y-10 px-4 pb-28 pt-6">
       <ScrollEngagementPrompt storageKey={`herb-prompt-${normalizedSlug}`} />
       <SchemaGraphScript graph={schemaGraph} />
       <HerbSchemaGenerator

--- a/components/evidence/EvidenceSummaryCard.tsx
+++ b/components/evidence/EvidenceSummaryCard.tsx
@@ -29,36 +29,36 @@ export default function EvidenceSummaryCard({
 
       <div className="grid gap-4 lg:grid-cols-3">
         {humanEvidence ? (
-          <div className="rounded-2xl bg-[#f5f3ec] p-4 space-y-2">
-            <p className="text-xs font-semibold tracking-wide uppercase text-[#5c6b63]">
+          <div className="rounded-2xl bg-[var(--surface-subtle)] p-4 space-y-2">
+            <p className="text-xs font-semibold tracking-wide uppercase text-[var(--text-muted)]">
               Human evidence
             </p>
 
-            <p className="text-sm leading-7 text-[#46574d]">
+            <p className="text-sm leading-7 text-[var(--text-secondary)]">
               {humanEvidence}
             </p>
           </div>
         ) : null}
 
         {mechanisticEvidence ? (
-          <div className="rounded-2xl bg-[#f5f3ec] p-4 space-y-2">
-            <p className="text-xs font-semibold tracking-wide uppercase text-[#5c6b63]">
+          <div className="rounded-2xl bg-[var(--surface-subtle)] p-4 space-y-2">
+            <p className="text-xs font-semibold tracking-wide uppercase text-[var(--text-muted)]">
               Research signal
             </p>
 
-            <p className="text-sm leading-7 text-[#46574d]">
+            <p className="text-sm leading-7 text-[var(--text-secondary)]">
               {mechanisticEvidence}
             </p>
           </div>
         ) : null}
 
         {safetyProfile ? (
-          <div className="rounded-2xl bg-[#f5f3ec] p-4 space-y-2">
-            <p className="text-xs font-semibold tracking-wide uppercase text-[#5c6b63]">
+          <div className="rounded-2xl bg-[var(--surface-subtle)] p-4 space-y-2">
+            <p className="text-xs font-semibold tracking-wide uppercase text-[var(--text-muted)]">
               Safety profile
             </p>
 
-            <p className="text-sm leading-7 text-[#46574d]">
+            <p className="text-sm leading-7 text-[var(--text-secondary)]">
               {safetyProfile}
             </p>
           </div>

--- a/components/ui/DecisionPrimitives.tsx
+++ b/components/ui/DecisionPrimitives.tsx
@@ -3,27 +3,9 @@ import { formatDisplayLabel } from '@/lib/display-utils'
 import {
   decisionChipClass,
   decisionMetadataClusterClass,
-  decisionMetricShellClass,
   decisionMicroLabelClass,
   decisionStatusBadgeClass,
-  publicSafetyLabel,
 } from '@/lib/decision-primitives'
-
-type DecisionMetricProps = {
-  label: string
-  value?: string
-}
-
-export function DecisionMetric({ label, value }: DecisionMetricProps) {
-  if (!value) return null
-
-  return (
-    <div className={decisionMetricShellClass}>
-      <p className={`${decisionMicroLabelClass} text-[#68786f]`}>{label}</p>
-      <p className="mt-1 line-clamp-2 text-sm font-semibold leading-5 text-[#26382f]">{value}</p>
-    </div>
-  )
-}
 
 type DecisionEmptyStateAction = {
   href: string
@@ -117,9 +99,6 @@ export function DecisionProfileCard({
   name,
   summary,
   bestFor,
-  evidence,
-  safety,
-  timeToEffect,
   mechanisms = [],
   featured = false,
   fallbackSummary,
@@ -128,20 +107,18 @@ export function DecisionProfileCard({
   name: string
   summary?: string
   bestFor: string
-  evidence: string
-  safety: string
-  timeToEffect?: string
   mechanisms?: string[]
   featured?: boolean
   fallbackSummary: string
 }) {
   const visibleMechanisms = mechanisms.map(formatDisplayLabel).filter(Boolean).slice(0, 2)
-  const visibleSafety = publicSafetyLabel(safety)
+  const hasBestFor = bestFor && bestFor !== 'Research context'
+  const bestForItems = hasBestFor ? bestFor.split(' • ').filter(Boolean) : []
 
   return (
     <Link
       href={href}
-      className="group flex h-full flex-col rounded-[0.85rem] border border-brand-900/10 bg-white/90 p-3 shadow-sm transition-colors duration-200 hover:border-brand-700/20 hover:bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40"
+      className="group flex h-full flex-col rounded-[0.85rem] border border-brand-900/10 bg-[var(--surface-card)] p-3 shadow-sm transition-colors duration-200 hover:border-brand-700/20 hover:bg-[var(--surface-card-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40"
     >
       <div className="flex flex-1 flex-col">
         <div className="flex min-w-0 items-start justify-between gap-3">
@@ -155,20 +132,20 @@ export function DecisionProfileCard({
           ) : null}
         </div>
 
-        <p className="mt-1.5 line-clamp-2 text-sm leading-5 text-[#46574d]">
+        <p className="mt-1.5 line-clamp-2 text-sm leading-5 text-[var(--text-secondary)]">
           {summary || fallbackSummary}
         </p>
 
-        <div className="mt-2 rounded-[0.75rem] border border-brand-900/10 bg-brand-50/45 p-2.5">
-          <p className={`${decisionMicroLabelClass} text-brand-800`}>Best-for context</p>
-          <p className="mt-1 text-sm font-semibold leading-5 text-[#203329]">{bestFor}</p>
-        </div>
-
-        <div className="mt-2 grid gap-2 sm:grid-cols-3">
-          <DecisionMetric label="Evidence" value={evidence} />
-          <DecisionMetric label="Safety" value={visibleSafety} />
-          <DecisionMetric label="Time" value={timeToEffect} />
-        </div>
+        {bestForItems.length > 0 ? (
+          <div className="mt-2">
+            <p className={`${decisionMicroLabelClass} mb-1.5 text-[var(--text-muted)]`}>Best for</p>
+            <div className={decisionMetadataClusterClass}>
+              {bestForItems.map((item, idx) => (
+                <span key={idx} className={decisionChipClass}>{item}</span>
+              ))}
+            </div>
+          </div>
+        ) : null}
 
         {visibleMechanisms.length > 0 ? (
           <div className={`${decisionMetadataClusterClass} mt-2 border-t border-brand-900/10 pt-2`}>
@@ -181,7 +158,7 @@ export function DecisionProfileCard({
         ) : null}
       </div>
 
-      <div className="mt-2 text-sm font-bold text-brand-800 transition group-hover:text-brand-900">
+      <div className="mt-3 text-sm font-bold text-brand-800 transition group-hover:text-brand-900">
         View profile <span aria-hidden="true">→</span>
       </div>
     </Link>

--- a/lib/decision-primitives.ts
+++ b/lib/decision-primitives.ts
@@ -35,7 +35,7 @@ export const decisionStatusBadgeClass =
   `${decisionBadgeClass} text-[0.72rem] uppercase tracking-[0.08em]`
 
 export const decisionChipClass =
-  'inline-flex min-h-6 max-w-full items-center rounded-full border border-brand-900/10 bg-white/75 px-2 py-0.5 text-[0.68rem] font-semibold leading-snug text-[#5f6f66] break-words'
+  'inline-flex min-h-6 max-w-full items-center rounded-full border border-brand-900/10 bg-[var(--surface-subtle)] px-2 py-0.5 text-[0.68rem] font-semibold leading-snug text-[var(--text-muted)] break-words'
 
 export const decisionMicroLabelClass =
   'text-[0.64rem] font-bold uppercase tracking-[0.09em] leading-none'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1889,6 +1889,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2775,6 +2776,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2797,6 +2799,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2819,6 +2822,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2835,6 +2839,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2851,6 +2856,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2867,6 +2873,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2883,6 +2890,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2899,6 +2907,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2915,6 +2924,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2931,6 +2941,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2947,6 +2958,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2963,6 +2975,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2979,6 +2992,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3001,6 +3015,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3023,6 +3038,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3045,6 +3061,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3067,6 +3084,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3089,6 +3107,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3111,6 +3130,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3133,6 +3153,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3155,6 +3176,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -3174,6 +3196,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3193,6 +3216,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3212,6 +3236,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [

--- a/public/data/_meta/build-info.json
+++ b/public/data/_meta/build-info.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-06-20T04:39:24.051Z",
+  "generatedAt": "2026-06-20T11:37:35.133Z",
   "source": {
-    "workbookPath": "C:\\Users\\Will\\Documents\\hippie-scientist-site\\data-sources\\herb_monograph_master.xlsx",
+    "workbookPath": "/home/user/hippie-scientist-site/data-sources/herb_monograph_master.xlsx",
     "workbook": "herb_monograph_master.xlsx"
   },
-  "output": "public\\data",
+  "output": "public/data",
   "counts": {
     "herbs": 287,
     "compounds": 597,

--- a/public/data/_meta/build-info.json
+++ b/public/data/_meta/build-info.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-20T11:37:35.133Z",
+  "generatedAt": "2026-06-20T11:58:28.083Z",
   "source": {
     "workbookPath": "/home/user/hippie-scientist-site/data-sources/herb_monograph_master.xlsx",
     "workbook": "herb_monograph_master.xlsx"


### PR DESCRIPTION
- Remove Evidence/Safety/Time metric boxes from herb and compound listing cards; cards now show name, summary, best-for chips, and mechanism chips only
- Hide empty Best-for Context box when no meaningful data; render chips instead of a bordered panel
- Replace all hardcoded bg-white/90 surfaces in article pages with bg-[var(--surface-card)] so dark mode no longer shows cheap pale boxes against the dark green brand
- Add dark mode text overrides for .content-prose (td, p, li, th, blockquote) which were using hardcoded light-mode colors
- Switch decisionChipClass to CSS variable colors so chips are readable in dark mode
- Add pb-28 bottom padding to herb index and herb profile pages so the mobile sticky nav does not crowd content
- Update a11y tests to match simplified card API

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GQDktELyD39zpXkR2owYdE