### PR TITLE
Add CI guard blocking full-build drift in top-level runtime lists

### DIFF
--- a/docs/promoting-profiles.md
+++ b/docs/promoting-profiles.md
@@ -85,6 +85,12 @@ npm run data:build:core
 ```
 not `npm run data:build`.
 
+**CI enforces this.** `npm run guard:no-full-build-drift`
+(`scripts/ci/guard-no-full-build-drift.mjs`, wired into `guard:source-of-truth`)
+fails the build if `herbs.json` / `compounds.json` are committed with the
+governance-overlay / postprocess signature — so the trap cannot be reintroduced,
+by a person or a parallel session.
+
 ---
 
 ## What `promote:profile` does, step by step

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "pipeline:apply-redirects": "node scripts/pipeline/apply-slug-redirects.mjs",
     "pipeline:clean-leaks": "node scripts/pipeline/clean-workbook-leaks.mjs",
     "generate:redirects": "node scripts/generate-redirects.mjs",
-    "guard:source-of-truth": "node scripts/ci/validate-workbook-source.mjs && node scripts/ci/validate-workbook-schema.mjs && node scripts/data/verify-workbook-only-path.mjs && node scripts/ci/validate-workbook-json-parity.mjs",
+    "guard:source-of-truth": "node scripts/ci/validate-workbook-source.mjs && node scripts/ci/validate-workbook-schema.mjs && node scripts/data/verify-workbook-only-path.mjs && node scripts/ci/validate-workbook-json-parity.mjs && node scripts/ci/guard-no-full-build-drift.mjs",
     "guard:generated-data": "node scripts/ci/guard-generated-data.mjs",
     "pretypecheck": "npm run -s check:deps && npm run content:build",
     "typecheck": "tsc --noEmit",
@@ -149,7 +149,8 @@
     "audit:data-governance": "node scripts/ci/validate-data-governance.mjs",
     "audit:data-governance:json": "node scripts/ci/validate-data-governance.mjs --json",
     "audit:data-governance:strict": "node scripts/ci/validate-data-governance.mjs --strict",
-    "validate:audit-hardening": "npm run audit:high && npm run audit:data-governance && npm run validate:security-headers"
+    "validate:audit-hardening": "npm run audit:high && npm run audit:data-governance && npm run validate:security-headers",
+    "guard:no-full-build-drift": "node scripts/ci/guard-no-full-build-drift.mjs"
   },
   "dependencies": {
     "@fontsource-variable/fraunces": "5.2.9",

--- a/scripts/ci/guard-no-full-build-drift.mjs
+++ b/scripts/ci/guard-no-full-build-drift.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * Guard: block committing the output of a full `npm run data:build`.
+ *
+ * The deploy path (`build:fast` -> `data:build:core`) regenerates the top-level
+ * runtime lists WITHOUT the governance overlay + postprocess. The full
+ * `npm run data:build` runs those extra steps, which stamp a `governance` object
+ * (and a default `safety` string / empty `sources[]`) onto EVERY record — ~855 of
+ * them — and apply source-gate downgrades. None of that belongs in the committed
+ * top-level lists: it produces a thousand-line diff unrelated to the actual change
+ * and conflicts with every parallel promotion.
+ *
+ * This is exactly the trap that turned a one-line profile change into a massive,
+ * quota-burning diff. The correct rebuild for a committed change is
+ * `npm run data:build:core` (or `npm run promote:profile` for a promotion), which
+ * this guard enforces by refusing the full-build signature.
+ *
+ * Convention this guard protects (verified on main):
+ *   - public/data/herbs.json     : NO `governance` blocks, NO postprocess safety-default
+ *   - public/data/compounds.json : NO `governance` blocks, NO postprocess safety-default
+ * (Detail files under *-detail/ ARE overlay-maintained and legitimately carry
+ *  `governance` — they are intentionally NOT checked here.)
+ *
+ * Exit 1 on drift, 0 when clean.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+
+const ROOT = process.cwd()
+
+// Top-level runtime lists that the deploy path commits without the overlay.
+const GUARDED_FILES = ['public/data/herbs.json', 'public/data/compounds.json']
+
+// Signatures that only the full-build (overlay + postprocess) steps introduce.
+const SIGNATURES = [
+  { label: 'governance overlay block', re: /"governance"\s*:/g },
+  { label: 'postprocess safety default', re: /Generally well tolerated for most users\./g },
+]
+
+const failures = []
+
+for (const rel of GUARDED_FILES) {
+  const file = path.join(ROOT, rel)
+  if (!fs.existsSync(file)) continue
+  const text = fs.readFileSync(file, 'utf8')
+  for (const sig of SIGNATURES) {
+    const count = (text.match(sig.re) || []).length
+    if (count > 0) failures.push({ rel, label: sig.label, count })
+  }
+}
+
+if (failures.length) {
+  console.error('\n[guard-no-full-build-drift] FAILED — full `data:build` output was committed to the top-level lists:\n')
+  for (const f of failures) {
+    console.error(`  - ${f.rel}: ${f.count} × ${f.label}`)
+  }
+  console.error('\nThese fields are added by the governance overlay + postprocess, which the deploy')
+  console.error('path (build:fast -> data:build:core) does NOT run. Committing them rewrites ~855')
+  console.error('records and conflicts with every parallel promotion.\n')
+  console.error('Fix: regenerate with the CORE pipeline, then re-commit these files:')
+  console.error('  git checkout -- public/data/herbs.json public/data/compounds.json   # drop the drift')
+  console.error('  npm run data:build:core                                             # drift-free rebuild')
+  console.error('For a profile promotion, prefer:  npm run promote:profile -- --slug <slug>')
+  console.error('See docs/promoting-profiles.md.\n')
+  process.exit(1)
+}
+
+console.log('[guard-no-full-build-drift] PASS: top-level runtime lists are free of full-build overlay/postprocess drift.')


### PR DESCRIPTION
## Why

This locks in the drift-trap fix so it cannot be reintroduced — by a person or a parallel session.

The deploy path (`build:fast` → `data:build:core`) commits `herbs.json` / `compounds.json` **without** the governance overlay + postprocess. A full `npm run data:build` stamps a `governance` object and a default `safety` string onto **every** record (~855) and applies source-gate downgrades. Committing that output produces a thousand-line diff unrelated to the actual change and conflicts with every parallel promotion. That is exactly what turned a one-line profile change into a quota-burning mess.

## What

- **`scripts/ci/guard-no-full-build-drift.mjs`** — fails if `public/data/herbs.json` or `public/data/compounds.json` carries the overlay/postprocess signature (`"governance":` blocks or the postprocess safety-default), with an actionable fix message pointing at `data:build:core` / `promote:profile`. Detail files under `*-detail/` are legitimately overlay-maintained and are intentionally **not** checked.
- **`package.json`** — wired into `guard:source-of-truth`; also exposed standalone as `guard:no-full-build-drift`.
- **`docs/promoting-profiles.md`** — documents the enforcement.

## Verification

- Passes on current clean `main` data; the full `guard:source-of-truth` chain is green with the new step.
- Fails as intended on an injected `governance` block (tested, then reverted), emitting the fix instructions.
- Touches only `scripts/ci/`, `package.json`, and docs — no workbook or `public/data` changes, so it does not conflict with in-flight promotion batches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5BJzyhpmTd72Awzn2PS6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5BJzyhpmTd72Awzn2PS6Q)_