### PR TITLE
Fix TS7022 typecheck failure in ContentCards.tsx

### DIFF
--- a/components/content/ContentCards.tsx
+++ b/components/content/ContentCards.tsx
@@ -48,7 +48,7 @@ function wrapInDetails(
 
   let current: Element | null = startEl
   while (current && current !== endEl) {
-    const next = current.nextElementSibling
+    const next: Element | null = current.nextElementSibling
     content.appendChild(current)
     current = next
   }
@@ -132,12 +132,12 @@ export default function ContentCards({ children }: { children: ReactNode }) {
 
       let current: Element | null = firstH2
       while (current) {
-        const next = current.nextElementSibling
+        const next: Element | null = current.nextElementSibling
         wrapper.appendChild(current)
         if (current === lastH2) {
-          let after = next
+          let after: Element | null = next
           while (after && after.tagName !== 'H2') {
-            const afterNext = after.nextElementSibling
+            const afterNext: Element | null = after.nextElementSibling
             wrapper.appendChild(after)
             after = afterNext
           }


### PR DESCRIPTION
## Summary

- The `CI` workflow was failing on `main` (including on the just-merged formatting-audit commit) at the `npm run typecheck` step, with two TS7022 "implicitly has type 'any'" errors in `components/content/ContentCards.tsx`. Confirmed via a clean worktree that this bug pre-dates the formatting-audit merge — it was already present when the file lived at its old path, just never actually reached by a completed CI run I could find.
- Fixed by explicitly annotating three `Element | null` locals (`next`, `after`, `afterNext`) that were being assigned from `nextElementSibling` inside `while` loops, instead of relying on inference.

## Verification

- [x] `npm run lint` — passes clean
- [x] `npm run typecheck` — passes clean (was failing)
- [x] `npm run test` — 449/449 passing
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs
- [x] no generated file corruption
- [x] static export compatible

## Risk Notes

- Single-file, type-annotation-only change — no runtime behavior change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01N5BJzyhpmTd72Awzn2PS6Q)_