### PR TITLE
Add FAQ JSON-LD quality gate

### DIFF
--- a/components/seo/FaqJsonLd.tsx
+++ b/components/seo/FaqJsonLd.tsx
@@ -7,15 +7,46 @@ type FaqJsonLdProps = {
   items: FaqItem[]
 }
 
+function normalizeFaqItem(item: FaqItem): FaqItem | null {
+  const question = String(item.question || '').trim()
+  const answer = String(item.answer || '').trim()
+
+  if (question.length < 12 || answer.length <= 50) {
+    return null
+  }
+
+  return { question, answer }
+}
+
+function getMeaningfulFaqItems(items: FaqItem[]): FaqItem[] {
+  const seenQuestions = new Set<string>()
+  const meaningfulItems: FaqItem[] = []
+
+  for (const item of items) {
+    const normalized = normalizeFaqItem(item)
+    if (!normalized) continue
+
+    const questionKey = normalized.question.toLowerCase()
+    if (seenQuestions.has(questionKey)) continue
+
+    seenQuestions.add(questionKey)
+    meaningfulItems.push(normalized)
+  }
+
+  return meaningfulItems
+}
+
 export default function FaqJsonLd({ items }: FaqJsonLdProps) {
-  if (!items?.length) {
+  const meaningfulItems = getMeaningfulFaqItems(items ?? [])
+
+  if (meaningfulItems.length === 0) {
     return null
   }
 
   const schema = {
     '@context': 'https://schema.org',
     '@type': 'FAQPage',
-    mainEntity: items.map((item) => ({
+    mainEntity: meaningfulItems.map((item) => ({
       '@type': 'Question',
       name: item.question,
       acceptedAnswer: {


### PR DESCRIPTION
## What changed

- Adds a quality gate to the reusable `FaqJsonLd` component.
- Trims FAQ question/answer text before emitting schema.
- Drops short or weak FAQ entries from JSON-LD output.
- Deduplicates repeated questions before generating `FAQPage` structured data.
- Keeps visible page FAQ content unchanged.

## Why this is high ROI

This protects educational pages using `FaqJsonLd` from emitting thin, duplicate, or placeholder FAQ schema. It is a small shared-component cleanup that improves Google-facing structured-data quality without changing the UI.

## Impact score

**455/1000** — useful shared schema hygiene, though narrower than the goal/footer/template-level SEO upgrades.

## Validation

- Compared branch against `main`: 1 file changed.
- No local build was run from this chat environment.