### PR TITLE
Remove forced child title brand suffix

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,7 +12,7 @@ import MobileBottomNav from '../src/components/mobile-bottom-nav'
 import ScrollToTopButton from '../src/components/ScrollToTopButton'
 import ClickTracker from '@/components/ClickTracker'
 import CitationDrawerLazy from '@/components/education/CitationDrawerLazy'
-import { buildPageMetadata, DEFAULT_TITLE, DEFAULT_DESCRIPTION, SITE_URL, SITE_NAME, websiteJsonLd, organizationJsonLd } from '../src/lib/seo'
+import { buildPageMetadata, DEFAULT_TITLE, DEFAULT_DESCRIPTION, SITE_URL, websiteJsonLd, organizationJsonLd } from '../src/lib/seo'
 import { DarkModeProvider } from '@/lib/dark-mode-provider'
 import DarkModeToggle from '@/components/DarkModeToggle'
 import './globals.css'
@@ -40,10 +40,9 @@ const rootMetadata = buildPageMetadata({
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
-  title: { default: DEFAULT_TITLE, template: `%s | ${SITE_NAME}` },
+  title: { default: DEFAULT_TITLE, template: '%s' },
   description: DEFAULT_DESCRIPTION,
   ...rootMetadata,
-  // ensure template wins for children
   openGraph: rootMetadata.openGraph,
   twitter: rootMetadata.twitter,
   robots: { index: true, follow: true },


### PR DESCRIPTION
## Summary

Removes the forced site-name suffix from child page title tags.

## What changed

- Changes the root title template from `%s | site name` to `%s`.
- Keeps the default homepage/root title unchanged.
- Removes an unused import created by the template change.
- Leaves descriptions, Open Graph, Twitter metadata, canonical URLs, and robots settings unchanged.

## Why this matters

The crawler report showed many title tags over the target length. A global child-title suffix adds significant length to every child page, so removing it is a high-leverage way to bring many generated and manual page titles under the warning threshold.

## Impact score

780/1000 — high-leverage metadata cleanup likely to reduce many long-title warnings across the site.

## Validation

Compared branch against main: 1 file changed, 2 additions, 3 deletions. No local build was run in this connector session.