### PR TITLE
Wire goal affiliate picks to regional override resolver

### DIFF
--- a/components/monetization/GoalTopAffiliatePicks.tsx
+++ b/components/monetization/GoalTopAffiliatePicks.tsx
@@ -1,7 +1,9 @@
 import { getGoal } from '@/data/goals'
 import { getRevenueProductSet } from '@/config/revenue-products'
+import { getRegionalRevenueProductOverride } from '@/config/regional-revenue-products'
 import ProductTrustAffiliate from '@/components/monetization/ProductTrustAffiliate'
 import { isRestrictedRecord } from '@/src/lib/restricted-ingredients'
+import { resolveRegionalUrl } from '@/src/lib/platforms'
 
 const SLOT_LABELS: Record<string, string> = {
   budget: 'Budget pick',
@@ -12,12 +14,14 @@ const SLOT_LABELS: Record<string, string> = {
 type GoalTopAffiliatePicksProps = {
   goalSlug: string
   limit?: number
+  preferredRegion?: string | null
   suppressMonetization?: boolean
 }
 
 export default function GoalTopAffiliatePicks({
   goalSlug,
   limit = 2,
+  preferredRegion = null,
   suppressMonetization = false,
 }: GoalTopAffiliatePicksProps) {
   if (suppressMonetization) return null
@@ -29,14 +33,26 @@ export default function GoalTopAffiliatePicks({
     if (isRestrictedRecord({ slug: pick.slug, name: pick.option })) return []
     const set = getRevenueProductSet(pick.slug)
     const product = set?.products.find((p) => p.slot === 'overall') ?? set?.products[0]
-    if (!product?.affiliateUrl || isRestrictedRecord(product)) return []
+    if (!product?.affiliateUrl || isRestrictedRecord(product) || !set) return []
+
+    const override = getRegionalRevenueProductOverride({
+      setSlug: set.slug,
+      slot: product.slot,
+      title: product.title || pick.option,
+    })
+    const href = resolveRegionalUrl({
+      defaultUrl: product.affiliateUrl,
+      regionalUrls: override?.regionalUrls,
+      preferredRegion,
+    })
+
     return [
       {
         key: pick.slug,
         need: pick.need,
         productName: product.title || pick.option,
         brand: product.brand,
-        href: product.affiliateUrl,
+        href,
         rationale: product.rationale || `Starting point for ${pick.need.toLowerCase()} — verify dose and safety on the full profile.`,
         slotLabel: SLOT_LABELS[product.slot] || 'Editor pick',
       },


### PR DESCRIPTION
## Summary

Follow-up for Issue #2128 after #2130, #2131, and #2132 landed.

This wires the regional override registry into the goal affiliate-pick flow while keeping the registry empty, so existing live affiliate destinations remain unchanged until verified UK/CA URLs are added.

## What changed

- Updates `components/monetization/GoalTopAffiliatePicks.tsx`
  - accepts optional `preferredRegion`
  - looks up regional overrides by product set slug + slot + product title
  - resolves hrefs through `resolveRegionalUrl`
  - falls back to the current product affiliate URL when no override exists

## Safety notes

- No product URLs changed.
- No unverified UK/CA links were added.
- No country auto-detection or auto-redirect behavior was added.
- Current US/default affiliate behavior remains the fallback.

## Validation

Not run locally from this connector.