### PR TITLE
[codex] Clean up SEO route signals

### DIFF
--- a/app/compounds/CompoundsIndexClient.tsx
+++ b/app/compounds/CompoundsIndexClient.tsx
@@ -219,7 +219,7 @@ function EmptyLibraryState() {
       actions={[
         { href: '/search', label: 'Search the site', variant: 'primary' },
         { href: '/herbs', label: 'Browse herbs' },
-        { href: '/goals', label: 'Explore goals' },
+        { href: '/guides', label: 'Explore guides' },
       ]}
     />
   )
@@ -289,7 +289,7 @@ const browsePaths = [
   },
   {
     label: 'Goal guides',
-    href: '/goals',
+    href: '/guides',
     description: 'Use goal guides when the practical context matters more than the molecule.',
   },
   {

--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -1173,7 +1173,7 @@ export default async function CompoundPage({ params }: PageProps) {
               {conditionLinks.slice(0, 5).map((link: RuntimeMapEntry) => (
                 <Link
                   key={link.slug}
-                  href={link.href || `/goals/${link.slug}`}
+                  href={link.href || '/guides/'}
                   className="rounded-full border border-brand-900/10 bg-white px-3 py-1.5 text-xs font-semibold text-brand-800 hover:bg-brand-50"
                 >
                   {link.label || formatDisplayLabel(link.slug)}

--- a/app/guides/anxiety/best-adaptogens-for-stress/page.tsx
+++ b/app/guides/anxiety/best-adaptogens-for-stress/page.tsx
@@ -250,7 +250,7 @@ export default function BestAdaptogensForStressPage() {
         <nav className="flex flex-wrap gap-4 text-sm font-semibold text-brand-700">
           <Link href="/guides/anxiety" className="hover:text-brand-800">Stress goal hub →</Link>
           <Link href="/guides/herbs/ashwagandha/" className="hover:text-brand-800">Ashwagandha Article →</Link>
-          <Link href="/guides/best-supplements-for-stress/" className="hover:text-brand-800">Best Supplements for Stress →</Link>
+          <Link href="/guides/best/supplements-for-stress/" className="hover:text-brand-800">Best Supplements for Stress →</Link>
           <Link href="/guides/how-to-lower-cortisol-naturally" className="hover:text-brand-800">How to Lower Cortisol Naturally →</Link>
           <Link href="/guides/compare/rhodiola-vs-ashwagandha" className="hover:text-brand-800">Rhodiola vs Ashwagandha →</Link>
           <Link href="/guides/rhodiola-complete-guide/" className="hover:text-brand-800">Complete Rhodiola Guide →</Link>

--- a/app/guides/anxiety/best-supplements-for-stress/page.tsx
+++ b/app/guides/anxiety/best-supplements-for-stress/page.tsx
@@ -9,18 +9,19 @@ import RecommendationSection from '@/components/RecommendationSection'
 import AffiliateDisclosure from '@/components/AffiliateDisclosure'
 import EmailCapture from '@/components/EmailCapture'
 
-const PAGE_URL = `${SITE_URL}/guides/anxiety/best-supplements-for-stress`
+const PAGE_URL = `${SITE_URL}/guides/best/supplements-for-stress`
 
 export const metadata: Metadata = {
   title: 'Best Supplements for Stress: Ashwagandha, Rhodiola, Magnesium & More',
   description:
     'Evidence-graded review of the best stress supplements: ashwagandha, rhodiola, phosphatidylserine, magnesium, and L-theanine. Mechanisms, dosing, safety, and when each works.',
-  alternates: { canonical: '/guides/anxiety/best-supplements-for-stress/' },
+  alternates: { canonical: '/guides/best/supplements-for-stress/' },
+  robots: { index: false, follow: true },
   openGraph: {
     title: 'Best Supplements for Stress: Ashwagandha, Rhodiola, Magnesium & More',
     description:
       'Which supplements actually reduce stress? Ashwagandha, rhodiola, magnesium, phosphatidylserine — evidence-graded with dosing, safety, and stacking notes.',
-    url: '/guides/anxiety/best-supplements-for-stress/',
+    url: '/guides/best/supplements-for-stress/',
     type: 'article',
     images: ['/og-default.jpg'],
   },

--- a/app/guides/anxiety/how-to-lower-cortisol-naturally/page.tsx
+++ b/app/guides/anxiety/how-to-lower-cortisol-naturally/page.tsx
@@ -274,7 +274,7 @@ export default function Page() {
         <section className="space-y-4">
           <h2 className="text-2xl font-semibold text-ink">Related guides &amp; comparisons</h2>
           <div className="grid gap-3 sm:grid-cols-2">
-            <Link href="/guides/best-supplements-for-stress/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Best Supplements for Stress →</Link>
+            <Link href="/guides/best/supplements-for-stress/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Best Supplements for Stress →</Link>
             <Link href="/guides/anxiety/best-adaptogens-for-stress" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Best Adaptogens for Stress →</Link>
             <Link href="/guides/best-herbs-for-stress-and-anxiety-at-night" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Best Herbs for Stress &amp; Anxiety at Night →</Link>
             <Link href="/guides/rhodiola-complete-guide/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Complete Rhodiola Guide →</Link>

--- a/app/guides/compare/dynamic/page.tsx
+++ b/app/guides/compare/dynamic/page.tsx
@@ -9,6 +9,7 @@ export const metadata: Metadata = buildPageMetadata({
   title: 'Dynamic Ingredient Comparison Matrix',
   description: 'Select and compare any two herbs, compounds, or adaptogens side-by-side on evidence strength, mechanisms, safety profiles, and dosages.',
   path: '/guides/compare/dynamic/',
+  robots: { index: false, follow: true },
 })
 
 export default async function DynamicComparePage() {

--- a/app/guides/compare/page.tsx
+++ b/app/guides/compare/page.tsx
@@ -212,7 +212,7 @@ export default async function ComparePage() {
         <p className="eyebrow-label">Decision next step</p>
         <h2 className="mt-2 text-xl font-semibold text-ink">Use comparisons to choose a safer path</h2>
         <div className="mt-4 grid gap-3 text-sm leading-6 text-muted md:grid-cols-4">
-          <Link href="/goals/" className="rounded-xl border border-brand-900/10 p-4 font-semibold text-ink transition hover:bg-brand-50 dark:border-white/10 dark:hover:bg-white/10">
+          <Link href="/guides/" className="rounded-xl border border-brand-900/10 p-4 font-semibold text-ink transition hover:bg-brand-50 dark:border-white/10 dark:hover:bg-white/10">
             Start from your goal
           </Link>
           <Link href="/guides/compare/dynamic/" className="rounded-xl border border-brand-900/10 p-4 font-semibold text-ink transition hover:bg-brand-50 dark:border-white/10 dark:hover:bg-white/10">

--- a/app/guides/focus/focus-without-caffeine-crash/page.tsx
+++ b/app/guides/focus/focus-without-caffeine-crash/page.tsx
@@ -252,7 +252,7 @@ export default function Page() {
         <section className="space-y-4">
           <h2 className="text-2xl font-semibold text-ink">Related guides &amp; comparisons</h2>
           <div className="grid gap-3 sm:grid-cols-2">
-            <Link href="/guides/best-supplements-for-focus" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Best Supplements for Focus →</Link>
+            <Link href="/guides/focus/best-supplements-for-focus" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Best Supplements for Focus →</Link>
             <Link href="/guides/focus/best-nootropics-for-focus" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Best Nootropics for Focus →</Link>
             <Link href="/guides/supplements-for-brain-fog-and-fatigue" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Supplements for Brain Fog &amp; Fatigue →</Link>
             <Link href="/guides/compare/caffeine-vs-l-theanine-vs-bacopa-for-focus" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Caffeine vs L-theanine vs Bacopa →</Link>

--- a/app/herbs/HerbsIndexClient.tsx
+++ b/app/herbs/HerbsIndexClient.tsx
@@ -257,7 +257,7 @@ export function EmptyLibraryState() {
       actions={[
         { href: '/search', label: 'Search the site', variant: 'primary' },
         { href: '/compounds', label: 'Browse compounds' },
-        { href: '/goals', label: 'Explore goals' },
+        { href: '/guides', label: 'Explore guides' },
       ]}
     />
   )
@@ -276,7 +276,7 @@ function EmptyFilteredState({ query, context, evidence }: { query: string; conte
       currentScan={currentScan || undefined}
       actions={[
         { href: '/herbs', label: 'Reset filters', variant: 'primary' },
-        { href: '/goals', label: 'Browse by goal' },
+        { href: '/guides', label: 'Browse by goal' },
       ]}
     />
   )
@@ -299,7 +299,7 @@ function HerbCard({ herb, featured = false }: { herb: RuntimeRecord; featured?: 
 const browsePaths = [
   {
     label: 'Stress & calm',
-    href: '/guides/best-supplements-for-stress/',
+    href: '/guides/best/supplements-for-stress/',
     description: 'Calming herbs, adaptogens, and interaction context.',
   },
   {
@@ -386,7 +386,7 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
               <p className="eyebrow-label">Search and filter</p>
               <h2 id="herb-search-heading" className="compact-heading">Start with the question you need answered.</h2>
             </div>
-            <Link href="/goals/" className="w-fit text-sm font-bold text-brand-800 transition hover:text-brand-900">Browse all goals →</Link>
+            <Link href="/guides/" className="w-fit text-sm font-bold text-brand-800 transition hover:text-brand-900">Browse all goals →</Link>
           </div>
 
           <form action="/herbs" className="mt-3 grid gap-2 sm:grid-cols-[1fr_auto]">

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -876,7 +876,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
             {conditionLinks.slice(0, 5).map((link: RuntimeMapEntry) => (
               <Link
                 key={link.slug}
-                href={link.href || `/goals/${link.slug}`}
+                href={link.href || '/guides/'}
                 className="rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-3 py-1.5 text-xs font-semibold text-brand-800 hover:bg-brand-50"
               >
                 {link.label || formatDisplayLabel(link.slug)}

--- a/app/info/about/AboutClient.tsx
+++ b/app/info/about/AboutClient.tsx
@@ -78,7 +78,7 @@ export default function AboutClient() {
               </Link>
 
               <Link
-                href="/goals/"
+                href="/guides/"
                 className="rounded-full border border-brand-900/20 px-5 py-3 text-sm font-semibold text-ink transition hover:border-brand-700 hover:bg-brand-50"
               >
                 Browse by goals

--- a/app/info/author/page.tsx
+++ b/app/info/author/page.tsx
@@ -129,7 +129,7 @@ export default function AuthorPage() {
         <span className="text-muted">·</span>
         <Link href="/compounds/" className="text-brand-800 hover:underline font-semibold">Compound library</Link>
         <span className="text-muted">·</span>
-        <Link href="/goals/" className="text-brand-800 hover:underline font-semibold">Goal guides</Link>
+        <Link href="/guides/" className="text-brand-800 hover:underline font-semibold">Goal guides</Link>
         <span className="text-muted">·</span>
         <Link href="/info/about/" className="text-brand-800 hover:underline font-semibold">About</Link>
         <span className="text-muted">·</span>

--- a/app/learn/page.tsx
+++ b/app/learn/page.tsx
@@ -314,7 +314,7 @@ export default function EducationHubPage() {
 
         <div className='flex flex-wrap gap-3'>
           <Link
-            href='/goals'
+            href='/guides'
             className='rounded-full border border-brand-900/15 px-4 py-2 text-sm font-medium text-ink transition hover:bg-ink hover:text-white'
           >
             Explore Goal Guides

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -51,7 +51,7 @@ export default function NotFound() {
           </Link>
 
           <Link
-            href='/goals'
+            href='/guides'
             className='button-secondary px-5 py-3 text-sm'
           >
             Goals

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -15,7 +15,6 @@ export default function robots(): MetadataRoute.Robots {
       // disclosing the existence of internal tooling endpoints).
       disallow: [
         '/api/',
-        '/guides/compare/dynamic',
         '/analytics',
         '/admin/',
         '/dashboard',
@@ -31,5 +30,6 @@ export default function robots(): MetadataRoute.Robots {
       ],
     },
     sitemap: `${siteUrl}/sitemap.xml`,
+    host: siteUrl,
   }
 }

--- a/app/search/SearchClient.tsx
+++ b/app/search/SearchClient.tsx
@@ -368,7 +368,7 @@ function GuidedDiscovery({ onSelect }: { onSelect: (query: string) => void }) {
             These entry points are orientation tools, not deterministic recommendations.
           </p>
         </div>
-        <Link href="/goals/" className="w-fit text-sm font-bold text-brand-800 transition hover:text-brand-900">Browse goal guides →</Link>
+        <Link href="/guides/" className="w-fit text-sm font-bold text-brand-800 transition hover:text-brand-900">Browse goal guides →</Link>
       </div>
 
       <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-4">

--- a/app/seo-entry-pages.tsx
+++ b/app/seo-entry-pages.tsx
@@ -212,6 +212,24 @@ const canonicalGuideRouteOverrides: Record<string, string> = {
   'herbs-for-sleep': 'articles/best-herbs-for-sleep',
 }
 
+const goalGuideRoutes: Record<string, string> = {
+  sleep: '/guides/sleep/',
+  stress: '/guides/anxiety/',
+  anxiety: '/guides/anxiety/',
+  focus: '/guides/focus/',
+  cognition: '/guides/focus/',
+  energy: '/guides/focus/',
+  pain: '/guides/best/supplements-for-joint-support/',
+  inflammation: '/guides/best/supplements-for-joint-support/',
+  'blood-pressure': '/guides/best/supplements-for-blood-pressure/',
+  'gut-health': '/guides/best/supplements-for-gut-health/',
+  'fat-loss': '/guides/best/supplements-for-fat-loss/',
+}
+
+function goalGuideHref(goalSlug: string): string {
+  return goalGuideRoutes[goalSlug] ?? '/guides/'
+}
+
 const manualGuideSeoEntryPages: SeoEntryConfig[] = manualSeoEntryPages.map((page) => ({
   ...page,
   route: canonicalGuideRouteOverrides[page.route]
@@ -480,7 +498,7 @@ export async function SeoEntryPage({ route, canonicalPath }: { route: string; ca
           <h1 className="mt-3 text-4xl font-black text-ink">{page.h1}</h1>
           <p className="mt-4 max-w-3xl text-base leading-7 text-muted">{page.intro}</p>
           <div className="mt-5 flex flex-wrap gap-3">
-            <Link href={`/goals/${goal.slug}`} className="rounded-full bg-emerald-300 px-4 py-2 text-sm font-bold text-black hover:bg-emerald-200">View ranked picks</Link>
+            <Link href={goalGuideHref(goal.slug)} className="rounded-full bg-emerald-300 px-4 py-2 text-sm font-bold text-black hover:bg-emerald-200">View ranked picks</Link>
             <Link href="/compounds/" className="rounded-full border border-brand-900/10 px-4 py-2 text-sm font-semibold text-ink hover:bg-brand-50">Browse compounds</Link>
           </div>
         </section>
@@ -583,7 +601,7 @@ export async function SeoEntryPage({ route, canonicalPath }: { route: string; ca
       <section className="rounded-3xl border border-amber-300/40 bg-amber-50 p-5">
         <h2 className="font-bold text-amber-900">Safety considerations</h2>
         <p className="mt-2 text-sm leading-6 text-amber-900/85">{sentence(goal.safetyNote)} Supplements are not risk-free, especially when combined with medications, medical conditions, pregnancy, surgery, sedatives, stimulants, or blood-pressure concerns.</p>
-        <Link href={`/goals/${goal.slug}`} className="mt-4 inline-block text-sm font-semibold text-emerald-700">Review full safety guidance →</Link>
+        <Link href={goalGuideHref(goal.slug)} className="mt-4 inline-block text-sm font-semibold text-emerald-700">Review full safety guidance →</Link>
       </section>
 
       {page.route === 'best-supplements-for-blood-pressure' ? (
@@ -643,7 +661,7 @@ export async function SeoEntryPage({ route, canonicalPath }: { route: string; ca
       <section className="rounded-3xl border border-brand-900/10 bg-white/90 p-6">
         <h2 className="text-2xl font-bold text-ink">Comparison context</h2>
         <p className="mt-2 max-w-3xl text-sm leading-6 text-muted">{pageSections.comparison}</p>
-        <Link href={`/goals/${goal.slug}`} className="mt-4 inline-block text-sm font-semibold text-emerald-700">Compare ranked options →</Link>
+        <Link href={goalGuideHref(goal.slug)} className="mt-4 inline-block text-sm font-semibold text-emerald-700">Compare ranked options →</Link>
       </section>
 
       {linkedCompounds.length > 0 ? (

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -522,7 +522,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
     route(normalizeSitemapUrl('/learn'), 'monthly', 0.75),
     route(normalizeSitemapUrl('/novel-psychoactive-substances'), 'monthly', 0.7, getSitemapLastModified(npsIndex)),
     route(normalizeSitemapUrl('/guides/compare'), 'monthly', 0.7),
-    route(normalizeSitemapUrl('/guides/compare/dynamic'), 'monthly', 0.6),
     route(normalizeSitemapUrl('/info/dosing'), 'monthly', 0.6),
     route(normalizeSitemapUrl('/info/affiliate-disclosure'), 'yearly', 0.5),
     route(normalizeSitemapUrl('/info/privacy'), 'yearly', 0.4),

--- a/public/_headers
+++ b/public/_headers
@@ -24,7 +24,6 @@
 
 /robots.txt
   Cache-Control: public, max-age=86400
-  Content-Type: text/plain; charset=utf-8
 
 /sitemap.xml
   Cache-Control: public, max-age=86400

--- a/public/_redirects
+++ b/public/_redirects
@@ -96,8 +96,8 @@ https://www.thehippiescientist.net/* https://thehippiescientist.net/:splat 301
 /best-for/non-stimulant-focus /goals/focus/ 301
 /best-for/non-sedating-calm /goals/anxiety/ 301
 /top/top-3-natural-sleep-aids /guides/best-supplements-for-sleep/ 301
-/top/top-3-supplements-for-focus /guides/best-supplements-for-focus/ 301
-/top/top-3-herbs-for-stress /guides/best-supplements-for-stress/ 301
+/top/top-3-supplements-for-focus /guides/focus/best-supplements-for-focus/ 301
+/top/top-3-herbs-for-stress /guides/best/supplements-for-stress/ 301
 /top/top-3-herbs-for-anxiety /guides/best-herbs-for-anxiety/ 301
 /top/best-herbs-for-cortisol /guides/how-to-lower-cortisol-naturally/ 301
 /buy-guide /learn/product-quality/ 301
@@ -120,7 +120,7 @@ https://www.thehippiescientist.net/* https://thehippiescientist.net/:splat 301
 /best/fat-loss /guides/best-supplements-for-fat-loss/ 301
 /best/testosterone /guides/natural-testosterone-boosters/ 301
 /best/brain-fog /guides/supplements-for-brain-fog-and-fatigue/ 301
-/best/best-supplements-for-focus /guides/best-supplements-for-focus/ 301
+/best/best-supplements-for-focus /guides/focus/best-supplements-for-focus/ 301
 /best/non-melatonin-sleep /guides/best-supplements-for-sleep/ 301
 # NEW REDIRECTS - ROUTE CONSOLIDATION AUDIT (June 1, 2026)
 /comparisons /compare/ 301
@@ -498,8 +498,8 @@ https://www.thehippiescientist.net/* https://thehippiescientist.net/:splat 301
 /best-supplements-for-blood-pressure/ /guides/best/supplements-for-blood-pressure/ 301
 /best-supplements-for-fat-loss /guides/best/supplements-for-fat-loss/ 301
 /best-supplements-for-fat-loss/ /guides/best/supplements-for-fat-loss/ 301
-/best-supplements-for-focus /guides/best/supplements-for-focus/ 301
-/best-supplements-for-focus/ /guides/best/supplements-for-focus/ 301
+/best-supplements-for-focus /guides/focus/best-supplements-for-focus/ 301
+/best-supplements-for-focus/ /guides/focus/best-supplements-for-focus/ 301
 /best-supplements-for-gut-health /guides/best/supplements-for-gut-health/ 301
 /best-supplements-for-gut-health/ /guides/best/supplements-for-gut-health/ 301
 /best-supplements-for-joint-support /guides/best/supplements-for-joint-support/ 301
@@ -606,8 +606,8 @@ https://www.thehippiescientist.net/* https://thehippiescientist.net/:splat 301
 /guides/best-herbs-for-anxiety/ /guides/anxiety/best-herbs-for-anxiety/ 301
 /guides/best-herbs-for-stress-and-anxiety-at-night /guides/anxiety/best-herbs-for-stress-and-anxiety-at-night/ 301
 /guides/best-herbs-for-stress-and-anxiety-at-night/ /guides/anxiety/best-herbs-for-stress-and-anxiety-at-night/ 301
-/guides/best-supplements-for-stress /guides/anxiety/best-supplements-for-stress/ 301
-/guides/best-supplements-for-stress/ /guides/anxiety/best-supplements-for-stress/ 301
+/guides/best-supplements-for-stress /guides/best/supplements-for-stress/ 301
+/guides/best-supplements-for-stress/ /guides/best/supplements-for-stress/ 301
 /guides/how-to-lower-cortisol-naturally /guides/anxiety/how-to-lower-cortisol-naturally/ 301
 /guides/how-to-lower-cortisol-naturally/ /guides/anxiety/how-to-lower-cortisol-naturally/ 301
 /guides/natural-alternatives-to-anxiety-medication /guides/anxiety/natural-alternatives-to-anxiety-medication/ 301

--- a/scripts/validators/validate-build-artifacts.mjs
+++ b/scripts/validators/validate-build-artifacts.mjs
@@ -89,8 +89,8 @@ function main() {
   const keyPages = [
     { name: 'Homepage', file: 'index.html' },
     { name: 'Guides index', file: 'guides/index.html' },
-    { name: 'FAQ', file: 'faq/index.html' },
-    { name: 'Compare', file: 'compare/index.html' }
+    { name: 'FAQ', file: 'info/faq/index.html' },
+    { name: 'Compare', file: 'guides/compare/index.html' }
   ]
 
   for (const page of keyPages) {

--- a/src/lib/canonical-routes.ts
+++ b/src/lib/canonical-routes.ts
@@ -2,8 +2,8 @@
 
 export const SEO_GUIDE_ROUTES = {
   sleep: '/guides/sleep/best-supplements-for-sleep',
-  stress: '/guides/best-supplements-for-stress/',
-  focus: '/guides/best-supplements-for-focus',
+  stress: '/guides/best/supplements-for-stress/',
+  focus: '/guides/focus/best-supplements-for-focus',
   anxiety: '/guides/anxiety/best-herbs-for-anxiety',
   adaptogensStress: '/guides/anxiety/best-adaptogens-for-stress',
 } as const

--- a/src/lib/goal-hub-links.ts
+++ b/src/lib/goal-hub-links.ts
@@ -51,19 +51,31 @@ const GOAL_COMPARE_SLUGS: Record<string, string[]> = {
 const GOAL_SEO_ENTRIES: Record<string, GoalHubLink> = {
   sleep: {
     label: 'Best supplements for sleep (entry guide)',
-    href: '/best-supplements-for-sleep/',
+    href: '/guides/sleep/best-supplements-for-sleep/',
     note: 'Broader sleep keyword landing page with ranked picks.',
   },
   stress: {
     label: 'Best supplements for stress (entry guide)',
-    href: '/best-supplements-for-stress/',
+    href: '/guides/best/supplements-for-stress/',
     note: 'Calming vs adaptogen framing for stress support.',
   },
   focus: {
     label: 'Best supplements for focus (entry guide)',
-    href: '/best-supplements-for-focus/',
+    href: '/guides/focus/best-supplements-for-focus/',
     note: 'Stimulant vs non-stimulant focus comparison entry.',
   },
+}
+
+const GOAL_GUIDE_ROUTES: Record<string, string> = {
+  sleep: '/guides/sleep/',
+  stress: '/guides/anxiety/',
+  anxiety: '/guides/anxiety/',
+  focus: '/guides/focus/',
+  cognition: '/guides/focus/',
+  energy: '/guides/focus/',
+  pain: '/guides/best/supplements-for-joint-support/',
+  inflammation: '/guides/best/supplements-for-joint-support/',
+  'joint-support': '/guides/best/supplements-for-joint-support/',
 }
 
 const FLAGSHIP_COMPARE_ROUTES = new Set([
@@ -150,6 +162,6 @@ export function getGoalsForEntity(slug: string): GoalHubLink[] {
   const goalSlugs = ENTITY_GOAL_MAP[normalized] ?? []
   return goalSlugs.map((goalSlug) => ({
     label: goalSlug.replace(/-/g, ' '),
-    href: `/goals/${goalSlug}/`,
+    href: GOAL_GUIDE_ROUTES[goalSlug] ?? '/guides/',
   }))
 }

--- a/src/lib/goal-seo.ts
+++ b/src/lib/goal-seo.ts
@@ -30,10 +30,24 @@ const GOAL_SEO_DESCRIPTIONS: Record<string, string> = {
 }
 
 const GOAL_SEO_ENTRY_ROUTES: Record<string, string> = {
-  sleep: '/best-supplements-for-sleep',
-  stress: '/best-supplements-for-stress',
-  focus: '/best-supplements-for-focus',
-  anxiety: '/best-supplements-for-anxiety',
+  sleep: '/guides/sleep/best-supplements-for-sleep',
+  stress: '/guides/best/supplements-for-stress',
+  focus: '/guides/focus/best-supplements-for-focus',
+  anxiety: '/guides/anxiety/best-herbs-for-anxiety',
+}
+
+const GOAL_GUIDE_ROUTES: Record<string, string> = {
+  sleep: '/guides/sleep',
+  stress: '/guides/anxiety',
+  anxiety: '/guides/anxiety',
+  focus: '/guides/focus',
+  cognition: '/guides/focus',
+  energy: '/guides/focus',
+  pain: '/guides/best/supplements-for-joint-support',
+  inflammation: '/guides/best/supplements-for-joint-support',
+  'blood-pressure': '/guides/best/supplements-for-blood-pressure',
+  'gut-health': '/guides/best/supplements-for-gut-health',
+  'fat-loss': '/guides/best/supplements-for-fat-loss',
 }
 
 function fallbackGoalTitle(goal: Goal): string {
@@ -74,7 +88,7 @@ export function buildGoalPageMetadata(
   return buildPageMetadata({
     title,
     description,
-    path: `/goals/${goal.slug}`,
+    path: GOAL_GUIDE_ROUTES[goal.slug] ?? '/guides',
     openGraphType: 'article',
   })
 }

--- a/src/lib/index-allowlist.ts
+++ b/src/lib/index-allowlist.ts
@@ -7,7 +7,6 @@ export const CORE_INDEXABLE_ROUTES = [
   '/info/dosing',
   '/evidence/evidence-digest',
   '/info/faq',
-  '/goals',
   '/guides',
   '/herbs',
   '/learn',
@@ -22,8 +21,6 @@ export const CORE_INDEXABLE_ROUTES = [
 
 export const MONEY_ENTRY_ROUTES = [
   '/best-supplements-for-sleep',
-  '/best-supplements-for-stress',
-  '/best-supplements-for-focus',
   '/best-supplements-for-fat-loss',
   '/best-supplements-for-blood-pressure',
   '/best-supplements-for-gut-health',

--- a/src/lib/internal-link-graph.ts
+++ b/src/lib/internal-link-graph.ts
@@ -55,7 +55,7 @@ function nodeHref(node: SemanticLinkNode): string {
 
   switch (node.type) {
     case 'goal':
-      return `/goals/${slug}`
+      return goalGuideHref(slug)
     case 'compare':
       return `/guides/compare/${slug}`
     case 'stack':
@@ -69,6 +69,23 @@ function nodeHref(node: SemanticLinkNode): string {
     default:
       return `/${slug}`
   }
+}
+
+function goalGuideHref(slug: string): string {
+  const routes: Record<string, string> = {
+    sleep: '/guides/sleep',
+    stress: '/guides/anxiety',
+    anxiety: '/guides/anxiety',
+    focus: '/guides/focus',
+    cognition: '/guides/focus',
+    energy: '/guides/focus',
+    pain: '/guides/best/supplements-for-joint-support',
+    inflammation: '/guides/best/supplements-for-joint-support',
+    'blood-pressure': '/guides/best/supplements-for-blood-pressure',
+    'gut-health': '/guides/best/supplements-for-gut-health',
+    'fat-loss': '/guides/best/supplements-for-fat-loss',
+  }
+  return routes[slug] ?? '/guides'
 }
 
 


### PR DESCRIPTION
## What changed
- Replaced stale SEO route signals after the audited zip replacement.
- Removed `/guides/compare/dynamic/` from sitemap generation and marked it noindex while allowing crawlers to see the directive.
- Consolidated the duplicate stress supplement intent toward `/guides/best/supplements-for-stress/`.
- Updated internal goal/best-guide links away from redirect-only `/goals` and legacy best-guide paths.
- Kept the static-export artifact validator pointed at current exported routes.

## Validation
- `npm run validate:route-seo`
- `npm run validate:canonical-host`
- `npm run verify:redirects`
- `npm run validate:sitemap`
- `npm run audit:seo-routes`
- `npm run typecheck`

No production build was run.