### PR TITLE
High ROI: add trust framing to compare product options

### DIFF
--- a/components/compare/CompareAffiliate.tsx
+++ b/components/compare/CompareAffiliate.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import type { CompareItem } from '@/lib/compare'
 import { revenueProductSets } from '@/config/revenue-products'
 import RecommendationSection from '@/components/RecommendationSection'
@@ -17,7 +18,27 @@ export default function CompareAffiliate({ item1, item2, isHR }: CompareAffiliat
   if (!set1 && !set2) return null
 
   return (
-    <div className="space-y-8">
+    <section aria-labelledby="compare-product-options-heading" className="space-y-8">
+      <div className="rounded-3xl border border-brand-900/10 bg-white/80 p-5 shadow-sm sm:p-6">
+        <div className="max-w-3xl space-y-2">
+          <p className="text-xs font-bold uppercase tracking-[0.18em] text-brand-700">
+            Product options
+          </p>
+          <h2 id="compare-product-options-heading" className="text-2xl font-semibold tracking-tight text-ink">
+            Only shop after the fit makes sense
+          </h2>
+          <p className="text-sm leading-6 text-muted">
+            Use the comparison, dosing notes, safety flags, and full profiles first. These product sections are optional next steps for readers who already know which side fits their goal.
+          </p>
+          <Link
+            href="/info/affiliate-disclosure/"
+            className="inline-flex text-xs font-bold text-brand-700 underline underline-offset-4 hover:text-brand-800"
+          >
+            Read our affiliate disclosure →
+          </Link>
+        </div>
+      </div>
+
       {set1 && (
         <RecommendationSection
           title={`If you choose ${item1.name}`}
@@ -30,6 +51,6 @@ export default function CompareAffiliate({ item1, item2, isHR }: CompareAffiliat
           products={set2.products}
         />
       )}
-    </div>
+    </section>
   )
 }


### PR DESCRIPTION
## What changed

Added evidence-first trust framing above compare-page product recommendations:

- Wraps the product block in an accessible section with a visible heading.
- Adds **Product options** / **Only shop after the fit makes sense** intro copy.
- Tells readers to use comparison, dosing notes, safety flags, and full profiles first.
- Adds a direct affiliate disclosure link.
- Keeps harm-reduction suppression unchanged with `if (isHR) return null`.

## Why this is high ROI

- Product blocks are monetization-sensitive and trust-sensitive.
- The old component jumped straight into recommendations with no framing.
- This should make the section feel more credible, less salesy, and better aligned with the site’s evidence-first brand.
- It improves conversion trust without changing product data, generated content, or affiliate suppression rules.

## Files changed

- `components/compare/CompareAffiliate.tsx`

## Risk level

Low. One presentational component only; no generated data, workbook logic, schema generation, routes, or product config changed.