### PR TITLE
Fix mobile homepage and navigation layout

### DIFF
--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -56,16 +56,16 @@ export function Navigation() {
       }`}
       aria-label="Primary"
     >
-      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <div className="flex h-16 items-center justify-between">
+      <div className="mx-auto max-w-7xl px-3 sm:px-6 lg:px-8">
+        <div className="flex h-14 items-center justify-between gap-2 sm:h-16">
           {/* Logo — Fraunces via font-display */}
           <Link
             href="/"
-            className="flex items-center gap-2 font-display text-[1.15rem] font-bold italic tracking-[-0.02em] text-ink transition hover:text-brand-700 dark:text-[var(--text-primary)]"
+            className="flex min-w-0 items-center gap-2 font-display text-[1rem] font-bold italic tracking-[-0.02em] text-ink transition hover:text-brand-700 dark:text-[var(--text-primary)] sm:text-[1.15rem]"
             aria-label="The Hippie Scientist home"
           >
             <Leaf aria-hidden="true" className="h-5 w-5 shrink-0 text-brand-700 dark:text-[var(--accent-teal)]" strokeWidth={1.75} />
-            The Hippie Scientist
+            <span className="max-w-[11.5rem] truncate sm:max-w-none">The Hippie Scientist</span>
           </Link>
 
           {/* Desktop nav links */}
@@ -87,7 +87,7 @@ export function Navigation() {
           </div>
 
           {/* Right side actions (desktop search trigger + mobile hamburger) */}
-          <div className="flex items-center gap-2">
+          <div className="flex shrink-0 items-center gap-1.5 sm:gap-2">
             {/* Global search command palette (Cmd/Ctrl+K, "/" hotkey, visible trigger) */}
             <GlobalSearchModal />
             <DarkModeToggle className="hidden md:inline-flex" />
@@ -95,7 +95,7 @@ export function Navigation() {
             <button
               type="button"
               onClick={() => setMobileOpen(!mobileOpen)}
-              className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md p-2 text-ink/70 transition hover:bg-brand-50 hover:text-ink focus-visible:outline-none dark:text-[var(--text-secondary)] dark:hover:bg-[var(--surface-subtle)] dark:hover:text-[var(--text-primary)] md:hidden"
+              className="inline-flex min-h-[42px] min-w-[42px] items-center justify-center rounded-full p-2 text-ink/70 transition hover:bg-brand-50 hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-700 focus-visible:ring-offset-2 dark:text-[var(--text-secondary)] dark:hover:bg-[var(--surface-subtle)] dark:hover:text-[var(--text-primary)] md:hidden"
               aria-label={mobileOpen ? 'Close menu' : 'Open menu'}
               aria-expanded={mobileOpen}
               aria-controls="mobile-nav"
@@ -111,7 +111,7 @@ export function Navigation() {
         <div id="mobile-nav" className="md:hidden">
           {/* Backdrop */}
           <div
-            className="fixed inset-0 z-40 bg-black/30"
+            className="fixed inset-0 z-40 bg-black/35 backdrop-blur-[1px]"
             onClick={closeMobile}
             aria-hidden="true"
           />
@@ -121,18 +121,18 @@ export function Navigation() {
             role="dialog"
             aria-modal="true"
             aria-label="Mobile navigation menu"
-            className="fixed inset-y-0 right-0 z-50 w-72 overflow-y-auto border-l border-brand-900/10 bg-white px-4 py-6 shadow-xl dark:border-[var(--border-strong)] dark:bg-[var(--surface-card-strong)]"
+            className="fixed inset-y-0 right-0 z-50 w-[min(22rem,calc(100vw-1rem))] overflow-y-auto rounded-l-2xl border-l border-brand-900/10 bg-white px-4 py-5 shadow-2xl dark:border-[var(--border-strong)] dark:bg-[var(--surface-card-strong)]"
             style={{ height: '100dvh' }}
           >
-            <div className="mb-6 flex items-center justify-between">
-              <Link href="/" onClick={closeMobile} className="flex items-center gap-2 font-display text-lg font-semibold text-ink">
+            <div className="mb-5 flex items-center justify-between gap-3">
+              <Link href="/" onClick={closeMobile} className="flex min-w-0 items-center gap-2 font-display text-base font-semibold text-ink dark:text-[var(--text-primary)]">
                 <Leaf aria-hidden="true" className="h-[1.125rem] w-[1.125rem] shrink-0 text-brand-700 dark:text-[var(--accent-teal)]" strokeWidth={1.75} />
-                The Hippie Scientist
+                <span className="truncate">The Hippie Scientist</span>
               </Link>
               <button
                 type="button"
                 onClick={closeMobile}
-                className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded p-2 text-ink/70 hover:bg-brand-50 dark:text-[var(--text-secondary)] dark:hover:bg-[var(--surface-subtle)] dark:hover:text-[var(--text-primary)]"
+                className="flex min-h-[42px] min-w-[42px] items-center justify-center rounded-full p-2 text-ink/70 hover:bg-brand-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-700 focus-visible:ring-offset-2 dark:text-[var(--text-secondary)] dark:hover:bg-[var(--surface-subtle)] dark:hover:text-[var(--text-primary)]"
                 aria-label="Close menu"
               >
                 <X aria-hidden="true" className="h-5 w-5" />
@@ -140,34 +140,34 @@ export function Navigation() {
             </div>
 
             {/* Mobile search — mirrors desktop command palette */}
-            <div className="mb-3">
+            <div className="mb-4">
               <GlobalSearchModal />
             </div>
 
-            <nav className="flex flex-col gap-1 text-base" aria-label="Mobile primary links">
+            <nav className="flex flex-col gap-1.5 text-base" aria-label="Mobile primary links">
               {primaryLinks.map((link) => (
                 <div key={link.href}>
                   <Link
                     href={toCanonicalHref(link.href)}
                     onClick={closeMobile}
                     aria-current={isActive(link.href) ? 'page' : undefined}
-                    className={`block rounded-lg px-3 py-2.5 font-medium transition ${
+                    className={`block rounded-xl px-3.5 py-3 font-semibold transition ${
                       isActive(link.href)
-                        ? 'border-l-2 border-brand-700 bg-brand-50/60 pl-[10px] font-semibold text-brand-900 dark:border-[var(--accent-teal)] dark:bg-[var(--surface-subtle)] dark:text-[var(--text-primary)]'
-                        : 'text-ink hover:bg-brand-50/60'
+                        ? 'border-l-2 border-brand-700 bg-brand-50 pl-3 text-brand-900 dark:border-[var(--accent-teal)] dark:bg-[var(--surface-subtle)] dark:text-[var(--text-primary)]'
+                        : 'text-ink hover:bg-brand-50/70 dark:text-[var(--text-secondary)] dark:hover:bg-[var(--surface-subtle)] dark:hover:text-[var(--text-primary)]'
                     }`}
                   >
                     {link.label}
                   </Link>
                   {link.children && link.children.length > 0 ? (
-                    <div className="ml-3 mt-1 border-l border-brand-900/10 pl-3 dark:border-[var(--border-soft)]">
+                    <div className="ml-3 mt-1.5 border-l border-brand-900/10 pl-3 dark:border-[var(--border-soft)]">
                       {link.children.map((child) => (
                         <Link
                           key={child.href}
                           href={toCanonicalHref(child.href)}
                           onClick={closeMobile}
                           aria-current={isActive(child.href) ? 'page' : undefined}
-                          className="block rounded-md px-3 py-2 text-sm font-medium text-ink/75 transition hover:bg-brand-50/60 hover:text-ink dark:text-[var(--text-secondary)] dark:hover:bg-[var(--surface-subtle)] dark:hover:text-[var(--text-primary)]"
+                          className="block rounded-lg px-3 py-2.5 text-sm font-medium text-ink/75 transition hover:bg-brand-50/60 hover:text-ink dark:text-[var(--text-secondary)] dark:hover:bg-[var(--surface-subtle)] dark:hover:text-[var(--text-primary)]"
                         >
                           {child.label}
                         </Link>
@@ -179,8 +179,8 @@ export function Navigation() {
 
               <div className="my-2 h-px bg-brand-900/10 dark:bg-[var(--border-soft)]" />
 
-              <div className="flex items-center justify-between rounded-lg px-3 py-2.5">
-                <span className="text-sm font-medium text-ink/70">Theme</span>
+              <div className="flex items-center justify-between rounded-xl bg-brand-50/60 px-3.5 py-3 dark:bg-[var(--surface-subtle)]">
+                <span className="text-sm font-semibold text-ink/70 dark:text-[var(--text-secondary)]">Theme</span>
                 <DarkModeToggle showLabel />
               </div>
             </nav>

--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -224,7 +224,7 @@ export default function HomepageV2() {
                       <p className='mt-1.5 text-sm leading-6 text-muted dark:text-[var(--text-secondary)] sm:mt-3'>{hGoal.prompt}</p>
                     </div>
                   </div>
-                  <span className='ml-13 mt-3 hidden text-sm font-bold text-brand-700 transition group-hover:translate-x-1 group-hover:text-brand-800 sm:ml-0 sm:mt-5 sm:inline-flex'>
+                  <span className='mt-3 hidden text-sm font-bold text-brand-700 transition group-hover:translate-x-1 group-hover:text-brand-800 sm:mt-5 sm:inline-flex'>
                     Start with {hGoal.title} <span aria-hidden='true' className='ml-1'>→</span>
                   </span>
                 </Link>

--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -100,7 +100,7 @@ const toolLinks = [
 function SectionHeader({ title, subtitle, as: HeadingTag = 'h2' }: SectionHeaderProps) {
   return (
     <div className='max-w-3xl space-y-1.5'>
-      <HeadingTag className='font-display text-2xl font-bold tracking-tight text-ink sm:text-3xl'>{title}</HeadingTag>
+      <HeadingTag className='font-display text-[1.65rem] font-bold leading-tight tracking-tight text-ink sm:text-3xl'>{title}</HeadingTag>
       {subtitle ? <p className='text-sm leading-6 text-muted sm:text-base'>{subtitle}</p> : null}
     </div>
   )
@@ -114,26 +114,29 @@ export default function HomepageV2() {
     .slice(0, 6)
 
   return (
-    <div className='overflow-x-clip bg-white'>
-      <div className='mx-auto max-w-6xl space-y-10 px-4 pb-12 pt-4 sm:px-6 sm:space-y-12 sm:pb-16 sm:pt-6 lg:px-8'>
+    <div className='overflow-x-clip bg-[#fbfaf7] dark:bg-[var(--surface-page)]'>
+      <div className='mx-auto max-w-6xl space-y-7 px-3 pb-10 pt-2 sm:space-y-12 sm:px-6 sm:pb-16 sm:pt-6 lg:px-8'>
 
         {/* ── Hero ─────────────────────────────────────────────── */}
-        <section className='relative px-4 py-10 sm:px-8 sm:py-14'>
+        <section className='relative rounded-[1.75rem] bg-white px-4 py-8 shadow-[0_1px_2px_rgba(13,23,18,0.05)] dark:bg-[var(--surface-card)] sm:px-8 sm:py-14'>
           <div className='relative mx-auto max-w-4xl'>
             <div className='flex flex-col items-center text-center'>
-              <h1 className='font-display text-[2.75rem] font-bold leading-[1.02] tracking-[-0.02em] text-ink break-words sm:text-5xl md:text-[3.75rem]'>
-                Herbs & supplements,<br />actually explained.
+              <p className='mb-3 rounded-full bg-brand-50 px-3 py-1 text-xs font-bold uppercase tracking-[0.18em] text-brand-800 dark:bg-[var(--surface-subtle)] dark:text-[var(--text-secondary)]'>
+                Supplement research, simplified
+              </p>
+              <h1 className='max-w-[12ch] text-balance font-display text-[2.35rem] font-bold leading-[0.98] tracking-[-0.035em] text-ink sm:max-w-none sm:text-5xl md:text-[3.75rem]'>
+                Herbs & supplements, actually explained.
               </h1>
-              <p className='mt-5 max-w-2xl text-base leading-7 text-muted sm:text-lg sm:leading-8'>
-                Evidence-based guides for sleep, stress, anxiety, and focus. 816 peer-reviewed studies, 557 compounds, zero marketing fluff.
+              <p className='mt-4 max-w-[34rem] text-[0.98rem] leading-7 text-muted sm:mt-5 sm:text-lg sm:leading-8'>
+                Evidence-based guides for sleep, stress, anxiety, and focus — without marketing fluff.
               </p>
 
-              <div className='mt-8 flex w-full max-w-sm flex-col'>
+              <div className='mt-6 flex w-full max-w-sm flex-col sm:mt-8'>
                 <Link
                   href='#choose-a-path'
-                  className='rounded-full bg-brand-700 px-8 py-4 text-base font-bold text-white shadow-[0_4px_16px_rgba(13,23,18,0.18)] transition-all duration-200 hover:-translate-y-0.5 hover:bg-brand-800 hover:shadow-[0_8px_24px_rgba(13,23,18,0.24)] active:translate-y-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2 text-center'
+                  className='rounded-full bg-brand-700 px-6 py-3.5 text-center text-base font-bold text-white shadow-[0_4px_16px_rgba(13,23,18,0.18)] transition-all duration-200 hover:-translate-y-0.5 hover:bg-brand-800 hover:shadow-[0_8px_24px_rgba(13,23,18,0.24)] active:translate-y-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2 sm:px-8 sm:py-4'
                 >
-                  Browse by Health Goal
+                  Choose your health goal
                 </Link>
               </div>
             </div>
@@ -141,41 +144,41 @@ export default function HomepageV2() {
         </section>
 
         {/* Comparisons and tools */}
-        <section className='grid gap-4 lg:grid-cols-[1fr_0.9fr]'>
-          <div className='rounded-xl bg-white p-6 shadow-[0_1px_2px_rgba(13,23,18,0.06)] sm:p-7 dark:bg-[var(--surface-card)]'>
+        <section className='grid gap-3 sm:gap-4 lg:grid-cols-[1fr_0.9fr]'>
+          <div className='rounded-2xl border border-brand-900/5 bg-white p-4 shadow-[0_1px_2px_rgba(13,23,18,0.05)] sm:p-7 dark:border-[var(--border-soft)] dark:bg-[var(--surface-card)]'>
             <SectionHeader
               title='Compare before you choose'
-              subtitle='Side-by-side pages help answer the high-intent questions people search before buying or stacking.'
+              subtitle='Side-by-side pages answer the questions people search before buying or stacking.'
               as='h2'
             />
-            <div className='mt-5 grid gap-2 sm:grid-cols-2'>
+            <div className='mt-4 grid gap-2 sm:mt-5 sm:grid-cols-2'>
               {comparisonLinks.map((comparison) => (
                 <Link
                   key={comparison.href}
                   href={comparison.href}
-                  className='rounded-lg bg-brand-50 px-4 py-3 text-sm font-bold text-brand-800 transition hover:bg-brand-100 dark:bg-[var(--surface-subtle)] dark:hover:bg-[var(--surface-code)]'
+                  className='rounded-xl bg-brand-50 px-3.5 py-3 text-sm font-bold leading-snug text-brand-800 transition hover:bg-brand-100 dark:bg-[var(--surface-subtle)] dark:hover:bg-[var(--surface-code)] sm:px-4'
                 >
                   {comparison.title} →
                 </Link>
               ))}
             </div>
-            <Link href='/guides/compare/' className='mt-5 inline-flex text-sm font-bold text-brand-700 transition hover:text-brand-800'>
+            <Link href='/guides/compare/' className='mt-4 inline-flex text-sm font-bold text-brand-700 transition hover:text-brand-800 sm:mt-5'>
               Browse all comparisons →
             </Link>
           </div>
 
-          <div className='rounded-xl bg-white p-6 shadow-[0_1px_2px_rgba(13,23,18,0.06)] sm:p-7 dark:bg-[var(--surface-card)]'>
+          <div className='rounded-2xl border border-brand-900/5 bg-white p-4 shadow-[0_1px_2px_rgba(13,23,18,0.05)] sm:p-7 dark:border-[var(--border-soft)] dark:bg-[var(--surface-card)]'>
             <SectionHeader
               title='Use the safety tools'
-              subtitle='The fastest win is avoiding mismatched products, risky stacks, and unclear supplement forms.'
+              subtitle='Avoid mismatched products, risky stacks, and unclear supplement forms.'
               as='h2'
             />
-            <div className='mt-5 space-y-3'>
+            <div className='mt-4 space-y-2.5 sm:mt-5 sm:space-y-3'>
               {toolLinks.map((tool) => (
                 <Link
                   key={tool.href}
                   href={tool.href}
-                  className='block rounded-lg bg-brand-50/70 p-4 transition hover:bg-brand-100 dark:bg-[var(--surface-subtle)] dark:hover:bg-[var(--surface-code)]'
+                  className='block rounded-xl bg-brand-50/70 p-3.5 transition hover:bg-brand-100 dark:bg-[var(--surface-subtle)] dark:hover:bg-[var(--surface-code)] sm:p-4'
                 >
                   <h3 className='text-sm font-bold text-ink'>{tool.title}</h3>
                   <p className='mt-1 text-sm leading-6 text-muted'>{tool.description}</p>
@@ -187,39 +190,41 @@ export default function HomepageV2() {
 
         {/* Goal Pathways */}
         <section id='choose-a-path' className='scroll-mt-24 space-y-4'>
-          <div className='flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between'>
+          <div className='flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between sm:gap-3'>
             <SectionHeader
               title='Choose one path'
-              subtitle='Most visitors should start here. Pick the outcome you care about, then compare options inside that guide.'
+              subtitle='Start with the outcome you care about, then compare options inside that guide.'
               as='h2'
             />
-            <Link href='/guides/' className='text-sm font-bold text-brand-700 transition hover:text-brand-800 shrink-0'>
+            <Link href='/guides/' className='text-sm font-bold text-brand-700 transition hover:text-brand-800 sm:shrink-0'>
               View all guides →
             </Link>
           </div>
 
-          <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-4'>
+          <div className='grid gap-3 sm:grid-cols-2 sm:gap-4 lg:grid-cols-4'>
             {heroGoals.map((hGoal) => {
               const Icon = hGoal.icon
               return (
                 <Link
                   key={hGoal.slug}
                   href={hGoal.slug === 'stress' || hGoal.slug === 'anxiety' ? '/guides/anxiety/' : `/guides/${hGoal.slug}/`}
-                  className={`group flex min-h-48 flex-col justify-between rounded-xl bg-white p-5 shadow-[0_1px_2px_rgba(13,23,18,0.06)] transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_8px_24px_rgba(13,23,18,0.12)] dark:bg-[var(--surface-card)]`}
+                  className='group flex rounded-2xl border border-brand-900/5 bg-white p-4 shadow-[0_1px_2px_rgba(13,23,18,0.05)] transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_8px_24px_rgba(13,23,18,0.12)] dark:border-[var(--border-soft)] dark:bg-[var(--surface-card)] sm:min-h-48 sm:flex-col sm:justify-between sm:p-5'
                 >
-                  <div>
+                  <div className='flex gap-3 sm:block'>
                     <span
-                      className={`mb-3 inline-flex h-12 w-12 items-center justify-center rounded-full bg-white ${hGoal.ring} ring-1 dark:bg-[var(--surface-subtle)] dark:text-[var(--text-primary)]`}
+                      className={`mt-0.5 inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white ${hGoal.ring} ring-1 dark:bg-[var(--surface-subtle)] dark:text-[var(--text-primary)] sm:mb-3 sm:h-12 sm:w-12`}
                       aria-hidden='true'
                     >
-                      <Icon className={`h-6 w-6 ${hGoal.accent}`} strokeWidth={1.75} />
+                      <Icon className={`h-5 w-5 ${hGoal.accent} sm:h-6 sm:w-6`} strokeWidth={1.75} />
                     </span>
-                    <h3 className={`text-2xl font-bold tracking-tight ${hGoal.accent} dark:text-[var(--text-primary)]`}>
-                      {hGoal.title}
-                    </h3>
-                    <p className='mt-3 text-sm leading-6 text-muted dark:text-[var(--text-secondary)]'>{hGoal.prompt}</p>
+                    <div>
+                      <h3 className={`text-xl font-bold tracking-tight ${hGoal.accent} dark:text-[var(--text-primary)] sm:text-2xl`}>
+                        {hGoal.title}
+                      </h3>
+                      <p className='mt-1.5 text-sm leading-6 text-muted dark:text-[var(--text-secondary)] sm:mt-3'>{hGoal.prompt}</p>
+                    </div>
                   </div>
-                  <span className='mt-5 inline-flex text-sm font-bold text-brand-700 transition group-hover:translate-x-1 group-hover:text-brand-800'>
+                  <span className='ml-13 mt-3 hidden text-sm font-bold text-brand-700 transition group-hover:translate-x-1 group-hover:text-brand-800 sm:ml-0 sm:mt-5 sm:inline-flex'>
                     Start with {hGoal.title} <span aria-hidden='true' className='ml-1'>→</span>
                   </span>
                 </Link>
@@ -231,24 +236,24 @@ export default function HomepageV2() {
         {/* Featured Articles */}
         {featuredArticles.length > 0 && (
           <section className='space-y-4'>
-            <div className='flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between'>
+            <div className='flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between sm:gap-3'>
               <SectionHeader
                 title='Latest research'
                 subtitle='Evidence reviews, mechanism deep-dives, and practical guides — updated regularly.'
                 as='h2'
               />
-              <Link href='/guides/' className='text-sm font-bold text-brand-700 transition hover:text-brand-800 shrink-0'>
+              <Link href='/guides/' className='text-sm font-bold text-brand-700 transition hover:text-brand-800 sm:shrink-0'>
                 Browse all guides →
               </Link>
             </div>
-            <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-3'>
+            <div className='grid gap-3 sm:grid-cols-2 sm:gap-4 lg:grid-cols-3'>
               {featuredArticles.map((article: any) => (
                 <Link
                   key={article.slug}
                   href={`/articles/${article.slug}/`}
-                  className='group flex flex-col gap-3 rounded-xl bg-white p-5 shadow-[0_1px_2px_rgba(13,23,18,0.06)] transition-all duration-200 hover:shadow-[0_8px_24px_rgba(13,23,18,0.12)] dark:bg-[var(--surface-card)]'
+                  className='group flex flex-col gap-2.5 rounded-2xl border border-brand-900/5 bg-white p-4 shadow-[0_1px_2px_rgba(13,23,18,0.05)] transition-all duration-200 hover:shadow-[0_8px_24px_rgba(13,23,18,0.12)] dark:border-[var(--border-soft)] dark:bg-[var(--surface-card)] sm:gap-3 sm:p-5'
                 >
-                  <div className='flex items-center gap-2'>
+                  <div className='flex flex-wrap items-center gap-2'>
                     {article.category && (
                       <span className={`rounded-full border px-2.5 py-0.5 text-[0.72rem] font-medium ${categoryTagClass(article.category)}`}>
                         {article.category}
@@ -271,8 +276,8 @@ export default function HomepageV2() {
         )}
 
         {/* Trust */}
-        <section className='rounded-xl bg-white p-6 shadow-[0_1px_2px_rgba(13,23,18,0.06)] sm:p-8 dark:bg-[var(--surface-card)]'>
-          <div className='grid gap-6 lg:grid-cols-[0.9fr_1.1fr] lg:items-start'>
+        <section className='rounded-2xl border border-brand-900/5 bg-white p-4 shadow-[0_1px_2px_rgba(13,23,18,0.05)] sm:p-8 dark:border-[var(--border-soft)] dark:bg-[var(--surface-card)]'>
+          <div className='grid gap-5 sm:gap-6 lg:grid-cols-[0.9fr_1.1fr] lg:items-start'>
             <SectionHeader
               title='Why trust the guide?'
               subtitle='The site is built for cautious decisions: what has human evidence, what is only plausible, and what needs safety review before use.'
@@ -287,7 +292,7 @@ export default function HomepageV2() {
               ))}
             </div>
           </div>
-          <div className='mt-6 text-sm font-bold'>
+          <div className='mt-5 text-sm font-bold sm:mt-6'>
             <Link href='/info/methodology/' className='text-brand-700 transition hover:text-brand-800'>
               Read the evidence methodology →
             </Link>


### PR DESCRIPTION
## What changed
- Tightened the mobile homepage spacing so the first screen feels cleaner and less oversized.
- Reworked the hero copy treatment, CTA sizing, card padding, section gaps, and rounded card surfaces for a more polished phone layout.
- Made goal cards more compact on mobile while preserving the larger desktop card layout.
- Improved mobile navigation wrapping, logo truncation, hamburger sizing, drawer width, backdrop, and touch target consistency.

## Why
The site was feeling visually heavy and cramped on mobile. This focuses on the highest-impact first impression: homepage hero, card rhythm, and mobile nav.

## Validation
- Compared branch against `main`: 2 files changed, 133 total line changes.
- No local build/test run was available from the connector, so CI/build should be used to verify before merge.