### PR TITLE
Add French top entry pages

### DIFF
--- a/app/fr/_components/FrenchPageShell.tsx
+++ b/app/fr/_components/FrenchPageShell.tsx
@@ -1,0 +1,104 @@
+import Link from 'next/link'
+
+type FrenchCard = {
+  title: string
+  body: string
+  href?: string
+  label?: string
+}
+
+type FrenchPageShellProps = {
+  eyebrow: string
+  title: string
+  description: string
+  primaryHref: string
+  primaryLabel: string
+  secondaryHref?: string
+  secondaryLabel?: string
+  cards: FrenchCard[]
+  note?: string
+}
+
+const frenchNav = [
+  { href: '/fr/', label: 'Accueil' },
+  { href: '/fr/goals/sleep/', label: 'Sommeil' },
+  { href: '/fr/goals/stress/', label: 'Stress' },
+  { href: '/fr/goals/anxiety/', label: 'Anxiété' },
+  { href: '/fr/goals/focus/', label: 'Concentration' },
+]
+
+export default function FrenchPageShell({
+  eyebrow,
+  title,
+  description,
+  primaryHref,
+  primaryLabel,
+  secondaryHref,
+  secondaryLabel,
+  cards,
+  note,
+}: FrenchPageShellProps) {
+  return (
+    <div className='mx-auto max-w-6xl px-4 py-10 sm:px-6 lg:px-8'>
+      <nav aria-label='Pages principales en français' className='mb-8 flex flex-wrap gap-2'>
+        {frenchNav.map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            className='rounded-full border border-brand-900/10 bg-white/80 px-3 py-1.5 text-xs font-semibold text-brand-800 transition-colors hover:bg-brand-50'
+          >
+            {item.label}
+          </Link>
+        ))}
+      </nav>
+
+      <section className='hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-sm sm:p-8 lg:p-10'>
+        <p className='eyebrow-label'>{eyebrow}</p>
+        <h1 className='mt-3 max-w-4xl text-3xl font-semibold tracking-tight text-ink sm:text-5xl'>
+          {title}
+        </h1>
+        <p className='mt-5 max-w-3xl text-base leading-7 text-muted sm:text-lg'>
+          {description}
+        </p>
+        <div className='mt-7 flex flex-wrap gap-3'>
+          <Link
+            href={primaryHref}
+            className='rounded-full bg-brand-700 px-5 py-3 text-sm font-bold text-white shadow-sm transition-colors hover:bg-brand-800'
+          >
+            {primaryLabel}
+          </Link>
+          {secondaryHref && secondaryLabel ? (
+            <Link
+              href={secondaryHref}
+              className='rounded-full border border-brand-900/10 bg-white px-5 py-3 text-sm font-bold text-brand-800 transition-colors hover:bg-brand-50'
+            >
+              {secondaryLabel}
+            </Link>
+          ) : null}
+        </div>
+      </section>
+
+      <section className='mt-8 grid gap-4 md:grid-cols-3'>
+        {cards.map((card) => (
+          <article key={card.title} className='card-premium p-5'>
+            <h2 className='text-lg font-bold text-ink'>{card.title}</h2>
+            <p className='mt-2 text-sm leading-6 text-muted'>{card.body}</p>
+            {card.href && card.label ? (
+              <Link href={card.href} className='mt-4 inline-flex text-sm font-bold text-brand-800 hover:underline'>
+                {card.label}
+              </Link>
+            ) : null}
+          </article>
+        ))}
+      </section>
+
+      <section className='mt-8 rounded-2xl border border-amber-900/10 bg-amber-50/70 p-5 text-sm leading-6 text-amber-950'>
+        <h2 className='font-bold'>Note éditoriale</h2>
+        <p className='mt-2'>
+          Cette version française est une traduction éditoriale des pages principales. Le contenu est éducatif et ne remplace pas un avis médical personnalisé.
+        </p>
+        {note ? <p className='mt-2'>{note}</p> : null}
+      </section>
+    </div>
+  )
+}

--- a/app/fr/goals/anxiety/page.tsx
+++ b/app/fr/goals/anxiety/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from 'next'
+import FrenchPageShell from '../../_components/FrenchPageShell'
+import { SITE_URL } from '@/src/lib/seo'
+
+export const metadata: Metadata = {
+  title: 'Anxiété et suppléments | The Hippie Scientist en français',
+  description:
+    'Guide en français pour explorer les suppléments et plantes liés à l’anxiété, au calme et à la sécurité, sans promesses exagérées.',
+  alternates: { canonical: `${SITE_URL}/fr/goals/anxiety/` },
+  robots: { index: true, follow: true },
+  openGraph: {
+    title: 'Anxiété et suppléments | The Hippie Scientist en français',
+    description: 'Une entrée en français pour explorer anxiété, calme, sécurité et qualité des preuves.',
+    url: `${SITE_URL}/fr/goals/anxiety/`,
+    siteName: 'The Hippie Scientist',
+    locale: 'fr_FR',
+    type: 'article',
+  },
+}
+
+export default function FrenchAnxietyPage() {
+  return (
+    <FrenchPageShell
+      eyebrow='Objectif : anxiété'
+      title='Anxiété : commencez avec prudence, contexte et langage clair.'
+      description='Cette page ne présente pas les suppléments comme un traitement. Elle sert de point de départ pour comprendre les options liées au calme, vérifier les risques d’interaction et distinguer les preuves humaines du marketing.'
+      primaryHref='/goals/anxiety/'
+      primaryLabel='Voir le guide complet en anglais'
+      secondaryHref='/fr/goals/stress/'
+      secondaryLabel='Comparer avec le stress'
+      cards={[
+        {
+          title: 'Tout n’est pas identique',
+          body: 'Inquiétude, tension, sommeil agité et crises de panique ne relèvent pas du même contexte. La page évite de tout mélanger en une seule promesse.',
+        },
+        {
+          title: 'Attention aux combinaisons',
+          body: 'Les options apaisantes peuvent compter davantage si vous utilisez des médicaments pour l’humeur, le sommeil, la tension artérielle, l’alcool ou d’autres produits sédatifs.',
+        },
+        {
+          title: 'Chercher de vraies preuves',
+          body: 'Les preuves utiles expliquent la taille des études, la population, la dose, la durée et les limites, pas seulement qu’un produit est naturel.',
+        },
+      ]}
+      note='Si les symptômes sont intenses, nouveaux ou dangereux, cherchez une aide professionnelle ou locale d’urgence. Cette page organise seulement des informations éducatives.'
+    />
+  )
+}

--- a/app/fr/goals/focus/page.tsx
+++ b/app/fr/goals/focus/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from 'next'
+import FrenchPageShell from '../../_components/FrenchPageShell'
+import { SITE_URL } from '@/src/lib/seo'
+
+export const metadata: Metadata = {
+  title: 'Concentration et suppléments | The Hippie Scientist en français',
+  description:
+    'Guide en français pour explorer concentration, énergie mentale, attention et sécurité des suppléments avec un langage fondé sur les preuves.',
+  alternates: { canonical: `${SITE_URL}/fr/goals/focus/` },
+  robots: { index: true, follow: true },
+  openGraph: {
+    title: 'Concentration et suppléments | The Hippie Scientist en français',
+    description: 'Une entrée en français pour explorer concentration, énergie mentale et preuves sans exagération.',
+    url: `${SITE_URL}/fr/goals/focus/`,
+    siteName: 'The Hippie Scientist',
+    locale: 'fr_FR',
+    type: 'article',
+  },
+}
+
+export default function FrenchFocusPage() {
+  return (
+    <FrenchPageShell
+      eyebrow='Objectif : concentration'
+      title='Concentration : distinguez énergie, clarté mentale et stimulation.'
+      description='Améliorer la concentration ne signifie pas toujours utiliser quelque chose de plus fort. Cette page organise les questions utiles sur le sommeil, la caféine, le stress, les habitudes, la sécurité et la qualité des preuves.'
+      primaryHref='/goals/focus/'
+      primaryLabel='Voir le guide complet en anglais'
+      secondaryHref='/fr/'
+      secondaryLabel='Retour à l’accueil français'
+      cards={[
+        {
+          title: 'L’énergie n’est pas la concentration',
+          body: 'Un produit peut vous faire sentir plus éveillé sans améliorer l’organisation, la mémoire ou le travail profond. Il vaut mieux séparer ces objectifs.',
+        },
+        {
+          title: 'Prudence avec les stimulants',
+          body: 'Caféine, stimulants, médicaments et autres produits peuvent s’additionner. La sécurité dépend du contexte personnel.',
+        },
+        {
+          title: 'Comparer par les preuves',
+          body: 'Les meilleures pages expliquent ce qui a été étudié, chez qui, pendant combien de temps et l’ampleur de l’effet observé.',
+        },
+      ]}
+      note='La page complète en anglais contient plus de liens internes pendant la préparation de la traduction de la bibliothèque.'
+    />
+  )
+}

--- a/app/fr/goals/sleep/page.tsx
+++ b/app/fr/goals/sleep/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from 'next'
+import FrenchPageShell from '../../_components/FrenchPageShell'
+import { SITE_URL } from '@/src/lib/seo'
+
+export const metadata: Metadata = {
+  title: 'Sommeil et suppléments | The Hippie Scientist en français',
+  description:
+    'Guide en français pour commencer à explorer les suppléments, plantes et habitudes liés au sommeil, avec un accent sur la sécurité et les preuves.',
+  alternates: { canonical: `${SITE_URL}/fr/goals/sleep/` },
+  robots: { index: true, follow: true },
+  openGraph: {
+    title: 'Sommeil et suppléments | The Hippie Scientist en français',
+    description: 'Une entrée en français pour aborder le sommeil avec prudence, sécurité et preuves.',
+    url: `${SITE_URL}/fr/goals/sleep/`,
+    siteName: 'The Hippie Scientist',
+    locale: 'fr_FR',
+    type: 'article',
+  },
+}
+
+export default function FrenchSleepPage() {
+  return (
+    <FrenchPageShell
+      eyebrow='Objectif : sommeil'
+      title='Sommeil : commencez par la sécurité, le rythme et les preuves.'
+      description='Le but n’est pas de trouver une solution magique. Il s’agit d’organiser les options : ce qui peut soutenir le repos, ce qui peut causer de la somnolence le lendemain et ce qui mérite une vérification si vous prenez des médicaments ou avez des conditions de santé.'
+      primaryHref='/goals/sleep/'
+      primaryLabel='Voir le guide complet en anglais'
+      secondaryHref='/fr/'
+      secondaryLabel='Retour à l’accueil français'
+      cards={[
+        {
+          title: 'D’abord : le contexte',
+          body: 'Avant de comparer des suppléments, examinez les horaires, la caféine, l’alcool, les écrans, le stress du soir et la régularité du sommeil.',
+        },
+        {
+          title: 'Ensuite : la sécurité',
+          body: 'Les options apaisantes peuvent interagir avec les sédatifs, l’alcool, certains médicaments, la grossesse ou d’autres facteurs personnels.',
+        },
+        {
+          title: 'Enfin : les preuves',
+          body: 'Une bonne page sur le sommeil doit distinguer tradition, mécanisme plausible et études humaines réelles sans exagérer les résultats.',
+        },
+      ]}
+      note='Cette page est une entrée traduite. Pour les profils complets d’ingrédients, utilisez le guide complet et les pages de bibliothèque liées.'
+    />
+  )
+}

--- a/app/fr/goals/stress/page.tsx
+++ b/app/fr/goals/stress/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from 'next'
+import FrenchPageShell from '../../_components/FrenchPageShell'
+import { SITE_URL } from '@/src/lib/seo'
+
+export const metadata: Metadata = {
+  title: 'Stress et suppléments | The Hippie Scientist en français',
+  description:
+    'Guide en français pour explorer les options liées au stress, au calme, à l’adaptation et à la sécurité des suppléments.',
+  alternates: { canonical: `${SITE_URL}/fr/goals/stress/` },
+  robots: { index: true, follow: true },
+  openGraph: {
+    title: 'Stress et suppléments | The Hippie Scientist en français',
+    description: 'Une entrée en français pour explorer stress, calme et suppléments avec une approche fondée sur les preuves.',
+    url: `${SITE_URL}/fr/goals/stress/`,
+    siteName: 'The Hippie Scientist',
+    locale: 'fr_FR',
+    type: 'article',
+  },
+}
+
+export default function FrenchStressPage() {
+  return (
+    <FrenchPageShell
+      eyebrow='Objectif : stress'
+      title='Stress : comparez calme, énergie et récupération sans exagération.'
+      description='Le stress peut signifier beaucoup de choses : tension physique, fatigue, irritabilité, pression mentale ou récupération lente. Cette page aide à séparer ces contextes avant de regarder des suppléments ou des plantes.'
+      primaryHref='/goals/stress/'
+      primaryLabel='Voir le guide complet en anglais'
+      secondaryHref='/fr/goals/anxiety/'
+      secondaryLabel='Comparer avec l’anxiété'
+      cards={[
+        {
+          title: 'Définir le problème',
+          body: 'Toutes les options liées au stress ne visent pas la même chose. Certaines concernent la détente, d’autres l’énergie ou la résilience perçue.',
+        },
+        {
+          title: 'Vérifier les interactions',
+          body: 'Les plantes et suppléments peuvent ne pas convenir si vous utilisez déjà des médicaments, des sédatifs, des stimulants ou des produits aux effets similaires.',
+        },
+        {
+          title: 'Regarder la qualité des preuves',
+          body: 'Une recommandation solide demande plus qu’une histoire populaire : elle doit expliquer les études humaines, les limites et la sécurité.',
+        },
+      ]}
+      note='Pour comparer des ingrédients précis, utilisez le guide complet en anglais pendant que la traduction s’élargit.'
+    />
+  )
+}

--- a/app/fr/page.tsx
+++ b/app/fr/page.tsx
@@ -1,0 +1,54 @@
+import type { Metadata } from 'next'
+import FrenchPageShell from './_components/FrenchPageShell'
+import { SITE_URL } from '@/src/lib/seo'
+
+export const metadata: Metadata = {
+  title: 'The Hippie Scientist en français | Recherche sur les suppléments',
+  description:
+    'Page d’accueil française de The Hippie Scientist : recherche claire sur les suppléments, plantes et composés pour le sommeil, le stress, l’anxiété et la concentration.',
+  alternates: { canonical: `${SITE_URL}/fr/` },
+  robots: { index: true, follow: true },
+  openGraph: {
+    title: 'The Hippie Scientist en français',
+    description: 'Recherche claire sur les suppléments, plantes et composés, avec des pages principales en français.',
+    url: `${SITE_URL}/fr/`,
+    siteName: 'The Hippie Scientist',
+    locale: 'fr_FR',
+    type: 'website',
+  },
+}
+
+export default function FrenchHomePage() {
+  return (
+    <FrenchPageShell
+      eyebrow='The Hippie Scientist en français'
+      title='La recherche sur les suppléments, expliquée avec clarté et prudence.'
+      description='Commencez par votre objectif : mieux dormir, gérer le stress, comprendre l’anxiété ou améliorer la concentration. Ces pages résument les points clés en français et renvoient vers la bibliothèque complète du site.'
+      primaryHref='/fr/goals/sleep/'
+      primaryLabel='Commencer par le sommeil'
+      secondaryHref='/goals/'
+      secondaryLabel='Voir les objectifs en anglais'
+      cards={[
+        {
+          title: 'Sommeil',
+          body: 'Un point de départ simple pour examiner le repos, les horaires, la sécurité et la qualité des preuves.',
+          href: '/fr/goals/sleep/',
+          label: 'Voir le sommeil en français',
+        },
+        {
+          title: 'Stress et anxiété',
+          body: 'Des introductions pour distinguer calme, tension, inquiétude et sécurité avant de comparer des options.',
+          href: '/fr/goals/stress/',
+          label: 'Voir le stress en français',
+        },
+        {
+          title: 'Concentration',
+          body: 'Une entrée claire pour réfléchir à l’énergie mentale, l’attention, les habitudes et les limites des preuves.',
+          href: '/fr/goals/focus/',
+          label: 'Voir la concentration en français',
+        },
+      ]}
+      note='La bibliothèque complète de plantes et de composés reste principalement en anglais pendant la mise en place du flux de traduction.'
+    />
+  )
+}

--- a/public/_redirects
+++ b/public/_redirects
@@ -2,9 +2,6 @@
 https://www.thehippiescientist.net/goals/ https://thehippiescientist.net/goals/ 301
 https://www.thehippiescientist.net/guides/supplements-for-brain-fog-and-fatigue/ https://thehippiescientist.net/guides/other/supplements-for-brain-fog-and-fatigue/ 301
 https://www.thehippiescientist.net/ https://thehippiescientist.net/ 301
-https://www.thehippiescientist.net/top/stress/ https://thehippiescientist.net/goals/stress/ 301
-https://www.thehippiescientist.net/top/sleep https://thehippiescientist.net/guides/sleep/best-natural-sleep-aids-that-work/ 301
-https://www.thehippiescientist.net/top/sleep/ https://thehippiescientist.net/guides/sleep/best-natural-sleep-aids-that-work/ 301
 https://www.thehippiescientist.net/guides/sleep-herbs-vs-melatonin/ https://thehippiescientist.net/guides/sleep/sleep-herbs-vs-melatonin/ 301
 https://www.thehippiescientist.net/guides/best-supplements-for-gut-health/ https://thehippiescientist.net/guides/best/supplements-for-gut-health/ 301
 https://www.thehippiescientist.net/guides/ https://thehippiescientist.net/guides/ 301
@@ -186,8 +183,6 @@ https://www.thehippiescientist.net/* https://thehippiescientist.net/:splat 301
 /citicoline-vs-alpha-gpc/ /guides/adhd/citicoline-vs-alpha-gpc/ 301
 /omega-3-for-adhd /guides/adhd/omega-3-and-adhd/ 301
 /omega-3-for-adhd/ /guides/adhd/omega-3-and-adhd/ 301
-/top/sleep /guides/sleep/best-natural-sleep-aids-that-work/ 301
-/top/sleep/ /guides/sleep/best-natural-sleep-aids-that-work/ 301
 # CONTENT TAXONOMY MIGRATION: Learn content is now surfaced from /guides;
 # keep /learn/ live for existing static learning-path content and sitemap hygiene.
 # Articles style category legacy redirect (field-notes → nootropics)


### PR DESCRIPTION
## Summary

Adds a focused French-language pilot for the top five entry pages:

1. `/fr/`
2. `/fr/goals/sleep/`
3. `/fr/goals/stress/`
4. `/fr/goals/anxiety/`
5. `/fr/goals/focus/`

## What changed

- Adds a shared French page shell component for consistent layout and navigation.
- Adds French homepage copy for the main site entry.
- Adds French goal-entry pages for sleep, stress, anxiety, and focus.
- Each page includes explicit metadata, canonical URL, Open Graph metadata, and index/follow robots metadata.
- Each translated page links back to the fuller English goal page while the full library remains English-first.

## Translation approach

This is a careful French entry-page pilot, not a mass translation of generated herb/compound profiles.

The pages are written as editorial French summaries of the top site entry points so we avoid creating hundreds of incomplete translated URLs.

## Safety notes

- No generated workbook/runtime data was edited.
- No herb or compound claims were expanded.
- No hreflang expansion was added yet.
- No affiliate/platform behavior changed.

## Validation

Not run locally from this connector.