### PR TITLE
Refresh brand visuals: forest-green footer, botanical icons, leaf logomark

### DIFF
--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { Menu, X } from 'lucide-react'
+import { Leaf, Menu, X } from 'lucide-react'
 import { GlobalSearchModal } from './search/GlobalSearchModal'
 import DarkModeToggle from './DarkModeToggle'
 import { mainNavigation } from '@/lib/navigation-config'
@@ -61,9 +61,10 @@ export function Navigation() {
           {/* Logo — Fraunces via font-display */}
           <Link
             href="/"
-            className="font-display text-[1.15rem] font-bold italic tracking-[-0.02em] text-ink transition hover:text-brand-700 dark:text-[var(--text-primary)]"
+            className="flex items-center gap-2 font-display text-[1.15rem] font-bold italic tracking-[-0.02em] text-ink transition hover:text-brand-700 dark:text-[var(--text-primary)]"
             aria-label="The Hippie Scientist home"
           >
+            <Leaf aria-hidden="true" className="h-5 w-5 shrink-0 text-brand-700 dark:text-[var(--accent-teal)]" strokeWidth={1.75} />
             The Hippie Scientist
           </Link>
 
@@ -123,7 +124,8 @@ export function Navigation() {
             style={{ height: '100dvh' }}
           >
             <div className="mb-6 flex items-center justify-between">
-              <Link href="/" onClick={closeMobile} className="font-display text-lg font-semibold text-ink">
+              <Link href="/" onClick={closeMobile} className="flex items-center gap-2 font-display text-lg font-semibold text-ink">
+                <Leaf aria-hidden="true" className="h-[1.125rem] w-[1.125rem] shrink-0 text-brand-700 dark:text-[var(--accent-teal)]" strokeWidth={1.75} />
                 The Hippie Scientist
               </Link>
               <button

--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { Cloud, Leaf, Moon, Zap } from 'lucide-react'
 import articlesData from '@/data/articles/articles.json'
 
 type SectionHeaderProps = { title: string; subtitle?: string; as?: 'h2' | 'h3' }
@@ -7,7 +8,7 @@ const heroGoals = [
   {
     slug: 'sleep',
     title: 'Sleep',
-    icon: '🌙',
+    icon: Moon,
     prompt: 'Fall asleep, stay asleep, and compare sleep supplements without guessing.',
     bg: 'from-[#eaf2fb] to-[#dceef8] border-[#a8c8e0]',
     accent: 'text-[#1a3d5c]',
@@ -15,7 +16,7 @@ const heroGoals = [
   {
     slug: 'stress',
     title: 'Stress',
-    icon: '🌿',
+    icon: Leaf,
     prompt: 'Sort adaptogens and calming supports by fatigue pattern, timing, and safety.',
     bg: 'from-[#edf6ee] to-[#ddf0df] border-[#8dc49a]',
     accent: 'text-[#1e4a2c]',
@@ -23,7 +24,7 @@ const heroGoals = [
   {
     slug: 'anxiety',
     title: 'Anxiety',
-    icon: '☁️',
+    icon: Cloud,
     prompt: 'Find grounded options for calm, overthinking, and daytime tension.',
     bg: 'from-[#f3eefc] to-[#ebe2f8] border-[#c4aadf]',
     accent: 'text-[#4a2d6e]',
@@ -31,7 +32,7 @@ const heroGoals = [
   {
     slug: 'focus',
     title: 'Focus',
-    icon: '⚡',
+    icon: Zap,
     prompt: 'Compare non-stimulant focus supports and caffeine-adjacent options.',
     bg: 'from-[#fdf5e6] to-[#f9ecce] border-[#d4aa62]',
     accent: 'text-[#5c3f0e]',
@@ -183,14 +184,21 @@ export default function HomepageV2() {
           </div>
 
           <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-4'>
-            {heroGoals.map((hGoal) => (
+            {heroGoals.map((hGoal) => {
+              const Icon = hGoal.icon
+              return (
                 <Link
                   key={hGoal.slug}
                   href={hGoal.slug === 'stress' || hGoal.slug === 'anxiety' ? '/guides/anxiety/' : `/guides/${hGoal.slug}/`}
                   className={`group flex min-h-48 flex-col justify-between rounded-[1.25rem] border bg-gradient-to-br ${hGoal.bg} p-5 shadow-sm transition-all duration-300 motion-safe:hover:-translate-y-1 hover:shadow-lg dark:border-[var(--border-strong)] dark:bg-[var(--surface-card)] dark:from-[var(--surface-card)] dark:to-[var(--surface-card)]`}
                 >
                   <div>
-                    <span className='mb-3 block text-2xl' aria-hidden='true'>{hGoal.icon}</span>
+                    <span
+                      className={`mb-3 inline-flex h-11 w-11 items-center justify-center rounded-full bg-white/70 shadow-sm ${hGoal.accent} dark:bg-[var(--surface-subtle)] dark:text-[var(--text-primary)]`}
+                      aria-hidden='true'
+                    >
+                      <Icon className='h-5 w-5' strokeWidth={1.75} />
+                    </span>
                     <h3 className={`text-2xl font-bold tracking-tight ${hGoal.accent} dark:text-[var(--text-primary)]`}>
                       {hGoal.title}
                     </h3>
@@ -200,7 +208,8 @@ export default function HomepageV2() {
                     Start with {hGoal.title} <span aria-hidden='true' className='ml-1'>→</span>
                   </span>
                 </Link>
-              ))}
+              )
+            })}
           </div>
         </section>
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { Leaf } from 'lucide-react'
 import { Link } from '../lib/router-compat'
 import ConsentManager from './ConsentManager'
 import { onOpenConsent } from '../lib/consentBus'
@@ -65,11 +66,14 @@ export default function Footer() {
   }
 
   return (
-    <footer className='mt-8 w-full border-t border-white/10 bg-[#07080F] px-4 py-12 dark:bg-[#07080F]'>
+    <footer className='mt-8 w-full px-4 py-12'>
       <div className='mx-auto w-full max-w-screen-lg'>
         <div className='grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-4'>
           <div>
-            <p className='font-display text-lg italic text-white'>The Hippie Scientist</p>
+            <div className='flex items-center gap-2'>
+              <Leaf aria-hidden='true' className='h-5 w-5 text-[#8dc49a]' strokeWidth={1.75} />
+              <p className='font-display text-lg italic text-white'>The Hippie Scientist</p>
+            </div>
             <p className='mt-1.5 text-[0.8rem] tracking-[0.02em] text-white/55'>
               Evidence-first botanical research. Not medical advice.
             </p>

--- a/styles/premium-surface-details.css
+++ b/styles/premium-surface-details.css
@@ -59,22 +59,22 @@ html.dark header [role='navigation'] a:hover {
   text-shadow: 0 0 20px rgba(203, 216, 192, 0.20);
 }
 
-/* Footer: intentional closing surface instead of plain bottom content. */
+/* Footer: forest-green closing surface — brand-consistent in both themes. */
 footer {
   position: relative;
   overflow: hidden;
-  border-top: 1px solid var(--surface-detail-border) !important;
+  border-top: 1px solid rgba(245, 240, 224, 0.1) !important;
   background:
-    radial-gradient(circle at 14% 0%, rgba(83, 111, 73, 0.13), transparent 24rem),
-    radial-gradient(circle at 88% 20%, rgba(192, 138, 53, 0.12), transparent 24rem),
-    linear-gradient(180deg, rgba(255, 253, 247, 0.72), rgba(246, 239, 224, 0.94)) !important;
+    radial-gradient(circle at 14% 0%, rgba(142, 186, 143, 0.14), transparent 24rem),
+    radial-gradient(circle at 88% 20%, rgba(196, 125, 46, 0.10), transparent 24rem),
+    linear-gradient(180deg, rgba(18, 38, 28, 0.97), rgba(9, 23, 16, 0.99)) !important;
 }
 
 html.dark footer {
   background:
     radial-gradient(circle at 14% 0%, rgba(142, 186, 143, 0.10), transparent 24rem),
     radial-gradient(circle at 88% 20%, rgba(196, 125, 46, 0.11), transparent 24rem),
-    linear-gradient(180deg, rgba(18, 38, 28, 0.88), rgba(8, 21, 15, 0.98)) !important;
+    linear-gradient(180deg, rgba(11, 29, 20, 0.98), rgba(6, 16, 11, 1)) !important;
 }
 
 footer::before {
@@ -82,7 +82,7 @@ footer::before {
   position: absolute;
   inset: 0 0 auto 0;
   height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(192, 138, 53, 0.34), rgba(83, 111, 73, 0.30), transparent);
+  background: linear-gradient(90deg, transparent, rgba(192, 138, 53, 0.34), rgba(142, 186, 143, 0.34), transparent);
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary
- Recolored the site footer from an off-brand near-black (`#07080F`) to the forest-green tone used across the rest of the botanical/evidence-based brand, in both light and dark mode
- Added a leaf logomark next to the "The Hippie Scientist" wordmark in the header nav (desktop + mobile) and footer, matching the botanical brand identity from the reference style guide
- Swapped the homepage "Choose one path" goal-card emoji (🌙🌿☁️⚡) for consistent `lucide-react` line icons (Moon/Leaf/Cloud/Zap) in colored icon badges, matching the reference mockups' professional iconography

The existing design system (Fraunces serif headings, forest-green/cream palette, evidence-grade A–D badges, safety tooling, comparison pages) already closely matched the provided reference mockups structurally — this PR closes the remaining visual gaps (off-brand footer color, missing logomark, emoji icons) without touching the mature, heavily-tested data-driven page architecture (herb/compound profiles, comparisons, evidence engine).

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes
- [x] `npm run test` — 293/293 tests pass
- [x] `npm run check` (typecheck + lint + article quality + data:build:core + validation) — passes
- [x] Verified visually in a local dev build: homepage hero/goal cards, header nav (light + dark mode), footer (light + dark mode)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EfTJURKd1XMnBxVQvDbTaB)_