### PR TITLE
Fix structured data markup errors

### DIFF
--- a/components/seo/AuthorityJsonLd.tsx
+++ b/components/seo/AuthorityJsonLd.tsx
@@ -69,7 +69,7 @@ export default function AuthorityJsonLd({
     description,
     url: canonical,
     isPartOf: { '@type': 'WebSite', name: 'The Hippie Scientist', url: SITE_URL },
-    ...(breadcrumbs.length ? { breadcrumb: { '@id': breadcrumbId } } : {}),
+    ...(type !== 'Article' && breadcrumbs.length ? { breadcrumb: { '@id': breadcrumbId } } : {}),
     ...(meaningfulFaqItems.length ? { hasPart: { '@id': faqId } } : {}),
     ...(citationUrls.length ? { citation: [...new Set(citationUrls)].filter(Boolean) } : {}),
   }

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -8,7 +8,7 @@
  *  - relatedLink + ItemList helpers for cluster interlinking
  */
 
-import { SITE_NAME, SITE_URL, toAbsoluteUrl } from '../src/lib/seo'
+import { SITE_URL, toAbsoluteUrl } from '../src/lib/seo'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Cluster types — consumed by lib/cluster-linking.ts and components
@@ -399,7 +399,7 @@ export function buildWorkbookEntitySchema(args: ProfileEntitySchemaArgs): Schema
   const mechanisms = textList(record?.mechanisms || record?.primary_mechanisms || record?.pathways, 8)
   const entityTypes =
     args.kind === 'herb'
-      ? ['DietarySupplement', 'MedicalSubstance', 'Thing']
+      ? ['MedicalSubstance', 'Thing']
       : molecularFormula || pubchemCid
         ? ['MolecularEntity', 'ChemicalSubstance']
         : ['ChemicalSubstance', 'Thing']
@@ -411,7 +411,6 @@ export function buildWorkbookEntitySchema(args: ProfileEntitySchemaArgs): Schema
     url: canonical,
     description: args.description,
     mainEntityOfPage: { '@id': `${canonical}#webpage` },
-    isPartOf: { '@type': 'WebSite', name: SITE_NAME, url: SITE_URL },
     identifier: buildWorkbookIdentifiers({ kind: args.kind, slug: args.slug, record }),
     ...(scientificName ? { alternateName: scientificName } : {}),
     ...(category ? { category } : {}),

--- a/src/lib/__tests__/schema-graph.test.ts
+++ b/src/lib/__tests__/schema-graph.test.ts
@@ -70,7 +70,7 @@ describe('schema-graph', () => {
     const article = nodes.find(n => n['@type'] === 'Article')
     expect(article?.headline).toBe('Best Supplements for Sleep | The Hippie Scientist')
     expect(article?.url).toBe('https://thehippiescientist.net/best-supplements-for-sleep/')
-    expect(article?.breadcrumb).toEqual({ '@id': 'https://thehippiescientist.net/best-supplements-for-sleep/#breadcrumb' })
+    expect(article?.breadcrumb).toBeUndefined()
     expect(article?.hasPart).toEqual({ '@id': 'https://thehippiescientist.net/best-supplements-for-sleep/#faq' })
 
     const breadcrumb = nodes.find(n => n['@type'] === 'BreadcrumbList')

--- a/src/lib/schema-graph.ts
+++ b/src/lib/schema-graph.ts
@@ -276,7 +276,6 @@ export function buildSeoEntrySchemaGraph(args: {
     author: { '@type': 'Organization', name: 'The Hippie Scientist', url: SITE_URL },
     publisher: { '@type': 'Organization', name: 'The Hippie Scientist', url: SITE_URL },
     datePublished: '2026-01-01',
-    breadcrumb: { '@id': breadcrumbId },
     ...(args.faqs.length ? { hasPart: { '@id': faqId } } : {}),
   }
 

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -887,6 +887,7 @@ export function itemListJsonLd(args: {
       '@type': 'ListItem',
       position: index + 1,
       name: item.name,
+      item: toAbsoluteUrl(item.url),
       url: toAbsoluteUrl(item.url),
     })),
   }


### PR DESCRIPTION
## Summary
- remove Product-like DietarySupplement typing from herb entity schema to avoid unsupported Product snippet requirements
- remove invalid breadcrumb references from Article JSON-LD while keeping standalone BreadcrumbList nodes
- add item to ItemList ListItem entries for carousel readiness

## Validation
- npm run typecheck
- npm run lint
- npx vitest run src/lib/__tests__/schema-graph.test.ts src/lib/__tests__/seo.test.ts src/lib/__tests__/structured-data.test.ts
- npm run audit:structured-data
- npm run validate:seo
- npm run build
- exported sample JSON-LD checks for CSV issue families