### PR TITLE
Make the compare render-guard validate against actually-built pages

### DIFF
--- a/app/__tests__/compare-link-integrity.test.ts
+++ b/app/__tests__/compare-link-integrity.test.ts
@@ -23,9 +23,12 @@ function compareSlug(href: string): string {
 
 describe('compare link integrity', () => {
   it('isBuiltComparisonSlug accepts a known built pair and rejects phantoms', () => {
-    // `aescin-vs-ajoene` is part of the generated/adjacent comparison set that
-    // `app/guides/compare/[slug]/page.tsx` builds via generateStaticParams.
-    expect(isBuiltComparisonSlug('aescin-vs-ajoene')).toBe(true)
+    // Only pages with a real `app/guides/compare/<slug>/page.tsx` are built.
+    expect(isBuiltComparisonSlug('rhodiola-vs-ashwagandha')).toBe(true)
+    expect(isBuiltComparisonSlug('kava-vs-alcohol')).toBe(true)
+    // Config "adjacent pairs" / combinations have NO page and must be rejected —
+    // treating them as built was the source of the /guides/compare/* 404 cluster.
+    expect(isBuiltComparisonSlug('aescin-vs-ajoene')).toBe(false)
     // Mechanism / signal "comparisons" and arbitrary pairs are not built pages.
     expect(isBuiltComparisonSlug('garcinia-indica-vs-nf-b-inhibition')).toBe(false)
     expect(isBuiltComparisonSlug('citicoline-vs-neuroprotective-activity')).toBe(false)

--- a/app/__tests__/compare-sitemap-integrity.test.ts
+++ b/app/__tests__/compare-sitemap-integrity.test.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'node:fs'
 import path from 'node:path'
 
 import { getBuiltCompareSlugs } from '@/lib/compare-pages'
+import { BUILT_COMPARE_SLUGS } from '@/lib/comparison-utils'
 import { COMPARE_COMBINATIONS } from '@/config/compare-combinations'
 
 /**
@@ -17,6 +18,13 @@ import { COMPARE_COMBINATIONS } from '@/config/compare-combinations'
 describe('compare sitemap integrity', () => {
   const built = getBuiltCompareSlugs()
   const builtSet = new Set(built)
+
+  it('BUILT_COMPARE_SLUGS (render-guard source of truth) matches the real page.tsx directories', () => {
+    // lib/comparison-utils.ts keeps a pure literal list (it is imported by RSC
+    // components and must not use node:fs). This asserts that literal never drifts
+    // from what the filesystem actually builds.
+    expect([...BUILT_COMPARE_SLUGS].sort()).toEqual([...built].sort())
+  })
 
   it('every built compare slug resolves to a real page.tsx', () => {
     expect(built.length).toBeGreaterThan(0)

--- a/lib/comparison-utils.ts
+++ b/lib/comparison-utils.ts
@@ -1,52 +1,34 @@
-import { generatedComparisons } from '@/data/generated-comparisons'
-import { supplementComparisons } from '@/data/comparisons'
-import { COMPARE_COMBINATIONS } from '@/config/compare-combinations'
-
-const adjacentPairs = [
-  '11-keto-beta-boswellic-acid-vs-acemannan',
-  'acemannan-vs-acetyl-11-keto-beta-boswellic-acid',
-  'acetyl-11-keto-beta-boswellic-acid-vs-acetyl-beta-boswellic-acid',
-  'acetyl-beta-boswellic-acid-vs-acetylshikonin',
-  'acetylshikonin-vs-acteoside',
-  'acteoside-vs-aescin',
-  'aescin-vs-ajoene',
-  'ajoene-vs-albiflorin',
-  'albiflorin-vs-alpha-asarone',
-  'alpha-asarone-vs-alpha-mangostin',
-  'alpha-mangostin-vs-anabasine',
-  'anabasine-vs-anatabine',
-  'anatabine-vs-andrographolide',
-  'andrographolide-vs-anethole',
-  'anethole-vs-angelicin',
-  'angelicin-vs-apigenin',
-  'apigenin-vs-arjunolic-acid',
-  'arjunolic-acid-vs-artemisinin',
-  'artemisinin-vs-artemisinin-b',
-  'artemisinin-b-vs-artesunate',
-  'artesunate-vs-asiatic-acid',
-  'asiatic-acid-vs-asiaticoside',
-  'asiaticoside-vs-aspalathin',
-  'aspalathin-vs-astragalin',
-]
-
-const staticComparePages = [
+/**
+ * The comparison pages that are ACTUALLY built as static routes under
+ * `app/guides/compare/<slug>/page.tsx`.
+ *
+ * Under static export there is no `[slug]` route and no `generateStaticParams`, so a
+ * `/guides/compare/<slug>` page exists **only** when its directory exists. The config
+ * comparison lists (`COMPARE_COMBINATIONS`, `generatedComparisons`, `supplementComparisons`)
+ * and the historical hard-coded "adjacent pair" list enumerate *intended* comparisons
+ * that are NOT built — treating them as built is what emitted internal links (and the
+ * sitemap) to hundreds of pages that 404, the `/guides/compare/*` Search Console cluster.
+ *
+ * This is the single runtime source of truth for the guards below. It is kept **pure**
+ * (no `node:fs`) because this module is imported by RSC/authority components. Drift from
+ * the real page.tsx directories fails CI via
+ * `app/__tests__/compare-sitemap-integrity.test.ts` (which diffs this against
+ * `getBuiltCompareSlugs()`), so add the slug here when you add a compare page.
+ */
+export const BUILT_COMPARE_SLUGS = [
   'ashwagandha-vs-l-theanine-vs-magnesium',
+  'berberine-vs-metformin',
   'caffeine-vs-l-theanine-vs-bacopa-for-focus',
   'curcumin-vs-boswellia-vs-omega-3',
-  'melatonin-vs-valerian-vs-magnesium-for-sleep',
-  'berberine-vs-metformin',
   'kanna-vs-ssris',
   'kava-vs-alcohol',
+  'melatonin-vs-magnesium',
+  'melatonin-vs-valerian-vs-magnesium-for-sleep',
+  'rhodiola-vs-ashwagandha',
   'sleep-herbs-vs-melatonin',
-]
+] as const
 
-const validSlugs = new Set([
-  ...generatedComparisons,
-  ...supplementComparisons.map(c => c.slug),
-  ...COMPARE_COMBINATIONS,
-  ...adjacentPairs,
-  ...staticComparePages,
-])
+const validSlugs = new Set<string>(BUILT_COMPARE_SLUGS)
 
 export function getValidComparisonSlug(a: string, b: string): string | undefined {
   const slug1 = `${a}-vs-${b}`
@@ -58,7 +40,7 @@ export function getValidComparisonSlug(a: string, b: string): string | undefined
 
 /**
  * Returns true only when `slug` resolves to a comparison page that is actually
- * built (i.e. emitted by `generateStaticParams` in `app/guides/compare/[slug]/page.tsx`).
+ * built — i.e. a directory in `BUILT_COMPARE_SLUGS` / `app/guides/compare/<slug>/`.
  *
  * This is the single guard every dynamic `/guides/compare/...` link generator must pass
  * its candidate slug through. Under static export, linking to a `/guides/compare/...`


### PR DESCRIPTION
## Why

Follow-up to #2103 (sitemap fix). `isBuiltComparisonSlug` / `getValidComparisonSlug` validated candidate comparison links against a ~640-entry `validSlugs` set assembled from the config comparison lists (`COMPARE_COMBINATIONS`, `generatedComparisons`, `supplementComparisons`) plus a hard-coded "adjacent pairs" list. **None of those are built as static pages** — there is no `app/guides/compare/[slug]` route — so the guard was blessing hundreds of phantom pairs. Every generator that trusts it (`buildComparisonRecommendations`, `semantic-internal-linking`, `conversion-aware-layouts`, `semantic-runtime`, `internal-link-density`, `authority-runtime`, `ComparisonRecommendations`) could emit an on-page `/guides/compare/<pair>` link that 404s.

## What

- **`lib/comparison-utils.ts`** — `validSlugs` now derives from `BUILT_COMPARE_SLUGS`, an exported **pure literal** of the 10 real `app/guides/compare/<slug>/page.tsx` pages. Kept `node:fs`-free because RSC/authority components import this module. Dropped the config-list imports and the adjacent-pairs list; corrected the `isBuiltComparisonSlug` JSDoc (it referenced a `[slug]` / `generateStaticParams` route that doesn't exist).
- **`app/__tests__/compare-sitemap-integrity.test.ts`** — asserts `BUILT_COMPARE_SLUGS` never drifts from the real `page.tsx` directories (`getBuiltCompareSlugs()`), so adding/removing a compare page without updating the literal fails CI.
- **`app/__tests__/compare-link-integrity.test.ts`** — corrected the assertion that wrongly encoded an unbuilt adjacent pair (`aescin-vs-ajoene`) as "built".

## Effect

The guard now allows exactly the 10 built pages. `getValidComparisonSlug` returns a slug only for real pages, so profile discovery sections and internal-link generators **stop emitting 404 comparison links**. This visibly reduces the number of on-page comparison links — but every removed link pointed at a page that doesn't exist.

## Verification

- Drove the guard directly: real built pairs resolve, unbuilt pairs return `undefined`, and **0 slugs leak past the guard**.
- Typecheck + ESLint clean; **full suite: 452 tests pass** (74 files).
- Pure-module invariant preserved (no `node:fs` in `comparison-utils.ts`); all consumers are server/lib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5BJzyhpmTd72Awzn2PS6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5BJzyhpmTd72Awzn2PS6Q)_