### PR TITLE
Editorial OS pass 3: Canonical Page Operating System (CPOS) + ComparisonVerdict

### DIFF
--- a/app/guides/anxiety/page.tsx
+++ b/app/guides/anxiety/page.tsx
@@ -1,49 +1,207 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { SITE_URL } from '@/src/lib/seo'
+import { HubSectionHeading } from '@/components/guides/HubSectionHeading'
+import { DecisionRouter, type IntentRoute } from '@/components/guides/DecisionRouter'
+import { GuideCardGrid, type GuideCard } from '@/components/guides/GuideCardGrid'
 
 export const metadata: Metadata = {
   title: 'Anxiety & Stress Supplement Guides',
-  description: 'Evidence-based guides on adaptogens, anxiolytics, and stress management: ashwagandha, L-theanine, rhodiola, magnesium, and more.',
+  description:
+    'Choose the right natural support based on the kind of anxiety or stress you have — overthinking, situational nerves, chronic stress, or nighttime worry. Evidence-based, decision-first guides.',
   alternates: { canonical: `${SITE_URL}/guides/anxiety/` },
-  openGraph: { title: 'Anxiety & Stress Guides', description: 'Adaptogens and anxiolytics backed by evidence.', url: `${SITE_URL}/guides/anxiety/`, type: 'website', images: ['/og-default.jpg'] },
+  openGraph: {
+    title: 'Anxiety & Stress Guides',
+    description: 'Match the right adaptogen or anxiolytic to the kind of anxiety you have.',
+    url: `${SITE_URL}/guides/anxiety/`,
+    type: 'website',
+    images: ['/og-default.jpg'],
+  },
 }
 
-const GUIDES = [
-  { slug: 'best-herbs-for-anxiety', title: 'Best Herbs for Anxiety', desc: 'Ashwagandha, kava, passionflower, lemon balm — evidence-graded with safety warnings.' },
-  { slug: 'best-adaptogens-for-stress', title: 'Best Adaptogens for Stress', desc: 'Ashwagandha, rhodiola, eleuthero, schisandra — how adaptogens work and when to use them.' },
-  { slug: 'best-supplements-for-stress', title: 'Best Supplements for Stress', desc: 'Ashwagandha, rhodiola, phosphatidylserine, magnesium — evidence-graded review.' },
-  { slug: 'best-supplements-for-overthinking', title: 'Best Supplements for Overthinking', desc: 'L-theanine, magnesium, lemon balm, ashwagandha — matched to your overthinking pattern.' },
-  { slug: 'best-herbs-for-stress-and-anxiety-at-night', title: 'Best Herbs for Nighttime Anxiety', desc: 'Racing thoughts at bedtime? Evidence-based herb guide for anxiety-driven insomnia.' },
-  { slug: 'how-to-lower-cortisol-naturally', title: 'How to Lower Cortisol Naturally', desc: 'Supplements and lifestyle strategies for managing chronically elevated cortisol.' },
-  { slug: 'natural-anxiety-relief', title: 'Natural Anxiety Relief', desc: 'Evidence-informed overview of supplements and non-supplement approaches for anxiety.' },
-  { slug: 'natural-anxiolytics-beyond-ashwagandha', title: 'Natural Anxiolytics Beyond Ashwagandha', desc: 'L-theanine, kava, kanna — calming botanicals compared with evidence-first analysis.' },
-  { slug: 'natural-alternatives-to-anxiety-medication', title: 'Alternatives to Anxiety Medication', desc: 'Educational overview of supportive herbs and routines — not a replacement for prescribed treatment.' },
-  { slug: 'ashwagandha-for-anxiety', title: 'Ashwagandha for Anxiety', desc: 'How ashwagandha reduces cortisol and supports stress resilience.' },
-  { slug: 'l-theanine-for-anxiety', title: 'L-Theanine for Anxiety', desc: 'L-theanine\'s calming mechanism and evidence for anxiety relief.' },
-  { slug: 'l-theanine-for-calm', title: 'L-Theanine for Calm', desc: 'Using L-theanine for calm focus without sedation.' },
-  { slug: 'cbd-vs-ashwagandha-for-anxiety', title: 'CBD vs Ashwagandha for Anxiety', desc: 'Comparing two popular natural anxiolytics — mechanisms, evidence, and safety.' },
-  { slug: 'anxiety-stack-guide', title: 'Anxiety Stack Guide', desc: 'How to combine supplements for anxiety — timing, safety, and synergy.' },
+// Decision-first routing: match the kind of anxiety/stress to the right first guide.
+const START_HERE: IntentRoute[] = [
+  {
+    problem: 'Overthinking — a mind that won’t switch off',
+    why: 'Calming supports matched to the overthinking pattern.',
+    cta: 'Supplements for Overthinking',
+    href: '/guides/anxiety/best-supplements-for-overthinking/',
+  },
+  {
+    problem: 'Situational nerves before a specific event',
+    why: 'Fast, non-sedating calm for a presentation, exam, or flight.',
+    cta: 'L-Theanine for Anxiety',
+    href: '/guides/anxiety/l-theanine-for-anxiety/',
+  },
+  {
+    problem: 'Chronic, ongoing baseline anxiety',
+    why: 'An adaptogen that lowers cortisol and baseline stress over weeks.',
+    cta: 'Ashwagandha for Anxiety',
+    href: '/guides/anxiety/ashwagandha-for-anxiety/',
+  },
+  {
+    problem: 'Racing thoughts keeping you up at night',
+    why: 'Calming herbs matched to anxiety-driven insomnia.',
+    cta: 'Herbs for Nighttime Anxiety',
+    href: '/guides/anxiety/best-herbs-for-stress-and-anxiety-at-night/',
+  },
+  {
+    problem: 'Chronically elevated stress / high cortisol',
+    why: 'Supplement and lifestyle strategies to bring cortisol down.',
+    cta: 'How to Lower Cortisol',
+    href: '/guides/anxiety/how-to-lower-cortisol-naturally/',
+  },
+  {
+    problem: 'You want a full plan',
+    why: 'How to combine anxiety supports safely — timing and synergy.',
+    cta: 'Anxiety Stack Guide',
+    href: '/guides/anxiety/anxiety-stack-guide/',
+  },
+  {
+    problem: 'Comparing your options',
+    why: 'Two popular anxiolytics, side by side with the evidence.',
+    cta: 'CBD vs Ashwagandha',
+    href: '/guides/anxiety/cbd-vs-ashwagandha-for-anxiety/',
+  },
+]
+
+const BEST_FIRST: GuideCard[] = [
+  {
+    href: '/guides/anxiety/natural-anxiety-relief/',
+    title: 'Natural Anxiety Relief',
+    desc: 'The evidence-informed overview — start here if you are not sure what you need.',
+  },
+  {
+    href: '/guides/anxiety/ashwagandha-for-anxiety/',
+    title: 'Ashwagandha for Anxiety',
+    desc: 'The best-studied adaptogen for chronic, cortisol-driven anxiety.',
+  },
+  {
+    href: '/guides/anxiety/l-theanine-for-anxiety/',
+    title: 'L-Theanine for Anxiety',
+    desc: 'Fast, non-sedating calm for in-the-moment nerves.',
+  },
+  {
+    href: '/guides/anxiety/anxiety-stack-guide/',
+    title: 'Anxiety Stack Guide',
+    desc: 'How to combine options into one coherent, safe routine.',
+  },
+]
+
+const COMPARISONS: GuideCard[] = [
+  {
+    href: '/guides/anxiety/cbd-vs-ashwagandha-for-anxiety/',
+    title: 'CBD vs Ashwagandha for Anxiety',
+    desc: 'Two popular anxiolytics — mechanisms, evidence, and safety.',
+  },
+  {
+    href: '/guides/anxiety/natural-anxiolytics-beyond-ashwagandha/',
+    title: 'Natural Anxiolytics Beyond Ashwagandha',
+    desc: 'L-theanine, kava, kanna — calming botanicals compared.',
+  },
+  {
+    href: '/guides/anxiety/best-adaptogens-for-stress/',
+    title: 'Best Adaptogens for Stress',
+    desc: 'Ashwagandha, rhodiola, eleuthero, schisandra — when to use which.',
+  },
+  {
+    href: '/guides/anxiety/natural-alternatives-to-anxiety-medication/',
+    title: 'Alternatives to Anxiety Medication',
+    desc: 'An educational overview — not a replacement for prescribed treatment.',
+  },
+]
+
+// Full library — kept, but secondary to the decision sections above.
+const ALL_GUIDES = [
+  { slug: 'natural-anxiety-relief', title: 'Natural Anxiety Relief' },
+  { slug: 'best-herbs-for-anxiety', title: 'Best Herbs for Anxiety' },
+  { slug: 'best-supplements-for-stress', title: 'Best Supplements for Stress' },
+  { slug: 'best-adaptogens-for-stress', title: 'Best Adaptogens for Stress' },
+  { slug: 'best-supplements-for-overthinking', title: 'Best Supplements for Overthinking' },
+  { slug: 'best-herbs-for-stress-and-anxiety-at-night', title: 'Best Herbs for Nighttime Anxiety' },
+  { slug: 'how-to-lower-cortisol-naturally', title: 'How to Lower Cortisol Naturally' },
+  { slug: 'natural-anxiolytics-beyond-ashwagandha', title: 'Natural Anxiolytics Beyond Ashwagandha' },
+  { slug: 'natural-alternatives-to-anxiety-medication', title: 'Alternatives to Anxiety Medication' },
+  { slug: 'ashwagandha-for-anxiety', title: 'Ashwagandha for Anxiety' },
+  { slug: 'l-theanine-for-anxiety', title: 'L-Theanine for Anxiety' },
+  { slug: 'l-theanine-for-calm', title: 'L-Theanine for Calm' },
+  { slug: 'cbd-vs-ashwagandha-for-anxiety', title: 'CBD vs Ashwagandha for Anxiety' },
+  { slug: 'anxiety-stack-guide', title: 'Anxiety Stack Guide' },
 ]
 
 export default function AnxietyGuideIndex() {
   return (
     <div className="mx-auto max-w-4xl px-4 pb-24 pt-8">
-      <nav className="text-xs text-muted mb-4">
-        <Link href="/guides/" className="hover:text-ink">Guides</Link><span className="mx-1.5">/</span><span className="text-ink font-medium">Anxiety & Stress</span>
+      <nav className="mb-4 text-xs text-muted">
+        <Link href="/guides/" className="hover:text-ink">
+          Guides
+        </Link>
+        <span className="mx-1.5">/</span>
+        <span className="font-medium text-ink">Anxiety &amp; Stress</span>
       </nav>
+
+      {/* Hero */}
       <header className="mb-10">
-        <h1 className="text-3xl font-bold text-ink sm:text-4xl">Anxiety & Stress Guides</h1>
-        <p className="mt-3 text-lg text-muted max-w-2xl">Adaptogens, anxiolytics, and stress management — evidence-graded with safety context.</p>
+        <h1 className="text-3xl font-bold tracking-tight text-ink sm:text-4xl">Anxiety &amp; Stress Guides</h1>
+        <p className="mt-3 max-w-2xl text-lg leading-8 text-muted">
+          Different kinds of anxiety need different tools. Tell us what yours feels like and we will
+          point you to the right guide first.
+        </p>
       </header>
-      <div className="grid gap-4 sm:grid-cols-2">
-        {GUIDES.map(g => (
-          <Link key={g.slug} href={`/guides/anxiety/${g.slug}/`} className="rounded-xl border border-brand-900/10 bg-white p-5 transition hover:border-brand-700/30 hover:shadow-sm">
-            <h3 className="font-semibold text-ink">{g.title}</h3>
-            <p className="mt-1.5 text-sm text-muted leading-relaxed">{g.desc}</p>
-          </Link>
-        ))}
-      </div>
+
+      {/* Start Here — decision routing */}
+      <section className="mb-12">
+        <HubSectionHeading
+          eyebrow="Start here"
+          title="What kind of anxiety do you have?"
+          sub="Pick the description that fits best — each routes you to the most relevant guide."
+        />
+        <DecisionRouter items={START_HERE} />
+      </section>
+
+      {/* Best first pages */}
+      <section className="mb-12">
+        <HubSectionHeading eyebrow="Best first reads" title="If you only read a few" />
+        <GuideCardGrid cards={BEST_FIRST} />
+      </section>
+
+      {/* Comparison guides */}
+      <section className="mb-12">
+        <HubSectionHeading
+          eyebrow="Compare & choose"
+          title="Deciding between options?"
+          sub="These weigh the alternatives instead of listing everything."
+        />
+        <GuideCardGrid cards={COMPARISONS} />
+      </section>
+
+      {/* Editorial note */}
+      <section className="mb-12 rounded-xl border-l-4 border-brand-700/40 bg-brand-50/60 p-5 dark:bg-[var(--surface-subtle)]">
+        <p className="text-sm leading-7 text-ink dark:text-[var(--text-secondary)]">
+          <span className="font-bold">A note on matching the tool to the problem.</span> Acute,
+          in-the-moment nerves and chronic, cortisol-driven stress respond to different supports — a
+          fast anxiolytic like L-theanine versus a slow adaptogen like ashwagandha. None of these
+          replaces care for a diagnosed anxiety disorder; if anxiety is severe or persistent, talk to
+          a clinician.
+        </p>
+      </section>
+
+      {/* All guides — secondary */}
+      <section>
+        <HubSectionHeading eyebrow="Full library" title="All anxiety & stress guides" />
+        <ul className="grid gap-x-6 gap-y-2 sm:grid-cols-2">
+          {ALL_GUIDES.map((g) => (
+            <li key={g.slug}>
+              <Link
+                href={`/guides/anxiety/${g.slug}/`}
+                className="text-sm font-medium text-brand-800 hover:underline dark:text-[var(--text-primary)]"
+              >
+                {g.title}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </section>
     </div>
   )
 }

--- a/app/guides/sleep/magnesium-vs-melatonin/page.tsx
+++ b/app/guides/sleep/magnesium-vs-melatonin/page.tsx
@@ -9,6 +9,7 @@ import RecommendationSection from '@/components/RecommendationSection';
 import AffiliateDisclosure from '@/components/AffiliateDisclosure';
 import EmailCapture from '@/components/EmailCapture';
 import References from '@/components/References'
+import ComparisonVerdict from '@/components/editorial/ComparisonVerdict'
 
 const CANONICAL_PATH = '/guides/sleep/magnesium-vs-melatonin/'
 const route = 'guides/magnesium-vs-melatonin';
@@ -51,6 +52,31 @@ export default function MagnesiumVsMelatoninGuidePage() {
           { label: 'Magnesium vs Melatonin', href: '/guides/sleep/magnesium-vs-melatonin' },
         ]}
       />
+
+      <ComparisonVerdict
+        optionA="Magnesium"
+        optionB="Melatonin"
+        chooseA={[
+          'Muscle tension or trouble winding down',
+          'You suspect a low magnesium intake (common)',
+          'You want sleep-quality support, not just faster onset',
+        ]}
+        chooseB={[
+          'A circadian / timing problem — jet lag, shift work, delayed sleep phase',
+          'You mainly struggle to fall asleep at the desired hour',
+          'You need it only occasionally, for a schedule shift',
+        ]}
+        useBoth={['Both relaxation and timing are issues — take magnesium in the evening and low-dose melatonin 30–120 min before your target bedtime.']}
+        avoidBoth={['Loud snoring with daytime exhaustion (possible sleep apnea) or chronic insomnia — see a clinician; neither supplement fixes these.']}
+        winners={[
+          { label: 'Fastest to act', winner: 'Melatonin' },
+          { label: 'Best for muscle tension', winner: 'Magnesium' },
+          { label: 'Best for jet lag / timing', winner: 'Melatonin' },
+          { label: 'Best safety for nightly use', winner: 'Magnesium', note: 'no morning grog' },
+        ]}
+      >
+        They solve different problems — magnesium calms the body and nervous system; melatonin shifts your clock. Most people should start with whichever matches the list above, and many combine them.
+      </ComparisonVerdict>
 
       <SeoEntryPage route={route} canonicalPath={CANONICAL_PATH} />
 

--- a/components/editorial/ComparisonVerdict.tsx
+++ b/components/editorial/ComparisonVerdict.tsx
@@ -1,0 +1,167 @@
+import type { ReactNode } from 'react'
+
+export type ComparisonWinner = {
+  /** The dimension being judged ("Fastest", "Best for sleep", "Best safety"). */
+  label: string
+  /** Which option wins it — usually one of the two option names, or "Either". */
+  winner: string
+  /** Optional short qualifier. */
+  note?: string
+}
+
+type ComparisonVerdictProps = {
+  title?: string
+  /** Names of the two things being compared. */
+  optionA: string
+  optionB: string
+  /** Situations where A is the better first choice. */
+  chooseA: string[]
+  /** Situations where B is the better first choice. */
+  chooseB: string[]
+  /** When to use both together. */
+  useBoth?: string[]
+  /** When neither is the answer. */
+  avoidBoth?: string[]
+  /** Quick "who wins what" verdict rows. */
+  winners?: ComparisonWinner[]
+  bottomLine?: ReactNode
+  children?: ReactNode
+}
+
+/**
+ * ComparisonVerdict — the decision module for comparison ("A vs B") pages.
+ *
+ * A comparison page's one job is to help the reader CHOOSE. This module makes
+ * the call up front: choose A if…, choose B if…, use both if…, avoid both if…,
+ * plus a quick grid of who-wins-what. Place it at the very top of a comparison
+ * page, before the deep mechanism/evidence sections.
+ *
+ * Static-safe server component; theme-aware; distinctions are labeled (not
+ * communicated by color alone).
+ *
+ * Usage (.tsx page):
+ *   <ComparisonVerdict
+ *     optionA="Magnesium" optionB="Melatonin"
+ *     chooseA={['Muscle tension or trouble winding down', 'Likely low magnesium status']}
+ *     chooseB={['A circadian/timing problem (jet lag, delayed sleep phase)']}
+ *     useBoth={['Both relaxation and timing are issues — mind the timing']}
+ *     winners={[
+ *       { label: 'Fastest to act', winner: 'Melatonin' },
+ *       { label: 'Best for muscle tension', winner: 'Magnesium' },
+ *       { label: 'Best safety profile', winner: 'Magnesium', note: 'no morning grog' },
+ *     ]}
+ *   >
+ *   They solve different problems and are often combined.
+ *   </ComparisonVerdict>
+ */
+export function ComparisonVerdict({
+  title = 'Which should you choose?',
+  optionA,
+  optionB,
+  chooseA,
+  chooseB,
+  useBoth,
+  avoidBoth,
+  winners,
+  bottomLine,
+  children,
+}: ComparisonVerdictProps) {
+  return (
+    <section
+      aria-label={`Verdict: ${optionA} vs ${optionB}`}
+      className="not-prose my-6 overflow-hidden rounded-2xl border-2 border-brand-900/15 bg-white shadow-md ring-1 ring-brand-900/5 dark:border-white/12 dark:bg-[var(--surface-card)]"
+    >
+      <div className="border-b border-brand-900/10 bg-brand-50/60 px-5 py-3 dark:border-white/10 dark:bg-[var(--surface-subtle)]">
+        <span className="text-xs font-bold uppercase tracking-[0.16em] text-brand-700">{title}</span>
+      </div>
+
+      <div className="px-5 py-4">
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div>
+            <p className="text-xs font-bold uppercase tracking-wider text-brand-800 dark:text-[var(--text-primary)]">
+              Choose {optionA} if
+            </p>
+            <ul className="mt-2 space-y-1.5">
+              {chooseA.map((item) => (
+                <li key={item} className="flex gap-2 text-sm leading-6 text-ink">
+                  <span aria-hidden="true" className="mt-0.5 font-bold text-emerald-600 dark:text-emerald-400">
+                    ✓
+                  </span>
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <p className="text-xs font-bold uppercase tracking-wider text-brand-800 dark:text-[var(--text-primary)]">
+              Choose {optionB} if
+            </p>
+            <ul className="mt-2 space-y-1.5">
+              {chooseB.map((item) => (
+                <li key={item} className="flex gap-2 text-sm leading-6 text-ink">
+                  <span aria-hidden="true" className="mt-0.5 font-bold text-sky-600 dark:text-sky-400">
+                    ✓
+                  </span>
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        {useBoth && useBoth.length > 0 ? (
+          <div className="mt-4 rounded-lg border border-emerald-500/25 bg-emerald-50/60 px-3 py-2 dark:border-emerald-400/20 dark:bg-emerald-900/20">
+            <p className="text-xs font-bold uppercase tracking-wider text-emerald-700 dark:text-emerald-300">
+              Use both if
+            </p>
+            <ul className="mt-1 space-y-1">
+              {useBoth.map((item) => (
+                <li key={item} className="text-sm leading-6 text-ink">
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+
+        {avoidBoth && avoidBoth.length > 0 ? (
+          <div className="mt-3 rounded-lg border border-rose-500/25 bg-rose-50/60 px-3 py-2 dark:border-rose-400/20 dark:bg-rose-900/20">
+            <p className="text-xs font-bold uppercase tracking-wider text-rose-700 dark:text-rose-300">
+              Neither is enough if
+            </p>
+            <ul className="mt-1 space-y-1">
+              {avoidBoth.map((item) => (
+                <li key={item} className="text-sm leading-6 text-ink">
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+
+        {winners && winners.length > 0 ? (
+          <dl className="mt-4 grid grid-cols-1 gap-x-6 gap-y-2 border-t border-brand-900/10 pt-4 dark:border-white/10 sm:grid-cols-2">
+            {winners.map((w) => (
+              <div key={w.label} className="flex items-baseline justify-between gap-3">
+                <dt className="text-sm text-muted">{w.label}</dt>
+                <dd className="text-right text-sm font-bold text-ink">
+                  {w.winner}
+                  {w.note ? <span className="ml-1 font-normal text-muted">({w.note})</span> : null}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        ) : null}
+
+        {(bottomLine || children) && (
+          <div className="mt-4 border-t border-brand-900/10 pt-4 text-sm leading-7 text-ink dark:border-white/10">
+            <span className="font-bold">Bottom line: </span>
+            {bottomLine ?? children}
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}
+
+export default ComparisonVerdict

--- a/content/articles/magnesium-glycinate.md
+++ b/content/articles/magnesium-glycinate.md
@@ -380,6 +380,15 @@ The effective range from clinical trials: **200–400 mg elemental magnesium per
 
 **Week 4:** Assess. If sleep has improved meaningfully, maintain at the effective dose. If no improvement, magnesium deficiency is unlikely to be the primary driver of your sleep issue — consider behavioral interventions, sleep study (if apnea is suspected), or other supplement pathways.
 
+<CommonMistakes
+  items={[
+    { mistake: 'Buying magnesium oxide for sleep', whyItMatters: "Oxide is the most common drugstore form but is barely absorbed (~4%) and mostly acts as a laxative.", betterApproach: 'Choose glycinate (or citrate if budget-limited) and dose by elemental magnesium.' },
+    { mistake: 'Dosing by the big number on the front of the bottle', whyItMatters: '"1,000 mg magnesium glycinate" may contain only ~140 mg of actual elemental magnesium.', betterApproach: 'Read the Supplement Facts panel and target 200–400 mg elemental.' },
+    { mistake: 'Quitting after two or three nights', whyItMatters: 'Beyond the first-night glycine calm, the real benefits build as tissue stores replete over weeks.', betterApproach: 'Give it a consistent 2–4 week trial before judging it.' },
+    { mistake: 'Expecting a sleeping-pill effect', whyItMatters: 'Magnesium enables better sleep physiology; it will not override caffeine, stress, or a sleep disorder.', betterApproach: 'Pair it with sleep hygiene and match it to tension/deficiency-driven sleep problems.' },
+  ]}
+/>
+
 ---
 
 ## Beyond Sleep & Anxiety: Magnesium's Full Application Spectrum

--- a/docs/canonical-page-operating-system.md
+++ b/docs/canonical-page-operating-system.md
@@ -1,0 +1,189 @@
+# Canonical Page Operating System (CPOS)
+
+The operating system for every indexable page on The Hippie Scientist. It is the
+"Human Interface Guidelines" for pages: from here on, **no page should exist
+without belonging to a defined page product below.**
+
+Companion docs:
+- [`editorial-components.md`](./editorial-components.md) — the reusable article/MDX
+  components (`ScientificVerdictCard`, `DecisionMatrix`, …) referenced throughout.
+- Hub primitives live in `components/guides/`; editorial components in
+  `components/editorial/` (all registered in `mdx-components.tsx`).
+
+---
+
+## Fundamental principle
+
+**Every page is a product, not a document.** Each product solves *one* primary
+reader problem, and its structure reflects that problem. The test every page
+must pass: within 30–60 seconds the reader knows what this is, whether it applies
+to them, whether it's worth considering, who should avoid it, how strong the
+evidence is, and where to go next.
+
+---
+
+## Page product inventory
+
+| Page product | Route(s) | Primary job |
+|---|---|---|
+| **Homepage** | `/` | Route a first-time visitor to the right goal or tool. |
+| **Goal hub** | `/guides/{sleep,anxiety,focus}/`, `/guides/adhd/` | Identify the reader's problem and route them to the right guide. |
+| **Guide / article (MDX)** | `/articles/{slug}/` | Help the reader decide whether a specific intervention fits their situation. |
+| **Guide page (curated)** | `/guides/{cluster}/{slug}/` | Answer one high-intent question ("best supplements for sleep"). |
+| **Comparison page** | `/guides/**/{a}-vs-{b}/`, `/compare/{slug}/` | Help the reader **choose** between two options. |
+| **Herb page** | `/herbs/{slug}/` | Authoritative profile of one herb (workbook-driven). |
+| **Compound page** | `/compounds/{slug}/` | Authoritative profile of one compound (workbook-driven). |
+| **Stack page** | `/articles/*-stack*`, `/stacks/{slug}/` | Help the reader combine supplements safely. |
+| **Educational page** | `/learn/{slug}/` | Explain a concept (evidence levels, a neurotransmitter) so a decision elsewhere makes sense. |
+| **Category index** | `/herbs/`, `/compounds/`, `/articles/`, `/guides/` | Let the reader browse/filter an ecosystem. |
+| **Discovery / search** | `/search/` | Find a specific page fast. |
+
+---
+
+## Blueprints
+
+Each blueprint is implementation-oriented. "Required components" reference the
+Pass 1–2 primitives.
+
+### 1. Goal hub (`/guides/{goal}/`)
+
+- **Purpose:** identify the reader's specific problem and route to the right guide.
+- **Primary intent:** "I have *this* problem — where do I go?" **Secondary:** browse the ecosystem.
+- **Must answer:** What kind of problem do you have? What's the first-line option for it? Where's the full plan? Which comparison decides it?
+- **Must NOT answer:** deep mechanism, exhaustive monographs, dosing tables. (Those belong to articles.)
+- **Required:** `HubSectionHeading`, `DecisionRouter` (the "what's your problem?" section), `GuideCardGrid` (best-first + comparisons), an editorial note, a secondary full-library list.
+- **Hierarchy:** Hero → **Start here / DecisionRouter** → Best first reads → Comparisons → Editorial note → Full library.
+- **Linking responsibility:** every DecisionRouter route points to a real, existing page; the hub is the *distributor* of link equity to its cluster.
+- **Entry:** homepage, nav, search, organic ("supplements for sleep"). **Exit:** a specific guide/article/comparison.
+- **SEO role:** cluster pillar; captures broad head terms, funnels to depth.
+- **Anti-patterns:** a flat card directory ("file cabinet"); listing 15 undifferentiated cards; routes to 404s.
+- **Acceptance:** a reader can self-identify in the DecisionRouter and reach the right page in one click; no broken routes; mobile-first; light+dark.
+- **Reference impl:** `app/guides/sleep/page.tsx`, `app/guides/anxiety/page.tsx`.
+
+### 2. Article / MDX guide (`/articles/{slug}/`)
+
+- **Purpose:** help the reader decide whether *this* intervention fits *their* situation.
+- **Primary intent:** "Should I use X, and how?" **Secondary:** understand the evidence and mechanism.
+- **Must answer:** Should I consider it? Who is it for / who should skip it? How fast? How to use it? Risks? What does the evidence actually show (and how strong)? What's better if it's not for me? Where next?
+- **Must NOT:** act as a directory/hub; re-explain another supplement's full biology (link out).
+- **Required:** trust strip + anchored references (template-provided), `ScientificVerdictCard` (opens the page), `DecisionMatrix`, `RealityCheck`, `EvidenceConfidence`, `BetterAlternatives`, `WhereNext`. **Optional:** `CommonMistakes`, `CollapsibleDetails` (deep mechanism), `EditorialNote`.
+- **Canonical flow (justified):**
+  1. **Brief intro** (1 line, names the entity) — orients + satisfies entity-integrity.
+  2. **ScientificVerdictCard** — the decision, up front.
+  3. **At a Glance** — scannable facts.
+  4. **DecisionMatrix ("Should you use it?")** — fit-by-situation.
+  5. **RealityCheck** — kill hype before it forms.
+  6. **Practical** (dosing/timing, `CommonMistakes`).
+  7. **EvidenceConfidence** → deep evidence → **mechanism** (collapsible) — progressive disclosure: the practical answer is never buried under biology.
+  8. **Safety** — visible, before deep science.
+  9. **BetterAlternatives** — trust.
+  10. **WhereNext** — journey, replacing generic "Related Articles".
+  11. **FAQ**.
+- **Linking responsibility:** inline-cite numeric claims to `#ref-{pmid}`; route out via BetterAlternatives/WhereNext.
+- **SEO role:** depth/authority; targets "{supplement} benefits/dosage/evidence".
+- **Anti-patterns:** opening with a dictionary definition; mechanism above the practical answer; a bare "Related Articles" dump.
+- **Acceptance:** verdict renders first; `validate:article-quality` passes; safety visible; no unsupported medical claims.
+- **Reference impl:** `content/articles/{l-theanine,ashwagandha,magnesium-glycinate}.md`.
+
+### 3. Comparison page (`/guides/**/{a}-vs-{b}/`)
+
+- **Purpose:** help the reader **choose**. This is the whole job.
+- **Primary intent:** "A or B — which is right for me?"
+- **Must answer:** Choose A if…, choose B if…, use both if…, when neither is enough, and who wins each dimension (fastest, best evidence, best safety, best for the specific goal).
+- **Must NOT:** re-teach the full biology of both compounds (link to each profile/article).
+- **Required:** `ComparisonVerdict` at the very top; a concise side-by-side table; short mechanism contrast; a bottom line with links to each option's profile.
+- **Hierarchy:** Breadcrumb → **ComparisonVerdict (the call)** → quick comparison table → how they differ (brief) → decision framework → bottom line + profile links.
+- **Linking responsibility:** links to both option profiles/articles and back to the parent goal hub.
+- **SEO role:** decision-stage intent ("magnesium vs melatonin") — high commercial value; make the call clearly.
+- **Anti-patterns:** "both may help" with no recommendation; two mini-monographs; no explicit winner rows.
+- **Acceptance:** the choice is stated above the fold; every situation maps to a clear lean.
+- **Reference impl:** `app/guides/sleep/magnesium-vs-melatonin/page.tsx`.
+
+### 4. Herb / Compound page (`/herbs/{slug}/`, `/compounds/{slug}/`)
+
+- **Purpose:** the authoritative, workbook-driven profile of one entity.
+- **Must answer:** what it is, evidence grade, primary effects, safety/interactions, and "is this for me?"
+- **Must NOT:** invent facts — structured data is owned by the workbook (`data-sources/…xlsx` → `public/data`). Do not hand-edit generated JSON; change the workbook and rebuild (`npm run data:build`).
+- **Required (where the type supports it):** a verdict/decision surface, evidence grade with plain-English context, visible safety, links to the relevant goal hub and any comparison.
+- **SEO role:** entity authority ("{herb} benefits/safety"). **Anti-pattern:** a PubMed dump with no decision layer.
+- **Note:** these are the biggest future-migration surface; treat CPOS adoption here as Pass 4+.
+
+### 5. Stack page (`/articles/*-stack*`, `/stacks/{slug}/`)
+
+- **Purpose:** help the reader combine supplements safely into one routine.
+- **Must answer:** what goes together, timing/dosing, why it works, and interaction cautions.
+- **Must NOT:** re-derive each ingredient's full evidence (link to each).
+- **Required:** a verdict/summary, a timing table, a safety/interaction callout, links to each component article.
+
+### 6. Educational page (`/learn/{slug}/`)
+
+- **Purpose:** explain a concept so a decision *elsewhere* makes sense (e.g. "what evidence grades mean").
+- **Must NOT:** recommend products. **SEO role:** informational, internal-link support for decision pages.
+
+### 7. Category index & search
+
+- **Purpose:** browse/filter (`/herbs`, `/compounds`) or find (`/search`).
+- **Must NOT:** carry editorial decision content — they are navigation surfaces. Keep filters labeled and accessible (see the `/herbs` evidence-filter fix).
+
+---
+
+## Content ownership rules (avoid duplication)
+
+Information lives in exactly one place; everything else links to it.
+
+| Information | Owner | Everyone else |
+|---|---|---|
+| Mechanism / biochemistry | **Article** (or herb/compound profile) | link to it |
+| "Is this for me?" decision for one supplement | **Article** (`ScientificVerdictCard` + `DecisionMatrix`) | link |
+| Problem identification & routing | **Goal hub** (`DecisionRouter`) | link |
+| A-vs-B choice logic | **Comparison page** (`ComparisonVerdict`) | link |
+| Combining/stacking logic | **Stack page** | link |
+| Structured facts (dose ranges, evidence grade, safety flags) | **Workbook → `public/data`** | render, never re-key |
+| Concept explainers (evidence levels, neurotransmitters) | **Educational page** | link |
+
+If two page types currently explain the same thing, the non-owner should be
+trimmed to a one-line summary + a link to the owner.
+
+---
+
+## Page relationship map (intended movement)
+
+```
+Homepage
+   ↓ (pick a goal)
+Goal hub  ──────────────►  Comparison page
+   ↓ (pick a supplement)        │ (pick the winner)
+Article  ◄─────────────────────┘
+   ↓ (not for me / what next)
+BetterAlternatives → another Article
+WhereNext → Comparison / Stack / back to Goal hub
+```
+
+Navigation should feel intentional: hubs distribute, comparisons decide,
+articles convince, stacks combine. Every decision surface offers a labeled next
+step (never a dead end).
+
+---
+
+## Editorial hierarchy (single responsibility)
+
+- Only **hubs** identify the reader's problem and organize an ecosystem.
+- Only **comparison pages** decide between named alternatives.
+- Only **articles / profiles** explain mechanism and make the per-supplement call.
+- Only **stack pages** own combination logic.
+- Only the **workbook** owns structured facts.
+- Only **educational pages** own concept explainers.
+
+When adding a page, name its product, confirm it isn't duplicating an owner's
+job, and give it the required components for that blueprint.
+
+---
+
+## Acceptance checklist for any new/edited page
+
+1. It maps to exactly one page product above.
+2. It answers that product's "must answer" questions and defers the rest via links.
+3. It uses the blueprint's required components.
+4. Every internal link resolves to a real route.
+5. `typecheck`, `lint`, `build`, and (for articles) `validate:article-quality` pass.
+6. Mobile-first, light+dark, no color-only meaning, semantic headings.

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -12,6 +12,7 @@ import ResponsiveTable from '@/components/ui/ResponsiveTable'
 import CollapsibleSection, { CollapsibleWarning, CollapsibleDetails } from '@/components/content/CollapsibleSection'
 import Collapsible from '@/components/content/Collapsible'
 import ScientificVerdictCard, { ScientificVerdict } from '@/components/editorial/ScientificVerdictCard'
+import ComparisonVerdict from '@/components/editorial/ComparisonVerdict'
 import DecisionMatrix from '@/components/editorial/DecisionMatrix'
 import RealityCheck from '@/components/editorial/RealityCheck'
 import CommonMistakes from '@/components/editorial/CommonMistakes'
@@ -64,6 +65,7 @@ const evidenceComponents = {
   Collapsible,
   ScientificVerdictCard,
   ScientificVerdict,
+  ComparisonVerdict,
   DecisionMatrix,
   RealityCheck,
   CommonMistakes,


### PR DESCRIPTION
Pass 3 of 8. Defines the **Canonical Page Operating System** — a blueprint for every indexable page type — and proves it on three representative page products. No repo-wide migration; only enough to prove the system.

## Documentation (core deliverable)
**`docs/canonical-page-operating-system.md`** — the "Human Interface Guidelines" for pages:
- **Page-product inventory** grounded in the real routes (homepage, goal hub, article, curated guide, comparison, herb, compound, stack, educational, category index, search).
- A **blueprint per type**: purpose, primary/secondary intent, questions it must / must-not answer, required + optional components, the **canonical flow (justified)**, internal-linking responsibility, entry/exit paths, SEO role, anti-patterns, and acceptance criteria.
- **Content-ownership rules** (one owner per fact — mechanism → article, routing → hub, A-vs-B → comparison, structured facts → workbook — everyone else links).
- A **page relationship map** and the **single-responsibility editorial hierarchy**.

## New reusable component
**`ComparisonVerdict`** (`components/editorial/`, registered in MDX) — the decision module for "A vs B" pages: **Choose A if / Choose B if / Use both if / neither is enough**, plus a who-wins-what grid (fastest, best safety, best for the goal). Distinctions are labeled, never color-only.

## Representative pages refactored (one per type)
- **Comparison** — `/guides/sleep/magnesium-vs-melatonin/` now **opens with a `ComparisonVerdict`** (makes the call up front instead of "both may help").
- **Goal hub** — `/guides/anxiety/` rebuilt decision-first with the Pass-1 hub primitives (`DecisionRouter` / `GuideCardGrid` / `HubSectionHeading`), routing by the *kind* of anxiety instead of a flat 14-card list.
- **Article** — added a `CommonMistakes` section to the magnesium article (also exercises the one Pass-2 component that had no live usage yet).

## Verification
- [x] `npm run typecheck` / `npm run lint` — pass
- [x] `npm run validate:article-quality` — PASS
- [x] `npm run build` (full `next build`) — passes
- [x] Browser pass (mobile): all three pages render their decision modules, no errors, no broken routes
- [x] Generated `data/articles/articles.json` intentionally not committed

## Report / tradeoffs / next
- **Page types identified:** 11 (table in the doc). **Blueprints:** one per type.
- **Architecture:** the CPOS + `ComparisonVerdict` complete the decision-module set (article verdict, comparison verdict, hub router). Duplication rules now have a written home.
- **Tradeoff:** herb/compound pages are workbook-driven and the largest migration surface — intentionally deferred (documented as Pass 4+). Only 3 pages refactored, by design.
- **Remaining weakness:** most curated `/guides/**` pages and all herb/compound pages don't yet follow their blueprints.
- **Recommended Pass 4:** apply the CPOS to the herb/compound profile type (a `HerbProfileHeader`/verdict surface driven by workbook data) and roll `ComparisonVerdict` across the remaining `/guides/**/*-vs-*` pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5BJzyhpmTd72Awzn2PS6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5BJzyhpmTd72Awzn2PS6Q)_