### PR TITLE
Compact compound, compare, and guide metadata titles

### DIFF
--- a/app/compare/[slug]/page.tsx
+++ b/app/compare/[slug]/page.tsx
@@ -39,6 +39,22 @@ const asString = (value: unknown, fallback = '') => typeof value === 'string' ? 
 const displayName = (compound: Record<string, unknown>) =>
   asString(compound?.displayName) || asString(compound?.name) || formatSlug(asString(compound?.slug, 'Compound'))
 
+// Metadata-only: strip parenthetical annotations (e.g. "(Withania somnifera)") to keep titles compact.
+const metaDisplayName = (compound: Record<string, unknown>) =>
+  (asString(compound?.displayName) || asString(compound?.name) || formatSlug(asString(compound?.slug, 'Compound')))
+    .replace(/\s*\([^)]+\)\s*/g, '').replace(/\s+/g, ' ').trim()
+
+// Produce a compact compare metadata title <= 60 chars.
+function compactCompareTitle(n1: string, n2: string): string {
+  const withSuffix = `${n1} vs ${n2}: Comparison`
+  if (withSuffix.length <= 60) return withSuffix
+  const vsOnly = `${n1} vs ${n2}`
+  if (vsOnly.length <= 60) return vsOnly
+  const cut = vsOnly.slice(0, 57)
+  const lastSpace = cut.lastIndexOf(' ')
+  return (lastSpace > 30 ? cut.slice(0, lastSpace) : cut) + '…'
+}
+
 const evidenceScore = (compound: Record<string, unknown>) => {
   const text = `${compound?.evidence_grade ?? ''} ${compound?.evidenceTier ?? ''} ${compound?.tier_level ?? ''} ${compound?.evidence ?? ''} ${compound?.summary_quality ?? ''}`.toLowerCase()
   if (/strong|high|tier\s*1|a-tier|meta|rct/.test(text)) return 5
@@ -158,18 +174,20 @@ export async function generateMetadata({ params }: Params): Promise<Metadata> {
   let description: string
 
   if (config?.title) {
-    title = `${config.title}: Which Is Better?`
+    title = `${config.title}: Comparison`
     description = config.summary || `Compare ${config.title} for benefits, safety, evidence, and best use cases.`
   } else if (parsed) {
     const { allRecords } = await getUnifiedRuntimeRecords()
     const a = allRecords.find((c: Record<string, unknown>) => c.slug === parsed.item1Slug)
     const b = allRecords.find((c: Record<string, unknown>) => c.slug === parsed.item2Slug)
-    const n1 = a ? displayName(a) : formatSlug(parsed.item1Slug)
-    const n2 = b ? displayName(b) : formatSlug(parsed.item2Slug)
-    title = `${n1} vs ${n2}: Complete Comparison | The Hippie Scientist`
-    description = `Evidence-based comparison of ${n1} and ${n2}. Compare mechanisms, dosing, safety, and which is right for your goals.`
+    const n1 = a ? metaDisplayName(a) : formatSlug(parsed.item1Slug)
+    const n2 = b ? metaDisplayName(b) : formatSlug(parsed.item2Slug)
+    title = compactCompareTitle(n1, n2)
+    const fullN1 = a ? displayName(a) : n1
+    const fullN2 = b ? displayName(b) : n2
+    description = `Evidence-based comparison of ${fullN1} and ${fullN2}. Compare mechanisms, dosing, safety, and which is right for your goals.`
   } else {
-    title = `${formatSlug(slug)}: Which Is Better?`
+    title = `${formatSlug(slug)}: Comparison`
     description = `Compare ${formatSlug(slug)} for benefits, safety, evidence, best use cases, and supplement buying options.`
   }
 

--- a/app/guides/kratom-7oh-withdrawal-management/page.tsx
+++ b/app/guides/kratom-7oh-withdrawal-management/page.tsx
@@ -7,7 +7,7 @@ import { ArticleLayout, TableOfContents } from '@/components/articles'
 import type { Heading } from '@/components/articles'
 
 export const metadata: Metadata = buildPageMetadata({
-  title: 'Kratom 7-OH Withdrawal Management | Evidence-Informed Harm Reduction Guide',
+  title: 'Kratom 7-OH Withdrawal: Harm Reduction Guide',
   description: 'Comprehensive evidence-informed guide to 7-hydroxymitragynine (7-OH) withdrawal management, symptom timeline, harm reduction strategies, and medical support context.',
   path: '/guides/kratom-7oh-withdrawal-management/',
 })

--- a/src/lib/__tests__/seo.test.ts
+++ b/src/lib/__tests__/seo.test.ts
@@ -39,7 +39,7 @@ describe('SEO Metadata & JSON-LD Utilities', () => {
     it('generates correct metadata for a compound', () => {
       const meta = generateDetailMetadata(mockCompound, 'compound')
 
-      expect(meta.title).toBe('L-Theanine Dosage, Effects & Safety: What the Evidence Says')
+      expect(meta.title).toBe('L-Theanine: Effects, Dose and Safety')
       expect(meta.description).toContain('L-Theanine dosage by use case')
       expect(meta.alternates?.canonical).toBe('https://thehippiescientist.net/compounds/l-theanine/')
     })

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -926,7 +926,7 @@ function getProfileEvidenceLabel(record: any): string {
 export function formatProfileTitle(displayName: string, type: 'herb' | 'compound'): string {
   return type === 'herb'
     ? `${displayName} Benefits, Dosage & Safety`
-    : `${displayName} Dosage, Effects & Safety: What the Evidence Says`
+    : `${displayName}: Effects, Dose and Safety`
 }
 
 function escapeRegExp(value: string): string {


### PR DESCRIPTION
## Summary

Fixes the remaining "Title too long" SEO issues from the crawler CSV across three route buckets: `/compounds/`, `/compare/`, and `/guides/`.

- **All visible H1s are unchanged** — only `<title>` metadata is affected.
- No medical, safety, or harm-reduction language was changed.
- No article body copy was changed.
- No generated JSON was edited.

## Files changed

| File | Change |
|------|--------|
| `src/lib/seo.ts` | Shorter compound title suffix |
| `app/compare/[slug]/page.tsx` | Compact compare metadata titles |
| `app/guides/kratom-7oh-withdrawal-management/page.tsx` | Shorter guide metadata title |

## Before / after examples

### Compound profiles (`src/lib/seo.ts:926–929`)

Old suffix: `{Name} Dosage, Effects & Safety: What the Evidence Says` (49 chars + space)  
New suffix: `{Name}: Effects, Dose and Safety` (25 chars)

| Page | Before (chars) | After (chars) |
|------|---------------|--------------|
| `/compounds/acarbose` | `Acarbose Dosage, Effects & Safety: What the Evidence Says` (58) | `Acarbose: Effects, Dose and Safety` (35) |
| `/compounds/acetyl-11-keto-beta-boswellic-acid` | `Acetyl 11 Keto Beta Boswellic Acid Dosage, Effects & Safety: What the Evidence Says` (84) | `Acetyl 11 Keto Beta Boswellic Acid: Effects, Dose and Safety` (60) |
| `/compounds/testosterone-boosters-generic` | `Testosterone Boosters Generic Dosage, Effects & Safety: What the Evidence Says` (79) | `Testosterone Boosters Generic: Effects, Dose and Safety` (55) |

### Compare pages (`app/compare/[slug]/page.tsx`)

Two helpers added (metadata-only, visible page unchanged):
- `metaDisplayName()` — strips botanical parentheticals like `(Withania somnifera)` from entity display names  
- `compactCompareTitle(n1, n2)` — targets ≤ 60 chars; falls back to `vs`-only then word-boundary truncation with `…`

| Page | Before (chars) | After (chars) |
|------|---------------|--------------|
| `/compare/reishi-vs-ashwagandha` | `Reishi (Ganoderma lucidum) vs Ashwagandha (Withania somnifera): Complete Comparison \| The Hippie Scientist` (106) | `Reishi vs Ashwagandha: Comparison` (34) |
| `/compare/turmeric-vs-ginger` | `Turmeric (Curcuma longa) vs Ginger (Zingiber officinale): Complete Comparison \| The Hippie Scientist` (100) | `Turmeric vs Ginger: Comparison` (31) |
| `/compare/ashwagandha-vs-l-theanine` | `Ashwagandha (Withania somnifera) vs L-theanine: Complete Comparison \| The Hippie Scientist` (90) | `Ashwagandha vs L-theanine: Comparison` (37) |
| `/compare/valerian-vs-passionflower` | `Valeriana officinalis vs Passionflower: Complete Comparison \| The Hippie Scientist` (82) | `Valeriana officinalis vs Passionflower: Comparison` (50) |
| `/compare/alpha-gpc-vs-cdp-choline` | `Alpha-GPC vs Citicoline / CDP-choline: Complete Comparison \| The Hippie Scientist` (81) | `Alpha-GPC vs Citicoline / CDP-choline: Comparison` (49) |
| `/compare/melatonin-vs-valerian` | `Melatonin vs Valeriana officinalis: Complete Comparison \| The Hippie Scientist` (78) | `Melatonin vs Valeriana officinalis: Comparison` (46) |

Config-based titles (supplementComparisons): `Which Is Better?` → `Comparison`.

### Guide (`app/guides/kratom-7oh-withdrawal-management/page.tsx`)

| Before | After |
|--------|-------|
| `Kratom 7-OH Withdrawal Management \| Evidence-Informed Harm Reduction Guide` (74 chars) | `Kratom 7-OH Withdrawal: Harm Reduction Guide` (44 chars) |

H1 "Kratom 7-OH Withdrawal Management" is unchanged.

## SEO audit results (`npm run audit:seo-reports`)

| Metric | Before | After |
|--------|--------|-------|
| `titleTooLong.count` (total) | **1128** | **79** |
| `/compounds/` | 455 | **0** |
| `/compare/` | 596 | **3** (2 static three-way pages + 1 special page — out of dynamic-route scope) |
| `/guides/` target | 1 | **0** |

Remaining 79 issues are in `/articles/`, `/goals/`, `/blog/`, `/guides/` (9 static pages), and 2 static compare pages — pre-existing issues outside the scope of this PR.

## Impact score

- **Compound bucket**: 455 pages fixed → eliminated entirely
- **Compare bucket**: 593 of 596 pages fixed
- **Guide target from CSV**: fixed
- No regressions introduced (typecheck + lint pass, full production build succeeds)

---
_Generated by [Claude Code](https://claude.ai/code/session_014uJJsPzTaJh8xoChCye5rt)_