### PR TITLE
High ROI: add above-fold decision CTA to compare pages

### DIFF
--- a/components/compare/CompareHero.tsx
+++ b/components/compare/CompareHero.tsx
@@ -158,6 +158,17 @@ export default function CompareHero({ item1, item2 }: CompareHeroProps) {
         <p className="text-base leading-relaxed text-muted">
           Compare evidence quality, mechanisms, dosing, and safety to identify the better fit for your goals.
         </p>
+        <div className="flex flex-col gap-2 pt-1 sm:flex-row sm:items-center">
+          <a
+            href="#compare-decision"
+            className="button-primary w-full px-5 py-2.5 text-center text-sm sm:w-auto"
+          >
+            Get a personal pick ↓
+          </a>
+          <p className="text-xs leading-5 text-muted sm:max-w-xs">
+            Takes about 20 seconds and keeps the recommendation evidence-first.
+          </p>
+        </div>
       </div>
 
       <div className="relative grid gap-6 md:grid-cols-2">

--- a/components/compare/ComparePageScaffold.tsx
+++ b/components/compare/ComparePageScaffold.tsx
@@ -79,7 +79,7 @@ export default function ComparePageScaffold({
 
       <CompareHero item1={item1} item2={item2} />
 
-      <section>
+      <section id="compare-decision" className="scroll-mt-24">
         <CompareDecisionWidget item1={item1} item2={item2} isHarmReduction={isHarmReduction} />
       </section>
 


### PR DESCRIPTION
## What changed

Added an above-fold decision CTA to compare pages:

- `CompareHero` now shows a **Get a personal pick** button near the page intro.
- `ComparePageScaffold` anchors the decision widget as `#compare-decision` with scroll offset.

## Why this is high ROI

- Compare visitors are already in decision mode.
- The interactive widget is one of the highest-value elements on the page, but it previously required scrolling without a clear prompt.
- This nudges users into the preference-based recommendation flow sooner.
- It pairs with PR #2148, which added next-step CTAs after the recommendation result.

## Files changed

- `components/compare/CompareHero.tsx`
- `components/compare/ComparePageScaffold.tsx`

## Risk level

Low. No generated data, workbook logic, schemas, routes, or monetization suppression rules were changed.