### PR TITLE
fix: resolve 3 Vitest blockers (SEO noindex, workbook streaming names, Quercetin search link)

### DIFF
--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -35,7 +35,7 @@ export default function SearchPage() {
     { name: 'Caffeine', href: '/compounds/caffeine' },
     { name: 'Alpha-GPC', href: '/compounds/alpha-gpc' },
     { name: 'Omega-3', href: '/compounds/omega-3' },
-    { name: 'Quercetin', href: '/compounds/quercetin' },
+    { name: 'Quercetin', href: '/search?q=quercetin' },
     { name: 'Panax Ginseng', href: '/herbs/panax-ginseng' },
   ]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1889,6 +1889,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2775,6 +2776,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2797,6 +2799,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2819,6 +2822,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2835,6 +2839,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2851,6 +2856,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2867,6 +2873,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2883,6 +2890,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2899,6 +2907,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2915,6 +2924,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2931,6 +2941,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2947,6 +2958,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2963,6 +2975,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2979,6 +2992,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3001,6 +3015,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3023,6 +3038,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3045,6 +3061,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3067,6 +3084,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3089,6 +3107,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3111,6 +3130,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3133,6 +3153,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3155,6 +3176,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -3174,6 +3196,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3193,6 +3216,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3212,6 +3236,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [

--- a/scripts/tests/workbook-reader-parity.test.mjs
+++ b/scripts/tests/workbook-reader-parity.test.mjs
@@ -124,12 +124,12 @@ if (process.env.VITEST) {
     assertWorkbookExists(workbookPath)
 
     const workbook = await readWorkbook(workbookPath, {
-      sheets: ['Herb Master V3'],
+      sheets: ['Entity_Master'],
     })
 
-    expect(getSheetNames(workbook)).toContain('Compound Master V3')
-    expect(sheetToRows(getSheet(workbook, 'Herb Master V3')).length).toBeGreaterThan(0)
-    expect(getSheet(workbook, 'Compound Master V3')).toBeNull()
+    expect(getSheetNames(workbook)).toContain('Source_Register')
+    expect(sheetToRows(getSheet(workbook, 'Entity_Master')).length).toBeGreaterThan(0)
+    expect(getSheet(workbook, 'Source_Register')).toBeNull()
   }, 30000)
 }
 

--- a/scripts/utils/read-workbook-exceljs.mjs
+++ b/scripts/utils/read-workbook-exceljs.mjs
@@ -83,23 +83,54 @@ async function readWorkbookStreaming(filePath, originalError) {
     styles: 'ignore',
     worksheets: 'emit',
   })
-  const sheetNames = []
-  const sheets = new Map()
+  // Collect entries during streaming; real names are resolved after the loop
+  // because workbookReader.model is only fully populated once all entries are read.
+  const sheetEntries = []
 
   try {
     for await (const worksheetReader of workbookReader) {
       const rawRows = []
-      sheetNames.push(worksheetReader.name)
 
       for await (const row of worksheetReader) {
         rawRows[row.number - 1] = rowToRawValues(row)
       }
 
-      sheets.set(worksheetReader.name, rawRowsToRecords(rawRows.filter(Boolean)))
+      sheetEntries.push({
+        id: worksheetReader.id,
+        name: worksheetReader.name,
+        rows: rawRowsToRecords(rawRows.filter(Boolean)),
+      })
     }
   } catch (streamingError) {
     streamingError.cause = originalError
     throw streamingError
+  }
+
+  // ExcelJS streaming fails to set worksheetReader.name when workbook.xml.rels
+  // uses absolute-style targets ("/xl/worksheets/sheetN.xml") instead of the
+  // relative form ("worksheets/sheetN.xml") the matching logic expects.
+  // After streaming completes, workbookReader.model.sheets and
+  // workbookReader.workbookRels are both populated; use them to build a
+  // sheetNo→realName map keyed by the number extracted from the filename.
+  const sheetNoToName = new Map()
+  const model = workbookReader.model
+  const rels = workbookReader.workbookRels
+  if (model && Array.isArray(model.sheets) && Array.isArray(rels)) {
+    for (const rel of rels) {
+      const match = String(rel.Target || '').match(/\/sheet(\d+)\.xml$/i)
+      if (!match) continue
+      const sheetNo = match[1]
+      const sheet = model.sheets.find((s) => s.rId === rel.Id)
+      if (sheet && sheet.name) sheetNoToName.set(sheetNo, sheet.name)
+    }
+  }
+
+  const sheetNames = []
+  const sheets = new Map()
+  for (const { id, name, rows } of sheetEntries) {
+    const realName = sheetNoToName.get(String(id)) || name
+    sheetNames.push(realName)
+    sheets.set(realName, rows)
   }
 
   return {

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -310,7 +310,7 @@ export function shouldIndexRoute(path: string, pageData?: Record<string, unknown
   const normalizedPath = normalizeIndexRoutePath(path)
   const noindexSignal = hasNoindexSignal(pageData)
   const hardNoindexSignal =
-    noindexSignal && /^(sitemap_included|robots|indexability_status|runtime_export_decision)=/.test(noindexSignal)
+    noindexSignal && /^(sitemap_included|robots|indexability_status|runtime_export_decision|profile_status)=/.test(noindexSignal)
       ? noindexSignal
       : null
 


### PR DESCRIPTION
## Summary

- **SEO noindex**: `profile_status=draft/archived/minimal/research_only` is now a hard noindex signal that curated slug allowlists cannot bypass; `summary_quality=weak` alone still defers to the curated list
- **Workbook streaming names**: fixed ExcelJS streaming fallback — after iteration, build `sheetNo→realName` from `workbookReader.model.sheets` + `workbookRels` to correct the absolute-path rels bug (`/xl/worksheets/sheetN.xml`) that caused generic `Sheet1/Sheet2` names; updated parity test fixtures to match actual workbook sheets
- **Quercetin link**: changed chip href from `/compounds/quercetin` (no detail file) to `/search?q=quercetin`, satisfying the route-integrity test

## Test plan

- [x] `npm run test` — 295 passed, 0 failed
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7oV129L38ReVh2JDyTu7u

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7oV129L38ReVh2JDyTu7u)_