### PR TITLE
Fix broken Search page tools link

### DIFF
--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -52,7 +52,7 @@ export default function SearchPage() {
   const researchTools = [
     { name: 'Safety Checker', href: '/safety-checker/' },
     { name: 'Compare Supplements', href: '/guides/compare/' },
-    { name: 'Research Tools Hub', href: '/tools/' },
+    { name: 'Evidence Checker', href: '/evidence/evidence-checker/' },
     { name: 'Citation Explorer', href: '/learn/citation-explorer/' },
     { name: 'Dosing Calculator', href: '/info/dosing/' },
     { name: 'Stack Builder', href: '/guides/' },


### PR DESCRIPTION
## What changed
- Replaced the Search page `Research Tools Hub` link from `/tools/` with `Evidence Checker` at `/evidence/evidence-checker/`.

## Why
`/tools/` does not have an App Router page, so the Search page was linking to a likely 404 from an indexable page. Broken internal links waste crawl paths and create a poor search experience.

## Validation
- Compared branch against `main`: 1 file changed, 2 total line changes.
- Confirmed `/learn/citation-explorer/` exists; `/tools/page.tsx` was not found through repository fetch.
- No local build/test run was available from the connector; CI/build should verify before merge.