### PR TITLE
Editorial OS pass 8: final consistency, guardrail hardening & operating handoff

### DIFF
--- a/docs/canonical-page-operating-system.md
+++ b/docs/canonical-page-operating-system.md
@@ -5,8 +5,13 @@ The operating system for every indexable page on The Hippie Scientist. It is the
 without belonging to a defined page product below.**
 
 Companion docs:
+- [`editorial-operating-system-handoff.md`](./editorial-operating-system-handoff.md)
+  — **start here to operate the system**: how to add a profile, upgrade a hub or
+  article, add a comparison, what to run before merging, and what never to do.
 - [`editorial-components.md`](./editorial-components.md) — the reusable article/MDX
   components (`ScientificVerdictCard`, `DecisionMatrix`, …) referenced throughout.
+- [`evidence-and-claim-discipline.md`](./evidence-and-claim-discipline.md) — how to
+  phrase evidence, safety, and recommendations.
 - Hub primitives live in `components/guides/`; editorial components in
   `components/editorial/` (all registered in `mdx-components.tsx`).
 

--- a/docs/editorial-components.md
+++ b/docs/editorial-components.md
@@ -9,6 +9,10 @@ All components use the existing design language (brand emerald, `text-ink` /
 `text-muted` tokens, rounded cards) and are theme-aware (light + dark). They are
 server components — safe for static export, no client JS.
 
+> To **operate** the system (add a profile, upgrade a hub/article, add a
+> comparison, what to run before merging), see
+> [`editorial-operating-system-handoff.md`](./editorial-operating-system-handoff.md).
+
 ---
 
 ## Article-body components (MDX)

--- a/docs/editorial-operating-system-handoff.md
+++ b/docs/editorial-operating-system-handoff.md
@@ -1,0 +1,248 @@
+# Editorial Operating System — Handoff & Operating Manual
+
+The 8-pass Editorial Operating System is complete. This is the practical manual
+for operating it — for future AI agents (Claude, Codex) and human editors. It
+tells you what the system is, how to use it, what to run, and what never to do.
+
+After this pass, the work shifts from **building the system** to **using it**.
+
+---
+
+## 1. What the Editorial Operating System is
+
+A layered system that turns ~850 encyclopedia pages into a **decision-first,
+evidence-disciplined** publication. Its core idea: separate **facts** (workbook),
+**judgement** (editorial overlay), **presentation** (components), and
+**guardrails** (validators) — so improving one layer improves the whole site
+without breaking the others.
+
+Reader journey the system creates:
+
+> problem → goal hub → start-here guide → profile verdict → evidence confidence →
+> compare → better alternative → safe next step
+
+---
+
+## 2. Page product types
+
+| Type | Route | Shape |
+|---|---|---|
+| **Goal hub** | `/guides/{sleep,anxiety,focus}/` | Decision-first: `DecisionRouter` "Start here" → best-first → comparisons → crossover → full library |
+| **Profile** (engine-rendered) | `/herbs/:slug`, `/compounds/:slug` | Hero → `ProfileDecisionPanel` → deep sections. ~850 pages, two templates |
+| **Comparison** | `/guides/compare/:slug` | `ComparisonVerdict`: choose A / choose B / use both / avoid |
+| **Article** | `/articles/:slug` (MDX) | Opens with `ScientificVerdict`; science lower, collapsible; inline PMID citations |
+
+See `docs/canonical-page-operating-system.md` for the full blueprint per type.
+
+---
+
+## 3. Reusable components
+
+Editorial (`components/editorial/`, registered in `mdx-components.tsx` — usable in
+any MDX with no import):
+
+- `ScientificVerdictCard` (a.k.a. `ScientificVerdict`) — the signature verdict module
+- `EvidenceConfidence` — grade → why not higher → why not lower → practical takeaway
+- `ComparisonVerdict` — choose A / B / both / avoid
+- `DecisionMatrix`, `RealityCheck`, `CommonMistakes`, `BetterAlternatives`,
+  `WhereNext`, `EditorialNote`
+- `ProfileDecisionPanel` — the shared profile decision surface (not for MDX)
+
+Hub primitives (`components/guides/`): `DecisionRouter`, `GuideCardGrid`,
+`HubSectionHeading`.
+
+Full reference: `docs/editorial-components.md`.
+
+---
+
+## 4. The profile verdict overlay system
+
+`config/profile-verdicts.ts` is an **opt-in editorial layer keyed by slug**. It
+never overrides workbook facts. A profile with no entry still renders a derived
+decision surface; adding an entry upgrades it to a full verdict with **zero
+template changes**.
+
+Overlay fields:
+
+| Field | Purpose |
+|---|---|
+| `recommendation` | Yes / Maybe / No / Situation-dependent |
+| `confidence` | one-line confidence read |
+| `bestFor` / `notIdealFor` | who it fits / who it doesn't |
+| `onset` / `evaluationWindow` | practical timing |
+| `safetyNote` | short safety flag (required for high-risk topics) |
+| `evidenceNote` | one line on the evidence base |
+| `evidenceConfidence` | structured `{ grade, whyNotHigher[], whyNotLower?[], practicalTakeaway }` |
+| `primaryGuide` | `{ label, href }` — the decision-graph "start here" entry point |
+| `betterAlternative` | `{ label, href, reason? }` — a clearly better fit nearby |
+| `comparisons[]` | `{ label, href, when }` — surface only real, useful comparisons |
+
+Rendering order in `ProfileDecisionPanel`:
+verdict → evidence confidence → **start here** → compare → continue reading.
+
+Currently curated: **18 money-cluster profiles** (sleep, stress, anxiety, focus).
+
+---
+
+## 5. The decision graph
+
+The 18 curated overlays together form a decision graph. Each field is a graph role:
+
+| Field | Graph role |
+|---|---|
+| `primaryGuide` | entry point (problem → hub → this guide) |
+| `bestFor` / `notIdealFor` | fit |
+| `evidenceConfidence` | trust |
+| `comparisons[]` | branch (decide before committing) |
+| `betterAlternative` | redirect (better fit nearby) |
+| continue-reading (derived in `lib/profile-decision.ts`) | exit (hub + browse index) |
+
+**Linking rule: route, compare, or stop.** Send the reader to the one best next
+step; surface a comparison only when it helps them *choose*; otherwise stop. Do
+not dump generic "related" links.
+
+Every graph link is guarded — see §7.
+
+---
+
+## 6. Evidence & trust rules (summary)
+
+- An evidence grade is a **conclusion** from six dimensions (human evidence,
+  study quality, consistency, practical relevance, safety confidence,
+  fit-to-use-case) — not a decorative badge.
+- Use calibrated language ("may help", "evidence suggests"); never banned
+  overclaims ("cures", "guaranteed", "treats anxiety", "completely safe", "no
+  side effects", …).
+- Soften a recommendation when evidence is thinner than the claim.
+- High-risk topics must surface cautions visibly.
+
+Full rulebook with good/bad examples: `docs/evidence-and-claim-discipline.md`.
+
+---
+
+## 7. The safety & guardrail validators
+
+| Command | Guards | Mode |
+|---|---|---|
+| `validate:profile-verdicts` | every keyed slug + **every `href`** (`primaryGuide`, `betterAlternative`, `comparisons`) resolves | hard fail |
+| `validate:claim-discipline` | curated overlay has no banned overclaim phrasing (article prose = warn-only) | hard fail (overlay) |
+| `validate:safety-visibility` | 7 high-risk overlays + 3 high-risk articles carry required cautions | hard fail |
+| `validate:evidence-language` | workbook `public/data` summaries (placeholder / disease-claim / tier alignment) | hard fail |
+| `validate:article-quality` | article structure / entity integrity | hard fail |
+| `validate:internal-links` | links resolve to an emitted page **or a `_redirects` rule (incl. `/*` wildcards)** | hard fail |
+
+The first three run inside `npm run check` (`check:fast`) and the release gate.
+
+---
+
+## 8. How to add a curated profile
+
+1. Confirm the slug exists (`public/data/herbs.json` / `compounds.json`).
+2. **Key by the record slug the live page uses.** For botanicals indexed under a
+   herb page with a botanical record slug (e.g. kava → `piper-methysticum`,
+   passionflower → `passiflora-incarnata`), key the botanical slug and alias the
+   common slug at the bottom of `config/profile-verdicts.ts`.
+3. Add the overlay entry (see §4). Verify every `href` is a real route.
+4. Add `safetyNote` + required cautions for any high-risk topic; if it's a new
+   high-risk slug, add it to `validate-safety-visibility.mjs`.
+5. Run `npm run validate:profile-verdicts && npm run validate:claim-discipline && npm run validate:safety-visibility`.
+6. Build and confirm the profile renders the panel; confirm the page is **not**
+   `noindex` (check `indexability_status` in the workbook — a governance-noindex
+   profile delivers user value but limited SEO value).
+
+---
+
+## 9. How to upgrade a hub
+
+Copy the shape from `app/guides/sleep/page.tsx` or `app/guides/focus/page.tsx`:
+hero → `DecisionRouter` (Start here) → `GuideCardGrid` (best first) →
+`GuideCardGrid` (comparisons) → cluster crossover → editorial note → full library.
+Every `href` must be a real route (the internal-link validator will catch misses).
+Do not redesign; match the existing shape.
+
+---
+
+## 10. How to upgrade an article
+
+Open with `<ScientificVerdict>`; add `<EvidenceConfidence>` after the evidence
+section; keep deep science lower and collapsible; inline-cite numeric claims to
+`#ref-<pmid>` anchors; add a visible safety block for high-risk topics
+(`SafetyNotice`, `CollapsibleWarning`, or a `safetyNote`). Do not bloat.
+
+---
+
+## 11. How to add a comparison
+
+- Canonical route is **`/guides/compare/:slug`** — never bare `/compare/…`.
+  (A `/compare/* → /guides/compare/:splat` redirect exists as a safety net, and
+  the internal-link validator honors it, but emit canonical links at the source.)
+- Only link a comparison that is actually built — gate candidate slugs through
+  `isBuiltComparisonSlug()` in `lib/comparison-utils.ts`.
+- Use `ComparisonVerdict` and make a specific choice; don't pretend two options
+  are equal when one fits a different problem.
+
+---
+
+## 12. What future AI agents must NEVER do
+
+- Never hand-edit `public/data/**` or `data/articles/articles.json` — regenerate
+  from the workbook (`npm run data:build`).
+- Never let the overlay override a workbook fact (evidence tier, safety flag).
+- Never fabricate evidence, routes, citations, or a credentialed reviewer.
+- Never use banned overclaim language or make medical/diagnostic/prescribing
+  claims, or tell readers to start/stop a prescribed medication.
+- Never emit bare `/compare/…` links.
+- Never flip a workbook `indexability_status` from code to "fix" SEO.
+- Never redesign the site or start a Pass 9. The system is built — operate it.
+
+---
+
+## 13. Commands to run before merging
+
+```bash
+npm run typecheck
+npm run lint
+npm run validate:article-quality
+npm run validate:claim-discipline
+npm run validate:profile-verdicts
+npm run validate:safety-visibility
+npm run validate:evidence-language
+npm run build          # or build:app for a faster app-only check
+node scripts/ci/validate-internal-links.mjs   # after a build
+```
+
+`npm run check` bundles the fast gate; `npm run check:full` is the release gate.
+
+---
+
+## 14. Known limitations after Pass 8
+
+- **Governance-noindex curated profiles.** `lavender`, `lemon-balm`, `chamomile`
+  (workbook `NOINDEX`) and `creatine` (`NEEDS_REVIEW`) render full verdicts but
+  their pages are `noindex` — user value, limited SEO value until the workbook
+  grounds/reviews them. `kava` is fine: its canonical (`piper-methysticum`,
+  `PUBLISH`) carries the verdict.
+- **Internal-link baseline.** After wildcard-aware validation the true baseline
+  under a partial `build:app` is ~260 (down from ~3.7k). The remainder are
+  pre-existing: phantom dynamic `/guides/compare/X-vs-Y` links (unbuilt combos),
+  and `build:app` partial-emission artifacts (e.g. `/compounds/dmt`, `/pagefind/`,
+  some `/info/`, `/evidence/`). None originate from the editorial decision
+  modules. A full `npm run build` emits more of these; assess there.
+- **Article claim-discipline is warn-only** (long-form prose legitimately quotes
+  bad claims as examples); the curated overlay is the hard gate.
+- **robots.txt Content-Signal** was a Cloudflare-edge injection (not in the repo);
+  disable it in the Cloudflare dashboard, not in code.
+
+---
+
+## 15. The first operating task
+
+**Curate the next batch of profile overlays** — extend `config/profile-verdicts.ts`
+from 18 toward the next 10 highest-traffic profiles (e.g. 5-HTP, GABA, lion's
+mane, citicoline, tongkat ali, NAC…), following §8. Each new overlay is a small,
+guarded, high-leverage improvement — exactly the kind of work the system was built
+to make safe and repeatable.
+
+(Alternatives: upgrade the next hub/broad guide index to decision-first per §9, or
+after deployment, monitor Search Console and request a recrawl of the money
+clusters.)

--- a/docs/evidence-and-claim-discipline.md
+++ b/docs/evidence-and-claim-discipline.md
@@ -140,13 +140,15 @@ buried. Minimums:
 
 Apply only where relevant — do not paste boilerplate onto low-risk profiles.
 
-**Machine-enforced.** For curated profiles, these minimums are checked by
+**Machine-enforced.** These minimums are checked by
 `npm run validate:safety-visibility` (`scripts/ci/validate-safety-visibility.mjs`,
 in `check:fast`): each high-risk profile's overlay block must contain the required
 caution phrasings (in `safetyNote`, `notIdealFor`, `bottomLine`, or the
-`evidenceConfidence` takeaway). Adding a high-risk profile without its cautions
-fails the build. To extend coverage, add the slug and its requirement groups to
-that script.
+`evidenceConfidence` takeaway), **and** the high-risk article files (kava,
+ashwagandha, magnesium-glycinate) must contain their caution keywords anywhere in
+the body (a deliberately loose whole-file check that stays reliable). Adding a
+high-risk profile or article without its cautions fails the build. To extend
+coverage, add the slug/file and its requirement groups to that script.
 
 ---
 
@@ -186,7 +188,8 @@ fact, edit the workbook and run `npm run data:build`.
 | `npm run validate:evidence-language` | workbook `public/data` summaries — placeholder & disease-claim/tier alignment | hard fail (critical) |
 | `npm run validate:claim-discipline` | **curated overlay** (`config/profile-verdicts.ts`) hard fail; **article prose** warn-only with negation/citation filtering | mixed |
 | `npm run validate:profile-verdicts` | overlay keyed slugs + all linked routes (`betterAlternative`, `comparisons`, `primaryGuide`) resolve | hard fail |
-| `npm run validate:safety-visibility` | high-risk curated profiles carry required cautions | hard fail |
+| `npm run validate:safety-visibility` | high-risk curated profiles **and high-risk articles** (kava, ashwagandha, magnesium-glycinate) carry required cautions | hard fail |
+| `node scripts/ci/validate-internal-links.mjs` | links resolve to an emitted page or a `_redirects` rule, including `/*` wildcard splats | hard fail (post-build) |
 | `npm run validate:article-quality` | article structure/entity integrity | hard fail |
 
 `validate:claim-discipline` and `validate:profile-verdicts` run inside

--- a/scripts/ci/validate-internal-links.mjs
+++ b/scripts/ci/validate-internal-links.mjs
@@ -8,8 +8,13 @@ if (!fs.existsSync(outDir)) {
   process.exit(1)
 }
 
-// 1. Load Redirects
+// 1. Load Redirects (exact sources + wildcard/splat prefixes).
+// Cloudflare `_redirects` honors trailing `/*` splats (e.g. `/compare/* ...`),
+// so a link like `/compare/foo` is a valid redirect target even though it is not
+// an emitted static file. The validator must mirror that to avoid flagging
+// wildcard-covered links as broken.
 const redirects = new Set()
+const redirectPrefixes = [] // root-relative sources ending in `/*`, sans the `*`
 const redirectsFile = path.join(outDir, '_redirects')
 if (fs.existsSync(redirectsFile)) {
   const content = fs.readFileSync(redirectsFile, 'utf8')
@@ -17,8 +22,13 @@ if (fs.existsSync(redirectsFile)) {
     const trimmed = line.trim()
     if (!trimmed || trimmed.startsWith('#')) return
     const parts = trimmed.split(/\s+/)
-    if (parts[0]) {
-      redirects.add(parts[0])
+    const source = parts[0]
+    if (!source) return
+    // Only root-relative sources can match internal root-relative routes.
+    if (source.startsWith('/') && source.endsWith('/*')) {
+      redirectPrefixes.push(source.slice(0, -1)) // keep trailing slash, drop `*`
+    } else {
+      redirects.add(source)
     }
   })
 }
@@ -33,8 +43,13 @@ function routeExists(route) {
     cleanRoute = '/'
   }
 
-  // Check redirects
+  // Check redirects (exact source match)
   if (redirects.has(cleanRoute) || redirects.has(cleanRoute + '/')) {
+    return true
+  }
+  // Check wildcard/splat redirect prefixes (e.g. `/compare/*` covers `/compare/foo`)
+  const withSlash = cleanRoute + '/'
+  if (redirectPrefixes.some(prefix => withSlash.startsWith(prefix))) {
     return true
   }
 

--- a/scripts/ci/validate-safety-visibility.mjs
+++ b/scripts/ci/validate-safety-visibility.mjs
@@ -67,21 +67,55 @@ const errors = []
 for (const [slug, reqs] of Object.entries(REQUIREMENTS)) {
   const block = blockFor(slug)
   if (!block) {
-    errors.push(`${slug}: no curated overlay block found (expected a high-risk profile entry)`)
+    errors.push(`overlay/${slug}: no curated overlay block found (expected a high-risk profile entry)`)
     continue
   }
   for (const req of reqs) {
     if (!req.any.some((re) => re.test(block))) {
-      errors.push(`${slug}: missing ${req.label}`)
+      errors.push(`overlay/${slug}: missing ${req.label}`)
+    }
+  }
+}
+
+/**
+ * High-risk ARTICLE prose checks. Deliberately loose: whole-file presence of a
+ * caution keyword that a responsible article on this topic must contain. This
+ * stays reliable (no false-positive chaos) because it only requires that the
+ * concept appears *somewhere* in the article, not a specific phrasing or place.
+ * Only files that exist are checked, so it never breaks when an article is absent.
+ */
+const ARTICLE_REQUIREMENTS = {
+  'content/articles/kava.md': [
+    { label: 'liver caution', any: [/liver/i, /hepato/i] },
+    { label: 'alcohol / sedative caution', any: [/alcohol/i, /sedativ/i, /benzodiazepine/i] },
+  ],
+  'content/articles/ashwagandha.md': [
+    { label: 'pregnancy caution', any: [/pregnan/i] },
+    { label: 'thyroid caution', any: [/thyroid/i] },
+  ],
+  'content/articles/magnesium-glycinate.md': [{ label: 'kidney / renal caution', any: [/kidney/i, /renal/i] }],
+}
+
+let articlesChecked = 0
+for (const [file, reqs] of Object.entries(ARTICLE_REQUIREMENTS)) {
+  const full = path.join(ROOT, file)
+  if (!fs.existsSync(full)) continue // absent article → skip, never fail
+  articlesChecked += 1
+  const text = fs.readFileSync(full, 'utf8')
+  for (const req of reqs) {
+    if (!req.any.some((re) => re.test(text))) {
+      errors.push(`${file}: missing ${req.label}`)
     }
   }
 }
 
 if (errors.length) {
-  console.error('validate-safety-visibility: FAILED — required cautions missing from curated overlay:')
+  console.error('validate-safety-visibility: FAILED — required cautions missing:')
   for (const e of errors) console.error(`  - ${e}`)
-  console.error('\nAdd the caution to the profile\'s safetyNote / notIdealFor / bottomLine in config/profile-verdicts.ts.')
+  console.error('\nAdd the caution to the overlay (safetyNote / notIdealFor / bottomLine) or to the article body.')
   process.exit(1)
 }
 
-console.log(`validate-safety-visibility: OK (${Object.keys(REQUIREMENTS).length} high-risk profiles carry required cautions)`)
+console.log(
+  `validate-safety-visibility: OK (${Object.keys(REQUIREMENTS).length} high-risk overlays + ${articlesChecked} article(s) carry required cautions)`,
+)

--- a/scripts/data/build-related-runtime-maps.mjs
+++ b/scripts/data/build-related-runtime-maps.mjs
@@ -574,7 +574,7 @@ function buildComparisonRecommendationMap(records, comparisonMap) {
         const candidate = recordsBySlug.get(entry.slug)
         if (!candidate) return null
         return {
-          href: `/compare/${sourceSlug}-vs-${entry.slug}`,
+          href: `/guides/compare/${sourceSlug}-vs-${entry.slug}`,
           sourceSlug,
           targetSlug: entry.slug,
           targetType: candidate.entityType || 'compound',


### PR DESCRIPTION
## What this does

The **final** pass of the 8-pass Editorial Operating System. It closes known loops, reconciles the link baseline to reality, hardens guardrails, and leaves a complete operating manual. No new architecture, no redesign — **stabilize, verify, document, hand off.**

## Changes

**`scripts/ci/validate-internal-links.mjs` — reconcile the baseline (Part 2)**
- Made the validator **wildcard/splat-aware**: `_redirects` rules ending in `/*` (e.g. `/compare/*`) now correctly cover their prefix. This drops the reported baseline from **~3706 → ~260** broken links — the earlier number was almost entirely wildcard-covered links the validator wasn't honoring. Remaining ~260 are pre-existing (phantom dynamic `/guides/compare/X-vs-Y` combos + `build:app` partial-emission artifacts like `/compounds/dmt`, `/pagefind/`), **none from the editorial modules**.

**`scripts/data/build-related-runtime-maps.mjs` — comparison route consistency (Part 1)**
- Emit canonical `/guides/compare/…` (was bare `/compare/…`) for comparison-recommendation hrefs, so future `data:build` produces canonical links at the source. A `/compare/* → /guides/compare/:splat` redirect already exists as the runtime safety net; runtime code (templates/components) already used the canonical prefix.

**`scripts/ci/validate-safety-visibility.mjs` — guardrail finalization (Part 5)**
- Extended beyond the curated overlay to high-risk **article prose** (kava, ashwagandha, magnesium-glycinate) with deliberately loose whole-file caution-keyword checks — reliable, no false-positive chaos. Absent articles are skipped, never fail.

**Docs (Part 6)**
- New **`docs/editorial-operating-system-handoff.md`** — the complete operating manual: what the system is, page types, components, overlay system, decision graph, evidence/safety rules, validators, how to add a profile / upgrade a hub or article / add a comparison, what agents must never do, pre-merge commands, and known limitations.
- Cross-linked from CPOS + editorial-components; evidence doc validator table updated for wildcard links + article safety.

## Verification
- **Validators (all pass):** typecheck, lint, `validate:article-quality`, `validate:claim-discipline`, `validate:profile-verdicts`, `validate:safety-visibility` (7 overlays + 3 articles), `validate:robots`, `validate:security-headers`, `validate:static-export`, `validate:sitemap`, `validate:canonical-host`, `validate:route-seo`; `build:app` succeeds.
- **Decision graph round-trip:** all 18 curated profiles render verdict + evidence confidence + start-here + (compare where useful) + continue at their real, alias-resolved routes (kava/passionflower via botanical slugs).
- **Hubs:** `/guides/{sleep,anxiety,focus}/` — **zero broken links**, no wrong routes.
- **No new broken links or static-export regressions.**

## Known limitations (documented in the handoff)
- A few curated profiles are workbook-governance `noindex` (lavender, lemon-balm, chamomile = `NOINDEX`; creatine = `NEEDS_REVIEW`) — full user-facing verdicts, limited SEO value until the workbook grounds/reviews them. `kava` is fine (canonical `piper-methysticum` is `PUBLISH`). Not overridden — source-of-truth is respected.
- Article claim-discipline stays warn-only by design; the curated overlay is the hard gate.

## robots.txt / Content-Signal (separately requested)
Verified the repo/build output contain **no** `Content-Signal` directive (`app/robots.ts` and `out/robots.txt` are clean; no `wrangler.toml`/Cloudflare config in-repo). The directive was a Cloudflare-edge injection, correctly disabled in the Cloudflare dashboard. The **live** endpoint couldn't be fetched from CI (network policy blocks outbound to the domain) — see PR notes / chat for the verification command to run externally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5BJzyhpmTd72Awzn2PS6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5BJzyhpmTd72Awzn2PS6Q)_