### PR TITLE
Fix beginner journey canonical links

### DIFF
--- a/lib/beginner-journeys.ts
+++ b/lib/beginner-journeys.ts
@@ -3,18 +3,30 @@ export const beginnerJourneys = [
     slug: 'new-to-sleep-support',
     title: 'New to sleep support?',
     description: 'Learn how calming compounds, circadian support, recovery, stress, and sleep architecture differ before trying random stacks.',
-    routes: ['/best-supplements-for-sleep', '/ecosystems/sleep', '/guides/compare/glycine-vs-theanine'],
+    routes: [
+      '/guides/sleep/best-supplements-for-sleep/',
+      '/guides/sleep/sleep-stack-guide/',
+      '/guides/compare/sleep-herbs-vs-melatonin/',
+    ],
   },
   {
     slug: 'improve-focus',
     title: 'Trying to improve focus?',
     description: 'Explore calm focus, stimulation, cholinergic pathways, cognitive energy, and realistic expectations.',
-    routes: ['/cognition-supplements', '/ecosystems/cognition', '/guides/compare/alpha-gpc-vs-citicoline'],
+    routes: [
+      '/guides/focus/best-supplements-for-focus/',
+      '/guides/focus/focus-without-caffeine-crash/',
+      '/guides/compare/caffeine-vs-l-theanine-vs-bacopa-for-focus/',
+    ],
   },
   {
     slug: 'understanding-adaptogens',
     title: 'Understanding adaptogens',
     description: 'Compare stress-response compounds through evidence, stimulation, recovery context, and tolerability.',
-    routes: ['/stress-supplements', '/ecosystems/stress', '/guides/compare/rhodiola-vs-ashwagandha'],
+    routes: [
+      '/guides/anxiety/best-adaptogens-for-stress/',
+      '/guides/anxiety/anxiety-stack-guide/',
+      '/guides/compare/rhodiola-vs-ashwagandha/',
+    ],
   },
 ]


### PR DESCRIPTION
## Summary
- Replaces redirect-heavy or stale beginner journey routes with active canonical guide routes.
- Points sleep, focus, and adaptogen journeys directly at relevant indexed guide/compare pages.
- Avoids sending users and crawl equity through old `/ecosystems/*`, top-level, or non-existent comparison URLs.

## Why this is high ROI
Beginner journey modules are internal navigation surfaces. Cleaner direct links improve UX, reduce redirect hops, and strengthen topical internal linking without changing page design.

## Validation
- Verified target pages exist for the selected canonical routes.
- Diff checked against `main`: 1 file changed, +15/-3.