### PR TITLE
Rebuild herb profile hero and homepage to match reference mockups

### DIFF
--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
+import { CircleCheck } from 'lucide-react'
 import { notFound, redirect } from 'next/navigation'
 import type { Herb, RuntimeRecord } from '../../../src/types/content'
 import { getHerbBySlug } from '../../../src/lib/runtime-data'
@@ -552,7 +553,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
 
       {/* Title Header */}
       <div className="hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-sm sm:p-8 lg:p-10">
-        <header className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px] lg:items-center">
+        <header className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px] lg:items-start">
           <div className="space-y-3">
           <div className="space-y-1">
             <p className="eyebrow-label">Herb Profile</p>
@@ -566,20 +567,67 @@ export default async function HerbDetailPage({ params }: PageProps) {
             <LastUpdatedBadge date={freshness.lastReviewed} citationCount={freshness.citationCount} />
             <EvidenceScoreBadge record={herbRecord} />
           </div>
+
+          {/* Safety Summary banner */}
+          <div
+            className={`rounded-xl border-2 px-4 py-3 ${
+              safetyTone === 'Standard caution'
+                ? 'border-emerald-600/30 bg-emerald-50/70 dark:border-emerald-300/20 dark:bg-emerald-300/10'
+                : 'border-amber-600/30 bg-amber-50/70 dark:border-amber-300/20 dark:bg-amber-300/10'
+            }`}
+          >
+            <p className="text-sm leading-6 text-ink">
+              <span
+                className={`font-bold ${
+                  safetyTone === 'Standard caution' ? 'text-emerald-800 dark:text-emerald-100' : 'text-amber-800 dark:text-amber-100'
+                }`}
+              >
+                Safety Summary:
+              </span>{' '}
+              <span className="font-semibold">{safetyTone}</span> — {safetySummary}
+            </p>
           </div>
-          <MonographHeroImage image={heroImage} label={displayName} eyebrow="Monograph visual" />
+          </div>
+
+          <div className="space-y-4">
+            <MonographHeroImage image={heroImage} label={displayName} eyebrow="Monograph visual" />
+
+            {/* Key Findings */}
+            {topUses.length > 0 && (
+              <div className="rounded-2xl border-2 border-emerald-600/25 bg-emerald-50/60 p-4 dark:border-emerald-300/20 dark:bg-emerald-300/10">
+                <h3 className="text-xs font-bold uppercase tracking-wider text-emerald-800 dark:text-emerald-100">Key Findings</h3>
+                <p className="mt-1 text-[11px] font-semibold text-muted">Primary reported uses</p>
+                <ul className="mt-3 space-y-2">
+                  {topUses.slice(0, 4).map((use) => (
+                    <li key={use} className="flex items-start gap-2 text-sm leading-5 text-ink">
+                      <CircleCheck aria-hidden="true" className="mt-0.5 h-4 w-4 shrink-0 text-emerald-700 dark:text-emerald-200" strokeWidth={1.75} />
+                      <span>{use}</span>
+                    </li>
+                  ))}
+                </ul>
+                <div className="mt-4 border-t border-emerald-600/15 pt-3 dark:border-emerald-300/15">
+                  <EvidenceScoreBadge record={herbRecord} size="circle" />
+                </div>
+              </div>
+            )}
+          </div>
         </header>
       </div>
 
       <ProfileTOC items={tocItems} variant="mobile" />
 
-      {/* Jump navigation — lets keyboard and screen-reader users reach sections directly */}
-      <nav aria-label="Jump to profile sections" className="flex flex-wrap gap-2">
-        {tocItems.slice(0, 7).map(({ label, id }) => (
+      {/* Jump navigation — styled as a segmented tab bar; still plain anchor links so all
+          section content stays server-rendered and reachable without JS. */}
+      <nav aria-label="Jump to profile sections" className="flex flex-wrap gap-1.5 rounded-full border border-brand-900/10 bg-[#182f22] p-1.5 sm:inline-flex sm:flex-nowrap sm:gap-1">
+        {tocItems.slice(0, 7).map(({ label, id }, index) => (
           <a
             key={id}
             href={`#${id}`}
-            className="rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-3 py-1.5 text-xs font-semibold text-brand-800 transition-colors hover:bg-brand-50"
+            className={`rounded-full px-3.5 py-1.5 text-xs font-semibold whitespace-nowrap transition-colors ${
+              index === 0
+                ? 'bg-white text-[#182f22]'
+                : 'text-white/70 hover:bg-white/10 hover:text-white'
+            }`}
           >
             {label}
           </a>
@@ -740,7 +788,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
       <section id="evidence" className="card-premium scroll-mt-24 p-4 sm:p-5 space-y-4">
         <div className="flex items-center gap-2 flex-wrap">
           <h2 className="text-lg font-bold text-ink">Evidence Summary</h2>
-          <EvidenceScoreBadge record={herbRecord} size="sm" />
+          <EvidenceScoreBadge record={herbRecord} size="circle" />
         </div>
         <ProfileEvidenceLens
           record={herbRecord}

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { Menu, X } from 'lucide-react'
+import { Leaf, Menu, X } from 'lucide-react'
 import { GlobalSearchModal } from './search/GlobalSearchModal'
 import DarkModeToggle from './DarkModeToggle'
 import { mainNavigation } from '@/lib/navigation-config'
@@ -61,9 +61,10 @@ export function Navigation() {
           {/* Logo — Fraunces via font-display */}
           <Link
             href="/"
-            className="font-display text-[1.15rem] font-bold italic tracking-[-0.02em] text-ink transition hover:text-brand-700 dark:text-[var(--text-primary)]"
+            className="flex items-center gap-2 font-display text-[1.15rem] font-bold italic tracking-[-0.02em] text-ink transition hover:text-brand-700 dark:text-[var(--text-primary)]"
             aria-label="The Hippie Scientist home"
           >
+            <Leaf aria-hidden="true" className="h-5 w-5 shrink-0 text-brand-700 dark:text-[var(--accent-teal)]" strokeWidth={1.75} />
             The Hippie Scientist
           </Link>
 
@@ -123,7 +124,8 @@ export function Navigation() {
             style={{ height: '100dvh' }}
           >
             <div className="mb-6 flex items-center justify-between">
-              <Link href="/" onClick={closeMobile} className="font-display text-lg font-semibold text-ink">
+              <Link href="/" onClick={closeMobile} className="flex items-center gap-2 font-display text-lg font-semibold text-ink">
+                <Leaf aria-hidden="true" className="h-[1.125rem] w-[1.125rem] shrink-0 text-brand-700 dark:text-[var(--accent-teal)]" strokeWidth={1.75} />
                 The Hippie Scientist
               </Link>
               <button

--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -10,7 +10,7 @@ const heroGoals = [
     title: 'Sleep',
     icon: Moon,
     prompt: 'Fall asleep, stay asleep, and compare sleep supplements without guessing.',
-    bg: 'from-[#eaf2fb] to-[#dceef8] border-[#a8c8e0]',
+    bg: 'bg-[#dceef8] border-[#a8c8e0]',
     accent: 'text-[#1a3d5c]',
   },
   {
@@ -18,7 +18,7 @@ const heroGoals = [
     title: 'Stress',
     icon: Leaf,
     prompt: 'Sort adaptogens and calming supports by fatigue pattern, timing, and safety.',
-    bg: 'from-[#edf6ee] to-[#ddf0df] border-[#8dc49a]',
+    bg: 'bg-[#ddf0df] border-[#8dc49a]',
     accent: 'text-[#1e4a2c]',
   },
   {
@@ -26,7 +26,7 @@ const heroGoals = [
     title: 'Anxiety',
     icon: Cloud,
     prompt: 'Find grounded options for calm, overthinking, and daytime tension.',
-    bg: 'from-[#f3eefc] to-[#ebe2f8] border-[#c4aadf]',
+    bg: 'bg-[#ebe2f8] border-[#c4aadf]',
     accent: 'text-[#4a2d6e]',
   },
   {
@@ -34,10 +34,24 @@ const heroGoals = [
     title: 'Focus',
     icon: Zap,
     prompt: 'Compare non-stimulant focus supports and caffeine-adjacent options.',
-    bg: 'from-[#fdf5e6] to-[#f9ecce] border-[#d4aa62]',
+    bg: 'bg-[#f9ecce] border-[#d4aa62]',
     accent: 'text-[#5c3f0e]',
   },
 ]
+
+const CATEGORY_TAG_COLORS: Record<string, string> = {
+  'metabolic health': 'border-stone-400/30 bg-stone-200/70 text-stone-800 dark:bg-stone-300/10 dark:text-stone-100',
+  'cognitive health': 'border-emerald-600/25 bg-emerald-100/70 text-emerald-900 dark:bg-emerald-300/10 dark:text-emerald-100',
+  'anxiety & sleep': 'border-violet-600/25 bg-violet-100/70 text-violet-900 dark:bg-violet-300/10 dark:text-violet-100',
+  general: 'border-amber-600/25 bg-amber-100/70 text-amber-900 dark:bg-amber-300/10 dark:text-amber-100',
+}
+
+function categoryTagClass(category: string): string {
+  return (
+    CATEGORY_TAG_COLORS[category.toLowerCase()] ||
+    'border-brand-900/10 bg-brand-50 text-brand-700 dark:bg-[var(--surface-subtle)] dark:text-[var(--text-secondary)]'
+  )
+}
 
 const trustSignals = [
   {
@@ -103,10 +117,10 @@ export default function HomepageV2() {
       <div className='mx-auto max-w-6xl space-y-8 px-4 pb-12 pt-4 sm:px-6 sm:space-y-10 sm:pb-16 sm:pt-6 lg:px-8'>
 
         {/* ── Hero ─────────────────────────────────────────────── */}
-        <section className='relative overflow-hidden rounded-[1.5rem] border border-brand-900/10 bg-gradient-to-br from-white via-[#fafdf6] to-[#f2f8ed] px-6 py-10 shadow-md sm:px-10 sm:py-16 dark:from-[#1a3028] dark:via-[#162a20] dark:to-[#0f2419]'>
+        <section className='relative px-6 py-8 sm:px-10 sm:py-12'>
           <div className='relative mx-auto max-w-4xl'>
             <div className='flex flex-col items-center text-center'>
-              <h1 className='font-display text-[2.5rem] font-bold leading-[1.05] tracking-[-0.04em] text-ink break-words sm:text-5xl md:text-6xl'>
+              <h1 className='font-display text-[2.75rem] font-bold leading-[1.02] tracking-[-0.02em] text-ink break-words sm:text-5xl md:text-[3.75rem]'>
                 Herbs & supplements,<br />actually explained.
               </h1>
               <p className='mt-5 max-w-2xl text-sm font-medium leading-7 text-muted sm:text-base sm:leading-8'>
@@ -149,7 +163,7 @@ export default function HomepageV2() {
             </Link>
           </div>
 
-          <div className='rounded-[1rem] border border-emerald-800/15 bg-emerald-50/70 p-5 shadow-sm sm:p-6 dark:border-[var(--border-strong)] dark:bg-[var(--surface-card)]'>
+          <div className='rounded-[1rem] border border-brand-900/10 bg-white/90 p-5 shadow-sm sm:p-6 dark:border-[var(--border-strong)] dark:bg-[var(--surface-card)]'>
             <SectionHeader
               title='Use the safety tools'
               subtitle='The fastest win is avoiding mismatched products, risky stacks, and unclear supplement forms.'
@@ -190,7 +204,7 @@ export default function HomepageV2() {
                 <Link
                   key={hGoal.slug}
                   href={hGoal.slug === 'stress' || hGoal.slug === 'anxiety' ? '/guides/anxiety/' : `/guides/${hGoal.slug}/`}
-                  className={`group flex min-h-48 flex-col justify-between rounded-[1.25rem] border bg-gradient-to-br ${hGoal.bg} p-5 shadow-sm transition-all duration-300 motion-safe:hover:-translate-y-1 hover:shadow-lg dark:border-[var(--border-strong)] dark:bg-[var(--surface-card)] dark:from-[var(--surface-card)] dark:to-[var(--surface-card)]`}
+                  className={`group flex min-h-48 flex-col justify-between rounded-[1.25rem] border ${hGoal.bg} p-5 shadow-sm transition-all duration-300 motion-safe:hover:-translate-y-1 hover:shadow-lg dark:border-[var(--border-strong)] dark:bg-[var(--surface-card)]`}
                 >
                   <div>
                     <span
@@ -235,7 +249,7 @@ export default function HomepageV2() {
                 >
                   <div className='flex items-center gap-2'>
                     {article.category && (
-                      <span className='rounded-full border border-brand-900/10 bg-brand-50 px-2.5 py-0.5 text-[0.72rem] font-medium text-brand-700 dark:bg-[var(--surface-subtle)] dark:text-[var(--text-secondary)]'>
+                      <span className={`rounded-full border px-2.5 py-0.5 text-[0.72rem] font-medium ${categoryTagClass(article.category)}`}>
                         {article.category}
                       </span>
                     )}

--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { Cloud, Leaf, Moon, Zap } from 'lucide-react'
 import articlesData from '@/data/articles/articles.json'
 
 type SectionHeaderProps = { title: string; subtitle?: string; as?: 'h2' | 'h3' }
@@ -7,7 +8,7 @@ const heroGoals = [
   {
     slug: 'sleep',
     title: 'Sleep',
-    icon: '🌙',
+    icon: Moon,
     prompt: 'Fall asleep, stay asleep, and compare sleep supplements without guessing.',
     bg: 'from-[#eaf2fb] to-[#dceef8] border-[#a8c8e0]',
     accent: 'text-[#1a3d5c]',
@@ -15,7 +16,7 @@ const heroGoals = [
   {
     slug: 'stress',
     title: 'Stress',
-    icon: '🌿',
+    icon: Leaf,
     prompt: 'Sort adaptogens and calming supports by fatigue pattern, timing, and safety.',
     bg: 'from-[#edf6ee] to-[#ddf0df] border-[#8dc49a]',
     accent: 'text-[#1e4a2c]',
@@ -23,7 +24,7 @@ const heroGoals = [
   {
     slug: 'anxiety',
     title: 'Anxiety',
-    icon: '☁️',
+    icon: Cloud,
     prompt: 'Find grounded options for calm, overthinking, and daytime tension.',
     bg: 'from-[#f3eefc] to-[#ebe2f8] border-[#c4aadf]',
     accent: 'text-[#4a2d6e]',
@@ -31,7 +32,7 @@ const heroGoals = [
   {
     slug: 'focus',
     title: 'Focus',
-    icon: '⚡',
+    icon: Zap,
     prompt: 'Compare non-stimulant focus supports and caffeine-adjacent options.',
     bg: 'from-[#fdf5e6] to-[#f9ecce] border-[#d4aa62]',
     accent: 'text-[#5c3f0e]',
@@ -183,14 +184,21 @@ export default function HomepageV2() {
           </div>
 
           <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-4'>
-            {heroGoals.map((hGoal) => (
+            {heroGoals.map((hGoal) => {
+              const Icon = hGoal.icon
+              return (
                 <Link
                   key={hGoal.slug}
                   href={hGoal.slug === 'stress' || hGoal.slug === 'anxiety' ? '/guides/anxiety/' : `/guides/${hGoal.slug}/`}
                   className={`group flex min-h-48 flex-col justify-between rounded-[1.25rem] border bg-gradient-to-br ${hGoal.bg} p-5 shadow-sm transition-all duration-300 motion-safe:hover:-translate-y-1 hover:shadow-lg dark:border-[var(--border-strong)] dark:bg-[var(--surface-card)] dark:from-[var(--surface-card)] dark:to-[var(--surface-card)]`}
                 >
                   <div>
-                    <span className='mb-3 block text-2xl' aria-hidden='true'>{hGoal.icon}</span>
+                    <span
+                      className={`mb-3 inline-flex h-11 w-11 items-center justify-center rounded-full bg-white/70 shadow-sm ${hGoal.accent} dark:bg-[var(--surface-subtle)] dark:text-[var(--text-primary)]`}
+                      aria-hidden='true'
+                    >
+                      <Icon className='h-5 w-5' strokeWidth={1.75} />
+                    </span>
                     <h3 className={`text-2xl font-bold tracking-tight ${hGoal.accent} dark:text-[var(--text-primary)]`}>
                       {hGoal.title}
                     </h3>
@@ -200,7 +208,8 @@ export default function HomepageV2() {
                     Start with {hGoal.title} <span aria-hidden='true' className='ml-1'>→</span>
                   </span>
                 </Link>
-              ))}
+              )
+            })}
           </div>
         </section>
 

--- a/components/ui/EvidenceScoreBadge.tsx
+++ b/components/ui/EvidenceScoreBadge.tsx
@@ -8,6 +8,7 @@ const GRADE_CONFIG: Record<EvidenceLetterGrade, {
   text: string
   border: string
   ringColor: string
+  solid: string
 }> = {
   A: {
     label: 'A',
@@ -16,6 +17,7 @@ const GRADE_CONFIG: Record<EvidenceLetterGrade, {
     text: 'text-[var(--color-evidence-strong)]',
     border: 'border-[var(--color-evidence-strong)]/20',
     ringColor: 'ring-[var(--color-evidence-strong)]/20',
+    solid: 'bg-[var(--color-evidence-strong)]',
   },
   B: {
     label: 'B',
@@ -24,6 +26,7 @@ const GRADE_CONFIG: Record<EvidenceLetterGrade, {
     text: 'text-[var(--color-evidence-moderate)]',
     border: 'border-[var(--color-evidence-moderate)]/20',
     ringColor: 'ring-[var(--color-evidence-moderate)]/20',
+    solid: 'bg-[var(--color-evidence-moderate)]',
   },
   C: {
     label: 'C',
@@ -32,6 +35,7 @@ const GRADE_CONFIG: Record<EvidenceLetterGrade, {
     text: 'text-[var(--color-evidence-limited)]',
     border: 'border-[var(--color-evidence-limited)]/20',
     ringColor: 'ring-[var(--color-evidence-limited)]/20',
+    solid: 'bg-[var(--color-evidence-limited)]',
   },
   D: {
     label: 'D',
@@ -40,13 +44,31 @@ const GRADE_CONFIG: Record<EvidenceLetterGrade, {
     text: 'text-[var(--color-evidence-theoretical)]',
     border: 'border-[var(--color-evidence-theoretical)]/20',
     ringColor: 'ring-[var(--color-evidence-theoretical)]/20',
+    solid: 'bg-[var(--color-evidence-theoretical)]',
   },
+}
+
+const GRADE_MEANING_SHORT: Record<EvidenceLetterGrade, string> = {
+  A: 'Strong',
+  B: 'Moderate',
+  C: 'Preliminary',
+  D: 'Traditional',
+}
+
+// Dark-mode-aware text color for the circle variant's label — the static
+// --color-evidence-* tokens don't have dark overrides and read low-contrast
+// against dark surfaces, so this uses adaptive Tailwind utilities instead.
+const GRADE_TEXT_ADAPTIVE: Record<EvidenceLetterGrade, string> = {
+  A: 'text-emerald-800 dark:text-emerald-100',
+  B: 'text-blue-800 dark:text-blue-100',
+  C: 'text-amber-800 dark:text-amber-100',
+  D: 'text-stone-700 dark:text-stone-200',
 }
 
 type EvidenceScoreBadgeProps = {
   record?: Record<string, unknown>
   grade?: EvidenceLetterGrade
-  size?: 'sm' | 'md'
+  size?: 'sm' | 'md' | 'circle'
   showLabel?: boolean
   className?: string
 }
@@ -60,6 +82,27 @@ export default function EvidenceScoreBadge({
 }: EvidenceScoreBadgeProps) {
   const letterGrade = grade ?? (record ? getEvidenceLetterGrade(record as RuntimeRecord) : 'C')
   const config = GRADE_CONFIG[letterGrade]
+
+  if (size === 'circle') {
+    return (
+      <span
+        className={`inline-flex items-center gap-2 ${className}`}
+        title={config.meaning}
+      >
+        <span
+          aria-hidden="true"
+          className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-sm font-bold text-white shadow-sm ${config.solid}`}
+        >
+          {letterGrade}
+        </span>
+        {showLabel && (
+          <span aria-label={`Evidence grade ${letterGrade}: ${config.meaning}`} className={`text-sm font-semibold ${GRADE_TEXT_ADAPTIVE[letterGrade]}`}>
+            {GRADE_MEANING_SHORT[letterGrade]}
+          </span>
+        )}
+      </span>
+    )
+  }
 
   const sizeClasses =
     size === 'sm'
@@ -76,10 +119,7 @@ export default function EvidenceScoreBadge({
       {showLabel && (
         <span className="font-semibold">
           {' '}
-          {letterGrade === 'A' && 'Strong'}
-          {letterGrade === 'B' && 'Moderate'}
-          {letterGrade === 'C' && 'Preliminary'}
-          {letterGrade === 'D' && 'Traditional'}
+          {GRADE_MEANING_SHORT[letterGrade]}
         </span>
       )}
     </span>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { Leaf } from 'lucide-react'
 import { Link } from '../lib/router-compat'
 import ConsentManager from './ConsentManager'
 import { onOpenConsent } from '../lib/consentBus'
@@ -65,11 +66,14 @@ export default function Footer() {
   }
 
   return (
-    <footer className='mt-8 w-full border-t border-white/10 bg-[#07080F] px-4 py-12 dark:bg-[#07080F]'>
+    <footer className='mt-8 w-full px-4 py-12'>
       <div className='mx-auto w-full max-w-screen-lg'>
         <div className='grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-4'>
           <div>
-            <p className='font-display text-lg italic text-white'>The Hippie Scientist</p>
+            <div className='flex items-center gap-2'>
+              <Leaf aria-hidden='true' className='h-5 w-5 text-[#8dc49a]' strokeWidth={1.75} />
+              <p className='font-display text-lg italic text-white'>The Hippie Scientist</p>
+            </div>
             <p className='mt-1.5 text-[0.8rem] tracking-[0.02em] text-white/55'>
               Evidence-first botanical research. Not medical advice.
             </p>

--- a/styles/herb-profile-polish.css
+++ b/styles/herb-profile-polish.css
@@ -36,35 +36,17 @@ html:not(.dark) main:has(nav[aria-label="Jump to profile sections"]) section.rou
   box-shadow: 0 18px 52px rgba(16, 32, 24, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.72);
 }
 
+/* Segmented tab-bar look: solid forest-green track, consistent in both themes,
+   with per-link active/inactive styling left to the component's own classes. */
 main:has(nav[aria-label="Jump to profile sections"]) nav[aria-label="Jump to profile sections"] {
   position: sticky;
   top: 4.75rem;
   z-index: 20;
-  border: 1px solid rgba(235, 246, 236, 0.14);
-  border-radius: 999px;
-  padding: 0.45rem;
-  background: rgba(11, 29, 20, 0.76);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
   box-shadow: 0 12px 36px rgba(0, 0, 0, 0.18);
 }
 
 html:not(.dark) main:has(nav[aria-label="Jump to profile sections"]) nav[aria-label="Jump to profile sections"] {
-  border-color: rgba(29, 74, 47, 0.12);
-  background: rgba(255, 253, 247, 0.82);
   box-shadow: 0 12px 32px rgba(16, 32, 24, 0.08);
-}
-
-main:has(nav[aria-label="Jump to profile sections"]) nav[aria-label="Jump to profile sections"] a {
-  border-color: rgba(235, 246, 236, 0.14);
-  background: rgba(255, 255, 255, 0.055);
-  color: #dceade;
-}
-
-html:not(.dark) main:has(nav[aria-label="Jump to profile sections"]) nav[aria-label="Jump to profile sections"] a {
-  border-color: rgba(29, 74, 47, 0.12);
-  background: rgba(255, 255, 255, 0.72);
-  color: #314b33;
 }
 
 main:has(nav[aria-label="Jump to profile sections"]) h1,

--- a/styles/premium-surface-details.css
+++ b/styles/premium-surface-details.css
@@ -59,22 +59,22 @@ html.dark header [role='navigation'] a:hover {
   text-shadow: 0 0 20px rgba(203, 216, 192, 0.20);
 }
 
-/* Footer: intentional closing surface instead of plain bottom content. */
+/* Footer: forest-green closing surface — brand-consistent in both themes. */
 footer {
   position: relative;
   overflow: hidden;
-  border-top: 1px solid var(--surface-detail-border) !important;
+  border-top: 1px solid rgba(245, 240, 224, 0.1) !important;
   background:
-    radial-gradient(circle at 14% 0%, rgba(83, 111, 73, 0.13), transparent 24rem),
-    radial-gradient(circle at 88% 20%, rgba(192, 138, 53, 0.12), transparent 24rem),
-    linear-gradient(180deg, rgba(255, 253, 247, 0.72), rgba(246, 239, 224, 0.94)) !important;
+    radial-gradient(circle at 14% 0%, rgba(142, 186, 143, 0.14), transparent 24rem),
+    radial-gradient(circle at 88% 20%, rgba(196, 125, 46, 0.10), transparent 24rem),
+    linear-gradient(180deg, rgba(18, 38, 28, 0.97), rgba(9, 23, 16, 0.99)) !important;
 }
 
 html.dark footer {
   background:
     radial-gradient(circle at 14% 0%, rgba(142, 186, 143, 0.10), transparent 24rem),
     radial-gradient(circle at 88% 20%, rgba(196, 125, 46, 0.11), transparent 24rem),
-    linear-gradient(180deg, rgba(18, 38, 28, 0.88), rgba(8, 21, 15, 0.98)) !important;
+    linear-gradient(180deg, rgba(11, 29, 20, 0.98), rgba(6, 16, 11, 1)) !important;
 }
 
 footer::before {
@@ -82,7 +82,7 @@ footer::before {
   position: absolute;
   inset: 0 0 auto 0;
   height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(192, 138, 53, 0.34), rgba(83, 111, 73, 0.30), transparent);
+  background: linear-gradient(90deg, transparent, rgba(192, 138, 53, 0.34), rgba(142, 186, 143, 0.34), transparent);
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary
Follow-up to the previous visual-refresh PR — that pass only retouched colors/icons but didn't rebuild the actual layouts the reference mockups show. This PR adds the structural pieces:

- **Herb profile hero** (`app/herbs/[slug]/page.tsx`): adds a "Safety Summary" banner and a green-bordered "Key Findings" sidebar card (top reported uses + overall evidence grade), matching the "Herb Detail: Evidence Profile" mockup
- **Circular evidence grade badge**: `EvidenceScoreBadge` gets a new `size="circle"` variant rendering a colored A/B/C/D circle, matching the mockup's clinical study grade badges
- **Segmented tab bar**: the profile jump-nav is restyled as a dark segmented control. This required fixing `styles/herb-profile-polish.css`, which had a more-specific legacy selector silently overriding the nav back to a plain cream pill row regardless of the new component classes
- **Homepage**: flattened the hero (dropped the gradient card wrapper), flattened the goal cards to solid pastel fills instead of gradients, and added per-category color coding to the "Latest research" tags — all matching the reference homepage mockup more closely
- Fixed a dark-mode contrast issue in the new Safety Summary / Key Findings text by using adaptive Tailwind utilities with explicit `dark:` variants instead of the static `--color-evidence-*`/`--color-safety-*` tokens (which have no dark-mode override)

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes
- [x] `npm run test` — 293/293 tests pass
- [x] `npm run check` — passes
- [x] Verified visually with a local dev build: homepage (light + dark), herb detail page (light + dark), confirmed the segmented tab bar and Key Findings/Safety Summary boxes render correctly and contrast holds up in dark mode


---
_Generated by [Claude Code](https://claude.ai/code/session_01EfTJURKd1XMnBxVQvDbTaB)_