### PR TITLE
feat: add AuthorityBreadcrumbs to dynamic compare route

### DIFF
--- a/app/compare/[slug]/page.tsx
+++ b/app/compare/[slug]/page.tsx
@@ -22,6 +22,7 @@ import {
   getRelatedComparisons,
   buildFAQs,
 } from '@/lib/compare'
+import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
 import CompareHero from '@/components/compare/CompareHero'
 import CompareDecisionWidget from '@/components/compare/CompareDecisionWidget'
 import CompareSummaryTable from '@/components/compare/CompareSummaryTable'
@@ -341,6 +342,14 @@ export default async function Page({ params }: Params) {
     <div className="mx-auto max-w-5xl px-4 py-8 space-y-12">
       <SchemaGraphScript graph={schemaGraph} />
       <CompareSchema item1={item1} item2={item2} slug={slug} faqs={faqs} />
+
+      <AuthorityBreadcrumbs
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Compare', href: '/compare' },
+          { label: title },
+        ]}
+      />
 
       {/* Hero */}
       <CompareHero item1={item1} item2={item2} />


### PR DESCRIPTION
## Summary

Adds `AuthorityBreadcrumbs` to the dynamic `[slug]` compare route — the one component present in every static compare page but missing from the dynamic route.

The other apparent gaps (`CompareGoalSection` / `CompareDecisionSection`) are already covered by richer equivalents in the dynamic route (`CompareGoalRouting` and `CompareDecisionWidget`), so no duplication needed there. The dynamic route now has full feature parity as the canonical premium scaffold.

## Component inventory after this change

| Component | Static pages | Dynamic route |
|---|---|---|
| `AuthorityBreadcrumbs` | ✅ | ✅ (added) |
| `CompareSchema` | ✅ | ✅ |
| `CompareHero` | ✅ | ✅ |
| `CompareSummaryTable` | ✅ | ✅ |
| `CompareMechanisms` | ✅ | ✅ |
| `CompareSafety` | ✅ | ✅ |
| `CompareDosing` | ✅ | ✅ |
| `CompareAffiliate` | ✅ | ✅ |
| `CompareFAQ` | ✅ | ✅ |
| `CompareGoalSection` | ✅ | → `CompareGoalRouting` |
| `CompareDecisionSection` | ✅ | → `CompareDecisionWidget` (interactive) |
| `CompareEvidenceMatrix` | — | ✅ |
| `CompareDecisionWidget` | — | ✅ |
| `CompareGoalRouting` | — | ✅ |
| `CompareSynergy` | — | ✅ |
| `CompareRelated` | — | ✅ |
| `CompareCitations` | — | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqYhMXMj8ekvHjgednjQGY

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqYhMXMj8ekvHjgednjQGY)_