### PR TITLE
[codex] Fix audit bugs and polish UI

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -228,9 +228,10 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-html,
-body,
-body * {
+/* Theme-switch transitions: only apply after hydration to prevent load flash */
+html.theme-ready,
+html.theme-ready body,
+html.theme-ready body * {
   transition-property: background-color, border-color, color, fill, stroke, box-shadow;
   transition-duration: 220ms;
   transition-timing-function: ease;
@@ -1029,6 +1030,10 @@ html.dark :is(
   .eyebrow {
     @apply text-xs font-bold tracking-[0.16em];
   }
+
+  .section-label {
+    @apply text-[0.68rem] font-bold tracking-[0.16em] uppercase text-white/50;
+  }
 }
 
 @layer components {
@@ -1036,6 +1041,22 @@ html.dark :is(
     @apply block border border-brand-900/10 bg-white/80 p-4 backdrop-blur transition-all duration-200 hover:border-brand-900/15 hover:bg-white;
     border-radius: var(--radius-card-compact);
     box-shadow: var(--shadow-card-calm);
+  }
+
+  .scientific-card[data-evidence="strong"] {
+    border-left: 3px solid var(--color-evidence-strong);
+  }
+
+  .scientific-card[data-evidence="moderate"] {
+    border-left: 3px solid var(--color-evidence-moderate);
+  }
+
+  .scientific-card[data-evidence="limited"] {
+    border-left: 3px solid var(--color-evidence-limited);
+  }
+
+  .scientific-card[data-evidence="theoretical"] {
+    border-left: 3px solid var(--color-evidence-theoretical);
   }
 
   .identity-herb {

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -67,7 +67,6 @@ const HERB_CANONICAL_SOURCE_ALIASES: Record<string, string> = {
 
 export async function generateStaticParams() {
   const herbs = await getHerbSummaryIndex()
-  console.log(`[generateStaticParams] read ${herbs.length} herbs from summary index`)
 
   const dynamicParams = herbs
     .filter((herb: RuntimeRecord) => getRuntimeVisibility(herb).canRender)
@@ -79,7 +78,6 @@ export async function generateStaticParams() {
     ...Object.keys(HERB_CANONICAL_SOURCE_ALIASES).map((slug) => ({ slug })),
   ]
 
-  console.log(`[generateStaticParams] returning ${totalParams.length} static params`)
   return totalParams
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -52,7 +52,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <head>
         <script
           dangerouslySetInnerHTML={{
-            __html: `(function(){try{var d=document.documentElement;var s=localStorage.getItem('theme');var p=window.matchMedia('(prefers-color-scheme: dark)').matches;var dark=s==='dark'||((s===null||s==='system')&&p);d.classList.toggle('dark',dark);d.dataset.theme=dark?'dark':'light';d.style.colorScheme=dark?'dark':'light'}catch(e){}})();`,
+            __html: `(function(){try{var d=document.documentElement;var s=localStorage.getItem('theme');var p=window.matchMedia('(prefers-color-scheme: dark)').matches;var dark=s==='dark'||((s===null||s==='system')&&p);d.classList.toggle('dark',dark);d.dataset.theme=dark?'dark':'light';d.style.colorScheme=dark?'dark':'light';d.classList.add('theme-ready')}catch(e){}})();`,
           }}
         />
       </head>

--- a/components/ClickTracker.tsx
+++ b/components/ClickTracker.tsx
@@ -35,24 +35,10 @@ export default function ClickTracker() {
                              ? pathname.split('/')[2]
                              : '')
 
-        const eventData = {
-          event: 'affiliate_click',
-          route: pathname,
-          href: href,
-          cta: cta,
-          ingredient: ingredient || 'unknown',
-          timestamp: new Date().toISOString()
-        }
-
         // 1. Send to GA4 if active
         trackAffiliateClick({ itemName: ingredient || cta || 'unknown', program: href.includes('amazon') || href.includes('amzn.to') ? 'Amazon' : 'Affiliate' })
 
-        // 2. Log to console in development
-        if (process.env.NODE_ENV !== 'production') {
-          console.log('[Analytics] Affiliate Click tracked:', eventData)
-        }
-
-        // 3. No localStorage click log (privacy: affiliate clicks are only sent to consented analytics if gtag present).
+        // 2. No localStorage click log (privacy: affiliate clicks are only sent to consented analytics if gtag present).
         //    Previously stored full eventData (href, route, CTA, ingredient, ts) in localStorage under 'affiliate_clicks'.
         //    Removed to reduce stored data; rely on GA4 (gated by consent) + dev console only.
       }

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -45,16 +45,16 @@ export function Navigation() {
   return (
     <nav
       className={`sticky top-0 z-50 border-b border-brand-900/10 transition-all dark:border-[var(--border-strong)] ${
-        scrolled ? 'bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/80 dark:bg-[var(--surface-card-strong)] dark:supports-[backdrop-filter]:bg-[var(--surface-card-strong)]' : 'bg-white dark:bg-[var(--surface)]'
+        scrolled ? 'bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/80 dark:bg-[var(--surface-card-strong)] dark:supports-[backdrop-filter]:bg-[var(--surface-card-strong)]' : 'bg-[#fffdf7]/95 dark:bg-[var(--surface)]'
       }`}
       aria-label="Primary"
     >
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <div className="flex h-14 items-center justify-between">
+        <div className="flex h-16 items-center justify-between">
           {/* Logo — Fraunces via font-display */}
           <Link
             href="/"
-            className="font-display text-xl font-semibold tracking-[-0.01em] text-ink transition hover:text-brand-800"
+            className="font-display text-[1.15rem] font-bold italic tracking-[-0.02em] text-ink transition hover:text-brand-700 dark:text-[var(--text-primary)]"
             aria-label="The Hippie Scientist home"
           >
             The Hippie Scientist
@@ -68,7 +68,7 @@ export function Navigation() {
                 href={link.href}
                 className={`font-medium transition-colors ${
                   isActive(link.href)
-                    ? 'text-brand-800 dark:text-brand-700'
+                    ? 'font-semibold text-brand-900 dark:text-[var(--text-primary)] underline underline-offset-4 decoration-brand-700/40'
                     : 'text-ink/80 hover:text-ink dark:text-[var(--text-secondary)] dark:hover:text-[var(--text-primary)]'
                 }`}
               >

--- a/components/articles/FocusAdhdArticlePage.tsx
+++ b/components/articles/FocusAdhdArticlePage.tsx
@@ -236,8 +236,12 @@ function parseBlocks(raw: string): Block[] {
 function inlineFormat(text: string) {
   return text
     .replace(/\[([^\]]+)]\(([^)]+)\)/g, (_match, label: string, href: string) => {
-      const external = /^https?:\/\//i.test(href)
-      return `<a href="${href}"${external ? ' target="_blank" rel="noopener noreferrer"' : ''} class="font-semibold text-brand-700 hover:text-brand-800 hover:underline">${label}</a>`
+      const safePrefixes = /^(https?:\/\/|\/)/i
+      const safeHref = safePrefixes.test(href.trim()) ? href.trim() : '#'
+      const external = /^https?:\/\//i.test(safeHref)
+      const escapedHref = safeHref.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      const safeLabel = label.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      return `<a href="${escapedHref}"${external ? ' target="_blank" rel="noopener noreferrer"' : ''} class="font-semibold text-brand-700 hover:text-brand-800 hover:underline">${safeLabel}</a>`
     })
     .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
     .replace(/\*(.+?)\*/g, '<em>$1</em>')

--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -7,37 +7,53 @@ const heroGoals = [
   {
     slug: 'sleep',
     title: 'Sleep',
+    icon: '🌙',
     prompt: 'Fall asleep, stay asleep, and compare sleep supplements without guessing.',
-    bg: 'border-[#b9c8d8] bg-[#f4f8fb]',
-    accent: 'text-[#244966]',
+    bg: 'from-[#eaf2fb] to-[#dceef8] border-[#a8c8e0]',
+    accent: 'text-[#1a3d5c]',
   },
   {
     slug: 'stress',
     title: 'Stress',
+    icon: '🌿',
     prompt: 'Sort adaptogens and calming supports by fatigue pattern, timing, and safety.',
-    bg: 'border-[#bdd2c2] bg-[#f3f8f1]',
-    accent: 'text-[#28593a]',
+    bg: 'from-[#edf6ee] to-[#ddf0df] border-[#8dc49a]',
+    accent: 'text-[#1e4a2c]',
   },
   {
     slug: 'anxiety',
     title: 'Anxiety',
+    icon: '☁️',
     prompt: 'Find grounded options for calm, overthinking, and daytime tension.',
-    bg: 'border-[#d3c4df] bg-[#faf6fc]',
-    accent: 'text-[#5a3f70]',
+    bg: 'from-[#f3eefc] to-[#ebe2f8] border-[#c4aadf]',
+    accent: 'text-[#4a2d6e]',
   },
   {
     slug: 'focus',
     title: 'Focus',
+    icon: '⚡',
     prompt: 'Compare non-stimulant focus supports and caffeine-adjacent options.',
-    bg: 'border-[#d8c7a5] bg-[#fbf7ec]',
-    accent: 'text-[#6b4d1f]',
+    bg: 'from-[#fdf5e6] to-[#f9ecce] border-[#d4aa62]',
+    accent: 'text-[#5c3f0e]',
   },
 ]
 
 const trustSignals = [
-  'Clinical evidence is separated from mechanism-only claims.',
-  'Safety, interactions, and uncertainty are surfaced before recommendations.',
-  'Guides are reviewed and linked to the site evidence methodology.',
+  {
+    n: '01',
+    label: 'Evidence tiered, not flattened',
+    body: 'Clinical evidence is separated from mechanism-only claims so you know what actually has human trial data.',
+  },
+  {
+    n: '02',
+    label: 'Safety before recommendations',
+    body: 'Interactions, contraindications, and uncertainty are surfaced before any product comparison.',
+  },
+  {
+    n: '03',
+    label: 'Methodology is public',
+    body: 'Every guide links to the evidence grading system so you can audit the claims yourself.',
+  },
 ]
 
 const comparisonLinks = [
@@ -83,12 +99,12 @@ export default function HomepageV2() {
   })
 
   return (
-    <div className='overflow-x-clip bg-site-bg'>
+    <div className='overflow-x-clip bg-[var(--bg)]'>
       <div className='mx-auto max-w-6xl space-y-8 px-4 pb-12 pt-4 sm:px-6 sm:space-y-10 sm:pb-16 sm:pt-6 lg:px-8'>
 
         {/* ── Hero ─────────────────────────────────────────────── */}
-        <section className='rounded-[1.25rem] border border-brand-900/10 bg-white/90 px-6 py-8 shadow-sm sm:px-10 sm:py-12'>
-          <div className='mx-auto max-w-4xl'>
+        <section className='relative overflow-hidden rounded-[1.5rem] border border-brand-900/10 bg-gradient-to-br from-white via-[#fafdf6] to-[#f2f8ed] px-6 py-10 shadow-md sm:px-10 sm:py-16 dark:from-[#1a3028] dark:via-[#162a20] dark:to-[#0f2419]'>
+          <div className='relative mx-auto max-w-4xl'>
             <div className='flex flex-col items-center text-center'>
               <p role='doc-subtitle' className='mb-3 inline-flex text-[0.7rem] font-bold uppercase tracking-[0.2em] text-brand-700'>
                 Start with the problem, not the product
@@ -110,7 +126,7 @@ export default function HomepageV2() {
               <div className='mt-6 flex w-full max-w-sm flex-col'>
                 <Link
                   href='#choose-a-path'
-                  className='rounded-full border border-brand-900/15 bg-brand-700 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:-translate-y-0.5 hover:bg-brand-800 focus:outline-none text-center'
+                  className='rounded-full bg-brand-800 px-6 py-3.5 text-sm font-bold text-white shadow-[0_4px_14px_rgba(11,29,20,0.22)] transition-all duration-200 hover:-translate-y-0.5 hover:bg-brand-700 hover:shadow-[0_8px_20px_rgba(11,29,20,0.28)] active:translate-y-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2 text-center'
                 >
                   Browse by Health Goal
                 </Link>
@@ -182,9 +198,10 @@ export default function HomepageV2() {
                 <Link
                   key={hGoal.slug}
                   href={`/goals/${hGoal.slug}`}
-                  className={`group flex min-h-44 flex-col justify-between rounded-[1rem] border ${hGoal.bg} p-5 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:border-[var(--border-strong)] dark:bg-[var(--surface-card)]`}
+                  className={`group flex min-h-48 flex-col justify-between rounded-[1.25rem] border bg-gradient-to-br ${hGoal.bg} p-5 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-lg dark:border-[var(--border-strong)] dark:bg-[var(--surface-card)] dark:from-[var(--surface-card)] dark:to-[var(--surface-card)]`}
                 >
                   <div>
+                    <span className='mb-3 block text-2xl' aria-hidden='true'>{hGoal.icon}</span>
                     <h3 className={`text-2xl font-bold tracking-tight ${hGoal.accent} dark:text-[var(--text-primary)]`}>
                       {hGoal.title}
                     </h3>
@@ -208,8 +225,12 @@ export default function HomepageV2() {
             />
             <div className='grid gap-3 sm:grid-cols-3'>
               {trustSignals.map((signal) => (
-                <div key={signal} className='rounded-[0.75rem] border border-brand-900/10 bg-brand-50/40 p-4 text-sm font-medium leading-6 text-ink dark:bg-[var(--surface-card)] dark:text-[var(--text-secondary)]'>
-                  {signal}
+                <div key={signal.n} className='flex gap-4 rounded-[0.85rem] border border-brand-900/10 bg-white/60 p-4 dark:bg-[var(--surface-card)] dark:text-[var(--text-secondary)]'>
+                  <span className='mt-0.5 shrink-0 font-mono text-[0.65rem] font-bold tracking-widest text-brand-400'>{signal.n}</span>
+                  <div>
+                    <p className='text-sm font-semibold text-ink'>{signal.label}</p>
+                    <p className='mt-1 text-sm leading-6 text-muted'>{signal.body}</p>
+                  </div>
                 </div>
               ))}
             </div>

--- a/components/scientific-discovery.tsx
+++ b/components/scientific-discovery.tsx
@@ -16,6 +16,14 @@ const kindStyles: Record<string, string> = {
   path: 'identity-path',
 }
 
+function evidenceTier(value = '') {
+  const normalized = value.toLowerCase()
+  if (/\b(strong|high|robust|meta|a[+-]?)\b/.test(normalized)) return 'strong'
+  if (/\b(moderate|promising|mixed|b[+-]?)\b/.test(normalized)) return 'moderate'
+  if (/\b(limited|early|traditional|preclinical|c[+-]?|d[+-]?)\b/.test(normalized)) return 'limited'
+  return 'theoretical'
+}
+
 export function ContentIdentityCard({ item }: { item: DiscoveryLink }) {
   const style = kindStyles[item.kind || 'path'] || kindStyles.path
 
@@ -25,7 +33,7 @@ export function ContentIdentityCard({ item }: { item: DiscoveryLink }) {
   if (!isSafeInternalHref(item.href) || !title || !isClean(title)) return null
 
   return (
-    <Link href={item.href} className={`scientific-card ${style} group`}>
+    <Link href={item.href} data-evidence={evidenceTier(item.evidenceLevel || item.meta)} className={`scientific-card ${style} group`}>
       <div className="flex items-center justify-between gap-3">
         <span className="identity-kicker">{item.kind || 'path'}</span>
         {item.meta ? <span className="identity-meta">{item.meta}</span> : null}

--- a/lib/editorial-discovery.ts
+++ b/lib/editorial-discovery.ts
@@ -8,6 +8,7 @@ export type DiscoveryLink = {
   description: string
   meta?: string
   kind?: 'herb' | 'compound' | 'article' | 'path'
+  evidenceLevel?: string
 }
 
 export type BlogPostRecord = {
@@ -219,6 +220,7 @@ export const findArticleEntities = (post: BlogPostRecord, entities: EditorialEnt
         description: [topics.effects[0], topics.mechanisms[0]].filter(Boolean).join(' • ') || 'Related research profile',
         meta: `${topics.maturity} • ${topics.researchStyle}`,
         kind,
+        evidenceLevel: text(entity.evidence_grade) || text(entity.evidenceLevel) || text(entity.evidence_tier),
       }
     })
 }

--- a/src/components/CompoundCard.tsx
+++ b/src/components/CompoundCard.tsx
@@ -129,7 +129,7 @@ export default function CompoundCard({ compound }: { compound: CompoundWithRefs 
     <motion.article
       whileHover={{ scale: 1.003 }}
       title={compound.herbsFound.map(h => h.name).join(', ')}
-      className='group relative flex h-full flex-col gap-2.5 rounded-[var(--radius-lg)] border border-white/8 bg-white/[0.03] p-4 text-left transition-all duration-200 hover:-translate-y-0.5 hover:border-white/16 hover:bg-white/[0.055] hover:shadow-[0_8px_32px_rgba(0,0,0,0.4)]'
+      className='group relative flex h-full flex-col gap-2.5 rounded-[var(--radius-lg)] border border-white/10 bg-white/[0.03] p-4 text-left transition-all duration-200 hover:-translate-y-0.5 hover:border-white/16 hover:bg-white/[0.055] hover:shadow-[0_8px_32px_rgba(0,0,0,0.4)]'
     >
       <div
         aria-hidden

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -61,24 +61,24 @@ export default function Footer() {
   }
 
   return (
-    <footer className='mt-8 w-full border-t border-white/8 bg-[#07080F] px-4 py-12'>
+    <footer className='mt-8 w-full border-t border-white/10 bg-[#07080F] px-4 py-12'>
       <div className='mx-auto w-full max-w-screen-lg'>
         <div className='grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-4'>
           <div>
             <p className='font-display text-lg italic text-white'>The Hippie Scientist</p>
-            <p className='mt-2 text-xs text-white/65'>
+            <p className='mt-1.5 text-[0.7rem] uppercase tracking-[0.14em] text-white/45'>
               Evidence-first botanical research. Not medical advice.
             </p>
             <div className='mt-4 flex flex-wrap items-center gap-x-2 text-xs text-white/50'>
-              <a href='https://twitter.com/HippieScientist' target='_blank' rel='noopener noreferrer' className='flex min-h-[44px] items-center px-1 transition-colors hover:text-white'>
+              <a href='https://twitter.com/HippieScientist' target='_blank' rel='noopener noreferrer' aria-label='The Hippie Scientist on Twitter' className='flex min-h-[44px] items-center gap-1.5 rounded-md px-2 text-xs font-medium text-white/55 transition-all duration-200 hover:bg-white/10 hover:text-white'>
                 Twitter
               </a>
               <span>•</span>
-              <a href='https://www.instagram.com/thehippiescientist' target='_blank' rel='noopener noreferrer' className='flex min-h-[44px] items-center px-1 transition-colors hover:text-white'>
+              <a href='https://www.instagram.com/thehippiescientist' target='_blank' rel='noopener noreferrer' aria-label='The Hippie Scientist on Instagram' className='flex min-h-[44px] items-center gap-1.5 rounded-md px-2 text-xs font-medium text-white/55 transition-all duration-200 hover:bg-white/10 hover:text-white'>
                 Instagram
               </a>
               <span>•</span>
-              <a href='https://www.youtube.com/@HippieScientist' target='_blank' rel='noopener noreferrer' className='flex min-h-[44px] items-center px-1 transition-colors hover:text-white'>
+              <a href='https://www.youtube.com/@HippieScientist' target='_blank' rel='noopener noreferrer' aria-label='The Hippie Scientist on YouTube' className='flex min-h-[44px] items-center gap-1.5 rounded-md px-2 text-xs font-medium text-white/55 transition-all duration-200 hover:bg-white/10 hover:text-white'>
                 YouTube
               </a>
             </div>
@@ -145,7 +145,7 @@ export default function Footer() {
           </NonEmpty>
         </div>
 
-        <div className='mt-10 flex flex-col justify-between gap-2 border-t border-white/8 pt-4 text-xs text-white/65 sm:flex-row'>
+        <div className='mt-10 flex flex-col justify-between gap-2 border-t border-white/10 pt-5 text-xs text-white/65 sm:flex-row'>
           {showBuildMeta && <div>Build {versionStampParts.join(' · ')}</div>}
           <div>© 2024–{copyrightYear} The Hippie Scientist – Educational use only. Not medical advice.</div>
         </div>

--- a/src/components/mobile-bottom-nav.tsx
+++ b/src/components/mobile-bottom-nav.tsx
@@ -49,12 +49,12 @@ export default function MobileBottomNav() {
               aria-current={active ? 'page' : undefined}
               className={`flex min-h-[3.45rem] min-w-0 flex-1 flex-col items-center justify-center gap-1.5 rounded-2xl px-0.5 py-2 text-center ${
                 active
-                  ? 'border-b-2 border-brand-800 bg-brand-50 text-brand-900 opacity-100 shadow-sm dark:border-brand-700 dark:bg-[var(--surface-subtle)] dark:text-brand-800'
-                  : 'text-[#405047] opacity-85 hover:bg-brand-50/60 hover:text-ink hover:opacity-100 dark:text-[var(--text-secondary)] dark:opacity-90 dark:hover:bg-[var(--surface-subtle)] dark:hover:text-[var(--text-primary)]'
+                  ? 'bg-brand-50 text-brand-900 opacity-100 shadow-sm ring-1 ring-brand-700/20 dark:bg-[var(--surface-subtle)] dark:text-[var(--text-primary)] dark:ring-[var(--border-strong)]'
+                  : 'text-[#405047] opacity-75 hover:opacity-100 hover:text-ink dark:text-[var(--text-secondary)] dark:opacity-70 dark:hover:text-[var(--text-primary)]'
               }`}
             >
               <Icon aria-hidden="true" className="h-6 w-6" strokeWidth={active ? 2.5 : 2.2} />
-              <span className={`max-w-full whitespace-nowrap text-[0.76rem] leading-none ${active ? 'font-semibold' : 'font-medium'}`}>
+              <span className={`max-w-full whitespace-nowrap text-[0.72rem] leading-none ${active ? 'font-semibold' : 'font-medium'}`}>
                 {item.label}
               </span>
             </Link>

--- a/src/components/ui/Collapse.tsx
+++ b/src/components/ui/Collapse.tsx
@@ -50,7 +50,7 @@ export default function Collapse({
             transition={{ duration: 0.22, ease: 'easeInOut' }}
             className='overflow-hidden'
           >
-            <div className='border-white/8 border-t px-4 py-3'>{children}</div>
+            <div className='border-white/10 border-t px-4 py-3'>{children}</div>
           </motion.div>
         )}
       </AnimatePresence>


### PR DESCRIPTION
## Summary
- Fixes undefined/missing Tailwind utilities, invalid opacity classes, production logs, and first-paint transition behavior.
- Sanitizes ADHD article inline links before `dangerouslySetInnerHTML` output.
- Polishes homepage hero, goal cards, trust signals, navigation, footer, mobile nav, and adds evidence-tier accents to scientific discovery cards.

## Validation
- `npm run validate:code`
- `node scripts/ci/validate-dangerously-set-inner-html.mjs`
- `npm run verify:output`

Note: `npm run build` completed in the background after the shell timeout; `verify:output` passed against the generated output.
