### PR TITLE
High ROI: strengthen related comparison paths

### DIFF
--- a/components/compare/CompareRelated.tsx
+++ b/components/compare/CompareRelated.tsx
@@ -14,24 +14,38 @@ export default function CompareRelated({ comparisons, currentSlug }: CompareRela
   if (related.length === 0) return null
 
   return (
-    <section className="space-y-6">
-      <div>
-        <p className="text-xs font-bold uppercase tracking-[0.18em] text-brand-700">
-          Related comparisons
-        </p>
-        <h2 className="mt-1 text-2xl font-semibold tracking-tight text-ink">
-          People also compare...
-        </h2>
+    <section className="rounded-3xl border border-brand-900/10 bg-white/80 p-5 shadow-sm sm:p-6 space-y-5">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div className="space-y-1">
+          <p className="text-xs font-bold uppercase tracking-[0.18em] text-brand-700">
+            Related comparisons
+          </p>
+          <h2 className="text-2xl font-semibold tracking-tight text-ink">
+            Still deciding? Compare the nearby options.
+          </h2>
+          <p className="max-w-2xl text-sm leading-6 text-muted">
+            Similar supplements can differ a lot by timing, stimulation, safety, and evidence quality. These next comparisons keep visitors in decision mode instead of sending them back to search.
+          </p>
+        </div>
+        <Link
+          href="/guides/compare/"
+          className="inline-flex shrink-0 rounded-full border border-brand-900/10 bg-brand-50 px-4 py-2 text-xs font-bold text-brand-800 transition-colors hover:bg-brand-100"
+        >
+          Open compare hub →
+        </Link>
       </div>
 
-      <div className="grid grid-cols-2 gap-3 md:grid-cols-3">
+      <div className="grid gap-3 sm:grid-cols-2 md:grid-cols-3">
         {related.map((slug) => (
           <Link
             key={slug}
             href={`/guides/compare/${slug}`}
-            className="rounded-2xl border border-brand-900/10 bg-paper-50 px-4 py-4 text-sm font-medium text-ink transition-colors hover:bg-brand-50 hover:text-brand-700"
+            className="group rounded-2xl border border-brand-900/10 bg-paper-50 px-4 py-4 text-sm font-medium text-ink transition-colors hover:bg-brand-50 hover:text-brand-700"
           >
-            {formatComparisonSlug(slug)}
+            <span className="block font-semibold">{formatComparisonSlug(slug)}</span>
+            <span className="mt-1 block text-xs leading-5 text-muted group-hover:text-brand-700/80">
+              Review tradeoffs →
+            </span>
           </Link>
         ))}
       </div>


### PR DESCRIPTION
## What changed

Upgraded `CompareRelated` from a simple related-link grid into a stronger continuation module:

- Adds decision-focused copy: **Still deciding? Compare the nearby options.**
- Adds a compare-hub CTA.
- Adds `Review tradeoffs →` microcopy to each related comparison card.
- Keeps the same data input and route structure.

## Why this is high ROI

- Compare pages attract visitors who are already deciding between options.
- The bottom related-comparison block is a natural continuation point after a user reads the first comparison.
- This should increase internal page depth and keep users in high-intent comparison paths instead of returning to search.
- It compounds with PR #2148 and PR #2149 by improving the compare-page funnel after the decision widget and page intro.

## Files changed

- `components/compare/CompareRelated.tsx`

## Risk level

Low. One presentational component only; no generated data, workbook logic, schemas, route generation, or affiliate rules changed.