### PR TITLE
fix(agent): await validation with correct contract in orchestrator

### DIFF
--- a/agent/orchestrator/run-orchestrator.js
+++ b/agent/orchestrator/run-orchestrator.js
@@ -170,8 +170,16 @@ async function main() {
         })),
       ]
 
-      const validation = runValidationAgent(evidenceRows)
-      const dedupedEvidence = runDedupeAgent(validation.approved_rows || [])
+      const validationResult = await runValidationAgent({
+        slug: result.slug,
+        evidence: evidenceRows,
+      })
+      const validation = validationResult?.data || {
+        validation_status: 'rejected',
+        rejection_reasons: ['validation_unavailable'],
+        entries: [],
+      }
+      const dedupedEvidence = runDedupeAgent(validation.entries || [])
       const scoring = runScoringAgent(dedupedEvidence)
 
       const arbitration = confidenceArbitration(validation, scoring)

--- a/agent/patches/2026-07-11/berberine-metadata-harvester-2183e739-8b01-4371-8231-ef1279cddb6f.json
+++ b/agent/patches/2026-07-11/berberine-metadata-harvester-2183e739-8b01-4371-8231-ef1279cddb6f.json
@@ -1,0 +1,73 @@
+{
+  "patch_id": "2183e739-8b01-4371-8231-ef1279cddb6f",
+  "schema_version": "2.0",
+  "source_agent": "metadata-harvester",
+  "agent_version": "2.0",
+  "created_at": "2026-07-11T17:38:26.366Z",
+  "slug": "berberine",
+  "patch_type": "evidence",
+  "research_depth": "metadata_only",
+  "metadata_sources": [
+    "pubmed",
+    "clinicaltrials"
+  ],
+  "confidence_notes": [
+    "Validation layer identified inconsistent or incomplete evidence.",
+    "Evidence confidence downgraded due to weak or conflicting support."
+  ],
+  "seo_assets": {
+    "faq_candidates": [
+      "What is berberine used for?",
+      "Is berberine evidence-based?"
+    ],
+    "seo_topics": [
+      "berberine benefits",
+      "berberine safety",
+      "berberine evidence"
+    ],
+    "internal_link_targets": [
+      "sleep",
+      "focus",
+      "recovery"
+    ],
+    "comparison_candidates": [
+      "berberine vs magnesium"
+    ],
+    "best_for": [
+      "general wellness"
+    ],
+    "avoid_if": [
+      "medication interactions"
+    ],
+    "product_quality_notes": [
+      "Prefer reputable third-party tested brands"
+    ]
+  },
+  "review_flags": [
+    "validation_conflicts",
+    "low_confidence"
+  ],
+  "evidence": [],
+  "validation": {
+    "patch_type": "validated_evidence",
+    "patch_id": "14efb889-3bbc-4cb5-a3fb-b631af691e4e",
+    "schema_version": "1.0",
+    "source_agent": "validation-agent",
+    "agent_version": "1.5",
+    "slug": "berberine",
+    "created_at": "2026-07-11T17:38:26.365Z",
+    "system_prompt": "You are the Validation Firewall for The Hippie Scientist.\nReject hallucinated citations, animal-only data, in-vitro-only data, vague claims, unsupported medical claims, and low-quality entries.\nBe extremely strict and conservative.",
+    "validation_status": "rejected",
+    "rejection_reasons": [
+      "no_approved_entries"
+    ],
+    "entries": []
+  },
+  "scoring": {
+    "confidence_score": 0.25,
+    "evidence_strength": "low",
+    "confidence_reasoning": [
+      "Scoring Rules:\n- Human meta-analysis > randomized trial > observational > pilot.\n- Small sample sizes reduce confidence.\n- Missing source attribution reduces confidence.\n- Evidence confidence must remain conservative.\n- Never output certainty language."
+    ]
+  }
+}

--- a/agent/patches/2026-07-11/creatine-metadata-harvester-bd9fad55-0f35-4aea-ab88-6d145112e333.json
+++ b/agent/patches/2026-07-11/creatine-metadata-harvester-bd9fad55-0f35-4aea-ab88-6d145112e333.json
@@ -1,0 +1,73 @@
+{
+  "patch_id": "bd9fad55-0f35-4aea-ab88-6d145112e333",
+  "schema_version": "2.0",
+  "source_agent": "metadata-harvester",
+  "agent_version": "2.0",
+  "created_at": "2026-07-11T17:38:26.367Z",
+  "slug": "creatine",
+  "patch_type": "evidence",
+  "research_depth": "metadata_only",
+  "metadata_sources": [
+    "pubmed",
+    "clinicaltrials"
+  ],
+  "confidence_notes": [
+    "Validation layer identified inconsistent or incomplete evidence.",
+    "Evidence confidence downgraded due to weak or conflicting support."
+  ],
+  "seo_assets": {
+    "faq_candidates": [
+      "What is creatine used for?",
+      "Is creatine evidence-based?"
+    ],
+    "seo_topics": [
+      "creatine benefits",
+      "creatine safety",
+      "creatine evidence"
+    ],
+    "internal_link_targets": [
+      "sleep",
+      "focus",
+      "recovery"
+    ],
+    "comparison_candidates": [
+      "creatine vs magnesium"
+    ],
+    "best_for": [
+      "general wellness"
+    ],
+    "avoid_if": [
+      "medication interactions"
+    ],
+    "product_quality_notes": [
+      "Prefer reputable third-party tested brands"
+    ]
+  },
+  "review_flags": [
+    "validation_conflicts",
+    "low_confidence"
+  ],
+  "evidence": [],
+  "validation": {
+    "patch_type": "validated_evidence",
+    "patch_id": "4a9e5134-656d-4e90-9d88-3d34eec7338d",
+    "schema_version": "1.0",
+    "source_agent": "validation-agent",
+    "agent_version": "1.5",
+    "slug": "creatine",
+    "created_at": "2026-07-11T17:38:26.367Z",
+    "system_prompt": "You are the Validation Firewall for The Hippie Scientist.\nReject hallucinated citations, animal-only data, in-vitro-only data, vague claims, unsupported medical claims, and low-quality entries.\nBe extremely strict and conservative.",
+    "validation_status": "rejected",
+    "rejection_reasons": [
+      "no_approved_entries"
+    ],
+    "entries": []
+  },
+  "scoring": {
+    "confidence_score": 0.25,
+    "evidence_strength": "low",
+    "confidence_reasoning": [
+      "Scoring Rules:\n- Human meta-analysis > randomized trial > observational > pilot.\n- Small sample sizes reduce confidence.\n- Missing source attribution reduces confidence.\n- Evidence confidence must remain conservative.\n- Never output certainty language."
+    ]
+  }
+}

--- a/agent/patches/2026-07-11/l-theanine-metadata-harvester-877867e6-7e5f-4139-820a-e694761fbe63.json
+++ b/agent/patches/2026-07-11/l-theanine-metadata-harvester-877867e6-7e5f-4139-820a-e694761fbe63.json
@@ -1,0 +1,73 @@
+{
+  "patch_id": "877867e6-7e5f-4139-820a-e694761fbe63",
+  "schema_version": "2.0",
+  "source_agent": "metadata-harvester",
+  "agent_version": "2.0",
+  "created_at": "2026-07-11T17:38:26.368Z",
+  "slug": "l-theanine",
+  "patch_type": "evidence",
+  "research_depth": "metadata_only",
+  "metadata_sources": [
+    "pubmed",
+    "clinicaltrials"
+  ],
+  "confidence_notes": [
+    "Validation layer identified inconsistent or incomplete evidence.",
+    "Evidence confidence downgraded due to weak or conflicting support."
+  ],
+  "seo_assets": {
+    "faq_candidates": [
+      "What is l-theanine used for?",
+      "Is l-theanine evidence-based?"
+    ],
+    "seo_topics": [
+      "l-theanine benefits",
+      "l-theanine safety",
+      "l-theanine evidence"
+    ],
+    "internal_link_targets": [
+      "sleep",
+      "focus",
+      "recovery"
+    ],
+    "comparison_candidates": [
+      "l-theanine vs magnesium"
+    ],
+    "best_for": [
+      "general wellness"
+    ],
+    "avoid_if": [
+      "medication interactions"
+    ],
+    "product_quality_notes": [
+      "Prefer reputable third-party tested brands"
+    ]
+  },
+  "review_flags": [
+    "validation_conflicts",
+    "low_confidence"
+  ],
+  "evidence": [],
+  "validation": {
+    "patch_type": "validated_evidence",
+    "patch_id": "c015cfab-0e24-4746-8fea-2197b1322050",
+    "schema_version": "1.0",
+    "source_agent": "validation-agent",
+    "agent_version": "1.5",
+    "slug": "l-theanine",
+    "created_at": "2026-07-11T17:38:26.368Z",
+    "system_prompt": "You are the Validation Firewall for The Hippie Scientist.\nReject hallucinated citations, animal-only data, in-vitro-only data, vague claims, unsupported medical claims, and low-quality entries.\nBe extremely strict and conservative.",
+    "validation_status": "rejected",
+    "rejection_reasons": [
+      "no_approved_entries"
+    ],
+    "entries": []
+  },
+  "scoring": {
+    "confidence_score": 0.25,
+    "evidence_strength": "low",
+    "confidence_reasoning": [
+      "Scoring Rules:\n- Human meta-analysis > randomized trial > observational > pilot.\n- Small sample sizes reduce confidence.\n- Missing source attribution reduces confidence.\n- Evidence confidence must remain conservative.\n- Never output certainty language."
+    ]
+  }
+}

--- a/agent/patches/2026-07-11/magnesium-glycinate-metadata-harvester-70796cc0-7cf5-4685-8646-0c400ca30297.json
+++ b/agent/patches/2026-07-11/magnesium-glycinate-metadata-harvester-70796cc0-7cf5-4685-8646-0c400ca30297.json
@@ -1,0 +1,73 @@
+{
+  "patch_id": "70796cc0-7cf5-4685-8646-0c400ca30297",
+  "schema_version": "2.0",
+  "source_agent": "metadata-harvester",
+  "agent_version": "2.0",
+  "created_at": "2026-07-11T17:38:26.367Z",
+  "slug": "magnesium-glycinate",
+  "patch_type": "evidence",
+  "research_depth": "metadata_only",
+  "metadata_sources": [
+    "pubmed",
+    "clinicaltrials"
+  ],
+  "confidence_notes": [
+    "Validation layer identified inconsistent or incomplete evidence.",
+    "Evidence confidence downgraded due to weak or conflicting support."
+  ],
+  "seo_assets": {
+    "faq_candidates": [
+      "What is magnesium-glycinate used for?",
+      "Is magnesium-glycinate evidence-based?"
+    ],
+    "seo_topics": [
+      "magnesium-glycinate benefits",
+      "magnesium-glycinate safety",
+      "magnesium-glycinate evidence"
+    ],
+    "internal_link_targets": [
+      "sleep",
+      "focus",
+      "recovery"
+    ],
+    "comparison_candidates": [
+      "magnesium-glycinate vs magnesium"
+    ],
+    "best_for": [
+      "general wellness"
+    ],
+    "avoid_if": [
+      "medication interactions"
+    ],
+    "product_quality_notes": [
+      "Prefer reputable third-party tested brands"
+    ]
+  },
+  "review_flags": [
+    "validation_conflicts",
+    "low_confidence"
+  ],
+  "evidence": [],
+  "validation": {
+    "patch_type": "validated_evidence",
+    "patch_id": "d8f43a7f-38d9-4241-8e33-d8c6422c3af8",
+    "schema_version": "1.0",
+    "source_agent": "validation-agent",
+    "agent_version": "1.5",
+    "slug": "magnesium-glycinate",
+    "created_at": "2026-07-11T17:38:26.367Z",
+    "system_prompt": "You are the Validation Firewall for The Hippie Scientist.\nReject hallucinated citations, animal-only data, in-vitro-only data, vague claims, unsupported medical claims, and low-quality entries.\nBe extremely strict and conservative.",
+    "validation_status": "rejected",
+    "rejection_reasons": [
+      "no_approved_entries"
+    ],
+    "entries": []
+  },
+  "scoring": {
+    "confidence_score": 0.25,
+    "evidence_strength": "low",
+    "confidence_reasoning": [
+      "Scoring Rules:\n- Human meta-analysis > randomized trial > observational > pilot.\n- Small sample sizes reduce confidence.\n- Missing source attribution reduces confidence.\n- Evidence confidence must remain conservative.\n- Never output certainty language."
+    ]
+  }
+}

--- a/agent/patches/2026-07-11/magnesium-metadata-harvester-99e60fc7-0316-421a-bbdb-e16c2954c262.json
+++ b/agent/patches/2026-07-11/magnesium-metadata-harvester-99e60fc7-0316-421a-bbdb-e16c2954c262.json
@@ -1,0 +1,73 @@
+{
+  "patch_id": "99e60fc7-0316-421a-bbdb-e16c2954c262",
+  "schema_version": "2.0",
+  "source_agent": "metadata-harvester",
+  "agent_version": "2.0",
+  "created_at": "2026-07-11T17:38:26.368Z",
+  "slug": "magnesium",
+  "patch_type": "evidence",
+  "research_depth": "metadata_only",
+  "metadata_sources": [
+    "pubmed",
+    "clinicaltrials"
+  ],
+  "confidence_notes": [
+    "Validation layer identified inconsistent or incomplete evidence.",
+    "Evidence confidence downgraded due to weak or conflicting support."
+  ],
+  "seo_assets": {
+    "faq_candidates": [
+      "What is magnesium used for?",
+      "Is magnesium evidence-based?"
+    ],
+    "seo_topics": [
+      "magnesium benefits",
+      "magnesium safety",
+      "magnesium evidence"
+    ],
+    "internal_link_targets": [
+      "sleep",
+      "focus",
+      "recovery"
+    ],
+    "comparison_candidates": [
+      "magnesium vs magnesium"
+    ],
+    "best_for": [
+      "general wellness"
+    ],
+    "avoid_if": [
+      "medication interactions"
+    ],
+    "product_quality_notes": [
+      "Prefer reputable third-party tested brands"
+    ]
+  },
+  "review_flags": [
+    "validation_conflicts",
+    "low_confidence"
+  ],
+  "evidence": [],
+  "validation": {
+    "patch_type": "validated_evidence",
+    "patch_id": "1c479945-34fd-406c-b6de-9423bcc2c65b",
+    "schema_version": "1.0",
+    "source_agent": "validation-agent",
+    "agent_version": "1.5",
+    "slug": "magnesium",
+    "created_at": "2026-07-11T17:38:26.368Z",
+    "system_prompt": "You are the Validation Firewall for The Hippie Scientist.\nReject hallucinated citations, animal-only data, in-vitro-only data, vague claims, unsupported medical claims, and low-quality entries.\nBe extremely strict and conservative.",
+    "validation_status": "rejected",
+    "rejection_reasons": [
+      "no_approved_entries"
+    ],
+    "entries": []
+  },
+  "scoring": {
+    "confidence_score": 0.25,
+    "evidence_strength": "low",
+    "confidence_reasoning": [
+      "Scoring Rules:\n- Human meta-analysis > randomized trial > observational > pilot.\n- Small sample sizes reduce confidence.\n- Missing source attribution reduces confidence.\n- Evidence confidence must remain conservative.\n- Never output certainty language."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Fix a real bug in `agent/orchestrator/run-orchestrator.js`: it passed a bare evidence **array** to `runValidationAgent` (which expects `{ slug, evidence }`), never `await`ed the async call, and read a non-existent `.approved_rows` field.
- Consequences of the bug: every metadata patch stored an **unresolved Promise** as its `validation` block (serialized to `{}`), dropped the `validation_conflicts` review flag, and logged a spurious `"Validation input entries must be an array"` error on every compound (the array's built-in `.entries` method tripped the `Array.isArray` guard).
- Fix: pass the documented `{ slug, evidence }` shape, `await` the result, and read `data.entries` / `data.validation_status` / `data.rejection_reasons`. Patches now carry a real validation object and correct review flags.
- Includes a fast-mode batch of 5 metadata patches produced by the fixed pipeline (berberine, creatine, magnesium, magnesium-glycinate, l-theanine). Evidence arrays are empty because the PubMed/clinical-trials harvester is still a stub and enrichment requires `OPENAI_API_KEY` — the fix is verified by `validation` now being a populated object rather than `{}`.

## Verification

- [x] `npx eslint agent/orchestrator/run-orchestrator.js` (clean)
- [x] `npm run agent:run -- --mode=fast --batch=5` runs with no validation errors; patches schema-valid
- [x] no package-lock drift
- [x] no `public/data` diffs
- [x] no generated file corruption
- [x] static export compatible (agent tooling only; not part of the site build)

## Risk Notes

- Low risk: change is confined to the offline agent-enrichment orchestrator, which runs separately via `npm run agent:run` and does not affect the site build or runtime data. Generated patches are review artifacts and are not applied to `public/data` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHLPuSC54yeZbRLMcVqmP6)_