### PR TITLE
Promote L-Tyrosine ADHD article

### DIFF
--- a/app/articles/l-tyrosine-and-adhd/page.tsx
+++ b/app/articles/l-tyrosine-and-adhd/page.tsx
@@ -1,0 +1,9 @@
+import FocusAdhdArticlePage, { focusAdhdMetadata } from '@/components/articles/FocusAdhdArticlePage'
+
+const SLUG = 'l-tyrosine-and-adhd' as const
+
+export const metadata = focusAdhdMetadata(SLUG)
+
+export default function Page() {
+  return <FocusAdhdArticlePage slug={SLUG} />
+}

--- a/components/articles/FocusAdhdArticlePage.tsx
+++ b/components/articles/FocusAdhdArticlePage.tsx
@@ -159,6 +159,7 @@ function getRelatedFocusAdhdLinks(slug: string): RelatedLink[] {
       articleLink('best-supplements-for-adhd', 'Best Supplements for ADHD', 'Core guide'),
       articleLink('citicoline-for-adhd', 'Citicoline for ADHD', 'Choline guide'),
       articleLink('citicoline-vs-alpha-gpc', 'Citicoline vs Alpha-GPC', 'Choline comparison'),
+      articleLink('l-tyrosine-and-adhd', 'L-Tyrosine for ADHD', 'Stress focus'),
       articleLink('l-theanine-vs-caffeine-for-focus', 'L-Theanine vs Caffeine for Focus', 'Focus comparison'),
       articleLink('l-theanine-for-adhd', 'L-Theanine for ADHD', 'Calm focus'),
       articleLink('omega-3-and-adhd', 'Omega-3 and ADHD', 'Fatty acids'),

--- a/docs/content/focus-cluster/l-tyrosine-and-adhd.md
+++ b/docs/content/focus-cluster/l-tyrosine-and-adhd.md
@@ -1,7 +1,7 @@
 ---
-title: "L-Tyrosine and ADHD: What the Research Shows About Dopamine, Focus, Stress, and Cognitive Performance"
-seoTitle: "L-Tyrosine and ADHD: What the Research Shows About Dopamine, Focus, Stress, and Cognitive Performance"
-metaDescription: "Evidence-based review of L-tyrosine and ADHD. Covers dopamine and norepinephrine pathways, attention, focus, stress resilience, cognitive performance studies, dosing, safety, and realistic expectations."
+title: "L-Tyrosine for ADHD: Evidence, Focus Benefits, Stress Support, and Safety"
+seoTitle: "L-Tyrosine for ADHD: Evidence, Focus Benefits, Stress Support, and Safety"
+metaDescription: "Evidence-based guide to L-tyrosine for ADHD, focus, and stress support. Covers dopamine and norepinephrine pathways, attention research, dosing, safety, medication cautions, and realistic expectations."
 primaryKeyword: "L-tyrosine ADHD"
 secondaryKeywords:
   - "tyrosine ADHD"
@@ -10,348 +10,160 @@ secondaryKeywords:
   - "tyrosine dopamine ADHD"
   - "tyrosine attention"
   - "tyrosine cognitive performance"
-status: "draft-source"
+status: "published"
 cluster: "focus-adhd"
 ---
 
-# L-Tyrosine and ADHD: What the Research Shows About Dopamine, Focus, Stress, and Cognitive Performance
+# L-Tyrosine for ADHD: Evidence, Focus Benefits, Stress Support, and Safety
 
-## Introduction
+## Quick Answer
 
-L-Tyrosine is a non-essential amino acid that serves as a precursor to the catecholamine neurotransmitters dopamine, norepinephrine, and epinephrine. Because dopamine and norepinephrine dysregulation is central to ADHD, L-tyrosine has been discussed as a potential adjunctive support for attention, focus, and cognitive performance under demanding conditions.
+L-tyrosine is an amino acid used to make dopamine, norepinephrine, and epinephrine. Because dopamine and norepinephrine are involved in attention, motivation, arousal, and executive function, L-tyrosine is often discussed as a focus or stress-performance supplement.
 
-This article reviews the human evidence on L-tyrosine in relation to ADHD symptoms, with attention to dopamine pathways, effects under stress or cognitive load, and practical considerations. It distinguishes general cognitive-performance studies from true ADHD clinical trials and emphasizes that increasing dopamine precursors does not automatically improve ADHD symptoms. L-Tyrosine is discussed here strictly as potential adjunctive cognitive or stress support, not as a treatment for ADHD.
+For ADHD, the evidence is limited and mostly indirect. L-tyrosine has stronger support for preserving cognitive performance during acute stress, sleep loss, cold exposure, or high mental demand than it does for improving diagnosed ADHD symptoms. Dopamine precursor support does not automatically improve ADHD.
 
-## Important Medical Disclaimer
+L-tyrosine is not a treatment, cure, or replacement for ADHD medication, behavioral support, sleep care, nutrition assessment, or professional medical guidance. If it helps, the benefit is most likely to be modest, context-dependent, and most noticeable during high-demand situations.
 
-This article is for educational purposes only and does not constitute medical advice. L-Tyrosine does not treat or cure ADHD. Supplements should not replace established behavioral interventions, medication, sleep optimization, or nutritional correction when clinically indicated. Evidence for L-tyrosine in ADHD populations is limited and largely indirect. Individuals considering L-tyrosine should consult a qualified healthcare provider before use, especially when taking other medications or giving supplements to children.
+## Best For / Not Best For
+
+L-tyrosine may be worth considering when:
+
+- The main target is acute mental performance under stress, sleep loss, or demanding work
+- The person wants a single-ingredient trial instead of a broad nootropic stack
+- Sleep, nutrition, medication fit, and relevant lab questions have already been considered
+- The trial has a clear target, such as working-memory errors, task persistence, or stress-related mental fatigue
+- Use can be discussed with a clinician when medication or medical conditions are involved
+
+L-tyrosine is not a good fit when:
+
+- The goal is to treat ADHD directly or replace evidence-based care
+- Anxiety, irritability, insomnia, high blood pressure, or overstimulation are already problems
+- The person uses MAOIs or medications that affect catecholamines without clinician guidance
+- Thyroid disease, bipolar disorder, seizure disorder, pregnancy, nursing, or pediatric use is involved
+- The plan is to combine multiple stimulating supplements and guess what happens
 
 ## What L-Tyrosine Is
 
-L-Tyrosine is a non-essential amino acid synthesized in the body from phenylalanine. It is obtained through diet from protein-rich foods and is available as a dietary supplement. L-Tyrosine is the biologically active form used in supplements and research.
+L-tyrosine is the biologically active form of tyrosine, a non-essential amino acid made from phenylalanine and obtained from protein-rich foods. It is used in the body for protein synthesis and for making several important molecules.
 
-## Tyrosine vs L-Tyrosine
+The main reason L-tyrosine appears in ADHD and focus discussions is its role as a precursor to catecholamines: dopamine, norepinephrine, and epinephrine. These neurotransmitters help regulate alertness, effort, stress response, working memory, and task engagement.
 
-“Tyrosine” and “L-tyrosine” are often used interchangeably in supplement contexts. L-tyrosine refers to the specific stereoisomer that the body uses. Most supplements labeled as tyrosine contain L-tyrosine.
-
-## Tyrosine as an Amino Acid
-
-As an amino acid, L-tyrosine participates in protein synthesis and serves as a building block for important molecules including thyroid hormones and the catecholamines dopamine, norepinephrine, and epinephrine.
-
-## Tyrosine and Catecholamines
-
-L-Tyrosine is the rate-limiting precursor for catecholamine synthesis. Under conditions of high demand or depletion, supplemental L-tyrosine can support continued production of dopamine and norepinephrine, which is why it has been studied for cognitive performance during stress or sleep loss.
+That does not mean ADHD is a simple tyrosine deficiency. It means L-tyrosine sits upstream of pathways that may become more relevant during high demand, stress, or sleep loss.
 
 ## How L-Tyrosine Works
 
-L-Tyrosine crosses the blood-brain barrier and is converted to L-DOPA by the enzyme tyrosine hydroxylase, then to dopamine. Dopamine can be further converted to norepinephrine and epinephrine. This pathway supports catecholamine availability during periods of increased demand.
+L-tyrosine crosses the blood-brain barrier and can be converted to L-DOPA, then dopamine. Dopamine can then be converted to norepinephrine and epinephrine. These catecholamines are involved in alertness, motivation, attention, and stress physiology.
 
-## L-Tyrosine and Dopamine
+The strongest practical rationale is demand support. Under acute stress, sleep deprivation, or heavy cognitive load, catecholamine turnover can increase. Supplemental L-tyrosine may help preserve performance when precursor availability becomes limiting.
 
-Dopamine is central to motivation, attention, reward processing, and executive function. L-Tyrosine supplementation can increase dopamine synthesis when precursor availability is limiting. However, simply increasing precursor availability does not automatically correct the complex dopamine dysregulation seen in ADHD.
+The key caution is that ADHD is not caused by too little tyrosine. ADHD involves complex signaling, receptor sensitivity, transporter function, sleep, environment, learning demands, emotion regulation, and executive habits. More precursor does not guarantee better signaling. Readers who want the broader model can start with [how focus and motivation work](/education/how-focus-and-motivation-work).
 
-## L-Tyrosine and Norepinephrine
+## What the Evidence Says About ADHD
 
-Norepinephrine supports arousal, attention, and stress response. L-Tyrosine can support norepinephrine production under demanding conditions. Effects on attention and alertness in research are often linked to this pathway.
+Direct evidence in diagnosed ADHD populations is limited. There are not enough strong ADHD trials to say L-tyrosine reliably improves core ADHD symptoms.
 
-## L-Tyrosine and Epinephrine
+The better-supported evidence comes from non-ADHD cognitive-performance studies under demanding conditions:
 
-Epinephrine (adrenaline) is involved in the acute stress response. L-Tyrosine supports its synthesis, though most cognitive research focuses on dopamine and norepinephrine rather than epinephrine.
+| Evidence area | What it suggests | ADHD relevance |
+|---|---|---|
+| Acute stress | May help preserve attention or working memory in some studies | Indirect but relevant to stress-sensitive focus |
+| Sleep deprivation | May reduce short-term cognitive decline in selected tasks | Indirect and situation-specific |
+| Cold or high cognitive load | May support performance under demanding conditions | Not the same as daily ADHD improvement |
+| Direct ADHD trials | Sparse and preliminary | Not enough for strong claims |
+| Medication combinations | Limited data | Requires clinical supervision |
 
-## Why Dopamine Precursors Do Not Automatically Treat ADHD
+Compared with better-studied options in the [best supplements for ADHD](/articles/best-supplements-for-adhd/) guide, L-tyrosine belongs in the experimental adjunct category. It may be more relevant for stress-performance situations than for everyday ADHD symptom control.
 
-ADHD involves complex dysregulation of dopamine signaling, receptor sensitivity, and transporter function rather than simple precursor deficiency. Increasing L-tyrosine availability may support catecholamine production under acute stress but does not address the underlying neurobiological features of ADHD. Evidence for core symptom improvement in ADHD populations remains limited.
+## L-Tyrosine for Focus, Attention, and Executive Function
 
-## Why Researchers Became Interested in Tyrosine and ADHD
+L-tyrosine may be most useful when focus breaks down under pressure: a long work block, poor sleep, time pressure, cold exposure, or emotionally stressful demands. That is where the general research signal is strongest.
 
-Interest developed from L-tyrosine’s established role as a catecholamine precursor and from studies showing cognitive benefits during acute stress, sleep deprivation, or high cognitive load in non-ADHD populations. These findings suggested potential relevance for ADHD-related challenges with attention and executive function under demanding conditions.
+For baseline ADHD symptoms, the case is weaker. It should not be expected to reliably improve procrastination, distractibility, emotional regulation, school performance, or executive function by itself.
 
-## Direct ADHD Evidence
+If used, it fits best as one carefully tracked variable inside a conservative [ADHD stack guide](/articles/adhd-stack-guide/) approach. The trial should answer a narrow question: does L-tyrosine help a specific high-demand focus problem enough to justify using it?
 
-High-quality randomized controlled trials specifically in diagnosed ADHD populations are very limited. Most available data come from general cognitive-performance studies conducted in healthy adults under stress or demanding conditions rather than core ADHD clinical trials. Direct applicability to ADHD remains uncertain.
+## L-Tyrosine vs Other ADHD and Focus Supports
 
-## Pediatric ADHD Evidence
+L-tyrosine is different from choline-focused supplements such as [citicoline for ADHD](/articles/citicoline-for-adhd/) and [Alpha-GPC for ADHD](/articles/alpha-gpc-and-adhd/). Citicoline and Alpha-GPC focus more on choline, acetylcholine, and membrane-related pathways. L-tyrosine focuses more on catecholamine precursor support.
 
-Direct randomized trials of L-tyrosine in children with ADHD are scarce. Some small or exploratory studies have examined cognitive or behavioral outcomes, but robust pediatric ADHD data are lacking. Evidence in children remains preliminary and largely indirect.
+It is also different from L-theanine and caffeine. Caffeine is an acute stimulant-like alertness tool. L-theanine may support calm focus and reduce caffeine edge for some people. Readers comparing arousal and calm can use [L-theanine vs caffeine for focus](/articles/l-theanine-vs-caffeine-for-focus/) and [L-theanine for ADHD](/articles/l-theanine-for-adhd/).
 
-## Adult ADHD Evidence
+Omega-3 and nutrient correction are a different category again. [Omega-3 and ADHD](/articles/omega-3-and-adhd/) has broader ADHD research than L-tyrosine, while [nutrient deficiencies and ADHD](/articles/nutrient-deficiencies-and-adhd/) and [ADHD blood tests](/articles/adhd-blood-tests/) help identify correctable factors that can worsen focus, fatigue, or mood.
 
-Adult-specific ADHD trials are also very limited. Most cognitive research on L-tyrosine has been conducted in healthy adults under controlled stress conditions rather than in diagnosed ADHD cohorts. Direct evidence in adult ADHD is preliminary.
+## Dosing and Timing
 
-## Evidence From Cognitive Performance Studies
+L-tyrosine research often uses acute dosing before a demanding task rather than continuous daily use. Studied doses vary widely, but practical adult use commonly falls somewhere around 500 mg to 2,000 mg taken 30-60 minutes before a high-demand period.
 
-L-Tyrosine has been studied extensively for cognitive performance in healthy adults exposed to acute stressors such as sleep deprivation, cold exposure, or high cognitive load. Some studies show modest preservation or improvement of attention, working memory, and executive function under these conditions. These findings come from non-ADHD populations.
+A conservative approach starts low, avoids late-day dosing, and does not combine L-tyrosine with several other stimulating inputs at the same time. Taking it earlier in the day may reduce sleep disruption risk.
 
-## Evidence Under Stress
+Daily use has less support than situational use. If someone uses it repeatedly, tracking sleep, anxiety, irritability, blood pressure symptoms, and actual performance outcomes matters more than chasing a stronger subjective feeling.
 
-Several studies demonstrate that L-tyrosine supplementation can help maintain cognitive performance during acute stress. Benefits are typically observed when catecholamine demand is high and precursor availability may become limiting. These effects are context-specific rather than general cognitive enhancement.
+## Side Effects and Safety
 
-## Evidence Under Sleep Deprivation
+L-tyrosine is generally tolerated in healthy adults at studied doses, but it can cause side effects. Possible issues include headache, nausea, stomach discomfort, restlessness, anxiety, irritability, insomnia, or a wired feeling.
 
-L-Tyrosine has shown some ability to mitigate declines in attention and working memory during sleep deprivation in certain studies. Effects are generally modest and most relevant for short-term performance preservation rather than long-term cognitive improvement.
+Use extra caution with:
 
-## Evidence Under Cold Exposure or High Cognitive Load
+- Stimulant or non-stimulant ADHD medications
+- MAOIs, certain antidepressants, or other catecholamine-active medications
+- High blood pressure or cardiovascular concerns
+- Thyroid disorders or thyroid medication
+- Bipolar disorder, panic, severe anxiety, or seizure disorders
+- Pregnancy, nursing, pediatric use, or complex medical conditions
 
-Similar modest protective effects have been observed in studies involving cold stress or sustained high cognitive demand. These findings support the idea that L-tyrosine may be most useful under specific demanding conditions rather than as daily cognitive support.
-
-## Effects on Attention
-
-Some cognitive studies report modest improvements or preservation of attention under stress with L-tyrosine. Direct evidence in ADHD populations for improved attention is very limited and indirect.
-
-## Effects on Focus
-
-L-Tyrosine is sometimes discussed for supporting focus during demanding tasks. Evidence from general populations under stress is modest and context-dependent. Direct ADHD-specific data are preliminary.
-
-## Effects on Working Memory
-
-Several studies show modest benefits for working memory performance under acute stress or sleep loss. These findings come primarily from non-ADHD populations and should be interpreted cautiously in ADHD contexts.
-
-## Effects on Processing Speed
-
-Limited data suggest possible modest effects on processing speed under demanding conditions. Evidence specific to ADHD is lacking.
-
-## Effects on Executive Function
-
-Some studies report preservation of executive function measures during stress. Direct evidence in ADHD for executive function improvement is very limited.
-
-## Effects on Motivation
-
-Limited research exists on motivation-related outcomes. Any potential effects are speculative and not well supported by ADHD-specific studies.
-
-## Effects on Emotional Regulation
-
-L-Tyrosine has not been robustly studied for emotional regulation in ADHD populations. Any claims in this area would be indirect and unsupported by current evidence.
-
-## Evidence Grade Assessment
-
-Direct ADHD clinical trial evidence for L-tyrosine is very limited and preliminary. Most supportive data come from general cognitive-performance studies under acute stress or demanding conditions in non-ADHD populations. Overall evidence strength for ADHD symptom improvement is low to preliminary. Benefits, if any, should be described as uncertain, context-dependent, or modest at best.
-
-## Why Results Are Mixed
-
-Variability in study populations, stress conditions, doses, and outcome measures contributes to mixed results. Many studies are small and conducted in healthy adults rather than ADHD populations.
-
-## Why ADHD-Specific Evidence Is Limited
-
-ADHD research on L-tyrosine has been less extensive than research on nutrients such as omega-3 or iron. Practical and ethical considerations have resulted in fewer large-scale, well-controlled ADHD trials for this amino acid.
-
-## L-Tyrosine as an Adjunct to ADHD Medication
-
-Limited data exist on combining L-tyrosine with ADHD medications. Some theoretical rationale exists based on catecholamine support, but clinical evidence for additive benefits or safety in combination is preliminary.
-
-## L-Tyrosine and Stimulants
-
-No robust trials have established clear benefits or risks of combining L-tyrosine with stimulant medications in ADHD. Any use in combination should occur only under clinical supervision.
-
-## L-Tyrosine and Non-Stimulant Medications
-
-Even less evidence exists for combinations with non-stimulant ADHD medications. Professional guidance is essential.
-
-## L-Tyrosine in ADHD Supplement Stacks
-
-L-Tyrosine is sometimes included in broader cognitive or stress-support stacks. It should be evaluated individually rather than added to large untested combinations. Evidence for synergistic effects with other common ADHD supplements remains limited.
-
-## Dosing Considerations
-
-### Common Study Doses
-
-Doses in cognitive research have commonly ranged from 100 mg to 2,000 mg or more, often taken acutely before a demanding task.
-
-### Lower-Dose Use
-
-Some studies use 100–500 mg for general cognitive support.
-
-### Higher-Dose Use
-
-Doses up to 2,000 mg or more have been studied in acute stress conditions, though higher doses increase cost and potential side effect risk.
-
-## Timing Considerations
-
-### Acute vs Daily Use
-
-Most positive cognitive studies use L-tyrosine acutely before or during demanding conditions rather than as daily supplementation. Daily use evidence is more limited.
-
-## How Long L-Tyrosine Takes To Work
-
-Acute cognitive effects in research are typically observed within 30–60 minutes when taken before a task. Effects from daily use are less well characterized.
-
-## Tolerance and Cycling Considerations
-
-Some individuals report diminished effects with continuous daily use. Periodic cycling or use only during high-demand periods is sometimes discussed, though evidence for optimal cycling protocols is limited.
-
-## Safety Profile
-
-L-Tyrosine is generally well tolerated at studied doses in healthy individuals.
-
-## Common Side Effects
-
-Reported side effects are usually mild and may include headache, gastrointestinal discomfort, or restlessness in sensitive individuals. Side effects are often dose-dependent.
-
-## Anxiety, Irritability, and Overstimulation
-
-Some individuals report increased anxiety or irritability, possibly related to catecholamine effects. These effects are not universal and may be more likely at higher doses.
-
-## Sleep Considerations
-
-L-Tyrosine may cause insomnia or increased alertness in some people when taken late in the day. Morning or early afternoon dosing is often preferred by those sensitive to sleep effects.
-
-## Blood Pressure Considerations
-
-Because L-tyrosine supports catecholamine production, individuals with hypertension or cardiovascular concerns should use caution and consult a healthcare provider.
-
-## Thyroid Considerations
-
-L-Tyrosine is a precursor for thyroid hormones. Individuals with thyroid disorders should consult a healthcare provider before use.
-
-## Medication Interactions
-
-L-Tyrosine may theoretically interact with medications affecting catecholamine systems, including MAOIs, stimulants, and certain antidepressants. Professional guidance is recommended.
-
-## MAOIs and Safety Concerns
-
-Combining L-tyrosine with monoamine oxidase inhibitors (MAOIs) can be dangerous due to risk of hypertensive crisis. This combination should be avoided.
-
-## Pediatric Considerations
-
-Direct safety and efficacy data in children with ADHD are very limited. Use in children should involve clinical supervision and careful dosing. Behavioral and foundational strategies should be optimized first.
-
-## Adult Considerations
-
-Most cognitive research on L-tyrosine has been conducted in adults under controlled stress conditions. Adult use should still be approached conservatively with attention to individual response and potential interactions.
-
-## L-Tyrosine vs Citicoline
-
-L-Tyrosine primarily supports catecholamine (dopamine and norepinephrine) synthesis. Citicoline supports acetylcholine and membrane metabolism. They address different pathways and may be complementary for some individuals. Direct comparative data in ADHD are lacking.
-
-## L-Tyrosine vs Alpha-GPC
-
-Alpha-GPC primarily supports cholinergic function. L-Tyrosine targets catecholamines. They have different mechanisms. Evidence for either in ADHD is limited.
-
-## L-Tyrosine vs Caffeine
-
-Caffeine provides acute stimulation through adenosine blockade. L-Tyrosine supports catecholamine production under demand. They have different time courses and mechanisms. Some individuals combine low-dose caffeine with L-tyrosine for acute performance, though evidence in ADHD is limited.
-
-## L-Tyrosine vs L-Theanine
-
-L-Theanine promotes calm focus through GABA and alpha-wave effects. L-Tyrosine supports catecholamines under stress. They may be complementary for some individuals seeking both calm and performance support under demanding conditions.
-
-## L-Tyrosine vs Omega-3
-
-Omega-3 fatty acids have more consistent meta-analysis support for modest behavioral improvements in ADHD. L-Tyrosine evidence is stronger for acute cognitive performance under stress in general populations. Both may be considered in broader approaches depending on individual needs.
-
-## Who Might Benefit Most
-
-Individuals with ADHD who experience significant performance declines under stress, sleep loss, or high cognitive demand may consider L-tyrosine as one potential adjunctive option for acute use. Evidence remains uncertain and context-dependent.
-
-## Who Should Use Caution
-
-People with bipolar disorder, seizure disorders, hypertension, thyroid disorders, or those taking medications affecting catecholamine systems (including MAOIs and stimulants) should use caution. Professional guidance is essential for children and anyone with complex medical conditions.
-
-## What Not To Expect
-
-L-Tyrosine does not produce large, consistent, or universal improvements in ADHD symptoms. Evidence for benefits in attention, focus, or executive function in ADHD populations is preliminary and largely indirect. It should not be expected to replace medication, therapy, sleep optimization, or nutritional correction. Benefits are most relevant for acute performance under demanding conditions rather than daily core symptom management.
+Combining L-tyrosine with MAOIs can be dangerous and should be avoided unless a clinician explicitly manages the situation. Anyone taking prescription medication should ask a qualified professional before using L-tyrosine.
 
 ## Practical Decision Framework
 
-A conservative approach includes optimizing sleep, nutrition, exercise, and behavioral strategies first; considering L-tyrosine primarily for acute use during high-demand periods rather than daily supplementation; starting at moderate studied doses (e.g., 500–1,000 mg) with clear timing before demanding tasks; tracking specific target symptoms such as attention or working memory during use; and reassessing need and continuing only if clear individual benefit is observed under relevant conditions.
+Use L-tyrosine only if the target and risk profile are clear.
 
-## Research Gaps
-
-Large, well-controlled randomized trials specifically in diagnosed ADHD populations are needed. Direct comparisons with other cognitive supports in ADHD contexts are lacking. Better understanding of optimal dosing, timing (acute vs daily), and which ADHD presentations or conditions (stress, sleep loss) are most likely to respond would improve guidance. Long-term safety and efficacy data in ADHD populations are also limited.
-
-## Conclusion
-
-L-Tyrosine has been studied for cognitive performance under acute stress, sleep deprivation, and high cognitive load in general populations, with some evidence for modest preservation of attention and working memory. Direct evidence in ADHD populations is very limited and preliminary. Any potential benefits should be viewed as uncertain and most relevant for acute performance support under demanding conditions rather than as a primary or daily treatment for core ADHD symptoms. L-Tyrosine may serve as one adjunctive cognitive or stress support option for selected individuals after foundational strategies are in place, but expectations should remain modest. Professional guidance, systematic tracking, and realistic assessment of individual response are essential.
+1. Define the use case. L-tyrosine makes the most sense for acute high-demand focus, not general ADHD treatment.
+2. Check the basics. Address sleep, food timing, protein intake, medication questions, stress load, and relevant labs first.
+3. Avoid stack confusion. Do not start L-tyrosine alongside caffeine changes, choline supplements, adaptogens, and new medications.
+4. Start conservatively. Use the lowest reasonable dose and earlier timing.
+5. Track outcomes. Compare the same kind of task with and without L-tyrosine.
+6. Stop if the tradeoff is poor. Anxiety, irritability, insomnia, blood-pressure symptoms, or no measurable benefit are enough reason to stop.
 
 ## FAQ
 
 ### Does L-tyrosine help ADHD?
 
-Direct evidence in diagnosed ADHD populations is very limited and preliminary. Most supportive data come from general cognitive studies under stress rather than ADHD clinical trials.
+Direct ADHD evidence is limited. L-tyrosine may support cognitive performance under stress for some people, but it has not been proven to reliably improve core ADHD symptoms.
 
-### Does tyrosine increase dopamine?
+### Does L-tyrosine increase dopamine?
 
-L-Tyrosine is a precursor that can support dopamine synthesis when availability is limiting. Simply increasing precursors does not automatically correct the complex dopamine dysregulation seen in ADHD.
+L-tyrosine is a precursor used to make dopamine. That can matter when precursor availability is limiting, but more precursor does not automatically mean better dopamine signaling or better ADHD control.
 
-### Can L-tyrosine improve focus?
+### Is L-tyrosine good for focus?
 
-Some cognitive studies show modest focus benefits under acute stress or demanding conditions. Direct evidence in ADHD is preliminary and indirect.
-
-### Can L-tyrosine improve executive function?
-
-Evidence from general populations under stress is modest. Direct ADHD-specific data are very limited.
-
-### Is L-tyrosine good for studying?
-
-Some studies suggest modest cognitive benefits during high cognitive load or sleep loss. Effects are context-dependent rather than general enhancement.
+It may help preserve focus under stress, sleep loss, or high cognitive demand. Evidence for everyday focus improvement in diagnosed ADHD is weaker.
 
 ### Is L-tyrosine better for stress than ADHD?
 
-Current evidence is stronger for supporting cognitive performance during acute stress or demanding conditions in general populations than for core ADHD symptom treatment.
+Current evidence is stronger for stress-related cognitive performance than for ADHD symptom treatment. That is why L-tyrosine should be framed as possible stress-performance support, not an ADHD treatment.
 
 ### Can L-tyrosine replace ADHD medication?
 
-No. L-Tyrosine does not have evidence comparable to established treatments for core ADHD symptoms.
+No. L-tyrosine does not have evidence comparable to established ADHD treatments and should not replace prescribed care or professional guidance.
 
 ### Can L-tyrosine be taken with stimulants?
 
-Limited clinical data exist on combinations. Professional supervision is recommended due to potential interactions with catecholamine systems.
-
-### Can L-tyrosine cause anxiety?
-
-Some individuals report increased anxiety or irritability, possibly related to catecholamine effects. These effects are not universal.
-
-### Can L-tyrosine affect sleep?
-
-Some people experience insomnia or increased alertness, particularly with later-day dosing. Morning or early dosing is often preferred.
+There is limited evidence on combining L-tyrosine with stimulant medication. Because both can affect catecholamine-related systems, combination use should be discussed with a clinician.
 
 ### How much L-tyrosine should I take?
 
-Studied doses for cognitive support range from 500 mg to 2,000 mg or more, often taken acutely. Professional guidance is recommended.
+Adult studies and practical use vary, often around 500 mg to 2,000 mg before demanding conditions. A conservative trial starts low. Children, medically complex users, and people taking medication need professional guidance.
 
 ### Should L-tyrosine be taken daily?
 
-Most positive research uses L-tyrosine acutely before demanding conditions rather than as daily supplementation. Daily use evidence is more limited.
-
-### How long does L-tyrosine take to work?
-
-Acute cognitive effects in research are typically observed within 30–60 minutes when taken before a task.
-
-### Is L-tyrosine safe for children?
-
-Direct safety and efficacy data in children with ADHD are very limited. Use in children requires clinical supervision.
+Most supportive cognitive-performance evidence uses acute dosing before demanding conditions. Daily use has less evidence and should be approached cautiously.
 
 ### Who should avoid L-tyrosine?
 
-People with bipolar disorder, seizure disorders, hypertension, thyroid disorders, or those taking MAOIs or certain other medications should avoid or use extreme caution.
+People taking MAOIs, people with uncontrolled hypertension, thyroid disorders, bipolar disorder, severe anxiety, seizure disorders, or complex medication regimens should avoid or use only with professional guidance.
 
-### Is L-tyrosine better than citicoline?
+## Conclusion
 
-They address different pathways (catecholamines vs acetylcholine and membranes). Direct comparative data in ADHD are lacking. Individual response and goals often guide choice.
+L-tyrosine is a plausible stress-performance supplement because it supports dopamine and norepinephrine synthesis under demand. That makes it relevant to focus, working memory, and mental effort during stressful or sleep-deprived conditions.
 
-## Evidence Summary Table
-
-| Area | Population | Key Findings | Evidence Strength | Practical Interpretation |
-|---|---|---|---|---|
-| Cognitive performance under stress | Healthy adults under acute stress | Modest preservation of attention and working memory | Moderate | Strongest evidence is context-specific (stress, sleep loss) |
-| Effects on attention | General cognitive studies | Modest improvements under demanding conditions | Preliminary to Moderate | Largely from non-ADHD populations |
-| Effects on working memory | Sleep deprivation and stress studies | Some preservation of performance | Preliminary to Moderate | Context-dependent rather than general enhancement |
-| Direct ADHD evidence | Children and adults with ADHD | Very limited direct trials | Limited | Most data are indirect |
-| Dopamine precursor effects | General research | Supports catecholamine synthesis under demand | Moderate | Does not automatically improve ADHD symptoms |
-| Safety | General and clinical populations | Generally well tolerated at studied doses | Moderate | Individual monitoring recommended |
-| Combination with stimulants | Limited data | Theoretical rationale exists but clinical data sparse | Preliminary | Requires professional supervision |
-
-## Related Articles
-
-- Best Supplements for ADHD: Evidence-Based Options for Focus, Sleep, and Emotional Regulation
-- ADHD Stack Guide: Building an Evidence-Based Approach to Focus, Sleep, and Emotional Regulation
-- Citicoline and ADHD: What the Research Shows About Attention, Focus, and Cognitive Performance
-- Alpha-GPC vs Citicoline: Which Choline Supplement Is Better for Focus and Cognitive Support
-- L-Theanine for ADHD: Evidence on Attention, Sleep, and Emotional Regulation
-- Omega-3 and ADHD: What the Research Shows About EPA, DHA, Symptoms, and Supplementation
-- Magnesium for ADHD: Forms, Evidence, Dosage, and Practical Use
-- Sleep and ADHD: Evidence-Based Strategies for Better Focus, Behavior, and Daily Functioning
-- Nutrient Deficiencies and ADHD: What the Research Shows
-
-## Internal Linking Recommendations
-
-This article should serve as a core supporting page within the ADHD cognitive-support and nootropic subcluster. It should link bidirectionally to the ADHD Stack Guide and Best Supplements for ADHD pillar. It should also connect strongly to the Citicoline and ADHD article and the Alpha-GPC vs Citicoline comparison. Supporting links should be created to L-Theanine for ADHD, Omega-3 and ADHD, Magnesium for ADHD, Sleep and ADHD, and Nutrient Deficiencies and ADHD. These connections help establish comprehensive topical authority around evidence-based cognitive and stress support options while guiding readers toward conservative, assessment-driven decision-making across the cluster.
+For ADHD, the evidence remains limited and indirect. L-tyrosine should not be presented as a treatment, cure, or substitute for medication or professional care. The most reasonable use case is a cautious, well-tracked trial for specific high-demand situations, with realistic expectations and careful attention to sleep, anxiety, blood pressure, thyroid status, and medication interactions.

--- a/lib/focus-adhd-articles.ts
+++ b/lib/focus-adhd-articles.ts
@@ -192,6 +192,17 @@ export const focusAdhdArticles: FocusAdhdArticle[] = [
     readingTime: '11 min read',
   },
   {
+    slug: 'l-tyrosine-and-adhd',
+    source: 'docs/content/focus-cluster/l-tyrosine-and-adhd.md',
+    title: 'L-Tyrosine for ADHD: Evidence, Focus Benefits, Stress Support, and Safety',
+    seoTitle: 'L-Tyrosine for ADHD: Evidence, Focus Benefits, Stress Support, and Safety',
+    description: 'Evidence-based guide to L-tyrosine for ADHD, focus, and stress support. Covers dopamine and norepinephrine pathways, attention research, dosing, safety, medication cautions, and realistic expectations.',
+    category: 'Supplement Evidence',
+    tags: ['Focus', 'ADHD', 'Supplement Evidence'],
+    date: '2026-06-22',
+    readingTime: '10 min read',
+  },
+  {
     slug: 'l-theanine-vs-caffeine-for-focus',
     source: 'docs/content/focus-cluster/l-theanine-vs-caffeine-for-focus-content-v1.md',
     title: 'L-Theanine vs Caffeine for Focus: Which Works Better for Attention and Calm Energy?',


### PR DESCRIPTION
## Summary
- Promotes `docs/content/focus-cluster/l-tyrosine-and-adhd.md` from draft source to published Single Compound / Supplement Evidence article.
- Registers and routes `/articles/l-tyrosine-and-adhd/` through the focus ADHD article scaffold.
- Adds L-Tyrosine for ADHD to the cognitive-focus related-link bucket now that the page is live.

## Issue
- Part of #1880

## Files changed
- `docs/content/focus-cluster/l-tyrosine-and-adhd.md`
- `lib/focus-adhd-articles.ts`
- `app/articles/l-tyrosine-and-adhd/page.tsx`
- `components/articles/FocusAdhdArticlePage.tsx`

## Routes created or changed
- Created `/articles/l-tyrosine-and-adhd/`
- Changed cognitive-focus related links for scaffolded focus articles

## Validation
- `npm run typecheck` passed
- `npm run lint` passed
- `npm run build` passed

## Issue closure
- Do not close #1880 yet. L-Tyrosine is complete, but Rhodiola Rosea still needs its separate PR.