### PR TITLE
Normalize breadcrumb schema URLs

### DIFF
--- a/components/Breadcrumbs.tsx
+++ b/components/Breadcrumbs.tsx
@@ -63,6 +63,17 @@ export function Breadcrumbs({
   )
 }
 
+function normalizeBreadcrumbSchemaItem(siteUrl: string, href: string): string {
+  const cleanSiteUrl = siteUrl.replace(/\/$/, '')
+  if (!href || href === '/') return `${cleanSiteUrl}/`
+  if (href.includes('?') || href.includes('#')) return `${cleanSiteUrl}${href}`
+  if (href.split('/').pop()?.includes('.')) return `${cleanSiteUrl}${href}`
+
+  const path = href.startsWith('/') ? href : `/${href}`
+  const canonicalPath = path.endsWith('/') ? path : `${path}/`
+  return `${cleanSiteUrl}${canonicalPath}`
+}
+
 /**
  * Breadcrumb structured data (JSON-LD)
  * Used by BreadcrumbSchema component for Schema.org markup
@@ -82,7 +93,7 @@ export function getBreadcrumbSchema(
       '@type': 'ListItem',
       position: index + 1,
       name: breadcrumb.label,
-      item: `${siteUrl}${breadcrumb.href}`,
+      item: normalizeBreadcrumbSchemaItem(siteUrl, breadcrumb.href),
     })),
   }
 }


### PR DESCRIPTION
## What changed

- Normalizes BreadcrumbList JSON-LD item URLs to trailing-slash canonical URLs.
- Keeps root and special hrefs unchanged.

## Why this is high ROI

Breadcrumb schema should use the same canonical URL style as page links. This small cleanup reduces mixed URL signals in structured data without changing rendered content.

## Impact score

**390/1000** — useful structured-data crawl hygiene, but narrower than template or sitewide internal-link updates.

## Validation

- Compared branch against `main`: 1 file changed, 12 additions / 1 deletion.
- No local build was run from this chat environment.