### PR TITLE
Revenue: sticky CTA on comparison pages + missing product recs

### DIFF
--- a/app/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium/page.tsx
+++ b/app/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium/page.tsx
@@ -17,6 +17,7 @@ import FAQSchema from '@/components/seo/FAQSchema'
 import { RelatedDiscoveryWidget } from '@/components/monetization/RelatedDiscoveryWidget'
 import RecommendationSection from '@/components/RecommendationSection'
 import { getRevenueProductSet } from '@/config/revenue-products'
+import ConversionStickyCTA from '@/components/conversion-sticky-cta'
 
 export default function AshwagandhaVsLTheanineVsMagnesiumPage() {
   const revenueProducts = ['ashwagandha', 'l-theanine', 'magnesium']
@@ -331,6 +332,12 @@ export default function AshwagandhaVsLTheanineVsMagnesiumPage() {
             href: '/guides/anxiety',
           },
         ]}
+      />
+
+      <ConversionStickyCTA
+        brand={revenueProducts[0]?.brand}
+        name={revenueProducts[0]?.title}
+        href={revenueProducts[0]?.affiliateUrl || '#'}
       />
 
       <div className="space-y-3">

--- a/app/guides/compare/berberine-vs-metformin/page.tsx
+++ b/app/guides/compare/berberine-vs-metformin/page.tsx
@@ -17,6 +17,7 @@ import FAQSchema from '@/components/seo/FAQSchema'
 import { RelatedDiscoveryWidget } from '@/components/monetization/RelatedDiscoveryWidget'
 import RecommendationSection from '@/components/RecommendationSection'
 import { getRevenueProductSet } from '@/config/revenue-products'
+import ConversionStickyCTA from '@/components/conversion-sticky-cta'
 
 export default function BerberineVsMetforminPage() {
   const berberineProducts = getRevenueProductSet('berberine')?.products ?? []
@@ -503,6 +504,11 @@ export default function BerberineVsMetforminPage() {
         <Link href="/guides/best/supplements-for-fat-loss" className="chip-readable">Fat Loss Goals</Link>
         <Link href="/guides/compare/" className="chip-readable">All Comparisons</Link>
       </div>
+      <ConversionStickyCTA
+        brand={berberineProducts[0]?.brand}
+        name={berberineProducts[0]?.title}
+        href={berberineProducts[0]?.affiliateUrl || '#'}
+      />
     </div>
   )
 }

--- a/app/guides/compare/caffeine-vs-l-theanine-vs-bacopa-for-focus/page.tsx
+++ b/app/guides/compare/caffeine-vs-l-theanine-vs-bacopa-for-focus/page.tsx
@@ -17,6 +17,7 @@ import FAQSchema from '@/components/seo/FAQSchema'
 import { RelatedDiscoveryWidget } from '@/components/monetization/RelatedDiscoveryWidget'
 import RecommendationSection from '@/components/RecommendationSection'
 import { getRevenueProductSet } from '@/config/revenue-products'
+import ConversionStickyCTA from '@/components/conversion-sticky-cta'
 
 export default function CaffeineVsLTheanineVsBacopaForFocusPage() {
   const revenueProducts = ['caffeine', 'l-theanine', 'bacopa']
@@ -333,6 +334,11 @@ export default function CaffeineVsLTheanineVsBacopaForFocusPage() {
           products={revenueProducts}
         />
       </div>
+      <ConversionStickyCTA
+        brand={revenueProducts[0]?.brand}
+        name={revenueProducts[0]?.title}
+        href={revenueProducts[0]?.affiliateUrl || '#'}
+      />
     </div>
   )
 }

--- a/app/guides/compare/curcumin-vs-boswellia-vs-omega-3/page.tsx
+++ b/app/guides/compare/curcumin-vs-boswellia-vs-omega-3/page.tsx
@@ -17,6 +17,7 @@ import FAQSchema from '@/components/seo/FAQSchema'
 import { RelatedDiscoveryWidget } from '@/components/monetization/RelatedDiscoveryWidget'
 import RecommendationSection from '@/components/RecommendationSection'
 import { getRevenueProductSet } from '@/config/revenue-products'
+import ConversionStickyCTA from '@/components/conversion-sticky-cta'
 
 export default function CurcuminVsBoswelliaVsOmega3Page() {
   const revenueProducts = ['turmeric', 'boswellia', 'omega-3']
@@ -368,6 +369,11 @@ export default function CurcuminVsBoswelliaVsOmega3Page() {
           products={revenueProducts}
         />
       </div>
+      <ConversionStickyCTA
+        brand={revenueProducts[0]?.brand}
+        name={revenueProducts[0]?.title}
+        href={revenueProducts[0]?.affiliateUrl || '#'}
+      />
     </div>
   )
 }

--- a/app/guides/compare/melatonin-vs-magnesium/page.tsx
+++ b/app/guides/compare/melatonin-vs-magnesium/page.tsx
@@ -11,8 +11,17 @@ export const metadata: Metadata = buildPageMetadata({
 import Link from 'next/link'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
+import RecommendationSection from '@/components/RecommendationSection'
+import AffiliateDisclosure from '../../../../components/AffiliateDisclosure'
+import { getRevenueProductSet } from '@/config/revenue-products'
+import ConversionStickyCTA from '@/components/conversion-sticky-cta'
 
 export default function MelatoninVsMagnesiumPage() {
+  const revenueProducts = ['melatonin', 'magnesium']
+    .map((slug) => getRevenueProductSet(slug))
+    .filter((set): set is NonNullable<typeof set> => Boolean(set))
+    .flatMap((set) => set.products)
+
   return (
     <div className="container-page py-10 space-y-10">
       <AuthorityJsonLd
@@ -98,6 +107,18 @@ export default function MelatoninVsMagnesiumPage() {
           </Link>
         </div>
       </section>
+
+      <AffiliateDisclosure />
+      <RecommendationSection
+        title="Melatonin &amp; Magnesium Product Picks"
+        description="Editor-recommended options for clean, third-party tested melatonin and magnesium formulations."
+        products={revenueProducts}
+      />
+      <ConversionStickyCTA
+        brand={revenueProducts[0]?.brand}
+        name={revenueProducts[0]?.title}
+        href={revenueProducts[0]?.affiliateUrl || '#'}
+      />
     </div>
   )
 }

--- a/app/guides/compare/melatonin-vs-valerian-vs-magnesium-for-sleep/page.tsx
+++ b/app/guides/compare/melatonin-vs-valerian-vs-magnesium-for-sleep/page.tsx
@@ -17,6 +17,7 @@ import FAQSchema from '@/components/seo/FAQSchema'
 import { RelatedDiscoveryWidget } from '@/components/monetization/RelatedDiscoveryWidget'
 import RecommendationSection from '@/components/RecommendationSection'
 import { getRevenueProductSet } from '@/config/revenue-products'
+import ConversionStickyCTA from '@/components/conversion-sticky-cta'
 
 export default function MelatoninVsValerianVsMagnesiumForSleepPage() {
   const revenueProducts = ['melatonin', 'valerian', 'magnesium']
@@ -333,6 +334,11 @@ export default function MelatoninVsValerianVsMagnesiumForSleepPage() {
           products={revenueProducts}
         />
       </div>
+      <ConversionStickyCTA
+        brand={revenueProducts[0]?.brand}
+        name={revenueProducts[0]?.title}
+        href={revenueProducts[0]?.affiliateUrl || '#'}
+      />
     </div>
   )
 }

--- a/app/guides/compare/rhodiola-vs-ashwagandha/page.tsx
+++ b/app/guides/compare/rhodiola-vs-ashwagandha/page.tsx
@@ -9,6 +9,7 @@ import { EnhancedEmailCapture } from '@/components/monetization/EnhancedEmailCap
 import { RelatedDiscoveryWidget } from '@/components/monetization/RelatedDiscoveryWidget'
 import RecommendationSection from '@/components/RecommendationSection'
 import { getRevenueProductSet } from '@/config/revenue-products'
+import ConversionStickyCTA from '@/components/conversion-sticky-cta'
 
 export const metadata: Metadata = buildPageMetadata({
   title: 'Rhodiola vs Ashwagandha for Stress & Fatigue',
@@ -122,6 +123,11 @@ export default function RhodiolaVsAshwagandhaComparePage() {
             type: 'comparison',
           },
         ]}
+      />
+      <ConversionStickyCTA
+        brand={revenueProducts[0]?.brand}
+        name={revenueProducts[0]?.title}
+        href={revenueProducts[0]?.affiliateUrl || '#'}
       />
     </div>
   )

--- a/app/guides/compare/sleep-herbs-vs-melatonin/page.tsx
+++ b/app/guides/compare/sleep-herbs-vs-melatonin/page.tsx
@@ -9,6 +9,7 @@ import { EnhancedEmailCapture } from '@/components/monetization/EnhancedEmailCap
 import { RelatedDiscoveryWidget } from '@/components/monetization/RelatedDiscoveryWidget'
 import RecommendationSection from '@/components/RecommendationSection'
 import { getRevenueProductSet } from '@/config/revenue-products'
+import ConversionStickyCTA from '@/components/conversion-sticky-cta'
 import FAQSchema from '@/components/seo/FAQSchema'
 
 export const metadata: Metadata = buildPageMetadata({
@@ -664,6 +665,11 @@ export default function SleepHerbsVsMelatoninComparePage() {
         <Link href="/learn/gaba" className="chip-readable">GABA Pathway</Link>
         <Link href="/guides/compare/" className="chip-readable">All Comparisons</Link>
       </div>
+      <ConversionStickyCTA
+        brand={melatoninProducts[0]?.brand}
+        name={melatoninProducts[0]?.title}
+        href={melatoninProducts[0]?.affiliateUrl || '#'}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Revenue optimization for comparison pages

### Sticky conversion CTA (7 pages)
The `ConversionStickyCTA` component existed in the codebase but was deployed **zero times**. It now appears on all 7 monetized comparison pages after ~22% scroll depth, showing the top product pick with a direct affiliate link.

### Missing product recs fixed (1 page)
`melatonin-vs-magnesium` was the only monetized comparison page without product recommendations. Added melatonin and magnesium product picks with affiliate links.

### Impact
- Comparison pages are the highest-intent pages on the site (users comparing before buying)
- Sticky CTA persists through the reading experience — no need to scroll back to find a buy link
- Top product is always the first visible CTA, reducing decision friction