### PR TITLE
Add render tests for evidence lens, study list, and cluster cross-linking components

### DIFF
--- a/components/__tests__/SeeAlsoCluster.test.tsx
+++ b/components/__tests__/SeeAlsoCluster.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { AnchorHTMLAttributes, ReactNode } from 'react'
+import SeeAlsoCluster from '../SeeAlsoCluster'
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: AnchorHTMLAttributes<HTMLAnchorElement> & { children: ReactNode; href: string }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+describe('SeeAlsoCluster', () => {
+  it('renders nothing for a slug that belongs to no cluster', () => {
+    const { container } = render(<SeeAlsoCluster slug="not-a-real-herb" kind="herb" />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders a single "guide" link and no per-group headings for a single-cluster entity', () => {
+    render(<SeeAlsoCluster slug="valerian" kind="herb" />)
+
+    expect(screen.getByText('Also in this cluster')).toBeTruthy()
+    expect(screen.getByRole('link', { name: /Sleep & Recovery guide/ })).toHaveAttribute('href', '/goals/sleep')
+  })
+
+  it('groups peer links under a per-cluster heading for a multi-cluster entity once the limit allows peers from more than one cluster', () => {
+    // bacopa belongs to 4 clusters, but adhd-focus alone has 6 peers, so the
+    // default limit of 6 never lets a second cluster's entries through.
+    render(<SeeAlsoCluster slug="bacopa" kind="herb" limit={20} />)
+
+    const links = screen.getAllByRole('link', { name: /Full guide/ })
+    expect(links.length).toBeGreaterThan(1)
+  })
+
+  it('never links back to the entity itself', () => {
+    render(<SeeAlsoCluster slug="bacopa" kind="herb" limit={20} />)
+    expect(screen.queryByRole('link', { name: /^Bacopa$/ })).toBeNull()
+  })
+
+  it('respects the limit prop on the number of peer entries shown', () => {
+    render(<SeeAlsoCluster slug="bacopa" kind="herb" limit={1} />)
+    const peerLinks = screen.getAllByRole('link').filter((link) => !/Full guide|guide →/.test(link.textContent || ''))
+    expect(peerLinks.length).toBeLessThanOrEqual(1)
+  })
+})

--- a/components/ui/__tests__/EvidenceGradeExplainer.test.tsx
+++ b/components/ui/__tests__/EvidenceGradeExplainer.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import EvidenceGradeExplainer from '../EvidenceGradeExplainer'
+
+describe('EvidenceGradeExplainer', () => {
+  it('renders all four evidence grades with their labels inside a collapsed disclosure', () => {
+    const { container } = render(<EvidenceGradeExplainer />)
+
+    expect(container.querySelector('details')).not.toBeNull()
+    expect(container.querySelector('details')?.hasAttribute('open')).toBe(false)
+
+    for (const [grade, label] of [
+      ['A', 'Strong'],
+      ['B', 'Moderate'],
+      ['C', 'Preliminary / Mixed'],
+      ['D', 'Traditional / Theoretical'],
+    ]) {
+      expect(screen.getByText(grade)).toBeTruthy()
+      expect(screen.getByText(label)).toBeTruthy()
+    }
+  })
+})

--- a/components/ui/__tests__/ProfileEvidenceLens.test.tsx
+++ b/components/ui/__tests__/ProfileEvidenceLens.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import ProfileEvidenceLens from '../ProfileEvidenceLens'
+
+describe('ProfileEvidenceLens', () => {
+  it('shows the strong-evidence meter and label for a strong-evidence record', () => {
+    render(<ProfileEvidenceLens record={{ slug: 'test', evidence_tier: 'Strong evidence' }} />)
+    expect(screen.getByText('Strong')).toBeTruthy()
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '100')
+  })
+
+  it('falls back to the "limited" meter for an unrecognized tier', () => {
+    render(<ProfileEvidenceLens record={{ slug: 'test' }} />)
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '50')
+  })
+
+  it('flags human clinical evidence as present when the record signals it', () => {
+    render(<ProfileEvidenceLens record={{ slug: 'test', evidence_tier: 'Strong human clinical trial evidence' }} />)
+    expect(screen.getByText('Present in source signals')).toBeTruthy()
+  })
+
+  it('flags human clinical evidence as absent for animal/preclinical-only records', () => {
+    render(<ProfileEvidenceLens record={{ slug: 'test', evidence_tier: 'Preclinical animal studies only' }} />)
+    expect(screen.getByText('Not the primary signal')).toBeTruthy()
+  })
+
+  it('lists cleaned mechanism labels when mechanisms are present', () => {
+    render(<ProfileEvidenceLens record={{ slug: 'test', mechanisms: ['gaba_modulation', 'cortisol_reduction'] }} />)
+    expect(screen.getByText(/Gaba Modulation/)).toBeTruthy()
+  })
+
+  it('uses singular "study" wording for exactly one citation', () => {
+    render(<ProfileEvidenceLens record={{ slug: 'test' }} citationsCount={1} />)
+    expect(screen.getByText('This profile cites 1 human study.')).toBeTruthy()
+  })
+
+  it('uses plural "studies" wording for more than one citation', () => {
+    render(<ProfileEvidenceLens record={{ slug: 'test' }} citationsCount={4} />)
+    expect(screen.getByText('This profile cites 4 human studies.')).toBeTruthy()
+  })
+
+  it('omits the citation count line entirely when citationsCount is 0', () => {
+    render(<ProfileEvidenceLens record={{ slug: 'test' }} citationsCount={0} />)
+    expect(screen.queryByText(/human stud/)).toBeNull()
+  })
+})

--- a/components/ui/__tests__/ShowMeTheStudies.test.tsx
+++ b/components/ui/__tests__/ShowMeTheStudies.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import ShowMeTheStudies from '../ShowMeTheStudies'
+import type { Citation } from '../ShowMeTheStudies'
+
+function citation(overrides: Partial<Citation> = {}): Citation {
+  return { title: 'A study title', ...overrides }
+}
+
+describe('ShowMeTheStudies', () => {
+  it('renders nothing when there are no citations', () => {
+    const { container } = render(<ShowMeTheStudies citations={[]} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when citations is null/undefined', () => {
+    const { container } = render(<ShowMeTheStudies citations={undefined as unknown as Citation[]} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('uses singular "study" wording for exactly one citation', () => {
+    render(<ShowMeTheStudies citations={[citation()]} />)
+    expect(screen.getByText(/1 cited study informing/)).toBeTruthy()
+  })
+
+  it('uses plural "studies" wording for more than one citation', () => {
+    render(<ShowMeTheStudies citations={[citation({ title: 'A' }), citation({ title: 'B' })]} />)
+    expect(screen.getByText(/2 cited studies informing/)).toBeTruthy()
+  })
+
+  it('links the study title and "PubMed" cell to PubMed when a pmid is present', () => {
+    render(<ShowMeTheStudies citations={[citation({ title: 'Ashwagandha RCT', pmid: '12345678' })]} />)
+    const links = screen.getAllByRole('link', { name: /Ashwagandha RCT|PubMed/ })
+    expect(links.length).toBeGreaterThan(0)
+    for (const link of links) {
+      expect(link).toHaveAttribute('href', 'https://pubmed.ncbi.nlm.nih.gov/12345678/')
+    }
+  })
+
+  it('shows a plain dash instead of a PubMed link when no pmid is present', () => {
+    render(<ShowMeTheStudies citations={[citation({ title: 'No PMID Study' })]} />)
+    expect(screen.queryByRole('link')).toBeNull()
+  })
+
+  it('shows sample size as "n=<value>" when provided, otherwise a dash', () => {
+    render(<ShowMeTheStudies citations={[citation({ title: 'Sized study', sampleSize: 42 })]} />)
+    expect(screen.getByText('n=42')).toBeTruthy()
+  })
+
+  it('keeps the first 6 citations visible and moves the rest behind a "Show N more" disclosure', () => {
+    const citations = Array.from({ length: 9 }, (_, i) => citation({ title: `Study ${i}` }))
+    const { container } = render(<ShowMeTheStudies citations={citations} />)
+
+    expect(container.querySelectorAll('tbody tr')).toHaveLength(9)
+    expect(screen.getByText('Show 3 more studies')).toBeTruthy()
+  })
+
+  it('omits the overflow disclosure entirely when 6 or fewer citations are given', () => {
+    const citations = Array.from({ length: 6 }, (_, i) => citation({ title: `Study ${i}` }))
+    const { container } = render(<ShowMeTheStudies citations={citations} />)
+    expect(container.querySelector('details')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

- Add render tests for `ProfileEvidenceLens` (evidence tier meter + human/mechanistic/preliminary signal cards), `ShowMeTheStudies` (citation table with study-type sorting, overflow disclosure, PubMed linking), `EvidenceGradeExplainer` (static grade legend), and `SeeAlsoCluster` (semantic cluster cross-linking) — more shared components rendered on herb/compound detail pages that previously had zero direct test coverage.
- `SeeAlsoCluster` tests exercise real cluster data from `lib/cluster-linking.ts` (`valerian` for the single-cluster path, `bacopa` for the multi-cluster path) rather than mocking the data layer.

## Verification

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` (449 tests passing)
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs
- [x] no generated file corruption
- [x] static export compatible

## Risk Notes

- Test-only changes; no production code paths modified.


---
_Generated by [Claude Code](https://claude.ai/code/session_016Fbfc2y4EwJmZctzkQcEWL)_