### PR TITLE
Ignore redirect shells in H1 audit

### DIFF
--- a/scripts/ci/build-seo-audit-reports.mjs
+++ b/scripts/ci/build-seo-audit-reports.mjs
@@ -60,6 +60,34 @@ function normalizeRoute(href) {
   return pathOnly.replace(/\/+$/, '') || '/'
 }
 
+function collectRedirectSources() {
+  const sources = new Set()
+  const addSource = (value) => {
+    const raw = String(value || '').trim()
+    if (!raw || raw.includes('*')) return
+    const route = normalizeRoute(raw)
+    if (route) sources.add(route)
+  }
+
+  const redirectsJson = readJson(path.join(root, 'public', '_redirects.json'), [])
+  if (Array.isArray(redirectsJson)) {
+    for (const row of redirectsJson) addSource(row?.source || row?.from)
+  }
+
+  const redirectsPath = path.join(root, 'public', '_redirects')
+  if (fs.existsSync(redirectsPath)) {
+    const lines = fs.readFileSync(redirectsPath, 'utf8').split(/\r?\n/)
+    for (const line of lines) {
+      const trimmed = line.trim()
+      if (!trimmed || trimmed.startsWith('#')) continue
+      const [source, _target, status] = trimmed.split(/\s+/)
+      if (status && /^30[1278]$/.test(status)) addSource(source)
+    }
+  }
+
+  return sources
+}
+
 function nonCanonicalInternalHref(href) {
   if (!href || href.startsWith('#') || href.startsWith('mailto:') || href.startsWith('tel:')) return null
   if (/^https?:\/\//i.test(href)) {
@@ -124,10 +152,8 @@ function collectHtmlRows() {
   })
 }
 
-function collectLinks(rows) {
+function collectLinks(rows, redirectSources) {
   const routes = new Set(rows.map((row) => row.route))
-  const redirects = readJson(path.join(root, 'public', '_redirects.json'), [])
-  const redirectSources = new Set(Array.isArray(redirects) ? redirects.map((row) => normalizeRoute(row?.source || row?.from)).filter(Boolean) : [])
   const links = []
   const nonCanonical = []
   const inbound = new Map([...routes].map((route) => [route, new Set()]))
@@ -203,7 +229,7 @@ function routeH1(row) {
   }
 }
 
-function collectTechnicalSeoIssues(rows, htmlRows) {
+function collectTechnicalSeoIssues(rows, htmlRows, redirectSources) {
   const titleTooLong = rows
     .filter((row) => String(row.title || '').length > titleTooLongThreshold)
     .map(routeTitle)
@@ -214,8 +240,13 @@ function collectTechnicalSeoIssues(rows, htmlRows) {
     .map(routeHtmlSize)
     .sort((a, b) => b.htmlSizeBytes - a.htmlSizeBytes || a.route.localeCompare(b.route))
 
+  const redirectH1Skipped = htmlRows
+    .filter((row) => row.h1Count === 0 && redirectSources.has(row.route))
+    .map(routeH1)
+    .sort((a, b) => a.route.localeCompare(b.route))
+
   const h1Missing = htmlRows
-    .filter((row) => row.h1Count === 0)
+    .filter((row) => row.h1Count === 0 && !redirectSources.has(row.route))
     .map(routeH1)
     .sort((a, b) => a.route.localeCompare(b.route))
 
@@ -245,6 +276,10 @@ function collectTechnicalSeoIssues(rows, htmlRows) {
     multipleH1: {
       count: multipleH1.length,
       pages: multipleH1,
+    },
+    redirectH1Skipped: {
+      count: redirectH1Skipped.length,
+      pages: redirectH1Skipped,
     },
   }
 }
@@ -298,9 +333,10 @@ function main() {
   const htmlRows = collectHtmlRows()
   const manifestRows = collectManifestRows()
   const rows = htmlRows.length ? htmlRows : manifestRows
-  const linkReport = htmlRows.length ? collectLinks(htmlRows) : { links: [], broken: [], nonCanonical: [], orphanRoutes: [] }
+  const redirectSources = collectRedirectSources()
+  const linkReport = htmlRows.length ? collectLinks(htmlRows, redirectSources) : { links: [], broken: [], nonCanonical: [], orphanRoutes: [] }
   const nonCanonicalSummary = summarizeNonCanonicalLinks(linkReport.nonCanonical)
-  const technicalSeoIssues = collectTechnicalSeoIssues(rows, htmlRows)
+  const technicalSeoIssues = collectTechnicalSeoIssues(rows, htmlRows, redirectSources)
   const duplicateSlugs = collectDuplicateSlugs()
   const duplicateMetadata = {
     generatedAt,
@@ -340,6 +376,7 @@ function main() {
       headings: {
         h1Missing: technicalSeoIssues.h1Missing.count,
         multipleH1: technicalSeoIssues.multipleH1.count,
+        redirectH1Skipped: technicalSeoIssues.redirectH1Skipped.count,
       },
       htmlSize: {
         warningBytes: htmlSizeWarningBytes,


### PR DESCRIPTION
## Summary

Updates the technical SEO audit so redirect-only shell pages are not counted as real missing-H1 content pages.

## What changed

- Updates `scripts/ci/build-seo-audit-reports.mjs`.
- Parses exact 301/302/307/308 redirect sources from `public/_redirects` as well as optional `public/_redirects.json`.
- Uses those redirect sources for internal-link existence checks.
- Excludes exact redirect-source routes from the `h1Missing` bucket when their exported shell has no H1.
- Reports those separately as `redirectH1Skipped` so they remain visible for debugging without polluting real content-page H1 counts.

## Why this matters

After the title cleanup and focused H1 fixes, the remaining H1-missing findings are mostly deprecated compound aliases such as `/compounds/coq10`, `/compounds/theanine`, `/compounds/garlic`, and other routes that already exist as redirects in `public/_redirects`.

Those should not receive fake H1s. They should either redirect or be tracked as redirect shells. This PR keeps the audit honest by separating redirect-shell noise from real rendered content issues.

## What stayed unchanged

- No page rendering changes.
- No content copy changes.
- No safety or harm-reduction language changes.
- No metadata title changes.
- No generated JSON manually edited.
- No canonical URL changes.

## Expected audit impact

- `titleTooLong.count`: should remain 0.
- `multipleH1.count`: should remain 0 after #1939.
- `h1Missing.count`: should drop by the exact number of missing-H1 redirect-source shell routes.
- New `redirectH1Skipped.count` records skipped redirect shells explicitly.

## Validation

Compared branch against latest merged H1 fixes: 1 file changed, 44 additions, 7 deletions. No local build was run in this connector session.

## Impact score

640/1000 — removes misleading redirect-shell H1 noise without adding fake headings or touching user-visible content.