### PR TITLE
fix: 404 remediation redirects from GSC coverage audit

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -71,8 +71,16 @@
 /comparisons /compare/ 301
 /comparisons/* /compare/:splat 301
 /start /goals/ 301
+/best/muscle /goals/energy/ 301
+/best/muscle/ /goals/energy/ 301
+/best/workout-performance /goals/energy/ 301
+/best/workout-performance/ /goals/energy/ 301
 /best/* /goals/:splat 301
 /best-for/* /goals/:splat 301
+/collections/gabaergic-herbs /goals/anxiety/ 301
+/collections/gabaergic-herbs/ /goals/anxiety/ 301
+/collections/stimulant-herb-combinations /goals/energy/ 301
+/collections/stimulant-herb-combinations/ /goals/energy/ 301
 /collections /goals/ 301
 /collections/* /goals/:splat 301
 /top /goals/ 301
@@ -340,3 +348,75 @@
 # Compare URL cleanup: l-threonate URL slug doesn't parse cleanly; redirect to data-accurate slug
 /compare/magnesium-glycinate-vs-l-threonate-for-sleep /compare/magnesium-glycinate-vs-magnesium-threonate/ 301
 /compare/magnesium-glycinate-vs-l-threonate-for-sleep/ /compare/magnesium-glycinate-vs-magnesium-threonate/ 301
+
+# GSC 404 remediation (2026-06-22) — compounds that belong under /herbs/
+/compounds/berberis /herbs/berberis/ 301
+/compounds/berberis/ /herbs/berberis/ 301
+/compounds/astragalus /herbs/astragalus/ 301
+/compounds/astragalus/ /herbs/astragalus/ 301
+/compounds/astragalus-membranaceus /herbs/astragalus/ 301
+/compounds/astragalus-membranaceus/ /herbs/astragalus/ 301
+/compounds/piper-methysticum /herbs/kava/ 301
+/compounds/piper-methysticum/ /herbs/kava/ 301
+/compounds/pau-d-arco /herbs/pau-d-arco/ 301
+/compounds/pau-d-arco/ /herbs/pau-d-arco/ 301
+/compounds/mangifera-indica /herbs/mangifera-indica/ 301
+/compounds/mangifera-indica/ /herbs/mangifera-indica/ 301
+/compounds/coffee-cherry /herbs/coffea-arabica/ 301
+/compounds/coffee-cherry/ /herbs/coffea-arabica/ 301
+/compounds/epigallocatechin-gallate /compounds/green-tea-extract/ 301
+/compounds/epigallocatechin-gallate/ /compounds/green-tea-extract/ 301
+
+# GSC 404 remediation — single-compound /stacks/ URLs
+/stacks/alpha-gpc /compounds/alpha-gpc/ 301
+/stacks/alpha-gpc/ /compounds/alpha-gpc/ 301
+/stacks/caffeine /compounds/caffeine/ 301
+/stacks/caffeine/ /compounds/caffeine/ 301
+/stacks/dihydrokavain /compounds/dihydrokavain/ 301
+/stacks/dihydrokavain/ /compounds/dihydrokavain/ 301
+/stacks/kavain /compounds/kavain/ 301
+/stacks/kavain/ /compounds/kavain/ 301
+/stacks/mangifera-indica /herbs/mangifera-indica/ 301
+/stacks/mangifera-indica/ /herbs/mangifera-indica/ 301
+
+# GSC 404 remediation — removed articles redirected to closest subject page
+/articles/2025-09-11-formulation-tips-skullcap-thursday-notes /herbs/scutellaria-lateriflora/ 301
+/articles/2025-09-11-formulation-tips-skullcap-thursday-notes/ /herbs/scutellaria-lateriflora/ 301
+/articles/2025-09-08-safety-set-setting-gotu-kola-monday-notes /herbs/gotu-kola/ 301
+/articles/2025-09-08-safety-set-setting-gotu-kola-monday-notes/ /herbs/gotu-kola/ 301
+/articles/2025-10-14-field-notes-damiana-tuesday-notes /herbs/damiana/ 301
+/articles/2025-10-14-field-notes-damiana-tuesday-notes/ /herbs/damiana/ 301
+
+# GSC 404 remediation — missing /guides/ slugs redirected to closest live content
+/guides/best-supplements-for-gut-health /best-supplements-for-gut-health/ 301
+/guides/best-supplements-for-gut-health/ /best-supplements-for-gut-health/ 301
+/guides/deep-sleep-support /guides/best-natural-sleep-aids-that-work/ 301
+/guides/deep-sleep-support/ /guides/best-natural-sleep-aids-that-work/ 301
+/guides/anti-inflammatory /guides/how-to-lower-cortisol-naturally/ 301
+/guides/anti-inflammatory/ /guides/how-to-lower-cortisol-naturally/ 301
+/guides/antioxidant /guides/how-to-lower-cortisol-naturally/ 301
+/guides/antioxidant/ /guides/how-to-lower-cortisol-naturally/ 301
+/guides/metabolic /goals/ 301
+/guides/metabolic/ /goals/ 301
+/guides/cardiovascular /goals/ 301
+/guides/cardiovascular/ /goals/ 301
+/guides/antimicrobial /guides/ 301
+/guides/antimicrobial/ /guides/ 301
+/guides/research-pending /guides/ 301
+/guides/research-pending/ /guides/ 301
+/guides/digestive /goals/ 301
+/guides/digestive/ /goals/ 301
+
+# GSC 404 remediation — education pages redirected to equivalent content
+/education/how-set-and-setting-work /guides/psychedelic-adjacent-herbs/ 301
+/education/how-set-and-setting-work/ /guides/psychedelic-adjacent-herbs/ 301
+/education/psychoactive-substances-overview /novel-psychoactive-substances/ 301
+/education/psychoactive-substances-overview/ /novel-psychoactive-substances/ 301
+
+# GSC 404 remediation — /herb/ typo (missing s)
+/herb/* /herbs/:splat 301
+
+# GSC 404 remediation — misc
+/sitemap /sitemap.xml 301
+/best-herbs-for-focus /guides/best-nootropics-for-focus/ 301
+/best-herbs-for-focus/ /guides/best-nootropics-for-focus/ 301


### PR DESCRIPTION
## Summary

Addresses ~88 non-compare 404 URLs identified in the GSC Coverage Validation report (June 22, 2026). The 912 compare 404s are junk URLs from old agent runs — not in the sitemap, will drop off naturally.

## Changes

- **Compounds → herbs**: `berberis`, `astragalus`, `astragalus-membranaceus`, `piper-methysticum`, `pau-d-arco`, `mangifera-indica`, `coffee-cherry`, `epigallocatechin-gallate` were missing `/compounds/` → `/herbs/` redirects
- **Single-compound `/stacks/`**: `alpha-gpc`, `caffeine`, `dihydrokavain`, `kavain`, `mangifera-indica` — no stacks exist for these, now redirect to compound/herb profiles
- **Removed articles**: 3 Sept/Oct 2025 field-notes articles redirected to closest herb profile page
- **Missing `/guides/` slugs**: 9 guide paths that never existed redirected to closest live content
- **Education pages**: 2 missing education paths redirected to equivalent content
- **`/best/*` wildcard fix**: `/best/muscle` and `/best/workout-performance` were hitting the wildcard and going to `/goals/muscle` (404). Specific rules added before the wildcard.
- **`/collections/*` wildcard fix**: `gabaergic-herbs` and `stimulant-herb-combinations` same issue — now redirect to `/goals/anxiety/` and `/goals/energy/`
- **`/herb/*` typo**: Missing `s` in `/herb/` redirected to `/herbs/:splat`
- **Misc**: `/sitemap` → `/sitemap.xml`, `/best-herbs-for-focus` → correct guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqYhMXMj8ekvHjgednjQGY)_