### PR TITLE
Add render tests for shared safety/evidence components and workbook parser

### DIFF
--- a/components/safety/__tests__/AdditiveRiskPanel.test.tsx
+++ b/components/safety/__tests__/AdditiveRiskPanel.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import AdditiveRiskPanel from '../AdditiveRiskPanel'
+import type { MechanismRisk } from '@/lib/interaction-risk'
+
+function risk(overrides: Partial<MechanismRisk> = {}): MechanismRisk {
+  return {
+    mechanism: 'serotonergic',
+    label: 'Serotonergic activity',
+    severity: 'severe',
+    partnerCount: 2,
+    topPartners: [
+      { slug: 'herb-b', name: 'Herb B' },
+      { slug: 'herb-c', name: 'Herb C' },
+    ],
+    ...overrides,
+  }
+}
+
+describe('AdditiveRiskPanel', () => {
+  it('renders nothing when there are no risks', () => {
+    const { container } = render(<AdditiveRiskPanel risks={[]} displayName="Ashwagandha" />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders the mechanism label, severity, and display name in the caution copy', () => {
+    render(<AdditiveRiskPanel risks={[risk()]} displayName="Ashwagandha" />)
+
+    expect(screen.getByText('Serotonergic activity')).toBeTruthy()
+    expect(screen.getByText('severe')).toBeTruthy()
+    expect(screen.getAllByText(/Ashwagandha/).length).toBeGreaterThan(0)
+  })
+
+  it('uses singular "supplement" wording when only one partner shares the flag', () => {
+    const { container } = render(
+      <AdditiveRiskPanel risks={[risk({ partnerCount: 1, topPartners: [{ slug: 'herb-b', name: 'Herb B' }] })]} displayName="Herb A" />,
+    )
+    expect(container.querySelector('.text-xs.text-muted')?.textContent).toMatch(/1\s*other supplement\s*share this flag/)
+  })
+
+  it('uses plural "supplements" wording when multiple partners share the flag', () => {
+    const { container } = render(<AdditiveRiskPanel risks={[risk({ partnerCount: 2 })]} displayName="Herb A" />)
+    expect(container.querySelector('.text-xs.text-muted')?.textContent).toMatch(/2\s*other supplements\s*share this flag/)
+  })
+
+  it('lists up to 3 example partners and appends a "+N more" count beyond that', () => {
+    render(
+      <AdditiveRiskPanel
+        risks={[
+          risk({
+            partnerCount: 5,
+            topPartners: [
+              { slug: 'a', name: 'Herb A' },
+              { slug: 'b', name: 'Herb B' },
+              { slug: 'c', name: 'Herb C' },
+            ],
+          }),
+        ]}
+        displayName="Test Herb"
+      />,
+    )
+
+    expect(screen.getByText(/Herb A, Herb B, Herb C/)).toBeTruthy()
+    expect(screen.getByText(/\+2 more/)).toBeTruthy()
+  })
+
+  it('falls back to empty description text for an unrecognized mechanism', () => {
+    render(<AdditiveRiskPanel risks={[risk({ mechanism: 'unknown_mechanism', label: 'Unknown Mechanism' })]} displayName="Test Herb" />)
+    expect(screen.getByText('Unknown Mechanism')).toBeTruthy()
+  })
+
+  it('renders one card per risk mechanism', () => {
+    render(
+      <AdditiveRiskPanel
+        risks={[risk({ mechanism: 'serotonergic', label: 'Serotonergic activity' }), risk({ mechanism: 'anticoagulant', label: 'Anticoagulant / bleeding' })]}
+        displayName="Test Herb"
+      />,
+    )
+
+    expect(screen.getByText('Serotonergic activity')).toBeTruthy()
+    expect(screen.getByText('Anticoagulant / bleeding')).toBeTruthy()
+  })
+})

--- a/components/ui/__tests__/EvidenceScoreBadge.test.tsx
+++ b/components/ui/__tests__/EvidenceScoreBadge.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import EvidenceScoreBadge from '../EvidenceScoreBadge'
+
+describe('EvidenceScoreBadge', () => {
+  it('derives the letter grade from a record when no explicit grade is given', () => {
+    render(<EvidenceScoreBadge record={{ evidence_tier: 'Strong evidence' }} />)
+    expect(screen.getByText('A')).toBeTruthy()
+    expect(screen.getByText('Strong')).toBeTruthy()
+  })
+
+  it('prefers an explicit grade prop over the record-derived grade', () => {
+    render(<EvidenceScoreBadge record={{ evidence_tier: 'Strong evidence' }} grade="D" />)
+    expect(screen.getByText('D')).toBeTruthy()
+    expect(screen.getByText('Traditional')).toBeTruthy()
+  })
+
+  it('defaults to grade C when neither record nor grade is given', () => {
+    render(<EvidenceScoreBadge />)
+    expect(screen.getByText('C')).toBeTruthy()
+    expect(screen.getByText('Preliminary')).toBeTruthy()
+  })
+
+  it('hides the label text when showLabel is false', () => {
+    render(<EvidenceScoreBadge grade="A" showLabel={false} />)
+    expect(screen.getByText('A')).toBeTruthy()
+    expect(screen.queryByText('Strong')).toBeNull()
+  })
+
+  it('renders the circle variant with an accessible label describing the full meaning', () => {
+    render(<EvidenceScoreBadge grade="B" size="circle" />)
+    expect(screen.getByLabelText(/Evidence grade B: Moderate Evidence/)).toBeTruthy()
+  })
+
+  it('sets a title attribute with the full grade meaning for all size variants', () => {
+    const { container } = render(<EvidenceScoreBadge grade="A" />)
+    const badge = container.firstElementChild as HTMLElement
+    expect(badge.title).toMatch(/Strong Evidence/)
+  })
+})

--- a/components/ui/__tests__/RelatedDiscoveryGroups.test.tsx
+++ b/components/ui/__tests__/RelatedDiscoveryGroups.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { AnchorHTMLAttributes, ReactNode } from 'react'
+import RelatedDiscoveryGroups from '../RelatedDiscoveryGroups'
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: AnchorHTMLAttributes<HTMLAnchorElement> & { children: ReactNode; href: string }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+describe('RelatedDiscoveryGroups', () => {
+  it('renders nothing when every group has zero links', () => {
+    const { container } = render(
+      <RelatedDiscoveryGroups groups={[{ title: 'Empty group', links: [] }]} />,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when there are no groups at all', () => {
+    const { container } = render(<RelatedDiscoveryGroups groups={[]} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('filters out empty groups but keeps groups that have links', () => {
+    render(
+      <RelatedDiscoveryGroups
+        groups={[
+          { title: 'Empty group', links: [] },
+          { title: 'Populated group', links: [{ href: '/herbs/ashwagandha/', label: 'Ashwagandha' }] },
+        ]}
+      />,
+    )
+
+    expect(screen.queryByText('Empty group')).toBeNull()
+    expect(screen.getByText('Populated group')).toBeTruthy()
+    expect(screen.getByRole('link', { name: 'Ashwagandha' })).toHaveAttribute('href', '/herbs/ashwagandha/')
+  })
+
+  it('caps rendered links per group at 4', () => {
+    const links = Array.from({ length: 6 }, (_, i) => ({ href: `/herbs/herb-${i}/`, label: `Herb ${i}` }))
+    render(<RelatedDiscoveryGroups groups={[{ title: 'Many links', links }]} />)
+
+    expect(screen.getAllByRole('link')).toHaveLength(4)
+  })
+
+  it('uses default eyebrow/title copy when not overridden', () => {
+    render(<RelatedDiscoveryGroups groups={[{ title: 'Group', links: [{ href: '/a/', label: 'A' }] }]} />)
+    expect(screen.getByText('Continue exploring')).toBeTruthy()
+    expect(screen.getByText('Choose a useful next step')).toBeTruthy()
+  })
+
+  it('renders the optional group description when provided', () => {
+    render(
+      <RelatedDiscoveryGroups
+        groups={[{ title: 'Group', description: 'A helpful description.', links: [{ href: '/a/', label: 'A' }] }]}
+      />,
+    )
+    expect(screen.getByText('A helpful description.')).toBeTruthy()
+  })
+})

--- a/components/ui/__tests__/SafetyGaugeMeter.test.tsx
+++ b/components/ui/__tests__/SafetyGaugeMeter.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import SafetyGaugeMeter from '../SafetyGaugeMeter'
+
+describe('SafetyGaugeMeter', () => {
+  it('renders the rounded score percentage and label', () => {
+    render(<SafetyGaugeMeter score={72.4} label="Generally well tolerated" />)
+    expect(screen.getByText('72%')).toBeTruthy()
+    expect(screen.getByText('Generally well tolerated')).toBeTruthy()
+  })
+
+  it('clamps scores above 100 down to 100', () => {
+    render(<SafetyGaugeMeter score={150} label="High" />)
+    expect(screen.getByText('100%')).toBeTruthy()
+  })
+
+  it('clamps negative scores up to 0', () => {
+    render(<SafetyGaugeMeter score={-20} label="Low" />)
+    expect(screen.getByText('0%')).toBeTruthy()
+  })
+
+  it('exposes an accessible label on the SVG describing the clamped score', () => {
+    render(<SafetyGaugeMeter score={45} label="Use caution" />)
+    expect(screen.getByRole('img', { name: 'Safety meter: 45 out of 100 — Use caution' })).toBeTruthy()
+  })
+})

--- a/scripts/data/build-interaction-data.test.mjs
+++ b/scripts/data/build-interaction-data.test.mjs
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest'
+import { deriveInteractionData } from './build-interaction-data.mjs'
+
+describe('deriveInteractionData', () => {
+  it('produces no tags or edges when no rows have contraindication flags', () => {
+    const data = deriveInteractionData([
+      { slug: 'herb-a', name: 'Herb A', contraindications_or_flags: '' },
+      { slug: 'herb-b', name: 'Herb B' },
+    ])
+
+    expect(data.tags).toEqual([])
+    expect(data.edges).toEqual([])
+    expect(data.edgesBySlug).toEqual({})
+    expect(data.tagsBySlug).toEqual({})
+  })
+
+  it('tags an additive mechanism (e.g. serotonergic) from matching keyword text', () => {
+    const data = deriveInteractionData([
+      { slug: 'herb-a', name: 'Herb A', contraindications_or_flags: 'May interact with SSRIs' },
+    ])
+
+    expect(data.tags).toHaveLength(1)
+    expect(data.tags[0]).toMatchObject({
+      entity_slug: 'herb-a',
+      risk_mechanism: 'serotonergic',
+      pair_behavior: 'additive',
+      confidence: 'high',
+    })
+  })
+
+  it('tags a non-additive mechanism (e.g. renal) as single_only and excludes it from edge generation', () => {
+    const data = deriveInteractionData([
+      { slug: 'herb-a', name: 'Herb A', contraindications_or_flags: 'Kidney disease caution' },
+      { slug: 'herb-b', name: 'Herb B', contraindications_or_flags: 'Kidney disease caution' },
+    ])
+
+    expect(data.tags).toHaveLength(2)
+    expect(data.tags.every((t) => t.pair_behavior === 'single_only')).toBe(true)
+    expect(data.edges).toEqual([])
+  })
+
+  it('matches keywords case-insensitively', () => {
+    const data = deriveInteractionData([
+      { slug: 'herb-a', name: 'Herb A', contraindications_or_flags: 'MAY CAUSE SEDATION' },
+    ])
+
+    expect(data.tags[0].risk_mechanism).toBe('cns_sedation')
+  })
+
+  it('splits multiple semicolon/comma-separated flags into separate matched phrases', () => {
+    const data = deriveInteractionData([
+      { slug: 'herb-a', name: 'Herb A', contraindications_or_flags: 'may interact with SSRIs; kidney disease caution' },
+    ])
+
+    expect(data.tags).toHaveLength(2)
+    expect(data.tags.map((t) => t.risk_mechanism).sort()).toEqual(['renal', 'serotonergic'])
+  })
+
+  it('creates a bidirectional additive-risk edge between two entities sharing the same mechanism', () => {
+    const data = deriveInteractionData([
+      { slug: 'herb-a', name: 'Herb A', contraindications_or_flags: 'interacts with SSRIs' },
+      { slug: 'herb-b', name: 'Herb B', contraindications_or_flags: 'serotonin syndrome risk' },
+    ])
+
+    expect(data.edges).toHaveLength(1)
+    const edge = data.edges[0]
+    expect(edge.source_slug).toBe('herb-a')
+    expect(edge.target_slug).toBe('herb-b')
+    expect(edge.risk_mechanism).toBe('serotonergic')
+    expect(edge.severity).toBe('severe')
+    expect(edge.weight_or_strength).toBe(90)
+    expect(edge.claim_language).toContain('Herb A')
+    expect(edge.claim_language).toContain('Herb B')
+
+    expect(data.edgesBySlug['herb-a']).toHaveLength(1)
+    expect(data.edgesBySlug['herb-a'][0].partner_slug).toBe('herb-b')
+    expect(data.edgesBySlug['herb-b']).toHaveLength(1)
+    expect(data.edgesBySlug['herb-b'][0].partner_slug).toBe('herb-a')
+  })
+
+  it('does not create an edge between entities that share only a single_only mechanism', () => {
+    const data = deriveInteractionData([
+      { slug: 'herb-a', name: 'Herb A', contraindications_or_flags: 'kidney disease caution' },
+      { slug: 'herb-b', name: 'Herb B', contraindications_or_flags: 'kidney disease caution' },
+    ])
+
+    expect(data.edges).toEqual([])
+    expect(data.edgesBySlug).toEqual({})
+  })
+
+  it('generates one edge per pair when three or more entities share an additive mechanism', () => {
+    const data = deriveInteractionData([
+      { slug: 'herb-a', name: 'Herb A', contraindications_or_flags: 'interacts with SSRIs' },
+      { slug: 'herb-b', name: 'Herb B', contraindications_or_flags: 'serotonin syndrome risk' },
+      { slug: 'herb-c', name: 'Herb C', contraindications_or_flags: 'MAOI interaction risk' },
+    ])
+
+    expect(data.edges).toHaveLength(3)
+    const pairs = data.edges.map((e) => `${e.source_slug}-${e.target_slug}`).sort()
+    expect(pairs).toEqual(['herb-a-herb-b', 'herb-a-herb-c', 'herb-b-herb-c'])
+  })
+
+  it('notes a shared second mechanism between two entities that overlap on more than one additive flag', () => {
+    const data = deriveInteractionData([
+      { slug: 'herb-a', name: 'Herb A', contraindications_or_flags: 'interacts with SSRIs; may cause sedation' },
+      { slug: 'herb-b', name: 'Herb B', contraindications_or_flags: 'serotonin syndrome risk; CNS depression risk' },
+    ])
+
+    expect(data.edges).toHaveLength(2)
+    for (const edge of data.edges) {
+      expect(edge.notes).toMatch(/pair also shares:/)
+    }
+  })
+
+  it('deduplicates an identical (slug, mechanism, behavior, phrase) tuple', () => {
+    const data = deriveInteractionData([
+      { slug: 'herb-a', name: 'Herb A', contraindications_or_flags: 'interacts with SSRIs, interacts with SSRIs' },
+    ])
+
+    expect(data.tags).toHaveLength(1)
+  })
+
+  it('ignores rows with no contraindications_or_flags field at all', () => {
+    const data = deriveInteractionData([{ slug: 'herb-a', name: 'Herb A' }])
+    expect(data.tags).toEqual([])
+  })
+
+  it('sorts edges by source slug, then target slug, then mechanism', () => {
+    const data = deriveInteractionData([
+      { slug: 'herb-c', name: 'Herb C', contraindications_or_flags: 'interacts with SSRIs' },
+      { slug: 'herb-a', name: 'Herb A', contraindications_or_flags: 'serotonin syndrome risk' },
+      { slug: 'herb-b', name: 'Herb B', contraindications_or_flags: 'MAOI interaction risk' },
+    ])
+
+    const pairs = data.edges.map((e) => `${e.source_slug}-${e.target_slug}`)
+    expect(pairs).toEqual(['herb-a-herb-b', 'herb-a-herb-c', 'herb-b-herb-c'])
+  })
+})

--- a/scripts/data/xlsx-optional-dependency-stub.mjs
+++ b/scripts/data/xlsx-optional-dependency-stub.mjs
@@ -1,0 +1,7 @@
+// Test-only stub for the optional 'xlsx' package, which is not an installed
+// dependency. It is only ever dynamically imported by the standalone CLI
+// runner branch of build-interaction-data.mjs (guarded by
+// `import.meta.url === file://process.argv[1]`), which never executes under
+// Vitest — but Vite's static import analysis still needs the specifier to
+// resolve, so vitest.config.ts aliases 'xlsx' to this stub for tests only.
+export default {}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,6 +23,15 @@ function workspaceAliasPlugin(): Plugin {
 }
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      // 'xlsx' is not an installed dependency — it's only referenced by a dead
+      // standalone-CLI branch in scripts/data/build-interaction-data.mjs that
+      // never executes under test. Alias it to a stub so Vite's static import
+      // analysis can still resolve the specifier when transforming that file.
+      xlsx: path.resolve(__dirname, 'scripts/data/xlsx-optional-dependency-stub.mjs'),
+    },
+  },
   plugins: [
     workspaceAliasPlugin(),
     {


### PR DESCRIPTION
## Summary

- Add render tests for `AdditiveRiskPanel`, `EvidenceScoreBadge`, `SafetyGaugeMeter`, and `RelatedDiscoveryGroups` — shared components rendered across herb/compound pages that previously had zero direct test coverage (only 2 of 198 `components/` files were tested).
- Add unit tests for `deriveInteractionData` in `scripts/data/build-interaction-data.mjs`, the parser that builds the additive-risk interaction graph from workbook rows consumed by `lib/interaction-risk.ts` (tested in #2048) and `AdditiveRiskPanel`.
- Alias the unused `xlsx` import to a small test-only stub in `vitest.config.ts` so the parser module (which has a dead standalone-CLI branch referencing that package) can be imported under Vitest without adding a real dependency.

## Verification

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` (426 tests passing)
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs
- [x] no generated file corruption
- [x] static export compatible (`npm run build:fast` completed successfully)

## Risk Notes

- Test-only changes; no production code paths modified.
- The `xlsx` alias in `vitest.config.ts` only affects the Vitest module graph, not the Next.js/webpack build.


---
_Generated by [Claude Code](https://claude.ai/code/session_016Fbfc2y4EwJmZctzkQcEWL)_