### PR TITLE
Promote Rhodiola ADHD article

### DIFF
--- a/app/articles/rhodiola-rosea-and-adhd/page.tsx
+++ b/app/articles/rhodiola-rosea-and-adhd/page.tsx
@@ -1,0 +1,9 @@
+import FocusAdhdArticlePage, { focusAdhdMetadata } from '@/components/articles/FocusAdhdArticlePage'
+
+const SLUG = 'rhodiola-rosea-and-adhd' as const
+
+export const metadata = focusAdhdMetadata(SLUG)
+
+export default function Page() {
+  return <FocusAdhdArticlePage slug={SLUG} />
+}

--- a/components/articles/FocusAdhdArticlePage.tsx
+++ b/components/articles/FocusAdhdArticlePage.tsx
@@ -160,6 +160,7 @@ function getRelatedFocusAdhdLinks(slug: string): RelatedLink[] {
       articleLink('citicoline-for-adhd', 'Citicoline for ADHD', 'Choline guide'),
       articleLink('citicoline-vs-alpha-gpc', 'Citicoline vs Alpha-GPC', 'Choline comparison'),
       articleLink('l-tyrosine-and-adhd', 'L-Tyrosine for ADHD', 'Stress focus'),
+      articleLink('rhodiola-rosea-and-adhd', 'Rhodiola Rosea for ADHD', 'Stress fatigue'),
       articleLink('l-theanine-vs-caffeine-for-focus', 'L-Theanine vs Caffeine for Focus', 'Focus comparison'),
       articleLink('l-theanine-for-adhd', 'L-Theanine for ADHD', 'Calm focus'),
       articleLink('omega-3-and-adhd', 'Omega-3 and ADHD', 'Fatty acids'),

--- a/docs/content/focus-cluster/rhodiola-rosea-and-adhd.md
+++ b/docs/content/focus-cluster/rhodiola-rosea-and-adhd.md
@@ -1,7 +1,7 @@
 ---
-title: "Rhodiola Rosea and ADHD: What the Research Shows About Stress, Fatigue, Focus, and Cognitive Performance"
-seoTitle: "Rhodiola Rosea and ADHD: What the Research Shows About Stress, Fatigue, Focus, and Cognitive Performance"
-metaDescription: "Evidence-based review of Rhodiola rosea and ADHD. Covers stress resilience, fatigue, mental performance, attention, dosing, safety, and realistic expectations as adjunctive support."
+title: "Rhodiola Rosea for ADHD: Evidence, Stress, Fatigue, Focus, and Safety"
+seoTitle: "Rhodiola Rosea for ADHD: Evidence, Stress, Fatigue, Focus, and Safety"
+metaDescription: "Evidence-based guide to Rhodiola rosea for ADHD, stress, fatigue, and focus. Covers adaptogen research, mental performance, dosing, safety, medication cautions, and realistic expectations."
 primaryKeyword: "Rhodiola ADHD"
 secondaryKeywords:
   - "Rhodiola rosea ADHD"
@@ -10,363 +10,166 @@ secondaryKeywords:
   - "Rhodiola fatigue ADHD"
   - "Rhodiola stress ADHD"
   - "Rhodiola cognitive performance"
-status: "draft-source"
+status: "published"
 cluster: "focus-adhd"
 ---
 
-# Rhodiola Rosea and ADHD: What the Research Shows About Stress, Fatigue, Focus, and Cognitive Performance
+# Rhodiola Rosea for ADHD: Evidence, Stress, Fatigue, Focus, and Safety
 
-## Introduction
+## Quick Answer
 
-Rhodiola rosea is a perennial herb traditionally used in Arctic and mountainous regions as an adaptogen to help the body resist physical and mental stress. It has been studied for effects on fatigue, mental performance under demanding conditions, and stress resilience. Because ADHD often involves challenges with sustained attention, mental fatigue, and stress-related symptom worsening, Rhodiola has attracted interest as a potential adjunctive support.
+Rhodiola rosea is an herb traditionally classified as an adaptogen. It is usually discussed for stress resilience, mental fatigue, and cognitive performance under demanding conditions.
 
-This article reviews the human evidence on Rhodiola rosea in relation to ADHD symptoms, with attention to stress, fatigue, focus, and cognitive performance. It distinguishes general fatigue and stress studies from true ADHD clinical trials and emphasizes that any potential benefits are uncertain, preliminary, context-dependent, or modest. Rhodiola is discussed here strictly as potential adjunctive support for stress-related fatigue and mental performance, not as a treatment for ADHD.
+For ADHD, the evidence is limited and mostly indirect. Rhodiola has been studied more for fatigue, burnout-like stress, and performance under strain than for diagnosed ADHD. It may be relevant when stress and fatigue make focus worse, but it has not been proven to treat core ADHD symptoms.
 
-## Important Medical Disclaimer
+Rhodiola is not a treatment, cure, or replacement for ADHD medication, therapy, sleep care, nutrition assessment, or professional guidance. If it helps, the benefit should be expected to be modest, context-dependent, and most relevant to stress-related fatigue rather than ADHD itself.
 
-This article is for educational purposes only and does not constitute medical advice. Rhodiola rosea does not treat or cure ADHD. Supplements should not replace established behavioral interventions, medication, sleep optimization, or nutritional correction when clinically indicated. Evidence for Rhodiola in ADHD populations is limited and largely indirect. Individuals considering Rhodiola should consult a qualified healthcare provider before use, especially when taking other medications or giving supplements to children.
+## Best For / Not Best For
+
+Rhodiola may be worth considering when:
+
+- The main target is mental fatigue, stress-related focus decline, or high-demand work periods
+- Sleep, nutrition, medication fit, and basic health factors have already been considered
+- The person wants a single adaptogen trial instead of a large supplement stack
+- The plan includes tracking fatigue, focus under stress, mood, and sleep
+- Use can be discussed with a clinician if medications or health conditions are involved
+
+Rhodiola is not a good fit when:
+
+- The goal is to treat ADHD directly or replace evidence-based care
+- Anxiety, irritability, insomnia, overstimulation, or bipolar symptoms are concerns
+- The person is taking stimulants, antidepressants, or other monoamine-active medications without guidance
+- The person is pregnant, nursing, a child, medically complex, or has uncontrolled blood pressure
+- The user expects an adaptogen to override poor sleep, burnout, or unaddressed deficiencies
 
 ## What Rhodiola Rosea Is
 
-Rhodiola rosea is a flowering plant that grows in cold, high-altitude regions of Europe, Asia, and North America. The root is the primary part used in traditional medicine and modern supplements. It contains several bioactive compounds, most notably rosavins and salidroside, which are often used to standardize extracts.
+Rhodiola rosea is a flowering plant that grows in cold, high-altitude regions of Europe, Asia, and North America. The root is the part most commonly used in supplements.
 
-## Rhodiola as an Adaptogen
+Modern Rhodiola extracts are often standardized for rosavins and salidroside. These marker compounds help make products more consistent, although standardization does not guarantee clinical benefit.
 
-Adaptogens are substances believed to help the body adapt to physical, chemical, and biological stressors. Rhodiola is classified as an adaptogen based on traditional use and some modern research showing effects on stress response systems and fatigue.
-
-## Key Active Compounds
-
-### Rosavins
-
-A group of compounds considered marker substances in many standardized Rhodiola extracts. They are often present in ratios such as 3% rosavins in common extracts.
-
-### Salidroside
-
-Another key compound with antioxidant and potential neuroprotective properties. Some extracts are standardized to both rosavins and salidroside (for example, 3% rosavins and 1% salidroside).
-
-## Standardized Extracts
-
-Most high-quality Rhodiola supplements are standardized to specific percentages of rosavins and salidroside to ensure consistent potency. Standardization helps with reproducibility in research and practical use.
+Rhodiola is usually grouped with stress and fatigue supports rather than classic nutrient supplements. In an ADHD context, that makes it most relevant for people whose attention worsens when they are exhausted, stressed, overloaded, or recovering poorly.
 
 ## How Rhodiola Works
 
-Rhodiola influences several physiological systems relevant to stress and fatigue. It appears to modulate the hypothalamic-pituitary-adrenal (HPA) axis, support monoamine neurotransmitter balance, and exert antioxidant effects in the brain. These mechanisms provide a plausible basis for effects on mental fatigue and performance under stress.
+Rhodiola appears to influence stress-response systems, fatigue signaling, and monoamine-related pathways. Research often discusses the HPA axis, cortisol regulation, serotonin, dopamine, norepinephrine, and cellular stress responses.
 
-## Rhodiola and Stress Response
+Those mechanisms are plausible for stress resilience and fatigue support, but they should not be overstated. ADHD is not simply an adaptogen deficiency or a stress-response problem. Stress and fatigue can amplify ADHD symptoms, but reducing fatigue does not necessarily treat the underlying attention disorder.
 
-Rhodiola has been shown in some studies to reduce perceived stress and improve stress resilience. It may help normalize cortisol responses and support recovery from stress-related fatigue.
+Readers trying to understand where stress, fatigue, and attention overlap may find [how focus and motivation work](/education/how-focus-and-motivation-work) and [why fatigue is biologically complex](/education/why-fatigue-is-biologically-complex) useful.
 
-## Rhodiola and the HPA Axis
+## What the Evidence Says About ADHD
 
-The HPA axis regulates the body’s response to stress. Rhodiola may help modulate HPA activity, potentially reducing excessive stress hormone output while supporting adaptive responses. This mechanism is frequently discussed in relation to its adaptogenic effects.
+Direct ADHD-specific evidence for Rhodiola is very limited. There are not enough strong trials in diagnosed ADHD populations to say Rhodiola improves core symptoms such as inattention, impulsivity, or executive dysfunction.
 
-## Rhodiola and Fatigue
+The more relevant research comes from stress and fatigue studies:
 
-Multiple studies have examined Rhodiola for mental and physical fatigue, particularly in demanding or stressful conditions. Some trials show reductions in fatigue scores and improvements in mental performance during prolonged work or stress exposure.
+| Evidence area | What it suggests | ADHD relevance |
+|---|---|---|
+| Mental fatigue | Some studies report reduced fatigue during demanding periods | Indirect but relevant to fatigue-sensitive focus |
+| Stress resilience | Some trials show improvements in perceived stress or burnout-like symptoms | May matter when stress worsens attention |
+| Cognitive performance | Some studies show modest effects under strain | Context-dependent, not ADHD-specific |
+| Direct ADHD evidence | Sparse and preliminary | Not enough for strong claims |
+| Medication combinations | Limited data | Requires clinical supervision |
 
-## Rhodiola and Monoamines
+The evidence grade for ADHD symptom improvement is low to preliminary. Rhodiola belongs in the "possible stress/fatigue support" category, not the core evidence category in the [best supplements for ADHD](/articles/best-supplements-for-adhd/) guide.
 
-Rhodiola may influence levels of serotonin, dopamine, and norepinephrine in certain brain regions. These effects are thought to contribute to its impact on mood, motivation, and cognitive performance under stress. However, simply modulating monoamines does not automatically improve ADHD symptoms.
+## Rhodiola for Focus, Stress, Fatigue, and Executive Function
 
-## Rhodiola, Dopamine, and Norepinephrine
+Rhodiola may be most relevant when the problem is not pure distractibility, but focus deterioration under strain. Examples include afternoon fatigue, sustained work fatigue, stress-related mental fog, or poor resilience during high-demand weeks.
 
-Rhodiola has been studied for potential effects on dopamine and norepinephrine systems. Some research suggests it may support catecholamine balance under stress. These findings come primarily from general stress and fatigue research rather than ADHD-specific trials.
+The most defensible claim is narrow: Rhodiola may help some people feel less mentally fatigued or maintain performance under stress. It should not be expected to reliably improve procrastination, impulse control, emotional regulation, school performance, or core executive function by itself.
 
-## Why Rhodiola Does Not Automatically Treat ADHD
+For ADHD, Rhodiola fits best inside a careful [ADHD stack guide](/articles/adhd-stack-guide/) approach. Test one variable, track specific outcomes, and stop if the benefit is unclear or the side-effect tradeoff is poor.
 
-ADHD involves complex neurobiological features beyond simple stress or fatigue. While Rhodiola may support resilience and mental performance under demanding conditions, increasing adaptogenic support does not address the core attention and executive function challenges that define ADHD. Evidence for core symptom improvement in ADHD populations remains very limited.
+## Rhodiola vs Other ADHD and Focus Supports
 
-## Why Researchers Became Interested in Rhodiola and ADHD
+Rhodiola is closest to stress-support articles such as [Ashwagandha for ADHD](/articles/ashwagandha-for-adhd/), but the two are not interchangeable. Rhodiola is often experienced as more activating, while ashwagandha is often positioned as more calming or sleep-adjacent. Individual response varies.
 
-Interest developed from Rhodiola’s established research in stress, fatigue, and cognitive performance under demanding conditions, combined with the observation that many individuals with ADHD experience significant mental fatigue and stress-related symptom exacerbation. Limited direct ADHD trials exist, so much of the discussion relies on indirect evidence from general stress and fatigue studies.
+Rhodiola also differs from [L-tyrosine for ADHD](/articles/l-tyrosine-and-adhd/). L-tyrosine is a catecholamine precursor most relevant to acute demand. Rhodiola has broader stress and fatigue framing. Both have limited direct ADHD evidence.
 
-## Direct ADHD Evidence
+Compared with choline-focused options such as [citicoline for ADHD](/articles/citicoline-for-adhd/) or [Alpha-GPC for ADHD](/articles/alpha-gpc-and-adhd/), Rhodiola is less about acetylcholine and more about stress/fatigue context. Compared with [L-theanine for ADHD](/articles/l-theanine-for-adhd/), Rhodiola may be more activating and less calming.
 
-High-quality randomized controlled trials specifically in diagnosed ADHD populations are very limited. Most available data come from general stress, fatigue, and cognitive performance studies in non-ADHD populations rather than core ADHD clinical trials. Direct applicability to ADHD remains uncertain.
+If fatigue or brain fog may be driven by low iron, low vitamin D, sleep problems, thyroid issues, or other correctable factors, start with [nutrient deficiencies and ADHD](/articles/nutrient-deficiencies-and-adhd/) and [ADHD blood tests](/articles/adhd-blood-tests/) before assuming an adaptogen is the answer.
 
-## Pediatric ADHD Evidence
+## Dosing and Timing
 
-Direct randomized trials of Rhodiola in children with ADHD are scarce. Some small or exploratory studies have examined cognitive or behavioral outcomes, but robust pediatric ADHD data are lacking. Evidence in children remains preliminary and largely indirect.
+Rhodiola studies commonly use standardized extracts in the 200 mg to 600 mg per day range, often standardized around rosavins and salidroside. Practical use often starts around 200 mg to 400 mg earlier in the day.
 
-## Adult ADHD Evidence
+Morning or early afternoon timing is usually preferred because some people find Rhodiola stimulating. Late-day use may worsen insomnia or restless sleep.
 
-Adult-specific ADHD trials are also very limited. Most cognitive and fatigue research on Rhodiola has been conducted in healthy adults under stress or in populations with burnout or chronic fatigue rather than diagnosed ADHD cohorts. Direct evidence in adult ADHD is preliminary.
+Some studies look at acute use during demanding periods, while others use daily dosing over several weeks. A conservative trial should track fatigue, focus, anxiety, irritability, and sleep for 2-4 weeks before deciding whether the supplement is worth continuing.
 
-## Evidence From Stress and Fatigue Studies
+## Side Effects and Safety
 
-Rhodiola has been studied extensively for mental fatigue and stress resilience in demanding work or academic settings. Some trials show reductions in fatigue and improvements in mental performance during prolonged stress exposure. These findings come from non-ADHD populations.
+Rhodiola is generally well tolerated in many adult studies, but side effects can occur. Reported issues include dizziness, dry mouth, gastrointestinal discomfort, headache, insomnia, anxiety, irritability, or a wired feeling.
 
-## Evidence From Cognitive Performance Studies
+Use extra caution with:
 
-Several studies report modest improvements in attention, processing speed, and mental clarity with Rhodiola during high cognitive load or stress. Effects are generally context-dependent and most relevant under demanding conditions rather than as general cognitive enhancement.
+- Stimulant or non-stimulant ADHD medications
+- Antidepressants or other monoamine-active medications
+- Bipolar disorder or mania risk
+- Panic, severe anxiety, irritability, or insomnia
+- High blood pressure or cardiovascular concerns
+- Pregnancy, nursing, pediatric use, or complex medical conditions
 
-## Evidence From Burnout and Mental Fatigue Research
-
-Rhodiola has shown benefits for symptoms of burnout and mental fatigue in some studies of healthcare workers and students under high stress. These populations differ from typical ADHD presentations, so direct translation to ADHD is limited.
-
-## Effects on Attention
-
-Some cognitive studies report modest improvements or preservation of attention during stress or fatigue with Rhodiola. Direct evidence in ADHD populations for improved attention is very limited and indirect.
-
-## Effects on Focus
-
-Rhodiola is sometimes discussed for supporting focus during demanding or stressful tasks. Evidence from general populations under stress is modest and context-dependent. Direct ADHD-specific data are preliminary.
-
-## Effects on Mental Fatigue
-
-Multiple studies show reductions in mental fatigue scores with Rhodiola during prolonged work or stress exposure. This is one of the more consistent findings in general research and may be relevant for individuals with ADHD who experience significant mental fatigue.
-
-## Effects on Processing Speed
-
-Limited data suggest possible modest effects on processing speed under demanding conditions. Evidence specific to ADHD is lacking.
-
-## Effects on Executive Function
-
-Some studies report preservation of executive function measures during stress. Direct evidence in ADHD for executive function improvement is very limited.
-
-## Effects on Motivation
-
-Limited research exists on motivation-related outcomes with Rhodiola. Any potential effects are speculative and not well supported by ADHD-specific studies.
-
-## Effects on Emotional Regulation
-
-Rhodiola has been studied for mood and stress resilience. Some trials report improvements in emotional stability under stress. Direct evidence in ADHD for emotional regulation is preliminary.
-
-## Effects on Sleep
-
-Rhodiola is sometimes discussed for stress-related sleep issues. Evidence for direct sleep improvements is mixed, and some individuals report increased alertness that may affect sleep if taken late in the day.
-
-## Evidence Grade Assessment
-
-Direct ADHD clinical trial evidence for Rhodiola is very limited and preliminary. Most supportive data come from general stress, fatigue, and cognitive performance studies in non-ADHD populations. Overall evidence strength for ADHD symptom improvement is low to preliminary. Benefits, if any, should be described as uncertain, context-dependent, or modest at best, with stronger signals for fatigue and stress-related performance.
-
-## Why Results Are Mixed
-
-Variability in study populations, stress conditions, extracts, doses, and outcome measures contributes to mixed results. Many studies are small and conducted in healthy adults under controlled stress rather than ADHD populations.
-
-## Why ADHD-Specific Evidence Is Limited
-
-ADHD research on Rhodiola has been less extensive than research on nutrients such as omega-3 or iron. Practical and ethical considerations have resulted in fewer large-scale, well-controlled ADHD trials for this adaptogen.
-
-## Rhodiola as an Adjunct to ADHD Medication
-
-Limited data exist on combining Rhodiola with ADHD medications. Some theoretical rationale exists based on stress resilience support, but clinical evidence for additive benefits or safety in combination is preliminary.
-
-## Rhodiola and Stimulants
-
-No robust trials have established clear benefits or risks of combining Rhodiola with stimulant medications in ADHD. Any use in combination should occur only under clinical supervision.
-
-## Rhodiola and Non-Stimulant Medications
-
-Even less evidence exists for combinations with non-stimulant ADHD medications. Professional guidance is essential.
-
-## Rhodiola in ADHD Supplement Stacks
-
-Rhodiola is sometimes included in broader stress or cognitive support stacks. It should be evaluated individually rather than added to large untested combinations. Evidence for synergistic effects with other common ADHD supplements remains limited.
-
-## Dosing Considerations
-
-### Common Study Doses
-
-Doses in cognitive and fatigue research have commonly ranged from 200 mg to 600 mg per day of standardized extract, often divided into one or two doses.
-
-### Rosavin/Salidroside Standardization
-
-Most studies use extracts standardized to 3% rosavins and 1% salidroside or similar ratios. Standardization helps ensure consistent active compound delivery.
-
-### Lower-Dose Use
-
-Some practical use involves 200–400 mg daily for general stress support.
-
-### Higher-Dose Use
-
-Doses up to 600 mg or more have been studied in acute stress or fatigue conditions, though higher doses increase cost and potential side effect risk.
-
-## Timing Considerations
-
-### Acute vs Daily Use
-
-Many positive fatigue and cognitive studies use Rhodiola acutely before or during demanding periods, while others examine daily use over weeks. Both approaches appear in research.
-
-## How Long Rhodiola Takes To Work
-
-Acute effects on fatigue or mental performance in some studies are observed within hours to days. Benefits from daily use for stress resilience are typically assessed after 2–4 weeks or longer.
-
-## Tolerance and Cycling Considerations
-
-Some individuals report diminished effects with continuous daily use over extended periods. Periodic cycling or use primarily during high-demand periods is sometimes discussed, though evidence for optimal protocols is limited.
-
-## Safety Profile
-
-Rhodiola is generally well tolerated at studied doses in healthy individuals.
-
-## Common Side Effects
-
-Reported side effects are usually mild and may include dizziness, dry mouth, or gastrointestinal discomfort in sensitive individuals. Side effects are often dose-dependent.
-
-## Anxiety, Irritability, and Overstimulation
-
-Some individuals report increased anxiety or irritability, possibly related to stimulating adaptogenic effects. These effects are not universal and may be more likely at higher doses or in sensitive people.
-
-## Sleep Considerations
-
-Rhodiola may cause insomnia or increased alertness in some people when taken late in the day. Morning or early afternoon dosing is often preferred by those sensitive to sleep effects.
-
-## Blood Pressure Considerations
-
-Rhodiola may have mild effects on blood pressure in some individuals. People with hypertension should use caution and consult a healthcare provider.
-
-## Bipolar Disorder and Mania Risk
-
-Adaptogens with stimulating properties, including Rhodiola, have been associated with mania risk in individuals with bipolar disorder. People with bipolar disorder should avoid Rhodiola or use it only under close psychiatric supervision.
-
-## Medication Interactions
-
-Rhodiola may theoretically interact with medications affecting monoamine systems, including antidepressants and stimulants. Professional guidance is recommended.
-
-## Pediatric Considerations
-
-Direct safety and efficacy data in children with ADHD are very limited. Use in children should involve clinical supervision and careful dosing. Behavioral and foundational strategies should be optimized first.
-
-## Adult Considerations
-
-Most research on Rhodiola has been conducted in adults under stress or fatigue conditions. Adult use should still be approached conservatively with attention to individual response and potential interactions.
-
-## Rhodiola vs Ashwagandha
-
-Both are adaptogens used for stress resilience. Rhodiola tends to have more stimulating properties and stronger evidence for acute fatigue and mental performance under demand. Ashwagandha is often described as more calming and has more data for anxiety and sleep. They may be complementary or chosen based on individual response and primary symptoms.
-
-## Rhodiola vs L-Tyrosine
-
-L-Tyrosine primarily supports catecholamine synthesis under demand. Rhodiola has broader adaptogenic effects on stress response and fatigue. They address different mechanisms and may be used together in some stacks. Evidence for either in ADHD is limited.
-
-## Rhodiola vs Citicoline
-
-Citicoline primarily supports acetylcholine and membrane metabolism. Rhodiola targets stress resilience and mental fatigue. They have different primary mechanisms and may be complementary for some individuals. Direct comparative data in ADHD are lacking.
-
-## Rhodiola vs Caffeine
-
-Caffeine provides acute stimulation. Rhodiola supports longer-term stress resilience and fatigue recovery. They have different time courses. Some individuals combine low-dose caffeine with Rhodiola for performance, though evidence in ADHD is limited.
-
-## Rhodiola vs L-Theanine
-
-L-Theanine promotes calm focus. Rhodiola supports performance under stress. They may be complementary for some individuals seeking both calm and resilience. Direct comparative data are lacking.
-
-## Who Might Benefit Most
-
-Individuals with ADHD who experience significant mental fatigue, stress-related performance declines, or burnout-like symptoms may consider Rhodiola as one potential adjunctive option for stress resilience and mental performance support. Evidence remains uncertain and context-dependent.
-
-## Who Should Use Caution
-
-People with bipolar disorder, seizure disorders, hypertension, or those taking medications affecting monoamine systems should use caution. Professional guidance is essential for children and anyone with complex medical conditions.
-
-## What Not To Expect
-
-Rhodiola does not produce large, consistent, or universal improvements in ADHD symptoms. Evidence for benefits in attention, focus, or executive function in ADHD populations is preliminary and largely indirect. It should not be expected to replace medication, therapy, sleep optimization, or nutritional correction. Benefits are most relevant for stress-related fatigue and mental performance under demanding conditions rather than daily core symptom management.
+Rhodiola may be too activating for some people. Anyone with bipolar disorder, significant anxiety, medication combinations, or cardiovascular concerns should involve a qualified clinician before use.
 
 ## Practical Decision Framework
 
-A conservative approach includes optimizing sleep, nutrition, exercise, and behavioral strategies first; considering Rhodiola primarily for stress-related fatigue or performance support during high-demand periods; starting at moderate studied doses (e.g., 200–400 mg of standardized extract) with clear timing; tracking specific target symptoms such as mental fatigue, focus under stress, or emotional resilience over 2–4 weeks; and reassessing need and continuing only if clear individual benefit is observed under relevant conditions.
+Use Rhodiola only when the target is specific and stress/fatigue related.
 
-## Research Gaps
-
-Large, well-controlled randomized trials specifically in diagnosed ADHD populations are needed. Direct comparisons with other adaptogens and cognitive supports in ADHD contexts are lacking. Better understanding of optimal dosing, timing (acute vs daily), extract standardization, and which ADHD presentations or conditions (stress, fatigue) are most likely to respond would improve guidance. Long-term safety and efficacy data in ADHD populations are also limited.
-
-## Conclusion
-
-Rhodiola rosea has been studied for stress resilience, mental fatigue, and cognitive performance under demanding conditions in general populations, with some evidence for modest benefits in fatigue reduction and mental clarity. Direct evidence in ADHD populations is very limited and preliminary. Any potential benefits should be viewed as uncertain, context-dependent, or modest and most relevant for stress-related fatigue and mental performance support rather than as a primary or daily treatment for core ADHD symptoms. Rhodiola may serve as one adjunctive support option for selected individuals after foundational strategies are in place, but expectations should remain modest. Professional guidance, systematic tracking, and realistic assessment of individual response are essential.
+1. Name the problem. Examples: afternoon fatigue, focus during stressful weeks, burnout-like mental fog, or low resilience after poor sleep.
+2. Check foundations first. Sleep, food timing, iron status, vitamin D, thyroid, medication fit, and workload may matter more.
+3. Choose one variable. Do not start Rhodiola alongside caffeine changes, L-tyrosine, choline supplements, and new adaptogens.
+4. Start earlier and lower. Morning dosing reduces sleep disruption risk.
+5. Track both benefit and cost. Fatigue scores, task endurance, anxiety, irritability, and sleep are all relevant.
+6. Stop if activation outweighs benefit. More energy is not useful if it comes with worse sleep, anxiety, or emotional volatility.
 
 ## FAQ
 
 ### Does Rhodiola help ADHD?
 
-Direct evidence in diagnosed ADHD populations is very limited and preliminary. Most supportive data come from general stress and fatigue studies rather than ADHD clinical trials.
+Direct ADHD evidence is very limited. Rhodiola may help some people with stress-related fatigue or focus decline, but it has not been proven to treat core ADHD symptoms.
 
 ### Is Rhodiola good for focus?
 
-Some cognitive studies show modest focus benefits during stress or demanding conditions. Evidence specific to ADHD is preliminary and indirect.
+It may support focus when fatigue or stress is the limiting factor. Evidence for baseline ADHD attention improvement is indirect and preliminary.
 
 ### Can Rhodiola help mental fatigue?
 
-Multiple studies in general populations show reductions in mental fatigue during prolonged stress or work. This is one of the more consistent findings and may be relevant for individuals with ADHD who experience significant mental fatigue.
+Mental fatigue is one of the more relevant areas of Rhodiola research. Some studies suggest modest benefit during demanding or stressful periods, but individual response varies.
 
 ### Is Rhodiola better for stress than ADHD?
 
-Current evidence is stronger for supporting stress resilience and fatigue recovery in general populations than for core ADHD symptom treatment.
-
-### Can Rhodiola improve motivation?
-
-Limited research exists on motivation-related outcomes. Any potential effects are speculative and not well supported by ADHD-specific studies.
-
-### Can Rhodiola improve executive function?
-
-Evidence from general populations under stress is modest. Direct ADHD-specific data are very limited.
+Yes, based on current evidence. The research case is stronger for stress and fatigue support than for ADHD symptom treatment.
 
 ### Does Rhodiola increase dopamine?
 
-Rhodiola has been studied for effects on monoamine systems including dopamine. These effects do not automatically improve ADHD symptoms.
+Rhodiola may influence monoamine systems, including dopamine and norepinephrine, but that does not mean it reliably improves ADHD. Mechanism is not the same as outcome.
 
 ### Can Rhodiola replace ADHD medication?
 
-No. Rhodiola does not have evidence comparable to established treatments for core ADHD symptoms.
+No. Rhodiola is not an ADHD treatment and should not replace medication, behavioral care, sleep treatment, nutrition correction, or professional guidance.
 
 ### Can Rhodiola be taken with stimulants?
 
-Limited clinical data exist on combinations. Professional supervision is recommended due to potential interactions with monoamine systems.
+There is limited evidence on combining Rhodiola with stimulant medication. Because both may affect arousal or monoamine-related systems, combination use should be discussed with a clinician.
 
-### Can Rhodiola cause anxiety?
+### Can Rhodiola cause anxiety or insomnia?
 
-Some individuals report increased anxiety or irritability, possibly related to stimulating adaptogenic effects. These effects are not universal.
-
-### Can Rhodiola affect sleep?
-
-Some people experience insomnia or increased alertness, particularly with later-day dosing. Morning or early dosing is often preferred.
+Yes, some people report anxiety, irritability, overstimulation, or insomnia. Morning dosing and lower starting doses may reduce risk, but some people are simply not good candidates.
 
 ### How much Rhodiola should I take?
 
-Studied doses for cognitive and fatigue support range from 200 mg to 600 mg daily of standardized extract. Professional guidance is recommended.
-
-### Should Rhodiola be taken daily?
-
-Many positive studies use Rhodiola during high-demand periods, while others examine daily use over weeks. Both approaches appear in research.
-
-### How long does Rhodiola take to work?
-
-Acute effects on fatigue or mental performance in some studies are observed within hours to days. Benefits from daily use are typically assessed after 2–4 weeks or longer.
-
-### Is Rhodiola safe for children?
-
-Direct safety and efficacy data in children with ADHD are very limited. Use in children requires clinical supervision.
+Adult studies commonly use 200 mg to 600 mg daily of standardized extract. A cautious trial usually starts low. Children, medically complex users, and people taking medication need professional guidance.
 
 ### Is Rhodiola better than ashwagandha?
 
-They have different profiles. Rhodiola tends to have more stimulating properties and stronger evidence for acute fatigue and mental performance. Ashwagandha is often described as more calming. Individual response often guides choice.
+Not universally. Rhodiola is often more activating and fatigue-focused; ashwagandha is often more calming. The better choice depends on the target, tolerability, and safety context.
 
-## Evidence Summary Table
+## Conclusion
 
-| Area | Population | Key Findings | Evidence Strength | Practical Interpretation |
-|---|---|---|---|---|
-| Mental fatigue and stress | Adults under demanding conditions | Reductions in fatigue and improvements in mental performance | Moderate | Strongest evidence is for stress-related fatigue |
-| Cognitive performance under stress | Healthy adults | Modest preservation or improvement in attention and clarity | Preliminary to Moderate | Context-dependent rather than general enhancement |
-| Effects on attention | General cognitive studies | Modest improvements under demanding conditions | Preliminary | Largely from non-ADHD populations |
-| Direct ADHD evidence | Children and adults with ADHD | Very limited direct trials | Limited | Most data are indirect |
-| Effects on emotional regulation | Stressed populations | Some improvements in stress resilience and mood | Preliminary | Limited direct ADHD data |
-| Safety | General and clinical populations | Generally well tolerated at studied doses | Moderate | Individual monitoring recommended |
-| Combination with stimulants | Limited data | Theoretical rationale exists but clinical data sparse | Preliminary | Requires professional supervision |
+Rhodiola rosea is a plausible stress and fatigue support, and some non-ADHD research suggests modest benefits for mental fatigue and performance under demanding conditions. That makes it relevant to ADHD only when stress and fatigue are major contributors to focus problems.
 
-## Related Articles
-
-- Best Supplements for ADHD: Evidence-Based Options for Focus, Sleep, and Emotional Regulation
-- ADHD Stack Guide: Building an Evidence-Based Approach to Focus, Sleep, and Emotional Regulation
-- Ashwagandha for ADHD: Evidence on Stress, Focus, Sleep, and Emotional Regulation
-- L-Tyrosine and ADHD: What the Research Shows About Dopamine, Focus, Stress, and Cognitive Performance
-- Citicoline and ADHD: What the Research Shows About Attention, Focus, and Cognitive Performance
-- L-Theanine for ADHD: Evidence on Attention, Sleep, and Emotional Regulation
-- Omega-3 and ADHD: What the Research Shows About EPA, DHA, Symptoms, and Supplementation
-- Magnesium for ADHD: Forms, Evidence, Dosage, and Practical Use
-- Sleep and ADHD: Evidence-Based Strategies for Better Focus, Behavior, and Daily Functioning
-- Nutrient Deficiencies and ADHD: What the Research Shows
-
-## Internal Linking Recommendations
-
-This article should serve as a core supporting page within the ADHD adaptogen and stress-performance subcluster. It should link bidirectionally to the ADHD Stack Guide and Best Supplements for ADHD pillar. It should also connect strongly to the Ashwagandha for ADHD article and the L-Tyrosine and ADHD article. Supporting links should be created to Citicoline and ADHD, L-Theanine for ADHD, Omega-3 and ADHD, Magnesium for ADHD, Sleep and ADHD, and Nutrient Deficiencies and ADHD. These connections help establish comprehensive topical authority around evidence-based adaptogenic and cognitive support options while guiding readers toward conservative, assessment-driven decision-making across the cluster.
+The direct ADHD evidence is limited. Rhodiola should not be framed as a treatment, cure, or replacement for professional care. The safest interpretation is cautious: it may be worth a tracked trial for selected adults with stress-related fatigue, but expectations should stay modest and safety should come first.

--- a/lib/focus-adhd-articles.ts
+++ b/lib/focus-adhd-articles.ts
@@ -203,6 +203,17 @@ export const focusAdhdArticles: FocusAdhdArticle[] = [
     readingTime: '10 min read',
   },
   {
+    slug: 'rhodiola-rosea-and-adhd',
+    source: 'docs/content/focus-cluster/rhodiola-rosea-and-adhd.md',
+    title: 'Rhodiola Rosea for ADHD: Evidence, Stress, Fatigue, Focus, and Safety',
+    seoTitle: 'Rhodiola Rosea for ADHD: Evidence, Stress, Fatigue, Focus, and Safety',
+    description: 'Evidence-based guide to Rhodiola rosea for ADHD, stress, fatigue, and focus. Covers adaptogen research, mental performance, dosing, safety, medication cautions, and realistic expectations.',
+    category: 'Supplement Evidence',
+    tags: ['Focus', 'ADHD', 'Supplement Evidence'],
+    date: '2026-06-22',
+    readingTime: '10 min read',
+  },
+  {
     slug: 'l-theanine-vs-caffeine-for-focus',
     source: 'docs/content/focus-cluster/l-theanine-vs-caffeine-for-focus-content-v1.md',
     title: 'L-Theanine vs Caffeine for Focus: Which Works Better for Attention and Calm Energy?',


### PR DESCRIPTION
## Summary
- Promotes `docs/content/focus-cluster/rhodiola-rosea-and-adhd.md` from draft source to published Single Compound / Supplement Evidence article.
- Registers and routes `/articles/rhodiola-rosea-and-adhd/` through the focus ADHD article scaffold.
- Adds Rhodiola Rosea for ADHD to the cognitive-focus related-link bucket now that the page is live.

## Issue
- Part of #1880

## Files changed
- `docs/content/focus-cluster/rhodiola-rosea-and-adhd.md`
- `lib/focus-adhd-articles.ts`
- `app/articles/rhodiola-rosea-and-adhd/page.tsx`
- `components/articles/FocusAdhdArticlePage.tsx`

## Routes created or changed
- Created `/articles/rhodiola-rosea-and-adhd/`
- Changed cognitive-focus related links for scaffolded focus articles

## Validation
- `npm run typecheck` passed
- `npm run lint` passed
- `npm run build` passed

## Issue closure
- This completes the third and final Phase 2 compound article for #1880.