### PR TITLE
Add lightweight article navigation upgrade

### DIFF
--- a/components/articles/ArticleLayout.tsx
+++ b/components/articles/ArticleLayout.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react'
+import BackToTop from './BackToTop'
 import KeyDetailsBox from './KeyDetailsBox'
 import RelatedArticles from './RelatedArticles'
 import type { KeyDetailsBoxProps } from './KeyDetailsBox'
@@ -57,6 +58,7 @@ export default function ArticleLayout({
           </aside>
         )}
       </div>
+      <BackToTop />
     </div>
   )
 }

--- a/components/articles/BackToTop.tsx
+++ b/components/articles/BackToTop.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface BackToTopProps {
+  minScrollY?: number;
+  minScrollableDistance?: number;
+}
+
+export default function BackToTop({
+  minScrollY = 720,
+  minScrollableDistance = 900,
+}: BackToTopProps) {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const updateVisibility = () => {
+      const documentHeight = document.documentElement.scrollHeight
+      const scrollableDistance = documentHeight - window.innerHeight
+      setVisible(scrollableDistance >= minScrollableDistance && window.scrollY >= minScrollY)
+    }
+
+    updateVisibility()
+
+    window.addEventListener('scroll', updateVisibility, { passive: true })
+    window.addEventListener('resize', updateVisibility)
+
+    return () => {
+      window.removeEventListener('scroll', updateVisibility)
+      window.removeEventListener('resize', updateVisibility)
+    }
+  }, [minScrollY, minScrollableDistance])
+
+  if (!visible) return null
+
+  return (
+    <button
+      type="button"
+      aria-label="Back to top"
+      onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+      className="fixed bottom-5 right-4 z-40 inline-flex size-11 items-center justify-center rounded-full border border-brand-900/10 bg-white/95 text-brand-800 shadow-lg shadow-brand-950/10 backdrop-blur transition hover:-translate-y-0.5 hover:bg-brand-50 hover:text-brand-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-brand-700 dark:border-brand-900/20 dark:bg-brand-950/90 dark:text-brand-100 dark:hover:bg-brand-900 sm:bottom-6 sm:right-6"
+    >
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 20 20"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        className="size-5"
+      >
+        <path d="M10 16V4" strokeLinecap="round" />
+        <path d="M5 9l5-5 5 5" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    </button>
+  )
+}

--- a/components/articles/TableOfContents.tsx
+++ b/components/articles/TableOfContents.tsx
@@ -1,72 +1,117 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import type { Heading } from './extractHeadings'
+
+const MIN_TOC_HEADINGS = 3
+const ACTIVE_OFFSET_PX = 112
 
 interface Props {
   headings: Heading[];
+  minHeadings?: number;
 }
 
-export default function TableOfContents({ headings }: Props) {
-  const [activeId, setActiveId] = useState<string>('');
-  const [mobileOpen, setMobileOpen] = useState(false);
-  const observer = useRef<IntersectionObserver | null>(null);
+function getActiveHeadingId(headings: Heading[]): string {
+  if (typeof window === 'undefined') return headings[0]?.id ?? ''
+
+  const currentY = window.scrollY + ACTIVE_OFFSET_PX
+  let activeId = headings[0]?.id ?? ''
+
+  for (const heading of headings) {
+    const element = document.getElementById(heading.id)
+    if (!element) continue
+    if (element.offsetTop <= currentY) activeId = heading.id
+  }
+
+  return activeId
+}
+
+export default function TableOfContents({ headings, minHeadings = MIN_TOC_HEADINGS }: Props) {
+  const [activeId, setActiveId] = useState<string>('')
+  const [mobileOpen, setMobileOpen] = useState(false)
+  const tocHeadings = useMemo(
+    () => headings.filter((heading) => heading.id && heading.text && (heading.level === 2 || heading.level === 3)),
+    [headings]
+  )
 
   useEffect(() => {
-    observer.current = new IntersectionObserver(
+    if (tocHeadings.length < minHeadings) return
+
+    const updateActiveHeading = () => {
+      setActiveId(getActiveHeadingId(tocHeadings))
+    }
+
+    updateActiveHeading()
+
+    const observer = new IntersectionObserver(
       (entries) => {
         const visible = entries
-          .filter(e => e.isIntersecting)
-          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+          .filter((entry) => entry.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top)
+
         if (visible.length > 0) {
-          setActiveId(visible[0].target.id);
+          setActiveId(visible[0].target.id)
+          return
         }
+
+        updateActiveHeading()
       },
-      { rootMargin: '-80px 0px -60% 0px', threshold: 0 }
-    );
+      { rootMargin: '-96px 0px -62% 0px', threshold: 0 }
+    )
 
-    headings.forEach(({ id }) => {
-      const el = document.getElementById(id);
-      if (el) observer.current?.observe(el);
-    });
+    tocHeadings.forEach(({ id }) => {
+      const element = document.getElementById(id)
+      if (element) observer.observe(element)
+    })
 
-    return () => observer.current?.disconnect();
-  }, [headings]);
+    window.addEventListener('scroll', updateActiveHeading, { passive: true })
+    window.addEventListener('resize', updateActiveHeading)
 
-  if (!headings.length) return null;
+    return () => {
+      observer.disconnect()
+      window.removeEventListener('scroll', updateActiveHeading)
+      window.removeEventListener('resize', updateActiveHeading)
+    }
+  }, [tocHeadings, minHeadings])
+
+  if (tocHeadings.length < minHeadings) return null
 
   const links = (
     <nav aria-label="Table of contents">
       <ol className="space-y-0.5">
-        {headings.map(h => (
-          <li key={h.id} className={h.level === 3 ? 'pl-3' : ''}>
-            <a
-              href={`#${h.id}`}
-              onClick={() => setMobileOpen(false)}
-              className={[
-                'block rounded-lg px-2.5 py-1.5 leading-snug transition-colors',
-                h.level === 3 ? 'text-xs' : 'text-sm',
-                activeId === h.id
-                  ? 'bg-brand-50 font-semibold text-brand-800'
-                  : 'text-muted hover:bg-brand-50/60 hover:text-brand-800',
-              ].join(' ')}
-            >
-              {h.text}
-            </a>
-          </li>
-        ))}
+        {tocHeadings.map((heading) => {
+          const isActive = activeId === heading.id
+
+          return (
+            <li key={heading.id} className={heading.level === 3 ? 'pl-3' : ''}>
+              <a
+                href={`#${heading.id}`}
+                aria-current={isActive ? 'location' : undefined}
+                onClick={() => setMobileOpen(false)}
+                className={[
+                  'block rounded-lg px-2.5 py-1.5 leading-snug transition-colors',
+                  heading.level === 3 ? 'text-xs' : 'text-sm',
+                  isActive
+                    ? 'bg-brand-50 font-semibold text-brand-800 shadow-sm dark:bg-brand-900/35 dark:text-brand-100'
+                    : 'text-muted hover:bg-brand-50/60 hover:text-brand-800 dark:hover:bg-brand-900/25 dark:hover:text-brand-100',
+                ].join(' ')}
+              >
+                {heading.text}
+              </a>
+            </li>
+          )
+        })}
       </ol>
     </nav>
-  );
+  )
 
   return (
     <>
-      {/* Mobile collapsible */}
-      <div className="rounded-xl border border-brand-900/10 bg-white/90 shadow-sm lg:hidden">
+      <div className="rounded-xl border border-brand-900/10 bg-white/90 shadow-sm dark:border-brand-900/20 dark:bg-brand-950/60 lg:hidden">
         <button
           type="button"
           aria-expanded={mobileOpen}
-          onClick={() => setMobileOpen(o => !o)}
+          onClick={() => setMobileOpen((open) => !open)}
           className="flex w-full items-center justify-between px-4 py-3 text-sm font-semibold text-ink"
         >
           On this page
@@ -82,19 +127,18 @@ export default function TableOfContents({ headings }: Props) {
           </svg>
         </button>
         {mobileOpen && (
-          <div className="border-t border-brand-900/10 px-4 py-3">
+          <div className="border-t border-brand-900/10 px-4 py-3 dark:border-brand-900/20">
             {links}
           </div>
         )}
       </div>
 
-      {/* Desktop always-visible */}
       <div className="hidden lg:block">
-        <p className="mb-3 text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">
+        <p className="mb-3 text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700 dark:text-brand-200">
           On this page
         </p>
         {links}
       </div>
     </>
-  );
+  )
 }

--- a/components/articles/index.ts
+++ b/components/articles/index.ts
@@ -1,6 +1,7 @@
 export { default as ArticleLayout } from './ArticleLayout'
 export { default as TableOfContents } from './TableOfContents'
 export { default as TableOfContentsAuto } from './TableOfContentsAuto'
+export { default as BackToTop } from './BackToTop'
 export { default as KeyDetailsBox } from './KeyDetailsBox'
 export { default as RelatedArticles } from './RelatedArticles'
 export type { Heading } from './extractHeadings'


### PR DESCRIPTION
## Summary

- Refines the existing article `TableOfContents` component instead of introducing a new UI library or duplicate navigation system.
- Adds active-section highlighting with IntersectionObserver plus a scroll-position fallback.
- Hides the TOC automatically when there are fewer than 3 detected headings.
- Adds a reusable `BackToTop` client component for long article/guide pages.
- Integrates `BackToTop` into the shared `ArticleLayout`, keeping it zone-safe and navigation-only.

## Notes

- No generated data files, workbook files, SEO scripts, sitemap, robots, headers, or route architecture were touched.
- This PR keeps the upgrade scoped to the article/guide reading experience.

## Validation

Not run in this connector session. Please run locally before merge:

```bash
npm run typecheck
npm run lint
npm run build
```
