### PR TITLE
Add high-ROI sleep gap guides

### DIFF
--- a/app/guides/sleep/apigenin-for-sleep/page.tsx
+++ b/app/guides/sleep/apigenin-for-sleep/page.tsx
@@ -1,0 +1,198 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { SITE_URL } from '@/src/lib/seo'
+
+const path = '/guides/sleep/apigenin-for-sleep/'
+
+export const metadata: Metadata = {
+  title: 'Apigenin for Sleep: Evidence, Dose Caution, and Reality Check',
+  description:
+    'A cautious evidence review of apigenin for sleep, why chamomile evidence does not automatically prove isolated apigenin works, and how to think about dose and safety.',
+  alternates: { canonical: `${SITE_URL}${path}` },
+  openGraph: {
+    title: 'Apigenin for Sleep',
+    description: 'A reality-check guide for the trending apigenin sleep supplement.',
+    url: `${SITE_URL}${path}`,
+    type: 'article',
+    images: ['/og-default.jpg'],
+  },
+}
+
+const quickTake = [
+  'Apigenin is a trending sleep compound, but the strongest public-facing evidence is still mostly chamomile-adjacent rather than isolated apigenin insomnia evidence.',
+  'Chamomile contains apigenin, but a chamomile tea or extract study does not automatically validate every standalone apigenin capsule.',
+  'The best framing is experimental calm support with low confidence, not a proven natural sleep medication.',
+]
+
+const verdictRows = [
+  {
+    question: 'Is apigenin proven for insomnia?',
+    answer: 'No',
+    note: 'Evidence is not strong enough to frame isolated apigenin as an insomnia treatment.',
+  },
+  {
+    question: 'Is chamomile evidence the same thing?',
+    answer: 'No',
+    note: 'Chamomile contains multiple compounds. Apigenin may be part of the story, but it is not the whole extract.',
+  },
+  {
+    question: 'Could it still be worth a cautious trial?',
+    answer: 'Maybe',
+    note: 'Only if expectations are modest and safety context is clean.',
+  },
+  {
+    question: 'Should it be stacked immediately?',
+    answer: 'No',
+    note: 'Start with one variable. Stacking apigenin with melatonin, magnesium, valerian, or sedatives makes response hard to interpret.',
+  },
+]
+
+const sections = [
+  {
+    heading: 'Why this page exists',
+    body: [
+      'Apigenin is popular because it sounds more scientific than chamomile tea. That creates a classic supplement-content gap: people search for a specific molecule, but most practical evidence comes from whole-herb chamomile studies or mechanistic discussion.',
+      'The useful answer is not hype or dismissal. The useful answer is separation: chamomile evidence, apigenin mechanism, isolated supplement claims, and safety context are related but not identical.',
+    ],
+  },
+  {
+    heading: 'Evidence grade: low to limited',
+    body: [
+      'Chamomile has small human studies and reviews around sleep quality, but results are mixed and not strong enough to treat it like a reliable insomnia intervention. Isolated apigenin has even less direct sleep-specific human evidence.',
+      'That means apigenin can be discussed as a plausible sleep-adjacent compound, but the claim ceiling should stay low: possible relaxation support, not proven sleep architecture optimization.',
+    ],
+  },
+  {
+    heading: 'Dose reality check',
+    body: [
+      'Apigenin labels vary. Some products use standalone apigenin, while others sell chamomile extracts or blends. Those are not interchangeable without knowing the extract standardization and serving size.',
+      'Because direct dose-response evidence for isolated apigenin sleep use is not mature, this page avoids pretending there is a universally proven sleep dose. The conservative decision is to avoid aggressive stacking and to reassess quickly if there is no clear benefit.',
+    ],
+  },
+  {
+    heading: 'Safety and interaction flags',
+    body: [
+      'The biggest practical safety issue is not that apigenin is uniquely scary. It is that sleep users often stack it with multiple calming products, alcohol, antihistamines, benzodiazepines, sleep medications, or other sedating substances.',
+      'Chamomile-related products may also matter for people with allergies to plants in the Asteraceae family. Pregnancy, breastfeeding, liver concerns, anticoagulant use, and complex medication regimens deserve individualized guidance before experimenting.',
+    ],
+  },
+  {
+    heading: 'Better first choices for most sleep problems',
+    body: [
+      'If the issue is sleep timing, melatonin is the more targeted tool. If the issue is body tension or low magnesium intake, magnesium glycinate is the cleaner first experiment. If the issue is mental arousal, L-theanine has a more practical calm-use history.',
+      'Apigenin fits best as a low-confidence, trend-driven curiosity page. That is still valuable content because it helps readers avoid buying a supplement only because the molecule name sounds precise.',
+    ],
+  },
+]
+
+const references = [
+  {
+    label: 'Chamomile sleep evidence overview, Verywell Health',
+    href: 'https://www.verywellhealth.com/what-the-research-says-about-popular-sleep-supplements-7970910',
+  },
+  {
+    label: 'Chamomile tea sleep evidence and apigenin discussion, Verywell Health',
+    href: 'https://www.verywellhealth.com/does-chamomile-tea-make-you-sleepy-8602726',
+  },
+]
+
+export default function Page() {
+  return (
+    <main className="mx-auto max-w-4xl px-4 pb-24 pt-8 sm:px-6 lg:px-8">
+      <nav className="mb-6 text-xs text-muted" aria-label="Breadcrumb">
+        <Link href="/guides/" className="hover:text-ink">Guides</Link>
+        <span className="mx-1.5">/</span>
+        <Link href="/guides/sleep/" className="hover:text-ink">Sleep</Link>
+        <span className="mx-1.5">/</span>
+        <span className="font-medium text-ink">Apigenin for Sleep</span>
+      </nav>
+
+      <article className="space-y-8">
+        <header className="rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-10 dark:border-white/10 dark:bg-[var(--surface-card)]">
+          <p className="eyebrow-label">Trend reality check</p>
+          <h1 className="heading-premium mt-3 text-ink dark:text-[var(--text-primary)]">Apigenin for Sleep: Evidence, Dose Caution, and Reality Check</h1>
+          <p className="mt-4 max-w-3xl text-base leading-8 text-muted dark:text-[var(--text-secondary)]">
+            Apigenin is getting searched like a proven sleep hack. The evidence is more complicated. This guide keeps the molecule, chamomile, and supplement-label claims in separate boxes.
+          </p>
+          <div className="mt-5 flex flex-wrap gap-2 text-xs font-semibold text-brand-800 dark:text-[var(--text-primary)]">
+            <span className="rounded-full border border-brand-900/10 bg-brand-50 px-3 py-1 dark:border-white/10 dark:bg-[var(--surface-subtle)]">8 min read</span>
+            <span className="rounded-full border border-brand-900/10 bg-brand-50 px-3 py-1 dark:border-white/10 dark:bg-[var(--surface-subtle)]">Low confidence</span>
+            <span className="rounded-full border border-brand-900/10 bg-brand-50 px-3 py-1 dark:border-white/10 dark:bg-[var(--surface-subtle)]">Updated July 8, 2026</span>
+          </div>
+        </header>
+
+        <section className="card-premium p-6 sm:p-8">
+          <h2 className="text-xl font-semibold text-ink dark:text-[var(--text-primary)]">TL;DR</h2>
+          <ul className="mt-4 space-y-3 text-sm leading-7 text-muted dark:text-[var(--text-secondary)]">
+            {quickTake.map((item) => (
+              <li key={item} className="flex gap-3">
+                <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-brand-700" />
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="card-premium p-6 sm:p-8">
+          <h2 className="text-xl font-semibold text-ink dark:text-[var(--text-primary)]">Verdict table</h2>
+          <div className="mt-5 overflow-x-auto">
+            <table className="min-w-full border-collapse text-left text-sm">
+              <thead>
+                <tr className="border-b border-brand-900/10 dark:border-white/10">
+                  <th className="py-3 pr-4 text-xs font-bold uppercase tracking-wider text-ink dark:text-[var(--text-primary)]">Question</th>
+                  <th className="py-3 pr-4 text-xs font-bold uppercase tracking-wider text-ink dark:text-[var(--text-primary)]">Answer</th>
+                  <th className="py-3 text-xs font-bold uppercase tracking-wider text-ink dark:text-[var(--text-primary)]">Context</th>
+                </tr>
+              </thead>
+              <tbody>
+                {verdictRows.map((row) => (
+                  <tr key={row.question} className="border-b border-brand-900/5 align-top last:border-0 dark:border-white/10">
+                    <td className="py-3 pr-4 font-semibold text-ink dark:text-[var(--text-primary)]">{row.question}</td>
+                    <td className="py-3 pr-4 text-muted dark:text-[var(--text-secondary)]">{row.answer}</td>
+                    <td className="py-3 text-muted dark:text-[var(--text-secondary)]">{row.note}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {sections.map((section) => (
+          <section key={section.heading} className="card-premium p-6 sm:p-8">
+            <h2 className="text-xl font-semibold text-ink dark:text-[var(--text-primary)]">{section.heading}</h2>
+            <div className="mt-4 space-y-4 text-sm leading-7 text-muted dark:text-[var(--text-secondary)]">
+              {section.body.map((paragraph) => (
+                <p key={paragraph}>{paragraph}</p>
+              ))}
+            </div>
+          </section>
+        ))}
+
+        <section className="rounded-2xl border border-amber-800/15 bg-amber-50/70 p-6 shadow-sm dark:border-white/10 dark:bg-[var(--surface-subtle)]">
+          <h2 className="text-xl font-semibold text-ink dark:text-[var(--text-primary)]">Better first reads</h2>
+          <p className="mt-2 text-sm leading-7 text-muted dark:text-[var(--text-secondary)]">
+            For most readers, apigenin should come after the cleaner decision pages. Start with the actual sleep problem, then decide whether a low-confidence trend supplement is even needed.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-3 text-sm font-semibold">
+            <Link href="/guides/sleep/sleep-best-supplements/" className="text-brand-800 hover:underline dark:text-[var(--text-primary)]">Best sleep supplements →</Link>
+            <Link href="/guides/sleep/l-theanine-for-sleep/" className="text-brand-800 hover:underline dark:text-[var(--text-primary)]">L-theanine for sleep →</Link>
+            <Link href="/guides/sleep/magnesium-for-sleep/" className="text-brand-800 hover:underline dark:text-[var(--text-primary)]">Magnesium for sleep →</Link>
+          </div>
+        </section>
+
+        <section className="card-premium p-6 sm:p-8">
+          <h2 className="text-xl font-semibold text-ink dark:text-[var(--text-primary)]">References</h2>
+          <ul className="mt-4 space-y-2 text-sm leading-7 text-muted dark:text-[var(--text-secondary)]">
+            {references.map((reference) => (
+              <li key={reference.href}>
+                <a href={reference.href} className="font-semibold text-brand-800 hover:underline dark:text-[var(--text-primary)]" rel="noreferrer" target="_blank">
+                  {reference.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </article>
+    </main>
+  )
+}

--- a/app/guides/sleep/glycine-for-sleep/page.tsx
+++ b/app/guides/sleep/glycine-for-sleep/page.tsx
@@ -1,0 +1,197 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { SITE_URL } from '@/src/lib/seo'
+
+const path = '/guides/sleep/glycine-for-sleep/'
+
+export const metadata: Metadata = {
+  title: 'Glycine for Sleep: Dose, Evidence, and Best Fit',
+  description:
+    'Evidence-first guide to glycine for sleep, including 3 gram dosing context, who it fits, what the evidence can and cannot say, and how it compares with magnesium glycinate.',
+  alternates: { canonical: `${SITE_URL}${path}` },
+  openGraph: {
+    title: 'Glycine for Sleep',
+    description: 'A cautious guide to glycine for sleep quality, next-day tiredness, and magnesium glycinate confusion.',
+    url: `${SITE_URL}${path}`,
+    type: 'article',
+    images: ['/og-default.jpg'],
+  },
+}
+
+const quickTake = [
+  'Glycine is a higher-dose amino acid sleep experiment, not the same thing as magnesium glycinate.',
+  'The most common sleep-oriented trial pattern is about 3 grams 30-60 minutes before bed, usually as powder because capsule counts get high fast.',
+  'The best-fit use case is sleep quality, subjective refreshment, or next-day tiredness after short sleep. It is not a strong sedative or insomnia treatment.',
+]
+
+const fitRows = [
+  {
+    situation: 'You fall asleep but wake up unrefreshed',
+    fit: 'Possible fit',
+    why: 'Glycine has human evidence around subjective sleep quality and next-day fatigue, but effects are modest.',
+  },
+  {
+    situation: 'You want a knockout sleep aid',
+    fit: 'Poor fit',
+    why: 'Glycine is better framed as sleep-quality support than as a heavy sedative.',
+  },
+  {
+    situation: 'You already take magnesium glycinate',
+    fit: 'Do not assume equivalence',
+    why: 'The glycine attached to magnesium glycinate is usually far below a standalone 3 gram glycine trial.',
+  },
+  {
+    situation: 'You have complex medication or metabolic issues',
+    fit: 'Caution',
+    why: 'Keep the experiment conservative and discuss it with a clinician if your situation is medically complex.',
+  },
+]
+
+const sections = [
+  {
+    heading: 'What glycine is trying to solve',
+    body: [
+      'Glycine is an amino acid that also acts as a signaling molecule in the nervous system. For sleep, the practical idea is not to force sedation. The more defensible idea is to support a calmer sleep transition and possibly improve perceived sleep quality or next-day alertness.',
+      'That makes glycine different from melatonin. Melatonin is mostly a timing signal. Glycine is not mainly about shifting the body clock. It belongs closer to the sleep-quality and recovery side of the decision tree.',
+    ],
+  },
+  {
+    heading: 'Evidence grade: limited but interesting',
+    body: [
+      'The glycine sleep evidence is smaller than the internet hype makes it sound. Human trials and reviews suggest possible improvements in subjective sleep quality, fatigue, or daytime performance, but this is not a giant insomnia evidence base.',
+      'That means the honest framing is: glycine may be worth a clean, short trial for the right sleep problem, but it should not be sold as a guaranteed deep-sleep enhancer.',
+    ],
+  },
+  {
+    heading: 'Dose and timing',
+    body: [
+      'A common study-informed sleep dose is 3 grams before bed. Most people who try this use powder mixed in water because reaching 3 grams with capsules can require several pills.',
+      'A practical experiment is 30-60 minutes before bed for several nights, while keeping caffeine timing, bedtime, light exposure, and other supplements stable. If you change everything at once, you cannot tell what helped.',
+    ],
+  },
+  {
+    heading: 'Glycine vs magnesium glycinate',
+    body: [
+      'Magnesium glycinate contains magnesium bound to glycine, but that does not make it a 3 gram glycine supplement. A magnesium glycinate product may be useful for magnesium intake and tolerability, while standalone glycine is a separate amino acid dose decision.',
+      'If your problem is body tension, low magnesium intake, or muscle tightness, magnesium glycinate may be the cleaner first experiment. If the problem is subjective sleep quality or next-day tiredness despite enough sleep opportunity, glycine may deserve its own page in the decision tree.',
+    ],
+  },
+  {
+    heading: 'Safety notes',
+    body: [
+      'Glycine is generally well tolerated in short-term supplement contexts, but sleep use still deserves basic discipline: start with one change, avoid combining with multiple sedating products, and stop if you feel worse.',
+      'People who are pregnant, breastfeeding, managing serious psychiatric or metabolic conditions, or using complex medication regimens should treat glycine like any other supplement experiment and get individualized guidance.',
+    ],
+  },
+]
+
+const references = [
+  {
+    label: 'Glycine and sleep-restricted daytime performance, PubMed',
+    href: 'https://pubmed.ncbi.nlm.nih.gov/22529837/',
+  },
+  {
+    label: 'Recent consumer evidence summary on glycine vs magnesium glycinate',
+    href: 'https://www.health.com/glycine-vs-magnesium-glycinate-for-sleep-11898452',
+  },
+]
+
+export default function Page() {
+  return (
+    <main className="mx-auto max-w-4xl px-4 pb-24 pt-8 sm:px-6 lg:px-8">
+      <nav className="mb-6 text-xs text-muted" aria-label="Breadcrumb">
+        <Link href="/guides/" className="hover:text-ink">Guides</Link>
+        <span className="mx-1.5">/</span>
+        <Link href="/guides/sleep/" className="hover:text-ink">Sleep</Link>
+        <span className="mx-1.5">/</span>
+        <span className="font-medium text-ink">Glycine for Sleep</span>
+      </nav>
+
+      <article className="space-y-8">
+        <header className="rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-10 dark:border-white/10 dark:bg-[var(--surface-card)]">
+          <p className="eyebrow-label">Sleep gap guide</p>
+          <h1 className="heading-premium mt-3 text-ink dark:text-[var(--text-primary)]">Glycine for Sleep: Dose, Evidence, and Best Fit</h1>
+          <p className="mt-4 max-w-3xl text-base leading-8 text-muted dark:text-[var(--text-secondary)]">
+            Glycine is one of the cleaner long-tail sleep topics because people confuse it with magnesium glycinate. This page separates the amino acid dose from the magnesium form so the decision stays practical.
+          </p>
+          <div className="mt-5 flex flex-wrap gap-2 text-xs font-semibold text-brand-800 dark:text-[var(--text-primary)]">
+            <span className="rounded-full border border-brand-900/10 bg-brand-50 px-3 py-1 dark:border-white/10 dark:bg-[var(--surface-subtle)]">9 min read</span>
+            <span className="rounded-full border border-brand-900/10 bg-brand-50 px-3 py-1 dark:border-white/10 dark:bg-[var(--surface-subtle)]">Limited evidence</span>
+            <span className="rounded-full border border-brand-900/10 bg-brand-50 px-3 py-1 dark:border-white/10 dark:bg-[var(--surface-subtle)]">Updated July 8, 2026</span>
+          </div>
+        </header>
+
+        <section className="card-premium p-6 sm:p-8">
+          <h2 className="text-xl font-semibold text-ink dark:text-[var(--text-primary)]">TL;DR</h2>
+          <ul className="mt-4 space-y-3 text-sm leading-7 text-muted dark:text-[var(--text-secondary)]">
+            {quickTake.map((item) => (
+              <li key={item} className="flex gap-3">
+                <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-brand-700" />
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="card-premium p-6 sm:p-8">
+          <h2 className="text-xl font-semibold text-ink dark:text-[var(--text-primary)]">Best-fit decision table</h2>
+          <div className="mt-5 overflow-x-auto">
+            <table className="min-w-full border-collapse text-left text-sm">
+              <thead>
+                <tr className="border-b border-brand-900/10 dark:border-white/10">
+                  <th className="py-3 pr-4 text-xs font-bold uppercase tracking-wider text-ink dark:text-[var(--text-primary)]">Situation</th>
+                  <th className="py-3 pr-4 text-xs font-bold uppercase tracking-wider text-ink dark:text-[var(--text-primary)]">Fit</th>
+                  <th className="py-3 text-xs font-bold uppercase tracking-wider text-ink dark:text-[var(--text-primary)]">Why</th>
+                </tr>
+              </thead>
+              <tbody>
+                {fitRows.map((row) => (
+                  <tr key={row.situation} className="border-b border-brand-900/5 align-top last:border-0 dark:border-white/10">
+                    <td className="py-3 pr-4 font-semibold text-ink dark:text-[var(--text-primary)]">{row.situation}</td>
+                    <td className="py-3 pr-4 text-muted dark:text-[var(--text-secondary)]">{row.fit}</td>
+                    <td className="py-3 text-muted dark:text-[var(--text-secondary)]">{row.why}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {sections.map((section) => (
+          <section key={section.heading} className="card-premium p-6 sm:p-8">
+            <h2 className="text-xl font-semibold text-ink dark:text-[var(--text-primary)]">{section.heading}</h2>
+            <div className="mt-4 space-y-4 text-sm leading-7 text-muted dark:text-[var(--text-secondary)]">
+              {section.body.map((paragraph) => (
+                <p key={paragraph}>{paragraph}</p>
+              ))}
+            </div>
+          </section>
+        ))}
+
+        <section className="rounded-2xl border border-emerald-800/15 bg-emerald-50/70 p-6 shadow-sm dark:border-white/10 dark:bg-[var(--surface-subtle)]">
+          <h2 className="text-xl font-semibold text-ink dark:text-[var(--text-primary)]">Next comparison</h2>
+          <p className="mt-2 text-sm leading-7 text-muted dark:text-[var(--text-secondary)]">
+            If the decision is actually about the magnesium form, compare this with the magnesium buying guide instead of assuming all glycinate products behave like standalone glycine.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-3 text-sm font-semibold">
+            <Link href="/guides/sleep/best-magnesium-for-sleep/" className="text-brand-800 hover:underline dark:text-[var(--text-primary)]">Best magnesium for sleep →</Link>
+            <Link href="/guides/sleep/magnesium-for-sleep/" className="text-brand-800 hover:underline dark:text-[var(--text-primary)]">Magnesium for sleep →</Link>
+          </div>
+        </section>
+
+        <section className="card-premium p-6 sm:p-8">
+          <h2 className="text-xl font-semibold text-ink dark:text-[var(--text-primary)]">References</h2>
+          <ul className="mt-4 space-y-2 text-sm leading-7 text-muted dark:text-[var(--text-secondary)]">
+            {references.map((reference) => (
+              <li key={reference.href}>
+                <a href={reference.href} className="font-semibold text-brand-800 hover:underline dark:text-[var(--text-primary)]" rel="noreferrer" target="_blank">
+                  {reference.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </article>
+    </main>
+  )
+}

--- a/app/guides/sleep/magnesium-glycinate-vs-l-threonate-for-sleep/page.tsx
+++ b/app/guides/sleep/magnesium-glycinate-vs-l-threonate-for-sleep/page.tsx
@@ -1,0 +1,209 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { SITE_URL } from '@/src/lib/seo'
+
+const path = '/guides/sleep/magnesium-glycinate-vs-l-threonate-for-sleep/'
+
+export const metadata: Metadata = {
+  title: 'Magnesium Glycinate vs L-Threonate for Sleep',
+  description:
+    'Compare magnesium glycinate and magnesium L-threonate for sleep by evidence, dose clarity, cost, tolerability, and when each form makes sense.',
+  alternates: { canonical: `${SITE_URL}${path}` },
+  openGraph: {
+    title: 'Magnesium Glycinate vs L-Threonate for Sleep',
+    description: 'A practical sleep-focused comparison of two popular magnesium forms.',
+    url: `${SITE_URL}${path}`,
+    type: 'article',
+    images: ['/og-default.jpg'],
+  },
+}
+
+const quickTake = [
+  'Magnesium glycinate is usually the cleaner first sleep pick because it is simpler, commonly tolerated, and easier to dose by elemental magnesium.',
+  'Magnesium L-threonate is more cognition-branded and more expensive. Sleep claims are interesting but not strong enough to beat glycinate for most first trials.',
+  'Do not buy either form only because the front label number looks big. Elemental magnesium, serving size, tolerability, and medication spacing matter more.',
+]
+
+const comparisonRows = [
+  {
+    factor: 'Best first sleep trial',
+    glycinate: 'Usually yes',
+    threonate: 'Maybe, but less necessary',
+    call: 'Glycinate wins for most readers.',
+  },
+  {
+    factor: 'Dose clarity',
+    glycinate: 'Often clearer if elemental magnesium is listed',
+    threonate: 'Can be confusing because total compound weight is emphasized',
+    call: 'Check elemental magnesium, not just capsule weight.',
+  },
+  {
+    factor: 'Tolerability',
+    glycinate: 'Often gentle, though not guaranteed',
+    threonate: 'Usually not as bowel-active as citrate, but product-specific',
+    call: 'Both can be reasonable; individual response matters.',
+  },
+  {
+    factor: 'Cost',
+    glycinate: 'Usually cheaper',
+    threonate: 'Usually premium-priced',
+    call: 'Do not pay premium unless the use case is clear.',
+  },
+  {
+    factor: 'Sleep evidence framing',
+    glycinate: 'Magnesium evidence plus practical form logic',
+    threonate: 'Emerging, product-specific, cognition-adjacent claims',
+    call: 'Neither deserves miracle-sleep language.',
+  },
+]
+
+const sections = [
+  {
+    heading: 'The practical answer',
+    body: [
+      'For most people comparing magnesium forms for sleep, magnesium glycinate or bisglycinate is the default first experiment. It is widely available, usually easier to tolerate than citrate, and fits the common sleep use case: physical tension, low intake, or general nervous-system calm.',
+      'Magnesium L-threonate is not useless. It is simply not the obvious first sleep purchase for most readers. It is usually marketed around brain magnesium and cognition, costs more, and the sleep story is still not strong enough to justify treating it as universally better.',
+    ],
+  },
+  {
+    heading: 'Evidence grade: form-specific claims are weaker than magnesium claims',
+    body: [
+      'The broad magnesium sleep evidence is already limited to moderate depending on the population and outcome. Once you narrow the claim to one exact form beating another exact form for sleep, the evidence gets weaker.',
+      'That is why this guide makes a practical call instead of a dramatic clinical claim: glycinate is the cleaner first buy for most sleep-focused users; L-threonate is a more expensive niche option with a less direct sleep rationale.',
+    ],
+  },
+  {
+    heading: 'How to read the label',
+    body: [
+      'Ignore the biggest front-label number until you know whether it refers to elemental magnesium or the total compound weight. A product can say hundreds or thousands of milligrams while delivering much less elemental magnesium.',
+      'For sleep, a conservative range often discussed on this site is 100-300 mg elemental magnesium in the evening. Start low if you are sensitive to supplements, have bowel issues, or already get a lot of magnesium from diet and other products.',
+    ],
+  },
+  {
+    heading: 'When L-threonate may make sense',
+    body: [
+      'L-threonate may make more sense when the buyer is specifically interested in cognition-adjacent magnesium claims and accepts the price premium. Even then, sleep should be tracked as an outcome, not assumed.',
+      'If the goal is simply better sleep quality with fewer variables, glycinate is usually the less complicated route. A simple, lower-cost experiment beats a premium supplement that solves the wrong problem.',
+    ],
+  },
+  {
+    heading: 'Safety and interaction notes',
+    body: [
+      'Both forms are magnesium supplements. The same high-level cautions apply: avoid unsupervised use in significant kidney disease, and separate magnesium from medications it can bind, including certain antibiotics, thyroid medication, and bisphosphonates.',
+      'Loose stools, nausea, dizziness, or next-day fog are reasons to reassess the dose, form, or the whole sleep plan. Do not stack magnesium with multiple calming products and assume more ingredients equals better sleep.',
+    ],
+  },
+]
+
+const references = [
+  {
+    label: 'Oral magnesium supplementation for insomnia review, PubMed',
+    href: 'https://pubmed.ncbi.nlm.nih.gov/33865376/',
+  },
+  {
+    label: 'Magnesium L-threonate summary and evidence caveats',
+    href: 'https://en.wikipedia.org/wiki/Magnesium_L-threonate',
+  },
+]
+
+export default function Page() {
+  return (
+    <main className="mx-auto max-w-4xl px-4 pb-24 pt-8 sm:px-6 lg:px-8">
+      <nav className="mb-6 text-xs text-muted" aria-label="Breadcrumb">
+        <Link href="/guides/" className="hover:text-ink">Guides</Link>
+        <span className="mx-1.5">/</span>
+        <Link href="/guides/sleep/" className="hover:text-ink">Sleep</Link>
+        <span className="mx-1.5">/</span>
+        <span className="font-medium text-ink">Magnesium Glycinate vs L-Threonate</span>
+      </nav>
+
+      <article className="space-y-8">
+        <header className="rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-10 dark:border-white/10 dark:bg-[var(--surface-card)]">
+          <p className="eyebrow-label">Sleep comparison guide</p>
+          <h1 className="heading-premium mt-3 text-ink dark:text-[var(--text-primary)]">Magnesium Glycinate vs L-Threonate for Sleep</h1>
+          <p className="mt-4 max-w-3xl text-base leading-8 text-muted dark:text-[var(--text-secondary)]">
+            This comparison fills a buyer-intent gap: people know they want magnesium for sleep, but they get stuck between glycinate and L-threonate. The answer is less glamorous than the labels make it sound.
+          </p>
+          <div className="mt-5 flex flex-wrap gap-2 text-xs font-semibold text-brand-800 dark:text-[var(--text-primary)]">
+            <span className="rounded-full border border-brand-900/10 bg-brand-50 px-3 py-1 dark:border-white/10 dark:bg-[var(--surface-subtle)]">10 min read</span>
+            <span className="rounded-full border border-brand-900/10 bg-brand-50 px-3 py-1 dark:border-white/10 dark:bg-[var(--surface-subtle)]">Buyer intent</span>
+            <span className="rounded-full border border-brand-900/10 bg-brand-50 px-3 py-1 dark:border-white/10 dark:bg-[var(--surface-subtle)]">Updated July 8, 2026</span>
+          </div>
+        </header>
+
+        <section className="card-premium p-6 sm:p-8">
+          <h2 className="text-xl font-semibold text-ink dark:text-[var(--text-primary)]">TL;DR</h2>
+          <ul className="mt-4 space-y-3 text-sm leading-7 text-muted dark:text-[var(--text-secondary)]">
+            {quickTake.map((item) => (
+              <li key={item} className="flex gap-3">
+                <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-brand-700" />
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="card-premium p-6 sm:p-8">
+          <h2 className="text-xl font-semibold text-ink dark:text-[var(--text-primary)]">Decision table</h2>
+          <div className="mt-5 overflow-x-auto">
+            <table className="min-w-full border-collapse text-left text-sm">
+              <thead>
+                <tr className="border-b border-brand-900/10 dark:border-white/10">
+                  <th className="py-3 pr-4 text-xs font-bold uppercase tracking-wider text-ink dark:text-[var(--text-primary)]">Factor</th>
+                  <th className="py-3 pr-4 text-xs font-bold uppercase tracking-wider text-ink dark:text-[var(--text-primary)]">Glycinate</th>
+                  <th className="py-3 pr-4 text-xs font-bold uppercase tracking-wider text-ink dark:text-[var(--text-primary)]">L-threonate</th>
+                  <th className="py-3 text-xs font-bold uppercase tracking-wider text-ink dark:text-[var(--text-primary)]">Call</th>
+                </tr>
+              </thead>
+              <tbody>
+                {comparisonRows.map((row) => (
+                  <tr key={row.factor} className="border-b border-brand-900/5 align-top last:border-0 dark:border-white/10">
+                    <td className="py-3 pr-4 font-semibold text-ink dark:text-[var(--text-primary)]">{row.factor}</td>
+                    <td className="py-3 pr-4 text-muted dark:text-[var(--text-secondary)]">{row.glycinate}</td>
+                    <td className="py-3 pr-4 text-muted dark:text-[var(--text-secondary)]">{row.threonate}</td>
+                    <td className="py-3 text-muted dark:text-[var(--text-secondary)]">{row.call}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {sections.map((section) => (
+          <section key={section.heading} className="card-premium p-6 sm:p-8">
+            <h2 className="text-xl font-semibold text-ink dark:text-[var(--text-primary)]">{section.heading}</h2>
+            <div className="mt-4 space-y-4 text-sm leading-7 text-muted dark:text-[var(--text-secondary)]">
+              {section.body.map((paragraph) => (
+                <p key={paragraph}>{paragraph}</p>
+              ))}
+            </div>
+          </section>
+        ))}
+
+        <section className="rounded-2xl border border-emerald-800/15 bg-emerald-50/70 p-6 shadow-sm dark:border-white/10 dark:bg-[var(--surface-subtle)]">
+          <h2 className="text-xl font-semibold text-ink dark:text-[var(--text-primary)]">Clean next step</h2>
+          <p className="mt-2 text-sm leading-7 text-muted dark:text-[var(--text-secondary)]">
+            If you are still early in the sleep decision, start with the broader magnesium guide, then use this page only when the form choice is the bottleneck.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-3 text-sm font-semibold">
+            <Link href="/guides/sleep/magnesium-for-sleep/" className="text-brand-800 hover:underline dark:text-[var(--text-primary)]">Magnesium for sleep →</Link>
+            <Link href="/guides/sleep/best-magnesium-for-sleep/" className="text-brand-800 hover:underline dark:text-[var(--text-primary)]">Best magnesium for sleep →</Link>
+          </div>
+        </section>
+
+        <section className="card-premium p-6 sm:p-8">
+          <h2 className="text-xl font-semibold text-ink dark:text-[var(--text-primary)]">References</h2>
+          <ul className="mt-4 space-y-2 text-sm leading-7 text-muted dark:text-[var(--text-secondary)]">
+            {references.map((reference) => (
+              <li key={reference.href}>
+                <a href={reference.href} className="font-semibold text-brand-800 hover:underline dark:text-[var(--text-primary)]" rel="noreferrer" target="_blank">
+                  {reference.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </article>
+    </main>
+  )
+}

--- a/app/guides/sleep/page.tsx
+++ b/app/guides/sleep/page.tsx
@@ -34,16 +34,34 @@ const START_HERE: IntentRoute[] = [
     href: '/guides/sleep/magnesium-for-sleep/',
   },
   {
+    problem: 'Waking up tired after short or light sleep',
+    why: 'Glycine is a sleep-quality experiment, not a knockout sedative.',
+    cta: 'Glycine for Sleep',
+    href: '/guides/sleep/glycine-for-sleep/',
+  },
+  {
     problem: 'Not sure which magnesium to buy',
     why: 'Glycinate, citrate, threonate and oxide are not interchangeable for sleep.',
     cta: 'Magnesium Types for Sleep',
     href: '/guides/sleep/magnesium-types-for-sleep/',
   },
   {
+    problem: 'Choosing glycinate vs L-threonate',
+    why: 'A buyer-intent comparison keeps premium forms from sounding automatically better.',
+    cta: 'Glycinate vs L-Threonate',
+    href: '/guides/sleep/magnesium-glycinate-vs-l-threonate-for-sleep/',
+  },
+  {
     problem: 'Stress-related insomnia',
     why: 'An adaptogen that lowers cortisol over weeks, not a same-night fix.',
     cta: 'Ashwagandha for Sleep',
     href: '/guides/sleep/ashwagandha-for-sleep/',
+  },
+  {
+    problem: 'Trending sleep supplements sound convincing',
+    why: 'Apigenin needs a reality check before it becomes another overstacked sleep trend.',
+    cta: 'Apigenin for Sleep',
+    href: '/guides/sleep/apigenin-for-sleep/',
   },
   {
     problem: 'Comparing your options',
@@ -77,6 +95,11 @@ const BEST_FIRST: GuideCard[] = [
     desc: 'The best-evidenced, lowest-risk first pick for most people.',
   },
   {
+    href: '/guides/sleep/glycine-for-sleep/',
+    title: 'Glycine for Sleep',
+    desc: 'For sleep-quality and next-day tiredness questions — not a knockout sedative.',
+  },
+  {
     href: '/guides/sleep/l-theanine-for-sleep/',
     title: 'L-Theanine for Sleep',
     desc: 'For a busy mind at lights-out — calm without grogginess.',
@@ -93,6 +116,11 @@ const COMPARISONS: GuideCard[] = [
     href: '/guides/sleep/magnesium-vs-melatonin/',
     title: 'Magnesium vs Melatonin',
     desc: 'Nervous-system calm vs circadian timing — which problem is yours?',
+  },
+  {
+    href: '/guides/sleep/magnesium-glycinate-vs-l-threonate-for-sleep/',
+    title: 'Magnesium Glycinate vs L-Threonate',
+    desc: 'Simple, lower-cost first trial vs premium cognition-branded magnesium.',
   },
   {
     href: '/guides/sleep/sleep-herbs-vs-melatonin/',
@@ -119,6 +147,9 @@ const ALL_GUIDES = [
   { slug: 'magnesium-for-sleep', title: 'Magnesium for Sleep' },
   { slug: 'best-magnesium-for-sleep', title: 'Best Magnesium for Sleep' },
   { slug: 'magnesium-types-for-sleep', title: 'Magnesium Types for Sleep' },
+  { slug: 'magnesium-glycinate-vs-l-threonate-for-sleep', title: 'Magnesium Glycinate vs L-Threonate for Sleep' },
+  { slug: 'glycine-for-sleep', title: 'Glycine for Sleep' },
+  { slug: 'apigenin-for-sleep', title: 'Apigenin for Sleep' },
   { slug: 'l-theanine-for-sleep', title: 'L-Theanine for Sleep' },
   { slug: 'ashwagandha-for-sleep', title: 'Ashwagandha for Sleep' },
   { slug: 'best-herbs-for-sleep', title: 'Best Herbs for Sleep' },


### PR DESCRIPTION
## Summary

- Adds three high-intent sleep guide pages:
  - `/guides/sleep/glycine-for-sleep/`
  - `/guides/sleep/apigenin-for-sleep/`
  - `/guides/sleep/magnesium-glycinate-vs-l-threonate-for-sleep/`
- Surfaces the new pages from the Sleep hub decision router, best-first cards, comparison cards, and full library.
- Keeps claims conservative: limited-evidence framing, clear safety cautions, references, and internal next-step links.

## Why this iteration

The content inventory flagged sleep supplement and magnesium-intent pages as thin / duplicate-risk opportunities. This pass fills adjacent long-tail and buyer-intent gaps without touching generated workbook data.

## Validation

- Not run locally from this connector.
- Changes are static App Router pages plus Sleep hub links; sitemap discovery should pick these up automatically via the existing app/guides scanner.