### PR TITLE
Fix dark footer override and polish mobile trust tiles

### DIFF
--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -317,12 +317,14 @@ export default function HomepageV2() {
               {trustItems.map((item) => {
                 const Icon = item.icon
                 return (
-                  <div key={item.label} className='editorial-link-tile rounded-[1.3rem] p-4'>
-                    <span className='editorial-icon-disc h-10 w-10'>
+                  <div key={item.label} className='editorial-link-tile flex items-center gap-3.5 rounded-[1.3rem] p-4 sm:block'>
+                    <span className='editorial-icon-disc h-10 w-10 shrink-0'>
                       <Icon className='h-5 w-5' aria-hidden='true' strokeWidth={1.8} />
                     </span>
-                    <p className='mt-3 text-sm font-bold text-[#123c2f] dark:text-[var(--text-primary)]'>{item.label}</p>
-                    <p className='mt-1 text-xs leading-5 text-muted'>{item.body}</p>
+                    <div>
+                      <p className='text-sm font-bold text-[#123c2f] sm:mt-3 dark:text-[var(--text-primary)]'>{item.label}</p>
+                      <p className='mt-0.5 text-xs leading-5 text-muted sm:mt-1'>{item.body}</p>
+                    </div>
                   </div>
                 )
               })}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -77,13 +77,13 @@ export default function Footer() {
             </p>
 
             <div className='mt-6 flex flex-wrap gap-2'>
-              <a href='https://twitter.com/HippieScientist' target='_blank' rel='noopener noreferrer' className='rounded-full border border-[#123c2f]/10 bg-[#fffdf8]/75 px-4 py-2 text-xs font-bold text-[#315f50] transition hover:border-[#b88a42]/35 hover:bg-[#fffdf8]'>
+              <a href='https://twitter.com/HippieScientist' target='_blank' rel='noopener noreferrer' className='rounded-full border border-[#123c2f]/10 bg-[#fffdf8]/75 px-4 py-2 text-xs font-bold text-[#315f50] transition hover:border-[#b88a42]/35 hover:bg-[#fffdf8] dark:border-white/10 dark:bg-white/5 dark:text-[#a9c6b3] dark:hover:border-[#dec69b]/30 dark:hover:bg-white/10 dark:hover:text-[#d9e8de]'>
                 Twitter
               </a>
-              <a href='https://www.instagram.com/thehippiescientist' target='_blank' rel='noopener noreferrer' className='rounded-full border border-[#123c2f]/10 bg-[#fffdf8]/75 px-4 py-2 text-xs font-bold text-[#315f50] transition hover:border-[#b88a42]/35 hover:bg-[#fffdf8]'>
+              <a href='https://www.instagram.com/thehippiescientist' target='_blank' rel='noopener noreferrer' className='rounded-full border border-[#123c2f]/10 bg-[#fffdf8]/75 px-4 py-2 text-xs font-bold text-[#315f50] transition hover:border-[#b88a42]/35 hover:bg-[#fffdf8] dark:border-white/10 dark:bg-white/5 dark:text-[#a9c6b3] dark:hover:border-[#dec69b]/30 dark:hover:bg-white/10 dark:hover:text-[#d9e8de]'>
                 Instagram
               </a>
-              <a href='https://www.youtube.com/@HippieScientist' target='_blank' rel='noopener noreferrer' className='rounded-full border border-[#123c2f]/10 bg-[#fffdf8]/75 px-4 py-2 text-xs font-bold text-[#315f50] transition hover:border-[#b88a42]/35 hover:bg-[#fffdf8]'>
+              <a href='https://www.youtube.com/@HippieScientist' target='_blank' rel='noopener noreferrer' className='rounded-full border border-[#123c2f]/10 bg-[#fffdf8]/75 px-4 py-2 text-xs font-bold text-[#315f50] transition hover:border-[#b88a42]/35 hover:bg-[#fffdf8] dark:border-white/10 dark:bg-white/5 dark:text-[#a9c6b3] dark:hover:border-[#dec69b]/30 dark:hover:bg-white/10 dark:hover:text-[#d9e8de]'>
                 YouTube
               </a>
             </div>
@@ -93,7 +93,7 @@ export default function Footer() {
               <p className='mt-3 text-sm leading-6 text-[#526159] dark:text-[var(--text-secondary)]'>
                 Use this library as an evidence map, not a prescription pad. Compare human evidence, dose realism, product standardization, and safety before buying or stacking.
               </p>
-              <Link className='mt-4 inline-flex text-sm font-bold text-[#315f50] hover:text-[#123c2f]' to='/info/methodology/' prefetch={true}>
+              <Link className='mt-4 inline-flex text-sm font-bold text-[#315f50] hover:text-[#123c2f] dark:text-[#8dc49a] dark:hover:text-[#c9e4d2]' to='/info/methodology/' prefetch={true}>
                 Read the evidence methodology →
               </Link>
             </div>
@@ -109,7 +109,7 @@ export default function Footer() {
                   prefetch={true}
                   className='editorial-link-tile group flex min-h-20 flex-col justify-between rounded-2xl p-4 text-[#123c2f] transition dark:text-[var(--text-primary)]'
                 >
-                  <Icon className='h-5 w-5 text-[#315f50]' aria-hidden='true' strokeWidth={1.7} />
+                  <Icon className='h-5 w-5 text-[#315f50] dark:text-[#8dc49a]' aria-hidden='true' strokeWidth={1.7} />
                   <span className='mt-3 text-sm font-bold'>{label}</span>
                 </Link>
               ))}
@@ -117,11 +117,11 @@ export default function Footer() {
 
             <div className='mt-8 grid gap-7 sm:grid-cols-3'>
               <div>
-                <h3 className='text-xs font-extrabold uppercase tracking-[0.15em] text-[#315f50]'>Popular goals</h3>
+                <h3 className='text-xs font-extrabold uppercase tracking-[0.15em] text-[#315f50] dark:text-[#8dc49a]'>Popular goals</h3>
                 <ul className='mt-3 space-y-2'>
                   {priorityGoalLinks.map((link) => (
                     <li key={`${link.href}-${link.label}`}>
-                      <Link className='text-sm font-medium text-[#526159] transition hover:text-[#123c2f]' to={link.href} prefetch={true}>
+                      <Link className='text-sm font-medium text-[#526159] transition hover:text-[#123c2f] dark:text-[var(--text-secondary)] dark:hover:text-[var(--text-primary)]' to={link.href} prefetch={true}>
                         {link.label}
                       </Link>
                     </li>
@@ -130,17 +130,17 @@ export default function Footer() {
               </div>
 
               <div>
-                <h3 className='text-xs font-extrabold uppercase tracking-[0.15em] text-[#315f50]'>Safety</h3>
+                <h3 className='text-xs font-extrabold uppercase tracking-[0.15em] text-[#315f50] dark:text-[#8dc49a]'>Safety</h3>
                 <ul className='mt-3 space-y-2'>
                   {safetyLinks.map((link) => (
                     <li key={link.href}>
-                      <Link className='text-sm font-medium text-[#526159] transition hover:text-[#123c2f]' to={link.href} prefetch={true}>
+                      <Link className='text-sm font-medium text-[#526159] transition hover:text-[#123c2f] dark:text-[var(--text-secondary)] dark:hover:text-[var(--text-primary)]' to={link.href} prefetch={true}>
                         {link.label}
                       </Link>
                     </li>
                   ))}
                   <li>
-                    <button className='text-sm font-medium text-[#526159] transition hover:text-[#123c2f]' type='button' onClick={() => setOpen(true)}>
+                    <button className='text-sm font-medium text-[#526159] transition hover:text-[#123c2f] dark:text-[var(--text-secondary)] dark:hover:text-[var(--text-primary)]' type='button' onClick={() => setOpen(true)}>
                       Privacy settings
                     </button>
                   </li>
@@ -148,11 +148,11 @@ export default function Footer() {
               </div>
 
               <div>
-                <h3 className='text-xs font-extrabold uppercase tracking-[0.15em] text-[#315f50]'>Legal</h3>
+                <h3 className='text-xs font-extrabold uppercase tracking-[0.15em] text-[#315f50] dark:text-[#8dc49a]'>Legal</h3>
                 <ul className='mt-3 space-y-2'>
                   {availableLegalLinks.map((link) => (
                     <li key={link.href}>
-                      <Link className='text-sm font-medium text-[#526159] transition hover:text-[#123c2f]' to={link.href} prefetch={true}>
+                      <Link className='text-sm font-medium text-[#526159] transition hover:text-[#123c2f] dark:text-[var(--text-secondary)] dark:hover:text-[var(--text-primary)]' to={link.href} prefetch={true}>
                         {link.label}
                       </Link>
                     </li>
@@ -163,7 +163,7 @@ export default function Footer() {
           </div>
         </div>
 
-        <div className='mt-10 flex flex-col justify-between gap-3 border-t border-[#123c2f]/10 pt-6 text-xs text-[#647168] sm:flex-row'>
+        <div className='mt-10 flex flex-col justify-between gap-3 border-t border-[#123c2f]/10 pt-6 text-xs text-[#647168] sm:flex-row dark:border-white/10 dark:text-[#93a89b]'>
           <div>© 2024–{copyrightYear} The Hippie Scientist. All rights reserved.</div>
           <div className='flex flex-wrap gap-x-4 gap-y-2'>
             <span>Educational use only</span>

--- a/styles/premium-surface-details.css
+++ b/styles/premium-surface-details.css
@@ -1,6 +1,6 @@
 /*
   Premium surface detail layer.
-  Extends the resonant visual language into navigation, footer, forms, tables,
+  Extends the resonant visual language into navigation, forms, tables,
   chips, FAQ/detail elements, and dense utility surfaces.
 */
 
@@ -54,38 +54,6 @@ header [role='navigation'] a:hover {
 html.dark header nav a:hover,
 html.dark header [role='navigation'] a:hover {
   text-shadow: 0 0 20px rgba(203, 216, 192, 0.20);
-}
-
-/* Footer: forest-green closing surface — brand-consistent in both themes. */
-footer {
-  position: relative;
-  overflow: hidden;
-  border-top: 1px solid rgba(245, 240, 224, 0.1) !important;
-  background:
-    radial-gradient(circle at 14% 0%, rgba(142, 186, 143, 0.14), transparent 24rem),
-    radial-gradient(circle at 88% 20%, rgba(196, 125, 46, 0.10), transparent 24rem),
-    linear-gradient(180deg, rgba(18, 38, 28, 0.97), rgba(9, 23, 16, 0.99)) !important;
-}
-
-html.dark footer {
-  background:
-    radial-gradient(circle at 14% 0%, rgba(142, 186, 143, 0.10), transparent 24rem),
-    radial-gradient(circle at 88% 20%, rgba(196, 125, 46, 0.11), transparent 24rem),
-    linear-gradient(180deg, rgba(11, 29, 20, 0.98), rgba(6, 16, 11, 1)) !important;
-}
-
-footer::before {
-  content: '';
-  position: absolute;
-  inset: 0 0 auto 0;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(192, 138, 53, 0.34), rgba(142, 186, 143, 0.34), transparent);
-  pointer-events: none;
-}
-
-footer > * {
-  position: relative;
-  z-index: 1;
 }
 
 /* Tables: better reading rhythm and premium row separation. */


### PR DESCRIPTION
## Summary

- Remove the leftover `footer { background: … !important }` dark forest gradient in `styles/premium-surface-details.css` that was overpowering the new light editorial footer, leaving the evergreen "The Hippie Scientist" heading invisible on dark green in light mode (also un-clobbers the scoped goal-page footer styles)
- Add missing dark-mode variants to footer text in `src/components/Footer.tsx` — social pills, column headings, link lists, methodology link, and bottom bar — so the dark-theme footer keeps readable contrast
- Lay the homepage trust tiles ("Evidence-first / Safety aware / Clear and honest") out horizontally on mobile in `components/homepage-v2.tsx` so they no longer render as mostly-empty full-width cards; desktop keeps the stacked three-across layout

## Verification

- [x] `npm run lint`
- [x] `npm run check`
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs
- [x] no generated file corruption
- [x] static export compatible

Also verified visually with Playwright mobile-viewport screenshots of the homepage footer and trust section in both light and dark themes; `npm run typecheck` and full Vitest suite (569 tests) pass.

## Risk Notes

- CSS-only removal plus additive `dark:` classes; the deleted `!important` rule affected every `<footer>` site-wide, so in-page footers (e.g. goal decision pages) now fall back to their intended scoped styling
- No data, routing, or build-config changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JAJCt2B3T4oedEUoZDsR3

---
_Generated by [Claude Code](https://claude.ai/code/session_016JAJCt2B3T4oedEUoZDsR3)_