### PR TITLE
Add hub links to L-theanine magnesium comparison

### DIFF
--- a/content/comparisons/l-theanine-vs-magnesium.md
+++ b/content/comparisons/l-theanine-vs-magnesium.md
@@ -1,9 +1,11 @@
-# L-Theanine vs Magnesium for Calm and Focus
+# L-Theanine vs Magnesium: Calm Focus, Anxiety, and Sleep
 
 **Cluster:** Anxiety/Stress + Sleep + Cognition  
 **Search intent:** People optimizing for calm focus or sleep who aren't sure which to use; also people stacking  
 **Evidence grade:** L-Theanine for calm focus — B | Magnesium for anxiety/calm — B-C  
 **Verdict:** L-theanine is the better acute calm-focus tool. Magnesium is the better systemic baseline support. They work through overlapping but complementary mechanisms and stack well — particularly for sleep. The choice depends more on what you're optimizing for than on which compound is "better."
+
+**Related guides:** [Full L-theanine evidence guide](/articles/l-theanine) · [L-theanine for anxiety](/articles/l-theanine-for-anxiety) · [L-theanine for sleep](/articles/l-theanine-for-sleep) · [Magnesium for sleep](/guides/magnesium-for-sleep)
 
 ---
 


### PR DESCRIPTION
## What changed

- Updated the comparison title to include calm focus, anxiety, and sleep intent.
- Added a compact related-guides row pointing to:
  - `/articles/l-theanine`
  - `/articles/l-theanine-for-anxiety`
  - `/articles/l-theanine-for-sleep`
  - `/guides/magnesium-for-sleep`

## Why this is high ROI

This connects the L-theanine vs magnesium comparison back into the L-theanine hub cluster without creating new pages or rewriting large TSX files. It supports the recently upgraded L-theanine guide and the anxiety/sleep spoke pages with clearer internal routing.

## Validation

Fetched the branch file after commit and verified the new title and related guide links are present.