### PR TITLE
Design refresh: Botanical Research Lab

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -13,18 +13,18 @@ differences are expected beyond Tailwind v4's generated CSS ordering.
   --font-display: var(--font-fraunces), Fraunces, ui-serif, Georgia;
   --font-mono: "JetBrains Mono", monospace;
 
-  --color-brand-50: #f3f5ee;
-  --color-brand-100: #e4eadc;
-  --color-brand-200: #cbd8c0;
-  --color-brand-300: #a7ba98;
-  --color-brand-400: #78956b;
-  --color-brand-500: #536f49;
-  --color-brand-600: #3f5c3c;
-  --color-brand-700: #314b33;
-  --color-brand-800: #243d2b;
-  --color-brand-900: #182f22;
-  --color-brand-950: #0b1d14;
-  --color-brand: #243d2b;
+  --color-brand-50: #eef5ef;
+  --color-brand-100: #d4e7d7;
+  --color-brand-200: #aed0b3;
+  --color-brand-300: #82b48b;
+  --color-brand-400: #5c9866;
+  --color-brand-500: #3f7c4a;
+  --color-brand-600: #2d6338;
+  --color-brand-700: #1f4d29;
+  --color-brand-800: #153a1f;
+  --color-brand-900: #0e2917;
+  --color-brand-950: #071a0e;
+  --color-brand: #153a1f;
 
   --color-sage-50: #f4f7f1;
   --color-sage-100: #e7eee0;
@@ -60,10 +60,10 @@ differences are expected beyond Tailwind v4's generated CSS ordering.
   --color-safety-avoid: #b91c1c;
   --color-safety-ok: #2f5f3a;
 
-  --color-background: #fffdf7;
-  --color-surface: #fbf6e9;
-  --color-ink: #111a16;
-  --color-muted: #4f5b56;
+  --color-background: #ffffff;
+  --color-surface: #f4f7f2;
+  --color-ink: #0d1712;
+  --color-muted: #47544d;
 
   --shadow-card: 0 18px 45px rgba(16, 32, 24, 0.08);
   --shadow-soft: 0 24px 70px rgba(16, 32, 24, 0.12);
@@ -85,16 +85,16 @@ differences are expected beyond Tailwind v4's generated CSS ordering.
   --font-fraunces: "Fraunces Variable", Fraunces, "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Palatino, "Times New Roman", serif;
   
   /* HSL-tailored colors */
-  --bg-h: 45;
-  --bg-s: 100%;
-  --bg-l: 98.4%;
-  --bg: hsl(var(--bg-h), var(--bg-s), var(--bg-l)); /* #fffdf7 */
+  --bg-h: 120;
+  --bg-s: 8%;
+  --bg-l: 98%;
+  --bg: hsl(var(--bg-h), var(--bg-s), var(--bg-l)); /* #f4f7f2 */
   
-  --surface-h: 42;
-  --surface-s: 53%;
-  --surface-l: 95.1%;
-  --surface: hsl(var(--surface-h), var(--surface-s), var(--surface-l)); /* #fbf6e9 */
-  --surface-elevated: rgba(255, 255, 255, 0.72);
+  --surface-h: 115;
+  --surface-s: 10%;
+  --surface-l: 96%;
+  --surface: hsl(var(--surface-h), var(--surface-s), var(--surface-l)); /* #f0f4ee */
+  --surface-elevated: #ffffff;
   
   --text-primary-h: 150;
   --text-primary-s: 21%;
@@ -125,9 +125,9 @@ differences are expected beyond Tailwind v4's generated CSS ordering.
   --surface-info: rgba(239, 246, 255, 0.82);
   --surface-neutral: rgba(248, 250, 252, 0.86);
   --ring-brand: rgba(49, 75, 51, 0.32);
-  --accent-primary: #314b33;
-  --accent-secondary: #6d5bd0;
-  --accent-teal: #536f49;
+  --accent-primary: #1a3b2e;
+  --accent-secondary: #5c4db8;
+  --accent-teal: #3d5a38;
   --accent-warning: #b45309;
   --accent-danger: #b91c1c;
   --bg-c: var(--bg);
@@ -135,12 +135,12 @@ differences are expected beyond Tailwind v4's generated CSS ordering.
   --text-c: var(--text-primary);
   --border-c: var(--border-soft);
   --radius-lg: var(--radius-card-premium);
-  --radius-card-premium: 0.9rem;
-  --radius-card-compact: 0.75rem;
-  --shadow-card-calm: 0 1px 3px rgba(16, 32, 24, 0.045);
-  --shadow-card-calm-hover: 0 4px 12px rgba(16, 32, 24, 0.06);
-  --shadow-button-primary: 0 4px 12px rgba(11, 29, 20, 0.14);
-  --shadow-button-secondary: 0 1px 3px rgba(16, 32, 24, 0.04);
+  --radius-card-premium: 0.75rem;
+  --radius-card-compact: 0.625rem;
+  --shadow-card-calm: 0 1px 2px rgba(13, 23, 18, 0.06);
+  --shadow-card-calm-hover: 0 4px 16px rgba(13, 23, 18, 0.10);
+  --shadow-button-primary: 0 2px 8px rgba(13, 23, 18, 0.18);
+  --shadow-button-secondary: 0 1px 2px rgba(13, 23, 18, 0.06);
 }
 
 /* Class-based dark mode variant for Tailwind v4 */
@@ -155,73 +155,62 @@ html {
 
 /* Dark mode variable overrides — applied when <html class="dark"> is set by DarkModeProvider */
 html.dark {
-  --color-background: #0f2419;
-  --color-surface: #1a3028;
-  --color-ink: #f5f0e6;
-  --color-muted: #c2d0c6;
-  --color-brand-50: #111f17;
-  --color-brand-100: #182a1f;
-  --color-brand-200: #24382b;
-  --color-brand-300: #314b37;
-  --color-brand-400: #4f6b55;
-  --color-brand-500: #6f8a73;
-  --color-brand-600: #8da892;
-  --color-brand-700: #a8bda9;
-  --color-brand-800: #c7d5c5;
-  --color-brand-900: #e0eadc;
-  --color-brand-950: #f2f6ee;
-  --bg: #0f2419;
-  --surface: #1a3028;
-  --surface-elevated: #243d32;
-  --text-primary: #f5f0e6;
-  --text-secondary: #e0dcd2;
-  --text-muted: #c2d0c6;
-  --border-soft: rgba(180, 210, 190, 0.18);
-  --border-strong: rgba(180, 210, 190, 0.30);
+  --color-background: #0d1712;
+  --color-surface: #14261d;
+  --color-ink: #f2efe5;
+  --color-muted: #b0bfb5;
+  --color-brand-50: #0e1f16;
+  --color-brand-100: #152b1f;
+  --color-brand-200: #1d3a2a;
+  --color-brand-300: #264d37;
+  --color-brand-400: #3d6b4d;
+  --color-brand-500: #5a8a65;
+  --color-brand-600: #78a380;
+  --color-brand-700: #95b99a;
+  --color-brand-800: #b5ceb8;
+  --color-brand-900: #d4e4d5;
+  --color-brand-950: #ecf3ec;
+  --bg: #0d1712;
+  --surface: #14261d;
+  --surface-elevated: #1a3028;
+  --text-primary: #f2efe5;
+  --text-secondary: #d8d5ca;
+  --text-muted: #b0bfb5;
+  --border-soft: rgba(180, 210, 190, 0.16);
+  --border-strong: rgba(180, 210, 190, 0.26);
   --border-default: var(--border-soft);
-  --surface-card: rgba(36, 61, 50, 0.97);
-  --surface-card-strong: rgba(42, 69, 56, 0.99);
+  --surface-card: rgba(26, 48, 40, 0.95);
+  --surface-card-strong: rgba(30, 55, 45, 0.98);
   --surface-1: var(--surface);
   --surface-2: var(--surface-card);
-  --surface-subtle: rgba(36, 61, 50, 0.55);
-  --surface-code: rgba(26, 48, 40, 0.90);
-  --surface-warning: rgba(61, 42, 20, 0.92);
-  --surface-danger: rgba(58, 22, 28, 0.88);
-  --surface-info: rgba(18, 38, 64, 0.88);
-  --surface-neutral: rgba(37, 47, 42, 0.9);
-  --ring-brand: rgba(168, 189, 169, 0.38);
-  --accent-primary: #c47d2e;
-  --accent-secondary: #b8aecf;
-  --accent-teal: #8da892;
+  --surface-subtle: rgba(26, 48, 40, 0.55);
+  --surface-code: rgba(20, 38, 29, 0.90);
+  --surface-warning: rgba(45, 32, 16, 0.92);
+  --surface-danger: rgba(48, 18, 24, 0.88);
+  --surface-info: rgba(14, 30, 52, 0.88);
+  --surface-neutral: rgba(30, 42, 36, 0.9);
+  --ring-brand: rgba(149, 185, 154, 0.32);
+  --accent-primary: #78a380;
+  --accent-secondary: #a89dcc;
+  --accent-teal: #5a8a65;
   --accent-warning: #c47d2e;
-  --accent-danger: #fca5a5;
+  --accent-danger: #f5a5a5;
   --bg-c: var(--bg);
   --surface-c: var(--surface-card);
   --text-c: var(--text-primary);
   --border-c: var(--border-soft);
-  --shadow-card-calm: 0 1px 3px rgba(0, 0, 0, 0.22);
-  --shadow-card-calm-hover: 0 8px 22px rgba(0, 0, 0, 0.24);
+  --shadow-card-calm: 0 1px 2px rgba(0, 0, 0, 0.24);
+  --shadow-card-calm-hover: 0 8px 24px rgba(0, 0, 0, 0.28);
   color-scheme: dark;
 }
 
 html.dark body {
-  background:
-    radial-gradient(ellipse at 80% 0%, rgba(196, 125, 46, 0.07), transparent 45%),
-    radial-gradient(ellipse at 10% 60%, rgba(36, 61, 50, 0.6), transparent 50%),
-    linear-gradient(180deg, #0f2419 0%, #0c1e13 100%);
-}
-
-html.dark .hero-shell {
-  background: var(--surface-card-strong);
+  background: #0d1712;
 }
 
 body {
   min-height: 100vh;
-  background:
-    radial-gradient(circle at 10% 20%, rgba(83, 111, 73, 0.08), transparent 45%),
-    radial-gradient(circle at 90% 10%, rgba(96, 116, 126, 0.07), transparent 40%),
-    radial-gradient(circle at 50% 80%, rgba(192, 138, 53, 0.06), transparent 50%),
-    linear-gradient(180deg, #fffdf7 0%, #fbf6e9 100%);
+  background: #ffffff;
   color: var(--text-primary);
   font-family: var(--font-inter), Inter, system-ui, sans-serif;
   font-feature-settings: 'kern' 1, 'liga' 1, 'calt' 1;
@@ -396,23 +385,20 @@ html.dark ::selection {
   }
 
   .card-premium {
-    border: 1px solid var(--border-soft);
-    background-color: var(--surface-card);
-    @apply backdrop-blur-xl transition-all duration-300;
+    background-color: #ffffff;
+    @apply transition-all duration-300;
     border-radius: var(--radius-card-premium);
     box-shadow: var(--shadow-card-calm);
   }
 
   .card-premium:hover {
-    border-color: var(--border-strong);
     box-shadow: var(--shadow-card-calm-hover);
   }
 
   .hero-shell {
     background:
-      radial-gradient(circle at 12% 8%, rgba(83, 111, 73, .12), transparent 30%),
-      radial-gradient(circle at 88% 12%, rgba(192, 138, 53, .10), transparent 24%),
-      linear-gradient(180deg, rgba(255,255,255,.84), rgba(251,246,233,.9));
+      linear-gradient(180deg, #ffffff, #f4f7f2);
+    border: 1px solid rgba(13, 23, 18, 0.06);
   }
 
   .section-spacing {
@@ -499,9 +485,8 @@ html.dark ::selection {
   }
 
   .section-frame {
-    border: 1px solid var(--border-soft);
-    background-color: var(--surface-card);
-    @apply p-4 backdrop-blur sm:p-5;
+    background-color: #ffffff;
+    @apply p-4 sm:p-5;
     border-radius: var(--radius-card-premium);
     box-shadow: var(--shadow-card-calm);
   }
@@ -522,16 +507,13 @@ html.dark ::selection {
   }
 
   .surface-subtle {
-    border: 1px solid var(--border-soft);
     background-color: var(--surface);
-    @apply shadow-sm backdrop-blur-xl;
+    @apply shadow-sm;
     border-radius: var(--radius-card-premium);
   }
 
   .surface-depth {
-    border: 1px solid var(--border-soft);
     background-color: var(--surface-elevated);
-    @apply backdrop-blur-xl;
     border-radius: var(--radius-card-premium);
     box-shadow: var(--shadow-card-calm);
   }
@@ -571,12 +553,12 @@ html.dark ::selection {
   }
 
   .button-primary {
-    @apply inline-flex items-center justify-center rounded-full bg-brand-800 px-4 py-2 text-sm font-semibold text-white transition-colors duration-200 hover:bg-brand-700 hover:text-white focus-visible:text-white;
+    @apply inline-flex items-center justify-center rounded-full bg-brand-700 px-4 py-2 text-sm font-semibold text-white transition-colors duration-200 hover:bg-brand-800 focus-visible:text-white;
     box-shadow: var(--shadow-button-primary);
   }
 
   .button-secondary {
-    @apply inline-flex items-center justify-center rounded-full border border-brand-900/10 bg-white/85 px-4 py-2 text-sm font-semibold text-ink transition-colors duration-200 hover:border-brand-700/20 hover:bg-white hover:text-brand-800;
+    @apply inline-flex items-center justify-center rounded-full border border-brand-200 bg-white px-4 py-2 text-sm font-semibold text-brand-800 transition-colors duration-200 hover:border-brand-300 hover:bg-brand-50;
     box-shadow: var(--shadow-button-secondary);
   }
 }
@@ -613,7 +595,7 @@ html.dark .content-prose blockquote {
   [class~="text-emerald-800"],
   [class~="text-emerald-900"]
 ) {
-  color: #2f5f3a;
+  color: #1f4d29;
 }
 
 :where(
@@ -621,7 +603,7 @@ html.dark .content-prose blockquote {
   [class~="hover:text-emerald-800"]:hover,
   [class~="hover:text-emerald-900"]:hover
 ) {
-  color: #243d2b;
+  color: #153a1f;
 }
 
 :where(
@@ -634,21 +616,21 @@ html.dark .content-prose blockquote {
   [class~="bg-emerald-50/80"],
   [class~="bg-emerald-100"]
 ) {
-  background-color: rgba(243, 245, 238, 0.86);
+  background-color: rgba(238, 245, 239, 0.86);
 }
 
 :where(
   [class~="bg-emerald-300"],
   [class~="bg-emerald-400"]
 ) {
-  background-color: #a8bda9;
+  background-color: #95b99a;
 }
 
 :where(
   [class~="bg-emerald-500"],
   [class~="bg-emerald-600"]
 ) {
-  background-color: #536f49;
+  background-color: #3f7c4a;
 }
 
 :where(
@@ -656,7 +638,7 @@ html.dark .content-prose blockquote {
   [class~="hover:bg-emerald-100"]:hover,
   [class~="hover:bg-emerald-200"]:hover
 ) {
-  background-color: #cbd8c0;
+  background-color: #aed0b3;
 }
 
 :where(
@@ -852,7 +834,7 @@ html.dark :is(
   [class~="text-brand-800"],
   [class~="text-brand-850"]
 ) {
-  color: #a8bda9;
+  color: #95b99a;
 }
 
 html.dark :is(
@@ -861,7 +843,7 @@ html.dark :is(
   [class~="hover:text-brand-800"]:hover,
   [class~="hover:text-ink"]:hover
 ) {
-  color: #c7d5c5;
+  color: #b5ceb8;
 }
 
 html.dark .content-prose blockquote {
@@ -947,34 +929,21 @@ html.dark :is(.button-secondary) {
 }
 
 html.dark :is(.button-primary) {
-  background-color: #8fa88e;
-  color: #030e06;
+  background-color: #78a380;
+  color: #07150c;
   box-shadow: 0 2px 10px rgba(0,0,0,0.30);
 }
 
-html.dark :is([class~="bg-brand-700"], [class~="bg-brand-800"], [class~="bg-brand-950"]) {
-  background-color: #a8bda9;
-  color: #07150c;
-}
-
 html.dark :is(
-  .btn-primary,
-  .btn-secondary,
-  .ds-card,
-  .ds-card-lg,
-  .ds-pill
+  [class~="bg-brand-700"], [class~="bg-brand-800"], [class~="bg-brand-950"]
 ) {
-  border-color: var(--border-soft);
+  background-color: #95b99a;
+  color: #07150c;
 }
 
 html.dark :is(.btn-primary) {
-  background-color: #a8bda9;
+  background-color: #95b99a;
   color: #07150c;
-}
-
-html.dark :is(.btn-secondary, .ds-card, .ds-card-lg, .ds-pill) {
-  background-color: var(--surface-card);
-  color: var(--text-primary);
 }
 
 html.dark input::placeholder,
@@ -1057,7 +1026,7 @@ html.dark :is(
 
 @layer components {
   .scientific-card {
-    @apply block border border-brand-900/10 bg-white/80 p-4 backdrop-blur transition-all duration-200 hover:border-brand-900/15 hover:bg-white;
+    @apply block bg-white p-4 transition-all duration-200 hover:bg-brand-50/50;
     border-radius: var(--radius-card-compact);
     box-shadow: var(--shadow-card-calm);
   }
@@ -1079,27 +1048,23 @@ html.dark :is(
   }
 
   .identity-herb {
-    @apply border-emerald-800/15;
-    background: linear-gradient(180deg, rgba(255,255,255,.86), rgba(236,253,245,.42));
+    background: linear-gradient(180deg, #ffffff, #f0f7f2);
   }
 
   .identity-compound {
-    @apply border-blue-800/15;
-    background: linear-gradient(180deg, rgba(255,255,255,.86), rgba(239,246,255,.48));
+    background: linear-gradient(180deg, #ffffff, #f2f5fc);
   }
 
   .identity-article {
-    @apply border-amber-800/15;
-    background: linear-gradient(180deg, rgba(255,255,255,.88), rgba(254,243,199,.42));
+    background: linear-gradient(180deg, #ffffff, #fcfaf2);
   }
 
   .identity-path {
-    @apply border-purple-800/15;
-    background: linear-gradient(180deg, rgba(255,255,255,.86), rgba(250,245,255,.46));
+    background: linear-gradient(180deg, #ffffff, #f7f4fc);
   }
 
   .identity-kicker {
-    @apply rounded-full border border-brand-900/10 bg-white/75 px-3 py-1 text-[0.78rem] font-semibold tracking-[0.03em] text-brand-800;
+    @apply rounded-full border border-brand-200 bg-brand-50 px-3 py-1 text-[0.78rem] font-semibold tracking-[0.02em] text-brand-700;
   }
 
   .identity-meta {

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -51,8 +51,8 @@ export function Navigation() {
 
   return (
     <nav
-      className={`sticky top-0 z-50 border-b border-brand-900/10 transition-all dark:border-[var(--border-strong)] ${
-        scrolled ? 'bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/80 dark:bg-[var(--surface-card-strong)] dark:supports-[backdrop-filter]:bg-[var(--surface-card-strong)]' : 'bg-[#fffdf7]/95 dark:bg-[var(--surface)]'
+      className={`sticky top-0 z-50 border-b border-black/5 transition-all dark:border-[var(--border-strong)] ${
+        scrolled ? 'bg-white shadow-sm dark:bg-[var(--surface-card-strong)]' : 'bg-white dark:bg-[var(--surface-card)]'
       }`}
       aria-label="Primary"
     >

--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -10,62 +10,63 @@ const heroGoals = [
     title: 'Sleep',
     icon: Moon,
     prompt: 'Fall asleep, stay asleep, and compare sleep supplements without guessing.',
-    bg: 'bg-[#dceef8] border-[#a8c8e0]',
     accent: 'text-[#1a3d5c]',
+    ring: 'ring-[#a8c8e0]/40',
+    bgHover: 'hover:bg-[#f0f6fa]',
   },
   {
     slug: 'stress',
     title: 'Stress',
     icon: Leaf,
     prompt: 'Sort adaptogens and calming supports by fatigue pattern, timing, and safety.',
-    bg: 'bg-[#ddf0df] border-[#8dc49a]',
     accent: 'text-[#1e4a2c]',
+    ring: 'ring-[#8dc49a]/40',
+    bgHover: 'hover:bg-[#f0f7f1]',
   },
   {
     slug: 'anxiety',
     title: 'Anxiety',
     icon: Cloud,
     prompt: 'Find grounded options for calm, overthinking, and daytime tension.',
-    bg: 'bg-[#ebe2f8] border-[#c4aadf]',
     accent: 'text-[#4a2d6e]',
+    ring: 'ring-[#c4aadf]/40',
+    bgHover: 'hover:bg-[#f5f1fa]',
   },
   {
     slug: 'focus',
     title: 'Focus',
     icon: Zap,
     prompt: 'Compare non-stimulant focus supports and caffeine-adjacent options.',
-    bg: 'bg-[#f9ecce] border-[#d4aa62]',
     accent: 'text-[#5c3f0e]',
+    ring: 'ring-[#d4aa62]/40',
+    bgHover: 'hover:bg-[#faf6ed]',
   },
 ]
 
 const CATEGORY_TAG_COLORS: Record<string, string> = {
-  'metabolic health': 'border-stone-400/30 bg-stone-200/70 text-stone-800 dark:bg-stone-300/10 dark:text-stone-100',
-  'cognitive health': 'border-emerald-600/25 bg-emerald-100/70 text-emerald-900 dark:bg-emerald-300/10 dark:text-emerald-100',
-  'anxiety & sleep': 'border-violet-600/25 bg-violet-100/70 text-violet-900 dark:bg-violet-300/10 dark:text-violet-100',
-  general: 'border-amber-600/25 bg-amber-100/70 text-amber-900 dark:bg-amber-300/10 dark:text-amber-100',
+  'metabolic health': 'border-stone-300 bg-stone-100 text-stone-700 dark:bg-stone-800/30 dark:text-stone-200 dark:border-stone-700',
+  'cognitive health': 'border-emerald-300 bg-emerald-100 text-emerald-800 dark:bg-emerald-800/20 dark:text-emerald-200 dark:border-emerald-700',
+  'anxiety & sleep': 'border-violet-300 bg-violet-100 text-violet-800 dark:bg-violet-800/20 dark:text-violet-200 dark:border-violet-700',
+  general: 'border-amber-300 bg-amber-100 text-amber-800 dark:bg-amber-800/20 dark:text-amber-200 dark:border-amber-700',
 }
 
 function categoryTagClass(category: string): string {
   return (
     CATEGORY_TAG_COLORS[category.toLowerCase()] ||
-    'border-brand-900/10 bg-brand-50 text-brand-700 dark:bg-[var(--surface-subtle)] dark:text-[var(--text-secondary)]'
+    'border-brand-200 bg-brand-50 text-brand-700 dark:bg-[var(--surface-subtle)] dark:text-[var(--text-secondary)]'
   )
 }
 
-const trustSignals = [
+const trustItems = [
   {
-    n: '01',
     label: 'Evidence tiered, not flattened',
     body: 'Clinical evidence is separated from mechanism-only claims so you know what actually has human trial data.',
   },
   {
-    n: '02',
     label: 'Safety before recommendations',
     body: 'Interactions, contraindications, and uncertainty are surfaced before any product comparison.',
   },
   {
-    n: '03',
     label: 'Methodology is public',
     body: 'Every guide links to the evidence grading system so you can audit the claims yourself.',
   },
@@ -98,7 +99,7 @@ const toolLinks = [
 
 function SectionHeader({ title, subtitle, as: HeadingTag = 'h2' }: SectionHeaderProps) {
   return (
-    <div className='max-w-3xl space-y-2'>
+    <div className='max-w-3xl space-y-1.5'>
       <HeadingTag className='font-display text-2xl font-bold tracking-tight text-ink sm:text-3xl'>{title}</HeadingTag>
       {subtitle ? <p className='text-sm leading-6 text-muted sm:text-base'>{subtitle}</p> : null}
     </div>
@@ -113,24 +114,24 @@ export default function HomepageV2() {
     .slice(0, 6)
 
   return (
-    <div className='overflow-x-clip bg-[var(--bg)]'>
-      <div className='mx-auto max-w-6xl space-y-8 px-4 pb-12 pt-4 sm:px-6 sm:space-y-10 sm:pb-16 sm:pt-6 lg:px-8'>
+    <div className='overflow-x-clip bg-white'>
+      <div className='mx-auto max-w-6xl space-y-10 px-4 pb-12 pt-4 sm:px-6 sm:space-y-12 sm:pb-16 sm:pt-6 lg:px-8'>
 
         {/* ── Hero ─────────────────────────────────────────────── */}
-        <section className='relative px-6 py-8 sm:px-10 sm:py-12'>
+        <section className='relative px-4 py-10 sm:px-8 sm:py-14'>
           <div className='relative mx-auto max-w-4xl'>
             <div className='flex flex-col items-center text-center'>
               <h1 className='font-display text-[2.75rem] font-bold leading-[1.02] tracking-[-0.02em] text-ink break-words sm:text-5xl md:text-[3.75rem]'>
                 Herbs & supplements,<br />actually explained.
               </h1>
-              <p className='mt-5 max-w-2xl text-sm font-medium leading-7 text-muted sm:text-base sm:leading-8'>
+              <p className='mt-5 max-w-2xl text-base leading-7 text-muted sm:text-lg sm:leading-8'>
                 Evidence-based guides for sleep, stress, anxiety, and focus. 816 peer-reviewed studies, 557 compounds, zero marketing fluff.
               </p>
 
               <div className='mt-8 flex w-full max-w-sm flex-col'>
                 <Link
                   href='#choose-a-path'
-                  className='rounded-full bg-brand-800 px-8 py-4 text-base font-bold text-white shadow-[0_6px_20px_rgba(11,29,20,0.3)] transition-all duration-200 motion-safe:hover:-translate-y-0.5 hover:bg-brand-700 hover:shadow-[0_10px_26px_rgba(11,29,20,0.35)] active:translate-y-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2 text-center'
+                  className='rounded-full bg-brand-700 px-8 py-4 text-base font-bold text-white shadow-[0_4px_16px_rgba(13,23,18,0.18)] transition-all duration-200 hover:-translate-y-0.5 hover:bg-brand-800 hover:shadow-[0_8px_24px_rgba(13,23,18,0.24)] active:translate-y-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2 text-center'
                 >
                   Browse by Health Goal
                 </Link>
@@ -141,7 +142,7 @@ export default function HomepageV2() {
 
         {/* Comparisons and tools */}
         <section className='grid gap-4 lg:grid-cols-[1fr_0.9fr]'>
-          <div className='rounded-[1rem] border-2 border-brand-900/12 bg-white/90 p-5 shadow-md sm:p-6 dark:border-[var(--border-strong)] dark:bg-[var(--surface-card)]'>
+          <div className='rounded-xl bg-white p-6 shadow-[0_1px_2px_rgba(13,23,18,0.06)] sm:p-7 dark:bg-[var(--surface-card)]'>
             <SectionHeader
               title='Compare before you choose'
               subtitle='Side-by-side pages help answer the high-intent questions people search before buying or stacking.'
@@ -152,7 +153,7 @@ export default function HomepageV2() {
                 <Link
                   key={comparison.href}
                   href={comparison.href}
-                  className='rounded-[0.75rem] border-2 border-brand-900/12 bg-brand-50/50 px-4 py-3 text-sm font-bold text-brand-800 transition hover:border-brand-700/25 hover:bg-brand-50 dark:bg-[var(--surface-subtle)]'
+                  className='rounded-lg bg-brand-50 px-4 py-3 text-sm font-bold text-brand-800 transition hover:bg-brand-100 dark:bg-[var(--surface-subtle)] dark:hover:bg-[var(--surface-code)]'
                 >
                   {comparison.title} →
                 </Link>
@@ -163,7 +164,7 @@ export default function HomepageV2() {
             </Link>
           </div>
 
-          <div className='rounded-[1rem] border-2 border-brand-900/12 bg-white/90 p-5 shadow-md sm:p-6 dark:border-[var(--border-strong)] dark:bg-[var(--surface-card)]'>
+          <div className='rounded-xl bg-white p-6 shadow-[0_1px_2px_rgba(13,23,18,0.06)] sm:p-7 dark:bg-[var(--surface-card)]'>
             <SectionHeader
               title='Use the safety tools'
               subtitle='The fastest win is avoiding mismatched products, risky stacks, and unclear supplement forms.'
@@ -174,7 +175,7 @@ export default function HomepageV2() {
                 <Link
                   key={tool.href}
                   href={tool.href}
-                  className='block rounded-[0.75rem] border-2 border-brand-900/12 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/25 hover:bg-white dark:bg-[var(--surface-subtle)]'
+                  className='block rounded-lg bg-brand-50/70 p-4 transition hover:bg-brand-100 dark:bg-[var(--surface-subtle)] dark:hover:bg-[var(--surface-code)]'
                 >
                   <h3 className='text-sm font-bold text-ink'>{tool.title}</h3>
                   <p className='mt-1 text-sm leading-6 text-muted'>{tool.description}</p>
@@ -204,19 +205,19 @@ export default function HomepageV2() {
                 <Link
                   key={hGoal.slug}
                   href={hGoal.slug === 'stress' || hGoal.slug === 'anxiety' ? '/guides/anxiety/' : `/guides/${hGoal.slug}/`}
-                  className={`group flex min-h-48 flex-col justify-between rounded-[1.25rem] border-2 ${hGoal.bg} p-5 shadow-md transition-all duration-300 motion-safe:hover:-translate-y-1 hover:shadow-xl dark:border-[var(--border-strong)] dark:bg-[var(--surface-card)]`}
+                  className={`group flex min-h-48 flex-col justify-between rounded-xl bg-white p-5 shadow-[0_1px_2px_rgba(13,23,18,0.06)] transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_8px_24px_rgba(13,23,18,0.12)] dark:bg-[var(--surface-card)]`}
                 >
                   <div>
                     <span
-                      className={`mb-3 inline-flex h-12 w-12 items-center justify-center rounded-full bg-white/80 shadow-sm ${hGoal.accent} dark:bg-[var(--surface-subtle)] dark:text-[var(--text-primary)]`}
+                      className={`mb-3 inline-flex h-12 w-12 items-center justify-center rounded-full bg-white ${hGoal.ring} ring-1 dark:bg-[var(--surface-subtle)] dark:text-[var(--text-primary)]`}
                       aria-hidden='true'
                     >
-                      <Icon className='h-6 w-6' strokeWidth={1.75} />
+                      <Icon className={`h-6 w-6 ${hGoal.accent}`} strokeWidth={1.75} />
                     </span>
                     <h3 className={`text-2xl font-bold tracking-tight ${hGoal.accent} dark:text-[var(--text-primary)]`}>
                       {hGoal.title}
                     </h3>
-                    <p className='mt-3 text-sm font-medium leading-6 text-prose-soft dark:text-[var(--text-secondary)]'>{hGoal.prompt}</p>
+                    <p className='mt-3 text-sm leading-6 text-muted dark:text-[var(--text-secondary)]'>{hGoal.prompt}</p>
                   </div>
                   <span className='mt-5 inline-flex text-sm font-bold text-brand-700 transition group-hover:translate-x-1 group-hover:text-brand-800'>
                     Start with {hGoal.title} <span aria-hidden='true' className='ml-1'>→</span>
@@ -245,7 +246,7 @@ export default function HomepageV2() {
                 <Link
                   key={article.slug}
                   href={`/articles/${article.slug}/`}
-                  className='group flex flex-col gap-3 rounded-[1rem] border-2 border-brand-900/12 bg-white/90 p-5 shadow-md transition-all duration-200 hover:border-brand-700/25 hover:shadow-lg dark:border-[var(--border-strong)] dark:bg-[var(--surface-card)]'
+                  className='group flex flex-col gap-3 rounded-xl bg-white p-5 shadow-[0_1px_2px_rgba(13,23,18,0.06)] transition-all duration-200 hover:shadow-[0_8px_24px_rgba(13,23,18,0.12)] dark:bg-[var(--surface-card)]'
                 >
                   <div className='flex items-center gap-2'>
                     {article.category && (
@@ -257,7 +258,7 @@ export default function HomepageV2() {
                       <span className='text-[0.72rem] text-muted'>{article.readingTime}</span>
                     )}
                   </div>
-                  <h3 className='text-base font-semibold leading-snug text-ink group-hover:text-brand-800 dark:group-hover:text-[var(--text-primary)]'>
+                  <h3 className='text-base font-semibold leading-snug text-ink group-hover:text-brand-700 dark:group-hover:text-[var(--text-primary)]'>
                     {article.title}
                   </h3>
                   {article.excerpt && (
@@ -270,26 +271,23 @@ export default function HomepageV2() {
         )}
 
         {/* Trust */}
-        <section className='rounded-[1rem] border-2 border-brand-900/12 bg-white/90 p-5 shadow-md sm:p-6'>
+        <section className='rounded-xl bg-white p-6 shadow-[0_1px_2px_rgba(13,23,18,0.06)] sm:p-8 dark:bg-[var(--surface-card)]'>
           <div className='grid gap-6 lg:grid-cols-[0.9fr_1.1fr] lg:items-start'>
             <SectionHeader
               title='Why trust the guide?'
               subtitle='The site is built for cautious decisions: what has human evidence, what is only plausible, and what needs safety review before use.'
               as='h2'
             />
-            <div className='grid gap-3 sm:grid-cols-3'>
-              {trustSignals.map((signal) => (
-                <div key={signal.n} className='flex gap-4 rounded-[0.85rem] border-2 border-brand-900/12 bg-white/70 p-4 shadow-sm dark:bg-[var(--surface-card)] dark:text-[var(--text-secondary)]'>
-                  <span className='mt-0.5 shrink-0 font-mono text-xs font-bold tracking-widest text-brand-400'>{signal.n}</span>
-                  <div>
-                    <p className='text-sm font-semibold text-ink'>{signal.label}</p>
-                    <p className='mt-1 text-sm leading-6 text-muted'>{signal.body}</p>
-                  </div>
+            <div className='grid gap-4 sm:grid-cols-3'>
+              {trustItems.map((item) => (
+                <div key={item.label} className='dark:text-[var(--text-secondary)]'>
+                  <p className='text-sm font-semibold text-ink'>{item.label}</p>
+                  <p className='mt-1.5 text-sm leading-6 text-muted'>{item.body}</p>
                 </div>
               ))}
             </div>
           </div>
-          <div className='mt-5 text-sm font-bold'>
+          <div className='mt-6 text-sm font-bold'>
             <Link href='/info/methodology/' className='text-brand-700 transition hover:text-brand-800'>
               Read the evidence methodology →
             </Link>

--- a/styles/premium-surface-details.css
+++ b/styles/premium-surface-details.css
@@ -30,18 +30,15 @@ html.dark {
 header nav,
 header [role='navigation'] {
   border-color: var(--surface-detail-border) !important;
-  background:
-    linear-gradient(180deg, rgba(255, 253, 247, 0.82), rgba(255, 253, 247, 0.64)) !important;
-  box-shadow: 0 10px 34px rgba(16, 32, 24, 0.075);
-  backdrop-filter: blur(18px) saturate(1.08);
-  -webkit-backdrop-filter: blur(18px) saturate(1.08);
+  background: #ffffff !important;
+  box-shadow: 0 1px 3px rgba(13, 23, 18, 0.06);
 }
 
 html.dark header nav,
 html.dark header [role='navigation'] {
   background:
-    linear-gradient(180deg, rgba(21, 42, 31, 0.88), rgba(13, 29, 20, 0.78)) !important;
-  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.28);
+    linear-gradient(180deg, rgba(20, 38, 29, 0.96), rgba(13, 23, 18, 0.94)) !important;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.24);
 }
 
 header nav a,

--- a/styles/resonant-theme-lighting.css
+++ b/styles/resonant-theme-lighting.css
@@ -29,21 +29,11 @@ html.dark {
 }
 
 body {
-  background:
-    radial-gradient(circle at 12% 7%, var(--resonance-emerald), transparent 34rem),
-    radial-gradient(circle at 88% 10%, var(--resonance-gold), transparent 30rem),
-    radial-gradient(circle at 55% 45%, var(--resonance-violet), transparent 36rem),
-    radial-gradient(circle at 18% 84%, var(--resonance-rose), transparent 28rem),
-    linear-gradient(180deg, #fffdf7 0%, #fbf6e9 44%, #f6efe0 100%);
+  background: #ffffff;
 }
 
 html.dark body {
-  background:
-    radial-gradient(circle at 15% 6%, rgba(142, 186, 143, 0.13), transparent 32rem),
-    radial-gradient(circle at 88% 12%, rgba(196, 125, 46, 0.14), transparent 32rem),
-    radial-gradient(circle at 54% 42%, rgba(184, 174, 207, 0.10), transparent 34rem),
-    radial-gradient(circle at 18% 84%, rgba(252, 165, 165, 0.055), transparent 28rem),
-    linear-gradient(180deg, #0f2419 0%, #0b1b12 52%, #08150f 100%);
+  background: #0d1712;
 }
 
 .hero-shell,
@@ -61,18 +51,12 @@ html.dark body {
 .hero-shell {
   overflow: hidden;
   background:
-    radial-gradient(circle at 7% 0%, var(--resonance-emerald-strong), transparent 34%),
-    radial-gradient(circle at 93% 6%, var(--resonance-gold), transparent 28%),
-    radial-gradient(circle at 54% 112%, var(--resonance-violet), transparent 34%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(251, 246, 233, 0.88));
+    linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(244, 247, 242, 0.88));
 }
 
 html.dark .hero-shell {
   background:
-    radial-gradient(circle at 7% 0%, rgba(142, 186, 143, 0.14), transparent 34%),
-    radial-gradient(circle at 93% 6%, rgba(196, 125, 46, 0.16), transparent 30%),
-    radial-gradient(circle at 54% 112%, rgba(184, 174, 207, 0.12), transparent 34%),
-    linear-gradient(180deg, rgba(39, 66, 52, 0.96), rgba(23, 42, 31, 0.94));
+    linear-gradient(180deg, rgba(26, 48, 40, 0.96), rgba(20, 38, 29, 0.94));
 }
 
 .hero-shell::before {
@@ -102,8 +86,7 @@ html.dark .hero-shell::before {
 .scientific-card,
 .library-card-premium {
   background:
-    radial-gradient(circle at 100% 0%, rgba(255, 255, 255, 0.38), transparent 12rem),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(251, 246, 233, 0.78));
+    linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(244, 247, 242, 0.82));
 }
 
 html.dark .card-premium,
@@ -113,8 +96,7 @@ html.dark .section-frame,
 html.dark .scientific-card,
 html.dark .library-card-premium {
   background:
-    radial-gradient(circle at 100% 0%, rgba(255, 255, 255, 0.055), transparent 12rem),
-    linear-gradient(180deg, rgba(36, 61, 50, 0.94), rgba(23, 42, 31, 0.9));
+    linear-gradient(180deg, rgba(26, 48, 40, 0.94), rgba(20, 38, 29, 0.9));
 }
 
 .card-premium:hover,


### PR DESCRIPTION
## What changed

Complete visual foundation refresh moving from beige/cream to a clean white botanical lab aesthetic.

### Palette
- **Background**: `#fffdf7` (cream) → `#ffffff` (white)
- **Brand green**: olive/sage → deeper forest green (`#153a1f`)
- **Dark mode**: rebalanced for new palette consistency

### Anti-slop fixes
- Cards: shadow **only** — removed the border+shadow combo pattern
- Removed numbered markers (`01`, `02`, `03`) from trust section
- Simplified hero to clean white background (no radial gradients)
- Navigation: clean white, minimal shadow (no backdrop blur)

### Files changed
- `app/globals.css` — new color system, simplified card classes
- `components/homepage-v2.tsx` — cleaner layout, no numbered markers
- `components/Navigation.tsx` — white background, lighter shadow
- `styles/resonant-theme-lighting.css` — adapted for white base
- `styles/premium-surface-details.css` — adapted nav for white base

### Remaining
A few `#fffdf7` references remain in edge components (`opengraph-image.tsx`, `SearchClient.tsx`, `AdhdMonetizationWidgets.tsx`) — can be cleaned in a follow-up.