### PR TITLE
[codex] Fix dark warning card contrast

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -780,6 +780,8 @@ html.dark :is(
   [class~="bg-red-50/70"],
   [class~="bg-rose-50"],
   [class~="bg-rose-50/50"],
+  [class~="bg-rose-50/70"],
+  [class~="bg-rose-50/80"],
   [class~="bg-rose-100"]
 ) {
   background-color: var(--surface-danger);
@@ -1008,7 +1010,8 @@ html.dark :is(
 html.dark :is(
   [class~="text-red-700/80"],
   [class~="text-red-950"],
-  [class~="text-rose-800"]
+  [class~="text-rose-800"],
+  [class~="text-rose-950"]
 ) {
   color: #f5b7ba;
 }


### PR DESCRIPTION
## Summary

Fixes unreadable dark-mode safety/warning cards that use rose utility classes with opacity variants.

## Root Cause

The global dark-mode compatibility CSS handled `bg-rose-50` and `text-rose-800`, but several warning cards use `bg-rose-50/80`, `bg-rose-50/70`, and `text-rose-950`. In dark mode, those utilities were not remapped, leaving low-contrast text on a light-tinted card.

## Validation

- `npm run lint` passed.
- `npm run typecheck` was attempted earlier and is blocked by existing stale `.next/types/app/education/*` references unrelated to this CSS change.
- Playwright screenshot verification was attempted, but the matching Chromium browser download timed out in the local environment.

## Notes

Only `app/globals.css` is included. The unrelated local change in `components/homepage-v2.tsx` was left uncommitted.