### PR TITLE
Fix FAQ schema minimum item count

### DIFF
--- a/components/StructuredData.tsx
+++ b/components/StructuredData.tsx
@@ -3,6 +3,7 @@ import JsonLd from './seo/JsonLd'
 const SITE_URL = 'https://thehippiescientist.net'
 const SITE_NAME = 'The Hippie Scientist'
 const DEFAULT_AUTHOR = 'Will Thomas'
+const MIN_FAQ_SCHEMA_ITEMS = 2
 
 const FAQ_FALLBACK_ANSWER_PREFIXES = [
   'See dosing guidelines and product labeling.',
@@ -135,7 +136,10 @@ export default function StructuredData({
     })
   }
 
-  if (meaningfulFaqs.length > 0) {
+  // FAQPage should only be emitted when there are enough meaningful Q&A pairs
+  // for rich-result eligibility. A one-item FAQ block creates avoidable schema
+  // noise across thin/partial pages without adding search value.
+  if (meaningfulFaqs.length >= MIN_FAQ_SCHEMA_ITEMS) {
     schemas.push({
       '@context': 'https://schema.org',
       '@type': 'FAQPage',


### PR DESCRIPTION
## Summary
- Only emit `FAQPage` structured data when at least 2 meaningful FAQ items are present.
- Adds a named `MIN_FAQ_SCHEMA_ITEMS` constant so the eligibility rule is explicit.
- Reduces avoidable rich-result/schema noise from pages with only one usable FAQ item.

## Why this is high ROI
The repo's own schema audit notes that FAQ schema needs 2+ valid Q&A pairs. This shared `StructuredData` component is reused across pages, so the change improves sitewide schema quality with a very small surface area.

## Validation
- Diff checked against `main`: 1 file changed, +5/-1.
- Recommended after merge: run `npm run validate:seo` and `npm run verify:build` if you want the full local gate.