### PR TITLE
Fix 404 on homepage Latest research cards

### DIFF
--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -230,7 +230,7 @@ export default function HomepageV2() {
               {featuredArticles.map((article: any) => (
                 <Link
                   key={article.slug}
-                  href={`/${article.slug}/`}
+                  href={`/articles/${article.slug}/`}
                   className='group flex flex-col gap-3 rounded-[1rem] border border-brand-900/10 bg-white/90 p-5 shadow-sm transition-all duration-200 hover:border-brand-700/20 hover:shadow-md dark:border-[var(--border-strong)] dark:bg-[var(--surface-card)]'
                 >
                   <div className='flex items-center gap-2'>


### PR DESCRIPTION
**Bug:** Clicking any card in the homepage "Latest research" section returned a 404.

**Cause:** The cards linked to `/${article.slug}/` (root level), but these articles are built at `/articles/<slug>/` — that's the URL content-collections assigns (`url: /articles/${slug}`) and the route that renders them (`app/articles/[slug]/page.tsx`). The root-level catch-all `app/[slug]/page.tsx` uses `dynamicParams = false` and only generates focus-cluster slugs, so `/berberine/`, `/creatine-brain-health/`, etc. had no page → 404.

**Fix:** Point the cards at `/articles/<slug>/`. Verified all 6 currently-featured slugs exist under `content/articles/`. One-line change; no other component links articles at root.