### PR TITLE
Fix structured data markup gaps from audit CSV

### DIFF
--- a/components/SchemaOrg.tsx
+++ b/components/SchemaOrg.tsx
@@ -1,4 +1,5 @@
 import type { SchemaNode } from '@/lib/schema'
+import { sanitizeJsonLdPayload } from '@/lib/json-ld-sanitize'
 
 type SchemaOrgProps = {
   graph?: Record<string, unknown> | null
@@ -35,7 +36,7 @@ function toPayload({
 }
 
 function serializeJsonLd(payload: Record<string, unknown> | SchemaNode): string {
-  return JSON.stringify(payload).replace(/</g, '\\u003c')
+  return JSON.stringify(sanitizeJsonLdPayload(payload)).replace(/</g, '\\u003c')
 }
 
 export default function SchemaOrg(props: SchemaOrgProps) {

--- a/components/SchemaOrg.tsx
+++ b/components/SchemaOrg.tsx
@@ -36,7 +36,8 @@ function toPayload({
 }
 
 function serializeJsonLd(payload: Record<string, unknown> | SchemaNode): string {
-  return JSON.stringify(sanitizeJsonLdPayload(payload)).replace(/</g, '\\u003c')
+  const sanitized = sanitizeJsonLdPayload(payload)
+  return JSON.stringify(sanitized ?? {}).replace(/</g, '\\u003c')
 }
 
 export default function SchemaOrg(props: SchemaOrgProps) {

--- a/components/seo/JsonLd.tsx
+++ b/components/seo/JsonLd.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
+import { sanitizeJsonLdPayload } from '@/lib/json-ld-sanitize'
 
 export default function JsonLd({ schema }: { schema: any }) {
   if (!schema) return null
 
-  // Safely serialize and escape HTML tags (like '<') to prevent XSS injection
-  const escapedJson = JSON.stringify(schema).replace(/</g, '\\u003c')
+  // Safely serialize and escape HTML tags (like '<') to prevent XSS injection.
+  // Also normalize known schema.org validation traps before JSON-LD reaches the page.
+  const escapedJson = JSON.stringify(sanitizeJsonLdPayload(schema)).replace(/</g, '\\u003c')
 
   return (
     <script

--- a/components/seo/JsonLd.tsx
+++ b/components/seo/JsonLd.tsx
@@ -6,7 +6,7 @@ export default function JsonLd({ schema }: { schema: any }) {
 
   // Safely serialize and escape HTML tags (like '<') to prevent XSS injection.
   // Also normalize known schema.org validation traps before JSON-LD reaches the page.
-  const escapedJson = JSON.stringify(sanitizeJsonLdPayload(schema)).replace(/</g, '\\u003c')
+  const escapedJson = JSON.stringify(sanitizeJsonLdPayload(schema) ?? {}).replace(/</g, '\\u003c')
 
   return (
     <script

--- a/lib/json-ld-sanitize.ts
+++ b/lib/json-ld-sanitize.ts
@@ -1,0 +1,119 @@
+type JsonLdPrimitive = string | number | boolean | null
+export type JsonLdValue = JsonLdPrimitive | JsonLdObject | JsonLdValue[]
+export type JsonLdObject = Record<string, JsonLdValue | undefined>
+
+const INVALID_SCHEMA_PROPERTIES = new Set([
+  'evidenceLevel',
+  'knownUse',
+  'safetyWarnings',
+])
+
+const NON_CREATIVE_ENTITY_TYPES = new Set([
+  'ChemicalSubstance',
+  'DietarySupplement',
+  'Drug',
+  'MedicalSubstance',
+  'MedicalTherapy',
+  'MolecularEntity',
+  'Thing',
+])
+
+const ARTICLE_TYPES = new Set(['Article', 'BlogPosting', 'NewsArticle'])
+
+function isObject(value: JsonLdValue | undefined): value is JsonLdObject {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function typeList(value: JsonLdValue | undefined): string[] {
+  if (typeof value === 'string') return [value]
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === 'string')
+  }
+  return []
+}
+
+function normalizedType(types: string[]): string | string[] | undefined {
+  const cleaned = types.filter((type) => type !== 'DietarySupplement')
+  if (!cleaned.length) return 'MedicalSubstance'
+  return cleaned.length === 1 ? cleaned[0] : cleaned
+}
+
+function isArticleLike(types: string[]): boolean {
+  return types.some((type) => ARTICLE_TYPES.has(type))
+}
+
+function isPureEntityNode(types: string[]): boolean {
+  return types.length > 0 && types.every((type) => NON_CREATIVE_ENTITY_TYPES.has(type))
+}
+
+function sanitizeObject(input: JsonLdObject): JsonLdObject {
+  const output: JsonLdObject = {}
+
+  for (const [key, value] of Object.entries(input)) {
+    if (INVALID_SCHEMA_PROPERTIES.has(key)) continue
+
+    if (Array.isArray(value)) {
+      output[key] = value.map((item) => sanitizeJsonLdValue(item)).filter((item): item is JsonLdValue => item !== undefined)
+      continue
+    }
+
+    output[key] = sanitizeJsonLdValue(value)
+  }
+
+  const types = typeList(output['@type'])
+
+  if (types.includes('DietarySupplement')) {
+    output['@type'] = normalizedType(types)
+  }
+
+  const nextTypes = typeList(output['@type'])
+
+  // Google reports `breadcrumb` as invalid on Article rich-result nodes. Keep the
+  // standalone BreadcrumbList node in the @graph; do not attach it directly to Article.
+  if (isArticleLike(nextTypes)) {
+    delete output.breadcrumb
+  }
+
+  // Entity nodes such as MedicalSubstance / ChemicalSubstance are not CreativeWorks;
+  // `isPartOf` is valid on WebPage/Article-style nodes, but creates rich-result
+  // warnings when validators classify an entity as a product/snippet candidate.
+  if (isPureEntityNode(nextTypes)) {
+    delete output.isPartOf
+  }
+
+  // Carousel / ItemList validation requires each ListItem to expose either `item`
+  // or `url`. Some internal comparison lists only had name/description.
+  if (nextTypes.includes('ListItem') && !output.item && !output.url) {
+    const name = typeof output.name === 'string' ? output.name : undefined
+    const description = typeof output.description === 'string' ? output.description : undefined
+    if (name || description) {
+      output.item = {
+        '@type': 'Thing',
+        ...(name ? { name } : {}),
+        ...(description ? { description } : {}),
+      }
+    }
+  }
+
+  return Object.fromEntries(
+    Object.entries(output).filter(([, value]) => {
+      if (value === undefined || value === null) return false
+      if (Array.isArray(value)) return value.length > 0
+      if (isObject(value)) return Object.keys(value).length > 0
+      return true
+    }),
+  ) as JsonLdObject
+}
+
+export function sanitizeJsonLdValue(value: JsonLdValue | undefined): JsonLdValue | undefined {
+  if (value === undefined) return undefined
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeJsonLdValue(item)).filter((item): item is JsonLdValue => item !== undefined)
+  }
+  if (isObject(value)) return sanitizeObject(value)
+  return value
+}
+
+export function sanitizeJsonLdPayload<T extends JsonLdValue | undefined>(payload: T): T {
+  return sanitizeJsonLdValue(payload) as T
+}

--- a/lib/json-ld-sanitize.ts
+++ b/lib/json-ld-sanitize.ts
@@ -20,7 +20,7 @@ const NON_CREATIVE_ENTITY_TYPES = new Set([
 
 const ARTICLE_TYPES = new Set(['Article', 'BlogPosting', 'NewsArticle'])
 
-function isObject(value: JsonLdValue | undefined): value is JsonLdObject {
+function isObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
 }
 
@@ -32,7 +32,7 @@ function typeList(value: JsonLdValue | undefined): string[] {
   return []
 }
 
-function normalizedType(types: string[]): string | string[] | undefined {
+function normalizedType(types: string[]): string | string[] {
   const cleaned = types.filter((type) => type !== 'DietarySupplement')
   if (!cleaned.length) return 'MedicalSubstance'
   return cleaned.length === 1 ? cleaned[0] : cleaned
@@ -46,7 +46,7 @@ function isPureEntityNode(types: string[]): boolean {
   return types.length > 0 && types.every((type) => NON_CREATIVE_ENTITY_TYPES.has(type))
 }
 
-function sanitizeObject(input: JsonLdObject): JsonLdObject {
+function sanitizeObject(input: Record<string, unknown>): JsonLdObject {
   const output: JsonLdObject = {}
 
   for (const [key, value] of Object.entries(input)) {
@@ -105,15 +105,18 @@ function sanitizeObject(input: JsonLdObject): JsonLdObject {
   ) as JsonLdObject
 }
 
-export function sanitizeJsonLdValue(value: JsonLdValue | undefined): JsonLdValue | undefined {
+export function sanitizeJsonLdValue(value: unknown): JsonLdValue | undefined {
   if (value === undefined) return undefined
+  if (value === null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value
+  }
   if (Array.isArray(value)) {
     return value.map((item) => sanitizeJsonLdValue(item)).filter((item): item is JsonLdValue => item !== undefined)
   }
   if (isObject(value)) return sanitizeObject(value)
-  return value
+  return undefined
 }
 
-export function sanitizeJsonLdPayload<T extends JsonLdValue | undefined>(payload: T): T {
-  return sanitizeJsonLdValue(payload) as T
+export function sanitizeJsonLdPayload(payload: unknown): JsonLdValue | undefined {
+  return sanitizeJsonLdValue(payload)
 }

--- a/lib/json-ld-sanitize.ts
+++ b/lib/json-ld-sanitize.ts
@@ -1,6 +1,5 @@
-type JsonLdPrimitive = string | number | boolean | null
-export type JsonLdValue = JsonLdPrimitive | JsonLdObject | JsonLdValue[]
-export type JsonLdObject = Record<string, JsonLdValue | undefined>
+export type JsonLdValue = unknown
+export type JsonLdObject = Record<string, unknown>
 
 const INVALID_SCHEMA_PROPERTIES = new Set([
   'evidenceLevel',
@@ -24,7 +23,7 @@ function isObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
 }
 
-function typeList(value: JsonLdValue | undefined): string[] {
+function typeList(value: unknown): string[] {
   if (typeof value === 'string') return [value]
   if (Array.isArray(value)) {
     return value.filter((item): item is string => typeof item === 'string')
@@ -53,7 +52,10 @@ function sanitizeObject(input: Record<string, unknown>): JsonLdObject {
     if (INVALID_SCHEMA_PROPERTIES.has(key)) continue
 
     if (Array.isArray(value)) {
-      output[key] = value.map((item) => sanitizeJsonLdValue(item)).filter((item): item is JsonLdValue => item !== undefined)
+      const sanitizedItems = value
+        .map((item) => sanitizeJsonLdValue(item))
+        .filter((item) => item !== undefined)
+      output[key] = sanitizedItems
       continue
     }
 
@@ -102,7 +104,7 @@ function sanitizeObject(input: Record<string, unknown>): JsonLdObject {
       if (isObject(value)) return Object.keys(value).length > 0
       return true
     }),
-  ) as JsonLdObject
+  )
 }
 
 export function sanitizeJsonLdValue(value: unknown): JsonLdValue | undefined {
@@ -111,7 +113,9 @@ export function sanitizeJsonLdValue(value: unknown): JsonLdValue | undefined {
     return value
   }
   if (Array.isArray(value)) {
-    return value.map((item) => sanitizeJsonLdValue(item)).filter((item): item is JsonLdValue => item !== undefined)
+    return value
+      .map((item) => sanitizeJsonLdValue(item))
+      .filter((item) => item !== undefined)
   }
   if (isObject(value)) return sanitizeObject(value)
   return undefined


### PR DESCRIPTION
## Summary

- Adds a shared JSON-LD sanitizer used at the schema render boundary.
- Removes invalid schema.org properties before output:
  - `evidenceLevel`
  - `knownUse`
  - `safetyWarnings`
- Removes `breadcrumb` from Article / BlogPosting nodes while keeping the standalone `BreadcrumbList` node in the graph.
- Removes `DietarySupplement` from entity `@type` arrays so herb entity nodes no longer get treated as Product snippets that require `offers`, `review`, or `aggregateRating`.
- Removes `isPartOf` from pure entity nodes where validators were reporting it as invalid.
- Adds a fallback `item` Thing to `ListItem` nodes that have name/description but no `item` or `url`, addressing the carousel/list error in the uploaded CSV.

## CSV diagnosis

Uploaded CSV: `thehippiescientist.net_structured_data_that_contains_markup_errors_20260708.csv`

Grouped root causes:

- Product snippet: 1,240 rows across 248 herb pages
  - missing `aggregateRating or offers or review`
  - invalid `isPartOf`
  - invalid `knownUse`
  - invalid `evidenceLevel`
  - invalid `safetyWarnings`
- Article: 10 rows
  - invalid `breadcrumb` property on Article nodes
- Carousel: 1 row
  - nested `ListItem` missing `item` or `url`

## Validation

- Not run locally from this connector.
- Fix is centralized at JSON-LD serialization, so it covers both schema graph output and standalone `JsonLd` usage without manually editing hundreds of generated pages.