### PR TITLE
Performance: preconnect hints + image priority fix

### DIFF
--- a/app/guides/sleep/magnesium-vs-melatonin/page.tsx
+++ b/app/guides/sleep/magnesium-vs-melatonin/page.tsx
@@ -146,6 +146,7 @@ export default function MagnesiumVsMelatoninGuidePage() {
                 alt="Decision flowchart for choosing magnesium vs melatonin"
                 width={784}
                 height={1176}
+                priority
                 className="w-full h-auto"
               />
             </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -53,6 +53,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     <html lang='en' suppressHydrationWarning>
       {/* Inline script runs before React hydration to prevent dark mode flash */}
       <head>
+        <link rel="preconnect" href="https://m.media-amazon.com" />
+        <link rel="preconnect" href="https://images-na.ssl-images-amazon.com" />
+        <link rel="dns-prefetch" href="https://www.amazon.com" />
         <script
           dangerouslySetInnerHTML={{
             __html: `(function(){try{var d=document.documentElement;var s=localStorage.getItem('theme');var p=window.matchMedia('(prefers-color-scheme: dark)').matches;var dark=s==='dark'||((s===null||s==='system')&&p);d.classList.toggle('dark',dark);d.dataset.theme=dark?'dark':'light';d.style.colorScheme=dark?'dark':'light';d.classList.add('theme-ready')}catch(e){}})();`,


### PR DESCRIPTION
## Performance optimizations

### Preconnect hints
Added preconnect for Amazon image CDNs (`m.media-amazon.com`, `images-na.ssl-images-amazon.com`) and dns-prefetch for `amazon.com`. Affiliate product images load faster with early connection establishment.

### Image priority
Added `priority` to hero image on `magnesium-vs-melatonin` guide page — improves LCP by telling the browser this above-fold image is critical.

### Already optimized (no changes needed)
- **Cloudflare Image Resizing** — `format=auto` + `quality=80` auto-converts to WebP/AVIF
- **Fonts** — @fontsource bundles Inter + Fraunces locally, no external CDN calls
- **Caching** — assets: 1yr immutable, data: 1h + 24h stale-while-revalidate
- **Security headers** — full CSP, HSTS, COOP/CORP, Referrer-Policy