### PR TITLE
Restore goals hub medical disclaimer

### DIFF
--- a/app/goals/page.tsx
+++ b/app/goals/page.tsx
@@ -67,7 +67,9 @@ export default function GoalsPage() {
           Choose by outcome, then compare options clearly.
         </h1>
         <p className="mt-4 max-w-3xl text-sm leading-7 text-muted sm:text-base">
-          These pages are educational comparison summaries designed for fast scanning. They help readers compare evidence context, tolerance considerations, and practical tradeoffs before opening a detailed profile.
+          These pages are educational comparison summaries designed for fast scanning. They are intended to
+          help readers compare evidence context, tolerance considerations, and practical tradeoffs — not to
+          diagnose, prescribe, or replace professional care.
         </p>
 
         <div className="mt-6 flex flex-wrap gap-3 text-[11px] font-semibold uppercase tracking-[0.13em] sm:gap-4 sm:text-xs">


### PR DESCRIPTION
## What changed

- Restores the stronger educational/medical disclaimer copy on `/goals/`.
- Keeps the goals hub schema graph intact.

## Why this matters

The schema upgrade is good, but visible safety language should not be weakened. This keeps the SEO win while preserving the site's medical-safety boundary.

## Impact score

**820/1000** — preserves the 825/1000 goals hub schema gain while correcting the safety-language regression.

## Validation

- Compared branch against `main`: 1 file changed, 3 additions / 1 deletion.
- No local build was run from this chat environment.