### PR TITLE
Fix ContentCards page crash and unbounded collapsible-warning bug

### DIFF
--- a/components/content/ContentCards.tsx
+++ b/components/content/ContentCards.tsx
@@ -46,15 +46,19 @@ function wrapInDetails(
   const parent = startEl.parentNode
   if (!parent) return
 
+  // Insert the (still-empty) details shell at startEl's original position
+  // before moving anything — startEl stops being parent's child the moment
+  // the loop below appends it into content, so inserting relative to it
+  // afterward would throw (it's no longer a child of parent).
+  parent.insertBefore(details, startEl)
+  details.appendChild(content)
+
   let current: Element | null = startEl
   while (current && current !== endEl) {
     const next: Element | null = current.nextElementSibling
     content.appendChild(current)
     current = next
   }
-
-  details.appendChild(content)
-  parent.insertBefore(details, startEl)
 }
 
 export default function ContentCards({ children }: { children: ReactNode }) {
@@ -79,10 +83,14 @@ export default function ContentCards({ children }: { children: ReactNode }) {
         // Find the parent list or paragraph to wrap
         const listParent = el.closest('ul, ol') || el.closest('p')
         if (listParent && !listParent.closest('details')) {
-          const endEl = listParent.nextElementSibling?.tagName === 'P' && /caution|avoid/i.test(listParent.nextElementSibling.textContent || '')
+          const cautionPara = listParent.nextElementSibling?.tagName === 'P' && /caution|avoid/i.test(listParent.nextElementSibling.textContent || '')
             ? listParent.nextElementSibling
             : null
-          wrapInDetails(listParent, endEl?.nextElementSibling || null, 'Combination Cautions', false)
+          // Bound the wrap to listParent (plus the caution paragraph, if any) —
+          // falling back to null here would make wrapInDetails walk every
+          // remaining sibling in the section into one collapsed block.
+          const endEl = cautionPara ? cautionPara.nextElementSibling : listParent.nextElementSibling
+          wrapInDetails(listParent, endEl, 'Combination Cautions', false)
         }
       }
 
@@ -130,6 +138,10 @@ export default function ContentCards({ children }: { children: ReactNode }) {
       const parent = firstH2.parentNode
       if (!parent) return
 
+      // Insert the wrapper at firstH2's original position before moving
+      // anything into it — same reasoning as wrapInDetails above.
+      parent.insertBefore(wrapper, firstH2)
+
       let current: Element | null = firstH2
       while (current) {
         const next: Element | null = current.nextElementSibling
@@ -145,8 +157,6 @@ export default function ContentCards({ children }: { children: ReactNode }) {
         }
         current = next
       }
-      
-      parent.insertBefore(wrapper, firstH2)
     })
 
     // ── Step 3: Wrap intro content ──

--- a/content/articles/berberine.md
+++ b/content/articles/berberine.md
@@ -182,8 +182,6 @@ Berberine is generally safe in healthy people at therapeutic doses for up to 6 m
 
 ---
 
-## FAQ
-
 </CollapsibleWarning>
 
 ## FAQ

--- a/content/articles/rhodiola-rosea.md
+++ b/content/articles/rhodiola-rosea.md
@@ -271,8 +271,6 @@ Rhodiola has a favorable safety profile in trials up to 12 weeks. The most commo
 
 ---
 
-## FAQ
-
 </CollapsibleWarning>
 
 ## FAQ


### PR DESCRIPTION
## Summary

- User reported the "combined with" combination-warning collapsible was "very very long" on an article page. Root cause: `ContentCards.tsx`'s Step 1 wraps a "Do NOT combine with:" list/paragraph in a native `<details>`, but when no adjacent caution paragraph is found (the common case), the end boundary fell back to `null` — and `wrapInDetails`'s loop only stops when `current === endEl`, so `null` means it never stops until it runs out of siblings, swallowing the rest of the section into one collapsed box.
- While tracing that, found a more severe bug in Step 2 (groups h2 headings into the visual section cards used on every article page): it calls `parent.insertBefore(wrapper, firstH2)` *after* the preceding loop has already moved `firstH2` out of `parent` — which throws `NotFoundError`. Verified in a real browser (Playwright) that this crashes `/articles/rhodiola-rosea/` to the generic `app/error.tsx` "Something went wrong" page after hydration. This runs on every article page with more than one canonical section group, i.e. nearly all of them.
- Fixed both by inserting the wrapper/details shell into its final DOM position *before* moving any content into it, and by bounding the "Combination Cautions" wrap to just the intended element when no caution paragraph follows.
- Also removed an orphaned duplicate `## FAQ` heading trapped inside `<CollapsibleWarning>` blocks in `content/articles/berberine.md` and `rhodiola-rosea.md`, noticed while tracing the crash.

## Verification

- [x] `npm run lint` — passes clean
- [x] `npm run typecheck` — passes clean
- [x] `npm run validate:article-quality` — PASS
- [x] `npm run test` — 449/449 passing
- [x] Verified in a real browser via Playwright: `/articles/rhodiola-rosea/`, `/articles/creatine-brain-health/`, `/articles/kava/`, `/articles/ginkgo-biloba/`, `/articles/berberine/` all render without crashing (no "Something went wrong" fallback), section cards render correctly, and the combination-warning `<details>` is collapsed by default with only its intended content (screenshots taken of collapsed/expanded states)
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs
- [x] no generated file corruption
- [x] static export compatible

## Risk Notes

- Behavioral change only in client-side DOM post-processing (`ContentCards.tsx`); no change to server-rendered markup or data.


---
_Generated by [Claude Code](https://claude.ai/code/session_01N5BJzyhpmTd72Awzn2PS6Q)_