### PR TITLE
Fix invalid Article structured data across profile & article pages

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -551,6 +551,7 @@ function ArticleJsonLd({
     description,
     url,
     mainEntityOfPage: url,
+    image: `${SITE_URL}/og-default.jpg`,
     dateModified,
     author: { '@type': 'Organization', name: SITE_NAME, url: SITE_URL },
     publisher: { '@type': 'Organization', name: SITE_NAME, url: SITE_URL },

--- a/app/articles/[slug]/page.tsx
+++ b/app/articles/[slug]/page.tsx
@@ -68,9 +68,13 @@ export default async function ArticleMonographPage({ params }: PageProps) {
     dateModified: page.lastUpdated,
     datePublished: page.date ?? page.lastUpdated,
     mainEntityOfPage: `${SITE_URL}/articles/${page.slug}/`,
+    image: `${SITE_URL}/og-default.jpg`,
     keywords: page.tags,
     articleSection: page.category,
-    ...(author ? { author: { '@type': 'Person', name: author } } : {}),
+    author: author
+      ? { '@type': 'Person', name: author }
+      : { '@type': 'Organization', name: 'The Hippie Scientist', url: SITE_URL },
+    publisher: { '@type': 'Organization', name: 'The Hippie Scientist', url: SITE_URL },
     citation: page.references.map((ref) => ({
       '@type': 'ScholarlyArticle',
       headline: ref.title,

--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -322,54 +322,14 @@ export async function generateMetadata({ params }: PageProps) {
 }
 
 function CompoundMdxPage({ page }: { page: (typeof allCompoundMdxPages)[number] }) {
-  const breadcrumbSchema = {
-    '@context': 'https://schema.org',
-    '@type': 'BreadcrumbList',
-    itemListElement: [
-      {
-        '@type': 'ListItem',
-        position: 1,
-        name: 'Compounds',
-        item: `${SITE_URL}/compounds/`,
-      },
-      {
-        '@type': 'ListItem',
-        position: 2,
-        name: page.title,
-        item: `${SITE_URL}/compounds/${page.slug}/`,
-      },
-    ],
-  }
-
-  const articleSchema = {
-    '@context': 'https://schema.org',
-    '@type': 'Article',
-    headline: page.title,
-    description: page.metaDescription,
-    dateModified: page.lastUpdated,
-    datePublished: page.lastUpdated,
-    mainEntityOfPage: `${SITE_URL}/compounds/${page.slug}/`,
-    keywords: page.keywords,
-    citation: page.references.map((ref) => ({
-      '@type': 'ScholarlyArticle',
-      headline: ref.title,
-      author: ref.authors,
-      datePublished: ref.year,
-      identifier: ref.pmid ? `PMID:${ref.pmid}` : undefined,
-      url: ref.url || (ref.pmid ? `https://pubmed.ncbi.nlm.nih.gov/${ref.pmid}/` : undefined),
-    })),
-  }
-
+  // Structured data (Article + BreadcrumbList + MedicalWebPage + FAQ) is emitted
+  // once via the complete <SchemaGraphScript graph={schemaGraph} /> below. A separate
+  // hand-built Article/BreadcrumbList used to be rendered here too, which produced a
+  // second, incomplete Article (missing author/publisher/image) on every compound
+  // page — the source of the invalid structured-data cluster. The graph is now the
+  // single source of truth, matching the herb profile page.
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
-      />
       <ReadingProgress />
 
       <article className="mx-auto max-w-5xl px-4 pb-20 pt-6 sm:px-6 lg:px-8">

--- a/app/novel-psychoactive-substances/[slug]/page.tsx
+++ b/app/novel-psychoactive-substances/[slug]/page.tsx
@@ -57,6 +57,9 @@ export default async function NovelPsychoactiveSubstanceArticlePage({ params }: 
     dateModified: page.lastUpdated,
     datePublished: page.lastUpdated,
     mainEntityOfPage: `${SITE_URL}/novel-psychoactive-substances/${page.slug}/`,
+    image: `${SITE_URL}/og-default.jpg`,
+    author: { '@type': 'Organization', name: 'The Hippie Scientist', url: SITE_URL },
+    publisher: { '@type': 'Organization', name: 'The Hippie Scientist', url: SITE_URL },
     keywords: page.keywords,
     articleSection: 'Novel Psychoactive Substances',
   }


### PR DESCRIPTION
Targets the Semrush **"930 structured data items are invalid"** error (the largest in the July 8 audit). The companion audit fixes from the same report — `llms.txt`, both broken guide images, and the compounds pagination description — already landed via #2105, so this PR is now scoped to the remaining structured-data problems and rebased onto current `main`.

## Changes
- **Compound profile pages** emitted a redundant, **incomplete** hand-built `Article` (no `author`/`publisher`/`image`) plus a duplicate `BreadcrumbList` *alongside* the complete `<SchemaGraphScript>` graph — a second, invalid Article on every compound page. Removed the redundant pair; the graph (valid `Article` + `BreadcrumbList` + `MedicalWebPage` + `FAQ`) is now the single source of truth, matching the herb profile page.
- Completed the remaining hand-built Article generators missing Google's required fields:
  - `novel-psychoactive-substances/[slug]` and `articles/[slug]` now include `image` + `publisher` (articles always carries an `author` — Person when reviewed, else the publishing Organization).
  - `app/[slug]` gained `image`.

## Verification
- Typecheck + ESLint clean; **full test suite: 451 tests pass** (74 files).
- Rebased cleanly onto current `main` (post-#2105); scoped to 4 files, no overlap with the already-merged companion fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5BJzyhpmTd72Awzn2PS6Q