### PR TITLE
Revenue/SEO fixes: robots meta, goal affiliate wiring, sticky CTA pointer fix

### DIFF
--- a/app/goals/[goal]/page.tsx
+++ b/app/goals/[goal]/page.tsx
@@ -14,7 +14,8 @@ import { getGoalStartHereLinks } from '@/lib/goal-start-here-links'
 import { getGoalContentExtension, getGoalFaqItems } from '@/data/goal-content'
 import { rankEntitiesForGoal } from '@/lib/goal-matching-engine'
 import { getAffiliateShopLinks } from '../../../src/lib/affiliate'
-import { getRevenueProductSet } from '@/config/revenue-products'
+import { getRevenueProductSet, revenueProductSets } from '@/config/revenue-products'
+import RecommendationSection from '@/components/RecommendationSection'
 import SafetyChecklistPromo from '@/components/monetization/SafetyChecklistPromo'
 import GoalTopAffiliatePicks from '@/components/monetization/GoalTopAffiliatePicks'
 import ProductTrustAffiliate from '@/components/monetization/ProductTrustAffiliate'
@@ -151,6 +152,22 @@ function buildDynamicEnrichedOption(
     mechanismCategoryTags,
     pathwayTags,
   }
+}
+
+// Product set keys per goal — kava excluded from anxiety (harm-reduction zone)
+const GOAL_PRODUCT_SETS: Record<string, string[]> = {
+  sleep: ['magnesium', 'melatonin', 'valerian'],
+  anxiety: ['ashwagandha', 'passionflower'],
+  focus: ['bacopa', 'caffeine'],
+  stress: ['ashwagandha', 'rhodiola'],
+  energy: ['rhodiola', 'maca'],
+  inflammation: ['turmeric', 'boswellia', 'quercetin'],
+  cognition: ['bacopa', 'reishi'],
+}
+
+function getGoalProducts(goalSlug: string) {
+  const keys = GOAL_PRODUCT_SETS[goalSlug] ?? []
+  return keys.flatMap((key) => revenueProductSets[key]?.products ?? [])
 }
 
 export const dynamicParams = false
@@ -303,19 +320,31 @@ export default async function GoalDecisionPage({
 
   const hubLinks = getGoalHubLinks(goal.slug)
   const startHereLinks = getGoalStartHereLinks(goal.slug)
+  const goalProducts = getGoalProducts(goal.slug)
+
   const goalEvidence = await getGoalEvidenceEngine(goal.slug)
   if (goalEvidence) {
     return (
-      <GoalDecisionExperience
-        goal={goal}
-        enrichedOptions={enrichedOptions}
-        evidence={goalEvidence}
-        structuredData={structuredData}
-        hubLinks={hubLinks}
-        startHereLinks={startHereLinks}
-        goalContent={goalContent}
-        captureGoal={goalCaptureGoal(goal.slug)}
-      />
+      <>
+        <GoalDecisionExperience
+          goal={goal}
+          enrichedOptions={enrichedOptions}
+          evidence={goalEvidence}
+          structuredData={structuredData}
+          hubLinks={hubLinks}
+          startHereLinks={startHereLinks}
+          goalContent={goalContent}
+          captureGoal={goalCaptureGoal(goal.slug)}
+        />
+        {goalProducts.length > 0 && (
+          <div className="mx-auto max-w-6xl px-4 pb-10 sm:px-6 lg:px-8">
+            <RecommendationSection
+              title={`${goal.title} product picks`}
+              products={goalProducts}
+            />
+          </div>
+        )}
+      </>
     )
   }
 
@@ -685,6 +714,13 @@ export default async function GoalDecisionPage({
       />
 
       <AuthorCredentials />
+
+      {goalProducts.length > 0 && (
+        <RecommendationSection
+          title={`${goal.title} product picks`}
+          products={goalProducts}
+        />
+      )}
 
       <footer className="rounded-2xl border border-brand-900/10 bg-brand-950/[0.02] p-5 text-xs leading-6 text-muted">
         Educational only. Not medical advice. Evidence varies by population, preparation, and study design.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -42,6 +42,7 @@ export const metadata: Metadata = {
   // ensure template wins for children
   openGraph: rootMetadata.openGraph,
   twitter: rootMetadata.twitter,
+  robots: { index: true, follow: true },
 }
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/components/conversion-sticky-cta.tsx
+++ b/components/conversion-sticky-cta.tsx
@@ -26,8 +26,8 @@ export default function ConversionStickyCTA({ brand, name, href }: Props) {
   return (
     <>
       {visible ? (
-        <div className="fixed bottom-20 left-1/2 z-40 w-[calc(100%-2rem)] max-w-xl -translate-x-1/2 rounded-2xl bg-ink px-4 py-3 text-white shadow-2xl ring-1 ring-black/10">
-          <div className="flex items-center justify-between gap-3">
+        <div className="pointer-events-none fixed bottom-20 left-1/2 z-40 w-[calc(100%-2rem)] max-w-xl -translate-x-1/2 rounded-2xl bg-ink px-4 py-3 text-white shadow-2xl ring-1 ring-black/10">
+          <div className="pointer-events-auto flex items-center justify-between gap-3">
             <div className="min-w-0">
               <p className="text-xs font-semibold uppercase tracking-wide text-white/60">Popular choice</p>
               <p className="truncate text-sm font-bold">{brand}{name ? ` — ${name}` : ''}</p>
@@ -39,8 +39,8 @@ export default function ConversionStickyCTA({ brand, name, href }: Props) {
         </div>
       ) : null}
 
-      <div className="fixed bottom-0 left-0 right-0 z-40 border-t border-neutral-200 bg-white/95 p-3 shadow-[0_-10px_30px_rgba(0,0,0,0.08)] backdrop-blur">
-        <div className="mx-auto flex max-w-5xl items-center justify-between gap-3">
+      <div className="pointer-events-none fixed bottom-0 left-0 right-0 z-40 border-t border-neutral-200 bg-white/95 p-3 shadow-[0_-10px_30px_rgba(0,0,0,0.08)] backdrop-blur">
+        <div className="pointer-events-auto mx-auto flex min-h-14 max-w-5xl items-center justify-between gap-3">
           <div className="min-w-0 text-sm">
             <p className="font-bold text-ink">Top pick</p>
             <p className="truncate text-muted">{brand}{name ? ` — ${name}` : ''}</p>


### PR DESCRIPTION
## Summary

- **`app/layout.tsx`** — Added `robots: { index: true, follow: true }` to the root metadata export so every page signals indexability to crawlers.
- **`app/goals/[goal]/page.tsx`** — Wired `RecommendationSection` into all 7 goal pages via the single dynamic route. Added a `GOAL_PRODUCT_SETS` mapping (kava excluded from anxiety per harm-reduction rule) and `getGoalProducts()` helper. Section renders in both the `GoalDecisionExperience` path and the fallback path, above the footer.
- **`components/conversion-sticky-cta.tsx`** — Added `pointer-events-none` to both fixed outer wrappers and `pointer-events-auto` to inner content divs, so the bars no longer swallow taps on underlying content. Added `min-h-14` (56 px) to the persistent bottom bar for tap-target compliance.

## Test plan

- [ ] Visit `/goals/sleep`, `/goals/anxiety`, `/goals/focus`, `/goals/stress`, `/goals/energy`, `/goals/inflammation`, `/goals/cognition` — confirm `RecommendationSection` renders near the bottom with correct product cards
- [ ] Confirm `/goals/anxiety` shows ashwagandha + passionflower only (no kava cards)
- [ ] Check `<head>` on any page for `<meta name="robots" content="index, follow">`
- [ ] On mobile, scroll a herb profile page that uses `ConversionStickyCTA` — tap links behind the sticky bar and confirm they respond

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ciR7eP4Wr19afoGYztnUh

---
_Generated by [Claude Code](https://claude.ai/code/session_018ciR7eP4Wr19afoGYztnUh)_