### PR TITLE
Fix asymmetric evidence-level filter pills on /herbs mobile view

### DIFF
--- a/app/herbs/HerbsIndexClient.tsx
+++ b/app/herbs/HerbsIndexClient.tsx
@@ -416,7 +416,7 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
 
           <div className="mt-2">
             <div className="mb-1.5 text-xs font-bold uppercase tracking-[0.12em] text-muted">Evidence level</div>
-            <div className="flex flex-wrap gap-2">
+            <div className="grid grid-cols-2 gap-2 sm:flex sm:flex-wrap">
               {EVIDENCE_FILTER_OPTIONS.map(opt => {
                 const href = buildEvidenceHref(opt.value, query, activeFilter)
                 const active = activeEvidence === opt.value
@@ -424,7 +424,7 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
                   <Link
                     key={opt.value}
                     href={href}
-                    className={`rounded-full border px-2.5 py-1 text-xs font-semibold transition ${active ? 'border-brand-700/25 bg-brand-50 text-brand-900' : 'border-brand-900/10 bg-[var(--surface-card)] text-[#33443a] hover:border-brand-700/20'}`}
+                    className={`rounded-full border px-2.5 py-1 text-center text-xs font-semibold transition ${active ? 'border-brand-700/25 bg-brand-50 text-brand-900' : 'border-brand-900/10 bg-[var(--surface-card)] text-[#33443a] hover:border-brand-700/20'}`}
                   >
                     {opt.label}
                   </Link>


### PR DESCRIPTION
## Summary

- On `/herbs`, the "Evidence level" filter row (Any evidence / Strong / Moderate / Limited / prelim) used `flex flex-wrap` with auto-width pill labels. On narrow mobile viewports the three shorter labels filled the first row while "Limited / prelim" (the longest label) wrapped alone onto a second row by itself — reported as looking "messed up" and lacking symmetry.
- Switched the container to a 2-column grid below the `sm` breakpoint so the 4 pills always form two even rows; above `sm` it falls back to the original `flex flex-wrap` single row where there's room for all four.

## Verification

- [x] `npm run lint` — passes clean
- [x] `npm run typecheck` — passes clean
- [x] `npm run test` — 449/449 passing
- [x] Verified visually with Playwright at a 390px mobile viewport (both light and dark mode) — pills now render as a clean 2×2 grid instead of an orphaned single pill on its own row
- [x] Verified at 1280px desktop viewport — unchanged, still renders as one row
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs
- [x] no generated file corruption
- [x] static export compatible

## Risk Notes

- Single-file, Tailwind-class-only change to one filter row on `/herbs`; no logic changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01N5BJzyhpmTd72Awzn2PS6Q)_