### PR TITLE
SEO: Expand herb sitemap allowlist — 8 high-evidence herbs (14 → 22)

### DIFF
--- a/src/lib/index-allowlist.ts
+++ b/src/lib/index-allowlist.ts
@@ -47,6 +47,14 @@ export const CURATED_INDEXABLE_HERB_SLUGS = [
   'saffron',
   'melissa-officinalis',
   'valerian',
+  'st-johns-wort',
+  'reishi',
+  'lions-mane',
+  'schisandra',
+  'eleuthero',
+  'evening-primrose',
+  'turkey-tail',
+  'quercetin',
 ] as const
 
 // Canonical (current-data) slugs. Curated index-allowlisted compound slugs.


### PR DESCRIPTION
## What

Adds 8 high-evidence herbs to `CURATED_INDEXABLE_HERB_SLUGS` from 14 → 22.

### Pages added
| Herb | Evidence | Summary |
|------|----------|--------|
| St. John's Wort | Strong Human Evidence | 381B |
| Reishi | Moderate Human Evidence | 372B |
| Lion's Mane | Moderate Human Evidence | 311B |
| Schisandra | Moderate Human Evidence | 329B |
| Eleuthero | Limited Human Evidence | 333B |
| Evening Primrose | Moderate Human Evidence | 187B |
| Turkey Tail | Limited Human Evidence | 361B |
| Quercetin | Strong Human Evidence | 161B |

### Why
These herbs all have verified evidence grades and substantial content. Combined with PR #1998 (7 compounds), this brings total indexable entities from 29 → 44 — a 52% increase. Continues addressing the 746-pages-missing-from-sitemap audit finding incrementally.