### PR TITLE
Fix build-breaking duplicate closing bracket + remove dead unused REFS arrays

### DIFF
--- a/app/guides/other/collagen-supplements/page.tsx
+++ b/app/guides/other/collagen-supplements/page.tsx
@@ -22,18 +22,6 @@ const FAQS = [
   { question: 'Can I get collagen from bone broth?', answer: 'Bone broth collagen content is unpredictable — one study found commercial broths ranged from undetectable to 5 g/serving [8]. Supplements provide standardized doses matching clinical trial protocols. Bone broth is a healthy food but not a reliable substitute for studied collagen doses.' },
 ];
 
-const COLLAGEN_REFS = [
-  { n: 1, text: 'de Miranda RB, et al. (2021). Hydrolyzed collagen on skin aging: meta-analysis. Int J Dermatol, 60(12): 1449-1461.', url: 'https://pubmed.ncbi.nlm.nih.gov/34617276/' },
-  { n: 2, text: 'Choi FD, et al. (2019). Oral collagen: systematic review. J Drugs Dermatol, 18(1): 9-16.', url: 'https://pubmed.ncbi.nlm.nih.gov/30681787/' },
-  { n: 3, text: 'Crowley DC, et al. (2009). Undenatured type II collagen in knee OA. Int J Med Sci, 6(6): 312-321.', url: 'https://pubmed.ncbi.nlm.nih.gov/19847319/' },
-  { n: 4, text: 'Bello A, Oesser S. (2006). Collagen hydrolysate for joint disorders. Curr Med Res Opin, 22(11): 2221-2232.', url: 'https://pubmed.ncbi.nlm.nih.gov/17076983/' },
-  { n: 5, text: 'Alcock RD, et al. (2019). Plasma amino acids after collagen. Front Nutr, 6: 140.', url: '' },
-  { n: 6, text: 'ConsumerLab.com. (2023). Collagen Supplements Review.', url: 'https://www.consumerlab.com/reviews/collagen-supplements-review/collagen/' },
-  { n: 7, text: 'König D, et al. (2018). Collagen peptides and bone density. Nutrients, 10(1): 97.', url: 'https://pubmed.ncbi.nlm.nih.gov/29337906/' },
-  { n: 8, text: 'Oikawa SY, et al. (2019). Collagen peptide with resistance training. Br J Nutr, 122(8): 889-898.', url: 'https://pubmed.ncbi.nlm.nih.gov/31294236/' },
-]
-]
-
 type RefProps = { n: number; text: string; url?: string }
 function Ref({ n, text, url }: RefProps) { return (<li id={`ref-${n}`} className="text-xs leading-5 text-muted"><span className="font-semibold text-ink">[{n}]</span> {text}{url ? <> <a href={url} target="_blank" rel="noopener noreferrer" className="text-brand-700 underline hover:text-brand-800">→</a></> : null}</li>) }
 

--- a/app/guides/other/electrolyte-supplements/page.tsx
+++ b/app/guides/other/electrolyte-supplements/page.tsx
@@ -19,16 +19,6 @@ const FAQS = [
   { question: 'Is LMNT worth it?', answer: 'For heavy sweaters and endurance athletes — reasonable. LMNT provides 1,000 mg sodium, 200 mg potassium, and 60 mg magnesium at ~$1.50/serving. The 5:1 sodium-to-potassium ratio reflects sweat composition [3]. For everyone else, salt your food and eat potassium-rich foods (bananas, potatoes, spinach) — same electrolytes at 1% of the cost.' },
 ];
 
-const ELECTROLYTE_REFS = [
-  { n: 1, text: 'Australian Institute of Sport. Electrolyte Supplement fact sheet.', url: 'https://www.ausport.gov.au/ais/nutrition/supplements/group_a/sports-foods2/electrolyte-supplement2' },
-  { n: 2, text: 'IOM. (2005). DRIs for Water, Potassium, Sodium, Chloride, and Sulfate.', url: 'https://pubmed.ncbi.nlm.nih.gov/15883093/' },
-  { n: 3, text: 'Baker LB. (2017). Sweating rate and sweat sodium. Sports Med, 47(S1): 65-77.', url: 'https://pubmed.ncbi.nlm.nih.gov/28332115/' },
-  { n: 4, text: 'Butler-Dawson J, et al. (2020). Electrolyte beverage in Guatemalan workers. J Occup Environ Med, 62(12): e739-747.', url: 'https://pubmed.ncbi.nlm.nih.gov/33298780/' },
-  { n: 5, text: 'Phinney SD, et al. (1983). Chronic ketosis without caloric restriction. Metabolism, 32(8): 769-776.', url: 'https://pubmed.ncbi.nlm.nih.gov/6865778/' },
-  { n: 6, text: 'Francisco R, et al. (2026). Athlete hydration and long-term health. Sports Med.', url: 'https://pubmed.ncbi.nlm.nih.gov/42020895/' },
-]
-]
-
 type RefProps = { n: number; text: string; url?: string }
 function Ref({ n, text, url }: RefProps) { return (<li id={`ref-${n}`} className="text-xs leading-5 text-muted"><span className="font-semibold text-ink">[{n}]</span> {text}{url ? <> <a href={url} target="_blank" rel="noopener noreferrer" className="text-brand-700 underline hover:text-brand-800">→</a></> : null}</li>) }
 

--- a/app/guides/other/prebiotics/page.tsx
+++ b/app/guides/other/prebiotics/page.tsx
@@ -22,14 +22,6 @@ const FAQS = [
   { question: 'Which prebiotic supplement is best?', answer: 'PHGG — best-tolerated, evidence for IBS [5]. Inulin/FOS — most studied for microbiome support, more gas [2]. GOS — gentler, supports immune function [6]. Resistant starch (green banana flour, potato starch) — metabolic health, 15-30 g/day. Start with PHGG if sensitive; inulin if fiber-tolerant. No supplement replicates the diversity of food fiber [4].' },
 ];
 
-const PREBIOTICS_REFS = [
-  { n: 1, text: 'Gibson GR, et al. (2017). ISAPP consensus on prebiotics. Nat Rev Gastroenterol Hepatol, 14(8): 491-502.', url: 'https://pubmed.ncbi.nlm.nih.gov/28611480/' },
-  { n: 2, text: 'Holscher HD. (2017). Dietary fiber and the GI microbiota. Gut Microbes, 8(2): 172-184.', url: 'https://pubmed.ncbi.nlm.nih.gov/28165863/' },
-  { n: 3, text: 'Reynolds A, et al. (2019). Carbohydrate quality and health: Lancet review. Lancet, 393: 434-445.', url: 'https://pubmed.ncbi.nlm.nih.gov/30638909/' },
-  { n: 4, text: 'Deehan EC, et al. (2020). Precision microbiome modulation with fiber. Cell Host Microbe, 27(3): 389-404.', url: 'https://pubmed.ncbi.nlm.nih.gov/32101703/' },
-  { n: 5, text: 'Slavin J. (2013). Fiber and prebiotics: mechanisms and health benefits. Nutrients, 5(4): 1417-1435.', url: 'https://pubmed.ncbi.nlm.nih.gov/23609775/' },
-]
-
 type RefProps = { n: number; text: string; url?: string }
 function Ref({ n, text, url }: RefProps) { return (<li id={`ref-${n}`} className="text-xs leading-5 text-muted"><span className="font-semibold text-ink">[{n}]</span> {text}{url ? <> <a href={url} target="_blank" rel="noopener noreferrer" className="text-brand-700 underline hover:text-brand-800">→</a></> : null}</li>) }
 


### PR DESCRIPTION
## Summary

`main` was failing `tsc`/the build again — a batch pass separating `FAQS`/`REFS` arrays across several guide pages left two files with a duplicate trailing `]` after the array literal (`collagen-supplements`, `electrolyte-supplements`) — a hard syntax error (`TS1128: Declaration or statement expected`).

Once the syntax was fixed, those two plus `prebiotics` still had an unused-variable lint warning: each defines a `COLLAGEN_REFS`/`ELECTROLYTE_REFS`/`PREBIOTICS_REFS` array that's never referenced anywhere. These three pages already render their citations via hardcoded `<Ref n={...} text="..." />` elements directly in JSX — so the separately-declared arrays were pure dead code duplicating the same citation data, not a "forgot to render" bug like the earlier PR. Removed them rather than wiring up a redundant second citation list.

## Test plan
- [x] `npm run typecheck` — clean (was failing with 2 hard errors)
- [x] `npm run lint` — 0 errors, 0 warnings (was 3 warnings)
- [x] `npm run test` — 449/449 pass
- [x] `npm run check:full` — exits 0


---
_Generated by [Claude Code](https://claude.ai/code/session_01EfTJURKd1XMnBxVQvDbTaB)_