### PR TITLE
Visual polish pass 2: profile jump bar, dark-mode CTA and caution contrast

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -793,6 +793,7 @@ html.dark :is(
   .compact-card,
   .semantic-rail-card,
   .accordion-readable,
+  .chip-readable,
   [class~="bg-white"],
   [class~="bg-white/50"],
   [class~="bg-white/60"],
@@ -1135,6 +1136,13 @@ html.dark :is(.btn-primary) {
   color: #07150c;
 }
 
+/* Sticky conversion CTA buttons: anchor elements whose light-mode colors are
+   hardcoded; this must sit after the html.dark link-color rule to win. */
+html.dark .sticky-cta-btn {
+  background-color: #95b99a;
+  color: #07150c;
+}
+
 html.dark input::placeholder,
 html.dark textarea::placeholder,
 html.dark [class*="placeholder:text"]::placeholder {
@@ -1163,6 +1171,15 @@ html.dark :is(
   [class~="text-amber-950"]
 ) {
   color: var(--text-primary);
+}
+
+/* Warm brown copy inside amber caution surfaces (article/compound/NPS
+   disclaimers) — the light-mode hex vanishes on the dark warning surface. */
+html.dark :is(
+  [class~="text-[#5b4a2c]"],
+  [class~="text-[#5f4a24]"]
+) {
+  color: #e9d8b2;
 }
 
 .safety-disclaimer {

--- a/components/conversion-sticky-cta.tsx
+++ b/components/conversion-sticky-cta.tsx
@@ -26,26 +26,26 @@ export default function ConversionStickyCTA({ brand, name, href }: Props) {
   return (
     <>
       {visible ? (
-        <div className="pointer-events-none fixed bottom-20 left-1/2 z-40 w-[calc(100%-2rem)] max-w-xl -translate-x-1/2 rounded-2xl bg-ink px-4 py-3 text-white shadow-2xl ring-1 ring-black/10">
+        <div className="pointer-events-none fixed bottom-20 left-1/2 z-40 w-[calc(100%-2rem)] max-w-xl -translate-x-1/2 rounded-2xl bg-[#111a16] px-4 py-3 text-white shadow-2xl ring-1 ring-black/10 dark:bg-[#1a3028] dark:ring-white/10">
           <div className="pointer-events-auto flex items-center justify-between gap-3">
             <div className="min-w-0">
               <p className="text-xs font-semibold uppercase tracking-wide text-white/60">Popular choice</p>
               <p className="truncate text-sm font-bold">{brand}{name ? ` — ${name}` : ''}</p>
             </div>
-            <a href={href} target="_blank" rel="noopener noreferrer sponsored" className="shrink-0 rounded-xl bg-white px-4 py-2 text-sm font-black text-ink">
+            <a href={href} target="_blank" rel="noopener noreferrer sponsored" className="sticky-cta-btn shrink-0 rounded-xl bg-[#fffdf7] px-4 py-2 text-sm font-black text-[#111a16]">
               Check price
             </a>
           </div>
         </div>
       ) : null}
 
-      <div className="pointer-events-none fixed bottom-0 left-0 right-0 z-40 border-t border-neutral-200 bg-white/95 p-3 shadow-[0_-10px_30px_rgba(0,0,0,0.08)] backdrop-blur">
+      <div className="pointer-events-none fixed bottom-0 left-0 right-0 z-40 border-t border-neutral-200 bg-white/95 p-3 shadow-[0_-10px_30px_rgba(0,0,0,0.08)] backdrop-blur dark:border-[var(--border-soft)]">
         <div className="pointer-events-auto mx-auto flex min-h-14 max-w-5xl items-center justify-between gap-3">
           <div className="min-w-0 text-sm">
             <p className="font-bold text-ink">Top pick</p>
             <p className="truncate text-muted">{brand}{name ? ` — ${name}` : ''}</p>
           </div>
-          <a href={href} target="_blank" rel="noopener noreferrer sponsored" className="rounded-xl bg-ink px-4 py-2 text-sm font-black text-white">
+          <a href={href} target="_blank" rel="noopener noreferrer sponsored" className="sticky-cta-btn rounded-xl bg-[#111a16] px-4 py-2 text-sm font-black text-white">
             View top pick
           </a>
         </div>

--- a/styles/herb-profile-polish.css
+++ b/styles/herb-profile-polish.css
@@ -42,11 +42,23 @@ main:has(nav[aria-label="Jump to profile sections"]) nav[aria-label="Jump to pro
   position: sticky;
   top: 4.75rem;
   z-index: 20;
+  /* Span the full content column: as an inline-flex island, page content
+     scrolled visibly past the bar's open right edge while stuck. */
+  display: flex;
+  width: 100%;
   box-shadow: 0 12px 36px rgba(0, 0, 0, 0.18);
 }
 
 html:not(.dark) main:has(nav[aria-label="Jump to profile sections"]) nav[aria-label="Jump to profile sections"] {
   box-shadow: 0 12px 32px rgba(16, 32, 24, 0.08);
+}
+
+/* Dark mode: the active pill's bg-white utility is remapped to the dark card
+   surface by the global overrides, leaving it indistinguishable from the
+   track. Restore a light pill with dark text. */
+html.dark main:has(nav[aria-label="Jump to profile sections"]) nav[aria-label="Jump to profile sections"] a:first-child {
+  background: #95b99a;
+  color: #07150c;
 }
 
 main:has(nav[aria-label="Jump to profile sections"]) h1,


### PR DESCRIPTION
## Summary

- The sticky section jump bar on herb/compound profiles now spans the full content column — as an inline-flex island, page content scrolled visibly past its open right edge while stuck. Its active pill also regains a distinct light-on-dark treatment in dark mode (the `bg-white` utility was being remapped to the same surface as the track).
- ConversionStickyCTA (compare pages): `bg-ink` inverts to cream in dark mode, which turned the floating "Popular choice" card white-on-white. The card and both CTA buttons now use theme-stable colors, with a dedicated `.sticky-cta-btn` dark override placed after the global link-color rule so anchor buttons keep dark text on the sage background.
- `.chip-readable` links ("Explore melatonin" etc.) rendered sage-on-white in dark mode because the global dark link color applies to the anchor while the pill background stayed light; the class now joins the dark surface remap.
- Article/compound/NPS disclaimer footers hardcode warm brown `#5b4a2c` (and `#5f4a24`) text that vanished on the dark amber warning surface; added a centralized dark remap to a warm light tone.

## Verification

- [x] `npm run lint`
- [x] `npm run typecheck` + `npm run test` (570 tests pass)
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs
- [x] no generated file corruption
- [x] static export compatible (CSS/markup-only changes)

## Risk Notes

- All fixes verified in the running app: computed styles probed in dark mode for the jump-bar active pill, chips, CTA buttons, and disclaimer footer; sticky engagement and full-width span verified at deep scroll in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxEFZMijgejnWWJbwJwPGR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxEFZMijgejnWWJbwJwPGR)_