### PR TITLE
Fix remaining long metadata titles

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -13,7 +13,7 @@ import {
   focusClusterArticleSources,
   getFocusClusterArticle,
 } from '@/lib/focus-cluster-markdown'
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, TWITTER_HANDLE } from '../../src/lib/seo'
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, TWITTER_HANDLE, compactMetaTitle } from '../../src/lib/seo'
 const ADHD_CHECKLIST_CAPTURE = {
   title: 'Get the ADHD Supplement Starter Checklist',
   description: 'A simple 4-week tracker for choosing one supplement at a time, watching side effects, and avoiding messy stimulant-heavy stacks.',
@@ -155,22 +155,23 @@ export async function generateMetadata({ params }: { params: PageParams }): Prom
   const article = getFocusClusterArticle(slug)
   if (!article) return {}
   const canonical = `${SITE_URL}/${article.slug}/`
+  const metaTitle = compactMetaTitle(article.seoTitle)
 
   return {
-    title: article.seoTitle,
+    title: metaTitle,
     description: article.metaDescription,
     alternates: { canonical },
     openGraph: {
-      title: article.seoTitle,
+      title: metaTitle,
       description: article.metaDescription,
       url: canonical,
       siteName: SITE_NAME,
       type: 'article',
-      images: [{ url: DEFAULT_OG_IMAGE, width: 1200, height: 630, alt: article.seoTitle }],
+      images: [{ url: DEFAULT_OG_IMAGE, width: 1200, height: 630, alt: metaTitle }],
     },
     twitter: {
       card: 'summary_large_image',
-      title: article.seoTitle,
+      title: metaTitle,
       description: article.metaDescription,
       images: [DEFAULT_OG_IMAGE],
       site: TWITTER_HANDLE,

--- a/app/articles/[slug]/page.tsx
+++ b/app/articles/[slug]/page.tsx
@@ -7,7 +7,7 @@ import BlogPostPage, {
   generateMetadata as generateBlogMetadata,
   generateStaticParams as generateBlogStaticParams,
 } from '@/components/blog/BlogPostPage'
-import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd, SITE_URL } from '../../../src/lib/seo'
+import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd, SITE_URL, compactMetaTitle } from '../../../src/lib/seo'
 import { formatDate } from '@/lib/blog-index'
 import LastUpdatedBadge from '../../../src/components/editorial/LastUpdatedBadge'
 import ResponsiveTable from '@/components/ui/ResponsiveTable'
@@ -73,10 +73,10 @@ export async function generateMetadata({ params }: { params: ArticleRouteParams 
   const { slug } = await params
   const mdxArticle = mdxArticles.find((a) => a.slug === slug)
   if (mdxArticle) {
-    const title = (mdxArticle as any).seoTitle || (mdxArticle as any).metaTitle || mdxArticle.title
+    const rawTitle = (mdxArticle as any).seoTitle || (mdxArticle as any).metaTitle || mdxArticle.title
     const description = (mdxArticle as any).seoDescription || (mdxArticle as any).metaDescription || mdxArticle.description
     return buildPageMetadata({
-      title,
+      title: compactMetaTitle(rawTitle),
       description,
       path: `/articles/${slug}/`,
       openGraphType: 'article',
@@ -86,11 +86,11 @@ export async function generateMetadata({ params }: { params: ArticleRouteParams 
   const article = allArticles.find((a) => a.slug === slug)
   if (!article) return generateBlogMetadata({ params: Promise.resolve({ slug }) })
 
-  const title = (article as any).seoTitle || (article as any).metaTitle || article.title
+  const rawTitle = (article as any).seoTitle || (article as any).metaTitle || article.title
   const description = (article as any).seoDescription || (article as any).metaDescription || article.description
 
   return buildPageMetadata({
-    title,
+    title: compactMetaTitle(rawTitle),
     description,
     path: `/articles/${slug}/`,
     openGraphType: 'article',

--- a/app/articles/anxiety-stack-guide/page.tsx
+++ b/app/articles/anxiety-stack-guide/page.tsx
@@ -3,7 +3,8 @@ import {
   buildPageMetadata,
   blogJsonLd,
   breadcrumbJsonLd,
-  faqPageJsonLd
+  faqPageJsonLd,
+  compactMetaTitle
 } from '../../../src/lib/seo';
 import LastUpdatedBadge from '../../../src/components/editorial/LastUpdatedBadge';
 import ResponsiveTable from '@/components/ui/ResponsiveTable';
@@ -20,7 +21,7 @@ const lastUpdated = "2026-06-10";
 const slug = "anxiety-stack-guide";
 
 export const metadata = buildPageMetadata({
-  title: articleTitle,
+  title: compactMetaTitle(articleTitle),
   description: articleDescription,
   path: `/articles/${slug}`,
   openGraphType: 'article',

--- a/app/articles/ashwagandha-for-anxiety/page.tsx
+++ b/app/articles/ashwagandha-for-anxiety/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd } from '../../../src/lib/seo'
+import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd, compactMetaTitle } from '../../../src/lib/seo'
 import EvidenceSummaryCard from '@/components/evidence/EvidenceSummaryCard'
 import SafetyNotice from '@/components/evidence/SafetyNotice'
 import EmailCapture from '@/components/EmailCapture'
@@ -18,7 +18,7 @@ const DESCRIPTION =
 const DATE = '2026-06-10'
 
 export const metadata = buildPageMetadata({
-  title: TITLE,
+  title: compactMetaTitle(TITLE),
   description: DESCRIPTION,
   path: `/articles/${SLUG}`,
   openGraphType: 'article',

--- a/app/articles/best-magnesium-supplement-for-adhd/page.tsx
+++ b/app/articles/best-magnesium-supplement-for-adhd/page.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import type { Metadata } from 'next'
-import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd } from '../../../src/lib/seo'
+import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd, compactMetaTitle } from '../../../src/lib/seo'
 import LastUpdatedBadge from '../../../src/components/editorial/LastUpdatedBadge'
 import ResponsiveTable from '@/components/ui/ResponsiveTable'
 import SafetyNotice from '@/components/evidence/SafetyNotice'
@@ -22,7 +22,7 @@ const TAGS = ['magnesium', 'ADHD', 'buying guide', 'sleep', 'supplements']
 const CATEGORY = 'Buying Guide'
 
 export const metadata: Metadata = buildPageMetadata({
-  title: TITLE,
+  title: compactMetaTitle(TITLE),
   description: DESCRIPTION,
   path: `/articles/${SLUG}`,
   openGraphType: 'article',

--- a/app/articles/cbd-vs-ashwagandha-for-anxiety/page.tsx
+++ b/app/articles/cbd-vs-ashwagandha-for-anxiety/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd } from '../../../src/lib/seo'
+import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd, compactMetaTitle } from '../../../src/lib/seo'
 import EvidenceSummaryCard from '@/components/evidence/EvidenceSummaryCard'
 import SafetyNotice from '@/components/evidence/SafetyNotice'
 import EmailCapture from '@/components/EmailCapture'
@@ -17,7 +17,7 @@ const DESCRIPTION =
 const DATE = '2026-06-10'
 
 export const metadata = buildPageMetadata({
-  title: TITLE,
+  title: compactMetaTitle(TITLE),
   description: DESCRIPTION,
   path: `/articles/${SLUG}`,
   openGraphType: 'article',

--- a/app/articles/l-theanine-for-anxiety/page.tsx
+++ b/app/articles/l-theanine-for-anxiety/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd } from '../../../src/lib/seo'
+import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd, compactMetaTitle } from '../../../src/lib/seo'
 import EvidenceSummaryCard from '@/components/evidence/EvidenceSummaryCard'
 import SafetyNotice from '@/components/evidence/SafetyNotice'
 import EmailCapture from '@/components/EmailCapture'
@@ -14,7 +14,7 @@ const DESCRIPTION =
 const DATE = '2026-06-10'
 
 export const metadata = buildPageMetadata({
-  title: TITLE,
+  title: compactMetaTitle(TITLE),
   description: DESCRIPTION,
   path: `/articles/${SLUG}`,
   openGraphType: 'article',

--- a/app/articles/l-theanine-for-sleep/page.tsx
+++ b/app/articles/l-theanine-for-sleep/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd } from '../../../src/lib/seo'
+import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd, compactMetaTitle } from '../../../src/lib/seo'
 import EvidenceSummaryCard from '@/components/evidence/EvidenceSummaryCard'
 import SafetyNotice from '@/components/evidence/SafetyNotice'
 import EmailCapture from '@/components/EmailCapture'
@@ -23,7 +23,7 @@ const TAGS = ['l-theanine', 'sleep', 'amino-acids', 'relaxation', 'stress']
 const CATEGORY = 'amino-acids'
 
 export const metadata = buildPageMetadata({
-  title: TITLE,
+  title: compactMetaTitle(TITLE),
   description: DESCRIPTION,
   path: `/articles/${SLUG}`,
   openGraphType: 'article',

--- a/app/articles/l-theanine-without-caffeine/page.tsx
+++ b/app/articles/l-theanine-without-caffeine/page.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import type { Metadata } from 'next'
-import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd } from '../../../src/lib/seo'
+import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd, compactMetaTitle } from '../../../src/lib/seo'
 import LastUpdatedBadge from '../../../src/components/editorial/LastUpdatedBadge'
 import ResponsiveTable from '@/components/ui/ResponsiveTable'
 import SafetyNotice from '@/components/evidence/SafetyNotice'
@@ -23,7 +23,7 @@ const TAGS = ['L-theanine', 'ADHD', 'focus', 'caffeine-free', 'calm']
 const CATEGORY = 'Focus'
 
 export const metadata: Metadata = buildPageMetadata({
-  title: TITLE,
+  title: compactMetaTitle(TITLE),
   description: DESCRIPTION,
   path: `/articles/${SLUG}`,
   openGraphType: 'article',

--- a/app/articles/magnesium-glycinate-vs-citrate-for-adhd/page.tsx
+++ b/app/articles/magnesium-glycinate-vs-citrate-for-adhd/page.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import type { Metadata } from 'next'
-import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd } from '../../../src/lib/seo'
+import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd, compactMetaTitle } from '../../../src/lib/seo'
 import LastUpdatedBadge from '../../../src/components/editorial/LastUpdatedBadge'
 import ResponsiveTable from '@/components/ui/ResponsiveTable'
 import SafetyNotice from '@/components/evidence/SafetyNotice'
@@ -23,7 +23,7 @@ const TAGS = ['magnesium', 'ADHD', 'focus', 'sleep', 'minerals']
 const CATEGORY = 'Supplement Evidence'
 
 export const metadata: Metadata = buildPageMetadata({
-  title: TITLE,
+  title: compactMetaTitle(TITLE),
   description: DESCRIPTION,
   path: `/articles/${SLUG}`,
   openGraphType: 'article',

--- a/app/articles/natural-anxiety-relief/page.tsx
+++ b/app/articles/natural-anxiety-relief/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd } from '../../../src/lib/seo'
+import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd, compactMetaTitle } from '../../../src/lib/seo'
 import EvidenceSummaryCard from '@/components/evidence/EvidenceSummaryCard'
 import SafetyNotice from '@/components/evidence/SafetyNotice'
 import EmailCapture from '@/components/EmailCapture'
@@ -23,7 +23,7 @@ const TAGS = ['anxiety', 'herbs', 'supplements', 'natural anxiety relief', 'adap
 const CATEGORY = 'anxiety'
 
 export const metadata = buildPageMetadata({
-  title: TITLE,
+  title: compactMetaTitle(TITLE),
   description: DESCRIPTION,
   path: `/articles/${SLUG}`,
   openGraphType: 'article',

--- a/app/articles/sleep-stack-guide/page.tsx
+++ b/app/articles/sleep-stack-guide/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd } from '../../../src/lib/seo'
+import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd, compactMetaTitle } from '../../../src/lib/seo'
 import EvidenceSummaryCard from '@/components/evidence/EvidenceSummaryCard'
 import SafetyNotice from '@/components/evidence/SafetyNotice'
 import EmailCapture from '@/components/EmailCapture'
@@ -23,7 +23,7 @@ const TAGS = ['sleep', 'magnesium', 'l-theanine', 'ashwagandha', 'supplement-sta
 const CATEGORY = 'sleep-stacks'
 
 export const metadata = buildPageMetadata({
-  title: TITLE,
+  title: compactMetaTitle(TITLE),
   description: DESCRIPTION,
   path: `/articles/${SLUG}`,
   openGraphType: 'article',

--- a/app/best-magnesium-supplements-for-adhd/page.tsx
+++ b/app/best-magnesium-supplements-for-adhd/page.tsx
@@ -8,7 +8,7 @@ import { buildPageMetadata, faqPageJsonLd } from '../../src/lib/seo'
 import JsonLd from '@/components/seo/JsonLd'
 
 export const metadata: Metadata = buildPageMetadata({
-  title: 'Best Magnesium Supplements for ADHD: Forms, Dose, and Buying Guide',
+  title: 'Best Magnesium Supplements for ADHD: Forms & Dose',
   description:
     'Compare magnesium glycinate, threonate, citrate, and other forms for ADHD-adjacent focus and sleep support. Includes safety notes and affiliate product picks.',
   path: '/best-magnesium-supplements-for-adhd',

--- a/app/compare/ashwagandha-vs-l-theanine-vs-magnesium/page.tsx
+++ b/app/compare/ashwagandha-vs-l-theanine-vs-magnesium/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 import { buildPageMetadata } from '../../../src/lib/seo'
 
 export const metadata: Metadata = buildPageMetadata({
-  title: 'Ashwagandha vs L-Theanine vs Magnesium for Stress & Anxiety',
+  title: 'Ashwagandha vs L-Theanine vs Magnesium',
   description: 'Evidence-informed 3-way comparison of ashwagandha, L-theanine, and magnesium for chronic tension, acute stress buffering, sleep latency, safety, and supplement selection.',
   path: '/compare/ashwagandha-vs-l-theanine-vs-magnesium/',
 })

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -17,7 +17,7 @@ const CompareTableClient = dynamic(
 )
 
 export const metadata: Metadata = buildPageMetadata({
-  title: `Herb & Supplement Comparison Center ${SEO_YEAR} | The Hippie Scientist`,
+  title: `Herb & Supplement Comparison Center ${SEO_YEAR}`,
   description:
     'Compare herbs and supplements side-by-side by evidence strength, mechanism, stimulation profile, safety, and dosing. Evidence-based decision support.',
   path: '/compare',

--- a/app/compare/sleep-herbs-vs-melatonin/page.tsx
+++ b/app/compare/sleep-herbs-vs-melatonin/page.tsx
@@ -10,7 +10,7 @@ import RecommendationSection from '@/components/RecommendationSection'
 import { getRevenueProductSet } from '@/config/revenue-products'
 
 export const metadata: Metadata = buildPageMetadata({
-  title: 'Sleep Herbs vs Melatonin – Magnesium, L-Theanine & Valerian Compared',
+  title: 'Sleep Herbs vs Melatonin: Evidence Comparison',
   description:
     'Evidence-graded comparison of melatonin, magnesium, L-theanine, and valerian for sleep. Understand mechanisms, onset, evidence quality, safety, and when to use each — or stack them.',
   path: '/compare/sleep-herbs-vs-melatonin/',

--- a/app/education/[slug]/page.tsx
+++ b/app/education/[slug]/page.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { Metadata } from 'next'
 import { getEducationArticleBySlug, getAllEducationArticles, parseMdxBlocks } from '@/lib/education'
-import { buildPageMetadata } from '../../../src/lib/seo'
+import { buildPageMetadata, compactMetaTitle } from '../../../src/lib/seo'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
 import LastUpdatedBadge from '../../../src/components/editorial/LastUpdatedBadge'
 import ResponsiveTable from '@/components/ui/ResponsiveTable'
@@ -26,7 +26,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!article) return {}
 
   return buildPageMetadata({
-    title: article.title,
+    title: compactMetaTitle(article.title),
     description: article.description,
     path: `/education/${slug}`,
     openGraphType: 'article',

--- a/app/education/efficacy-model/page.tsx
+++ b/app/education/efficacy-model/page.tsx
@@ -3,7 +3,7 @@ import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import EfficacyModelerClient from '../../../src/components/education/EfficacyModelerClient'
 
 export const metadata: Metadata = {
-  title: 'Interactive Supplement Efficacy Modeler & Pharmacokinetics Visualizer',
+  title: 'Supplement Efficacy & Pharmacokinetics Modeler',
   description:
     'Simulate absorption onset, peak action, half-life clearance timelines, and cumulative build-up curves for herbs and compounds.',
   alternates: { canonical: '/education/efficacy-model/' },

--- a/app/goals/page.tsx
+++ b/app/goals/page.tsx
@@ -14,7 +14,7 @@ import {
   SITE_URL,
 } from '../../src/lib/seo'
 
-const GOALS_PAGE_TITLE = `Supplement Goal Guides ${SEO_YEAR} – Evidence, Safety & Comparisons`
+const GOALS_PAGE_TITLE = `Supplement Goal Guides ${SEO_YEAR}: Evidence & Safety`
 const GOALS_PAGE_DESCRIPTION =
   'Choose your goal — sleep, stress, focus, anxiety, pain, and more — then compare herbs and compounds by evidence strength, safety, and practical tradeoffs.'
 const GOALS_CANONICAL_URL = `${SITE_URL}/goals/`

--- a/app/guides/[slug]/page.tsx
+++ b/app/guides/[slug]/page.tsx
@@ -4,7 +4,7 @@ import { Metadata } from "next";
 import Script from "next/script";
 import Link from "next/link";
 import StructuredData from "@/components/StructuredData";
-import { buildPageMetadata, SITE_URL } from "../../../src/lib/seo";
+import { buildPageMetadata, SITE_URL, compactMetaTitle } from "../../../src/lib/seo";
 import { ArticleLayout, RelatedArticles } from "@/components/articles";
 import type { RelatedArticle } from "@/components/articles";
 
@@ -75,7 +75,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const guide = await getGuideBySlug(slug);
   if (!guide) return {};
   return buildPageMetadata({
-    title: guide.title,
+    title: compactMetaTitle(guide.title),
     description: guide.description,
     path: `/guides/${slug}/`,
   });

--- a/app/guides/adhd-supplements/page.tsx
+++ b/app/guides/adhd-supplements/page.tsx
@@ -9,7 +9,7 @@ import { getRevenueProductSet } from '@/config/revenue-products'
 import RecommendationSection from '@/components/RecommendationSection'
 
 const SLUG = 'adhd-supplements'
-const TITLE = 'ADHD Supplements Guide: Evidence, Safety, Testing, and Practical Use'
+const TITLE = 'ADHD Supplements: Evidence, Safety & Testing'
 const DESCRIPTION = 'Start here for evidence-based ADHD supplement guidance, including nutrient deficiencies, sleep support, focus stacks, safety, and testing.'
 
 export const metadata: Metadata = buildPageMetadata({

--- a/app/guides/elderberry/page.tsx
+++ b/app/guides/elderberry/page.tsx
@@ -17,7 +17,7 @@ import type { Heading } from '@/components/articles'
 
 const SLUG = 'elderberry'
 const PAGE_URL = 'https://thehippiescientist.net/guides/elderberry'
-const TITLE = 'Elderberry for Colds and Flu: Clinical Evidence and Practical Guidance'
+const TITLE = 'Elderberry for Colds and Flu: Evidence & Guidance'
 const DESCRIPTION =
   'Evidence-based review of elderberry (Sambucus nigra) for upper respiratory infections: meta-analyses, mechanisms, the cyanogenic-glycoside safety issue, quality, and dosing.'
 const DATE_PUBLISHED = '2024-06-09'

--- a/app/guides/kava/page.tsx
+++ b/app/guides/kava/page.tsx
@@ -16,7 +16,7 @@ import type { Heading } from '@/components/articles'
 
 const SLUG = 'kava'
 const PAGE_URL = 'https://thehippiescientist.net/guides/kava'
-const TITLE = 'Kava: Clinical Evidence for Anxiety, Hepatotoxicity Risk, and Harm Reduction'
+const TITLE = 'Kava: Anxiety Evidence, Liver Risk & Harm Reduction'
 const DESCRIPTION =
   'Evidence review of kava (Piper methysticum) for anxiety: kavalactones, GABA mechanism, the serious liver-injury risk, noble vs tudei cultivars, and harm-reduction guidance.'
 const DATE_PUBLISHED = '2024-06-09'

--- a/app/guides/natural-alternatives-to-anxiety-medication/page.tsx
+++ b/app/guides/natural-alternatives-to-anxiety-medication/page.tsx
@@ -7,7 +7,7 @@ import AffiliateDisclosure from '@/components/AffiliateDisclosure'
 import EmailCapture from '@/components/EmailCapture'
 
 export const metadata: Metadata = {
-  title: 'Natural Alternatives to Anxiety Medication | Educational Guide',
+  title: 'Natural Alternatives to Anxiety Medication',
   description: 'Educational overview of supportive herbs and non-supplement routines for anxiety-related stress patterns.',
   alternates: { canonical: '/guides/best-herbs-for-anxiety/' },
 }

--- a/app/guides/passionflower/page.tsx
+++ b/app/guides/passionflower/page.tsx
@@ -17,7 +17,7 @@ import type { Heading } from '@/components/articles'
 
 const SLUG = 'passionflower'
 const PAGE_URL = 'https://thehippiescientist.net/guides/passionflower'
-const TITLE = 'Passionflower for Anxiety and Sleep: Clinical Evidence and Guidance'
+const TITLE = 'Passionflower for Anxiety & Sleep: Evidence Guide'
 const DESCRIPTION =
   'Evidence-based review of passionflower (Passiflora incarnata) for anxiety and sleep: GABA mechanism, clinical trials, safety, drug interactions, and dosing.'
 const DATE_PUBLISHED = '2024-06-09'

--- a/app/guides/rhodiola-complete-guide/page.tsx
+++ b/app/guides/rhodiola-complete-guide/page.tsx
@@ -18,7 +18,7 @@ import type { Heading } from '@/components/articles'
 
 const SLUG = 'rhodiola-complete-guide'
 const PAGE_URL = 'https://thehippiescientist.net/guides/rhodiola-complete-guide'
-const TITLE = 'Rhodiola: Complete Science-Backed Guide to Forms, Benefits & Dosing'
+const TITLE = 'Rhodiola: Forms, Benefits & Dosing Guide'
 const DESCRIPTION =
   'Evidence-based guide to Rhodiola rosea: forms compared, what the research shows for fatigue and stress, correct dosing, safety, and how to choose a product.'
 const DATE_PUBLISHED = '2024-06-09'

--- a/app/guides/rhodiola-sleep-stack/page.tsx
+++ b/app/guides/rhodiola-sleep-stack/page.tsx
@@ -17,7 +17,7 @@ import type { Heading } from '@/components/articles'
 
 const SLUG = 'rhodiola-sleep-stack'
 const PAGE_URL = 'https://thehippiescientist.net/guides/rhodiola-sleep-stack'
-const TITLE = 'Rhodiola + Magnesium for Sleep: The Adaptogen Stack That Works'
+const TITLE = 'Rhodiola + Magnesium for Sleep: Adaptogen Stack'
 const DESCRIPTION =
   'The rhodiola-magnesium sleep stack explained: complementary mechanisms, dosing and timing protocols, realistic expectations, and who should avoid it.'
 const DATE_PUBLISHED = '2024-06-09'

--- a/app/guides/turmeric-curcumin/page.tsx
+++ b/app/guides/turmeric-curcumin/page.tsx
@@ -17,7 +17,7 @@ import type { Heading } from '@/components/articles'
 
 const SLUG = 'turmeric-curcumin'
 const PAGE_URL = 'https://thehippiescientist.net/guides/turmeric-curcumin'
-const TITLE = 'Turmeric & Curcumin: Evidence, Dosage, and Bioavailability Guide'
+const TITLE = 'Turmeric & Curcumin: Evidence, Dose, Bioavailability'
 const DESCRIPTION =
   'A science-backed breakdown of curcumin bioavailability, anti-inflammatory evidence, dosage ranges, form comparison, and safety context — including what the research actually shows versus the hype.'
 const DATE_PUBLISHED = '2025-01-15'

--- a/app/learn/[slug]/page.tsx
+++ b/app/learn/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation'
 import { getLearnPost, learnPosts } from '../data'
 import RelatedDiscoveryGroups from '@/components/ui/RelatedDiscoveryGroups'
 import Breadcrumbs from '@/components/ui/Breadcrumbs'
+import { compactMetaTitle } from '../../../src/lib/seo'
 
 type LearnRouteParams = Promise<{ slug: string }>
 
@@ -26,7 +27,7 @@ export async function generateMetadata({ params }: LearnRouteProps): Promise<Met
   }
 
   return {
-    title: `${post.title} | Guides`,
+    title: compactMetaTitle(post.title),
     description: post.description,
     alternates: { canonical: `/learn/${post.slug}` },
   }

--- a/app/novel-psychoactive-substances/[slug]/page.tsx
+++ b/app/novel-psychoactive-substances/[slug]/page.tsx
@@ -6,7 +6,7 @@ import { allNovelPsychoactiveSubstancePages } from '../../../.content-collection
 import ArticleMdx from '@/components/articles/ArticleMdx'
 import Breadcrumbs from '@/components/ui/Breadcrumbs'
 import JsonLd from '@/components/seo/JsonLd'
-import { SITE_URL } from '../../../src/lib/seo'
+import { SITE_URL, compactMetaTitle } from '../../../src/lib/seo'
 
 type PageProps = {
   params: Promise<{ slug: string }>
@@ -23,13 +23,15 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const page = articlePages.find((item) => item.slug === slug)
   if (!page) return {}
 
+  const metaTitle = (page as { metaTitle?: string }).metaTitle ?? compactMetaTitle(page.title)
+
   return {
-    title: page.title,
+    title: metaTitle,
     description: page.metaDescription,
     keywords: page.keywords,
     alternates: { canonical: `${SITE_URL}/novel-psychoactive-substances/${page.slug}/` },
     openGraph: {
-      title: page.title,
+      title: metaTitle,
       description: page.metaDescription,
       type: 'article',
       url: `${SITE_URL}/novel-psychoactive-substances/${page.slug}/`,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import HomepageV2 from '@/components/homepage-v2'
 import { buildPageMetadata } from '../src/lib/seo'
 
 export const metadata: Metadata = buildPageMetadata({
-  title: 'The Hippie Scientist - Clinical Evidence & Safety for Herbs & Supplements',
+  title: 'The Hippie Scientist: Evidence & Safety for Supplements',
   description:
     'Compare evidence-based plant medicine, herbs, and supplements by goal. Explore human clinical trial evidence, biological mechanisms, and drug interactions for sleep, anxiety, focus, and stress.',
   keywords: [

--- a/components/blog/BlogPostPage.tsx
+++ b/components/blog/BlogPostPage.tsx
@@ -10,47 +10,18 @@ import {
   shouldNoindexBlogPost,
   type BlogPost,
 } from '@/lib/blog-index'
-import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd } from '../../src/lib/seo'
+import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, compactMetaTitle } from '../../src/lib/seo'
 import LastUpdatedBadge from '../../src/components/editorial/LastUpdatedBadge'
 import EmailCapture from '@/components/EmailCapture'
 import NewsletterCtaBlock from '@/components/NewsletterCtaBlock'
 import JsonLd from '@/components/seo/JsonLd'
 
 const allPosts: BlogPost[] = posts
-const ARTICLE_META_TITLE_LIMIT = 60
 
 type BlogRouteParams = Promise<{ slug: string }>
 
 export type BlogRouteProps = {
   params: BlogRouteParams
-}
-
-function compactArticleMetaTitle(value: string): string {
-  const cleaned = String(value || '').replace(/\s+/g, ' ').trim()
-  if (cleaned.length <= ARTICLE_META_TITLE_LIMIT) return cleaned
-
-  const withoutParenthetical = cleaned.replace(/\s*\([^)]*\)\s*$/, '').trim()
-  if (withoutParenthetical.length <= ARTICLE_META_TITLE_LIMIT) return withoutParenthetical
-
-  const beforeColon = cleaned.split(':')[0]?.trim()
-  if (beforeColon && beforeColon.length >= 24 && beforeColon.length <= ARTICLE_META_TITLE_LIMIT) return beforeColon
-
-  const simplified = cleaned
-    .replace(/\bEvidence-Based\b/gi, 'Evidence')
-    .replace(/\bEvidence-Informed\b/gi, 'Evidence')
-    .replace(/\bSupplementation\b/gi, 'Safety')
-    .replace(/\bClinical Relevance\b/gi, 'Clinical Use')
-    .replace(/\bDaily Functioning\b/gi, 'Daily Function')
-    .replace(/\bCognitive Support\b/gi, 'Focus')
-    .replace(/\bEmotional Regulation\b/gi, 'Calm')
-    .replace(/\s+/g, ' ')
-    .trim()
-  if (simplified.length <= ARTICLE_META_TITLE_LIMIT) return simplified
-
-  const cutoff = simplified.slice(0, ARTICLE_META_TITLE_LIMIT - 1)
-  const lastBreak = Math.max(cutoff.lastIndexOf(' '), cutoff.lastIndexOf(','), cutoff.lastIndexOf(':'))
-  const compact = (lastBreak > 36 ? cutoff.slice(0, lastBreak) : cutoff).trim()
-  return `${compact}…`
 }
 
 export function generateStaticParams() {
@@ -65,7 +36,7 @@ export async function generateMetadata({ params }: BlogRouteProps) {
 
   const path = `/articles/${resolvedParams.slug}/`
   const rawTitle = (post as any).seoTitle || (post as any).metaTitle || post.title
-  const title = compactArticleMetaTitle(rawTitle)
+  const title = compactMetaTitle(rawTitle)
   const description = (post as any).seoDescription || (post as any).metaDescription || post.excerpt || 'Research note with mechanisms, evidence, and safety context.'
 
   const base = {

--- a/content-collections.ts
+++ b/content-collections.ts
@@ -88,6 +88,7 @@ const novelPsychoactiveSubstancePages = defineCollection({
   include: '**/*.mdx',
   schema: z.object({
     title: z.string().min(1),
+    metaTitle: z.string().min(1).optional(),
     metaDescription: z.string().min(1),
     keywords: z.array(z.string()).default([]),
     lastUpdated: z.string().regex(isoDatePattern),

--- a/lib/goal-clusters.ts
+++ b/lib/goal-clusters.ts
@@ -1,3 +1,5 @@
+import { compactMetaTitle } from '../src/lib/seo'
+
 export type GoalCategory = 'sleep' | 'energy' | 'mood' | 'immune' | 'memory'
 
 export type GoalArticleKind = 'cornerstone' | 'satellite' | 'product-guide'
@@ -32,7 +34,8 @@ const makeArticle = (
 ): GoalArticle => ({
   slug,
   title,
-  seoTitle: `${title} | The Hippie Scientist`,
+  // Metadata <title> only — keeps the visible H1 (title) intact while capping length.
+  seoTitle: compactMetaTitle(title),
   description,
   category,
   kind,

--- a/novel-psychoactive-substances/harm-reduction-considerations-for-kratom-derived-semi-synthetic-opioids.mdx
+++ b/novel-psychoactive-substances/harm-reduction-considerations-for-kratom-derived-semi-synthetic-opioids.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Harm Reduction Considerations for Kratom-Derived Semi-Synthetic Opioids"
+metaTitle: "Harm Reduction for Kratom-Derived Opioids"
 metaDescription: "Practical harm reduction information for compounds such as 7-hydroxymitragynine, MGM-15, and mitragynine pseudoindoxyl, with emphasis on known risks and significant data limitations."
 keywords: ["kratom derivatives harm reduction", "7-hydroxymitragynine risks", "MGM-15 safety", "mitragynine pseudoindoxyl"]
 lastUpdated: "2026-06-15"

--- a/public/blog/blue-lotus-aporphines/index.html
+++ b/public/blog/blue-lotus-aporphines/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Blue Lotus (Nymphaea) and Aporphines for Gentle Sedation — The Hippie Scientist</title>
+    <title>Blue Lotus (Nymphaea) and Aporphines for Gentle Sedation</title>
     <meta name="description" content="Blue lotus (Nymphaea caerulea) evokes images of ancient Egyptian rites and tranquil pools. Today, herbal enthusiasts infuse its petals in tea, wine, or tinctures for serene evenings. The key to under…" />
     <link rel="canonical" href="https://thehippiescientist.net/blog/blue-lotus-aporphines/">
     <meta property="og:type" content="article" />

--- a/public/blog/cacao-theobromine-stimulant/index.html
+++ b/public/blog/cacao-theobromine-stimulant/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Cacao and Theobromine: A Gentle Stimulant Profile — The Hippie Scientist</title>
+    <title>Cacao and Theobromine: A Gentle Stimulant Profile</title>
     <meta name="description" content="Cacao ceremonies and morning cacao tonics are surging in popularity as people seek alternatives to coffee. Theobromine-rich cacao offers a smoother stimulant experience that supports focus, heart ope…" />
     <link rel="canonical" href="https://thehippiescientist.net/blog/cacao-theobromine-stimulant/">
     <meta property="og:type" content="article" />

--- a/public/blog/kava-safety-kavalactones/index.html
+++ b/public/blog/kava-safety-kavalactones/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Kava Safety: Kavalactones, Extraction, and Liver Risk — The Hippie Scientist</title>
+    <title>Kava Safety: Kavalactones, Extraction, and Liver Risk</title>
     <meta name="description" content="Kava (Piper methysticum) carries a dual reputation: a beloved ceremonial relaxant in the South Pacific and a controversial herb in Western regulatory circles. This article examines how kavalactone ch…" />
     <link rel="canonical" href="https://thehippiescientist.net/blog/kava-safety-kavalactones/">
     <meta property="og:type" content="article" />

--- a/public/blog/lions-mane-bdnf/index.html
+++ b/public/blog/lions-mane-bdnf/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Lion's Mane and BDNF: What the Evidence Shows — The Hippie Scientist</title>
+    <title>Lion's Mane and BDNF: What the Evidence Shows</title>
     <meta name="description" content="Lion’s mane mushroom (Hericium erinaceus) has become synonymous with brain health in modern herbal circles. Central to its reputation is brain-derived neurotrophic factor (BDNF), a signaling protein…" />
     <link rel="canonical" href="https://thehippiescientist.net/blog/lions-mane-bdnf/">
     <meta property="og:type" content="article" />

--- a/public/blog/mugwort-dreaming-tradition/index.html
+++ b/public/blog/mugwort-dreaming-tradition/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Mugwort and Dreaming: Tradition Meets Evidence — The Hippie Scientist</title>
+    <title>Mugwort and Dreaming: Tradition Meets Evidence</title>
     <meta name="description" content="Mugwort (Artemisia vulgaris) has woven itself into dream lore across Europe, Asia, and North America. Herbalists burn it as smudge, tuck sprigs under pillows, or sip it as bedtime tea to stimulate vi…" />
     <link rel="canonical" href="https://thehippiescientist.net/blog/mugwort-dreaming-tradition/">
     <meta property="og:type" content="article" />

--- a/public/blog/nightly-blend-guide/index.html
+++ b/public/blog/nightly-blend-guide/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Start Here: Building a Simple Nightly Herb Blend — The Hippie Scientist</title>
+    <title>Start Here: Building a Simple Nightly Herb Blend</title>
     <meta name="description" content="Creating a nightly herb blend can transform bedtime from a scramble into a nourishing ritual. Instead of chasing complex formulas, start with a thoughtful foundation that aligns with your constitutio…" />
     <link rel="canonical" href="https://thehippiescientist.net/blog/nightly-blend-guide/">
     <meta property="og:type" content="article" />

--- a/public/blog/reishi-sleep-immunity/index.html
+++ b/public/blog/reishi-sleep-immunity/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Reishi for Sleep and Immunity: What the Studies Say — The Hippie Scientist</title>
+    <title>Reishi for Sleep and Immunity: What the Studies Say</title>
     <meta name="description" content="Reishi (Ganoderma lucidum) is revered as the “mushroom of immortality” in East Asian traditions. Modern research explores its beta-glucans, triterpenes, and polysaccharides for immune modulation and…" />
     <link rel="canonical" href="https://thehippiescientist.net/blog/reishi-sleep-immunity/">
     <meta property="og:type" content="article" />

--- a/public/blog/rhodiola-vs-ashwagandha/index.html
+++ b/public/blog/rhodiola-vs-ashwagandha/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Rhodiola vs. Ashwagandha: Matching Adaptogens to Your Needs — The Hippie Scientist</title>
+    <title>Rhodiola vs. Ashwagandha: Matching Adaptogens to Your Needs</title>
     <meta name="description" content="Rhodiola (Rhodiola rosea) and ashwagandha (Withania somnifera) are two of the most popular adaptogens for stress resilience. While both herbs modulate the hypothalamic-pituitary-adrenal (HPA) axis, t…" />
     <link rel="canonical" href="https://thehippiescientist.net/blog/rhodiola-vs-ashwagandha/">
     <meta property="og:type" content="article" />

--- a/public/blog/yerba-mate-vs-green-tea/index.html
+++ b/public/blog/yerba-mate-vs-green-tea/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Yerba Mate vs. Green Tea: Balancing Caffeine and L-Theanine — The Hippie Scientist</title>
+    <title>Yerba Mate vs. Green Tea: Balancing Caffeine and L-Theanine</title>
     <meta name="description" content="Yerba mate and green tea share a reputation for steady energy, yet their chemistry and cultural contexts diverge. Mate gourds clink in South American plazas, while Japanese tea ceremonies unfold with…" />
     <link rel="canonical" href="https://thehippiescientist.net/blog/yerba-mate-vs-green-tea/">
     <meta property="og:type" content="article" />

--- a/src/lib/goal-seo.ts
+++ b/src/lib/goal-seo.ts
@@ -1,16 +1,19 @@
 import type { Metadata } from 'next'
-import { formatMetaDescription, buildPageMetadata, SEO_YEAR } from './seo'
+import { formatMetaDescription, buildPageMetadata, compactMetaTitle, SEO_YEAR } from './seo'
 import type { Goal } from '@/data/goals'
 
 const GOAL_SEO_TITLES: Record<string, string> = {
-  sleep: `Best Evidence-Based Supplements for Sleep ${SEO_YEAR} – Safety & Comparisons`,
-  stress: `Best Supplements for Stress ${SEO_YEAR} – Evidence, Safety & What to Avoid`,
-  anxiety: `Best Natural Options for Anxiety Support ${SEO_YEAR} – Compared by Evidence`,
-  focus: `Best Focus Supplements ${SEO_YEAR} – Stimulant vs Non-Stimulant Compared`,
-  pain: `Best Supplements for Pain Support ${SEO_YEAR} – Evidence & Safety Compared`,
-  inflammation: `Best Anti-Inflammatory Supplements ${SEO_YEAR} – Compared by Evidence`,
-  cognition: `Best Cognitive Support Supplements ${SEO_YEAR} – Memory & Focus Compared`,
-  energy: `Best Energy Supplements ${SEO_YEAR} – Stimulant vs Adaptogen Compared`,
+  sleep: `Best Sleep Supplements ${SEO_YEAR}: Evidence & Safety`,
+  stress: `Best Stress Supplements ${SEO_YEAR}: Evidence & Safety`,
+  anxiety: `Best Anxiety Supplements ${SEO_YEAR}: Evidence & Safety`,
+  focus: `Best Focus Supplements ${SEO_YEAR}: Stimulant vs Non-Stimulant`,
+  pain: `Best Pain Supplements ${SEO_YEAR}: Evidence & Safety`,
+  inflammation: `Best Anti-Inflammatory Supplements ${SEO_YEAR}: Evidence`,
+  cognition: `Best Cognitive Supplements ${SEO_YEAR}: Memory & Focus`,
+  energy: `Best Energy Supplements ${SEO_YEAR}: Stimulant vs Adaptogen`,
+  longevity: `Best Longevity Supplements ${SEO_YEAR}: Evidence & Safety`,
+  'blood-pressure': `Best Blood Pressure Supplements ${SEO_YEAR}: Evidence`,
+  'testosterone-support': `Best Testosterone Supplements ${SEO_YEAR}: Evidence`,
 }
 
 const GOAL_SEO_DESCRIPTIONS: Record<string, string> = {
@@ -39,7 +42,8 @@ function fallbackGoalTitle(goal: Goal): string {
 }
 
 export function getGoalSeoTitle(goal: Goal): string {
-  return GOAL_SEO_TITLES[goal.slug] ?? fallbackGoalTitle(goal)
+  // Cap the metadata <title> at 60 chars; the visible goal-page H1 is unaffected.
+  return compactMetaTitle(GOAL_SEO_TITLES[goal.slug] ?? fallbackGoalTitle(goal))
 }
 
 export function buildGoalMetaDescription(

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -22,6 +22,53 @@ export const DEFAULT_DESCRIPTION = `The Hippie Scientist — evidence-first refe
 export const DEFAULT_TITLE_TEMPLATE = `%s | ${SITE_NAME}`
 export const SITEMAP_URL_CAP = 450
 
+export const META_TITLE_LIMIT = 60
+
+/**
+ * Compact a metadata <title> to <= META_TITLE_LIMIT characters without touching
+ * the visible H1/headline. Applied only at metadata-generation points.
+ *
+ * Strategy (in order, stopping at the first result that fits):
+ *  1. Strip a trailing brand suffix ("… | The Hippie Scientist", "… | Guides").
+ *  2. Drop a trailing parenthetical ("(2026)").
+ *  3. Drop a trailing em-dash clause ("Topic — Mechanisms and Evidence").
+ *  4. For colon-structured titles, keep "{Head}: {first clause}" so the primary
+ *     keyword and one descriptive clause survive; fall back to the head alone.
+ *  5. Last resort: truncate at a word boundary with an ellipsis.
+ */
+export function compactMetaTitle(value: string, limit: number = META_TITLE_LIMIT): string {
+  const cleaned = stripBrandSuffix(String(value || '').replace(/\s+/g, ' ').trim())
+  if (cleaned.length <= limit) return cleaned
+
+  const noTrailingParen = cleaned.replace(/\s*\([^)]*\)\s*$/, '').trim()
+  if (noTrailingParen.length <= limit) return noTrailingParen
+
+  const noDashTail = noTrailingParen.replace(/\s*[—–]\s*[^—–]*$/, '').trim()
+  if (noDashTail.length <= limit && /[A-Za-z]/.test(noDashTail)) return noDashTail
+
+  const colonIdx = noTrailingParen.indexOf(':')
+  if (colonIdx > 0) {
+    const head = noTrailingParen.slice(0, colonIdx).trim()
+    const tail = noTrailingParen.slice(colonIdx + 1).trim()
+    const firstClause = tail.split(/\s*[,—–]\s*| - /)[0]?.trim()
+    const withClause = firstClause ? `${head}: ${firstClause}` : ''
+    if (withClause && withClause.length <= limit) return withClause
+    if (head.length >= 10 && head.length <= limit) return head
+  }
+
+  const cutoff = noDashTail.slice(0, limit - 1)
+  const lastBreak = Math.max(cutoff.lastIndexOf(' '), cutoff.lastIndexOf(','), cutoff.lastIndexOf(':'))
+  const compact = (lastBreak > 30 ? cutoff.slice(0, lastBreak) : cutoff).replace(/[\s,:—–-]+$/, '').trim()
+  return `${compact}…`
+}
+
+function stripBrandSuffix(value: string): string {
+  return value
+    .replace(/\s*[|–—-]\s*The Hippie Scientist\s*$/i, '')
+    .replace(/\s*\|\s*Guides\s*$/i, '')
+    .trim()
+}
+
 export type PageType = 'website' | 'article'
 
 export type IndexDecision = {


### PR DESCRIPTION
Metadata-only cleanup that brings the audit's titleTooLong findings to zero
(79 -> 0) without changing any visible H1, body copy, or safety language.

Shared helper:
- Add compactMetaTitle() in src/lib/seo.ts: caps metadata <title> at 60 chars
  by stripping brand suffixes, trailing parentheticals/em-dash clauses, then
  keeping "{Head}: {first clause}" so the primary keyword survives. Applied at
  metadata-generation points only, leaving H1s/headlines intact.
- Replace the duplicated compactor in components/blog/BlogPostPage.tsx with it.

Applied across route buckets:
- /articles/: compact titles in the dynamic [slug] route (markdown + MDX) and
  in the static article pages (metadata title wrapped; H1 untouched).
- /goals/: rewrite GOAL_SEO_TITLES map + add longevity/blood-pressure/
  testosterone entries, guard with the compactor; shorten the goals index title.
- /guides/: shorten static guide TITLE constants and compact the [slug] route.
- /compare/: shorten static compare metadata titles (H1 hero unchanged).
- /blog/: drop the " — The Hippie Scientist" suffix from the static HTML
  <title> tags (og/twitter already suffix-free; pages have no H1).
- novel-psychoactive-substances: compact the [slug] metadata, add an optional
  metaTitle frontmatter field, and set it on the harm-reduction page.
- goal-cluster seoTitle, education/[slug], learn/[slug], app/[slug] focus
  cluster, homepage, efficacy-model, best-magnesium-supplements-for-adhd.

Safety/harm-reduction wording preserved (e.g. Kava keeps "Liver Risk & Harm
Reduction"; kratom pages keep "Harm Reduction"). No affiliate links, no
generated JSON edited by hand, canonical trailing-slash URLs unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VNS8ZSmttXWdpRUZVZhvEq