### PR TITLE
Collapse and rail long herb-profile lists to cap page length

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -356,6 +356,13 @@ html.theme-ready body * {
     content: 'Close';
   }
 
+  /* Summaries that render their own chevron (an aria-hidden marker span)
+     don't need the generated Open/Close label on top of it. */
+  summary:has(span[aria-hidden])::after,
+  details[open] summary:has(span[aria-hidden])::after {
+    content: none;
+  }
+
   details > * + * {
     @apply mt-4;
   }

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -660,7 +660,19 @@ export default async function HerbDetailPage({ params }: PageProps) {
         ))}
       </nav>
 
-      {normalizedSlug === 'ashwagandha' && <AshwagandhaStressClaim />}
+      {normalizedSlug === 'ashwagandha' && (
+        <section className="card-premium p-4 sm:p-5">
+          <details className="group">
+            <summary className="flex cursor-pointer items-center justify-between gap-4 text-lg font-bold text-ink select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40 focus-visible:rounded">
+              <span>Evidence deep dive: the stress claim</span>
+              <span aria-hidden="true" className="text-brand-500 transition-transform group-open:rotate-180">v</span>
+            </summary>
+            <div className="mt-4 border-t border-brand-900/10 pt-4">
+              <AshwagandhaStressClaim />
+            </div>
+          </details>
+        </section>
+      )}
 
       {expansion ? (
         <section id="editorial-review" className="card-premium scroll-mt-24 p-4 sm:p-5">
@@ -899,12 +911,12 @@ export default async function HerbDetailPage({ params }: PageProps) {
           {goalLinks.length > 0 ? (
             <div>
               <p className="text-[10px] font-bold uppercase tracking-wider text-brand-700">Goal guides</p>
-              <div className="mt-2 flex flex-wrap gap-2">
+              <div className="mt-2 flex gap-2 overflow-x-auto pb-1.5 [-webkit-overflow-scrolling:touch] [scrollbar-width:thin]">
                 {goalLinks.map((link) => (
                   <Link
                     key={link.href}
                     href={link.href}
-                    className="rounded-full border border-brand-900/10 bg-brand-50/50 px-3 py-1.5 text-xs font-semibold capitalize text-brand-800 hover:bg-brand-50"
+                    className="shrink-0 whitespace-nowrap rounded-full border border-brand-900/10 bg-brand-50/50 px-3 py-1.5 text-xs font-semibold capitalize text-brand-800 hover:bg-brand-50"
                   >
                     {link.label}
                   </Link>
@@ -915,12 +927,12 @@ export default async function HerbDetailPage({ params }: PageProps) {
           {conditionLinks.length > 0 ? (
             <div id="conditions" className="scroll-mt-24">
               <p className="text-[10px] font-bold uppercase tracking-wider text-brand-700">Condition guides</p>
-              <div className="mt-2 flex flex-wrap gap-2">
+              <div className="mt-2 flex gap-2 overflow-x-auto pb-1.5 [-webkit-overflow-scrolling:touch] [scrollbar-width:thin]">
                 {conditionLinks.slice(0, 5).map((link: RuntimeMapEntry) => (
                   <Link
                     key={link.slug}
                     href={link.href || '/guides/'}
-                    className="rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-3 py-1.5 text-xs font-semibold text-brand-800 hover:bg-brand-50"
+                    className="shrink-0 whitespace-nowrap rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-3 py-1.5 text-xs font-semibold text-brand-800 hover:bg-brand-50"
                   >
                     {link.label || formatDisplayLabel(link.slug)}
                   </Link>

--- a/components/RecommendationSection.tsx
+++ b/components/RecommendationSection.tsx
@@ -45,9 +45,9 @@ export default function RecommendationSection({
         <AffiliateDisclosure variant='compact' className='mt-2' />
       </div>
 
-      <div className='mt-4 grid gap-4 md:grid-cols-3'>
+      <div className='mt-4 flex gap-3 overflow-x-auto pb-2 [-webkit-overflow-scrolling:touch] [scrollbar-width:thin] md:grid md:grid-cols-3 md:gap-4 md:overflow-visible md:pb-0'>
         {ordered.map((product) => (
-          <div key={`${product.slot}-${product.title || product.name}`} className='flex flex-col gap-2'>
+          <div key={`${product.slot}-${product.title || product.name}`} className='flex w-[16rem] shrink-0 flex-col gap-2 md:w-auto md:shrink'>
             <p className='text-xs font-bold uppercase tracking-[0.16em] text-brand-700 dark:text-brand-200'>{slotLabels[product.slot]}</p>
             <AffiliateProductCard
               product={{

--- a/components/SeeAlsoCluster.tsx
+++ b/components/SeeAlsoCluster.tsx
@@ -91,13 +91,13 @@ export default function SeeAlsoCluster({
               </Link>
             </div>
           )}
-          <div className='flex flex-wrap gap-2'>
+          <div className='flex gap-2 overflow-x-auto pb-1.5 [-webkit-overflow-scrolling:touch] [scrollbar-width:thin]'>
             {group.entries.map((entry) => (
               <Link
                 key={`${entry.kind}:${entry.slug}`}
                 href={entry.href}
                 title={entry.reason}
-                className='rounded-full border border-brand-900/10 bg-brand-50/50 px-3 py-1.5 text-xs font-semibold capitalize text-brand-800 hover:bg-brand-50 transition'
+                className='shrink-0 whitespace-nowrap rounded-full border border-brand-900/10 bg-brand-50/50 px-3 py-1.5 text-xs font-semibold capitalize text-brand-800 hover:bg-brand-50 transition'
               >
                 {entry.label}
               </Link>

--- a/components/StackRecommendationSection.tsx
+++ b/components/StackRecommendationSection.tsx
@@ -24,9 +24,9 @@ export default function StackRecommendationSection({
         <AffiliateDisclosure variant='compact' className='mt-2' />
       </div>
 
-      <div className='mt-4 grid gap-4 md:grid-cols-3'>
+      <div className='mt-4 flex gap-3 overflow-x-auto pb-2 [-webkit-overflow-scrolling:touch] [scrollbar-width:thin] md:grid md:grid-cols-3 md:gap-4 md:overflow-visible md:pb-0'>
         {recommendations.map((rec) => (
-          <div key={rec.targetSlug} className='flex flex-col gap-2'>
+          <div key={rec.targetSlug} className='flex w-[16rem] shrink-0 flex-col gap-2 md:w-auto md:shrink'>
             <p className='text-xs font-bold uppercase tracking-[0.16em] text-brand-700'>Pairs well</p>
             <AffiliateProductCard
               product={{

--- a/components/editorial/EvidenceConfidence.tsx
+++ b/components/editorial/EvidenceConfidence.tsx
@@ -41,12 +41,16 @@ export function EvidenceConfidence({
 }) {
   const gradeStyle = GRADE_STYLE[String(grade).toLowerCase()] ?? GRADE_STYLE.moderate
   return (
-    <section className="not-prose my-6 rounded-2xl border border-brand-900/12 bg-white p-5 shadow-[0_1px_2px_rgba(13,23,18,0.05)] dark:border-white/10 dark:bg-[var(--surface-card)]">
-      <div className="flex flex-wrap items-center gap-3">
-        <h2 className="text-xl font-bold tracking-tight text-ink sm:text-2xl">{title}</h2>
-        <span className={`rounded-full border px-3 py-0.5 text-sm font-bold ${gradeStyle}`}>{grade}</span>
-      </div>
-      <div className="mt-4 grid gap-4 sm:grid-cols-2">
+    <section className="not-prose my-4 rounded-2xl border border-brand-900/12 bg-white p-4 shadow-[0_1px_2px_rgba(13,23,18,0.05)] dark:border-white/10 dark:bg-[var(--surface-card)]">
+      <details className="group">
+        <summary className="flex cursor-pointer flex-wrap items-center justify-between gap-3 select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40 focus-visible:rounded">
+          <span className="flex flex-wrap items-center gap-3">
+            <span className="text-base font-bold tracking-tight text-ink">{title}</span>
+            <span className={`rounded-full border px-3 py-0.5 text-sm font-bold ${gradeStyle}`}>{grade}</span>
+          </span>
+          <span aria-hidden="true" className="shrink-0 text-brand-500 transition-transform group-open:rotate-180">v</span>
+        </summary>
+      <div className="mt-4 grid gap-4 border-t border-brand-900/10 pt-4 sm:grid-cols-2 dark:border-white/10">
         <div>
           <p className="text-xs font-bold uppercase tracking-wider text-muted">Why not higher</p>
           <ul className="mt-2 space-y-1.5">
@@ -82,6 +86,7 @@ export function EvidenceConfidence({
         <span className="font-bold">Practical takeaway: </span>
         {practicalTakeaway}
       </p>
+      </details>
     </section>
   )
 }

--- a/components/editorial/ProfileDecisionPanel.tsx
+++ b/components/editorial/ProfileDecisionPanel.tsx
@@ -58,6 +58,12 @@ export function ProfileDecisionPanel({
           aria-label="Where to go next"
           className="not-prose rounded-2xl border border-brand-900/12 bg-brand-50/40 p-4 dark:border-white/10 dark:bg-[var(--surface-subtle)]"
         >
+          <details className="group">
+            <summary className="flex cursor-pointer items-center justify-between gap-3 select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40 focus-visible:rounded">
+              <span className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700">Where to go next — guides &amp; comparisons</span>
+              <span aria-hidden="true" className="shrink-0 text-brand-500 transition-transform group-open:rotate-180">v</span>
+            </summary>
+            <div className="mt-3 border-t border-brand-900/10 pt-3 dark:border-white/10">
           {verdict?.primaryGuide ? (
             <p className="text-sm leading-6">
               <span className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700 dark:text-emerald-300">Start here</span>{' '}
@@ -110,6 +116,8 @@ export function ProfileDecisionPanel({
               </ul>
             </div>
           ) : null}
+            </div>
+          </details>
         </section>
       ) : null}
     </div>

--- a/components/editorial/ScientificVerdictCard.tsx
+++ b/components/editorial/ScientificVerdictCard.tsx
@@ -126,7 +126,7 @@ export function ScientificVerdictCard({
 
       <div className="px-5 py-4">
         {(best.length > 0 || not.length > 0) && (
-          <div className="grid gap-4 sm:grid-cols-2">
+          <div className="grid grid-cols-2 gap-4">
             {best.length > 0 && (
               <div>
                 <p className="text-xs font-bold uppercase tracking-wider text-emerald-700 dark:text-emerald-300">
@@ -165,7 +165,7 @@ export function ScientificVerdictCard({
         )}
 
         {stats.length > 0 && (
-          <dl className="mt-4 grid grid-cols-1 gap-3 border-t border-brand-900/10 pt-4 dark:border-white/10 sm:grid-cols-3">
+          <dl className="mt-4 grid grid-cols-3 gap-3 border-t border-brand-900/10 pt-4 dark:border-white/10">
             {stats.map((stat) => (
               <div key={stat.label}>
                 <dt className="text-[0.7rem] font-bold uppercase tracking-wider text-muted">{stat.label}</dt>

--- a/components/seo/HerbCompoundLinks.tsx
+++ b/components/seo/HerbCompoundLinks.tsx
@@ -25,10 +25,13 @@ export default async function HerbCompoundLinks({ herbSlug, herbName }: HerbComp
           Key constituents studied in {herbName || 'this herb'}, with full pharmacology and safety profiles.
         </p>
       </div>
-      <ul className="space-y-2">
+      <ul className="flex gap-2 overflow-x-auto pb-1.5 [-webkit-overflow-scrolling:touch] [scrollbar-width:thin]">
         {links.map((link) => (
-          <li key={link.slug}>
-            <Link href={link.href} className="text-sm font-semibold text-brand-800 hover:underline">
+          <li key={link.slug} className="shrink-0">
+            <Link
+              href={link.href}
+              className="inline-block whitespace-nowrap rounded-full border border-brand-900/10 bg-brand-50/50 px-3 py-1.5 text-xs font-semibold text-brand-800 hover:bg-brand-50"
+            >
               {link.anchor}
             </Link>
           </li>

--- a/components/ui/EvidenceGradeExplainer.tsx
+++ b/components/ui/EvidenceGradeExplainer.tsx
@@ -37,7 +37,7 @@ export default function EvidenceGradeExplainer() {
   return (
     <details className="group">
       <summary className="flex cursor-pointer items-center gap-2 text-xs font-semibold uppercase tracking-wider text-muted select-none hover:text-ink transition-colors">
-        <span className="text-brand-500 group-open:rotate-90 transition-transform inline-block">▶</span>
+        <span aria-hidden="true" className="text-brand-500 group-open:rotate-90 transition-transform inline-block">▶</span>
         How evidence grades work
       </summary>
       <div className="mt-3 rounded-xl border border-brand-900/10 bg-white/70 p-3 space-y-2">

--- a/components/ui/RelatedDiscoveryGroups.tsx
+++ b/components/ui/RelatedDiscoveryGroups.tsx
@@ -33,9 +33,9 @@ export default function RelatedDiscoveryGroups({
         <p className="eyebrow-label">{eyebrow}</p>
         <h2 className="text-lg font-semibold tracking-tight text-ink">{title}</h2>
       </div>
-      <div className="mt-3 grid gap-3 md:grid-cols-2 lg:grid-cols-4">
+      <div className="mt-3 flex gap-3 overflow-x-auto pb-2 [-webkit-overflow-scrolling:touch] [scrollbar-width:thin] md:grid md:grid-cols-2 md:overflow-visible md:pb-0 lg:grid-cols-4">
         {visibleGroups.map((group) => (
-          <article key={group.title} className="rounded-xl border border-brand-900/10 bg-white/90 p-3">
+          <article key={group.title} className="w-[15rem] shrink-0 rounded-xl border border-brand-900/10 bg-white/90 p-3 md:w-auto md:shrink">
             <h3 className="text-sm font-semibold text-ink">{group.title}</h3>
             {group.description ? <p className="mt-1 text-xs leading-5 text-muted">{group.description}</p> : null}
             <div className="mt-2 space-y-1.5">

--- a/components/ui/ShowMeTheStudies.tsx
+++ b/components/ui/ShowMeTheStudies.tsx
@@ -137,14 +137,17 @@ export default function ShowMeTheStudies({ citations }: Props) {
   const overflow = sorted.slice(VISIBLE_ROWS)
 
   return (
-    <div className="overflow-hidden rounded-2xl border-2 border-brand-900/10 dark:border-white/10">
-      <div className="border-b border-brand-900/10 bg-brand-50/70 px-4 py-3 dark:border-white/10 dark:bg-[var(--surface-subtle)]">
-        <h3 className="text-sm font-bold text-ink">Clinical Study Summaries</h3>
-        <p className="mt-0.5 text-[11px] leading-5 text-muted">
-          {citations.length} cited stud{citations.length === 1 ? 'y' : 'ies'} informing this profile. RCTs and reviews shown first.
-        </p>
-      </div>
-      <div className="overflow-x-auto">
+    <details className="group/studies overflow-hidden rounded-2xl border-2 border-brand-900/10 dark:border-white/10">
+      <summary className="flex cursor-pointer items-center justify-between gap-3 bg-brand-50/70 px-4 py-3 select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40 dark:bg-[var(--surface-subtle)]">
+        <span>
+          <span className="block text-sm font-bold text-ink">Clinical Study Summaries ({citations.length})</span>
+          <span className="mt-0.5 block text-[11px] leading-5 text-muted">
+            Cited studies informing this profile. RCTs and reviews shown first.
+          </span>
+        </span>
+        <span aria-hidden="true" className="shrink-0 text-brand-500 transition-transform group-open/studies:rotate-180">v</span>
+      </summary>
+      <div className="overflow-x-auto border-t border-brand-900/10 dark:border-white/10">
         <table className="w-full min-w-[560px] border-collapse text-left text-sm">
           <thead>
             <tr className="bg-[var(--surface-card)] text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -178,6 +181,6 @@ export default function ShowMeTheStudies({ citations }: Props) {
           </div>
         </details>
       )}
-    </div>
+    </details>
   )
 }

--- a/components/ui/__tests__/ShowMeTheStudies.test.tsx
+++ b/components/ui/__tests__/ShowMeTheStudies.test.tsx
@@ -18,14 +18,14 @@ describe('ShowMeTheStudies', () => {
     expect(container).toBeEmptyDOMElement()
   })
 
-  it('uses singular "study" wording for exactly one citation', () => {
+  it('shows the citation count in the collapsed summary heading', () => {
     render(<ShowMeTheStudies citations={[citation()]} />)
-    expect(screen.getByText(/1 cited study informing/)).toBeTruthy()
+    expect(screen.getByText(/Clinical Study Summaries \(1\)/)).toBeTruthy()
   })
 
-  it('uses plural "studies" wording for more than one citation', () => {
+  it('shows the total count for more than one citation', () => {
     render(<ShowMeTheStudies citations={[citation({ title: 'A' }), citation({ title: 'B' })]} />)
-    expect(screen.getByText(/2 cited studies informing/)).toBeTruthy()
+    expect(screen.getByText(/Clinical Study Summaries \(2\)/)).toBeTruthy()
   })
 
   it('links the study title and "PubMed" cell to PubMed when a pmid is present', () => {
@@ -75,7 +75,8 @@ describe('ShowMeTheStudies', () => {
 
   it('omits the overflow disclosure entirely when 6 or fewer citations are given', () => {
     const citations = Array.from({ length: 6 }, (_, i) => citation({ title: `Study ${i}` }))
-    const { container } = render(<ShowMeTheStudies citations={citations} />)
-    expect(container.querySelector('details')).toBeNull()
+    render(<ShowMeTheStudies citations={citations} />)
+    // The whole module is one collapsed <details>; no nested "Show N more" disclosure.
+    expect(screen.queryByText(/Show \d+ more/)).toBeNull()
   })
 })

--- a/src/components/InteractionWarnings.tsx
+++ b/src/components/InteractionWarnings.tsx
@@ -59,58 +59,63 @@ export function InteractionWarnings({ edges, slugTypeMap }: InteractionWarningsP
     <section id="interactions" className="space-y-4 scroll-mt-24">
       <h2 className="text-lg font-bold text-ink">Caution When Combined With</h2>
       <p className="text-sm leading-6 text-muted">
-        These pairings share a flagged risk mechanism — an additive-effect caution derived from
-        contraindication data, not a confirmed clinical interaction. Consult a clinician before combining.
+        Mechanistic cautions from contraindication data, not confirmed clinical interactions — consult a clinician before combining.
       </p>
 
       {bySeverity.map(({ severity, items }) => {
         const config = SEVERITY_CONFIG[severity]
-        // One compact chip list per mechanism instead of a paragraph per pairing.
+        // One horizontally scrolling chip rail per mechanism instead of a paragraph
+        // per pairing. Only severe groups start expanded.
         const byMechanism = [...new Set(items.map(e => e.risk_mechanism))].map(mechanism => ({
           mechanism,
           edges: items.filter(e => e.risk_mechanism === mechanism),
         }))
+        const mechanismSummary = byMechanism
+          .map(({ mechanism }) => MECHANISM_LABELS[mechanism] ?? mechanism)
+          .join(', ')
 
         return (
-          <div key={severity} className={config.wrapper}>
-            <h3 className={`text-xs font-bold uppercase tracking-wider ${config.heading}`}>
-              {config.label} ({items.length})
-            </h3>
-            {byMechanism.map(({ mechanism, edges: mechanismEdges }) => (
-              <div key={mechanism} className="space-y-2">
-                <span
-                  className={`inline-block text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full ${config.badge}`}
-                >
-                  {MECHANISM_LABELS[mechanism] ?? mechanism}
-                </span>
-                <ul className="flex flex-wrap gap-1.5">
-                  {mechanismEdges.map(edge => {
-                    const partnerType = slugTypeMap[edge.partner_slug]
-                    const partnerHref = partnerType
-                      ? `/${partnerType === 'compound' ? 'compounds' : 'herbs'}/${edge.partner_slug}`
-                      : null
+          <details key={severity} className={`group ${config.wrapper}`} {...(severity === 'severe' ? { open: true } : {})}>
+            <summary className="flex cursor-pointer items-center justify-between gap-3 select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-700/40 focus-visible:rounded">
+              <span className={`text-xs font-bold uppercase tracking-wider ${config.heading}`}>
+                {config.label} ({items.length}) <span className="font-semibold normal-case tracking-normal opacity-80">— {mechanismSummary}</span>
+              </span>
+              <span aria-hidden="true" className={`shrink-0 transition-transform group-open:rotate-180 ${config.heading}`}>v</span>
+            </summary>
+            <div className="mt-3 space-y-3">
+              {byMechanism.map(({ mechanism, edges: mechanismEdges }) => (
+                <div key={mechanism} className="space-y-1.5">
+                  <span
+                    className={`inline-block text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full ${config.badge}`}
+                  >
+                    {MECHANISM_LABELS[mechanism] ?? mechanism}
+                  </span>
+                  <ul className="flex gap-1.5 overflow-x-auto pb-1.5 [-webkit-overflow-scrolling:touch] [scrollbar-width:thin]">
+                    {mechanismEdges.map(edge => {
+                      const partnerType = slugTypeMap[edge.partner_slug]
+                      const partnerHref = partnerType
+                        ? `/${partnerType === 'compound' ? 'compounds' : 'herbs'}/${edge.partner_slug}`
+                        : null
+                      const chipClass =
+                        'inline-block shrink-0 whitespace-nowrap rounded-full border border-amber-900/15 bg-white/70 px-2.5 py-1 text-xs font-semibold leading-5 text-ink dark:border-white/15 dark:bg-white/10'
 
-                    return (
-                      <li key={`${edge.partner_slug}-${edge.risk_mechanism}`} title={edge.claim_language}>
-                        {partnerHref ? (
-                          <Link
-                            href={partnerHref}
-                            className="inline-block rounded-full border border-amber-900/15 bg-white/70 px-2.5 py-1 text-xs font-semibold text-ink hover:bg-white"
-                          >
-                            {edge.partner_name}
-                          </Link>
-                        ) : (
-                          <span className="inline-block rounded-full border border-amber-900/15 bg-white/70 px-2.5 py-1 text-xs font-semibold text-ink">
-                            {edge.partner_name}
-                          </span>
-                        )}
-                      </li>
-                    )
-                  })}
-                </ul>
-              </div>
-            ))}
-          </div>
+                      return (
+                        <li key={`${edge.partner_slug}-${edge.risk_mechanism}`} className="shrink-0" title={edge.claim_language}>
+                          {partnerHref ? (
+                            <Link href={partnerHref} className={`${chipClass} hover:bg-white dark:hover:bg-white/20`}>
+                              {edge.partner_name}
+                            </Link>
+                          ) : (
+                            <span className={chipClass}>{edge.partner_name}</span>
+                          )}
+                        </li>
+                      )
+                    })}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          </details>
         )
       })}
     </section>

--- a/src/components/monetization/WhyWeRecommend.tsx
+++ b/src/components/monetization/WhyWeRecommend.tsx
@@ -25,32 +25,30 @@ export default function WhyWeRecommend({
   className = '',
 }: WhyWeRecommendProps) {
   return (
-    <aside
-      className={`rounded-2xl border border-emerald-900/10 bg-emerald-50/40 p-5 ${className}`}
-    >
-      <p className='text-xs font-bold uppercase tracking-[0.16em] text-emerald-800'>
-        Why we recommend
-      </p>
-      <h3 className='mt-2 text-base font-semibold text-ink'>
-        {productName
-          ? `How we evaluate ${productName} products`
-          : 'How we evaluate affiliate picks'}
-      </h3>
-      <ul className='mt-4 space-y-3 text-sm leading-6 text-muted'>
-        {CRITERIA.map((item) => (
-          <li key={item.title}>
-            <strong className='font-semibold text-ink'>{item.title}:</strong> {item.body}
-          </li>
-        ))}
-      </ul>
-      <div className='mt-4 flex flex-wrap gap-3 text-xs font-semibold'>
-        <Link href='/learn/product-quality' className='text-emerald-800 hover:underline'>
-          Product quality guide →
-        </Link>
-        <Link href='/info/affiliate-disclosure' className='text-emerald-800 hover:underline'>
-          Affiliate disclosure →
-        </Link>
-      </div>
+    <aside className={`rounded-2xl border border-emerald-900/10 bg-emerald-50/40 p-4 ${className}`}>
+      <details className='group'>
+        <summary className='flex cursor-pointer items-center justify-between gap-3 select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-700/40 focus-visible:rounded'>
+          <span className='text-xs font-bold uppercase tracking-[0.16em] text-emerald-800'>
+            {productName ? `How we evaluate ${productName} products` : 'How we evaluate affiliate picks'}
+          </span>
+          <span aria-hidden='true' className='shrink-0 text-emerald-700 transition-transform group-open:rotate-180'>v</span>
+        </summary>
+        <ul className='mt-3 space-y-2 border-t border-emerald-900/10 pt-3 text-sm leading-6 text-muted'>
+          {CRITERIA.map((item) => (
+            <li key={item.title}>
+              <strong className='font-semibold text-ink'>{item.title}:</strong> {item.body}
+            </li>
+          ))}
+        </ul>
+        <div className='mt-3 flex flex-wrap gap-3 text-xs font-semibold'>
+          <Link href='/learn/product-quality' className='text-emerald-800 hover:underline'>
+            Product quality guide →
+          </Link>
+          <Link href='/info/affiliate-disclosure' className='text-emerald-800 hover:underline'>
+            Affiliate disclosure →
+          </Link>
+        </div>
+      </details>
     </aside>
   )
 }

--- a/styles/herb-profile-polish.css
+++ b/styles/herb-profile-polish.css
@@ -217,8 +217,8 @@ main:has(nav[aria-label="Jump to profile sections"]) .overflow-x-auto {
   scrollbar-width: thin;
 }
 
-#ashwagandha-stress-claim .overflow-x-auto::after,
-main:has(nav[aria-label="Jump to profile sections"]) .overflow-x-auto::after {
+#ashwagandha-stress-claim .overflow-x-auto:has(table)::after,
+main:has(nav[aria-label="Jump to profile sections"]) .overflow-x-auto:has(table)::after {
   content: 'Swipe table →';
   display: none;
   padding: 0.7rem 0.85rem;
@@ -230,8 +230,8 @@ main:has(nav[aria-label="Jump to profile sections"]) .overflow-x-auto::after {
   text-transform: uppercase;
 }
 
-html:not(.dark) #ashwagandha-stress-claim .overflow-x-auto::after,
-html:not(.dark) main:has(nav[aria-label="Jump to profile sections"]) .overflow-x-auto::after {
+html:not(.dark) #ashwagandha-stress-claim .overflow-x-auto:has(table)::after,
+html:not(.dark) main:has(nav[aria-label="Jump to profile sections"]) .overflow-x-auto:has(table)::after {
   border-top-color: rgba(29, 74, 47, 0.1);
   color: #5f6f66;
 }
@@ -307,8 +307,8 @@ main:has(nav[aria-label="Jump to profile sections"]) a {
     line-height: 1.18 !important;
   }
 
-  #ashwagandha-stress-claim .overflow-x-auto::after,
-  main:has(nav[aria-label="Jump to profile sections"]) .overflow-x-auto::after {
+  #ashwagandha-stress-claim .overflow-x-auto:has(table)::after,
+  main:has(nav[aria-label="Jump to profile sections"]) .overflow-x-auto:has(table)::after {
     display: block;
   }
 


### PR DESCRIPTION
## Summary

- Interaction caution groups are now collapsible (severe stays open) and render partners in a single horizontally scrolling chip rail per mechanism — the 60-pill vertical wall on ashwagandha is now one collapsed row
- See-also, goal/condition, and active-compound link lists become horizontal scroll rails
- Product recommendation, stack, and related-discovery cards scroll horizontally on mobile (grid preserved on md+)
- Collapsed by default: Clinical Study Summaries table, WhyWeRecommend criteria, EvidenceConfidence breakdown, decision-panel navigation links, and the ashwagandha evidence deep-dive block
- Verdict card lists/stats keep multi-column layout on mobile instead of stacking
- Global summary Open/Close label suppressed when a summary renders its own chevron; mobile "Swipe table →" hint scoped to actual tables

Measured mobile page height (390×844): ashwagandha **33 → 14 screens**, typical profile 13.4 → 10 screens.

## Verification

- [x] `npm run lint`
- [x] `npm run check` (run in previous round; this round adds no data/build changes — typecheck + lint re-run clean)
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs
- [x] no generated file corruption
- [x] static export compatible

Full Vitest suite passes (88 files, 569 tests; ShowMeTheStudies tests updated for the collapsed design). Verified rendering and measured section heights at mobile viewport with headless Chromium on `/herbs/ashwagandha/` and `/herbs/panax-quinquefolius/`.

## Risk Notes

- Interaction claim sentences remain available as chip tooltips and severity groups keep counts; severe-severity groups stay expanded by default for safety visibility
- Shared components (EvidenceConfidence, WhyWeRecommend, verdict card, discovery groups) also compact compound and article pages that use them
- Horizontal rails rely on standard `overflow-x-auto`; the global details/summary styling still applies its card chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013X2YPYQRubSVheePJz2NHP

---
_Generated by [Claude Code](https://claude.ai/code/session_013X2YPYQRubSVheePJz2NHP)_