### PR TITLE
SEO: Final sitemap expansion — compounds 25→32, total entities 54 (+86%)

### DIFF
--- a/src/lib/index-allowlist.ts
+++ b/src/lib/index-allowlist.ts
@@ -89,4 +89,11 @@ export const CURATED_INDEXABLE_COMPOUND_SLUGS = [
   'krill-oil',
   'pomegranate-extract',
   'panax-ginseng-extract',
+  'alpha-lipoic-acid',
+  'glycine',
+  'taurine',
+  'zinc',
+  'saffron-extract',
+  'creatine-beta-alanine',
+  'iron',
 ] as const


### PR DESCRIPTION
Adds 7 high-evidence compounds: alpha-lipoic-acid, glycine, taurine, zinc, saffron-extract, creatine-beta-alanine, iron.

Final tally across all sitemap PRs:
- Herbs: 14 → 22 (+57%)
- Compounds: 15 → 32 (+113%)
- Total: 29 → 54 (+86%)