### PR TITLE
Add H1 to compound pagination pages

### DIFF
--- a/app/compounds/page/[page]/page.tsx
+++ b/app/compounds/page/[page]/page.tsx
@@ -40,6 +40,16 @@ export default async function CompoundsPageN({ params }: P) {
 
   return (
     <div className="mx-auto max-w-6xl space-y-8 px-4 py-8 sm:py-10">
+      <header className="rounded-xl border border-brand-900/10 bg-white/85 p-4 shadow-sm sm:p-5">
+        <p className="eyebrow-label">Compound research library</p>
+        <h1 className="mt-2 font-display text-3xl font-semibold tracking-tight text-ink sm:text-4xl">
+          Compound Profiles &amp; Research Library — Page {p.currentPage}
+        </h1>
+        <p className="mt-2 max-w-2xl text-sm leading-6 text-[#46574d]">
+          Browse evidence, mechanism, and safety summaries for published compound profiles.
+        </p>
+      </header>
+
       <nav className="rounded-xl border border-brand-900/10 bg-white/80 p-4 text-sm">
         <p className="font-semibold">Page {p.currentPage} of {p.totalPages}</p>
         <div className="mt-2 flex gap-4">


### PR DESCRIPTION
## Summary

Adds a page-level H1 to paginated compound library routes.

## What changed

- Updates `app/compounds/page/[page]/page.tsx`.
- Adds a small header with one H1: `Compound Profiles & Research Library — Page {n}`.
- Leaves compound cards, filtering, pagination behavior, and runtime data logic unchanged.

## Why this matters

The fresh technical SEO audit shows missing H1 findings for `/compounds/page/2` through `/compounds/page/16`. The root `/compounds` page already has an H1, but paginated library pages did not.

## What stayed unchanged

- Compound profile data unchanged.
- Metadata title cleanup untouched.
- Generated JSON not manually edited.
- Canonical URLs unchanged.
- Safety language unchanged.

## Expected audit impact

- `h1Missing.count`: expected 72 → 57 if applied alone to the 15 paginated compound routes.
- `multipleH1.count`: unchanged.
- `titleTooLong.count`: should remain 0.

## Validation

Compared branch against main: 1 file changed, 10 additions, 0 deletions. No local build was run in this connector session.

## Impact score

560/1000 — fixes a repeated paginated-library H1 bucket with a small route-level change.