### PR TITLE
[codex] Add healthy dip alternatives guide

### DIFF
--- a/app/guides/other/healthy-dipping-tobacco-alternatives/page.tsx
+++ b/app/guides/other/healthy-dipping-tobacco-alternatives/page.tsx
@@ -1,0 +1,403 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import StructuredData from '@/components/StructuredData'
+import { SITE_URL } from '@/lib/navigation-config'
+import { ArticleLayout, TableOfContents } from '@/components/articles'
+import type { Heading } from '@/components/articles'
+
+const PAGE_PATH = '/guides/other/healthy-dipping-tobacco-alternatives'
+const PAGE_URL = `${SITE_URL}${PAGE_PATH}`
+const TITLE = 'Healthy Alternatives to Dipping Tobacco'
+const DESCRIPTION =
+  'Evidence-informed guide to replacing dipping tobacco, including nicotine replacement therapy, oral substitutes, tobacco-free pouches, cardiovascular inflammation context, and carotid artery safety.'
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  alternates: { canonical: `${PAGE_PATH}/` },
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    url: `${PAGE_PATH}/`,
+    type: 'article',
+    images: ['/og-default.jpg'],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: TITLE,
+    description: 'A science-first guide to replacing dip without pretending nicotine pouches are vascular health products.',
+  },
+}
+
+const FAQS = [
+  {
+    question: 'What is the healthiest replacement for dipping tobacco?',
+    answer:
+      'For most adults trying to quit dip, the healthiest evidence-based replacement is not another consumer pouch. It is a quit plan that uses behavioral support plus FDA-approved cessation aids such as nicotine gum, lozenges, patches, varenicline, or bupropion when appropriate. Non-nicotine oral substitutes like sugar-free gum, xylitol mints, sunflower seeds, toothpicks, or tobacco-free herbal pouches can help with the mouth habit, but they do not treat nicotine dependence by themselves.',
+  },
+  {
+    question: 'Are nicotine pouches like ZYN healthy?',
+    answer:
+      'No. Tobacco-free nicotine pouches likely reduce exposure to tobacco-specific nitrosamines compared with traditional dip, but they still deliver addictive nicotine. Nicotine can acutely raise heart rate and blood pressure through sympathetic nervous system activation, and nicotine pouches are not the same thing as FDA-approved nicotine replacement therapy.',
+  },
+  {
+    question: 'Can any dip replacement reduce inflammation around the carotid artery?',
+    answer:
+      'No oral pouch, lozenge, gum, herb, or supplement is proven to specifically reduce inflammation around the carotid artery or reverse carotid plaque. The evidence-based move is to stop smokeless tobacco exposure, control blood pressure and lipids, address diabetes and sleep apnea if present, maintain dental care, and work with a clinician if carotid plaque, bruit, TIA symptoms, or stroke risk factors are present.',
+  },
+  {
+    question: 'Is nicotine replacement therapy safer for arteries than dip?',
+    answer:
+      'Nicotine replacement therapy still contains nicotine, so it is not a cardiovascular wellness product. However, regulated NRT avoids tobacco leaf, combustion products, and many tobacco-specific toxicants, and it delivers nicotine more predictably than dip. It is best used as a temporary bridge to full nicotine freedom, especially with counseling or quitline support.',
+  },
+]
+
+const HEADINGS: Heading[] = [
+  { id: 'bottom-line', text: 'Bottom Line', level: 2 },
+  { id: 'ranked-options', text: 'Ranked Replacement Options', level: 2 },
+  { id: 'carotid-inflammation', text: 'Carotid Artery Inflammation', level: 2 },
+  { id: 'mechanisms', text: 'Why Dip Stresses Blood Vessels', level: 2 },
+  { id: 'protocol', text: 'Practical Quit Protocol', level: 2 },
+  { id: 'supplements', text: 'Supplements and Vascular Context', level: 2 },
+  { id: 'red-flags', text: 'Red Flags', level: 2 },
+  { id: 'faq', text: 'FAQ', level: 2 },
+  { id: 'references', text: 'References', level: 2 },
+]
+
+const replacementOptions = [
+  {
+    name: 'Behavioral support + FDA-approved cessation medication',
+    role: 'Best evidence-first path',
+    vascularRead: 'Designed to end tobacco and nicotine exposure over time',
+    details:
+      'Quitline coaching, clinician support, nicotine gum/lozenge/patch, varenicline, or bupropion address both the chemical dependence and the cue loop. This is the closest thing to a medical-grade replacement strategy.',
+  },
+  {
+    name: 'Nicotine gum or lozenges',
+    role: 'Best mouth-feel bridge when oral fixation is the problem',
+    vascularRead: 'Still nicotine, but regulated and easier to taper than dip',
+    details:
+      'Useful when the cue is putting something in the lip or cheek. Gum and lozenges deliver nicotine through the oral mucosa without tobacco leaf or tobacco-specific nitrosamines from cured tobacco.',
+  },
+  {
+    name: 'Nicotine patch + short-acting gum or lozenge',
+    role: 'Best for heavy daily users',
+    vascularRead: 'Lower peaks than repeated dip hits, but not nicotine-free',
+    details:
+      'The patch gives baseline coverage; gum or lozenge handles breakthrough cravings. This often works better than short-acting products alone for high-dependence users.',
+  },
+  {
+    name: 'Non-nicotine oral substitutes',
+    role: 'Best for replacing the ritual',
+    vascularRead: 'No nicotine; choose low-sugar, mouth-safe options',
+    details:
+      'Sugar-free gum, xylitol mints, cinnamon or mint toothpicks, sunflower seeds, cut vegetables, and plain herbal pouches can occupy the mouth without continuing nicotine dependence.',
+  },
+  {
+    name: 'Tobacco-free nicotine pouches',
+    role: 'Harm-reduction fallback, not a health product',
+    vascularRead: 'Less tobacco toxicant exposure, but ongoing nicotine stress',
+    details:
+      'These may be less toxic than dip because they remove cured tobacco leaf, but they can preserve addiction and still acutely increase heart rate and blood pressure.',
+  },
+] as const
+
+const vascularSupports = [
+  {
+    name: 'Omega-3',
+    href: '/compounds/omega-3',
+    evidence: 'Useful for triglycerides and cardiometabolic context; not a carotid plaque treatment.',
+  },
+  {
+    name: 'Psyllium husk',
+    href: '/compounds/psyllium-husk',
+    evidence: 'Soluble fiber can support LDL-C reduction, which matters more for plaque biology than chasing a single anti-inflammatory supplement.',
+  },
+  {
+    name: 'Turmeric / curcumin',
+    href: '/herbs/turmeric',
+    evidence: 'Anti-inflammatory biomarker interest, but no good evidence that it reverses carotid plaque or replaces vascular risk management.',
+  },
+  {
+    name: 'Aged garlic extract',
+    href: '/compounds/aged-garlic-extract',
+    evidence: 'Interesting blood pressure and vascular marker literature; still adjunctive and not a substitute for indicated medication.',
+  },
+  {
+    name: 'Nattokinase',
+    href: '/compounds/nattokinase',
+    evidence: 'Often marketed for circulation, but bleeding and medication-interaction questions make it a clinician-discussion supplement, not a casual dip replacement.',
+  },
+] as const
+
+const references = [
+  ['CDC: Health Effects of Smokeless Tobacco', 'https://www.cdc.gov/tobacco/other-tobacco-products/smokeless-tobacco-health-effects.html'],
+  ['CDC: How to Quit Smoking or Smokeless Tobacco', 'https://www.cdc.gov/tobacco/campaign/tips/quit-smoking/index.html'],
+  ['FDA: FDA-approved cessation products can help', 'https://www.fda.gov/consumers/consumer-updates/want-quit-smoking-fda-approved-and-fda-cleared-cessation-products-can-help'],
+  ['Cochrane review: Nicotine replacement therapy for smoking cessation', 'https://pubmed.ncbi.nlm.nih.gov/23152200/'],
+  ['Stopping smokeless tobacco with varenicline: randomized controlled trial', 'https://pubmed.ncbi.nlm.nih.gov/21134997/'],
+  ['Smokeless tobacco cessation interventions: systematic review', 'https://pmc.ncbi.nlm.nih.gov/articles/PMC6362721/'],
+  ['AHA scientific statement: Smokeless oral nicotine products and cardiovascular disease', 'https://professional.heart.org/en/science-news/impact-of-smokeless-oral-nicotine-products-on-cardiovascular-disease/top-things-to-know'],
+  ['Noncigarette tobacco products and inflammatory/carotid markers', 'https://pubmed.ncbi.nlm.nih.gov/39866105/'],
+  ['Smokeless tobacco use and atherosclerosis', 'https://pubmed.ncbi.nlm.nih.gov/9247364/'],
+  ['Smokeless tobacco use and circulatory disease risk', 'https://pmc.ncbi.nlm.nih.gov/articles/PMC6196954/'],
+  ['NCI: Smokeless tobacco and cancer', 'https://www.cancer.gov/about-cancer/causes-prevention/risk/tobacco/smokeless-fact-sheet'],
+  ['Mayo Clinic: Ways to resist tobacco cravings', 'https://www.mayoclinic.org/diseases-conditions/nicotine-dependence/in-depth/nicotine-craving/art-20045454'],
+] as const
+
+export default function Page() {
+  const toc = <TableOfContents headings={HEADINGS} />
+
+  return (
+    <ArticleLayout toc={toc} zone="harm-reduction">
+      <StructuredData
+        pageUrl={PAGE_URL}
+        headline={TITLE}
+        description={DESCRIPTION}
+        datePublished="2026-07-01"
+        dateModified="2026-07-01"
+        faqs={FAQS}
+        breadcrumbs={[
+          { label: 'Home', href: '/' },
+          { label: 'Guides', href: '/guides/' },
+          { label: 'Healthy Dipping Tobacco Alternatives', href: `${PAGE_PATH}/` },
+        ]}
+      />
+
+      <div className="space-y-10">
+        <section className="hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-10">
+          <p className="eyebrow-label">Harm reduction guide</p>
+          <h1 className="mt-3 text-3xl font-semibold tracking-tight text-ink sm:text-4xl">
+            Healthy Alternatives to Dipping Tobacco
+          </h1>
+          <p className="mt-2 text-xs text-muted">
+            Written and reviewed by{' '}
+            <Link href="/author/" className="font-medium text-brand-700 hover:underline">Will Thomas</Link>
+            {' '}· Last updated July 2026
+          </p>
+          <p className="detail-reading mt-4 text-muted">
+            If the goal is a healthier replacement for dip, the target is not a cleaner-looking pouch.
+            It is removing cured tobacco toxicants, lowering nicotine dependence, protecting the mouth,
+            and reducing cardiovascular strain over time. This guide ranks the real options and explains
+            what is known, and not known, about carotid artery inflammation.
+          </p>
+        </section>
+
+        <section className="rounded-2xl border border-rose-900/15 bg-rose-50/80 p-5 text-sm leading-6 text-rose-950">
+          <p className="font-semibold">Medical scope and carotid artery warning</p>
+          <p className="mt-2">
+            This page is educational and cannot diagnose carotid artery disease, plaque, vasculitis, neck pain,
+            bruit, transient ischemic attack, or stroke risk. Seek urgent care for face drooping, arm weakness,
+            speech trouble, sudden one-sided numbness, sudden severe headache, vision loss, chest pain, fainting,
+            or new neurologic symptoms. If a clinician has mentioned carotid plaque or carotid stenosis, use this
+            guide as a conversation starter, not as a treatment plan.
+          </p>
+        </section>
+
+        <section id="bottom-line" className="card-premium scroll-mt-20 space-y-4 p-6">
+          <h2 className="text-2xl font-semibold text-ink">Bottom line</h2>
+          <p className="text-muted">
+            The healthiest replacement for dipping tobacco is usually a two-part plan: use an evidence-based
+            cessation aid to control nicotine withdrawal, and use a non-nicotine mouth substitute to replace
+            the ritual. Nicotine pouches can be lower-toxicant than dip, but they are not healthy, not
+            anti-inflammatory, and not proven to protect the carotid arteries.
+          </p>
+          <div className="grid gap-3 sm:grid-cols-3">
+            <div className="rounded-xl border border-brand-900/10 bg-brand-50/60 p-4">
+              <p className="text-sm font-semibold text-ink">Best evidence</p>
+              <p className="mt-1 text-xs leading-6 text-muted">Counseling plus NRT, varenicline, or bupropion when appropriate.</p>
+            </div>
+            <div className="rounded-xl border border-brand-900/10 bg-brand-50/60 p-4">
+              <p className="text-sm font-semibold text-ink">Best oral habit swap</p>
+              <p className="mt-1 text-xs leading-6 text-muted">Sugar-free gum, mints, toothpicks, seeds, or non-nicotine pouches.</p>
+            </div>
+            <div className="rounded-xl border border-brand-900/10 bg-brand-50/60 p-4">
+              <p className="text-sm font-semibold text-ink">Best artery move</p>
+              <p className="mt-1 text-xs leading-6 text-muted">Quit tobacco, then taper nicotine rather than staying on high-dose pouches.</p>
+            </div>
+          </div>
+        </section>
+
+        <section id="ranked-options" className="scroll-mt-20 space-y-5">
+          <h2 className="text-2xl font-semibold text-ink">Ranked replacement options</h2>
+          <div className="space-y-4">
+            {replacementOptions.map((option, index) => (
+              <article key={option.name} className="card-premium p-5">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-[0.14em] text-brand-700">
+                      Option {index + 1}
+                    </p>
+                    <h3 className="mt-1 text-lg font-semibold text-ink">{option.name}</h3>
+                    <p className="mt-1 text-sm font-medium text-brand-800">{option.role}</p>
+                  </div>
+                  <p className="rounded-full border border-brand-900/10 bg-white px-3 py-1 text-xs font-semibold text-muted">
+                    {option.vascularRead}
+                  </p>
+                </div>
+                <p className="mt-3 text-sm leading-7 text-muted">{option.details}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section id="carotid-inflammation" className="scroll-mt-20 space-y-4">
+          <p className="eyebrow-label">Carotid artery context</p>
+          <h2 className="text-2xl font-semibold text-ink">Can a dip replacement help carotid inflammation?</h2>
+          <p className="text-muted">
+            There is no good evidence that any commercially available dip substitute specifically reduces
+            inflammation around the carotid artery. Carotid artery disease is usually a plaque-and-risk-factor
+            problem: LDL-containing particles enter the artery wall, immune cells ingest oxidized lipids,
+            smooth muscle cells remodel the plaque, and inflammatory signaling can make plaque more active.
+            Tobacco and nicotine can worsen this environment through vascular tone, blood pressure, endothelial
+            function, platelet biology, and inflammatory biomarkers.
+          </p>
+          <div className="rounded-2xl border border-amber-200 bg-amber-50/80 p-5 text-sm leading-7 text-amber-950">
+            <p className="font-semibold">Careful interpretation</p>
+            <p className="mt-2">
+              Some studies link noncigarette tobacco products with markers such as high-sensitivity CRP,
+              interleukin-6, fibrinogen, carotid intima-media thickness, or carotid plaque. Other older
+              studies found weaker or mixed signals for certain low-nitrosamine snus products. That does not
+              make dip safe. It means product chemistry, nicotine dose, user history, and baseline risk matter.
+            </p>
+          </div>
+        </section>
+
+        <section id="mechanisms" className="scroll-mt-20 space-y-5">
+          <h2 className="text-2xl font-semibold text-ink">Why dip stresses blood vessels</h2>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="card-premium p-5">
+              <h3 className="text-base font-semibold text-ink">Nicotine and sympathetic drive</h3>
+              <p className="mt-2 text-sm leading-7 text-muted">
+                Nicotine activates nicotinic acetylcholine receptors in autonomic ganglia and the adrenal medulla,
+                increasing catecholamine signaling. Acutely, this can raise heart rate, blood pressure, and
+                vascular tone. For a person worried about carotid disease, repeated nicotine peaks are the wrong
+                direction even when tobacco leaf is removed.
+              </p>
+            </div>
+            <div className="card-premium p-5">
+              <h3 className="text-base font-semibold text-ink">Tobacco-specific nitrosamines</h3>
+              <p className="mt-2 text-sm leading-7 text-muted">
+                Cured smokeless tobacco contains tobacco-specific nitrosamines, including NNN and NNK, formed
+                during growing, curing, fermenting, and aging. These are central reasons dip is linked to oral,
+                esophageal, and pancreatic cancer risk.
+              </p>
+            </div>
+            <div className="card-premium p-5">
+              <h3 className="text-base font-semibold text-ink">Endothelium and plaque biology</h3>
+              <p className="mt-2 text-sm leading-7 text-muted">
+                The endothelium regulates vessel dilation, clotting balance, leukocyte adhesion, and local
+                inflammation. Tobacco exposure can push this system toward vasoconstriction, oxidative stress,
+                adhesion molecule expression, and a more pro-thrombotic environment.
+              </p>
+            </div>
+            <div className="card-premium p-5">
+              <h3 className="text-base font-semibold text-ink">Mouth injury feeds the loop</h3>
+              <p className="mt-2 text-sm leading-7 text-muted">
+                Dip holds irritants against the gingiva and oral mucosa for long periods. Gum recession,
+                leukoplakia, periodontal inflammation, and tooth decay are local harms, and chronic oral
+                inflammation can add systemic inflammatory burden.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section id="protocol" className="scroll-mt-20 space-y-4">
+          <h2 className="text-2xl font-semibold text-ink">A practical quit protocol for dip users</h2>
+          <ol className="space-y-3 pl-5 text-sm leading-7 text-muted">
+            <li>
+              <strong className="text-ink">Measure the pattern.</strong> Track cans or pouches per day, first use
+              after waking, strongest cue times, and whether cravings are chemical, oral, emotional, or social.
+            </li>
+            <li>
+              <strong className="text-ink">Pick the bridge.</strong> Heavy users often do better with a patch plus
+              short-acting gum or lozenge. People mainly attached to the lip ritual may prefer gum or lozenge plus
+              non-nicotine substitutes.
+            </li>
+            <li>
+              <strong className="text-ink">Separate nicotine from the ritual.</strong> Use NRT on a schedule, then
+              use sugar-free oral substitutes for the mouth cue. This prevents every cue from becoming another
+              nicotine dose.
+            </li>
+            <li>
+              <strong className="text-ink">Taper the nicotine bridge.</strong> The goal is not permanent gum,
+              lozenge, or pouch use. Step down dose, frequency, or both once cravings are stable.
+            </li>
+            <li>
+              <strong className="text-ink">Use free support.</strong> In the United States, 1-800-QUIT-NOW connects
+              people to state quitline coaching. The NCI quitline for smokeless tobacco is 1-877-44U-QUIT.
+            </li>
+            <li>
+              <strong className="text-ink">Check the mouth.</strong> Schedule dental evaluation for gum recession,
+              leukoplakia, non-healing sores, bleeding, or oral pain after long-term dip use.
+            </li>
+          </ol>
+        </section>
+
+        <section id="supplements" className="scroll-mt-20 space-y-5">
+          <h2 className="text-2xl font-semibold text-ink">Supplements and vascular context</h2>
+          <p className="text-muted">
+            Supplements should not be sold as carotid inflammation treatments. If you are using them at all, think
+            in terms of cardiovascular risk context: lipids, blood pressure, glucose control, sleep, diet quality,
+            exercise, and dental inflammation. These are adjuncts to a quit plan, not replacements for cessation
+            medication or cardiovascular care.
+          </p>
+          <div className="grid gap-4 md:grid-cols-2">
+            {vascularSupports.map((item) => (
+              <Link key={item.name} href={item.href} className="card-premium block p-5 hover:border-brand-700/40">
+                <h3 className="text-base font-semibold text-brand-800">{item.name}</h3>
+                <p className="mt-2 text-sm leading-7 text-muted">{item.evidence}</p>
+              </Link>
+            ))}
+          </div>
+        </section>
+
+        <section id="red-flags" className="scroll-mt-20 rounded-2xl border border-rose-900/15 bg-rose-50/80 p-6">
+          <h2 className="text-xl font-semibold text-rose-950">Red flags that need medical care</h2>
+          <ul className="mt-3 space-y-2 text-sm leading-7 text-rose-950">
+            <li>New neurologic symptoms: one-sided weakness, numbness, facial droop, speech difficulty, confusion, vision loss, or severe sudden headache.</li>
+            <li>A clinician heard a carotid bruit or imaging showed carotid stenosis, plaque, or dissection.</li>
+            <li>Chest pain, fainting, severe shortness of breath, uncontrolled blood pressure, or heart rhythm symptoms.</li>
+            <li>Mouth sores, white or red patches, lumps, bleeding, or pain that lasts more than two weeks.</li>
+            <li>Pregnancy, breastfeeding, recent heart attack or stroke, or use of blood thinners before adding nicotine medication or circulation supplements.</li>
+          </ul>
+        </section>
+
+        <section id="faq" className="scroll-mt-20 space-y-4">
+          <h2 className="text-2xl font-semibold text-ink">FAQ</h2>
+          <div className="space-y-3">
+            {FAQS.map((faq) => (
+              <details key={faq.question} className="card-premium p-5">
+                <summary className="cursor-pointer text-base font-semibold text-ink">{faq.question}</summary>
+                <p className="mt-2 text-sm leading-7 text-muted">{faq.answer}</p>
+              </details>
+            ))}
+          </div>
+        </section>
+
+        <section id="references" className="scroll-mt-20 space-y-4">
+          <h2 className="text-2xl font-semibold text-ink">References</h2>
+          <ul className="space-y-2 text-sm leading-6 text-muted">
+            {references.map(([label, href]) => (
+              <li key={href}>
+                <a href={href} className="font-medium text-brand-700 hover:underline" rel="noreferrer">
+                  {label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="text-2xl font-semibold text-ink">Related Hippie Scientist pages</h2>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Link href="/compounds/nicotine" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Nicotine compound profile -&gt;</Link>
+            <Link href="/learn/inflammation" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Inflammation guide -&gt;</Link>
+            <Link href="/guides/best/supplements-for-blood-pressure" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Supplements for blood pressure -&gt;</Link>
+            <Link href="/guides/compare/curcumin-vs-boswellia-vs-omega-3" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Curcumin vs boswellia vs omega-3 -&gt;</Link>
+          </div>
+        </section>
+      </div>
+    </ArticleLayout>
+  )
+}

--- a/app/guides/page.tsx
+++ b/app/guides/page.tsx
@@ -65,6 +65,13 @@ const SECTIONS = [
     color: 'border-l-purple-500',
     articles: ['Best for blood pressure', 'Best for fat loss', 'Best for joint support', 'Best for gut health'],
   },
+  {
+    title: 'Other & Harm Reduction',
+    href: '/guides/other/healthy-dipping-tobacco-alternatives/',
+    desc: 'Evidence-informed guides that sit outside the main goal clusters, including tobacco replacement, peptides, and psychoactive harm reduction.',
+    color: 'border-l-stone-500',
+    articles: ['Dipping tobacco alternatives', 'Kratom 7-OH withdrawal', 'Psychedelic-adjacent herbs', 'Brain fog and fatigue'],
+  },
 ]
 
 export default function GuidesHub() {


### PR DESCRIPTION
## Summary

- Add a harm-reduction guide for healthy alternatives to dipping tobacco.
- Include carotid artery and vascular inflammation context with conservative medical framing.
- Add the new guide to the `/guides` hub under an "Other & Harm Reduction" section.

## Validation

- `npm run check:fast` passed.
- `npm run build:app` passed and statically exported `/guides/other/healthy-dipping-tobacco-alternatives`.
- `npm run verify:output` was attempted and failed on pre-existing `dangerouslySetInnerHTML` usage in older pages; the new page uses the approved `StructuredData` component and was not listed in the failure.

## Notes

- Left the pre-existing untracked `sitemap-diff.patch` untouched.
