### PR TITLE
Wire regional URLs into recommendation cards

### DIFF
--- a/components/AffiliateProductCard.tsx
+++ b/components/AffiliateProductCard.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image'
 import { isOptimizableRemoteImage } from '../src/lib/image-hosts'
+import { getOutboundLinkRel, resolveRegionalUrl, type RegionalUrlMap } from '../src/lib/platforms'
 import { trackRevenueEvent } from '../src/lib/revenue-tracking'
 
 export type AffiliateProduct = {
@@ -19,6 +20,8 @@ export type AffiliateProduct = {
   affiliateUrl?: string
   url?: string
   link?: string
+  regionalUrls?: RegionalUrlMap
+  preferredRegion?: string | null
   trackingLocation?: string
 }
 
@@ -32,8 +35,15 @@ export default function AffiliateProductCard({ product, compact = false }: Affil
   const imageUrl = product.imageUrl || product.image
   const rationale = product.rationale || product.notes || 'Review the label, dose, third-party testing, and safety context before buying.'
   const rawUrl = product.affiliateUrl || product.url || product.link
-  const isValidUrl = typeof rawUrl === 'string' && (rawUrl.startsWith('http://') || rawUrl.startsWith('https://'))
-  const affiliateUrl = isValidUrl ? rawUrl : ''
+  const resolvedUrl = rawUrl
+    ? resolveRegionalUrl({
+        defaultUrl: rawUrl,
+        regionalUrls: product.regionalUrls,
+        preferredRegion: product.preferredRegion,
+      })
+    : ''
+  const isValidUrl = typeof resolvedUrl === 'string' && (resolvedUrl.startsWith('http://') || resolvedUrl.startsWith('https://'))
+  const affiliateUrl = isValidUrl ? resolvedUrl : ''
   const ctaLabel = product.ctaLabel || 'Check current price'
 
   return (
@@ -72,7 +82,7 @@ export default function AffiliateProductCard({ product, compact = false }: Affil
           <a
             href={affiliateUrl}
             target='_blank'
-            rel='noopener noreferrer nofollow sponsored'
+            rel={getOutboundLinkRel(true)}
             onClick={() => trackRevenueEvent({
               kind: 'recommendation_click',
               location: product.trackingLocation || 'recommendation-section',

--- a/components/RecommendationSection.tsx
+++ b/components/RecommendationSection.tsx
@@ -12,6 +12,7 @@ type RecommendationSectionProps = {
   title?: string
   description?: string
   products: RecommendationProduct[]
+  preferredRegion?: string | null
   suppressMonetization?: boolean
 }
 
@@ -25,6 +26,7 @@ export default function RecommendationSection({
   title = 'Product recommendations',
   description = 'Use these as sourcing starting points, not medical recommendations. Product quality, dose, and fit still need review.',
   products,
+  preferredRegion = null,
   suppressMonetization = false,
 }: RecommendationSectionProps) {
   if (suppressMonetization) return null
@@ -47,7 +49,14 @@ export default function RecommendationSection({
         {ordered.map((product) => (
           <div key={`${product.slot}-${product.title || product.name}`} className='flex flex-col gap-2'>
             <p className='text-xs font-bold uppercase tracking-[0.16em] text-brand-700 dark:text-brand-200'>{slotLabels[product.slot]}</p>
-            <AffiliateProductCard product={{ ...product, trackingLocation: 'recommendation-section' }} compact />
+            <AffiliateProductCard
+              product={{
+                ...product,
+                preferredRegion: product.preferredRegion ?? preferredRegion,
+                trackingLocation: 'recommendation-section',
+              }}
+              compact
+            />
           </div>
         ))}
       </div>

--- a/components/__tests__/AffiliateProductCard.regional.test.tsx
+++ b/components/__tests__/AffiliateProductCard.regional.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import AffiliateProductCard from '../AffiliateProductCard'
+
+vi.mock('next/image', () => ({
+  default: ({ alt }: { alt: string }) => <img alt={alt} />,
+}))
+
+describe('AffiliateProductCard regional URLs', () => {
+  it('uses an explicitly configured regional URL when preferredRegion is available', () => {
+    render(
+      <AffiliateProductCard
+        product={{
+          title: 'Test Magnesium',
+          affiliateUrl: 'https://www.amazon.com/test-magnesium',
+          preferredRegion: 'UK',
+          regionalUrls: {
+            US: 'https://www.amazon.com/test-magnesium',
+            UK: 'https://www.amazon.co.uk/test-magnesium',
+          },
+        }}
+      />,
+    )
+
+    expect(screen.getByRole('link', { name: /check current price/i })).toHaveAttribute(
+      'href',
+      'https://www.amazon.co.uk/test-magnesium',
+    )
+  })
+
+  it('falls back to the US URL when the preferred regional URL is missing', () => {
+    render(
+      <AffiliateProductCard
+        product={{
+          title: 'Test Theanine',
+          affiliateUrl: 'https://retailer.example/default-theanine',
+          preferredRegion: 'CA',
+          regionalUrls: {
+            US: 'https://www.amazon.com/test-theanine',
+          },
+        }}
+      />,
+    )
+
+    expect(screen.getByRole('link', { name: /check current price/i })).toHaveAttribute(
+      'href',
+      'https://www.amazon.com/test-theanine',
+    )
+  })
+
+  it('keeps sponsored affiliate rel values on outbound links', () => {
+    render(
+      <AffiliateProductCard
+        product={{
+          title: 'Test Rhodiola',
+          affiliateUrl: 'https://www.amazon.com/test-rhodiola',
+        }}
+      />,
+    )
+
+    expect(screen.getByRole('link', { name: /check current price/i })).toHaveAttribute(
+      'rel',
+      'sponsored nofollow noopener noreferrer',
+    )
+  })
+})

--- a/components/__tests__/AffiliateProductCard.regional.test.tsx
+++ b/components/__tests__/AffiliateProductCard.regional.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import AffiliateProductCard from '../AffiliateProductCard'
 
 vi.mock('next/image', () => ({
-  default: ({ alt }: { alt: string }) => <img alt={alt} />,
+  default: ({ alt }: { alt: string }) => <span aria-label={alt} role="img" />,
 }))
 
 describe('AffiliateProductCard regional URLs', () => {


### PR DESCRIPTION
## Summary

Stacked follow-up to #2130 for Issue #2128.

This PR wires the new platform resolver into the product recommendation UI while preserving the current US/default affiliate behavior.

## What changed

- Updates `components/AffiliateProductCard.tsx`
  - adds optional `regionalUrls` to `AffiliateProduct`
  - adds optional `preferredRegion`
  - resolves outbound URLs through `resolveRegionalUrl`
  - keeps current `affiliateUrl` / `url` / `link` fallback behavior
  - uses the shared sponsored-link `rel` helper
- Updates `components/RecommendationSection.tsx`
  - accepts optional `preferredRegion`
  - passes region preference into product cards
  - preserves per-product region override support
- Adds `components/__tests__/AffiliateProductCard.regional.test.tsx`
  - verifies explicit UK URL selection
  - verifies US fallback when Canada URL is missing
  - verifies sponsored affiliate rel values stay present

## Safety notes

- Does not change existing product data yet.
- Does not add regional URLs without verification.
- Does not auto-detect country or browser language.
- Does not assume OneLink is enabled.
- Current US affiliate links remain the fallback path.

## Stack note

This PR is intentionally based on `platforms/international-foundation` because it depends on the platform helpers introduced in #2130. Merge #2130 first, then this PR can be retargeted/merged cleanly.

## Validation

Not run locally from this connector.