### PR TITLE
Fix build-breaking unescaped '&gt;' character in nootropic evaluation guide

### DIFF
--- a/app/learn/what-is-a-nootropic/page.tsx
+++ b/app/learn/what-is-a-nootropic/page.tsx
@@ -206,7 +206,7 @@ export default function NootropicEducationPage() {
         ]}
       />
 
-      <section className="card-premium p-6 space-y-4 mb-8"><h2 className="text-2xl font-semibold tracking-tight text-ink">How to evaluate nootropic claims</h2><p className="text-sm leading-7 text-muted">Most nootropic claims are based on animal studies, small uncontrolled trials, or mechanistic speculation. Reliable evidence requires: human RCTs with placebo control, n>30, at least 4 weeks duration, and independent replication. The only nootropics meeting these criteria for healthy adults: caffeine, L-theanine, creatine (under stress), and bacopa (for memory). Everything else has substantially weaker evidence. The nootropic industry is largely unregulated. Apply the same skepticism you would to any health claim.</p></section>
+      <section className="card-premium p-6 space-y-4 mb-8"><h2 className="text-2xl font-semibold tracking-tight text-ink">How to evaluate nootropic claims</h2><p className="text-sm leading-7 text-muted">Most nootropic claims are based on animal studies, small uncontrolled trials, or mechanistic speculation. Reliable evidence requires: human RCTs with placebo control, n&gt;30, at least 4 weeks duration, and independent replication. The only nootropics meeting these criteria for healthy adults: caffeine, L-theanine, creatine (under stress), and bacopa (for memory). Everything else has substantially weaker evidence. The nootropic industry is largely unregulated. Apply the same skepticism you would to any health claim.</p></section>
 
       <References refs={WHAT_IS_A_NOOTROPIC_REFS} />
       </EducationPageLayout>


### PR DESCRIPTION
## Summary

`main` was failing `tsc`/the build again. `app/learn/what-is-a-nootropic/page.tsx` used a literal `n>30` (sample-size comparator) in JSX text content — an unescaped `>` in JSX text is invalid syntax (`TS1382`), same class of bug as the earlier "Jersey > Holstein" fix in `guides/other/bovine-colostrum`. Escaped it to `n&gt;30`.

## Test plan
- [x] `npm run typecheck` — clean (was failing with 1 hard error)
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm run test` — 449/449 pass
- [x] `npm run check:full` — exits 0


---
_Generated by [Claude Code](https://claude.ai/code/session_01EfTJURKd1XMnBxVQvDbTaB)_