### PR TITLE
Fix SEO errors: noindex fallbacks, missing Twitter cards, phantom sitemap routes

### DIFF
--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -12,7 +12,7 @@ import RelatedDiscoveryGroups from '@/components/ui/RelatedDiscoveryGroups'
 import { getRuntimeVisibility } from '../../../lib/runtime-visibility'
 import { cleanSummary, formatDisplayLabel, isClean, list, text, unique } from '@/lib/display-utils'
 import { normalizeSlug } from '@/lib/slug-utils'
-import { faqPageJsonLd, generateDetailMetadata, isMeaningfulFaqAnswer, shouldIndexRoute, SITE_URL } from '../../../src/lib/seo'
+import { buildPageMetadata, faqPageJsonLd, generateDetailMetadata, isMeaningfulFaqAnswer, shouldIndexRoute, SITE_URL } from '../../../src/lib/seo'
 import SchemaGraphScript from '@/components/seo/SchemaGraphScript'
 import CompoundSourceHerbs from '@/components/seo/CompoundSourceHerbs'
 import ProfileTOC from '@/components/ui/ProfileTOC'
@@ -220,23 +220,18 @@ export async function generateMetadata({ params }: PageProps) {
   const canonicalSlug = redirectedCanonical || normalizedSlug
   const mdxPage = allCompoundMdxPages.find((page) => page.slug === canonicalSlug)
   if (mdxPage) {
-    return {
+    return buildPageMetadata({
       title: mdxPage.title,
-      description: mdxPage.metaDescription,
+      description: mdxPage.metaDescription || '',
+      path: `/compounds/${mdxPage.slug}`,
+      openGraphType: 'article',
       keywords: mdxPage.keywords,
-      alternates: { canonical: `${SITE_URL}/compounds/${mdxPage.slug}/` },
-      openGraph: {
-        title: mdxPage.title,
-        description: mdxPage.metaDescription,
-        type: 'article',
-        url: `${SITE_URL}/compounds/${mdxPage.slug}/`,
-      },
-    }
+    })
   }
 
   const compound = await getCompoundMetadataRecord(canonicalSlug)
 
-  if (!compound) return {}
+  if (!compound) return { title: 'Compound Not Found', robots: { index: false, follow: true } }
 
   const metadata = generateDetailMetadata(compound, 'compound')
   if (canonicalSlug !== normalizedSlug) {

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -92,6 +92,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   if (!herb) {
     return {
       title: 'Herb Not Found',
+      robots: { index: false, follow: true },
     }
   }
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -218,6 +218,9 @@ function checkRouteFileEligibility(normalizedRoute: string): boolean {
   const clean = normalizedRoute.replace(/^\//, '');
   if (clean.includes('[') || clean.includes(']')) return true;
 
+  // Root route is always eligible
+  if (!clean) return true;
+
   const possiblePaths = [
     path.join(process.cwd(), 'app', clean, 'page.tsx'),
     path.join(process.cwd(), 'app', clean, 'page.ts'),
@@ -231,8 +234,11 @@ function checkRouteFileEligibility(normalizedRoute: string): boolean {
       path.join(process.cwd(), 'app', ...segments.slice(0, -1), '[slug]', 'page.ts'),
     );
   }
+
+  let fileFound = false;
   for (const filePath of possiblePaths) {
     if (existsSync(filePath)) {
+      fileFound = true;
       try {
         const content = readFileSync(filePath, 'utf8');
         if (/robots\s*:\s*["'][^"']*noindex/i.test(content) || /robots\s*:\s*\{\s*index\s*:\s*false/i.test(content)) {
@@ -251,7 +257,9 @@ function checkRouteFileEligibility(normalizedRoute: string): boolean {
       }
     }
   }
-  return true;
+
+  // Routes with no matching page file should not be included in the sitemap
+  return fileFound;
 }
 
 function isAllowedRouteManifestEntry(routeStr: string): boolean {
@@ -684,9 +692,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     'best-supplements-for-blood-pressure',
     'best-supplements-for-gut-health',
     'best-supplements-for-joint-support',
-    'best-herbs-for-anxiety',
-    'best-nootropics-for-focus',
-    'best-adaptogens-for-stress',
+    'best-magnesium-supplements-for-adhd',
   ];
   topPages.forEach((p) => {
     addRoute(`/${p}`, 'monthly', 0.6);

--- a/scripts/ci/validate-evidence-language.mjs
+++ b/scripts/ci/validate-evidence-language.mjs
@@ -50,8 +50,16 @@ export function auditRecord(record, datasetName = 'test') {
   const textToAudit = `${summary} ${description}`.trim()
   const localFindings = []
 
-  // 1. Missing fields (Critical)
-  if (!summary.trim() && !description.trim()) {
+  // Determine if this record is published/indexable. Only PUBLISH records
+  // are expected to have content; NOINDEX, NEEDS_REVIEW, BLOCKED, hidden,
+  // and redirect-only records are not flagged for empty content.
+  const indexabilityStatus = String(record.indexability_status || '').toUpperCase()
+  const runtimeExportDecision = String(record.runtime_export_decision || '').toLowerCase()
+  const isPublished = indexabilityStatus === 'PUBLISH' &&
+    !['hidden', 'hidden_until_grounded', 'alias_redirect_only', 'research_archive_runtime'].includes(runtimeExportDecision)
+
+  // 1. Missing fields (Critical) — only for published/indexable records
+  if (isPublished && !summary.trim() && !description.trim()) {
     return [{
       type: 'critical',
       dataset: datasetName,
@@ -61,6 +69,9 @@ export function auditRecord(record, datasetName = 'test') {
       reason: 'Both summary and description are empty'
     }]
   }
+
+  // Skip all further checks for records with no auditable content
+  if (!textToAudit) return []
 
   // 2. Placeholder checks (Critical)
   for (const kw of PLACEHOLDER_KEYWORDS) {

--- a/src/lib/index-allowlist.ts
+++ b/src/lib/index-allowlist.ts
@@ -28,9 +28,7 @@ export const MONEY_ENTRY_ROUTES = [
   '/best-supplements-for-blood-pressure',
   '/best-supplements-for-gut-health',
   '/best-supplements-for-joint-support',
-  '/best-herbs-for-anxiety',
-  '/best-nootropics-for-focus',
-  '/best-adaptogens-for-stress',
+  '/best-magnesium-supplements-for-adhd',
 ] as const
 
 // Canonical (current-data) slugs. Curated index-allowlisted herb slugs.

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1059,8 +1059,7 @@ export function generateDetailMetadata(record: any, type: 'herb' | 'compound'): 
     ? `${displayName} effects, dosage, drug interactions, and harm-reduction safety guide.`
     : `${displayName} dosage, effects, onset, and safety graded against research evidence.`
 
-  const rawDescription = (record.meta_description || record.metaDescription || '').trim() ||
-                         (record.description || record.metaDescription || '').trim()
+  const rawDescription = (record.meta_description || record.metaDescription || record.description || '').trim()
   const description = normalizeProfileNameInText(rawDescription, displayName) ||
                       keywordFirstDescription ||
                       safeFallbackDescription


### PR DESCRIPTION
## Summary

- **Compound page MDX metadata**: replaced manual metadata object with `buildPageMetadata()` so MDX compound pages now emit full Twitter card tags (`twitter:card`, `twitter:title`, `twitter:description`, `twitter:image`, `twitter:site`) that were previously missing
- **Missing record noindex**: `app/compounds/[slug]/page.tsx` was returning an empty `{}` metadata object for unknown compound slugs — now returns `{ title: 'Compound Not Found', robots: { index: false, follow: true } }`; same fix applied to herb page's "Herb Not Found" fallback
- **Phantom sitemap entries**: removed three non-existent routes (`best-herbs-for-anxiety`, `best-nootropics-for-focus`, `best-adaptogens-for-stress`) from `MONEY_ENTRY_ROUTES` and the sitemap `topPages` array — they had no `app/*/page.tsx` and would have produced 404 sitemap entries; added the existing `best-magnesium-supplements-for-adhd` page that was missing from both
- **`checkRouteFileEligibility` false-positive**: function was returning `true` (eligible) when no matching page file existed, allowing ghost routes into the sitemap — now returns `false` when no file is found for a non-dynamic route
- **`generateDetailMetadata` description fallback**: removed redundant double-lookup of `record.metaDescription` in the fallback chain
- **Evidence language validator**: 3 false-positive critical violations for `NOINDEX`/`NEEDS_REVIEW`/hidden herb records with empty content — the validator now skips the empty-content critical check for non-`PUBLISH` records since empty content is expected for unpublished entries; result goes from 3 critical → 0 critical

---
_Generated by [Claude Code](https://claude.ai/code/session_01CfekCs9wD3qmZm9czcXa7r)_