### PR TITLE
fix: resolve Ahrefs audit issues — passes 1-4

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -576,7 +576,7 @@ export default async function FocusClusterRootArticlePage({ params }: { params: 
       />
 
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
-        <Link href="/articles" className="transition hover:text-ink">Articles</Link>
+        <Link href="/articles/" className="transition hover:text-ink">Articles</Link>
         <span>/</span>
         <span className="line-clamp-1 text-ink">{article.title}</span>
       </nav>

--- a/app/about/AboutClient.tsx
+++ b/app/about/AboutClient.tsx
@@ -64,21 +64,21 @@ export default function AboutClient() {
 
             <div className="mt-7 flex flex-wrap gap-3">
               <Link
-                href="/herbs"
+                href="/herbs/"
                 className="rounded-full bg-brand-800 px-5 py-3 text-sm font-semibold text-white transition hover:bg-brand-900"
               >
                 Explore herbs
               </Link>
 
               <Link
-                href="/compounds"
+                href="/compounds/"
                 className="rounded-full border border-brand-900/20 px-5 py-3 text-sm font-semibold text-ink transition hover:border-brand-700 hover:bg-brand-50"
               >
                 Explore compounds
               </Link>
 
               <Link
-                href="/goals"
+                href="/goals/"
                 className="rounded-full border border-brand-900/20 px-5 py-3 text-sm font-semibold text-ink transition hover:border-brand-700 hover:bg-brand-50"
               >
                 Browse by goals

--- a/app/articles/[slug]/page.tsx
+++ b/app/articles/[slug]/page.tsx
@@ -139,7 +139,7 @@ function MdxArticlePage({ article }: { article: (typeof mdxArticles)[number] }) 
       />
 
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted" aria-label="Breadcrumb">
-        <Link href="/articles" className="transition hover:text-ink">Articles</Link>
+        <Link href="/articles/" className="transition hover:text-ink">Articles</Link>
         <span>/</span>
         <span className="line-clamp-1 text-ink">{article.title}</span>
       </nav>
@@ -188,8 +188,8 @@ function MdxArticlePage({ article }: { article: (typeof mdxArticles)[number] }) 
       <footer className="mt-8 rounded-[0.9rem] border border-amber-700/20 bg-amber-50/80 p-4 text-sm leading-6 text-amber-900">
         Educational disclaimer: this monograph is for research literacy and harm-reduction context only. It is not medical advice, diagnosis, or a recommendation to use any substance. Talk with a licensed clinician about personal risks, medications, dependence, withdrawal, or urgent symptoms.
         <div className="mt-3 flex flex-wrap gap-4 font-semibold text-brand-800">
-          <Link href="/articles" className="hover:underline">All articles</Link>
-          <Link href="/safety-checker" className="hover:underline">Safety checker</Link>
+          <Link href="/articles/" className="hover:underline">All articles</Link>
+          <Link href="/safety-checker/" className="hover:underline">Safety checker</Link>
         </div>
       </footer>
     </article>
@@ -557,7 +557,7 @@ export default async function ArticlePage({ params }: { params: ArticleRoutePara
 
       {/* Breadcrumb */}
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
-        <Link href="/articles" className="transition hover:text-ink">Articles</Link>
+        <Link href="/articles/" className="transition hover:text-ink">Articles</Link>
         <span>/</span>
         <span className="text-ink line-clamp-1">{article.title}</span>
       </nav>
@@ -584,7 +584,7 @@ export default async function ArticlePage({ params }: { params: ArticleRoutePara
 
         <p className="mt-2 text-sm text-muted">
           By{' '}
-          <Link href="/about" rel="author" className="font-medium text-ink hover:underline">
+          <Link href="/about/" rel="author" className="font-medium text-ink hover:underline">
             {article.author}
           </Link>
         </p>
@@ -664,16 +664,16 @@ export default async function ArticlePage({ params }: { params: ArticleRoutePara
           <div className="rounded-[1rem] border border-brand-900/10 bg-[var(--surface-card)] p-4 shadow-sm">
             <p className="text-[10px] font-bold uppercase tracking-wider text-muted">Explore more</p>
             <div className="mt-3 space-y-2">
-              <Link href="/safety-checker" className="block text-sm font-medium text-brand-700 hover:text-brand-800">
+              <Link href="/safety-checker/" className="block text-sm font-medium text-brand-700 hover:text-brand-800">
                 Safety Checker →
               </Link>
-              <Link href="/goals" className="block text-sm font-medium text-brand-700 hover:text-brand-800">
+              <Link href="/goals/" className="block text-sm font-medium text-brand-700 hover:text-brand-800">
                 Evidence Reviews →
               </Link>
-              <Link href="/herbs" className="block text-sm font-medium text-brand-700 hover:text-brand-800">
+              <Link href="/herbs/" className="block text-sm font-medium text-brand-700 hover:text-brand-800">
                 Herb Profiles →
               </Link>
-              <Link href="/articles" className="block text-sm font-medium text-brand-700 hover:text-brand-800">
+              <Link href="/articles/" className="block text-sm font-medium text-brand-700 hover:text-brand-800">
                 Articles →
               </Link>
             </div>
@@ -683,10 +683,10 @@ export default async function ArticlePage({ params }: { params: ArticleRoutePara
 
       {/* Back link */}
       <div className="mt-8">
-        <Link href="/articles" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
+        <Link href="/articles/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
           ← Back to Articles
         </Link>
-        <Link href="/safety-checker" className="ml-4 text-sm font-semibold text-brand-700 hover:text-brand-800">
+        <Link href="/safety-checker/" className="ml-4 text-sm font-semibold text-brand-700 hover:text-brand-800">
           Safety Checker →
         </Link>
       </div>

--- a/app/articles/ashwagandha-for-sleep/page.tsx
+++ b/app/articles/ashwagandha-for-sleep/page.tsx
@@ -94,7 +94,7 @@ export default function AshwagandhaForSleepPage() {
 
       {/* Breadcrumb */}
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
-        <Link href="/articles" className="transition hover:text-ink">
+        <Link href="/articles/" className="transition hover:text-ink">
           Articles
         </Link>
         <span>/</span>
@@ -129,7 +129,7 @@ export default function AshwagandhaForSleepPage() {
 
         <p className="mt-2 text-sm text-muted">
           By{' '}
-          <Link href="/about" rel="author" className="font-medium text-ink hover:underline">
+          <Link href="/about/" rel="author" className="font-medium text-ink hover:underline">
             {AUTHOR}
           </Link>
         </p>
@@ -707,7 +707,7 @@ export default function AshwagandhaForSleepPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/articles"
+                  href="/articles/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -971,13 +971,13 @@ export default function AshwagandhaForSleepPage() {
                 Natural anxiolytics →
               </Link>
               <Link
-                href="/herbs"
+                href="/herbs/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 All herb profiles →
               </Link>
               <Link
-                href="/articles"
+                href="/articles/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 All articles →
@@ -988,7 +988,7 @@ export default function AshwagandhaForSleepPage() {
       </div>
 
       <div className="mt-8">
-        <Link href="/articles" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
+        <Link href="/articles/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
           ← Back to Articles
         </Link>
       </div>

--- a/app/articles/ashwagandha-vs-magnesium-for-sleep/page.tsx
+++ b/app/articles/ashwagandha-vs-magnesium-for-sleep/page.tsx
@@ -99,7 +99,7 @@ export default function AshwagandhaVsMagnesiumForSleepPage() {
 
       {/* Breadcrumb */}
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
-        <Link href="/articles" className="transition hover:text-ink">
+        <Link href="/articles/" className="transition hover:text-ink">
           Articles
         </Link>
         <span>/</span>
@@ -134,7 +134,7 @@ export default function AshwagandhaVsMagnesiumForSleepPage() {
 
         <p className="mt-2 text-sm text-muted">
           By{' '}
-          <Link href="/about" rel="author" className="font-medium text-ink hover:underline">
+          <Link href="/about/" rel="author" className="font-medium text-ink hover:underline">
             {AUTHOR}
           </Link>
         </p>
@@ -1134,7 +1134,7 @@ export default function AshwagandhaVsMagnesiumForSleepPage() {
                 Sleep herbs vs melatonin →
               </Link>
               <Link
-                href="/articles"
+                href="/articles/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 All articles →
@@ -1145,7 +1145,7 @@ export default function AshwagandhaVsMagnesiumForSleepPage() {
       </div>
 
       <div className="mt-8">
-        <Link href="/articles" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
+        <Link href="/articles/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
           ← Back to Articles
         </Link>
       </div>

--- a/app/articles/ashwagandha/page.tsx
+++ b/app/articles/ashwagandha/page.tsx
@@ -104,7 +104,7 @@ export default function AshwagandhaArticlePage() {
 
       {/* Breadcrumb */}
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
-        <Link href="/articles" className="transition hover:text-ink">
+        <Link href="/articles/" className="transition hover:text-ink">
           Articles
         </Link>
         <span>/</span>
@@ -139,7 +139,7 @@ export default function AshwagandhaArticlePage() {
 
         <p className="mt-2 text-sm text-muted">
           By{' '}
-          <Link href="/about" rel="author" className="font-medium text-ink hover:underline">
+          <Link href="/about/" rel="author" className="font-medium text-ink hover:underline">
             {AUTHOR}
           </Link>
         </p>
@@ -1005,7 +1005,7 @@ export default function AshwagandhaArticlePage() {
                 Stress goal hub →
               </Link>
               <Link
-                href="/articles"
+                href="/articles/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 All articles →
@@ -1016,7 +1016,7 @@ export default function AshwagandhaArticlePage() {
       </div>
 
       <div className="mt-8">
-        <Link href="/articles" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
+        <Link href="/articles/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
           ← Back to Articles
         </Link>
       </div>

--- a/app/articles/best-herbs-for-sleep/page.tsx
+++ b/app/articles/best-herbs-for-sleep/page.tsx
@@ -99,7 +99,7 @@ export default function BestHerbsForSleepPage() {
 
       {/* Breadcrumb */}
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
-        <Link href="/articles" className="transition hover:text-ink">
+        <Link href="/articles/" className="transition hover:text-ink">
           Articles
         </Link>
         <span>/</span>
@@ -134,7 +134,7 @@ export default function BestHerbsForSleepPage() {
 
         <p className="mt-2 text-sm text-muted">
           By{' '}
-          <Link href="/about" rel="author" className="font-medium text-ink hover:underline">
+          <Link href="/about/" rel="author" className="font-medium text-ink hover:underline">
             {AUTHOR}
           </Link>
         </p>
@@ -1110,13 +1110,13 @@ export default function BestHerbsForSleepPage() {
                 Sleep herbs vs melatonin →
               </Link>
               <Link
-                href="/herbs"
+                href="/herbs/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 All herb profiles →
               </Link>
               <Link
-                href="/articles"
+                href="/articles/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 All articles →
@@ -1168,7 +1168,7 @@ export default function BestHerbsForSleepPage() {
       </div>
 
       <div className="mt-8">
-        <Link href="/articles" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
+        <Link href="/articles/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
           ← Back to Articles
         </Link>
       </div>

--- a/app/articles/best-magnesium-supplement-for-adhd/page.tsx
+++ b/app/articles/best-magnesium-supplement-for-adhd/page.tsx
@@ -93,7 +93,7 @@ export default function BestMagnesiumForAdhdPage() {
       {faqLd && <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />}
 
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
-        <Link href="/articles" className="transition hover:text-ink">Articles</Link>
+        <Link href="/articles/" className="transition hover:text-ink">Articles</Link>
         <span>/</span>
         <span className="text-ink line-clamp-1">{TITLE}</span>
       </nav>
@@ -117,7 +117,7 @@ export default function BestMagnesiumForAdhdPage() {
         </h1>
         <p className="mt-2 text-sm text-muted">
           By{' '}
-          <Link href="/about" rel="author" className="font-medium text-ink hover:underline">
+          <Link href="/about/" rel="author" className="font-medium text-ink hover:underline">
             {AUTHOR}
           </Link>
         </p>
@@ -555,7 +555,7 @@ export default function BestMagnesiumForAdhdPage() {
       </div>
 
       <div className="mt-8">
-        <Link href="/articles" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
+        <Link href="/articles/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
           ← Back to Articles
         </Link>
       </div>

--- a/app/articles/l-theanine-for-sleep/page.tsx
+++ b/app/articles/l-theanine-for-sleep/page.tsx
@@ -99,7 +99,7 @@ export default function LTheanineForSleepPage() {
 
       {/* Breadcrumb */}
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
-        <Link href="/articles" className="transition hover:text-ink">
+        <Link href="/articles/" className="transition hover:text-ink">
           Articles
         </Link>
         <span>/</span>
@@ -134,7 +134,7 @@ export default function LTheanineForSleepPage() {
 
         <p className="mt-2 text-sm text-muted">
           By{' '}
-          <Link href="/about" rel="author" className="font-medium text-ink hover:underline">
+          <Link href="/about/" rel="author" className="font-medium text-ink hover:underline">
             {AUTHOR}
           </Link>
         </p>
@@ -1352,7 +1352,7 @@ export default function LTheanineForSleepPage() {
                 Sleep herbs vs melatonin →
               </Link>
               <Link
-                href="/articles"
+                href="/articles/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 All articles →
@@ -1363,7 +1363,7 @@ export default function LTheanineForSleepPage() {
       </div>
 
       <div className="mt-8">
-        <Link href="/articles" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
+        <Link href="/articles/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
           ← Back to Articles
         </Link>
       </div>

--- a/app/articles/l-theanine-magnesium-adhd-stack/page.tsx
+++ b/app/articles/l-theanine-magnesium-adhd-stack/page.tsx
@@ -80,7 +80,7 @@ export default function LTheanineMagnesiumAdhdStackPage() {
 
       {/* Breadcrumb */}
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
-        <Link href="/articles" className="transition hover:text-ink">Articles</Link>
+        <Link href="/articles/" className="transition hover:text-ink">Articles</Link>
         <span>/</span>
         <span className="text-ink line-clamp-1">{TITLE}</span>
       </nav>
@@ -105,7 +105,7 @@ export default function LTheanineMagnesiumAdhdStackPage() {
         </h1>
         <p className="mt-2 text-sm text-muted">
           By{' '}
-          <Link href="/about" rel="author" className="font-medium text-ink hover:underline">
+          <Link href="/about/" rel="author" className="font-medium text-ink hover:underline">
             {AUTHOR}
           </Link>
         </p>
@@ -465,7 +465,7 @@ export default function LTheanineMagnesiumAdhdStackPage() {
       </div>
 
       <div className="mt-8">
-        <Link href="/articles" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
+        <Link href="/articles/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
           ← Back to Articles
         </Link>
       </div>

--- a/app/articles/l-theanine-without-caffeine/page.tsx
+++ b/app/articles/l-theanine-without-caffeine/page.tsx
@@ -80,7 +80,7 @@ export default function LTheanineWithoutCaffeinePage() {
       {faqLd && <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />}
 
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
-        <Link href="/articles" className="transition hover:text-ink">Articles</Link>
+        <Link href="/articles/" className="transition hover:text-ink">Articles</Link>
         <span>/</span>
         <span className="text-ink line-clamp-1">{TITLE}</span>
       </nav>
@@ -104,7 +104,7 @@ export default function LTheanineWithoutCaffeinePage() {
         </h1>
         <p className="mt-2 text-sm text-muted">
           By{' '}
-          <Link href="/about" rel="author" className="font-medium text-ink hover:underline">
+          <Link href="/about/" rel="author" className="font-medium text-ink hover:underline">
             {AUTHOR}
           </Link>
         </p>
@@ -550,7 +550,7 @@ export default function LTheanineWithoutCaffeinePage() {
       </div>
 
       <div className="mt-8">
-        <Link href="/articles" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
+        <Link href="/articles/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
           ← Back to Articles
         </Link>
       </div>

--- a/app/articles/l-theanine/page.tsx
+++ b/app/articles/l-theanine/page.tsx
@@ -104,7 +104,7 @@ export default function LTheanineArticlePage() {
 
       {/* Breadcrumb */}
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
-        <Link href="/articles" className="transition hover:text-ink">
+        <Link href="/articles/" className="transition hover:text-ink">
           Articles
         </Link>
         <span>/</span>
@@ -139,7 +139,7 @@ export default function LTheanineArticlePage() {
 
         <p className="mt-2 text-sm text-muted">
           By{' '}
-          <Link href="/about" rel="author" className="font-medium text-ink hover:underline">
+          <Link href="/about/" rel="author" className="font-medium text-ink hover:underline">
             {AUTHOR}
           </Link>
         </p>
@@ -1015,7 +1015,7 @@ export default function LTheanineArticlePage() {
                 Focus goal hub →
               </Link>
               <Link
-                href="/articles"
+                href="/articles/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 All articles →
@@ -1026,7 +1026,7 @@ export default function LTheanineArticlePage() {
       </div>
 
       <div className="mt-8">
-        <Link href="/articles" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
+        <Link href="/articles/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
           ← Back to Articles
         </Link>
       </div>

--- a/app/articles/magnesium-glycinate-vs-citrate-for-adhd/page.tsx
+++ b/app/articles/magnesium-glycinate-vs-citrate-for-adhd/page.tsx
@@ -81,7 +81,7 @@ export default function MagnesiumGlycinateCitrateAdhdPage() {
 
       {/* Breadcrumb */}
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
-        <Link href="/articles" className="transition hover:text-ink">Articles</Link>
+        <Link href="/articles/" className="transition hover:text-ink">Articles</Link>
         <span>/</span>
         <span className="text-ink line-clamp-1">{TITLE}</span>
       </nav>
@@ -107,7 +107,7 @@ export default function MagnesiumGlycinateCitrateAdhdPage() {
         </h1>
         <p className="mt-2 text-sm text-muted">
           By{' '}
-          <Link href="/about" rel="author" className="font-medium text-ink hover:underline">
+          <Link href="/about/" rel="author" className="font-medium text-ink hover:underline">
             {AUTHOR}
           </Link>
         </p>
@@ -488,7 +488,7 @@ export default function MagnesiumGlycinateCitrateAdhdPage() {
       </div>
 
       <div className="mt-8">
-        <Link href="/articles" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
+        <Link href="/articles/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
           ← Back to Articles
         </Link>
       </div>

--- a/app/articles/magnesium-types-for-sleep/page.tsx
+++ b/app/articles/magnesium-types-for-sleep/page.tsx
@@ -99,7 +99,7 @@ export default function MagnesiumTypesForSleepPage() {
 
       {/* Breadcrumb */}
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
-        <Link href="/articles" className="transition hover:text-ink">
+        <Link href="/articles/" className="transition hover:text-ink">
           Articles
         </Link>
         <span>/</span>
@@ -134,7 +134,7 @@ export default function MagnesiumTypesForSleepPage() {
 
         <p className="mt-2 text-sm text-muted">
           By{' '}
-          <Link href="/about" rel="author" className="font-medium text-ink hover:underline">
+          <Link href="/about/" rel="author" className="font-medium text-ink hover:underline">
             {AUTHOR}
           </Link>
         </p>
@@ -1158,13 +1158,13 @@ export default function MagnesiumTypesForSleepPage() {
                 Sleep herbs vs melatonin →
               </Link>
               <Link
-                href="/herbs"
+                href="/herbs/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 All herb profiles →
               </Link>
               <Link
-                href="/articles"
+                href="/articles/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 All articles →
@@ -1216,7 +1216,7 @@ export default function MagnesiumTypesForSleepPage() {
       </div>
 
       <div className="mt-8">
-        <Link href="/articles" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
+        <Link href="/articles/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
           ← Back to Articles
         </Link>
       </div>

--- a/app/articles/natural-anxiety-relief/page.tsx
+++ b/app/articles/natural-anxiety-relief/page.tsx
@@ -99,7 +99,7 @@ export default function NaturalAnxietyReliefPage() {
 
       {/* Breadcrumb */}
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
-        <Link href="/articles" className="transition hover:text-ink">
+        <Link href="/articles/" className="transition hover:text-ink">
           Articles
         </Link>
         <span>/</span>
@@ -134,7 +134,7 @@ export default function NaturalAnxietyReliefPage() {
 
         <p className="mt-2 text-sm text-muted">
           By{' '}
-          <Link href="/about" rel="author" className="font-medium text-ink hover:underline">
+          <Link href="/about/" rel="author" className="font-medium text-ink hover:underline">
             {AUTHOR}
           </Link>
         </p>
@@ -1490,7 +1490,7 @@ export default function NaturalAnxietyReliefPage() {
       </div>
 
       <div className="mt-8">
-        <Link href="/articles" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
+        <Link href="/articles/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
           ← Back to Articles
         </Link>
       </div>

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -197,7 +197,7 @@ function CategoryFilterBar({ active }: { active: string }) {
   return (
     <div className="flex flex-wrap gap-2" role="tablist" aria-label="Filter by category">
       <Link
-        href="/articles"
+        href="/articles/"
         className={`rounded-full border px-3 py-1 text-xs font-semibold transition ${!active ? 'border-brand-700/25 bg-brand-50 text-brand-900 dark:border-white/15 dark:bg-white/10 dark:text-brand-50' : 'border-brand-900/10 bg-white/80 text-muted hover:border-brand-700/20 dark:border-white/10 dark:bg-white/5 dark:text-brand-100'}`}
       >
         All notes
@@ -312,13 +312,13 @@ export default async function BlogPage({
         <p className="mt-2 text-sm font-semibold text-muted">{count} archive items available</p>
         <div className="mt-6 flex flex-wrap gap-3">
           <Link
-            href="/guides"
+            href="/guides/"
             className="inline-flex min-h-11 items-center rounded-full bg-brand-950 px-5 py-2.5 text-sm font-bold text-white shadow-sm hover:bg-brand-900 dark:bg-brand-200 dark:text-brand-950 dark:hover:bg-brand-100"
           >
             Use practical guides
           </Link>
           <Link
-            href="/goals"
+            href="/goals/"
             className="inline-flex min-h-11 items-center rounded-full border border-brand-900/15 bg-white/80 px-5 py-2.5 text-sm font-bold text-brand-900 shadow-sm hover:bg-white dark:border-white/15 dark:bg-white/5 dark:text-brand-50 dark:hover:bg-white/10"
           >
             Browse goals
@@ -348,7 +348,7 @@ export default async function BlogPage({
 
         {pageItems.length === 0 ? (
           <div className="card-premium p-6 text-sm text-muted">
-            No archive items in this filter. <Link href="/articles" className="font-semibold text-brand-800 dark:text-brand-100">View all</Link>.
+            No archive items in this filter. <Link href="/articles/" className="font-semibold text-brand-800 dark:text-brand-100">View all</Link>.
           </div>
         ) : (
           <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">

--- a/app/articles/sleep-stack-guide/page.tsx
+++ b/app/articles/sleep-stack-guide/page.tsx
@@ -99,7 +99,7 @@ export default function SleepStackGuidePage() {
 
       {/* Breadcrumb */}
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
-        <Link href="/articles" className="transition hover:text-ink">
+        <Link href="/articles/" className="transition hover:text-ink">
           Articles
         </Link>
         <span>/</span>
@@ -134,7 +134,7 @@ export default function SleepStackGuidePage() {
 
         <p className="mt-2 text-sm text-muted">
           By{' '}
-          <Link href="/about" rel="author" className="font-medium text-ink hover:underline">
+          <Link href="/about/" rel="author" className="font-medium text-ink hover:underline">
             {AUTHOR}
           </Link>
         </p>
@@ -1632,7 +1632,7 @@ export default function SleepStackGuidePage() {
                 Sleep herbs vs melatonin →
               </Link>
               <Link
-                href="/articles"
+                href="/articles/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 All articles →
@@ -1643,7 +1643,7 @@ export default function SleepStackGuidePage() {
       </div>
 
       <div className="mt-8">
-        <Link href="/articles" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
+        <Link href="/articles/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
           ← Back to Articles
         </Link>
       </div>

--- a/app/articles/style/[style]/page.tsx
+++ b/app/articles/style/[style]/page.tsx
@@ -83,7 +83,7 @@ export default async function BlogStylePage({ params }: BlogStyleRouteProps) {
   return (
     <div className="section-spacing pb-10">
       <nav className="flex items-center gap-2 text-sm text-muted">
-        <Link href="/articles" className="transition hover:text-ink">
+        <Link href="/articles/" className="transition hover:text-ink">
           Research notes
         </Link>
         <span>/</span>
@@ -103,7 +103,7 @@ export default async function BlogStylePage({ params }: BlogStyleRouteProps) {
             <p className="eyebrow-label">Archive</p>
             <h2 className="mt-2 max-w-3xl">{group.title}</h2>
           </div>
-          <Link href="/articles" className="text-sm font-semibold text-brand-800 transition hover:text-brand-900">
+          <Link href="/articles/" className="text-sm font-semibold text-brand-800 transition hover:text-brand-900">
             View all notes
           </Link>
         </div>

--- a/app/author/page.tsx
+++ b/app/author/page.tsx
@@ -24,13 +24,13 @@ export default function AuthorPage() {
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
           <Link
-            href="/about"
+            href="/about/"
             className="rounded-full bg-brand-800 px-5 py-3 text-sm font-semibold text-white transition hover:bg-brand-900"
           >
             Editorial standards
           </Link>
           <Link
-            href="/herbs"
+            href="/herbs/"
             className="rounded-full border border-brand-900/20 px-5 py-3 text-sm font-semibold text-ink transition hover:border-brand-700 hover:bg-brand-50"
           >
             Herb library
@@ -116,7 +116,7 @@ export default function AuthorPage() {
           Found an error, outdated citation, or evidence summary that overstates what the data supports? Please reach out. Corrections improve the resource for everyone and are taken seriously.
         </p>
         <Link
-          href="/contact"
+          href="/contact/"
           className="inline-block rounded-full border border-brand-900/20 px-5 py-2.5 text-sm font-semibold text-ink transition hover:border-brand-700 hover:bg-brand-50"
         >
           Send a correction →
@@ -125,15 +125,15 @@ export default function AuthorPage() {
 
       {/* Navigation */}
       <nav aria-label="Content links" className="flex flex-wrap gap-3 text-sm">
-        <Link href="/herbs" className="text-brand-800 hover:underline font-semibold">Herb library</Link>
+        <Link href="/herbs/" className="text-brand-800 hover:underline font-semibold">Herb library</Link>
         <span className="text-muted">·</span>
-        <Link href="/compounds" className="text-brand-800 hover:underline font-semibold">Compound library</Link>
+        <Link href="/compounds/" className="text-brand-800 hover:underline font-semibold">Compound library</Link>
         <span className="text-muted">·</span>
-        <Link href="/goals" className="text-brand-800 hover:underline font-semibold">Goal guides</Link>
+        <Link href="/goals/" className="text-brand-800 hover:underline font-semibold">Goal guides</Link>
         <span className="text-muted">·</span>
-        <Link href="/about" className="text-brand-800 hover:underline font-semibold">About</Link>
+        <Link href="/about/" className="text-brand-800 hover:underline font-semibold">About</Link>
         <span className="text-muted">·</span>
-        <Link href="/disclaimer" className="text-brand-800 hover:underline font-semibold">Disclaimer</Link>
+        <Link href="/disclaimer/" className="text-brand-800 hover:underline font-semibold">Disclaimer</Link>
       </nav>
     </div>
   )

--- a/app/best-supplements-for-sleep/page.tsx
+++ b/app/best-supplements-for-sleep/page.tsx
@@ -25,7 +25,7 @@ export const metadata: Metadata = buildPageMetadata({
   title: 'Best Supplements for Sleep: Evidence-First Buyer Guide',
   description: DESCRIPTION,
   path: PATH,
-  image: '/og/guides/best-supplements-for-sleep.png',
+  image: '/og-default.jpg',
   openGraphType: 'article',
 })
 
@@ -297,7 +297,7 @@ export default function BestSupplementsForSleepPage() {
       <nav className="flex items-center gap-2 text-sm text-muted" aria-label="Breadcrumb">
         <Link href="/" className="hover:text-ink">Home</Link>
         <span>/</span>
-        <Link href="/guides" className="hover:text-ink">Guides</Link>
+        <Link href="/guides/" className="hover:text-ink">Guides</Link>
         <span>/</span>
         <span className="line-clamp-1 text-ink">{TITLE}</span>
       </nav>
@@ -320,7 +320,7 @@ export default function BestSupplementsForSleepPage() {
               Compare supplements
             </a>
             <Link
-              href="/goals/sleep"
+              href="/goals/sleep/"
               className="rounded-full border border-brand-900/10 bg-white/80 px-5 py-2.5 text-sm font-semibold text-ink transition hover:border-brand-700/30"
             >
               Open sleep goal guide
@@ -455,7 +455,7 @@ export default function BestSupplementsForSleepPage() {
             ))}
           </ul>
           <p className="mt-4 text-sm leading-7 text-[#46574d]">
-            See the full <Link href="/methodology" className="font-semibold text-brand-700 hover:underline">methodology</Link> for
+            See the full <Link href="/methodology/" className="font-semibold text-brand-700 hover:underline">methodology</Link> for
             how evidence, safety, and product-quality signals are handled across the site.
           </p>
         </section>
@@ -493,7 +493,7 @@ export default function BestSupplementsForSleepPage() {
           ))}
         </div>
         <p className="mt-4 text-sm leading-7 text-red-950/85">
-          Review the <Link href="/disclaimer" className="font-semibold text-red-900 hover:underline">medical disclaimer</Link> and
+          Review the <Link href="/disclaimer/" className="font-semibold text-red-900 hover:underline">medical disclaimer</Link> and
           involve a qualified clinician for persistent insomnia, sleep apnea symptoms, complex medication
           use, pregnancy, breastfeeding, children, or chronic disease.
         </p>

--- a/app/compare/berberine-vs-metformin/page.tsx
+++ b/app/compare/berberine-vs-metformin/page.tsx
@@ -473,7 +473,7 @@ export default function BerberineVsMetforminPage() {
         <Link href="/compare/berberine-vs-psyllium" className="chip-readable">Berberine vs Psyllium</Link>
         <Link href="/goals/gut-health" className="chip-readable">Gut Health Goals</Link>
         <Link href="/goals/fat-loss" className="chip-readable">Fat Loss Goals</Link>
-        <Link href="/compare" className="chip-readable">All Comparisons</Link>
+        <Link href="/compare/" className="chip-readable">All Comparisons</Link>
       </div>
     </div>
   )

--- a/app/compare/curcumin-vs-boswellia-vs-omega-3/page.tsx
+++ b/app/compare/curcumin-vs-boswellia-vs-omega-3/page.tsx
@@ -243,7 +243,7 @@ export default function CurcuminVsBoswelliaVsOmega3Page() {
           </ul>
           <p>
             Stacking all three compounds the bleeding caution. Review interactions on the{' '}
-            <Link href="/safety-checker" className="font-semibold text-emerald-700 hover:underline">safety checker</Link>{' '}
+            <Link href="/safety-checker/" className="font-semibold text-emerald-700 hover:underline">safety checker</Link>{' '}
             and with a qualified clinician before combining.
           </p>
         </div>

--- a/app/compare/sleep-herbs-vs-melatonin/page.tsx
+++ b/app/compare/sleep-herbs-vs-melatonin/page.tsx
@@ -585,7 +585,7 @@ export default function SleepHerbsVsMelatoninComparePage() {
             label: 'Comparison',
             title: 'Magnesium Glycinate vs L-Threonate for Sleep',
             description: 'When the more expensive threonate form is worth it — sleep vs cognition positioning.',
-            href: '/compare/magnesium-glycinate-vs-l-threonate-for-sleep',
+            href: '/compare/magnesium-glycinate-vs-magnesium-threonate',
           },
           {
             type: 'guide',
@@ -629,11 +629,11 @@ export default function SleepHerbsVsMelatoninComparePage() {
 
       <div className="flex flex-wrap gap-3">
         <Link href="/compare/l-theanine-vs-magnesium" className="chip-readable">L-Theanine vs Magnesium</Link>
-        <Link href="/compare/magnesium-glycinate-vs-l-threonate-for-sleep" className="chip-readable">Magnesium Glycinate vs L-Threonate</Link>
+        <Link href="/compare/magnesium-glycinate-vs-magnesium-threonate" className="chip-readable">Magnesium Glycinate vs L-Threonate</Link>
         <Link href="/compare/magnesium-glycinate-vs-magnesium-oxide" className="chip-readable">Magnesium Glycinate vs Oxide</Link>
         <Link href="/goals/sleep" className="chip-readable">Sleep Goals</Link>
         <Link href="/education/gaba" className="chip-readable">GABA Pathway</Link>
-        <Link href="/compare" className="chip-readable">All Comparisons</Link>
+        <Link href="/compare/" className="chip-readable">All Comparisons</Link>
       </div>
     </div>
   )

--- a/app/compounds/CompoundsIndexClient.tsx
+++ b/app/compounds/CompoundsIndexClient.tsx
@@ -347,7 +347,7 @@ export default function CompoundsIndexClient({ compounds: sourceCompounds, allCo
               <p className="eyebrow-label">Search and filter</p>
               <h2 id="compound-search-heading" className="compact-heading">Start with the question you need answered.</h2>
             </div>
-            <Link href="/herbs" className="w-fit text-sm font-bold text-brand-800 transition hover:text-brand-900">Browse herb sources →</Link>
+            <Link href="/herbs/" className="w-fit text-sm font-bold text-brand-800 transition hover:text-brand-900">Browse herb sources →</Link>
           </div>
 
           <form action="/compounds" className="mt-3 grid gap-2 sm:grid-cols-[1fr_auto]">

--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -341,9 +341,9 @@ function CompoundMdxPage({ page }: { page: (typeof allCompoundMdxPages)[number] 
         <footer className="mt-8 rounded-[0.9rem] border border-amber-700/20 bg-amber-50/80 p-4 text-sm leading-6 text-[#5b4a2c]">
           Educational disclaimer: this page is for evidence review and harm-reduction context only. It is not medical advice, legal advice, sourcing guidance, or a recommendation to use any opioid-acting kratom derivative.
           <div className="mt-3 flex flex-wrap gap-4 font-semibold text-brand-800">
-            <Link href="/compounds" className="hover:underline">Compounds library</Link>
+            <Link href="/compounds/" className="hover:underline">Compounds library</Link>
             <Link href="/articles/7-hydroxymitragynine" className="hover:underline">7-OH article</Link>
-            <Link href="/safety-checker" className="hover:underline">Safety checker</Link>
+            <Link href="/safety-checker/" className="hover:underline">Safety checker</Link>
           </div>
         </footer>
       </article>
@@ -1201,10 +1201,10 @@ export default async function CompoundPage({ params }: PageProps) {
         <AuthorCredentials />
 
         <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between">
-          <Link href="/compounds" className="inline-flex rounded-full border border-brand-900/10 bg-white px-4 py-2 text-sm font-bold text-ink transition hover:bg-sand-50">
+          <Link href="/compounds/" className="inline-flex rounded-full border border-brand-900/10 bg-white px-4 py-2 text-sm font-bold text-ink transition hover:bg-sand-50">
             ← Back to compounds library
           </Link>
-          <Link href="/safety-checker" className="text-sm font-bold text-brand-800 hover:underline">
+          <Link href="/safety-checker/" className="text-sm font-bold text-brand-800 hover:underline">
             Safety checker →
           </Link>
         </div>

--- a/app/education/[slug]/page.tsx
+++ b/app/education/[slug]/page.tsx
@@ -250,7 +250,7 @@ export default async function EducationArticlePage({ params }: Props) {
 
       {/* Footer / Navigation */}
       <footer className="flex justify-between items-center pt-4 border-t border-brand-900/10" aria-label="Education article navigation">
-        <Link href="/education" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
+        <Link href="/education/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
           ← Back to Education Index
         </Link>
       </footer>

--- a/app/education/page.tsx
+++ b/app/education/page.tsx
@@ -160,6 +160,81 @@ const researchTools = [
   },
 ]
 
+const neurotransmitters = [
+  { title: 'Dopamine', href: '/education/dopamine/' },
+  { title: 'Serotonin', href: '/education/serotonin/' },
+  { title: 'GABA Pathway', href: '/education/gaba/' },
+  { title: 'Glutamate', href: '/education/glutamate/' },
+  { title: 'Cholinergic System', href: '/education/cholinergic-system/' },
+  { title: 'GABA vs Serotonin', href: '/education/gaba-vs-serotonin/' },
+  { title: 'Evidence Levels', href: '/education/evidence-levels/' },
+  { title: 'What Is Neuropharmacology?', href: '/education/what-is-neuropharmacology/' },
+]
+
+const researchLiteracy = [
+  { title: 'Why Human Trials Matter', href: '/education/why-human-trials-matter/' },
+  { title: 'Why Studies Conflict', href: '/education/why-studies-conflict/' },
+  { title: 'Why Neuroscience Is Difficult', href: '/education/why-neuroscience-is-difficult/' },
+  { title: 'Why Individual Variability Matters', href: '/education/why-individual-variability-matters/' },
+  { title: 'Why Online Supplement Claims Spread', href: '/education/why-online-supplement-claims-spread/' },
+  { title: 'Common Neurochemistry Myths', href: '/education/common-neurochemistry-myths/' },
+  { title: 'Scientific but Human Neuroscience', href: '/education/scientific-but-human-neuroscience/' },
+  { title: 'Understanding Individual Variability', href: '/education/understanding-individual-variability/' },
+]
+
+const psychoactivePlants = [
+  { title: 'What Are Psychoactive Herbs?', href: '/education/what-are-psychoactive-herbs/' },
+  { title: 'What Is an Entheogen?', href: '/education/what-is-an-entheogen/' },
+  { title: 'How Psychoactive Plants Affect the Brain', href: '/education/how-psychoactive-plants-affect-the-brain/' },
+  { title: 'How Psychoactive Substances Affect Perception', href: '/education/how-psychoactive-substances-affect-perception/' },
+  { title: 'How Herbal Psychoactives Differ from Pharmaceuticals', href: '/education/how-herbal-psychoactives-differ-from-pharmaceuticals/' },
+]
+
+const burnoutFatigue = [
+  { title: 'Why Burnout Affects Cognition', href: '/education/why-burnout-affects-cognition/' },
+  { title: 'Stress and Cognition Continuity', href: '/education/stress-and-cognition-continuity/' },
+  { title: 'Cognitive Resilience Systems', href: '/education/cognitive-resilience-systems/' },
+  { title: 'Emotional Amplification Systems', href: '/education/emotional-amplification-systems/' },
+  { title: 'Why Fatigue Is Biologically Complex', href: '/education/why-fatigue-is-biologically-complex/' },
+]
+
+const variabilityAndContext = [
+  { title: 'Understanding Placebo and Expectancy', href: '/education/understanding-placebo-and-expectancy/' },
+  { title: 'Placebo and Context Effects', href: '/education/placebo-and-context-effects/' },
+  { title: 'What Is Anxiety Neurochemistry?', href: '/education/what-is-anxiety-neurochemistry/' },
+  { title: 'Why Overstimulation Impairs Focus', href: '/education/why-overstimulation-impairs-focus/' },
+  { title: 'Why Calm Focus Differs from Stimulation', href: '/education/why-calm-focus-differs-from-stimulation/' },
+  { title: 'Why Sleep Matters for Mental Health', href: '/education/why-sleep-matters-for-mental-health/' },
+  { title: 'Why Sleep Changes Emotional Regulation', href: '/education/why-sleep-changes-emotional-regulation/' },
+  { title: 'Neuroscience Glossary', href: '/education/neuroscience-glossary/' },
+  { title: 'Inflammation and the Brain', href: '/education/inflammation/' },
+]
+
+function CompactSection({
+  title,
+  items,
+}: {
+  title: string
+  items: { title: string; href: string }[]
+}) {
+  return (
+    <section className='space-y-4'>
+      <h2 className='text-xl font-semibold tracking-tight text-ink'>{title}</h2>
+      <div className='grid gap-2 sm:grid-cols-2 lg:grid-cols-3'>
+        {items.map(item => (
+          <Link
+            key={item.href}
+            href={item.href}
+            className='rounded-xl border border-brand-900/10 bg-white/70 px-4 py-3 text-sm font-medium text-brand-800 transition hover:border-brand-700/20 hover:bg-brand-50/30'
+          >
+            {item.title} →
+          </Link>
+        ))}
+      </div>
+    </section>
+  )
+}
+
 function Section({
   title,
   description,
@@ -275,6 +350,21 @@ export default function EducationHubPage() {
         description='Methodology, citation, modeling, pathway, and safety pages that should be reachable from the main education hub instead of sitting isolated.'
         items={researchTools}
       />
+
+      <section className='space-y-10'>
+        <div className='space-y-2'>
+          <p className='eyebrow-label'>Complete Topic Index</p>
+          <h2 className='text-3xl font-semibold tracking-tight text-ink'>All Education Topics</h2>
+          <p className='text-base leading-8 text-[#46574d] max-w-3xl'>
+            Explore the full depth of the educational ecosystem — neurotransmitter pathways, research literacy, psychoactive plant science, burnout biology, individual variability, and reference pages.
+          </p>
+        </div>
+        <CompactSection title='Neurotransmitter Pathways' items={neurotransmitters} />
+        <CompactSection title='Research Literacy and Evidence Limitations' items={researchLiteracy} />
+        <CompactSection title='Psychoactive Plant Science' items={psychoactivePlants} />
+        <CompactSection title='Burnout, Fatigue, and Resilience' items={burnoutFatigue} />
+        <CompactSection title='Context, Variability, and Applied Topics' items={variabilityAndContext} />
+      </section>
 
       <section className='card-premium p-8 space-y-6'>
         <div className='space-y-3 max-w-3xl'>

--- a/app/education/study-design-snapshot/page.tsx
+++ b/app/education/study-design-snapshot/page.tsx
@@ -48,8 +48,8 @@ export default function StudyDesignSnapshotHubPage() {
           and tucks the &ldquo;why&rdquo; — trial design and limitations — into an optional,
           expandable panel. The same component is embeddable inside our structured education
           content. For the full methodology guide, see{' '}
-          <Link href="/education/evidence-literacy" className="font-semibold text-brand-700 hover:text-brand-800">
-            Evidence Literacy
+          <Link href="/education/evidence-hierarchy" className="font-semibold text-brand-700 hover:text-brand-800">
+            Evidence Hierarchy
           </Link>
           .
         </p>

--- a/app/goals/[goal]/page.tsx
+++ b/app/goals/[goal]/page.tsx
@@ -664,13 +664,13 @@ export default async function GoalDecisionPage({
           full profile or speaking with a qualified clinician.
         </p>
         <div className="mt-4 flex flex-wrap gap-4 text-xs font-semibold uppercase tracking-[0.14em]">
-          <Link href="/methodology" className="text-brand-800 hover:text-brand-700 hover:underline">
+          <Link href="/methodology/" className="text-brand-800 hover:text-brand-700 hover:underline">
             Research methodology →
           </Link>
-          <Link href="/education/evidence-hierarchy" className="text-brand-800 hover:text-brand-700 hover:underline">
+          <Link href="/education/evidence-hierarchy/" className="text-brand-800 hover:text-brand-700 hover:underline">
             Evidence hierarchy →
           </Link>
-          <Link href="/disclaimer" className="text-brand-800 hover:text-brand-700 hover:underline">
+          <Link href="/disclaimer/" className="text-brand-800 hover:text-brand-700 hover:underline">
             Disclaimer →
           </Link>
         </div>

--- a/app/guides/adhd-supplements/page.tsx
+++ b/app/guides/adhd-supplements/page.tsx
@@ -349,10 +349,10 @@ export default function AdhdSupplementsHub() {
           No supplement diagnoses, treats, cures, or prevents ADHD. Always discuss any changes with a qualified healthcare provider. This is especially critical when starting supplements in children, during pregnancy or breastfeeding, or if prescription ADHD stimulants or other medications are currently in use.
         </p>
         <div className="pt-2 flex gap-3 text-xs font-bold text-amber-900">
-          <Link href="/safety-checker" className="hover:text-amber-950 hover:underline">
+          <Link href="/safety-checker/" className="hover:text-amber-950 hover:underline">
             Open Safety Checker →
           </Link>
-          <Link href="/compare" className="hover:text-amber-950 hover:underline">
+          <Link href="/compare/" className="hover:text-amber-950 hover:underline">
             Side-by-Side Comparison Tool →
           </Link>
         </div>

--- a/app/guides/best-adaptogens-for-stress/page.tsx
+++ b/app/guides/best-adaptogens-for-stress/page.tsx
@@ -253,7 +253,7 @@ export default function BestAdaptogensForStressPage() {
           <Link href="/guides/how-to-lower-cortisol-naturally" className="hover:text-brand-800">How to Lower Cortisol Naturally →</Link>
           <Link href="/compare/rhodiola-vs-ashwagandha" className="hover:text-brand-800">Rhodiola vs Ashwagandha →</Link>
           <Link href="/guides/rhodiola-complete-guide" className="hover:text-brand-800">Complete Rhodiola Guide →</Link>
-          <Link href="/guides" className="hover:text-brand-800">All Guides →</Link>
+          <Link href="/guides/" className="hover:text-brand-800">All Guides →</Link>
         </nav>
       </div>
       </ArticleLayout>

--- a/app/guides/best-herbs-for-anxiety/page.tsx
+++ b/app/guides/best-herbs-for-anxiety/page.tsx
@@ -379,7 +379,7 @@ export default function BestHerbsForAnxietyPage() {
           <Link href="/guides/natural-alternatives-to-anxiety-medication" className="hover:text-brand-800">Natural Alternatives to Anxiety Meds →</Link>
           <Link href="/guides/kava" className="hover:text-brand-800">Kava Safety Guide →</Link>
           <Link href="/guides/best-supplements-for-overthinking" className="hover:text-brand-800">Supplements for Overthinking →</Link>
-          <Link href="/guides" className="hover:text-brand-800">All Guides →</Link>
+          <Link href="/guides/" className="hover:text-brand-800">All Guides →</Link>
         </nav>
       </div>
     </ArticleLayout>

--- a/app/guides/best-herbs-for-stress-and-anxiety-at-night/page.tsx
+++ b/app/guides/best-herbs-for-stress-and-anxiety-at-night/page.tsx
@@ -87,7 +87,7 @@ export default function Page() {
           </h1>
           <p className="mt-2 text-xs text-muted">
             Written and reviewed by{' '}
-            <Link href="/author" className="font-medium text-brand-700 hover:underline">Will Thomas</Link>
+            <Link href="/author/" className="font-medium text-brand-700 hover:underline">Will Thomas</Link>
             {' '}· Last updated June 2026
           </p>
           <p className="detail-reading mt-4 text-muted">

--- a/app/guides/best-natural-sleep-aids-that-work/page.tsx
+++ b/app/guides/best-natural-sleep-aids-that-work/page.tsx
@@ -87,7 +87,7 @@ export default function Page() {
           </h1>
           <p className="mt-2 text-xs text-muted">
             Written and reviewed by{' '}
-            <Link href="/author" className="font-medium text-brand-700 hover:underline">Will Thomas</Link>
+            <Link href="/author/" className="font-medium text-brand-700 hover:underline">Will Thomas</Link>
             {' '}· Last updated June 2026
           </p>
           <p className="detail-reading mt-4 text-muted">

--- a/app/guides/best-nootropics-for-focus/page.tsx
+++ b/app/guides/best-nootropics-for-focus/page.tsx
@@ -273,7 +273,7 @@ export default function BestNootropicsForFocusPage() {
           <Link href="/guides/adhd-supplements" className="hover:text-brand-800">ADHD Supplements Hub →</Link>
           <Link href="/guides/supplements-for-brain-fog-and-fatigue" className="hover:text-brand-800">Brain Fog & Fatigue →</Link>
           <Link href="/compare/caffeine-vs-l-theanine-vs-bacopa-for-focus" className="hover:text-brand-800">Caffeine vs L-Theanine vs Bacopa →</Link>
-          <Link href="/guides" className="hover:text-brand-800">All Guides →</Link>
+          <Link href="/guides/" className="hover:text-brand-800">All Guides →</Link>
         </nav>
       </div>
     </ArticleLayout>

--- a/app/guides/best-supplements-for-focus/page.tsx
+++ b/app/guides/best-supplements-for-focus/page.tsx
@@ -223,7 +223,7 @@ export default function BestSupplementsForFocusPage() {
           <Link href="/articles/ashwagandha" className="hover:text-brand-800">Ashwagandha Article →</Link>
           <Link href="/articles/l-theanine" className="hover:text-brand-800">L-Theanine Article →</Link>
           <Link href="/goals/focus" className="hover:text-brand-800">Focus Goal Hub →</Link>
-          <Link href="/guides" className="hover:text-brand-800">All Guides →</Link>
+          <Link href="/guides/" className="hover:text-brand-800">All Guides →</Link>
         </nav>
       </div>
       </ArticleLayout>

--- a/app/guides/best-supplements-for-overthinking/page.tsx
+++ b/app/guides/best-supplements-for-overthinking/page.tsx
@@ -87,7 +87,7 @@ export default function Page() {
           </h1>
           <p className="mt-2 text-xs text-muted">
             Written and reviewed by{' '}
-            <Link href="/author" className="font-medium text-brand-700 hover:underline">Will Thomas</Link>
+            <Link href="/author/" className="font-medium text-brand-700 hover:underline">Will Thomas</Link>
             {' '}· Last updated June 2026
           </p>
           <p className="detail-reading mt-4 text-muted">

--- a/app/guides/best-supplements-for-sleep/page.tsx
+++ b/app/guides/best-supplements-for-sleep/page.tsx
@@ -149,7 +149,7 @@ export default function BestSupplementsForSleepPage() {
           </h1>
           <p className="mt-2 text-xs text-muted">
             Written and reviewed by{' '}
-            <Link href="/author" className="font-medium text-brand-700 hover:underline">Will Thomas</Link>
+            <Link href="/author/" className="font-medium text-brand-700 hover:underline">Will Thomas</Link>
             {' '}· Last updated June 26, 2026
           </p>
           <p className="mt-4 text-sm leading-7 text-muted sm:text-base">
@@ -298,8 +298,8 @@ export default function BestSupplementsForSleepPage() {
           <Link href="/guides/magnesium-vs-melatonin" className="hover:text-brand-800">Magnesium vs Melatonin →</Link>
           <Link href="/compare/sleep-herbs-vs-melatonin" className="hover:text-brand-800">Sleep Herbs vs Melatonin →</Link>
           <Link href="/guides/magnesium-for-sleep" className="hover:text-brand-800">Magnesium for Sleep Guide →</Link>
-          <Link href="/compare/magnesium-glycinate-vs-l-threonate-for-sleep" className="hover:text-brand-800">Glycinate vs L-Threonate →</Link>
-          <Link href="/guides" className="hover:text-brand-800">All Guides →</Link>
+          <Link href="/compare/magnesium-glycinate-vs-magnesium-threonate" className="hover:text-brand-800">Glycinate vs L-Threonate →</Link>
+          <Link href="/guides/" className="hover:text-brand-800">All Guides →</Link>
         </nav>
       </div>
       </ArticleLayout>

--- a/app/guides/best-supplements-for-stress/page.tsx
+++ b/app/guides/best-supplements-for-stress/page.tsx
@@ -210,7 +210,7 @@ export default function BestSupplementsForStressPage() {
           <Link href="/guides/how-to-lower-cortisol-naturally" className="hover:text-brand-800">How to Lower Cortisol Naturally →</Link>
           <Link href="/compare/rhodiola-vs-ashwagandha" className="hover:text-brand-800">Rhodiola vs Ashwagandha →</Link>
           <Link href="/guides/rhodiola-complete-guide" className="hover:text-brand-800">Complete Rhodiola Guide →</Link>
-          <Link href="/guides" className="hover:text-brand-800">All Guides →</Link>
+          <Link href="/guides/" className="hover:text-brand-800">All Guides →</Link>
         </nav>
       </div>
       </ArticleLayout>

--- a/app/guides/elderberry/page.tsx
+++ b/app/guides/elderberry/page.tsx
@@ -252,7 +252,7 @@ export default function ElderberryGuidePage() {
             <p className="mt-1 text-sm font-semibold text-ink">Passionflower</p>
             <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Evidence for anxiety and sleep, with safety and dosing context.</p>
           </Link>
-          <Link href="/herbs" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+          <Link href="/herbs/" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
             <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Library</p>
             <p className="mt-1 text-sm font-semibold text-ink">Herb Library</p>
             <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Browse full herb profiles with mechanism maps and safety data.</p>
@@ -262,8 +262,8 @@ export default function ElderberryGuidePage() {
 
       {/* Bottom nav */}
       <div className="flex flex-wrap gap-4 border-t border-brand-900/10 pt-6 text-sm">
-        <Link href="/guides" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">← All Guides</Link>
-        <Link href="/herbs" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">Herb Library →</Link>
+        <Link href="/guides/" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">← All Guides</Link>
+        <Link href="/herbs/" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">Herb Library →</Link>
       </div>
       </div>{/* end space-y-8 */}
     </ArticleLayout>

--- a/app/guides/focus-without-caffeine-crash/page.tsx
+++ b/app/guides/focus-without-caffeine-crash/page.tsx
@@ -87,7 +87,7 @@ export default function Page() {
           </h1>
           <p className="mt-2 text-xs text-muted">
             Written and reviewed by{' '}
-            <Link href="/author" className="font-medium text-brand-700 hover:underline">Will Thomas</Link>
+            <Link href="/author/" className="font-medium text-brand-700 hover:underline">Will Thomas</Link>
             {' '}· Last updated June 2026
           </p>
           <p className="detail-reading mt-4 text-muted">

--- a/app/guides/how-to-lower-cortisol-naturally/page.tsx
+++ b/app/guides/how-to-lower-cortisol-naturally/page.tsx
@@ -86,7 +86,7 @@ export default function Page() {
           </h1>
           <p className="mt-2 text-xs text-muted">
             Written and reviewed by{' '}
-            <Link href="/author" className="font-medium text-brand-700 hover:underline">Will Thomas</Link>
+            <Link href="/author/" className="font-medium text-brand-700 hover:underline">Will Thomas</Link>
             {' '}· Last updated June 2026
           </p>
           <p className="detail-reading mt-4 text-muted">

--- a/app/guides/kava/page.tsx
+++ b/app/guides/kava/page.tsx
@@ -237,9 +237,9 @@ export default function KavaGuidePage() {
             <p className="mt-1 text-sm font-semibold text-ink">Passionflower</p>
             <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Modest anxiety reduction with a more favorable safety profile.</p>
           </Link>
-          <Link href="/guides/ashwagandha" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+          <Link href="/guides/best-adaptogens-for-stress" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
             <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Guide</p>
-            <p className="mt-1 text-sm font-semibold text-ink">Ashwagandha</p>
+            <p className="mt-1 text-sm font-semibold text-ink">Ashwagandha & Adaptogens</p>
             <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Adaptogen with the strongest stress/anxiety evidence base.</p>
           </Link>
           <Link href="/guides/natural-anxiolytics-beyond-ashwagandha" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
@@ -252,8 +252,8 @@ export default function KavaGuidePage() {
 
       {/* Bottom nav */}
       <div className="flex flex-wrap gap-4 border-t border-brand-900/10 pt-6 text-sm">
-        <Link href="/guides" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">← All Guides</Link>
-        <Link href="/herbs" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">Herb Library →</Link>
+        <Link href="/guides/" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">← All Guides</Link>
+        <Link href="/herbs/" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">Herb Library →</Link>
       </div>
       </div>{/* end space-y-8 */}
     </ArticleLayout>

--- a/app/guides/kratom-7oh-withdrawal-management/page.tsx
+++ b/app/guides/kratom-7oh-withdrawal-management/page.tsx
@@ -304,7 +304,7 @@ export default function Page() {
       </section>
 
       <div className="mt-8 flex gap-4 flex-wrap">
-        <Link href="/guides" className="text-sm font-medium text-emerald-700 hover:underline">Back to guides →</Link>
+        <Link href="/guides/" className="text-sm font-medium text-emerald-700 hover:underline">Back to guides →</Link>
         <Link href="/articles/7-hydroxymitragynine" className="text-sm font-medium text-emerald-700 hover:underline">Read the 7-OH monograph →</Link>
         <Link href="/articles/mitragynine" className="text-sm font-medium text-emerald-700 hover:underline">Read the mitragynine monograph →</Link>
         <Link href="/compare/mitragynine-vs-7-hydroxymitragynine" className="text-sm font-medium text-emerald-700 hover:underline">Compare mitragynine vs 7-OH →</Link>

--- a/app/guides/natural-anxiolytics-beyond-ashwagandha/page.tsx
+++ b/app/guides/natural-anxiolytics-beyond-ashwagandha/page.tsx
@@ -178,10 +178,10 @@ export default function NaturalAnxiolyticsPage() {
           Always review your personal contraindications, potential drug-supplement interactions, and consult with a qualified medical professional before introducing new supplements.
         </p>
         <div className="mt-4 flex gap-3">
-          <Link href="/compare" className="text-xs font-bold text-amber-900 hover:text-amber-950 hover:underline">
+          <Link href="/compare/" className="text-xs font-bold text-amber-900 hover:text-amber-950 hover:underline">
             Side-by-Side Compare Tool →
           </Link>
-          <Link href="/safety-checker" className="text-xs font-bold text-amber-900 hover:text-amber-950 hover:underline">
+          <Link href="/safety-checker/" className="text-xs font-bold text-amber-900 hover:text-amber-950 hover:underline">
             Interactive Safety Checker →
           </Link>
         </div>

--- a/app/guides/passionflower/page.tsx
+++ b/app/guides/passionflower/page.tsx
@@ -250,8 +250,8 @@ export default function PassionflowerGuidePage() {
 
       {/* Bottom nav */}
       <div className="flex flex-wrap gap-4 border-t border-brand-900/10 pt-6 text-sm">
-        <Link href="/guides" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">← All Guides</Link>
-        <Link href="/herbs" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">Herb Library →</Link>
+        <Link href="/guides/" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">← All Guides</Link>
+        <Link href="/herbs/" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">Herb Library →</Link>
       </div>
 
       </div>{/* end space-y-8 */}

--- a/app/guides/psychedelic-adjacent-herbs/page.tsx
+++ b/app/guides/psychedelic-adjacent-herbs/page.tsx
@@ -66,7 +66,7 @@ export default function PsychedelicAdjacentHerbsPage() {
           <Link href="/compare/kanna-vs-ssris" className="text-brand-700 hover:text-brand-800 hover:underline">
             Kanna vs SSRIs Compare →
           </Link>
-          <Link href="/disclaimer" className="text-brand-700 hover:text-brand-800 hover:underline">
+          <Link href="/disclaimer/" className="text-brand-700 hover:text-brand-800 hover:underline">
             Safety Disclaimer →
           </Link>
         </div>
@@ -135,10 +135,10 @@ export default function PsychedelicAdjacentHerbsPage() {
           These pages are for educational and harm reduction purposes only. The Hippie Scientist does not advocate for the use of unregulated or illegal substances. Always review clinical contraindications and consult with a licensed physician before introducing any botanical supplements into your lifestyle.
         </p>
         <div className="mt-4 flex gap-3">
-          <Link href="/compare" className="text-xs font-bold text-amber-900 hover:text-amber-950 hover:underline">
+          <Link href="/compare/" className="text-xs font-bold text-amber-900 hover:text-amber-950 hover:underline">
             Side-by-Side Compare Tool →
           </Link>
-          <Link href="/safety-checker" className="text-xs font-bold text-amber-900 hover:text-amber-950 hover:underline">
+          <Link href="/safety-checker/" className="text-xs font-bold text-amber-900 hover:text-amber-950 hover:underline">
             Interactive Safety Checker →
           </Link>
         </div>

--- a/app/guides/rhodiola-complete-guide/page.tsx
+++ b/app/guides/rhodiola-complete-guide/page.tsx
@@ -302,8 +302,8 @@ export default function RhodiolaCompleteGuidePage() {
 
       {/* Bottom nav */}
       <div className="flex flex-wrap gap-4 border-t border-brand-900/10 pt-6 text-sm">
-        <Link href="/guides" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">← All Guides</Link>
-        <Link href="/herbs" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">Herb Library →</Link>
+        <Link href="/guides/" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">← All Guides</Link>
+        <Link href="/herbs/" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">Herb Library →</Link>
       </div>
       </div>
     </ArticleLayout>

--- a/app/guides/rhodiola-energy/page.tsx
+++ b/app/guides/rhodiola-energy/page.tsx
@@ -288,8 +288,8 @@ export default function RhodiolaEnergyGuidePage() {
 
       {/* Bottom nav */}
       <div className="flex flex-wrap gap-4 border-t border-brand-900/10 pt-6 text-sm">
-        <Link href="/guides" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">← All Guides</Link>
-        <Link href="/herbs" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">Herb Library →</Link>
+        <Link href="/guides/" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">← All Guides</Link>
+        <Link href="/herbs/" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">Herb Library →</Link>
       </div>
       </div>
     </ArticleLayout>

--- a/app/guides/rhodiola-extract-vs-powder/page.tsx
+++ b/app/guides/rhodiola-extract-vs-powder/page.tsx
@@ -229,8 +229,8 @@ export default function RhodiolaExtractVsPowderGuidePage() {
 
       {/* Bottom nav */}
       <div className="flex flex-wrap gap-4 border-t border-brand-900/10 pt-6 text-sm">
-        <Link href="/guides" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">← All Guides</Link>
-        <Link href="/herbs" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">Herb Library →</Link>
+        <Link href="/guides/" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">← All Guides</Link>
+        <Link href="/herbs/" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">Herb Library →</Link>
       </div>
       </div>
     </ArticleLayout>

--- a/app/guides/rhodiola-sleep-stack/page.tsx
+++ b/app/guides/rhodiola-sleep-stack/page.tsx
@@ -284,8 +284,8 @@ export default function RhodiolaSleepStackGuidePage() {
 
       {/* Bottom nav */}
       <div className="flex flex-wrap gap-4 border-t border-brand-900/10 pt-6 text-sm">
-        <Link href="/guides" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">← All Guides</Link>
-        <Link href="/herbs" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">Herb Library →</Link>
+        <Link href="/guides/" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">← All Guides</Link>
+        <Link href="/herbs/" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">Herb Library →</Link>
       </div>
       </div>
     </ArticleLayout>

--- a/app/guides/sleep-herbs-vs-melatonin/page.tsx
+++ b/app/guides/sleep-herbs-vs-melatonin/page.tsx
@@ -95,7 +95,7 @@ export default function SleepHerbsVsMelatoninPage() {
           <Link href="/guides/magnesium-vs-melatonin" className="text-brand-700 hover:text-brand-800 hover:underline">
             Magnesium vs Melatonin Guide →
           </Link>
-          <Link href="/best-supplements-for-sleep" className="text-brand-700 hover:text-brand-800 hover:underline">
+          <Link href="/best-supplements-for-sleep/" className="text-brand-700 hover:text-brand-800 hover:underline">
             Browse Sleep Supplements →
           </Link>
         </div>
@@ -173,10 +173,10 @@ export default function SleepHerbsVsMelatoninPage() {
           Hormones and sedating botanicals interact with your nervous system. Melatonin should be kept at physiological doses (0.3mg to 1mg) to prevent receptor desensitization and grogginess. Botanical options like Valerian or Lemon Balm should be evaluated for potential polypharmacy interactions if you are already taking clinical sleep medications.
         </p>
         <div className="mt-4 flex gap-3">
-          <Link href="/compare" className="text-xs font-bold text-amber-900 hover:text-amber-950 hover:underline">
+          <Link href="/compare/" className="text-xs font-bold text-amber-900 hover:text-amber-950 hover:underline">
             Side-by-Side Compare Tool →
           </Link>
-          <Link href="/safety-checker" className="text-xs font-bold text-amber-900 hover:text-amber-950 hover:underline">
+          <Link href="/safety-checker/" className="text-xs font-bold text-amber-900 hover:text-amber-950 hover:underline">
             Interactive Safety Checker →
           </Link>
         </div>

--- a/app/guides/turmeric-curcumin/page.tsx
+++ b/app/guides/turmeric-curcumin/page.tsx
@@ -382,13 +382,13 @@ export default function TurmericCurcuminGuidePage() {
       {/* Bottom nav */}
       <div className="flex flex-wrap gap-4 border-t border-brand-900/10 pt-6 text-sm">
         <Link
-          href="/guides"
+          href="/guides/"
           className="font-medium text-brand-700 hover:text-brand-800 hover:underline"
         >
           ← All Guides
         </Link>
         <Link
-          href="/herbs"
+          href="/herbs/"
           className="font-medium text-brand-700 hover:text-brand-800 hover:underline"
         >
           Herb Library →

--- a/app/herbs/HerbsIndexClient.tsx
+++ b/app/herbs/HerbsIndexClient.tsx
@@ -386,7 +386,7 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
               <p className="eyebrow-label">Search and filter</p>
               <h2 id="herb-search-heading" className="compact-heading">Start with the question you need answered.</h2>
             </div>
-            <Link href="/goals" className="w-fit text-sm font-bold text-brand-800 transition hover:text-brand-900">Browse all goals →</Link>
+            <Link href="/goals/" className="w-fit text-sm font-bold text-brand-800 transition hover:text-brand-900">Browse all goals →</Link>
           </div>
 
           <form action="/herbs" className="mt-3 grid gap-2 sm:grid-cols-[1fr_auto]">
@@ -435,7 +435,7 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
 
           {hasActiveFilters && (
             <div className="pt-1">
-              <Link href="/herbs" className="text-xs font-semibold text-brand-800 underline-offset-2 hover:underline">
+              <Link href="/herbs/" className="text-xs font-semibold text-brand-800 underline-offset-2 hover:underline">
                 Clear all filters
               </Link>
             </div>

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -486,7 +486,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
         <div className="flex-1 min-w-0 space-y-10">
           {/* Header Breadcrumb - use only common name, not scientific name */}
       <nav className="flex items-center gap-2 text-xs text-muted">
-        <Link href="/herbs" className="transition hover:text-ink">Herbs</Link>
+        <Link href="/herbs/" className="transition hover:text-ink">Herbs</Link>
         <span>/</span>
         <span className="text-ink font-medium">{displayName}</span>
       </nav>
@@ -860,10 +860,10 @@ export default async function HerbDetailPage({ params }: PageProps) {
       <AuthorCredentials />
 
       <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between">
-        <Link href="/herbs" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">
+        <Link href="/herbs/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">
           ← Back to herbs library
         </Link>
-        <Link href="/safety-checker" className="text-sm font-bold text-brand-800 hover:underline">
+        <Link href="/safety-checker/" className="text-sm font-bold text-brand-800 hover:underline">
           Safety checker →
         </Link>
       </div>

--- a/app/novel-psychoactive-substances/[slug]/page.tsx
+++ b/app/novel-psychoactive-substances/[slug]/page.tsx
@@ -125,8 +125,8 @@ export default async function NovelPsychoactiveSubstanceArticlePage({ params }: 
       <footer className="mt-8 rounded-[0.9rem] border border-amber-700/20 bg-amber-50/80 p-4 text-sm leading-6 text-[#5b4a2c]">
         Educational disclaimer: this page is for evidence review and harm-reduction context only. It is not medical advice, legal advice, sourcing guidance, dosing guidance, or a recommendation to use any novel psychoactive substance.
         <div className="mt-3 flex flex-wrap gap-4 font-semibold text-brand-800">
-          <Link href="/novel-psychoactive-substances" className="hover:underline">NPS section</Link>
-          <Link href="/safety-checker" className="hover:underline">Safety checker</Link>
+          <Link href="/novel-psychoactive-substances/" className="hover:underline">NPS section</Link>
+          <Link href="/safety-checker/" className="hover:underline">Safety checker</Link>
         </div>
       </footer>
     </article>

--- a/app/search/SearchClient.tsx
+++ b/app/search/SearchClient.tsx
@@ -368,7 +368,7 @@ function GuidedDiscovery({ onSelect }: { onSelect: (query: string) => void }) {
             These entry points are orientation tools, not deterministic recommendations.
           </p>
         </div>
-        <Link href="/goals" className="w-fit text-sm font-bold text-brand-800 transition hover:text-brand-900">Browse goal guides →</Link>
+        <Link href="/goals/" className="w-fit text-sm font-bold text-brand-800 transition hover:text-brand-900">Browse goal guides →</Link>
       </div>
 
       <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-4">

--- a/app/seo-entry-pages.tsx
+++ b/app/seo-entry-pages.tsx
@@ -413,13 +413,11 @@ export function generateSeoEntryMetadata(route: string): Metadata {
   const isGeneratedGuideRoute = route.startsWith('guides/')
     && !indexableGuidePages.some((item) => item.route === route)
 
-  const slug = route.startsWith('guides/') ? route.replace('guides/', '') : route
-
   let meta = buildPageMetadata({
     title: page.title,
     description: page.intro,
     path: `/${canonicalRoute}`,
-    image: `/og/guides/${slug}.png`,
+    image: '/og-default.jpg',
     openGraphType: 'article',
   })
   if (isGeneratedGuideRoute) {
@@ -483,7 +481,7 @@ export async function SeoEntryPage({ route }: { route: string }) {
           <p className="mt-4 max-w-3xl text-base leading-7 text-muted">{page.intro}</p>
           <div className="mt-5 flex flex-wrap gap-3">
             <Link href={`/goals/${goal.slug}`} className="rounded-full bg-emerald-300 px-4 py-2 text-sm font-bold text-black hover:bg-emerald-200">View ranked picks</Link>
-            <Link href="/compounds" className="rounded-full border border-brand-900/10 px-4 py-2 text-sm font-semibold text-ink hover:bg-brand-50">Browse compounds</Link>
+            <Link href="/compounds/" className="rounded-full border border-brand-900/10 px-4 py-2 text-sm font-semibold text-ink hover:bg-brand-50">Browse compounds</Link>
           </div>
         </section>
       </div>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -491,6 +491,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const sitemapEntries: MetadataRoute.Sitemap = [
     route(normalizeSitemapUrl('/'), 'weekly', 1.0),
     route(normalizeSitemapUrl('/about'), 'yearly', 0.6),
+    route(normalizeSitemapUrl('/author'), 'yearly', 0.6),
+    route(normalizeSitemapUrl('/search'), 'monthly', 0.6),
     route(normalizeSitemapUrl('/contact'), 'yearly', 0.5),
     route(normalizeSitemapUrl('/faq'), 'monthly', 0.7),
     route(normalizeSitemapUrl('/methodology'), 'yearly', 0.6),
@@ -738,6 +740,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
     'best-supplements-for-gut-health',
     'best-supplements-for-joint-support',
     'best-magnesium-supplements-for-adhd',
+    'natural-testosterone-boosters',
+    'best-herbs-for-anxiety',
+    'herbs-for-sleep',
+    'best-nootropics-for-focus',
+    'best-adaptogens-for-stress',
   ];
   topPages.forEach((p) => {
     addRoute(`/${p}`, 'monthly', 0.6);

--- a/app/stacks/[slug]/page.tsx
+++ b/app/stacks/[slug]/page.tsx
@@ -153,8 +153,8 @@ export default async function StackPage({ params }: Params) {
     })
 
     const overviewBreadcrumbJsonLd = breadcrumbJsonLd([
-      { name: 'Stacks', url: 'https://thehippiescientist.net/stacks' },
-      { name: displayTitle, url: `https://thehippiescientist.net/stacks/${slug}` },
+      { name: 'Stacks', url: 'https://thehippiescientist.net/stacks/' },
+      { name: displayTitle, url: `https://thehippiescientist.net/stacks/${slug}/` },
     ])
 
     return (
@@ -229,11 +229,11 @@ export default async function StackPage({ params }: Params) {
   })
 
   const stackBreadcrumbJsonLd = breadcrumbJsonLd([
-    { name: 'Stacks', url: 'https://thehippiescientist.net/stacks' },
+    { name: 'Stacks', url: 'https://thehippiescientist.net/stacks/' },
     ...(namedStack
-      ? [{ name: formatGoal(namedStack.parentSlug), url: `https://thehippiescientist.net/stacks/${namedStack.parentSlug}` }]
+      ? [{ name: formatGoal(namedStack.parentSlug), url: `https://thehippiescientist.net/stacks/${namedStack.parentSlug}/` }]
       : []),
-    { name: displayTitle, url: `https://thehippiescientist.net/stacks/${slug}` },
+    { name: displayTitle, url: `https://thehippiescientist.net/stacks/${slug}/` },
   ])
 
   // Helper to resolve affiliate fields for a stack item card

--- a/app/stacks/page.tsx
+++ b/app/stacks/page.tsx
@@ -148,7 +148,7 @@ export default function StacksPage() {
             <h2 className="mt-1 text-3xl font-black text-ink">Stack library</h2>
             <p className="mt-1 text-sm text-muted">Each stack shows the actual pattern before the click.</p>
           </div>
-          <Link href="/goals" className="text-sm font-black text-emerald-700 hover:text-emerald-900">Explore goal guides →</Link>
+          <Link href="/goals/" className="text-sm font-black text-emerald-700 hover:text-emerald-900">Explore goal guides →</Link>
         </div>
 
         {remaining.length > 0 ? (

--- a/components/AuthorCredentials.tsx
+++ b/components/AuthorCredentials.tsx
@@ -33,7 +33,7 @@ export default function AuthorCredentials() {
             <strong className="font-semibold text-ink">Editorial Process:</strong> We synthesize preclinical pharmacology, human clinical data, and source registry context while preserving uncertainty and avoiding commercial hype.
           </p>
           <Link
-            href="/about"
+            href="/about/"
             className="font-bold text-brand-800 hover:text-brand-700 hover:underline transition self-start sm:self-center flex-shrink-0"
           >
             Read Editorial Standards &rarr;

--- a/components/EvidenceMeterDetail.tsx
+++ b/components/EvidenceMeterDetail.tsx
@@ -62,7 +62,7 @@ export default function EvidenceMeterDetail({ data }: Props) {
         Evidence ratings are editorial assessments based on available published research. They are
         not medical recommendations.{' '}
         <Link
-          href="/education/evidence-hierarchy"
+          href="/education/evidence-hierarchy/"
           className="font-semibold text-brand-700 underline underline-offset-2 hover:text-brand-800 focus:outline-none focus-visible:ring-1 focus-visible:ring-brand-700 dark:text-brand-100 dark:hover:text-white"
         >
           How we rate evidence →

--- a/components/WhatToBuyFirst.tsx
+++ b/components/WhatToBuyFirst.tsx
@@ -194,7 +194,7 @@ export default function WhatToBuyFirst({
         only link products we&apos;ve reviewed. Always read the profile and consult a clinician
         before use.{' '}
         <Link
-          href="/disclaimer"
+          href="/disclaimer/"
           className="font-semibold text-brand-700 hover:text-brand-800 hover:underline focus:outline-none focus-visible:ring-1 focus-visible:ring-brand-700 dark:text-brand-100 dark:hover:text-white"
         >
           Full disclaimer →

--- a/components/articles/AdhdMonetizationWidgets.tsx
+++ b/components/articles/AdhdMonetizationWidgets.tsx
@@ -40,7 +40,7 @@ export function AdhdCtaDashboard({ currentSlug }: { currentSlug: string }) {
       <h3 className="text-base font-bold text-ink">Next Steps &amp; Practical Resources</h3>
       <p className="mt-1 text-sm text-muted">Review these guides to translate evidence into safe, personalized actions.</p>
       <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        <Link href="/compare" className="flex flex-col justify-between rounded-lg border border-brand-900/10 bg-white/50 p-4 transition hover:border-brand-700/20 hover:bg-brand-50/10">
+        <Link href="/compare/" className="flex flex-col justify-between rounded-lg border border-brand-900/10 bg-white/50 p-4 transition hover:border-brand-700/20 hover:bg-brand-50/10">
           <div>
             <p className="text-[0.68rem] font-bold uppercase tracking-wider text-brand-700">Database</p>
             <h4 className="mt-1 text-sm font-bold text-ink">Compare Options</h4>
@@ -50,7 +50,7 @@ export function AdhdCtaDashboard({ currentSlug }: { currentSlug: string }) {
         </Link>
         
         {currentSlug !== 'adhd-stack-guide' ? (
-          <Link href="/articles/adhd-stack-guide" className="flex flex-col justify-between rounded-lg border border-brand-900/10 bg-white/50 p-4 transition hover:border-brand-700/20 hover:bg-brand-50/10">
+          <Link href="/articles/adhd-stack-guide/" className="flex flex-col justify-between rounded-lg border border-brand-900/10 bg-white/50 p-4 transition hover:border-brand-700/20 hover:bg-brand-50/10">
             <div>
               <p className="text-[0.68rem] font-bold uppercase tracking-wider text-brand-700">Formulation</p>
               <h4 className="mt-1 text-sm font-bold text-ink">Read the Stack Guide</h4>
@@ -59,7 +59,7 @@ export function AdhdCtaDashboard({ currentSlug }: { currentSlug: string }) {
             <span className="mt-3 text-xs font-semibold text-brand-700 inline-flex items-center gap-1">View Stack Guide →</span>
           </Link>
         ) : (
-          <Link href="/articles/best-supplements-for-adhd" className="flex flex-col justify-between rounded-lg border border-brand-900/10 bg-white/50 p-4 transition hover:border-brand-700/20 hover:bg-brand-50/10">
+          <Link href="/articles/best-supplements-for-adhd/" className="flex flex-col justify-between rounded-lg border border-brand-900/10 bg-white/50 p-4 transition hover:border-brand-700/20 hover:bg-brand-50/10">
             <div>
               <p className="text-[0.68rem] font-bold uppercase tracking-wider text-brand-700">Directory</p>
               <h4 className="mt-1 text-sm font-bold text-ink">Best Supplements</h4>
@@ -69,7 +69,7 @@ export function AdhdCtaDashboard({ currentSlug }: { currentSlug: string }) {
           </Link>
         )}
 
-        <Link href="/safety-checker" className="flex flex-col justify-between rounded-lg border border-brand-900/10 bg-white/50 p-4 transition hover:border-brand-700/20 hover:bg-brand-50/10">
+        <Link href="/safety-checker/" className="flex flex-col justify-between rounded-lg border border-brand-900/10 bg-white/50 p-4 transition hover:border-brand-700/20 hover:bg-brand-50/10">
           <div>
             <p className="text-[0.68rem] font-bold uppercase tracking-wider text-brand-700">Safety First</p>
             <h4 className="mt-1 text-sm font-bold text-ink">Check Safety Notes</h4>

--- a/components/articles/FocusAdhdArticlePage.tsx
+++ b/components/articles/FocusAdhdArticlePage.tsx
@@ -380,7 +380,7 @@ export default function FocusAdhdArticlePage({ slug }: { slug: string }) {
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }} />
 
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
-        <Link href="/articles" className="transition hover:text-ink">Articles</Link>
+        <Link href="/articles/" className="transition hover:text-ink">Articles</Link>
         <span>/</span>
         <span className="line-clamp-1 text-ink">{article.title}</span>
       </nav>
@@ -433,13 +433,13 @@ export default function FocusAdhdArticlePage({ slug }: { slug: string }) {
           <h2 className="text-lg font-semibold tracking-tight text-ink">Related Sleep &amp; Calm Guides</h2>
           <p className="text-xs text-muted mt-1">For general sleep research and comparative guides on these ingredients:</p>
           <div className="mt-3 grid gap-2 sm:grid-cols-3">
-            <Link href="/articles/l-theanine-for-sleep" className="rounded-[0.75rem] border border-brand-900/10 bg-brand-50/30 px-3 py-2 text-sm font-semibold text-brand-800 hover:border-brand-900/20 hover:bg-white transition">
+            <Link href="/articles/l-theanine-for-sleep/" className="rounded-[0.75rem] border border-brand-900/10 bg-brand-50/30 px-3 py-2 text-sm font-semibold text-brand-800 hover:border-brand-900/20 hover:bg-white transition">
               L-Theanine for Sleep →
             </Link>
-            <Link href="/articles/magnesium-types-for-sleep" className="rounded-[0.75rem] border border-brand-900/10 bg-brand-50/30 px-3 py-2 text-sm font-semibold text-brand-800 hover:border-brand-900/20 hover:bg-white transition">
+            <Link href="/articles/magnesium-types-for-sleep/" className="rounded-[0.75rem] border border-brand-900/10 bg-brand-50/30 px-3 py-2 text-sm font-semibold text-brand-800 hover:border-brand-900/20 hover:bg-white transition">
               Magnesium Types for Sleep →
             </Link>
-            <Link href="/articles/best-herbs-for-sleep" className="rounded-[0.75rem] border border-brand-900/10 bg-brand-50/30 px-3 py-2 text-sm font-semibold text-brand-800 hover:border-brand-900/20 hover:bg-white transition">
+            <Link href="/articles/best-herbs-for-sleep/" className="rounded-[0.75rem] border border-brand-900/10 bg-brand-50/30 px-3 py-2 text-sm font-semibold text-brand-800 hover:border-brand-900/20 hover:bg-white transition">
               Best Herbs for Sleep →
             </Link>
           </div>
@@ -459,7 +459,7 @@ export default function FocusAdhdArticlePage({ slug }: { slug: string }) {
       </section>
 
       <div className="mt-8">
-        <Link href="/articles" className="text-sm font-semibold text-brand-700 hover:text-brand-800">Back to Articles</Link>
+        <Link href="/articles/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">Back to Articles</Link>
       </div>
     </article>
   )

--- a/components/blog/BlogPostPage.tsx
+++ b/components/blog/BlogPostPage.tsx
@@ -109,7 +109,7 @@ export default async function BlogPostPage({ params }: BlogRouteProps) {
       <JsonLd schema={pageBreadcrumb} />
 
       <nav className="flex items-center gap-2 text-sm text-muted">
-        <Link href="/articles" className="transition hover:text-ink">
+        <Link href="/articles/" className="transition hover:text-ink">
           Articles
         </Link>
 
@@ -126,7 +126,7 @@ export default async function BlogPostPage({ params }: BlogRouteProps) {
         </div>
       )}
 
-      <Link href="/articles" className="text-sm font-bold text-brand-800">&lt;- Back to articles</Link>
+      <Link href="/articles/" className="text-sm font-bold text-brand-800">&lt;- Back to articles</Link>
 
       <section className="hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8 lg:p-10">
         <div className="flex flex-wrap items-center gap-3">
@@ -137,7 +137,7 @@ export default async function BlogPostPage({ params }: BlogRouteProps) {
         <h1 className="mt-4 heading-premium max-w-4xl">{post.title}</h1>
         <p className="mt-3 text-sm text-muted">
           By{' '}
-          <Link href="/about" rel="author" className="font-medium text-ink hover:underline">
+          <Link href="/about/" rel="author" className="font-medium text-ink hover:underline">
             Will
           </Link>
         </p>

--- a/components/guides/GuidePage.tsx
+++ b/components/guides/GuidePage.tsx
@@ -403,10 +403,10 @@ export default function GuidePage({ guide }: Props) {
 
       {/* Bottom nav */}
       <div className="flex flex-wrap gap-4 border-t border-brand-900/10 pt-6 text-sm">
-        <Link href="/guides" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">
+        <Link href="/guides/" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">
           ← All Guides
         </Link>
-        <Link href="/herbs" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">
+        <Link href="/herbs/" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">
           Herb Library →
         </Link>
       </div>

--- a/components/search/GlobalSearchModal.tsx
+++ b/components/search/GlobalSearchModal.tsx
@@ -236,7 +236,7 @@ export function GlobalSearchModal() {
                 <span>↑↓ navigate</span>
                 <span>↵ open</span>
                 <Link
-                  href="/search"
+                  href="/search/"
                   onClick={close}
                   className="font-semibold text-brand-700 hover:text-brand-900"
                 >

--- a/components/ui/EvidenceBadge.tsx
+++ b/components/ui/EvidenceBadge.tsx
@@ -21,7 +21,7 @@ export default function EvidenceBadge({
 
   return (
     <Link
-      href="/education/evidence-levels"
+      href="/education/evidence-levels/"
       title={tooltip}
       aria-label={`${label}. ${tooltip}`}
       className={`${decisionStatusBadgeClass} ${evidenceToneClasses(tone)} ${className}`}

--- a/public/data/_meta/build-info.json
+++ b/public/data/_meta/build-info.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-06-27T03:51:53.170Z",
+  "generatedAt": "2026-06-28T17:22:43.668Z",
   "source": {
-    "workbookPath": "C:\\Users\\Will\\Documents\\hippie-scientist-site\\data-sources\\herb_monograph_master.xlsx",
+    "workbookPath": "/home/user/hippie-scientist-site/data-sources/herb_monograph_master.xlsx",
     "workbook": "herb_monograph_master.xlsx"
   },
-  "output": "public\\data",
+  "output": "public/data",
   "counts": {
     "herbs": 290,
     "compounds": 557,

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -11,31 +11,31 @@ import { PUBLIC_ROUTES } from '../lib/public-routes'
 const exploreLinks = [
   { href: PUBLIC_ROUTES.herbs, label: 'Herb Database' },
   { href: PUBLIC_ROUTES.compounds, label: 'Compounds' },
-  { href: '/stacks', label: 'Stacks' },
-  { href: '/compare', label: 'Compare' },
+  { href: '/stacks/', label: 'Stacks' },
+  { href: '/compare/', label: 'Compare' },
   { href: PUBLIC_ROUTES.guides, label: 'Guides' },
   { href: PUBLIC_ROUTES.articles, label: 'Articles' },
-  { href: '/education', label: 'Learn the Science' },
-  { href: '/search', label: 'Search' },
-  { href: '/goals', label: 'Goals' },
+  { href: '/education/', label: 'Learn the Science' },
+  { href: '/search/', label: 'Search' },
+  { href: PUBLIC_ROUTES.goals, label: 'Goals' },
 ]
 
 const priorityGoalLinks = [
-  { href: '/goals/sleep', label: 'Sleep' },
-  { href: '/goals/stress', label: 'Stress' },
-  { href: '/goals/anxiety', label: 'Anxiety' },
-  { href: '/goals/focus', label: 'Focus' },
+  { href: '/goals/sleep/', label: 'Sleep' },
+  { href: '/goals/stress/', label: 'Stress' },
+  { href: '/goals/anxiety/', label: 'Anxiety' },
+  { href: '/goals/focus/', label: 'Focus' },
 ]
 
 const safetyLinks = [
-  { href: '/methodology', label: 'Methodology' },
+  { href: '/methodology/', label: 'Methodology' },
   { href: PUBLIC_ROUTES.disclaimer, label: 'Disclaimer' },
   { href: PUBLIC_ROUTES.contact, label: 'Contact' },
 ]
 
 const legalLinks = [
   { href: PUBLIC_ROUTES.privacy, label: 'Privacy Policy' },
-  { href: '/affiliate-disclosure', label: 'Affiliate Disclosure' },
+  { href: '/affiliate-disclosure/', label: 'Affiliate Disclosure' },
   { href: '/sitemap.xml', label: 'Sitemap' },
 ]
 


### PR DESCRIPTION
Pass 1: Fix broken internal links
- /education/evidence-literacy → /education/evidence-hierarchy (study-design-snapshot)
- /guides/ashwagandha → /guides/best-adaptogens-for-stress (kava guide)
- /compare/magnesium-glycinate-vs-l-threonate-for-sleep → correct slug (2 files)

Pass 2: Add trailing slashes to all internal links (links-to-redirect)
- Fixed 70+ href= attributes across app/ and components/ directories
- Covers articles, about, goals, guides, herbs, compounds, compare,
  safety-checker, stacks, education, methodology, disclaimer, search,
  novel-psychoactive-substances, author, contact paths

Pass 2: Fix broken OG image references
- /og/guides/best-supplements-for-sleep.png → /og-default.jpg
- /og/guides/${slug}.png → /og-default.jpg in seo-entry-pages

Pass 2: Fix stacks breadcrumb JSON-LD URLs missing trailing slashes

Pass 3: Fix orphan pages — add 35 unlisted education pages to index
- New CompactSection component with grouped thematic link lists
- Neurotransmitters, research literacy, psychoactive plants, burnout,
  context/variability clusters added to /education/ index

Pass 4: Sitemap completeness
- Add /author and /search to static sitemap routes
- Add natural-testosterone-boosters, best-herbs-for-anxiety,
  herbs-for-sleep, best-nootropics-for-focus, best-adaptogens-for-stress
  to topPages list in sitemap.ts

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GJK2SFy5gdzaBNPVtcTzH6