### PR TITLE
Demote MDX body H1 headings

### DIFF
--- a/components/articles/ArticleMdx.tsx
+++ b/components/articles/ArticleMdx.tsx
@@ -1,12 +1,17 @@
 import { MDXContent } from '@content-collections/mdx/react'
+import type { ComponentPropsWithoutRef } from 'react'
 import { useMDXComponents } from '@/mdx-components'
 
 type ArticleMdxProps = {
   code: string
 }
 
+function BodyHeadingOne({ children, ...props }: ComponentPropsWithoutRef<'h1'>) {
+  return <h2 {...props}>{children}</h2>
+}
+
 export default function ArticleMdx({ code }: ArticleMdxProps) {
-  const components = useMDXComponents({})
+  const components = useMDXComponents({ h1: BodyHeadingOne })
 
   return <MDXContent code={code} components={components} />
 }


### PR DESCRIPTION
## Summary

Fixes the duplicate-H1 pattern for MDX-backed article and novel psychoactive substance pages.

## What changed

- Updates `components/articles/ArticleMdx.tsx`.
- Provides a body-level MDX override that renders markdown `#` headings as `<h2>` inside article body content.
- Keeps page-template hero H1s as the single real page H1.

## Why this matters

The fresh technical SEO audit shows `multipleH1.count = 9`, affecting MDX-backed `/articles/` and `/novel-psychoactive-substances/` pages. Those templates already render a page hero H1, so body-level MDX top headings should not render as additional H1s.

## What stayed unchanged

- Visible hero H1s unchanged.
- Body copy unchanged.
- Harm-reduction and safety language unchanged.
- Metadata/title cleanup untouched.
- Generated JSON not manually edited.
- Canonical URLs unchanged.

## Expected audit impact

- `multipleH1.count`: expected 9 → 0 if this is the only duplicate-H1 source.
- `h1Missing.count`: unchanged by this PR.
- `titleTooLong.count`: should remain 0.

## Validation

Compared branch against main: 1 file changed, 6 additions, 1 deletion. No local build was run in this connector session.

## Impact score

610/1000 — targeted shared renderer fix for all currently reported duplicate-H1 MDX pages.