### PR TITLE
Stop the sitemap advertising ~640 unbuilt /guides/compare 404s

### DIFF
--- a/app/__tests__/compare-sitemap-integrity.test.ts
+++ b/app/__tests__/compare-sitemap-integrity.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+
+import { getBuiltCompareSlugs } from '@/lib/compare-pages'
+import { COMPARE_COMBINATIONS } from '@/config/compare-combinations'
+
+/**
+ * Guards against re-introducing the `/guides/compare/*` "Not found (404)" cluster.
+ *
+ * Under static export a `/guides/compare/<slug>` page exists ONLY when
+ * `app/guides/compare/<slug>/page.tsx` exists (there is no `[slug]` route). The
+ * sitemap must therefore advertise only those built pages — never the config
+ * comparison lists (COMPARE_COMBINATIONS et al.), which enumerate intended
+ * comparisons that are not built and 404 the moment a crawler follows them.
+ */
+describe('compare sitemap integrity', () => {
+  const built = getBuiltCompareSlugs()
+  const builtSet = new Set(built)
+
+  it('every built compare slug resolves to a real page.tsx', () => {
+    expect(built.length).toBeGreaterThan(0)
+    for (const slug of built) {
+      const page = path.join(process.cwd(), 'app/guides/compare', slug, 'page.tsx')
+      expect(existsSync(page), `${slug} should have a page.tsx`).toBe(true)
+    }
+  })
+
+  it('does not treat unbuilt config comparison combinations as built pages', () => {
+    // COMPARE_COMBINATIONS enumerates intended comparisons that have no static page.
+    const unbuilt = COMPARE_COMBINATIONS.filter((slug) => !builtSet.has(slug))
+    // The overwhelming majority are unbuilt — that is exactly why emitting them
+    // to the sitemap produced hundreds of 404s. Assert they are excluded.
+    expect(unbuilt.length).toBeGreaterThan(0)
+    for (const slug of unbuilt) {
+      expect(existsSync(path.join(process.cwd(), 'app/guides/compare', slug, 'page.tsx'))).toBe(false)
+    }
+  })
+})

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -11,6 +11,7 @@ import {
 } from '../src/lib/index-allowlist';
 import { learnPosts } from './learn/data';
 import { getAllFocusClusterArticles } from '@/lib/focus-cluster-markdown';
+import { getBuiltCompareSlugs } from '@/lib/compare-pages';
 
 type SitemapSourceItem = {
   slug?: string;
@@ -118,26 +119,6 @@ function readAppGuidePageSlugs(relativePath: string, slugPrefix = ''): SitemapSo
   }
 }
 
-// Discovers App Router compare pages by scanning app/guides/compare/ for subdirectories
-// that contain a page.tsx. This picks up custom compare pages.
-function readAppComparePageSlugs(relativePath: string): SitemapSourceItem[] {
-  const dirPath = path.join(process.cwd(), relativePath);
-  if (!existsSync(dirPath)) return [];
-
-  try {
-    return readdirSync(dirPath, { withFileTypes: true })
-      .filter((entry) => {
-        if (!entry.isDirectory()) return false;
-        if (/^\[/.test(entry.name)) return false; // skip [slug] dynamic routes
-        if (entry.name === 'dynamic') return false; // skip dynamic utility directory
-        return existsSync(path.join(dirPath, entry.name, 'page.tsx'));
-      })
-      .map((entry) => ({ slug: entry.name }));
-  } catch {
-    return [];
-  }
-}
-
 // Parses data/goals.ts and extracts top-level goal slugs from the `goals` array.
 // Top-level goal objects are formatted as two-space-indented `{` on their own line
 // followed by a four-space-indented `slug:` property. Nested option slugs are on a
@@ -154,28 +135,6 @@ function readTsGoalSlugs(relativePath: string): SitemapSourceItem[] {
       if (m[1]) results.push({ slug: m[1] });
     }
     return results;
-  } catch {
-    return [];
-  }
-}
-
-function readTsStringArray(relativePath: string, varName: string): string[] {
-  const filePath = path.join(process.cwd(), relativePath);
-  if (!existsSync(filePath)) return [];
-  try {
-    const src = readFileSync(filePath, 'utf8');
-    // Match export const varName = [ 'a', 'b', ... ]
-    const re = new RegExp(`export\\s+const\\s+${varName}\\s*=\\s*\\[([\\s\\S]*?)\\]`, 'm');
-    const m = src.match(re);
-    if (!m) return [];
-    const body = m[1];
-    const items: string[] = [];
-    const itemRe = /['"]([^'"]+)['"]/g;
-    let im;
-    while ((im = itemRe.exec(body)) !== null) {
-      if (im[1]) items.push(im[1]);
-    }
-    return items;
   } catch {
     return [];
   }
@@ -719,15 +678,14 @@ export default function sitemap(): MetadataRoute.Sitemap {
     addRoute(`/novel-psychoactive-substances/${page.slug}`, 'monthly', 0.65, getSitemapLastModified(page), page);
   });
 
-  // Add compare detail routes (data-driven + custom directories + generated combinations)
-  const compareFromGen = readTsStringArray('data/generated-comparisons.ts', 'generatedComparisons');
-  const compareFromData = readTsStringArray('data/comparisons.ts', 'supplementComparisons')
-    .map((s: string) => s)
-    .filter(Boolean);
-  const compareFromCombinations = readTsStringArray('config/compare-combinations.ts', 'COMPARE_COMBINATIONS');
-  const compareFromDirs = readAppComparePageSlugs('app/compare').map(item => item.slug).filter((s): s is string => Boolean(s));
-  Array.from(new Set([...compareFromGen, ...compareFromData, ...compareFromCombinations, ...compareFromDirs])).forEach((slug) => {
-    if (slug) addRoute(`/guides/compare/${slug}`, 'monthly', 0.6);
+  // Add compare detail routes — ONLY pages that are actually built as static routes
+  // (app/guides/compare/<slug>/page.tsx). There is no [slug] route, so the config
+  // comparison lists (generated-comparisons, supplementComparisons, COMPARE_COMBINATIONS)
+  // do NOT correspond to built pages; emitting them previously advertised ~640 hard 404s
+  // to search engines (the /guides/compare/* not-found cluster). getBuiltCompareSlugs()
+  // scans the filesystem so the sitemap can never drift from what the build emits.
+  getBuiltCompareSlugs().forEach((slug) => {
+    addRoute(`/guides/compare/${slug}`, 'monthly', 0.6);
   });
 
   // Inactive collections routes (redirect targets or defined in lib) are excluded from the sitemap.

--- a/lib/compare-pages.ts
+++ b/lib/compare-pages.ts
@@ -1,0 +1,35 @@
+import { existsSync, readdirSync } from 'node:fs'
+import path from 'node:path'
+
+/**
+ * The comparison pages that are ACTUALLY built as static routes — the single
+ * source of truth for "does /guides/compare/<slug> exist".
+ *
+ * Under `output: 'export'`, a `/guides/compare/<slug>` page exists **iff**
+ * `app/guides/compare/<slug>/page.tsx` exists. There is no `[slug]` dynamic route
+ * and no `generateStaticParams`, so the config comparison lists
+ * (`COMPARE_COMBINATIONS`, `generatedComparisons`, `supplementComparisons`) enumerate
+ * *intended* comparisons that are NOT built as pages. Advertising those anywhere
+ * crawlable (sitemap, internal links) produces hard 404s — the historical
+ * `/guides/compare/*` "Not found (404)" cluster in Search Console.
+ *
+ * Scanning the filesystem here means callers can never drift from what the build
+ * actually emits. Server/build-only (uses `node:fs`); do not import from client code.
+ */
+export function getBuiltCompareSlugs(root: string = process.cwd()): string[] {
+  const dir = path.join(root, 'app/guides/compare')
+  if (!existsSync(dir)) return []
+  try {
+    return readdirSync(dir, { withFileTypes: true })
+      .filter((entry) => {
+        if (!entry.isDirectory()) return false
+        if (/^\[/.test(entry.name)) return false // dynamic [slug] route (none today)
+        if (entry.name === 'dynamic') return false // client-side matrix, not a per-pair page
+        return existsSync(path.join(dir, entry.name, 'page.tsx'))
+      })
+      .map((entry) => entry.name)
+      .sort()
+  } catch {
+    return []
+  }
+}


### PR DESCRIPTION
## Why

Under static export a `/guides/compare/<slug>` page exists **only** when `app/guides/compare/<slug>/page.tsx` exists — there is no `[slug]` route and no `generateStaticParams`. The sitemap was emitting every slug from the config comparison lists (`COMPARE_COMBINATIONS` + `generated-comparisons` + `supplementComparisons`) with **no build-existence check**, advertising ~640 pages that 404 the moment a crawler follows them (the historical `/guides/compare/*` "Not found (404)" cluster in Search Console). It also scanned the wrong directory — `readAppComparePageSlugs('app/compare')`, which doesn't exist — so two real pages were omitted.

## What

- **`lib/compare-pages.ts`** — `getBuiltCompareSlugs()` scans `app/guides/compare` for real `page.tsx` directories: the single source of truth for what the build actually emits.
- **`app/sitemap.ts`** — emit only `getBuiltCompareSlugs()` (10 real pages) instead of a union that mixed 2 built pages with 595+ phantom combinations. Removed the now-unused `readAppComparePageSlugs` (mis-pointed at `app/compare`) and `readTsStringArray`.
- **`app/__tests__/compare-sitemap-integrity.test.ts`** — asserts every emitted compare slug has a real `page.tsx`, and that unbuilt `COMPARE_COMBINATIONS` are excluded.

## Impact

- **595 of 597** `COMPARE_COMBINATIONS` (plus the unbuilt `generated`/`supplement` pairs) no longer appear in the sitemap — those were all 404s.
- The 2 previously-omitted built pages (`melatonin-vs-magnesium`, `rhodiola-vs-ashwagandha`) are now included.

## Verification

- Typecheck + ESLint clean; 16 tests pass across `route-integrity`, `route-consolidation-guardrails`, `sitemap-last-modified`, `compare-link-integrity`, and the new `compare-sitemap-integrity`.
- Provably correct without a full build: static export emits a page iff its `page.tsx` exists, and `_redirects` has no `/guides/compare/*` fallback (only `/compare/* → /guides/compare/:splat`), so unbuilt pairs are hard 404s.

## Follow-up (not in this PR)

The render-time guard `isBuiltComparisonSlug` (in `lib/comparison-utils.ts`) still validates against a hand-maintained `validSlugs` set rather than the built pages, so it can still bless a handful of unbuilt pairs in on-page links. That's a separate, higher-blast-radius change; this PR fixes the confirmed sitemap harm first. `getBuiltCompareSlugs()` is the reusable source of truth to migrate that guard to next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5BJzyhpmTd72Awzn2PS6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5BJzyhpmTd72Awzn2PS6Q)_