### PR TITLE
Fix CI build failure: unapproved dangerouslySetInnerHTML + affiliate-audit false positive

### DIFF
--- a/components/seo/FAQSchema.tsx
+++ b/components/seo/FAQSchema.tsx
@@ -1,10 +1,12 @@
 /**
  * FAQ Structured Data Component
- * 
- * Renders FAQPage JSON-LD for FAQ sections. 
+ *
+ * Renders FAQPage JSON-LD for FAQ sections.
  * Use when a page has real FAQ content that should earn rich results.
  * Only emits when questions array is non-empty.
  */
+import JsonLd from './JsonLd'
+
 type FAQItem = { question: string; answer: string }
 
 export default function FAQSchema({ questions, pagePath }: { questions: FAQItem[]; pagePath: string }) {
@@ -24,10 +26,5 @@ export default function FAQSchema({ questions, pagePath }: { questions: FAQItem[
     url: `https://thehippiescientist.net${pagePath}`,
   }
 
-  return (
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-    />
-  )
+  return <JsonLd schema={faqJsonLd} />
 }

--- a/scripts/ci/audit-sitemap-affiliate-links.mjs
+++ b/scripts/ci/audit-sitemap-affiliate-links.mjs
@@ -41,8 +41,23 @@ function main() {
   let failed = false
   const errors = []
 
-  // Simple regex to find href links
-  const hrefRegex = /href="([^"]*?)"/gi
+  // Only scan clickable <a> links — <link rel="preconnect"/"dns-prefetch"> resource
+  // hints (e.g. to m.media-amazon.com, images-na.ssl-images-amazon.com for image CDN
+  // performance) are not outbound purchase links and never carry affiliate tags.
+  const anchorRegex = /<a\b[^>]*\shref="([^"]*)"[^>]*>/gi
+
+  // Real Amazon storefront/product domains only — excludes CDN/image subdomains like
+  // media-amazon.com or ssl-images-amazon.com, which a plain substring match on
+  // "amazon.com" would incorrectly catch.
+  const AMAZON_RETAIL_HOSTS = new Set(['amazon.com', 'www.amazon.com', 'amazon.co.uk', 'www.amazon.co.uk', 'amzn.to'])
+
+  function isAmazonRetailLink(href) {
+    try {
+      return AMAZON_RETAIL_HOSTS.has(new URL(href).hostname.toLowerCase())
+    } catch {
+      return false
+    }
+  }
 
   for (const url of urls) {
     let urlObj
@@ -67,20 +82,16 @@ function main() {
 
     const htmlContent = fs.readFileSync(localPath, 'utf8')
     let match
-    while ((match = hrefRegex.exec(htmlContent)) !== null) {
+    while ((match = anchorRegex.exec(htmlContent)) !== null) {
       const href = match[1]
-      const isAmazon = href.includes('amazon.com') || href.includes('amzn.to') || href.includes('amazon.co.uk')
-      if (isAmazon) {
-        const isStandardAmazonLink = href.includes('amazon.com') || href.includes('amazon.co.uk')
-        if (isStandardAmazonLink) {
-          const hasTag = href.includes(`tag=${AMAZON_TAG}`)
-          // Exclude non-product pages like customer service, registry, privacy, policy, etc., if any
-          const isSupportPage = href.includes('/gp/help/') || href.includes('/privacy') || href.includes('/gp/customer-service')
-          
-          if (!hasTag && !isSupportPage) {
-            errors.push(`Page "${pathname}" contains non-compliant Amazon link: "${href}" (missing "tag=${AMAZON_TAG}")`)
-            failed = true
-          }
+      if (isAmazonRetailLink(href)) {
+        const hasTag = href.includes(`tag=${AMAZON_TAG}`)
+        // Exclude non-product pages like customer service, registry, privacy, policy, etc., if any
+        const isSupportPage = href.includes('/gp/help/') || href.includes('/privacy') || href.includes('/gp/customer-service')
+
+        if (!hasTag && !isSupportPage) {
+          errors.push(`Page "${pathname}" contains non-compliant Amazon link: "${href}" (missing "tag=${AMAZON_TAG}")`)
+          failed = true
         }
       }
     }


### PR DESCRIPTION
## Summary

Traced the actual CI failure on `main` (the "CI" and "Site Health Check" workflows were both red on the tip commit) down to `npm run verify:output`, which runs in two chained sub-steps. Two separate, previously-hidden issues, each only surfacing after the one before it got fixed:

1. **`components/seo/FAQSchema.tsx`** rendered its JSON-LD via a raw `dangerouslySetInnerHTML` instead of the shared, HTML-escaping `JsonLd` component. `validate-dangerously-set-inner-html.mjs` correctly flags this — an unescaped `<` in FAQ answer text could break out of the `<script>` tag (the same class of issue `JsonLd.tsx` exists specifically to prevent). Refactored `FAQSchema` to delegate to `JsonLd`, same pattern every other structured-data component in the codebase already uses.

2. Once that passed, `verify:postbuild`'s outbound-Amazon-link audit (`audit-sitemap-affiliate-links.mjs`) failed next — but this one was a **false positive in the validator itself**. Its Amazon-domain check was a plain substring match on `"amazon.com"`, which also matches the CDN subdomains used by the `<link rel="preconnect">` / `<link rel="dns-prefetch">` performance hints in `app/layout.tsx` (`m.media-amazon.com`, `images-na.ssl-images-amazon.com`) — resource hints, not outbound purchase links, that were never supposed to carry affiliate tags. The regex also matched any `href="..."`, including `<link>` tags, not just `<a>` tags. Narrowed the scan to `<a>` tags only and switched to an exact-hostname allowlist (`amazon.com`/`www.amazon.com`/`amazon.co.uk`/`amzn.to`) so CDN domains are correctly excluded while real product links missing the tag are still caught — verified real `<a href="https://www.amazon.com/s?...&tag=dev-affiliate-00">` links still pass correctly.

## Test plan
- [x] `npm run typecheck` / `npm run lint` — clean
- [x] `npm run test` — 449/449 pass
- [x] **`npm run check:full` — exits 0** (this is the first time this full gate has passed end-to-end this session; it chains typecheck, lint, build, `verify:output` [both prebuild and postbuild sub-checks], evidence-language validation, and data-governance audit)
- [x] Confirmed via the built HTML output that the preconnect/dns-prefetch links to Amazon CDN domains are correctly excluded, while real affiliate product links (e.g. `guides/adhd/l-theanine-magnesium-adhd-stack`) still carry and are validated for `tag=dev-affiliate-00`


---
_Generated by [Claude Code](https://claude.ai/code/session_01EfTJURKd1XMnBxVQvDbTaB)_