### PR TITLE
Add canonical citation export bridge

### DIFF
--- a/components/ui/ShowMeTheStudies.tsx
+++ b/components/ui/ShowMeTheStudies.tsx
@@ -1,6 +1,8 @@
 export interface Citation {
   title: string
   pmid?: string
+  doi?: string
+  url?: string
   year?: number | string
   authors?: string
   studyType?: string
@@ -66,19 +68,26 @@ function sortByStudyType(a: Citation, b: Citation) {
   return aRank - bRank
 }
 
+function citationKey(citation: Citation, index: number) {
+  return citation.pmid || citation.doi || citation.url || citation.title || index
+}
+
 function StudyRow({ citation, index }: { citation: Citation; index: number }) {
   const pubmedUrl = citation.pmid ? `https://pubmed.ncbi.nlm.nih.gov/${citation.pmid}/` : null
+  const doiLink = citation.doi ? `https://doi.org/${citation.doi}` : null
+  const sourceUrl = citation.url || pubmedUrl || doiLink
+  const sourceLabel = citation.pmid ? 'PubMed' : citation.doi ? 'DOI' : sourceUrl ? 'Source' : ''
 
   return (
     <tr
-      key={citation.pmid || citation.title || index}
+      key={citationKey(citation, index)}
       className="border-t border-brand-900/10 dark:border-white/10"
     >
       <td className="px-3 py-3 align-top sm:px-4">
         <p className="text-[13px] font-semibold leading-snug text-ink">
-          {pubmedUrl ? (
+          {sourceUrl ? (
             <a
-              href={pubmedUrl}
+              href={sourceUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="hover:text-brand-700 hover:underline dark:hover:text-brand-100"
@@ -103,14 +112,14 @@ function StudyRow({ citation, index }: { citation: Citation; index: number }) {
         {citation.sampleSize ? `n=${citation.sampleSize}` : '—'}
       </td>
       <td className="px-3 py-3 text-right align-top sm:px-4">
-        {pubmedUrl ? (
+        {sourceUrl ? (
           <a
-            href={pubmedUrl}
+            href={sourceUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="text-[11px] font-semibold text-brand-700 hover:underline dark:text-brand-100"
           >
-            PubMed →
+            {sourceLabel} →
           </a>
         ) : (
           <span className="text-xs text-muted">—</span>
@@ -147,7 +156,7 @@ export default function ShowMeTheStudies({ citations }: Props) {
           </thead>
           <tbody>
             {visible.map((citation, index) => (
-              <StudyRow key={citation.pmid || citation.title || index} citation={citation} index={index} />
+              <StudyRow key={citationKey(citation, index)} citation={citation} index={index} />
             ))}
           </tbody>
         </table>
@@ -162,7 +171,7 @@ export default function ShowMeTheStudies({ citations }: Props) {
             <table className="w-full min-w-[560px] border-collapse text-left text-sm">
               <tbody>
                 {overflow.map((citation, index) => (
-                  <StudyRow key={citation.pmid || citation.title || index} citation={citation} index={index} />
+                  <StudyRow key={citationKey(citation, index)} citation={citation} index={index} />
                 ))}
               </tbody>
             </table>

--- a/components/ui/__tests__/ShowMeTheStudies.test.tsx
+++ b/components/ui/__tests__/ShowMeTheStudies.test.tsx
@@ -37,7 +37,25 @@ describe('ShowMeTheStudies', () => {
     }
   })
 
-  it('shows a plain dash instead of a PubMed link when no pmid is present', () => {
+  it('links DOI-only studies to the DOI resolver', () => {
+    render(<ShowMeTheStudies citations={[citation({ title: 'L-theanine trial', doi: '10.1000/example-doi' })]} />)
+    const links = screen.getAllByRole('link', { name: /L-theanine trial|DOI/ })
+    expect(links).toHaveLength(2)
+    for (const link of links) {
+      expect(link).toHaveAttribute('href', 'https://doi.org/10.1000/example-doi')
+    }
+  })
+
+  it('uses an explicit source URL when one is provided', () => {
+    render(<ShowMeTheStudies citations={[citation({ title: 'Publisher study', url: 'https://example.com/study' })]} />)
+    const links = screen.getAllByRole('link', { name: /Publisher study|Source/ })
+    expect(links).toHaveLength(2)
+    for (const link of links) {
+      expect(link).toHaveAttribute('href', 'https://example.com/study')
+    }
+  })
+
+  it('shows a plain dash instead of a source link when no identifier is present', () => {
     render(<ShowMeTheStudies citations={[citation({ title: 'No PMID Study' })]} />)
     expect(screen.queryByRole('link')).toBeNull()
   })

--- a/lib/citations.ts
+++ b/lib/citations.ts
@@ -5,27 +5,39 @@ function parsePmid(value: string): string | undefined {
   return match?.[1]
 }
 
+function parseDoi(value: string): string | undefined {
+  const match = value.match(/\b(10\.\d{4,9}\/[-._;()/:A-Z0-9]+)\b/i)
+  return match?.[1]?.replace(/[.,;)]$/, '')
+}
+
+function doiUrl(doi: string | undefined): string | undefined {
+  return doi ? `https://doi.org/${doi}` : undefined
+}
+
 function sourceObjectToCitation(src: Record<string, unknown>): Citation {
   const title =
     (src.title as string) ||
     (src.citation as string) ||
     (src.ref as string) ||
     ''
-
+  const rawUrl = String(src.url || src.href || '').trim()
+  const citationText = String(src.citation || '').trim()
+  const doi = src.doi
+    ? parseDoi(String(src.doi)) || String(src.doi).replace(/^https?:\/\/(?:dx\.)?doi\.org\//i, '')
+    : parseDoi(rawUrl) || parseDoi(citationText)
   const pmid =
     src.pmid
       ? String(src.pmid)
-      : typeof src.href === 'string'
-        ? parsePmid(src.href)
-        : typeof src.citation === 'string'
-          ? parsePmid(src.citation)
-          : undefined
+      : parsePmid(rawUrl) || parsePmid(citationText)
+  const url = rawUrl || doiUrl(doi) || (pmid ? `https://pubmed.ncbi.nlm.nih.gov/${pmid}/` : undefined)
 
   return {
     title,
     pmid,
+    doi,
+    url,
     year: src.year as number | string | undefined,
-    authors: src.authors as string | undefined,
+    authors: (src.authors || src.author_or_label) as string | undefined,
     studyType: (src.studyType || src.study_type || src.type) as string | undefined,
     sampleSize: (src.sampleSize || src.sample_size || src.n) as string | number | undefined,
   }
@@ -33,20 +45,42 @@ function sourceObjectToCitation(src: Record<string, unknown>): Citation {
 
 function stringToCitation(src: string): Citation {
   const pmid = parsePmid(src)
-  return { title: src, pmid }
+  const doi = parseDoi(src)
+  const directUrl = /^https?:\/\//i.test(src.trim()) ? src.trim() : undefined
+  const url = directUrl || doiUrl(doi) || (pmid ? `https://pubmed.ncbi.nlm.nih.gov/${pmid}/` : undefined)
+  return { title: src, pmid, doi, url }
+}
+
+function citationKey(citation: Citation): string {
+  return citation.pmid
+    ? `pmid:${citation.pmid}`
+    : citation.doi
+      ? `doi:${citation.doi.toLowerCase()}`
+      : citation.url
+        ? `url:${citation.url.toLowerCase()}`
+        : `title:${citation.title.trim().toLowerCase()}`
 }
 
 export function extractCitationsFromRecord(record: Record<string, unknown>): Citation[] {
   const results: Citation[] = []
+  const seen = new Set<string>()
+
+  const pushCitation = (citation: Citation) => {
+    if (!citation.title && !citation.pmid && !citation.doi && !citation.url) return
+    const key = citationKey(citation)
+    if (seen.has(key)) return
+    seen.add(key)
+    results.push(citation)
+  }
 
   const sources = record?.sources
   if (Array.isArray(sources)) {
     for (const src of sources) {
       if (!src) continue
       if (typeof src === 'string') {
-        results.push(stringToCitation(src))
+        pushCitation(stringToCitation(src))
       } else if (typeof src === 'object') {
-        results.push(sourceObjectToCitation(src as Record<string, unknown>))
+        pushCitation(sourceObjectToCitation(src as Record<string, unknown>))
       }
     }
   }
@@ -56,9 +90,11 @@ export function extractCitationsFromRecord(record: Record<string, unknown>): Cit
     for (const pmid of pmids) {
       if (!pmid) continue
       const id = String(pmid)
-      if (!results.some(c => c.pmid === id)) {
-        results.push({ title: `PubMed ${id}`, pmid: id })
-      }
+      pushCitation({
+        title: `PubMed ${id}`,
+        pmid: id,
+        url: `https://pubmed.ncbi.nlm.nih.gov/${id}/`,
+      })
     }
   }
 
@@ -67,18 +103,12 @@ export function extractCitationsFromRecord(record: Record<string, unknown>): Cit
     for (const ref of references) {
       if (!ref) continue
       if (typeof ref === 'string') {
-        const pmid = parsePmid(ref)
-        if (!results.some(c => c.pmid === pmid)) {
-          results.push(stringToCitation(ref))
-        }
+        pushCitation(stringToCitation(ref))
       } else if (typeof ref === 'object') {
-        const c = sourceObjectToCitation(ref as Record<string, unknown>)
-        if (!results.some(r => r.pmid && r.pmid === c.pmid)) {
-          results.push(c)
-        }
+        pushCitation(sourceObjectToCitation(ref as Record<string, unknown>))
       }
     }
   }
 
-  return results.filter(c => c.title || c.pmid)
+  return results
 }

--- a/scripts/data/build-runtime-summary-indexes.mjs
+++ b/scripts/data/build-runtime-summary-indexes.mjs
@@ -6,6 +6,7 @@ import {
   createStageTimer,
   printBuildTimingReport,
 } from '../ci/report-build-stage-timings.mjs'
+import { exportCanonicalCitationsToRuntime } from './canonical/citation-export.mjs'
 
 const DATA_DIR_ARG = process.argv.find((arg) => arg.startsWith('--data-dir='))
 const DATA_DIR = DATA_DIR_ARG
@@ -229,6 +230,13 @@ function buildAlphaEntityShards(records) {
 
 async function main() {
   const totalTimer = createStageTimer('summary-index-build')
+  const citationTimer = createStageTimer('canonical-citation-export')
+  const citationReport = exportCanonicalCitationsToRuntime({ dataDir: DATA_DIR })
+  citationTimer.finish({
+    profiles: citationReport.profilesWithCanonicalClaims,
+    updated: citationReport.updated.length,
+    missingDetails: citationReport.skippedMissingDetail.length,
+  })
 
   const herbs = await readJson(path.join(DATA_DIR, 'herbs.json'))
   const compounds = await readJson(path.join(DATA_DIR, 'compounds.json'))

--- a/scripts/data/canonical/__tests__/citation-export.test.mjs
+++ b/scripts/data/canonical/__tests__/citation-export.test.mjs
@@ -92,7 +92,7 @@ describe('buildCanonicalCitationOverlay', () => {
 })
 
 describe('mergeCanonicalCitationOverlay', () => {
-  it('preserves existing detail citations and adds canonical claims without duplicates', () => {
+  it('preserves existing detail citations and enriches duplicates from canonical metadata', () => {
     const overlay = buildCanonicalCitationOverlay(fixtureDataset()).get('l-theanine')
     const existing = {
       slug: 'l-theanine',
@@ -111,6 +111,12 @@ describe('mergeCanonicalCitationOverlay', () => {
     const merged = mergeCanonicalCitationOverlay(existing, overlay)
 
     expect(merged.sources).toHaveLength(1)
+    expect(merged.sources[0]).toMatchObject({
+      id: 'src_stress',
+      title: 'Randomized placebo-controlled L-theanine trial',
+      doi: '10.1000/example-doi',
+      authors: 'Example et al.',
+    })
     expect(merged.claimMap).toHaveLength(2)
     expect(merged.evidence.sourceCount).toBe(1)
     expect(merged.evidence.claimCount).toBe(2)

--- a/scripts/data/canonical/__tests__/citation-export.test.mjs
+++ b/scripts/data/canonical/__tests__/citation-export.test.mjs
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildCanonicalCitationOverlay,
+  mergeCanonicalCitationOverlay,
+} from '../citation-export.mjs'
+
+function fixtureDataset() {
+  return {
+    entities: [
+      {
+        id: 'ent_compound_l_theanine',
+        entity_type: 'compound',
+        slug: 'l-theanine',
+        canonical_name: 'L-theanine',
+      },
+    ],
+    claims: [
+      {
+        id: 'clm_stress',
+        subject_id: 'ent_compound_l_theanine',
+        predicate: 'supports_outcome',
+        object_literal: 'A small trial reported a lower acute stress response than placebo.',
+        source_ids: ['src_stress'],
+        evidence_level: 'human_obs',
+        confidence: 0.66,
+        review_status: 'pending',
+        notes: 'Keep the claim narrow.',
+      },
+      {
+        id: 'clm_sleep',
+        subject_id: 'ent_compound_l_theanine',
+        predicate: 'supports_outcome',
+        object_literal: 'Some sleep-quality subscales improved, but the total score did not.',
+        source_ids: ['src_stress'],
+        evidence_level: 'human_obs',
+        confidence: 0.62,
+        review_status: 'approved',
+      },
+      {
+        id: 'clm_unsourced',
+        subject_id: 'ent_compound_l_theanine',
+        predicate: 'supports_outcome',
+        object_literal: 'This must not be exported without a traceable source.',
+        source_ids: [],
+        review_status: 'pending',
+      },
+    ],
+    sources: [
+      {
+        id: 'src_stress',
+        doi: '10.1000/example-doi',
+        title: 'Randomized placebo-controlled L-theanine trial',
+        year: '2024',
+        author_or_label: 'Example et al.',
+        review_status: 'approved',
+      },
+    ],
+  }
+}
+
+describe('buildCanonicalCitationOverlay', () => {
+  it('links sourced canonical claims to deduplicated references by profile slug', () => {
+    const overlay = buildCanonicalCitationOverlay(fixtureDataset()).get('l-theanine')
+
+    expect(overlay).toBeTruthy()
+    expect(overlay.claimMap).toHaveLength(2)
+    expect(overlay.sources).toHaveLength(1)
+    expect(overlay.sources[0]).toMatchObject({
+      id: 'src_stress',
+      doi: '10.1000/example-doi',
+      url: 'https://doi.org/10.1000/example-doi',
+      studyType: 'Randomized controlled trial',
+    })
+    expect(overlay.claimMap[0].sourceRefIds).toEqual(['src_stress'])
+    expect(overlay.evidence).toMatchObject({
+      reviewStatus: 'sourced_pending_review',
+      sourceCount: 1,
+      claimCount: 2,
+    })
+  })
+
+  it('does not export claims whose sources cannot be resolved', () => {
+    const dataset = fixtureDataset()
+    dataset.claims = [{
+      ...dataset.claims[0],
+      id: 'clm_missing_source',
+      source_ids: ['src_missing'],
+    }]
+
+    expect(buildCanonicalCitationOverlay(dataset).has('l-theanine')).toBe(false)
+  })
+})
+
+describe('mergeCanonicalCitationOverlay', () => {
+  it('preserves existing detail citations and adds canonical claims without duplicates', () => {
+    const overlay = buildCanonicalCitationOverlay(fixtureDataset()).get('l-theanine')
+    const existing = {
+      slug: 'l-theanine',
+      sources: [{
+        id: 'src_stress',
+        title: 'Existing title',
+        url: 'https://doi.org/10.1000/example-doi',
+      }],
+      claimMap: [overlay.claimMap[0]],
+      evidence: {
+        reviewStatus: 'sourced',
+        sourceIds: ['src_stress'],
+      },
+    }
+
+    const merged = mergeCanonicalCitationOverlay(existing, overlay)
+
+    expect(merged.sources).toHaveLength(1)
+    expect(merged.claimMap).toHaveLength(2)
+    expect(merged.evidence.sourceCount).toBe(1)
+    expect(merged.evidence.claimCount).toBe(2)
+    expect(merged.evidence.sourceIds).toEqual(['src_stress'])
+  })
+})

--- a/scripts/data/canonical/citation-export.mjs
+++ b/scripts/data/canonical/citation-export.mjs
@@ -124,6 +124,50 @@ function uniqueBy(values, keyFn) {
   return output
 }
 
+function mergeSources(existingSources, canonicalSources) {
+  const byKey = new Map()
+
+  for (const source of existingSources) {
+    const key = sourceKey(source)
+    if (key) byKey.set(key, source)
+  }
+
+  for (const source of canonicalSources) {
+    const key = sourceKey(source)
+    if (!key) continue
+    const existing = byKey.get(key)
+    if (existing && typeof existing === 'object' && typeof source === 'object') {
+      byKey.set(key, compact({ ...existing, ...source }))
+    } else {
+      byKey.set(key, source)
+    }
+  }
+
+  return [...byKey.values()]
+}
+
+function mergeClaims(existingClaims, canonicalClaims) {
+  const byKey = new Map()
+
+  for (const claim of existingClaims) {
+    const key = claimKey(claim)
+    if (key) byKey.set(key, claim)
+  }
+
+  for (const claim of canonicalClaims) {
+    const key = claimKey(claim)
+    if (!key) continue
+    const existing = byKey.get(key)
+    if (existing && typeof existing === 'object' && typeof claim === 'object') {
+      byKey.set(key, compact({ ...existing, ...claim }))
+    } else {
+      byKey.set(key, claim)
+    }
+  }
+
+  return [...byKey.values()]
+}
+
 export function buildCanonicalCitationOverlay(dataset) {
   const entities = Array.isArray(dataset?.entities) ? dataset.entities : []
   const claims = Array.isArray(dataset?.claims) ? dataset.claims : []
@@ -211,8 +255,8 @@ export function mergeCanonicalCitationOverlay(record, overlay) {
 
   const existingSources = Array.isArray(record.sources) ? record.sources : []
   const existingClaims = Array.isArray(record.claimMap) ? record.claimMap : []
-  const sources = uniqueBy([...existingSources, ...(overlay.sources || [])], sourceKey)
-  const claimMap = uniqueBy([...existingClaims, ...(overlay.claimMap || [])], claimKey)
+  const sources = mergeSources(existingSources, overlay.sources || [])
+  const claimMap = mergeClaims(existingClaims, overlay.claimMap || [])
   const existingEvidence = record.evidence && typeof record.evidence === 'object' ? record.evidence : {}
   const sourceIds = uniqueBy([
     ...(Array.isArray(existingEvidence.sourceIds) ? existingEvidence.sourceIds : []),

--- a/scripts/data/canonical/citation-export.mjs
+++ b/scripts/data/canonical/citation-export.mjs
@@ -1,0 +1,287 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { loadDataset } from './store.mjs'
+
+const EXCLUDED_REVIEW_STATUSES = new Set(['rejected', 'deprecated'])
+const PROFILE_TYPES = new Set(['herb', 'compound'])
+
+function text(value) {
+  return String(value ?? '').trim()
+}
+
+function compact(record) {
+  return Object.fromEntries(
+    Object.entries(record).filter(([, value]) => {
+      if (value == null) return false
+      if (typeof value === 'string') return value.trim().length > 0
+      if (Array.isArray(value)) return value.length > 0
+      return true
+    }),
+  )
+}
+
+function normalizeDoi(value) {
+  return text(value)
+    .replace(/^https?:\/\/(?:dx\.)?doi\.org\//i, '')
+    .replace(/^doi:\s*/i, '')
+}
+
+function sourceUrl(source) {
+  const direct = text(source?.url)
+  if (direct) return direct
+  const doi = normalizeDoi(source?.doi)
+  if (doi) return `https://doi.org/${doi}`
+  const pmid = text(source?.pmid)
+  if (pmid) return `https://pubmed.ncbi.nlm.nih.gov/${pmid}/`
+  return ''
+}
+
+function inferStudyType(source) {
+  const haystack = [
+    source?.title,
+    source?.citation,
+    source?.used_for,
+    source?.legacy?.record_type,
+    source?.legacy?.study_type,
+  ].map(text).join(' ').toLowerCase()
+
+  if (/meta[- ]analysis/.test(haystack)) return 'Meta-analysis'
+  if (/systematic review/.test(haystack)) return 'Systematic review'
+  if (/randomi[sz]ed|\brct\b|placebo[- ]controlled|crossover/.test(haystack)) return 'Randomized controlled trial'
+  if (/observational|cohort|cross[- ]sectional/.test(haystack)) return 'Observational'
+  if (/animal|rodent|mouse|mice|rat\b|in vivo/.test(haystack)) return 'Animal'
+  if (/in vitro|cell culture|mechanistic/.test(haystack)) return 'Mechanistic'
+  return ''
+}
+
+function normalizeSource(source) {
+  if (!source || typeof source !== 'object') return null
+
+  const id = text(source.id)
+  if (!id) return null
+
+  const doi = normalizeDoi(source.doi)
+  const pmid = text(source.pmid)
+  const url = sourceUrl(source)
+  const citation = text(source.citation)
+  const title = text(source.title) || citation || (doi ? `DOI ${doi}` : pmid ? `PubMed ${pmid}` : url)
+  if (!title && !url) return null
+
+  return compact({
+    id,
+    title,
+    url,
+    doi,
+    pmid,
+    year: source.year,
+    authors: text(source.author_or_label),
+    journal: text(source.journal),
+    citation,
+    note: text(source.used_for),
+    studyType: inferStudyType(source),
+    reviewStatus: text(source.review_status) || 'pending',
+  })
+}
+
+function claimText(claim, entityById) {
+  const literal = text(claim?.object_literal)
+  if (literal && literal.toLowerCase() !== 'unspecified') return literal
+
+  const notes = text(claim?.notes)
+  if (notes) return notes
+
+  const object = entityById.get(text(claim?.object_id))
+  if (object?.canonical_name) return text(object.canonical_name)
+
+  return ''
+}
+
+function claimKey(claim) {
+  const sourceIds = Array.isArray(claim?.sourceRefIds) ? claim.sourceRefIds.join('|') : ''
+  return text(claim?.id) || `${text(claim?.predicate)}|${text(claim?.claim)}|${sourceIds}`
+}
+
+function sourceKey(source) {
+  if (typeof source === 'string') return `string:${source.trim().toLowerCase()}`
+  if (!source || typeof source !== 'object') return ''
+  const doi = normalizeDoi(source.doi)
+  const pmid = text(source.pmid || source.pubmedId)
+  const url = text(source.url || source.href)
+  const id = text(source.id || source.sourceId)
+  const title = text(source.title)
+  return id || (doi ? `doi:${doi.toLowerCase()}` : '') || (pmid ? `pmid:${pmid}` : '') || (url ? `url:${url.toLowerCase()}` : '') || (title ? `title:${title.toLowerCase()}` : '')
+}
+
+function uniqueBy(values, keyFn) {
+  const seen = new Set()
+  const output = []
+  for (const value of values) {
+    const key = keyFn(value)
+    if (!key || seen.has(key)) continue
+    seen.add(key)
+    output.push(value)
+  }
+  return output
+}
+
+export function buildCanonicalCitationOverlay(dataset) {
+  const entities = Array.isArray(dataset?.entities) ? dataset.entities : []
+  const claims = Array.isArray(dataset?.claims) ? dataset.claims : []
+  const sources = Array.isArray(dataset?.sources) ? dataset.sources : []
+
+  const entityById = new Map(entities.map((entity) => [entity.id, entity]))
+  const sourceById = new Map(sources.map((source) => [source.id, source]))
+  const grouped = new Map()
+
+  for (const claim of [...claims].sort((a, b) => text(a?.id).localeCompare(text(b?.id)))) {
+    if (EXCLUDED_REVIEW_STATUSES.has(text(claim?.review_status).toLowerCase())) continue
+
+    const subject = entityById.get(text(claim?.subject_id))
+    if (!subject || !PROFILE_TYPES.has(subject.entity_type) || !text(subject.slug)) continue
+
+    const sourceIds = uniqueBy(
+      (Array.isArray(claim?.source_ids) ? claim.source_ids : [])
+        .map(text)
+        .filter((id) => sourceById.has(id)),
+      (id) => id,
+    ).sort()
+    if (!sourceIds.length) continue
+
+    const value = claimText(claim, entityById)
+    if (!value) continue
+
+    const slug = text(subject.slug)
+    if (!grouped.has(slug)) {
+      grouped.set(slug, {
+        entityType: subject.entity_type,
+        claims: [],
+        sources: new Map(),
+      })
+    }
+
+    const group = grouped.get(slug)
+    for (const sourceId of sourceIds) {
+      const normalized = normalizeSource(sourceById.get(sourceId))
+      if (normalized) group.sources.set(sourceId, normalized)
+    }
+
+    group.claims.push(compact({
+      id: text(claim.id),
+      claim: value,
+      predicate: text(claim.predicate),
+      evidenceLevel: text(claim.evidence_level) || 'none',
+      confidence: typeof claim.confidence === 'number' ? claim.confidence : undefined,
+      reviewStatus: text(claim.review_status) || 'pending',
+      notes: text(claim.notes),
+      qualifiers: claim.qualifiers && typeof claim.qualifiers === 'object' ? claim.qualifiers : undefined,
+      sourceRefIds: sourceIds,
+    }))
+  }
+
+  const overlays = new Map()
+  for (const [slug, group] of grouped.entries()) {
+    const claimMap = uniqueBy(group.claims, claimKey)
+      .sort((a, b) => text(a.id).localeCompare(text(b.id)))
+    const normalizedSources = [...group.sources.values()]
+      .sort((a, b) => text(a.id).localeCompare(text(b.id)))
+    const sourceIds = normalizedSources.map((source) => source.id)
+    const claimIds = claimMap.map((claim) => claim.id).filter(Boolean)
+    const hasPendingReview = claimMap.some((claim) => text(claim.reviewStatus).toLowerCase() !== 'approved')
+      || normalizedSources.some((source) => text(source.reviewStatus).toLowerCase() !== 'approved')
+
+    overlays.set(slug, {
+      entityType: group.entityType,
+      claimMap,
+      sources: normalizedSources,
+      evidence: {
+        reviewStatus: hasPendingReview ? 'sourced_pending_review' : 'sourced',
+        sourceCount: sourceIds.length,
+        sourceIds,
+        claimCount: claimMap.length,
+        claimIds,
+      },
+    })
+  }
+
+  return overlays
+}
+
+export function mergeCanonicalCitationOverlay(record, overlay) {
+  if (!record || typeof record !== 'object' || !overlay) return record
+
+  const existingSources = Array.isArray(record.sources) ? record.sources : []
+  const existingClaims = Array.isArray(record.claimMap) ? record.claimMap : []
+  const sources = uniqueBy([...existingSources, ...(overlay.sources || [])], sourceKey)
+  const claimMap = uniqueBy([...existingClaims, ...(overlay.claimMap || [])], claimKey)
+  const existingEvidence = record.evidence && typeof record.evidence === 'object' ? record.evidence : {}
+  const sourceIds = uniqueBy([
+    ...(Array.isArray(existingEvidence.sourceIds) ? existingEvidence.sourceIds : []),
+    ...(overlay.evidence?.sourceIds || []),
+  ].map(text).filter(Boolean), (id) => id).sort()
+  const claimIds = uniqueBy([
+    ...(Array.isArray(existingEvidence.claimIds) ? existingEvidence.claimIds : []),
+    ...(overlay.evidence?.claimIds || []),
+  ].map(text).filter(Boolean), (id) => id).sort()
+
+  return {
+    ...record,
+    sources,
+    claimMap,
+    evidence: {
+      ...existingEvidence,
+      reviewStatus: overlay.evidence?.reviewStatus || existingEvidence.reviewStatus || 'needs_review',
+      sourceCount: sourceIds.length,
+      sourceIds,
+      claimCount: claimMap.length,
+      claimIds,
+    },
+  }
+}
+
+function readJson(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+  } catch {
+    return null
+  }
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8')
+}
+
+export function exportCanonicalCitationsToRuntime({ dataDir = 'public/data', dataset = loadDataset() } = {}) {
+  const resolvedDataDir = path.resolve(process.cwd(), dataDir)
+  const overlays = buildCanonicalCitationOverlay(dataset)
+  const report = {
+    dataDir: path.relative(process.cwd(), resolvedDataDir),
+    profilesWithCanonicalClaims: overlays.size,
+    updated: [],
+    skippedMissingDetail: [],
+  }
+
+  for (const [slug, overlay] of overlays.entries()) {
+    const detailDir = overlay.entityType === 'herb' ? 'herbs-detail' : 'compounds-detail'
+    const detailPath = path.join(resolvedDataDir, detailDir, `${slug}.json`)
+    const record = readJson(detailPath)
+    if (!record || typeof record !== 'object' || Array.isArray(record)) {
+      report.skippedMissingDetail.push(slug)
+      continue
+    }
+
+    const merged = mergeCanonicalCitationOverlay(record, overlay)
+    if (JSON.stringify(merged) === JSON.stringify(record)) continue
+    writeJson(detailPath, merged)
+    report.updated.push({
+      slug,
+      entityType: overlay.entityType,
+      claimCount: overlay.claimMap.length,
+      sourceCount: overlay.sources.length,
+    })
+  }
+
+  report.updated.sort((a, b) => a.slug.localeCompare(b.slug))
+  report.skippedMissingDetail.sort()
+  return report
+}

--- a/scripts/data/export-canonical-citations.mjs
+++ b/scripts/data/export-canonical-citations.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+import { exportCanonicalCitationsToRuntime } from './canonical/citation-export.mjs'
+
+const dataDirArg = process.argv.find((arg) => arg.startsWith('--data-dir='))
+const dataDir = dataDirArg ? dataDirArg.split('=').slice(1).join('=') : 'public/data'
+const report = exportCanonicalCitationsToRuntime({ dataDir })
+
+console.log(
+  `[citation-export] profiles=${report.profilesWithCanonicalClaims} updated=${report.updated.length} missingDetail=${report.skippedMissingDetail.length}`,
+)
+for (const item of report.updated) {
+  console.log(`[citation-export] ${item.entityType}:${item.slug} claims=${item.claimCount} sources=${item.sourceCount}`)
+}


### PR DESCRIPTION
## What changed

- Adds a deterministic canonical citation-export bridge that joins canonical claims to their canonical sources by `source_ids`.
- Writes the resulting `claimMap`, deduplicated `sources`, and evidence counts into matching herb/compound detail records.
- Runs the bridge automatically during the shared runtime-summary build stage, after detail records exist and before the site consumes them.
- Preserves existing detail citations while enriching duplicate source records with fuller canonical metadata.
- Adds DOI and direct-source link support to the existing **Clinical Study Summaries** component; PubMed behavior remains intact.
- Adds focused tests for claim/source linkage, source deduplication/enrichment, exclusion of untraceable claims, and DOI/source links.

## Why

Canonical patches already preserve source metadata and attach source IDs to claims, but the runtime detail export left `claimMap` empty and did not project canonical sources into the profile record. As a result, source-backed enrichment stayed backstage and the L-theanine page could not use it.

## Expected behavior

After a patch is normalized, reviewed, and applied to canonical data, the next data build will populate the matching detail JSON with:

- `claimMap[].sourceRefIds`
- `sources[]` with DOI/PMID/direct links and available metadata
- `evidence.sourceIds`, `sourceCount`, `claimIds`, and `claimCount`

The compound page already reads the detail record and will display the exported references through `ShowMeTheStudies`.

## Validation

- Added unit coverage for the canonical citation bridge.
- Added UI coverage for DOI-only and explicit-source citations.
- Compared the branch with `main`; only the seven intended files are changed.

The six L-theanine research patches remain pending in `data/patches/inbox/`. This PR creates the bridge but does not bypass their required review or apply them automatically.