### PR TITLE
Add international platform integration foundation

### DIFF
--- a/docs/seo/international-platform-integration.md
+++ b/docs/seo/international-platform-integration.md
@@ -1,0 +1,91 @@
+# International Platform Integration
+
+This document defines the first safe implementation layer for regional shopping and commerce links.
+
+## Current priority
+
+The business goal is to make international visitors more useful without creating fake translated pages first.
+
+The first supported regions are:
+
+- United States (`US`)
+- United Kingdom (`UK`)
+- Canada (`CA`)
+
+The first platform modeled is Amazon, because many current product links use Amazon US.
+
+## Core rule
+
+Regional links must be explicit.
+
+Do not guess that a US product URL, ASIN, search URL, or product detail page automatically maps cleanly to the same product in another country. Product availability, listing IDs, pricing, and compliance can differ by marketplace.
+
+## Safe fallback order
+
+When resolving a product destination:
+
+1. Use the explicitly configured URL for the user-selected region.
+2. Fall back to the explicitly configured US URL.
+3. Fall back to the generic default URL already stored on the product.
+
+This preserves current monetization behavior while allowing regional upgrades one product at a time.
+
+## What this foundation does
+
+- Adds a central region/platform model.
+- Supports explicit regional URL maps.
+- Keeps US as the default fallback.
+- Keeps outbound link `rel` behavior explicit.
+- Adds tests for fallback behavior.
+
+## What this foundation intentionally does not do
+
+- It does not auto-redirect by IP address.
+- It does not auto-redirect by browser language.
+- It does not create Spanish/French/etc. translated pages.
+- It does not add `hreflang` for pages that do not exist.
+- It does not rewrite every product card yet.
+- It does not assume Amazon OneLink is enabled.
+- It does not reuse a US tracking ID for UK or Canada.
+
+## Future PR sequence
+
+### PR 1: foundation
+
+- Platform region config
+- Resolver tests
+- Documentation
+
+### PR 2: revenue product data model
+
+Add optional regional URLs to product entries, for example:
+
+```ts
+regionalUrls: {
+  US: 'https://www.amazon.com/...',
+  UK: 'https://www.amazon.co.uk/...',
+  CA: 'https://www.amazon.ca/...',
+}
+```
+
+### PR 3: recommendation component wiring
+
+Let recommendation cards use the resolver while preserving current US fallback behavior.
+
+### PR 4: user-selected region
+
+Add a lightweight region selector with local storage:
+
+- US
+- UK
+- Canada
+
+No forced redirects.
+
+### PR 5: product-by-product regional expansion
+
+Add regional URLs only where they are confirmed.
+
+## Amazon OneLink note
+
+OneLink or any equivalent platform-routing feature should be evaluated separately before implementation. The site should only rely on it if the account setup, store IDs, and tracking behavior are confirmed.

--- a/src/lib/__tests__/platforms.test.ts
+++ b/src/lib/__tests__/platforms.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_PLATFORM_REGION,
+  getOutboundLinkRel,
+  getPlatformRegionConfig,
+  normalizePlatformRegion,
+  resolveRegionalUrl,
+} from '../platforms'
+
+describe('international platform helpers', () => {
+  it('defaults unknown or missing regions to the US platform region', () => {
+    expect(DEFAULT_PLATFORM_REGION).toBe('US')
+    expect(normalizePlatformRegion()).toBe('US')
+    expect(normalizePlatformRegion('')).toBe('US')
+    expect(normalizePlatformRegion('unknown')).toBe('US')
+  })
+
+  it('normalizes common region aliases', () => {
+    expect(normalizePlatformRegion('usa')).toBe('US')
+    expect(normalizePlatformRegion('United States')).toBe('US')
+    expect(normalizePlatformRegion('gb')).toBe('UK')
+    expect(normalizePlatformRegion('United Kingdom')).toBe('UK')
+    expect(normalizePlatformRegion('canada')).toBe('CA')
+  })
+
+  it('exposes the expected regional platform metadata', () => {
+    expect(getPlatformRegionConfig('US').amazonHost).toBe('www.amazon.com')
+    expect(getPlatformRegionConfig('UK').amazonHost).toBe('www.amazon.co.uk')
+    expect(getPlatformRegionConfig('CA').amazonHost).toBe('www.amazon.ca')
+  })
+
+  it('resolves an explicitly configured regional URL when available', () => {
+    expect(
+      resolveRegionalUrl({
+        defaultUrl: 'https://www.amazon.com/example',
+        preferredRegion: 'UK',
+        regionalUrls: {
+          US: 'https://www.amazon.com/example',
+          UK: 'https://www.amazon.co.uk/example',
+        },
+      }),
+    ).toBe('https://www.amazon.co.uk/example')
+  })
+
+  it('falls back to the US URL before the generic default URL', () => {
+    expect(
+      resolveRegionalUrl({
+        defaultUrl: 'https://retailer.example/default',
+        preferredRegion: 'CA',
+        regionalUrls: {
+          US: 'https://www.amazon.com/example',
+        },
+      }),
+    ).toBe('https://www.amazon.com/example')
+  })
+
+  it('falls back to the generic default URL when no regional URL exists', () => {
+    expect(
+      resolveRegionalUrl({
+        defaultUrl: 'https://retailer.example/default',
+        preferredRegion: 'CA',
+      }),
+    ).toBe('https://retailer.example/default')
+  })
+
+  it('keeps outbound link rel values explicit', () => {
+    expect(getOutboundLinkRel()).toBe('sponsored nofollow noopener noreferrer')
+    expect(getOutboundLinkRel(false)).toBe('noopener noreferrer')
+  })
+})

--- a/src/lib/platforms.ts
+++ b/src/lib/platforms.ts
@@ -1,0 +1,77 @@
+export const PLATFORM_REGIONS = ['US', 'UK', 'CA'] as const
+export type PlatformRegion = (typeof PLATFORM_REGIONS)[number]
+
+export type CommercePlatform = 'amazon'
+
+export type PlatformRegionConfig = {
+  region: PlatformRegion
+  countryCode: string
+  label: string
+  amazonHost: string
+  currencyCode: string
+}
+
+export type RegionalUrlMap = Partial<Record<PlatformRegion, string>>
+
+export type ResolveRegionalUrlInput = {
+  defaultUrl: string
+  regionalUrls?: RegionalUrlMap
+  preferredRegion?: string | null
+}
+
+export const DEFAULT_PLATFORM_REGION: PlatformRegion = 'US'
+
+export const PLATFORM_REGION_CONFIG: Record<PlatformRegion, PlatformRegionConfig> = {
+  US: {
+    region: 'US',
+    countryCode: 'US',
+    label: 'United States',
+    amazonHost: 'www.amazon.com',
+    currencyCode: 'USD',
+  },
+  UK: {
+    region: 'UK',
+    countryCode: 'GB',
+    label: 'United Kingdom',
+    amazonHost: 'www.amazon.co.uk',
+    currencyCode: 'GBP',
+  },
+  CA: {
+    region: 'CA',
+    countryCode: 'CA',
+    label: 'Canada',
+    amazonHost: 'www.amazon.ca',
+    currencyCode: 'CAD',
+  },
+}
+
+const REGION_ALIASES: Record<string, PlatformRegion> = {
+  US: 'US',
+  USA: 'US',
+  'UNITED STATES': 'US',
+  UK: 'UK',
+  GB: 'UK',
+  'UNITED KINGDOM': 'UK',
+  CA: 'CA',
+  CANADA: 'CA',
+}
+
+export function normalizePlatformRegion(region?: string | null): PlatformRegion {
+  if (!region) return DEFAULT_PLATFORM_REGION
+
+  const normalized = region.trim().toUpperCase()
+  return REGION_ALIASES[normalized] ?? DEFAULT_PLATFORM_REGION
+}
+
+export function getPlatformRegionConfig(region?: string | null): PlatformRegionConfig {
+  return PLATFORM_REGION_CONFIG[normalizePlatformRegion(region)]
+}
+
+export function getOutboundLinkRel(isSponsored = true) {
+  return isSponsored ? 'sponsored nofollow noopener noreferrer' : 'noopener noreferrer'
+}
+
+export function resolveRegionalUrl({ defaultUrl, regionalUrls, preferredRegion }: ResolveRegionalUrlInput): string {
+  const region = normalizePlatformRegion(preferredRegion)
+  return regionalUrls?.[region] ?? regionalUrls?.[DEFAULT_PLATFORM_REGION] ?? defaultUrl
+}


### PR DESCRIPTION
## Summary

First implementation PR for Issue #2128: international platform integration.

This adds the safe foundation for regional shopping/platform routing without changing every product card yet.

## What changed

- Adds `src/lib/platforms.ts`
  - platform regions: US, UK, CA
  - Amazon marketplace host metadata
  - region normalization helpers
  - explicit regional URL resolver
  - outbound `rel` helper for sponsored links
- Adds `src/lib/__tests__/platforms.test.ts`
  - US fallback behavior
  - UK/Canada region aliases
  - platform metadata checks
  - explicit regional URL selection
  - sponsored/non-sponsored rel behavior
- Adds `docs/seo/international-platform-integration.md`
  - regional platform strategy
  - safe fallback order
  - future PR sequence
  - OneLink caution note

## What this intentionally does not do

- Does not rewrite all current revenue product links yet.
- Does not auto-detect or auto-redirect by country.
- Does not assume OneLink is enabled.
- Does not reuse a US tracking ID for UK or Canada.
- Does not create fake translated pages or premature hreflang entries.

## Why this sequence

The current revenue product config builds mostly US Amazon links. This PR creates the tested resolver/fallback foundation first, so the next PR can wire regional product URLs into recommendation cards without risking a broad monetization regression.

Closes no issue yet; this is the first implementation step toward #2128.

## Validation

Not run locally from this connector.