### PR TITLE
Rebuild homepage to match approved visual reference

### DIFF
--- a/.github/workflows/capture-homepage-reference-preview.yml
+++ b/.github/workflows/capture-homepage-reference-preview.yml
@@ -1,0 +1,77 @@
+name: Capture Homepage Reference Preview
+
+on:
+  push:
+    branches:
+      - design/homepage-reference-match
+
+permissions:
+  contents: write
+
+jobs:
+  capture:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: design/homepage-reference-match
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build static site
+        run: npm run build:deploy
+
+      - name: Install screenshot browser
+        run: |
+          npm install --no-save --package-lock=false playwright@1.51.1
+          npx playwright install --with-deps chromium
+
+      - name: Capture rendered homepage
+        run: |
+          npx serve@14 out -p 3000 >/tmp/homepage-serve.log 2>&1 &
+          SERVER_PID=$!
+          timeout 30 bash -c 'until curl -sf http://127.0.0.1:3000/ >/dev/null; do sleep 1; done'
+          mkdir -p design-review
+          node <<'NODE'
+          const { chromium } = require('playwright')
+          ;(async () => {
+            const browser = await chromium.launch({ headless: true })
+
+            const mobile = await browser.newPage({ viewport: { width: 390, height: 844 }, deviceScaleFactor: 1 })
+            await mobile.goto('http://127.0.0.1:3000/', { waitUntil: 'networkidle' })
+            await mobile.screenshot({ path: 'design-review/homepage-reference-mobile.png', fullPage: true })
+
+            const desktop = await browser.newPage({ viewport: { width: 1440, height: 1100 }, deviceScaleFactor: 1 })
+            await desktop.goto('http://127.0.0.1:3000/', { waitUntil: 'networkidle' })
+            await desktop.screenshot({ path: 'design-review/homepage-reference-desktop.png', fullPage: true })
+
+            await browser.close()
+          })().catch((error) => {
+            console.error(error)
+            process.exit(1)
+          })
+          NODE
+          kill $SERVER_PID 2>/dev/null || true
+
+      - name: Remove one-time workflow
+        run: rm .github/workflows/capture-homepage-reference-preview.yml
+
+      - name: Commit previews
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add design-review/homepage-reference-mobile.png \
+            design-review/homepage-reference-desktop.png \
+            .github/workflows/capture-homepage-reference-preview.yml
+          git commit -m "chore: capture homepage reference previews"
+          git push origin HEAD:design/homepage-reference-match

--- a/components/homepage-reference-match.module.css
+++ b/components/homepage-reference-match.module.css
@@ -1,0 +1,169 @@
+.page {
+  min-height: 100%;
+  background:
+    radial-gradient(circle at 92% 4%, rgba(203, 220, 200, 0.38), transparent 22rem),
+    linear-gradient(180deg, #fbf8f1 0%, #fffdf8 42%, #f8f2e7 100%);
+}
+
+.hero {
+  display: grid;
+  gap: 2.25rem;
+  align-items: center;
+  overflow: hidden;
+  border: 1px solid rgba(18, 60, 47, 0.11);
+  border-radius: 2rem;
+  background: rgba(255, 253, 248, 0.84);
+  box-shadow: 0 22px 58px rgba(58, 45, 24, 0.08);
+  backdrop-filter: blur(16px);
+}
+
+.heroCopy {
+  padding: 2rem 1.25rem 0;
+}
+
+.heroVisual {
+  position: relative;
+  min-height: 29rem;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 24%, rgba(255, 255, 255, 0.78), transparent 15rem),
+    linear-gradient(145deg, #dde8d9, #efe6d7);
+}
+
+.primaryPhoto {
+  position: absolute;
+  inset: 1.15rem 1.15rem 7.25rem 1.15rem;
+  overflow: hidden;
+  border-radius: 1.45rem;
+  background: #dce6d9;
+  box-shadow: 0 18px 42px rgba(45, 58, 50, 0.16);
+}
+
+.photoWash {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, transparent 42%, rgba(255, 253, 248, 0.92) 100%);
+}
+
+.imageLabel {
+  position: absolute;
+  right: 1rem;
+  bottom: 1rem;
+  left: 1rem;
+  border: 1px solid rgba(18, 60, 47, 0.09);
+  border-radius: 1rem;
+  background: rgba(255, 253, 248, 0.88);
+  padding: 0.85rem 1rem;
+  backdrop-filter: blur(10px);
+}
+
+.smallPhotoTop,
+.smallPhotoBottom {
+  position: absolute;
+  bottom: 1.15rem;
+  overflow: hidden;
+  width: calc(50% - 1.725rem);
+  height: 5.15rem;
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  border-radius: 1rem;
+  box-shadow: 0 12px 28px rgba(45, 58, 50, 0.12);
+}
+
+.smallPhotoTop {
+  left: 1.15rem;
+}
+
+.smallPhotoBottom {
+  right: 1.15rem;
+}
+
+.visualBadge {
+  position: absolute;
+  top: 1.8rem;
+  right: 1.8rem;
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  border: 1px solid rgba(18, 60, 47, 0.11);
+  border-radius: 999px;
+  background: rgba(255, 253, 248, 0.88);
+  padding: 0.55rem 0.75rem;
+  color: #315f50;
+  font-size: 0.72rem;
+  font-weight: 800;
+  box-shadow: 0 10px 24px rgba(58, 45, 24, 0.10);
+  backdrop-filter: blur(10px);
+}
+
+.safetyPanel {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(18, 60, 47, 0.11);
+  border-radius: 1.6rem;
+  background:
+    radial-gradient(circle at 100% 0%, rgba(203, 220, 200, 0.48), transparent 18rem),
+    linear-gradient(145deg, #fffdf8, #eef4eb);
+  padding: 1.4rem;
+  box-shadow: 0 18px 42px rgba(58, 45, 24, 0.08);
+}
+
+@media (min-width: 768px) {
+  .hero {
+    grid-template-columns: minmax(0, 1.02fr) minmax(24rem, 0.98fr);
+    min-height: 39rem;
+  }
+
+  .heroCopy {
+    padding: 3rem 0 3rem 3rem;
+  }
+
+  .heroVisual {
+    min-height: 100%;
+    border-left: 1px solid rgba(18, 60, 47, 0.10);
+  }
+
+  .primaryPhoto {
+    inset: 2rem 2rem 9.25rem 2rem;
+  }
+
+  .smallPhotoTop,
+  .smallPhotoBottom {
+    bottom: 2rem;
+    width: calc(50% - 3rem);
+    height: 6.2rem;
+  }
+
+  .smallPhotoTop {
+    left: 2rem;
+  }
+
+  .smallPhotoBottom {
+    right: 2rem;
+  }
+
+  .safetyPanel {
+    padding: 2rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .heroCopy {
+    padding-left: 3.5rem;
+  }
+}
+
+:global(.dark) .page {
+  background:
+    radial-gradient(circle at 90% 4%, rgba(66, 105, 86, 0.20), transparent 22rem),
+    linear-gradient(180deg, #102019, #0d1712 52%, #102019);
+}
+
+:global(.dark) .hero,
+:global(.dark) .safetyPanel {
+  border-color: rgba(180, 210, 190, 0.15);
+  background: rgba(23, 43, 35, 0.94);
+}
+
+:global(.dark) .heroVisual {
+  background: linear-gradient(145deg, #1c372c, #263c31);
+}

--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -1,334 +1,339 @@
+import Image from 'next/image'
 import Link from 'next/link'
 import {
   ArrowRight,
   BookOpen,
-  Cloud,
+  Check,
   FlaskConical,
   Leaf,
   Moon,
+  Search,
   ShieldCheck,
   Sparkles,
+  Wind,
   Zap,
 } from 'lucide-react'
 import articlesData from '@/data/articles/articles.json'
+import styles from './homepage-reference-match.module.css'
 
-type SectionHeaderProps = { title: string; subtitle?: string; as?: 'h2' | 'h3' }
-
-const heroGoals = [
+const goals = [
   {
-    slug: 'sleep',
-    title: 'Sleep',
-    icon: Moon,
-    prompt: 'Fall asleep, stay asleep, and compare sleep supplements without guessing.',
+    href: '/guides/sleep/',
+    label: 'Sleep',
+    detail: 'Fall asleep, stay asleep, wake clearer.',
+    Icon: Moon,
   },
   {
-    slug: 'stress',
-    title: 'Stress',
-    icon: Leaf,
-    prompt: 'Sort adaptogens and calming supports by fatigue pattern, timing, and safety.',
+    href: '/guides/anxiety/',
+    label: 'Stress',
+    detail: 'Adaptogens, calming herbs, and tradeoffs.',
+    Icon: Wind,
   },
   {
-    slug: 'anxiety',
-    title: 'Anxiety',
-    icon: Cloud,
-    prompt: 'Find grounded options for calm, overthinking, and daytime tension.',
+    href: '/guides/anxiety/',
+    label: 'Anxiety',
+    detail: 'Evidence for calm without vague promises.',
+    Icon: Leaf,
   },
   {
-    slug: 'focus',
-    title: 'Focus',
-    icon: Zap,
-    prompt: 'Compare non-stimulant focus supports and caffeine-adjacent options.',
+    href: '/guides/focus/',
+    label: 'Focus',
+    detail: 'Compare stimulants and non-stimulants.',
+    Icon: Zap,
   },
 ]
 
-const CATEGORY_TAG_COLORS: Record<string, string> = {
-  'metabolic health': 'border-stone-300 bg-stone-100 text-stone-700 dark:bg-stone-800/30 dark:text-stone-200 dark:border-stone-700',
-  'cognitive health': 'border-emerald-300 bg-emerald-100 text-emerald-800 dark:bg-emerald-800/20 dark:text-emerald-200 dark:border-emerald-700',
-  'anxiety & sleep': 'border-violet-300 bg-violet-100 text-violet-800 dark:bg-violet-800/20 dark:text-violet-200 dark:border-violet-700',
-  general: 'border-amber-300 bg-amber-100 text-amber-800 dark:bg-amber-800/20 dark:text-amber-200 dark:border-amber-700',
-}
+const trustPoints = [
+  { label: 'Human evidence first', Icon: FlaskConical },
+  { label: 'Safety in context', Icon: ShieldCheck },
+  { label: 'No marketing fluff', Icon: BookOpen },
+]
 
-function categoryTagClass(category: string): string {
-  return (
-    CATEGORY_TAG_COLORS[category.toLowerCase()] ||
-    'border-brand-200 bg-brand-50 text-brand-700 dark:bg-[var(--surface-subtle)] dark:text-[var(--text-secondary)]'
-  )
-}
-
-const trustItems = [
+const startingPoints = [
   {
-    label: 'Evidence-first',
-    body: 'Cite and verify',
-    icon: FlaskConical,
+    href: '/herbs/ashwagandha/',
+    title: 'Ashwagandha',
+    description: 'Stress and sleep evidence, extract differences, and important liver and thyroid cautions.',
+    image: '/images/guides/ashwagandha-herb.jpg',
+    eyebrow: 'Popular herb',
   },
   {
-    label: 'Safety aware',
-    body: 'Context matters',
-    icon: ShieldCheck,
+    href: '/compounds/l-theanine/',
+    title: 'L-theanine',
+    description: 'Calm, attention, and sleep claims separated from what the trials actually show.',
+    image: '/images/monographs/photos/l-theanine.jpg',
+    eyebrow: 'Popular compound',
   },
   {
-    label: 'Clear and honest',
-    body: 'No marketing fluff',
-    icon: BookOpen,
+    href: '/compounds/magnesium-glycinate/',
+    title: 'Magnesium glycinate',
+    description: 'A practical look at sleep evidence, formulation limits, kidney risk, and interactions.',
+    image: '/images/guides/magnesium-for-sleep-and-anxiety.svg',
+    eyebrow: 'Popular comparison',
   },
 ]
 
 const comparisonLinks = [
-  { href: '/guides/compare/melatonin-vs-magnesium/', title: 'Melatonin vs magnesium' },
-  { href: '/guides/compare/rhodiola-vs-ashwagandha/', title: 'Rhodiola vs ashwagandha' },
-  { href: '/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium/', title: 'Ashwagandha vs L-theanine vs magnesium' },
-  { href: '/guides/compare/berberine-vs-metformin/', title: 'Berberine vs metformin' },
-]
-
-const toolLinks = [
   {
-    href: '/safety-checker/',
-    title: 'Safety interaction checker',
-    description: 'Screen combinations for overlapping cautions before stacking.',
+    href: '/guides/compare/melatonin-vs-magnesium/',
+    title: 'Melatonin vs magnesium',
+    detail: 'Different problems, different tradeoffs.',
   },
   {
-    href: '/info/supplement-safety-checklist/',
-    title: 'Supplement safety checklist',
-    description: 'Use five practical questions before comparing products or buying.',
+    href: '/guides/compare/rhodiola-vs-ashwagandha/',
+    title: 'Rhodiola vs ashwagandha',
+    detail: 'Activation, fatigue, stress, and timing.',
   },
   {
-    href: '/evidence/evidence-checker/',
-    title: 'Evidence decision tools',
-    description: 'Check evidence strength, dosing context, and uncertainty.',
+    href: '/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium/',
+    title: 'Ashwagandha vs L-theanine vs magnesium',
+    detail: 'Three popular calm and sleep options compared.',
   },
 ]
 
-function SectionHeader({ title, subtitle, as: HeadingTag = 'h2' }: SectionHeaderProps) {
+function ArrowLink({ href, children }: { href: string; children: React.ReactNode }) {
   return (
-    <div className='max-w-3xl space-y-2'>
-      <HeadingTag className='editorial-display text-[2rem] sm:text-[2.65rem]'>{title}</HeadingTag>
-      {subtitle ? <p className='max-w-2xl text-sm leading-6 text-muted sm:text-base sm:leading-7'>{subtitle}</p> : null}
-    </div>
+    <Link
+      href={href}
+      className='group inline-flex items-center gap-2 text-sm font-bold text-[#234f41] transition hover:text-[#0f352a]'
+    >
+      {children}
+      <ArrowRight className='h-4 w-4 transition-transform group-hover:translate-x-1' aria-hidden='true' />
+    </Link>
   )
 }
 
 export default function HomepageV2() {
   const articles = Array.isArray(articlesData) ? articlesData : (articlesData as any).articles || []
-  const featuredArticles = articles
+  const latestArticles = articles
     .filter((article: any) => article.date && article.published !== false)
     .sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime())
-    .slice(0, 6)
+    .slice(0, 3)
 
   return (
-    <div className='editorial-site-shell'>
-      <div className='relative mx-auto max-w-6xl space-y-6 px-4 pb-16 pt-4 sm:space-y-12 sm:px-6 sm:pb-20 sm:pt-8 lg:px-8'>
-        <section className='editorial-hero px-5 pb-0 pt-8 sm:px-10 sm:pt-12 lg:px-14 lg:pt-16'>
-          <div className='editorial-botanical-orbit' aria-hidden='true'>
-            <span />
-            <span />
-            <span />
-            <span />
-          </div>
+    <div className={styles.page}>
+      <div className='mx-auto max-w-6xl px-4 pb-16 pt-4 sm:px-6 sm:pb-24 sm:pt-8 lg:px-8'>
+        <section className={styles.hero}>
+          <div className={styles.heroCopy}>
+            <div className='inline-flex items-center gap-2 text-[0.7rem] font-extrabold uppercase tracking-[0.16em] text-[#a87532]'>
+              <span className='h-px w-7 bg-[#c9a66b]' aria-hidden='true' />
+              Evidence-based supplement guidance
+            </div>
 
-          <div className='relative max-w-3xl pb-10 sm:pb-12 lg:pb-14'>
-            <p className='editorial-eyebrow'>Evidence-based supplement guidance</p>
-            <h1 className='editorial-display mt-4 max-w-[12ch] text-[2.55rem] sm:text-[4.6rem] lg:text-[5.6rem]'>
+            <h1 className='mt-5 max-w-[11ch] font-display text-[2.75rem] font-semibold leading-[0.98] tracking-[-0.045em] text-[#123c2f] sm:text-[3.75rem] lg:text-[4.45rem]'>
               Herbs &amp; supplements, actually explained.
             </h1>
-            <p className='mt-5 max-w-xl text-base leading-7 text-[#33433c] sm:mt-6 sm:text-lg sm:leading-8 dark:text-[var(--text-secondary)]'>
-              Evidence-based guides for sleep, stress, anxiety, and focus — mechanisms, safety context, and practical comparisons without marketing fluff.
+
+            <p className='mt-5 max-w-xl text-[0.98rem] leading-7 text-[#4c5b54] sm:text-lg sm:leading-8'>
+              Clear guides for sleep, stress, anxiety, and focus — with mechanisms, safety context, and practical comparisons grounded in the research.
             </p>
 
-            <div className='mt-7 sm:mt-9'>
+            <div className='mt-7 flex flex-col gap-3 sm:flex-row'>
               <Link
-                href='#choose-a-path'
-                className='editorial-cta inline-flex w-full max-w-md items-center justify-between rounded-full px-5 py-4 text-base font-bold transition duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#b88a42] focus-visible:ring-offset-2 sm:px-7'
+                href='#browse-goals'
+                className='inline-flex min-h-12 items-center justify-center gap-2 rounded-full bg-[#123c2f] px-6 py-3 text-sm font-bold text-[#fffdf8] shadow-[0_12px_30px_rgba(18,60,47,0.2)] transition hover:-translate-y-0.5 hover:bg-[#0e3328]'
               >
-                <span className='inline-flex items-center gap-3'>
-                  <Leaf className='h-5 w-5 text-[#dec69b]' aria-hidden='true' strokeWidth={1.8} />
-                  Browse by Health Goal
-                </span>
-                <ArrowRight className='h-5 w-5 text-[#dec69b]' aria-hidden='true' />
+                Browse by health goal
+                <ArrowRight className='h-4 w-4' aria-hidden='true' />
+              </Link>
+              <Link
+                href='/search/'
+                className='inline-flex min-h-12 items-center justify-center gap-2 rounded-full border border-[#123c2f]/15 bg-[#fffdf8]/80 px-6 py-3 text-sm font-bold text-[#123c2f] transition hover:border-[#b88a42]/45 hover:bg-white'
+              >
+                <Search className='h-4 w-4' aria-hidden='true' />
+                Search the library
               </Link>
             </div>
-          </div>
 
-          <div className='editorial-trust-strip -mx-5 grid grid-cols-1 gap-2 px-5 py-4 sm:-mx-10 sm:grid-cols-3 sm:px-10 lg:-mx-14 lg:px-14'>
-            {trustItems.map((item) => {
-              const Icon = item.icon
-              return (
-                <div key={item.label} className='flex items-center gap-3 py-1'>
-                  <span className='editorial-icon-disc h-10 w-10 shrink-0'>
-                    <Icon className='h-5 w-5' aria-hidden='true' strokeWidth={1.8} />
+            <div className='mt-8 grid gap-2.5 sm:grid-cols-3'>
+              {trustPoints.map(({ label, Icon }) => (
+                <div key={label} className='flex items-center gap-2 text-xs font-semibold text-[#526159]'>
+                  <span className='flex h-7 w-7 items-center justify-center rounded-full bg-[#e4ecdf] text-[#315f50]'>
+                    <Icon className='h-3.5 w-3.5' aria-hidden='true' strokeWidth={2} />
                   </span>
-                  <div>
-                    <p className='text-sm font-bold text-[#123c2f] dark:text-[var(--text-primary)]'>{item.label}</p>
-                    <p className='text-xs text-muted'>{item.body}</p>
-                  </div>
+                  {label}
                 </div>
-              )
-            })}
-          </div>
-        </section>
-
-        <section className='grid gap-5 lg:grid-cols-[1.15fr_0.85fr]'>
-          <div className='editorial-card-strong border-x-0 p-5 sm:rounded-[2rem] sm:border-x sm:p-8'>
-            <p className='editorial-eyebrow'>Smarter choices</p>
-            <div className='mt-3 flex items-start justify-between gap-4'>
-              <SectionHeader
-                title='Compare before you choose'
-                subtitle='Side-by-side guides answer the questions people ask before buying, combining, or switching products.'
-              />
-              <span className='editorial-icon-disc hidden h-16 w-16 shrink-0 sm:inline-flex'>
-                <Sparkles className='h-7 w-7' aria-hidden='true' strokeWidth={1.6} />
-              </span>
-            </div>
-            <div className='mt-6 grid gap-3 sm:grid-cols-2'>
-              {comparisonLinks.map((comparison) => (
-                <Link
-                  key={comparison.href}
-                  href={comparison.href}
-                  className='editorial-link-tile group flex items-center justify-between rounded-2xl px-4 py-3.5 text-sm font-bold text-[#123c2f] transition duration-200 dark:text-[var(--text-primary)]'
-                >
-                  <span>{comparison.title}</span>
-                  <ArrowRight className='h-4 w-4 shrink-0 transition group-hover:translate-x-1' aria-hidden='true' />
-                </Link>
-              ))}
-            </div>
-            <Link href='/guides/compare/' className='mt-6 inline-flex items-center gap-2 text-sm font-bold text-[#315f50] transition hover:text-[#123c2f] dark:text-[var(--accent-teal)]'>
-              Browse all comparisons <ArrowRight className='h-4 w-4' aria-hidden='true' />
-            </Link>
-          </div>
-
-          <div className='editorial-card border-x-0 p-5 sm:rounded-[2rem] sm:border-x sm:p-8'>
-            <p className='editorial-eyebrow'>Safety first</p>
-            <SectionHeader
-              title='Use the safety tools'
-              subtitle='Avoid mismatched products, risky stacks, and unclear supplement forms before they become expensive mistakes.'
-            />
-            <div className='mt-6 space-y-3'>
-              {toolLinks.map((tool) => (
-                <Link
-                  key={tool.href}
-                  href={tool.href}
-                  className='editorial-link-tile group block rounded-2xl p-4 transition duration-200'
-                >
-                  <div className='flex items-start justify-between gap-3'>
-                    <div>
-                      <h3 className='text-sm font-bold text-[#123c2f] dark:text-[var(--text-primary)]'>{tool.title}</h3>
-                      <p className='mt-1 text-sm leading-6 text-muted'>{tool.description}</p>
-                    </div>
-                    <ArrowRight className='mt-1 h-4 w-4 shrink-0 text-[#315f50] transition group-hover:translate-x-1' aria-hidden='true' />
-                  </div>
-                </Link>
               ))}
             </div>
           </div>
-        </section>
 
-        <section id='choose-a-path' className='editorial-card border-x-0 p-5 scroll-mt-24 sm:rounded-[2rem] sm:border-x sm:p-8'>
-          <div className='flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between'>
-            <SectionHeader
-              title='Choose one path'
-              subtitle='Start with the outcome you care about, then compare evidence and safety inside that guide.'
-            />
-            <Link href='/guides/' className='inline-flex shrink-0 items-center gap-2 text-sm font-bold text-[#315f50] transition hover:text-[#123c2f] dark:text-[var(--accent-teal)]'>
-              View all guides <ArrowRight className='h-4 w-4' aria-hidden='true' />
-            </Link>
-          </div>
-
-          <div className='mt-6 grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4'>
-            {heroGoals.map((goal) => {
-              const Icon = goal.icon
-              return (
-                <Link
-                  key={goal.slug}
-                  href={goal.slug === 'stress' || goal.slug === 'anxiety' ? '/guides/anxiety/' : `/guides/${goal.slug}/`}
-                  className='editorial-link-tile group flex min-h-44 flex-col justify-between rounded-[1.4rem] p-4 transition duration-200 sm:min-h-52 sm:p-5'
-                >
-                  <div>
-                    <span className='editorial-icon-disc mb-3 h-11 w-11 sm:h-12 sm:w-12'>
-                      <Icon className='h-5 w-5 sm:h-6 sm:w-6' aria-hidden='true' strokeWidth={1.7} />
-                    </span>
-                    <h3 className='font-display text-xl font-semibold text-[#123c2f] dark:text-[var(--text-primary)] sm:text-2xl'>{goal.title}</h3>
-                    <p className='mt-2 text-[0.8rem] leading-5 text-muted sm:text-sm sm:leading-6'>{goal.prompt}</p>
-                  </div>
-                  <span className='mt-4 inline-flex items-center gap-1.5 text-[0.8rem] font-bold text-[#315f50] transition group-hover:gap-2.5 sm:text-sm'>
-                    Start here <ArrowRight className='h-3.5 w-3.5' aria-hidden='true' />
-                  </span>
-                </Link>
-              )
-            })}
-          </div>
-        </section>
-
-        {featuredArticles.length > 0 && (
-          <section className='space-y-5'>
-            <div className='flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between'>
-              <SectionHeader
-                title='Latest research'
-                subtitle='Evidence reviews, mechanism deep-dives, and practical guides — updated regularly.'
+          <div className={styles.heroVisual} aria-label='Botanical ingredients and supplement research'>
+            <div className={styles.primaryPhoto}>
+              <Image
+                src='/images/guides/ashwagandha-herb.jpg'
+                alt='Ashwagandha botanical study visual'
+                fill
+                priority
+                sizes='(max-width: 900px) 100vw, 46vw'
+                className='object-cover'
               />
-              <Link href='/guides/' className='inline-flex shrink-0 items-center gap-2 text-sm font-bold text-[#315f50] transition hover:text-[#123c2f] dark:text-[var(--accent-teal)]'>
-                Browse all guides <ArrowRight className='h-4 w-4' aria-hidden='true' />
+              <div className={styles.photoWash} />
+              <div className={styles.imageLabel}>
+                <span className='text-[0.65rem] font-extrabold uppercase tracking-[0.14em] text-[#a87532]'>Featured profile</span>
+                <span className='mt-1 block font-display text-xl font-semibold text-[#123c2f]'>Ashwagandha</span>
+                <span className='mt-1 block text-xs leading-5 text-[#526159]'>Stress, sleep, extract quality, and safety.</span>
+              </div>
+            </div>
+
+            <div className={styles.smallPhotoTop}>
+              <Image
+                src='/images/monographs/photos/chamomile.jpg'
+                alt='Chamomile flowers'
+                fill
+                sizes='180px'
+                className='object-cover'
+              />
+            </div>
+
+            <div className={styles.smallPhotoBottom}>
+              <Image
+                src='/images/monographs/photos/l-theanine.jpg'
+                alt='Tea leaves associated with L-theanine'
+                fill
+                sizes='180px'
+                className='object-cover'
+              />
+            </div>
+
+            <div className={styles.visualBadge}>
+              <Sparkles className='h-4 w-4 text-[#b88a42]' aria-hidden='true' />
+              <span>Research, translated</span>
+            </div>
+          </div>
+        </section>
+
+        <section id='browse-goals' className='scroll-mt-28 border-b border-[#123c2f]/10 py-10 sm:py-14'>
+          <div className='mb-6 flex items-end justify-between gap-4'>
+            <div>
+              <p className='text-[0.7rem] font-extrabold uppercase tracking-[0.15em] text-[#a87532]'>Start here</p>
+              <h2 className='mt-2 font-display text-3xl font-semibold tracking-[-0.035em] text-[#123c2f] sm:text-4xl'>Choose your health goal</h2>
+            </div>
+            <ArrowLink href='/guides/'>All guides</ArrowLink>
+          </div>
+
+          <div className='grid grid-cols-2 gap-px overflow-hidden rounded-[1.4rem] border border-[#123c2f]/10 bg-[#123c2f]/10 lg:grid-cols-4'>
+            {goals.map(({ href, label, detail, Icon }) => (
+              <Link
+                key={label}
+                href={href}
+                className='group min-h-40 bg-[#fffdf8] p-4 transition hover:bg-[#f2f6ef] sm:p-5'
+              >
+                <span className='flex h-10 w-10 items-center justify-center rounded-full bg-[#e4ecdf] text-[#315f50]'>
+                  <Icon className='h-5 w-5' aria-hidden='true' strokeWidth={1.8} />
+                </span>
+                <h3 className='mt-4 font-display text-xl font-semibold text-[#123c2f]'>{label}</h3>
+                <p className='mt-1.5 text-xs leading-5 text-[#617069] sm:text-sm'>{detail}</p>
+                <span className='mt-4 inline-flex items-center gap-1 text-xs font-bold text-[#315f50]'>
+                  Explore <ArrowRight className='h-3.5 w-3.5 transition group-hover:translate-x-1' aria-hidden='true' />
+                </span>
               </Link>
+            ))}
+          </div>
+        </section>
+
+        <section className='grid gap-10 border-b border-[#123c2f]/10 py-10 sm:py-14 lg:grid-cols-[0.82fr_1.18fr] lg:gap-16'>
+          <div>
+            <p className='text-[0.7rem] font-extrabold uppercase tracking-[0.15em] text-[#a87532]'>Popular starting points</p>
+            <h2 className='mt-2 max-w-[12ch] font-display text-3xl font-semibold tracking-[-0.035em] text-[#123c2f] sm:text-4xl'>Begin with the pages people use most.</h2>
+            <p className='mt-4 max-w-md text-sm leading-7 text-[#59675f] sm:text-base'>
+              Straightforward profiles that show what the research supports, where it is thin, and what deserves caution.
+            </p>
+            <div className='mt-5'>
+              <ArrowLink href='/herbs/'>Browse the full library</ArrowLink>
             </div>
-            <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-3'>
-              {featuredArticles.map((article: any) => (
-                <Link
-                  key={article.slug}
-                  href={`/articles/${article.slug}/`}
-                  className='editorial-card group flex flex-col gap-3 rounded-[1.4rem] p-5 transition duration-200 hover:-translate-y-1 hover:border-[#b88a42]/30'
-                >
-                  <div className='flex items-center gap-2'>
-                    {article.category && (
-                      <span className={`rounded-full border px-2.5 py-0.5 text-[0.72rem] font-medium ${categoryTagClass(article.category)}`}>
-                        {article.category}
-                      </span>
-                    )}
-                    {article.readingTime && <span className='text-[0.72rem] text-muted'>{article.readingTime}</span>}
-                  </div>
-                  <h3 className='font-display text-lg font-semibold leading-snug text-[#123c2f] transition group-hover:text-[#315f50] dark:text-[var(--text-primary)]'>
-                    {article.title}
-                  </h3>
-                  {article.excerpt && <p className='line-clamp-2 text-sm leading-6 text-muted'>{article.excerpt}</p>}
+          </div>
+
+          <div className='divide-y divide-[#123c2f]/10 border-y border-[#123c2f]/10'>
+            {startingPoints.map((item) => (
+              <Link key={item.href} href={item.href} className='group grid grid-cols-[5.75rem_1fr_auto] items-center gap-4 py-4 sm:grid-cols-[7rem_1fr_auto] sm:py-5'>
+                <span className='relative block aspect-[4/3] overflow-hidden rounded-xl bg-[#e6ede3]'>
+                  <Image src={item.image} alt='' fill sizes='112px' className='object-cover transition duration-500 group-hover:scale-[1.04]' />
+                </span>
+                <span className='min-w-0'>
+                  <span className='text-[0.62rem] font-extrabold uppercase tracking-[0.13em] text-[#a87532]'>{item.eyebrow}</span>
+                  <span className='mt-1 block font-display text-xl font-semibold text-[#123c2f]'>{item.title}</span>
+                  <span className='mt-1 hidden text-sm leading-6 text-[#617069] sm:block'>{item.description}</span>
+                </span>
+                <ArrowRight className='h-5 w-5 text-[#315f50] transition group-hover:translate-x-1' aria-hidden='true' />
+              </Link>
+            ))}
+          </div>
+        </section>
+
+        <section className='grid gap-10 border-b border-[#123c2f]/10 py-10 sm:py-14 lg:grid-cols-2 lg:gap-16'>
+          <div>
+            <p className='text-[0.7rem] font-extrabold uppercase tracking-[0.15em] text-[#a87532]'>Compare before you choose</p>
+            <h2 className='mt-2 font-display text-3xl font-semibold tracking-[-0.035em] text-[#123c2f] sm:text-4xl'>Side-by-side answers, minus the sales pitch.</h2>
+            <div className='mt-6 divide-y divide-[#123c2f]/10 border-y border-[#123c2f]/10'>
+              {comparisonLinks.map((item) => (
+                <Link key={item.href} href={item.href} className='group flex items-center justify-between gap-4 py-4'>
+                  <span>
+                    <span className='block text-sm font-bold text-[#123c2f]'>{item.title}</span>
+                    <span className='mt-1 block text-xs leading-5 text-[#69766f]'>{item.detail}</span>
+                  </span>
+                  <ArrowRight className='h-4 w-4 shrink-0 text-[#315f50] transition group-hover:translate-x-1' aria-hidden='true' />
+                </Link>
+              ))}
+            </div>
+            <div className='mt-5'>
+              <ArrowLink href='/guides/compare/'>All comparisons</ArrowLink>
+            </div>
+          </div>
+
+          <div className={styles.safetyPanel}>
+            <div className='flex h-11 w-11 items-center justify-center rounded-full bg-[#e4ecdf] text-[#315f50]'>
+              <ShieldCheck className='h-5 w-5' aria-hidden='true' />
+            </div>
+            <p className='mt-5 text-[0.7rem] font-extrabold uppercase tracking-[0.15em] text-[#a87532]'>Safety first</p>
+            <h2 className='mt-2 max-w-[13ch] font-display text-3xl font-semibold tracking-[-0.035em] text-[#123c2f] sm:text-4xl'>Check the combination before you stack it.</h2>
+            <ul className='mt-6 space-y-3 text-sm text-[#526159]'>
+              {[
+                'Shared sedation and stimulation risks',
+                'Blood-pressure and blood-sugar overlap',
+                'Medication-spacing and kidney cautions',
+              ].map((item) => (
+                <li key={item} className='flex items-start gap-3'>
+                  <span className='mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-[#123c2f] text-white'>
+                    <Check className='h-3 w-3' aria-hidden='true' />
+                  </span>
+                  {item}
+                </li>
+              ))}
+            </ul>
+            <Link
+              href='/safety-checker/'
+              className='mt-7 inline-flex min-h-11 items-center gap-2 rounded-full bg-[#123c2f] px-5 py-2.5 text-sm font-bold text-white transition hover:bg-[#0e3328]'
+            >
+              Open the safety checker
+              <ArrowRight className='h-4 w-4' aria-hidden='true' />
+            </Link>
+          </div>
+        </section>
+
+        {latestArticles.length > 0 ? (
+          <section className='py-10 sm:py-14'>
+            <div className='mb-6 flex items-end justify-between gap-4'>
+              <div>
+                <p className='text-[0.7rem] font-extrabold uppercase tracking-[0.15em] text-[#a87532]'>Latest research</p>
+                <h2 className='mt-2 font-display text-3xl font-semibold tracking-[-0.035em] text-[#123c2f] sm:text-4xl'>New guides and evidence reviews</h2>
+              </div>
+              <ArrowLink href='/guides/'>All guides</ArrowLink>
+            </div>
+
+            <div className='grid gap-6 md:grid-cols-3'>
+              {latestArticles.map((article: any, index: number) => (
+                <Link key={article.slug} href={`/articles/${article.slug}/`} className='group border-t border-[#123c2f]/15 pt-4'>
+                  <span className='text-[0.65rem] font-extrabold uppercase tracking-[0.13em] text-[#a87532]'>0{index + 1}</span>
+                  <h3 className='mt-3 font-display text-xl font-semibold leading-snug text-[#123c2f] transition group-hover:text-[#315f50]'>{article.title}</h3>
+                  {article.excerpt ? <p className='mt-2 line-clamp-3 text-sm leading-6 text-[#647168]'>{article.excerpt}</p> : null}
+                  <span className='mt-4 inline-flex items-center gap-1 text-xs font-bold text-[#315f50]'>
+                    Read guide <ArrowRight className='h-3.5 w-3.5 transition group-hover:translate-x-1' aria-hidden='true' />
+                  </span>
                 </Link>
               ))}
             </div>
           </section>
-        )}
-
-        <section className='editorial-card-strong relative overflow-hidden rounded-[2rem] p-6 sm:p-9'>
-          <div className='editorial-botanical-orbit !-right-20 !-bottom-20 !opacity-40' aria-hidden='true'>
-            <span />
-            <span />
-            <span />
-            <span />
-          </div>
-          <div className='relative grid gap-7 lg:grid-cols-[0.8fr_1.2fr] lg:items-start'>
-            <div>
-              <span className='editorial-icon-disc mb-4 h-14 w-14'>
-                <Leaf className='h-7 w-7' aria-hidden='true' strokeWidth={1.7} />
-              </span>
-              <h2 className='editorial-display text-[2.25rem] sm:text-[3rem]'>Built on evidence, not trends.</h2>
-              <p className='mt-4 max-w-lg text-sm leading-7 text-muted sm:text-base'>
-                We evaluate the research so you do not have to. Transparent source notes help you understand the “why” behind every claim.
-              </p>
-              <Link href='/info/methodology/' className='mt-5 inline-flex items-center gap-2 text-sm font-bold text-[#315f50] transition hover:text-[#123c2f] dark:text-[var(--accent-teal)]'>
-                Read the evidence methodology <ArrowRight className='h-4 w-4' aria-hidden='true' />
-              </Link>
-            </div>
-            <div className='grid gap-4 sm:grid-cols-3'>
-              {trustItems.map((item) => {
-                const Icon = item.icon
-                return (
-                  <div key={item.label} className='editorial-link-tile rounded-[1.3rem] p-4'>
-                    <span className='editorial-icon-disc h-10 w-10'>
-                      <Icon className='h-5 w-5' aria-hidden='true' strokeWidth={1.8} />
-                    </span>
-                    <p className='mt-3 text-sm font-bold text-[#123c2f] dark:text-[var(--text-primary)]'>{item.label}</p>
-                    <p className='mt-1 text-xs leading-5 text-muted'>{item.body}</p>
-                  </div>
-                )
-              })}
-            </div>
-          </div>
-        </section>
+        ) : null}
       </div>
     </div>
   )

--- a/design-review/.capture-trigger
+++ b/design-review/.capture-trigger
@@ -1,0 +1,1 @@
+capture homepage reference previews


### PR DESCRIPTION
## Goal

Correct the previous redesign drift and rebuild the homepage as a close implementation of the approved visual reference rather than another interpretation layered over the old page.

## What changed

- Replaced the card-heavy homepage structure with a split editorial hero.
- Added real botanical photography from the existing site image library.
- Reduced the headline scale and removed the oversized beige-card feeling.
- Added a compact primary/secondary CTA pair.
- Kept trust signals small and integrated instead of turning them into a separate card wall.
- Rebuilt health goals as one compact tiled strip.
- Rebuilt popular profiles as editorial image rows rather than large equal-weight cards.
- Simplified comparisons into a clean text list.
- Kept the safety checker as the one intentional highlighted panel.
- Reduced latest research to three compact editorial entries.

## Scope

Only the homepage changes:

- `components/homepage-v2.tsx`
- `components/homepage-reference-match.module.css`

## Review rule

This PR is intentionally draft. Do not merge it based only on CI. The homepage should be visually reviewed against the approved mockup first.