### PR TITLE
Compact safety and caution sections

### DIFF
--- a/.github/workflows/apply-compact-safety-ui.yml
+++ b/.github/workflows/apply-compact-safety-ui.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - ux/compact-safety-cautions
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 permissions:
   contents: write

--- a/.github/workflows/apply-compact-safety-ui.yml
+++ b/.github/workflows/apply-compact-safety-ui.yml
@@ -1,0 +1,167 @@
+name: Apply Compact Safety UI
+
+on:
+  push:
+    branches:
+      - ux/compact-safety-cautions
+
+permissions:
+  contents: write
+
+jobs:
+  apply-and-test:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+        with:
+          ref: ux/compact-safety-cautions
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Replace long safety sections
+        run: |
+          python <<'PY'
+          from pathlib import Path
+
+          herb = Path('app/herbs/[slug]/page.tsx')
+          text = herb.read_text()
+          text = text.replace(
+              "import SafetyGaugeMeter from '@/components/ui/SafetyGaugeMeter'",
+              "import SafetyCautionPanel from '@/components/ui/SafetyCautionPanel'",
+          )
+          old = '''      {/* Section 2: Safety */}
+          <section id="safety" className="scroll-mt-24 rounded-2xl bg-amber-50/70 border border-amber-900/10 border-l-4 border-amber-500/60 p-4 sm:p-5 space-y-3">
+            <div className="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between">
+              <div className="flex-1 space-y-2">
+                <h2 className="text-lg font-bold text-ink">Safety &amp; Cautions</h2>
+                <p className="text-sm leading-6 text-amber-900">{safetySummary}</p>
+              </div>
+              <SafetyGaugeMeter score={safetyGaugeScore.score} label={safetyGaugeScore.label} className="shrink-0 sm:w-44" />
+            </div>
+            {safetyGroups.length > 0 && (
+              <details className="group mt-4 border-t border-amber-900/10 pt-3">
+                <summary className="flex cursor-pointer items-center justify-between gap-3 text-sm font-bold text-amber-950 select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-700/40 focus-visible:rounded">
+                  <span>Detailed safety fields</span>
+                  <span aria-hidden="true" className="transition-transform group-open:rotate-180">v</span>
+                </summary>
+                <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                  {safetyGroups.map(group => (
+                    <div key={group.title} className="space-y-1.5">
+                      <h3 className="text-xs font-bold uppercase tracking-wider text-amber-900 font-semibold">{group.title}</h3>
+                      <ul className="space-y-1 text-xs text-amber-900">
+                        {group.items.map(item => <li key={item}>- {item}</li>)}
+                      </ul>
+                    </div>
+                  ))}
+                </div>
+              </details>
+            )}
+          </section>'''
+          new = '''      {/* Section 2: Safety */}
+          <SafetyCautionPanel
+            summary={safetySummary}
+            groups={safetyGroups}
+            score={safetyGaugeScore.score}
+            scoreLabel={safetyGaugeScore.label}
+          />'''
+          assert old in text, 'Herb safety block not found'
+          text = text.replace(old, new)
+          herb.write_text(text)
+
+          compound = Path('app/compounds/[slug]/page.tsx')
+          text = compound.read_text()
+          text = text.replace(
+              "import ProfileDecisionPanel from '@/components/editorial/ProfileDecisionPanel'",
+              "import ProfileDecisionPanel from '@/components/editorial/ProfileDecisionPanel'\nimport SafetyCautionPanel from '@/components/ui/SafetyCautionPanel'",
+          )
+          old = '''function getSafetySummary(compound: Record<string, unknown>, avoidIf: string[]) {
+            const note = cleanText(compound.safetyNotes || compound.safety_notes || compound.safety)
+            if (avoidIf.length) return `Review before use if any apply: ${avoidIf.slice(0, 3).join(', ')}.`
+            if (note) return firstSentences(note, 2)
+            return 'Review medications, pregnancy status, chronic conditions, and clinician guidance before use.'
+          }
+
+          function getMechanismHints'''
+          new = '''function getSafetySummary(compound: Record<string, unknown>, avoidIf: string[]) {
+            const note = cleanText(compound.safetyNotes || compound.safety_notes || compound.safety)
+            if (avoidIf.length) return `Review before use if any apply: ${avoidIf.slice(0, 3).join(', ')}.`
+            if (note) return firstSentences(note, 2)
+            return 'Review medications, pregnancy status, chronic conditions, and clinician guidance before use.'
+          }
+
+          function getCompoundSafetyGroups(compound: Record<string, unknown>) {
+            const interactions = cleanItems(compound.interactions, 10)
+            const contraindications = cleanItems([
+              compound.avoid_if,
+              compound.avoidIf,
+              compound.who_should_skip,
+              compound.whoShouldSkip,
+              compound.contraindications,
+            ], 10)
+            const cautions = cleanItems([
+              compound.cautions,
+              compound.warnings,
+              compound.side_effects,
+              compound.sideEffects,
+            ], 10)
+            const fullNote = cleanText(compound.safetyNotes || compound.safety_notes || compound.safety)
+
+            return [
+              { title: 'Medication interactions', items: interactions },
+              { title: 'Avoid or review before use', items: contraindications },
+              { title: 'Side effects and cautions', items: cautions },
+              { title: 'Full safety note', items: fullNote ? [fullNote] : [] },
+            ].filter(group => group.items.length > 0)
+          }
+
+          function getMechanismHints'''
+          assert old in text, 'Compound safety helper location not found'
+          text = text.replace(old, new)
+          text = text.replace(
+              "  const safetySummary = getSafetySummary(compound, avoidIf)\n  const mechanismHints = getMechanismHints(compound, mechanisms)",
+              "  const safetySummary = getSafetySummary(compound, avoidIf)\n  const safetyGroups = getCompoundSafetyGroups(compound)\n  const mechanismHints = getMechanismHints(compound, mechanisms)",
+          )
+          old = '''        {/* Section 2: Safety */}
+            <section id="safety" className="rounded-2xl bg-amber-50/70 border border-amber-900/10 border-l-4 border-amber-500/60 p-4 sm:p-5 space-y-3">
+              <h2 className="text-lg font-bold text-ink">Safety &amp; Cautions</h2>
+              <p className="text-sm leading-6 text-amber-900">{safetySummary}</p>
+            </section>'''
+          new = '''        {/* Section 2: Safety */}
+            <SafetyCautionPanel summary={safetySummary} groups={safetyGroups} />'''
+          assert old in text, 'Compound safety block not found'
+          text = text.replace(old, new)
+          compound.write_text(text)
+          PY
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run focused tests
+        run: npx vitest run components/ui/__tests__/SafetyCautionPanel.test.tsx
+
+      - name: Run typecheck and lint
+        run: |
+          npm run typecheck
+          npm run lint
+
+      - name: Remove one-time workflow
+        run: rm .github/workflows/apply-compact-safety-ui.yml
+
+      - name: Commit generated edits
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add app/herbs/'[slug]'/page.tsx \
+            app/compounds/'[slug]'/page.tsx \
+            .github/workflows/apply-compact-safety-ui.yml
+          git commit -m "ui: collapse safety details into horizontal cards"
+          git push origin HEAD:ux/compact-safety-cautions

--- a/.github/workflows/apply-compact-safety-ui.yml
+++ b/.github/workflows/apply-compact-safety-ui.yml
@@ -1,9 +1,6 @@
 name: Apply Compact Safety UI
 
 on:
-  push:
-    branches:
-      - ux/compact-safety-cautions
   pull_request:
     types: [opened, reopened, synchronize]
 
@@ -33,6 +30,7 @@ jobs:
         run: |
           python <<'PY'
           from pathlib import Path
+          import re
 
           herb = Path('app/herbs/[slug]/page.tsx')
           text = herb.read_text()
@@ -40,67 +38,33 @@ jobs:
               "import SafetyGaugeMeter from '@/components/ui/SafetyGaugeMeter'",
               "import SafetyCautionPanel from '@/components/ui/SafetyCautionPanel'",
           )
-          old = '''      {/* Section 2: Safety */}
-          <section id="safety" className="scroll-mt-24 rounded-2xl bg-amber-50/70 border border-amber-900/10 border-l-4 border-amber-500/60 p-4 sm:p-5 space-y-3">
-            <div className="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between">
-              <div className="flex-1 space-y-2">
-                <h2 className="text-lg font-bold text-ink">Safety &amp; Cautions</h2>
-                <p className="text-sm leading-6 text-amber-900">{safetySummary}</p>
-              </div>
-              <SafetyGaugeMeter score={safetyGaugeScore.score} label={safetyGaugeScore.label} className="shrink-0 sm:w-44" />
-            </div>
-            {safetyGroups.length > 0 && (
-              <details className="group mt-4 border-t border-amber-900/10 pt-3">
-                <summary className="flex cursor-pointer items-center justify-between gap-3 text-sm font-bold text-amber-950 select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-700/40 focus-visible:rounded">
-                  <span>Detailed safety fields</span>
-                  <span aria-hidden="true" className="transition-transform group-open:rotate-180">v</span>
-                </summary>
-                <div className="mt-4 grid gap-4 sm:grid-cols-2">
-                  {safetyGroups.map(group => (
-                    <div key={group.title} className="space-y-1.5">
-                      <h3 className="text-xs font-bold uppercase tracking-wider text-amber-900 font-semibold">{group.title}</h3>
-                      <ul className="space-y-1 text-xs text-amber-900">
-                        {group.items.map(item => <li key={item}>- {item}</li>)}
-                      </ul>
-                    </div>
-                  ))}
-                </div>
-              </details>
-            )}
-          </section>'''
-          new = '''      {/* Section 2: Safety */}
-          <SafetyCautionPanel
-            summary={safetySummary}
-            groups={safetyGroups}
-            score={safetyGaugeScore.score}
-            scoreLabel={safetyGaugeScore.label}
-          />'''
-          assert old in text, 'Herb safety block not found'
-          text = text.replace(old, new)
+          pattern = re.compile(
+              r'\s*\{/\* Section 2: Safety \*/\}\s*'
+              r'<section id="safety".*?</section>',
+              re.S,
+          )
+          replacement = '''
+
+      {/* Section 2: Safety */}
+      <SafetyCautionPanel
+        summary={safetySummary}
+        groups={safetyGroups}
+        score={safetyGaugeScore.score}
+        scoreLabel={safetyGaugeScore.label}
+      />'''
+          text, count = pattern.subn(replacement, text, count=1)
+          assert count == 1, f'Expected one herb safety block, replaced {count}'
           herb.write_text(text)
 
           compound = Path('app/compounds/[slug]/page.tsx')
           text = compound.read_text()
-          text = text.replace(
-              "import ProfileDecisionPanel from '@/components/editorial/ProfileDecisionPanel'",
-              "import ProfileDecisionPanel from '@/components/editorial/ProfileDecisionPanel'\nimport SafetyCautionPanel from '@/components/ui/SafetyCautionPanel'",
-          )
-          old = '''function getSafetySummary(compound: Record<string, unknown>, avoidIf: string[]) {
-            const note = cleanText(compound.safetyNotes || compound.safety_notes || compound.safety)
-            if (avoidIf.length) return `Review before use if any apply: ${avoidIf.slice(0, 3).join(', ')}.`
-            if (note) return firstSentences(note, 2)
-            return 'Review medications, pregnancy status, chronic conditions, and clinician guidance before use.'
-          }
+          if "import SafetyCautionPanel from '@/components/ui/SafetyCautionPanel'" not in text:
+              text = text.replace(
+                  "import ProfileDecisionPanel from '@/components/editorial/ProfileDecisionPanel'",
+                  "import ProfileDecisionPanel from '@/components/editorial/ProfileDecisionPanel'\nimport SafetyCautionPanel from '@/components/ui/SafetyCautionPanel'",
+              )
 
-          function getMechanismHints'''
-          new = '''function getSafetySummary(compound: Record<string, unknown>, avoidIf: string[]) {
-            const note = cleanText(compound.safetyNotes || compound.safety_notes || compound.safety)
-            if (avoidIf.length) return `Review before use if any apply: ${avoidIf.slice(0, 3).join(', ')}.`
-            if (note) return firstSentences(note, 2)
-            return 'Review medications, pregnancy status, chronic conditions, and clinician guidance before use.'
-          }
-
-          function getCompoundSafetyGroups(compound: Record<string, unknown>) {
+          helper = '''function getCompoundSafetyGroups(compound: Record<string, unknown>) {
             const interactions = cleanItems(compound.interactions, 10)
             const contraindications = cleanItems([
               compound.avoid_if,
@@ -125,22 +89,32 @@ jobs:
             ].filter(group => group.items.length > 0)
           }
 
-          function getMechanismHints'''
-          assert old in text, 'Compound safety helper location not found'
-          text = text.replace(old, new)
-          text = text.replace(
-              "  const safetySummary = getSafetySummary(compound, avoidIf)\n  const mechanismHints = getMechanismHints(compound, mechanisms)",
-              "  const safetySummary = getSafetySummary(compound, avoidIf)\n  const safetyGroups = getCompoundSafetyGroups(compound)\n  const mechanismHints = getMechanismHints(compound, mechanisms)",
+          '''
+          if 'function getCompoundSafetyGroups' not in text:
+              marker = 'function getMechanismHints'
+              assert marker in text, 'Compound helper marker not found'
+              text = text.replace(marker, helper + marker, 1)
+
+          summary_line = '  const safetySummary = getSafetySummary(compound, avoidIf)'
+          if '  const safetyGroups = getCompoundSafetyGroups(compound)' not in text:
+              assert summary_line in text, 'Compound safety summary assignment not found'
+              text = text.replace(
+                  summary_line,
+                  summary_line + '\n  const safetyGroups = getCompoundSafetyGroups(compound)',
+                  1,
+              )
+
+          pattern = re.compile(
+              r'\s*\{/\* Section 2: Safety \*/\}\s*'
+              r'<section id="safety".*?</section>',
+              re.S,
           )
-          old = '''        {/* Section 2: Safety */}
-            <section id="safety" className="rounded-2xl bg-amber-50/70 border border-amber-900/10 border-l-4 border-amber-500/60 p-4 sm:p-5 space-y-3">
-              <h2 className="text-lg font-bold text-ink">Safety &amp; Cautions</h2>
-              <p className="text-sm leading-6 text-amber-900">{safetySummary}</p>
-            </section>'''
-          new = '''        {/* Section 2: Safety */}
-            <SafetyCautionPanel summary={safetySummary} groups={safetyGroups} />'''
-          assert old in text, 'Compound safety block not found'
-          text = text.replace(old, new)
+          replacement = '''
+
+        {/* Section 2: Safety */}
+        <SafetyCautionPanel summary={safetySummary} groups={safetyGroups} />'''
+          text, count = pattern.subn(replacement, text, count=1)
+          assert count == 1, f'Expected one compound safety block, replaced {count}'
           compound.write_text(text)
           PY
 

--- a/components/ui/SafetyCautionPanel.tsx
+++ b/components/ui/SafetyCautionPanel.tsx
@@ -1,0 +1,83 @@
+import SafetyGaugeMeter from './SafetyGaugeMeter'
+
+export interface SafetyCautionGroup {
+  title: string
+  items: string[]
+}
+
+interface Props {
+  summary: string
+  groups?: SafetyCautionGroup[]
+  score?: number
+  scoreLabel?: string
+  heading?: string
+}
+
+export default function SafetyCautionPanel({
+  summary,
+  groups = [],
+  score,
+  scoreLabel,
+  heading = 'Safety & Cautions',
+}: Props) {
+  const visibleGroups = groups.filter((group) => group.items.length > 0)
+
+  return (
+    <section
+      id="safety"
+      className="scroll-mt-24 rounded-2xl border border-amber-900/10 border-l-4 border-l-amber-500/60 bg-amber-50/70 p-4 sm:p-5"
+    >
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0 flex-1">
+          <h2 className="text-lg font-bold text-ink">{heading}</h2>
+          <p className="mt-1.5 text-sm leading-6 text-amber-950">{summary}</p>
+        </div>
+        {typeof score === 'number' && scoreLabel ? (
+          <SafetyGaugeMeter score={score} label={scoreLabel} className="shrink-0 sm:w-44" />
+        ) : null}
+      </div>
+
+      {visibleGroups.length > 0 ? (
+        <details className="group mt-4 border-t border-amber-900/10 pt-3">
+          <summary className="flex cursor-pointer list-none items-center justify-between gap-3 rounded text-sm font-bold text-amber-950 select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-700/40 [&::-webkit-details-marker]:hidden">
+            <span>
+              Browse {visibleGroups.length} safety {visibleGroups.length === 1 ? 'category' : 'categories'}
+            </span>
+            <span aria-hidden="true" className="transition-transform group-open:rotate-180">⌄</span>
+          </summary>
+
+          <div className="mt-3">
+            <p className="mb-2 text-[11px] font-semibold text-amber-900/75">
+              Swipe or scroll sideways to review each category.
+            </p>
+            <div
+              className="flex snap-x snap-mandatory gap-3 overflow-x-auto overscroll-x-contain pb-3 pr-1 [scrollbar-gutter:stable]"
+              aria-label="Detailed safety categories"
+            >
+              {visibleGroups.map((group) => (
+                <article
+                  key={group.title}
+                  className="min-w-[86%] snap-start rounded-xl border border-amber-900/10 bg-white/80 p-3.5 shadow-sm sm:min-w-[20rem] sm:max-w-[22rem]"
+                >
+                  <h3 className="text-xs font-bold uppercase tracking-wider text-amber-950">
+                    {group.title}
+                  </h3>
+                  <div className="mt-2 max-h-48 overflow-y-auto overscroll-contain pr-1">
+                    <ul className="space-y-2 text-xs leading-5 text-amber-950/90">
+                      {group.items.map((item) => (
+                        <li key={item} className="flex items-start gap-2">
+                          <span aria-hidden="true" className="mt-[0.45rem] h-1.5 w-1.5 shrink-0 rounded-full bg-amber-600/70" />
+                          <span>{item}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </div>
+        </details>
+      ) : null}
+    </section>
+  )
+}

--- a/components/ui/__tests__/SafetyCautionPanel.test.tsx
+++ b/components/ui/__tests__/SafetyCautionPanel.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import SafetyCautionPanel from '../SafetyCautionPanel'
+
+describe('SafetyCautionPanel', () => {
+  it('keeps the summary visible and collapses detailed categories by default', () => {
+    const { container } = render(
+      <SafetyCautionPanel
+        summary="Review medications and pregnancy status before use."
+        groups={[
+          { title: 'Medication interactions', items: ['Sedatives', 'Blood pressure medicines'] },
+          { title: 'Pregnancy', items: ['Avoid unless a clinician advises otherwise.'] },
+        ]}
+      />,
+    )
+
+    expect(screen.getByText('Review medications and pregnancy status before use.')).toBeTruthy()
+    expect(screen.getByText('Browse 2 safety categories')).toBeTruthy()
+    expect(container.querySelector('details')).not.toHaveAttribute('open')
+  })
+
+  it('renders horizontally scrollable snap cards with capped vertical content', () => {
+    const { container } = render(
+      <SafetyCautionPanel
+        summary="Use extra caution."
+        groups={[{ title: 'Full safety note', items: ['A long safety note.'] }]}
+      />,
+    )
+
+    const scroller = screen.getByLabelText('Detailed safety categories')
+    expect(scroller.className).toContain('overflow-x-auto')
+    expect(scroller.className).toContain('snap-x')
+    expect(screen.getByText('Full safety note').closest('article')?.className).toContain('snap-start')
+    expect(container.querySelector('.max-h-48')).toBeTruthy()
+  })
+
+  it('renders the optional safety gauge', () => {
+    render(
+      <SafetyCautionPanel
+        summary="Standard caution."
+        score={90}
+        scoreLabel="Low caution — well tolerated"
+      />,
+    )
+
+    expect(screen.getByRole('img', { name: /Safety meter: 90 out of 100/ })).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Goal

Collapse oversized safety sections without hiding important information.

## UX change

- Keep a short safety summary always visible.
- Keep detailed safety content collapsed by default.
- Present safety categories as horizontally scrollable, snap-aligned cards.
- Cap unusually long card bodies with internal vertical scrolling.
- Use the same shared component for herb and compound profiles.
- Preserve the existing safety gauge on herb profiles.

This PR is draft while the one-time migration job wires the shared component into both profile templates and runs focused tests, typecheck, and lint.