### PR TITLE
feat(data): map high-frequency mechanism synonyms to canonical taxonomy

### DIFF
--- a/public/data/_meta/build-info.json
+++ b/public/data/_meta/build-info.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-11T15:05:30.072Z",
+  "generatedAt": "2026-07-11T17:31:59.844Z",
   "source": {
     "workbookPath": "data-sources/herb_monograph_master.xlsx",
     "workbook": "herb_monograph_master.xlsx"

--- a/public/data/canonical-mechanisms.json
+++ b/public/data/canonical-mechanisms.json
@@ -78,7 +78,9 @@
       "ampk upregulation",
       "amp-activated protein kinase activation",
       "cellular energy sensing",
-      "AMPK Signaling"
+      "AMPK Signaling",
+      "AMPK",
+      "AMPK pathway"
     ],
     "confidence_status": "active_needs_review"
   },
@@ -113,7 +115,9 @@
       "inflammation reduction",
       "prostaglandin modulation",
       "Inflammatory Signaling Modulation",
-      "inflammatory signaling"
+      "inflammatory signaling",
+      "inflammatory",
+      "inflammation"
     ],
     "confidence_status": "active_needs_review"
   },
@@ -131,7 +135,9 @@
       "free radical scavenger",
       "oxidative stress reduction",
       "Oxidative Stress Modulation",
-      "redox modulation"
+      "redox modulation",
+      "Oxidative Stress",
+      "Antioxidant defense"
     ],
     "confidence_status": "active_needs_review"
   },
@@ -319,7 +325,9 @@
       "endocannabinoid support",
       "cb1 modulation",
       "cb2 modulation",
-      "cannabinoid receptor modulation"
+      "cannabinoid receptor modulation",
+      "endocannabinoid",
+      "endocannabinoid system"
     ],
     "confidence_status": "active_needs_review"
   },
@@ -370,7 +378,8 @@
       "blood sugar support",
       "glycemic control",
       "blood glucose support",
-      "Glucose Metabolism Support"
+      "Glucose Metabolism Support",
+      "Glucose Metabolism"
     ],
     "confidence_status": "active_needs_review"
   },
@@ -417,7 +426,9 @@
       "microbiome support",
       "prebiotic effect",
       "gut flora modulation",
-      "microbial diversity"
+      "microbial diversity",
+      "gut_microbiome",
+      "gut microbiome"
     ],
     "confidence_status": "active_needs_review"
   },
@@ -448,7 +459,9 @@
       "Hormonal signaling context",
       "hormonal signaling",
       "endocrine modulation",
-      "endocrine support"
+      "endocrine support",
+      "endocrine",
+      "endocrine signaling"
     ],
     "confidence_status": "active_needs_review"
   },
@@ -512,7 +525,8 @@
       "Lipid metabolism support",
       "cholesterol metabolism support",
       "lipid regulation",
-      "fat metabolism support"
+      "fat metabolism support",
+      "Lipid Metabolism"
     ],
     "confidence_status": "active_needs_review"
   },
@@ -592,7 +606,9 @@
       "Metabolic regulation",
       "metabolic support",
       "metabolic signaling",
-      "metabolic modulation"
+      "metabolic modulation",
+      "metabolic",
+      "metabolism"
     ],
     "confidence_status": "active_needs_review"
   },
@@ -610,7 +626,8 @@
       "pgc-1alpha activation",
       "energy metabolism support",
       "energy metabolism",
-      "cellular energy support"
+      "cellular energy support",
+      "mitochondrial"
     ],
     "confidence_status": "active_needs_review"
   },
@@ -626,7 +643,9 @@
       "mtor inhibition",
       "mtor activation",
       "mechanistic target of rapamycin",
-      "mTOR Signaling"
+      "mTOR Signaling",
+      "mTOR",
+      "mTOR pathway"
     ],
     "confidence_status": "active_needs_review"
   },
@@ -641,7 +660,8 @@
       "Neuroprotective activity",
       "neuroprotection",
       "neural protection",
-      "neuronal protection"
+      "neuronal protection",
+      "neuroprotective"
     ],
     "confidence_status": "active_needs_review"
   },
@@ -660,7 +680,10 @@
       "nf-kb downregulation",
       "pro-inflammatory gene downregulation",
       "NF-kB Modulation",
-      "NF kB modulation"
+      "NF kB modulation",
+      "NF-kB",
+      "NF-kB signaling",
+      "NF-kB pathway"
     ],
     "confidence_status": "active_needs_review"
   },
@@ -694,7 +717,9 @@
       "nrf2 upregulation",
       "nrf2 pathway",
       "antioxidant response element",
-      "are activation"
+      "are activation",
+      "Nrf2",
+      "Nrf2 signaling"
     ],
     "confidence_status": "active_needs_review"
   },
@@ -852,7 +877,9 @@
       "Vascular function support",
       "circulatory support",
       "blood flow support",
-      "vascular tone support"
+      "vascular tone support",
+      "Endothelial Function",
+      "cardiovascular"
     ],
     "confidence_status": "active_needs_review"
   }

--- a/public/data/compounds.json
+++ b/public/data/compounds.json
@@ -43,10 +43,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -340,10 +338,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "Strong drug evidence",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -449,10 +445,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -563,11 +557,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -671,10 +662,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -788,10 +777,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -911,9 +898,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "metabolic",
-      "mitochondrial"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "moderate-high",
     "evidence_tier": "Mechanistic Evidence",
@@ -1041,11 +1026,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -1236,13 +1218,15 @@
       "Mitochondrial biogenesis",
       "Immune modulation",
       "Neuroprotective activity",
-      "NF-kB inhibition"
+      "NF-kB inhibition",
+      "Nrf2 activation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
       "immune",
-      "inflammatory"
+      "inflammatory",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
@@ -1250,11 +1234,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -1350,10 +1331,8 @@
       "Receptor interaction"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "cardiovascular"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -1462,7 +1441,9 @@
       "Cellular protection",
       "Vascular function support",
       "Immune modulation",
-      "AMPK activation"
+      "AMPK activation",
+      "Glucose regulation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
@@ -1471,16 +1452,12 @@
     ],
     "mechanism_classes": [
       "Physiological effect",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism",
-      "Lipid Metabolism",
-      "Endothelial Function"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -1696,12 +1673,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism",
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -1812,8 +1785,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Endothelial Function"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "low",
     "evidence_tier": "Mechanistic Evidence",
@@ -1913,10 +1885,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -2027,8 +1997,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Oxidative Stress"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -2127,10 +2096,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "metabolic"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -2222,10 +2189,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -2330,8 +2295,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -2449,8 +2413,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Lipid Metabolism"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
@@ -2560,24 +2523,24 @@
       "Metabolic regulation",
       "Hormonal signaling context",
       "HPA-axis modulation",
-      "Neuroprotective activity"
+      "Neuroprotective activity",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
-      "stress"
+      "stress",
+      "metabolic"
     ],
     "mechanism_classes": [
       "Physiological effect",
       "Physiological/cellular effect",
-      "Neuroendocrine modulation"
+      "Neuroendocrine modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "high",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -2686,10 +2649,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -2801,10 +2762,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -2897,15 +2856,20 @@
       "FAAH degradation",
       "endocannabinoid"
     ],
-    "canonical_mechanisms": [],
-    "mechanism_categories": [],
-    "mechanism_classes": [],
+    "canonical_mechanisms": [
+      "Endocannabinoid modulation"
+    ],
+    "mechanism_categories": [
+      "neuro-immune"
+    ],
+    "mechanism_classes": [
+      "Receptor interaction"
+    ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "unmapped",
+    "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
       "endogenous CB1 agonism",
-      "FAAH degradation",
-      "endocannabinoid"
+      "FAAH degradation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -3006,10 +2970,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -3139,11 +3101,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -3252,8 +3211,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "inflammatory"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -3362,10 +3320,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -3469,24 +3425,25 @@
       "Antioxidant",
       "Mitochondrial biogenesis",
       "HPA-axis modulation",
-      "Neuroprotective activity"
+      "Neuroprotective activity",
+      "Nrf2 activation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
-      "stress"
+      "stress",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
       "Physiological/cellular effect",
-      "Neuroendocrine modulation"
+      "Neuroendocrine modulation",
+      "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Nrf2",
-      "Oxidative Stress"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "D",
     "evidence_tier": "Mechanistic Evidence",
@@ -3586,10 +3543,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -3688,10 +3643,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Endothelial Function"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -3807,10 +3760,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -3903,10 +3854,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -4004,10 +3953,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -4110,10 +4057,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "a",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -4229,11 +4174,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -4462,8 +4404,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "endocrine"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "moderate-high",
     "evidence_tier": "Mechanistic Evidence",
@@ -4693,10 +4634,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -4799,10 +4738,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -4917,12 +4854,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "AMPK",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -5025,7 +4958,8 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Cellular protection",
-      "Hormonal signaling context"
+      "Hormonal signaling context",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
@@ -5036,11 +4970,8 @@
       "Physiological/cellular effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -5161,25 +5092,25 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Vascular function support",
-      "Immune modulation"
+      "Immune modulation",
+      "Nrf2 activation",
+      "AMPK activation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
-      "immune"
+      "immune",
+      "redox",
+      "metabolic"
     ],
     "mechanism_classes": [
       "Physiological effect",
-      "Physiological/cellular effect"
+      "Physiological/cellular effect",
+      "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "AMPK",
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -5286,13 +5217,15 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Immune modulation",
-      "AMPK activation"
+      "AMPK activation",
+      "Nrf2 activation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
       "immune",
-      "metabolic"
+      "metabolic",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
@@ -5300,12 +5233,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "AMPK",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -5407,10 +5336,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -5518,10 +5445,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -5636,10 +5561,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -5761,10 +5684,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -5873,8 +5794,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Oxidative Stress"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "moderate",
     "evidence_tier": "Moderate Human Evidence",
@@ -5991,22 +5911,25 @@
       "Metabolic regulation",
       "Cellular protection",
       "Immune modulation",
-      "Neuroprotective activity"
+      "Neuroprotective activity",
+      "AMPK activation",
+      "Glucose regulation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
-      "immune"
+      "immune",
+      "metabolic"
     ],
     "mechanism_classes": [
-      "Physiological effect"
+      "Physiological effect",
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "AMPK",
-      "Glucose Metabolism",
-      "Lipid Metabolism"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Moderate Human Evidence",
@@ -6122,8 +6045,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Oxidative Stress"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -6232,22 +6154,25 @@
       "Metabolic regulation",
       "Cellular protection",
       "Immune modulation",
-      "Neuroprotective activity"
+      "Neuroprotective activity",
+      "AMPK activation",
+      "Glucose regulation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
-      "immune"
+      "immune",
+      "metabolic"
     ],
     "mechanism_classes": [
-      "Physiological effect"
+      "Physiological effect",
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "AMPK",
-      "Glucose Metabolism",
-      "Lipid Metabolism"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -6354,25 +6279,26 @@
       "Antioxidant",
       "Mitochondrial biogenesis",
       "Immune modulation",
-      "HPA-axis modulation"
+      "HPA-axis modulation",
+      "Nrf2 activation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
       "immune",
-      "stress"
+      "stress",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
       "Physiological/cellular effect",
-      "Neuroendocrine modulation"
+      "Neuroendocrine modulation",
+      "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Nrf2",
-      "Oxidative Stress"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
@@ -6482,25 +6408,26 @@
       "Antioxidant",
       "Mitochondrial biogenesis",
       "Immune modulation",
-      "HPA-axis modulation"
+      "HPA-axis modulation",
+      "Nrf2 activation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
       "immune",
-      "stress"
+      "stress",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
       "Physiological/cellular effect",
-      "Neuroendocrine modulation"
+      "Neuroendocrine modulation",
+      "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Nrf2",
-      "Oxidative Stress"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
@@ -6604,10 +6531,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "Limited human evidence",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -6704,10 +6629,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "mTOR"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "insufficient",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -6898,11 +6821,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate-high",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -7011,10 +6931,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Endothelial Function"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "high",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -7123,10 +7041,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -7238,12 +7154,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "high",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -7371,12 +7283,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "high",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -7494,10 +7402,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -7596,10 +7502,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -7808,8 +7712,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "inflammatory"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -7996,8 +7899,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "inflammatory"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -8109,11 +8011,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "high",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -8216,11 +8115,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -8301,14 +8197,19 @@
       "Methyl donor supporting homocysteine remethylation.",
       "Lipid Metabolism"
     ],
-    "canonical_mechanisms": [],
-    "mechanism_categories": [],
-    "mechanism_classes": [],
+    "canonical_mechanisms": [
+      "Lipid metabolism support"
+    ],
+    "mechanism_categories": [
+      "core"
+    ],
+    "mechanism_classes": [
+      "Physiological effect"
+    ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "unmapped",
+    "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Methyl donor supporting homocysteine remethylation.",
-      "Lipid Metabolism"
+      "Methyl donor supporting homocysteine remethylation."
     ],
     "evidence_grade": "insufficient",
     "evidence_tier": "Mechanistic Evidence",
@@ -8402,7 +8303,8 @@
       "Lipid Metabolism"
     ],
     "canonical_mechanisms": [
-      "Vascular function support"
+      "Vascular function support",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core"
@@ -8411,10 +8313,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -8510,15 +8410,20 @@
       "gut_microbiome",
       "liver_detoxification"
     ],
-    "canonical_mechanisms": [],
-    "mechanism_categories": [],
-    "mechanism_classes": [],
+    "canonical_mechanisms": [
+      "Gut microbiome modulation"
+    ],
+    "mechanism_categories": [
+      "gut"
+    ],
+    "mechanism_classes": [
+      "Microbiome modulation"
+    ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "unmapped",
+    "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
       "Acidifies gastric contents",
       "mechanism-only for digestion claims.",
-      "gut_microbiome",
       "liver_detoxification"
     ],
     "evidence_grade": "insufficient",
@@ -8626,10 +8531,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Endothelial Function"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -8757,11 +8660,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -9076,10 +8976,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "limited",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -9183,10 +9081,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -9303,11 +9199,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -9406,10 +9299,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -9524,8 +9415,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "inflammatory"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -9633,13 +9523,15 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Immune modulation",
-      "AMPK activation"
+      "AMPK activation",
+      "Nrf2 activation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
       "immune",
-      "metabolic"
+      "metabolic",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
@@ -9647,12 +9539,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "AMPK",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -9765,10 +9653,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "insufficient",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -9874,11 +9760,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "endocrine",
-      "metabolic"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -9969,10 +9852,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -10073,10 +9954,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate-high",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -10190,10 +10069,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -10284,10 +10161,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -10500,10 +10375,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "low-moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -10605,10 +10478,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -10721,10 +10592,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Endothelial Function"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -10821,10 +10690,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -10920,10 +10787,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Endothelial Function"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -11028,26 +10893,27 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Vascular function support",
-      "NF-kB inhibition"
+      "NF-kB inhibition",
+      "Nrf2 activation",
+      "Glucose regulation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
-      "inflammatory"
+      "inflammatory",
+      "redox",
+      "metabolic"
     ],
     "mechanism_classes": [
       "Physiological effect",
       "Physiological/cellular effect",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Glucose Metabolism",
-      "Lipid Metabolism",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -11158,27 +11024,26 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "NF-kB inhibition",
-      "Nrf2 activation"
+      "Nrf2 activation",
+      "Glucose regulation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
       "inflammatory",
-      "redox"
+      "redox",
+      "metabolic"
     ],
     "mechanism_classes": [
       "Physiological effect",
       "Physiological/cellular effect",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Glucose Metabolism",
-      "Lipid Metabolism",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -11297,8 +11162,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "endocrine"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "high",
     "evidence_tier": "Moderate Human Evidence",
@@ -11413,8 +11277,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "B-",
     "evidence_tier": "Strong Human Evidence",
@@ -11621,10 +11484,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "metabolic"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -11733,12 +11594,14 @@
       "Metabolic regulation",
       "Vascular function support",
       "Hormonal signaling context",
-      "AMPK activation"
+      "AMPK activation",
+      "Nrf2 activation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
-      "metabolic"
+      "metabolic",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
@@ -11746,13 +11609,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "AMPK",
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -11858,8 +11716,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "5-HT1A activity",
-      "endocannabinoid"
+      "5-HT1A activity"
     ],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
@@ -11954,10 +11811,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "metabolic"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "strong",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -12059,10 +11914,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -12175,25 +12028,25 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "HPA-axis modulation",
-      "Neuroprotective activity"
+      "Neuroprotective activity",
+      "Nrf2 activation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
-      "stress"
+      "stress",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
       "Physiological/cellular effect",
-      "Neuroendocrine modulation"
+      "Neuroendocrine modulation",
+      "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Lipid Metabolism",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -12306,11 +12159,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -12415,10 +12265,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -12525,8 +12373,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "inflammatory"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -12642,11 +12489,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -12761,28 +12605,26 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Vascular function support",
-      "AMPK activation"
+      "AMPK activation",
+      "Nrf2 activation",
+      "Glucose regulation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
-      "metabolic"
+      "metabolic",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
       "Physiological/cellular effect",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "AMPK",
-      "Glucose Metabolism",
-      "Lipid Metabolism",
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -12973,15 +12815,20 @@
       "alpha-2 adrenergic and TRP channel activity preclinical",
       "endocannabinoid"
     ],
-    "canonical_mechanisms": [],
-    "mechanism_categories": [],
-    "mechanism_classes": [],
+    "canonical_mechanisms": [
+      "Endocannabinoid modulation"
+    ],
+    "mechanism_categories": [
+      "neuro-immune"
+    ],
+    "mechanism_classes": [
+      "Receptor interaction"
+    ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "unmapped",
+    "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
       "weak CB1/CB2 interaction",
-      "alpha-2 adrenergic and TRP channel activity preclinical",
-      "endocannabinoid"
+      "alpha-2 adrenergic and TRP channel activity preclinical"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -13089,10 +12936,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -13198,10 +13043,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -13303,8 +13146,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "inflammatory"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -13408,8 +13250,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
@@ -13524,11 +13365,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -13639,27 +13477,26 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "NF-kB inhibition",
-      "Nrf2 activation"
+      "Nrf2 activation",
+      "Glucose regulation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
       "inflammatory",
-      "redox"
+      "redox",
+      "metabolic"
     ],
     "mechanism_classes": [
       "Physiological effect",
       "Physiological/cellular effect",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Glucose Metabolism",
-      "Lipid Metabolism",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -13764,11 +13601,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "insufficient",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -13893,12 +13727,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -14004,8 +13834,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Lipid Metabolism"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "strong",
     "evidence_tier": "Mechanistic Evidence",
@@ -14202,10 +14031,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -14302,10 +14129,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -14493,10 +14318,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -14590,10 +14413,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -14706,8 +14527,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Lipid Metabolism"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
@@ -14820,8 +14640,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "inflammatory"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -14923,10 +14742,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Endothelial Function"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate-high",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -15141,10 +14958,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -15235,10 +15050,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -15337,10 +15150,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "metabolic"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -15443,7 +15254,8 @@
       "Metabolic regulation",
       "Vascular function support",
       "HPA-axis modulation",
-      "Neuroprotective activity"
+      "Neuroprotective activity",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
@@ -15456,11 +15268,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate-high",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -15573,10 +15382,8 @@
       "Physiological/cellular effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate-high",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -15795,10 +15602,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -15896,10 +15701,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -16021,11 +15824,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -16123,10 +15923,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -16237,10 +16035,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -16339,10 +16135,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -16438,10 +16232,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "mitochondrial"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "low-moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -16541,10 +16333,8 @@
       "Physiological/cellular effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "mitochondrial"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -16674,11 +16464,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -16781,10 +16568,8 @@
       "Physiological/cellular effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "B",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -16885,10 +16670,8 @@
       "Physiological/cellular effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "mitochondrial"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -16994,11 +16777,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "mitochondrial",
-      "metabolic"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "insufficient",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -17109,11 +16889,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "mitochondrial",
-      "metabolic"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "high",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -17230,25 +17007,25 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Vascular function support",
-      "HPA-axis modulation"
+      "HPA-axis modulation",
+      "Nrf2 activation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
-      "stress"
+      "stress",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
       "Physiological/cellular effect",
-      "Neuroendocrine modulation"
+      "Neuroendocrine modulation",
+      "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Lipid Metabolism",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -17361,13 +17138,15 @@
       "Antioxidant",
       "Mitochondrial biogenesis",
       "HPA-axis modulation",
-      "NF-kB inhibition"
+      "NF-kB inhibition",
+      "Nrf2 activation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
       "stress",
-      "inflammatory"
+      "inflammatory",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
@@ -17378,9 +17157,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Nrf2",
-      "Oxidative Stress"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -17495,10 +17272,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -17595,10 +17370,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -17716,10 +17489,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -17836,13 +17607,15 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Immune modulation",
-      "AMPK activation"
+      "AMPK activation",
+      "Nrf2 activation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
       "immune",
-      "metabolic"
+      "metabolic",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
@@ -17850,12 +17623,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "AMPK",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -17962,13 +17731,15 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Immune modulation",
-      "AMPK activation"
+      "AMPK activation",
+      "Nrf2 activation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
       "immune",
-      "metabolic"
+      "metabolic",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
@@ -17976,12 +17747,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "AMPK",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -18169,10 +17936,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -18368,11 +18133,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "mitochondrial",
-      "metabolic"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -18501,12 +18263,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -18622,12 +18380,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -18824,10 +18578,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -19024,13 +18776,15 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Immune modulation",
-      "AMPK activation"
+      "AMPK activation",
+      "Nrf2 activation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
       "immune",
-      "metabolic"
+      "metabolic",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
@@ -19038,12 +18792,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "AMPK",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -19153,10 +18903,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -19276,12 +19024,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -19385,8 +19129,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -19692,11 +19435,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -19785,16 +19525,21 @@
       "gut_microbiome",
       "liver_detoxification"
     ],
-    "canonical_mechanisms": [],
-    "mechanism_categories": [],
-    "mechanism_classes": [],
+    "canonical_mechanisms": [
+      "Gut microbiome modulation"
+    ],
+    "mechanism_categories": [
+      "gut"
+    ],
+    "mechanism_classes": [
+      "Microbiome modulation"
+    ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "unmapped",
+    "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
       "macronutrient breakdown via proteases",
       "lipases",
       "and amylases",
-      "gut_microbiome",
       "liver_detoxification"
     ],
     "evidence_grade": "moderate",
@@ -19900,8 +19645,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -20009,8 +19753,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -20116,11 +19859,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "endocrine",
-      "metabolic"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -20225,10 +19965,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -20330,10 +20068,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "cardiovascular"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -20428,10 +20164,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "mTOR"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "insufficient",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -20533,10 +20267,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "mTOR"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "strong",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -20643,10 +20375,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -20761,13 +20491,15 @@
       "Mitochondrial biogenesis",
       "Immune modulation",
       "Neuroprotective activity",
-      "NF-kB inhibition"
+      "NF-kB inhibition",
+      "Nrf2 activation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
       "immune",
-      "inflammatory"
+      "inflammatory",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
@@ -20775,11 +20507,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -20904,28 +20633,29 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Vascular function support",
-      "HPA-axis modulation"
+      "HPA-axis modulation",
+      "Nrf2 activation",
+      "AMPK activation",
+      "Glucose regulation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
-      "stress"
+      "stress",
+      "redox",
+      "metabolic"
     ],
     "mechanism_classes": [
       "Physiological effect",
       "Physiological/cellular effect",
-      "Neuroendocrine modulation"
+      "Neuroendocrine modulation",
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "AMPK",
-      "Glucose Metabolism",
-      "Lipid Metabolism",
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -21041,11 +20771,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -21151,10 +20878,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -21364,11 +21089,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "mitochondrial",
-      "metabolic"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -21480,8 +21202,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "inflammatory"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -21578,10 +21299,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -21791,14 +21510,16 @@
       "Metabolic regulation",
       "Immune modulation",
       "HPA-axis modulation",
-      "AMPK activation"
+      "AMPK activation",
+      "Nrf2 activation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
       "immune",
       "stress",
-      "metabolic"
+      "metabolic",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
@@ -21807,12 +21528,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "AMPK",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -21933,12 +21650,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "AMPK",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -22049,27 +21762,28 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Vascular function support",
-      "HPA-axis modulation"
+      "HPA-axis modulation",
+      "Nrf2 activation",
+      "Glucose regulation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
-      "stress"
+      "stress",
+      "redox",
+      "metabolic"
     ],
     "mechanism_classes": [
       "Physiological effect",
       "Physiological/cellular effect",
-      "Neuroendocrine modulation"
+      "Neuroendocrine modulation",
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Glucose Metabolism",
-      "Lipid Metabolism",
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -22185,11 +21899,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -22294,10 +22005,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -22416,28 +22125,26 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Vascular function support",
-      "AMPK activation"
+      "AMPK activation",
+      "Nrf2 activation",
+      "Glucose regulation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
-      "metabolic"
+      "metabolic",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
       "Physiological/cellular effect",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "AMPK",
-      "Glucose Metabolism",
-      "Lipid Metabolism",
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -22539,10 +22246,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -22660,28 +22365,26 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Vascular function support",
-      "AMPK activation"
+      "AMPK activation",
+      "Nrf2 activation",
+      "Glucose regulation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
-      "metabolic"
+      "metabolic",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
       "Physiological/cellular effect",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "AMPK",
-      "Glucose Metabolism",
-      "Lipid Metabolism",
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -22776,10 +22479,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -22899,10 +22600,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -23102,10 +22801,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -23201,10 +22898,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "metabolic"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -23300,10 +22995,8 @@
       "Receptor interaction"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "endocrine"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -23511,8 +23204,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Lipid Metabolism"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -23709,10 +23401,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -23825,10 +23515,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "insufficient",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -23947,27 +23635,26 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "NF-kB inhibition",
-      "Nrf2 activation"
+      "Nrf2 activation",
+      "Glucose regulation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
       "inflammatory",
-      "redox"
+      "redox",
+      "metabolic"
     ],
     "mechanism_classes": [
       "Physiological effect",
       "Physiological/cellular effect",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Glucose Metabolism",
-      "Lipid Metabolism",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -24079,10 +23766,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -24185,10 +23870,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "metabolic"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -24388,12 +24071,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -24609,11 +24288,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -24801,10 +24477,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "Limited human evidence",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -24993,8 +24667,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Moderate Human Evidence",
@@ -25108,25 +24781,25 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Vascular function support",
-      "Immune modulation"
+      "Immune modulation",
+      "Nrf2 activation",
+      "AMPK activation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
-      "immune"
+      "immune",
+      "redox",
+      "metabolic"
     ],
     "mechanism_classes": [
       "Physiological effect",
-      "Physiological/cellular effect"
+      "Physiological/cellular effect",
+      "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "AMPK",
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -25339,27 +25012,26 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "NF-kB inhibition",
-      "Nrf2 activation"
+      "Nrf2 activation",
+      "Glucose regulation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
       "inflammatory",
-      "redox"
+      "redox",
+      "metabolic"
     ],
     "mechanism_classes": [
       "Physiological effect",
       "Physiological/cellular effect",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Glucose Metabolism",
-      "Lipid Metabolism",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -25474,28 +25146,26 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Vascular function support",
-      "AMPK activation"
+      "AMPK activation",
+      "Nrf2 activation",
+      "Glucose regulation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
-      "metabolic"
+      "metabolic",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
       "Physiological/cellular effect",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "AMPK",
-      "Glucose Metabolism",
-      "Lipid Metabolism",
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -25592,10 +25262,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "metabolic"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "Low/mixed human evidence",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -25712,10 +25380,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -25836,12 +25502,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism",
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -25953,11 +25615,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism",
-      "Endothelial Function"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate-high",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -26167,12 +25826,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -26265,18 +25920,23 @@
       "Collagen and elastin remodeling",
       "Antioxidant defense"
     ],
-    "canonical_mechanisms": [],
-    "mechanism_categories": [],
-    "mechanism_classes": [],
+    "canonical_mechanisms": [
+      "Antioxidant"
+    ],
+    "mechanism_categories": [
+      "core"
+    ],
+    "mechanism_classes": [
+      "Physiological effect"
+    ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "unmapped",
+    "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
       "Copper Cofactor Delivery (Lysyl Oxidase and Superoxide Dismutase)",
       "Collagen and Elastin Synthesis Stimulation",
       "Antioxidant and Anti-Inflammatory Activity",
       "Wound-Healing Angiogenesis Support",
-      "Collagen and elastin remodeling",
-      "Antioxidant defense"
+      "Collagen and elastin remodeling"
     ],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
@@ -26386,10 +26046,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -26493,10 +26151,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -26606,10 +26262,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -26718,10 +26372,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -26830,10 +26482,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -26935,10 +26585,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "cardiovascular"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -27056,23 +26704,25 @@
       "Antioxidant",
       "Mitochondrial biogenesis",
       "Metabolic regulation",
-      "Vascular function support"
+      "Vascular function support",
+      "Nrf2 activation",
+      "AMPK activation"
     ],
     "mechanism_categories": [
       "core",
-      "mitochondrial"
+      "mitochondrial",
+      "redox",
+      "metabolic"
     ],
     "mechanism_classes": [
       "Physiological effect",
-      "Physiological/cellular effect"
+      "Physiological/cellular effect",
+      "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Nrf2",
-      "AMPK",
-      "Oxidative Stress"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
@@ -27182,23 +26832,24 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Vascular function support",
-      "Neuroprotective activity"
+      "Neuroprotective activity",
+      "Nrf2 activation",
+      "AMPK activation"
     ],
     "mechanism_categories": [
       "core",
-      "mitochondrial"
+      "mitochondrial",
+      "redox",
+      "metabolic"
     ],
     "mechanism_classes": [
       "Physiological effect",
-      "Physiological/cellular effect"
+      "Physiological/cellular effect",
+      "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "AMPK",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -27309,10 +26960,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -27407,7 +27056,8 @@
     ],
     "canonical_mechanisms": [
       "Vascular function support",
-      "HPA-axis modulation"
+      "HPA-axis modulation",
+      "Hormonal signaling context"
     ],
     "mechanism_categories": [
       "core",
@@ -27418,11 +27068,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "endocrine",
-      "cardiovascular"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -27526,11 +27173,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -27638,11 +27282,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -27730,20 +27371,22 @@
       "Glucose Metabolism"
     ],
     "canonical_mechanisms": [
-      "Anti-inflammatory"
+      "Anti-inflammatory",
+      "AMPK activation",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
-      "core"
+      "core",
+      "metabolic"
     ],
     "mechanism_classes": [
-      "Physiological effect"
+      "Physiological effect",
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -27855,10 +27498,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "metabolic"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "limited",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -27951,10 +27592,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "limited",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -28253,8 +27892,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Oxidative Stress"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "moderate",
     "evidence_tier": "Moderate Human Evidence",
@@ -28464,10 +28102,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -28580,12 +28216,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory",
-      "endocrine",
-      "metabolic"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -28695,9 +28327,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "endocrine",
-      "inflammatory"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
@@ -28809,11 +28439,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -28909,10 +28536,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "mitochondrial"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -29021,11 +28646,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -29135,10 +28757,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -29255,7 +28875,9 @@
       "Cellular protection",
       "Immune modulation",
       "AMPK activation",
-      "NF-kB inhibition"
+      "NF-kB inhibition",
+      "Glucose regulation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
@@ -29265,15 +28887,12 @@
     ],
     "mechanism_classes": [
       "Physiological effect",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -29377,10 +28996,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -29503,11 +29120,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -29615,11 +29229,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -29731,10 +29342,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -29838,10 +29447,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -29934,10 +29541,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "cardiovascular"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "Mixed human evidence",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -30121,10 +29726,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "neuroprotective"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -30239,26 +29842,25 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Vascular function support",
-      "HPA-axis modulation"
+      "HPA-axis modulation",
+      "Nrf2 activation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
-      "stress"
+      "stress",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
       "Physiological/cellular effect",
-      "Neuroendocrine modulation"
+      "Neuroendocrine modulation",
+      "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Lipid Metabolism",
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -30360,10 +29962,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "mTOR"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -30616,9 +30216,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "inflammatory",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -30819,8 +30417,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
@@ -30938,8 +30535,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -31139,13 +30735,15 @@
       "Mitochondrial biogenesis",
       "Vascular function support",
       "HPA-axis modulation",
-      "NF-kB inhibition"
+      "NF-kB inhibition",
+      "Nrf2 activation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
       "stress",
-      "inflammatory"
+      "inflammatory",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
@@ -31154,12 +30752,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -31555,10 +31149,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Endothelial Function"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -31665,8 +31257,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Oxidative Stress"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -31749,20 +31340,22 @@
       "Glucose Metabolism"
     ],
     "canonical_mechanisms": [
-      "Vascular function support"
+      "Vascular function support",
+      "AMPK activation",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
-      "core"
+      "core",
+      "metabolic"
     ],
     "mechanism_classes": [
-      "Physiological effect"
+      "Physiological effect",
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -31862,11 +31455,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "endocrine",
-      "metabolic"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -31965,10 +31555,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "B for PCOS; D for core goals",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -32086,8 +31674,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Glucose Metabolism"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -32204,9 +31791,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Glucose Metabolism",
-      "Lipid Metabolism"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -32309,10 +31894,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "metabolic"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -32401,10 +31984,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "endocrine"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "strong",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -32627,11 +32208,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "metabolic",
-      "mitochondrial"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "a",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -32748,8 +32326,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Oxidative Stress"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -32848,10 +32425,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "limited",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -32971,12 +32546,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -33087,13 +32658,15 @@
       "Mitochondrial biogenesis",
       "Vascular function support",
       "Immune modulation",
-      "NF-kB inhibition"
+      "NF-kB inhibition",
+      "Nrf2 activation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
       "immune",
-      "inflammatory"
+      "inflammatory",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
@@ -33101,12 +32674,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "insufficient",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -33213,26 +32782,27 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Vascular function support",
-      "NF-kB inhibition"
+      "NF-kB inhibition",
+      "Nrf2 activation",
+      "Glucose regulation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
-      "inflammatory"
+      "inflammatory",
+      "redox",
+      "metabolic"
     ],
     "mechanism_classes": [
       "Physiological effect",
       "Physiological/cellular effect",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Glucose Metabolism",
-      "Lipid Metabolism",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -33339,8 +32909,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Oxidative Stress"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "moderate-high",
     "evidence_tier": "Mechanistic Evidence",
@@ -33450,8 +33019,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Oxidative Stress"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -33562,8 +33130,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Oxidative Stress"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -33758,10 +33325,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "limited",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -33947,11 +33512,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "metabolic",
-      "mitochondrial"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -34057,10 +33619,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Endothelial Function"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -34165,8 +33725,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "moderate-high",
     "evidence_tier": "Moderate Human Evidence",
@@ -34277,8 +33836,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "B-",
     "evidence_tier": "Moderate Human Evidence",
@@ -34402,8 +33960,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Oxidative Stress"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "C+",
     "evidence_tier": "Mechanistic Evidence",
@@ -34613,10 +34170,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -34720,8 +34275,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
@@ -34959,11 +34513,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -35078,8 +34629,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Lipid Metabolism"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "insufficient",
     "evidence_tier": "Mechanistic Evidence",
@@ -35190,9 +34740,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "metabolic",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
@@ -35398,10 +34946,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "mTOR"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "strong",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -35600,9 +35146,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "endocrine",
-      "inflammatory"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -35716,10 +35260,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Endothelial Function"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -35825,8 +35367,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -35923,10 +35464,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "endocrine"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -36031,13 +35570,15 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Immune modulation",
-      "NF-kB inhibition"
+      "NF-kB inhibition",
+      "Nrf2 activation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
       "immune",
-      "inflammatory"
+      "inflammatory",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
@@ -36045,11 +35586,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -36237,10 +35775,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "high",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -36359,26 +35895,25 @@
       "Mitochondrial biogenesis",
       "Vascular function support",
       "Immune modulation",
-      "HPA-axis modulation"
+      "HPA-axis modulation",
+      "Nrf2 activation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
       "immune",
-      "stress"
+      "stress",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
       "Physiological/cellular effect",
-      "Neuroendocrine modulation"
+      "Neuroendocrine modulation",
+      "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -36480,10 +36015,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "limited",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -36675,10 +36208,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "metabolic"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -36801,10 +36332,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -36906,10 +36435,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -37014,10 +36541,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "high",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -37122,10 +36647,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "metabolic"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "strong",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -37238,8 +36761,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
@@ -37344,10 +36866,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "metabolic"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -37453,10 +36973,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "neuroprotective"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "insufficient",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -37575,10 +37093,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -37691,9 +37207,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "inflammatory",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -37798,11 +37312,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -37907,13 +37418,15 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Immune modulation",
-      "AMPK activation"
+      "AMPK activation",
+      "Nrf2 activation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
       "immune",
-      "metabolic"
+      "metabolic",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
@@ -37921,12 +37434,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "AMPK",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -38033,13 +37542,15 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Immune modulation",
-      "AMPK activation"
+      "AMPK activation",
+      "Nrf2 activation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
       "immune",
-      "metabolic"
+      "metabolic",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
@@ -38047,12 +37558,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "AMPK",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -38161,10 +37668,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -38460,10 +37965,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -38563,10 +38066,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "limited",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -38676,10 +38177,8 @@
       "Receptor interaction"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "endocrine"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "high",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -39098,11 +38597,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "a",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -39206,8 +38702,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "inflammatory"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -39407,9 +38902,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "inflammatory",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -39503,10 +38996,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "metabolic"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -39713,8 +39204,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -39825,7 +39315,9 @@
       "Cellular protection",
       "Vascular function support",
       "Immune modulation",
-      "AMPK activation"
+      "AMPK activation",
+      "Glucose regulation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
@@ -39834,15 +39326,12 @@
     ],
     "mechanism_classes": [
       "Physiological effect",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -39955,25 +39444,25 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Vascular function support",
-      "Immune modulation"
+      "Immune modulation",
+      "Nrf2 activation",
+      "AMPK activation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
-      "immune"
+      "immune",
+      "redox",
+      "metabolic"
     ],
     "mechanism_classes": [
       "Physiological effect",
-      "Physiological/cellular effect"
+      "Physiological/cellular effect",
+      "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "AMPK",
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -40076,23 +39565,23 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Cellular protection",
-      "Immune modulation"
+      "Immune modulation",
+      "Nrf2 activation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
-      "immune"
+      "immune",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
-      "Physiological/cellular effect"
+      "Physiological/cellular effect",
+      "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -40191,10 +39680,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "insufficient",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -40401,10 +39888,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -40521,26 +40006,27 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Vascular function support",
-      "Immune modulation"
+      "Immune modulation",
+      "Nrf2 activation",
+      "AMPK activation",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
-      "immune"
+      "immune",
+      "redox",
+      "metabolic"
     ],
     "mechanism_classes": [
       "Physiological effect",
-      "Physiological/cellular effect"
+      "Physiological/cellular effect",
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "AMPK",
-      "Glucose Metabolism",
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -40647,8 +40133,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "inflammatory"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -40757,10 +40242,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate-high",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -40878,8 +40361,7 @@
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
       "SIRT1 Signaling",
-      "SIRT1",
-      "Oxidative Stress"
+      "SIRT1"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
@@ -40979,10 +40461,8 @@
       "Physiological/cellular effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -41095,7 +40575,9 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Vascular function support",
-      "AMPK activation"
+      "AMPK activation",
+      "Glucose regulation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
@@ -41105,17 +40587,12 @@
     "mechanism_classes": [
       "Physiological effect",
       "Physiological/cellular effect",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism",
-      "Lipid Metabolism",
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -41226,26 +40703,26 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Vascular function support",
-      "HPA-axis modulation"
+      "HPA-axis modulation",
+      "AMPK activation",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
-      "stress"
+      "stress",
+      "metabolic"
     ],
     "mechanism_classes": [
       "Physiological effect",
       "Physiological/cellular effect",
-      "Neuroendocrine modulation"
+      "Neuroendocrine modulation",
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism",
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -41338,10 +40815,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "cardiovascular"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "preliminary",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -41461,11 +40936,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -41579,9 +41051,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "inflammatory",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -41679,10 +41149,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -41785,8 +41253,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Lipid Metabolism"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "b",
     "evidence_tier": "Strong Human Evidence",
@@ -41890,10 +41357,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -42317,8 +41782,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Lipid Metabolism"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -42412,10 +41876,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "neuroprotective"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -42527,12 +41989,15 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Vascular function support",
-      "NF-kB inhibition"
+      "NF-kB inhibition",
+      "Nrf2 activation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
-      "inflammatory"
+      "inflammatory",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
@@ -42540,13 +42005,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Lipid Metabolism",
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -42649,8 +42109,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "metabolic"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -42758,13 +42217,15 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Immune modulation",
-      "AMPK activation"
+      "AMPK activation",
+      "Nrf2 activation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
       "immune",
-      "metabolic"
+      "metabolic",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
@@ -42772,12 +42233,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "AMPK",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "insufficient",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -42888,12 +42345,15 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Vascular function support",
-      "NF-kB inhibition"
+      "NF-kB inhibition",
+      "Nrf2 activation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
-      "inflammatory"
+      "inflammatory",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
@@ -42901,13 +42361,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Lipid Metabolism",
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -43020,28 +42475,26 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Vascular function support",
-      "AMPK activation"
+      "AMPK activation",
+      "Nrf2 activation",
+      "Glucose regulation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
-      "metabolic"
+      "metabolic",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
       "Physiological/cellular effect",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "AMPK",
-      "Glucose Metabolism",
-      "Lipid Metabolism",
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "a",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -43152,11 +42605,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "limited",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -43270,10 +42720,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -43384,10 +42832,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "a",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -43500,10 +42946,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -43616,7 +43060,8 @@
       "Metabolic regulation",
       "Cellular protection",
       "Vascular function support",
-      "Neuroprotective activity"
+      "Neuroprotective activity",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core"
@@ -43625,11 +43070,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "high",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -43755,12 +43197,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -43861,11 +43299,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "high",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -43956,10 +43391,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -44059,8 +43492,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "endocrine"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
@@ -44250,10 +43682,8 @@
       "Physiological/cellular effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -44358,10 +43788,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -44472,12 +43900,14 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Vascular function support",
-      "AMPK activation"
+      "AMPK activation",
+      "Nrf2 activation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
-      "metabolic"
+      "metabolic",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
@@ -44487,11 +43917,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Nrf2",
-      "AMPK",
-      "SIRT1",
-      "Endothelial Function",
-      "Oxidative Stress"
+      "SIRT1"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -44609,10 +44035,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -44732,11 +44156,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -44845,10 +44266,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -44956,11 +44375,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "metabolic",
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -45076,9 +44492,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Glucose Metabolism",
-      "Endothelial Function"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
@@ -45199,8 +44613,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Endothelial Function"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
@@ -45314,8 +44727,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "metabolic"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
@@ -45423,10 +44835,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -45612,8 +45022,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
@@ -45823,8 +45232,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -46207,11 +45615,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "insufficient",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -46307,10 +45712,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "mTOR"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -46422,8 +45825,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Lipid Metabolism"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "insufficient",
     "evidence_tier": "Mechanistic Evidence",
@@ -46518,10 +45920,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "metabolic"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "strong",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -46629,10 +46029,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "insufficient",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -46736,10 +46134,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "high",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -46855,11 +46251,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -46958,10 +46351,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "limited",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -47073,11 +46464,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "insufficient",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -47181,10 +46569,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "cardiovascular"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "high",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -47284,7 +46670,6 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "cardiovascular",
       "liver_detoxification"
     ],
     "evidence_grade": "high",
@@ -47392,10 +46777,8 @@
       "Physiological/cellular effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "insufficient",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -47896,10 +47279,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "metabolic"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -47995,19 +47376,20 @@
       "immune_modulation"
     ],
     "canonical_mechanisms": [
-      "Immune modulation"
+      "Immune modulation",
+      "Gut microbiome modulation"
     ],
     "mechanism_categories": [
-      "immune"
+      "immune",
+      "gut"
     ],
     "mechanism_classes": [
-      "Physiological effect"
+      "Physiological effect",
+      "Microbiome modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "gut_microbiome"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -48206,10 +47588,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -48298,10 +47678,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "endocrine"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -48407,10 +47785,8 @@
       "Physiological/cellular effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -48512,11 +47888,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "high",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -48746,12 +48119,14 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Vascular function support",
-      "AMPK activation"
+      "AMPK activation",
+      "Nrf2 activation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
-      "metabolic"
+      "metabolic",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
@@ -48761,11 +48136,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Nrf2",
-      "AMPK",
-      "SIRT1",
-      "Endothelial Function",
-      "Oxidative Stress"
+      "SIRT1"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -48886,12 +48257,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -48996,11 +48363,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "low-moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -49099,10 +48463,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -49211,10 +48573,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Endothelial Function"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -49321,11 +48681,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -49427,10 +48784,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -49545,9 +48900,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "metabolic",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "moderate",
     "evidence_tier": "Strong Human Evidence",
@@ -49651,7 +49004,8 @@
       "Metabolic regulation",
       "Vascular function support",
       "HPA-axis modulation",
-      "Neuroprotective activity"
+      "Neuroprotective activity",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
@@ -49662,12 +49016,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism",
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -49864,10 +49214,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "high",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -49965,10 +49313,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -50074,10 +49420,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -50176,10 +49520,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "limited",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -50303,11 +49645,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -50422,11 +49761,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -50538,11 +49874,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -50662,9 +49995,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Nrf2",
-      "Oxidative Stress"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -50778,25 +50109,25 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Vascular function support",
-      "Immune modulation"
+      "Immune modulation",
+      "Nrf2 activation",
+      "AMPK activation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
-      "immune"
+      "immune",
+      "redox",
+      "metabolic"
     ],
     "mechanism_classes": [
       "Physiological effect",
-      "Physiological/cellular effect"
+      "Physiological/cellular effect",
+      "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "AMPK",
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -50882,18 +50213,20 @@
       "immune_modulation"
     ],
     "canonical_mechanisms": [
-      "Immune modulation"
+      "Immune modulation",
+      "Gut microbiome modulation"
     ],
     "mechanism_categories": [
-      "immune"
+      "immune",
+      "gut"
     ],
     "mechanism_classes": [
-      "Physiological effect"
+      "Physiological effect",
+      "Microbiome modulation"
     ],
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "gut_microbiome",
       "liver_detoxification"
     ],
     "evidence_grade": "moderate-high",
@@ -51000,10 +50333,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "Moderate human evidence",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -51120,9 +50451,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "inflammatory",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -51225,8 +50554,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "inflammatory"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -51338,10 +50666,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -51454,8 +50780,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Glucose Metabolism"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
@@ -51565,11 +50890,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -51667,8 +50989,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "cardiovascular"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "moderate-high",
     "evidence_tier": "Mechanistic Evidence",
@@ -51769,10 +51090,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -51882,10 +51201,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "insufficient",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -52015,11 +51332,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -52125,11 +51439,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -52225,10 +51536,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -52336,10 +51645,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -52438,10 +51745,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "a",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -52679,10 +51984,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Endothelial Function"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -52774,10 +52077,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "neuroprotective"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -52868,10 +52169,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "limited",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -52990,11 +52289,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -53079,20 +52375,20 @@
       "mitochondrial"
     ],
     "canonical_mechanisms": [
-      "Mitochondrial biogenesis"
+      "Mitochondrial biogenesis",
+      "Hormonal signaling context"
     ],
     "mechanism_categories": [
-      "mitochondrial"
+      "mitochondrial",
+      "core"
     ],
     "mechanism_classes": [
-      "Physiological/cellular effect"
+      "Physiological/cellular effect",
+      "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "endocrine",
-      "mitochondrial"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -53289,10 +52585,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -53395,14 +52689,16 @@
       "Mitochondrial biogenesis",
       "Immune modulation",
       "HPA-axis modulation",
-      "NF-kB inhibition"
+      "NF-kB inhibition",
+      "Nrf2 activation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
       "immune",
       "stress",
-      "inflammatory"
+      "inflammatory",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
@@ -53411,11 +52707,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -53506,10 +52799,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "metabolic"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -53612,11 +52903,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -53721,11 +53009,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -53835,11 +53120,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -53951,10 +53233,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -54057,8 +53337,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "insufficient",
     "evidence_tier": "Mechanistic Evidence",
@@ -54416,10 +53695,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "high",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -54532,7 +53809,6 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "mTOR",
       "Autophagy"
     ],
     "evidence_grade": "c",
@@ -54639,11 +53915,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "insufficient",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -54755,10 +54028,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -54872,11 +54143,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "limited",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -54970,10 +54238,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Endothelial Function"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -55079,8 +54345,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Oxidative Stress"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "moderate",
     "evidence_tier": "Strong Human Evidence",
@@ -55186,8 +54451,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -55710,10 +54974,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -55927,28 +55189,26 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Vascular function support",
-      "AMPK activation"
+      "AMPK activation",
+      "Nrf2 activation",
+      "Glucose regulation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
-      "metabolic"
+      "metabolic",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
       "Physiological/cellular effect",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "AMPK",
-      "Glucose Metabolism",
-      "Lipid Metabolism",
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -56051,8 +55311,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "B",
     "evidence_tier": "Moderate Human Evidence",
@@ -56180,28 +55439,26 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Vascular function support",
-      "AMPK activation"
+      "AMPK activation",
+      "Nrf2 activation",
+      "Glucose regulation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
-      "metabolic"
+      "metabolic",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
       "Physiological/cellular effect",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "AMPK",
-      "Glucose Metabolism",
-      "Lipid Metabolism",
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -56302,8 +55559,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -56409,8 +55665,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
@@ -56529,11 +55784,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -56643,7 +55895,9 @@
       "Cellular protection",
       "Vascular function support",
       "Immune modulation",
-      "AMPK activation"
+      "AMPK activation",
+      "Glucose regulation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
@@ -56652,15 +55906,12 @@
     ],
     "mechanism_classes": [
       "Physiological effect",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -56897,9 +56148,7 @@
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
       "SIRT1 Signaling",
-      "AMPK",
-      "SIRT1",
-      "Oxidative Stress"
+      "SIRT1"
     ],
     "evidence_grade": "b",
     "evidence_tier": "Strong Human Evidence",
@@ -57015,26 +56264,25 @@
       "Metabolic regulation",
       "Vascular function support",
       "Neuroprotective activity",
-      "Nrf2 activation"
+      "Nrf2 activation",
+      "Glucose regulation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
-      "redox"
+      "redox",
+      "metabolic"
     ],
     "mechanism_classes": [
       "Physiological effect",
       "Physiological/cellular effect",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Glucose Metabolism",
-      "Lipid Metabolism",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -57130,10 +56378,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "metabolic"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -57341,10 +56587,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "low-moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -57435,10 +56679,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "endocrine"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -57541,13 +56783,15 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Immune modulation",
-      "NF-kB inhibition"
+      "NF-kB inhibition",
+      "Nrf2 activation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
       "immune",
-      "inflammatory"
+      "inflammatory",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
@@ -57555,11 +56799,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -57678,12 +56919,15 @@
       "Mitochondrial biogenesis",
       "Metabolic regulation",
       "Vascular function support",
-      "NF-kB inhibition"
+      "NF-kB inhibition",
+      "Nrf2 activation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
-      "inflammatory"
+      "inflammatory",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
@@ -57691,13 +56935,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Lipid Metabolism",
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -57804,10 +57043,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate-high",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -58021,11 +57258,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -58114,10 +57348,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "metabolic"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -58217,10 +57449,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "insufficient",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -58318,10 +57548,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -58424,11 +57652,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory",
-      "metabolic"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "insufficient",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -58521,10 +57746,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "neuroprotective"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -58635,8 +57858,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -58735,8 +57957,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
@@ -58842,8 +58063,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -58937,8 +58157,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -59262,13 +58481,15 @@
       "Mitochondrial biogenesis",
       "Immune modulation",
       "Neuroprotective activity",
-      "NF-kB inhibition"
+      "NF-kB inhibition",
+      "Nrf2 activation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
       "immune",
-      "inflammatory"
+      "inflammatory",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
@@ -59276,11 +58497,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -59382,10 +58600,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "limited",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -59590,10 +58806,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "strong",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -59701,8 +58915,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Lipid Metabolism"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
@@ -59810,9 +59023,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "metabolic",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "high",
     "evidence_tier": "Strong Human Evidence",
@@ -59918,10 +59129,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -60028,10 +59237,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "metabolic"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "high",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -60143,8 +59350,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "endocrine"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "B",
     "evidence_tier": "Mechanistic Evidence",
@@ -60380,11 +59586,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -60483,10 +59686,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "metabolic"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "moderate",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -60579,10 +59780,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "mTOR"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "high",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -60673,15 +59872,20 @@
       "limited pharmacological data",
       "endocannabinoid"
     ],
-    "canonical_mechanisms": [],
-    "mechanism_categories": [],
-    "mechanism_classes": [],
+    "canonical_mechanisms": [
+      "Endocannabinoid modulation"
+    ],
+    "mechanism_categories": [
+      "neuro-immune"
+    ],
+    "mechanism_classes": [
+      "Receptor interaction"
+    ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "unmapped",
+    "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
       "proposed cannabinoid-like effects",
-      "limited pharmacological data",
-      "endocannabinoid"
+      "limited pharmacological data"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -60905,11 +60109,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -61026,8 +60227,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "inflammatory"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -61121,7 +60321,8 @@
     "canonical_mechanisms": [
       "Anti-inflammatory",
       "HPA-axis modulation",
-      "GABA modulation"
+      "GABA modulation",
+      "Hormonal signaling context"
     ],
     "mechanism_categories": [
       "core",
@@ -61136,9 +60337,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "inflammatory",
-      "endocrine"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
@@ -61244,8 +60443,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
@@ -61353,23 +60551,24 @@
       "Antioxidant",
       "Mitochondrial biogenesis",
       "Immune modulation",
-      "Neuroprotective activity"
+      "Neuroprotective activity",
+      "Nrf2 activation"
     ],
     "mechanism_categories": [
       "core",
       "mitochondrial",
-      "immune"
+      "immune",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
-      "Physiological/cellular effect"
+      "Physiological/cellular effect",
+      "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Nrf2",
-      "Oxidative Stress"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -61476,10 +60675,8 @@
       "Physiological/cellular effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -61583,8 +60780,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -61667,14 +60863,19 @@
       "anthraquinone-related laxative effects (traditional/preclinical)",
       "gut_microbiome"
     ],
-    "canonical_mechanisms": [],
-    "mechanism_categories": [],
-    "mechanism_classes": [],
+    "canonical_mechanisms": [
+      "Gut microbiome modulation"
+    ],
+    "mechanism_categories": [
+      "gut"
+    ],
+    "mechanism_classes": [
+      "Microbiome modulation"
+    ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "unmapped",
+    "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "anthraquinone-related laxative effects (traditional/preclinical)",
-      "gut_microbiome"
+      "anthraquinone-related laxative effects (traditional/preclinical)"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -61772,10 +60973,8 @@
       "Receptor interaction"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "metabolic"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "Moderate efficacy / high safety caution",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -61884,10 +61083,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "high",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -61984,10 +61181,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "high",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -62082,10 +61277,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "limited",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",

--- a/public/data/herbs.json
+++ b/public/data/herbs.json
@@ -35,10 +35,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -335,24 +333,24 @@
       "Metabolic regulation",
       "Immune modulation",
       "AMPK activation",
-      "Glucose regulation"
+      "Glucose regulation",
+      "Gut microbiome modulation"
     ],
     "mechanism_categories": [
       "core",
       "immune",
-      "metabolic"
+      "metabolic",
+      "gut"
     ],
     "mechanism_classes": [
       "Physiological effect",
       "Signaling pathway modulation",
-      "Metabolic modulation"
+      "Metabolic modulation",
+      "Microbiome modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory",
-      "gut_microbiome"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -457,10 +455,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -564,7 +560,6 @@
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
       "Neurotransmitter Modulation",
-      "Oxidative Stress",
       "Neurotransmitter Signaling"
     ],
     "evidence_grade": "c",
@@ -670,10 +665,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -779,7 +772,8 @@
       "Metabolic regulation",
       "Neuroprotective activity",
       "AMPK activation",
-      "Nrf2 activation"
+      "Nrf2 activation",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
       "core",
@@ -788,15 +782,12 @@
     ],
     "mechanism_classes": [
       "Physiological effect",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Nrf2",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -901,11 +892,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB",
-      "Nrf2"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -1320,10 +1308,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -1543,12 +1529,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress",
-      "Endothelial Function",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -1768,11 +1750,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -1878,11 +1857,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB",
-      "Nrf2"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -1992,11 +1968,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -2090,20 +2063,20 @@
     ],
     "canonical_mechanisms": [
       "Antioxidant",
-      "Metabolic regulation"
+      "Metabolic regulation",
+      "AMPK activation"
     ],
     "mechanism_categories": [
-      "core"
+      "core",
+      "metabolic"
     ],
     "mechanism_classes": [
-      "Physiological effect"
+      "Physiological effect",
+      "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -2433,23 +2406,26 @@
     "canonical_mechanisms": [
       "Anti-inflammatory",
       "Hormonal signaling context",
-      "HPA-axis modulation"
+      "HPA-axis modulation",
+      "NF-kB inhibition",
+      "Nrf2 activation",
+      "Antioxidant"
     ],
     "mechanism_categories": [
       "core",
-      "stress"
+      "stress",
+      "inflammatory",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
-      "Neuroendocrine modulation"
+      "Neuroendocrine modulation",
+      "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
       "Neurotransmitter Modulation",
-      "NF-kB",
-      "Nrf2",
-      "Oxidative Stress",
       "Neurotransmitter Signaling"
     ],
     "evidence_grade": "a",
@@ -2545,7 +2521,8 @@
     "canonical_mechanisms": [
       "Metabolic regulation",
       "Neuroprotective activity",
-      "Glucose regulation"
+      "Glucose regulation",
+      "Vascular function support"
     ],
     "mechanism_categories": [
       "core",
@@ -2556,11 +2533,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism",
-      "Endothelial Function"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "C+",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -2781,7 +2755,8 @@
       "Hormonal signaling context",
       "HPA-axis modulation",
       "AMPK activation",
-      "NF-kB inhibition"
+      "NF-kB inhibition",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
       "core",
@@ -2793,15 +2768,12 @@
     "mechanism_classes": [
       "Physiological effect",
       "Neuroendocrine modulation",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "NF-kB",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -3011,10 +2983,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -3123,7 +3093,6 @@
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
       "Neurotransmitter Modulation",
-      "Oxidative Stress",
       "Neurotransmitter Signaling"
     ],
     "evidence_grade": "a",
@@ -3223,10 +3192,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -3332,11 +3299,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -3433,10 +3397,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -3560,13 +3522,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "NF-kB",
-      "Glucose Metabolism",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "a",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -3672,7 +3629,8 @@
     "canonical_mechanisms": [
       "Metabolic regulation",
       "AMPK activation",
-      "NF-kB inhibition"
+      "NF-kB inhibition",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
       "core",
@@ -3681,15 +3639,12 @@
     ],
     "mechanism_classes": [
       "Physiological effect",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "NF-kB",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -3797,11 +3752,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -3904,10 +3856,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -4110,10 +4060,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "a",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -4234,12 +4182,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress",
-      "Endothelial Function",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -4452,25 +4396,23 @@
       "Metabolic regulation",
       "Vascular function support",
       "Neuroprotective activity",
-      "AMPK activation"
+      "AMPK activation",
+      "Nrf2 activation",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
       "core",
-      "metabolic"
+      "metabolic",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Nrf2",
-      "Oxidative Stress",
-      "Endothelial Function",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "a",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -4754,10 +4696,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -4859,11 +4799,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -4965,11 +4902,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -5092,13 +5026,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB",
-      "Nrf2",
-      "Endothelial Function",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "a",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -5209,10 +5138,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -5315,10 +5242,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -5603,7 +5528,8 @@
     ],
     "canonical_mechanisms": [
       "Vascular function support",
-      "Nitric oxide modulation"
+      "Nitric oxide modulation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
@@ -5614,11 +5540,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Endothelial Function",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "a",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -5817,10 +5740,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -6305,10 +6226,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -6393,19 +6312,20 @@
       "Glucose Metabolism"
     ],
     "canonical_mechanisms": [
-      "Metabolic regulation"
+      "Metabolic regulation",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
-      "core"
+      "core",
+      "metabolic"
     ],
     "mechanism_classes": [
-      "Physiological effect"
+      "Physiological effect",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -6504,10 +6424,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -6613,10 +6531,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "inflammatory"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -6932,8 +6848,6 @@
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
       "Neurotransmitter Modulation",
-      "NF-kB",
-      "Oxidative Stress",
       "Neurotransmitter Signaling"
     ],
     "evidence_grade": "c",
@@ -7055,10 +6969,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -7259,12 +7171,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB",
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -7484,11 +7392,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "a",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -7589,10 +7494,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -7680,19 +7583,20 @@
     ],
     "canonical_mechanisms": [
       "Anti-inflammatory",
-      "Metabolic regulation"
+      "Metabolic regulation",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
-      "core"
+      "core",
+      "metabolic"
     ],
     "mechanism_classes": [
-      "Physiological effect"
+      "Physiological effect",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -7778,19 +7682,20 @@
       "Glucose Metabolism"
     ],
     "canonical_mechanisms": [
-      "Neuroprotective activity"
+      "Neuroprotective activity",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
-      "core"
+      "core",
+      "metabolic"
     ],
     "mechanism_classes": [
-      "Physiological effect"
+      "Physiological effect",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -7888,24 +7793,24 @@
     "canonical_mechanisms": [
       "Neuroprotective activity",
       "Nrf2 activation",
-      "Mitochondrial biogenesis"
+      "Mitochondrial biogenesis",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
       "core",
       "redox",
-      "mitochondrial"
+      "mitochondrial",
+      "metabolic"
     ],
     "mechanism_classes": [
       "Physiological effect",
       "Signaling pathway modulation",
-      "Physiological/cellular effect"
+      "Physiological/cellular effect",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -8135,13 +8040,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "NF-kB",
-      "Endothelial Function",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "a",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -8244,23 +8144,22 @@
       "Antioxidant",
       "Metabolic regulation",
       "Vascular function support",
-      "NF-kB inhibition"
+      "NF-kB inhibition",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
       "core",
-      "inflammatory"
+      "inflammatory",
+      "metabolic"
     ],
     "mechanism_classes": [
       "Physiological effect",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB",
-      "Oxidative Stress",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -8772,12 +8671,8 @@
       "Physiological/cellular effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -8997,11 +8892,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -9119,11 +9011,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -9223,7 +9112,8 @@
     "canonical_mechanisms": [
       "Metabolic regulation",
       "AMPK activation",
-      "NF-kB inhibition"
+      "NF-kB inhibition",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
       "core",
@@ -9232,15 +9122,12 @@
     ],
     "mechanism_classes": [
       "Physiological effect",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "NF-kB",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -9468,10 +9355,7 @@
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
       "Neurotransmitter Modulation",
-      "Nrf2",
-      "Neurotransmitter Signaling",
-      "Glucose Metabolism",
-      "Lipid Metabolism"
+      "Neurotransmitter Signaling"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
@@ -9575,23 +9459,22 @@
       "Antioxidant",
       "Metabolic regulation",
       "Hormonal signaling context",
-      "Nrf2 activation"
+      "Nrf2 activation",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
       "core",
-      "redox"
+      "redox",
+      "metabolic"
     ],
     "mechanism_classes": [
       "Physiological effect",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Oxidative Stress",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -9787,10 +9670,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -9902,7 +9783,6 @@
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
       "Neurotransmitter Modulation",
-      "Oxidative Stress",
       "Neurotransmitter Signaling"
     ],
     "evidence_grade": "c",
@@ -10105,10 +9985,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -10202,7 +10080,8 @@
     "canonical_mechanisms": [
       "Anti-inflammatory",
       "Metabolic regulation",
-      "NF-kB inhibition"
+      "NF-kB inhibition",
+      "Antioxidant"
     ],
     "mechanism_categories": [
       "core",
@@ -10213,10 +10092,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "a",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -10306,20 +10183,20 @@
     ],
     "canonical_mechanisms": [
       "Antioxidant",
-      "Metabolic regulation"
+      "Metabolic regulation",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
-      "core"
+      "core",
+      "metabolic"
     ],
     "mechanism_classes": [
-      "Physiological effect"
+      "Physiological effect",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -10421,10 +10298,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -10534,7 +10409,6 @@
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
       "Neurotransmitter Modulation",
-      "NF-kB",
       "Neurotransmitter Signaling"
     ],
     "evidence_grade": "c",
@@ -10730,22 +10604,21 @@
     ],
     "canonical_mechanisms": [
       "NF-kB inhibition",
-      "Nrf2 activation"
+      "Nrf2 activation",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
       "inflammatory",
-      "redox"
+      "redox",
+      "metabolic"
     ],
     "mechanism_classes": [
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB",
-      "Nrf2",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "a",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -10948,10 +10821,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -11046,10 +10917,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -11263,10 +11132,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -11361,10 +11228,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -11561,10 +11426,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -11665,7 +11528,8 @@
       "Anti-inflammatory",
       "Immune modulation",
       "HPA-axis modulation",
-      "AMPK activation"
+      "AMPK activation",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
       "core",
@@ -11676,14 +11540,12 @@
     "mechanism_classes": [
       "Physiological effect",
       "Neuroendocrine modulation",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -11780,10 +11642,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -11890,10 +11750,8 @@
       "Physiological/cellular effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Endothelial Function"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -12006,10 +11864,8 @@
       "Physiological/cellular effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Endothelial Function"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -12501,11 +12357,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -12612,7 +12465,6 @@
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
       "Neurotransmitter Modulation",
-      "NF-kB",
       "Neurotransmitter Signaling"
     ],
     "evidence_grade": "c",
@@ -12723,11 +12575,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -12834,10 +12683,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -12948,11 +12795,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB",
-      "Nrf2"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -13146,23 +12990,22 @@
     "canonical_mechanisms": [
       "Antioxidant",
       "Metabolic regulation",
-      "NF-kB inhibition"
+      "NF-kB inhibition",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
       "core",
-      "inflammatory"
+      "inflammatory",
+      "metabolic"
     ],
     "mechanism_classes": [
       "Physiological effect",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB",
-      "Oxidative Stress",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -13270,11 +13113,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -13382,11 +13222,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Endothelial Function",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "a",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -13499,10 +13336,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -13714,8 +13549,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "Oxidative Stress"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "b+",
     "evidence_tier": "Moderate Human Evidence",
@@ -14011,7 +13845,8 @@
       "Anti-inflammatory",
       "Mitochondrial biogenesis",
       "AMPK activation",
-      "NF-kB inhibition"
+      "NF-kB inhibition",
+      "Neuroprotective activity"
     ],
     "mechanism_categories": [
       "core",
@@ -14027,7 +13862,6 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "neuroprotective",
       "liver_detoxification"
     ],
     "evidence_grade": "c",
@@ -14142,9 +13976,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "cardiovascular",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
@@ -14248,7 +14080,8 @@
       "Antioxidant",
       "Vascular function support",
       "HPA-axis modulation",
-      "Nitric oxide modulation"
+      "Nitric oxide modulation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
@@ -14261,12 +14094,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress",
-      "Endothelial Function",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -14470,24 +14299,23 @@
       "Antioxidant",
       "Metabolic regulation",
       "Vascular function support",
-      "Nitric oxide modulation"
+      "Nitric oxide modulation",
+      "AMPK activation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
-      "cardiovascular"
+      "cardiovascular",
+      "metabolic"
     ],
     "mechanism_classes": [
       "Physiological effect",
-      "Signaling molecule modulation"
+      "Signaling molecule modulation",
+      "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Oxidative Stress",
-      "Endothelial Function",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "a",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -14574,7 +14402,8 @@
     ],
     "canonical_mechanisms": [
       "Metabolic regulation",
-      "Vascular function support"
+      "Vascular function support",
+      "Antioxidant"
     ],
     "mechanism_categories": [
       "core"
@@ -14583,10 +14412,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -14680,7 +14507,8 @@
     "canonical_mechanisms": [
       "Anti-inflammatory",
       "Antioxidant",
-      "Adenosine modulation"
+      "Adenosine modulation",
+      "Vascular function support"
     ],
     "mechanism_categories": [
       "core",
@@ -14691,10 +14519,8 @@
       "Receptor interaction"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "cardiovascular"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -14793,10 +14619,8 @@
       "Physiological/cellular effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -14908,11 +14732,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -15012,10 +14833,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -15114,10 +14933,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -15422,24 +15239,26 @@
       "Antioxidant",
       "Metabolic regulation",
       "Hormonal signaling context",
-      "HPA-axis modulation"
+      "HPA-axis modulation",
+      "AMPK activation",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
       "core",
-      "stress"
+      "stress",
+      "metabolic"
     ],
     "mechanism_classes": [
       "Physiological effect",
-      "Neuroendocrine modulation"
+      "Neuroendocrine modulation",
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
       "Neurotransmitter Modulation",
-      "AMPK",
-      "Oxidative Stress",
-      "Neurotransmitter Signaling",
-      "Glucose Metabolism"
+      "Neurotransmitter Signaling"
     ],
     "evidence_grade": "b",
     "evidence_tier": "Strong Human Evidence",
@@ -15541,22 +15360,22 @@
       "Anti-inflammatory",
       "Antioxidant",
       "Metabolic regulation",
-      "HPA-axis modulation"
+      "HPA-axis modulation",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
       "core",
-      "stress"
+      "stress",
+      "metabolic"
     ],
     "mechanism_classes": [
       "Physiological effect",
-      "Neuroendocrine modulation"
+      "Neuroendocrine modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -15642,19 +15461,20 @@
       "Glucose Metabolism"
     ],
     "canonical_mechanisms": [
-      "Metabolic regulation"
+      "Metabolic regulation",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
-      "core"
+      "core",
+      "metabolic"
     ],
     "mechanism_classes": [
-      "Physiological effect"
+      "Physiological effect",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -15758,10 +15578,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -15960,10 +15778,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -16382,11 +16198,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "a",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -16607,11 +16420,7 @@
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "AMPK",
-      "NF-kB",
-      "Nrf2",
-      "SIRT1",
-      "Oxidative Stress"
+      "SIRT1"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -16804,22 +16613,22 @@
     ],
     "canonical_mechanisms": [
       "Antioxidant",
-      "HPA-axis modulation"
+      "HPA-axis modulation",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
       "core",
-      "stress"
+      "stress",
+      "metabolic"
     ],
     "mechanism_classes": [
       "Physiological effect",
-      "Neuroendocrine modulation"
+      "Neuroendocrine modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -17220,20 +17029,20 @@
     "canonical_mechanisms": [
       "Antioxidant",
       "Metabolic regulation",
-      "Vascular function support"
+      "Vascular function support",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
-      "core"
+      "core",
+      "metabolic"
     ],
     "mechanism_classes": [
-      "Physiological effect"
+      "Physiological effect",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -17344,10 +17153,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -17653,10 +17460,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -17769,7 +17574,6 @@
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
       "Neurotransmitter Modulation",
-      "Oxidative Stress",
       "Neurotransmitter Signaling"
     ],
     "evidence_grade": "b",
@@ -17873,10 +17677,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -18082,10 +17884,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -18203,10 +18003,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -18407,10 +18205,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "neuroprotective"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Mechanistic Evidence",
     "evidence_design_match": "",
@@ -18505,10 +18301,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -18704,10 +18498,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -18800,20 +18592,20 @@
     ],
     "canonical_mechanisms": [
       "Antioxidant",
-      "Metabolic regulation"
+      "Metabolic regulation",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
-      "core"
+      "core",
+      "metabolic"
     ],
     "mechanism_classes": [
-      "Physiological effect"
+      "Physiological effect",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -18918,10 +18710,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "endocrine"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -19127,10 +18917,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -19238,7 +19026,8 @@
       "Metabolic regulation",
       "AMPK activation",
       "NF-kB inhibition",
-      "Nrf2 activation"
+      "Nrf2 activation",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
       "core",
@@ -19248,17 +19037,12 @@
     ],
     "mechanism_classes": [
       "Physiological effect",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "NF-kB",
-      "Nrf2",
-      "Oxidative Stress",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -19359,10 +19143,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -19546,19 +19328,20 @@
       "Glucose Metabolism"
     ],
     "canonical_mechanisms": [
-      "Anti-inflammatory"
+      "Anti-inflammatory",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
-      "core"
+      "core",
+      "metabolic"
     ],
     "mechanism_classes": [
-      "Physiological effect"
+      "Physiological effect",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -19763,10 +19546,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -19872,10 +19653,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -19996,12 +19775,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB",
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -20116,7 +19891,8 @@
       "AMPK activation",
       "NF-kB inhibition",
       "Nrf2 activation",
-      "Glucose regulation"
+      "Glucose regulation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
@@ -20130,15 +19906,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "NF-kB",
-      "Nrf2",
-      "Oxidative Stress",
-      "Glucose Metabolism",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -20250,12 +20019,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -20373,7 +20138,6 @@
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
       "Neurotransmitter Modulation",
-      "Oxidative Stress",
       "Neurotransmitter Signaling"
     ],
     "evidence_grade": "c",
@@ -20682,12 +20446,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -20887,10 +20647,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -20984,20 +20742,21 @@
     "canonical_mechanisms": [
       "Anti-inflammatory",
       "Metabolic regulation",
-      "Immune modulation"
+      "Immune modulation",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
       "core",
-      "immune"
+      "immune",
+      "metabolic"
     ],
     "mechanism_classes": [
-      "Physiological effect"
+      "Physiological effect",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -21104,7 +20863,8 @@
       "Metabolic regulation",
       "HPA-axis modulation",
       "AMPK activation",
-      "NF-kB inhibition"
+      "NF-kB inhibition",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
       "core",
@@ -21115,15 +20875,12 @@
     "mechanism_classes": [
       "Physiological effect",
       "Neuroendocrine modulation",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "NF-kB",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -21213,7 +20970,8 @@
     ],
     "canonical_mechanisms": [
       "Anti-inflammatory",
-      "Hormonal signaling context"
+      "Hormonal signaling context",
+      "Antioxidant"
     ],
     "mechanism_categories": [
       "core"
@@ -21222,10 +20980,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -21326,7 +21082,8 @@
       "AMPK activation",
       "NF-kB inhibition",
       "Nrf2 activation",
-      "Glucose regulation"
+      "Glucose regulation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
@@ -21340,14 +21097,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "NF-kB",
-      "Nrf2",
-      "Glucose Metabolism",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "a",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -21452,10 +21203,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -21769,12 +21518,14 @@
       "Antioxidant",
       "Metabolic regulation",
       "HPA-axis modulation",
-      "NF-kB inhibition"
+      "NF-kB inhibition",
+      "Nrf2 activation"
     ],
     "mechanism_categories": [
       "core",
       "stress",
-      "inflammatory"
+      "inflammatory",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
@@ -21785,9 +21536,6 @@
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
       "Neurotransmitter Modulation",
-      "NF-kB",
-      "Nrf2",
-      "Oxidative Stress",
       "Neurotransmitter Signaling"
     ],
     "evidence_grade": "c",
@@ -21999,7 +21747,8 @@
       "Metabolic regulation",
       "Vascular function support",
       "Glucose regulation",
-      "Nitric oxide modulation"
+      "Nitric oxide modulation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
@@ -22012,13 +21761,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress",
-      "Endothelial Function",
-      "Glucose Metabolism",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -22222,12 +21966,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "NF-kB",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -22317,20 +22057,22 @@
       "Glucose Metabolism"
     ],
     "canonical_mechanisms": [
-      "Cellular protection"
+      "Cellular protection",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
-      "core"
+      "core",
+      "metabolic"
     ],
     "mechanism_classes": [
-      "Physiological effect"
+      "Physiological effect",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
       "Neurotransmitter Modulation",
-      "Neurotransmitter Signaling",
-      "Glucose Metabolism"
+      "Neurotransmitter Signaling"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -22443,10 +22185,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -22560,11 +22300,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB",
-      "Nrf2"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -22668,10 +22405,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -22785,8 +22520,6 @@
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
       "Neurotransmitter Modulation",
-      "Nrf2",
-      "Oxidative Stress",
       "Neurotransmitter Signaling"
     ],
     "evidence_grade": "c",
@@ -22990,10 +22723,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -23290,10 +23021,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -23409,11 +23138,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -23517,7 +23243,8 @@
       "Anti-inflammatory",
       "Metabolic regulation",
       "AMPK activation",
-      "NF-kB inhibition"
+      "NF-kB inhibition",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
       "core",
@@ -23526,15 +23253,12 @@
     ],
     "mechanism_classes": [
       "Physiological effect",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "NF-kB",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -23635,7 +23359,8 @@
       "Cellular protection",
       "Hormonal signaling context",
       "HPA-axis modulation",
-      "Neuroprotective activity"
+      "Neuroprotective activity",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
@@ -23646,10 +23371,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -23757,11 +23480,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -23869,10 +23589,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -23976,10 +23694,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -24085,11 +23801,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -24296,7 +24009,8 @@
       "Antioxidant",
       "Vascular function support",
       "NF-kB inhibition",
-      "Nrf2 activation"
+      "Nrf2 activation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
@@ -24308,13 +24022,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB",
-      "Nrf2",
-      "Oxidative Stress",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -24536,10 +24245,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -24654,11 +24361,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -24769,11 +24473,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -25082,11 +24783,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Endothelial Function",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -25190,11 +24888,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB",
-      "Nrf2"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -25303,11 +24998,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -25405,7 +25097,8 @@
     "canonical_mechanisms": [
       "Anti-inflammatory",
       "Metabolic regulation",
-      "AMPK activation"
+      "AMPK activation",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
       "core",
@@ -25413,14 +25106,12 @@
     ],
     "mechanism_classes": [
       "Physiological effect",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -25511,19 +25202,20 @@
     ],
     "canonical_mechanisms": [
       "Anti-inflammatory",
-      "Metabolic regulation"
+      "Metabolic regulation",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
-      "core"
+      "core",
+      "metabolic"
     ],
     "mechanism_classes": [
-      "Physiological effect"
+      "Physiological effect",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -25727,10 +25419,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "D+",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -25838,24 +25528,24 @@
       "Antioxidant",
       "Mitochondrial biogenesis",
       "Metabolic regulation",
-      "Vascular function support"
+      "Vascular function support",
+      "AMPK activation"
     ],
     "mechanism_categories": [
       "core",
-      "mitochondrial"
+      "mitochondrial",
+      "metabolic"
     ],
     "mechanism_classes": [
       "Physiological effect",
-      "Physiological/cellular effect"
+      "Physiological/cellular effect",
+      "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
       "SIRT1 Signaling",
-      "AMPK",
-      "SIRT1",
-      "Endothelial Function",
-      "Oxidative Stress"
+      "SIRT1"
     ],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
@@ -25952,10 +25642,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -26066,7 +25754,6 @@
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
       "Neurotransmitter Modulation",
-      "AMPK",
       "Neurotransmitter Signaling"
     ],
     "evidence_grade": "C+",
@@ -26186,7 +25873,8 @@
       "Metabolic regulation",
       "Vascular function support",
       "AMPK activation",
-      "Nrf2 activation"
+      "Nrf2 activation",
+      "Lipid metabolism support"
     ],
     "mechanism_categories": [
       "core",
@@ -26198,13 +25886,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Nrf2",
-      "Oxidative Stress",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "a",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -26302,7 +25985,8 @@
     "canonical_mechanisms": [
       "Antioxidant",
       "AMPK activation",
-      "Nrf2 activation"
+      "Nrf2 activation",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
       "core",
@@ -26311,16 +25995,12 @@
     ],
     "mechanism_classes": [
       "Physiological effect",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "Nrf2",
-      "Oxidative Stress",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -26426,11 +26106,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -26525,20 +26202,20 @@
     "canonical_mechanisms": [
       "Antioxidant",
       "Metabolic regulation",
-      "Vascular function support"
+      "Vascular function support",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
-      "core"
+      "core",
+      "metabolic"
     ],
     "mechanism_classes": [
-      "Physiological effect"
+      "Physiological effect",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -26662,13 +26339,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "NF-kB",
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -26781,7 +26453,6 @@
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
       "Neurotransmitter Modulation",
-      "Oxidative Stress",
       "Neurotransmitter Signaling"
     ],
     "evidence_grade": "c",
@@ -26893,13 +26564,15 @@
       "HPA-axis modulation",
       "Neuroprotective activity",
       "AMPK activation",
-      "NF-kB inhibition"
+      "NF-kB inhibition",
+      "Nrf2 activation"
     ],
     "mechanism_categories": [
       "core",
       "stress",
       "metabolic",
-      "inflammatory"
+      "inflammatory",
+      "redox"
     ],
     "mechanism_classes": [
       "Physiological effect",
@@ -26907,13 +26580,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "AMPK",
-      "NF-kB",
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -27017,10 +26685,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -27125,11 +26791,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress",
-      "Endothelial Function"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -27212,7 +26875,8 @@
     "canonical_mechanisms": [
       "Anti-inflammatory",
       "Hormonal signaling context",
-      "Lipid metabolism support"
+      "Lipid metabolism support",
+      "Metabolic regulation"
     ],
     "mechanism_categories": [
       "core"
@@ -27221,11 +26885,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "endocrine",
-      "metabolic"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -27311,23 +26972,24 @@
     "canonical_mechanisms": [
       "Mitochondrial biogenesis",
       "HPA-axis modulation",
-      "Nrf2 activation"
+      "Nrf2 activation",
+      "Antioxidant"
     ],
     "mechanism_categories": [
       "mitochondrial",
       "stress",
-      "redox"
+      "redox",
+      "core"
     ],
     "mechanism_classes": [
       "Physiological/cellular effect",
       "Neuroendocrine modulation",
-      "Signaling pathway modulation"
+      "Signaling pathway modulation",
+      "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -27531,10 +27193,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -27662,12 +27322,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB",
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -27773,10 +27429,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -27889,10 +27543,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -28290,10 +27942,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -28401,10 +28051,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -28503,10 +28151,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -28622,11 +28268,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress",
-      "Lipid Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -28828,10 +28471,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -28930,10 +28571,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -29037,10 +28676,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -29144,10 +28781,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -29353,10 +28988,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -29451,20 +29084,20 @@
     ],
     "canonical_mechanisms": [
       "Antioxidant",
-      "Metabolic regulation"
+      "Metabolic regulation",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
-      "core"
+      "core",
+      "metabolic"
     ],
     "mechanism_classes": [
-      "Physiological effect"
+      "Physiological effect",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress",
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -29564,10 +29197,8 @@
       "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Glucose Metabolism"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -29660,10 +29291,8 @@
       "Signaling molecule modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Endothelial Function"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -29758,10 +29387,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "a",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -29879,7 +29506,6 @@
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
       "Neurotransmitter Modulation",
-      "NF-kB",
       "Neurotransmitter Signaling"
     ],
     "evidence_grade": "c",
@@ -29986,10 +29612,8 @@
       "Neuroendocrine modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "endocrine"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -30075,7 +29699,8 @@
       "endocrine"
     ],
     "canonical_mechanisms": [
-      "Vascular function support"
+      "Vascular function support",
+      "Hormonal signaling context"
     ],
     "mechanism_categories": [
       "core"
@@ -30084,10 +29709,8 @@
       "Physiological effect"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "endocrine"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
     "evidence_design_match": "",
@@ -30191,10 +29814,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "a",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -30420,11 +30041,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Nrf2",
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "b+",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -30613,19 +30231,21 @@
       "neuroprotective"
     ],
     "canonical_mechanisms": [
-      "HPA-axis modulation"
+      "HPA-axis modulation",
+      "Neuroprotective activity"
     ],
     "mechanism_categories": [
-      "stress"
+      "stress",
+      "core"
     ],
     "mechanism_classes": [
-      "Neuroendocrine modulation"
+      "Neuroendocrine modulation",
+      "Physiological effect"
     ],
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "neuroprotective"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "b",
     "evidence_tier": "Moderate Human Evidence",
@@ -30730,10 +30350,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "NF-kB"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
     "evidence_design_match": "",
@@ -30933,19 +30551,20 @@
       "Glucose Metabolism"
     ],
     "canonical_mechanisms": [
-      "PPAR activation"
+      "PPAR activation",
+      "Glucose regulation"
     ],
     "mechanism_categories": [
       "metabolic"
     ],
     "mechanism_classes": [
-      "Nuclear receptor modulation"
+      "Nuclear receptor modulation",
+      "Metabolic modulation"
     ],
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "PI3K/Akt modulation",
-      "Glucose Metabolism"
+      "PI3K/Akt modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",
@@ -31265,10 +30884,8 @@
       "Signaling pathway modulation"
     ],
     "mechanism_target_systems": [],
-    "mechanism_normalization_status": "partially_mapped",
-    "unmapped_mechanisms": [
-      "Oxidative Stress"
-    ],
+    "mechanism_normalization_status": "fully_mapped",
+    "unmapped_mechanisms": [],
     "evidence_grade": "c",
     "evidence_tier": "Strong Human Evidence",
     "evidence_design_match": "",
@@ -31363,19 +30980,21 @@
       "cardiovascular"
     ],
     "canonical_mechanisms": [
-      "HPA-axis modulation"
+      "HPA-axis modulation",
+      "Vascular function support"
     ],
     "mechanism_categories": [
-      "stress"
+      "stress",
+      "core"
     ],
     "mechanism_classes": [
-      "Neuroendocrine modulation"
+      "Neuroendocrine modulation",
+      "Physiological effect"
     ],
     "mechanism_target_systems": [],
     "mechanism_normalization_status": "partially_mapped",
     "unmapped_mechanisms": [
-      "Neurotransmitter Modulation",
-      "cardiovascular"
+      "Neurotransmitter Modulation"
     ],
     "evidence_grade": "c",
     "evidence_tier": "Limited Human Evidence",

--- a/public/data/mechanism-normalization-report.json
+++ b/public/data/mechanism-normalization-report.json
@@ -2,78 +2,22 @@
   "reportVersion": 1,
   "canonicalMechanisms": 53,
   "records": 856,
-  "fullyMappedRecords": 91,
-  "partiallyMappedRecords": 702,
-  "unmappedRecords": 63,
+  "fullyMappedRecords": 622,
+  "partiallyMappedRecords": 179,
+  "unmappedRecords": 55,
   "noRawMechanismRecords": 0,
   "unmappedMechanisms": [
     {
-      "term": "Oxidative Stress",
-      "count": 283
-    },
-    {
       "term": "Neurotransmitter Modulation",
       "count": 158
-    },
-    {
-      "term": "Glucose Metabolism",
-      "count": 131
-    },
-    {
-      "term": "Nrf2",
-      "count": 111
-    },
-    {
-      "term": "AMPK",
-      "count": 109
-    },
-    {
-      "term": "Lipid Metabolism",
-      "count": 106
-    },
-    {
-      "term": "NF-kB",
-      "count": 80
-    },
-    {
-      "term": "Endothelial Function",
-      "count": 71
-    },
-    {
-      "term": "inflammatory",
-      "count": 63
-    },
-    {
-      "term": "neuroprotective",
-      "count": 45
-    },
-    {
-      "term": "metabolic",
-      "count": 40
     },
     {
       "term": "Neurotransmitter Signaling",
       "count": 40
     },
     {
-      "term": "endocrine",
-      "count": 23
-    },
-    {
-      "term": "cardiovascular",
-      "count": 12
-    },
-    {
-      "term": "mitochondrial",
-      "count": 12
-    },
-    {
       "term": "liver_detoxification",
       "count": 11
-    },
-    {
-      "term": "mTOR",
-      "count": 8
     },
     {
       "term": "SIRT1",
@@ -84,16 +28,8 @@
       "count": 7
     },
     {
-      "term": "gut_microbiome",
-      "count": 6
-    },
-    {
       "term": "SIRT1 Signaling",
       "count": 5
-    },
-    {
-      "term": "endocannabinoid",
-      "count": 4
     },
     {
       "term": "Added as site-safe referenced entity during workbook readiness pass",
@@ -209,10 +145,6 @@
     },
     {
       "term": "Antioxidant and Anti-Inflammatory Activity",
-      "count": 1
-    },
-    {
-      "term": "Antioxidant defense",
       "count": 1
     },
     {

--- a/scripts/data/build-runtime-from-workbook.mjs
+++ b/scripts/data/build-runtime-from-workbook.mjs
@@ -358,8 +358,39 @@ function canonicalMechanismRow(row) {
   })
 }
 
+// Curated synonym overlay for canonical mechanisms, keyed by canonical_mechanism_id.
+// These are high-confidence aliases that appear frequently in workbook mechanism
+// fields as the bare concept or target system (e.g. "Nrf2" for "Nrf2 activation",
+// "Oxidative Stress" for "Antioxidant"). Kept in code, not the workbook, so it
+// survives data:build regeneration and stays reviewable. Only unambiguous terms
+// are mapped — genuinely ambiguous terms (e.g. "Neurotransmitter Modulation")
+// are deliberately left unmapped rather than guess a specific pathway.
+const MECHANISM_SYNONYM_OVERLAY = {
+  'nrf2-activation': ['Nrf2', 'Nrf2 signaling', 'Nrf2 pathway'],
+  'ampk-activation': ['AMPK', 'AMPK signaling', 'AMPK pathway'],
+  'nf-kb-inhibition': ['NF-kB', 'NF-kB signaling', 'NF-kB pathway'],
+  'mtor-modulation': ['mTOR', 'mTOR signaling', 'mTOR pathway'],
+  'neuroprotective-activity': ['neuroprotective', 'neuroprotection'],
+  'gut-microbiome-modulation': ['gut_microbiome', 'gut microbiome'],
+  'endocannabinoid-modulation': ['endocannabinoid', 'endocannabinoid system'],
+  'lipid-metabolism-support': ['Lipid Metabolism', 'lipid metabolism'],
+  'metabolic-regulation': ['metabolic', 'metabolism'],
+  'antioxidant': ['Oxidative Stress', 'oxidative stress', 'Antioxidant defense', 'antioxidant defense'],
+  'anti-inflammatory': ['inflammatory', 'inflammation'],
+  'glucose-regulation': ['Glucose Metabolism', 'glucose metabolism'],
+  'vascular-function-support': ['Endothelial Function', 'endothelial function', 'cardiovascular'],
+  'mitochondrial-biogenesis': ['mitochondrial', 'mitochondrial function'],
+  'hormonal-signaling-context': ['endocrine', 'endocrine signaling'],
+}
+
 function buildMechanismTaxonomy(rows) {
   const mechanisms = normalizeRows(rows, canonicalMechanismRow)
+  for (const mechanism of mechanisms) {
+    const overlay = MECHANISM_SYNONYM_OVERLAY[mechanism.canonical_mechanism_id]
+    if (overlay) {
+      mechanism.synonyms = uniqueList([mechanism.synonyms || [], overlay])
+    }
+  }
   const aliasToMechanism = new Map()
   for (const mechanism of mechanisms) {
     for (const alias of uniqueList([mechanism.canonical_label, mechanism.label, mechanism.synonyms || []])) {


### PR DESCRIPTION
## Summary

- Add a curated synonym overlay in `scripts/data/build-runtime-from-workbook.mjs` so common bare-concept mechanism terms resolve to existing canonical mechanisms (e.g. `Nrf2` → `Nrf2 activation`, `AMPK` → `AMPK activation`, `Oxidative Stress` → `Antioxidant`, `NF-kB` → `NF-kB inhibition`, `Glucose Metabolism` → `Glucose regulation`).
- Cuts unmapped mechanism occurrences from **1463 → 358 (~75%)** and lifts fully-mapped records, improving the semantic graph and mechanism-based internal linking across ~130+ herb/compound profiles.
- Overlay lives in code (not the workbook), so it survives `data:build` regeneration and stays reviewable. Genuinely ambiguous terms (e.g. `Neurotransmitter Modulation`, 198×) are deliberately left unmapped rather than guessing a specific pathway.
- Regenerated `public/data` (`herbs.json`, `compounds.json`, `canonical-mechanisms.json`, `mechanism-normalization-report.json`) via the core pipeline.

## Verification

- [x] `npm run lint`
- [x] `npm run check`
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs (only mechanism-mapping fields + build-info timestamp)
- [x] no generated file corruption (full Vitest suite: 553 tests pass)
- [x] static export compatible (build-script + generated data only; no runtime/config change)

## Risk Notes

- Low risk: change is confined to a data-normalization overlay in the build pipeline. Only mechanism mapping fields (`canonical_mechanisms`, `unmapped_mechanisms`, `mechanism_normalization_status`) and synonym lists change; no schema, route, or runtime behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHLPuSC54yeZbRLMcVqmP6)_