### PR TITLE
High ROI: add answer summary to compare decision result

### DIFF
--- a/components/compare/CompareDecisionWidget.tsx
+++ b/components/compare/CompareDecisionWidget.tsx
@@ -116,6 +116,18 @@ const GOAL_LABELS: Record<Goal, string> = {
   immune: 'Immune Health',
 }
 
+const TIMING_LABELS: Record<Timing, string> = {
+  morning: 'Morning',
+  evening: 'Evening',
+  flexible: 'Flexible',
+}
+
+const STIM_SENSITIVITY_LABELS: Record<StimSensitivity, string> = {
+  yes: 'Sensitive to stimulants',
+  no: 'Not stimulant-sensitive',
+  unsure: 'Not sure',
+}
+
 function buildReason(
   recommended: CompareItem,
   other: CompareItem,
@@ -317,22 +329,28 @@ export default function CompareDecisionWidget({
 
       {/* Result */}
       {allAnswered && (() => {
+        const resolved = selections as ResolvedSelections
         const { recommended, other, isTie } = chooseRecommendation(
           item1,
           item2,
-          selections as ResolvedSelections
+          resolved
         )
         const reason = buildReason(
           recommended,
           other,
-          selections as ResolvedSelections,
+          resolved,
           isTie
         )
         const stackSuggestion = buildStackSuggestion(
           item1,
           item2,
-          selections as ResolvedSelections
+          resolved
         )
+        const answerSummary = [
+          { label: 'Goal', value: GOAL_LABELS[resolved.goal] },
+          { label: 'Timing', value: TIMING_LABELS[resolved.timing] },
+          { label: 'Stimulants', value: STIM_SENSITIVITY_LABELS[resolved.stimSensitive] },
+        ]
 
         return (
           <div className="rounded-2xl border border-brand-200 bg-brand-50 px-5 py-5 space-y-4">
@@ -352,6 +370,23 @@ export default function CompareDecisionWidget({
             <p className="text-sm leading-relaxed text-ink">
               {reason}
             </p>
+
+            {/* Answer summary */}
+            <div className="rounded-xl border border-brand-900/10 bg-white/70 p-3 space-y-2">
+              <p className="text-xs font-bold uppercase tracking-wider text-brand-700">
+                Based on your answers
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {answerSummary.map(({ label, value }) => (
+                  <span
+                    key={label}
+                    className="rounded-full border border-brand-900/10 bg-paper-50 px-3 py-1 text-xs font-medium text-ink"
+                  >
+                    <span className="text-muted">{label}:</span> {value}
+                  </span>
+                ))}
+              </div>
+            </div>
 
             {/* Next-step CTAs */}
             <div className="rounded-xl border border-brand-900/10 bg-white/75 p-4 space-y-3">


### PR DESCRIPTION
## What changed

Added transparent answer-summary chips to the compare decision widget result:

- Adds reusable labels for timing and stimulant-sensitivity selections.
- Stores the resolved selections once instead of repeatedly casting inside the result block.
- Adds a **Based on your answers** panel showing:
  - Goal
  - Timing
  - Stimulant sensitivity
- Keeps the existing recommendation scoring, reason text, next-step CTAs, stack suggestion, and harm-reduction notice unchanged.

## Why this is high ROI

- The interactive widget is one of the highest-intent parts of compare pages.
- Showing the user’s selected preferences makes the recommendation feel more transparent and trustworthy.
- It reduces “why did it pick this?” friction without changing the underlying scoring logic.
- It compounds with the prior compare-page funnel improvements.

## Files changed

- `components/compare/CompareDecisionWidget.tsx`

## Risk level

Low. One client component only; no generated data, workbook logic, route generation, product data, or scoring behavior changed.