### PR TITLE
Add commerce link audit script

### DIFF
--- a/docs/seo/commerce-link-audit.md
+++ b/docs/seo/commerce-link-audit.md
@@ -1,0 +1,50 @@
+# Commerce Link Audit
+
+The international platform-integration project should audit existing commerce links before adding regional marketplace URLs.
+
+## Why this exists
+
+The site currently has a US-first revenue-product system. Before adding UK/Canada marketplace destinations, we need a repeatable way to inspect the current commerce-link surface area.
+
+The audit script is intentionally read-only.
+
+```bash
+node scripts/audit-commerce-links.mjs
+```
+
+To write a JSON report:
+
+```bash
+node scripts/audit-commerce-links.mjs --out reports/commerce-link-audit.json
+```
+
+## What it checks
+
+The script inventories:
+
+- revenue product affiliate URL call sites
+- explicit ASIN-backed product entries
+- generic Amazon search fallback entries
+- Amazon host mentions across commerce-related files
+- whether the regional override registry exists
+- UK/Canada override mentions
+
+## What it does not verify
+
+This script does not confirm that a product exists in Amazon UK or Amazon Canada.
+
+It also does not confirm Amazon Associates tracking IDs, OneLink setup, product availability, pricing, or compliance.
+
+Those checks still require manual verification before adding regional URLs.
+
+## Safe rollout sequence
+
+1. Run the audit.
+2. Confirm regional affiliate accounts / store IDs.
+3. Confirm whether OneLink is available and compliant for the account.
+4. Add regional override URLs only when the exact product destination has been verified.
+5. Keep US/default affiliate links as the fallback path.
+
+## Guardrail
+
+Do not mass-generate UK/Canada marketplace URLs from US URLs or ASINs. Regional Amazon listings can differ by marketplace, seller, availability, price, supplement rules, and tracking setup.

--- a/scripts/audit-commerce-links.mjs
+++ b/scripts/audit-commerce-links.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const repoRoot = path.resolve(__dirname, '..')
+
+const AMAZON_HOSTS = ['www.amazon.com', 'www.amazon.co.uk', 'www.amazon.ca']
+const SOURCE_FILES = [
+  'config/revenue-products.ts',
+  'config/regional-revenue-products.ts',
+  'components/AffiliateProductCard.tsx',
+  'components/RecommendationSection.tsx',
+  'components/monetization/GoalTopAffiliatePicks.tsx',
+]
+
+function readSourceFile(relativePath) {
+  const absolutePath = path.join(repoRoot, relativePath)
+  return existsSync(absolutePath) ? readFileSync(absolutePath, 'utf8') : ''
+}
+
+function countOccurrences(source, needle) {
+  if (!source || !needle) return 0
+  return source.split(needle).length - 1
+}
+
+function countMatches(source, pattern) {
+  return Array.from(source.matchAll(pattern)).length
+}
+
+function extractAmazonHosts(source) {
+  return AMAZON_HOSTS.map((host) => ({
+    host,
+    count: countOccurrences(source, host),
+  }))
+}
+
+function buildAuditReport() {
+  const sources = SOURCE_FILES.map((relativePath) => ({
+    path: relativePath,
+    content: readSourceFile(relativePath),
+  }))
+  const combinedSource = sources.map((source) => source.content).join('\n')
+  const revenueProducts = sources.find((source) => source.path === 'config/revenue-products.ts')?.content ?? ''
+  const regionalOverrides = sources.find((source) => source.path === 'config/regional-revenue-products.ts')?.content ?? ''
+
+  const affiliateUrlCount = countMatches(revenueProducts, /affiliateUrl:\s*amazonProductUrl/g)
+  const explicitAsinCount = countMatches(revenueProducts, /\basin:\s*['"][^'"]+['"]/g)
+  const searchFallbackCount = Math.max(affiliateUrlCount - explicitAsinCount, 0)
+
+  return {
+    generatedAt: new Date().toISOString(),
+    scope: {
+      sourceFiles: SOURCE_FILES,
+      purpose: 'Inventory current commerce-link plumbing before adding verified regional marketplace URLs.',
+    },
+    revenueProducts: {
+      affiliateUrlCount,
+      explicitAsinCount,
+      searchFallbackCount,
+      note: 'Counts are source-code inventory signals, not live marketplace verification.',
+    },
+    amazonHosts: extractAmazonHosts(combinedSource),
+    regionalOverrides: {
+      registryPresent: regionalOverrides.length > 0,
+      explicitUsFallbackMentions: countMatches(regionalOverrides, /regionalUrls:\s*{[\s\S]*?US:/g),
+      ukMentions: countMatches(regionalOverrides, /\bUK:/g),
+      canadaMentions: countMatches(regionalOverrides, /\bCA:/g),
+      note: 'The override registry should stay sparse until each marketplace destination is manually verified.',
+    },
+    nextSteps: [
+      'Verify Amazon Associates account/store IDs for each supported region.',
+      'Confirm whether OneLink is enabled before relying on automated marketplace routing.',
+      'Add UK/Canada URLs only for products with confirmed matching marketplace listings.',
+      'Keep US/default URLs as the safe fallback path.',
+    ],
+  }
+}
+
+function printReport(report) {
+  console.log(JSON.stringify(report, null, 2))
+}
+
+function writeReport(report, outputPath) {
+  const absoluteOutputPath = path.isAbsolute(outputPath) ? outputPath : path.join(repoRoot, outputPath)
+  mkdirSync(path.dirname(absoluteOutputPath), { recursive: true })
+  writeFileSync(absoluteOutputPath, `${JSON.stringify(report, null, 2)}\n`)
+}
+
+const outputArgIndex = process.argv.indexOf('--out')
+const outputPath = outputArgIndex >= 0 ? process.argv[outputArgIndex + 1] : null
+const report = buildAuditReport()
+
+if (outputPath) {
+  writeReport(report, outputPath)
+} else {
+  printReport(report)
+}


### PR DESCRIPTION
## Summary

Follow-up for Issue #2128: international platform integration.

This adds a read-only audit script for the current commerce-link surface area before verified UK/Canada marketplace URLs are added.

## What changed

- Adds `scripts/audit-commerce-links.mjs`
  - inventories revenue product affiliate URL call sites
  - counts explicit ASIN-backed entries
  - counts generic Amazon search fallback entries
  - counts Amazon host mentions across commerce-related files
  - checks whether the regional override registry exists
  - reports UK/Canada override mentions
- Adds `docs/seo/commerce-link-audit.md`
  - documents how to run the audit
  - explains what the audit does and does not verify
  - reinforces the guardrail against mass-generating regional Amazon URLs

## Safety notes

- Read-only script.
- No production logic changed.
- No product URLs changed.
- No UK/Canada links added.
- No OneLink assumptions added.

## Validation

Not run locally from this connector.