### PR TITLE
Visual polish: fix TOC overlap, dark-mode gaps, skip-link bleed, mobile brand fit

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -796,6 +796,7 @@ html.dark :is(
   [class~="bg-white"],
   [class~="bg-white/50"],
   [class~="bg-white/60"],
+  [class~="bg-white/70"],
   [class~="bg-white/75"],
   [class~="bg-white/80"],
   [class~="bg-white/85"],
@@ -819,6 +820,7 @@ html.dark :is(
 
 html.dark :is(
   [class~="hover:bg-white"]:hover,
+  [class~="hover:bg-white/70"]:hover,
   [class~="hover:bg-white/90"]:hover,
   [class~="hover:bg-brand-50"]:hover,
   [class~="hover:bg-brand-50/20"]:hover,

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -56,7 +56,7 @@ export function Navigation() {
         <div className='flex h-[4.35rem] items-center justify-between gap-3 sm:h-[4.8rem]'>
           <Link
             href='/'
-            className='flex min-w-0 items-center gap-2.5 font-display text-[1.08rem] font-semibold tracking-[-0.025em] text-[#123c2f] transition hover:text-[#315f50] dark:text-[var(--text-primary)] sm:text-[1.28rem]'
+            className='flex min-w-0 items-center gap-2.5 font-display text-[clamp(0.8rem,calc((100vw-15.2rem)/9.4),1rem)] font-semibold tracking-[-0.025em] text-[#123c2f] transition hover:text-[#315f50] dark:text-[var(--text-primary)] sm:text-[1.28rem]'
             aria-label='The Hippie Scientist home'
           >
             <span className='editorial-icon-disc h-9 w-9 shrink-0 border-none bg-transparent shadow-none sm:h-10 sm:w-10'>

--- a/components/content/GlobalTOC.tsx
+++ b/components/content/GlobalTOC.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState, useRef } from 'react'
+import { usePathname } from 'next/navigation'
 
 type Heading = {
   id: string
@@ -14,8 +15,22 @@ export default function GlobalTOC() {
   const [visible, setVisible] = useState(false)
   const [mobileOpen, setMobileOpen] = useState(false)
   const observer = useRef<IntersectionObserver | null>(null)
+  const pathname = usePathname()
 
   useEffect(() => {
+    // This component lives in the persistent root layout, so re-scan the new
+    // page's headings on every route change instead of only on first mount.
+    setActiveId('')
+    setMobileOpen(false)
+
+    // Profile pages ship their own curated section nav (ProfileTOC). Rendering
+    // this generic TOC there produces a second "On this page" box that overlaps
+    // the sticky sidebar, so stand down when one exists.
+    if (document.querySelector('nav[aria-label="Page sections"]')) {
+      setVisible(false)
+      return
+    }
+
     // Find all h2/h3 with ids in the main content area
     const selector = 'article h2[id], article h3[id], main h2[id], main h3[id], .content-prose h2[id], .content-prose h3[id], .article-body h2[id], .article-body h3[id]'
     const elements = document.querySelectorAll(selector)
@@ -60,7 +75,7 @@ export default function GlobalTOC() {
     })
 
     return () => observer.current?.disconnect()
-  }, [])
+  }, [pathname])
 
   if (!visible) return null
 

--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -213,7 +213,7 @@ export default function HomepageV2() {
                       <h3 className='text-sm font-bold text-[#123c2f] dark:text-[var(--text-primary)]'>{tool.title}</h3>
                       <p className='mt-1 text-sm leading-6 text-muted'>{tool.description}</p>
                     </div>
-                    <ArrowRight className='mt-1 h-4 w-4 shrink-0 text-[#315f50] transition group-hover:translate-x-1' aria-hidden='true' />
+                    <ArrowRight className='mt-1 h-4 w-4 shrink-0 text-[#315f50] transition group-hover:translate-x-1 dark:text-[var(--accent-teal)]' aria-hidden='true' />
                   </div>
                 </Link>
               ))}
@@ -248,7 +248,7 @@ export default function HomepageV2() {
                     <h3 className='font-display text-xl font-semibold text-[#123c2f] dark:text-[var(--text-primary)] sm:text-2xl'>{goal.title}</h3>
                     <p className='mt-2 text-[0.8rem] leading-5 text-muted sm:text-sm sm:leading-6'>{goal.prompt}</p>
                   </div>
-                  <span className='mt-4 inline-flex items-center gap-1.5 text-[0.8rem] font-bold text-[#315f50] transition group-hover:gap-2.5 sm:text-sm'>
+                  <span className='mt-4 inline-flex items-center gap-1.5 text-[0.8rem] font-bold text-[#315f50] transition group-hover:gap-2.5 dark:text-[var(--accent-teal)] sm:text-sm'>
                     Start here <ArrowRight className='h-3.5 w-3.5' aria-hidden='true' />
                   </span>
                 </Link>

--- a/styles/accessibility-wcag-22.css
+++ b/styles/accessibility-wcag-22.css
@@ -30,7 +30,10 @@ html {
   left: 1rem;
   top: 1rem;
   z-index: 9999;
-  transform: translateY(-140%);
+  /* Clear the viewport entirely when unfocused — the focus ring and drop
+     shadow extend well past the element box, so -140% leaves a visible
+     glow bleeding into the top-left corner of every page. */
+  transform: translateY(calc(-100% - 4rem));
   border: 2px solid var(--a11y-focus-ring);
   border-radius: 999px;
   background: var(--a11y-focus-bg);


### PR DESCRIPTION
## Summary

- GlobalTOC no longer renders a second overlapping "On this page" box on herb/compound profile pages that ship their own ProfileTOC sidebar, and it re-scans headings on client-side navigation instead of keeping the first page's stale list (it lives in the persistent root layout).
- Homepage dark mode: the "Start here" links on the goal path cards and the safety-tool arrows were hardcoded `#315f50` and nearly invisible on dark cards; they now use the dark accent token like sibling links.
- Dark mode: `bg-white/70` and `hover:bg-white/70` were missing from the centralized dark remap in `globals.css`, leaving light pills with light text (e.g. the "N profiles" count chip on /compounds and /herbs).
- The accessibility skip link now translates fully clear of the viewport when unfocused, so its focus-ring glow no longer bleeds into the top-left corner of every page (keyboard focus behavior unchanged).
- The header brand scales fluidly below 640px so "The Hippie Scientist" no longer ellipsizes mid-word on 360–390px phones.

## Verification

- [x] `npm run lint`
- [x] `npm run typecheck` + `npm run test` (570 tests pass)
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs
- [x] no generated file corruption
- [x] static export compatible (CSS/markup-only changes; no server features introduced)

## Risk Notes

- All changes verified in the running app across light/dark and 360–1440px viewports, including SPA navigation for the GlobalTOC change (still renders on pages like /learn/serotonin/ that rely on it, hidden on profile pages with their own nav).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxEFZMijgejnWWJbwJwPGR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxEFZMijgejnWWJbwJwPGR)_