### PR TITLE
Normalize public route helpers

### DIFF
--- a/src/lib/public-routes.ts
+++ b/src/lib/public-routes.ts
@@ -1,26 +1,26 @@
 export const PUBLIC_ROUTES = {
   home: '/',
-  herbs: '/herbs',
-  compounds: '/compounds',
-  goals: '/goals',
-  build: '/build',
-  blog: '/articles',
-  researchNotes: '/articles',
-  articles: '/articles',
-  guides: '/guides',
-  learning: '/learn',
-  about: '/about',
-  contact: '/contact',
-  privacy: '/privacy',
-  disclaimer: '/disclaimer',
+  herbs: '/herbs/',
+  compounds: '/compounds/',
+  goals: '/goals/',
+  build: '/build/',
+  blog: '/articles/',
+  researchNotes: '/articles/',
+  articles: '/articles/',
+  guides: '/guides/',
+  learning: '/learn/',
+  about: '/about/',
+  contact: '/contact/',
+  privacy: '/privacy/',
+  disclaimer: '/disclaimer/',
 } as const
 
 export type PublicRouteKey = keyof typeof PUBLIC_ROUTES
 
 export function herbDetailRoute(slug: string): string {
-  return `${PUBLIC_ROUTES.herbs}/${slug}`
+  return `${PUBLIC_ROUTES.herbs}${slug}/`
 }
 
 export function compoundDetailRoute(slug: string): string {
-  return `${PUBLIC_ROUTES.compounds}/${slug}`
+  return `${PUBLIC_ROUTES.compounds}${slug}/`
 }


### PR DESCRIPTION
## What changed

- Normalizes shared `PUBLIC_ROUTES` values to trailing-slash canonical URLs.
- Updates `herbDetailRoute()` and `compoundDetailRoute()` to return canonical trailing-slash profile URLs.

## Why this is high ROI

This is a central route helper used for public navigation and profile links. Normalizing it reduces mixed internal-link signals like `/herbs` vs `/herbs/` and helps future links default to canonical URLs.

## Impact score

**515/1000** — useful crawl-hygiene upgrade because it improves a shared route source of truth, but it is narrower than template/schema work.

## Validation

- Compared branch against `main`: 1 file changed, 15 additions / 15 deletions.
- No local build was run from this chat environment.