### PR TITLE
Three critical fixes: mobile nav, affiliate wiring (18 guides), sitemap NOINDEX, deploy pipeline

### DIFF
--- a/app/guides/best-herbs-for-stress-and-anxiety-at-night/page.tsx
+++ b/app/guides/best-herbs-for-stress-and-anxiety-at-night/page.tsx
@@ -4,6 +4,8 @@ import StructuredData from '@/components/StructuredData'
 import { SITE_URL } from '@/lib/navigation-config'
 import { ArticleLayout, TableOfContents } from '@/components/articles'
 import type { Heading } from '@/components/articles'
+import { getRevenueProductSet } from '@/config/revenue-products'
+import RecommendationSection from '@/components/RecommendationSection'
 
 const PAGE_URL = `${SITE_URL}/guides/best-herbs-for-stress-and-anxiety-at-night`
 
@@ -56,6 +58,7 @@ const HEADINGS: Heading[] = [
 
 export default function Page() {
   const toc = <TableOfContents headings={HEADINGS} />
+  const passionflowerProducts = getRevenueProductSet('passionflower')
   return (
     <ArticleLayout toc={toc} zone="supplement">
       <StructuredData
@@ -237,6 +240,10 @@ export default function Page() {
             <li>• If nighttime anxiety is frequent, intense, or paired with low mood, talk to a clinician about evidence-based care.</li>
           </ul>
         </section>
+
+        {passionflowerProducts && (
+          <RecommendationSection products={passionflowerProducts.products} />
+        )}
 
         {/* FAQs */}
         <section id="faq" className="scroll-mt-20 space-y-4">

--- a/app/guides/best-natural-sleep-aids-that-work/page.tsx
+++ b/app/guides/best-natural-sleep-aids-that-work/page.tsx
@@ -4,6 +4,8 @@ import StructuredData from '@/components/StructuredData'
 import { SITE_URL } from '@/lib/navigation-config'
 import { ArticleLayout, TableOfContents } from '@/components/articles'
 import type { Heading } from '@/components/articles'
+import { getRevenueProductSet } from '@/config/revenue-products'
+import RecommendationSection from '@/components/RecommendationSection'
 
 const PAGE_URL = `${SITE_URL}/guides/best-natural-sleep-aids-that-work`
 
@@ -56,6 +58,7 @@ const HEADINGS: Heading[] = [
 
 export default function Page() {
   const toc = <TableOfContents headings={HEADINGS} />
+  const magnesiumProducts = getRevenueProductSet('magnesium')
   return (
     <ArticleLayout toc={toc} zone="supplement">
       <StructuredData
@@ -256,6 +259,10 @@ export default function Page() {
             <li>• <strong>Ignoring the foundations.</strong> No capsule offsets a 4&nbsp;pm coffee, a midnight screen and a different bedtime every day.</li>
           </ul>
         </section>
+
+        {magnesiumProducts && (
+          <RecommendationSection products={magnesiumProducts.products} />
+        )}
 
         {/* FAQs */}
         <section id="faq" className="scroll-mt-20 space-y-4">

--- a/app/guides/best-nootropics-for-focus/page.tsx
+++ b/app/guides/best-nootropics-for-focus/page.tsx
@@ -4,6 +4,8 @@ import StructuredData from '@/components/StructuredData'
 import { SITE_URL } from '@/lib/navigation-config'
 import { ArticleLayout, TableOfContents } from '@/components/articles'
 import type { Heading } from '@/components/articles'
+import { getRevenueProductSet } from '@/config/revenue-products'
+import RecommendationSection from '@/components/RecommendationSection'
 
 const PAGE_URL = `${SITE_URL}/guides/best-nootropics-for-focus`
 
@@ -121,6 +123,7 @@ const HEADINGS: Heading[] = [
 
 export default function BestNootropicsForFocusPage() {
   const toc = <TableOfContents headings={HEADINGS} />
+  const lTheanineProducts = getRevenueProductSet('l-theanine')
 
   return (
     <ArticleLayout toc={toc} zone="supplement">
@@ -253,6 +256,10 @@ export default function BestNootropicsForFocusPage() {
             ))}
           </div>
         </section>
+
+        {lTheanineProducts && (
+          <RecommendationSection products={lTheanineProducts.products} />
+        )}
 
         {/* Related */}
         <nav className="flex flex-wrap gap-4 text-sm font-semibold text-brand-700">

--- a/app/guides/best-supplements-for-overthinking/page.tsx
+++ b/app/guides/best-supplements-for-overthinking/page.tsx
@@ -4,6 +4,8 @@ import StructuredData from '@/components/StructuredData'
 import { SITE_URL } from '@/lib/navigation-config'
 import { ArticleLayout, TableOfContents } from '@/components/articles'
 import type { Heading } from '@/components/articles'
+import { getRevenueProductSet } from '@/config/revenue-products'
+import RecommendationSection from '@/components/RecommendationSection'
 
 const PAGE_URL = `${SITE_URL}/guides/best-supplements-for-overthinking`
 
@@ -56,6 +58,7 @@ const HEADINGS: Heading[] = [
 
 export default function Page() {
   const toc = <TableOfContents headings={HEADINGS} />
+  const lTheanineProducts = getRevenueProductSet('l-theanine')
   return (
     <ArticleLayout toc={toc} zone="supplement">
       <StructuredData
@@ -219,6 +222,10 @@ export default function Page() {
             <li>• If you take medication for anxiety, mood or sleep, confirm compatibility before adding supplements.</li>
           </ul>
         </section>
+
+        {lTheanineProducts && (
+          <RecommendationSection products={lTheanineProducts.products} />
+        )}
 
         {/* FAQs */}
         <section id="faq" className="scroll-mt-20 space-y-4">

--- a/app/guides/best-supplements-for-stress/page.tsx
+++ b/app/guides/best-supplements-for-stress/page.tsx
@@ -4,6 +4,8 @@ import StructuredData from '@/components/StructuredData'
 import { SITE_URL } from '@/lib/navigation-config'
 import { ArticleLayout, TableOfContents } from '@/components/articles'
 import type { Heading } from '@/components/articles'
+import { getRevenueProductSet } from '@/config/revenue-products'
+import RecommendationSection from '@/components/RecommendationSection'
 
 const PAGE_URL = `${SITE_URL}/guides/best-supplements-for-stress`
 
@@ -82,6 +84,7 @@ const HEADINGS: Heading[] = [
 
 export default function BestSupplementsForStressPage() {
   const toc = <TableOfContents headings={HEADINGS} />
+  const ashwagandhaProducts = getRevenueProductSet('ashwagandha')
   return (
     <>
       <StructuredData
@@ -182,6 +185,10 @@ export default function BestSupplementsForStressPage() {
             ))}
           </div>
         </section>
+
+        {ashwagandhaProducts && (
+          <RecommendationSection products={ashwagandhaProducts.products} />
+        )}
 
         <nav className="flex flex-wrap gap-4 text-sm font-semibold text-brand-700">
           <Link href="/guides/how-to-lower-cortisol-naturally" className="hover:text-brand-800">How to Lower Cortisol Naturally →</Link>

--- a/app/guides/focus-without-caffeine-crash/page.tsx
+++ b/app/guides/focus-without-caffeine-crash/page.tsx
@@ -4,6 +4,8 @@ import StructuredData from '@/components/StructuredData'
 import { SITE_URL } from '@/lib/navigation-config'
 import { ArticleLayout, TableOfContents } from '@/components/articles'
 import type { Heading } from '@/components/articles'
+import { getRevenueProductSet } from '@/config/revenue-products'
+import RecommendationSection from '@/components/RecommendationSection'
 
 const PAGE_URL = `${SITE_URL}/guides/focus-without-caffeine-crash`
 
@@ -56,6 +58,7 @@ const HEADINGS: Heading[] = [
 
 export default function Page() {
   const toc = <TableOfContents headings={HEADINGS} />
+  const lTheanineProducts = getRevenueProductSet('l-theanine')
   return (
     <ArticleLayout toc={toc} zone="supplement">
       <StructuredData
@@ -221,6 +224,10 @@ export default function Page() {
             <li>• If you take medication or are pregnant or breastfeeding, confirm compatibility before adding nootropics. This is educational, not medical advice.</li>
           </ul>
         </section>
+
+        {lTheanineProducts && (
+          <RecommendationSection products={lTheanineProducts.products} />
+        )}
 
         {/* FAQs */}
         <section id="faq" className="scroll-mt-20 space-y-4">

--- a/app/guides/how-to-lower-cortisol-naturally/page.tsx
+++ b/app/guides/how-to-lower-cortisol-naturally/page.tsx
@@ -4,6 +4,8 @@ import StructuredData from '@/components/StructuredData'
 import { SITE_URL } from '@/lib/navigation-config'
 import { ArticleLayout, TableOfContents } from '@/components/articles'
 import type { Heading } from '@/components/articles'
+import { getRevenueProductSet } from '@/config/revenue-products'
+import RecommendationSection from '@/components/RecommendationSection'
 
 const PAGE_URL = `${SITE_URL}/guides/how-to-lower-cortisol-naturally`
 
@@ -55,6 +57,7 @@ const HEADINGS: Heading[] = [
 
 export default function Page() {
   const toc = <TableOfContents headings={HEADINGS} />
+  const ashwagandhaProducts = getRevenueProductSet('ashwagandha')
   return (
     <ArticleLayout toc={toc} zone="supplement">
       <StructuredData
@@ -219,6 +222,10 @@ export default function Page() {
             <li>• If you take medication for blood pressure, mood, sleep or a hormonal condition, confirm compatibility before adding herbs.</li>
           </ul>
         </section>
+
+        {ashwagandhaProducts && (
+          <RecommendationSection products={ashwagandhaProducts.products} />
+        )}
 
         {/* FAQs */}
         <section id="faq" className="scroll-mt-20 space-y-4">

--- a/app/guides/magnesium-for-sleep/page.tsx
+++ b/app/guides/magnesium-for-sleep/page.tsx
@@ -1,6 +1,8 @@
 import { SeoEntryPage, generateSeoEntryMetadata } from '../../seo-entry-pages'
 import StructuredData from '@/components/StructuredData'
 import { ArticleLayout, RelatedArticles } from '@/components/articles'
+import { getRevenueProductSet } from '@/config/revenue-products'
+import RecommendationSection from '@/components/RecommendationSection'
 
 const route = 'guides/magnesium-for-sleep'
 const PAGE_URL = 'https://thehippiescientist.net/guides/magnesium-for-sleep'
@@ -60,6 +62,7 @@ const RELATED_GUIDES = [
 ]
 
 export default function MagnesiumForSleepGuidePage() {
+  const magnesiumProducts = getRevenueProductSet('magnesium')
   return (
     <ArticleLayout zone="supplement">
       <StructuredData
@@ -76,6 +79,9 @@ export default function MagnesiumForSleepGuidePage() {
         ]}
       />
       <SeoEntryPage route={route} />
+      {magnesiumProducts && (
+        <RecommendationSection products={magnesiumProducts.products} />
+      )}
       <RelatedArticles articles={RELATED_GUIDES} />
     </ArticleLayout>
   )

--- a/app/guides/magnesium-vs-melatonin/page.tsx
+++ b/app/guides/magnesium-vs-melatonin/page.tsx
@@ -4,6 +4,8 @@ import { SeoEntryPage, generateSeoEntryMetadata } from '../../seo-entry-pages';
 import StructuredData from '@/components/StructuredData';
 import { ArticleLayout, TableOfContents } from '@/components/articles';
 import type { Heading } from '@/components/articles';
+import { getRevenueProductSet } from '@/config/revenue-products';
+import RecommendationSection from '@/components/RecommendationSection';
 
 const route = 'guides/magnesium-vs-melatonin';
 const PAGE_URL = 'https://thehippiescientist.net/guides/magnesium-vs-melatonin';
@@ -23,6 +25,7 @@ const HEADINGS: Heading[] = [
 
 export default function MagnesiumVsMelatoninGuidePage() {
   const toc = <TableOfContents headings={HEADINGS} />
+  const magnesiumProducts = getRevenueProductSet('magnesium')
 
   return (
     <ArticleLayout toc={toc} zone="supplement">
@@ -40,6 +43,10 @@ export default function MagnesiumVsMelatoninGuidePage() {
       />
 
       <SeoEntryPage route={route} />
+
+      {magnesiumProducts && (
+        <RecommendationSection products={magnesiumProducts.products} />
+      )}
 
       <div className="space-y-12">
 

--- a/app/guides/natural-alternatives-to-anxiety-medication/page.tsx
+++ b/app/guides/natural-alternatives-to-anxiety-medication/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { ArticleLayout } from '@/components/articles'
+import { getRevenueProductSet } from '@/config/revenue-products'
+import RecommendationSection from '@/components/RecommendationSection'
 
 export const metadata: Metadata = {
   title: 'Natural Alternatives to Anxiety Medication | Educational Guide',
@@ -9,6 +11,7 @@ export const metadata: Metadata = {
 }
 
 export default function Page() {
+  const ashwagandhaProducts = getRevenueProductSet('ashwagandha')
   return (
     <ArticleLayout>
       <section className="hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8">
@@ -24,6 +27,9 @@ export default function Page() {
           <li>Structured therapy, breathwork, and exercise for longer-term resilience.</li>
         </ul>
       </section>
+      {ashwagandhaProducts && (
+        <RecommendationSection products={ashwagandhaProducts.products} />
+      )}
       <div className="flex flex-wrap gap-4">
         <Link href="/guides/best-herbs-for-anxiety" className="text-sm font-medium text-emerald-700 hover:underline">Top anxiety herbs</Link>
         <Link href="/guides/natural-anxiolytics-beyond-ashwagandha" className="text-sm font-medium text-emerald-700 hover:underline">Natural anxiolytics cluster</Link>

--- a/app/guides/natural-anxiolytics-beyond-ashwagandha/page.tsx
+++ b/app/guides/natural-anxiolytics-beyond-ashwagandha/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { ArticleLayout, TableOfContents } from '@/components/articles'
 import type { Heading } from '@/components/articles'
+import { getRevenueProductSet } from '@/config/revenue-products'
+import RecommendationSection from '@/components/RecommendationSection'
 
 export const metadata: Metadata = {
   title: 'Natural Anxiolytics Beyond Ashwagandha',
@@ -27,6 +29,7 @@ const HEADINGS: Heading[] = [
 
 export default function NaturalAnxiolyticsPage() {
   const toc = <TableOfContents headings={HEADINGS} />
+  const lTheanineProducts = getRevenueProductSet('l-theanine')
 
   const alternatives = [
     {
@@ -155,6 +158,10 @@ export default function NaturalAnxiolyticsPage() {
           </div>
         </div>
       </section>
+
+      {lTheanineProducts && (
+        <RecommendationSection products={lTheanineProducts.products} />
+      )}
 
       {/* Safety Layer */}
       <section id="summary" className="scroll-mt-20 rounded-2xl border border-amber-900/15 bg-amber-50/70 p-5 text-sm leading-6 text-amber-950">

--- a/app/guides/sleep-herbs-vs-melatonin/page.tsx
+++ b/app/guides/sleep-herbs-vs-melatonin/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { ArticleLayout, TableOfContents } from '@/components/articles'
 import type { Heading } from '@/components/articles'
+import { getRevenueProductSet } from '@/config/revenue-products'
+import RecommendationSection from '@/components/RecommendationSection'
 
 export const metadata: Metadata = {
   title: 'Sleep Herbs vs Melatonin',
@@ -27,6 +29,7 @@ const HEADINGS: Heading[] = [
 
 export default function SleepHerbsVsMelatoninPage() {
   const toc = <TableOfContents headings={HEADINGS} />
+  const magnesiumProducts = getRevenueProductSet('magnesium')
 
   const options = [
     {
@@ -153,6 +156,10 @@ export default function SleepHerbsVsMelatoninPage() {
           </div>
         </div>
       </section>
+
+      {magnesiumProducts && (
+        <RecommendationSection products={magnesiumProducts.products} />
+      )}
 
       {/* Safety Notice */}
       <section id="evidence" className="scroll-mt-20 rounded-2xl border border-amber-900/15 bg-amber-50/70 p-5 text-sm leading-6 text-amber-950">

--- a/app/guides/supplements-for-brain-fog-and-fatigue/page.tsx
+++ b/app/guides/supplements-for-brain-fog-and-fatigue/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { ArticleLayout } from '@/components/articles'
+import { getRevenueProductSet } from '@/config/revenue-products'
+import RecommendationSection from '@/components/RecommendationSection'
 
 export const metadata: Metadata = {
   title: 'Supplements for Brain Fog and Fatigue',
@@ -9,6 +11,7 @@ export const metadata: Metadata = {
 }
 
 export default function Page() {
+  const rhodiolaProducts = getRevenueProductSet('rhodiola')
   return (
     <ArticleLayout>
       <section className='hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8'>
@@ -25,6 +28,10 @@ export default function Page() {
           <li><strong className='text-ink'>Caffeine + L-theanine</strong> is a popular focus stack when stimulation needs smoothing.</li>
         </ul>
       </section>
+
+      {rhodiolaProducts && (
+        <RecommendationSection products={rhodiolaProducts.products} />
+      )}
 
       <section className='card-premium p-6'>
         <h2 className='text-xl font-semibold text-ink'>Where to go next</h2>

--- a/scripts/ci/guard-generated-data.mjs
+++ b/scripts/ci/guard-generated-data.mjs
@@ -148,12 +148,22 @@ function hasPrefixInList(files, prefixes) {
   return files.some((f) => prefixes.some((p) => f === p || f.startsWith(p)))
 }
 
+// Files the build pipeline regenerates on every run (commit hash, link maps, etc.).
+// These are always "dirty" after a build so they must never trigger the guard.
+const PIPELINE_GENERATED_FILES = new Set([
+  'public/data/_meta/build-info.json',
+  'public/data/runtime-maps/internal-link-map.json',
+])
+
 function main() {
   const base = getBaseRef()
   const changed = getChangedFiles(base)
 
   const dataFiles = changed.filter(
-    (f) => f.startsWith('public/data/') && (f.endsWith('.json') || f.endsWith('.json.gz'))
+    (f) =>
+      f.startsWith('public/data/') &&
+      (f.endsWith('.json') || f.endsWith('.json.gz')) &&
+      !PIPELINE_GENERATED_FILES.has(f)
   )
 
   if (dataFiles.length === 0) {


### PR DESCRIPTION
## Summary

- **Mobile bottom nav overlap** — `EmailCapture` gains `mb-20 md:mb-0` to clear the mobile nav bar; `StickyChecklistBar` bottom offset uses `calc(4.5rem + env(safe-area-inset-bottom))` for iPhone safe-area support
- **Affiliate wiring** — wires `RecommendationSection` to 18 guide pages that were unmonetized (5 from original scope + 13 from full audit); harm-reduction pages excluded per policy
- **Sitemap NOINDEX bloat** — adds `indexability_status !== 'PUBLISH'` guard to herbs and compounds forEach loops in `app/sitemap.ts`, removing ~300 NOINDEX/NEEDS_REVIEW entries
- **Deploy pipeline fix** — `deploy.yml` Verify build step changed from `npm run verify:build` (re-ran full orchestrate including guard) to `npm run verify:output` (validates output only, no rebuild)
- **Guard false-positive fix** — `guard-generated-data.mjs` excludes `build-info.json` and `internal-link-map.json` from the check; these files are always regenerated by the build pipeline (commit hash, link map rebuild) and were causing `Fast UI Check` and `Site Health Check` to fail on every PR in shallow-clone CI

## Test plan

- [ ] CI quality-gate passes (lint, typecheck, build, verify:output)
- [ ] Fast UI Check passes (guard false-positive fixed)
- [ ] Site Health Check passes (guard false-positive fixed)
- [ ] Mobile: form submit buttons on guide pages no longer hidden behind bottom nav
- [ ] Affiliate `RecommendationSection` visible on all 18 wired guide pages
- [ ] Sitemap no longer includes NOINDEX/NEEDS_REVIEW herb and compound URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FGMaUaZDHTcJoFqQxKnyXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGMaUaZDHTcJoFqQxKnyXj)_