### PR TITLE
Normalize goals hub discovery links

### DIFF
--- a/app/goals/page.tsx
+++ b/app/goals/page.tsx
@@ -73,13 +73,13 @@ export default function GoalsPage() {
         </p>
 
         <div className="mt-6 flex flex-wrap gap-3 text-[11px] font-semibold uppercase tracking-[0.13em] sm:gap-4 sm:text-xs">
-          <Link href="/methodology" className="text-brand-700 hover:text-brand-800 hover:underline dark:text-brand-100 dark:hover:text-white">
+          <Link href="/methodology/" className="text-brand-700 hover:text-brand-800 hover:underline dark:text-brand-100 dark:hover:text-white">
             Research methodology →
           </Link>
-          <Link href="/education/evidence-hierarchy" className="text-brand-700 hover:text-brand-800 hover:underline dark:text-brand-100 dark:hover:text-white">
+          <Link href="/education/evidence-hierarchy/" className="text-brand-700 hover:text-brand-800 hover:underline dark:text-brand-100 dark:hover:text-white">
             Evidence hierarchy →
           </Link>
-          <Link href="/disclaimer" className="text-brand-700 hover:text-brand-800 hover:underline dark:text-brand-100 dark:hover:text-white">
+          <Link href="/disclaimer/" className="text-brand-700 hover:text-brand-800 hover:underline dark:text-brand-100 dark:hover:text-white">
             Disclaimer →
           </Link>
         </div>
@@ -89,8 +89,8 @@ export default function GoalsPage() {
       <DecisionCtaGroup
         ctas={[
           { label: 'Browse goal paths', href: '#goals', variant: 'primary' },
-          { label: 'Search the library', href: '/search', variant: 'secondary' },
-          { label: 'Compare compounds', href: '/compare', variant: 'ghost' },
+          { label: 'Search the library', href: '/search/', variant: 'secondary' },
+          { label: 'Compare compounds', href: '/compare/', variant: 'ghost' },
         ]}
       />
 
@@ -98,7 +98,7 @@ export default function GoalsPage() {
         {goals.map((goal) => (
           <Link
             key={goal.slug}
-            href={`/goals/${goal.slug}`}
+            href={`/goals/${goal.slug}/`}
             className="group card-premium flex min-h-[17rem] flex-col justify-between overflow-hidden p-4 sm:min-h-[18rem] sm:p-6"
           >
             <div>


### PR DESCRIPTION
## What changed

- Normalizes `/goals/` hub support links to trailing-slash canonical URLs.
- Normalizes CTA links to `/search/` and `/compare/`.
- Normalizes each goal card link like `/goals/sleep/`.
- Leaves the existing goals hub schema graph unchanged.

## Why this matters

The goals hub now has canonical schema URLs. This aligns the visible discovery links with that schema, reducing mixed internal-link signals on a core user-intent hub.

## Impact score

**660/1000** — strong hub-level crawl-signal cleanup on a core discovery page.

## Validation

- Compared branch against `main`: 1 file changed, 6 additions / 6 deletions.
- No local build was run from this chat environment.