### PR TITLE
[codex] add reusable article scaffold system

### DIFF
--- a/docs/content/ARTICLE_SCAFFOLD_SYSTEM.md
+++ b/docs/content/ARTICLE_SCAFFOLD_SYSTEM.md
@@ -1,0 +1,261 @@
+# The Hippie Scientist Article Scaffold System
+
+This document defines reusable article stamps for The Hippie Scientist. Use it to keep future articles consistent, readable, cautious, and internally linked without turning every page into a one-off project.
+
+The goal is simple: every article should answer the reader quickly, separate direct evidence from indirect evidence, avoid exaggerated claims, and make the next useful page obvious.
+
+## Global Quality Rules
+
+Every article should:
+
+1. Start with a clear answer.
+2. Explain who the page is for.
+3. Separate direct evidence from indirect evidence.
+4. Avoid mechanism hype.
+5. Avoid treatment, cure, or guaranteed-benefit claims.
+6. Keep safety language specific but not alarmist.
+7. Use short, useful sections instead of long research dumps.
+8. Remove editorial planning notes from visible content.
+9. Link only to live, relevant routes.
+10. Make the reader's next step obvious.
+
+## Global Internal-Linking Rules
+
+Each article should usually link to:
+
+1. The closest comparison article.
+2. The relevant pillar guide.
+3. The relevant stack or decision guide.
+4. One safer or more foundational alternative.
+5. One mechanism education page when relevant.
+6. One testing or foundation page when relevant.
+
+Do not link to:
+
+- draft-source docs
+- non-live routes
+- unrelated articles just to increase link count
+- monetized product pages from harm-reduction content
+
+## 1. Single Compound / Supplement Evidence Article
+
+Use for single supplement, herb, nutrient, or compound evidence pages.
+
+Examples:
+
+- Citicoline for ADHD
+- L-Theanine for ADHD
+- Magnesium for ADHD
+- Omega-3 and ADHD
+- Ashwagandha for Stress
+- Magnesium for Sleep
+
+Reusable structure:
+
+1. Quick Answer
+2. Best For / Not Best For
+3. What [Compound] Is
+4. How [Compound] Works
+5. What the Evidence Says About [Goal/Condition]
+6. [Compound] for [Primary Outcome]
+7. [Compound] vs Closest Alternative
+8. [Compound] vs Other Supports
+9. Dosing and Timing
+10. Side Effects and Safety
+11. Practical Decision Framework
+12. FAQ
+13. Conclusion
+
+Section purpose:
+
+- Quick Answer: give the plain-English verdict fast.
+- Best For / Not Best For: help the reader self-sort.
+- What It Is: define the compound simply.
+- How It Works: explain mechanism without implying proof.
+- Evidence Section: separate direct evidence from indirect evidence.
+- Outcome Section: translate evidence into realistic expectations.
+- Comparison Section: bridge to the closest comparison article.
+- Other Supports: place the compound in the broader decision tree.
+- Dosing and Timing: provide cautious context, not personalized advice.
+- Safety: make the page trustworthy.
+- Decision Framework: help the reader avoid random stacking.
+- FAQ: capture objections and long-tail search.
+- Conclusion: end with a balanced verdict.
+
+## 2. Comparison Article
+
+Use for X vs Y pages.
+
+Examples:
+
+- Citicoline vs Alpha-GPC
+- L-Theanine vs Caffeine
+- Magnesium Glycinate vs Citrate
+- Ashwagandha vs Rhodiola
+
+Reusable structure:
+
+1. Quick Verdict
+2. Best Overall / Best by Use Case
+3. Side-by-Side Comparison Table
+4. What Each One Is
+5. Mechanism Differences
+6. Evidence Comparison
+7. Effects Comparison
+8. Safety / Side Effects Comparison
+9. Dosing / Timing Comparison
+10. Which Should You Choose?
+11. FAQ
+12. Conclusion
+
+Key rule: comparison pages should reduce decision friction. Do not bury the verdict.
+
+## 3. Stack Article
+
+Use for combination and stacking pages.
+
+Examples:
+
+- ADHD Stack Guide
+- L-Theanine and Magnesium Stack
+- Sleep Supplement Stack
+- Stress Support Stack
+
+Reusable structure:
+
+1. Quick Answer
+2. Who This Stack Is For / Not For
+3. Stack Philosophy
+4. Core Stack
+5. Optional Add-Ons
+6. What Not To Combine Casually
+7. Timing Example
+8. Safety and Medication Cautions
+9. How To Test One Variable At A Time
+10. FAQ
+11. Conclusion
+
+Key rule: stack pages should encourage conservative, one-variable-at-a-time thinking.
+
+## 4. Pillar Guide
+
+Use for major SEO guides and broad decision pages.
+
+Examples:
+
+- Best Supplements for ADHD
+- Best Supplements for Sleep
+- Best Supplements for Anxiety
+- Best Herbs for Stress
+
+Reusable structure:
+
+1. Quick Answer
+2. How To Use This Guide
+3. Evidence Ranking / Tier Table
+4. Best Options by Use Case
+5. Detailed Breakdown of Each Option
+6. Safety and Interaction Overview
+7. What To Avoid
+8. When To Talk To A Professional
+9. Related Guides
+10. FAQ
+11. Conclusion
+
+Key rule: pillar guides should organize the category, not try to be every article at once.
+
+## 5. Mechanism / Education Article
+
+Use for educational support pages.
+
+Examples:
+
+- Cholinergic System
+- How Focus and Motivation Work
+- GABA and Anxiety
+- Cortisol and Stress
+- Circadian Rhythm and Sleep
+
+Reusable structure:
+
+1. Plain-English Summary
+2. Why This Matters
+3. Core Mechanism
+4. How It Affects Symptoms or Goals
+5. What Supplements Can and Cannot Do
+6. Common Misconceptions
+7. Related Compounds / Herbs
+8. Practical Takeaways
+9. FAQ
+10. Conclusion
+
+Key rule: mechanism pages should teach concepts without turning mechanisms into outcome claims.
+
+## 6. Goal / Discovery Page
+
+Use for reader navigation pages, not deep research articles.
+
+Examples:
+
+- Sleep
+- Stress
+- Anxiety
+- Focus
+
+Reusable structure:
+
+1. Goal Summary
+2. Choose Your Situation
+3. Best Starting Points
+4. Evidence-Based Options
+5. Safety Notes
+6. Related Articles
+7. Next Best Guide
+
+Key rule: discovery pages should help readers choose where to go next.
+
+## 7. Safety / Harm-Reduction Article
+
+Use for safety-first or higher-risk topic pages.
+
+Examples:
+
+- Kava safety
+- Kratom safety
+- psychoactive compound pages
+- interaction-risk pages
+
+Reusable structure:
+
+1. Safety Summary
+2. What This Is
+3. Main Risks
+4. Who Should Avoid It
+5. Interaction Concerns
+6. Safer-Use / Harm-Reduction Principles
+7. When To Seek Help
+8. FAQ
+9. Conclusion
+
+Harm-reduction pages must not include:
+
+- affiliate links
+- product recommendation blocks
+- best product framing
+- monetized CTAs
+- casual try-this language
+
+## Acceptance Checklist For Future Articles
+
+Before publishing an article, verify:
+
+- The article uses the right scaffold type.
+- The opening answer is clear.
+- The evidence language is cautious and specific.
+- Direct and indirect evidence are separated.
+- Mechanisms are not overstated.
+- Safety sections are specific enough to be useful.
+- Internal links point only to live, relevant pages.
+- Editorial planning notes are removed from visible content.
+- The next reader action is obvious.
+- Typecheck, lint, and build pass after implementation.


### PR DESCRIPTION
## What changed

Adds `docs/content/ARTICLE_SCAFFOLD_SYSTEM.md`, a reusable content operating document for The Hippie Scientist.

## Why

The site needs reusable article stamps instead of one-off article prompts. This doc defines practical scaffolds for:

- Single compound / supplement evidence articles
- Comparison articles
- Stack articles
- Pillar guides
- Mechanism / education articles
- Goal / discovery pages
- Safety / harm-reduction articles

## Notes

This PR intentionally does **not** edit the Citicoline article body, route registration, related links, or generated data. Those remain a separate implementation task because the connected write tool blocked health/supplement article-body changes.

## Validation

Not run through this connector. This is a markdown-only documentation change.