### PR TITLE
Add priority goal links to footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -20,6 +20,13 @@ const exploreLinks = [
   { href: '/goals', label: 'Goals' },
 ]
 
+const priorityGoalLinks = [
+  { href: '/goals/sleep', label: 'Sleep' },
+  { href: '/goals/stress', label: 'Stress' },
+  { href: '/goals/anxiety', label: 'Anxiety' },
+  { href: '/goals/focus', label: 'Focus' },
+]
+
 const safetyLinks = [
   { href: '/methodology', label: 'Methodology' },
   { href: PUBLIC_ROUTES.disclaimer, label: 'Disclaimer' },
@@ -90,6 +97,23 @@ export default function Footer() {
                 <h3 className='section-label mb-3'>Explore</h3>
                 <ul className='space-y-2'>
                   {exploreLinks.map(link => (
+                    <li key={link.href}>
+                      <Link className='text-sm text-white/70 transition-colors hover:text-white' to={link.href} prefetch={true}>
+                        {link.label}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </NonEmpty>
+
+          <NonEmpty>
+            {priorityGoalLinks.length > 0 && (
+              <div>
+                <h3 className='section-label mb-3'>Popular Goals</h3>
+                <ul className='space-y-2'>
+                  {priorityGoalLinks.map(link => (
                     <li key={link.href}>
                       <Link className='text-sm text-white/70 transition-colors hover:text-white' to={link.href} prefetch={true}>
                         {link.label}


### PR DESCRIPTION
## What changed

- Adds a `Popular Goals` footer column.
- Links directly to the four core site priorities:
  - `/goals/sleep`
  - `/goals/stress`
  - `/goals/anxiety`
  - `/goals/focus`

## Why this is high ROI

These are the site’s core topic pillars and likely long-term traffic/revenue pages. Adding sitewide footer links gives them consistent internal-link support from every page without creating new content or changing the page hierarchy.

## Impact score

**710/1000** — major internal-linking improvement because it strengthens four priority goal hubs sitewide.

## Validation

- Compared branch against `main`: 1 file changed, 24 additions / 0 deletions.
- No local build was run from this chat environment.