### PR TITLE
Remove invalid schema.org properties from herb entity structured data

### DIFF
--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -415,15 +415,18 @@ export function buildWorkbookEntitySchema(args: ProfileEntitySchemaArgs): Schema
     identifier: buildWorkbookIdentifiers({ kind: args.kind, slug: args.slug, record }),
     ...(scientificName ? { alternateName: scientificName } : {}),
     ...(category ? { category } : {}),
-    ...(evidenceLevel ? { evidenceLevel } : {}),
-    ...(safetyNotes ? { safetyWarnings: safetyNotes } : {}),
-    ...(knownUse.length ? { knownUse } : {}),
     ...(mechanisms.length ? { mechanismOfAction: mechanisms.join('; ') } : {}),
     ...(molecularFormula ? { molecularFormula } : {}),
     ...(sameAs.length ? { sameAs } : {}),
+    // `evidenceLevel`, `knownUse`, and `safetyWarnings` are NOT schema.org properties.
+    // On the herb entity's medical types (DietarySupplement / MedicalSubstance) the
+    // structured-data validator rejects them as invalid, so this data lives in
+    // `additionalProperty` (valid on any Thing) instead — no information is lost.
     additionalProperty: [
       propertyValue('workbook source', WORKBOOK_SOURCE_ID),
       propertyValue('static route', canonical),
+      ...(evidenceLevel ? [propertyValue('evidence level', String(evidenceLevel))] : []),
+      ...(safetyNotes ? [propertyValue('safety notes', String(safetyNotes))] : []),
       ...(mechanisms.length ? [propertyValue('mechanism summary', mechanisms.join('; '))] : []),
       ...(knownUse.length ? [propertyValue('profile use contexts', knownUse.join('; '))] : []),
     ],


### PR DESCRIPTION
Targets the **remaining structured-data errors** in the re-crawl. After the Article fix (#2106), the count dropped **930 → 259** — and **259 ≈ the 261 indexable herb pages**, which pinned the source.

## Diagnosis
The entity node is the only schema difference between page types: herbs are typed `DietarySupplement` / `MedicalSubstance`, compounds `ChemicalSubstance` / `MolecularEntity`. A herbs-only error therefore has to live on the entity node — and on the herb's medical types the validator rejects three **non-schema.org properties**:
- `evidenceLevel` — not a schema.org property
- `knownUse` — not a schema.org property
- `safetyWarnings` — no such property (the valid one is `safetyConsideration`)

(Compounds carry the same properties but their non-medical types aren't validated as strictly, which is why only herbs were flagged.)

## Fix
Moved all three into `additionalProperty` (valid on any `Thing`) as `PropertyValue`s — information preserved, node now validates. Valid top-level properties (`identifier`, `mechanismOfAction`, `molecularFormula`, `sameAs`, `category`, `alternateName`) are unchanged. Applies to compounds too (same data, now in `additionalProperty`) with no regression.

## Verification
- Re-dumped a herb's built graph: **no invalid top-level properties remain** on the entity node; the data is intact in `additionalProperty`.
- Typecheck + ESLint clean; **full suite: 451 tests pass**.

## Honest caveat
I can't run Google's Rich Results Test from this environment (proxy blocks external hosts), so this is a strong **evidence-based** fix (herb-count correlation + genuinely invalid property names) rather than validator-confirmed. If the next crawl still shows a residual, it'll narrow the target further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5BJzyhpmTd72Awzn2PS6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5BJzyhpmTd72Awzn2PS6Q)_