### PR TITLE
Fix profile open graph metadata type

### DIFF
--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -69,7 +69,7 @@ function stripBrandSuffix(value: string): string {
     .trim()
 }
 
-export type PageType = 'website' | 'article'
+export type PageType = 'website' | 'article' | 'profile'
 
 export type IndexDecision = {
   index: boolean
@@ -158,7 +158,7 @@ export function normalizeCanonicalPath(path: string, keepQueryParams: string[] =
 }
 
 export type BuildPageMetadataArgs = BuildMetaArgs & {
-  openGraphType?: 'website' | 'article'
+  openGraphType?: PageType
   robots?: Metadata['robots']
   keywords?: string[] | string
 }


### PR DESCRIPTION
## What changed

- Allow `buildPageMetadata` to accept `openGraphType: 'profile'`.
- Reuse the shared `PageType` alias for metadata helper arguments.

## Why

The deploy build failed during Next type checking when the author page used profile Open Graph metadata. The helper type was narrower than the metadata value the page emits.

## Validation

- `npm run typecheck`
- `npm run build:deploy`
