### PR TITLE
Editorial OS pass 4: profile decision engine (herb + compound templates)

### DIFF
--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -36,6 +36,8 @@ import Disclaimer from '../../../src/components/Disclaimer'
 import EvidenceScoreBadge from '@/components/ui/EvidenceScoreBadge'
 import EvidenceMeter from '@/components/ui/EvidenceMeter'
 import ProfileEvidenceLens from '@/components/ui/ProfileEvidenceLens'
+import ProfileDecisionPanel from '@/components/editorial/ProfileDecisionPanel'
+import { buildProfileDecision } from '@/lib/profile-decision'
 import EvidenceGradeExplainer from '@/components/ui/EvidenceGradeExplainer'
 import ShowMeTheStudies from '@/components/ui/ShowMeTheStudies'
 import EvidenceGradeRationale from '@/components/education/EvidenceGradeRationale'
@@ -766,6 +768,7 @@ export default async function CompoundPage({ params }: PageProps) {
     .slice(0, 8)
 
   const displayName = formatDisplayLabel(compound.name || compound.slug)
+  const profileDecision = buildProfileDecision(compound as Record<string, unknown>, 'compound')
   const quickSummary = firstSentences(summary, 1) || 'Compound profile with safety, mechanism, and fit context.'
   const timeline = getTimeline(compound)
   const avoidIf = getAvoidIf(compound)
@@ -894,6 +897,10 @@ export default async function CompoundPage({ params }: PageProps) {
             <MonographHeroImage image={heroImage} label={displayName} eyebrow="Monograph visual" />
           </header>
         </div>
+
+        {/* Decision surface — verdict (when curated) + intent-based routing.
+            Rendered by the shared ProfileDecisionPanel so all profiles benefit. */}
+        <ProfileDecisionPanel decision={profileDecision} name={displayName} />
 
         {/* Jump navigation — lets keyboard and screen-reader users reach sections directly */}
         <nav aria-label="Jump to profile sections" className="flex flex-wrap gap-2">

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -38,6 +38,8 @@ import Disclaimer from '../../../src/components/Disclaimer'
 import EvidenceScoreBadge from '@/components/ui/EvidenceScoreBadge'
 import SafetyGaugeMeter from '@/components/ui/SafetyGaugeMeter'
 import ProfileEvidenceLens from '@/components/ui/ProfileEvidenceLens'
+import ProfileDecisionPanel from '@/components/editorial/ProfileDecisionPanel'
+import { buildProfileDecision } from '@/lib/profile-decision'
 import EvidenceGradeExplainer from '@/components/ui/EvidenceGradeExplainer'
 import ShowMeTheStudies from '@/components/ui/ShowMeTheStudies'
 import RelatedDiscoveryGroups from '@/components/ui/RelatedDiscoveryGroups'
@@ -431,6 +433,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
   const mechanisms = getMechanisms(herb)
   const evidenceLimitations = deriveEvidenceLimitations({ profile: herb })
   const topUses = getTopUses(herb)
+  const profileDecision = buildProfileDecision(herbRecord as Record<string, unknown>, 'herb')
   const safetyTone = getSafetyTone(safetySummary, avoidIf, safetySensitivity)
   const safetyGaugeScore = getSafetyGaugeScore(safetySensitivity)
   const relatedHerbLinks = getRelatedLinks(relatedHerbs, 'herb')
@@ -622,6 +625,10 @@ export default async function HerbDetailPage({ params }: PageProps) {
           </div>
         </header>
       </div>
+
+      {/* Decision surface — verdict (when curated) + intent-based routing.
+          Rendered by the shared ProfileDecisionPanel so all profiles benefit. */}
+      <ProfileDecisionPanel decision={profileDecision} name={displayName} />
 
       <ProfileTOC items={tocItems} variant="mobile" />
 

--- a/components/editorial/ProfileDecisionPanel.tsx
+++ b/components/editorial/ProfileDecisionPanel.tsx
@@ -1,0 +1,68 @@
+import Link from 'next/link'
+import type { ProfileDecision } from '@/lib/profile-decision'
+import ScientificVerdictCard from '@/components/editorial/ScientificVerdictCard'
+
+/**
+ * ProfileDecisionPanel — the shared decision surface for every herb and
+ * compound profile. Rendered once by each profile template, so improving it
+ * improves hundreds of pages at once.
+ *
+ * - When the slug has a curated verdict (config/profile-verdicts.ts), it opens
+ *   with a full ScientificVerdictCard.
+ * - Always shows an intent-based "Continue reading" nav derived from the
+ *   record's own data — replacing generic related-link dumps with routing.
+ *
+ * Static-safe server component; theme-aware. Data comes from
+ * `buildProfileDecision(record, kind)`.
+ */
+export function ProfileDecisionPanel({
+  decision,
+  name,
+}: {
+  decision: ProfileDecision
+  name: string
+}) {
+  const { verdict, continueReading } = decision
+  if (!verdict && continueReading.length === 0) return null
+
+  return (
+    <div className="space-y-4">
+      {verdict ? (
+        <ScientificVerdictCard
+          title={`Verdict: ${name}`}
+          recommendation={verdict.recommendation}
+          bestFor={verdict.bestFor}
+          notIdealFor={verdict.notIdealFor}
+          onset={verdict.onset}
+          evaluationWindow={verdict.evaluationWindow}
+          betterAlternative={verdict.betterAlternative}
+          bottomLine={verdict.bottomLine}
+        />
+      ) : null}
+
+      {continueReading.length > 0 ? (
+        <section
+          aria-label="Continue reading"
+          className="not-prose rounded-2xl border border-brand-900/12 bg-brand-50/40 p-5 dark:border-white/10 dark:bg-[var(--surface-subtle)]"
+        >
+          <p className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700">Continue reading</p>
+          <ul className="mt-3 space-y-2">
+            {continueReading.map((path) => (
+              <li key={path.href} className="text-sm leading-6">
+                <span className="text-muted">If you want {path.ifYouWant} → </span>
+                <Link
+                  href={path.href}
+                  className="font-bold text-brand-800 hover:underline dark:text-[var(--text-primary)]"
+                >
+                  {path.goTo}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+    </div>
+  )
+}
+
+export default ProfileDecisionPanel

--- a/config/profile-verdicts.ts
+++ b/config/profile-verdicts.ts
@@ -1,0 +1,80 @@
+/**
+ * Editorial verdict overlay for herb/compound profiles.
+ *
+ * This is an OPT-IN editorial layer, keyed by slug. It is NOT workbook data and
+ * never overrides structured facts — the workbook remains the source of truth
+ * for evidence grades, safety flags, dosing, etc. This file only holds the
+ * curated editorial *judgement* (recommendation, best/not-ideal framing,
+ * a better alternative, bottom line) that data alone cannot express.
+ *
+ * A profile with no entry here still renders a derived decision surface
+ * (evidence + safety + intent-based "continue reading") — see
+ * `lib/profile-decision.ts`. Adding an entry upgrades that profile to a full
+ * Scientific Verdict with zero template changes.
+ *
+ * Rules:
+ * - Never invent facts. Only summarize what the profile/article already supports.
+ * - Keep it honest: use "No" / "Situation-dependent" and a real "not ideal for".
+ * - `betterAlternative.href` must be a real route.
+ */
+
+export type ProfileVerdictOverlay = {
+  recommendation: 'Yes' | 'Maybe' | 'No' | 'Situation-dependent'
+  bestFor: string[]
+  notIdealFor: string[]
+  onset?: string
+  evaluationWindow?: string
+  bottomLine: string
+  betterAlternative?: { label: string; href: string; reason?: string }
+}
+
+export const PROFILE_VERDICTS: Record<string, ProfileVerdictOverlay> = {
+  // ── Herb ──────────────────────────────────────────────────────────────
+  ashwagandha: {
+    recommendation: 'Yes',
+    bestFor: [
+      'Chronic stress with anxiety',
+      'Stress-related sleep disruption',
+      'High cortisol — feeling "wired but tired"',
+    ],
+    notIdealFor: [
+      'Acute anxiety or panic (works over weeks, not minutes)',
+      'A same-night sleep aid',
+      'Pregnancy, thyroid disease, or use with sedatives',
+    ],
+    onset: 'Gradual — first shifts in 2–4 weeks',
+    evaluationWindow: '6–8 weeks',
+    bottomLine:
+      'The best-studied adaptogen for chronic stress — it lowers cortisol and eases stress-related sleep over weeks. Not a quick fix, and the wrong tool for acute anxiety.',
+    betterAlternative: {
+      label: 'L-theanine',
+      href: '/compounds/l-theanine/',
+      reason: 'for acute, in-the-moment calm',
+    },
+  },
+
+  // ── Compound ──────────────────────────────────────────────────────────
+  'l-theanine': {
+    recommendation: 'Yes',
+    bestFor: [
+      'Caffeine jitters',
+      'Racing thoughts at bedtime',
+      'Mild situational anxiety (presentations, exams)',
+      'Calm focus without sedation',
+    ],
+    notIdealFor: ['Severe insomnia', 'Panic attacks', 'Chronic baseline stress alone'],
+    onset: '30–40 minutes',
+    evaluationWindow: 'Same day to 2 weeks',
+    bottomLine:
+      'A strong first choice for calm without sedation — smoothing caffeine and quieting a busy mind. Not the best primary tool for chronic stress or severe anxiety.',
+    betterAlternative: {
+      label: 'Ashwagandha',
+      href: '/herbs/ashwagandha/',
+      reason: 'for chronic baseline stress',
+    },
+  },
+}
+
+export function getProfileVerdict(slug: string): ProfileVerdictOverlay | undefined {
+  return PROFILE_VERDICTS[slug]
+}

--- a/docs/canonical-page-operating-system.md
+++ b/docs/canonical-page-operating-system.md
@@ -179,6 +179,62 @@ job, and give it the required components for that blueprint.
 
 ---
 
+## Profile Template Specification (herb & compound engine)
+
+Herb (`/herbs/{slug}/`) and compound (`/compounds/{slug}/`) profiles are
+**engine-rendered**: ~850 pages share two templates. The rule for this type is
+*improve the machine, not the output* — a change to the shared template or its
+data layer improves every profile at once. Do not hand-polish individual
+profiles.
+
+### The three layers (clean boundaries)
+
+| Layer | Owns | Files |
+|---|---|---|
+| **Workbook / runtime data** | structured facts: evidence tier, safety flags, dosing, effects, interactions | `data-sources/*.xlsx` → `public/data/**` (generated; never hand-edit) |
+| **Editorial verdict overlay** | curated *judgement*: recommendation, best/not-ideal framing, better alternative, bottom line | `config/profile-verdicts.ts` (opt-in, keyed by slug) |
+| **Rendering** | how the decision surface looks and derives intent-nav from data | `lib/profile-decision.ts` + `components/editorial/ProfileDecisionPanel.tsx`, mounted in both `[slug]/page.tsx` templates |
+
+This preserves the workbook source-of-truth philosophy: the overlay **never
+overrides facts** — it only adds the editorial layer that data alone can't
+express. `lib/profile-decision.ts` surfaces only reliably-clean data and derives
+intent-based "continue reading" routes; it never invents facts (runtime fields
+like `primary_effects` are noisy — e.g. a compound may list "GABA" — so the
+derived surface stays conservative).
+
+### What a profile communicates (before deep science)
+
+Hero (name, summary, evidence badge, **visible safety summary**, key uses) →
+**ProfileDecisionPanel**: a full Scientific Verdict when the slug is curated,
+plus intent-based *Continue reading* routing for every profile → then the
+existing deep sections (quick stats, evidence, mechanisms, interactions, safety
+detail, compare). Progressive disclosure: practical/decision on top, science below.
+
+### How to upgrade a profile
+
+- **To add a full verdict:** add one entry to `config/profile-verdicts.ts`
+  (`recommendation`, `bestFor`, `notIdealFor`, `onset`, `evaluationWindow`,
+  `bottomLine`, `betterAlternative`). No template edits. The panel renders it.
+- **To improve every profile at once:** edit `ProfileDecisionPanel` /
+  `buildProfileDecision`.
+- **To fix a fact:** edit the workbook and run `npm run data:build` — never edit
+  `public/data` JSON by hand.
+
+### Migration strategy & extensibility
+
+Curate verdict overlays for the highest-traffic profiles first (sleep/anxiety/
+focus cluster); the long tail keeps the derived surface until curated. Future
+extensions (e.g. deriving `bestFor` from cleaned workbook fields, or a
+`ComparisonVerdict` auto-surfaced from `comparisonBySlug`) slot into
+`buildProfileDecision` without touching the templates.
+
+### Reference impl
+`config/profile-verdicts.ts` (ashwagandha herb, l-theanine compound),
+`lib/profile-decision.ts`, `components/editorial/ProfileDecisionPanel.tsx`,
+mounted in `app/herbs/[slug]/page.tsx` and `app/compounds/[slug]/page.tsx`.
+
+---
+
 ## Acceptance checklist for any new/edited page
 
 1. It maps to exactly one page product above.

--- a/lib/profile-decision.ts
+++ b/lib/profile-decision.ts
@@ -1,0 +1,89 @@
+import { getProfileVerdict, type ProfileVerdictOverlay } from '@/config/profile-verdicts'
+
+/**
+ * Derives the decision surface for a herb/compound profile from runtime data
+ * that already exists in the workbook export, plus the opt-in editorial verdict
+ * overlay. It never invents facts: only reliably-clean fields are surfaced, and
+ * the richer verdict comes from `config/profile-verdicts.ts` when present.
+ *
+ * This keeps the source-of-truth boundary clean:
+ *   - structured facts  → workbook / runtime data (evidence tier, safety flags)
+ *   - editorial verdict → config/profile-verdicts.ts (curated, opt-in)
+ *   - rendering         → components/editorial/ProfileDecisionPanel
+ */
+
+export type ContinuePath = {
+  ifYouWant: string
+  goTo: string
+  href: string
+}
+
+export type ProfileDecision = {
+  /** Curated verdict, present only when the slug has an overlay entry. */
+  verdict?: ProfileVerdictOverlay
+  /** Intent-based "continue reading" routes derived from the record. Always present (may be empty). */
+  continueReading: ContinuePath[]
+}
+
+type LooseRecord = Record<string, unknown>
+
+const asStringList = (value: unknown): string[] => {
+  if (Array.isArray(value)) return value.map((v) => String(v)).filter(Boolean)
+  if (typeof value === 'string') return value ? [value] : []
+  return []
+}
+
+/** Build a lowercased keyword corpus from the fields that describe what a profile is about. */
+function corpusOf(record: LooseRecord): string {
+  return [
+    record.name,
+    record.summary,
+    record.description,
+    ...asStringList(record.effects),
+    ...asStringList(record.primary_effects),
+    ...asStringList(record.conditions),
+    ...asStringList(record.tags),
+    ...asStringList(record.keywords),
+  ]
+    .map((v) => String(v ?? '').toLowerCase())
+    .join(' ')
+}
+
+// Intent → goal hub, matched by keyword. Ordered by priority; deduped by href.
+const INTENT_ROUTES: { keywords: string[]; path: ContinuePath }[] = [
+  {
+    keywords: ['sleep', 'insomnia', 'melatonin', 'sedative', 'rest'],
+    path: { ifYouWant: 'help sleeping', goTo: 'Sleep guides', href: '/guides/sleep/' },
+  },
+  {
+    keywords: ['anxiety', 'stress', 'cortisol', 'calm', 'gaba', 'anxiolytic', 'adaptogen', 'relax'],
+    path: { ifYouWant: 'help with anxiety or stress', goTo: 'Anxiety & stress guides', href: '/guides/anxiety/' },
+  },
+  {
+    keywords: ['focus', 'cognition', 'cognitive', 'attention', 'nootropic', 'adhd', 'memory', 'concentration'],
+    path: { ifYouWant: 'sharper focus', goTo: 'Focus guides', href: '/guides/focus/' },
+  },
+]
+
+export function buildProfileDecision(record: LooseRecord, kind: 'herb' | 'compound'): ProfileDecision {
+  const slug = String(record.slug ?? '')
+  const verdict = getProfileVerdict(slug)
+
+  const corpus = corpusOf(record)
+  const continueReading: ContinuePath[] = []
+  const seen = new Set<string>()
+  for (const { keywords, path } of INTENT_ROUTES) {
+    if (keywords.some((k) => corpus.includes(k)) && !seen.has(path.href)) {
+      continueReading.push(path)
+      seen.add(path.href)
+    }
+  }
+  // Always offer a browse-the-ecosystem exit relevant to this profile type.
+  const indexPath: ContinuePath =
+    kind === 'herb'
+      ? { ifYouWant: 'to browse more herbs', goTo: 'All herbs', href: '/herbs/' }
+      : { ifYouWant: 'to browse more compounds', goTo: 'All compounds', href: '/compounds/' }
+  if (!seen.has(indexPath.href)) continueReading.push(indexPath)
+
+  return { verdict, continueReading }
+}


### PR DESCRIPTION
Pass 4 of 8 — improve the **engine**, not the output. One change to the shared herb/compound rendering system gives a decision surface to **~850 profiles** (277 herbs + 573 compounds) at once. No per-page rewrites; no workbook violations.

## Three clean layers
| Layer | Owns | Files |
|---|---|---|
| **Workbook / runtime data** | structured facts (evidence tier, safety flags, dosing) | `public/data/**` — unchanged, never hand-edited |
| **Editorial verdict overlay** | curated *judgement* (recommendation, best/not-ideal, better alternative, bottom line) | `config/profile-verdicts.ts` — **opt-in**, keyed by slug |
| **Rendering** | derive intent-nav from data; render the verdict | `lib/profile-decision.ts` + `components/editorial/ProfileDecisionPanel.tsx`, mounted in both `[slug]/page.tsx` |

The overlay **never overrides facts** — it only adds the editorial layer data can't express, preserving the workbook source-of-truth. The derivation stays conservative because runtime effect fields are noisy (a compound may list "GABA" as a "primary effect"), so it surfaces only reliably-clean signals + intent-based routing — **it never invents data.**

## What changed
- Both `[slug]` templates now mount `<ProfileDecisionPanel>` right after the hero.
- **Curated** profiles (ashwagandha herb, l-theanine compound) render a full `ScientificVerdictCard` (recommendation, best/not-ideal, onset/window, "consider instead" link, bottom line).
- **Every other** profile renders derived, intent-based "Continue reading" routing (sleep/anxiety/focus hubs matched from the record's own data) instead of a generic related dump.

## Why it matters
- Upgrading any profile to a full verdict = **one config entry, zero template edits.**
- Improving all 850 profiles = **one component change.**
- Consistency through architecture, not repetitive editing.

## Verification
- [x] `npm run typecheck` / `npm run lint` — pass
- [x] `npm run validate:article-quality` — PASS
- [x] `npm run build` (full `next build`) — passes; verified in built HTML that curated profiles show verdicts, non-curated show derived nav, across 277 herb + 573 compound pages
- [x] Browser pass: curated + non-curated herb and compound profiles render correctly, no errors, no broken profile rendering
- [x] No workbook edits; generated `data/articles/articles.json` not committed

## Report / next
- **Template improvements:** shared decision panel + derived intent-nav on every profile; extensible verdict overlay.
- **Remaining weakness:** only 2 profiles are curated; the long tail shows the derived surface until curated. `bestFor`/`notIdealFor` are not yet derivable from workbook data (fields are too noisy) — curated overlay is the honest interim.
- **Recommended Pass 5:** curate verdict overlays for the top ~15 sleep/anxiety/focus profiles; optionally add a workbook column for a clean `primaryUses` list so `bestFor` can be partly data-driven; and auto-surface `ComparisonVerdict` on profiles that have a strong `comparisonBySlug` match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5BJzyhpmTd72Awzn2PS6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5BJzyhpmTd72Awzn2PS6Q)_