### PR TITLE
feat: zero-touch maintenance pipeline (Lighthouse CI, a11y gate, link checker, ScholarlyArticle)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Run typecheck
         run: npm run typecheck
 
+      - name: Run tests (vitest + a11y gate)
+        run: npm run test
+
       - name: Guard workbook source of truth
         run: npm run guard:source-of-truth
 

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,74 @@
+name: Lighthouse CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: lighthouse-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lighthouse:
+    name: Lighthouse audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Cache Next.js build cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.next/cache
+          key: ${{ runner.os }}-nextjs-lhci-${{ hashFiles('package-lock.json') }}-${{ hashFiles('**/*.ts', '**/*.tsx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-lhci-${{ hashFiles('package-lock.json') }}-
+            ${{ runner.os }}-nextjs-lhci-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build static export
+        env:
+          COMMIT_HASH: ${{ github.sha }}
+        run: npm run build:deploy
+
+      - name: Run Lighthouse CI
+        run: |
+          npx serve@14 out -p 3000 &
+          SERVER_PID=$!
+          # Wait for server to be ready
+          timeout 30 bash -c 'until curl -sf http://localhost:3000 > /dev/null; do sleep 1; done'
+          npx @lhci/cli@0.14 collect --config=.lighthouserc.json
+          npx @lhci/cli@0.14 assert --config=.lighthouserc.json
+          kill $SERVER_PID 2>/dev/null || true
+
+      - name: Upload Lighthouse results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-results-${{ github.run_number }}
+          path: .lighthouseci/
+          retention-days: 30
+
+      - name: Add workflow summary
+        if: always()
+        run: |
+          echo "## Lighthouse CI Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Thresholds: Performance ≥ 80, Accessibility ≥ 90 (hard fail), SEO ≥ 90, Best Practices ≥ 85" >> "$GITHUB_STEP_SUMMARY"
+          echo "- URLs tested: /, /herbs/ashwagandha/, /compounds/l-theanine/" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Artifact: lighthouse-results-${{ github.run_number }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Status: ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -1,0 +1,90 @@
+name: Link Checker
+
+on:
+  schedule:
+    # Every Monday at 06:00 UTC
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      target_url:
+        description: 'Target URL to crawl (default: production site)'
+        required: false
+        default: 'https://thehippiescientist.net'
+      max_depth:
+        description: 'Maximum crawl depth'
+        required: false
+        default: '3'
+
+permissions:
+  contents: read
+
+jobs:
+  check-links:
+    name: External link health check
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run critical-route health check
+        run: node scripts/check-links.mjs
+        env:
+          SITE_URL: ${{ github.event.inputs.target_url || 'https://thehippiescientist.net' }}
+
+      - name: Full site crawl (linkinator)
+        run: |
+          TARGET="${{ github.event.inputs.target_url || 'https://thehippiescientist.net' }}"
+          DEPTH="${{ github.event.inputs.max_depth || '3' }}"
+          npx linkinator@6 "$TARGET" \
+            --recurse \
+            --timeout 15000 \
+            --retry-errors \
+            --retry-errors-count 2 \
+            --concurrency 5 \
+            --skip "amazon\\.com|twitter\\.com|x\\.com|instagram\\.com|linkedin\\.com|facebook\\.com|youtube\\.com|reddit\\.com|mailto:|tel:" \
+            --markdown \
+            --verbosity error \
+            --format json \
+            --output link-check-results.json || true
+          node -e "
+            const fs = require('fs');
+            if (!fs.existsSync('link-check-results.json')) { console.log('No results file generated'); process.exit(0); }
+            const raw = fs.readFileSync('link-check-results.json', 'utf8');
+            const results = JSON.parse(raw);
+            const broken = (results.links || []).filter(l => l.state === 'BROKEN');
+            if (broken.length > 0) {
+              console.error('Broken links found:');
+              broken.forEach(l => console.error('  ' + l.status + ' ' + l.url + ' (from: ' + l.parent + ')'));
+              process.exit(1);
+            }
+            console.log('All links OK (' + (results.links || []).length + ' checked)');
+          "
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: link-check-results-${{ github.run_number }}
+          path: link-check-results.json
+          retention-days: 14
+          if-no-files-found: ignore
+
+      - name: Add workflow summary
+        if: always()
+        run: |
+          echo "## Link Checker Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Target: ${{ github.event.inputs.target_url || 'https://thehippiescientist.net' }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Skipped: amazon.com, twitter.com, instagram.com, linkedin.com, facebook.com, youtube.com, reddit.com" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Artifact: link-check-results-${{ github.run_number }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Status: ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -1,0 +1,26 @@
+{
+  "ci": {
+    "collect": {
+      "url": [
+        "http://localhost:3000/",
+        "http://localhost:3000/herbs/ashwagandha/",
+        "http://localhost:3000/compounds/l-theanine/"
+      ],
+      "numberOfRuns": 1,
+      "settings": {
+        "chromeFlags": "--no-sandbox --disable-dev-shm-usage"
+      }
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["warn", { "minScore": 0.8 }],
+        "categories:accessibility": ["error", { "minScore": 0.9 }],
+        "categories:best-practices": ["warn", { "minScore": 0.85 }],
+        "categories:seo": ["warn", { "minScore": 0.9 }]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}

--- a/ARCHITECTURE_OVERVIEW.md
+++ b/ARCHITECTURE_OVERVIEW.md
@@ -1,0 +1,224 @@
+# Architecture Overview — The Hippie Scientist
+
+_Generated: 2026-06-23 | Engineer: Maintenance Pipeline Audit_
+
+---
+
+## 1. Stack Summary
+
+| Layer | Technology | Notes |
+|-------|------------|-------|
+| Framework | Next.js 15 (App Router) | Static export (`output: 'export'`) |
+| Deployment | Cloudflare Pages | `out/` directory, CDN-first |
+| Styling | Tailwind CSS v4 | CSS custom properties in `globals.css`; no `tailwind.config.js` |
+| State | Zustand 5 | Client-side only (static export constraint) |
+| Search | Fuse.js 7 + Pagefind | Client-side fuzzy + index-based |
+| Testing | Vitest 4 + Testing Library | jsdom, OXC transpiler, 50% parallel |
+| Accessibility | axe-core 4.11.3 + jsx-a11y | ESLint strict mode on active paths |
+| Data | ExcelJS (workbook → JSON) | `data-sources/herb_monograph_master.xlsx` |
+| AI Enrichment | OpenAI API | Agent patch system under `agent/` |
+| Edge Workers | Wrangler 4 | Cloudflare deployment tooling |
+
+---
+
+## 2. Repository Layout
+
+```
+hippie-scientist-site/
+├── app/                     # Next.js App Router (41 route directories)
+│   ├── herbs/[slug]/        # Botanical monograph depth pages
+│   ├── compounds/[slug]/    # Compound detail pages
+│   ├── goals/[goal]/        # Goal-cluster discovery pages
+│   ├── stacks/[slug]/       # Supplement stack pages
+│   ├── compare/             # Herb comparison engine
+│   ├── articles/            # Long-form articles
+│   ├── __tests__/           # Vitest integration + a11y tests (13 files)
+│   ├── sitemap.ts           # Dynamic sitemap (716 lines, 1000+ entries)
+│   └── robots.ts            # Dynamic robots.txt
+├── components/              # Shared React components (20 subdirectories)
+│   ├── ui/                  # Primitive UI components
+│   ├── seo/                 # JSON-LD, schema, OG components
+│   ├── evidence/            # EvidenceMatrix, EvidenceMeter
+│   └── ...                  # Domain-specific component groups
+├── lib/                     # Active business logic (100+ files)
+│   ├── schema.ts            # Schema.org node builders
+│   ├── metadata-engine.ts   # Unified metadata generation
+│   ├── evidence*.ts         # Evidence scoring & stratification
+│   └── runtime/             # Data loading abstractions
+├── src/                     # Partially-legacy client lib + components
+│   ├── lib/                 # Runtime data loaders, SEO helpers
+│   └── components/          # Herb/compound profile components
+├── scripts/                 # Build tooling (200+ files)
+│   ├── ci/                  # CI validators (20+ scripts)
+│   ├── data/                # Data pipeline (workbook → JSON)
+│   └── audit/               # Content and SEO auditors
+├── agent/                   # AI enrichment pipeline
+│   ├── agents/              # Individual enrichment agents
+│   ├── patches/             # Generated patch files
+│   └── orchestrator/        # Batch runner
+├── data-sources/            # Source of truth (xlsx workbook)
+├── public/
+│   ├── data/                # Generated runtime JSON (disposable)
+│   ├── _headers             # Cloudflare Pages security headers (authoritative)
+│   ├── _redirects           # 21KB redirect rules
+│   ├── robots.txt           # Static fallback (superseded by app/robots.ts)
+│   └── manifest.json        # PWA manifest
+└── .github/workflows/       # 18 GitHub Actions workflows
+```
+
+---
+
+## 3. Data Pipeline
+
+```
+data-sources/herb_monograph_master.xlsx
+         │
+         ▼
+scripts/data/build-runtime-from-workbook.mjs
+         │
+         ├─► public/data/herbs.json          (1.05 MB)
+         ├─► public/data/compounds.json      (2.38 MB)
+         ├─► public/data/herbs-detail/       (per-herb JSON)
+         ├─► public/data/compounds-detail/   (per-compound JSON)
+         ├─► public/data/search-index.json
+         ├─► public/data/herb-compound-map.json
+         ├─► public/data/stacks.json
+         ├─► public/data/goal-pages.json
+         └─► public/data/runtime-manifests/route-manifest.json
+```
+
+**Contract:** Workbook is the source of truth. `public/data/**` is disposable and regenerated on every `npm run data:build`. Direct edits to JSON survive only until the next regeneration; persist changes in the workbook.
+
+---
+
+## 4. Routing & Content Architecture
+
+### Two-Layer Model
+
+**Discovery layer** — broad search intent, funnels to depth:
+- `/goals/:slug` — goal clusters (sleep, focus, anxiety, etc.)
+- `/best-supplements-for-*` — SEO entry pages (seo-entry-pages.tsx, 50KB)
+- `/natural-anxiolytics-beyond-ashwagandha`, `/sleep-herbs-vs-melatonin` — editorial hubs
+
+**Depth layer** — authoritative, research-backed profiles:
+- `/herbs/:slug` — botanical monographs (primary content type)
+- `/compounds/:slug` — compound profiles (500+ pages)
+- `/stacks/:slug` — curated supplement combinations
+- `/compare/:slug` — head-to-head comparisons
+
+### Stable Route Contracts
+
+These are indexed and linked widely; never rename without a redirect in `public/_redirects`:
+
+| Route | Description |
+|-------|-------------|
+| `/herbs/:slug` | Botanical monographs |
+| `/compounds/:slug` | Compound profiles |
+| `/goals/:slug` | Goal clusters |
+| `/stacks/:slug` | Stack pages |
+| `/compare/:slug` | Comparison pages |
+
+---
+
+## 5. SEO & Structured Data
+
+### Existing JSON-LD Coverage
+
+| Schema Type | Used On | Status |
+|------------|---------|--------|
+| WebSite | Homepage | ✅ |
+| Organization | Global layout | ✅ |
+| BreadcrumbList | All pages (client-side) | ✅ |
+| MedicalWebPage + Article | Herb/compound profiles | ✅ |
+| Article | Herb profiles (via SchemaGenerator) | ✅ → being upgraded to ScholarlyArticle |
+| FAQPage | FAQ pages + accordions | ✅ |
+| DietarySupplement + WebPage | Monetized zones | ✅ |
+| Person | Author pages | ✅ |
+
+### Sitemap
+
+Dynamic `app/sitemap.ts` generates 1000+ entries across all route families with correct priority tiers (1.0 homepage → 0.6 compare), `lastmod` dates sourced from content fields, and deprecated slug exclusion.
+
+### robots.txt
+
+Dynamic `app/robots.ts` — allows all user agents on `/`, blocks `/api/`, `/admin/`, `/data/`, `/preview/`, and internal paths.
+
+---
+
+## 6. Security & Headers
+
+**Authoritative source:** `public/_headers` (Cloudflare Pages format)
+
+| Header | Value | Status |
+|--------|-------|--------|
+| `Content-Security-Policy` | default-src self; script/style unsafe-inline; Amazon CDN img | ✅ |
+| `Strict-Transport-Security` | max-age=31536000; includeSubDomains; preload | ✅ |
+| `X-Frame-Options` | DENY | ✅ |
+| `X-Content-Type-Options` | nosniff | ✅ |
+| `Referrer-Policy` | strict-origin-when-cross-origin | ✅ |
+| `Permissions-Policy` | camera/mic/geo/payment/usb all blocked | ✅ |
+| `Cross-Origin-Opener-Policy` | same-origin | ✅ |
+| `Cross-Origin-Resource-Policy` | same-origin | ✅ |
+
+**Note:** `next.config.mjs` does not define `headers()` — under `output: 'export'`, Next.js ignores that function (and would emit a build warning). CDN-level headers via `public/_headers` are the correct pattern for Cloudflare Pages deployments.
+
+**CI validation:** `scripts/ci/validate-security-headers.mjs` runs on every push.
+
+---
+
+## 7. Accessibility Infrastructure
+
+| Tool | Status | Coverage |
+|------|--------|---------|
+| `axe-core` (v4.11.3) | ✅ installed | Component-level test suite in `app/__tests__/a11y.test.tsx` |
+| `eslint-plugin-jsx-a11y` | ✅ strict mode | Active production paths: `app/**`, `components/**`, `lib/**` |
+| Skip link | ✅ | `<a href="#main-content" className="sr-only">` in layout |
+| `<main id="main-content">` | ✅ | Single landmark per WCAG |
+| Dark mode | ✅ | `DarkModeProvider` + `DarkModeToggle` |
+| **CI enforcement** | ⚠️ GAP | Vitest a11y tests exist but are NOT run in `ci.yml` → **Fixed in this pipeline** |
+
+---
+
+## 8. Performance Budgets
+
+| Metric | Budget | Tracked By |
+|--------|--------|-----------|
+| Main JS bundle | ≤ 350 KB | `report-performance-budget.mjs` |
+| Search index | ≤ 1.0 MB | `report-performance-budget.mjs` |
+| Total search payload | ≤ 2.0 MB | `report-performance-budget.mjs` |
+| Largest JSON file | ≤ 2.5 MB | `report-performance-budget.mjs` |
+| Lighthouse Performance | ≥ 80 | **New: lighthouse.yml** |
+| Lighthouse Accessibility | ≥ 90 | **New: lighthouse.yml** |
+| Lighthouse SEO | ≥ 90 | **New: lighthouse.yml** |
+
+---
+
+## 9. CI/CD Pipeline
+
+### Workflow Inventory (18 workflows)
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `ci.yml` | push/PR | Quality gate: lint → typecheck → build → verify → security audit |
+| `deploy.yml` | CI success | Cloudflare Pages deploy |
+| `check.yml` | manual/schedule | Full health check (`check:full`) |
+| `lighthouse.yml` | **NEW** push/PR | Lighthouse performance + a11y scoring |
+| `linkchecker.yml` | **NEW** weekly cron | External link health validation |
+| `deep-enrichment.yml` | manual | AI agent enrichment run |
+| `review-patches.yml` | manual | Agent patch review |
+| `refresh-runtime-data.yml` | manual | Workbook → JSON regeneration |
+| `seo-assets.yml` | manual | SEO asset generation |
+| `sitemap-seo.yml` | manual | Sitemap validation |
+
+---
+
+## 10. Identified Gaps → Remediation Status
+
+| Gap | Severity | Status |
+|-----|----------|--------|
+| No Lighthouse CI workflow | High | ✅ **Fixed** — `.github/workflows/lighthouse.yml` |
+| Vitest/a11y tests not in CI | High | ✅ **Fixed** — added test step to `ci.yml` |
+| No link checker | Medium | ✅ **Fixed** — `.github/workflows/linkchecker.yml` + `scripts/check-links.mjs` |
+| Herb schema uses Article not ScholarlyArticle | Medium | ✅ **Fixed** — `src/lib/schema-injector.ts` upgraded |
+| `next.config.mjs` has no security header documentation | Low | ✅ **Documented** — comment added to config |
+| `public/_headers` has no COOP/CORP on sub-paths | Low | Tracked — defer to next security review |

--- a/DEVELOPER_HEALTH_LOG.md
+++ b/DEVELOPER_HEALTH_LOG.md
@@ -1,0 +1,120 @@
+# Developer Health Log — The Hippie Scientist
+
+_Canonical log of all maintenance pipeline actions, audit results, and decisions._
+_Format: newest entry at top. Never delete entries — mark superseded ones [SUPERSEDED]._
+
+---
+
+## 2026-06-23 — Initial Pipeline Audit & Remediation
+
+**Author:** Maintenance Pipeline (automated)
+**Scope:** Full repository audit; Task A (Technical Foundations) implementation
+
+### Audit Findings
+
+#### A. Lighthouse CI — MISSING → FIXED
+
+**Finding:** No Lighthouse CI workflow existed. Performance was tracked only via manual `scripts/report-performance-budget.mjs` which covers bundle sizes but not Core Web Vitals or accessibility scores.
+
+**Action:** Created `.github/workflows/lighthouse.yml` — runs on every push and pull request.
+- Builds static export (`npm run build:deploy`)
+- Serves `out/` with `npx serve`
+- Runs `@lhci/cli@0.14` against homepage, `/herbs/ashwagandha/`, and `/compounds/l-theanine/`
+- Enforces thresholds via `.lighthouserc.json`:
+  - Performance ≥ 80 (warn)
+  - Accessibility ≥ 90 (error — hard fail)
+  - Best Practices ≥ 85 (warn)
+  - SEO ≥ 90 (warn)
+
+**Created files:**
+- `.github/workflows/lighthouse.yml`
+- `.lighthouserc.json`
+
+#### B. Accessibility CI Gate — MISSING → FIXED
+
+**Finding:** `axe-core` (v4.11.3) is installed and `app/__tests__/a11y.test.tsx` covers SafetyBadge, DecisionProfileCard, and ProfileEvidenceLens components. However, the CI workflow (`ci.yml`) does NOT run Vitest — meaning all a11y tests are unenforced in the automated pipeline.
+
+**Action:** Added a `Run tests (vitest + a11y gate)` step to `.github/workflows/ci.yml`, placed after lint/typecheck and before the build. This ensures a11y regressions fail CI before expensive build work is wasted.
+
+**Modified files:**
+- `.github/workflows/ci.yml` (added vitest step)
+
+#### C. Link Checker — MISSING → FIXED
+
+**Finding:** `scripts/ci/audit-internal-links.mjs` validates internal links during the build, but no external link validator exists. Dead external links represent a silent SEO and UX risk.
+
+**Action:** Created:
+- `scripts/check-links.mjs` — Node.js script sampling 20+ critical routes for HTTP 200 status
+- `.github/workflows/linkchecker.yml` — weekly cron + manual trigger, using `linkinator` to crawl the live site
+
+**Note:** Rate-limited social platforms (Twitter, Instagram, LinkedIn) are excluded from validation to avoid false positives from bot-blocking.
+
+#### D. ScholarlyArticle JSON-LD for Botanical Monographs — UPGRADED
+
+**Finding:** Herb profile pages (`/herbs/:slug`) use `HerbSchemaGenerator` → `buildHerbArticleSchema()` which emits `@type: 'Article'`. For botanical research pages, `ScholarlyArticle` is semantically more accurate and produces stronger AI-search discovery signals per Schema.org hierarchy.
+
+**Action:** Updated `src/lib/schema-injector.ts`:
+- Changed `@type` from `'Article'` to `['ScholarlyArticle', 'Article']`
+- Added optional `citations` array parameter (emits `citation` nodes with `@type: 'CreativeWork'`)
+- Backward compatible — ScholarlyArticle is a strict subtype of Article; Google Rich Results eligibility unchanged
+
+**Modified files:**
+- `src/lib/schema-injector.ts`
+
+#### E. Security Headers Strategy — DOCUMENTED (no code change needed)
+
+**Finding:** The task called for security headers in `next.config.js`. This project uses `output: 'export'` (static export to Cloudflare Pages). Under this mode, `headers()` in `next.config.mjs` is unsupported and would trigger a Next.js build error.
+
+**Decision:** The correct architecture is headers via `public/_headers` (Cloudflare Pages native format). This file is already comprehensive and validated in CI by `scripts/ci/validate-security-headers.mjs`.
+
+**Action:** Added an explanatory comment block to `next.config.mjs` documenting the header strategy and referencing `public/_headers` as the authoritative source.
+
+**No security regression** — all `security-headers.com` standards are met via `public/_headers`.
+
+### Metrics Baseline (pre-pipeline)
+
+| Metric | Baseline | Target |
+|--------|----------|--------|
+| Lighthouse Performance | Unknown (no CI data) | ≥ 80 |
+| Lighthouse Accessibility | Unknown (no CI data) | ≥ 90 |
+| Lighthouse SEO | Unknown (no CI data) | ≥ 90 |
+| CI a11y test enforcement | ❌ None | ✅ Every push |
+| External link validation | ❌ None | Weekly + manual |
+| Herb schema type | Article | ScholarlyArticle + Article |
+
+### Files Created/Modified
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `ARCHITECTURE_OVERVIEW.md` | Created | Repository architecture documentation |
+| `DEVELOPER_HEALTH_LOG.md` | Created | This log |
+| `.github/workflows/lighthouse.yml` | Created | Lighthouse CI on every push |
+| `.lighthouserc.json` | Created | Lighthouse score thresholds |
+| `.github/workflows/linkchecker.yml` | Created | Weekly external link health check |
+| `scripts/check-links.mjs` | Created | Critical-route HTTP health check script |
+| `.github/workflows/ci.yml` | Modified | Added Vitest a11y test enforcement step |
+| `src/lib/schema-injector.ts` | Modified | ScholarlyArticle upgrade for herb monographs |
+| `next.config.mjs` | Modified | Added security header strategy comment |
+
+---
+
+## Log Template
+
+```
+## YYYY-MM-DD — [Action Title]
+
+**Author:** [Person or system]
+**Scope:** [Area affected]
+
+### Finding
+[What was discovered]
+
+### Decision
+[What was chosen and why]
+
+### Action
+[What was done]
+
+### Outcome
+[Result / metrics change]
+```

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,13 @@
 import bundleAnalyzer from '@next/bundle-analyzer'
 import { withContentCollections } from '@content-collections/next'
 
+// Security headers are managed at the CDN/edge layer rather than here.
+// Rationale: this project uses `output: 'export'` (fully static), which means
+// Next.js's `headers()` config function is unsupported and ignored. All
+// production security headers (CSP, HSTS, X-Frame-Options, COOP, CORP, etc.)
+// are defined in `public/_headers` (Cloudflare Pages format) and validated in
+// CI by `scripts/ci/validate-security-headers.mjs`. See ARCHITECTURE_OVERVIEW.md §6.
+
 const withBundleAnalyzer = bundleAnalyzer({ enabled: process.env.ANALYZE === 'true' })
 
 /** @type {import('next').NextConfig} */

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * Critical-route HTTP health checker.
+ *
+ * Samples a representative set of production routes and verifies each
+ * returns a 2xx response. Intended as a fast smoke test before the
+ * heavier linkinator crawl in linkchecker.yml, or as a standalone
+ * manual check: node scripts/check-links.mjs [--url=https://example.com]
+ *
+ * Exit code 0 = all OK, 1 = one or more failures.
+ */
+
+import { parseArgs } from 'node:util'
+
+const { values: args } = parseArgs({
+  options: {
+    url: { type: 'string', default: process.env.SITE_URL ?? 'https://thehippiescientist.net' },
+    timeout: { type: 'string', default: '10000' },
+  },
+  strict: false,
+})
+
+const BASE_URL = args.url.replace(/\/$/, '')
+const TIMEOUT_MS = parseInt(args.timeout, 10)
+
+const CRITICAL_ROUTES = [
+  '/',
+  '/herbs/ashwagandha/',
+  '/herbs/lions-mane/',
+  '/herbs/valerian-root/',
+  '/compounds/l-theanine/',
+  '/compounds/ashwagandha-ksm-66/',
+  '/goals/sleep/',
+  '/goals/anxiety/',
+  '/goals/focus/',
+  '/stacks/sleep-stack/',
+  '/about/',
+  '/faq/',
+  '/methodology/',
+  '/safety-checker/',
+  '/evidence-digest/',
+  '/sitemap.xml',
+  '/robots.txt',
+  '/search/',
+  '/compare/',
+  '/articles/',
+]
+
+async function checkUrl(url) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS)
+  try {
+    const res = await fetch(url, {
+      method: 'HEAD',
+      signal: controller.signal,
+      redirect: 'follow',
+      headers: { 'User-Agent': 'HippieScientist-LinkChecker/1.0' },
+    })
+    clearTimeout(timer)
+    return { url, status: res.status, ok: res.status >= 200 && res.status < 400 }
+  } catch (err) {
+    clearTimeout(timer)
+    return { url, status: 0, ok: false, error: err.message }
+  }
+}
+
+async function main() {
+  console.log(`Checking ${CRITICAL_ROUTES.length} critical routes against ${BASE_URL}\n`)
+
+  const results = await Promise.all(
+    CRITICAL_ROUTES.map(route => checkUrl(`${BASE_URL}${route}`))
+  )
+
+  const passed = results.filter(r => r.ok)
+  const failed = results.filter(r => !r.ok)
+
+  for (const r of results) {
+    const icon = r.ok ? '✓' : '✗'
+    const detail = r.error ? ` (${r.error})` : ''
+    console.log(`${icon} ${r.status.toString().padStart(3)} ${r.url}${detail}`)
+  }
+
+  console.log(`\n${passed.length}/${results.length} routes OK`)
+
+  if (failed.length > 0) {
+    console.error(`\nFailed routes (${failed.length}):`)
+    for (const r of failed) {
+      console.error(`  ${r.status} ${r.url}${r.error ? ' — ' + r.error : ''}`)
+    }
+    process.exit(1)
+  }
+}
+
+main().catch(err => {
+  console.error('Unexpected error:', err)
+  process.exit(1)
+})

--- a/src/lib/schema-injector.ts
+++ b/src/lib/schema-injector.ts
@@ -58,6 +58,12 @@ export type HerbArticleSchemaArgs = {
    * the core Article fields.
    */
   evidenceGrade?: string
+  /**
+   * Optional list of cited sources emitted as schema:citation nodes.
+   * Each entry should be a descriptive title or full bibliographic reference.
+   * Strengthens AI-search discovery signals for scholarly herb research pages.
+   */
+  citations?: string[]
 }
 
 /**
@@ -80,7 +86,10 @@ export function buildHerbArticleSchema(args: HerbArticleSchemaArgs): JsonLdNode 
 
   const node: JsonLdNode = {
     '@context': 'https://schema.org',
-    '@type': 'Article',
+    // ScholarlyArticle is a Schema.org subtype of Article — keeps Article rich
+    // result eligibility while providing stronger AI-search discovery signals
+    // for botanical research pages.
+    '@type': ['ScholarlyArticle', 'Article'],
     headline: args.headline,
     description: args.description,
     url: args.url,
@@ -102,6 +111,13 @@ export function buildHerbArticleSchema(args: HerbArticleSchemaArgs): JsonLdNode 
       name: 'Evidence grade',
       value: args.evidenceGrade,
     }
+  }
+
+  if (args.citations && args.citations.length > 0) {
+    node.citation = args.citations.map(title => ({
+      '@type': 'CreativeWork',
+      name: title,
+    }))
   }
 
   return node


### PR DESCRIPTION
## Summary

- **Lighthouse CI** — new `.github/workflows/lighthouse.yml` runs on every push/PR: builds static export, serves `out/`, audits homepage + two key herb/compound routes. Hard-fails if Accessibility < 90; warns on Performance < 80 and SEO < 90. Results artifact retained 30 days.
- **Accessibility gate in CI** — `npm run test` (vitest + axe-core) added to `ci.yml` between typecheck and build. The 5 existing a11y test cases were never enforced in the pipeline; now they are.
- **Link checker** — `scripts/check-links.mjs` (fast HTTP smoke test, 20+ critical routes) + `.github/workflows/linkchecker.yml` (weekly cron + full `linkinator` crawl against live site, bot-blocking domains excluded).
- **ScholarlyArticle JSON-LD** — `src/lib/schema-injector.ts` upgraded from `@type: 'Article'` to `['ScholarlyArticle', 'Article']` on all herb botanical monograph pages. Adds optional `citations` array for structured bibliography nodes.
- **Security header strategy documented** — comment in `next.config.mjs` explaining why `headers()` is absent (static export constraint) and pointing to `public/_headers` as the authoritative CDN-layer source.
- **Repository docs** — `ARCHITECTURE_OVERVIEW.md` (full stack/routing/data/CI audit) and `DEVELOPER_HEALTH_LOG.md` (initialized audit log with baseline metrics).

## Test plan

- [ ] CI passes: lint → typecheck → vitest a11y → build → verify
- [ ] Lighthouse workflow runs and uploads artifact
- [ ] Link checker workflow runs manually via workflow_dispatch
- [ ] Herb profile pages (`/herbs/ashwagandha/`) emit `ScholarlyArticle` in JSON-LD (verify via browser devtools → view source)
- [ ] `ARCHITECTURE_OVERVIEW.md` and `DEVELOPER_HEALTH_LOG.md` present in repo root

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C22oRFZgKs9UXdEdmxE9zB

---
_Generated by [Claude Code](https://claude.ai/code/session_01C22oRFZgKs9UXdEdmxE9zB)_