### PR TITLE
fix(content): mitragynine family /compounds/ → /articles/

### DIFF
--- a/content/articles/7-hydroxymitragynine.mdx
+++ b/content/articles/7-hydroxymitragynine.mdx
@@ -76,7 +76,7 @@ This content is for educational purposes only and does **not** constitute medica
 
 7-Hydroxymitragynine (7-OH) is a minor alkaloid found in the kratom plant (*Mitragyna speciosa*) and a metabolite of its primary alkaloid, mitragynine. In recent years, commercial products containing significantly elevated levels of 7-OH have appeared on the market. These concentrated products differ substantially from traditional whole-leaf kratom preparations in both composition and risk profile.
 
-In July 2025, the U.S. Food and Drug Administration recommended that certain 7-OH products be placed under the Controlled Substances Act and issued warning letters to companies marketing them [4]. Enforcement actions, including product seizures, have followed [5]. These developments have highlighted the need for clear, evidence-based information distinguishing natural kratom leaf from concentrated 7-OH products. For practical harm-reduction context, see the [Kratom 7-OH withdrawal management guide](/guides/kratom-7oh-withdrawal-management) and the [7-hydroxymitragynine compound profile](/compounds/7-hydroxymitragynine).
+In July 2025, the U.S. Food and Drug Administration recommended that certain 7-OH products be placed under the Controlled Substances Act and issued warning letters to companies marketing them [4]. Enforcement actions, including product seizures, have followed [5]. These developments have highlighted the need for clear, evidence-based information distinguishing natural kratom leaf from concentrated 7-OH products. For practical harm-reduction context, see the [Kratom 7-OH withdrawal management guide](/guides/kratom-7oh-withdrawal-management) and the [7-hydroxymitragynine compound profile](/articles/7-hydroxymitragynine/).
 
 This monograph reviews the available scientific evidence on 7-OH, including its pharmacology, human pharmacokinetic data, safety signals, and regulatory status as of June 2026. It is intended as an educational resource only.
 
@@ -155,7 +155,7 @@ In July 2025, the U.S. Food and Drug Administration recommended that certain 7-O
 
 As of this review, the FDA had recommended scheduling certain 7-OH products, while federal scheduling status remained subject to DEA review. Readers should verify current federal, state, and local law before relying on any regulatory status statement.
 
-State-level rules for kratom and concentrated 7-OH products vary and may change quickly. Readers should check current state and local law before relying on any legal-status statement; the [7-hydroxymitragynine compound profile](/compounds/7-hydroxymitragynine) contains the site’s structured regulatory context.
+State-level rules for kratom and concentrated 7-OH products vary and may change quickly. Readers should check current state and local law before relying on any legal-status statement; the [7-hydroxymitragynine compound profile](/articles/7-hydroxymitragynine/) contains the site’s structured regulatory context.
 
 ---
 

--- a/content/articles/mitragynine.mdx
+++ b/content/articles/mitragynine.mdx
@@ -56,7 +56,7 @@ Overall, the human evidence base for mitragynine is **limited to moderate** depe
 
 Respiratory depression appears less pronounced than with classical full mu-opioid agonists in available studies, but this does not eliminate risk, especially with concentrated extracts, elevated 7-hydroxymitragynine exposure, or polydrug use. Dependence and withdrawal phenomena are documented in preclinical models and human reports, though severity and prevalence require better characterization.
 
-For the reference profile, see [mitragynine](/compounds/mitragynine). For the higher-potency metabolite context, read the [7-hydroxymitragynine evidence monograph](/articles/7-hydroxymitragynine), the [7-OH compound profile](/compounds/7-hydroxymitragynine), and the [mitragynine vs 7-hydroxymitragynine comparison](/compare/mitragynine-vs-7-hydroxymitragynine).
+For the reference profile, see [mitragynine](/articles/mitragynine/). For the higher-potency metabolite context, read the [7-hydroxymitragynine evidence monograph](/articles/7-hydroxymitragynine/), the [7-OH compound profile](/articles/7-hydroxymitragynine/), and the [mitragynine vs 7-hydroxymitragynine comparison](/compare/mitragynine-vs-7-hydroxymitragynine).
 
 ---
 


### PR DESCRIPTION
Mitragynine and 7-hydroxymitragynine live under /articles/<slug>/ (deep-dive pages), not /compounds/<slug>/. Three inline links across two MDX files corrected at source.