### PR TITLE
Normalize primary navigation hrefs

### DIFF
--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -10,6 +10,11 @@ import { mainNavigation } from '@/lib/navigation-config'
 
 const primaryLinks = mainNavigation.map(({ href, label }) => ({ href, label }))
 
+function toCanonicalHref(href: string) {
+  if (!href || href === '/' || href.includes('?') || href.includes('#')) return href
+  return href.endsWith('/') ? href : `${href}/`
+}
+
 export function Navigation() {
   const [mobileOpen, setMobileOpen] = useState(false)
   const [scrolled, setScrolled] = useState(false)
@@ -65,7 +70,7 @@ export function Navigation() {
             {primaryLinks.map((link) => (
               <Link
                 key={link.href}
-                href={link.href}
+                href={toCanonicalHref(link.href)}
                 className={`font-medium transition-colors ${
                   isActive(link.href)
                     ? 'font-semibold text-brand-800 underline underline-offset-[6px] decoration-brand-700/35 decoration-2 dark:text-[var(--text-primary)] dark:decoration-[var(--accent-teal)]/40'
@@ -137,7 +142,7 @@ export function Navigation() {
               {primaryLinks.map((link) => (
                 <Link
                   key={link.href}
-                  href={link.href}
+                  href={toCanonicalHref(link.href)}
                   onClick={closeMobile}
                   className={`rounded-lg px-3 py-2.5 font-medium transition ${
                     isActive(link.href)

--- a/src/components/mobile-bottom-nav.tsx
+++ b/src/components/mobile-bottom-nav.tsx
@@ -32,6 +32,11 @@ const navItems = [
   },
 ]
 
+function toCanonicalHref(href: string) {
+  if (!href || href === '/' || href.includes('?') || href.includes('#')) return href
+  return href.endsWith('/') ? href : `${href}/`
+}
+
 export default function MobileBottomNav() {
   const pathname = usePathname() || '/'
 
@@ -45,7 +50,7 @@ export default function MobileBottomNav() {
           return (
             <Link
               key={item.href}
-              href={item.href}
+              href={toCanonicalHref(item.href)}
               aria-current={active ? 'page' : undefined}
               className={`flex min-h-[3rem] min-w-0 flex-1 flex-col items-center justify-center gap-1 rounded-xl px-0.5 py-1.5 text-center transition ${
                 active


### PR DESCRIPTION
## What changed

- Normalizes rendered header navigation links to trailing-slash canonical URLs.
- Normalizes rendered mobile bottom navigation links to trailing-slash canonical URLs.
- Preserves existing active-state matching by keeping the raw route values for comparisons.

## Why this matters

These navigation surfaces appear across the site. Rendering canonical hrefs reduces mixed internal-link signals like `/goals` vs `/goals/` while keeping UI behavior unchanged.

## Impact score

**560/1000** — strong sitewide crawl-hygiene improvement, but smaller than the goals hub schema architecture upgrade.

## Validation

- Compared branch against `main`: 2 files changed, 13 additions / 3 deletions.
- No local build was run from this chat environment.