### PR TITLE
Extend editorial botanical style across content pages

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,6 +30,7 @@ import '@/styles/article-visual-polish.css'
 import '@/styles/compact-safety-cautions.css'
 import '@/styles/editorial-global-tokens.css'
 import '@/styles/editorial-botanical-refresh.css'
+import '@/styles/editorial-content-surfaces.css'
 
 const HOME_TITLE = 'The Hippie Scientist | Supplement Research'
 

--- a/components/ui/ProfileTOC.tsx
+++ b/components/ui/ProfileTOC.tsx
@@ -12,22 +12,24 @@ export default function ProfileTOC({ items, variant = 'all' }: { items: TocItem[
   useEffect(() => {
     const observer = new IntersectionObserver(
       (entries) => {
-        const visible = entries.find(e => e.isIntersecting)
+        const visible = entries.find((entry) => entry.isIntersecting)
         if (visible) setActiveId(visible.target.id)
       },
-      { rootMargin: '-20% 0px -70% 0px' }
+      { rootMargin: '-20% 0px -70% 0px' },
     )
+
     items.forEach(({ id }) => {
-      const el = document.getElementById(id)
-      if (el) observer.observe(el)
+      const element = document.getElementById(id)
+      if (element) observer.observe(element)
     })
+
     return () => observer.disconnect()
   }, [items])
 
   if (items.length === 0) return null
 
   const links = (
-    <ol className="space-y-1">
+    <ol className='space-y-1'>
       {items.map(({ id, label }) => {
         const isActive = activeId === id
         return (
@@ -35,6 +37,7 @@ export default function ProfileTOC({ items, variant = 'all' }: { items: TocItem[
             <a
               href={`#${id}`}
               onClick={() => setMobileOpen(false)}
+              aria-current={isActive ? 'location' : undefined}
               className={`block rounded-xl px-3 py-2 text-sm transition-colors ${
                 isActive
                   ? 'bg-brand-50 font-semibold text-brand-900 shadow-sm dark:bg-white/10 dark:text-brand-50'
@@ -53,30 +56,30 @@ export default function ProfileTOC({ items, variant = 'all' }: { items: TocItem[
     <>
       {variant !== 'desktop' ? (
         <nav
-          aria-label="Page sections"
-          className="rounded-2xl border border-brand-900/10 bg-white/90 p-3 shadow-sm backdrop-blur lg:hidden dark:border-white/10 dark:bg-white/5"
+          aria-label='Page sections'
+          className='rounded-2xl border border-brand-900/10 bg-white/90 p-3 shadow-sm backdrop-blur lg:hidden dark:border-white/10 dark:bg-white/5'
         >
           <button
-            type="button"
+            type='button'
             aria-expanded={mobileOpen}
-            onClick={() => setMobileOpen(open => !open)}
-            className="flex w-full items-center justify-between rounded-xl px-2 py-1 text-left text-sm font-semibold text-ink"
+            onClick={() => setMobileOpen((open) => !open)}
+            className='flex w-full items-center justify-between rounded-xl px-2 py-1 text-left text-sm font-semibold text-ink'
           >
             On this page
-            <span aria-hidden="true" className={`text-muted transition-transform ${mobileOpen ? 'rotate-180' : ''}`}>
+            <span aria-hidden='true' className={`text-muted transition-transform ${mobileOpen ? 'rotate-180' : ''}`}>
               v
             </span>
           </button>
-          {mobileOpen ? <div className="mt-3 border-t border-brand-900/10 pt-3 dark:border-white/10">{links}</div> : null}
+          {mobileOpen ? <div className='mt-3 border-t border-brand-900/10 pt-3 dark:border-white/10'>{links}</div> : null}
         </nav>
       ) : null}
 
       {variant !== 'mobile' ? (
         <nav
-          aria-label="Page sections"
-          className="hidden w-56 shrink-0 self-start rounded-2xl border border-brand-900/10 bg-white/75 p-3 shadow-sm backdrop-blur lg:sticky lg:top-24 lg:block dark:border-white/10 dark:bg-white/5"
+          aria-label='Page sections'
+          className='hidden w-56 shrink-0 self-start rounded-2xl border border-brand-900/10 bg-white/75 p-3 shadow-sm backdrop-blur lg:sticky lg:top-24 lg:block dark:border-white/10 dark:bg-white/5'
         >
-          <p className="eyebrow-label mb-3 px-2">On this page</p>
+          <p className='eyebrow-label mb-3 px-2'>On this page</p>
           {links}
         </nav>
       ) : null}

--- a/styles/editorial-content-surfaces.css
+++ b/styles/editorial-content-surfaces.css
@@ -1,0 +1,268 @@
+/* Editorial content pass two
+   Extends the botanical system from the homepage into profiles, comparisons,
+   evidence surfaces, accordions, tables, search, and tool controls. */
+
+html:not(.dark) :where(
+  .library-card-premium,
+  .card-premium,
+  .scientific-card,
+  .surface-depth,
+  .surface-subtle,
+  .section-frame,
+  .glass-card
+) {
+  border-color: rgba(18, 60, 47, 0.11);
+  background:
+    radial-gradient(circle at 100% 0%, rgba(203, 220, 200, 0.28), transparent 32%),
+    linear-gradient(145deg, rgba(255, 253, 248, 0.98), rgba(247, 241, 230, 0.88));
+  box-shadow:
+    0 16px 42px rgba(58, 45, 24, 0.075),
+    inset 0 1px 0 rgba(255, 255, 255, 0.88);
+}
+
+html:not(.dark) :where(
+  .library-card-premium,
+  .card-premium,
+  .scientific-card,
+  .surface-depth,
+  .surface-subtle,
+  .section-frame,
+  .glass-card
+):hover {
+  border-color: rgba(184, 138, 66, 0.28);
+  background:
+    radial-gradient(circle at 100% 0%, rgba(203, 220, 200, 0.34), transparent 34%),
+    linear-gradient(145deg, #fffdf8, #f8f2e7);
+  box-shadow:
+    0 20px 48px rgba(58, 45, 24, 0.10),
+    inset 0 1px 0 rgba(255, 255, 255, 0.92);
+}
+
+html:not(.dark) :where(
+  .library-card-premium,
+  .card-premium,
+  .scientific-card,
+  .surface-depth,
+  .surface-subtle,
+  .section-frame,
+  .glass-card
+) :where(h2, h3) {
+  color: var(--editorial-evergreen);
+}
+
+html:not(.dark) :where(
+  .library-card-premium,
+  .card-premium,
+  .scientific-card,
+  .surface-depth,
+  .surface-subtle,
+  .section-frame,
+  .glass-card
+) p {
+  color: #526159;
+}
+
+html:not(.dark) .eyebrow-label {
+  color: var(--editorial-gold);
+  font-weight: 800;
+  letter-spacing: 0.14em;
+}
+
+html:not(.dark) :where(.identity-kicker, .chip-readable, .evidence-pill-strong, .evidence-pill-moderate) {
+  border-color: rgba(18, 60, 47, 0.10);
+  background: linear-gradient(145deg, rgba(223, 233, 220, 0.78), rgba(255, 253, 248, 0.92));
+  color: var(--editorial-evergreen);
+}
+
+/* Herb and compound profile shells */
+html:not(.dark) main:has(nav[aria-label="Jump to profile sections"]) {
+  background:
+    radial-gradient(circle at 96% 3%, rgba(203, 220, 200, 0.34), transparent 23rem),
+    linear-gradient(180deg, #fbf8f1, #f8f2e7 46%, #fbf8f1);
+}
+
+html:not(.dark) main:has(nav[aria-label="Jump to profile sections"]) > div.mx-auto {
+  max-width: 74rem;
+}
+
+html:not(.dark) main:has(nav[aria-label="Jump to profile sections"]) .hero-shell {
+  border-color: rgba(184, 138, 66, 0.20);
+  background:
+    radial-gradient(circle at 88% 10%, rgba(255, 255, 255, 0.92), transparent 17rem),
+    radial-gradient(circle at 100% 100%, rgba(203, 220, 200, 0.42), transparent 19rem),
+    linear-gradient(145deg, #fffdf8, #f5efe2);
+  box-shadow: var(--editorial-shadow);
+}
+
+html:not(.dark) main:has(nav[aria-label="Jump to profile sections"]) .hero-shell h1 {
+  color: var(--editorial-evergreen);
+  font-family: var(--font-fraunces), Fraunces, Georgia, serif;
+  font-weight: 650;
+  letter-spacing: -0.045em;
+}
+
+html:not(.dark) main:has(nav[aria-label="Jump to profile sections"]) .hero-shell .rounded-xl {
+  border-color: rgba(18, 60, 47, 0.10);
+  background: rgba(255, 253, 248, 0.78);
+  box-shadow: 0 7px 22px rgba(58, 45, 24, 0.055);
+}
+
+html:not(.dark) main:has(nav[aria-label="Jump to profile sections"]) nav[aria-label="Jump to profile sections"] {
+  top: 5.25rem;
+  border-color: rgba(18, 60, 47, 0.12) !important;
+  background: rgba(255, 253, 248, 0.94) !important;
+  box-shadow: 0 12px 34px rgba(58, 45, 24, 0.10);
+  backdrop-filter: blur(18px);
+}
+
+html:not(.dark) main:has(nav[aria-label="Jump to profile sections"]) nav[aria-label="Jump to profile sections"] a {
+  color: #526159 !important;
+}
+
+html:not(.dark) main:has(nav[aria-label="Jump to profile sections"]) nav[aria-label="Jump to profile sections"] a:first-child {
+  background: linear-gradient(135deg, #123c2f, #245846) !important;
+  color: #fffdf8 !important;
+  box-shadow: 0 7px 18px rgba(18, 60, 47, 0.18);
+}
+
+html:not(.dark) main:has(nav[aria-label="Jump to profile sections"]) nav[aria-label="Jump to profile sections"] a:not(:first-child):hover {
+  background: #f5efe2 !important;
+  color: var(--editorial-evergreen) !important;
+}
+
+/* Shared profile TOC */
+html:not(.dark) nav[aria-label="Page sections"] {
+  border-color: rgba(18, 60, 47, 0.11) !important;
+  background: rgba(255, 253, 248, 0.92) !important;
+  box-shadow: 0 12px 34px rgba(58, 45, 24, 0.08) !important;
+}
+
+html:not(.dark) nav[aria-label="Page sections"] a {
+  color: #526159;
+}
+
+html:not(.dark) nav[aria-label="Page sections"] a[aria-current="true"],
+html:not(.dark) nav[aria-label="Page sections"] a:hover {
+  background: #f5efe2;
+  color: var(--editorial-evergreen);
+}
+
+/* Accordions and editorial disclosures */
+html:not(.dark) :where(.card-premium, .surface-depth, .scientific-card) > details > summary,
+html:not(.dark) main:has(nav[aria-label="Jump to profile sections"]) details > summary {
+  color: var(--editorial-evergreen);
+}
+
+html:not(.dark) :where(.card-premium, .surface-depth, .scientific-card) > details > summary:hover,
+html:not(.dark) main:has(nav[aria-label="Jump to profile sections"]) details > summary:hover {
+  color: var(--editorial-evergreen-soft);
+}
+
+html:not(.dark) details[open] > summary {
+  margin-bottom: 0.15rem;
+}
+
+html:not(.dark) details > summary + div {
+  border-top-color: rgba(18, 60, 47, 0.10) !important;
+}
+
+/* Evidence tables */
+html:not(.dark) main table {
+  border-color: rgba(18, 60, 47, 0.10);
+  background: rgba(255, 253, 248, 0.90);
+}
+
+html:not(.dark) main table thead {
+  background: linear-gradient(180deg, #edf3ea, #e6eee3) !important;
+  color: var(--editorial-evergreen);
+}
+
+html:not(.dark) main table tbody tr:nth-child(even) {
+  background: rgba(245, 239, 226, 0.50);
+}
+
+html:not(.dark) main table :where(th, td) {
+  border-color: rgba(18, 60, 47, 0.085) !important;
+}
+
+/* Compare pages */
+html:not(.dark) main:has(#compare-decision) {
+  background:
+    radial-gradient(circle at 95% 4%, rgba(203, 220, 200, 0.32), transparent 23rem),
+    linear-gradient(180deg, #fbf8f1, #f7f1e6 48%, #fbf8f1);
+}
+
+html:not(.dark) main:has(#compare-decision) h1,
+html:not(.dark) main:has(#compare-decision) h2 {
+  color: var(--editorial-evergreen);
+  font-family: var(--font-fraunces), Fraunces, Georgia, serif;
+}
+
+html:not(.dark) main:has(#compare-decision) :where(.rounded-2xl, .rounded-3xl) {
+  border-color: rgba(18, 60, 47, 0.10);
+}
+
+/* Inputs, search, filters, and tools */
+html:not(.dark) main :where(input, select, textarea) {
+  border-color: rgba(18, 60, 47, 0.14);
+  background: rgba(255, 253, 248, 0.94);
+  color: var(--editorial-evergreen);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.82);
+}
+
+html:not(.dark) main :where(input, select, textarea)::placeholder {
+  color: #7a867f;
+}
+
+html:not(.dark) main :where(input, select, textarea):focus {
+  border-color: rgba(184, 138, 66, 0.56);
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(184, 138, 66, 0.14);
+}
+
+html:not(.dark) main button:not([class*="bg-red"]):not([class*="bg-amber"]):not([class*="bg-emerald"]) {
+  text-underline-offset: 0.18em;
+}
+
+/* Safety and status blocks retain semantic color but lose the harsh flat fill. */
+html:not(.dark) main :where([class*="bg-amber-50"], [class*="bg-yellow-50"]) {
+  border-color: rgba(184, 138, 66, 0.22) !important;
+  background:
+    radial-gradient(circle at 100% 0%, rgba(222, 198, 155, 0.24), transparent 32%),
+    linear-gradient(145deg, rgba(255, 252, 241, 0.96), rgba(248, 240, 223, 0.88)) !important;
+}
+
+html:not(.dark) main [class*="bg-emerald-50"] {
+  border-color: rgba(49, 95, 80, 0.18) !important;
+  background:
+    radial-gradient(circle at 100% 0%, rgba(203, 220, 200, 0.34), transparent 32%),
+    linear-gradient(145deg, rgba(247, 251, 246, 0.96), rgba(231, 240, 228, 0.86)) !important;
+}
+
+/* Library/index cards and discovery rails */
+html:not(.dark) main :where(article, section) > a.rounded-xl,
+html:not(.dark) main :where(article, section) > a.rounded-2xl {
+  transition: transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
+}
+
+html:not(.dark) main :where(article, section) > a.rounded-xl:hover,
+html:not(.dark) main :where(article, section) > a.rounded-2xl:hover {
+  transform: translateY(-2px);
+  border-color: rgba(184, 138, 66, 0.28);
+  box-shadow: 0 12px 30px rgba(58, 45, 24, 0.08);
+}
+
+@media (max-width: 768px) {
+  html:not(.dark) main:has(nav[aria-label="Jump to profile sections"]) nav[aria-label="Jump to profile sections"] {
+    border-radius: 1.25rem !important;
+  }
+
+  html:not(.dark) main:has(nav[aria-label="Jump to profile sections"]) .hero-shell {
+    border-radius: 1.45rem !important;
+    padding: 1.1rem !important;
+  }
+
+  html:not(.dark) main:has(nav[aria-label="Jump to profile sections"]) .hero-shell h1 {
+    font-size: clamp(2.35rem, 11vw, 3.25rem) !important;
+  }
+}


### PR DESCRIPTION
## Summary

Carries the new editorial botanical visual system beyond the homepage and global chrome into the content-heavy parts of the site.

## What changes

- Restyles shared premium cards, scientific cards, and glass surfaces in the cream/sage/evergreen system.
- Gives herb and compound profile heroes the new editorial treatment.
- Replaces the old dark-green profile jump bar in light mode with a cream glass navigation dock.
- Restyles profile TOCs and adds a proper `aria-current="location"` state for the active section.
- Unifies profile accordions, evidence tables, comparison pages, filters, search inputs, and tool controls.
- Softens amber and emerald status blocks while preserving their safety meaning.
- Adds mobile-specific profile spacing and typography refinements.

## Validation

- Fast UI Check — success
- Full CI — success
- Build Check — success
- Site Health Check — success
- Lighthouse CI — success
- Lint and typecheck — success
- Vitest and accessibility gate — success
- Canonical-data validation — success
- Production static export and output verification — success
- SEO coverage and security audit gate — success

## Scope

- `styles/editorial-content-surfaces.css`
- `app/layout.tsx`
- `components/ui/ProfileTOC.tsx`

This pass is intentionally CSS-led so it updates many pages without touching generated evidence or workbook-backed content.