### PR TITLE
Stabilize compare page SEO schema

### DIFF
--- a/components/compare/ComparePageScaffold.tsx
+++ b/components/compare/ComparePageScaffold.tsx
@@ -60,10 +60,12 @@ export default function ComparePageScaffold({
   relatedDiscoveryGroups,
   children,
 }: ComparePageScaffoldProps) {
+  const schemaFaqs = isHarmReduction ? [] : faqs
+
   return (
     <div className="mx-auto max-w-5xl px-4 py-8 space-y-12">
       <SchemaGraphScript graph={schemaGraph} />
-      <CompareSchema item1={item1} item2={item2} slug={slug} faqs={faqs} />
+      <CompareSchema item1={item1} item2={item2} slug={slug} faqs={schemaFaqs} />
 
       <AuthorityBreadcrumbs
         items={[

--- a/components/compare/CompareSchema.tsx
+++ b/components/compare/CompareSchema.tsx
@@ -17,9 +17,9 @@ interface CompareSchemaProps {
 }
 
 export default function CompareSchema({ item1, item2, slug, faqs, dateModified }: CompareSchemaProps) {
-  const pageUrl = `${SITE_URL}/compare/${slug}`
+  const pageUrl = `${SITE_URL}/compare/${slug}/`
   const headline = `${item1.name} vs ${item2.name}: Complete Comparison`
-  const modified = dateModified || new Date().toISOString().slice(0, 10)
+  const description = `Compare ${item1.name} and ${item2.name} by evidence, mechanisms, dosing, safety, and best-fit use cases.`
 
   const schema = {
     '@context': 'https://schema.org',
@@ -27,6 +27,7 @@ export default function CompareSchema({ item1, item2, slug, faqs, dateModified }
       {
         '@type': 'Article',
         headline,
+        description,
         author: {
           '@type': 'Organization',
           name: 'The Hippie Scientist',
@@ -37,18 +38,30 @@ export default function CompareSchema({ item1, item2, slug, faqs, dateModified }
           name: 'The Hippie Scientist',
           url: SITE_URL,
         },
-        dateModified: modified,
+        ...(dateModified ? { dateModified } : {}),
         url: pageUrl,
         mainEntityOfPage: {
           '@type': 'WebPage',
           '@id': pageUrl,
         },
+        about: [
+          {
+            '@type': item1.type === 'herb' ? 'MedicalTherapy' : 'ChemicalSubstance',
+            name: item1.name,
+            url: `${SITE_URL}/${item1.type === 'herb' ? 'herbs' : 'compounds'}/${item1.slug}/`,
+          },
+          {
+            '@type': item2.type === 'herb' ? 'MedicalTherapy' : 'ChemicalSubstance',
+            name: item2.name,
+            url: `${SITE_URL}/${item2.type === 'herb' ? 'herbs' : 'compounds'}/${item2.slug}/`,
+          },
+        ],
       },
       {
         '@type': 'BreadcrumbList',
         itemListElement: [
-          { '@type': 'ListItem', position: 1, name: 'Home', item: SITE_URL },
-          { '@type': 'ListItem', position: 2, name: 'Compare', item: `${SITE_URL}/compare` },
+          { '@type': 'ListItem', position: 1, name: 'Home', item: `${SITE_URL}/` },
+          { '@type': 'ListItem', position: 2, name: 'Compare', item: `${SITE_URL}/compare/` },
           { '@type': 'ListItem', position: 3, name: `${item1.name} vs ${item2.name}`, item: pageUrl },
         ],
       },


### PR DESCRIPTION
## What changed

- Normalizes compare-page structured-data URLs to the canonical trailing-slash format.
- Removes the build-date `dateModified` fallback from compare schema so pages do not falsely claim freshness on every deploy.
- Adds a concise schema description and `about` entities for both compared ingredients.
- Keeps visible compare FAQs, but suppresses FAQ JSON-LD on harm-reduction comparisons.

## Why this is high ROI

Compare pages are scalable SEO entry pages. This patch improves structured-data trust signals across the compare template without creating new content, new routes, or a broad redesign.

## Validation

- Compared branch against `main`: 2 files changed, 21 net additions.
- No local build was run from this chat environment.