### PR TITLE
Clean up mobile visual design

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1163,6 +1163,39 @@ html.dark :is(
   color: var(--text-primary);
 }
 
+.safety-disclaimer {
+  color: #5b3a12;
+}
+
+html.dark .safety-disclaimer {
+  border-color: rgba(245, 190, 85, 0.55);
+  background: rgba(89, 55, 14, 0.28);
+}
+
+html.dark .safety-disclaimer,
+html.dark .safety-disclaimer * {
+  color: #fff1cf !important;
+}
+
+@media (max-width: 767px) {
+  .profile-hero {
+    border-left: 0;
+    border-right: 0;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  .profile-quick-stats > div {
+    border-left: 0;
+    border-right: 0;
+    border-radius: 0;
+    background: transparent;
+  }
+}
+
 html.dark :is(
   [class~="text-red-700/80"],
   [class~="text-red-950"],

--- a/app/guides/page.tsx
+++ b/app/guides/page.tsx
@@ -84,18 +84,18 @@ export default function GuidesHub() {
         </p>
       </header>
 
-      <div className="grid gap-8 md:grid-cols-2">
+      <div className="grid gap-0 border-y border-brand-900/10 md:grid-cols-2 md:gap-6 md:border-0">
         {SECTIONS.map((section) => (
           <Link
             key={section.href}
             href={section.href}
-            className={`rounded-2xl border border-brand-900/10 bg-white p-6 transition hover:shadow-md hover:border-brand-700/20 ${section.color} border-l-4`}
+            className="border-b border-brand-900/10 py-6 transition hover:bg-brand-50/30 md:rounded-lg md:border md:bg-white md:p-6 md:hover:border-brand-700/20"
           >
             <h2 className="text-xl font-bold text-ink">{section.title}</h2>
             <p className="mt-2 text-sm text-muted leading-relaxed">{section.desc}</p>
             <div className="mt-4 flex flex-wrap gap-1.5">
               {section.articles.map((a) => (
-                <span key={a} className="rounded-full bg-brand-50 px-2.5 py-0.5 text-xs text-brand-700 font-medium">{a}</span>
+                <span key={a} className="border-b border-brand-900/10 px-0.5 py-1 text-xs font-medium text-brand-700 md:rounded-full md:border-0 md:bg-brand-50 md:px-2.5 md:py-0.5">{a}</span>
               ))}
             </div>
           </Link>

--- a/app/herbs/HerbsIndexClient.tsx
+++ b/app/herbs/HerbsIndexClient.tsx
@@ -238,15 +238,6 @@ function buildEvidenceHref(evidenceValue: string, query: string, context: string
   return suffix ? `/herbs?${suffix}` : '/herbs'
 }
 
-function StatCard({ value, label }: { value: number; label: string }) {
-  return (
-    <div className="min-w-0 rounded-[0.8rem] border border-brand-900/10 bg-[var(--surface-card)] p-2.5 shadow-sm sm:p-3">
-      <p className="text-xl font-semibold tracking-tight text-ink sm:text-2xl">{value}</p>
-      <p className="mt-0.5 text-[0.62rem] font-bold uppercase leading-snug tracking-[0.1em] text-[var(--text-muted)]">{label}</p>
-    </div>
-  )
-}
-
 // Unused local empty state
 export function EmptyLibraryState() {
   return (
@@ -339,47 +330,12 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
     ? `Showing ${showingFrom}–${showingTo} of ${totalProfiles}`
     : `${totalProfiles}`
 
-  const readyProfiles = baseHerbs.filter((herb: RuntimeRecord) =>
-    /complete|strong|high|ready/i.test(
-      text(herb.profile_status || herb.summary_quality || herb.safety?.confidence)
-    )
-  ).length
-
-  const evidenceForward = baseHerbs.filter((herb: RuntimeRecord) =>
-    /human|clinical|strong|high/i.test(
-      text(herb.evidence_tier || herb.evidence_grade || herb.evidenceLevel)
-    )
-  ).length
-
   const featuredHerbs = hasActiveFilters || paginated ? [] : baseHerbs.slice(0, 6)
   const libraryHerbs = hasActiveFilters ? visibleHerbs : paginated ? herbs : baseHerbs.slice(featuredHerbs.length)
 
   return (
     <div className="px-2 pb-28 pt-2 text-ink sm:px-3 sm:pt-3">
       <div className="mx-auto max-w-7xl space-y-3 sm:space-y-4">
-        <section className="hero-shell relative overflow-hidden rounded-[0.95rem] border border-brand-900/10 px-3 py-4 shadow-sm sm:px-4 sm:py-5">
-          <div className="relative grid gap-3 lg:grid-cols-[1.05fr_.95fr] lg:items-end">
-            <div className="max-w-3xl space-y-2">
-              <p className="eyebrow-label">Botanical research library</p>
-              <h2 className="max-w-[18ch] text-balance font-display text-2xl font-semibold leading-[1.08] tracking-tight text-ink sm:text-4xl">
-                Herbal research library
-              </h2>
-              <p className="max-w-2xl text-sm leading-6 text-muted">
-                Scan by practical context first, then compare evidence, timing, and caution notes where source data supports them.
-              </p>
-            </div>
-
-            <div className="rounded-[0.8rem] border border-brand-900/10 bg-[var(--surface-card)] p-2.5 shadow-sm">
-              <p className="text-xs font-bold uppercase tracking-[0.16em] text-brand-800">Library signal</p>
-              <div className="mt-2 grid grid-cols-3 gap-2">
-                <StatCard value={totalProfiles} label="Profiles" />
-                <StatCard value={evidenceForward} label="Evidence-led" />
-                <StatCard value={readyProfiles || 12} label="Safety expanding" />
-              </div>
-            </div>
-          </div>
-        </section>
-
         <section className="rounded-[0.85rem] border border-brand-900/10 bg-[var(--surface-card)] p-3 shadow-sm sm:p-4" aria-labelledby="herb-search-heading">
           <div className="flex flex-col gap-1.5 sm:flex-row sm:items-end sm:justify-between">
             <div className="max-w-2xl space-y-1">
@@ -411,8 +367,7 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
           <details className="mt-3 group" open={hasActiveFilters}>
             <summary className="flex min-h-11 cursor-pointer list-none items-center justify-between rounded-full border border-brand-900/10 px-4 py-2 text-sm font-bold text-ink/80 transition hover:bg-[var(--surface-card-strong)] [&::-webkit-details-marker]:hidden">
               <span>Advanced filters</span>
-              <span className="text-xs text-muted group-open:hidden">Open</span>
-              <span className="hidden text-xs text-muted group-open:inline">Close</span>
+              <span className="text-xs text-muted">Options</span>
             </summary>
 
             <div className="mt-3 space-y-3 border-t border-brand-900/10 pt-3">

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -563,7 +563,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
       </nav>
 
       {/* Title Header — includes the quick-stat strip so the essentials fit in one screen */}
-      <div id="overview" className="hero-shell scroll-mt-24 rounded-[2rem] border border-brand-900/10 p-5 shadow-sm sm:p-6">
+      <div id="overview" className="profile-hero hero-shell scroll-mt-24 rounded-[2rem] border border-brand-900/10 p-5 shadow-sm sm:p-6">
         <header className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_260px] lg:items-start">
           <div className="space-y-3">
             <div className="space-y-1">
@@ -601,7 +601,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
             </div>
 
             {/* Quick stats strip */}
-            <dl className="grid gap-2 sm:grid-cols-3">
+            <dl className="profile-quick-stats grid gap-2 sm:grid-cols-3">
               <div className="rounded-xl border border-brand-900/10 bg-[var(--surface-card)] px-3 py-2">
                 <dt className="text-[10px] font-bold uppercase tracking-wider text-muted">Evidence</dt>
                 <dd className="mt-0.5 text-sm font-semibold text-ink">{evidenceStrength || 'Mixed or uncertain'}</dd>

--- a/app/herbs/page.tsx
+++ b/app/herbs/page.tsx
@@ -65,9 +65,9 @@ export default async function HerbsPage() {
         </p>
       </div>
 
-      <nav className="rounded-[0.8rem] border border-brand-900/10 bg-white/80 p-3 text-sm" aria-label="Herb pagination">
+      <nav className="flex items-center gap-3 border-y border-brand-900/10 py-3 text-sm" aria-label="Herb pagination">
         <p className="font-semibold">Page 1 of {pageData.totalPages}</p>
-        {pageData.hasNext ? <Link rel="next" href="/herbs/page/2">Next page →</Link> : null}
+        {pageData.hasNext ? <Link rel="next" href="/herbs/page/2" className="font-semibold text-brand-800">Next page →</Link> : null}
       </nav>
 
       <nav aria-label="Herb profiles index" className="sr-only">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,7 +17,6 @@ import { buildPageMetadata, DEFAULT_DESCRIPTION, SITE_URL, websiteJsonLd, organi
 import { serializeJsonLd } from '../src/lib/schema-injector'
 import { DEFAULT_LOCALE, DEFAULT_OG_LOCALE, LOCALE_TEXT_DIRECTION } from '../src/lib/international-seo'
 import { DarkModeProvider } from '@/lib/dark-mode-provider'
-import DarkModeToggle from '@/components/DarkModeToggle'
 import './globals.css'
 import '@/styles/foundation-readability.css'
 import '@/styles/premium-library-polish.css'
@@ -102,7 +101,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             <main
               id='main-content'
               data-pagefind-body
-              className='pb-[calc(env(safe-area-inset-bottom)+9rem)] md:pb-8'
+              className='pb-[calc(env(safe-area-inset-bottom)+6rem)] md:pb-8'
               tabIndex={-1}
             >
               <GlobalTOC />
@@ -114,9 +113,6 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             <CitationDrawerLazy />
             <ClickTracker />
             <ConsentBanner />
-            <div className='fixed bottom-[6.75rem] right-4 z-[86] md:hidden'>
-              <DarkModeToggle />
-            </div>
           </div>
         </DarkModeProvider>
       </body>

--- a/components/AuthorCredentials.tsx
+++ b/components/AuthorCredentials.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 
 export default function AuthorCredentials() {
   return (
-    <section className="rounded-[1.25rem] border border-brand-700/15 bg-gradient-to-br from-brand-50/60 to-white/90 p-4 shadow-sm dark:border-[var(--border-strong)] dark:from-[var(--surface-card)] dark:to-[var(--surface-card-strong)]">
+    <section className="border-y border-brand-700/15 py-5">
       <div className="relative flex flex-col gap-2 pl-4 before:absolute before:inset-y-0 before:left-0 before:w-[3px] before:rounded-full before:bg-brand-700/30 sm:flex-row sm:items-center sm:justify-between dark:before:bg-[var(--accent-teal)]/40">
         <div>
           <h3 className="text-xs font-bold uppercase tracking-[0.16em] text-brand-700">

--- a/components/NewsletterSignup.tsx
+++ b/components/NewsletterSignup.tsx
@@ -16,8 +16,8 @@ type NewsletterSignupProps = {
 }
 
 const variantClasses: Record<NonNullable<NewsletterSignupProps['variant']>, string> = {
-  card: 'rounded-[1.5rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8',
-  inline: 'rounded-[1.25rem] border border-brand-900/10 bg-white/85 p-5',
+  card: 'border-y border-brand-900/10 bg-white/60 px-4 py-6 sm:rounded-[1.5rem] sm:border sm:p-8',
+  inline: 'border-y border-brand-900/10 bg-white/60 px-4 py-5 sm:rounded-[1.25rem] sm:border sm:p-5',
   footer: 'rounded-xl border border-white/10 bg-white/5 p-4',
   compact: 'rounded-2xl border border-emerald-800/15 bg-emerald-50/80 p-4',
 }
@@ -89,7 +89,7 @@ export default function NewsletterSignup({
           <p className={`text-xs font-bold uppercase tracking-[0.18em] ${isFooter ? 'text-emerald-300' : 'text-brand-700'}`}>
             Free safety checklist
           </p>
-          <h2 className={`mt-2 text-xl font-semibold ${textColor} sm:text-2xl`}>{title}</h2>
+          <h2 className={`mt-2 text-lg font-semibold leading-tight ${textColor} sm:text-2xl`}>{title}</h2>
           <p className={`mt-3 text-sm leading-7 ${mutedColor}`}>{description}</p>
           <p className={`mt-2 text-xs leading-5 ${mutedColor}`}>
             {safetyChecklistLeadMagnet.privacyNote}{' '}

--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -116,8 +116,8 @@ export default function HomepageV2() {
 
   return (
     <div className='editorial-site-shell'>
-      <div className='relative mx-auto max-w-6xl space-y-8 px-4 pb-16 pt-4 sm:space-y-12 sm:px-6 sm:pb-20 sm:pt-8 lg:px-8'>
-        <section className='editorial-hero px-6 pb-0 pt-9 sm:px-10 sm:pt-12 lg:px-14 lg:pt-16'>
+      <div className='relative mx-auto max-w-6xl space-y-6 px-4 pb-16 pt-4 sm:space-y-12 sm:px-6 sm:pb-20 sm:pt-8 lg:px-8'>
+        <section className='editorial-hero px-5 pb-0 pt-8 sm:px-10 sm:pt-12 lg:px-14 lg:pt-16'>
           <div className='editorial-botanical-orbit' aria-hidden='true'>
             <span />
             <span />
@@ -127,7 +127,7 @@ export default function HomepageV2() {
 
           <div className='relative max-w-3xl pb-10 sm:pb-12 lg:pb-14'>
             <p className='editorial-eyebrow'>Evidence-based supplement guidance</p>
-            <h1 className='editorial-display mt-4 max-w-[11ch] text-[3.25rem] sm:text-[4.6rem] lg:text-[5.6rem]'>
+            <h1 className='editorial-display mt-4 max-w-[12ch] text-[2.55rem] sm:text-[4.6rem] lg:text-[5.6rem]'>
               Herbs &amp; supplements, actually explained.
             </h1>
             <p className='mt-5 max-w-xl text-base leading-7 text-[#33433c] sm:mt-6 sm:text-lg sm:leading-8 dark:text-[var(--text-secondary)]'>
@@ -148,7 +148,7 @@ export default function HomepageV2() {
             </div>
           </div>
 
-          <div className='editorial-trust-strip -mx-6 grid grid-cols-1 gap-3 px-6 py-4 sm:-mx-10 sm:grid-cols-3 sm:px-10 lg:-mx-14 lg:px-14'>
+          <div className='editorial-trust-strip -mx-5 grid grid-cols-1 gap-2 px-5 py-4 sm:-mx-10 sm:grid-cols-3 sm:px-10 lg:-mx-14 lg:px-14'>
             {trustItems.map((item) => {
               const Icon = item.icon
               return (
@@ -167,7 +167,7 @@ export default function HomepageV2() {
         </section>
 
         <section className='grid gap-5 lg:grid-cols-[1.15fr_0.85fr]'>
-          <div className='editorial-card-strong rounded-[2rem] p-6 sm:p-8'>
+          <div className='editorial-card-strong border-x-0 p-5 sm:rounded-[2rem] sm:border-x sm:p-8'>
             <p className='editorial-eyebrow'>Smarter choices</p>
             <div className='mt-3 flex items-start justify-between gap-4'>
               <SectionHeader
@@ -195,7 +195,7 @@ export default function HomepageV2() {
             </Link>
           </div>
 
-          <div className='editorial-card rounded-[2rem] p-6 sm:p-8'>
+          <div className='editorial-card border-x-0 p-5 sm:rounded-[2rem] sm:border-x sm:p-8'>
             <p className='editorial-eyebrow'>Safety first</p>
             <SectionHeader
               title='Use the safety tools'
@@ -221,7 +221,7 @@ export default function HomepageV2() {
           </div>
         </section>
 
-        <section id='choose-a-path' className='editorial-card rounded-[2rem] p-6 scroll-mt-24 sm:p-8'>
+        <section id='choose-a-path' className='editorial-card border-x-0 p-5 scroll-mt-24 sm:rounded-[2rem] sm:border-x sm:p-8'>
           <div className='flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between'>
             <SectionHeader
               title='Choose one path'

--- a/src/components/Disclaimer.tsx
+++ b/src/components/Disclaimer.tsx
@@ -7,18 +7,18 @@ type DisclaimerProps = {
 export default function Disclaimer({ className = '' }: DisclaimerProps) {
   return (
     <section
-      className={`rounded-2xl border border-amber-600/25 bg-amber-50/80 p-4 text-sm text-amber-950 shadow-sm dark:border-amber-200/25 dark:bg-amber-300/10 dark:text-amber-50 ${className}`.trim()}
+      className={`safety-disclaimer border-l-2 border-amber-600/50 bg-amber-50/70 px-4 py-3 text-sm ${className}`.trim()}
       aria-label='Safety disclaimer'
     >
-      <p className='font-semibold uppercase tracking-wide text-amber-900 dark:text-amber-100'>Safety first · Harm reduction</p>
-      <p className='mt-2 text-amber-950/90 dark:text-amber-50/90'>
+      <p className='font-semibold uppercase tracking-wide'>Safety first · Harm reduction</p>
+      <p className='mt-2 opacity-90'>
         This information is educational and not medical advice. Start low, avoid risky combinations,
         and consult a licensed clinician before making health decisions—especially if you use
         medications, have diagnosed conditions, or are pregnant/breastfeeding.
       </p>
-      <p className='mt-2 text-amber-950/85 dark:text-amber-50/85'>
+      <p className='mt-2 opacity-90'>
         Learn how we evaluate confidence, safety, and intensity on the{' '}
-        <Link to='/info/methodology' className='font-semibold text-amber-950 underline decoration-dotted underline-offset-4 dark:text-amber-50'>
+        <Link to='/info/methodology' className='font-semibold underline decoration-dotted underline-offset-4'>
           methodology page
         </Link>
         .

--- a/src/components/ScrollToTopButton.tsx
+++ b/src/components/ScrollToTopButton.tsx
@@ -16,7 +16,7 @@ export default function ScrollToTopButton() {
     <button
       type="button"
       onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-      className={`fixed bottom-[9.25rem] right-4 z-[85] min-h-11 min-w-11 rounded-full border border-white/20 bg-violet-500/90 p-2.5 text-white shadow-lg backdrop-blur transition-all motion-safe:hover:scale-105 md:bottom-8 md:right-6 md:flex ${visible ? 'opacity-100' : 'pointer-events-none opacity-0'}`}
+      className={`fixed bottom-[5.25rem] right-3 z-[85] min-h-10 min-w-10 rounded-full border border-brand-900/15 bg-[var(--surface-card-strong)] p-2 text-brand-800 shadow-sm backdrop-blur transition-all motion-safe:hover:scale-105 md:bottom-8 md:right-6 md:flex ${visible ? 'opacity-100' : 'pointer-events-none opacity-0'}`}
       aria-label='Scroll to top'
     >
       <ArrowUp aria-hidden="true" className="h-5 w-5" />

--- a/src/components/mobile-bottom-nav.tsx
+++ b/src/components/mobile-bottom-nav.tsx
@@ -23,9 +23,9 @@ export default function MobileBottomNav() {
   return (
     <nav
       aria-label='Primary mobile navigation'
-      className='editorial-mobile-dock mobile-bottom-nav fixed inset-x-3 bottom-[calc(env(safe-area-inset-bottom)+0.55rem)] z-[90] mx-auto max-w-[34rem] rounded-[1.75rem] md:hidden'
+      className='editorial-mobile-dock mobile-bottom-nav fixed inset-x-2 bottom-[calc(env(safe-area-inset-bottom)+0.35rem)] z-[90] mx-auto max-w-[34rem] rounded-2xl md:hidden'
     >
-      <div className='flex items-end gap-0.5 px-2 pb-2 pt-2'>
+      <div className='flex items-center gap-0.5 px-1.5 py-1.5'>
         {mobileBottomNavItems.map((item) => {
           const active = pathname === item.href || pathname.startsWith(`${item.href}/`)
           const isSearch = item.label === 'Search'
@@ -36,9 +36,7 @@ export default function MobileBottomNav() {
               key={item.href}
               href={toCanonicalHref(item.href)}
               aria-current={active ? 'page' : undefined}
-              className={`group relative flex min-h-[3.45rem] min-w-0 flex-1 flex-col items-center justify-end gap-1 rounded-2xl px-0.5 pb-1 text-center transition ${
-                isSearch ? 'pt-0' : 'pt-1.5'
-              } ${
+              className={`group relative flex min-h-[3rem] min-w-0 flex-1 flex-col items-center justify-center gap-0.5 rounded-xl px-0.5 text-center transition ${
                 active && !isSearch
                   ? 'text-[#123c2f] dark:text-[var(--text-primary)]'
                   : 'text-[#526159] hover:text-[#123c2f] dark:text-[var(--text-secondary)] dark:hover:text-[var(--text-primary)]'
@@ -47,13 +45,13 @@ export default function MobileBottomNav() {
               <span
                 className={`inline-flex items-center justify-center transition ${
                   isSearch
-                    ? 'editorial-mobile-search -mt-5 h-14 w-14 rounded-full'
+                    ? 'editorial-mobile-search h-8 w-10 rounded-full'
                     : active
                       ? 'h-7 w-9 rounded-full bg-[#dfe9dc] dark:bg-[rgba(255,255,255,0.09)]'
                       : 'h-7 w-9 rounded-full'
                 }`}
               >
-                <Icon aria-hidden='true' className={isSearch ? 'h-6 w-6' : 'h-5 w-5'} strokeWidth={active || isSearch ? 2.35 : 1.9} />
+                <Icon aria-hidden='true' className='h-5 w-5' strokeWidth={active || isSearch ? 2.2 : 1.8} />
               </span>
               <span className={`max-w-full whitespace-nowrap text-[0.69rem] leading-none ${active ? 'font-bold' : 'font-semibold'}`}>
                 {item.label}

--- a/styles/editorial-botanical-refresh.css
+++ b/styles/editorial-botanical-refresh.css
@@ -315,3 +315,26 @@ html:not(.dark) body {
   border-color: rgba(180, 210, 190, 0.14);
   background: rgba(29, 53, 43, 0.92);
 }
+
+.dark .editorial-trust-strip {
+  border-color: rgba(180, 210, 190, 0.14);
+  background: rgba(12, 27, 21, 0.72);
+}
+
+.dark .editorial-trust-strip .editorial-icon-disc {
+  background: rgba(238, 242, 233, 0.92);
+  color: #174837;
+}
+
+@media (max-width: 767px) {
+  .editorial-card,
+  .editorial-card-strong {
+    box-shadow: none;
+    backdrop-filter: none;
+  }
+
+  .editorial-link-tile:hover {
+    transform: none;
+    box-shadow: none;
+  }
+}


### PR DESCRIPTION
## Summary
- reduce mobile card density across the homepage, guides hub, herb index, and herb profiles
- compact the bottom navigation and reposition the scroll-to-top control
- fix dark-mode contrast for trust and safety surfaces
- remove duplicate herb-library framing and simplify shared editorial/signup blocks

## Impact
Mobile pages now expose more content above the dock, use a quieter editorial hierarchy, and avoid the stacked rounded-card appearance shown in the reported screenshots. Routes and content data are unchanged.

## Validation
- npm run typecheck
- npm run lint
- npm run build
- light and dark mobile browser checks at 390x844