### PR TITLE
Content: expand thin comparison pages (kava-vs-alcohol, kanna-vs-ssris)

### DIFF
--- a/app/guides/compare/kanna-vs-ssris/page.tsx
+++ b/app/guides/compare/kanna-vs-ssris/page.tsx
@@ -9,6 +9,7 @@ export const metadata: Metadata = buildPageMetadata({
 })
 
 import Link from 'next/link'
+import FAQSchema from '@/components/seo/FAQSchema'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
 import COAList from '../../../../src/components/coa/COAList'
@@ -93,34 +94,82 @@ export default function KannaVsSSRIsPage() {
       <section className="grid gap-6 lg:grid-cols-2">
         <div className="card-premium p-6 space-y-4">
           <p className="eyebrow-label">Ethnobotanical System</p>
-
-          <h2 className="text-3xl font-semibold tracking-tight text-ink">
-            Kanna
-          </h2>
-
+          <h2 className="text-3xl font-semibold tracking-tight text-ink">Kanna</h2>
           <p className="text-sm leading-7 text-muted">
-            Traditionally used psychoactive ethnobotanical associated with emotional regulation, stress modulation, and serotonergic mechanisms.
+            Kanna (Sceletium tortuosum) contains mesembrine and related alkaloids that act as serotonin reuptake inhibitors and PDE4 inhibitors. Traditional South African use includes mood elevation, stress reduction, and social bonding — but the pharmacology is under-studied compared to pharmaceutical antidepressants.
           </p>
-
-          <Link href="/herbs/kanna" className="chip-readable">
-            Explore Kanna
-          </Link>
+          <Link href="/herbs/kanna" className="chip-readable">Explore Kanna</Link>
         </div>
 
         <div className="card-premium p-6 space-y-4">
           <p className="eyebrow-label">Pharmaceutical System</p>
-
-          <h2 className="text-3xl font-semibold tracking-tight text-ink">
-            SSRIs
-          </h2>
-
+          <h2 className="text-3xl font-semibold tracking-tight text-ink">SSRIs</h2>
           <p className="text-sm leading-7 text-muted">
-            Selective serotonin reuptake inhibitors are prescription medications associated with serotonergic modulation and mood-related neuropharmacology.
+            Selective serotonin reuptake inhibitors (fluoxetine, sertraline, escitalopram, etc.) are FDA-approved medications with decades of clinical trial data for depression and anxiety. They work by blocking serotonin transporter (SERT) proteins, gradually increasing synaptic serotonin over weeks.
           </p>
         </div>
       </section>
 
       <COAList entries={exampleCOAEntries} title="COA verification snapshot" />
+
+      {/* Mechanism comparison */}
+      <section className="card-premium p-6 space-y-4 max-w-4xl">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Why the comparison is uneven</h2>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div>
+            <h3 className="font-semibold text-ink">Kanna: Under-studied SRI</h3>
+            <p className="mt-2 text-sm leading-7 text-muted">
+              Kanna's mesembrine alkaloids inhibit serotonin reuptake — but the potency, selectivity, and clinical effect size are not well-characterized in human trials. There is no standardized dosing, no long-term safety data, and significant variability between products (plant part, extraction method, alkaloid content).
+            </p>
+          </div>
+          <div>
+            <h3 className="font-semibold text-ink">SSRIs: Extensively studied</h3>
+            <p className="mt-2 text-sm leading-7 text-muted">
+              SSRIs have been studied in tens of thousands of patients across decades. Their efficacy, side effect profiles, drug interactions, withdrawal syndromes, and contraindications are well-documented. They are prescribed within a medical monitoring framework that includes dose titration and follow-up.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Safety warning */}
+      <section className="rounded-2xl border-2 border-red-400 bg-red-50 p-6 max-w-4xl">
+        <p className="text-sm font-black uppercase tracking-wider text-red-800">Do not combine kanna with SSRIs</p>
+        <p className="mt-3 text-sm leading-7 text-red-900">
+          Kanna has serotonergic activity. Combining it with SSRIs, SNRIs, MAOIs, tramadol, St. John's Wort, or other serotonergic substances increases the risk of serotonin syndrome — a potentially life-threatening condition. Symptoms include agitation, confusion, rapid heart rate, high blood pressure, dilated pupils, muscle rigidity, and hyperthermia. If you take any serotonergic medication, do not use kanna.
+        </p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <Link href="/learn/serotonin" className="rounded-full bg-red-100 px-3 py-1.5 text-xs font-bold text-red-800">Serotonin Pathway</Link>
+          <Link href="/learn/serotonergic-stacking-risks" className="rounded-full bg-red-100 px-3 py-1.5 text-xs font-bold text-red-800">Serotonergic Risks</Link>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <section className="card-premium p-6 space-y-4 max-w-4xl">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Frequently asked questions</h2>
+        <div className="space-y-4 text-sm leading-7 text-muted">
+          <div>
+            <h3 className="text-lg font-semibold text-ink">Can kanna replace an SSRI?</h3>
+            <p>No. Kanna is not a replacement for prescribed antidepressants. SSRIs are titrated under medical supervision with known efficacy and safety data. Kanna has no standardized dosing, no long-term outcome studies, and no regulatory quality control. Changing your depression treatment without medical guidance is dangerous.</p>
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold text-ink">What is serotonin syndrome?</h3>
+            <p>Serotonin syndrome is a potentially life-threatening condition caused by excessive serotonergic activity. It can occur when multiple serotonergic substances are combined. Symptoms range from mild (shivering, diarrhea) to severe (hyperthermia, seizures, death). If you suspect serotonin syndrome, seek emergency medical attention immediately.</p>
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold text-ink">Is kanna safe on its own?</h3>
+            <p>For most healthy adults not taking serotonergic medications, kanna at moderate doses appears to have a reasonable short-term safety profile based on traditional use and limited modern data. However, long-term safety is not established. Side effects may include headache, GI discomfort, and mild sedation. Start low and avoid daily use without breaks.</p>
+          </div>
+        </div>
+      </section>
+
+      <FAQSchema
+        pagePath="/guides/compare/kanna-vs-ssris/"
+        questions={[
+          { question: 'Can kanna replace an SSRI?', answer: 'No. Kanna is not a replacement for prescribed antidepressants. SSRIs are titrated under medical supervision with known efficacy and safety data. Kanna has no standardized dosing, no long-term outcome studies, and no regulatory quality control. Changing your depression treatment without medical guidance is dangerous.' },
+          { question: 'What is serotonin syndrome?', answer: 'Serotonin syndrome is a potentially life-threatening condition caused by excessive serotonergic activity. It can occur when multiple serotonergic substances are combined. Symptoms range from mild (shivering, diarrhea) to severe (hyperthermia, seizures, death). If you suspect serotonin syndrome, seek emergency medical attention immediately.' },
+          { question: 'Is kanna safe on its own?', answer: 'For most healthy adults not taking serotonergic medications, kanna at moderate doses appears to have a reasonable short-term safety profile based on traditional use and limited modern data. However, long-term safety is not established. Side effects may include headache, GI discomfort, and mild sedation.' },
+        ]}
+      />
 
       <section className="surface-subtle rounded-3xl p-6 space-y-5">
         <h2 className="text-2xl font-semibold tracking-tight text-ink">

--- a/app/guides/compare/kava-vs-alcohol/page.tsx
+++ b/app/guides/compare/kava-vs-alcohol/page.tsx
@@ -9,6 +9,7 @@ export const metadata: Metadata = buildPageMetadata({
 })
 
 import Link from 'next/link'
+import FAQSchema from '@/components/seo/FAQSchema'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
 
@@ -62,9 +63,9 @@ export default function KavaVsAlcoholPage() {
         <div className="card-premium p-6 space-y-4">
           <h2 className="text-2xl font-semibold">Kava</h2>
           <p className="text-sm leading-7 text-muted">
-            Traditionally used calming ethnobotanical associated with stress modulation, relaxation, and inhibitory signaling systems.
+            Kava (Piper methysticum) modulates GABA-A receptors via kavalactones, producing relaxation without the cognitive impairment or dependence profile associated with alcohol. Traditional Pacific Island use spans centuries in social and ceremonial contexts.
           </p>
-          <Link href="/compounds/kava" className="chip-readable">
+          <Link href="/herbs/kava" className="chip-readable">
             Explore Kava
           </Link>
         </div>
@@ -72,10 +73,85 @@ export default function KavaVsAlcoholPage() {
         <div className="card-premium p-6 space-y-4">
           <h2 className="text-2xl font-semibold">Alcohol</h2>
           <p className="text-sm leading-7 text-muted">
-            Widely consumed psychoactive substance associated with sedation, disinhibition, impaired cognition, dependence risk, and broad systemic effects.
+            Alcohol is a CNS depressant with broad effects across GABA, glutamate, dopamine, and opioid systems. While socially accepted, it carries well-documented risks including dependence, liver damage, impaired cognition, and increased cancer risk with regular use.
           </p>
         </div>
       </section>
+
+      {/* Mechanism comparison */}
+      <section className="card-premium p-6 space-y-4 max-w-4xl">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">How they work on the brain</h2>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div>
+            <h3 className="font-semibold text-ink">Kava: GABA-A modulation</h3>
+            <p className="mt-2 text-sm leading-7 text-muted">
+              Kavalactones bind to GABA-A receptors at a site distinct from alcohol and benzodiazepines. This produces anxiolysis and muscle relaxation without significant respiratory depression, cognitive fog, or addictive reinforcement. Liver safety depends on cultivar, extraction method, and individual factors.
+            </p>
+          </div>
+          <div>
+            <h3 className="font-semibold text-ink">Alcohol: Broad-spectrum depressant</h3>
+            <p className="mt-2 text-sm leading-7 text-muted">
+              Alcohol enhances GABA-A activity while suppressing glutamate (NMDA) signaling. The dual action produces sedation, disinhibition, and at higher doses, significant cognitive and motor impairment. Chronic use leads to receptor adaptation, tolerance, and withdrawal risk.
+            </p>
+          </div>
+        </div>
+        <div className="mt-4 p-4 rounded-xl bg-amber-50/60 border border-amber-200">
+          <p className="text-sm font-bold text-amber-900">Key safety note</p>
+          <p className="mt-1 text-sm leading-6 text-amber-800">Do not combine kava with alcohol. Both substances affect GABA signaling and overlapping use can amplify sedation, impair liver function, and increase accident risk. If you currently drink alcohol regularly, discuss any change with a clinician before introducing kava.</p>
+        </div>
+      </section>
+
+      {/* Practical comparison */}
+      <section className="card-premium p-6 space-y-4 max-w-4xl">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Practical differences at a glance</h2>
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-sm">
+            <thead>
+              <tr className="border-b">
+                <th className="text-left py-3 pr-4 font-semibold">Factor</th>
+                <th className="text-left py-3 pr-4 font-semibold">Kava</th>
+                <th className="text-left py-3 font-semibold">Alcohol</th>
+              </tr>
+            </thead>
+            <tbody className="text-muted">
+              <tr className="border-b"><td className="py-3 pr-4">Onset</td><td className="py-3 pr-4">15–30 min</td><td className="py-3">10–20 min</td></tr>
+              <tr className="border-b"><td className="py-3 pr-4">Duration</td><td className="py-3 pr-4">2–4 hours</td><td className="py-3">Dose-dependent (1–4+ hours)</td></tr>
+              <tr className="border-b"><td className="py-3 pr-4">Cognitive effects</td><td className="py-3 pr-4">Mild relaxation, mental clarity preserved</td><td className="py-3">Impaired judgment, memory, coordination</td></tr>
+              <tr className="border-b"><td className="py-3 pr-4">Dependence risk</td><td className="py-3 pr-4">Low (no established withdrawal syndrome)</td><td className="py-3">Moderate to high (physical + psychological)</td></tr>
+              <tr className="border-b"><td className="py-3 pr-4">Liver concerns</td><td className="py-3 pr-4">Cultivar-dependent; noble kava safer</td><td className="py-3">Well-established dose-dependent toxicity</td></tr>
+              <tr><td className="py-3 pr-4">Sleep impact</td><td className="py-3 pr-4">May improve sleep quality</td><td className="py-3">Fragments sleep architecture</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <section className="card-premium p-6 space-y-4 max-w-4xl">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Frequently asked questions</h2>
+        <div className="space-y-4 text-sm leading-7 text-muted">
+          <div>
+            <h3 className="text-lg font-semibold text-ink">Is kava a safe alternative to alcohol?</h3>
+            <p>Kava has a different risk profile than alcohol — lower dependence potential, no known carcinogenicity, and preserved cognitive function. However, kava is not risk-free. Liver safety depends on using noble cultivars and avoiding contaminants. It should not be treated as a direct substitute without understanding individual health context.</p>
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold text-ink">Can kava damage your liver?</h3>
+            <p>Historically, cases of liver toxicity were associated with non-noble (tudei) cultivars, aerial plant parts (leaves/stems), and ethanol-based extracts. Noble kava root prepared as a traditional water extract has a much stronger safety record. Still, anyone with existing liver conditions or taking hepatically-metabolized medications should avoid kava.</p>
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold text-ink">Does kava feel like alcohol?</h3>
+            <p>Not really. Kava produces relaxation and mild euphoria but preserves mental clarity — users typically describe feeling calm but alert. Alcohol produces disinhibition, cognitive fog, and impaired coordination. The experiences are qualitatively different even though both affect GABA systems.</p>
+          </div>
+        </div>
+      </section>
+
+      <FAQSchema
+        pagePath="/guides/compare/kava-vs-alcohol/"
+        questions={[
+          { question: 'Is kava a safe alternative to alcohol?', answer: 'Kava has a different risk profile than alcohol — lower dependence potential, no known carcinogenicity, and preserved cognitive function. However, kava is not risk-free. Liver safety depends on using noble cultivars and avoiding contaminants. It should not be treated as a direct substitute without understanding individual health context.' },
+          { question: 'Can kava damage your liver?', answer: 'Historically, cases of liver toxicity were associated with non-noble (tudei) cultivars, aerial plant parts (leaves/stems), and ethanol-based extracts. Noble kava root prepared as a traditional water extract has a much stronger safety record. Still, anyone with existing liver conditions or taking hepatically-metabolized medications should avoid kava.' },
+          { question: 'Does kava feel like alcohol?', answer: 'Not really. Kava produces relaxation and mild euphoria but preserves mental clarity — users typically describe feeling calm but alert. Alcohol produces disinhibition, cognitive fog, and impaired coordination. The experiences are qualitatively different even though both affect GABA systems.' },
+        ]}
+      />
 
       <section className="surface-subtle rounded-3xl p-6 space-y-4">
         <h2 className="text-2xl font-semibold tracking-tight text-ink">


### PR DESCRIPTION
## Content quality improvements for comparison pages

### kava-vs-alcohol (101 → 177 lines)
- Added GABA mechanism comparison — kavalactones vs broad-spectrum alcohol effects
- Added practical comparison table (onset, duration, dependence risk, liver concerns, sleep impact)
- Added safety warning box for combining kava + alcohol
- Added 3-question FAQ with FAQPage structured data
- Expanded product descriptions with specific pharmacology

### kanna-vs-ssris (146 → 195 lines)
- Added serotonergic mechanism comparison — under-studied SRI vs extensively-studied SSRIs
- Added prominent red-box serotonin syndrome warning
- Added 3-question FAQ with FAQPage structured data  
- Expanded both product descriptions with pharmacology detail

Both pages were harm-reduction content using the same thin template. Now they have substantive educational content matching the quality of other comparison pages.