### PR TITLE
Upgrade magnesium glycinate article: goal sections, internal links, collapsible fix

### DIFF
--- a/content/articles/magnesium-glycinate.md
+++ b/content/articles/magnesium-glycinate.md
@@ -26,6 +26,19 @@ tags:
   - evidence review
 profile_status: published
 ai_assisted: false
+faqs:
+  - question: "What is magnesium glycinate best used for?"
+    answer: "Magnesium glycinate is best for stress-related insomnia, nighttime muscle tension and jaw clenching, mild anxiety, and correcting the dietary magnesium shortfall that affects more than half of US adults. It is the preferred form for sleep and anxiety because it absorbs well without the laxative effect of oxide or citrate."
+  - question: "How much magnesium glycinate should I take for sleep?"
+    answer: "The clinically effective range is 200-400 mg of elemental magnesium, taken 30-60 minutes before bed. Dose by the elemental magnesium number in the Supplement Facts panel, not the larger compound weight on the front of the bottle."
+  - question: "Does magnesium glycinate help anxiety and stress?"
+    answer: "For mild anxiety, the evidence is moderate: a systematic review found 12 of 18 trials showed reduced anxiety, strongest at 200-400 mg/day for at least four weeks and in people with low magnesium status. It works best as a low-risk adjunct, not a replacement for treatment of a diagnosed anxiety disorder."
+  - question: "How long does magnesium glycinate take to work?"
+    answer: "Some people notice easier sleep on the first night thanks to the glycine component. Anxiety and stress benefits usually take 2-4 weeks as tissue magnesium stores replete. If nothing changes after four weeks, magnesium deficiency may not be your main issue."
+  - question: "Why glycinate instead of other forms of magnesium?"
+    answer: "Glycinate is absorbed through amino-acid transport pathways, so it delivers high absorption with minimal laxative effect even at 400 mg elemental. The glycine it is bound to is also a calming neurotransmitter that independently supports sleep, making the chelate uniquely suited to sleep and anxiety."
+  - question: "Who should avoid magnesium glycinate?"
+    answer: "People with chronic kidney disease (GFR under 30), myasthenia gravis, or high-grade heart block should avoid supplemental magnesium without medical supervision, because the kidney clears magnesium and impaired clearance raises the risk of hypermagnesemia."
 references:
   - title: "The effect of magnesium supplementation on primary insomnia in elderly: A double-blind placebo-controlled clinical trial"
     authors: "Abbasi B, Kimiagar M, Sadeghniiat K, Shirazi MM, Hedayati M, Rashidkhani B"
@@ -139,6 +152,37 @@ People who benefit describe it as:
 - A sedative — won't make you drowsy during the day at therapeutic doses
 - A quick fix — correcting a mineral deficiency takes weeks, not hours
 - A substitute for sleep hygiene — it enables better sleep physiology; it doesn't manufacture sleep from nothing
+
+---
+
+## Best Use Cases
+
+Magnesium glycinate is a foundational, low-cost pick for a few clear situations:
+
+- **Stress-related insomnia** — trouble falling or staying asleep when you're wound up. It pairs naturally with a full [sleep](/guides/sleep/) routine.
+- **Nighttime muscle tension** — jaw clenching, tight shoulders, or leg cramps that surface at night.
+- **Mild [anxiety](/guides/anxiety/) and everyday [stress](/guides/best/supplements-for-stress/)** — especially if your diet is low in magnesium, which is common.
+- **Correcting a likely dietary shortfall** — more than half of US adults fall short of the recommended magnesium intake.
+
+It is not a focus or energy supplement, and it won't override caffeine, acute stress, or a sleep disorder like apnea.
+
+## For Sleep
+
+- **Strength of evidence:** Moderate (RCTs and meta-analyses in insomnia)
+- **Protocol:** 200–400 mg elemental magnesium (as glycinate), 30–60 minutes before bed
+- **What to track:** Time to fall asleep, 3 AM awakenings, nighttime jaw/muscle tension, morning grogginess (there should be none)
+- **Expected result:** Easier sleep onset and steadier sleep through the night, building over 2–4 weeks
+
+The [glycine](/compounds/glycine/) bound to the magnesium is itself a calming neurotransmitter that lowers core body temperature and supports sleep, which is why glycinate outperforms other forms here. For a ready-made combination, see the [magnesium + L-theanine sleep stack](/articles/magnesium-l-theanine-sleep-stack/), and the full [sleep guide](/guides/sleep/) for the wider toolkit.
+
+## For Anxiety & Stress
+
+- **Strength of evidence:** Moderate for mild anxiety; strongest when magnesium status is low
+- **Protocol:** 200 mg morning + 200 mg evening for daytime coverage, or a single evening dose
+- **What to track:** Baseline tension, stress reactivity, sleep knock-on effects
+- **Expected result:** A gradual easing of everyday [stress](/guides/best/supplements-for-stress/) and mild [anxiety](/guides/anxiety/) over 4+ weeks — a low-risk adjunct, not a replacement for treating a diagnosed anxiety disorder
+
+Because magnesium and cortisol deplete each other in a feedback loop, correcting a shortfall can help settle an overactive stress response. For chronic, cortisol-driven stress, it stacks well with [ashwagandha](/articles/ashwagandha/); for acute, in-the-moment nerves, pair it with fast-acting [L-theanine](/articles/l-theanine/).
 
 ---
 
@@ -260,11 +304,7 @@ The glycine molecule bound to magnesium in the glycinate chelate is not pharmaco
 - A **co-agonist** at NMDA receptors (facilitatory in forebrain, but the net effect of glycine at supplemental doses is calming)
 - Demonstrated in small Japanese RCTs to **lower core body temperature and improve subjective sleep quality** at doses of 1–3 g
 
-When you take 400 mg of elemental magnesium as magnesium glycinate, you're also consuming approximately 2–3 g of glycine. This dual action — magnesium's GABAergic and NMDA-modulating effects plus glycine's independent sleep-promoting effects — makes the glycinate chelate uniquely suited for sleep applications.
-
----
-
-## Forms Comparison: Every Magnesium, Ranked
+When you take 400 mg of elemental magnesium as magnesium glycinate, you're also consuming approximately 2–3 g of [glycine](/compounds/glycine/). This dual action — magnesium's GABAergic and NMDA-modulating effects plus glycine's independent sleep-promoting effects — makes the glycinate chelate uniquely suited for sleep applications.
 
 </CollapsibleDetails>
 
@@ -379,10 +419,6 @@ Magnesium glycinate is among the best-tolerated oral supplements available. The 
 | **Calcium (high-dose)** | Calcium and magnesium compete for intestinal absorption | Separate by 2+ hours; calcium AM, magnesium PM is a practical protocol that aligns with their respective optimal timing |
 | **Gabapentinoids (gabapentin, pregabalin)** | Magnesium may reduce gabapentin absorption | Separate dosing by 2+ hours |
 
----
-
-## How to Choose a Magnesium Glycinate Product
-
 </CollapsibleWarning>
 
 ## How to Choose a Magnesium Glycinate Product
@@ -434,5 +470,8 @@ Magnesium glycinate naturally has a mild "fishy" or amine-like odor — this is 
 - [Magnesium + L-Theanine Sleep Stack](/articles/magnesium-l-theanine-sleep-stack/)
 - [Ashwagandha: Benefits, Dosage & Evidence](/articles/ashwagandha/)
 - [L-Theanine: Calm Focus Guide](/articles/l-theanine/)
+- [Glycine: The Calming Amino Acid](/compounds/glycine/)
 - [Valerian Root for Sleep](/articles/valerian-root/)
+- [Best Supplements for Sleep](/guides/sleep/)
+- [Best Supplements for Anxiety](/guides/anxiety/)
 - [How to Choose a Quality Supplement](/articles/how-to-choose-supplement-quality/)


### PR DESCRIPTION
Applies the same content-quality pattern (used on Ashwagandha and L-theanine) to `/articles/magnesium-glycinate`. The page was already very thorough, so this is a **focused upgrade, not a rewrite** — no architecture changes, no new medical claims.

## What changed (`content/articles/magnesium-glycinate.md`)

- **Scannable goal layer**: added a "Best Use Cases" section and dedicated **For Sleep** and **For Anxiety & Stress** decision blocks in the strength-of-evidence / protocol / what-to-track / expected-result format, as clean bullet lists.
- **Internal linking**: added natural links to the **sleep / anxiety / stress** hubs and the **glycine** compound page — glycine is the amino acid the chelate is built on and is discussed throughout the article but was never linked. Existing ashwagandha / L-theanine / sleep-stack links retained.
- **Structured data**: added a `faqs` frontmatter array for parity with the other upgraded articles.
- **Bug fix**: removed two orphaned duplicate headings left inside the `<CollapsibleDetails>` and `<CollapsibleWarning>` blocks — a dangling "Forms Comparison" and "How to Choose" heading that rendered with no content when the section was expanded (same collapsible artifact previously fixed on berberine and rhodiola).
- Deliberately **no "For Focus" section** — magnesium has no focus-specific evidence, so adding one would be an unsupported claim.

All existing factual claims, dosing, and the 12 PubMed references are unchanged.

## Verification

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes
- [x] `npm run build` (full `next build`) — passes; `/articles/magnesium-glycinate/` prerenders statically with the new sections and internal links present in the built HTML
- [x] `validate:article-quality` — PASS
- [x] Browser render pass (Playwright, mobile): no errors, no broken images, goal sections render as clean bullets, "Forms Comparison" heading now appears once (orphan fix confirmed)
- [x] Generated `data/articles/articles.json` intentionally not committed (regenerated by the build/CI pipeline)

## Next page recommendation after magnesium glycinate

**Rhodiola rosea** (`/articles/rhodiola-rosea/`) — it's the natural counterpart that keeps coming up as the "stimulating adaptogen" foil to ashwagandha across these pages, it already has verified references, and upgrading it would round out the stress/energy side of the cluster (calm: L-theanine + magnesium + ashwagandha; energy/fatigue: rhodiola).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5BJzyhpmTd72Awzn2PS6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5BJzyhpmTd72Awzn2PS6Q)_