### PR TITLE
High ROI: soften compare widget stacking copy

### DIFF
--- a/components/compare/CompareDecisionWidget.tsx
+++ b/components/compare/CompareDecisionWidget.tsx
@@ -419,7 +419,7 @@ export default function CompareDecisionWidget({
             {/* Stack suggestion */}
             <div className="border-t border-brand-900/10 pt-4 space-y-1">
               <p className="text-xs font-bold uppercase tracking-wider text-brand-700">
-                Or take both:
+                If considering both:
               </p>
               <p className="text-xs leading-relaxed text-muted">
                 {stackSuggestion}


### PR DESCRIPTION
## What changed

Softened the compare decision widget stacking label:

- Changed **“Or take both:”** to **“If considering both:”**.

## Why this is high ROI

- The old wording could sound like the site is casually encouraging supplement stacking.
- The new wording keeps the useful guidance while making the safety boundary clearer.
- This is especially important for supplement, herb, and compound comparison pages.

## Files changed

- `components/compare/CompareDecisionWidget.tsx`

## Risk level

Very low. One text-only copy change; no generated data, workbook logic, scoring behavior, routes, schemas, products, or layout structure changed.