### PR TITLE
Harden JSON-LD serialization and FAQ eligibility

### DIFF
--- a/components/SchemaOrg.tsx
+++ b/components/SchemaOrg.tsx
@@ -1,4 +1,5 @@
 import type { SchemaNode } from '@/lib/schema'
+import { serializeJsonLd } from '@/src/lib/schema-injector'
 
 type SchemaOrgProps = {
   graph?: Record<string, unknown> | null
@@ -32,10 +33,6 @@ function toPayload({
     '@context': 'https://schema.org',
     '@graph': graphNodes.map(({ '@context': _context, ...item }) => item),
   }
-}
-
-function serializeJsonLd(payload: Record<string, unknown> | SchemaNode): string {
-  return JSON.stringify(payload).replace(/</g, '\\u003c')
 }
 
 export default function SchemaOrg(props: SchemaOrgProps) {

--- a/components/seo/AuthorityJsonLd.tsx
+++ b/components/seo/AuthorityJsonLd.tsx
@@ -1,5 +1,8 @@
 import { buildSchemaGraph } from '../../src/lib/schema-graph'
+import { serializeJsonLd } from '../../src/lib/schema-injector'
 import { SITE_URL } from '../../src/lib/seo'
+
+const MIN_FAQ_SCHEMA_ITEMS = 2
 
 type FaqItem = { question: string; answer: string }
 
@@ -58,6 +61,7 @@ export default function AuthorityJsonLd({
   const breadcrumbId = `${canonical}#breadcrumb`
   const faqId = `${canonical}#faq`
   const meaningfulFaqItems = getMeaningfulFaqItems(faqItems)
+  const hasEligibleFaqSchema = meaningfulFaqItems.length >= MIN_FAQ_SCHEMA_ITEMS
 
   const webpage = {
     '@type': type === 'MedicalWebPage' ? ['MedicalWebPage', 'WebPage'] : type,
@@ -68,7 +72,7 @@ export default function AuthorityJsonLd({
     url: canonical,
     isPartOf: { '@type': 'WebSite', name: 'The Hippie Scientist', url: SITE_URL },
     ...(breadcrumbs.length ? { breadcrumb: { '@id': breadcrumbId } } : {}),
-    ...(meaningfulFaqItems.length ? { hasPart: { '@id': faqId } } : {}),
+    ...(hasEligibleFaqSchema ? { hasPart: { '@id': faqId } } : {}),
   }
 
   const breadcrumb = breadcrumbs.length
@@ -85,7 +89,7 @@ export default function AuthorityJsonLd({
     : null
 
   const faq =
-    meaningfulFaqItems.length > 0
+    hasEligibleFaqSchema
       ? {
           '@type': 'FAQPage',
           '@id': faqId,
@@ -105,7 +109,7 @@ export default function AuthorityJsonLd({
     <script
       type="application/ld+json"
       dangerouslySetInnerHTML={{
-        __html: JSON.stringify(graph).replace(/</g, '\u003c'),
+        __html: serializeJsonLd(graph),
       }}
     />
   )

--- a/components/seo/FaqJsonLd.tsx
+++ b/components/seo/FaqJsonLd.tsx
@@ -1,3 +1,7 @@
+import JsonLd from './JsonLd'
+
+const MIN_FAQ_SCHEMA_ITEMS = 2
+
 type FaqItem = {
   question: string
   answer: string
@@ -39,7 +43,7 @@ function getMeaningfulFaqItems(items: FaqItem[]): FaqItem[] {
 export default function FaqJsonLd({ items }: FaqJsonLdProps) {
   const meaningfulItems = getMeaningfulFaqItems(items ?? [])
 
-  if (meaningfulItems.length === 0) {
+  if (meaningfulItems.length < MIN_FAQ_SCHEMA_ITEMS) {
     return null
   }
 
@@ -56,12 +60,5 @@ export default function FaqJsonLd({ items }: FaqJsonLdProps) {
     })),
   }
 
-  return (
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{
-        __html: JSON.stringify(schema),
-      }}
-    />
-  )
+  return <JsonLd schema={schema} />
 }

--- a/components/seo/JsonLd.tsx
+++ b/components/seo/JsonLd.tsx
@@ -1,15 +1,13 @@
-import React from 'react'
+import type { JsonLdNode } from '@/src/lib/schema-injector'
+import { serializeJsonLd } from '@/src/lib/schema-injector'
 
-export default function JsonLd({ schema }: { schema: any }) {
+export default function JsonLd({ schema }: { schema: JsonLdNode }) {
   if (!schema) return null
-
-  // Safely serialize and escape HTML tags (like '<') to prevent XSS injection
-  const escapedJson = JSON.stringify(schema).replace(/</g, '\\u003c')
 
   return (
     <script
       type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: escapedJson }}
+      dangerouslySetInnerHTML={{ __html: serializeJsonLd(schema) }}
     />
   )
 }


### PR DESCRIPTION
## Summary
- Routes the shared `JsonLd` and `SchemaOrg` components through the central JSON-LD serializer.
- Applies the 2+ meaningful FAQ item rule to dedicated FAQ/authority schema components.
- Prevents one-item FAQ schema blocks and reduces inconsistent JSON-LD escaping across shared schema emitters.

## Why this is high ROI
The site has several shared JSON-LD emitters. Tightening them improves schema hygiene across many pages with a small, reviewable diff.

## Validation
- Diff checked against `main`: 4 files changed, +18/-22.
- Recommended after merge: `npm run validate:seo` and `npm run verify:build`.