### PR TITLE
Fix goal education-only monetization gating

### DIFF
--- a/app/goals/[goal]/GoalDecisionExperience.tsx
+++ b/app/goals/[goal]/GoalDecisionExperience.tsx
@@ -49,6 +49,7 @@ type GoalDecisionExperienceProps = {
   startHereLinks?: GoalStartHereLink[]
   goalContent?: GoalContentExtension | null
   captureGoal?: EmailCaptureGoal
+  isEducationOnly?: boolean
 }
 
 type SafetyCard = {
@@ -118,6 +119,7 @@ export default function GoalDecisionExperience({
   startHereLinks = [],
   goalContent = null,
   captureGoal = 'default',
+  isEducationOnly = false,
 }: GoalDecisionExperienceProps) {
   const freshness = getGoalFreshness(goal.slug)
   const config = evidence.config ?? {}
@@ -131,8 +133,8 @@ export default function GoalDecisionExperience({
   const heroHeadline = config.heroHeadline ?? `${goal.title.replace(/ decisions$/, '')}: What does the evidence actually support?`
   const heroDescription = goal.description
   const heroCta = config.heroCta ?? 'Start with the quick answer'
-  const safetyHeading = config.safetyHeading ?? 'Safety notes before buying'
-  const safetyBody = config.safetyBody ?? 'Use this as a screening layer before comparing products. Medication use, pregnancy, chronic conditions, and psychiatric history can change the risk calculation.'
+  const safetyHeading = config.safetyHeading ?? (isEducationOnly ? 'Safety notes before use' : 'Safety notes before buying')
+  const safetyBody = config.safetyBody ?? 'Use this as a screening layer before comparing options. Medication use, pregnancy, chronic conditions, and psychiatric history can change the risk calculation.'
 
   return (
     <div className="mx-auto max-w-6xl space-y-10 px-4 pb-28 pt-8 sm:px-6 sm:py-10 lg:px-8">
@@ -265,7 +267,7 @@ export default function GoalDecisionExperience({
         />
       ) : null}
 
-      <GoalTopAffiliatePicks goalSlug={goal.slug} limit={4} />
+      <GoalTopAffiliatePicks goalSlug={goal.slug} limit={4} suppressMonetization={isEducationOnly} />
 
       <SafetyChecklistPromo goal={captureGoal} variant="hero" />
 

--- a/app/goals/[goal]/page.tsx
+++ b/app/goals/[goal]/page.tsx
@@ -23,7 +23,7 @@ import Breadcrumbs from '@/components/ui/Breadcrumbs'
 import AuthorCredentials from '@/components/AuthorCredentials'
 import SeeAlsoInCluster from '@/components/SeeAlsoInCluster'
 import { getGoalCluster } from '@/lib/goal-clusters'
-import { isRestrictedRecord } from '../../../src/lib/restricted-ingredients'
+import { goalContainsRestrictedIngredient, isRestrictedRecord } from '../../../src/lib/restricted-ingredients'
 
 import GoalDecisionExperience from './GoalDecisionExperience'
 import GoalHubSections from '../../../src/components/goals/GoalHubSections'
@@ -175,11 +175,14 @@ const GOAL_PRODUCT_SETS: Record<string, string[]> = {
 }
 
 function getGoalProducts(goalSlug: string) {
+  return getGoalProductRecords(goalSlug)
+    .filter((p) => !isRestrictedRecord(p))
+}
+
+function getGoalProductRecords(goalSlug: string) {
   const keys = GOAL_PRODUCT_SETS[goalSlug] ?? []
   return keys
-    .filter((key) => !isRestrictedRecord({ slug: key }))
     .flatMap((key) => revenueProductSets[key]?.products ?? [])
-    .filter((p) => !isRestrictedRecord(p))
 }
 
 export const dynamicParams = false
@@ -344,7 +347,9 @@ export default async function GoalDecisionPage({
 
   const hubLinks = getGoalHubLinks(goal.slug)
   const startHereLinks = getGoalStartHereLinks(goal.slug)
-  const goalProducts = getGoalProducts(goal.slug)
+  const goalProductRecords = getGoalProductRecords(goal.slug)
+  const isEducationOnly = goalContainsRestrictedIngredient(goal, enrichedOptions, goalProductRecords)
+  const goalProducts = isEducationOnly ? [] : getGoalProducts(goal.slug)
 
   const goalEvidence = await getGoalEvidenceEngine(goal.slug)
   if (goalEvidence) {
@@ -359,6 +364,7 @@ export default async function GoalDecisionPage({
           startHereLinks={startHereLinks}
           goalContent={goalContent}
           captureGoal={goalCaptureGoal(goal.slug)}
+          isEducationOnly={isEducationOnly}
         />
       </>
     )
@@ -529,7 +535,7 @@ export default async function GoalDecisionPage({
               </div>
               {/* Sourcing CTA */}
               {(() => {
-                if (isRestrictedRecord({ slug: option.slug, name: option.name }) || (compound && isRestrictedRecord(compound))) {
+                if (isEducationOnly || isRestrictedRecord({ slug: option.slug, name: option.name }) || (compound && isRestrictedRecord(compound))) {
                   return null
                 }
                 const revenue = getRevenueProductSet(option.slug)
@@ -676,7 +682,7 @@ export default async function GoalDecisionPage({
         </div>
       </section>
 
-      <GoalTopAffiliatePicks goalSlug={goal.slug} limit={4} />
+      <GoalTopAffiliatePicks goalSlug={goal.slug} limit={4} suppressMonetization={isEducationOnly} />
 
       <GoalStartHereLinks links={startHereLinks} />
 
@@ -686,18 +692,20 @@ export default async function GoalDecisionPage({
         <SeeAlsoInCluster currentPath="/goals/focus" />
       ) : null}
 
-      <section className='rounded-2xl border border-emerald-800/15 bg-emerald-50/70 p-5 shadow-sm sm:p-6'>
-        <h2 className='text-xl font-semibold text-ink'>Ready to start?</h2>
-        <p className='mt-2 max-w-3xl text-sm leading-6 text-muted'>
-          Which supplement should you start with? Review the ranked options, then open the product-quality notes before buying.
-        </p>
-        <Link
-          href={goal.slug === 'focus' ? '/best-magnesium-supplements-for-adhd/' : `/goals/${goal.slug}/#comparison-table`}
-          className='mt-4 inline-flex min-h-11 items-center rounded-full bg-brand-950 px-5 py-2.5 text-sm font-bold text-white hover:bg-brand-900'
-        >
-          See ranked options
-        </Link>
-      </section>
+      {!isEducationOnly ? (
+        <section className='rounded-2xl border border-emerald-800/15 bg-emerald-50/70 p-5 shadow-sm sm:p-6'>
+          <h2 className='text-xl font-semibold text-ink'>Ready to start?</h2>
+          <p className='mt-2 max-w-3xl text-sm leading-6 text-muted'>
+            Which supplement should you start with? Review the ranked options, then open the product-quality notes before buying.
+          </p>
+          <Link
+            href={goal.slug === 'focus' ? '/best-magnesium-supplements-for-adhd/' : `/goals/${goal.slug}/#comparison-table`}
+            className='mt-4 inline-flex min-h-11 items-center rounded-full bg-brand-950 px-5 py-2.5 text-sm font-bold text-white hover:bg-brand-900'
+          >
+            See ranked options
+          </Link>
+        </section>
+      ) : null}
 
       <section className="card-premium p-6 sm:p-8">
         <h2 className="text-xl font-semibold text-ink">Related Goals</h2>
@@ -734,7 +742,7 @@ export default async function GoalDecisionPage({
 
       <AuthorCredentials />
 
-      {goalProducts.length > 0 && (
+      {!isEducationOnly && goalProducts.length > 0 && (
         <RecommendationSection
           title={`${goal.title} product picks`}
           products={goalProducts}

--- a/components/RecommendationSection.tsx
+++ b/components/RecommendationSection.tsx
@@ -12,6 +12,7 @@ type RecommendationSectionProps = {
   title?: string
   description?: string
   products: RecommendationProduct[]
+  suppressMonetization?: boolean
 }
 
 const slotLabels: Record<RecommendationSlot, string> = {
@@ -24,7 +25,9 @@ export default function RecommendationSection({
   title = 'Product recommendations',
   description = 'Use these as sourcing starting points, not medical recommendations. Product quality, dose, and fit still need review.',
   products,
+  suppressMonetization = false,
 }: RecommendationSectionProps) {
+  if (suppressMonetization) return null
   if (products.length === 0) return null
 
   const ordered = ['budget', 'overall', 'premium'].flatMap((slot) =>

--- a/components/monetization/GoalTopAffiliatePicks.tsx
+++ b/components/monetization/GoalTopAffiliatePicks.tsx
@@ -12,9 +12,16 @@ const SLOT_LABELS: Record<string, string> = {
 type GoalTopAffiliatePicksProps = {
   goalSlug: string
   limit?: number
+  suppressMonetization?: boolean
 }
 
-export default function GoalTopAffiliatePicks({ goalSlug, limit = 4 }: GoalTopAffiliatePicksProps) {
+export default function GoalTopAffiliatePicks({
+  goalSlug,
+  limit = 4,
+  suppressMonetization = false,
+}: GoalTopAffiliatePicksProps) {
+  if (suppressMonetization) return null
+
   const goal = getGoal(goalSlug)
   if (!goal) return null
 

--- a/components/monetization/ProductTrustAffiliate.tsx
+++ b/components/monetization/ProductTrustAffiliate.tsx
@@ -7,6 +7,7 @@ type ProductTrustAffiliateProps = {
   rationale: string
   slotLabel?: string
   compact?: boolean
+  suppressMonetization?: boolean
 }
 
 export default function ProductTrustAffiliate({
@@ -16,7 +17,10 @@ export default function ProductTrustAffiliate({
   rationale,
   slotLabel,
   compact = false,
+  suppressMonetization = false,
 }: ProductTrustAffiliateProps) {
+  if (suppressMonetization) return null
+
   const displayTitle = brand ? `${brand} — ${productName}` : productName
 
   if (compact) {

--- a/components/monetization/__tests__/goal-education-only.test.tsx
+++ b/components/monetization/__tests__/goal-education-only.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react'
+import type { AnchorHTMLAttributes, ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { getGoal } from '@/data/goals'
+import type { EvidenceEnginePayload } from '@/src/lib/evidence-engine'
+import GoalDecisionExperience from '@/app/goals/[goal]/GoalDecisionExperience'
+import GoalTopAffiliatePicks from '../GoalTopAffiliatePicks'
+import ProductTrustAffiliate from '../ProductTrustAffiliate'
+import RecommendationSection from '@/components/RecommendationSection'
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: AnchorHTMLAttributes<HTMLAnchorElement> & { children: ReactNode; href: string }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+const evidence: EvidenceEnginePayload = {
+  goal: 'anxiety',
+  updatedAt: '2026-06-24',
+  problemLabels: {},
+  claims: [],
+  safetyNotes: [],
+  sourcesByClaim: {},
+}
+
+function enrichedOptionsForGoal(slug: string) {
+  const goal = getGoal(slug)
+  if (!goal) throw new Error(`Missing goal fixture: ${slug}`)
+
+  return goal.options.map((option) => ({
+    option,
+    profileHref: `/compounds/${option.slug}`,
+    evidenceLabel: option.evidence,
+    safetyLabel: option.risk,
+  }))
+}
+
+describe('goal education-only monetization boundary', () => {
+  it('suppresses goal-page affiliate and recommendation UI for anxiety', () => {
+    const anxiety = getGoal('anxiety')
+    if (!anxiety) throw new Error('Missing anxiety goal')
+
+    render(
+      <GoalDecisionExperience
+        goal={anxiety}
+        enrichedOptions={enrichedOptionsForGoal('anxiety')}
+        evidence={evidence}
+        isEducationOnly
+      />
+    )
+
+    expect(screen.queryByText(/Sourcing picks for this goal/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Why we recommend it/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Affiliate-ready sourcing/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /Amazon/i })).not.toBeInTheDocument()
+    expect(screen.queryByText(/before buying/i)).not.toBeInTheDocument()
+  })
+
+  it('suppresses individual monetization components when parent gating is enabled', () => {
+    const products = [
+      {
+        slot: 'overall' as const,
+        title: 'Example product',
+        brand: 'Example',
+        rationale: 'Example rationale',
+        affiliateUrl: 'https://www.amazon.com/dp/example?tag=test',
+      },
+    ]
+
+    const { rerender } = render(<GoalTopAffiliatePicks goalSlug="sleep" suppressMonetization />)
+    expect(screen.queryByText(/Sourcing picks for this goal/i)).not.toBeInTheDocument()
+
+    rerender(
+      <ProductTrustAffiliate
+        productName="Example product"
+        href="https://www.amazon.com/dp/example?tag=test"
+        rationale="Example rationale"
+        suppressMonetization
+      />
+    )
+    expect(screen.queryByRole('link', { name: /Amazon/i })).not.toBeInTheDocument()
+
+    rerender(<RecommendationSection products={products} suppressMonetization />)
+    expect(screen.queryByText(/Affiliate-ready sourcing/i)).not.toBeInTheDocument()
+  })
+
+  it('keeps sleep, stress, and focus monetization visible when not education-only', () => {
+    for (const slug of ['sleep', 'stress', 'focus']) {
+      const { unmount } = render(<GoalTopAffiliatePicks goalSlug={slug} />)
+
+      expect(screen.getByText(/Sourcing picks for this goal/i)).toBeInTheDocument()
+      expect(screen.getAllByRole('link', { name: /Amazon/i }).length).toBeGreaterThan(0)
+
+      unmount()
+    }
+  })
+})

--- a/src/components/herb-profile/__tests__/SchemaGenerator.test.tsx
+++ b/src/components/herb-profile/__tests__/SchemaGenerator.test.tsx
@@ -17,7 +17,10 @@ function getScripts(c: HTMLElement): { product?: Record<string, unknown>; articl
   const scripts = c.querySelectorAll('script[type="application/ld+json"]')
   const parsed = Array.from(scripts).map(s => JSON.parse(s.textContent ?? '{}'))
   const product = parsed.find(p => p['@type'] === 'Product')
-  const article = parsed.find(p => p['@type'] === 'Article')!
+  const article = parsed.find(p => {
+    const type = p['@type']
+    return type === 'Article' || (Array.isArray(type) && type.includes('Article'))
+  })!
   return { product, article }
 }
 
@@ -27,7 +30,7 @@ describe('HerbSchemaGenerator', () => {
     const scripts = c.querySelectorAll('script[type="application/ld+json"]')
     expect(scripts.length).toBe(1)
     const { article, product } = getScripts(c)
-    expect(article['@type']).toBe('Article')
+    expect(article['@type']).toEqual(expect.arrayContaining(['ScholarlyArticle', 'Article']))
     expect(product).toBeUndefined()
   })
 
@@ -43,7 +46,7 @@ describe('HerbSchemaGenerator', () => {
     const { container: c } = render(<HerbSchemaGenerator {...BASE_PROPS} />)
     const { article } = getScripts(c)
     expect(article['@context']).toBe('https://schema.org')
-    expect(article['@type']).toBe('Article')
+    expect(article['@type']).toEqual(expect.arrayContaining(['ScholarlyArticle', 'Article']))
   })
 
   it('Article headline includes the herb name (Google Rich Results required)', () => {

--- a/src/lib/__tests__/affiliate-governance.test.ts
+++ b/src/lib/__tests__/affiliate-governance.test.ts
@@ -5,7 +5,8 @@ import {
   getAffiliateShopLinks,
   getGovernedCompoundSearchLinks,
 } from '../affiliate'
-import { isRestrictedRecord } from '../restricted-ingredients'
+import { getGoal } from '@/data/goals'
+import { goalContainsRestrictedIngredient, isRestrictedRecord } from '../restricted-ingredients'
 
 const baseAffiliateRecord = {
   slug: 'l-theanine',
@@ -78,5 +79,23 @@ describe('affiliate governance gates', () => {
       expect(getAffiliateShopLinks(rec, rec.displayName, 'compound')).toEqual([])
       expect(getGovernedCompoundSearchLinks(rec, rec.displayName)).toEqual([])
     })
+  })
+
+  it('blocks kava and kavalactone markers for monetization governance', () => {
+    expect(isRestrictedRecord({ slug: 'kava' })).toBe(true)
+    expect(isRestrictedRecord({ name: 'Piper methysticum' })).toBe(true)
+    expect(isRestrictedRecord({ slug: 'kavain' })).toBe(true)
+  })
+
+  it('detects the anxiety goal as education-only because it contains kava', () => {
+    const anxiety = getGoal('anxiety')
+
+    expect(goalContainsRestrictedIngredient(anxiety)).toBe(true)
+  })
+
+  it('keeps sleep, stress, and focus outside education-only mode when their ingredients are unrestricted', () => {
+    for (const slug of ['sleep', 'stress', 'focus']) {
+      expect(goalContainsRestrictedIngredient(getGoal(slug))).toBe(false)
+    }
   })
 })

--- a/src/lib/__tests__/revenue-products.test.ts
+++ b/src/lib/__tests__/revenue-products.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { getRevenueProductSet, revenueProductSets } from '@/config/revenue-products'
+import { isRestrictedRecord } from '../restricted-ingredients'
 
 describe('revenue product recommendations', () => {
   it('provides three real recommendation slots for priority ingredients', () => {
@@ -26,9 +27,15 @@ describe('revenue product recommendations', () => {
     const allProducts = Object.values(revenueProductSets).flatMap(set => set.products)
 
     expect(allProducts.length).toBe(276)
-    for (const product of allProducts) {
+    for (const product of allProducts.filter(product => !isRestrictedRecord(product))) {
       expect(product.affiliateUrl).toContain('tag=')
       expect(product.affiliateUrl).toMatch(/^https:\/\/www\.amazon\.com\//)
     }
+  })
+
+  it('does not return restricted kava product sets for monetization', () => {
+    expect(getRevenueProductSet('kava')).toBeNull()
+    expect(getRevenueProductSet('piper-methysticum')).toBeNull()
+    expect(getRevenueProductSet('kavalactones')).toBeNull()
   })
 })

--- a/src/lib/__tests__/schema-injector.test.ts
+++ b/src/lib/__tests__/schema-injector.test.ts
@@ -59,7 +59,7 @@ describe('buildHerbArticleSchema', () => {
   it('emits required @context and @type', () => {
     const schema = buildHerbArticleSchema(base)
     expect(schema['@context']).toBe('https://schema.org')
-    expect(schema['@type']).toBe('Article')
+    expect(schema['@type']).toEqual(expect.arrayContaining(['ScholarlyArticle', 'Article']))
   })
 
   it('includes headline (required for Article rich results)', () => {

--- a/src/lib/restricted-ingredients.ts
+++ b/src/lib/restricted-ingredients.ts
@@ -19,6 +19,10 @@ const RESTRICTED_TERMS = [
   'harmine',
   'ibogaine',
   'ketamine',
+  'kava',
+  'kavain',
+  'kavalactone',
+  'kavalactones',
   'kratom',
   'lobeline',
   'lsa',
@@ -29,11 +33,18 @@ const RESTRICTED_TERMS = [
   'nicotiana tabacum',
   'noopept',
   'psilocybin',
+  'piper methysticum',
+  'piper-methysticum',
   'salvinorin',
   'sinicuichi',
   'tetrahydroharmine',
   'thc',
   'thcv',
+  'dihydrokavain',
+  'methysticin',
+  'dihydromethysticin',
+  'yangonin',
+  'desmethoxyyangonin',
 ]
 
 const RESTRICTED_STATUS_PATTERNS = [
@@ -98,8 +109,11 @@ export function isRestrictedRecord(record: any) {
 
   return [
     record.slug,
+    record.title,
     record.name,
     record.displayName,
+    record.productName,
+    record.product_name,
     record.compoundName,
     record.canonicalCompoundName,
     record.scientific_name,
@@ -117,4 +131,68 @@ export function isRestrictedRecord(record: any) {
     record.active_constituents,
     record.compound_profile,
   ].some(isRestrictedIngredient)
+}
+
+type GoalRestrictedCheckInput = {
+  slug?: unknown
+  title?: unknown
+  description?: unknown
+  quickPicks?: Array<{
+    slug?: unknown
+    option?: unknown
+    name?: unknown
+  }>
+  options?: Array<{
+    slug?: unknown
+    name?: unknown
+  }>
+}
+
+type EnrichedRestrictedCheckInput = {
+  slug?: unknown
+  name?: unknown
+  displayName?: unknown
+  option?: {
+    slug?: unknown
+    name?: unknown
+  }
+  compound?: unknown
+  herb?: unknown
+  record?: unknown
+}
+
+export function goalContainsRestrictedIngredient(
+  goal: GoalRestrictedCheckInput | null | undefined,
+  enrichedOptions: EnrichedRestrictedCheckInput[] = [],
+  products: unknown[] = []
+) {
+  if (!goal) return false
+
+  const goalRecords = [
+    { slug: goal.slug, name: goal.title, description: goal.description },
+    ...(goal.quickPicks ?? []).map((pick) => ({
+      slug: pick.slug,
+      name: pick.option ?? pick.name,
+    })),
+    ...(goal.options ?? []).map((option) => ({
+      slug: option.slug,
+      name: option.name,
+    })),
+  ]
+
+  if (goalRecords.some(isRestrictedRecord)) return true
+
+  const enrichedRecords = enrichedOptions.flatMap((enriched) => [
+    {
+      slug: enriched.option?.slug ?? enriched.slug,
+      name: enriched.option?.name ?? enriched.name ?? enriched.displayName,
+    },
+    enriched.compound,
+    enriched.herb,
+    enriched.record,
+  ])
+
+  if (enrichedRecords.some(isRestrictedRecord)) return true
+
+  return products.some(isRestrictedRecord)
 }


### PR DESCRIPTION
## Summary
- Treat kava and related kavalactone terms as restricted for monetization.
- Add page-level goal education-only detection and thread it through goal monetization surfaces.
- Suppress affiliate/recommendation UI for restricted goal pages while keeping educational content visible.
- Update tests for the current Article JSON-LD type shape from main.

## Validation
- npm run typecheck
- npm test
