### PR TITLE
Refine editorial visual design

### DIFF
--- a/app/articles/[slug]/page.tsx
+++ b/app/articles/[slug]/page.tsx
@@ -112,7 +112,7 @@ export default async function ArticleMonographPage({ params }: PageProps) {
         ]}
       />
 
-      <header className="mt-6 rounded-[1rem] border-2 border-brand-900/15 bg-white p-6 shadow-md ring-1 ring-brand-900/5 sm:p-8 lg:p-10">
+      <header className="mt-6 border-b border-brand-900/15 pb-8 pt-4 sm:pb-10 sm:pt-6">
         <div className="flex flex-wrap items-center gap-2 text-xs">
           <span className="rounded-full border border-brand-700/20 bg-brand-50 px-2.5 py-0.5 font-bold uppercase tracking-wider text-brand-800">
             {page.category}
@@ -129,7 +129,7 @@ export default async function ArticleMonographPage({ params }: PageProps) {
           <span className="text-muted">{typeof page.readingTime === 'number' ? `${page.readingTime} min read` : page.readingTime}</span>
         </div>
 
-        <h1 className="mt-4 font-display text-3xl font-bold leading-tight tracking-tight text-ink sm:text-4xl lg:text-5xl">
+        <h1 className="mt-4 max-w-[22ch] font-display text-2xl font-bold leading-[1.08] text-ink sm:text-4xl lg:text-5xl">
           {page.title}
         </h1>
 
@@ -181,7 +181,7 @@ export default async function ArticleMonographPage({ params }: PageProps) {
       </div>
 
       {page.references.length > 0 ? (
-        <section id="references" className="mt-8 scroll-mt-24 rounded-[0.9rem] border-2 border-brand-900/15 bg-white p-5 shadow-md ring-1 ring-brand-900/5">
+        <section id="references" className="mt-8 scroll-mt-24 border-t border-brand-900/15 py-8">
           <h2 className="text-lg font-bold text-ink">References</h2>
           <ol className="mt-4 list-decimal space-y-2 pl-5 text-sm leading-6 text-muted marker:font-semibold marker:text-brand-800">
             {page.references.map((ref, index) => (
@@ -204,14 +204,14 @@ export default async function ArticleMonographPage({ params }: PageProps) {
       ) : null}
 
       {relatedPages.length > 0 ? (
-        <section className="mt-8 rounded-[0.9rem] border-2 border-brand-900/15 bg-white p-5 shadow-md ring-1 ring-brand-900/5">
+        <section className="mt-8 border-t border-brand-900/15 py-8">
           <h2 className="text-lg font-bold text-ink">Related Articles</h2>
           <div className="mt-4 grid gap-3 sm:grid-cols-2">
             {relatedPages.map((relatedPage) => (
               <Link
                 key={relatedPage.slug}
                 href={relatedPage.url}
-                className="rounded-[0.75rem] border-2 border-brand-700/15 bg-brand-50/60 p-4 text-sm font-semibold leading-6 text-brand-800 shadow-sm hover:border-brand-700/30 hover:bg-brand-50 hover:shadow-md transition-all"
+                className="border-b border-brand-900/10 py-3 text-sm font-semibold leading-6 text-brand-800 transition hover:border-brand-700/30 hover:text-brand-700"
               >
                 {relatedPage.title}
               </Link>
@@ -220,7 +220,7 @@ export default async function ArticleMonographPage({ params }: PageProps) {
         </section>
       ) : null}
 
-      <footer className="mt-8 rounded-[0.9rem] border-2 border-amber-600/30 bg-amber-50 p-4 shadow-sm text-sm leading-6 text-[#5b4a2c]">
+      <footer className="mt-8 border-l-2 border-amber-600/50 bg-amber-50/50 px-4 py-3 text-sm leading-6 text-[#5b4a2c]">
         Educational disclaimer: this article is for evidence review and educational context only. It is not medical advice, legal advice, or a recommendation to use any substance discussed.
         <div className="mt-3 flex flex-wrap gap-4 font-semibold text-brand-800">
           <Link href="/articles/" className="hover:underline">All articles</Link>

--- a/app/globals.css
+++ b/app/globals.css
@@ -417,6 +417,7 @@ html.dark ::selection {
 
   .content-prose {
     @apply max-w-reading space-y-4 text-[1rem] leading-[1.72] text-[#36483e];
+    text-wrap: pretty;
   }
 
   .content-prose > * {
@@ -431,6 +432,11 @@ html.dark ::selection {
 
   .content-prose p {
     @apply max-w-reading leading-[1.74] text-[#36483e];
+  }
+
+  .content-prose p,
+  .content-prose li {
+    max-width: min(100%, 68ch);
   }
 
   .content-prose ul,
@@ -455,7 +461,8 @@ html.dark ::selection {
   }
 
   .content-prose table {
-    @apply w-full border-collapse text-left text-sm;
+    @apply w-full text-left text-sm;
+    border-collapse: separate;
     border-spacing: 0;
   }
 
@@ -464,12 +471,14 @@ html.dark ::selection {
   }
 
   .content-prose th {
-    @apply bg-brand-50/60 px-4 py-3 text-left text-xs font-bold uppercase tracking-[0.10em] text-brand-800 whitespace-nowrap;
+    @apply bg-brand-50/60 px-4 py-3 text-left text-xs font-bold uppercase tracking-[0.08em] text-brand-800;
     border-bottom: 2px solid rgba(30, 60, 40, 0.15);
+    vertical-align: bottom;
   }
 
   .content-prose td {
     @apply border-b border-brand-900/10 px-4 py-3 align-top leading-6 text-[#36483e];
+    min-width: 11rem;
   }
 
   .content-prose tbody tr:nth-child(even) {
@@ -493,6 +502,93 @@ html.dark ::selection {
 
   .content-prose .article-table {
     @apply my-6 max-w-full bg-[var(--surface-card)];
+  }
+
+  .article-card-flow {
+    @apply space-y-0;
+  }
+
+  .article-section-card {
+    @apply my-0 max-w-none border-t border-brand-900/15 py-8 sm:py-10;
+  }
+
+  .article-section-card > h2:first-child {
+    @apply mb-4 max-w-[22ch] font-display text-[1.75rem] leading-tight text-ink;
+  }
+
+  .article-section-card > h2 + p,
+  .article-intro-card > p:first-child {
+    @apply text-[1.02rem] leading-8 text-[#2f4137];
+  }
+
+  .article-section-card > ul,
+  .article-section-card > ol {
+    @apply py-1 pl-5;
+  }
+
+  .article-section-card > ul li,
+  .article-section-card > ol li {
+    @apply pl-1;
+  }
+
+  .article-caution-block {
+    @apply my-5 overflow-hidden border-l-2 border-amber-600/60 bg-amber-50/40;
+  }
+
+  .responsive-table-shell {
+    @apply my-7 max-w-full overflow-hidden border-y border-brand-900/15 bg-transparent;
+  }
+
+  .responsive-table-title {
+    @apply border-b border-brand-900/10 px-4 py-3 font-display text-sm font-semibold text-ink;
+  }
+
+  .accessible-table-region {
+    @apply max-w-full overflow-x-auto bg-white;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(31, 77, 41, 0.38) transparent;
+  }
+
+  .accessible-table-region:focus-visible {
+    outline: 2px solid var(--accent-primary);
+    outline-offset: -2px;
+  }
+
+  .accessible-table-region table {
+    border-collapse: separate;
+    border-spacing: 0;
+  }
+
+  .accessible-table-region th {
+    @apply bg-brand-50/50 px-4 py-3 text-left text-xs font-semibold text-ink;
+    vertical-align: bottom;
+  }
+
+  .accessible-table-region td {
+    @apply border-t border-brand-900/10 px-4 py-3 align-top text-sm leading-6 text-muted;
+    min-width: 11rem;
+  }
+
+  .accessible-table-region :is(th, td):first-child {
+    @apply sticky left-0 z-10 border-r border-brand-900/10 bg-[var(--bg)] font-semibold text-ink;
+    min-width: 12rem;
+  }
+
+  .accessible-table-region th:first-child {
+    @apply bg-brand-50/70;
+    z-index: 20;
+  }
+
+  .accessible-table-region tbody tr:nth-child(even) td {
+    background-color: rgba(243, 245, 238, 0.42);
+  }
+
+  .accessible-table-region tbody tr:nth-child(even) td:first-child {
+    background-color: #f8faf4;
+  }
+
+  .accessible-table-region tbody tr:hover td {
+    background-color: rgba(230, 240, 230, 0.55);
   }
 
   .detail-reading {
@@ -892,6 +988,55 @@ html.dark .content-prose tbody tr:nth-child(even) {
 
 html.dark .content-prose .article-table {
   background-color: var(--surface-card-strong);
+}
+
+html.dark :is(.article-section-card, .responsive-table-shell, .accessible-table-region) {
+  border-color: var(--border-soft);
+  background-color: transparent;
+}
+
+html.dark .article-section-card {
+  box-shadow: none;
+}
+
+html.dark .article-section-card > h2:first-child {
+  border-color: var(--border-soft);
+}
+
+html.dark .article-section-card > :is(ul, ol) {
+  background-color: transparent;
+}
+
+html.dark .article-caution-block {
+  border-color: rgba(196, 125, 46, 0.32);
+  background-color: var(--surface-warning);
+}
+
+html.dark .responsive-table-title,
+html.dark .accessible-table-region th,
+html.dark .accessible-table-region th:first-child {
+  background-color: rgba(168, 189, 169, 0.14);
+  color: var(--text-primary);
+}
+
+html.dark .accessible-table-region :is(th, td):first-child {
+  border-color: var(--border-soft);
+  background-color: var(--surface-card-strong);
+  color: var(--text-primary);
+}
+
+html.dark .accessible-table-region td {
+  border-color: var(--border-soft);
+  color: var(--text-muted);
+}
+
+html.dark .accessible-table-region tbody tr:nth-child(even) td,
+html.dark .accessible-table-region tbody tr:nth-child(even) td:first-child {
+  background-color: rgba(168, 189, 169, 0.07);
+}
+
+html.dark .accessible-table-region tbody tr:hover td {
+  background-color: rgba(168, 189, 169, 0.12);
 }
 
 html.dark :is(

--- a/components/articles/FocusAdhdArticlePage.tsx
+++ b/components/articles/FocusAdhdArticlePage.tsx
@@ -447,13 +447,13 @@ export default function FocusAdhdArticlePage({ slug, basePath = ADHD_GUIDE_BASE 
         <span className="line-clamp-1 text-ink">{article.title}</span>
       </nav>
 
-      <section className="rounded-[1.25rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+      <section className="border-b border-brand-900/15 pb-8 pt-4 sm:pb-10 sm:pt-6">
         <div className="flex flex-wrap items-center gap-2 text-xs">
           <span className="rounded-full border border-brand-900/10 bg-brand-50 px-2.5 py-0.5 font-bold uppercase tracking-wider text-brand-800">{article.category}</span>
           {article.tags.slice(0, 4).map((tag) => <span key={tag} className="rounded-full border border-brand-900/10 bg-white px-2.5 py-0.5 font-semibold text-muted">{tag}</span>)}
           <span className="text-muted">{article.readingTime}</span>
         </div>
-        <h1 className="mt-4 font-display text-3xl font-bold leading-tight tracking-tight text-ink sm:text-4xl lg:text-5xl">{article.title}</h1>
+        <h1 className="mt-4 max-w-[22ch] font-display text-2xl font-bold leading-[1.08] text-ink sm:text-4xl lg:text-5xl">{article.title}</h1>
         <div className="mt-3"><LastUpdatedBadge date={article.date} label="Last updated" /></div>
         <p className="mt-4 max-w-3xl text-base leading-7 text-muted">{article.description}</p>
 

--- a/components/content/ContentCards.tsx
+++ b/components/content/ContentCards.tsx
@@ -2,14 +2,14 @@
 
 import { useEffect, useRef, type ReactNode } from 'react'
 
-const CANONICAL_GROUPS: { label: string; patterns: string[]; color: string }[] = [
-  { label: 'Quick Facts', patterns: ['At a Glance', 'Quick Answer', 'Evidence Snapshot', 'TL;DR'], color: 'border-l-brand-800' },
-  { label: 'What to Expect', patterns: ['What to Expect', 'What .+ Feels Like', 'What .+ Actually', 'Timeline', 'Real Talk'], color: 'border-l-brand-700' },
-  { label: 'How to Use It', patterns: ['Dosage', 'Dosing', 'Practical Dosage', 'How to Take', 'Timing', 'Protocol', 'Stacking', 'How to Choose', 'Buying Guide', 'Product Selection', 'Extract Types', 'Forms'], color: 'border-l-sage-500' },
-  { label: 'The Evidence', patterns: ['Clinical Evidence', 'The Evidence', 'Study', 'Trial', 'Research'], color: 'border-l-brand-600' },
-  { label: 'How It Works', patterns: ['How It Works', 'Mechanism', 'Chemistry', 'Pharmacology', 'Active Compound'], color: 'border-l-brand-500' },
-  { label: 'Safety & Cautions', patterns: ['Safety', 'Contraindication', 'Side Effect', 'Drug Interaction', 'Liver Safety', 'Warning', 'Cautions'], color: 'border-l-amber-600' },
-  { label: 'FAQ', patterns: ['FAQ', 'Frequently Asked'], color: 'border-l-sage-400' },
+const CANONICAL_GROUPS: { patterns: string[] }[] = [
+  { patterns: ['At a Glance', 'Quick Answer', 'Evidence Snapshot', 'TL;DR'] },
+  { patterns: ['What to Expect', 'What .+ Feels Like', 'What .+ Actually', 'Timeline', 'Real Talk'] },
+  { patterns: ['Dosage', 'Dosing', 'Practical Dosage', 'How to Take', 'Timing', 'Protocol', 'Stacking', 'How to Choose', 'Buying Guide', 'Product Selection', 'Extract Types', 'Forms'] },
+  { patterns: ['Clinical Evidence', 'The Evidence', 'Study', 'Trial', 'Research'] },
+  { patterns: ['How It Works', 'Mechanism', 'Chemistry', 'Pharmacology', 'Active Compound'] },
+  { patterns: ['Safety', 'Contraindication', 'Side Effect', 'Drug Interaction', 'Liver Safety', 'Warning', 'Cautions'] },
+  { patterns: ['FAQ', 'Frequently Asked'] },
 ]
 
 function findGroup(title: string): (typeof CANONICAL_GROUPS)[number] | null {
@@ -32,7 +32,7 @@ function wrapInDetails(
   open = false
 ) {
   const details = document.createElement('details')
-  details.className = 'my-4 rounded-lg border-2 border-amber-600/30 bg-amber-50/60 overflow-hidden group'
+  details.className = 'article-caution-block group'
   if (open) details.setAttribute('open', '')
 
   const summary = document.createElement('summary')
@@ -41,7 +41,7 @@ function wrapInDetails(
   const icon = document.createElement('span')
   icon.className = 'text-xs mr-1'
   icon.setAttribute('aria-hidden', 'true')
-  icon.textContent = '⚠️'
+  icon.textContent = '!'
 
   const label = document.createElement('span')
   label.textContent = title
@@ -65,7 +65,7 @@ function wrapInDetails(
   details.appendChild(summary)
 
   const content = document.createElement('div')
-  content.className = 'px-4 pb-4 pt-2 text-sm leading-6 text-amber-900/80 border-t border-amber-600/20'
+  content.className = 'border-t border-amber-600/20 px-4 pb-4 pt-2 text-sm leading-6 text-amber-900/80'
 
   const parent = startEl.parentNode
   if (!parent) return
@@ -151,17 +151,7 @@ export default function ContentCards({ children }: { children: ReactNode }) {
     plan.forEach((entry) => {
       if (entry.h2s.length === 0) return
       const wrapper = document.createElement('section')
-      const isMulti = entry.h2s.length > 1
-      const color = entry.group?.color || 'border-l-brand-500'
-      
-      wrapper.className = `my-6 rounded-xl border-2 border-brand-900/12 bg-white p-5 shadow-sm ring-1 ring-brand-900/5 border-l-4 ${color}`
-      
-      if (entry.group && isMulti) {
-        const label = document.createElement('div')
-        label.className = 'text-xs font-bold uppercase tracking-wider text-brand-600 mb-3 pb-2 border-b border-brand-900/10'
-        label.textContent = entry.group.label
-        wrapper.appendChild(label)
-      }
+      wrapper.className = 'article-section-card'
       
       const firstH2 = entry.h2s[0]
       const lastH2 = entry.h2s[entry.h2s.length - 1]
@@ -196,7 +186,7 @@ export default function ContentCards({ children }: { children: ReactNode }) {
     const firstSection = ref.current.querySelector('section')
     if (firstSection) {
       const introCard = document.createElement('section')
-      introCard.className = 'my-6 rounded-xl border-2 border-brand-900/12 bg-white p-5 shadow-sm ring-1 ring-brand-900/5 border-l-4 border-l-brand-800'
+      introCard.className = 'article-section-card article-intro-card'
       let el = ref.current.firstElementChild
       while (el && el !== firstSection) {
         const next = el.nextElementSibling
@@ -208,7 +198,7 @@ export default function ContentCards({ children }: { children: ReactNode }) {
   }, [])
 
   return (
-    <div ref={ref} className="content-prose max-w-none [&>*]:max-w-reading [&_a]:font-semibold [&_a]:text-brand-800 [&_a:hover]:underline [&_blockquote]:max-w-reading [&_blockquote]:rounded-r-lg [&_blockquote]:border-l-4 [&_blockquote]:border-brand-700/40 [&_blockquote]:bg-brand-50/60 [&_blockquote]:py-3 [&_blockquote]:pl-5 [&_blockquote]:pr-4 [&_code]:break-all [&_h2]:mt-0 [&_h2]:text-2xl [&_table]:w-full [&_table]:text-sm [&_td]:border-t [&_td]:border-brand-900/10 [&_td]:py-3 [&_td]:pr-4 [&_td]:align-top [&_td]:break-words [&_th]:border-b [&_th]:border-brand-900/10 [&_th]:pb-2 [&_th]:pr-4 [&_th]:text-left [&_ul]:list-disc">
+    <div ref={ref} className="content-prose article-card-flow max-w-none [&>*]:max-w-reading [&_a]:font-semibold [&_a]:text-brand-800 [&_a:hover]:underline [&_blockquote]:max-w-reading [&_blockquote]:rounded-r-lg [&_blockquote]:border-l-4 [&_blockquote]:border-brand-700/40 [&_blockquote]:bg-brand-50/60 [&_blockquote]:py-3 [&_blockquote]:pl-5 [&_blockquote]:pr-4 [&_code]:break-all [&_h2]:mt-0 [&_h2]:text-2xl [&_table]:w-full [&_table]:text-sm [&_td]:border-t [&_td]:border-brand-900/10 [&_td]:py-3 [&_td]:pr-4 [&_td]:align-top [&_td]:break-words [&_th]:border-b [&_th]:border-brand-900/10 [&_th]:pb-2 [&_th]:pr-4 [&_th]:text-left [&_ul]:list-disc">
       {children}
     </div>
   )

--- a/components/ui/ResponsiveTable.tsx
+++ b/components/ui/ResponsiveTable.tsx
@@ -19,19 +19,27 @@ export default function ResponsiveTable({
   hint = 'This table scrolls horizontally on small screens. Use Tab to focus the table region, then scroll with arrow keys or touch.',
 }: ResponsiveTableProps) {
   const hintId = `${slugifyLabel(label)}-scroll-hint`
+  const showTitle = !/^article table$/i.test(label.trim())
 
   return (
-    <div
-      role="region"
-      aria-label={label}
-      aria-describedby={hintId}
-      tabIndex={0}
-      className={`accessible-table-region overflow-x-auto rounded-xl border border-brand-900/10 bg-white shadow-sm dark:border-[var(--border-soft)] dark:bg-[var(--surface-card-strong)] ${className}`}
-    >
-      <p id={hintId} className="sr-only">
-        {hint}
-      </p>
-      {children}
+    <div className={`responsive-table-shell ${className}`}>
+      {showTitle ? (
+        <div className="responsive-table-title" aria-hidden="true">
+          {label}
+        </div>
+      ) : null}
+      <div
+        role="region"
+        aria-label={label}
+        aria-describedby={hintId}
+        tabIndex={0}
+        className="accessible-table-region"
+      >
+        <p id={hintId} className="sr-only">
+          {hint}
+        </p>
+        {children}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- replace repetitive article cards with a quieter editorial section rhythm
- improve responsive tables and caution treatments
- tighten article hero typography and simplify references, related links, and disclaimers

## Impact
Long-form pages now feel more publication-like and less templated, with improved mobile headline sizing and more readable reference tables. Routes and content data are unchanged.

## Validation
- npm run typecheck
- npm run lint
- npm run build
- desktop and mobile browser checks