### PR TITLE
Warn on malformed redirect targets

### DIFF
--- a/scripts/verify-redirects.mjs
+++ b/scripts/verify-redirects.mjs
@@ -81,6 +81,19 @@ if (lines.includes(obsoleteAppShellRewrite)) {
   process.exit(1)
 }
 
+const malformedTargetRules = lines.filter((line) => {
+  const [, target = ''] = line.split(/\s+/)
+  if (!target) return true
+  return !target.startsWith('/') && !/^https?:\/\//i.test(target)
+})
+
+if (malformedTargetRules.length) {
+  console.warn(`[verify-redirects] Warning: ${malformedTargetRules.length} redirect rules have malformed-looking targets:`)
+  for (const rule of malformedTargetRules.slice(0, 20)) {
+    console.warn(`[verify-redirects]   ${rule}`)
+  }
+}
+
 const atomRedirectRule = '/atom.xml /feed.xml 301'
 if (!lines.includes(atomRedirectRule)) {
   console.error(`[verify-redirects] Expected feed compatibility redirect "${atomRedirectRule}"`)


### PR DESCRIPTION
## Summary

Adds a non-blocking warning for malformed-looking redirect targets in the existing redirect verification script.

## What changed

- Parses active `_redirects` rules during `verify-redirects`.
- Warns when a redirect target does not start with `/` or `http(s)://`.
- Prints up to 20 questionable rules for review.
- Keeps the check non-blocking so current builds are not unexpectedly failed.

## Why this matters

The crawler export includes 4xx errors, and `public/_redirects` currently contains retired route rules pointing at `404/`. This makes those problems visible during verification without forcing a risky large redirects-file rewrite.

## Impact score

520/1000 — useful redirect hygiene guardrail that surfaces likely 4xx-related rules safely.

## Validation

Compared branch against main: 1 file changed, 13 additions, 0 deletions. No local build was run in this connector session.