### PR TITLE
Fix SEO crawl paths and internal link errors

### DIFF
--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -20,7 +20,7 @@ export const metadata: Metadata = buildPageMetadata({
   title: `Herb & Supplement Comparison Center ${SEO_YEAR}`,
   description:
     'Compare herbs and supplements side-by-side by evidence strength, mechanism, stimulation profile, safety, and dosing. Evidence-based decision support.',
-  path: '/compare',
+  path: '/compare/',
 })
 
 type CompareCategory = {
@@ -92,6 +92,7 @@ const popularComparisonPairs = [
   { label: 'Rhodiola vs Ashwagandha', href: '/compare/rhodiola-vs-ashwagandha/' },
   { label: 'Ashwagandha vs L-Theanine vs Magnesium', href: '/compare/ashwagandha-vs-l-theanine-vs-magnesium/' },
   { label: 'Caffeine vs L-Theanine vs Bacopa for Focus', href: '/compare/caffeine-vs-l-theanine-vs-bacopa-for-focus/' },
+  { label: 'Dynamic Ingredient Comparison Matrix', href: '/compare/dynamic/' },
 ]
 
 const guidanceCards = [
@@ -127,7 +128,7 @@ export default async function ComparePage() {
     }))
 
   const schemaGraph = buildCompareHubSchemaGraph({
-    path: '/compare',
+    path: '/compare/',
     title: `Compare Supplements Side by Side ${SEO_YEAR} – Evidence & Safety`,
     description: 'Compare herbs and supplements by evidence strength, mechanism, stimulation profile, safety, and dosing. Free research tool.',
     breadcrumbs: [
@@ -194,7 +195,7 @@ export default async function ComparePage() {
         <ul className="mt-4 grid gap-2 text-sm leading-6 text-muted sm:grid-cols-2">
           {popularComparisonPairs.map(pair => (
             <li key={pair.href}>
-              <a href={pair.href} className="font-semibold text-brand-800 hover:underline dark:text-brand-100 dark:hover:text-white">{pair.label}</a>
+              <Link href={pair.href} className="font-semibold text-brand-800 hover:underline dark:text-brand-100 dark:hover:text-white">{pair.label}</Link>
             </li>
           ))}
         </ul>
@@ -210,9 +211,12 @@ export default async function ComparePage() {
       <PremiumCard as="section" className="p-5">
         <p className="eyebrow-label">Decision next step</p>
         <h2 className="mt-2 text-xl font-semibold text-ink">Use comparisons to choose a safer path</h2>
-        <div className="mt-4 grid gap-3 text-sm leading-6 text-muted md:grid-cols-3">
+        <div className="mt-4 grid gap-3 text-sm leading-6 text-muted md:grid-cols-4">
           <Link href="/goals/" className="rounded-xl border border-brand-900/10 p-4 font-semibold text-ink transition hover:bg-brand-50 dark:border-white/10 dark:hover:bg-white/10">
             Start from your goal
+          </Link>
+          <Link href="/compare/dynamic/" className="rounded-xl border border-brand-900/10 p-4 font-semibold text-ink transition hover:bg-brand-50 dark:border-white/10 dark:hover:bg-white/10">
+            Open dynamic matrix
           </Link>
           <Link href="/safety-checker/" className="rounded-xl border border-brand-900/10 p-4 font-semibold text-ink transition hover:bg-brand-50 dark:border-white/10 dark:hover:bg-white/10">
             Check safety context

--- a/app/education/page.tsx
+++ b/app/education/page.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
     title: 'Neuroscience and Neuropharmacology Education',
     description:
       'Explore education on neurochemistry, cognition, stress biology, recovery systems, and psychoactive neuroscience.',
-    url: '/education',
+    url: '/education/',
   },
   twitter: {
     card: 'summary_large_image',
@@ -27,28 +27,28 @@ const supernodes = [
     title: 'Stress and Recovery Biology',
     description:
       'Educational exploration of stress neurobiology, burnout systems, recovery-oriented neuropharmacology, sleep continuity, fatigue systems, and nervous-system resilience.',
-    href: '/education/how-stress-affects-the-brain',
+    href: '/education/how-stress-affects-the-brain/',
     category: 'Recovery Neuroscience',
   },
   {
     title: 'Cognition and Neuroplasticity',
     description:
       'Explore memory formation, neuroplasticity, focus continuity, executive-function systems, learning adaptation, and cognition-oriented neuroscience.',
-    href: '/education/how-learning-affects-neuroplasticity',
+    href: '/education/how-learning-affects-neuroplasticity/',
     category: 'Cognition Systems',
   },
   {
     title: 'Psychoactive Education',
     description:
       'Systems-oriented psychoactive education covering altered states, contextual neurobiology, emotional processing, set and setting, and harm-reduction framing.',
-    href: '/education/understanding-altered-states',
+    href: '/education/understanding-altered-states/',
     category: 'Contextual Neurobiology',
   },
   {
     title: 'Adaptogens and Stress Resilience',
     description:
       'Educational exploration of adaptogens, stress-response physiology, neuroendocrine adaptation, burnout systems, and resilience biology.',
-    href: '/education/what-are-adaptogens',
+    href: '/education/what-are-adaptogens/',
     category: 'Stress Physiology',
   },
 ]
@@ -56,80 +56,107 @@ const supernodes = [
 const foundational = [
   {
     title: 'Evidence Literacy: Clinical Trial Design',
-    href: '/education/evidence-literacy',
+    href: '/education/study-design-snapshot/',
+  },
+  {
+    title: 'How to Read Scientific Studies',
+    href: '/education/how-to-read-scientific-studies/',
   },
   {
     title: 'How Neurotransmitters Work',
-    href: '/education/how-neurotransmitters-work',
+    href: '/education/how-neurotransmitters-work/',
   },
   {
     title: 'How Receptors Work',
-    href: '/education/how-receptors-work',
+    href: '/education/how-receptors-work/',
   },
   {
     title: 'Why Neurochemistry Is Complex',
-    href: '/education/why-neurochemistry-is-complex',
+    href: '/education/why-neurochemistry-is-complex/',
   },
   {
     title: 'Evidence Hierarchy',
-    href: '/education/evidence-hierarchy',
+    href: '/education/evidence-hierarchy/',
   },
 ]
 
 const cognition = [
   {
     title: 'How Focus and Motivation Work',
-    href: '/education/how-focus-and-motivation-work',
+    href: '/education/how-focus-and-motivation-work/',
   },
   {
     title: 'How Memory Formation Works',
-    href: '/education/how-memory-formation-works',
+    href: '/education/how-memory-formation-works/',
   },
   {
     title: 'How Learning Affects Neuroplasticity',
-    href: '/education/how-learning-affects-neuroplasticity',
+    href: '/education/how-learning-affects-neuroplasticity/',
   },
   {
     title: 'What Is a Nootropic?',
-    href: '/education/what-is-a-nootropic',
+    href: '/education/what-is-a-nootropic/',
   },
 ]
 
 const recovery = [
   {
     title: 'How Sleep Affects Neurochemistry',
-    href: '/education/how-sleep-affects-neurochemistry',
+    href: '/education/how-sleep-affects-neurochemistry/',
   },
   {
     title: 'How the Brain Recovers From Fatigue',
-    href: '/education/how-the-brain-recovers-from-fatigue',
+    href: '/education/how-the-brain-recovers-from-fatigue/',
   },
   {
     title: 'What Is Neuroinflammation?',
-    href: '/education/what-is-neuroinflammation',
+    href: '/education/what-is-neuroinflammation/',
   },
   {
     title: 'How Emotional Regulation Works',
-    href: '/education/how-emotional-regulation-works',
+    href: '/education/how-emotional-regulation-works/',
   },
 ]
 
 const psychoactive = [
   {
     title: 'Understanding Altered States',
-    href: '/education/understanding-altered-states',
+    href: '/education/understanding-altered-states/',
   },
   {
-    title: 'How Set and Setting Work',
-    href: '/education/why-set-and-setting-matter',
+    title: 'How Set and Setting Matter',
+    href: '/education/why-set-and-setting-matter/',
   },
   {
     title: 'Psychoactive Substances Overview',
-    href: '/education/understanding-altered-states',
+    href: '/novel-psychoactive-substances/',
   },
   {
     title: 'Psychoactive Education Hub',
-    href: '/psychoactive',
+    href: '/psychoactive/',
+  },
+]
+
+const researchTools = [
+  {
+    title: 'Scientific Evidence Citation Explorer',
+    href: '/education/citation-explorer/',
+  },
+  {
+    title: 'Interactive Supplement Efficacy Modeler',
+    href: '/education/efficacy-model/',
+  },
+  {
+    title: 'Biological Pathway Connectivity Explorer',
+    href: '/education/explorer/',
+  },
+  {
+    title: 'Research Methodology',
+    href: '/education/research-methodology/',
+  },
+  {
+    title: 'Safety and Educational Disclaimers',
+    href: '/education/safety-and-disclaimers/',
   },
 ]
 
@@ -183,7 +210,7 @@ export default function EducationHubPage() {
       <AuthorityJsonLd
         title='Neuroscience and Neuropharmacology Education'
         description='Evidence-informed educational ecosystem covering neurochemistry, cognition systems, stress biology, recovery neuropharmacology, psychoactive education, and systems-oriented neuroscience.'
-        url='https://thehippiescientist.net/education'
+        url='https://thehippiescientist.net/education/'
         type='CollectionPage'
       />
 
@@ -241,6 +268,12 @@ export default function EducationHubPage() {
         title='Psychoactive and Altered-State Education'
         description='Systems-oriented psychoactive education focused on perception, contextual neurobiology, altered states, emotional intensity, and harm-reduction awareness.'
         items={psychoactive}
+      />
+
+      <Section
+        title='Research Tools and Safety Pages'
+        description='Methodology, citation, modeling, pathway, and safety pages that should be reachable from the main education hub instead of sitting isolated.'
+        items={researchTools}
       />
 
       <section className='card-premium p-8 space-y-6'>

--- a/app/guides/[slug]/page.tsx
+++ b/app/guides/[slug]/page.tsx
@@ -26,19 +26,19 @@ const GUIDE_SLUGS = [
 const RELATED_GUIDE_MAP: Record<string, RelatedArticle[]> = {
   ashwagandha: [
     {
-      href: "/guides/turmeric-curcumin",
+      href: "/guides/turmeric-curcumin/",
       title: "Turmeric & Curcumin Guide",
       description: "Anti-inflammatory evidence, bioavailability forms, and dosage comparison.",
       category: "stress",
     },
     {
-      href: "/guides/lions-mane",
+      href: "/guides/lions-mane/",
       title: "Lion's Mane Guide",
       description: "Cognitive support, NGF synthesis, and neuroregeneration evidence.",
       category: "focus",
     },
     {
-      href: "/guides/magnesium-for-sleep",
+      href: "/guides/magnesium-for-sleep/",
       title: "Magnesium for Sleep Guide",
       description: "Magnesium forms, dosage, and evidence for sleep and anxiety support.",
       category: "sleep",
@@ -46,19 +46,19 @@ const RELATED_GUIDE_MAP: Record<string, RelatedArticle[]> = {
   ],
   "lions-mane": [
     {
-      href: "/guides/ashwagandha",
+      href: "/guides/ashwagandha/",
       title: "Ashwagandha Guide",
       description: "Cortisol modulation, stress adaptation, and sleep quality evidence.",
       category: "stress",
     },
     {
-      href: "/guides/turmeric-curcumin",
+      href: "/guides/turmeric-curcumin/",
       title: "Turmeric & Curcumin Guide",
       description: "Anti-inflammatory and neuroprotective evidence with bioavailability context.",
       category: "stress",
     },
     {
-      href: "/guides/magnesium-for-sleep",
+      href: "/guides/magnesium-for-sleep/",
       title: "Magnesium for Sleep Guide",
       description: "Magnesium forms, dosage, and evidence for sleep and anxiety support.",
       category: "sleep",
@@ -87,7 +87,7 @@ export default async function GuidePage({ params }: Props) {
   if (!guide) notFound();
 
   const ga4Id = process.env.NEXT_PUBLIC_GA4_ID?.trim() || "";
-  const pageUrl = `${SITE_URL}/guides/${slug}`;
+  const pageUrl = `${SITE_URL}/guides/${slug}/`;
   const publishDate = guide.publishDate || "2024-01-01";
   const contentBlocks = guide.content
     .split(/\n{2,}/)
@@ -105,8 +105,8 @@ export default async function GuidePage({ params }: Props) {
         datePublished={publishDate}
         breadcrumbs={[
           { label: "Home", href: "/" },
-          { label: "Guides", href: "/guides" },
-          { label: guide.title, href: `/guides/${slug}` },
+          { label: "Guides", href: "/guides/" },
+          { label: guide.title, href: `/guides/${slug}/` },
         ]}
       />
       {ga4Id && (
@@ -118,7 +118,7 @@ export default async function GuidePage({ params }: Props) {
               window.dataLayer = window.dataLayer || [];
               function gtag(){dataLayer.push(arguments);}
               gtag('event', 'page_view', {
-                page_path: '/guides/${slug}',
+                page_path: '/guides/${slug}/',
                 page_title: '${guide.title.replace(/'/g, "\\'")}',
                 guide_slug: '${slug}',
                 guide_type: 'guide'
@@ -141,9 +141,9 @@ export default async function GuidePage({ params }: Props) {
           <RelatedArticles articles={relatedGuides} />
         )}
         <nav className="flex flex-wrap gap-4 text-sm font-semibold text-brand-700" aria-label="Guide support links">
-          <Link href="/guides" className="hover:text-brand-800">All guides</Link>
-          <Link href="/articles" className="hover:text-brand-800">Articles</Link>
-          <Link href="/safety-checker" className="hover:text-brand-800">Safety checker</Link>
+          <Link href="/guides/" className="hover:text-brand-800">All guides</Link>
+          <Link href="/articles/" className="hover:text-brand-800">Articles</Link>
+          <Link href="/safety-checker/" className="hover:text-brand-800">Safety checker</Link>
         </nav>
       </div>
     </ArticleLayout>

--- a/app/guides/page.tsx
+++ b/app/guides/page.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
     title: 'Supplement Guides — The Hippie Scientist',
     description:
       'The main guide library for choosing supplements by goal, comparing options, and checking safety tradeoffs before buying.',
-    url: '/guides',
+    url: '/guides/',
     type: 'website',
   },
   twitter: {
@@ -27,65 +27,94 @@ const GOAL_GUIDES = [
   {
     label: 'Anxiety',
     slug: 'anxiety',
-    goalHref: '/goals/anxiety',
+    goalHref: '/goals/anxiety/',
     description: 'Start here when the question is calm, worry, overthinking, or anxiety-support tradeoffs.',
     guides: [
-      { href: '/guides/best-herbs-for-anxiety', title: 'Best Herbs for Anxiety', meta: 'Herbal shortlist · 8 min' },
-      { href: '/guides/natural-anxiolytics-beyond-ashwagandha', title: 'Natural Anxiolytics Beyond Ashwagandha', meta: 'Alternatives · 7 min' },
-      { href: '/guides/best-supplements-for-overthinking', title: 'Best Supplements for Overthinking', meta: 'Calm thinking · 6 min' },
+      { href: '/guides/best-herbs-for-anxiety/', title: 'Best Herbs for Anxiety', meta: 'Herbal shortlist · 8 min' },
+      { href: '/guides/natural-anxiolytics-beyond-ashwagandha/', title: 'Natural Anxiolytics Beyond Ashwagandha', meta: 'Alternatives · 7 min' },
+      { href: '/guides/best-supplements-for-overthinking/', title: 'Best Supplements for Overthinking', meta: 'Calm thinking · 6 min' },
     ],
   },
   {
     label: 'Sleep',
     slug: 'sleep',
-    goalHref: '/goals/sleep',
+    goalHref: '/goals/sleep/',
     description: 'Use these when the problem is sleep onset, sleep quality, or choosing between common sleep aids.',
     guides: [
-      { href: '/guides/best-supplements-for-sleep', title: 'Best Supplements for Sleep', meta: 'Main guide · 10 min' },
-      { href: '/guides/best-natural-sleep-aids-that-work', title: 'Best Natural Sleep Aids That Work', meta: 'Shortlist · 8 min' },
-      { href: '/guides/magnesium-vs-melatonin', title: 'Magnesium vs Melatonin', meta: 'Comparison · 6 min' },
+      { href: '/guides/best-supplements-for-sleep/', title: 'Best Supplements for Sleep', meta: 'Main guide · 10 min' },
+      { href: '/guides/best-natural-sleep-aids-that-work/', title: 'Best Natural Sleep Aids That Work', meta: 'Shortlist · 8 min' },
+      { href: '/guides/magnesium-vs-melatonin/', title: 'Magnesium vs Melatonin', meta: 'Comparison · 6 min' },
+      { href: '/guides/magnesium-for-sleep/', title: 'Magnesium for Sleep', meta: 'Form guide · 7 min' },
     ],
   },
   {
     label: 'Stress',
     slug: 'stress',
-    goalHref: '/goals/stress',
+    goalHref: '/goals/stress/',
     description: 'For stress load, adaptogens, cortisol-adjacent claims, and calmer recovery decisions.',
     guides: [
-      { href: '/guides/best-supplements-for-stress', title: 'Best Supplements for Stress', meta: 'Main guide · 9 min' },
-      { href: '/guides/best-adaptogens-for-stress', title: 'Best Adaptogens for Stress', meta: 'Adaptogens · 8 min' },
-      { href: '/guides/how-to-lower-cortisol-naturally', title: 'How to Lower Cortisol Naturally', meta: 'Context · 8 min' },
+      { href: '/guides/best-supplements-for-stress/', title: 'Best Supplements for Stress', meta: 'Main guide · 9 min' },
+      { href: '/guides/best-adaptogens-for-stress/', title: 'Best Adaptogens for Stress', meta: 'Adaptogens · 8 min' },
+      { href: '/guides/how-to-lower-cortisol-naturally/', title: 'How to Lower Cortisol Naturally', meta: 'Context · 8 min' },
     ],
   },
   {
     label: 'Focus',
     slug: 'focus',
-    goalHref: '/goals/focus',
+    goalHref: '/goals/focus/',
     description: 'Use these for attention, ADHD-adjacent support, nootropics, and avoiding stimulant-heavy choices.',
     guides: [
-      { href: '/guides/best-supplements-for-focus', title: 'Best Supplements for Focus', meta: 'Main guide · 8 min' },
-      { href: '/guides/best-nootropics-for-focus', title: 'Best Nootropics for Focus', meta: 'Nootropics · 9 min' },
-      { href: '/guides/focus-without-caffeine-crash', title: 'Focus Without the Caffeine Crash', meta: 'Stimulant-light · 7 min' },
+      { href: '/guides/best-supplements-for-focus/', title: 'Best Supplements for Focus', meta: 'Main guide · 8 min' },
+      { href: '/guides/best-nootropics-for-focus/', title: 'Best Nootropics for Focus', meta: 'Nootropics · 9 min' },
+      { href: '/guides/focus-without-caffeine-crash/', title: 'Focus Without the Caffeine Crash', meta: 'Stimulant-light · 7 min' },
+      { href: '/best-magnesium-supplements-for-adhd/', title: 'Best Magnesium Supplements for ADHD', meta: 'Buying guide · 8 min' },
     ],
   },
 ]
 
 const COMPARISONS = [
-  { href: '/guides/magnesium-vs-melatonin', title: 'Magnesium vs Melatonin', subtitle: 'Relaxation support vs sleep-timing support' },
-  { href: '/guides/sleep-herbs-vs-melatonin', title: 'Sleep Herbs vs Melatonin', subtitle: 'Herbals vs hormone for sleep onset' },
-  { href: '/compare/rhodiola-vs-ashwagandha', title: 'Rhodiola vs Ashwagandha', subtitle: 'Performance adaptogen vs recovery adaptogen' },
-  { href: '/compare', title: 'Browse All Comparisons', subtitle: 'Full side-by-side comparison index' },
+  { href: '/guides/magnesium-vs-melatonin/', title: 'Magnesium vs Melatonin', subtitle: 'Relaxation support vs sleep-timing support' },
+  { href: '/guides/sleep-herbs-vs-melatonin/', title: 'Sleep Herbs vs Melatonin', subtitle: 'Herbals vs hormone for sleep onset' },
+  { href: '/compare/rhodiola-vs-ashwagandha/', title: 'Rhodiola vs Ashwagandha', subtitle: 'Performance adaptogen vs recovery adaptogen' },
+  { href: '/compare/', title: 'Browse All Comparisons', subtitle: 'Full side-by-side comparison index' },
+]
+
+const CORE_HERB_GUIDES = [
+  {
+    href: '/guides/ashwagandha/',
+    title: 'Ashwagandha Guide',
+    subtitle: 'Stress, sleep, anxiety, forms, and safety context.',
+    meta: 'Core guide · stress',
+  },
+  {
+    href: '/guides/lions-mane/',
+    title: "Lion's Mane Guide",
+    subtitle: 'Focus, cognitive support, mushroom forms, and evidence limits.',
+    meta: 'Core guide · focus',
+  },
+  {
+    href: '/guides/turmeric-curcumin/',
+    title: 'Turmeric & Curcumin Guide',
+    subtitle: 'Inflammation support, bioavailability, and product-quality tradeoffs.',
+    meta: 'Core guide · inflammation',
+  },
+  {
+    href: '/guides/supplements-for-brain-fog-and-fatigue/',
+    title: 'Supplements for Brain Fog and Fatigue',
+    subtitle: 'Bridge guide for fatigue, focus, recovery, and energy support.',
+    meta: 'Bridge guide · focus',
+  },
 ]
 
 const SAFETY_GUIDES = [
   {
-    href: '/guides/psychedelic-adjacent-herbs',
+    href: '/guides/psychedelic-adjacent-herbs/',
     title: 'Psychedelic-Adjacent Herbs',
     subtitle: 'Safety context for altered-state-adjacent herbs without romanticizing risky use.',
     meta: 'Safety · 10 min',
   },
   {
-    href: '/guides/kratom-7oh-withdrawal-management',
+    href: '/guides/kratom-7oh-withdrawal-management/',
     title: 'Kratom 7-OH Withdrawal Management',
     subtitle: 'Evidence-informed withdrawal education, symptom timelines, and conservative taper context.',
     meta: 'Harm reduction · 12 min',
@@ -93,17 +122,18 @@ const SAFETY_GUIDES = [
 ]
 
 const LIBRARY_MAP = [
-  { label: 'Goals', href: '/goals', description: 'Problem decision pages.' },
-  { label: 'Guides', href: '/guides', description: 'Practical choosing guides.' },
-  { label: 'Articles', href: '/articles', description: 'Research notes and education.' },
-  { label: 'Herbs & compounds', href: '/herbs', description: 'Reference database.' },
-  { label: 'Compare', href: '/compare', description: 'Direct side-by-side pages.' },
+  { label: 'Goals', href: '/goals/', description: 'Problem decision pages.' },
+  { label: 'Guides', href: '/guides/', description: 'Practical choosing guides.' },
+  { label: 'Articles', href: '/articles/', description: 'Research notes and education.' },
+  { label: 'Herbs & compounds', href: '/herbs/', description: 'Reference database.' },
+  { label: 'Compare', href: '/compare/', description: 'Direct side-by-side pages.' },
 ]
 
 function GuidesCollectionJsonLd() {
   const allGuideLinks = [
     ...GOAL_GUIDES.flatMap((goal) => goal.guides),
     ...COMPARISONS,
+    ...CORE_HERB_GUIDES,
     ...SAFETY_GUIDES,
   ]
   const graph = {
@@ -211,6 +241,25 @@ export default function GuidesPage() {
 
       <section className="space-y-4">
         <PremiumSectionHeader
+          eyebrow="Core guide links"
+          title="Do not leave useful guides isolated."
+          description="These supporting guides strengthen crawl paths into the practical library and keep older guide assets reachable from the main hub."
+        />
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {CORE_HERB_GUIDES.map((guide) => (
+            <PremiumLinkCard
+              key={guide.href}
+              href={guide.href}
+              eyebrow={guide.meta}
+              title={guide.title}
+              description={guide.subtitle}
+            />
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <PremiumSectionHeader
           eyebrow="Compare"
           title="Head-to-head choosing guides."
           description="Use comparisons when you are deciding between two options and want mechanism, evidence, timing, and tradeoffs side by side."
@@ -250,7 +299,7 @@ export default function GuidesPage() {
 
       <PremiumCallout>
         Looking for deeper research notes, mechanisms, individual herb writeups, or education-heavy posts? Use the{' '}
-        <Link href="/articles" className="font-bold text-brand-800 underline underline-offset-4 dark:text-brand-100">
+        <Link href="/articles/" className="font-bold text-brand-800 underline underline-offset-4 dark:text-brand-100">
           articles archive
         </Link>
         . This page stays focused on practical choosing guides.

--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -6,8 +6,8 @@ import { buildPageMetadata } from '../../src/lib/seo'
 
 export const metadata: Metadata = buildPageMetadata({
   title: 'Research Tools',
-  description: 'Interactive tools for navigating herb and compound evidence: safety checker, comparisons, goal guides, and site search.',
-  path: '/tools',
+  description: 'Interactive tools for navigating herb and compound evidence: safety checker, comparisons, goal guides, dosage context, stack builder, and research explorers.',
+  path: '/tools/',
 })
 
 type ToolCard = {
@@ -20,50 +20,71 @@ type ToolCard = {
 
 const tools: ToolCard[] = [
   {
-    href: '/safety-checker',
+    href: '/safety-checker/',
     title: 'Safety Checker',
     description: 'Check interactions, contraindications, and cautions for herbs and compounds against your medications or conditions.',
     icon: Shield,
     available: true,
   },
   {
-    href: '/compare',
+    href: '/compare/',
     title: 'Herb & Compound Comparison',
     description: 'Side-by-side evidence, mechanisms, and safety comparison of two or more profiles.',
     icon: GitCompare,
     available: true,
   },
   {
-    href: '/goals',
+    href: '/goals/',
     title: 'Goal-Based Guides',
-    description: 'Browse by practical goal (sleep, focus, stress) with evidence-ranked recommendations and context.',
+    description: 'Browse by practical goal — sleep, focus, stress, and anxiety — with evidence-ranked recommendations and context.',
     icon: Target,
     available: true,
   },
   {
-    href: '/search',
+    href: '/search/',
     title: 'Site Search',
-    description: 'Full-text search across all herb, compound, and research note profiles powered by Pagefind.',
+    description: 'Full-text search across herb, compound, guide, and research note profiles powered by Pagefind.',
+    icon: Search,
+    available: true,
+  },
+  {
+    href: '/dosing/',
+    title: 'Dosing Context Calculator',
+    description: 'Estimate active compound yield and dosage context before comparing forms or products.',
+    icon: Calculator,
+    available: true,
+  },
+  {
+    href: '/stacks/builder/',
+    title: 'Supplement Stack Builder',
+    description: 'Build a cautious supplement stack and review overlap risk before combining options.',
+    icon: Target,
+    available: true,
+  },
+  {
+    href: '/education/citation-explorer/',
+    title: 'Citation Explorer',
+    description: 'Open the evidence trail behind claims and research notes when you want to audit the source quality.',
+    icon: BookOpen,
+    available: true,
+  },
+  {
+    href: '/education/efficacy-model/',
+    title: 'Efficacy Modeler',
+    description: 'Explore how evidence strength, dose context, and uncertainty change confidence in an option.',
+    icon: AlertTriangle,
+    available: true,
+  },
+  {
+    href: '/education/explorer/',
+    title: 'Pathway Explorer',
+    description: 'Browse biological pathway connections across herbs, compounds, goals, and mechanisms.',
     icon: Search,
     available: true,
   },
 ]
 
 const plannedTools: ToolCard[] = [
-  {
-    href: '#',
-    title: 'Dosing Calculator',
-    description: 'Evidence-informed starting ranges and titration guidance (with safety guardrails).',
-    icon: Calculator,
-    available: false,
-  },
-  {
-    href: '#',
-    title: 'Interaction Checker',
-    description: 'Deeper medication + supplement interaction matrix with references.',
-    icon: AlertTriangle,
-    available: false,
-  },
   {
     href: '#',
     title: 'Evidence Tracker',


### PR DESCRIPTION
## Summary
- Fixes a broken education hub link by replacing `/education/evidence-literacy` with the live study-design page.
- Adds crawl paths from `/tools/` to weak/orphaned tool pages: dosing, stack builder, citation explorer, efficacy modeler, and pathway explorer.
- Adds crawl paths from `/education/` to methodology, safety, citation, modeling, and explorer pages.
- Strengthens `/guides/` internal linking to core guide assets, including Lion's Mane, Magnesium for Sleep, Ashwagandha, Turmeric/Curcumin, brain fog/fatigue, and the ADHD magnesium buying guide.
- Adds a direct crawl path from `/compare/` to `/compare/dynamic/`.
- Canonicalizes several internal hub/detail links with trailing slashes to reduce non-canonical internal href noise.

## SEO impact
This targets the highest-impact technical SEO issue visible in the repo audit artifacts: weak/orphan internal links and at least one broken internal route reference. It improves crawl discovery without expanding the site or changing the product direction.

## Validation
Not run locally from this environment. Recommended before merge:
- `npm run typecheck`
- `npm run lint`
- `npm run build:deploy`
- `npm run audit:seo-reports`