### PR TITLE
fix: mobile menu drawer height — force 100dvh

### DIFF
--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -118,6 +118,7 @@ export function Navigation() {
             aria-modal="true"
             aria-label="Mobile navigation menu"
             className="fixed inset-y-0 right-0 z-50 w-72 overflow-y-auto border-l border-brand-900/10 bg-white px-4 py-6 shadow-xl dark:border-[var(--border-strong)] dark:bg-[var(--surface-card-strong)]"
+            style={{ height: '100dvh' }}
           >
             <div className="mb-6 flex items-center justify-between">
               <Link href="/" onClick={closeMobile} className="font-display text-lg font-semibold text-ink">


### PR DESCRIPTION
## Summary

- 

## Verification

- [ ] `npm run lint`
- [ ] `npm run check`
- [ ] no package-lock drift
- [ ] no unexpected `public/data` diffs
- [ ] no generated file corruption
- [ ] static export compatible

## Risk Notes

- 
