### PR TITLE
Fix rendering test to match renamed herbs page heading

### DIFF
--- a/app/__tests__/rendering.test.tsx
+++ b/app/__tests__/rendering.test.tsx
@@ -58,7 +58,7 @@ describe('Rendering and Content Quality Tests', () => {
     )
     
     // The main title in the client component must be an h2, since the server page page.tsx renders the h1
-    const heading = screen.getByRole('heading', { name: /Herbal research library/i })
+    const heading = screen.getByRole('heading', { name: /Find an herb/i })
     expect(heading.tagName).toBe('H2')
   })
 


### PR DESCRIPTION
## Summary

- Fixes the CI `quality-gate` failure on `main`: the herbs index heading was renamed from "Herbal research library" to "Find an herb" in the mobile visual cleanup (#2193), but `app/__tests__/rendering.test.tsx` still queried the old heading text.
- Updates the test's heading query to `/Find an herb/i`; the assertion that the client component renders its title as an `h2` (server page owns the `h1`) is unchanged.

## Verification

- [x] `npm run lint`
- [x] full Vitest suite passes locally (88 files, 569 tests)
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs
- [x] no generated file corruption
- [x] static export compatible (test-only change)

## Risk Notes

- Test-only, one-line change; no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSAF7tS4ufPpRjdRaBexNk

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSAF7tS4ufPpRjdRaBexNk)_