### PR TITLE
Editorial OS pass 1: decision-first Sleep hub + reusable ScientificVerdict/DecisionRouter components

### DIFF
--- a/app/guides/sleep/page.tsx
+++ b/app/guides/sleep/page.tsx
@@ -1,54 +1,229 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { SITE_URL } from '@/src/lib/seo'
+import { HubSectionHeading } from '@/components/guides/HubSectionHeading'
+import { DecisionRouter, type IntentRoute } from '@/components/guides/DecisionRouter'
+import { GuideCardGrid, type GuideCard } from '@/components/guides/GuideCardGrid'
 
 export const metadata: Metadata = {
   title: 'Sleep Supplement Guides & Natural Sleep Aids',
-  description: 'Evidence-based guides on natural sleep aids: magnesium, melatonin, L-theanine, valerian, ashwagandha, and sleep hygiene strategies.',
+  description:
+    'Choose the right natural sleep support based on what is actually keeping you awake — racing thoughts, physical tension, stress, or timing. Evidence-based, decision-first guides.',
   alternates: { canonical: `${SITE_URL}/guides/sleep/` },
-  openGraph: { title: 'Sleep Supplement Guides', description: 'Natural sleep aids backed by evidence.', url: `${SITE_URL}/guides/sleep/`, type: 'website', images: ['/og-default.jpg'] },
+  openGraph: {
+    title: 'Sleep Supplement Guides',
+    description: 'Match the right natural sleep aid to the reason you cannot sleep.',
+    url: `${SITE_URL}/guides/sleep/`,
+    type: 'website',
+    images: ['/og-default.jpg'],
+  },
 }
 
-const GUIDES = [
-  { slug: 'best-supplements-for-sleep', title: 'Best Supplements for Sleep', desc: 'Evidence-graded review: magnesium glycinate, L-theanine, melatonin, valerian, and more.' },
-  { slug: 'best-natural-sleep-aids-that-work', title: 'Best Natural Sleep Aids That Work', desc: 'Which natural sleep remedies actually have clinical evidence behind them.' },
-  { slug: 'magnesium-for-sleep', title: 'Magnesium for Sleep', desc: 'How magnesium glycinate improves sleep quality, onset latency, and deep sleep.' },
-  { slug: 'magnesium-types-for-sleep', title: 'Magnesium Types for Sleep', desc: 'Glycinate vs citrate vs threonate — which magnesium is best for sleep?' },
-  { slug: 'magnesium-vs-melatonin', title: 'Magnesium vs Melatonin', desc: 'When to use each and how they work differently for sleep.' },
-  { slug: 'sleep-herbs-vs-melatonin', title: 'Sleep Herbs vs Melatonin', desc: 'Valerian, passionflower, and lemon balm compared to melatonin.' },
-  { slug: 'l-theanine-for-sleep', title: 'L-Theanine for Sleep', desc: 'How L-theanine promotes relaxation and improves sleep quality.' },
-  { slug: 'ashwagandha-for-sleep', title: 'Ashwagandha for Sleep', desc: 'Ashwagandha\'s cortisol-lowering effect and its impact on sleep.' },
-  { slug: 'ashwagandha-vs-magnesium-for-sleep', title: 'Ashwagandha vs Magnesium for Sleep', desc: 'Which to choose based on your sleep issue — stress vs muscle tension.' },
-  { slug: 'best-herbs-for-sleep', title: 'Best Herbs for Sleep', desc: 'Valerian, passionflower, lemon balm, chamomile — evidence-graded.' },
-  { slug: 'best-magnesium-for-sleep', title: 'Best Magnesium for Sleep', desc: 'Finding the right magnesium form and dose for your sleep needs.' },
-  { slug: 'rhodiola-sleep-stack', title: 'Rhodiola Sleep Stack', desc: 'Combining rhodiola with magnesium and L-theanine for sleep support.' },
-  { slug: 'sleep-stack-guide', title: 'Sleep Stack Guide', desc: 'How to combine supplements for sleep — timing, dosing, and safety.' },
-  { slug: 'sleep-stack-magnesium-melatonin', title: 'Magnesium + Melatonin Sleep Stack', desc: 'Combined approach for sleep onset and sleep maintenance.' },
-  { slug: 'sleep-best-supplements', title: 'Best Sleep Supplements', desc: 'Quick-reference guide to the top sleep supplements.' },
-  { slug: 'melatonin-for-adhd-sleep', title: 'Melatonin for ADHD Sleep', desc: 'Melatonin strategies for ADHD-related sleep difficulties.' },
-  { slug: 'sleep-and-adhd', title: 'Sleep and ADHD', desc: 'The ADHD-sleep connection and supplement strategies.' },
+// Decision-first routing: match the reason you can't sleep to the right first guide.
+const START_HERE: IntentRoute[] = [
+  {
+    problem: 'Racing thoughts at bedtime',
+    why: 'A calming amino acid quiets mental chatter without sedation.',
+    cta: 'L-Theanine for Sleep',
+    href: '/guides/sleep/l-theanine-for-sleep/',
+  },
+  {
+    problem: 'Physical tension or a restless body',
+    why: 'Magnesium relaxes muscles and calms an overactive nervous system.',
+    cta: 'Magnesium for Sleep',
+    href: '/guides/sleep/magnesium-for-sleep/',
+  },
+  {
+    problem: 'Not sure which magnesium to buy',
+    why: 'Glycinate, citrate, threonate and oxide are not interchangeable for sleep.',
+    cta: 'Magnesium Types for Sleep',
+    href: '/guides/sleep/magnesium-types-for-sleep/',
+  },
+  {
+    problem: 'Stress-related insomnia',
+    why: 'An adaptogen that lowers cortisol over weeks, not a same-night fix.',
+    cta: 'Ashwagandha for Sleep',
+    href: '/guides/sleep/ashwagandha-for-sleep/',
+  },
+  {
+    problem: 'Comparing your options',
+    why: 'A mineral and a circadian signal solve different problems.',
+    cta: 'Magnesium vs Melatonin',
+    href: '/guides/sleep/magnesium-vs-melatonin/',
+  },
+  {
+    problem: 'You want a full plan',
+    why: 'How to combine supplements safely — timing, dosing, and stacking.',
+    cta: 'Sleep Stack Guide',
+    href: '/guides/sleep/sleep-stack-guide/',
+  },
+  {
+    problem: 'ADHD-related sleep issues',
+    why: 'Delayed sleep and stimulant timing need a different approach.',
+    cta: 'Sleep & ADHD',
+    href: '/guides/adhd/sleep-and-adhd/',
+  },
+]
+
+const BEST_FIRST: GuideCard[] = [
+  {
+    href: '/guides/sleep/best-supplements-for-sleep/',
+    title: 'Best Supplements for Sleep',
+    desc: 'The evidence-graded overview — start here if you are not sure what you need.',
+  },
+  {
+    href: '/guides/sleep/magnesium-for-sleep/',
+    title: 'Magnesium for Sleep',
+    desc: 'The best-evidenced, lowest-risk first pick for most people.',
+  },
+  {
+    href: '/guides/sleep/l-theanine-for-sleep/',
+    title: 'L-Theanine for Sleep',
+    desc: 'For a busy mind at lights-out — calm without grogginess.',
+  },
+  {
+    href: '/guides/sleep/sleep-stack-guide/',
+    title: 'Sleep Stack Guide',
+    desc: 'How to combine options into one coherent, safe routine.',
+  },
+]
+
+const COMPARISONS: GuideCard[] = [
+  {
+    href: '/guides/sleep/magnesium-vs-melatonin/',
+    title: 'Magnesium vs Melatonin',
+    desc: 'Nervous-system calm vs circadian timing — which problem is yours?',
+  },
+  {
+    href: '/guides/sleep/sleep-herbs-vs-melatonin/',
+    title: 'Sleep Herbs vs Melatonin',
+    desc: 'Valerian, passionflower and lemon balm compared to melatonin.',
+  },
+  {
+    href: '/guides/sleep/ashwagandha-vs-magnesium-for-sleep/',
+    title: 'Ashwagandha vs Magnesium for Sleep',
+    desc: 'Stress-driven insomnia vs physical tension.',
+  },
+  {
+    href: '/guides/sleep/magnesium-types-for-sleep/',
+    title: 'Magnesium Types for Sleep',
+    desc: 'Glycinate vs citrate vs threonate vs oxide, ranked for sleep.',
+  },
+]
+
+// Full library — kept, but secondary to the decision sections above.
+const ALL_GUIDES = [
+  { slug: 'best-supplements-for-sleep', title: 'Best Supplements for Sleep' },
+  { slug: 'best-natural-sleep-aids-that-work', title: 'Best Natural Sleep Aids That Work' },
+  { slug: 'sleep-best-supplements', title: 'Best Sleep Supplements (Quick Reference)' },
+  { slug: 'magnesium-for-sleep', title: 'Magnesium for Sleep' },
+  { slug: 'best-magnesium-for-sleep', title: 'Best Magnesium for Sleep' },
+  { slug: 'magnesium-types-for-sleep', title: 'Magnesium Types for Sleep' },
+  { slug: 'l-theanine-for-sleep', title: 'L-Theanine for Sleep' },
+  { slug: 'ashwagandha-for-sleep', title: 'Ashwagandha for Sleep' },
+  { slug: 'best-herbs-for-sleep', title: 'Best Herbs for Sleep' },
+  { slug: 'rhodiola-sleep-stack', title: 'Rhodiola Sleep Stack' },
+  { slug: 'sleep-stack-guide', title: 'Sleep Stack Guide' },
+  { slug: 'sleep-stack-magnesium-melatonin', title: 'Magnesium + Melatonin Sleep Stack' },
+  { slug: 'magnesium-vs-melatonin', title: 'Magnesium vs Melatonin' },
+  { slug: 'sleep-herbs-vs-melatonin', title: 'Sleep Herbs vs Melatonin' },
+  { slug: 'ashwagandha-vs-magnesium-for-sleep', title: 'Ashwagandha vs Magnesium for Sleep' },
+]
+
+const ADHD_SLEEP = [
+  { href: '/guides/adhd/sleep-and-adhd/', title: 'Sleep & ADHD' },
+  { href: '/guides/adhd/melatonin-for-adhd-sleep/', title: 'Melatonin for ADHD Sleep' },
 ]
 
 export default function SleepGuideIndex() {
   return (
     <div className="mx-auto max-w-4xl px-4 pb-24 pt-8">
-      <nav className="text-xs text-muted mb-4">
-        <Link href="/guides/" className="hover:text-ink">Guides</Link>
+      <nav className="mb-4 text-xs text-muted">
+        <Link href="/guides/" className="hover:text-ink">
+          Guides
+        </Link>
         <span className="mx-1.5">/</span>
-        <span className="text-ink font-medium">Sleep</span>
+        <span className="font-medium text-ink">Sleep</span>
       </nav>
+
+      {/* Hero */}
       <header className="mb-10">
-        <h1 className="text-3xl font-bold text-ink sm:text-4xl">Sleep Supplement Guides</h1>
-        <p className="mt-3 text-lg text-muted max-w-2xl">Natural sleep aids backed by clinical evidence — from magnesium to melatonin alternatives.</p>
+        <h1 className="text-3xl font-bold tracking-tight text-ink sm:text-4xl">Sleep Supplement Guides</h1>
+        <p className="mt-3 max-w-2xl text-lg leading-8 text-muted">
+          Supplements work best when they match the actual reason you cannot sleep. Tell us what is
+          keeping you awake and we will point you to the right guide first.
+        </p>
       </header>
-      <div className="grid gap-4 sm:grid-cols-2">
-        {GUIDES.map(g => (
-          <Link key={g.slug} href={`/guides/sleep/${g.slug}/`} className="rounded-xl border border-brand-900/10 bg-white p-5 transition hover:border-brand-700/30 hover:shadow-sm">
-            <h3 className="font-semibold text-ink">{g.title}</h3>
-            <p className="mt-1.5 text-sm text-muted leading-relaxed">{g.desc}</p>
-          </Link>
-        ))}
-      </div>
+
+      {/* Start Here — decision routing */}
+      <section className="mb-12">
+        <HubSectionHeading
+          eyebrow="Start here"
+          title="What is keeping you awake?"
+          sub="Pick the description that fits best — each routes you to the most relevant guide."
+        />
+        <DecisionRouter items={START_HERE} />
+      </section>
+
+      {/* Best first pages */}
+      <section className="mb-12">
+        <HubSectionHeading eyebrow="Best first reads" title="If you only read a few" />
+        <GuideCardGrid cards={BEST_FIRST} />
+      </section>
+
+      {/* Comparison guides */}
+      <section className="mb-12">
+        <HubSectionHeading
+          eyebrow="Comparisons"
+          title="Deciding between two options?"
+          sub="These make a clear call instead of saying “both may help.”"
+        />
+        <GuideCardGrid cards={COMPARISONS} />
+      </section>
+
+      {/* ADHD sleep */}
+      <section className="mb-12">
+        <HubSectionHeading eyebrow="ADHD & sleep" title="ADHD-related sleep problems" />
+        <div className="flex flex-wrap gap-3">
+          {ADHD_SLEEP.map((g) => (
+            <Link
+              key={g.href}
+              href={g.href}
+              className="rounded-full border border-brand-900/12 bg-white px-4 py-2 text-sm font-semibold text-brand-800 transition hover:border-brand-700/30 hover:bg-brand-50 dark:border-white/10 dark:bg-[var(--surface-card)] dark:text-[var(--text-primary)]"
+            >
+              {g.title} →
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      {/* Editorial note */}
+      <section className="mb-12 rounded-xl border-l-4 border-brand-700/40 bg-brand-50/60 p-5 dark:bg-[var(--surface-subtle)]">
+        <p className="text-sm leading-7 text-ink dark:text-[var(--text-secondary)]">
+          <span className="font-bold">A note on matching the tool to the problem.</span> Supplements are
+          most useful when matched to the actual sleep issue. A calming amino acid (L-theanine), a
+          mineral (magnesium), an adaptogen (ashwagandha), and a circadian signal (melatonin) solve
+          different problems — and none of them replaces consistent sleep habits or care for a
+          diagnosed sleep disorder.
+        </p>
+      </section>
+
+      {/* All guides — secondary */}
+      <section>
+        <HubSectionHeading eyebrow="Full library" title="All sleep guides" />
+        <ul className="grid gap-x-6 gap-y-2 sm:grid-cols-2">
+          {ALL_GUIDES.map((g) => (
+            <li key={g.slug}>
+              <Link
+                href={`/guides/sleep/${g.slug}/`}
+                className="text-sm font-medium text-brand-800 hover:underline dark:text-[var(--text-primary)]"
+              >
+                {g.title}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </section>
     </div>
   )
 }

--- a/components/content/ScientificVerdict.tsx
+++ b/components/content/ScientificVerdict.tsx
@@ -1,0 +1,166 @@
+import type { ReactNode } from 'react'
+
+type Recommendation = 'Yes' | 'Maybe' | 'No' | 'Situation-dependent'
+
+type ScientificVerdictProps = {
+  /** Overall call: Yes | Maybe | No | Situation-dependent. */
+  recommendation: Recommendation | string
+  /** Who it's for. Array, or a single pipe-delimited string for MDX use: "Racing thoughts|Caffeine jitters". */
+  bestFor?: string | string[]
+  /** Who should skip it. Array or pipe-delimited string. */
+  notFor?: string | string[]
+  /** Evidence confidence label, e.g. "Moderate". */
+  confidence?: string
+  /** Expected onset, e.g. "30–40 minutes". */
+  onset?: string
+  /** How long to trial it before judging, e.g. "Same day to 2 weeks". */
+  evaluationWindow?: string
+  /** Bottom-line sentence. Prefer children in MDX; this prop is the .tsx path. */
+  bottomLine?: ReactNode
+  children?: ReactNode
+}
+
+const toList = (value?: string | string[]): string[] => {
+  if (!value) return []
+  if (Array.isArray(value)) return value.map((v) => String(v).trim()).filter(Boolean)
+  return String(value)
+    .split('|')
+    .map((v) => v.trim())
+    .filter(Boolean)
+}
+
+const RECOMMENDATION_STYLES: Record<string, string> = {
+  yes: 'border-emerald-500/40 bg-emerald-100 text-emerald-900 dark:border-emerald-400/30 dark:bg-emerald-900/40 dark:text-emerald-100',
+  maybe: 'border-amber-500/40 bg-amber-100 text-amber-900 dark:border-amber-400/30 dark:bg-amber-900/40 dark:text-amber-100',
+  no: 'border-rose-500/40 bg-rose-100 text-rose-900 dark:border-rose-400/30 dark:bg-rose-900/40 dark:text-rose-100',
+  'situation-dependent':
+    'border-sky-500/40 bg-sky-100 text-sky-900 dark:border-sky-400/30 dark:bg-sky-900/40 dark:text-sky-100',
+}
+
+/**
+ * ScientificVerdict — the signature decision module for The Hippie Scientist.
+ *
+ * Every major article/herb/compound/comparison page should OPEN with one of
+ * these. It answers, at a glance: would we recommend this, for whom, for what
+ * use, how confident are we, how fast does it work, and when to choose
+ * something else — before any biochemistry.
+ *
+ * Registered as an MDX component (see mdx-components.tsx), so any article can
+ * drop it at the top of the body:
+ *
+ *   <ScientificVerdict
+ *     recommendation="Yes"
+ *     bestFor="Racing thoughts at bedtime|Caffeine jitters|Mild situational anxiety"
+ *     notFor="Severe insomnia|Panic attacks|Chronic stress alone"
+ *     confidence="Moderate"
+ *     onset="30–40 minutes"
+ *     evaluationWindow="Same day to 2 weeks"
+ *   >
+ *   L-theanine is a strong first choice for calm focus, but not the best
+ *   primary tool for chronic stress or severe anxiety.
+ *   </ScientificVerdict>
+ *
+ * Lists accept a pipe-delimited string (MDX-friendly) or a real array (.tsx).
+ * Keep it honest: use "No" / "Situation-dependent" when the evidence warrants.
+ */
+export function ScientificVerdict({
+  recommendation,
+  bestFor,
+  notFor,
+  confidence,
+  onset,
+  evaluationWindow,
+  bottomLine,
+  children,
+}: ScientificVerdictProps) {
+  const best = toList(bestFor)
+  const not = toList(notFor)
+  const badgeStyle =
+    RECOMMENDATION_STYLES[String(recommendation).toLowerCase()] ?? RECOMMENDATION_STYLES.maybe
+  const stats = [
+    confidence ? { label: 'Evidence confidence', value: confidence } : null,
+    onset ? { label: 'Expected onset', value: onset } : null,
+    evaluationWindow ? { label: 'Give it', value: evaluationWindow } : null,
+  ].filter((s): s is { label: string; value: string } => Boolean(s))
+
+  return (
+    // Root is a <section> (not <aside>) on purpose: the article body is
+    // post-processed by ContentCards, which wraps any pre-section "intro"
+    // content in its own card. Being a section makes ContentCards treat this
+    // as the first section and leave it standalone instead of double-wrapping.
+    <section
+      aria-label="Scientific verdict"
+      className="not-prose my-6 overflow-hidden rounded-2xl border-2 border-brand-900/15 bg-white shadow-md ring-1 ring-brand-900/5 dark:border-white/12 dark:bg-[var(--surface-card)]"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-brand-900/10 bg-brand-50/60 px-5 py-3 dark:border-white/10 dark:bg-[var(--surface-subtle)]">
+        <span className="text-xs font-bold uppercase tracking-[0.16em] text-brand-700">
+          Scientific Verdict
+        </span>
+        <span className={`rounded-full border px-3 py-1 text-sm font-bold ${badgeStyle}`}>
+          {recommendation}
+        </span>
+      </div>
+
+      <div className="px-5 py-4">
+        {(best.length > 0 || not.length > 0) && (
+          <div className="grid gap-4 sm:grid-cols-2">
+            {best.length > 0 && (
+              <div>
+                <p className="text-xs font-bold uppercase tracking-wider text-emerald-700 dark:text-emerald-300">
+                  Best for
+                </p>
+                <ul className="mt-2 space-y-1.5">
+                  {best.map((item) => (
+                    <li key={item} className="flex gap-2 text-sm leading-6 text-ink">
+                      <span aria-hidden="true" className="mt-0.5 font-bold text-emerald-600 dark:text-emerald-400">
+                        ✓
+                      </span>
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {not.length > 0 && (
+              <div>
+                <p className="text-xs font-bold uppercase tracking-wider text-rose-700 dark:text-rose-300">
+                  Not ideal for
+                </p>
+                <ul className="mt-2 space-y-1.5">
+                  {not.map((item) => (
+                    <li key={item} className="flex gap-2 text-sm leading-6 text-muted">
+                      <span aria-hidden="true" className="mt-0.5 font-bold text-rose-500 dark:text-rose-400">
+                        ✕
+                      </span>
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        )}
+
+        {stats.length > 0 && (
+          <dl className="mt-4 grid grid-cols-1 gap-3 border-t border-brand-900/10 pt-4 dark:border-white/10 sm:grid-cols-3">
+            {stats.map((stat) => (
+              <div key={stat.label}>
+                <dt className="text-[0.7rem] font-bold uppercase tracking-wider text-muted">{stat.label}</dt>
+                <dd className="mt-0.5 text-sm font-semibold text-ink">{stat.value}</dd>
+              </div>
+            ))}
+          </dl>
+        )}
+
+        {(bottomLine || children) && (
+          <div className="mt-4 border-t border-brand-900/10 pt-4 text-sm leading-7 text-ink dark:border-white/10">
+            <span className="font-bold">Bottom line: </span>
+            {bottomLine ?? children}
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}
+
+export default ScientificVerdict

--- a/components/guides/DecisionRouter.tsx
+++ b/components/guides/DecisionRouter.tsx
@@ -1,0 +1,51 @@
+import Link from 'next/link'
+
+export type IntentRoute = {
+  /** The user's situation, phrased as they'd recognize it ("Racing thoughts at bedtime"). */
+  problem: string
+  /** One-line editorial reason this route fits — the "why". Optional but recommended. */
+  why?: string
+  /** The destination page's short label ("L-Theanine for Sleep"). */
+  cta: string
+  /** Destination href. Must be a real, existing route. */
+  href: string
+}
+
+/**
+ * DecisionRouter — the signature "field guide" routing module for hub pages.
+ *
+ * Instead of a flat directory of cards, it asks the reader to identify their
+ * situation and routes each one to the single most relevant page. This is the
+ * core of the decision-first hub standard: a hub should behave like an editor,
+ * not a file cabinet.
+ *
+ * Reuse: give it an array of {problem, why, cta, href}. Intended for the
+ * "Start here / what's your problem?" section of every goal hub (sleep,
+ * anxiety, stress, focus). Keep routes pointed at real pages — each card is a
+ * promise that the destination answers that specific problem.
+ */
+export function DecisionRouter({ items }: { items: IntentRoute[] }) {
+  return (
+    <div className="grid gap-3 sm:grid-cols-2">
+      {items.map((item) => (
+        <Link
+          key={item.href + item.problem}
+          href={item.href}
+          className="group flex flex-col rounded-xl border-2 border-brand-900/12 bg-white p-5 shadow-[0_1px_2px_rgba(13,23,18,0.06)] transition-all hover:-translate-y-0.5 hover:border-brand-700/30 hover:shadow-md dark:border-white/10 dark:bg-[var(--surface-card)]"
+        >
+          <span className="text-[0.7rem] font-bold uppercase tracking-wider text-brand-700">
+            If your problem is
+          </span>
+          <span className="mt-1 text-base font-bold leading-snug text-ink">{item.problem}</span>
+          {item.why ? <span className="mt-2 text-sm leading-6 text-muted">{item.why}</span> : null}
+          <span className="mt-3 inline-flex items-center gap-1 text-sm font-bold text-brand-800 transition group-hover:gap-1.5 dark:text-[var(--text-primary)]">
+            Start with {item.cta}
+            <span aria-hidden="true">→</span>
+          </span>
+        </Link>
+      ))}
+    </div>
+  )
+}
+
+export default DecisionRouter

--- a/components/guides/GuideCardGrid.tsx
+++ b/components/guides/GuideCardGrid.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link'
+
+export type GuideCard = {
+  /** Destination href (absolute, real route). */
+  href: string
+  title: string
+  /** Optional one-line "why read this" description. */
+  desc?: string
+}
+
+/**
+ * GuideCardGrid — the standard two-up card grid for hub pages.
+ *
+ * Used for the "best first reads" and "comparisons" sections of a hub. A card
+ * is a title + a short editorial reason to read it (not a generic blurb).
+ *
+ * Reuse: pass an array of {href, title, desc}. Shared by every goal hub so the
+ * card styling stays identical site-wide. For the top-of-hub decision routing,
+ * use DecisionRouter instead.
+ */
+export function GuideCardGrid({ cards }: { cards: GuideCard[] }) {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      {cards.map((card) => (
+        <Link
+          key={card.href}
+          href={card.href}
+          className="rounded-xl border-2 border-brand-900/12 bg-white p-5 shadow-[0_1px_2px_rgba(13,23,18,0.06)] transition hover:border-brand-700/30 hover:shadow-md dark:border-white/10 dark:bg-[var(--surface-card)]"
+        >
+          <h3 className="font-bold text-ink">{card.title}</h3>
+          {card.desc ? <p className="mt-1.5 text-sm leading-relaxed text-muted">{card.desc}</p> : null}
+        </Link>
+      ))}
+    </div>
+  )
+}
+
+export default GuideCardGrid

--- a/components/guides/HubSectionHeading.tsx
+++ b/components/guides/HubSectionHeading.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from 'react'
+
+/**
+ * HubSectionHeading — the standard section header for guide hub pages.
+ *
+ * An eyebrow label + title (+ optional sub) used to separate the decision
+ * sections of a hub ("Start here", "Comparisons", "Full library", …). Keeps
+ * every goal hub (sleep, anxiety, stress, focus) visually consistent.
+ *
+ * Reuse: import and place above each hub section grid. Do not hand-roll
+ * section headers on hub pages — use this so spacing and type scale stay uniform.
+ */
+export function HubSectionHeading({
+  eyebrow,
+  title,
+  sub,
+}: {
+  eyebrow: string
+  title: string
+  sub?: ReactNode
+}) {
+  return (
+    <div className="mb-5">
+      <p className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700">{eyebrow}</p>
+      <h2 className="mt-1 text-2xl font-bold tracking-tight text-ink">{title}</h2>
+      {sub ? <p className="mt-1.5 text-sm leading-6 text-muted">{sub}</p> : null}
+    </div>
+  )
+}
+
+export default HubSectionHeading

--- a/content/articles/magnesium-glycinate.md
+++ b/content/articles/magnesium-glycinate.md
@@ -113,7 +113,16 @@ references:
     url: "https://pubmed.ncbi.nlm.nih.gov/12663588/"
 ---
 
-> **The bottom line:** Magnesium glycinate is the best-studied magnesium form for sleep and anxiety. Human trials show improved sleep quality, reduced anxiety, and lower cortisol at 200–400 mg elemental magnesium before bed. Unlike oxide or citrate, it's well-absorbed without laxative effects — and the glycine molecule it's bound to adds independent sleep benefits. Best for: stress-related insomnia, muscle tension, and correcting the magnesium deficiency that affects roughly half of US adults ([Rosanoff 2012](#ref-25540137)). Evidence grade: **Moderate** for sleep and anxiety.
+<ScientificVerdict
+  recommendation="Yes"
+  bestFor="Stress-related insomnia|Nighttime muscle tension or jaw clenching|Mild anxiety|A likely dietary magnesium shortfall"
+  notFor="A fast, same-night sleeping pill|Severe or primary insomnia (sleep apnea, restless legs)|Kidney disease without medical supervision"
+  confidence="Moderate"
+  onset="Glycine calm within ~1 hr; full effect over 2–4 weeks"
+  evaluationWindow="2–4 weeks"
+>
+Magnesium glycinate is a low-risk, well-absorbed first pick for stress- and tension-related sleep problems. It is not a sedative — it works best when a deficiency or an overactive nervous system is part of the picture, and it pairs well with better sleep habits rather than replacing them.
+</ScientificVerdict>
 
 ## At a Glance
 

--- a/docs/editorial-components.md
+++ b/docs/editorial-components.md
@@ -1,0 +1,143 @@
+# Editorial Components
+
+Reusable building blocks for The Hippie Scientist's **decision-first** editorial
+system. Prefer these over one-off markup so every guide hub and article page
+stays visually consistent and behaves like a field guide (help the reader decide
+what to do next), not an encyclopedia.
+
+All components use the existing design language (brand emerald, `text-ink` /
+`text-muted` tokens, rounded cards) and are theme-aware (light + dark). They are
+server components — safe for static export, no client JS.
+
+---
+
+## Article-body components (MDX)
+
+These are registered in [`mdx-components.tsx`](../mdx-components.tsx), so any
+`.md`/`.mdx` article can use them inline with **no import**.
+
+### `<ScientificVerdict>` — the signature decision module
+
+`components/content/ScientificVerdict.tsx`
+
+The recognizable module every major article/herb/compound/comparison page should
+**open** with. It answers, before any biochemistry: would we recommend this, for
+whom, for what use, how confident are we, how fast does it work, and when to
+choose something else.
+
+```mdx
+<ScientificVerdict
+  recommendation="Yes"          {/* Yes | Maybe | No | Situation-dependent */}
+  bestFor="Racing thoughts at bedtime|Caffeine jitters|Mild situational anxiety"
+  notFor="Severe insomnia|Panic attacks|Chronic stress alone"
+  confidence="Moderate"
+  onset="30–40 minutes"
+  evaluationWindow="Same day to 2 weeks"
+>
+L-theanine is a strong first choice for calm focus and caffeine jitters, but not
+the best primary tool for chronic stress or severe anxiety.
+</ScientificVerdict>
+```
+
+- `bestFor` / `notFor` accept a **pipe-delimited string** (MDX-friendly) or a
+  real array (`.tsx`).
+- The bottom line is the component's **children** (or a `bottomLine` prop).
+- The recommendation badge is color-coded: Yes = emerald, Maybe = amber,
+  No = rose, Situation-dependent = sky.
+- **Placement:** put it at the very top of the article body (it replaces the old
+  "> **The bottom line:**" blockquote). Its root is a `<section>` so
+  `ContentCards` treats it as the first section and does not double-wrap it.
+- **Voice:** be honest — use `No` / `Situation-dependent` and a real "Not ideal
+  for" list when the evidence warrants. That honesty is the brand.
+
+Live example: [`content/articles/magnesium-glycinate.md`](../content/articles/magnesium-glycinate.md).
+
+### Other registered MDX components
+
+Already available in article bodies (see `mdx-components.tsx`):
+`CollapsibleDetails`, `CollapsibleWarning`, `CollapsibleSection`,
+`StudyDesignSnapshot`, `EvidenceSummaryCard`, `ResearchLimitations`,
+`MisconceptionCallout`, `SafetyNotice`, `ComparisonTable`, `EvidenceNote`.
+
+### Inline citations + trust strip (article template)
+
+Not components you place, but conventions the article template
+(`app/articles/[slug]/page.tsx`) provides automatically:
+
+- **Trust strip** in the header: author · explicit `lastReviewed` date · live
+  "N cited sources" count · Evidence standards link. Add `lastReviewed`,
+  `reviewedBy`, `reviewerCredential` in frontmatter when true — never fabricate a
+  reviewer.
+- **Anchored references:** each frontmatter reference renders with
+  `id="ref-<pmid>"`. Deep-link a numeric claim to its source inline:
+  `... reduced sleep onset ~17 min ([Abbasi 2012](#ref-22163214))`.
+
+---
+
+## Guide hub components
+
+`components/guides/*` — for the goal hubs (`/guides/sleep`, `/guides/anxiety`,
+`/guides/stress`, `/guides/focus`). A hub should route the reader by their
+problem, not list files.
+
+### `<DecisionRouter items={...} />` — "what's your problem?" routing
+
+`components/guides/DecisionRouter.tsx`
+
+The signature hub module: a grid of "If your problem is X → start with Y" cards.
+This is what makes a hub behave like an editor.
+
+```tsx
+import { DecisionRouter, type IntentRoute } from '@/components/guides/DecisionRouter'
+
+const START_HERE: IntentRoute[] = [
+  { problem: 'Racing thoughts at bedtime', why: 'A calming amino acid…',
+    cta: 'L-Theanine for Sleep', href: '/guides/sleep/l-theanine-for-sleep/' },
+  // …
+]
+
+<DecisionRouter items={START_HERE} />
+```
+
+Every `href` must be a **real, existing route** — each card is a promise the
+destination answers that specific problem.
+
+### `<GuideCardGrid cards={...} />` — standard two-up card grid
+
+`components/guides/GuideCardGrid.tsx`
+
+For the "best first reads" and "comparisons" sections. Each card is a title +
+short editorial reason to read it (not a generic blurb).
+
+```tsx
+import { GuideCardGrid, type GuideCard } from '@/components/guides/GuideCardGrid'
+
+const BEST_FIRST: GuideCard[] = [
+  { href: '/guides/sleep/magnesium-for-sleep/', title: 'Magnesium for Sleep',
+    desc: 'The best-evidenced, lowest-risk first pick for most people.' },
+]
+
+<GuideCardGrid cards={BEST_FIRST} />
+```
+
+### `<HubSectionHeading eyebrow title sub />` — section header
+
+`components/guides/HubSectionHeading.tsx`
+
+Eyebrow + title (+ optional sub) that separates hub sections ("Start here",
+"Comparisons", "Full library"). Use it for every hub section so spacing and type
+scale stay uniform.
+
+Reference implementation of all three: [`app/guides/sleep/page.tsx`](../app/guides/sleep/page.tsx).
+
+---
+
+## How to apply this to the next hub / article
+
+1. **Hubs** (anxiety, stress, focus): copy the section skeleton from the sleep
+   hub — hero → `DecisionRouter` (Start here) → `GuideCardGrid` (best first) →
+   `GuideCardGrid` (comparisons) → editorial note → full library. Swap in that
+   goal's real routes.
+2. **Articles**: open with `<ScientificVerdict>`, keep the deeper science lower
+   and collapsible, and inline-cite numeric claims to `#ref-<pmid>` anchors.
+3. Never invent routes or medical claims; verify every `href` exists first.

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -11,6 +11,7 @@ import { NPSDisclaimer } from '@/components/NPSDisclaimer'
 import ResponsiveTable from '@/components/ui/ResponsiveTable'
 import CollapsibleSection, { CollapsibleWarning, CollapsibleDetails } from '@/components/content/CollapsibleSection'
 import Collapsible from '@/components/content/Collapsible'
+import ScientificVerdict from '@/components/content/ScientificVerdict'
 
 type MDXComponents = Record<string, ComponentType<Record<string, unknown>>>
 type MdxTableProps = Record<string, unknown> & { children?: ReactNode }
@@ -54,6 +55,7 @@ const evidenceComponents = {
   CollapsibleWarning,
   CollapsibleDetails,
   Collapsible,
+  ScientificVerdict,
   table: MdxTable,
 } as unknown as MDXComponents
 


### PR DESCRIPTION
Pass 1 of the editorial experience spec. Establishes the **reusable, decision-first editorial system** and applies it to the Sleep hub. This isn't a one-off content edit — it leaves the component architecture in a better state for every future hub and article pass.

## New reusable components
All use the existing design language, are theme-aware (light/dark), and are server components (static-export-safe).

- **`ScientificVerdict`** (`components/content/`) — the signature brand module: *would we recommend this, for whom, how confident, how fast, when to choose something else, bottom line*. Registered in `mdx-components.tsx` so **any article can open with it** (`<ScientificVerdict recommendation="Yes" bestFor="a|b|c" notFor="x|y" … />`). Its root is a `<section>` so `ContentCards` treats it as the first section and leaves it standalone instead of double-wrapping it.
- **`DecisionRouter`** (`components/guides/`) — the "If your problem is X → start with Y" routing grid that makes a hub behave like an editor, not a file cabinet.
- **`GuideCardGrid`** + **`HubSectionHeading`** (`components/guides/`) — the standard hub card grid and section header, so every goal hub stays visually consistent.

## Sleep hub (`/guides/sleep/`) — rebuilt into a decision hub
- **"What is keeping you awake?"** DecisionRouter: racing thoughts → L-theanine, physical tension → magnesium, unsure which magnesium → types, stress → ashwagandha, comparing → mag vs melatonin, full plan → stack guide, ADHD → sleep & ADHD.
- Best-first reads, a comparison section that makes a clear call, an ADHD-sleep row, an editorial trust note, and the full library kept as a **secondary** list.
- **Fixed two broken links**: the old ADHD cards pointed at nonexistent `/guides/sleep/{sleep-and-adhd,melatonin-for-adhd-sleep}/` routes → corrected to the real `/guides/adhd/` pages.
- Decision-first metadata description; **canonical unchanged**.

## Demonstration + documentation
- Opened the flagship **magnesium glycinate** article with a `ScientificVerdict` (replaces the old bottom-line blockquote), validating the component end-to-end.
- **`docs/editorial-components.md`** documents every reusable component, its props, placement rules, and how to apply the pattern to the next hub/article.

## Verification
- [x] `npm run typecheck` / `npm run lint` — pass
- [x] `npm run build` (full `next build`) — passes; sleep hub + verdict present in built static HTML
- [x] Browser pass (light + dark, mobile + desktop): hub routes render, ADHD links fixed (zero broken `/guides/sleep/sleep-and-adhd/`), verdict renders standalone (confirmed not double-wrapped)
- [x] Generated `data/articles/articles.json` intentionally not committed

## Report / next pass
- **Files:** new — 4 components + `docs/editorial-components.md`; modified — sleep hub, `mdx-components.tsx`, magnesium article.
- **Why it matters:** the hub now routes by intent (decision clarity, better internal linking, fixed 404s), and the reusable `ScientificVerdict`/`DecisionRouter` primitives make the next passes fast and consistent.
- **No unresolved issues.** Static export intact, routes/canonicals preserved.
- **Recommended next pass (2/6):** roll `ScientificVerdict` onto the top sleep articles (L-theanine, magnesium, ashwagandha for sleep) and give the same DecisionRouter treatment to the **Anxiety** hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5BJzyhpmTd72Awzn2PS6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5BJzyhpmTd72Awzn2PS6Q)_