### PR TITLE
SEO Audit: Ahrefs comprehensive analysis — Jul 2026 (6 reports)

### DIFF
--- a/seo-audit/00-executive-summary.md
+++ b/seo-audit/00-executive-summary.md
@@ -1,0 +1,63 @@
+# SEO Audit Summary — Skills #1-4
+
+**Date**: 2026-07-03  
+**Target**: thehippiescientist.net  
+**Pages**: ~1,543 live
+
+---
+
+## Skill #1: Site Explorer Baseline
+
+| Metric | Value |
+|--------|-------|
+| Domain Rating | **0** |
+| Organic Traffic | 0 |
+| Organic Keywords | 0 |
+| Top Pages w/ Traffic | 0 |
+| Backlinks (current) | 271 |
+| Referring Domains | 240 |
+
+All backlinks nofollow, 46/50 sampled are spam.
+
+## Skill #2: Site Audit (Crawl 2, Jun 28)
+
+| Severity | Count |
+|----------|-------|
+| Critical | 336 |
+| Warning | 1,182 |
+| Notice | 3,618 |
+| **Total** | **5,136** |
+
+Top issues: 746 pages missing from sitemap, 264 broken internal links, 466 noindex pages, 22 404s, 878 schema errors.
+
+## Skill #3: Google Search Console
+
+| Metric | Value |
+|--------|-------|
+| Keywords w/ impressions | 30+ |
+| Total impressions (28 days) | 159 |
+| Total clicks | **0** |
+| Average position | 70.4 |
+
+## Skill #4: Backlink Analysis
+
+240 referring domains. Only 1 legitimate (github.com). Zero dofollow links. DR = 0.
+
+## Root Cause
+
+1. Spam backlink attack — 240 domains, all nofollow, likely triggering penalty
+2. Massive indexability gap — 466 noindex + 746 pages not in sitemap
+3. Zero link equity — DR 0, no page can rank
+
+## Priority Roadmap
+
+| Priority | Action |
+|----------|--------|
+| P0 | Submit disavow file in GSC |
+| P0 | Fix 746 pages missing from sitemap |
+| P0 | Review 466 noindex pages |
+| P1 | Fix 264 broken internal links |
+| P1 | Add internal links to 10 orphan pages |
+| P1 | Fix 878 schema validation errors |
+| P2 | Fix meta descriptions & titles (0% CTR) |
+| P2 | Build 5-10 legitimate backlinks |

--- a/seo-audit/01-site-explorer-baseline.md
+++ b/seo-audit/01-site-explorer-baseline.md
@@ -1,0 +1,58 @@
+# Skill #1: Ahrefs Site Explorer — Organic Baseline
+
+**Date**: 2026-07-03  
+**Target**: thehippiescientist.net
+
+## Summary
+
+The site has **1,543+ pages** but **virtually zero organic presence** in Google.
+
+## Key Metrics
+
+| Metric | Value |
+|--------|-------|
+| Domain Rating (DR) | **0** |
+| Ahrefs Rank | Not ranked |
+| Organic Traffic | 0 |
+| Organic Keywords | 0 ranked |
+| Top Pages w/ Traffic | 0 |
+| Backlinks (current) | 271 |
+| Referring Domains (current) | 240 |
+| Referring Domains (all-time) | 255 |
+
+## Country Breakdown
+
+- 189 countries analyzed
+- Only Germany shows 1 keyword (zero traffic)
+- 188 countries: zero keywords
+
+## Historical Trend
+
+- June 2026: 0 traffic, 0 impressions
+- July 2026: 0 traffic, 0 impressions
+- No organic growth detected in the past year
+
+## Backlink Profile (Top 50 by DR)
+
+- **46/50 links are spam** (is_spam_domain: true)
+- **50/50 are nofollow** — zero dofollow links
+- **All have 0 referring page traffic** — links from dead/SEO-spam pages
+- **All have URL Rating of 0** — no link equity
+- Legitimate links: 2 from github.com (Razzleberrytt profile)
+- Spam domains include: fiverr-quality-seo-at-affordable-rates.site, rank-now.website, seoexpress-related domains
+- Anchor text is predominantly spammy testimonials for SEO services
+
+## Critical Issues
+
+1. **Domain Rating = 0**: No link equity — the spam backlinks carry zero value
+2. **No indexed/ranking pages**: Despite 1,543+ pages, Google isn't ranking any
+3. **Spam backlink attack**: 240+ referring domains are SEO spam, likely triggering Google penalties
+4. **Zero dofollow links**: Every single backlink is nofollow
+
+## Recommended Next Steps
+
+1. Submit disavow file (already prepared: 199 domains)
+2. Site audit to check indexability (robots.txt, meta robots, canonical tags)
+3. Verify Google Search Console indexing status
+4. Content quality audit — ensure pages meet Google's quality bar
+5. Build legitimate backlinks from relevant health/supplement sites

--- a/seo-audit/02-site-audit.md
+++ b/seo-audit/02-site-audit.md
@@ -1,0 +1,80 @@
+# Skill #2: Ahrefs Site Audit — Technical Health
+
+**Date**: 2026-07-03  
+**Target**: thehippiescientist.net  
+**Project**: "Thehippiescientist" (ID: 10017926)
+
+## Crawl History
+
+| Crawl | Date | Status | Pages Crawled |
+|-------|------|--------|---------------|
+| 5 | Jul 2 | Failed | — |
+| 4 | Jul 1 | Failed | — |
+| 3 | Jun 30 | Stopped | — |
+| 2 | Jun 28 | Completed | 2,503 |
+| 1 | Jun 27 | Completed | 2,503 |
+
+Last 3 crawls have failed — needs investigation.
+
+## Health Overview (from Crawl 2)
+
+| Metric | Value |
+|--------|-------|
+| Pages crawled | 2,503 |
+| Billed pages | 1,687 |
+| URLs with errors | 307 / 1,849 (16.6%) |
+| **Total issues** | **5,136** |
+| — Critical | 336 |
+| — Warnings | 1,182 |
+| — Notices | 3,618 |
+
+## Top 10 Critical Issues
+
+| # | Count | Issue |
+|---|-------|-------|
+| 1 | 264 | Page has links to broken page |
+| 2 | 22 | 404 page |
+| 3 | 22 | 4XX page |
+| 4 | 10 | Orphan page (no incoming internal links) |
+| 5 | 8 | Canonical points to 4XX |
+| 6 | 3 | Double slash in URL |
+| 7 | 3 | Image broken |
+| 8 | 3 | Page size exceeds 2 MB |
+| 9 | 1 | Page has broken image |
+
+## Top Warning Issues
+
+| # | Count | Issue |
+|---|-------|-------|
+| 1 | 466 | Noindex page |
+| 2 | 426 | Links to broken page |
+| 3 | 93 | Meta description too long |
+| 4 | 67 | Links to redirect |
+| 5 | 49 | 3XX redirect |
+| 6 | 37 | OG URL not matching canonical |
+| 7 | 21 | OG tags incomplete |
+
+## Key Notice Issues
+
+| # | Count | Issue |
+|---|-------|-------|
+| 1 | 974 | Pages to submit to IndexNow |
+| 2 | 878 | Schema.org validation errors |
+| 3 | **746** | Indexable page not in sitemap |
+| 4 | 466 | Noindex follow page |
+| 5 | 398 | External 5XX |
+| 6 | 91 | Only 1 dofollow internal link |
+| 7 | 34 | H1 tag missing or empty |
+| 8 | 33 | Low word count |
+| 9 | 33 | HTML lang attribute missing |
+
+## Priority Actions
+
+1. Fix 746 pages missing from sitemap
+2. Fix 264 pages with broken internal links
+3. Review 466 noindex pages — intentional or blocking?
+4. Fix 22 404 pages — create redirects or remove links
+5. Add internal links to 10 orphan pages
+6. Fix 878 schema.org validation errors
+7. Fix 93 meta descriptions that are too long
+8. Resolve crawl failures (last 3 failed)

--- a/seo-audit/03-gsc-data.md
+++ b/seo-audit/03-gsc-data.md
@@ -1,0 +1,53 @@
+# Skill #3: Google Search Console Data
+
+**Date**: 2026-07-03  
+**Target**: thehippiescientist.net  
+**Source**: Ahrefs GSC integration, last 28 days
+
+## Overview
+
+| Metric | Value |
+|--------|-------|
+| Keywords w/ impressions | 30+ |
+| Total impressions (28 days) | 159 |
+| Total clicks | **0** |
+| Average position | 70.4 |
+| Position 1-10 | 1 (site: search only) |
+| Position 11-30 | 0 |
+| Position 31-50 | 3 |
+| Position 51+ | 26 |
+
+## Top Keywords by Impressions
+
+| Keyword | Impr | Pos | Page |
+|---------|------|-----|------|
+| melatonin vs magnesium | 33 | 76.7 | /compare/melatonin-vs-magnesium/ |
+| adhd supplements | 25 | 81.6 | /best-supplements-for-adhd |
+| supplements for adhd | 14 | 74.7 | /best-supplements-for-adhd |
+| is magnesium glycinate safe | 7 | 82.6 | /compounds/magnesium-glycinate/ |
+| effects of magnesium glycinate | 6 | 85.5 | /compounds/magnesium-glycinate/ |
+| berberine vs inositol | 6 | 60.7 | /compare/berberine-vs-inositol/ |
+| zinc or magnesium | 5 | 89.0 | /compare/magnesium-vs-zinc |
+
+## Top Pages by Keyword Count
+
+| Keywords | Page |
+|----------|------|
+| 6 | /compare/melatonin-vs-magnesium/ |
+| 5 | /best-supplements-for-adhd |
+| 5 | /compounds/magnesium-glycinate/ |
+| 3 | /compare/berberine-vs-inositol/ |
+
+## Diagnosis
+
+The site IS indexed and getting impressions, but **zero clicks** because:
+1. Avg position 70 = page 7+ in Google (essentially invisible)
+2. Meta titles/descriptions may not be compelling enough even at higher positions
+3. Content likely doesn't match search intent well enough at current ranking positions
+
+## Priority Keywords to Target (position 31-50)
+
+These have the best chance of reaching page 1-3 with optimization:
+- "magnesium vs melatonin reddit" (pos 41)
+- "is hizzaboloufazic good or bad" (pos 47.5)
+- "inositol vs berberine" (pos 46.5)

--- a/seo-audit/04-backlinks-analysis.md
+++ b/seo-audit/04-backlinks-analysis.md
@@ -1,0 +1,45 @@
+# Skill #4: Backlink & Referring Domain Analysis
+
+**Date**: 2026-07-03  
+**Target**: thehippiescientist.net
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Referring Domains | 240 |
+| Backlinks (current) | 271 |
+| Dofollow links | **0** |
+| Nofollow links | 271 (100%) |
+| URL Rating | 0 |
+| Domain Rating | 0 |
+
+## Referring Domains by DR (Top Sample)
+
+| Domain | DR | Links | Legit? |
+|--------|-----|-------|--------|
+| github.com | 97 | 2 | ✅ Only legitimate link |
+| rankyour.website | 74 | 1 | ❌ SEO spam |
+| buybacklinks.agency | 72 | 1 | ❌ SEO spam |
+| fiverr-quality-seo-at-affordable-rates.site | 71 | 2 | ❌ SEO spam |
+| rank-now.website | 65 | 2 | ❌ SEO spam |
+
+Mean DR across all 240 domains is 53, but inflated by a few high-DR spam farms. Nearly all domains have zero organic traffic themselves.
+
+## Key Observations
+
+1. **Zero dofollow links** — no link equity passes to the site
+2. **All anchor text is spam** — SEO service testimonials, not natural references
+3. **No legitimate health/supplement backlinks** — no .edu, .gov, or medical journal links
+4. **Spam attack pattern** — domains registered specifically for link drops, likely a negative SEO attack or purchased spam package
+5. **Only links to homepage** — no deep pages have any backlinks at all
+
+## Action Items
+
+1. Submit disavow file (199 domains already prepared)
+2. Build 5-10 legitimate backlinks from:
+   - Health/supplement blogs
+   - PubMed/NCBI citations (the site already references these)
+   - GitHub (author profile, relevant repos)
+   - Reddit (r/Nootropics, r/Supplements, r/StackAdvice)
+3. Create link-worthy content: original research, data studies, comprehensive guides

--- a/seo-audit/06-page-analysis.md
+++ b/seo-audit/06-page-analysis.md
@@ -1,0 +1,50 @@
+# Skill #6: Page-Level Analysis — Crawled Page Deep Dive
+
+**Date**: 2026-07-03  
+**Source**: Site Audit crawl 2 (Jun 28), 2,503 pages
+
+## 404 Pages (22 total)
+
+All follow the same pattern — herb species pages under `/herbs/`:
+
+| URL | Issue |
+|-----|-------|
+| /herbs/ganoderma-lucidum/ | 404 — 0 byte response |
+| /herbs/angelica-sinensis/ | 404 — 0 byte response |
+| /herbs/hericium-erinaceus/ | 404 — 0 byte response |
+| /herbs/piper-methysticum/ | 404 — 0 byte response |
+| /herbs/passiflora-incarnata/ | 404 — 0 byte response |
+
+All NOT in sitemap, NOT HTML, depth=1. Appear to be broken herb species slugs.
+
+## Critical: Canonical → 404 Chain
+
+`/compounds/kava/` → canonical points to `/herbs/piper-methysticum/` → **which is a 404 page**
+
+## External URLs in Crawl (Wasting Budget)
+
+- pubmed.ncbi.nlm.nih.gov URLs crawled as internal pages
+- amazon.com affiliate links (tag=razzleberry02-20) crawled as internal pages
+- These inflate crawl counts and waste crawl budget
+
+## Pages Not in Sitemap (746 total, Sample)
+
+| URL | Title |
+|-----|-------|
+| /compounds/dim/ | Diindolylmethane: Effects, Dose and Safety |
+| /compounds/wogonin/ | Wogonin: Effects, Dose and Safety |
+| /compare/acerola-vs-astragalus/ | Acerola vs Astragalus: Comparison |
+| /evidence-report/ | The State of Supplement Evidence 2026 |
+
+## H1 Issues
+
+- `/compare/acerola-vs-astragalus/` — H1: "AcerolavsAstragalus" (missing spaces)
+- `/compare/acerola-vs-cat-s-claw/` — H1: "AcerolavsCat's Claw" (missing space)
+
+## Priority Actions
+
+1. Fix canonical → 404 chain: /compounds/kava/ → /herbs/piper-methysticum/ (dead)
+2. Fix 22 herb species 404s: redirect to compound equivalents or remove links
+3. Exclude external URLs from crawl: amazon/pubmed links shouldn't be crawled as internal
+4. Fix H1 formatting: "AcerolavsAstragalus" → "Acerola vs Astragalus"
+5. Add 746 missing pages to sitemap


### PR DESCRIPTION
## What's in this PR

6 SEO audit reports from a full Ahrefs analysis of thehippiescientist.net:

### Key Findings

- **DR: 0** — no link equity, zero dofollow backlinks
- **5,136 site audit issues** — 746 pages missing from sitemap, 264 broken internal links, 466 noindex pages
- **0% CTR from GSC** — 159 impressions, zero clicks, avg position 70
- **240 spam referring domains** — only 1 legitimate link (GitHub)
- **22 dead herb pages** + canonical-to-404 chain

### Reports
1. `00-executive-summary.md` — Prioritized action roadmap
2. `01-site-explorer-baseline.md` — Organic metrics + backlink profile
3. `02-site-audit.md` — 5,136 technical issues with severity breakdown
4. `03-gsc-data.md` — Google Search Console keyword performance
5. `04-backlinks-analysis.md` — Referring domain audit + strategy
6. `06-page-analysis.md` — 404s, canonical chains, sitemap gaps, H1 bugs