### PR TITLE
fix: unblock email forms, wire affiliate to 5 guides, strip NOINDEX f…

### DIFF
--- a/app/guides/adhd-supplements/page.tsx
+++ b/app/guides/adhd-supplements/page.tsx
@@ -5,6 +5,8 @@ import { focusAdhdArticles } from '@/lib/focus-adhd-articles'
 import { AdhdInlineCta } from '@/components/articles/AdhdMonetizationWidgets'
 import { ArticleLayout, TableOfContents } from '@/components/articles'
 import type { Heading } from '@/components/articles'
+import { getRevenueProductSet } from '@/config/revenue-products'
+import RecommendationSection from '@/components/RecommendationSection'
 
 const SLUG = 'adhd-supplements'
 const TITLE = 'ADHD Supplements Guide: Evidence, Safety, Testing, and Practical Use'
@@ -60,6 +62,7 @@ const HEADINGS: Heading[] = [
 ]
 
 export default function AdhdSupplementsHub() {
+  const magnesiumProducts = getRevenueProductSet('magnesium')
   const collectionSchema = {
     '@context': 'https://schema.org',
     '@graph': [
@@ -308,6 +311,10 @@ export default function AdhdSupplementsHub() {
           </div>
         </div>
       </section>
+
+      {magnesiumProducts && (
+        <RecommendationSection products={magnesiumProducts.products} />
+      )}
 
       {/* FAQ Accordion */}
       <section id="faq" className="scroll-mt-20 rounded-2xl border border-brand-900/10 bg-white/90 p-6 space-y-4 shadow-sm">

--- a/app/guides/best-adaptogens-for-stress/page.tsx
+++ b/app/guides/best-adaptogens-for-stress/page.tsx
@@ -4,6 +4,8 @@ import StructuredData from '@/components/StructuredData'
 import { SITE_URL } from '@/lib/navigation-config'
 import { ArticleLayout, TableOfContents } from '@/components/articles'
 import type { Heading } from '@/components/articles'
+import { getRevenueProductSet } from '@/config/revenue-products'
+import RecommendationSection from '@/components/RecommendationSection'
 
 const PAGE_URL = `${SITE_URL}/guides/best-adaptogens-for-stress`
 
@@ -96,6 +98,7 @@ const HEADINGS: Heading[] = [
 ]
 
 export default function BestAdaptogensForStressPage() {
+  const ashwagandhaProducts = getRevenueProductSet('ashwagandha')
   const toc = <TableOfContents headings={HEADINGS} />
   return (
     <>
@@ -204,6 +207,10 @@ export default function BestAdaptogensForStressPage() {
             <li>• <strong>Standardization:</strong> Two "ashwagandha" products can be 5–10× different in withanolide content. Always check the standardized extract label.</li>
           </ul>
         </section>
+
+        {ashwagandhaProducts && (
+          <RecommendationSection products={ashwagandhaProducts.products} />
+        )}
 
         {/* Related */}
         <nav className="flex flex-wrap gap-4 text-sm font-semibold text-brand-700">

--- a/app/guides/best-herbs-for-anxiety/page.tsx
+++ b/app/guides/best-herbs-for-anxiety/page.tsx
@@ -5,6 +5,8 @@ import JsonLd from '@/components/seo/JsonLd'
 import { SITE_URL } from '@/lib/navigation-config'
 import { ArticleLayout, TableOfContents } from '@/components/articles'
 import type { Heading } from '@/components/articles'
+import { getRevenueProductSet } from '@/config/revenue-products'
+import RecommendationSection from '@/components/RecommendationSection'
 
 const PAGE_URL = `${SITE_URL}/guides/best-herbs-for-anxiety`
 
@@ -136,6 +138,8 @@ const HEADINGS: Heading[] = [
 ]
 
 export default function BestHerbsForAnxietyPage() {
+  const ashwagandhaProducts = getRevenueProductSet('ashwagandha')
+
   const faqSchema = {
     '@context': 'https://schema.org',
     '@type': 'FAQPage',
@@ -327,6 +331,10 @@ export default function BestHerbsForAnxietyPage() {
             </table>
           </div>
         </section>
+
+        {ashwagandhaProducts && (
+          <RecommendationSection products={ashwagandhaProducts.products} />
+        )}
 
         <section id="faq" className="scroll-mt-20 rounded-[1.65rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm">
           <h2 className="text-xl font-semibold text-ink">Frequently asked questions</h2>

--- a/app/guides/best-supplements-for-focus/page.tsx
+++ b/app/guides/best-supplements-for-focus/page.tsx
@@ -4,6 +4,8 @@ import StructuredData from '@/components/StructuredData'
 import { SITE_URL } from '@/lib/navigation-config'
 import { ArticleLayout, TableOfContents } from '@/components/articles'
 import type { Heading } from '@/components/articles'
+import { getRevenueProductSet } from '@/config/revenue-products'
+import RecommendationSection from '@/components/RecommendationSection'
 
 const PAGE_URL = `${SITE_URL}/guides/best-supplements-for-focus`
 
@@ -90,6 +92,7 @@ const HEADINGS: Heading[] = [
 ]
 
 export default function BestSupplementsForFocusPage() {
+  const lTheanineProducts = getRevenueProductSet('l-theanine')
   const toc = <TableOfContents headings={HEADINGS} />
   return (
     <>
@@ -178,6 +181,10 @@ export default function BestSupplementsForFocusPage() {
             ))}
           </div>
         </section>
+
+        {lTheanineProducts && (
+          <RecommendationSection products={lTheanineProducts.products} />
+        )}
 
         {/* Related */}
         <nav className="flex flex-wrap gap-4 text-sm font-semibold text-brand-700">

--- a/app/guides/best-supplements-for-sleep/page.tsx
+++ b/app/guides/best-supplements-for-sleep/page.tsx
@@ -4,6 +4,8 @@ import StructuredData from '@/components/StructuredData'
 import { SITE_URL } from '@/lib/navigation-config'
 import { ArticleLayout, TableOfContents } from '@/components/articles'
 import type { Heading } from '@/components/articles'
+import { getRevenueProductSet } from '@/config/revenue-products'
+import RecommendationSection from '@/components/RecommendationSection'
 
 const PAGE_URL = `${SITE_URL}/guides/best-supplements-for-sleep`
 
@@ -119,6 +121,7 @@ const HEADINGS: Heading[] = [
 ]
 
 export default function BestSupplementsForSleepPage() {
+  const magnesiumProducts = getRevenueProductSet('magnesium')
   const toc = <TableOfContents headings={HEADINGS} />
   return (
     <>
@@ -276,6 +279,10 @@ export default function BestSupplementsForSleepPage() {
             <li>• <strong>Ignoring magnesium form:</strong> Magnesium oxide is cheap but poorly absorbed. Glycinate or L-threonate for sleep/cognition.</li>
           </ul>
         </section>
+
+        {magnesiumProducts && (
+          <RecommendationSection products={magnesiumProducts.products} />
+        )}
 
         {/* Related */}
         <nav className="flex flex-wrap gap-4 text-sm font-semibold text-brand-700">

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -469,6 +469,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
     if (!herb.slug) return;
     if (DEPRECATED_HERBS.has(herb.slug.toLowerCase())) return;
     if (!indexableHerbsSlugs.has(herb.slug)) return;
+    // Only include herbs explicitly approved for indexing.
+    if (herb.indexability_status !== 'PUBLISH') return;
 
     addRoute(`/herbs/${herb.slug}`, 'monthly', 0.7, herb.lastUpdated || herb.updatedAt, herb);
   });
@@ -477,6 +479,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
     if (!compound.slug) return;
     if (DEPRECATED_COMPOUNDS.has(compound.slug.toLowerCase())) return;
     if (!indexableCompoundsSlugs.has(compound.slug)) return;
+    // Only include compounds explicitly approved for indexing.
+    if (compound.indexability_status !== 'PUBLISH') return;
 
     addRoute(`/compounds/${compound.slug}`, 'monthly', 0.7, compound.lastUpdated || compound.updatedAt, compound);
   });

--- a/components/EmailCapture.tsx
+++ b/components/EmailCapture.tsx
@@ -36,7 +36,7 @@ export default function EmailCapture({
   }
 
   return (
-    <section className={`rounded-[1.5rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8 ${className}`}>
+    <section className={`rounded-[1.5rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8 mb-20 md:mb-0 ${className}`}>
       <div className='grid gap-5 lg:grid-cols-[1fr_0.9fr] lg:items-center'>
         <div>
           <p className='text-xs font-bold uppercase tracking-[0.18em] text-brand-700'>Email updates</p>

--- a/components/monetization/StickyChecklistBar.tsx
+++ b/components/monetization/StickyChecklistBar.tsx
@@ -40,7 +40,7 @@ export default function StickyChecklistBar({ storageKey = 'sticky-checklist-bar'
 
   return (
     <div
-      className='fixed bottom-[4.5rem] left-0 right-0 z-40 border-t border-emerald-800/15 bg-white/95 px-4 py-2.5 shadow-[0_-4px_20px_rgba(0,0,0,0.08)] backdrop-blur-sm md:bottom-0'
+      className='fixed bottom-[calc(4.5rem+env(safe-area-inset-bottom))] left-0 right-0 z-40 border-t border-emerald-800/15 bg-white/95 px-4 py-2.5 shadow-[0_-4px_20px_rgba(0,0,0,0.08)] backdrop-blur-sm md:bottom-0'
       role='region'
       aria-label='Safety checklist reminder'
     >


### PR DESCRIPTION
…rom sitemap

- components/EmailCapture.tsx: add mb-20 md:mb-0 to clear mobile bottom nav on form section
- components/monetization/StickyChecklistBar.tsx: fix bottom offset with safe-area-inset calc to prevent nav overlap
- app/guides/adhd-supplements/page.tsx: wire RecommendationSection (magnesium products)
- app/guides/best-herbs-for-anxiety/page.tsx: wire RecommendationSection (ashwagandha products)
- app/guides/best-supplements-for-sleep/page.tsx: wire RecommendationSection (magnesium products)
- app/guides/best-supplements-for-focus/page.tsx: wire RecommendationSection (l-theanine products)
- app/guides/best-adaptogens-for-stress/page.tsx: wire RecommendationSection (ashwagandha products)
- app/sitemap.ts: add indexability_status !== 'PUBLISH' guard for herbs and compounds to strip NOINDEX entries from sitemap


Claude-Session: https://claude.ai/code/session_01FGMaUaZDHTcJoFqQxKnyXj

## Summary

- 

## Verification

- [ ] `npm run lint`
- [ ] `npm run check`
- [ ] no package-lock drift
- [ ] no unexpected `public/data` diffs
- [ ] no generated file corruption
- [ ] static export compatible

## Risk Notes

- 
