### PR TITLE
High ROI: bound and enforce the JSON-LD safety boundary

### DIFF
--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -1,5 +1,6 @@
 import Head from 'next/head'
 import Link from 'next/link'
+import JsonLd from '@/components/seo/JsonLd'
 
 const pageUrl = 'https://thehippiescientist.net/500/'
 
@@ -32,10 +33,7 @@ export default function Custom500() {
         <meta name="twitter:title" content="Server Error | The Hippie Scientist" />
         <meta name="twitter:description" content="Temporary server error page for The Hippie Scientist." />
       </Head>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
-      />
+      <JsonLd schema={structuredData} />
       <main style={{ margin: '0 auto', maxWidth: 720, padding: '4rem 1.5rem', fontFamily: 'system-ui, sans-serif' }}>
         <p style={{ color: '#66736b', fontSize: 14, fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase' }}>
           The Hippie Scientist

--- a/scripts/ci/validate-dangerously-set-inner-html.mjs
+++ b/scripts/ci/validate-dangerously-set-inner-html.mjs
@@ -53,7 +53,7 @@ const RAW_JSON_LD_BASELINE = new Map([
   ['components/articles/FocusAdhdArticlePage.tsx', 2],
 ])
 
-const JSON_LD_SCRIPT_PATTERN = /<script\b(?=[^>]*\btype\s*=\s*["']application\/ld\+json["'])[^>]*>[\s\S]*?<\/script>|<script\b(?=[^>]*\btype\s*=\s*["']application\/ld\+json["'])[^>]*\/>/g
+const JSON_LD_SCRIPT_PATTERN = /<script\b(?=[^>]*\btype\s*=\s*["']application\/ld\+json["'])[^>]*\/>|<script\b(?=[^>]*\btype\s*=\s*["']application\/ld\+json["'])[^>]*>[\s\S]*?<\/script>/g
 
 function countRawJsonLdSerializations(content) {
   return [...content.matchAll(JSON_LD_SCRIPT_PATTERN)]
@@ -64,8 +64,13 @@ function countRawJsonLdSerializations(content) {
 function assertDetectorWorks() {
   const unsafe = '<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }} />'
   const safe = '<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: serializeJsonLd(schema) }} />'
+  const mixed = `${safe}\n${unsafe}\n<script>unrelated()</script>`
 
-  if (countRawJsonLdSerializations(unsafe) !== 1 || countRawJsonLdSerializations(safe) !== 0) {
+  if (
+    countRawJsonLdSerializations(unsafe) !== 1 ||
+    countRawJsonLdSerializations(safe) !== 0 ||
+    countRawJsonLdSerializations(mixed) !== 1
+  ) {
     throw new Error('Raw JSON-LD detector self-test failed.')
   }
 }

--- a/scripts/ci/validate-dangerously-set-inner-html.mjs
+++ b/scripts/ci/validate-dangerously-set-inner-html.mjs
@@ -4,7 +4,7 @@ import path from 'node:path'
 
 const ROOT = process.cwd()
 
-const SCAN_DIRS = ['app', 'components', 'lib', 'src']
+const SCAN_DIRS = ['app', 'components', 'lib', 'pages', 'src']
 const ALLOWLIST = new Set([
   'app/about/page.tsx',
   'app/articles/[slug]/page.tsx',
@@ -41,51 +41,100 @@ const ALLOWLIST = new Set([
   'components/SchemaOrg.tsx',
   'components/articles/FocusAdhdArticlePage.tsx',
   'components/seo/AuthorityJsonLd.tsx',
-  'components/seo/FaqJsonLd.tsx',
   'components/seo/JsonLd.tsx',
   'src/app/protocols/[slug]/page.tsx',
-  'src/components/ecosystem-supernode.tsx',
 ])
 
-function scanDirectory(dir, violations = []) {
+// These are the only remaining raw JSON.stringify-based JSON-LD emitters.
+// Exact counts make the debt visible and prevent this baseline from growing.
+const RAW_JSON_LD_BASELINE = new Map([
+  ['app/compounds/[slug]/page.tsx', 1],
+  ['app/herbs/[slug]/page.tsx', 1],
+  ['components/articles/FocusAdhdArticlePage.tsx', 2],
+])
+
+const JSON_LD_SCRIPT_PATTERN = /<script\b(?=[^>]*\btype\s*=\s*["']application\/ld\+json["'])[^>]*>[\s\S]*?<\/script>|<script\b(?=[^>]*\btype\s*=\s*["']application\/ld\+json["'])[^>]*\/>/g
+
+function countRawJsonLdSerializations(content) {
+  return [...content.matchAll(JSON_LD_SCRIPT_PATTERN)]
+    .filter((match) => /JSON\.stringify\s*\(/.test(match[0]))
+    .length
+}
+
+function assertDetectorWorks() {
+  const unsafe = '<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }} />'
+  const safe = '<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: serializeJsonLd(schema) }} />'
+
+  if (countRawJsonLdSerializations(unsafe) !== 1 || countRawJsonLdSerializations(safe) !== 0) {
+    throw new Error('Raw JSON-LD detector self-test failed.')
+  }
+}
+
+function scanDirectory(dir, violations = [], rawJsonLdCounts = new Map()) {
   const absDir = path.join(ROOT, dir)
-  if (!fs.existsSync(absDir)) return violations
+  if (!fs.existsSync(absDir)) return { violations, rawJsonLdCounts }
 
   const entries = fs.readdirSync(absDir, { withFileTypes: true })
   for (const entry of entries) {
     const fullPath = path.join(absDir, entry.name)
     if (entry.isDirectory()) {
       if (['node_modules', '.next', 'out', 'legacy-quarantine', '__tests__'].includes(entry.name)) continue
-      scanDirectory(path.relative(ROOT, fullPath), violations)
+      scanDirectory(path.relative(ROOT, fullPath), violations, rawJsonLdCounts)
     } else if (entry.isFile() && /\.(tsx|ts|jsx|js)$/.test(entry.name)) {
       const relPath = path.relative(ROOT, fullPath).replace(/\\/g, '/')
-      if (ALLOWLIST.has(relPath)) continue
-
       const content = fs.readFileSync(fullPath, 'utf8')
-      if (content.includes('dangerouslySetInnerHTML')) {
+      const rawJsonLdCount = countRawJsonLdSerializations(content)
+
+      if (rawJsonLdCount > 0) rawJsonLdCounts.set(relPath, rawJsonLdCount)
+
+      if (!ALLOWLIST.has(relPath) && content.includes('dangerouslySetInnerHTML')) {
         violations.push({ file: relPath, text: 'dangerouslySetInnerHTML' })
       }
     }
   }
-  return violations
+  return { violations, rawJsonLdCounts }
+}
+
+function validateRawJsonLdBaseline(rawJsonLdCounts, violations) {
+  const files = new Set([...RAW_JSON_LD_BASELINE.keys(), ...rawJsonLdCounts.keys()])
+
+  for (const file of files) {
+    const expected = RAW_JSON_LD_BASELINE.get(file) ?? 0
+    const actual = rawJsonLdCounts.get(file) ?? 0
+    if (actual !== expected) {
+      violations.push({
+        file,
+        text: `raw JSON-LD serialization count changed (expected ${expected}, found ${actual})`,
+      })
+    }
+  }
 }
 
 function main() {
-  console.log('[validate-html-injection] Scanning active codebases for unapproved dangerouslySetInnerHTML...')
+  console.log('[validate-html-injection] Scanning active codebases for unapproved HTML injection...')
+  assertDetectorWorks()
+
   const violations = []
+  const rawJsonLdCounts = new Map()
   for (const dir of SCAN_DIRS) {
-    scanDirectory(dir, violations)
+    scanDirectory(dir, violations, rawJsonLdCounts)
   }
+  validateRawJsonLdBaseline(rawJsonLdCounts, violations)
 
   if (violations.length > 0) {
-    console.error('[validate-html-injection] FAIL: Unapproved dangerouslySetInnerHTML usage detected!')
-    violations.forEach(v => {
-      console.error(`  - ${v.file}: Contains dangerouslySetInnerHTML. Render structured data via components/seo/JsonLd.tsx instead.`)
+    console.error('[validate-html-injection] FAIL: Unapproved HTML or raw JSON-LD serialization detected!')
+    violations.forEach((violation) => {
+      if (violation.text === 'dangerouslySetInnerHTML') {
+        console.error(`  - ${violation.file}: Contains dangerouslySetInnerHTML. Render structured data via components/seo/JsonLd.tsx instead.`)
+      } else {
+        console.error(`  - ${violation.file}: ${violation.text}. Use JsonLd/SchemaOrg or serializeJsonLd, then update the baseline downward.`)
+      }
     })
     process.exit(1)
   }
 
-  console.log('[validate-html-injection] PASS: No unapproved dangerouslySetInnerHTML usages found.')
+  const remainingRawCount = [...rawJsonLdCounts.values()].reduce((sum, count) => sum + count, 0)
+  console.log(`[validate-html-injection] PASS: No unapproved usages found; raw JSON-LD baseline remains bounded at ${remainingRawCount}.`)
   process.exit(0)
 }
 

--- a/src/components/ecosystem-supernode.tsx
+++ b/src/components/ecosystem-supernode.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import DecisionVisualGrid from './decision-visual-grid'
 import WhyThisInsteadPanel from './why-this-instead-panel'
 import { formatDisplayLabel } from '@/lib/display-utils'
+import JsonLd from '@/components/seo/JsonLd'
 
 type EcosystemSupernodeProps = {
   hub: {
@@ -108,10 +109,7 @@ export default function EcosystemSupernode({ hub, profileHref }: EcosystemSupern
 
   return (
     <div className="space-y-6">
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema(hub)) }}
-      />
+      <JsonLd schema={faqSchema(hub)} />
 
       <DecisionVisualGrid record={record} title={`${hub.title}: decision map`} compact />
 


### PR DESCRIPTION
## What changed

- Routes the custom 500 page through the shared `JsonLd` sanitizer instead of raw `JSON.stringify` output.
- Routes ecosystem-supernode FAQ schema through the shared `JsonLd` component, covering the reusable ecosystem hub surface.
- Extends the existing HTML-injection prebuild validator to scan the legacy `pages/` directory too.
- Adds a raw JSON-LD detector with executable safe, unsafe, and mixed self-tests.
- Establishes an exact, non-growing baseline for the only three remaining legacy emitters:
  - herb profiles: 1
  - compound profiles: 1
  - shared Focus/ADHD article template: 2
- Fails CI when a new raw JSON-LD emitter appears, when an existing file adds another one, or when the baseline changes without being explicitly reduced.
- Removes the ecosystem component from the broad `dangerouslySetInnerHTML` allowlist after converting it.

## Why this is high ROI

The previous PR created a safe shared JSON-LD boundary. This PR makes that architectural improvement durable:

- reusable ecosystem pages now receive the sanitization and escaping behavior automatically;
- the legacy Pages Router error surface no longer bypasses it;
- future page work cannot silently reintroduce raw `JSON.stringify` structured-data output;
- the remaining debt is measured exactly instead of hidden inside a broad allowlist.

The validator already runs in `verify:prebuild`, so this protection applies to the normal production verification path without adding another workflow or dependency.

## Files changed

- `pages/500.tsx`
- `src/components/ecosystem-supernode.tsx`
- `scripts/ci/validate-dangerously-set-inner-html.mjs`

## Risk

Low. Visible content and generated schema objects are unchanged; only the final serialization path and CI enforcement change.

## Validation

- ✅ CI — lint, typecheck, tests/a11y, workbook guard, production build, SEO coverage, and security audit
- ✅ Build Check
- ✅ Site Health Check
- ✅ Lighthouse CI
- ✅ Fast UI Check