### PR TITLE
SEO docs: GSC keyword tracker + disavow guide

### DIFF
--- a/seo-audit/disavow-guide.md
+++ b/seo-audit/disavow-guide.md
@@ -1,0 +1,26 @@
+# Disavow Submission Guide
+
+## Current Status
+
+- File: `disavow-thehippiescientist.txt` (199 domains)
+- All 240 referring domains are spam/nofollow
+- DR = 0, zero dofollow links
+
+## How to Submit
+
+1. Go to [Google Search Console Disavow Tool](https://search.google.com/search-console/disavow-links)
+2. Select property: `thehippiescientist.net`
+3. Upload `disavow-thehippiescientist.txt`
+4. Submit
+
+## Post-Disavow Timeline
+
+- 2-4 weeks for Google to process
+- Expect gradual DR recovery if penalty exists
+- Monitor Ahrefs for new spam domains weekly
+
+## Prevention
+
+- Set up Ahrefs Alerts for new backlinks
+- Monitor GSC "Links" report monthly
+- Never buy backlinks or use SEO services that offer "link building"

--- a/seo-audit/gsc-priority-keywords.md
+++ b/seo-audit/gsc-priority-keywords.md
@@ -1,0 +1,36 @@
+# GSC Priority Keywords — July 2026
+
+Keywords getting impressions but zero clicks. Optimize these pages for CTR.
+
+## Position 31-50 (Best opportunity — 1 page of improvement = page 1-3)
+
+| Keyword | Pos | Impr | Page |
+|---------|-----|------|------|
+| magnesium vs melatonin reddit | 41.0 | 2 | /compare/melatonin-vs-magnesium/ |
+| inositol vs berberine | 46.5 | 2 | /compare/berberine-vs-inositol/ |
+| is hizzaboloufazic good or bad | 47.5 | 2 | /compounds/hyperforin/ |
+
+## Position 51-75 (Mid-term opportunity)
+
+| Keyword | Pos | Impr | Page |
+|---------|-----|------|------|
+| berberine vs inositol | 60.7 | 6 | /compare/berberine-vs-inositol/ |
+| what is mgm-15 | 61.0 | 2 | /novel-psychoactive-substances/... |
+| mgm15 | 61.0 | 2 | /novel-psychoactive-substances/... |
+| clean nootropic for training | 60.0 | 2 | /best-supplements-for-focus/ |
+| citicoline vs alpha gpc | 62.5 | 2 | /citicoline-vs-alpha-gpc/ |
+
+## CTR Optimization Checklist
+
+For each priority page:
+1. ✅ Title includes exact keyword match near the front
+2. ✅ Meta description is 110-160 chars with a compelling hook
+3. ✅ H1 matches search intent (question → answer format)
+4. ✅ Page has FAQ schema with 2+ Q&A pairs
+5. ✅ Featured snippet optimization: concise 40-60 word answer in first paragraph
+
+## Quick Wins
+
+- **melatonin vs magnesium**: Add "Reddit" comparison angle — summarize what Reddit users say
+- **inositol vs berberine**: Already ranking — optimize title to "Inositol vs Berberine: Which Is Better for Blood Sugar?"
+- **citicoline vs alpha gpc**: Add FAQ schema and a comparison summary table


### PR DESCRIPTION
Two operational docs from audit:
- gsc-priority-keywords.md: 9 keywords at positions 31-75 with CTR optimization checklist
- disavow-guide.md: Step-by-step for submitting 199-domain disavow file

#7-10 of 10 skills.