### PR TITLE
Feature L-theanine magnesium comparison on compare hub

### DIFF
--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -54,6 +54,7 @@ const FEATURED_CATEGORIES: CompareCategory[] = [
       { slug: 'valerian-vs-passionflower', label: 'Valerian vs Passionflower' },
       { slug: 'glycine-vs-melatonin', label: 'Glycine vs Melatonin' },
       { slug: 'melatonin-vs-l-theanine', label: 'Melatonin vs L-Theanine' },
+      { slug: 'l-theanine-vs-magnesium', label: 'L-Theanine vs Magnesium' },
     ],
   },
   {


### PR DESCRIPTION
## What changed

- Added `L-Theanine vs Magnesium` to the Sleep featured comparisons section on `/compare`.

## Why this is high ROI

This surfaces an existing dynamic comparison route that supports the L-theanine sleep/anxiety/focus cluster. It improves discovery from the main comparison hub without creating a new page or changing the comparison page scaffold.

## Validation

Fetched the branch file after commit and verified the Sleep category now includes `l-theanine-vs-magnesium`.