### PR TITLE
Auto-bootstrap missing node modules

### DIFF
--- a/.zipignore
+++ b/.zipignore
@@ -1,0 +1,33 @@
+# Keep handoff archives small and reproducible.
+# Do not include installed dependencies or generated build output.
+node_modules/
+.next/
+out/
+dist/
+build/
+coverage/
+.cache/
+.eslintcache
+*.tsbuildinfo
+
+# Local/editor/system clutter
+.DS_Store
+*.log
+*.tmp
+*.temp
+*.bak
+*.orig
+*~
+
+# Local secrets and agent state
+.env.local
+.env.*.local
+.claude/
+ops/state.db
+agent/cache/
+
+# Large/generated archives
+*.zip
+*.tar
+*.tar.gz
+*.tgz

--- a/scripts/ci/check-dependencies-installed.mjs
+++ b/scripts/ci/check-dependencies-installed.mjs
@@ -3,11 +3,15 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { createRequire } from 'node:module'
+import { spawnSync } from 'node:child_process'
 
 const root = process.cwd()
 const requireFromRoot = createRequire(path.join(root, 'package.json'))
 
-const installMessage = 'Dependencies are not installed. Run: npm ci'
+const installMessage = 'Dependencies are not installed. Running: npm ci'
+const installDisabledMessage = 'Dependencies are not installed. Run: npm ci'
+const autoInstallDisabled = process.env.SKIP_AUTO_NPM_CI === '1' || process.env.NO_AUTO_INSTALL === '1'
+const packageLockPath = path.join(root, 'package-lock.json')
 
 const requiredPackages = [
   '@content-collections/cli',
@@ -40,33 +44,65 @@ function binExists(name) {
   return extensions.some((ext) => fs.existsSync(path.join(root, 'node_modules', '.bin', `${name}${ext}`)))
 }
 
-const missing = []
+function getMissingDependencies() {
+  const missing = []
 
-if (!fs.existsSync(path.join(root, 'node_modules'))) {
-  missing.push('node_modules/')
-}
+  if (!fs.existsSync(path.join(root, 'node_modules'))) {
+    missing.push('node_modules/')
+  }
 
-for (const packageName of requiredPackages) {
-  try {
-    requireFromRoot.resolve(packageName)
-  } catch {
-    if (
-      !fs.existsSync(path.join(root, 'node_modules', packageName)) &&
-      !fs.existsSync(path.join(root, 'node_modules', packageName, 'package.json'))
-    ) {
-      missing.push(packageName)
+  for (const packageName of requiredPackages) {
+    try {
+      requireFromRoot.resolve(packageName)
+    } catch {
+      if (
+        !fs.existsSync(path.join(root, 'node_modules', packageName)) &&
+        !fs.existsSync(path.join(root, 'node_modules', packageName, 'package.json'))
+      ) {
+        missing.push(packageName)
+      }
     }
   }
+
+  for (const binName of requiredBins) {
+    if (!binExists(binName)) {
+      missing.push(`node_modules/.bin/${binName}`)
+    }
+  }
+
+  return missing
 }
 
-for (const binName of requiredBins) {
-  if (!binExists(binName)) {
-    missing.push(`node_modules/.bin/${binName}`)
-  }
+let missing = getMissingDependencies()
+
+if (missing.length === 0) {
+  process.exit(0)
 }
+
+if (autoInstallDisabled || !fs.existsSync(packageLockPath)) {
+  console.error(installDisabledMessage)
+  console.error(`Missing dependency artifacts: ${missing.join(', ')}`)
+  process.exit(1)
+}
+
+console.warn(installMessage)
+console.warn(`Missing dependency artifacts: ${missing.join(', ')}`)
+
+const install = spawnSync('npm', ['ci'], {
+  cwd: root,
+  stdio: 'inherit',
+  shell: process.platform === 'win32',
+})
+
+if (install.status !== 0) {
+  console.error('Automatic npm ci failed. Run it manually, then retry the command.')
+  process.exit(install.status ?? 1)
+}
+
+missing = getMissingDependencies()
 
 if (missing.length > 0) {
-  console.error(installMessage)
+  console.error('Dependencies are still missing after npm ci.')
   console.error(`Missing dependency artifacts: ${missing.join(', ')}`)
   process.exit(1)
 }


### PR DESCRIPTION
## Summary
- Updates the dependency guard so missing `node_modules` automatically runs `npm ci` once instead of failing immediately.
- Re-checks dependencies after the install and still fails clearly if anything remains missing.
- Adds `.zipignore` rules so handoff archives do not include `node_modules`, build output, caches, logs, or local agent state.

## Why this fixes the recurring problem
The repo already ignored `node_modules` for Git, but commands still failed whenever a fresh checkout or uploaded ZIP had no installed dependencies. This makes the common path self-healing while preserving an opt-out with `SKIP_AUTO_NPM_CI=1` or `NO_AUTO_INSTALL=1`.

## Validation
- Diff checked against `main`: 2 files changed.
- `scripts/ci/check-dependencies-installed.mjs`: auto-runs `npm ci` when dependency artifacts are missing.
- `.zipignore`: explicitly excludes `node_modules/` and generated artifacts.