### PR TITLE
Fix duplicate profile titles (Semrush duplicate-title error)

### DIFF
--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1047,15 +1047,41 @@ export function formatProfileDescription(
   return formatMetaDescription(raw, fallback, 160)
 }
 
+/**
+ * Explicit metadata overrides for near-duplicate profile slugs — sleep/context
+ * variant pages and alias/salt forms whose generated title collapses to the same
+ * string as their primary (the parenthetical qualifier in `name`, e.g.
+ * "Glycine (Sleep Use)", is stripped by getProfileDisplayName). Each override gives
+ * the SECONDARY page of a pair a unique, accurate title (and a description where the
+ * generated one also collided), resolving the duplicate-title / duplicate-meta SEO
+ * issue while keeping both pages indexable. The primary page keeps its generated title.
+ */
+const PROFILE_METADATA_OVERRIDES: Record<string, { title: string; description?: string }> = {
+  'glycine-sleep': { title: 'Glycine for Sleep: Effects, Dose & Safety' },
+  'inositol-sleep': { title: 'Inositol for Sleep & Anxiety: Effects, Dose & Safety' },
+  'l-theanine-sleep': { title: 'L-Theanine for Sleep: Effects, Dose & Safety' },
+  'taurine-sleep': { title: 'Taurine for Sleep: Effects, Dose & Safety' },
+  'berberine-hcl': {
+    title: 'Berberine HCl: Effects, Dose & Safety',
+    description:
+      'Berberine HCl (hydrochloride salt) dosage, absorption, blood-sugar and lipid effects, onset, and safety limits, graded against research evidence.',
+  },
+  'coenzyme-q10': { title: 'Coenzyme Q10 (CoQ10): Effects, Dose & Safety' },
+  'silybum-marianum': { title: 'Silybum Marianum (Milk Thistle): Benefits, Dosage & Safety' },
+}
+
 export function generateDetailMetadata(record: any, type: 'herb' | 'compound'): Metadata {
   const displayName = getProfileDisplayName(record)
+  const override = PROFILE_METADATA_OVERRIDES[String(record?.slug || '').toLowerCase()]
 
   // Title Priority:
+  // 0. near-duplicate disambiguation override (see PROFILE_METADATA_OVERRIDES)
   // 1. meta_title
   // 2. seoTitle
   // 3. keyword-first generated title
   // 4. fallback entity/page title
-  const title = getSafeProfileTitleOverride(record, displayName, type) ||
+  const title = override?.title ||
+                getSafeProfileTitleOverride(record, displayName, type) ||
                 formatProfileTitle(displayName, type) ||
                 displayName
 
@@ -1070,7 +1096,8 @@ export function generateDetailMetadata(record: any, type: 'herb' | 'compound'): 
     : `${displayName} dosage, effects, onset, and safety graded against research evidence.`
 
   const rawDescription = (record.meta_description || record.metaDescription || record.description || '').trim()
-  const description = normalizeProfileNameInText(rawDescription, displayName) ||
+  const description = override?.description ||
+                      normalizeProfileNameInText(rawDescription, displayName) ||
                       keywordFirstDescription ||
                       safeFallbackDescription
 


### PR DESCRIPTION
Resolves the Semrush **duplicate `<title>` tags** error by locating and fixing the collisions in code.

## Root cause
`getProfileDisplayName` deliberately strips the trailing parenthetical qualifier from a record's name (e.g. `"Glycine (Sleep Use)"` → `"Glycine"`). That collapsed **7 same-substance pairs** (14 pages) to identical titles:

| Pair | Was (both) |
|---|---|
| glycine / glycine-sleep | "Glycine: Effects, Dose and Safety" |
| inositol / inositol-sleep | "Inositol: …" |
| l-theanine / l-theanine-sleep | "L-Theanine: …" |
| taurine / taurine-sleep | "Taurine: …" |
| berberine / berberine-hcl | "Berberine: …" |
| coenzyme-q10 / coq10 | "Coenzyme Q10: …" |
| milk-thistle / silybum-marianum | "Milk Thistle Benefits, Dosage & Safety" |

## Fix
Added `PROFILE_METADATA_OVERRIDES` in `generateDetailMetadata` — an explicit, reviewable per-slug title (plus description where the generated one also collided) for the **secondary** page of each pair, keeping both indexable with unique, accurate metadata. Primaries are unchanged.
- Sleep/context variants → `"<X> for Sleep: …"`.
- Salt/alias forms → `"Berberine HCl"` (with a unique description — the one pair whose generated description *also* collided), `"Coenzyme Q10 (CoQ10)"`, `"Silybum Marianum (Milk Thistle)"`.

## Verification
- Recomputed every indexable profile's title + description via the real `generateDetailMetadata`: **0 duplicate titles, 0 duplicate descriptions remain**, no new collisions introduced.
- Typecheck + ESLint clean; rendering / route-integrity / a11y tests pass.

## Note
For the two genuine same-molecule pairs (coq10↔coenzyme-q10, berberine↔berberine-hcl), the remaining Semrush "duplicate content" flag (near-identical page bodies) would ideally be consolidated with a `rel=canonical` — but that's a ranking-consolidation decision I've left for you, since the site currently marks both as public/indexable. This PR makes their metadata unique, which clears the title/description errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5BJzyhpmTd72Awzn2PS6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5BJzyhpmTd72Awzn2PS6Q)_