### PR TITLE
Canonicalize same-molecule duplicate profiles (duplicate-content fix)

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -4,7 +4,7 @@ import { MetadataRoute } from 'next';
 import matter from 'gray-matter';
 
 import { SITE_URL } from '../src/lib/site';
-import { shouldIndexRoute } from '../src/lib/seo';
+import { shouldIndexRoute, CANONICALIZED_AWAY_PROFILE_SLUGS } from '../src/lib/seo';
 import {
   CURATED_INDEXABLE_HERB_SLUGS,
   CURATED_INDEXABLE_COMPOUND_SLUGS,
@@ -574,6 +574,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   herbsData.forEach((herb) => {
     if (!herb.slug) return;
     if (DEPRECATED_HERBS.has(herb.slug.toLowerCase())) return;
+    if (CANONICALIZED_AWAY_PROFILE_SLUGS.has(herb.slug.toLowerCase())) return;
 
     const isCurated = curatedHerbs.has(herb.slug);
     if (!isCurated) {
@@ -586,6 +587,9 @@ export default function sitemap(): MetadataRoute.Sitemap {
   compoundsData.forEach((compound) => {
     if (!compound.slug) return;
     if (DEPRECATED_COMPOUNDS.has(compound.slug.toLowerCase())) return;
+    // Same-molecule duplicates canonicalized to their primary must not appear as
+    // their own URL in the sitemap (list canonical URLs only).
+    if (CANONICALIZED_AWAY_PROFILE_SLUGS.has(compound.slug.toLowerCase())) return;
 
     const isCurated = curatedCompounds.has(compound.slug);
     if (!isCurated) {

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1056,19 +1056,36 @@ export function formatProfileDescription(
  * generated one also collided), resolving the duplicate-title / duplicate-meta SEO
  * issue while keeping both pages indexable. The primary page keeps its generated title.
  */
-const PROFILE_METADATA_OVERRIDES: Record<string, { title: string; description?: string }> = {
+const PROFILE_METADATA_OVERRIDES: Record<string, { title: string; description?: string; canonical?: string }> = {
   'glycine-sleep': { title: 'Glycine for Sleep: Effects, Dose & Safety' },
   'inositol-sleep': { title: 'Inositol for Sleep & Anxiety: Effects, Dose & Safety' },
   'l-theanine-sleep': { title: 'L-Theanine for Sleep: Effects, Dose & Safety' },
   'taurine-sleep': { title: 'Taurine for Sleep: Effects, Dose & Safety' },
+  // Same-molecule duplicates (identical/near-identical page body): consolidate to the
+  // primary with rel=canonical so Google indexes one URL. `canonical` points the
+  // SECONDARY at its primary (berberine base; coq10 is the primary_runtime_priority
+  // form of Coenzyme Q10). The unique title/description above still render as a
+  // fallback signal in case the canonical is ignored.
   'berberine-hcl': {
     title: 'Berberine HCl: Effects, Dose & Safety',
     description:
       'Berberine HCl (hydrochloride salt) dosage, absorption, blood-sugar and lipid effects, onset, and safety limits, graded against research evidence.',
+    canonical: '/compounds/berberine/',
   },
-  'coenzyme-q10': { title: 'Coenzyme Q10 (CoQ10): Effects, Dose & Safety' },
+  'coenzyme-q10': { title: 'Coenzyme Q10 (CoQ10): Effects, Dose & Safety', canonical: '/compounds/coq10/' },
   'silybum-marianum': { title: 'Silybum Marianum (Milk Thistle): Benefits, Dosage & Safety' },
 }
+
+/**
+ * Profile slugs whose canonical points at a *different* (primary) URL — same-molecule
+ * duplicates consolidated via rel=canonical. They stay crawlable but must be kept OUT
+ * of the sitemap (a sitemap should list canonical URLs only).
+ */
+export const CANONICALIZED_AWAY_PROFILE_SLUGS: ReadonlySet<string> = new Set(
+  Object.entries(PROFILE_METADATA_OVERRIDES)
+    .filter(([slug, v]) => v.canonical && !v.canonical.includes(`/${slug}/`))
+    .map(([slug]) => slug),
+)
 
 export function generateDetailMetadata(record: any, type: 'herb' | 'compound'): Metadata {
   const displayName = getProfileDisplayName(record)
@@ -1102,6 +1119,10 @@ export function generateDetailMetadata(record: any, type: 'herb' | 'compound'): 
                       safeFallbackDescription
 
   const path = `/${type === 'herb' ? 'herbs' : 'compounds'}/${record.slug}`
+  // For same-molecule duplicates, point the canonical (and og:url) at the primary
+  // so search engines consolidate them; the real `path` still drives the robots
+  // decision below so the page itself stays crawlable and self-consistent.
+  const canonicalPath = override?.canonical || path
   const meta = buildMeta({ title, description, path })
 
   const indexDecision = shouldIndexRoute(path, record)
@@ -1124,7 +1145,7 @@ export function generateDetailMetadata(record: any, type: 'herb' | 'compound'): 
   return buildPageMetadata({
     title: meta.title,
     description: meta.description,
-    path,
+    path: canonicalPath,
     image: profileOgImage,
     openGraphType: 'article',
     robots: indexDecision.index


### PR DESCRIPTION
Follow-up to #2107, addressing the Semrush **duplicate-content** flag for the two profile pairs that are genuinely the same molecule under two slugs.

## Verified before acting
- **berberine-hcl**: summary/content **identical** to `berberine` → clear duplicate.
- **coenzyme-q10 / coq10**: same molecule; `coq10` is the designated `primary_runtime_priority` form.

## Changes
- Extended `PROFILE_METADATA_OVERRIDES` with an optional `canonical`, applied to the profile's `rel=canonical` + `og:url` in `generateDetailMetadata`:
  - `berberine-hcl` → `/compounds/berberine/`
  - `coenzyme-q10` → `/compounds/coq10/`
  - The **real path still drives the robots decision**, so the pages stay crawlable and self-consistent; the unique titles/descriptions from #2107 remain as a fallback signal if the canonical is ignored.
- Exported `CANONICALIZED_AWAY_PROFILE_SLUGS` and taught `app/sitemap.ts` to skip those slugs, so the sitemap lists **canonical URLs only** (avoids introducing non-canonical sitemap entries).

## Verification
- Confirmed canonicals resolve secondary → primary via the real `generateDetailMetadata`; the exported set is `{berberine-hcl, coenzyme-q10}`.
- Typecheck + ESLint clean; **full test suite: 451 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5BJzyhpmTd72Awzn2PS6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5BJzyhpmTd72Awzn2PS6Q)_