### PR TITLE
Render the citation sections that a batch pass defined but never displayed

### DIFF
--- a/app/guides/adhd/l-theanine-magnesium-adhd-stack/page.tsx
+++ b/app/guides/adhd/l-theanine-magnesium-adhd-stack/page.tsx
@@ -494,6 +494,7 @@ export default function LTheanineMagnesiumAdhdStackPage() {
           ← Back to Articles
         </Link>
       </div>
+      <References refs={L_THEANINE_MAGNESIUM_ADHD_STACK_REFS} />
     </article>
   )
 }

--- a/app/guides/adhd/magnesium-glycinate-vs-citrate-for-adhd/page.tsx
+++ b/app/guides/adhd/magnesium-glycinate-vs-citrate-for-adhd/page.tsx
@@ -517,6 +517,7 @@ export default function MagnesiumGlycinateCitrateAdhdPage() {
           ← Back to Articles
         </Link>
       </div>
+      <References refs={MAGNESIUM_GLYCINATE_VS_CITRATE_FOR_ADHD_REFS} />
     </article>
   )
 }

--- a/app/guides/adhd/page.tsx
+++ b/app/guides/adhd/page.tsx
@@ -75,6 +75,7 @@ export default function AdhdGuideIndex() {
           </Link>
         ))}
       </div>
+      <References refs={ADHD_REFS} />
     </div>
   )
 }

--- a/app/guides/compare/berberine-vs-metformin/page.tsx
+++ b/app/guides/compare/berberine-vs-metformin/page.tsx
@@ -520,6 +520,7 @@ export default function BerberineVsMetforminPage() {
         name={berberineProducts[0]?.title}
         href={berberineProducts[0]?.affiliateUrl || '#'}
       />
+      <References refs={BERBERINE_VS_METFORMIN_REFS} />
     </div>
   )
 }

--- a/app/guides/compare/caffeine-vs-l-theanine-vs-bacopa-for-focus/page.tsx
+++ b/app/guides/compare/caffeine-vs-l-theanine-vs-bacopa-for-focus/page.tsx
@@ -349,6 +349,7 @@ export default function CaffeineVsLTheanineVsBacopaForFocusPage() {
         name={revenueProducts[0]?.title}
         href={revenueProducts[0]?.affiliateUrl || '#'}
       />
+      <References refs={CAFFEINE_VS_THEANINE_VS_BACOPA_REFS} />
     </div>
   )
 }

--- a/app/guides/compare/curcumin-vs-boswellia-vs-omega-3/page.tsx
+++ b/app/guides/compare/curcumin-vs-boswellia-vs-omega-3/page.tsx
@@ -384,6 +384,7 @@ export default function CurcuminVsBoswelliaVsOmega3Page() {
         name={revenueProducts[0]?.title}
         href={revenueProducts[0]?.affiliateUrl || '#'}
       />
+      <References refs={CURCUMIN_VS_BOSWELLIA_VS_OMEGA3_REFS} />
     </div>
   )
 }

--- a/app/guides/compare/kanna-vs-ssris/page.tsx
+++ b/app/guides/compare/kanna-vs-ssris/page.tsx
@@ -199,6 +199,7 @@ export default function KannaVsSSRIsPage() {
           </Link>
         </div>
       </section>
+      <References refs={KANNA_VS_SSRIS_REFS} />
     </div>
   )
 }

--- a/app/guides/compare/kava-vs-alcohol/page.tsx
+++ b/app/guides/compare/kava-vs-alcohol/page.tsx
@@ -181,6 +181,7 @@ export default function KavaVsAlcoholPage() {
           </Link>
         </div>
       </section>
+      <References refs={KAVA_VS_ALCOHOL_REFS} />
     </div>
   )
 }

--- a/app/guides/compare/melatonin-vs-magnesium/page.tsx
+++ b/app/guides/compare/melatonin-vs-magnesium/page.tsx
@@ -128,6 +128,7 @@ export default function MelatoninVsMagnesiumPage() {
         name={revenueProducts[0]?.title}
         href={revenueProducts[0]?.affiliateUrl || '#'}
       />
+      <References refs={MELATONIN_VS_MAGNESIUM_REFS} />
     </div>
   )
 }

--- a/app/guides/compare/melatonin-vs-valerian-vs-magnesium-for-sleep/page.tsx
+++ b/app/guides/compare/melatonin-vs-valerian-vs-magnesium-for-sleep/page.tsx
@@ -349,6 +349,7 @@ export default function MelatoninVsValerianVsMagnesiumForSleepPage() {
         name={revenueProducts[0]?.title}
         href={revenueProducts[0]?.affiliateUrl || '#'}
       />
+      <References refs={MELATONIN_VS_VALERIAN_VS_MAGNESIUM_REFS} />
     </div>
   )
 }

--- a/app/guides/compare/sleep-herbs-vs-melatonin/page.tsx
+++ b/app/guides/compare/sleep-herbs-vs-melatonin/page.tsx
@@ -682,6 +682,7 @@ export default function SleepHerbsVsMelatoninComparePage() {
         name={melatoninProducts[0]?.title}
         href={melatoninProducts[0]?.affiliateUrl || '#'}
       />
+      <References refs={SLEEP_HERBS_VS_MELATONIN_REFS} />
     </div>
   )
 }

--- a/app/guides/focus/l-theanine-without-caffeine/page.tsx
+++ b/app/guides/focus/l-theanine-without-caffeine/page.tsx
@@ -580,6 +580,7 @@ export default function LTheanineWithoutCaffeinePage() {
           ← Back to Articles
         </Link>
       </div>
+      <References refs={L_THEANINE_WITHOUT_CAFFEINE_REFS} />
     </article>
   )
 }

--- a/app/guides/herbs/kava/page.tsx
+++ b/app/guides/herbs/kava/page.tsx
@@ -282,6 +282,7 @@ export default function KavaGuidePage() {
         <Link href="/herbs/" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">Herb Library →</Link>
       </div>
       </div>{/* end space-y-8 */}
+      <References refs={KAVA_REFS} />
     </ArticleLayout>
   )
 }

--- a/app/guides/other/bpc-157/page.tsx
+++ b/app/guides/other/bpc-157/page.tsx
@@ -160,6 +160,7 @@ export default function Page() {
 
       </div>
     </div>
+    <References refs={BPC_157_REFS} />
     </ArticleLayout>
   )
 }

--- a/app/guides/other/cjc-1295/page.tsx
+++ b/app/guides/other/cjc-1295/page.tsx
@@ -152,6 +152,7 @@ export default function Page() {
 
       </div>
     </div>
+    <References refs={CJC_1295_REFS} />
     </ArticleLayout>
   )
 }

--- a/app/guides/other/ghk-cu/page.tsx
+++ b/app/guides/other/ghk-cu/page.tsx
@@ -144,6 +144,7 @@ export default function Page() {
 
       </div>
     </div>
+    <References refs={GHK_CU_REFS} />
     </ArticleLayout>
   )
 }

--- a/app/guides/other/ipamorelin/page.tsx
+++ b/app/guides/other/ipamorelin/page.tsx
@@ -152,6 +152,7 @@ export default function Page() {
 
       </div>
     </div>
+    <References refs={IPAMORELIN_REFS} />
     </ArticleLayout>
   )
 }

--- a/app/guides/other/kratom-7oh-withdrawal-management/page.tsx
+++ b/app/guides/other/kratom-7oh-withdrawal-management/page.tsx
@@ -337,6 +337,7 @@ export default function Page() {
         <Link href="/compounds/7-hydroxymitragynine" className="text-sm font-medium text-emerald-700 hover:underline">View 7-OH compound profile →</Link>
       </div>
     </div>
+    <References refs={KRATOM_7OH_WITHDRAWAL_MANAGEMENT_REFS} />
     </ArticleLayout>
   )
 }

--- a/app/guides/other/psychedelic-adjacent-herbs/page.tsx
+++ b/app/guides/other/psychedelic-adjacent-herbs/page.tsx
@@ -169,6 +169,7 @@ export default function PsychedelicAdjacentHerbsPage() {
         </div>
       </section>
     </div>
+    <References refs={PSYCHEDELIC_ADJACENT_HERBS_REFS} />
     </ArticleLayout>
   )
 }

--- a/app/guides/other/pt-141/page.tsx
+++ b/app/guides/other/pt-141/page.tsx
@@ -141,6 +141,7 @@ export default function Page() {
 
       </div>
     </div>
+    <References refs={PT_141_REFS} />
     </ArticleLayout>
   )
 }

--- a/app/guides/other/semaglutide/page.tsx
+++ b/app/guides/other/semaglutide/page.tsx
@@ -149,6 +149,7 @@ export default function Page() {
 
       </div>
     </div>
+    <References refs={SEMAGLUTIDE_REFS} />
     </ArticleLayout>
   )
 }

--- a/app/guides/other/tb-500/page.tsx
+++ b/app/guides/other/tb-500/page.tsx
@@ -152,6 +152,7 @@ export default function Page() {
 
       </div>
     </div>
+    <References refs={TB_500_REFS} />
     </ArticleLayout>
   )
 }

--- a/app/guides/other/tirzepatide/page.tsx
+++ b/app/guides/other/tirzepatide/page.tsx
@@ -145,6 +145,7 @@ export default function Page() {
 
       </div>
     </div>
+    <References refs={TIRZEPATIDE_REFS} />
     </ArticleLayout>
   )
 }

--- a/app/info/faq/page.tsx
+++ b/app/info/faq/page.tsx
@@ -182,6 +182,7 @@ export default function FaqPage() {
           </div>
         </aside>
       </section>
+      <References refs={FAQ_REFS} />
     </div>
   )
 }

--- a/app/info/methodology/page.tsx
+++ b/app/info/methodology/page.tsx
@@ -185,6 +185,7 @@ export default function MethodologyPage() {
       </section>
 
       <SafetyDisclaimerBox />
+      <References refs={METHODOLOGY_REFS} />
     </div>
   )
 }

--- a/app/learn/calming/page.tsx
+++ b/app/learn/calming/page.tsx
@@ -80,6 +80,7 @@ export default function CalmingPsychoactivesPage() {
           </Link>
         ))}
       </section>
+      <References refs={CALMING_REFS} />
     </div>
   )
 }

--- a/app/learn/cholinergic-system/page.tsx
+++ b/app/learn/cholinergic-system/page.tsx
@@ -83,6 +83,7 @@ export default function CholinergicSystemPage() {
           </Link>
         ))}
       </section>
+      <References refs={CHOLINERGIC_SYSTEM_REFS} />
     </div>
   )
 }

--- a/app/learn/cognitive-resilience-systems/page.tsx
+++ b/app/learn/cognitive-resilience-systems/page.tsx
@@ -166,6 +166,7 @@ export default function CognitiveResilienceSystemsPage() {
         title='Explore the broader resilience ecosystem'
         systems={relatedSystems}
       />
+      <References refs={COGNITIVE_RESILIENCE_SYSTEMS_REFS} />
     </div>
   )
 }

--- a/app/learn/common-neurochemistry-myths/page.tsx
+++ b/app/learn/common-neurochemistry-myths/page.tsx
@@ -106,6 +106,7 @@ export default function NeurochemistryMythsPage() {
           'Psychological, environmental, and behavioral factors strongly influence subjective experiences.',
         ]}
       />
+      <References refs={COMMON_NEUROCHEMISTRY_MYTHS_REFS} />
     </div>
   )
 }

--- a/app/learn/dissociative-mechanisms/page.tsx
+++ b/app/learn/dissociative-mechanisms/page.tsx
@@ -77,6 +77,7 @@ export default function DissociativeMechanismsPage() {
           </Link>
         ))}
       </section>
+      <References refs={DISSOCIATIVE_MECHANISMS_REFS} />
     </div>
   )
 }

--- a/app/learn/dopamine/page.tsx
+++ b/app/learn/dopamine/page.tsx
@@ -83,6 +83,7 @@ export default function DopaminePathwayPage() {
           </Link>
         ))}
       </section>
+      <References refs={DOPAMINE_REFS} />
     </div>
   )
 }

--- a/app/learn/dream-herbs/page.tsx
+++ b/app/learn/dream-herbs/page.tsx
@@ -77,6 +77,7 @@ export default function DreamHerbsPage() {
           </Link>
         ))}
       </section>
+      <References refs={DREAM_HERBS_REFS} />
     </div>
   )
 }

--- a/app/learn/efficacy-model/page.tsx
+++ b/app/learn/efficacy-model/page.tsx
@@ -40,6 +40,7 @@ export default function EfficacyModelPage() {
       <section className='card-premium p-6 sm:p-8'>
         <EfficacyModelerClient />
       </section>
+      <References refs={EFFICACY_MODEL_REFS} />
     </div>
   )
 }

--- a/app/learn/emotional-amplification-systems/page.tsx
+++ b/app/learn/emotional-amplification-systems/page.tsx
@@ -146,6 +146,7 @@ export default function EmotionalAmplificationSystemsPage() {
           ))}
         </div>
       </section>
+      <References refs={EMOTIONAL_AMPLIFICATION_SYSTEMS_REFS} />
     </div>
   )
 }

--- a/app/learn/entheogens/page.tsx
+++ b/app/learn/entheogens/page.tsx
@@ -73,6 +73,7 @@ export default function EntheogensPage() {
           </Link>
         ))}
       </section>
+      <References refs={ENTHEOGENS_REFS} />
     </div>
   )
 }

--- a/app/learn/evidence-hierarchy/page.tsx
+++ b/app/learn/evidence-hierarchy/page.tsx
@@ -86,6 +86,7 @@ export default function EvidenceHierarchyPage() {
           },
         ]}
       />
+      <References refs={EVIDENCE_HIERARCHY_REFS} />
     </div>
   )
 }

--- a/app/learn/evidence-literacy/page.tsx
+++ b/app/learn/evidence-literacy/page.tsx
@@ -181,6 +181,7 @@ export default function EvidenceLiteracyPage() {
             ))}
           </div>
         </section>
+        <References refs={EVIDENCE_LITERACY_REFS} />
       </EducationPageLayout>
     </>
   )

--- a/app/learn/gaba-vs-serotonin/page.tsx
+++ b/app/learn/gaba-vs-serotonin/page.tsx
@@ -68,6 +68,7 @@ export default function GabaVsSerotoninPage() {
           </div>
         </div>
       </section>
+      <References refs={GABA_VS_SEROTONIN_REFS} />
     </div>
   )
 }

--- a/app/learn/gaba/page.tsx
+++ b/app/learn/gaba/page.tsx
@@ -207,6 +207,7 @@ export default function GabaPathwayPage() {
           </Link>
         </div>
       </section>
+      <References refs={GABA_REFS} />
     </div>
   )
 }

--- a/app/learn/glutamate/page.tsx
+++ b/app/learn/glutamate/page.tsx
@@ -83,6 +83,7 @@ export default function GlutamatePathwayPage() {
           </Link>
         ))}
       </section>
+      <References refs={GLUTAMATE_REFS} />
     </div>
   )
 }

--- a/app/learn/harm-reduction/page.tsx
+++ b/app/learn/harm-reduction/page.tsx
@@ -85,6 +85,7 @@ export default function HarmReductionPage() {
           </Link>
         ))}
       </section>
+      <References refs={HARM_REDUCTION_REFS} />
     </div>
   )
 }

--- a/app/learn/how-emotional-regulation-works/page.tsx
+++ b/app/learn/how-emotional-regulation-works/page.tsx
@@ -173,6 +173,7 @@ export default function EmotionalRegulationPage() {
           },
         ]}
       />
+      <References refs={HOW_EMOTIONAL_REGULATION_WORKS_REFS} />
     </div>
   )
 }

--- a/app/learn/how-focus-and-motivation-work/page.tsx
+++ b/app/learn/how-focus-and-motivation-work/page.tsx
@@ -173,6 +173,7 @@ export default function FocusMotivationPage() {
           },
         ]}
       />
+      <References refs={HOW_FOCUS_AND_MOTIVATION_WORK_REFS} />
     </div>
   )
 }

--- a/app/learn/how-herbal-psychoactives-differ-from-pharmaceuticals/page.tsx
+++ b/app/learn/how-herbal-psychoactives-differ-from-pharmaceuticals/page.tsx
@@ -85,6 +85,7 @@ export default function HerbalVsPharmaPage() {
           </Link>
         ))}
       </section>
+      <References refs={HOW_HERBAL_PSYCHOACTIVES_DIFFER_FROM_PHARMACEUTICALS_REFS} />
     </div>
   )
 }

--- a/app/learn/how-learning-affects-neuroplasticity/page.tsx
+++ b/app/learn/how-learning-affects-neuroplasticity/page.tsx
@@ -260,6 +260,7 @@ export default function NeuroplasticityEducationPage() {
           },
         ]}
       />
+      <References refs={HOW_LEARNING_AFFECTS_NEUROPLASTICITY_REFS} />
     </div>
   )
 }

--- a/app/learn/how-memory-formation-works/page.tsx
+++ b/app/learn/how-memory-formation-works/page.tsx
@@ -260,6 +260,7 @@ export default function MemoryFormationEducationPage() {
           },
         ]}
       />
+      <References refs={HOW_MEMORY_FORMATION_WORKS_REFS} />
     </div>
   )
 }

--- a/app/learn/how-neurotransmitters-work/page.tsx
+++ b/app/learn/how-neurotransmitters-work/page.tsx
@@ -130,6 +130,7 @@ export default function NeurotransmittersPage() {
           },
         ]}
       />
+      <References refs={HOW_NEUROTRANSMITTERS_WORK_REFS} />
       </EducationPageLayout>
     </>
   )

--- a/app/learn/how-psychoactive-plants-affect-the-brain/page.tsx
+++ b/app/learn/how-psychoactive-plants-affect-the-brain/page.tsx
@@ -81,6 +81,7 @@ export default function PsychoactiveBrainPage() {
           </Link>
         ))}
       </section>
+      <References refs={HOW_PSYCHOACTIVE_PLANTS_AFFECT_THE_BRAIN_REFS} />
     </div>
   )
 }

--- a/app/learn/how-psychoactive-substances-affect-perception/page.tsx
+++ b/app/learn/how-psychoactive-substances-affect-perception/page.tsx
@@ -116,6 +116,7 @@ export default function PsychoactivePerceptionPage() {
           },
         ]}
       />
+      <References refs={HOW_PSYCHOACTIVE_SUBSTANCES_AFFECT_PERCEPTION_REFS} />
     </div>
   )
 }

--- a/app/learn/how-receptors-work/page.tsx
+++ b/app/learn/how-receptors-work/page.tsx
@@ -124,6 +124,7 @@ export default function ReceptorsPage() {
           },
         ]}
       />
+      <References refs={HOW_RECEPTORS_WORK_REFS} />
     </div>
   )
 }

--- a/app/learn/how-sleep-affects-neurochemistry/page.tsx
+++ b/app/learn/how-sleep-affects-neurochemistry/page.tsx
@@ -173,6 +173,7 @@ export default function SleepNeurochemistryPage() {
           },
         ]}
       />
+      <References refs={HOW_SLEEP_AFFECTS_NEUROCHEMISTRY_REFS} />
     </div>
   )
 }

--- a/app/learn/how-stress-affects-the-brain/page.tsx
+++ b/app/learn/how-stress-affects-the-brain/page.tsx
@@ -173,6 +173,7 @@ export default function StressBrainEducationPage() {
           },
         ]}
       />
+      <References refs={HOW_STRESS_AFFECTS_THE_BRAIN_REFS} />
     </div>
   )
 }

--- a/app/learn/how-the-brain-recovers-from-fatigue/page.tsx
+++ b/app/learn/how-the-brain-recovers-from-fatigue/page.tsx
@@ -173,6 +173,7 @@ export default function FatigueRecoveryPage() {
           },
         ]}
       />
+      <References refs={HOW_THE_BRAIN_RECOVERS_FROM_FATIGUE_REFS} />
     </div>
   )
 }

--- a/app/learn/how-to-read-scientific-studies/page.tsx
+++ b/app/learn/how-to-read-scientific-studies/page.tsx
@@ -96,6 +96,7 @@ export default function ReadScientificStudiesPage() {
           'Publication bias and selective reporting may affect interpretation quality.',
         ]}
       />
+      <References refs={HOW_TO_READ_SCIENTIFIC_STUDIES_REFS} />
     </div>
   )
 }

--- a/app/learn/interactions/page.tsx
+++ b/app/learn/interactions/page.tsx
@@ -85,6 +85,7 @@ export default function PsychoactiveInteractionsPage() {
           </Link>
         ))}
       </section>
+      <References refs={INTERACTIONS_REFS} />
     </div>
   )
 }

--- a/app/learn/page.tsx
+++ b/app/learn/page.tsx
@@ -472,6 +472,7 @@ export default function EducationHubPage() {
           </div>
         </div>
       </section>
+      <References refs={PAGE_REFS} />
     </div>
   )
 }

--- a/app/learn/placebo-and-context-effects/page.tsx
+++ b/app/learn/placebo-and-context-effects/page.tsx
@@ -132,6 +132,7 @@ export default function PlaceboAndContextEffectsPage() {
           ))}
         </div>
       </section>
+      <References refs={PLACEBO_AND_CONTEXT_EFFECTS_REFS} />
     </div>
   )
 }

--- a/app/learn/product-quality/page.tsx
+++ b/app/learn/product-quality/page.tsx
@@ -5,7 +5,6 @@ import { getRuntimeVisibility } from '../../../lib/runtime-visibility'
 import BuyGuideClient from '../../../src/components/sourcing/BuyGuideClient'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import { isRestrictedRecord } from '../../../src/lib/restricted-ingredients'
-import References from '@/components/References'
 
 export const metadata: Metadata = {
   title: 'Supplement Product Quality Guide',

--- a/app/learn/research-methodology/page.tsx
+++ b/app/learn/research-methodology/page.tsx
@@ -106,6 +106,7 @@ export default function ResearchMethodologyPage() {
           </Link>
         </div>
       </section>
+      <References refs={RESEARCH_METHODOLOGY_REFS} />
     </div>
   )
 }

--- a/app/learn/scientific-but-human-neuroscience/page.tsx
+++ b/app/learn/scientific-but-human-neuroscience/page.tsx
@@ -169,6 +169,7 @@ export default function ScientificButHumanNeurosciencePage() {
         title='Explore the broader neuroscience ecosystem'
         systems={relatedSystems}
       />
+      <References refs={SCIENTIFIC_BUT_HUMAN_NEUROSCIENCE_REFS} />
     </div>
   )
 }

--- a/app/learn/serotonergic-stacking-risks/page.tsx
+++ b/app/learn/serotonergic-stacking-risks/page.tsx
@@ -85,6 +85,7 @@ export default function SerotonergicRisksPage() {
           </Link>
         ))}
       </section>
+      <References refs={SEROTONERGIC_STACKING_RISKS_REFS} />
     </div>
   )
 }

--- a/app/learn/serotonin/page.tsx
+++ b/app/learn/serotonin/page.tsx
@@ -102,6 +102,7 @@ export default function SerotoninPathwayPage() {
           </Link>
         ))}
       </section>
+      <References refs={SEROTONIN_REFS} />
     </div>
   )
 }

--- a/app/learn/stress-and-cognition-continuity/page.tsx
+++ b/app/learn/stress-and-cognition-continuity/page.tsx
@@ -162,6 +162,7 @@ export default function StressAndCognitionContinuityPage() {
         title='Continue exploring recovery-oriented neuroscience'
         systems={relatedSystems}
       />
+      <References refs={STRESS_AND_COGNITION_CONTINUITY_REFS} />
     </div>
   )
 }

--- a/app/learn/study-design-snapshot/page.tsx
+++ b/app/learn/study-design-snapshot/page.tsx
@@ -122,6 +122,7 @@ export default function StudyDesignSnapshotHubPage() {
           and so you can judge the evidence for yourself.
         </p>
       </section>
+      <References refs={STUDY_DESIGN_SNAPSHOT_REFS} />
     </div>
   )
 }

--- a/app/learn/understanding-altered-states/page.tsx
+++ b/app/learn/understanding-altered-states/page.tsx
@@ -260,6 +260,7 @@ export default function AlteredStatesEducationPage() {
           },
         ]}
       />
+      <References refs={UNDERSTANDING_ALTERED_STATES_REFS} />
     </div>
   )
 }

--- a/app/learn/understanding-individual-variability/page.tsx
+++ b/app/learn/understanding-individual-variability/page.tsx
@@ -89,6 +89,7 @@ export default function IndividualVariabilityPage() {
           'Average study outcomes may not predict individual experiences.',
         ]}
       />
+      <References refs={UNDERSTANDING_INDIVIDUAL_VARIABILITY_REFS} />
     </div>
   )
 }

--- a/app/learn/understanding-placebo-and-expectancy/page.tsx
+++ b/app/learn/understanding-placebo-and-expectancy/page.tsx
@@ -74,6 +74,7 @@ export default function PlaceboExpectancyPage() {
           'Small studies may overestimate effect size reliability.',
         ]}
       />
+      <References refs={UNDERSTANDING_PLACEBO_AND_EXPECTANCY_REFS} />
     </div>
   )
 }

--- a/app/learn/what-are-adaptogens/page.tsx
+++ b/app/learn/what-are-adaptogens/page.tsx
@@ -220,6 +220,7 @@ export default function AdaptogensEducationPage() {
           },
         ]}
       />
+      <References refs={WHAT_ARE_ADAPTOGENS_REFS} />
     </div>
   )
 }

--- a/app/learn/what-are-psychoactive-herbs/page.tsx
+++ b/app/learn/what-are-psychoactive-herbs/page.tsx
@@ -192,6 +192,7 @@ export default function WhatArePsychoactiveHerbsPage() {
           </Link>
         </div>
       </section>
+      <References refs={WHAT_ARE_PSYCHOACTIVE_HERBS_REFS} />
     </div>
   )
 }

--- a/app/learn/what-is-a-nootropic/page.tsx
+++ b/app/learn/what-is-a-nootropic/page.tsx
@@ -205,6 +205,7 @@ export default function NootropicEducationPage() {
           },
         ]}
       />
+      <References refs={WHAT_IS_A_NOOTROPIC_REFS} />
       </EducationPageLayout>
     </>
   )

--- a/app/learn/what-is-an-entheogen/page.tsx
+++ b/app/learn/what-is-an-entheogen/page.tsx
@@ -73,6 +73,7 @@ export default function EntheogenEducationPage() {
           </Link>
         ))}
       </section>
+      <References refs={WHAT_IS_AN_ENTHEOGEN_REFS} />
       </EducationPageLayout>
     </>
   )

--- a/app/learn/what-is-anxiety-neurochemistry/page.tsx
+++ b/app/learn/what-is-anxiety-neurochemistry/page.tsx
@@ -95,6 +95,7 @@ export default function AnxietyNeurochemistryPage() {
           </Link>
         ))}
       </section>
+      <References refs={WHAT_IS_ANXIETY_NEUROCHEMISTRY_REFS} />
     </div>
   )
 }

--- a/app/learn/what-is-neuroinflammation/page.tsx
+++ b/app/learn/what-is-neuroinflammation/page.tsx
@@ -259,6 +259,7 @@ export default function NeuroinflammationEducationPage() {
           },
         ]}
       />
+      <References refs={WHAT_IS_NEUROINFLAMMATION_REFS} />
     </div>
   )
 }

--- a/app/learn/what-is-neuropharmacology/page.tsx
+++ b/app/learn/what-is-neuropharmacology/page.tsx
@@ -87,6 +87,7 @@ export default function NeuropharmacologyPage() {
           </Link>
         ))}
       </section>
+      <References refs={WHAT_IS_NEUROPHARMACOLOGY_REFS} />
     </div>
   )
 }

--- a/app/learn/why-burnout-affects-cognition/page.tsx
+++ b/app/learn/why-burnout-affects-cognition/page.tsx
@@ -103,6 +103,7 @@ export default function WhyBurnoutAffectsCognitionPage() {
           ))}
         </div>
       </section>
+      <References refs={WHY_BURNOUT_AFFECTS_COGNITION_REFS} />
     </div>
   )
 }

--- a/app/learn/why-calm-focus-differs-from-stimulation/page.tsx
+++ b/app/learn/why-calm-focus-differs-from-stimulation/page.tsx
@@ -132,6 +132,7 @@ export default function WhyCalmFocusDiffersFromStimulationPage() {
           ))}
         </div>
       </section>
+      <References refs={WHY_CALM_FOCUS_DIFFERS_FROM_STIMULATION_REFS} />
     </div>
   )
 }

--- a/app/learn/why-fatigue-is-biologically-complex/page.tsx
+++ b/app/learn/why-fatigue-is-biologically-complex/page.tsx
@@ -133,6 +133,7 @@ export default function WhyFatigueIsBiologicallyComplexPage() {
           ))}
         </div>
       </section>
+      <References refs={WHY_FATIGUE_IS_BIOLOGICALLY_COMPLEX_REFS} />
     </div>
   )
 }

--- a/app/learn/why-human-trials-matter/page.tsx
+++ b/app/learn/why-human-trials-matter/page.tsx
@@ -84,6 +84,7 @@ export default function HumanTrialsMatterPage() {
           },
         ]}
       />
+      <References refs={WHY_HUMAN_TRIALS_MATTER_REFS} />
     </div>
   )
 }

--- a/app/learn/why-individual-variability-matters/page.tsx
+++ b/app/learn/why-individual-variability-matters/page.tsx
@@ -131,6 +131,7 @@ export default function WhyIndividualVariabilityMattersPage() {
           ))}
         </div>
       </section>
+      <References refs={WHY_INDIVIDUAL_VARIABILITY_MATTERS_REFS} />
     </div>
   )
 }

--- a/app/learn/why-neurochemistry-is-complex/page.tsx
+++ b/app/learn/why-neurochemistry-is-complex/page.tsx
@@ -112,6 +112,7 @@ export default function NeurochemistryComplexityPage() {
           },
         ]}
       />
+      <References refs={WHY_NEUROCHEMISTRY_IS_COMPLEX_REFS} />
     </div>
   )
 }

--- a/app/learn/why-neuroscience-is-difficult/page.tsx
+++ b/app/learn/why-neuroscience-is-difficult/page.tsx
@@ -131,6 +131,7 @@ export default function WhyNeuroscienceIsDifficultPage() {
           ))}
         </div>
       </section>
+      <References refs={WHY_NEUROSCIENCE_IS_DIFFICULT_REFS} />
     </div>
   )
 }

--- a/app/learn/why-online-supplement-claims-spread/page.tsx
+++ b/app/learn/why-online-supplement-claims-spread/page.tsx
@@ -131,6 +131,7 @@ export default function WhyOnlineSupplementClaimsSpreadPage() {
           ))}
         </div>
       </section>
+      <References refs={WHY_ONLINE_SUPPLEMENT_CLAIMS_SPREAD_REFS} />
     </div>
   )
 }

--- a/app/learn/why-overstimulation-impairs-focus/page.tsx
+++ b/app/learn/why-overstimulation-impairs-focus/page.tsx
@@ -135,6 +135,7 @@ export default function WhyOverstimulationImpairsFocusPage() {
           ))}
         </div>
       </section>
+      <References refs={WHY_OVERSTIMULATION_IMPAIRS_FOCUS_REFS} />
     </div>
   )
 }

--- a/app/learn/why-set-and-setting-matter/page.tsx
+++ b/app/learn/why-set-and-setting-matter/page.tsx
@@ -146,6 +146,7 @@ export default function WhySetAndSettingMatterPage() {
           ))}
         </div>
       </section>
+      <References refs={WHY_SET_AND_SETTING_MATTER_REFS} />
     </div>
   )
 }

--- a/app/learn/why-sleep-changes-emotional-regulation/page.tsx
+++ b/app/learn/why-sleep-changes-emotional-regulation/page.tsx
@@ -132,6 +132,7 @@ export default function WhySleepChangesEmotionalRegulationPage() {
           ))}
         </div>
       </section>
+      <References refs={WHY_SLEEP_CHANGES_EMOTIONAL_REGULATION_REFS} />
     </div>
   )
 }

--- a/app/learn/why-sleep-matters-for-mental-health/page.tsx
+++ b/app/learn/why-sleep-matters-for-mental-health/page.tsx
@@ -125,6 +125,7 @@ export default function SleepMentalHealthPage() {
           },
         ]}
       />
+      <References refs={WHY_SLEEP_MATTERS_FOR_MENTAL_HEALTH_REFS} />
     </div>
   )
 }

--- a/app/learn/why-studies-conflict/page.tsx
+++ b/app/learn/why-studies-conflict/page.tsx
@@ -120,6 +120,7 @@ export default function WhyStudiesConflictPage() {
           ))}
         </div>
       </section>
+      <References refs={WHY_STUDIES_CONFLICT_REFS} />
       </EducationPageLayout>
     </>
   )


### PR DESCRIPTION
## Summary

Closes out the known follow-up flagged in #2045/#2046: `npm run lint` (part of the `npm run check` gate, run with `--max-warnings=0`) reported 173 warnings across 87 pages. Each page imported the shared `References` component and defined a `*_REFS` citation array, but never actually rendered `<References refs={...} />` anywhere — the citation data was correct, it just wasn't wired into the JSX, so none of those pages displayed their sources.

Inserted `<References refs={PAGE_REFS} />` as the last element inside each page's outermost content wrapper, matching the placement already used correctly elsewhere in the codebase (right before wherever that page's shell closes — a plain wrapper `<div>`, `<article>`, `<ArticleLayout>`, or `<EducationPageLayout>`).

One file (`learn/product-quality`) had no citation data behind its unused `References` import at all — just leftover dead code — so that import was removed instead of fabricating a references block.

`npm run lint` now passes with **0 errors and 0 warnings** (was 173 warnings before this).

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors, 0 warnings (down from 173 warnings)
- [x] `npm run test` — 293/293 pass
- [x] `npm run build` — full production build completes end-to-end, sitemap validated (637 URLs)
- [x] Spot-checked the built output on two pages using different layout wrappers (`learn/dopamine` — plain div wrapper, `guides/adhd/l-theanine-magnesium-adhd-stack` — `<article>` wrapper) and confirmed the References section renders in a sensible spot with the correct citation content, not just present in the DOM


---
_Generated by [Claude Code](https://claude.ai/code/session_01EfTJURKd1XMnBxVQvDbTaB)_