### PR TITLE
fix(link-engine): strip Next.js route-group folders from generated routes

### DIFF
--- a/scripts/data/build-internal-link-engine.mjs
+++ b/scripts/data/build-internal-link-engine.mjs
@@ -132,7 +132,7 @@ async function listPageFiles(dir = path.join(ROOT, 'app')) {
 
 function staticRouteFromPageFile(file) {
   const relative = path.relative(path.join(ROOT, 'app'), file).replace(/\\/g, '/')
-  const parts = relative.split('/').slice(0, -1)
+  const parts = relative.split('/').slice(0, -1).filter((part) => !/^\(.*\)$/.test(part))
   if (parts.some((part) => part.startsWith('['))) return ''
   return normalizeRoute(`/${parts.join('/')}`)
 }


### PR DESCRIPTION
Internal link engine was emitting /(public)/build as a route key because it didn't filter Next.js route-group segments. That caused every compound page to render href=(public)/build/ in the Related research paths section. Fix matches the existing pattern in scripts/ci/generate-route-inventory.mjs which already strips route groups correctly.