### PR TITLE
Add safety gauge, visible studies table, and bolder card styling

### DIFF
--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -36,6 +36,7 @@ import { SourcingCta } from '../../../src/components/sourcing/SourcingCta'
 import AuthorCredentials from '@/components/AuthorCredentials'
 import Disclaimer from '../../../src/components/Disclaimer'
 import EvidenceScoreBadge from '@/components/ui/EvidenceScoreBadge'
+import SafetyGaugeMeter from '@/components/ui/SafetyGaugeMeter'
 import ProfileEvidenceLens from '@/components/ui/ProfileEvidenceLens'
 import EvidenceGradeExplainer from '@/components/ui/EvidenceGradeExplainer'
 import ShowMeTheStudies from '@/components/ui/ShowMeTheStudies'
@@ -249,6 +250,12 @@ function getSafetyTone(summary: string, avoidIf: string[], sensitivity: string) 
   return 'Standard caution'
 }
 
+function getSafetyGaugeScore(sensitivity: string): { score: number; label: string } {
+  if (/low/i.test(sensitivity)) return { score: 90, label: 'Low caution — well tolerated' }
+  if (/moderate/i.test(sensitivity)) return { score: 60, label: 'Moderate caution — review before use' }
+  return { score: 28, label: 'High caution — review carefully' }
+}
+
 function getTopUses(herb: Herb) {
   const terms = unique([...getEffects(herb), ...getTraditionalUses(herb), ...deriveResearchFocusAreas({ profile: herb })])
   const selected: string[] = []
@@ -424,6 +431,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
   const evidenceLimitations = deriveEvidenceLimitations({ profile: herb })
   const topUses = getTopUses(herb)
   const safetyTone = getSafetyTone(safetySummary, avoidIf, safetySensitivity)
+  const safetyGaugeScore = getSafetyGaugeScore(safetySensitivity)
   const relatedHerbLinks = getRelatedLinks(relatedHerbs, 'herb')
   const revenueProducts = getRevenueProductSet(normalizedSlug)
   const stackRecommendations = getStackRecommendations(normalizedSlug, 3)
@@ -756,8 +764,13 @@ export default async function HerbDetailPage({ params }: PageProps) {
 
       {/* Section 2: Safety */}
       <section id="safety" className="scroll-mt-24 rounded-2xl bg-amber-50/70 border border-amber-900/10 border-l-4 border-amber-500/60 p-4 sm:p-5 space-y-3">
-        <h2 className="text-lg font-bold text-ink">Safety &amp; Cautions</h2>
-        <p className="text-sm leading-6 text-amber-900">{safetySummary}</p>
+        <div className="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between">
+          <div className="flex-1 space-y-2">
+            <h2 className="text-lg font-bold text-ink">Safety &amp; Cautions</h2>
+            <p className="text-sm leading-6 text-amber-900">{safetySummary}</p>
+          </div>
+          <SafetyGaugeMeter score={safetyGaugeScore.score} label={safetyGaugeScore.label} className="shrink-0 sm:w-44" />
+        </div>
         {safetyGroups.length > 0 && (
           <details className="group mt-4 border-t border-amber-900/10 pt-3">
             <summary className="flex cursor-pointer items-center justify-between gap-3 text-sm font-bold text-amber-950 select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-700/40 focus-visible:rounded">

--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -99,7 +99,7 @@ const toolLinks = [
 function SectionHeader({ title, subtitle, as: HeadingTag = 'h2' }: SectionHeaderProps) {
   return (
     <div className='max-w-3xl space-y-2'>
-      <HeadingTag className='text-xl font-semibold tracking-tight text-ink sm:text-2xl'>{title}</HeadingTag>
+      <HeadingTag className='font-display text-2xl font-bold tracking-tight text-ink sm:text-3xl'>{title}</HeadingTag>
       {subtitle ? <p className='text-sm leading-6 text-muted sm:text-base'>{subtitle}</p> : null}
     </div>
   )
@@ -127,10 +127,10 @@ export default function HomepageV2() {
                 Evidence-based guides for sleep, stress, anxiety, and focus. 816 peer-reviewed studies, 557 compounds, zero marketing fluff.
               </p>
 
-              <div className='mt-6 flex w-full max-w-sm flex-col'>
+              <div className='mt-8 flex w-full max-w-sm flex-col'>
                 <Link
                   href='#choose-a-path'
-                  className='rounded-full bg-brand-800 px-6 py-3.5 text-sm font-bold text-white shadow-[0_4px_14px_rgba(11,29,20,0.22)] transition-all duration-200 motion-safe:hover:-translate-y-0.5 hover:bg-brand-700 hover:shadow-[0_8px_20px_rgba(11,29,20,0.28)] active:translate-y-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2 text-center'
+                  className='rounded-full bg-brand-800 px-8 py-4 text-base font-bold text-white shadow-[0_6px_20px_rgba(11,29,20,0.3)] transition-all duration-200 motion-safe:hover:-translate-y-0.5 hover:bg-brand-700 hover:shadow-[0_10px_26px_rgba(11,29,20,0.35)] active:translate-y-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2 text-center'
                 >
                   Browse by Health Goal
                 </Link>
@@ -141,7 +141,7 @@ export default function HomepageV2() {
 
         {/* Comparisons and tools */}
         <section className='grid gap-4 lg:grid-cols-[1fr_0.9fr]'>
-          <div className='rounded-[1rem] border border-brand-900/10 bg-white/90 p-5 shadow-sm sm:p-6 dark:border-[var(--border-strong)] dark:bg-[var(--surface-card)]'>
+          <div className='rounded-[1rem] border-2 border-brand-900/12 bg-white/90 p-5 shadow-md sm:p-6 dark:border-[var(--border-strong)] dark:bg-[var(--surface-card)]'>
             <SectionHeader
               title='Compare before you choose'
               subtitle='Side-by-side pages help answer the high-intent questions people search before buying or stacking.'
@@ -152,7 +152,7 @@ export default function HomepageV2() {
                 <Link
                   key={comparison.href}
                   href={comparison.href}
-                  className='rounded-[0.75rem] border border-brand-900/10 bg-brand-50/40 px-4 py-3 text-sm font-bold text-brand-800 transition hover:border-brand-700/20 hover:bg-brand-50 dark:bg-[var(--surface-subtle)]'
+                  className='rounded-[0.75rem] border-2 border-brand-900/12 bg-brand-50/50 px-4 py-3 text-sm font-bold text-brand-800 transition hover:border-brand-700/25 hover:bg-brand-50 dark:bg-[var(--surface-subtle)]'
                 >
                   {comparison.title} →
                 </Link>
@@ -163,7 +163,7 @@ export default function HomepageV2() {
             </Link>
           </div>
 
-          <div className='rounded-[1rem] border border-brand-900/10 bg-white/90 p-5 shadow-sm sm:p-6 dark:border-[var(--border-strong)] dark:bg-[var(--surface-card)]'>
+          <div className='rounded-[1rem] border-2 border-brand-900/12 bg-white/90 p-5 shadow-md sm:p-6 dark:border-[var(--border-strong)] dark:bg-[var(--surface-card)]'>
             <SectionHeader
               title='Use the safety tools'
               subtitle='The fastest win is avoiding mismatched products, risky stacks, and unclear supplement forms.'
@@ -174,7 +174,7 @@ export default function HomepageV2() {
                 <Link
                   key={tool.href}
                   href={tool.href}
-                  className='block rounded-[0.75rem] border border-emerald-900/10 bg-white/80 p-4 transition hover:border-emerald-700/20 hover:bg-white dark:bg-[var(--surface-subtle)]'
+                  className='block rounded-[0.75rem] border-2 border-brand-900/12 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/25 hover:bg-white dark:bg-[var(--surface-subtle)]'
                 >
                   <h3 className='text-sm font-bold text-ink'>{tool.title}</h3>
                   <p className='mt-1 text-sm leading-6 text-muted'>{tool.description}</p>
@@ -204,14 +204,14 @@ export default function HomepageV2() {
                 <Link
                   key={hGoal.slug}
                   href={hGoal.slug === 'stress' || hGoal.slug === 'anxiety' ? '/guides/anxiety/' : `/guides/${hGoal.slug}/`}
-                  className={`group flex min-h-48 flex-col justify-between rounded-[1.25rem] border ${hGoal.bg} p-5 shadow-sm transition-all duration-300 motion-safe:hover:-translate-y-1 hover:shadow-lg dark:border-[var(--border-strong)] dark:bg-[var(--surface-card)]`}
+                  className={`group flex min-h-48 flex-col justify-between rounded-[1.25rem] border-2 ${hGoal.bg} p-5 shadow-md transition-all duration-300 motion-safe:hover:-translate-y-1 hover:shadow-xl dark:border-[var(--border-strong)] dark:bg-[var(--surface-card)]`}
                 >
                   <div>
                     <span
-                      className={`mb-3 inline-flex h-11 w-11 items-center justify-center rounded-full bg-white/70 shadow-sm ${hGoal.accent} dark:bg-[var(--surface-subtle)] dark:text-[var(--text-primary)]`}
+                      className={`mb-3 inline-flex h-12 w-12 items-center justify-center rounded-full bg-white/80 shadow-sm ${hGoal.accent} dark:bg-[var(--surface-subtle)] dark:text-[var(--text-primary)]`}
                       aria-hidden='true'
                     >
-                      <Icon className='h-5 w-5' strokeWidth={1.75} />
+                      <Icon className='h-6 w-6' strokeWidth={1.75} />
                     </span>
                     <h3 className={`text-2xl font-bold tracking-tight ${hGoal.accent} dark:text-[var(--text-primary)]`}>
                       {hGoal.title}
@@ -245,7 +245,7 @@ export default function HomepageV2() {
                 <Link
                   key={article.slug}
                   href={`/articles/${article.slug}/`}
-                  className='group flex flex-col gap-3 rounded-[1rem] border border-brand-900/10 bg-white/90 p-5 shadow-sm transition-all duration-200 hover:border-brand-700/20 hover:shadow-md dark:border-[var(--border-strong)] dark:bg-[var(--surface-card)]'
+                  className='group flex flex-col gap-3 rounded-[1rem] border-2 border-brand-900/12 bg-white/90 p-5 shadow-md transition-all duration-200 hover:border-brand-700/25 hover:shadow-lg dark:border-[var(--border-strong)] dark:bg-[var(--surface-card)]'
                 >
                   <div className='flex items-center gap-2'>
                     {article.category && (
@@ -270,7 +270,7 @@ export default function HomepageV2() {
         )}
 
         {/* Trust */}
-        <section className='rounded-[1rem] border border-brand-900/10 bg-white/90 p-5 shadow-sm sm:p-6'>
+        <section className='rounded-[1rem] border-2 border-brand-900/12 bg-white/90 p-5 shadow-md sm:p-6'>
           <div className='grid gap-6 lg:grid-cols-[0.9fr_1.1fr] lg:items-start'>
             <SectionHeader
               title='Why trust the guide?'
@@ -279,7 +279,7 @@ export default function HomepageV2() {
             />
             <div className='grid gap-3 sm:grid-cols-3'>
               {trustSignals.map((signal) => (
-                <div key={signal.n} className='flex gap-4 rounded-[0.85rem] border border-brand-900/10 bg-white/60 p-4 dark:bg-[var(--surface-card)] dark:text-[var(--text-secondary)]'>
+                <div key={signal.n} className='flex gap-4 rounded-[0.85rem] border-2 border-brand-900/12 bg-white/70 p-4 shadow-sm dark:bg-[var(--surface-card)] dark:text-[var(--text-secondary)]'>
                   <span className='mt-0.5 shrink-0 font-mono text-xs font-bold tracking-widest text-brand-400'>{signal.n}</span>
                   <div>
                     <p className='text-sm font-semibold text-ink'>{signal.label}</p>

--- a/components/ui/SafetyGaugeMeter.tsx
+++ b/components/ui/SafetyGaugeMeter.tsx
@@ -1,0 +1,51 @@
+type SafetyGaugeMeterProps = {
+  /** 0-100 safety score; higher is safer */
+  score: number
+  label: string
+  className?: string
+}
+
+function polarToCartesian(cx: number, cy: number, r: number, angleDeg: number) {
+  const rad = (angleDeg * Math.PI) / 180
+  return { x: cx + r * Math.cos(rad), y: cy - r * Math.sin(rad) }
+}
+
+function describeArc(cx: number, cy: number, r: number, startAngle: number, endAngle: number) {
+  const start = polarToCartesian(cx, cy, r, startAngle)
+  const end = polarToCartesian(cx, cy, r, endAngle)
+  const largeArcFlag = Math.abs(startAngle - endAngle) > 180 ? 1 : 0
+  return `M ${start.x} ${start.y} A ${r} ${r} 0 ${largeArcFlag} 0 ${end.x} ${end.y}`
+}
+
+export default function SafetyGaugeMeter({ score, label, className = '' }: SafetyGaugeMeterProps) {
+  const clamped = Math.max(0, Math.min(100, Math.round(score)))
+  const needleAngle = 180 - (180 * clamped) / 100
+  const needleTip = polarToCartesian(50, 50, 34, needleAngle)
+
+  return (
+    <div className={`flex flex-col items-center ${className}`}>
+      <svg
+        viewBox="0 0 100 58"
+        className="w-full max-w-[200px]"
+        role="img"
+        aria-label={`Safety meter: ${clamped} out of 100 — ${label}`}
+      >
+        <path d={describeArc(50, 50, 40, 180, 120)} stroke="#dc4c3c" strokeWidth="9" fill="none" strokeLinecap="round" />
+        <path d={describeArc(50, 50, 40, 120, 60)} stroke="#e8a13c" strokeWidth="9" fill="none" strokeLinecap="round" />
+        <path d={describeArc(50, 50, 40, 60, 0)} stroke="#2f9e52" strokeWidth="9" fill="none" strokeLinecap="round" />
+        <line
+          x1="50"
+          y1="50"
+          x2={needleTip.x}
+          y2={needleTip.y}
+          className="stroke-ink dark:stroke-white"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+        />
+        <circle cx="50" cy="50" r="3.5" className="fill-ink dark:fill-white" />
+      </svg>
+      <p className="-mt-2 text-2xl font-bold text-ink">{clamped}%</p>
+      <p className="text-xs font-semibold uppercase tracking-wide text-muted">{label}</p>
+    </div>
+  )
+}

--- a/components/ui/ShowMeTheStudies.tsx
+++ b/components/ui/ShowMeTheStudies.tsx
@@ -12,6 +12,7 @@ interface Props {
 }
 
 const STUDY_TYPE_ORDER = ['Randomized controlled trial', 'Systematic review', 'Meta-analysis', 'Observational', 'Mechanistic', 'Animal', 'In vitro']
+const VISIBLE_ROWS = 6
 
 function StudyTypeBadge({ type }: { type: string }) {
   const lower = type.toLowerCase()
@@ -65,70 +66,109 @@ function sortByStudyType(a: Citation, b: Citation) {
   return aRank - bRank
 }
 
+function StudyRow({ citation, index }: { citation: Citation; index: number }) {
+  const pubmedUrl = citation.pmid ? `https://pubmed.ncbi.nlm.nih.gov/${citation.pmid}/` : null
+
+  return (
+    <tr
+      key={citation.pmid || citation.title || index}
+      className="border-t border-brand-900/10 dark:border-white/10"
+    >
+      <td className="px-3 py-3 align-top sm:px-4">
+        <p className="text-[13px] font-semibold leading-snug text-ink">
+          {pubmedUrl ? (
+            <a
+              href={pubmedUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-brand-700 hover:underline dark:hover:text-brand-100"
+            >
+              {citation.title}
+            </a>
+          ) : (
+            citation.title
+          )}
+        </p>
+        {(citation.authors || citation.year) && (
+          <p className="mt-0.5 text-[11px] text-muted">
+            {citation.authors}
+            {citation.year ? ` (${citation.year})` : ''}
+          </p>
+        )}
+      </td>
+      <td className="px-3 py-3 align-top sm:px-4">
+        {citation.studyType ? <StudyTypeBadge type={citation.studyType} /> : <span className="text-xs text-muted">—</span>}
+      </td>
+      <td className="whitespace-nowrap px-3 py-3 align-top text-[12px] text-muted sm:px-4">
+        {citation.sampleSize ? `n=${citation.sampleSize}` : '—'}
+      </td>
+      <td className="px-3 py-3 text-right align-top sm:px-4">
+        {pubmedUrl ? (
+          <a
+            href={pubmedUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[11px] font-semibold text-brand-700 hover:underline dark:text-brand-100"
+          >
+            PubMed →
+          </a>
+        ) : (
+          <span className="text-xs text-muted">—</span>
+        )}
+      </td>
+    </tr>
+  )
+}
+
 export default function ShowMeTheStudies({ citations }: Props) {
   if (!citations || citations.length === 0) return null
 
   const sorted = [...citations].sort(sortByStudyType)
+  const visible = sorted.slice(0, VISIBLE_ROWS)
+  const overflow = sorted.slice(VISIBLE_ROWS)
 
   return (
-    <details className="group rounded-2xl border border-brand-900/10 bg-white/70 p-3 dark:border-white/10 dark:bg-white/5">
-      <summary className="flex cursor-pointer select-none items-center gap-2 text-xs font-semibold uppercase tracking-wider text-muted transition-colors hover:text-ink dark:hover:text-brand-50">
-        <span className="inline-block text-brand-500 transition-transform group-open:rotate-90 dark:text-brand-200">▶</span>
-        Show me the studies ({citations.length})
-      </summary>
-      <div className="mt-3 rounded-xl border border-brand-900/10 bg-white/70 p-3 space-y-2 dark:border-white/10 dark:bg-white/5">
-        <p className="text-[11px] leading-5 text-muted">
-          Research sources informing this profile. Study type ordering: RCTs and reviews first, then observational and mechanistic work.
+    <div className="overflow-hidden rounded-2xl border-2 border-brand-900/10 dark:border-white/10">
+      <div className="border-b border-brand-900/10 bg-brand-50/70 px-4 py-3 dark:border-white/10 dark:bg-[var(--surface-subtle)]">
+        <h3 className="text-sm font-bold text-ink">Clinical Study Summaries</h3>
+        <p className="mt-0.5 text-[11px] leading-5 text-muted">
+          {citations.length} cited stud{citations.length === 1 ? 'y' : 'ies'} informing this profile. RCTs and reviews shown first.
         </p>
-        <div className="space-y-2">
-          {sorted.map((c, i) => {
-            const pubmedUrl = c.pmid ? `https://pubmed.ncbi.nlm.nih.gov/${c.pmid}/` : null
-            return (
-              <div
-                key={c.pmid || c.title || i}
-                className="space-y-1.5 rounded-lg border border-brand-900/10 bg-white/90 p-3 dark:border-white/10 dark:bg-white/5"
-              >
-                <p className="text-[12px] font-semibold leading-snug text-ink">
-                  {pubmedUrl ? (
-                    <a
-                      href={pubmedUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="hover:text-brand-700 hover:underline dark:hover:text-brand-100"
-                    >
-                      {c.title}
-                    </a>
-                  ) : (
-                    c.title
-                  )}
-                </p>
-                <div className="flex flex-wrap gap-x-4 gap-y-1">
-                  {c.authors && (
-                    <span className="text-[11px] text-muted">{c.authors}{c.year ? ` (${c.year})` : ''}</span>
-                  )}
-                  {!c.authors && c.year && (
-                    <span className="text-[11px] text-muted">{c.year}</span>
-                  )}
-                  {c.studyType && <StudyTypeBadge type={c.studyType} />}
-                  {c.sampleSize && (
-                    <span className="text-[11px] text-muted">n={c.sampleSize}</span>
-                  )}
-                  {pubmedUrl && (
-                    <a
-                      href={pubmedUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-[11px] font-medium text-brand-700 hover:underline dark:text-brand-100"
-                    >
-                      PubMed →
-                    </a>
-                  )}
-                </div>
-              </div>
-            )
-          })}
-        </div>
       </div>
-    </details>
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[560px] border-collapse text-left text-sm">
+          <thead>
+            <tr className="bg-[var(--surface-card)] text-[10px] font-bold uppercase tracking-wider text-muted">
+              <th className="px-3 py-2 sm:px-4">Study</th>
+              <th className="px-3 py-2 sm:px-4">Type</th>
+              <th className="px-3 py-2 sm:px-4">Sample</th>
+              <th className="px-3 py-2 text-right sm:px-4">Source</th>
+            </tr>
+          </thead>
+          <tbody>
+            {visible.map((citation, index) => (
+              <StudyRow key={citation.pmid || citation.title || index} citation={citation} index={index} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {overflow.length > 0 && (
+        <details className="group border-t border-brand-900/10 dark:border-white/10">
+          <summary className="flex cursor-pointer select-none items-center gap-1.5 px-4 py-2.5 text-xs font-semibold text-brand-700 hover:text-brand-800 dark:text-brand-100 dark:hover:text-white">
+            <span aria-hidden="true" className="inline-block transition-transform group-open:rotate-90">▶</span>
+            Show {overflow.length} more stud{overflow.length === 1 ? 'y' : 'ies'}
+          </summary>
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[560px] border-collapse text-left text-sm">
+              <tbody>
+                {overflow.map((citation, index) => (
+                  <StudyRow key={citation.pmid || citation.title || index} citation={citation} index={index} />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </details>
+      )}
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
Third pass on the visual redesign — the first two passes were still reading as too minimal against the reference mockups. This addresses the three concrete gaps: missing components, thin visual weight, and underused color.

- **New `SafetyGaugeMeter` component** (`components/ui/SafetyGaugeMeter.tsx`): a semi-circle red/orange/green safety dial matching the brand style guide's gauge widget, wired into the herb profile's Safety & Cautions section, driven by the existing safety-sensitivity classification (low → ~90%, moderate → ~60%, high → ~28%)
- **`ShowMeTheStudies` rewritten**: was a fully-collapsed `<details>` accordion hiding all citations by default; now renders an always-visible "Clinical Study Summaries" table (Study / Type / Sample / Source columns), matching the reference mockup's clinical evidence table, with anything past 6 rows tucked behind a "show more" disclosure. Shared by both herb and compound profile pages — verified both still render correctly.
- **Homepage visual weight**: thicker borders (`border-2`), deeper shadows (`shadow-md`/`shadow-lg`), a larger CTA button, bigger section headings, and bigger icon badges on the goal cards

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes
- [x] `npm run test` — 293/293 tests pass
- [x] `npm run check` — passes
- [x] Verified visually with a local dev build: the safety gauge renders correctly and needle position matches the score, the studies table displays real citation data, homepage cards read with more visual weight, and `/compounds/5-htp/` (which shares `ShowMeTheStudies`) still renders (200) after the rewrite


---
_Generated by [Claude Code](https://claude.ai/code/session_01EfTJURKd1XMnBxVQvDbTaB)_