### PR TITLE
Add regional revenue override registry

### DIFF
--- a/config/regional-revenue-products.ts
+++ b/config/regional-revenue-products.ts
@@ -1,0 +1,58 @@
+import type { RecommendationSlot } from '@/components/RecommendationSection'
+import type { RegionalUrlMap } from '../src/lib/platforms'
+
+type RegionalRevenueProductKeyInput = {
+  setSlug: string
+  slot: RecommendationSlot
+  title: string
+}
+
+export type RegionalRevenueProductOverride = {
+  regionalUrls: RegionalUrlMap
+  verifiedAt?: string
+  notes?: string
+}
+
+export type RegionalRevenueProductOverrideMap = Record<string, RegionalRevenueProductOverride>
+
+export const regionalRevenueProductOverrides = {} satisfies RegionalRevenueProductOverrideMap
+
+export function normalizeRegionalRevenueProductTitle(title: string) {
+  return title
+    .trim()
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+export function makeRegionalRevenueProductKey({ setSlug, slot, title }: RegionalRevenueProductKeyInput) {
+  return `${setSlug}:${slot}:${normalizeRegionalRevenueProductTitle(title)}`
+}
+
+export function getRegionalRevenueProductOverride(
+  input: RegionalRevenueProductKeyInput,
+  overrides: RegionalRevenueProductOverrideMap = regionalRevenueProductOverrides,
+) {
+  return overrides[makeRegionalRevenueProductKey(input)]
+}
+
+export function validateRegionalRevenueProductOverrides(
+  overrides: RegionalRevenueProductOverrideMap = regionalRevenueProductOverrides,
+) {
+  const errors: string[] = []
+
+  for (const [key, override] of Object.entries(overrides)) {
+    if (!override.regionalUrls.US) {
+      errors.push(`${key}: regional override must include an explicit US fallback URL`)
+    }
+
+    for (const [region, url] of Object.entries(override.regionalUrls)) {
+      if (!url.startsWith('https://')) {
+        errors.push(`${key}: ${region} URL must be absolute HTTPS`)
+      }
+    }
+  }
+
+  return errors
+}

--- a/docs/seo/regional-revenue-overrides.md
+++ b/docs/seo/regional-revenue-overrides.md
@@ -1,0 +1,60 @@
+# Regional Revenue Product Overrides
+
+This file documents the product-by-product override layer for international platform integration.
+
+## Purpose
+
+The existing revenue product config can continue to use its current US/default URLs.
+
+Regional URLs should be added separately through `config/regional-revenue-products.ts` only after each marketplace destination is manually verified.
+
+## Why separate overrides?
+
+Keeping regional URLs in a separate registry reduces risk:
+
+- existing US affiliate behavior remains unchanged
+- UK/Canada URLs can be added one product at a time
+- unverified marketplace guesses are avoided
+- product-card routing can use the same resolver introduced in the platform foundation
+
+## Key format
+
+A regional override key is built from:
+
+```txt
+<product-set-slug>:<slot>:<normalized-product-title>
+```
+
+Example:
+
+```txt
+omega-3:premium:sports-research-triple-strength-omega-3
+```
+
+## Required fallback
+
+Every override must include a US fallback URL.
+
+This keeps behavior stable when a selected region lacks a verified URL.
+
+## URL requirements
+
+Regional URLs must be absolute HTTPS URLs.
+
+Do not add:
+
+- relative URLs
+- HTTP URLs
+- guessed Amazon marketplace URLs
+- unverified ASIN mappings
+- affiliate tags from the wrong regional account
+
+## Future wiring
+
+The next implementation step is to enrich product cards with regional override data by matching:
+
+- revenue product set slug
+- recommendation slot
+- product title
+
+After that, UK/Canada URLs can be added gradually with verification notes.


### PR DESCRIPTION
## Summary

Follow-up for Issue #2128, stacked on #2131.

This adds a separate regional revenue override registry so UK/Canada product URLs can be added product-by-product without rewriting the existing US revenue product config.

## What changed

- Adds `config/regional-revenue-products.ts`
  - stable key builder using product set slug + slot + normalized product title
  - empty override registry for now
  - lookup helper for future wiring
  - validation helper requiring explicit US fallback URLs and absolute HTTPS URLs
- Adds `docs/seo/regional-revenue-overrides.md`
  - explains the override workflow
  - documents why regional URLs stay separate from the existing US product config
  - warns against guessed marketplace URLs or wrong regional affiliate tags

## What this intentionally does not do

- Does not add unverified UK/Canada product URLs.
- Does not rewrite the existing `config/revenue-products.ts` file.
- Does not change live product destinations yet.
- Does not assume Amazon OneLink is enabled.
- Does not auto-detect country or browser language.

## Stack note

This PR is based on `platforms/revenue-product-regional-urls` because it depends on #2131's regional product-card support. Merge order should be:

1. #2131
2. this PR

## Validation

Not run locally from this connector.