### PR TITLE
Editorial OS pass 2: reusable editorial component system + L-theanine/Ashwagandha upgrade

### DIFF
--- a/components/content/ContentCards.tsx
+++ b/components/content/ContentCards.tsx
@@ -67,11 +67,17 @@ export default function ContentCards({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (!ref.current) return
 
-    const h2s = Array.from(ref.current.querySelectorAll('h2'))
+    // Editorial components (ScientificVerdictCard, DecisionMatrix, RealityCheck,
+    // …) render self-contained blocks marked `.not-prose`. Their internal
+    // headings/paragraphs must be left untouched — grouping or re-parenting them
+    // would tear the components apart. `isEditorial` excludes that whole subtree.
+    const isEditorial = (el: Element) => Boolean(el.closest('.not-prose'))
+
+    const h2s = Array.from(ref.current.querySelectorAll('h2')).filter((h2) => !isEditorial(h2))
     if (h2s.length === 0) return
 
     // ── Step 1: Wrap combination warnings in collapsible <details> ──
-    const allElements = Array.from(ref.current.querySelectorAll('*'))
+    const allElements = Array.from(ref.current.querySelectorAll('*')).filter((el) => !isEditorial(el))
     for (const el of allElements) {
       const text = el.textContent?.trim() || ''
       
@@ -148,7 +154,10 @@ export default function ContentCards({ children }: { children: ReactNode }) {
         wrapper.appendChild(current)
         if (current === lastH2) {
           let after: Element | null = next
-          while (after && after.tagName !== 'H2') {
+          // Stop at the next heading OR any standalone editorial block so those
+          // components stay as top-level siblings instead of being absorbed
+          // (and double-wrapped) into this section card.
+          while (after && after.tagName !== 'H2' && !isEditorial(after)) {
             const afterNext: Element | null = after.nextElementSibling
             wrapper.appendChild(after)
             after = afterNext

--- a/components/editorial/BetterAlternatives.tsx
+++ b/components/editorial/BetterAlternatives.tsx
@@ -1,0 +1,66 @@
+import Link from 'next/link'
+import type { ReactNode } from 'react'
+
+export type AlternativeItem = {
+  /** The condition under which something else is the better call. */
+  condition: string
+  /** What to use instead. */
+  recommendation: string
+  /** Why it's the better fit. */
+  reason: ReactNode
+  href?: string
+}
+
+/**
+ * BetterAlternatives — builds trust by routing readers elsewhere when the
+ * page's subject is not their best option.
+ *
+ * MDX usage:
+ *   <BetterAlternatives
+ *     intro="L-theanine is not always the right first tool."
+ *     alternatives={[
+ *       { condition: 'Your main issue is physical tension', recommendation: 'Magnesium glycinate',
+ *         reason: 'supports muscle relaxation and nervous-system calm.', href: '/articles/magnesium-glycinate/' },
+ *       { condition: 'Your main issue is chronic stress', recommendation: 'Ashwagandha',
+ *         reason: 'targets baseline stress and cortisol over weeks.', href: '/articles/ashwagandha/' },
+ *     ]}
+ *   />
+ */
+export function BetterAlternatives({
+  title = 'When something else may be better',
+  intro,
+  alternatives,
+}: {
+  title?: string
+  intro?: ReactNode
+  alternatives: AlternativeItem[]
+}) {
+  return (
+    <section className="not-prose my-6">
+      <h2 className="text-xl font-bold tracking-tight text-ink sm:text-2xl">{title}</h2>
+      {intro ? <p className="mt-2 text-sm leading-6 text-muted">{intro}</p> : null}
+      <div className="mt-4 space-y-2.5">
+        {alternatives.map((alt, i) => (
+          <div
+            key={`${alt.condition}-${i}`}
+            className="rounded-xl border border-brand-900/10 bg-white p-4 shadow-[0_1px_2px_rgba(13,23,18,0.05)] dark:border-white/10 dark:bg-[var(--surface-card)]"
+          >
+            <p className="text-sm font-semibold text-muted">{alt.condition}</p>
+            <p className="mt-1 text-sm leading-6 text-ink">
+              {alt.href ? (
+                <Link href={alt.href} className="font-bold text-brand-800 hover:underline dark:text-[var(--text-primary)]">
+                  {alt.recommendation}
+                </Link>
+              ) : (
+                <span className="font-bold">{alt.recommendation}</span>
+              )}{' '}
+              — {alt.reason}
+            </p>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+export default BetterAlternatives

--- a/components/editorial/CommonMistakes.tsx
+++ b/components/editorial/CommonMistakes.tsx
@@ -1,0 +1,63 @@
+import type { ReactNode } from 'react'
+
+export type CommonMistakeItem = {
+  mistake: string
+  whyItMatters: ReactNode
+  betterApproach?: ReactNode
+}
+
+/**
+ * CommonMistakes — prevents misuse and improves practical usefulness.
+ *
+ * Each entry pairs a mistake with why it matters and (ideally) the better
+ * approach. Reduces the "I tried it and it didn't work" failure mode.
+ *
+ * MDX usage:
+ *   <CommonMistakes
+ *     items={[
+ *       { mistake: 'Starting five supplements at once',
+ *         whyItMatters: 'You cannot tell what helped or what caused a side effect.',
+ *         betterApproach: 'Add one at a time and track it for 1–2 weeks.' },
+ *     ]}
+ *   />
+ */
+export function CommonMistakes({
+  title = 'Common mistakes',
+  items,
+}: {
+  title?: string
+  items: CommonMistakeItem[]
+}) {
+  return (
+    <section className="not-prose my-6">
+      <h2 className="text-xl font-bold tracking-tight text-ink sm:text-2xl">{title}</h2>
+      <ol className="mt-4 space-y-3">
+        {items.map((item, i) => (
+          <li
+            key={`${item.mistake}-${i}`}
+            className="rounded-xl border border-brand-900/10 bg-white p-4 shadow-[0_1px_2px_rgba(13,23,18,0.05)] dark:border-white/10 dark:bg-[var(--surface-card)]"
+          >
+            <p className="flex gap-2 text-sm font-bold text-ink">
+              <span aria-hidden="true" className="text-amber-600 dark:text-amber-400">
+                ⚠
+              </span>
+              <span>{item.mistake}</span>
+            </p>
+            <p className="mt-1.5 text-sm leading-6 text-muted">
+              <span className="font-semibold text-ink">Why it matters: </span>
+              {item.whyItMatters}
+            </p>
+            {item.betterApproach ? (
+              <p className="mt-1.5 text-sm leading-6 text-muted">
+                <span className="font-semibold text-emerald-700 dark:text-emerald-300">Better: </span>
+                {item.betterApproach}
+              </p>
+            ) : null}
+          </li>
+        ))}
+      </ol>
+    </section>
+  )
+}
+
+export default CommonMistakes

--- a/components/editorial/DecisionMatrix.tsx
+++ b/components/editorial/DecisionMatrix.tsx
@@ -1,0 +1,108 @@
+import Link from 'next/link'
+import type { ReactNode } from 'react'
+
+export type DecisionFit = 'good' | 'maybe' | 'poor' | 'avoid'
+
+export type DecisionMatrixItem = {
+  /** The reader's situation ("Racing thoughts before bed"). */
+  situation: string
+  /** How well this page's subject fits that situation. */
+  fit: DecisionFit
+  /** Plain-English guidance for that situation. */
+  guidance: ReactNode
+  /** Optional link to a more relevant page. */
+  href?: string
+  hrefLabel?: string
+}
+
+const FIT: Record<DecisionFit, { label: string; badge: string; rail: string }> = {
+  good: {
+    label: 'Good fit',
+    badge:
+      'border-emerald-500/40 bg-emerald-100 text-emerald-900 dark:border-emerald-400/30 dark:bg-emerald-900/40 dark:text-emerald-100',
+    rail: 'border-l-emerald-500/60',
+  },
+  maybe: {
+    label: 'Maybe',
+    badge:
+      'border-amber-500/40 bg-amber-100 text-amber-900 dark:border-amber-400/30 dark:bg-amber-900/40 dark:text-amber-100',
+    rail: 'border-l-amber-500/60',
+  },
+  poor: {
+    label: 'Poor fit',
+    badge:
+      'border-slate-400/40 bg-slate-100 text-slate-700 dark:border-white/20 dark:bg-white/10 dark:text-[var(--text-secondary)]',
+    rail: 'border-l-slate-400/60',
+  },
+  avoid: {
+    label: 'Avoid',
+    badge:
+      'border-rose-500/40 bg-rose-100 text-rose-900 dark:border-rose-400/30 dark:bg-rose-900/40 dark:text-rose-100',
+    rail: 'border-l-rose-500/60',
+  },
+}
+
+/**
+ * DecisionMatrix — "Should you use it?" fit-by-situation.
+ *
+ * Helps the reader self-identify whether the page matches their problem. Each
+ * row states a situation, a labeled fit (Good fit / Maybe / Poor fit / Avoid —
+ * never communicated by color alone), plain guidance, and an optional route to
+ * a better page. More useful than a generic pros/cons table.
+ *
+ * MDX usage (items is a JS expression):
+ *   <DecisionMatrix
+ *     title="Should you use L-theanine?"
+ *     items={[
+ *       { situation: 'Racing thoughts before bed', fit: 'good',
+ *         guidance: 'May quiet mental chatter without sedation.' },
+ *       { situation: 'Severe panic attacks', fit: 'poor',
+ *         guidance: 'Supplements are unlikely to be enough on their own.' },
+ *     ]}
+ *   />
+ */
+export function DecisionMatrix({
+  title,
+  intro,
+  items,
+}: {
+  title: string
+  intro?: ReactNode
+  items: DecisionMatrixItem[]
+}) {
+  return (
+    <section className="not-prose my-6">
+      <h2 className="text-xl font-bold tracking-tight text-ink sm:text-2xl">{title}</h2>
+      {intro ? <p className="mt-2 text-sm leading-6 text-muted">{intro}</p> : null}
+      <div className="mt-4 space-y-2.5">
+        {items.map((item, i) => {
+          const fit = FIT[item.fit]
+          return (
+            <div
+              key={`${item.situation}-${i}`}
+              className={`rounded-xl border border-brand-900/10 border-l-4 ${fit.rail} bg-white p-4 shadow-[0_1px_2px_rgba(13,23,18,0.05)] dark:border-white/10 dark:bg-[var(--surface-card)]`}
+            >
+              <div className="flex flex-wrap items-center gap-2">
+                <span className={`rounded-full border px-2.5 py-0.5 text-xs font-bold ${fit.badge}`}>
+                  {fit.label}
+                </span>
+                <span className="text-sm font-bold text-ink">{item.situation}</span>
+              </div>
+              <p className="mt-1.5 text-sm leading-6 text-muted">{item.guidance}</p>
+              {item.href ? (
+                <Link
+                  href={item.href}
+                  className="mt-1.5 inline-flex text-sm font-semibold text-brand-800 hover:underline dark:text-[var(--text-primary)]"
+                >
+                  {item.hrefLabel ?? 'Read more'} →
+                </Link>
+              ) : null}
+            </div>
+          )
+        })}
+      </div>
+    </section>
+  )
+}
+
+export default DecisionMatrix

--- a/components/editorial/EditorialNote.tsx
+++ b/components/editorial/EditorialNote.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from 'react'
+
+type Variant = 'default' | 'caution' | 'positive' | 'neutral'
+
+const VARIANT: Record<Variant, string> = {
+  default: 'border-l-brand-700/50 bg-brand-50/60 text-ink dark:bg-[var(--surface-subtle)] dark:text-[var(--text-secondary)]',
+  positive:
+    'border-l-emerald-500/60 bg-emerald-50/70 text-emerald-950 dark:bg-emerald-900/20 dark:text-emerald-100',
+  caution:
+    'border-l-amber-500/60 bg-amber-50/70 text-amber-950 dark:bg-amber-900/20 dark:text-amber-100',
+  neutral: 'border-l-slate-400/50 bg-slate-50 text-ink dark:bg-white/5 dark:text-[var(--text-secondary)]',
+}
+
+/**
+ * EditorialNote — a short, trust-building callout in the publication's voice.
+ * Use sparingly: a single honest aside, not a decorative box.
+ *
+ * MDX usage:
+ *   <EditorialNote variant="caution">
+ *   Supplements are most useful matched to the actual problem — and none of
+ *   them replaces care for a diagnosed condition.
+ *   </EditorialNote>
+ */
+export function EditorialNote({
+  children,
+  variant = 'default',
+}: {
+  children: ReactNode
+  variant?: Variant
+}) {
+  return (
+    <aside
+      className={`not-prose my-6 rounded-xl border-l-4 p-4 text-sm leading-7 ${VARIANT[variant]}`}
+    >
+      <span className="mr-1.5 font-bold">Editor's note:</span>
+      {children}
+    </aside>
+  )
+}
+
+export default EditorialNote

--- a/components/editorial/EvidenceConfidence.tsx
+++ b/components/editorial/EvidenceConfidence.tsx
@@ -1,0 +1,89 @@
+import type { ReactNode } from 'react'
+
+const GRADE_STYLE: Record<string, string> = {
+  strong:
+    'border-emerald-500/40 bg-emerald-100 text-emerald-900 dark:border-emerald-400/30 dark:bg-emerald-900/40 dark:text-emerald-100',
+  'moderate-high':
+    'border-emerald-500/40 bg-emerald-100 text-emerald-900 dark:border-emerald-400/30 dark:bg-emerald-900/40 dark:text-emerald-100',
+  moderate:
+    'border-amber-500/40 bg-amber-100 text-amber-900 dark:border-amber-400/30 dark:bg-amber-900/40 dark:text-amber-100',
+  limited:
+    'border-slate-400/40 bg-slate-100 text-slate-700 dark:border-white/20 dark:bg-white/10 dark:text-[var(--text-secondary)]',
+  preliminary:
+    'border-slate-400/40 bg-slate-100 text-slate-700 dark:border-white/20 dark:bg-white/10 dark:text-[var(--text-secondary)]',
+}
+
+/**
+ * EvidenceConfidence — explains an evidence grade in plain English instead of
+ * leaving "Moderate" unexplained. States why it isn't higher, why it isn't
+ * lower, and the practical takeaway. Builds trust and calibrates expectations.
+ *
+ * MDX usage:
+ *   <EvidenceConfidence
+ *     grade="Moderate"
+ *     whyNotHigher={['Most trials are small', 'Long-term data is limited', 'Outcomes vary by dose']}
+ *     whyNotLower={['Multiple human trials exist', 'Effects are biologically plausible', 'Short-term safety is favorable']}
+ *     practicalTakeaway="Reasonable to try for mild situational use, not a replacement for medical care."
+ *   />
+ */
+export function EvidenceConfidence({
+  title = 'How strong is the evidence?',
+  grade,
+  whyNotHigher,
+  whyNotLower,
+  practicalTakeaway,
+}: {
+  title?: string
+  grade: string
+  whyNotHigher: string[]
+  whyNotLower?: string[]
+  practicalTakeaway: ReactNode
+}) {
+  const gradeStyle = GRADE_STYLE[String(grade).toLowerCase()] ?? GRADE_STYLE.moderate
+  return (
+    <section className="not-prose my-6 rounded-2xl border border-brand-900/12 bg-white p-5 shadow-[0_1px_2px_rgba(13,23,18,0.05)] dark:border-white/10 dark:bg-[var(--surface-card)]">
+      <div className="flex flex-wrap items-center gap-3">
+        <h2 className="text-xl font-bold tracking-tight text-ink sm:text-2xl">{title}</h2>
+        <span className={`rounded-full border px-3 py-0.5 text-sm font-bold ${gradeStyle}`}>{grade}</span>
+      </div>
+      <div className="mt-4 grid gap-4 sm:grid-cols-2">
+        <div>
+          <p className="text-xs font-bold uppercase tracking-wider text-muted">Why not higher</p>
+          <ul className="mt-2 space-y-1.5">
+            {whyNotHigher.map((item) => (
+              <li key={item} className="flex gap-2 text-sm leading-6 text-muted">
+                <span aria-hidden="true" className="mt-0.5">
+                  –
+                </span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+        {whyNotLower && whyNotLower.length > 0 ? (
+          <div>
+            <p className="text-xs font-bold uppercase tracking-wider text-emerald-700 dark:text-emerald-300">
+              Why not lower
+            </p>
+            <ul className="mt-2 space-y-1.5">
+              {whyNotLower.map((item) => (
+                <li key={item} className="flex gap-2 text-sm leading-6 text-ink">
+                  <span aria-hidden="true" className="mt-0.5 font-bold text-emerald-600 dark:text-emerald-400">
+                    +
+                  </span>
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+      </div>
+      <p className="mt-4 border-t border-brand-900/10 pt-3 text-sm leading-7 text-ink dark:border-white/10">
+        <span className="font-bold">Practical takeaway: </span>
+        {practicalTakeaway}
+      </p>
+    </section>
+  )
+}
+
+export default EvidenceConfidence

--- a/components/editorial/RealityCheck.tsx
+++ b/components/editorial/RealityCheck.tsx
@@ -1,0 +1,71 @@
+import type { ReactNode } from 'react'
+
+/**
+ * RealityCheck — corrects hype and sets honest expectations.
+ *
+ * A two-column "people expect / reality" contrast that defuses inflated
+ * marketing claims before the reader forms them. Core to the brand's trust.
+ *
+ * MDX usage:
+ *   <RealityCheck
+ *     title="What to actually expect"
+ *     expectations={['Instant calm', 'Strong sedation', 'Anxiety gone completely']}
+ *     reality={['Effects are usually subtle', 'Calm without drowsiness', 'Severe anxiety needs more than a supplement']}
+ *     bottomLine="Think 'quieter and smoother', not 'switched off'."
+ *   />
+ */
+export function RealityCheck({
+  title = 'Reality check',
+  expectations,
+  reality,
+  bottomLine,
+}: {
+  title?: string
+  expectations: string[]
+  reality: string[]
+  bottomLine?: ReactNode
+}) {
+  return (
+    <section className="not-prose my-6 rounded-2xl border border-brand-900/12 bg-white p-5 shadow-[0_1px_2px_rgba(13,23,18,0.05)] dark:border-white/10 dark:bg-[var(--surface-card)]">
+      <h2 className="text-xl font-bold tracking-tight text-ink sm:text-2xl">{title}</h2>
+      <div className="mt-4 grid gap-4 sm:grid-cols-2">
+        <div>
+          <p className="text-xs font-bold uppercase tracking-wider text-muted">People often expect</p>
+          <ul className="mt-2 space-y-1.5">
+            {expectations.map((item) => (
+              <li key={item} className="flex gap-2 text-sm leading-6 text-muted line-through decoration-rose-400/50">
+                <span aria-hidden="true" className="mt-0.5 not-line-through">
+                  ✕
+                </span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <p className="text-xs font-bold uppercase tracking-wider text-emerald-700 dark:text-emerald-300">
+            What's realistic
+          </p>
+          <ul className="mt-2 space-y-1.5">
+            {reality.map((item) => (
+              <li key={item} className="flex gap-2 text-sm leading-6 text-ink">
+                <span aria-hidden="true" className="mt-0.5 font-bold text-emerald-600 dark:text-emerald-400">
+                  ✓
+                </span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+      {bottomLine ? (
+        <p className="mt-4 border-t border-brand-900/10 pt-3 text-sm leading-7 text-ink dark:border-white/10">
+          <span className="font-bold">Bottom line: </span>
+          {bottomLine}
+        </p>
+      ) : null}
+    </section>
+  )
+}
+
+export default RealityCheck

--- a/components/editorial/ScientificVerdictCard.tsx
+++ b/components/editorial/ScientificVerdictCard.tsx
@@ -1,22 +1,43 @@
+import Link from 'next/link'
 import type { ReactNode } from 'react'
 
 type Recommendation = 'Yes' | 'Maybe' | 'No' | 'Situation-dependent'
 
-type ScientificVerdictProps = {
+type BetterAlternative = {
+  label: string
+  href: string
+  reason?: string
+}
+
+type ScientificVerdictCardProps = {
+  /** Heading label. Defaults to "Scientific Verdict". */
+  title?: string
   /** Overall call: Yes | Maybe | No | Situation-dependent. */
   recommendation: Recommendation | string
-  /** Who it's for. Array, or a single pipe-delimited string for MDX use: "Racing thoughts|Caffeine jitters". */
-  bestFor?: string | string[]
-  /** Who should skip it. Array or pipe-delimited string. */
-  notFor?: string | string[]
   /** Evidence confidence label, e.g. "Moderate". */
   confidence?: string
+  /** Who it's for. Array, or a pipe-delimited string for MDX: "A|B|C". */
+  bestFor?: string | string[]
+  /** Who should skip it. Array or pipe-delimited string. */
+  notIdealFor?: string | string[]
+  /** Alias for notIdealFor (Pass-1 compatibility). */
+  notFor?: string | string[]
   /** Expected onset, e.g. "30–40 minutes". */
   onset?: string
   /** How long to trial it before judging, e.g. "Same day to 2 weeks". */
   evaluationWindow?: string
   /** Bottom-line sentence. Prefer children in MDX; this prop is the .tsx path. */
   bottomLine?: ReactNode
+  /** A better first choice for a different problem. */
+  betterAlternative?: BetterAlternative
+  /** Short safety caveat surfaced inside the verdict. */
+  safetyNote?: ReactNode
+  /** Short note on the evidence base. */
+  evidenceNote?: ReactNode
+  /** Overrides the recommendation pill text (keeps the recommendation color). */
+  badgeLabel?: string
+  /** Reserved for future visual variants; currently only "default". */
+  variant?: 'default'
   children?: ReactNode
 }
 
@@ -38,43 +59,47 @@ const RECOMMENDATION_STYLES: Record<string, string> = {
 }
 
 /**
- * ScientificVerdict — the signature decision module for The Hippie Scientist.
+ * ScientificVerdictCard — the signature decision module for The Hippie Scientist.
  *
  * Every major article/herb/compound/comparison page should OPEN with one of
- * these. It answers, at a glance: would we recommend this, for whom, for what
- * use, how confident are we, how fast does it work, and when to choose
- * something else — before any biochemistry.
+ * these. It answers, before any biochemistry: would we recommend this, for
+ * whom, for what use, how confident, how fast, and when to choose something
+ * else. Registered as an MDX component (also under the alias `ScientificVerdict`
+ * for Pass-1 compatibility) so any article can drop it at the top of the body.
  *
- * Registered as an MDX component (see mdx-components.tsx), so any article can
- * drop it at the top of the body:
- *
- *   <ScientificVerdict
+ *   <ScientificVerdictCard
  *     recommendation="Yes"
- *     bestFor="Racing thoughts at bedtime|Caffeine jitters|Mild situational anxiety"
- *     notFor="Severe insomnia|Panic attacks|Chronic stress alone"
- *     confidence="Moderate"
- *     onset="30–40 minutes"
- *     evaluationWindow="Same day to 2 weeks"
+ *     bestFor="Racing thoughts|Caffeine jitters|Mild situational anxiety"
+ *     notIdealFor="Severe insomnia|Panic attacks|Chronic stress alone"
+ *     confidence="Moderate" onset="30–40 minutes" evaluationWindow="Same day to 2 weeks"
+ *     betterAlternative={{ label: 'Ashwagandha', href: '/articles/ashwagandha/',
+ *       reason: 'for chronic baseline stress' }}
  *   >
- *   L-theanine is a strong first choice for calm focus, but not the best
- *   primary tool for chronic stress or severe anxiety.
- *   </ScientificVerdict>
+ *   L-theanine is a strong first choice for calm focus, not for chronic stress.
+ *   </ScientificVerdictCard>
  *
  * Lists accept a pipe-delimited string (MDX-friendly) or a real array (.tsx).
- * Keep it honest: use "No" / "Situation-dependent" when the evidence warrants.
+ * Keep it honest: use "No" / "Situation-dependent" and a real "Not ideal for"
+ * list when the evidence warrants.
  */
-export function ScientificVerdict({
+export function ScientificVerdictCard({
+  title = 'Scientific Verdict',
   recommendation,
-  bestFor,
-  notFor,
   confidence,
+  bestFor,
+  notIdealFor,
+  notFor,
   onset,
   evaluationWindow,
   bottomLine,
+  betterAlternative,
+  safetyNote,
+  evidenceNote,
+  badgeLabel,
   children,
-}: ScientificVerdictProps) {
+}: ScientificVerdictCardProps) {
   const best = toList(bestFor)
-  const not = toList(notFor)
+  const not = toList(notIdealFor ?? notFor)
   const badgeStyle =
     RECOMMENDATION_STYLES[String(recommendation).toLowerCase()] ?? RECOMMENDATION_STYLES.maybe
   const stats = [
@@ -93,11 +118,9 @@ export function ScientificVerdict({
       className="not-prose my-6 overflow-hidden rounded-2xl border-2 border-brand-900/15 bg-white shadow-md ring-1 ring-brand-900/5 dark:border-white/12 dark:bg-[var(--surface-card)]"
     >
       <div className="flex flex-wrap items-center justify-between gap-3 border-b border-brand-900/10 bg-brand-50/60 px-5 py-3 dark:border-white/10 dark:bg-[var(--surface-subtle)]">
-        <span className="text-xs font-bold uppercase tracking-[0.16em] text-brand-700">
-          Scientific Verdict
-        </span>
+        <span className="text-xs font-bold uppercase tracking-[0.16em] text-brand-700">{title}</span>
         <span className={`rounded-full border px-3 py-1 text-sm font-bold ${badgeStyle}`}>
-          {recommendation}
+          {badgeLabel ?? recommendation}
         </span>
       </div>
 
@@ -158,9 +181,36 @@ export function ScientificVerdict({
             {bottomLine ?? children}
           </div>
         )}
+
+        {safetyNote ? (
+          <p className="mt-3 rounded-lg border border-amber-500/30 bg-amber-50/70 px-3 py-2 text-sm leading-6 text-amber-900 dark:border-amber-400/25 dark:bg-amber-900/25 dark:text-amber-100">
+            <span className="font-bold">Safety: </span>
+            {safetyNote}
+          </p>
+        ) : null}
+
+        {evidenceNote ? (
+          <p className="mt-3 text-sm leading-6 text-muted">
+            <span className="font-semibold text-ink">On the evidence: </span>
+            {evidenceNote}
+          </p>
+        ) : null}
+
+        {betterAlternative ? (
+          <p className="mt-4 border-t border-brand-900/10 pt-4 text-sm leading-6 dark:border-white/10">
+            <span className="font-bold text-ink">Consider instead: </span>
+            <Link href={betterAlternative.href} className="font-semibold text-brand-800 hover:underline dark:text-[var(--text-primary)]">
+              {betterAlternative.label}
+            </Link>
+            {betterAlternative.reason ? <span className="text-muted"> — {betterAlternative.reason}</span> : null}
+          </p>
+        ) : null}
       </div>
     </section>
   )
 }
 
-export default ScientificVerdict
+/** Pass-1 compatibility alias. Prefer `ScientificVerdictCard` going forward. */
+export const ScientificVerdict = ScientificVerdictCard
+
+export default ScientificVerdictCard

--- a/components/editorial/WhereNext.tsx
+++ b/components/editorial/WhereNext.tsx
@@ -1,0 +1,57 @@
+import Link from 'next/link'
+import type { ReactNode } from 'react'
+
+export type NextPath = {
+  /** What the reader might want next ("to compare sleep options"). */
+  ifYouWant: string
+  /** The destination label ("Magnesium vs Melatonin"). */
+  goTo: string
+  /** Destination href — must be a real route. */
+  href: string
+  /** Optional one-line reason. */
+  reason?: ReactNode
+}
+
+/**
+ * WhereNext — context-aware journey navigation that replaces a generic
+ * "Related articles" list. Each path is intent-based routing, not a dump.
+ *
+ * MDX usage:
+ *   <WhereNext
+ *     paths={[
+ *       { ifYouWant: 'to compare sleep options', goTo: 'Magnesium vs Melatonin',
+ *         href: '/guides/sleep/magnesium-vs-melatonin/' },
+ *       { ifYouWant: 'help with stress-related insomnia', goTo: 'Ashwagandha for Sleep',
+ *         href: '/guides/sleep/ashwagandha-for-sleep/' },
+ *     ]}
+ *   />
+ */
+export function WhereNext({
+  title = 'Where to go next',
+  intro,
+  paths,
+}: {
+  title?: string
+  intro?: ReactNode
+  paths: NextPath[]
+}) {
+  return (
+    <section className="not-prose my-6 rounded-2xl border-2 border-brand-900/12 bg-brand-50/40 p-5 dark:border-white/10 dark:bg-[var(--surface-subtle)]">
+      <h2 className="text-xl font-bold tracking-tight text-ink sm:text-2xl">{title}</h2>
+      {intro ? <p className="mt-2 text-sm leading-6 text-muted">{intro}</p> : null}
+      <ul className="mt-4 space-y-2.5">
+        {paths.map((path, i) => (
+          <li key={`${path.href}-${i}`} className="text-sm leading-6">
+            <span className="text-muted">If you want {path.ifYouWant} → </span>
+            <Link href={path.href} className="font-bold text-brand-800 hover:underline dark:text-[var(--text-primary)]">
+              {path.goTo}
+            </Link>
+            {path.reason ? <span className="text-muted"> — {path.reason}</span> : null}
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+export default WhereNext

--- a/content/articles/ashwagandha.md
+++ b/content/articles/ashwagandha.md
@@ -139,7 +139,20 @@ references:
     url: "https://pubmed.ncbi.nlm.nih.gov/10956379/"
 ---
 
-> **The bottom line:** Ashwagandha is the most-studied adaptogen for stress. Multiple RCTs show 300–600 mg/day of standardized root extract reduces cortisol by 28% and perceived stress by 44% over 6–8 weeks. It's not a quick fix — effects build gradually through HPA axis recalibration. Best fit: chronic stress with anxiety or sleep disruption. Evidence grade: **Moderate-high** for stress; moderate for anxiety and sleep.
+**Ashwagandha** (*Withania somnifera*) is the most-studied adaptogen for chronic stress. Here's the honest read on when it helps — and when it doesn't.
+
+<ScientificVerdictCard
+  recommendation="Yes"
+  bestFor="Chronic stress with anxiety|Stress-related sleep disruption|High cortisol — feeling 'wired but tired'"
+  notIdealFor="Acute anxiety or panic (works over weeks, not minutes)|A same-night sleep aid|Pregnancy, thyroid disease, or use with sedatives"
+  confidence="Moderate-high"
+  onset="Gradual — first shifts in 2–4 weeks"
+  evaluationWindow="6–8 weeks"
+  betterAlternative={{ label: 'L-theanine', href: '/articles/l-theanine/', reason: 'for acute, in-the-moment calm' }}
+  safetyNote="Avoid in pregnancy, thyroid disease, and active liver disease, and with sedatives; several cholestatic liver-injury case reports exist. See the safety section."
+>
+Ashwagandha is the best-studied adaptogen for chronic stress — standardized root extract lowers cortisol and eases stress-related sleep over weeks in multiple RCTs. It is not a quick fix and it is the wrong tool for acute anxiety or panic.
+</ScientificVerdictCard>
 
 ## At a Glance
 
@@ -153,10 +166,31 @@ Ashwagandha (*Withania somnifera*) is a calming adaptogen — not a sedative, no
 | When to reassess | 4–8 weeks, not after a few doses |
 | Who should avoid it | Pregnancy, thyroid disease, liver disease, sedative users, thyroid meds, immunosuppressants |
 | Common side effects | Mild GI upset (~5–10% of users, usually resolves in first week); rare emotional blunting at high doses |
-| Better fit for fatigue-dominant stress? | Try [Rhodiola](/guides/rhodiola-complete-guide/) — stimulating, not calming |
+| Better fit for fatigue-dominant stress? | Try [Rhodiola](/guides/herbs/rhodiola-complete-guide/) — stimulating, not calming |
 | Better fit for acute calm? | Try [L-theanine](/guides/anxiety/l-theanine-for-anxiety/) — works in 30–40 minutes |
 
-![Ashwagandha root and powder](/images/monographs/photos/ashwagandha.jpg)
+![Ashwagandha root and powder](/images/guides/ashwagandha-herb.jpg)
+
+---
+
+<DecisionMatrix
+  title="Should you use ashwagandha?"
+  intro="Ashwagandha is a slow, baseline-stress tool. Match your situation to the fit."
+  items={[
+    { situation: 'Chronic stress that builds over weeks', fit: 'good', guidance: 'Its strongest, best-evidenced use — lowers cortisol and perceived stress over 6–8 weeks.' },
+    { situation: 'Stress-related insomnia', fit: 'good', guidance: 'Helps stress-driven sleep, especially at an evening dose.', href: '/guides/sleep/ashwagandha-for-sleep/', hrefLabel: 'Ashwagandha for sleep' },
+    { situation: 'Fatigue and burnout with low motivation', fit: 'maybe', guidance: 'A stimulating adaptogen like rhodiola may fit better if fatigue dominates.', href: '/guides/herbs/rhodiola-complete-guide/', hrefLabel: 'Rhodiola guide' },
+    { situation: 'Acute anxiety before a specific event', fit: 'poor', guidance: 'It works over weeks, not minutes — reach for L-theanine instead.', href: '/articles/l-theanine/', hrefLabel: 'L-theanine' },
+    { situation: 'Pregnancy, thyroid disease, or you take sedatives', fit: 'avoid', guidance: 'Contraindicated or requires clinician oversight — see the safety section.' },
+  ]}
+/>
+
+<RealityCheck
+  title="What to actually expect"
+  expectations={['A calm feeling within a day or two', 'Noticeable sedation or a mood lift', 'Stress and anxiety gone entirely']}
+  reality={['Little for the first 1–2 weeks; effects build gradually', 'A lower baseline — the same triggers feel less overwhelming', 'Roughly 15–25% of people feel nothing even after 8 weeks']}
+  bottomLine="Judge it at 6–8 weeks, not after a few doses. If you need relief tonight, this is the wrong tool."
+/>
 
 ---
 
@@ -172,7 +206,7 @@ This is what ashwagandha users typically report in clinical trials and community
 | **Week 6–8** | **This is the window where clinical trials show measurable effects.** Anxiety scores drop measurably. Sleep consolidates into deeper, more restorative architecture. You may notice you're less reactive to stressors — the same trigger that would have derailed your afternoon now feels manageable. Testosterone effects in men may become measurable. | Still not a sedative. Won't stop a panic attack. Won't replace therapy, exercise, or addressing the structural sources of your stress. |
 | **Week 8–12** | Effects plateau for most people. Some choose to cycle off (2–4 week break) to reassess their baseline. Long-term users frequently report sustained stress resilience without evidence of tolerance. | Effects won't keep increasing indefinitely — you're normalizing a dysregulated stress system, not optimizing indefinitely. |
 
-> **If you feel nothing after 8 weeks at 600 mg/day:** ashwagandha probably isn't your adaptogen. This happens for roughly 15–25% of people. Consider [rhodiola](/guides/rhodiola-complete-guide/) (if fatigue-dominant), a [magnesium + L-theanine sleep stack](/guides/magnesium-l-theanine-sleep-stack/) (if sleep-dominant), or addressing whether your stress is situational rather than physiological.
+> **If you feel nothing after 8 weeks at 600 mg/day:** ashwagandha probably isn't your adaptogen. This happens for roughly 15–25% of people. Consider [rhodiola](/guides/herbs/rhodiola-complete-guide/) (if fatigue-dominant), a [magnesium + L-theanine sleep stack](/articles/magnesium-l-theanine-sleep-stack/) (if sleep-dominant), or addressing whether your stress is situational rather than physiological.
 
 ## What Ashwagandha Actually Feels Like
 
@@ -231,6 +265,13 @@ All guidance below is based on standardized extracts used in human trials. It do
 ## The Clinical Evidence: Study-by-Study
 
 > **Key finding:** Multiple randomized, double-blind, placebo-controlled trials show ashwagandha reduces perceived stress and serum cortisol. The main weakness: most trials are small (n=50–65), short (8–10 weeks), and industry-funded, using different branded extracts that complicate cross-comparison.
+
+<EvidenceConfidence
+  grade="Moderate-high"
+  whyNotHigher={['Most trials are small (n=50–65) and short (8–10 weeks)', 'Many are industry-funded by extract manufacturers', 'Branded extracts differ in standardization, complicating comparison', 'Little long-term safety data beyond 12 weeks']}
+  whyNotLower={['Multiple independent RCTs point the same direction', 'Objective cortisol biomarkers back the subjective stress scales', 'The HPA-axis mechanism is biologically plausible', 'Short-term safety is generally favorable']}
+  practicalTakeaway="Well-supported for a 6–8 week trial in chronic stress with standardized extract — but not a treatment for a diagnosed anxiety disorder, and worth clinician oversight for long-term use."
+/>
 
 ### Evidence Summary Table
 
@@ -444,6 +485,15 @@ The ashwagandha market is saturated. Here's how to cut through the noise:
 | Stress-related cognitive fog | **Ashwagandha** | Bacopa monnieri | Ashwagandha addresses the stress driving the fog; bacopa supports memory formation directly. Different mechanisms, can stack. |
 | Perimenopausal anxiety + sleep disruption | **Ashwagandha** | Magnesium + L-theanine | HPA axis dysregulation is common in perimenopause; ashwagandha addresses this directly. Limited perimenopause-specific trial data. |
 
+<BetterAlternatives
+  intro="If your main problem isn't chronic stress, one of these is a better first pick:"
+  alternatives={[
+    { condition: 'You need calm for a specific moment (a presentation, a bad night)', recommendation: 'L-theanine', reason: 'works in 30–40 minutes, where ashwagandha needs weeks.', href: '/articles/l-theanine/' },
+    { condition: 'Your main issue is physical tension or restless sleep', recommendation: 'Magnesium glycinate', reason: 'relaxes muscles and the nervous system, and is very low-risk.', href: '/articles/magnesium-glycinate/' },
+    { condition: 'You are exhausted and unmotivated more than anxious', recommendation: 'Rhodiola', reason: 'a stimulating adaptogen for fatigue-dominant burnout.', href: '/guides/herbs/rhodiola-complete-guide/' },
+  ]}
+/>
+
 ---
 
 ## FAQ
@@ -474,11 +524,19 @@ KSM-66 is a root-only extract (≥5% withanolides) with 22+ clinical trials — 
 
 ---
 
-## Related Articles
+<WhereNext
+  intro="Depending on what you're solving for next:"
+  paths={[
+    { ifYouWant: 'help with stress-related insomnia', goTo: 'Ashwagandha for Sleep', href: '/guides/sleep/ashwagandha-for-sleep/' },
+    { ifYouWant: 'to choose between the two most common picks', goTo: 'Ashwagandha vs Magnesium for Sleep', href: '/guides/sleep/ashwagandha-vs-magnesium-for-sleep/' },
+    { ifYouWant: 'fast, in-the-moment calm instead', goTo: 'L-Theanine', href: '/articles/l-theanine/', reason: 'works in 30–40 minutes' },
+    { ifYouWant: 'an energizing adaptogen for fatigue', goTo: 'Rhodiola Rosea', href: '/articles/rhodiola-rosea/' },
+    { ifYouWant: 'to browse all stress options', goTo: 'Best Supplements for Stress', href: '/guides/best/supplements-for-stress/' },
+  ]}
+/>
 
-- [Rhodiola Rosea: Benefits, Dosage & Evidence](/articles/rhodiola-rosea/)
-- [Magnesium Glycinate: Sleep, Anxiety & Stress](/articles/magnesium-glycinate/)
+## Related Reading
+
 - [Magnesium + L-Theanine Sleep Stack](/articles/magnesium-l-theanine-sleep-stack/)
-- [L-Theanine: Calm Focus Guide](/articles/l-theanine/)
 - [Kava for Anxiety & Sleep](/articles/kava/)
 - [How to Choose a Quality Supplement](/articles/how-to-choose-supplement-quality/)

--- a/content/articles/l-theanine.md
+++ b/content/articles/l-theanine.md
@@ -71,7 +71,17 @@ references:
     url: "https://pubmed.ncbi.nlm.nih.gov/21208586/"
 ---
 
-> **The bottom line:** L-theanine is an amino acid from tea that produces "alert relaxation" — calm focus without sedation. It increases alpha brain waves within 30–40 minutes, making it one of the fastest-acting anxiolytic supplements. Best for: caffeine jitter reduction, acute situational [anxiety](/guides/anxiety/) (presentations, exams, social settings), and racing thoughts at bedtime. It does not build tolerance or cause dependence. Evidence grade: **Moderate** for acute relaxation; limited for chronic anxiety and sleep.
+<ScientificVerdictCard
+  recommendation="Yes"
+  bestFor="Caffeine jitters|Racing thoughts at bedtime|Mild situational anxiety (presentations, exams)|Calm focus without sedation"
+  notIdealFor="Severe insomnia|Panic attacks|Chronic baseline stress alone"
+  confidence="Moderate"
+  onset="30–40 minutes"
+  evaluationWindow="Same day to 2 weeks"
+  betterAlternative={{ label: 'Ashwagandha', href: '/articles/ashwagandha/', reason: 'for chronic baseline stress that builds over weeks' }}
+>
+L-theanine is a strong first choice for calm without sedation — smoothing caffeine and quieting a busy mind — but not the best primary tool for chronic stress or severe anxiety. It works within 30–40 minutes, builds no tolerance, and is one of the safest supplements for daily use.
+</ScientificVerdictCard>
 
 ## At a Glance
 
@@ -110,24 +120,27 @@ L-theanine's subjective effects are consistent across most users.
 - You remain alert and capable — this is not sedation or cognitive impairment
 - The effect is often described as similar to the mental state after 10–15 minutes of meditation
 
-**What it's NOT:**
-- Not a sedative — won't make you drowsy or impair driving
-- Not a "high" — no euphoria, no altered perception
-- Not a stimulant-style cognitive enhancer — it won't increase raw processing speed
-- Not a fix for the source of your anxiety — it provides acute symptom relief, not root-cause resolution
+<RealityCheck
+  title="What to actually expect"
+  expectations={['Instant, powerful calm', 'Sedation that puts you to sleep', 'Anxiety disappearing completely']}
+  reality={['A subtle drop in mental "volume" within ~40 minutes', 'Calm while staying alert — you can drive and work', 'Smoother caffeine and quieter thoughts, not a cure for severe anxiety']}
+  bottomLine="Think 'quieter and smoother', not 'switched off'. If you expect a strong hit, you may conclude it 'did nothing'."
+/>
 
 ---
 
-## Best Use Cases
-
-L-theanine is a precise tool, not a cure-all. It shines in a few specific situations:
-
-- **Taming caffeine** — smoothing the jitters, anxiety, and crash from coffee or pre-workout.
-- **Situational calm** — a presentation, exam, interview, flight, or difficult conversation where you need to be composed *and* sharp.
-- **Bedtime mental chatter** — quieting an overactive mind so you can fall asleep, especially as part of a [sleep](/guides/sleep/) routine.
-- **Calmer daytime [focus](/guides/focus/)** — reducing background mental noise during deep work, with or without caffeine.
-
-If your challenge is **chronic, ongoing stress** rather than an acute moment, L-theanine is better used as a complement to a cortisol-focused adaptogen — see [ashwagandha](/articles/ashwagandha/) and the [best supplements for stress](/guides/best/supplements-for-stress/).
+<DecisionMatrix
+  title="Should you use L-theanine?"
+  intro="Match your situation to the fit. L-theanine is a precise tool, not a cure-all."
+  items={[
+    { situation: 'Caffeine jitters or afternoon crash', fit: 'good', guidance: 'Pairs with caffeine to smooth the edge while keeping the focus.', href: '/guides/focus/l-theanine-vs-caffeine-for-focus/', hrefLabel: 'L-theanine vs caffeine' },
+    { situation: 'Racing thoughts at bedtime', fit: 'good', guidance: 'May quiet mental chatter without sedation.', href: '/guides/sleep/l-theanine-for-sleep/', hrefLabel: 'L-theanine for sleep' },
+    { situation: 'Situational nerves (presentation, exam, flight)', fit: 'good', guidance: 'Fast, non-sedating calm for a specific stressful moment.', href: '/guides/anxiety/l-theanine-for-anxiety/', hrefLabel: 'L-theanine for anxiety' },
+    { situation: 'Physical tension or restless body at night', fit: 'maybe', guidance: 'Magnesium may be the better first choice for muscle-driven tension.', href: '/articles/magnesium-glycinate/', hrefLabel: 'Magnesium glycinate' },
+    { situation: 'Chronic, ongoing baseline stress', fit: 'maybe', guidance: 'Better as an add-on to a cortisol-focused adaptogen than as the main tool.', href: '/articles/ashwagandha/', hrefLabel: 'Ashwagandha' },
+    { situation: 'Severe anxiety or panic attacks', fit: 'poor', guidance: 'A mild supplement is unlikely to be enough; speak with a clinician.' },
+  ]}
+/>
 
 ---
 
@@ -221,6 +234,13 @@ No cycling needed — L-theanine doesn't build tolerance. You can use it daily o
 
 The evidence is strongest for acute, single-dose relaxation effects — that's where L-theanine's rapid alpha-wave mechanism provides a clear, measurable signal. For chronic anxiety or sleep disorders, the evidence is thinner and L-theanine is better used as a component of a broader approach (stacked with [magnesium](/articles/magnesium-glycinate/), [ashwagandha](/articles/ashwagandha/), or cognitive-behavioral interventions).
 
+<EvidenceConfidence
+  grade="Moderate"
+  whyNotHigher={['Most trials are small (n=15–40)', 'Effects are measured acutely, not over months', 'Chronic-anxiety and sleep-disorder data are thin']}
+  whyNotLower={['Multiple human RCTs with objective EEG endpoints', 'The alpha-wave and caffeine-synergy effects are consistent and biologically plausible', 'Safety profile is excellent with no tolerance']}
+  practicalTakeaway="A reasonable, low-risk first choice for acute, situational calm and caffeine pairing — not a treatment for a diagnosed anxiety or sleep disorder."
+/>
+
 ---
 
 ## How It Works
@@ -273,6 +293,17 @@ L-theanine has an excellent safety profile. No serious adverse events have been 
 
 ---
 
+<BetterAlternatives
+  intro="L-theanine is not always the right first tool. If one of these fits you better, start there."
+  alternatives={[
+    { condition: 'Your main issue is physical tension or a restless body at night', recommendation: 'Magnesium glycinate', reason: 'it supports muscle relaxation and nervous-system calm.', href: '/articles/magnesium-glycinate/' },
+    { condition: 'Your main issue is chronic, baseline stress', recommendation: 'Ashwagandha', reason: 'it lowers cortisol and baseline stress over weeks, where L-theanine only helps in the moment.', href: '/articles/ashwagandha/' },
+    { condition: 'Your main issue is severe anxiety or panic', recommendation: 'A clinician, not a supplement', reason: 'mild anxiolytics are unlikely to be enough; this is a medical conversation.' },
+  ]}
+/>
+
+---
+
 ## FAQ
 
 ### Does L-theanine help with sleep?
@@ -295,13 +326,19 @@ Some people don't notice L-theanine's effects, particularly if they're expecting
 
 ---
 
-## Related Articles
+<WhereNext
+  intro="Depending on what you're solving for next:"
+  paths={[
+    { ifYouWant: 'to quiet a racing mind at bedtime', goTo: 'L-Theanine for Sleep', href: '/guides/sleep/l-theanine-for-sleep/' },
+    { ifYouWant: 'calm, jitter-free focus', goTo: 'L-Theanine vs Caffeine for Focus', href: '/guides/focus/l-theanine-vs-caffeine-for-focus/' },
+    { ifYouWant: 'a ready-made sleep combination', goTo: 'Magnesium + L-Theanine Sleep Stack', href: '/articles/magnesium-l-theanine-sleep-stack/' },
+    { ifYouWant: 'help with chronic, baseline stress', goTo: 'Ashwagandha', href: '/articles/ashwagandha/', reason: 'works over weeks on cortisol' },
+    { ifYouWant: 'to browse all calm & sleep options', goTo: 'Best Supplements for Anxiety', href: '/guides/anxiety/' },
+  ]}
+/>
 
-- [Magnesium + L-Theanine Sleep Stack](/articles/magnesium-l-theanine-sleep-stack/)
-- [Ashwagandha: Benefits, Dosage & Evidence](/articles/ashwagandha/)
+## Related Reading
+
 - [Magnesium Glycinate: Sleep, Anxiety & Stress](/articles/magnesium-glycinate/)
-- [Best Supplements for Sleep](/guides/sleep/)
-- [Best Supplements for Anxiety](/guides/anxiety/)
-- [Best Supplements for Focus](/guides/focus/)
 - [Kava for Anxiety & Sleep](/articles/kava/)
 - [Passionflower for Anxiety](/articles/passionflower/)

--- a/docs/editorial-components.md
+++ b/docs/editorial-components.md
@@ -16,9 +16,14 @@ server components — safe for static export, no client JS.
 These are registered in [`mdx-components.tsx`](../mdx-components.tsx), so any
 `.md`/`.mdx` article can use them inline with **no import**.
 
-### `<ScientificVerdict>` — the signature decision module
+> **Location:** the editorial component system lives in `components/editorial/`.
+> The guide-hub primitives live in `components/guides/`. All are registered in
+> [`mdx-components.tsx`](../mdx-components.tsx) where they're usable in articles.
 
-`components/content/ScientificVerdict.tsx`
+### `<ScientificVerdictCard>` — the signature decision module
+
+`components/editorial/ScientificVerdictCard.tsx` (also exported/registered as
+`ScientificVerdict` for backward compatibility)
 
 The recognizable module every major article/herb/compound/comparison page should
 **open** with. It answers, before any biochemistry: would we recommend this, for
@@ -51,6 +56,61 @@ the best primary tool for chronic stress or severe anxiety.
   for" list when the evidence warrants. That honesty is the brand.
 
 Live example: [`content/articles/magnesium-glycinate.md`](../content/articles/magnesium-glycinate.md).
+
+### `<DecisionMatrix>` — "Should you use it?" fit-by-situation
+
+`components/editorial/DecisionMatrix.tsx`
+
+Rows of situation → labeled fit (**Good fit / Maybe / Poor fit / Avoid**, never
+color alone) → guidance → optional route. Place it near the top as the
+"Should you use it?" section. `items` is a JS expression:
+
+```mdx
+<DecisionMatrix title="Should you use L-theanine?" items={[
+  { situation: 'Racing thoughts before bed', fit: 'good',
+    guidance: 'May quiet mental chatter without sedation.',
+    href: '/guides/sleep/l-theanine-for-sleep/', hrefLabel: 'L-theanine for sleep' },
+  { situation: 'Severe panic attacks', fit: 'poor',
+    guidance: 'A mild supplement is unlikely to be enough.' },
+]} />
+```
+
+### `<RealityCheck>` — expectation vs reality
+
+`components/editorial/RealityCheck.tsx`. Two columns:
+`expectations={[…]}` (struck through) vs `reality={[…]}`, with optional
+`bottomLine`. Defuses hype.
+
+### `<EvidenceConfidence>` — explain the grade in plain English
+
+`components/editorial/EvidenceConfidence.tsx`.
+`grade`, `whyNotHigher={[…]}`, `whyNotLower={[…]}`, `practicalTakeaway`.
+Use instead of leaving "Moderate" unexplained.
+
+### `<CommonMistakes>` — prevent misuse
+
+`components/editorial/CommonMistakes.tsx`.
+`items={[{ mistake, whyItMatters, betterApproach? }]}`.
+
+### `<BetterAlternatives>` — route elsewhere when appropriate
+
+`components/editorial/BetterAlternatives.tsx`.
+`alternatives={[{ condition, recommendation, reason, href? }]}`. Trust-building.
+
+### `<WhereNext>` — intent-based journey nav (replaces "Related Articles")
+
+`components/editorial/WhereNext.tsx`.
+`paths={[{ ifYouWant, goTo, href, reason? }]}`.
+
+### `<EditorialNote variant>` — short editor's aside
+
+`components/editorial/EditorialNote.tsx`.
+`variant`: `default | caution | positive | neutral`. Use sparingly.
+
+> **Architecture note:** editorial components render self-contained `.not-prose`
+> blocks. `ContentCards` (the article-body post-processor) explicitly skips any
+> `.not-prose` subtree, so their internal headings are never re-grouped or
+> re-parented. Keep the `.not-prose` root class on any new editorial component.
 
 ### Other registered MDX components
 

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -11,7 +11,14 @@ import { NPSDisclaimer } from '@/components/NPSDisclaimer'
 import ResponsiveTable from '@/components/ui/ResponsiveTable'
 import CollapsibleSection, { CollapsibleWarning, CollapsibleDetails } from '@/components/content/CollapsibleSection'
 import Collapsible from '@/components/content/Collapsible'
-import ScientificVerdict from '@/components/content/ScientificVerdict'
+import ScientificVerdictCard, { ScientificVerdict } from '@/components/editorial/ScientificVerdictCard'
+import DecisionMatrix from '@/components/editorial/DecisionMatrix'
+import RealityCheck from '@/components/editorial/RealityCheck'
+import CommonMistakes from '@/components/editorial/CommonMistakes'
+import BetterAlternatives from '@/components/editorial/BetterAlternatives'
+import WhereNext from '@/components/editorial/WhereNext'
+import EvidenceConfidence from '@/components/editorial/EvidenceConfidence'
+import EditorialNote from '@/components/editorial/EditorialNote'
 
 type MDXComponents = Record<string, ComponentType<Record<string, unknown>>>
 type MdxTableProps = Record<string, unknown> & { children?: ReactNode }
@@ -55,7 +62,15 @@ const evidenceComponents = {
   CollapsibleWarning,
   CollapsibleDetails,
   Collapsible,
+  ScientificVerdictCard,
   ScientificVerdict,
+  DecisionMatrix,
+  RealityCheck,
+  CommonMistakes,
+  BetterAlternatives,
+  WhereNext,
+  EvidenceConfidence,
+  EditorialNote,
   table: MdxTable,
 } as unknown as MDXComponents
 


### PR DESCRIPTION
Pass 2 of 6. Builds a reusable **editorial component system** and applies it to two flagship articles so they read as decision-first evidence guides.

## Components created (`components/editorial/`)
All TypeScript, static-export-safe server components, theme-aware, accessible (fit/grade communicated by **label + color, never color alone**), and registered in `mdx-components.tsx` for use in article MDX.

| Component | Purpose |
|---|---|
| **ScientificVerdictCard** | Signature verdict module. Moved here from `components/content` and extended per spec: `betterAlternative`, `safetyNote`, `evidenceNote`, `badgeLabel`, `title`. Keeps a `ScientificVerdict` alias so Pass-1 usage (magnesium) still works. |
| **DecisionMatrix** | "Should you use it?" — situation → Good fit / Maybe / Poor fit / Avoid → guidance → route. |
| **RealityCheck** | Expectation vs reality; defuses hype. |
| **EvidenceConfidence** | Explains the grade (why not higher / why not lower / practical takeaway) in plain English. |
| **CommonMistakes** | Mistake → why it matters → better approach. |
| **BetterAlternatives** | Routes readers elsewhere when the page isn't their best option. |
| **WhereNext** | Intent-based journey nav that replaces generic "Related Articles". |
| **EditorialNote** | Short editor's aside (`default/caution/positive/neutral`). |

## Architecture improvement (not a workaround)
Editorial components render self-contained `.not-prose` blocks. `ContentCards` (the article-body post-processor) now **skips any `.not-prose` subtree** and stops section-grouping at editorial blocks — so their internal headings are never re-grouped or re-parented (which would otherwise tear the components apart), and each block stays standalone. Documented inline and in the docs.

## Articles upgraded
Both **L-theanine** and **Ashwagandha** now open with a `ScientificVerdictCard` and use `DecisionMatrix`, `RealityCheck`, `EvidenceConfidence`, `BetterAlternatives`, and `WhereNext`. Strong existing evidence sections were **preserved**; net length is roughly neutral, decision value much higher.

**Bonus fixes** (pre-existing issues found while editing): the `rhodiola-complete-guide` links were missing the `/herbs/` segment (broken 404s), a `/guides/` magnesium-stack link pointed at a nonexistent route, and the ashwagandha monograph image referenced a missing file — all corrected.

## Verification
- [x] `npm run typecheck` / `npm run lint` — pass
- [x] `npm run validate:article-quality` — PASS (caught and fixed an entity-intro check after the verdict replaced the intro blockquote)
- [x] `npm run build` (full `next build`) — passes
- [x] Browser pass (mobile + dark): all 6 components render on both articles, no page errors, no broken images, no duplicate headings
- [x] Generated `data/articles/articles.json` intentionally not committed

## Report / next pass
- **Files:** 8 new components, `ContentCards` + `mdx-components` updated, 2 articles upgraded, docs expanded.
- **Recommended Pass 3:** roll the component set across the remaining sleep-cluster articles (magnesium-for-sleep guide, ashwagandha-for-sleep) and the comparison pages, and build a `ComparisonVerdict`-style component for the `/guides/sleep/*-vs-*` pages (decision-stage intent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5BJzyhpmTd72Awzn2PS6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5BJzyhpmTd72Awzn2PS6Q)_