### PR TITLE
Add safe legacy compare redirects

### DIFF
--- a/functions/compare/[[path]].ts
+++ b/functions/compare/[[path]].ts
@@ -1,0 +1,17 @@
+type PagesFunctionContext = {
+  request: Request
+}
+
+function buildCompareTarget(request: Request, legacyPrefix: string): string {
+  const url = new URL(request.url)
+  const rest = url.pathname
+    .replace(new RegExp(`^/${legacyPrefix}/?`), '')
+    .replace(/^\/+|\/+$/g, '')
+
+  url.pathname = rest ? `/guides/compare/${rest}/` : '/guides/compare/'
+  return url.toString()
+}
+
+export const onRequest = async ({ request }: PagesFunctionContext): Promise<Response> => {
+  return Response.redirect(buildCompareTarget(request, 'compare'), 301)
+}

--- a/functions/comparisons/[[path]].ts
+++ b/functions/comparisons/[[path]].ts
@@ -1,0 +1,17 @@
+type PagesFunctionContext = {
+  request: Request
+}
+
+function buildCompareTarget(request: Request, legacyPrefix: string): string {
+  const url = new URL(request.url)
+  const rest = url.pathname
+    .replace(new RegExp(`^/${legacyPrefix}/?`), '')
+    .replace(/^\/+|\/+$/g, '')
+
+  url.pathname = rest ? `/guides/compare/${rest}/` : '/guides/compare/'
+  return url.toString()
+}
+
+export const onRequest = async ({ request }: PagesFunctionContext): Promise<Response> => {
+  return Response.redirect(buildCompareTarget(request, 'comparisons'), 301)
+}


### PR DESCRIPTION
## Summary
- Adds Cloudflare Pages Functions for legacy `/compare/*` and `/comparisons/*` URLs.
- Redirects those legacy paths to canonical `/guides/compare/*` destinations with 301 status.
- Preserves query strings and avoids touching the large `public/_redirects` file.

## Why this fixes the important note
The earlier direct `_redirects` edit was unsafe because the file is large and preview-limited. This PR fixes the legacy compare redirect issue without replacing or truncating `_redirects`.

## Validation
- Diff checked against `main`: only 2 new files added.
- `functions/compare/[[path]].ts`: +17 lines.
- `functions/comparisons/[[path]].ts`: +17 lines.