### PR TITLE
Improve thin utility pages and guard structured data

### DIFF
--- a/app/info/dosing/page.tsx
+++ b/app/info/dosing/page.tsx
@@ -57,6 +57,39 @@ export default async function DosingPage() {
         </p>
       </section>
 
+      <section className='grid gap-4 md:grid-cols-3' aria-label='How to interpret supplement dose estimates'>
+        <article className='rounded-2xl border border-brand-900/10 bg-white/85 p-5 shadow-sm'>
+          <h2 className='text-base font-bold text-ink'>Separate label dose from active yield</h2>
+          <p className='mt-2 text-sm leading-6 text-muted'>
+            A capsule can list 500 mg of extract while delivering a much smaller amount of the active marker compound. Standardization, extract ratio, and marker percentage matter more than the front-label milligram number when comparing products.
+          </p>
+        </article>
+        <article className='rounded-2xl border border-brand-900/10 bg-white/85 p-5 shadow-sm'>
+          <h2 className='text-base font-bold text-ink'>Treat ranges as starting context</h2>
+          <p className='mt-2 text-sm leading-6 text-muted'>
+            Published ranges are not personal prescriptions. Individual sensitivity, medications, sleep debt, caffeine use, body size, liver metabolism, and health conditions can shift what feels too weak, useful, or too strong.
+          </p>
+        </article>
+        <article className='rounded-2xl border border-brand-900/10 bg-white/85 p-5 shadow-sm'>
+          <h2 className='text-base font-bold text-ink'>Avoid stacking unknowns</h2>
+          <p className='mt-2 text-sm leading-6 text-muted'>
+            When testing a new supplement, changing multiple ingredients at once makes side effects harder to trace. A conservative approach changes one variable, starts low, tracks response, and avoids combining similar mechanisms too quickly.
+          </p>
+        </article>
+      </section>
+
+      <section className='rounded-2xl border border-brand-900/10 bg-white/85 p-5 shadow-sm'>
+        <h2 className='text-xl font-bold tracking-tight text-ink'>Why supplement dose math gets confusing</h2>
+        <div className='mt-4 space-y-4 text-sm leading-7 text-muted'>
+          <p>
+            Supplement labels often mix several measurement systems: raw herb weight, extract weight, extract ratio, standardized marker percentage, and serving size. Two products can look similar on the front label while delivering very different amounts of the compounds most likely to drive the effect.
+          </p>
+          <p>
+            The safest use of this calculator is comparison, not escalation. It helps translate a product label into a conservative reference estimate so you can compare forms, spot unusually aggressive serving sizes, and decide whether a product deserves more safety review before use.
+          </p>
+        </div>
+      </section>
+
       <DosageCalculatorClient
         herbs={herbs.map((herb) => toDosingToolRecord(herb, 'herb'))}
         compounds={compounds.map((compound) => toDosingToolRecord(compound, 'compound'))}

--- a/app/learn/explorer/page.tsx
+++ b/app/learn/explorer/page.tsx
@@ -54,6 +54,39 @@ export default async function PathwayExplorerPage() {
         </p>
       </section>
 
+      <section className='grid gap-4 md:grid-cols-3' aria-label='How to read pathway relationships'>
+        <article className='rounded-2xl border border-brand-900/10 bg-white/85 p-5 shadow-sm'>
+          <h2 className='text-base font-bold text-ink'>Mechanism is not the same as outcome</h2>
+          <p className='mt-2 text-sm leading-6 text-muted'>
+            A compound can interact with a receptor, enzyme, transporter, or pathway without producing a predictable real-world effect in every person. The explorer is best used to understand plausible directions of action before reading the full evidence profile.
+          </p>
+        </article>
+        <article className='rounded-2xl border border-brand-900/10 bg-white/85 p-5 shadow-sm'>
+          <h2 className='text-base font-bold text-ink'>Look for converging signals</h2>
+          <p className='mt-2 text-sm leading-6 text-muted'>
+            Stronger confidence usually comes from multiple signals pointing the same direction: mechanism data, human trials, safety history, dose realism, and practical fit. A pathway match alone should not be treated as proof of benefit.
+          </p>
+        </article>
+        <article className='rounded-2xl border border-brand-900/10 bg-white/85 p-5 shadow-sm'>
+          <h2 className='text-base font-bold text-ink'>Use caution with stacking</h2>
+          <p className='mt-2 text-sm leading-6 text-muted'>
+            If several ingredients influence the same pathway, the combined effect can be stronger than expected. This matters most for sedating, stimulating, serotonergic, blood-pressure, anticoagulant, and liver-metabolism patterns.
+          </p>
+        </article>
+      </section>
+
+      <section className='rounded-2xl border border-brand-900/10 bg-white/85 p-5 shadow-sm'>
+        <h2 className='text-xl font-bold tracking-tight text-ink'>How this explorer fits into the evidence workflow</h2>
+        <div className='mt-4 space-y-4 text-sm leading-7 text-muted'>
+          <p>
+            Pathway maps are useful for discovery, but they are only one layer of supplement evaluation. A GABA, dopamine, serotonin, acetylcholine, inflammation, or stress-response connection tells you where to investigate next; it does not tell you whether a product is effective, safe, or appropriately dosed.
+          </p>
+          <p>
+            Use the explorer to generate better questions: which profiles share similar mechanisms, which ingredients might duplicate each other in a stack, which safety warnings should be checked, and which pages deserve deeper reading before buying or combining anything.
+          </p>
+        </div>
+      </section>
+
       <PathwayExplorerClient herbs={herbs} compounds={compounds} />
     </div>
   )

--- a/app/safety-checker/page.tsx
+++ b/app/safety-checker/page.tsx
@@ -83,6 +83,45 @@ export default async function SafetyCheckerPage() {
         </p>
       </section>
 
+      <section className='grid gap-4 md:grid-cols-3' aria-label='How to use the supplement safety checker'>
+        <article className='rounded-2xl border border-brand-900/10 bg-white/85 p-5 shadow-sm'>
+          <h2 className='text-base font-bold text-ink'>Start with your full stack</h2>
+          <p className='mt-2 text-sm leading-6 text-muted'>
+            Add every herb, supplement, compound, and high-impact medication context you are trying to reason about. The most useful safety review looks for the combined burden: sedation, stimulation, blood-pressure effects, serotonergic load, bleeding risk, liver stress, or overlapping receptor targets.
+          </p>
+        </article>
+        <article className='rounded-2xl border border-brand-900/10 bg-white/85 p-5 shadow-sm'>
+          <h2 className='text-base font-bold text-ink'>Read patterns, not permissions</h2>
+          <p className='mt-2 text-sm leading-6 text-muted'>
+            A low-risk result does not mean a stack is guaranteed safe, and a caution flag does not diagnose an interaction. Treat the output as a screening layer that helps you decide what to simplify, research more carefully, or review with a clinician or pharmacist.
+          </p>
+        </article>
+        <article className='rounded-2xl border border-brand-900/10 bg-white/85 p-5 shadow-sm'>
+          <h2 className='text-base font-bold text-ink'>Escalate high-risk contexts</h2>
+          <p className='mt-2 text-sm leading-6 text-muted'>
+            Pregnancy, breastfeeding, surgery, bleeding disorders, liver or kidney disease, heart rhythm concerns, blood-pressure medication, anticoagulants, antidepressants, sedatives, and stimulants all deserve extra caution before experimenting with supplement combinations.
+          </p>
+        </article>
+      </section>
+
+      <section className='rounded-2xl border border-brand-900/10 bg-white/85 p-5 shadow-sm'>
+        <h2 className='text-xl font-bold tracking-tight text-ink'>What this checker can and cannot tell you</h2>
+        <div className='mt-4 grid gap-5 md:grid-cols-2'>
+          <div>
+            <h3 className='text-sm font-bold uppercase tracking-wide text-emerald-800'>Useful for</h3>
+            <p className='mt-2 text-sm leading-6 text-muted'>
+              Spotting repeated mechanism categories, comparing caution levels before buying, finding ingredient combinations that deserve slower titration, and identifying when a stack is becoming too complex to reason about from labels alone.
+            </p>
+          </div>
+          <div>
+            <h3 className='text-sm font-bold uppercase tracking-wide text-rose-800'>Not useful for</h3>
+            <p className='mt-2 text-sm leading-6 text-muted'>
+              Predicting individual side effects, replacing prescription guidance, checking exact drug metabolism for every medication, or proving that a combination is safe at a specific dose. Personal medical history can change the risk profile completely.
+            </p>
+          </div>
+        </div>
+      </section>
+
       <Suspense fallback={<WizardSkeleton />}>
         <SafetyCheckerClient
           herbs={herbs.map((herb) => toSafetyToolRecord(herb, 'herb'))}

--- a/docs/audits/thin-content-structured-data-guard-2026-07-08.md
+++ b/docs/audits/thin-content-structured-data-guard-2026-07-08.md
@@ -1,0 +1,47 @@
+# Thin Content + Structured Data Guard Pass — 2026-07-08
+
+## Goal
+
+Follow-up after the Semrush cleanup PRs to reduce thin utility-page content and prevent the structured-data markup errors from returning.
+
+The earlier structured data exports showed 259–276 affected pages depending on crawl timing. The recurring patterns were:
+
+- Product snippet nodes missing `aggregateRating`, `offers`, or `review`
+- Invalid entity properties: `knownUse`, `evidenceLevel`, `safetyWarnings`
+- Invalid entity `isPartOf`
+- Invalid direct `breadcrumb` on Article-like nodes
+- Nested `ListItem` rows missing `item` or `url`
+
+## Implemented structured-data guard
+
+Added `scripts/ci/validate-structured-data-regressions.mjs` and wired it into `scripts/build-deploy.mjs` after the static export and canonical repair steps.
+
+The new validator scans every exported HTML file under `out/`, parses every JSON-LD script block, and fails the deploy build if any known Semrush-style regression appears.
+
+It blocks:
+
+- Invalid properties: `evidenceLevel`, `knownUse`, `safetyWarnings`
+- `Product` / `DietarySupplement` nodes that do not include real product support fields
+- Article-like nodes with direct `breadcrumb`
+- `ListItem` nodes missing both `item` and `url`
+- Entity nodes such as `MedicalSubstance`, `ChemicalSubstance`, `Drug`, or `MolecularEntity` with invalid `isPartOf`
+
+This is intentionally a build-time guard, not just documentation, so future schema regressions should fail before Cloudflare deployment.
+
+## Thin-content improvements
+
+Added crawlable explanatory content to utility/tool pages that are useful to readers but previously leaned heavily on interactive client components:
+
+- `/safety-checker/`
+- `/info/dosing/`
+- `/learn/explorer/`
+
+Each page now includes additional explanatory sections before the client-heavy tool UI. The new sections clarify:
+
+- How to interpret the tool output
+- What the tool can and cannot answer
+- When safety or clinician review matters
+- How mechanism/pathway information fits into evidence evaluation
+- Why dose math, extract standardization, and stacking can be misleading
+
+The intent is to improve content depth without inflating runtime data payloads or turning tool pages into long unfocused articles.

--- a/docs/audits/thin-content-structured-data-guard-2026-07-08.md
+++ b/docs/audits/thin-content-structured-data-guard-2026-07-08.md
@@ -30,6 +30,30 @@ A refreshed aggregate issue CSV, `thehippiescientist.net_issues_20260708 2.csv`,
 
 The remaining 3 structured-data failures require a URL-level export before exact row remediation. The validator below therefore runs in report-only mode by default during deploy builds, but supports strict mode for exact debugging.
 
+## Low text-to-HTML ratio export
+
+The uploaded low text-to-HTML CSV, `thehippiescientist.net_text_html_ratio_20260708 2.csv`, included 570 affected URLs:
+
+| URL family | Rows |
+| --- | ---: |
+| `/herbs/` | 187 |
+| `/compounds/` | 171 |
+| `/guides/` | 100 |
+| `/learn/` | 73 |
+| `/articles/` | 15 |
+| `/info/` | 13 |
+| `/novel-psychoactive-substances/` | 5 |
+| `/evidence/` | 3 |
+| Home/search/safety-checker | 3 |
+
+The fix is intentionally template/build-level rather than 570 manual edits.
+
+Implemented coverage:
+
+- Added crawlable explanatory sections directly to `/safety-checker/`, `/info/dosing/`, and `/learn/explorer/`.
+- Added a normal React-rendered footer research-context block that appears across the site and explains how to use profiles, guides, safety checks, and affiliate/product content.
+- Added `scripts/seo/inject-content-depth-support.mjs`, a post-export step that injects route-aware supporting copy into exported HTML for the URL families in the Semrush export: herb profiles, compound profiles, guide pages, compare pages, learn pages, articles, info/tools, evidence pages, search, safety checker, and the homepage.
+
 ## Implemented structured-data regression audit
 
 Added `scripts/ci/validate-structured-data-regressions.mjs` and wired it into `scripts/build-deploy.mjs` after the static export and canonical repair steps.

--- a/docs/audits/thin-content-structured-data-guard-2026-07-08.md
+++ b/docs/audits/thin-content-structured-data-guard-2026-07-08.md
@@ -12,13 +12,31 @@ The earlier structured data exports showed 259–276 affected pages depending on
 - Invalid direct `breadcrumb` on Article-like nodes
 - Nested `ListItem` rows missing `item` or `url`
 
-## Implemented structured-data guard
+## Refreshed Semrush issue summary
+
+A refreshed aggregate issue CSV, `thehippiescientist.net_issues_20260708 2.csv`, showed major cleanup progress after the redirect and schema work landed:
+
+| Issue | Failed checks |
+| --- | ---: |
+| 4xx errors | 0 |
+| Broken internal links | 0 |
+| Large HTML page size | 0 |
+| Structured data that contains markup errors | 3 |
+| Low text to HTML ratio | 570 |
+| Low word count | 36 |
+| Duplicate content in H1 and title | 130 |
+| Pages with only one internal link | 68 |
+| Content not optimized | 236 |
+
+The remaining 3 structured-data failures require a URL-level export before exact row remediation. The validator below therefore runs in report-only mode by default during deploy builds, but supports strict mode for exact debugging.
+
+## Implemented structured-data regression audit
 
 Added `scripts/ci/validate-structured-data-regressions.mjs` and wired it into `scripts/build-deploy.mjs` after the static export and canonical repair steps.
 
-The new validator scans every exported HTML file under `out/`, parses every JSON-LD script block, and fails the deploy build if any known Semrush-style regression appears.
+The validator scans every exported HTML file under `out/`, parses every JSON-LD script block, and reports any known Semrush-style regression pattern.
 
-It blocks:
+It reports:
 
 - Invalid properties: `evidenceLevel`, `knownUse`, `safetyWarnings`
 - `Product` / `DietarySupplement` nodes that do not include real product support fields
@@ -26,7 +44,7 @@ It blocks:
 - `ListItem` nodes missing both `item` and `url`
 - Entity nodes such as `MedicalSubstance`, `ChemicalSubstance`, `Drug`, or `MolecularEntity` with invalid `isPartOf`
 
-This is intentionally a build-time guard, not just documentation, so future schema regressions should fail before Cloudflare deployment.
+By default, the deploy build writes `ops/reports/structured-data-regressions.json` and warns without failing. Set `STRICT_STRUCTURED_DATA_REGRESSIONS=1` to make the audit blocking once the remaining URL-level Semrush export is available.
 
 ## Thin-content improvements
 

--- a/scripts/build-deploy.mjs
+++ b/scripts/build-deploy.mjs
@@ -24,11 +24,12 @@
  * 11. build-semantic-snapshots (snapshot generation)
  * 12. build-production (next build)
  * 13. repair-broken-canonicals (replace deprecated canonical aliases in exported HTML)
- * 14. apply-redirect-overrides (prepend exact audit-cleanup redirects)
- * 15. write-static-sitemap (physical out/sitemap.xml for Cloudflare Pages)
- * 16. validate-sitemap-static (prove /sitemap.xml is real XML, not HTML)
- * 17. repair-static-blog-h1s (legacy static blog heading repair)
- * 18. build-pagefind (static search index)
+ * 14. validate-structured-data-regressions (block known Semrush schema failures)
+ * 15. apply-redirect-overrides (prepend exact audit-cleanup redirects)
+ * 16. write-static-sitemap (physical out/sitemap.xml for Cloudflare Pages)
+ * 17. validate-sitemap-static (prove /sitemap.xml is real XML, not HTML)
+ * 18. repair-static-blog-h1s (legacy static blog heading repair)
+ * 19. build-pagefind (static search index)
  *
  * Time estimate: cold builds are dominated by Next static export and Pagefind;
  * warm builds skip cacheable generation steps when inputs and outputs match.
@@ -148,6 +149,13 @@ const steps = [
     cmd: 'node scripts/seo/repair-broken-canonicals.mjs',
     inputs: ['out/**/*.html', 'scripts/seo/repair-broken-canonicals.mjs'],
     outputs: ['out/**/*.html'],
+    cacheable: false,
+  },
+  {
+    name: 'validate-structured-data-regressions',
+    cmd: 'node scripts/ci/validate-structured-data-regressions.mjs',
+    inputs: ['out/**/*.html', 'scripts/ci/validate-structured-data-regressions.mjs'],
+    outputs: [],
     cacheable: false,
   },
   {

--- a/scripts/build-deploy.mjs
+++ b/scripts/build-deploy.mjs
@@ -24,12 +24,13 @@
  * 11. build-semantic-snapshots (snapshot generation)
  * 12. build-production (next build)
  * 13. repair-broken-canonicals (replace deprecated canonical aliases in exported HTML)
- * 14. validate-structured-data-regressions (block known Semrush schema failures)
- * 15. apply-redirect-overrides (prepend exact audit-cleanup redirects)
- * 16. write-static-sitemap (physical out/sitemap.xml for Cloudflare Pages)
- * 17. validate-sitemap-static (prove /sitemap.xml is real XML, not HTML)
- * 18. repair-static-blog-h1s (legacy static blog heading repair)
- * 19. build-pagefind (static search index)
+ * 14. inject-content-depth-support (add route-aware supporting copy for low text/HTML pages)
+ * 15. validate-structured-data-regressions (report known Semrush schema failures)
+ * 16. apply-redirect-overrides (prepend exact audit-cleanup redirects)
+ * 17. write-static-sitemap (physical out/sitemap.xml for Cloudflare Pages)
+ * 18. validate-sitemap-static (prove /sitemap.xml is real XML, not HTML)
+ * 19. repair-static-blog-h1s (legacy static blog heading repair)
+ * 20. build-pagefind (static search index)
  *
  * Time estimate: cold builds are dominated by Next static export and Pagefind;
  * warm builds skip cacheable generation steps when inputs and outputs match.
@@ -148,6 +149,13 @@ const steps = [
     name: 'repair-broken-canonicals',
     cmd: 'node scripts/seo/repair-broken-canonicals.mjs',
     inputs: ['out/**/*.html', 'scripts/seo/repair-broken-canonicals.mjs'],
+    outputs: ['out/**/*.html'],
+    cacheable: false,
+  },
+  {
+    name: 'inject-content-depth-support',
+    cmd: 'node scripts/seo/inject-content-depth-support.mjs',
+    inputs: ['out/**/*.html', 'scripts/seo/inject-content-depth-support.mjs'],
     outputs: ['out/**/*.html'],
     cacheable: false,
   },

--- a/scripts/ci/validate-structured-data-regressions.mjs
+++ b/scripts/ci/validate-structured-data-regressions.mjs
@@ -4,6 +4,7 @@ import path from 'node:path'
 
 const root = process.cwd()
 const outDir = path.join(root, 'out')
+const strictMode = process.env.STRICT_STRUCTURED_DATA_REGRESSIONS === '1'
 
 const INVALID_SCHEMA_PROPERTIES = new Set([
   'evidenceLevel',
@@ -132,6 +133,7 @@ for (const filePath of walkHtmlFiles(outDir)) {
 
 const report = {
   generatedAt: new Date().toISOString(),
+  strictMode,
   routeCount,
   blockCount,
   errorCount: errors.length,
@@ -145,10 +147,17 @@ fs.writeFileSync(
 )
 
 if (errors.length > 0) {
-  console.error(`[validate-structured-data-regressions] FAIL: ${errors.length} Semrush-style structured data regressions found.`)
+  const prefix = strictMode ? 'FAIL' : 'WARN'
+  console.error(`[validate-structured-data-regressions] ${prefix}: ${errors.length} Semrush-style structured data regression candidates found.`)
   errors.slice(0, 80).forEach((error) => console.error(`  - ${error}`))
   console.error('[validate-structured-data-regressions] Full report: ops/reports/structured-data-regressions.json')
-  process.exit(1)
+
+  if (strictMode) {
+    process.exit(1)
+  }
+
+  console.error('[validate-structured-data-regressions] Report-only mode: set STRICT_STRUCTURED_DATA_REGRESSIONS=1 to make this blocking.')
+  process.exit(0)
 }
 
 console.log(`[validate-structured-data-regressions] PASS: ${blockCount} JSON-LD blocks across ${routeCount} routes have no known Semrush regression patterns.`)

--- a/scripts/ci/validate-structured-data-regressions.mjs
+++ b/scripts/ci/validate-structured-data-regressions.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const outDir = path.join(root, 'out')
+
+const INVALID_SCHEMA_PROPERTIES = new Set([
+  'evidenceLevel',
+  'knownUse',
+  'safetyWarnings',
+])
+
+const ARTICLE_TYPES = new Set(['Article', 'BlogPosting', 'NewsArticle', 'ScholarlyArticle'])
+const PRODUCT_SNIPPET_TYPES = new Set(['Product', 'DietarySupplement'])
+const ENTITY_TYPES_REJECTING_IS_PART_OF = new Set([
+  'ChemicalSubstance',
+  'DietarySupplement',
+  'Drug',
+  'MedicalSubstance',
+  'MedicalTherapy',
+  'MolecularEntity',
+])
+
+function* walkHtmlFiles(dir) {
+  if (!fs.existsSync(dir)) return
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === '_next' || entry.name === 'pagefind') continue
+    const fullPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      yield* walkHtmlFiles(fullPath)
+    } else if (entry.isFile() && entry.name.endsWith('.html')) {
+      yield fullPath
+    }
+  }
+}
+
+function routeFromFile(filePath) {
+  const rel = path.relative(outDir, filePath).replace(/\\/g, '/')
+  if (rel === 'index.html') return '/'
+  return `/${rel.replace(/\/index\.html$/, '').replace(/\.html$/, '')}`
+}
+
+function jsonLdBlocks(html) {
+  return [...html.matchAll(/<script[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi)]
+    .map((match) => match[1].trim())
+    .filter(Boolean)
+}
+
+function typeList(value) {
+  if (typeof value === 'string') return [value]
+  if (Array.isArray(value)) return value.filter((item) => typeof item === 'string')
+  return []
+}
+
+function hasProductSupport(node) {
+  return Boolean(node.aggregateRating || node.offers || node.review)
+}
+
+function traverse(value, visitor, pathLabel = '$') {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => traverse(item, visitor, `${pathLabel}[${index}]`))
+    return
+  }
+
+  if (!value || typeof value !== 'object') return
+
+  visitor(value, pathLabel)
+
+  for (const [key, nested] of Object.entries(value)) {
+    traverse(nested, visitor, `${pathLabel}.${key}`)
+  }
+}
+
+function validateNode(node, route, blockIndex, objectPath, errors) {
+  for (const key of Object.keys(node)) {
+    if (INVALID_SCHEMA_PROPERTIES.has(key)) {
+      errors.push(`${route} block ${blockIndex} ${objectPath}: invalid Schema.org property "${key}"`)
+    }
+  }
+
+  const types = typeList(node['@type'])
+
+  if (types.some((type) => PRODUCT_SNIPPET_TYPES.has(type)) && !hasProductSupport(node)) {
+    errors.push(`${route} block ${blockIndex} ${objectPath}: product-snippet type without aggregateRating/offers/review (${types.join(', ')})`)
+  }
+
+  if (types.some((type) => ARTICLE_TYPES.has(type)) && Object.prototype.hasOwnProperty.call(node, 'breadcrumb')) {
+    errors.push(`${route} block ${blockIndex} ${objectPath}: Article-like node has invalid direct breadcrumb property`)
+  }
+
+  if (types.includes('ListItem') && !node.item && !node.url) {
+    errors.push(`${route} block ${blockIndex} ${objectPath}: ListItem missing item or url`)
+  }
+
+  if (types.some((type) => ENTITY_TYPES_REJECTING_IS_PART_OF.has(type)) && Object.prototype.hasOwnProperty.call(node, 'isPartOf')) {
+    errors.push(`${route} block ${blockIndex} ${objectPath}: entity node has invalid isPartOf property (${types.join(', ')})`)
+  }
+}
+
+if (!fs.existsSync(outDir)) {
+  console.log('[validate-structured-data-regressions] SKIP: out/ not found. Run a build first.')
+  process.exit(0)
+}
+
+const errors = []
+let routeCount = 0
+let blockCount = 0
+
+for (const filePath of walkHtmlFiles(outDir)) {
+  const route = routeFromFile(filePath)
+  const html = fs.readFileSync(filePath, 'utf8')
+  const blocks = jsonLdBlocks(html)
+  if (blocks.length === 0) continue
+
+  routeCount += 1
+  blockCount += blocks.length
+
+  blocks.forEach((block, index) => {
+    let parsed
+    try {
+      parsed = JSON.parse(block)
+    } catch (error) {
+      errors.push(`${route} block ${index + 1}: invalid JSON-LD (${error.message})`)
+      return
+    }
+
+    traverse(parsed, (node, objectPath) => validateNode(node, route, index + 1, objectPath, errors))
+  })
+}
+
+const report = {
+  generatedAt: new Date().toISOString(),
+  routeCount,
+  blockCount,
+  errorCount: errors.length,
+  errors: errors.slice(0, 250),
+}
+
+fs.mkdirSync(path.join(root, 'ops/reports'), { recursive: true })
+fs.writeFileSync(
+  path.join(root, 'ops/reports/structured-data-regressions.json'),
+  JSON.stringify(report, null, 2),
+)
+
+if (errors.length > 0) {
+  console.error(`[validate-structured-data-regressions] FAIL: ${errors.length} Semrush-style structured data regressions found.`)
+  errors.slice(0, 80).forEach((error) => console.error(`  - ${error}`))
+  console.error('[validate-structured-data-regressions] Full report: ops/reports/structured-data-regressions.json')
+  process.exit(1)
+}
+
+console.log(`[validate-structured-data-regressions] PASS: ${blockCount} JSON-LD blocks across ${routeCount} routes have no known Semrush regression patterns.`)

--- a/scripts/seo/inject-content-depth-support.mjs
+++ b/scripts/seo/inject-content-depth-support.mjs
@@ -1,0 +1,263 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const outDir = path.join(root, 'out')
+const marker = 'data-content-depth-support="true"'
+
+function* walkHtmlFiles(dir) {
+  if (!fs.existsSync(dir)) return
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === '_next' || entry.name === 'pagefind') continue
+    const fullPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      yield* walkHtmlFiles(fullPath)
+    } else if (entry.isFile() && entry.name.endsWith('.html')) {
+      yield fullPath
+    }
+  }
+}
+
+function routeFromFile(filePath) {
+  const rel = path.relative(outDir, filePath).replace(/\\/g, '/')
+  if (rel === 'index.html') return '/'
+  return `/${rel.replace(/\/index\.html$/, '/').replace(/\.html$/, '/')}`.replace(/\/+/g, '/')
+}
+
+function decodeEntities(value) {
+  return value
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#x27;/g, "'")
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+}
+
+function extractFirst(html, regex) {
+  const match = html.match(regex)
+  return match ? decodeEntities(match[1].replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim()) : ''
+}
+
+function getPageTitle(html, route) {
+  return (
+    extractFirst(html, /<h1[^>]*>([\s\S]*?)<\/h1>/i) ||
+    extractFirst(html, /<title[^>]*>([\s\S]*?)<\/title>/i).replace(/\s*\|\s*The Hippie Scientist\s*$/i, '') ||
+    route.split('/').filter(Boolean).pop()?.replace(/-/g, ' ') ||
+    'this page'
+  )
+}
+
+function getMetaDescription(html) {
+  return extractFirst(html, /<meta\s+name=["']description["']\s+content=["']([^"']+)["'][^>]*>/i)
+}
+
+function escapeHtml(value) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+function paragraph(text) {
+  return `<p>${escapeHtml(text)}</p>`
+}
+
+function buildBlock({ title, eyebrow, paragraphs, links = [] }) {
+  const linkList = links.length
+    ? `<ul>${links.map((link) => `<li><a href="${link.href}">${escapeHtml(link.label)}</a></li>`).join('')}</ul>`
+    : ''
+
+  return `
+<section ${marker} class="content-depth-support" aria-label="Additional editorial context">
+  <div class="content-depth-support__inner">
+    <p class="content-depth-support__eyebrow">${escapeHtml(eyebrow)}</p>
+    <h2>${escapeHtml(title)}</h2>
+    ${paragraphs.map(paragraph).join('\n    ')}
+    ${linkList}
+  </div>
+</section>`
+}
+
+function routeFamily(route) {
+  if (route === '/') return 'home'
+  if (/^\/herbs\/page\/\d+\/?$/.test(route)) return 'herb-index'
+  if (route === '/herbs/' || route.startsWith('/herbs/')) return 'herb'
+  if (/^\/compounds\/page\/\d+\/?$/.test(route)) return 'compound-index'
+  if (route === '/compounds/' || route.startsWith('/compounds/')) return 'compound'
+  if (route.startsWith('/guides/compare/')) return 'compare'
+  if (route.startsWith('/guides/')) return 'guide'
+  if (route.startsWith('/learn/')) return 'learn'
+  if (route.startsWith('/articles/')) return 'article'
+  if (route.startsWith('/novel-psychoactive-substances/')) return 'harm-reduction'
+  if (route.startsWith('/info/')) return 'info'
+  if (route === '/safety-checker/') return 'safety'
+  if (route === '/search/') return 'search'
+  if (route.startsWith('/evidence/')) return 'evidence'
+  return null
+}
+
+function supportCopy(family, title, description) {
+  const pageName = title || 'this page'
+  const summary = description || `${pageName} is part of The Hippie Scientist evidence library.`
+
+  switch (family) {
+    case 'home':
+      return buildBlock({
+        eyebrow: 'How to use this library',
+        title: 'Evidence-first supplement research, not hype',
+        paragraphs: [
+          'The Hippie Scientist is organized around practical questions: sleep, stress, anxiety, focus, safety, dosing, and product quality. Start with the goal that matches your situation, then use the herb and compound profiles to compare evidence strength, mechanism plausibility, and safety tradeoffs before buying anything.',
+          'Each page is written to separate what is known from what is only mechanistically plausible. The goal is not to make every ingredient sound useful; it is to help you narrow choices, avoid unnecessary stacks, and understand when a supplement question belongs with a clinician or pharmacist.',
+        ],
+        links: [
+          { label: 'Browse herb profiles', href: '/herbs/' },
+          { label: 'Browse compound profiles', href: '/compounds/' },
+          { label: 'Check supplement safety', href: '/safety-checker/' },
+        ],
+      })
+    case 'herb-index':
+    case 'herb':
+      return buildBlock({
+        eyebrow: 'Botanical profile context',
+        title: `How to interpret ${pageName}`,
+        paragraphs: [
+          `${summary} Use this herb profile as a starting point for evidence review, not as a recommendation to start a new supplement. Botanical products can vary by plant part, extract ratio, standardization, dose, and contaminant testing, so two labels with the same common name may not behave the same way.`,
+          `When reviewing ${pageName}, compare the traditional-use context against the human evidence, mechanism notes, and safety cautions. Pay special attention to pregnancy, breastfeeding, liver or kidney disease, blood-pressure effects, sedation, stimulation, anticoagulant use, antidepressants, and any prescription medication overlap.`,
+          'For product decisions, prefer transparent labels, named extracts, clear serving sizes, and third-party quality testing. Avoid treating a long list of possible mechanisms as proof that an herb will solve a specific condition.',
+        ],
+        links: [
+          { label: 'Browse all herbs', href: '/herbs/' },
+          { label: 'Use the safety checker', href: '/safety-checker/' },
+          { label: 'Learn product quality basics', href: '/learn/product-quality/' },
+        ],
+      })
+    case 'compound-index':
+    case 'compound':
+      return buildBlock({
+        eyebrow: 'Compound profile context',
+        title: `How to interpret ${pageName}`,
+        paragraphs: [
+          `${summary} Use this compound profile to understand mechanism, evidence quality, and practical safety context before comparing products or building a stack. A biochemical pathway connection can be useful for discovery, but it is not the same as proven benefit in humans.`,
+          `When reviewing ${pageName}, separate the active molecule from the product category around it. Dose form, absorption, extract standardization, medication interactions, and individual sensitivity can change the real-world risk-benefit picture.`,
+          'For supplement planning, avoid combining multiple compounds with overlapping sedating, stimulating, serotonergic, blood-pressure, anticoagulant, or liver-metabolism effects unless a qualified clinician has reviewed the context.',
+        ],
+        links: [
+          { label: 'Browse all compounds', href: '/compounds/' },
+          { label: 'Compare safety interactions', href: '/safety-checker/' },
+          { label: 'Review dosing concepts', href: '/info/dosing/' },
+        ],
+      })
+    case 'compare':
+      return buildBlock({
+        eyebrow: 'Comparison guide context',
+        title: `How to use ${pageName}`,
+        paragraphs: [
+          `${summary} Comparison pages are meant to clarify tradeoffs, not declare one ingredient universally better. The better choice depends on the goal, evidence quality, safety profile, dose realism, and whether the ingredient duplicates something already in a stack.`,
+          `Read ${pageName} by looking for differences in mechanism, onset, tolerability, interaction risk, and product quality. A stronger evidence rating for one use case does not automatically transfer to another goal.`,
+          'If both options influence the same pathway, consider simplifying rather than stacking. Reducing overlap often makes side effects easier to identify and decisions easier to reverse.',
+        ],
+        links: [
+          { label: 'Browse compare guides', href: '/guides/compare/' },
+          { label: 'Check stack safety', href: '/safety-checker/' },
+        ],
+      })
+    case 'guide':
+    case 'article':
+    case 'harm-reduction':
+      return buildBlock({
+        eyebrow: 'Editorial reading context',
+        title: `How to read ${pageName}`,
+        paragraphs: [
+          `${summary} This guide is intended to help readers make sense of evidence, safety, and practical fit without turning supplement research into a one-size-fits-all checklist. Use it alongside the linked herb and compound profiles for deeper mechanism and safety details.`,
+          `For ${pageName}, focus on whether the evidence matches the exact outcome you care about, whether the dose discussed is realistic, and whether the safety profile fits your medical context. Strong marketing language should carry less weight than human evidence and transparent product quality.`,
+          'When a page discusses dependence-forming substances, restricted compounds, or high-risk contexts, treat it as harm-reduction education only. It is not a buying guide, dosing instruction, or substitute for professional care.',
+        ],
+        links: [
+          { label: 'Browse guides', href: '/guides/' },
+          { label: 'Search the library', href: '/search/' },
+        ],
+      })
+    case 'learn':
+    case 'evidence':
+      return buildBlock({
+        eyebrow: 'Learning context',
+        title: `How this concept connects to supplement decisions`,
+        paragraphs: [
+          `${summary} Learning pages explain the reasoning layer behind the herb and compound library. They are designed to make mechanisms, evidence quality, safety tradeoffs, and product claims easier to interpret.`,
+          `Use ${pageName} to build better questions before choosing a supplement: what outcome is being targeted, what mechanism is claimed, what human evidence exists, what dose was studied, and what risks could change the answer for a specific person?`,
+          'Mechanistic plausibility is useful, but it should be weighed against trial design, safety history, product quality, and the possibility that a simpler intervention may be more appropriate.',
+        ],
+        links: [
+          { label: 'Evidence checker', href: '/evidence/evidence-checker/' },
+          { label: 'Product quality guide', href: '/learn/product-quality/' },
+        ],
+      })
+    case 'info':
+    case 'safety':
+    case 'search':
+      return buildBlock({
+        eyebrow: 'Tool context',
+        title: `How to use ${pageName}`,
+        paragraphs: [
+          `${summary} Tool and utility pages are meant to support research decisions, not replace the full evidence review. Use the results as a triage layer that points you toward the profile, guide, or safety topic that deserves closer reading.`,
+          `For ${pageName}, the most useful approach is conservative: check one question at a time, compare the result against the full profile, and avoid assuming that an automated output proves safety, effectiveness, or correct dosing.`,
+          'If the question involves prescription medications, pregnancy, breastfeeding, chronic disease, surgery, addiction risk, or a child, the next step should include a clinician or pharmacist rather than relying only on a supplement website.',
+        ],
+        links: [
+          { label: 'Safety checker', href: '/safety-checker/' },
+          { label: 'Dosing calculator', href: '/info/dosing/' },
+          { label: 'Search the site', href: '/search/' },
+        ],
+      })
+    default:
+      return null
+  }
+}
+
+function injectBeforeMainEnd(html, block) {
+  if (html.includes(marker)) return html
+
+  const mainClose = html.lastIndexOf('</main>')
+  if (mainClose !== -1) {
+    return `${html.slice(0, mainClose)}${block}\n${html.slice(mainClose)}`
+  }
+
+  const bodyClose = html.lastIndexOf('</body>')
+  if (bodyClose !== -1) {
+    return `${html.slice(0, bodyClose)}${block}\n${html.slice(bodyClose)}`
+  }
+
+  return html
+}
+
+if (!fs.existsSync(outDir)) {
+  console.warn('[content-depth-support] out directory not found; skipping.')
+  process.exit(0)
+}
+
+let touched = 0
+
+for (const filePath of walkHtmlFiles(outDir)) {
+  const route = routeFromFile(filePath)
+  const family = routeFamily(route)
+  if (!family) continue
+
+  const html = fs.readFileSync(filePath, 'utf8')
+  if (html.includes(marker)) continue
+
+  const title = getPageTitle(html, route)
+  const description = getMetaDescription(html)
+  const block = supportCopy(family, title, description)
+  if (!block) continue
+
+  const next = injectBeforeMainEnd(html, block)
+  if (next !== html) {
+    fs.writeFileSync(filePath, next)
+    touched += 1
+  }
+}
+
+console.log(`[content-depth-support] Added route-aware supporting copy to ${touched} exported HTML pages.`)

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -170,6 +170,21 @@ export default function Footer() {
           </NonEmpty>
         </div>
 
+        <section className='mt-10 rounded-2xl border border-white/10 bg-white/[0.03] p-5 text-sm leading-6 text-white/62' aria-label='How to use this research library'>
+          <p className='section-label mb-3 !text-white/55'>How to use this research</p>
+          <div className='grid gap-4 md:grid-cols-3'>
+            <p>
+              Use The Hippie Scientist as an evidence map, not a prescription pad. Herb, compound, guide, and comparison pages are designed to help you separate human evidence from mechanism speculation, marketing language, and traditional-use context.
+            </p>
+            <p>
+              Before buying or stacking supplements, compare the goal, evidence quality, dose realism, product standardization, and safety cautions. Pregnancy, medications, chronic illness, surgery, dependence risk, and use in children all deserve qualified clinical review.
+            </p>
+            <p>
+              Product links and affiliate disclosures should never outweigh safety or evidence. The safest workflow is simple: define the goal, read the profile, check interactions, avoid duplicate mechanisms, and choose transparent products only when the risk-benefit picture still makes sense.
+            </p>
+          </div>
+        </section>
+
         <div className='mt-10 flex flex-col justify-between gap-2 border-t border-white/10 pt-5 text-xs text-white/65 sm:flex-row'>
           {showBuildMeta && <div>Build {versionStampParts.join(' · ')}</div>}
           <div>© 2024–{copyrightYear} The Hippie Scientist – Educational use only. Not medical advice.</div>


### PR DESCRIPTION
## Summary

Follow-up after the merged Semrush cleanup PRs, updated with the refreshed aggregate issue CSV and the low text-to-HTML URL export.

This PR now does three things:

1. Adds crawlable explanatory content to thin tool/utility pages.
2. Adds a sitewide React-rendered research-context block in the footer.
3. Adds a route-aware post-export content-depth support step for the 570 low text-to-HTML URL families.
4. Adds a structured-data regression audit that reports known Semrush schema patterns during deploy builds, with strict blocking mode available for exact URL-level debugging.

## Refreshed audit snapshot

The newest aggregate issue CSV showed the biggest cleanup categories are now fixed:

- 4xx errors: 0 failed checks
- Broken internal links: 0 failed checks
- Large HTML page size: 0 failed checks
- Structured data markup errors: 3 failed checks

Remaining nonzero buckets are mostly content-quality warnings/notices:

- Low text to HTML ratio: 570
- Low word count: 36
- Duplicate content in H1 and title: 130
- Pages with only one internal link: 68
- Content not optimized: 236

## Low text-to-HTML ratio export coverage

The uploaded `thehippiescientist.net_text_html_ratio_20260708 2.csv` contained 570 affected URLs:

- `/herbs/`: 187
- `/compounds/`: 171
- `/guides/`: 100
- `/learn/`: 73
- `/articles/`: 15
- `/info/`: 13
- `/novel-psychoactive-substances/`: 5
- `/evidence/`: 3
- Home/search/safety-checker: 3

This PR addresses that at the template/build level instead of hand-editing 570 pages.

### Added coverage

- Adds additional crawlable sections to:
  - `/safety-checker/`
  - `/info/dosing/`
  - `/learn/explorer/`
- Adds a normal React-rendered footer research-context block explaining how to use the site, safety checks, product links, and evidence profiles.
- Adds `scripts/seo/inject-content-depth-support.mjs`, which injects route-aware supporting copy after static export for the affected page families: herb profiles, compound profiles, guide pages, compare pages, learn pages, article pages, harm-reduction pages, info/tools, evidence pages, search, safety checker, and homepage.
- Wires that post-export support step into `scripts/build-deploy.mjs` after canonical repair and before schema validation/redirect/sitemap work.

## Structured-data regression audit

Adds `scripts/ci/validate-structured-data-regressions.mjs`.

The script scans every exported HTML file under `out/`, parses JSON-LD blocks, and reports known Semrush regression patterns:

- invalid Schema.org properties: `evidenceLevel`, `knownUse`, `safetyWarnings`
- `Product` / `DietarySupplement` nodes without real product support fields
- Article-like nodes with direct `breadcrumb`
- `ListItem` nodes missing both `item` and `url`
- entity nodes like `MedicalSubstance`, `ChemicalSubstance`, `Drug`, or `MolecularEntity` with invalid `isPartOf`

The audit is report-only by default in `build:deploy` so it does not block Cloudflare without the exact remaining URL-level export. Set `STRICT_STRUCTURED_DATA_REGRESSIONS=1` to make it blocking during focused schema debugging.

## Notes

This does not add fake ratings, fake offers, or fake reviews. The structured-data goal is valid editorial/entity schema, not forced Product rich-result eligibility.

## Validation

Not run locally from this connector.