### PR TITLE
Normalize search discovery links

### DIFF
--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -24,28 +24,29 @@ export const metadata: Metadata = {
 
 export default function SearchPage() {
   const popularSearches = [
-    { name: 'Ashwagandha', href: '/herbs/ashwagandha' },
-    { name: 'Magnesium Glycinate', href: '/compounds/magnesium-glycinate' },
-    { name: 'Creatine', href: '/compounds/creatine' },
-    { name: 'Melatonin', href: '/compounds/melatonin' },
-    { name: 'L-Theanine', href: '/compounds/l-theanine' },
-    { name: 'Bacopa', href: '/herbs/bacopa' },
-    { name: 'Berberine', href: '/compounds/berberine' },
-    { name: 'Black Seed Oil', href: '/compounds/black-seed-oil' },
-    { name: 'Caffeine', href: '/compounds/caffeine' },
-    { name: 'Alpha-GPC', href: '/compounds/alpha-gpc' },
-    { name: 'Omega-3', href: '/compounds/omega-3' },
-    { name: 'Quercetin', href: '/search?q=quercetin' },
-    { name: 'Panax Ginseng', href: '/herbs/panax-ginseng' },
+    { name: 'Ashwagandha', href: '/herbs/ashwagandha/' },
+    { name: 'Magnesium Glycinate', href: '/compounds/magnesium-glycinate/' },
+    { name: 'Creatine', href: '/compounds/creatine/' },
+    { name: 'Melatonin', href: '/compounds/melatonin/' },
+    { name: 'L-Theanine', href: '/compounds/l-theanine/' },
+    { name: 'Bacopa', href: '/herbs/bacopa/' },
+    { name: 'Berberine', href: '/compounds/berberine/' },
+    { name: 'Black Seed Oil', href: '/compounds/black-seed-oil/' },
+    { name: 'Caffeine', href: '/compounds/caffeine/' },
+    { name: 'Alpha-GPC', href: '/compounds/alpha-gpc/' },
+    { name: 'Omega-3', href: '/compounds/omega-3/' },
+    { name: 'Quercetin Phytosome', href: '/compounds/quercetin-phytosome/' },
+    { name: 'Panax Ginseng', href: '/herbs/panax-ginseng/' },
   ]
 
   const popularGoals = [
-    { name: 'Sleep Support', href: '/goals/sleep' },
-    { name: 'Stress Resilience', href: '/goals/stress' },
-    { name: 'Focus & Cognition', href: '/goals/focus' },
-    { name: 'Fat Loss', href: '/goals/fat-loss' },
-    { name: 'Gut Health', href: '/goals/gut-health' },
-    { name: 'Joint Support', href: '/goals/joint-support' },
+    { name: 'Sleep Support', href: '/goals/sleep/' },
+    { name: 'Stress Resilience', href: '/goals/stress/' },
+    { name: 'Anxiety Support', href: '/goals/anxiety/' },
+    { name: 'Focus & Cognition', href: '/goals/focus/' },
+    { name: 'Fat Loss', href: '/goals/fat-loss/' },
+    { name: 'Gut Health', href: '/goals/gut-health/' },
+    { name: 'Joint Support', href: '/goals/joint-support/' },
   ]
 
   return (
@@ -101,12 +102,12 @@ export default function SearchPage() {
             <h2 className="text-xs font-bold uppercase tracking-wider text-muted font-semibold">Browse by Category</h2>
             <ul className="space-y-1">
               <li>
-                <Link href="/herbs" className="text-sm font-semibold text-brand-800 hover:underline">
+                <Link href="/herbs/" className="text-sm font-semibold text-brand-800 hover:underline">
                   Herb & Botanical Library ({HERB_COUNT} Profiles)
                 </Link>
               </li>
               <li>
-                <Link href="/compounds" className="text-sm font-semibold text-brand-800 hover:underline">
+                <Link href="/compounds/" className="text-sm font-semibold text-brand-800 hover:underline">
                   Compound & Nootropic Library ({COMPOUND_COUNT} Profiles)
                 </Link>
               </li>


### PR DESCRIPTION
## What changed

- Normalizes crawlable `/search/` page discovery links to trailing-slash canonical URLs.
- Adds the missing `/goals/anxiety/` core pillar link to the static goal list.
- Replaces the crawlable `/search?q=quercetin` self-query link with a canonical compound profile link for `/compounds/quercetin-phytosome/`.

## Why this is high ROI

The indexed search page is a crawlable discovery page. This improves internal-link consistency, reduces query-URL crawl noise, and gives all four core goal pillars visible static links.

## Impact score

**585/1000** — strong crawl-hygiene and internal-linking upgrade on an indexed discovery page.

## Validation

- Compared branch against `main`: 1 file changed, 22 additions / 21 deletions.
- No local build was run from this chat environment.