### PR TITLE
High ROI: add decision CTA to compare FAQ

### DIFF
--- a/components/compare/CompareFAQ.tsx
+++ b/components/compare/CompareFAQ.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link'
+
 interface FAQItem {
   question: string
   answer: string
@@ -44,6 +46,31 @@ export default function CompareFAQ({ faqs }: CompareFAQProps) {
             </div>
           </details>
         ))}
+      </div>
+
+      <div className="rounded-2xl border border-brand-900/10 bg-brand-50/80 p-4 sm:flex sm:items-center sm:justify-between sm:gap-4">
+        <div className="space-y-1">
+          <p className="text-xs font-bold uppercase tracking-wider text-brand-700">
+            Need a faster decision?
+          </p>
+          <p className="text-sm leading-6 text-muted">
+            Use the preference quiz above, or browse the full compare hub for nearby tradeoffs.
+          </p>
+        </div>
+        <div className="mt-3 flex flex-col gap-2 sm:mt-0 sm:flex-row">
+          <a
+            href="#compare-decision"
+            className="rounded-full bg-brand-700 px-4 py-2 text-center text-xs font-bold text-white transition-colors hover:bg-brand-600"
+          >
+            Get a personal pick ↑
+          </a>
+          <Link
+            href="/guides/compare/"
+            className="rounded-full border border-brand-900/10 bg-white px-4 py-2 text-center text-xs font-bold text-brand-800 transition-colors hover:bg-brand-100"
+          >
+            Compare hub →
+          </Link>
+        </div>
       </div>
     </section>
   )


### PR DESCRIPTION
## What changed

Added a compact CTA block at the end of `CompareFAQ`:

- Re-routes FAQ readers back to the anchored preference widget with **Get a personal pick**.
- Adds a secondary link to the main compare hub.
- Keeps FAQ content and schema inputs unchanged.

## Why this is high ROI

- FAQ sections often catch users after objections/questions.
- The previous FAQ ended after answers with no strong next step.
- This creates another re-entry point into the decision flow and high-intent comparison hub.
- It compounds with PR #2148, #2149, and #2150 across the compare-page funnel.

## Files changed

- `components/compare/CompareFAQ.tsx`

## Risk level

Low. One presentational component only; no generated data, workbook logic, schema generation, routes, or affiliate rules changed.