### PR TITLE
chore: gitignore agent/cache/ and untrack existing cache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ docs/internal/
 
 # Build cache directory
 .build-cache/
+
+# Agent metadata harvester cache (auto-generated, regenerates on each run)
+agent/cache/

--- a/agent/cache/11-keto-beta-boswellic-acid-clinicaltrials.json
+++ b/agent/cache/11-keto-beta-boswellic-acid-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "11-keto-beta-boswellic-acid",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.661Z"
-}

--- a/agent/cache/11-keto-beta-boswellic-acid-pubmed.json
+++ b/agent/cache/11-keto-beta-boswellic-acid-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "11-keto-beta-boswellic-acid",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.661Z"
-}

--- a/agent/cache/23-epi-26-deoxyactein-clinicaltrials.json
+++ b/agent/cache/23-epi-26-deoxyactein-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "23-epi-26-deoxyactein",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.662Z"
-}

--- a/agent/cache/23-epi-26-deoxyactein-pubmed.json
+++ b/agent/cache/23-epi-26-deoxyactein-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "23-epi-26-deoxyactein",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.662Z"
-}

--- a/agent/cache/5-htp-clinicaltrials.json
+++ b/agent/cache/5-htp-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "5-htp",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.662Z"
-}

--- a/agent/cache/5-htp-pubmed.json
+++ b/agent/cache/5-htp-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "5-htp",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.662Z"
-}

--- a/agent/cache/7-hydroxymitragynine-clinicaltrials.json
+++ b/agent/cache/7-hydroxymitragynine-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "7-hydroxymitragynine",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.662Z"
-}

--- a/agent/cache/7-hydroxymitragynine-pubmed.json
+++ b/agent/cache/7-hydroxymitragynine-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "7-hydroxymitragynine",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.662Z"
-}

--- a/agent/cache/acarbose-clinicaltrials.json
+++ b/agent/cache/acarbose-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "acarbose",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.662Z"
-}

--- a/agent/cache/acarbose-pubmed.json
+++ b/agent/cache/acarbose-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "acarbose",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.662Z"
-}

--- a/agent/cache/acemannan-clinicaltrials.json
+++ b/agent/cache/acemannan-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "acemannan",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.662Z"
-}

--- a/agent/cache/acemannan-pubmed.json
+++ b/agent/cache/acemannan-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "acemannan",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.662Z"
-}

--- a/agent/cache/acetate-clinicaltrials.json
+++ b/agent/cache/acetate-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "acetate",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.662Z"
-}

--- a/agent/cache/acetate-pubmed.json
+++ b/agent/cache/acetate-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "acetate",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.662Z"
-}

--- a/agent/cache/acetyl-11-keto-beta-boswellic-acid-clinicaltrials.json
+++ b/agent/cache/acetyl-11-keto-beta-boswellic-acid-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "acetyl-11-keto-beta-boswellic-acid",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.662Z"
-}

--- a/agent/cache/acetyl-11-keto-beta-boswellic-acid-pubmed.json
+++ b/agent/cache/acetyl-11-keto-beta-boswellic-acid-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "acetyl-11-keto-beta-boswellic-acid",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.662Z"
-}

--- a/agent/cache/acetyl-beta-boswellic-acid-clinicaltrials.json
+++ b/agent/cache/acetyl-beta-boswellic-acid-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "acetyl-beta-boswellic-acid",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.662Z"
-}

--- a/agent/cache/acetyl-beta-boswellic-acid-pubmed.json
+++ b/agent/cache/acetyl-beta-boswellic-acid-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "acetyl-beta-boswellic-acid",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.662Z"
-}

--- a/agent/cache/acetyl-l-carnitine-clinicaltrials.json
+++ b/agent/cache/acetyl-l-carnitine-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "acetyl-l-carnitine",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.662Z"
-}

--- a/agent/cache/acetyl-l-carnitine-pubmed.json
+++ b/agent/cache/acetyl-l-carnitine-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "acetyl-l-carnitine",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.662Z"
-}

--- a/agent/cache/acetylshikonin-clinicaltrials.json
+++ b/agent/cache/acetylshikonin-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "acetylshikonin",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.662Z"
-}

--- a/agent/cache/acetylshikonin-pubmed.json
+++ b/agent/cache/acetylshikonin-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "acetylshikonin",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.662Z"
-}

--- a/agent/cache/actein-clinicaltrials.json
+++ b/agent/cache/actein-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "actein",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.662Z"
-}

--- a/agent/cache/actein-pubmed.json
+++ b/agent/cache/actein-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "actein",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.662Z"
-}

--- a/agent/cache/acteoside-clinicaltrials.json
+++ b/agent/cache/acteoside-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "acteoside",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/acteoside-pubmed.json
+++ b/agent/cache/acteoside-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "acteoside",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/adenosine-clinicaltrials.json
+++ b/agent/cache/adenosine-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "adenosine",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/adenosine-pubmed.json
+++ b/agent/cache/adenosine-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "adenosine",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/aescin-clinicaltrials.json
+++ b/agent/cache/aescin-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "aescin",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/aescin-pubmed.json
+++ b/agent/cache/aescin-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "aescin",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/agaricus-blazei-clinicaltrials.json
+++ b/agent/cache/agaricus-blazei-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "agaricus-blazei",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/agaricus-blazei-pubmed.json
+++ b/agent/cache/agaricus-blazei-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "agaricus-blazei",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/aged-garlic-extract-clinicaltrials.json
+++ b/agent/cache/aged-garlic-extract-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "aged-garlic-extract",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/aged-garlic-extract-pubmed.json
+++ b/agent/cache/aged-garlic-extract-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "aged-garlic-extract",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/agmatine-sulfate-clinicaltrials.json
+++ b/agent/cache/agmatine-sulfate-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "agmatine-sulfate",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/agmatine-sulfate-pubmed.json
+++ b/agent/cache/agmatine-sulfate-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "agmatine-sulfate",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/ajoene-clinicaltrials.json
+++ b/agent/cache/ajoene-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "ajoene",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/ajoene-pubmed.json
+++ b/agent/cache/ajoene-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "ajoene",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/albiflorin-clinicaltrials.json
+++ b/agent/cache/albiflorin-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "albiflorin",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/albiflorin-pubmed.json
+++ b/agent/cache/albiflorin-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "albiflorin",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/alkylamides-clinicaltrials.json
+++ b/agent/cache/alkylamides-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "alkylamides",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/alkylamides-pubmed.json
+++ b/agent/cache/alkylamides-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "alkylamides",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/allicin-clinicaltrials.json
+++ b/agent/cache/allicin-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "allicin",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/allicin-pubmed.json
+++ b/agent/cache/allicin-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "allicin",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/aloe-vera-clinicaltrials.json
+++ b/agent/cache/aloe-vera-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "aloe-vera",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/aloe-vera-pubmed.json
+++ b/agent/cache/aloe-vera-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "aloe-vera",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/alpha-asarone-clinicaltrials.json
+++ b/agent/cache/alpha-asarone-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "alpha-asarone",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/alpha-asarone-pubmed.json
+++ b/agent/cache/alpha-asarone-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "alpha-asarone",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/alpha-gpc-clinicaltrials.json
+++ b/agent/cache/alpha-gpc-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "alpha-gpc",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/alpha-gpc-pubmed.json
+++ b/agent/cache/alpha-gpc-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "alpha-gpc",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/alpha-lipoic-acid-clinicaltrials.json
+++ b/agent/cache/alpha-lipoic-acid-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "alpha-lipoic-acid",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/alpha-lipoic-acid-pubmed.json
+++ b/agent/cache/alpha-lipoic-acid-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "alpha-lipoic-acid",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/alpha-mangostin-clinicaltrials.json
+++ b/agent/cache/alpha-mangostin-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "alpha-mangostin",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/alpha-mangostin-pubmed.json
+++ b/agent/cache/alpha-mangostin-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "alpha-mangostin",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/american-ginseng-extract-clinicaltrials.json
+++ b/agent/cache/american-ginseng-extract-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "american-ginseng-extract",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/american-ginseng-extract-pubmed.json
+++ b/agent/cache/american-ginseng-extract-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "american-ginseng-extract",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/anandamide-clinicaltrials.json
+++ b/agent/cache/anandamide-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "anandamide",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/anandamide-pubmed.json
+++ b/agent/cache/anandamide-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "anandamide",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/andrographis-clinicaltrials.json
+++ b/agent/cache/andrographis-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "andrographis",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.664Z"
-}

--- a/agent/cache/andrographis-pubmed.json
+++ b/agent/cache/andrographis-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "andrographis",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.663Z"
-}

--- a/agent/cache/andrographolide-clinicaltrials.json
+++ b/agent/cache/andrographolide-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "andrographolide",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.664Z"
-}

--- a/agent/cache/andrographolide-pubmed.json
+++ b/agent/cache/andrographolide-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "andrographolide",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.664Z"
-}

--- a/agent/cache/anethole-clinicaltrials.json
+++ b/agent/cache/anethole-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "anethole",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.664Z"
-}

--- a/agent/cache/anethole-pubmed.json
+++ b/agent/cache/anethole-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "anethole",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.664Z"
-}

--- a/agent/cache/angelicin-clinicaltrials.json
+++ b/agent/cache/angelicin-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "angelicin",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.664Z"
-}

--- a/agent/cache/angelicin-pubmed.json
+++ b/agent/cache/angelicin-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "angelicin",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.664Z"
-}

--- a/agent/cache/apigenin-clinicaltrials.json
+++ b/agent/cache/apigenin-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "apigenin",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.664Z"
-}

--- a/agent/cache/apigenin-pubmed.json
+++ b/agent/cache/apigenin-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "apigenin",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.664Z"
-}

--- a/agent/cache/arabinoxylan-clinicaltrials.json
+++ b/agent/cache/arabinoxylan-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "arabinoxylan",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.664Z"
-}

--- a/agent/cache/arabinoxylan-pubmed.json
+++ b/agent/cache/arabinoxylan-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "arabinoxylan",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.664Z"
-}

--- a/agent/cache/arjunolic-acid-clinicaltrials.json
+++ b/agent/cache/arjunolic-acid-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "arjunolic-acid",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.664Z"
-}

--- a/agent/cache/arjunolic-acid-pubmed.json
+++ b/agent/cache/arjunolic-acid-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "arjunolic-acid",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.664Z"
-}

--- a/agent/cache/artemisinin-b-clinicaltrials.json
+++ b/agent/cache/artemisinin-b-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "artemisinin-b",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.664Z"
-}

--- a/agent/cache/artemisinin-b-pubmed.json
+++ b/agent/cache/artemisinin-b-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "artemisinin-b",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.664Z"
-}

--- a/agent/cache/artemisinin-clinicaltrials.json
+++ b/agent/cache/artemisinin-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "artemisinin",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.664Z"
-}

--- a/agent/cache/artemisinin-pubmed.json
+++ b/agent/cache/artemisinin-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "artemisinin",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.664Z"
-}

--- a/agent/cache/artesunate-clinicaltrials.json
+++ b/agent/cache/artesunate-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "artesunate",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.664Z"
-}

--- a/agent/cache/artesunate-pubmed.json
+++ b/agent/cache/artesunate-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "artesunate",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.664Z"
-}

--- a/agent/cache/artichoke-extract-clinicaltrials.json
+++ b/agent/cache/artichoke-extract-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "artichoke-extract",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.664Z"
-}

--- a/agent/cache/artichoke-extract-pubmed.json
+++ b/agent/cache/artichoke-extract-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "artichoke-extract",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.664Z"
-}

--- a/agent/cache/ashitaba-clinicaltrials.json
+++ b/agent/cache/ashitaba-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "ashitaba",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.664Z"
-}

--- a/agent/cache/ashitaba-extract-clinicaltrials.json
+++ b/agent/cache/ashitaba-extract-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "ashitaba-extract",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.664Z"
-}

--- a/agent/cache/ashitaba-extract-pubmed.json
+++ b/agent/cache/ashitaba-extract-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "ashitaba-extract",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.664Z"
-}

--- a/agent/cache/ashitaba-pubmed.json
+++ b/agent/cache/ashitaba-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "ashitaba",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.664Z"
-}

--- a/agent/cache/ashwagandha-extract-ksm-66-clinicaltrials.json
+++ b/agent/cache/ashwagandha-extract-ksm-66-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "ashwagandha-extract-ksm-66",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.664Z"
-}

--- a/agent/cache/ashwagandha-extract-ksm-66-pubmed.json
+++ b/agent/cache/ashwagandha-extract-ksm-66-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "ashwagandha-extract-ksm-66",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.664Z"
-}

--- a/agent/cache/berberine-clinicaltrials.json
+++ b/agent/cache/berberine-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "berberine",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:38:24.328Z"
-}

--- a/agent/cache/berberine-pubmed.json
+++ b/agent/cache/berberine-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "berberine",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:38:24.327Z"
-}

--- a/agent/cache/creatine-clinicaltrials.json
+++ b/agent/cache/creatine-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "creatine",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:38:24.328Z"
-}

--- a/agent/cache/creatine-pubmed.json
+++ b/agent/cache/creatine-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "creatine",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:38:24.328Z"
-}

--- a/agent/cache/l-arginine-clinicaltrials.json
+++ b/agent/cache/l-arginine-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "l-arginine",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.664Z"
-}

--- a/agent/cache/l-arginine-pubmed.json
+++ b/agent/cache/l-arginine-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "l-arginine",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.664Z"
-}

--- a/agent/cache/l-theanine-clinicaltrials.json
+++ b/agent/cache/l-theanine-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "l-theanine",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:38:24.328Z"
-}

--- a/agent/cache/l-theanine-pubmed.json
+++ b/agent/cache/l-theanine-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "l-theanine",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:38:24.328Z"
-}

--- a/agent/cache/magnesium-clinicaltrials.json
+++ b/agent/cache/magnesium-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "magnesium",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:38:24.328Z"
-}

--- a/agent/cache/magnesium-glycinate-clinicaltrials.json
+++ b/agent/cache/magnesium-glycinate-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "magnesium-glycinate",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:38:24.328Z"
-}

--- a/agent/cache/magnesium-glycinate-pubmed.json
+++ b/agent/cache/magnesium-glycinate-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "magnesium-glycinate",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:38:24.328Z"
-}

--- a/agent/cache/magnesium-pubmed.json
+++ b/agent/cache/magnesium-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "magnesium",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:38:24.328Z"
-}

--- a/agent/cache/n-acetylcysteine-clinicaltrials.json
+++ b/agent/cache/n-acetylcysteine-clinicaltrials.json
@@ -1,7 +1,0 @@
-{
-  "source": "clinicaltrials",
-  "slug": "n-acetylcysteine",
-  "trial_ids": [],
-  "trial_metadata": [],
-  "harvested_at": "2026-06-22T13:39:08.661Z"
-}

--- a/agent/cache/n-acetylcysteine-pubmed.json
+++ b/agent/cache/n-acetylcysteine-pubmed.json
@@ -1,8 +1,0 @@
-{
-  "source": "pubmed",
-  "slug": "n-acetylcysteine",
-  "pmids": [],
-  "abstracts": [],
-  "study_types": [],
-  "harvested_at": "2026-06-22T13:39:08.661Z"
-}


### PR DESCRIPTION
## Summary

- Adds `agent/cache/` to `.gitignore` — these are ephemeral stub files auto-generated by the metadata harvester on every `npm run agent:run`, with no source value
- Untracks the 101 cache files that were already committed (removes them from git history going forward, files remain on disk locally)

Future agent runs will generate cache files locally without polluting the repo or triggering the untracked-files stop hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqYhMXMj8ekvHjgednjQGY

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqYhMXMj8ekvHjgednjQGY)_