### PR TITLE
Improve product quality audit page

### DIFF
--- a/app/learn/product-quality/page.tsx
+++ b/app/learn/product-quality/page.tsx
@@ -7,13 +7,33 @@ import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import { isRestrictedRecord } from '../../../src/lib/restricted-ingredients'
 import { toBuyingToolRecord } from '../../../src/lib/tool-page-payloads'
 import type { RuntimeRecord } from '../../../src/types/content'
+import { buildPageMetadata } from '../../../src/lib/seo'
 
-export const metadata: Metadata = {
+export const metadata: Metadata = buildPageMetadata({
   title: 'Supplement Product Quality Guide',
   description:
     'Learn how to evaluate supplement labels, standardized extracts, third-party testing, certificates of analysis, and product-quality tradeoffs before buying.',
-  alternates: { canonical: '/learn/product-quality/' },
-}
+  path: '/learn/product-quality/',
+  openGraphType: 'article',
+})
+
+const qualityStartingPoints = [
+  {
+    title: 'Before buying for sleep',
+    href: '/guides/sleep/',
+    body: 'Match the product to the sleep bottleneck first: timing, relaxation, stress, or sleep maintenance.',
+  },
+  {
+    title: 'Before buying for stress',
+    href: '/guides/anxiety/',
+    body: 'Separate acute calm from adaptogen-style support before choosing a standardized extract.',
+  },
+  {
+    title: 'Before buying for focus',
+    href: '/guides/focus/',
+    body: 'Check stimulant load, caffeine timing, and anxiety or blood-pressure context before comparing nootropics.',
+  },
+]
 
 export default async function ProductQualityPage() {
   const [rawHerbs, rawCompounds] = await Promise.all([getHerbs(), getCompounds()])
@@ -78,6 +98,28 @@ export default async function ProductQualityPage() {
           <p className='text-xs leading-relaxed text-slate-500'>
             Proprietary blends can hide under-dosed or over-stacked formulas. Favor transparent products with clear ingredient amounts.
           </p>
+        </div>
+      </section>
+
+      <section className='rounded-3xl border border-brand-900/10 bg-white/90 p-5 shadow-sm'>
+        <div className='max-w-3xl space-y-2'>
+          <p className='eyebrow-label'>Use this page after intent is clear</p>
+          <h2 className='text-2xl font-bold tracking-tight text-ink'>Start with the goal, then judge product quality</h2>
+          <p className='text-sm leading-6 text-muted'>
+            A clean certificate of analysis does not make the wrong supplement useful. Pick the goal page first, then use this checklist to compare form, dose transparency, third-party testing, and safety context.
+          </p>
+        </div>
+        <div className='mt-5 grid gap-3 md:grid-cols-3'>
+          {qualityStartingPoints.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className='rounded-2xl border border-brand-900/10 bg-brand-50/50 p-4 transition hover:border-brand-300 hover:bg-white'
+            >
+              <h3 className='text-sm font-bold text-ink'>{item.title}</h3>
+              <p className='mt-2 text-xs leading-5 text-muted'>{item.body}</p>
+            </Link>
+          ))}
         </div>
       </section>
 

--- a/src/components/sourcing/BuyGuideClient.tsx
+++ b/src/components/sourcing/BuyGuideClient.tsx
@@ -21,7 +21,7 @@ interface BuyGuideClientProps {
   compounds: any[]
 }
 
-const DEFAULT_VISIBLE_ITEMS = 72
+const DEFAULT_VISIBLE_ITEMS = 12
 
 export default function BuyGuideClient({ herbs, compounds }: BuyGuideClientProps) {
   const [searchQuery, setSearchQuery] = useState('')
@@ -130,7 +130,7 @@ export default function BuyGuideClient({ herbs, compounds }: BuyGuideClientProps
       {/* Grid of Sourcing Cards */}
       {!searchQuery && allItems.length > DEFAULT_VISIBLE_ITEMS ? (
         <p className='text-xs text-slate-500'>
-          Showing {DEFAULT_VISIBLE_ITEMS} common sourcing checklists. Search by ingredient name to inspect the full library.
+          Showing {DEFAULT_VISIBLE_ITEMS} common sourcing checklists to keep the page scannable. Search by ingredient name to inspect the full library.
         </p>
       ) : null}
       <div className='grid gap-6 sm:grid-cols-2 lg:grid-cols-3'>


### PR DESCRIPTION
## Summary
- Strengthens /learn/product-quality/ metadata with the shared SEO metadata helper for canonical, Open Graph, and Twitter tags.
- Adds goal-first routing cards so users choose the relevant supplement intent before judging product quality.
- Reduces default sourcing checklist cards from 72 to 12 to lower crawl-visible link density while preserving full search access.

## Validation
- npm run check:fast
- npm run build
- git diff --check
- Exported /learn/product-quality/ confirmed with title, canonical URL, 63 links, and 15 external links.