### PR TITLE
Fix a11y: minimum text sizes raised to 12px

### DIFF
--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -216,7 +216,7 @@ export default function HomepageV2() {
             <div className='grid gap-3 sm:grid-cols-3'>
               {trustSignals.map((signal) => (
                 <div key={signal.n} className='flex gap-4 rounded-[0.85rem] border border-brand-900/10 bg-white/60 p-4 dark:bg-[var(--surface-card)] dark:text-[var(--text-secondary)]'>
-                  <span className='mt-0.5 shrink-0 font-mono text-[0.65rem] font-bold tracking-widest text-brand-400'>{signal.n}</span>
+                  <span className='mt-0.5 shrink-0 font-mono text-xs font-bold tracking-widest text-brand-400'>{signal.n}</span>
                   <div>
                     <p className='text-sm font-semibold text-ink'>{signal.label}</p>
                     <p className='mt-1 text-sm leading-6 text-muted'>{signal.body}</p>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -73,7 +73,7 @@ export default function Footer() {
         <div className='grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-4'>
           <div>
             <p className='font-display text-lg italic text-white'>The Hippie Scientist</p>
-            <p className='mt-1.5 text-[0.7rem] uppercase tracking-[0.14em] text-white/45'>
+            <p className='mt-1.5 text-xs uppercase tracking-[0.14em] text-white/55'>
               Evidence-first botanical research. Not medical advice.
             </p>
             <div className='mt-4 flex flex-wrap items-center gap-x-2 text-xs text-white/50'>

--- a/src/components/mobile-bottom-nav.tsx
+++ b/src/components/mobile-bottom-nav.tsx
@@ -59,7 +59,7 @@ export default function MobileBottomNav() {
               }`}
             >
               <Icon aria-hidden="true" className="h-5 w-5" strokeWidth={active ? 2.45 : 2.1} />
-              <span className={`max-w-full whitespace-nowrap text-[0.66rem] leading-none ${active ? 'font-semibold' : 'font-medium'}`}>
+              <span className={`max-w-full whitespace-nowrap text-xs leading-none ${active ? 'font-semibold' : 'font-medium'}`}>
                 {item.label}
               </span>
             </Link>


### PR DESCRIPTION
- Footer disclaimer: 0.7rem → text-xs (12px), opacity 45% → 55%
- Mobile nav labels: 0.66rem → text-xs (12px)
- Trust signal numbers: 0.65rem → text-xs (12px)

## Summary

- 

## Verification

- [ ] `npm run lint`
- [ ] `npm run check`
- [ ] no package-lock drift
- [ ] no unexpected `public/data` diffs
- [ ] no generated file corruption
- [ ] static export compatible

## Risk Notes

- 
