### PR TITLE
Restructure evidence lookup: collapsible directory with search and tier filter

### DIFF
--- a/app/evidence/evidence-checker/EvidenceLookupClient.tsx
+++ b/app/evidence/evidence-checker/EvidenceLookupClient.tsx
@@ -1,0 +1,236 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+
+export interface LookupCompound {
+  slug: string
+  name: string
+  evidence_tier: string
+}
+
+const TIERS = [
+  'Strong Human Evidence',
+  'Moderate Human Evidence',
+  'Limited Human Evidence',
+  'Mechanistic Evidence',
+] as const
+
+const TIER_SHORT: Record<string, string> = {
+  'Strong Human Evidence': 'Strong',
+  'Moderate Human Evidence': 'Moderate',
+  'Limited Human Evidence': 'Limited',
+  'Mechanistic Evidence': 'Mechanism',
+}
+
+/* Tier badges follow the site evidence palette (strong=green, moderate=blue,
+   limited=amber, mechanism-only=slate) using color families the dark-mode
+   overrides in globals.css already remap. */
+const TIER_BADGE: Record<string, string> = {
+  'Strong Human Evidence': 'bg-emerald-50 border-emerald-200 text-emerald-800',
+  'Moderate Human Evidence': 'bg-blue-50 border-blue-200 text-blue-800',
+  'Limited Human Evidence': 'bg-amber-50 border-amber-200 text-amber-900',
+  'Mechanistic Evidence': 'bg-slate-50 border-slate-200 text-slate-700',
+}
+
+const TIER_CHIP_ACTIVE: Record<string, string> = {
+  'Strong Human Evidence': 'border-emerald-700/40 bg-emerald-50 text-emerald-800',
+  'Moderate Human Evidence': 'border-blue-700/40 bg-blue-50 text-blue-800',
+  'Limited Human Evidence': 'border-amber-700/40 bg-amber-50 text-amber-900',
+  'Mechanistic Evidence': 'border-slate-500/40 bg-slate-50 text-slate-700',
+}
+
+function CompoundRow({ compound }: { compound: LookupCompound }) {
+  return (
+    <Link
+      href={`/compounds/${compound.slug}/`}
+      className="flex min-h-11 items-center justify-between gap-4 rounded-xl border border-brand-900/10 bg-white/70 px-4 py-2.5 transition hover:border-brand-700/30 hover:bg-white"
+    >
+      <span className="truncate text-sm font-medium text-ink">{compound.name}</span>
+      <span
+        className={`shrink-0 rounded-full border px-2.5 py-0.5 text-[0.65rem] font-bold uppercase tracking-[0.06em] ${
+          TIER_BADGE[compound.evidence_tier] || 'bg-slate-50 border-slate-200 text-slate-700'
+        }`}
+      >
+        {TIER_SHORT[compound.evidence_tier] || compound.evidence_tier}
+      </span>
+    </Link>
+  )
+}
+
+export default function EvidenceLookupClient({ compounds }: { compounds: LookupCompound[] }) {
+  const [query, setQuery] = useState('')
+  const [tier, setTier] = useState<string | null>(null)
+  const [openLetters, setOpenLetters] = useState<Set<string>>(new Set())
+
+  const byLetter = useMemo(() => {
+    const groups: Record<string, LookupCompound[]> = {}
+    for (const c of compounds) {
+      const letter = c.name.charAt(0).toUpperCase()
+      if (!groups[letter]) groups[letter] = []
+      groups[letter].push(c)
+    }
+    return groups
+  }, [compounds])
+
+  const letters = useMemo(() => Object.keys(byLetter).sort(), [byLetter])
+
+  const tierCounts = useMemo(() => {
+    const counts: Record<string, number> = {}
+    for (const c of compounds) counts[c.evidence_tier] = (counts[c.evidence_tier] || 0) + 1
+    return counts
+  }, [compounds])
+
+  // Deep links (#letter-X) should land on an expanded section.
+  useEffect(() => {
+    const match = window.location.hash.match(/^#letter-(.)$/)
+    if (match) {
+      setOpenLetters((prev) => new Set(prev).add(match[1].toUpperCase()))
+    }
+  }, [])
+
+  const normalizedQuery = query.trim().toLowerCase()
+  const filtering = normalizedQuery.length > 0 || tier !== null
+
+  const matches = useMemo(() => {
+    if (!filtering) return []
+    return compounds.filter(
+      (c) =>
+        (!normalizedQuery || c.name.toLowerCase().includes(normalizedQuery)) &&
+        (!tier || c.evidence_tier === tier),
+    )
+  }, [compounds, filtering, normalizedQuery, tier])
+
+  const openLetter = (letter: string) => {
+    setOpenLetters((prev) => new Set(prev).add(letter))
+  }
+
+  const toggleLetter = (letter: string, open: boolean) => {
+    setOpenLetters((prev) => {
+      const next = new Set(prev)
+      if (open) next.add(letter)
+      else next.delete(letter)
+      return next
+    })
+  }
+
+  return (
+    <div className="max-w-3xl space-y-6">
+      {/* Search + tier filter */}
+      <div className="space-y-3">
+        <label htmlFor="evidence-lookup-search" className="sr-only">
+          Search compounds by name
+        </label>
+        <input
+          id="evidence-lookup-search"
+          type="search"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search compounds by name…"
+          className="w-full rounded-xl border border-brand-900/15 bg-white px-4 py-3 text-sm text-ink shadow-sm placeholder:text-muted"
+        />
+        <div className="flex flex-wrap gap-2" role="group" aria-label="Filter by evidence tier">
+          <button
+            type="button"
+            onClick={() => setTier(null)}
+            aria-pressed={tier === null}
+            className={`min-h-9 rounded-full border px-3.5 py-1 text-xs font-semibold transition ${
+              tier === null
+                ? 'border-brand-700/40 bg-brand-50 text-brand-800'
+                : 'border-brand-900/10 bg-white/70 text-muted hover:border-brand-700/25 hover:text-ink'
+            }`}
+          >
+            All ({compounds.length})
+          </button>
+          {TIERS.map((t) => (
+            <button
+              key={t}
+              type="button"
+              onClick={() => setTier((current) => (current === t ? null : t))}
+              aria-pressed={tier === t}
+              className={`min-h-9 rounded-full border px-3.5 py-1 text-xs font-semibold transition ${
+                tier === t
+                  ? TIER_CHIP_ACTIVE[t]
+                  : 'border-brand-900/10 bg-white/70 text-muted hover:border-brand-700/25 hover:text-ink'
+              }`}
+            >
+              {TIER_SHORT[t]} ({tierCounts[t] || 0})
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {filtering ? (
+        <section aria-label="Search results" className="space-y-3">
+          <p className="text-sm text-muted" role="status">
+            {matches.length} of {compounds.length} compounds
+            {normalizedQuery ? ` matching “${query.trim()}”` : ''}
+            {tier ? ` with ${TIER_SHORT[tier].toLowerCase()} evidence` : ''}.
+          </p>
+          {matches.length > 0 ? (
+            <div className="space-y-2">
+              {matches.map((compound) => (
+                <CompoundRow key={compound.slug} compound={compound} />
+              ))}
+            </div>
+          ) : (
+            <div className="rounded-xl border border-brand-900/10 bg-white/70 px-4 py-6 text-sm text-muted">
+              No compounds match. Try a shorter name fragment or clear the tier filter.
+            </div>
+          )}
+        </section>
+      ) : (
+        <>
+          {/* Alphabet nav */}
+          <nav aria-label="Jump to letter" className="flex flex-wrap gap-1.5">
+            {letters.map((letter) => (
+              <a
+                key={letter}
+                href={`#letter-${letter}`}
+                onClick={() => openLetter(letter)}
+                className="flex h-9 w-9 items-center justify-center rounded-lg border border-brand-900/10 bg-white text-sm font-semibold text-ink transition hover:border-brand-700/30 hover:bg-brand-50"
+              >
+                {letter}
+              </a>
+            ))}
+          </nav>
+
+          {/* Collapsible letter sections. All rows are server-rendered inside
+              (closed) details, so every compound link stays in the static HTML. */}
+          <div className="space-y-3">
+            {letters.map((letter) => {
+              const group = byLetter[letter]
+              const isOpen = openLetters.has(letter)
+              return (
+                <details
+                  key={letter}
+                  id={`letter-${letter}`}
+                  open={isOpen}
+                  onToggle={(event) => toggleLetter(letter, (event.target as HTMLDetailsElement).open)}
+                  className="scroll-mt-24"
+                >
+                  <summary className="flex items-center justify-between gap-4">
+                    <span>
+                      {letter}
+                      <span className="ml-2 text-sm font-normal text-muted">
+                        ({group.length} compound{group.length !== 1 ? 's' : ''})
+                      </span>
+                    </span>
+                    <span aria-hidden="true" className={`text-muted transition-transform ${isOpen ? 'rotate-180' : ''}`}>
+                      v
+                    </span>
+                  </summary>
+                  <div className="space-y-2">
+                    {group.map((compound) => (
+                      <CompoundRow key={compound.slug} compound={compound} />
+                    ))}
+                  </div>
+                </details>
+              )
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/app/evidence/evidence-checker/page.tsx
+++ b/app/evidence/evidence-checker/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { buildPageMetadata } from '../../../src/lib/seo'
 import fs from 'node:fs'
 import path from 'node:path'
+import EvidenceLookupClient, { type LookupCompound } from './EvidenceLookupClient'
 
 export const metadata: Metadata = buildPageMetadata({
   title: 'Supplement Evidence Lookup — Search Compounds by Clinical Evidence Grade',
@@ -10,15 +11,7 @@ export const metadata: Metadata = buildPageMetadata({
   path: '/evidence/evidence-checker/',
 })
 
-interface Compound {
-  slug: string
-  name: string
-  summary: string
-  evidence_grade: string
-  evidence_tier: string
-}
-
-function loadCompounds(): Compound[] {
+function loadCompounds(): LookupCompound[] {
   const filePath = path.join(process.cwd(), 'public', 'data', 'compounds.json')
   const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8'))
   return raw
@@ -26,37 +19,13 @@ function loadCompounds(): Compound[] {
     .map((c: Record<string, unknown>) => ({
       slug: String(c.slug || ''),
       name: String(c.name || ''),
-      summary: String(c.summary || ''),
-      evidence_grade: String(c.evidence_grade || ''),
       evidence_tier: String(c.evidence_tier || ''),
     }))
-    .sort((a: Compound, b: Compound) => a.name.localeCompare(b.name))
-}
-
-const TIER_COLORS: Record<string, string> = {
-  'Strong Human Evidence': 'bg-emerald-50 border-emerald-200 text-emerald-800',
-  'Moderate Human Evidence': 'bg-lime-50 border-lime-200 text-lime-800',
-  'Limited Human Evidence': 'bg-amber-50 border-amber-200 text-amber-800',
-  'Mechanism Only': 'bg-orange-50 border-orange-200 text-orange-800',
-  'Insufficient Evidence': 'bg-red-50 border-red-200 text-red-800',
-}
-
-const COMPOUNDS_BY_LETTER: Record<string, Compound[]> = {}
-function getCompoundsByLetter(): Record<string, Compound[]> {
-  if (Object.keys(COMPOUNDS_BY_LETTER).length > 0) return COMPOUNDS_BY_LETTER
-  const compounds = loadCompounds()
-  for (const c of compounds) {
-    const letter = c.name.charAt(0).toUpperCase()
-    if (!COMPOUNDS_BY_LETTER[letter]) COMPOUNDS_BY_LETTER[letter] = []
-    COMPOUNDS_BY_LETTER[letter].push(c)
-  }
-  return COMPOUNDS_BY_LETTER
+    .sort((a: LookupCompound, b: LookupCompound) => a.name.localeCompare(b.name))
 }
 
 export default function EvidenceCheckerPage() {
-  const byLetter = getCompoundsByLetter()
-  const letters = Object.keys(byLetter).sort()
-  const total = Object.values(byLetter).reduce((sum, arr) => sum + arr.length, 0)
+  const compounds = loadCompounds()
 
   return (
     <div className="container-page py-10 space-y-8">
@@ -66,61 +35,21 @@ export default function EvidenceCheckerPage() {
           Supplement Evidence Lookup
         </h1>
         <p className="text-lg leading-8 text-muted">
-          Browse {total} compounds by their clinical evidence grade — from strong human trials (Grade A)
-          to mechanism-only data (Grade D). The list is generated from the current research library, so it stays aligned as the workbook changes.
+          Search {compounds.length} compounds by name or filter by clinical evidence tier — from strong human trials
+          to mechanism-only data. The list is generated from the current research library, so it stays aligned as the workbook changes.
         </p>
       </section>
 
-      {/* Alphabet nav */}
-      <nav className="flex flex-wrap gap-1.5 max-w-3xl">
-        {letters.map(letter => (
-          <a
-            key={letter}
-            href={`#letter-${letter}`}
-            className="flex h-9 w-9 items-center justify-center rounded-lg border border-brand-900/10 bg-white text-sm font-semibold text-ink transition hover:border-brand-700/30 hover:bg-brand-50"
-          >
-            {letter}
-          </a>
-        ))}
-      </nav>
-
-      {/* Compounds by letter */}
-      <div className="max-w-3xl space-y-10">
-        {letters.map(letter => (
-          <section key={letter} id={`letter-${letter}`} className="scroll-mt-24 space-y-3">
-            <h2 className="text-xl font-bold text-ink border-b border-brand-900/10 pb-2 sticky top-0 bg-[var(--bg)] pt-2">
-              {letter}
-              <span className="ml-2 text-sm font-normal text-muted">
-                ({byLetter[letter].length} compound{byLetter[letter].length !== 1 ? 's' : ''})
-              </span>
-            </h2>
-            <div className="space-y-2">
-              {byLetter[letter].map(compound => (
-                <Link
-                  key={compound.slug}
-                  href={`/compounds/${compound.slug}/`}
-                  className="flex items-center justify-between gap-4 rounded-xl border border-brand-900/10 bg-white/70 px-4 py-3 transition hover:border-brand-700/30 hover:bg-white"
-                >
-                  <span className="font-medium text-ink text-sm truncate">{compound.name}</span>
-                  <span className={`shrink-0 rounded-full border px-2.5 py-0.5 text-[0.65rem] font-bold ${TIER_COLORS[compound.evidence_tier] || 'bg-gray-50 border-gray-200 text-gray-600'}`}>
-                    {compound.evidence_grade.toUpperCase()}
-                  </span>
-                </Link>
-              ))}
-            </div>
-          </section>
-        ))}
-      </div>
+      <EvidenceLookupClient compounds={compounds} />
 
       {/* Legend */}
       <section className="max-w-3xl card-premium p-6 space-y-4">
-        <h2 className="text-xl font-semibold text-ink">Evidence Grade Guide</h2>
+        <h2 className="text-xl font-semibold text-ink">Evidence Tier Guide</h2>
         <div className="space-y-2 text-sm leading-7 text-muted">
-          <p><strong>Grade A:</strong> Multiple high-quality RCTs with consistent findings.</p>
-          <p><strong>Grade B:</strong> Several RCTs with generally positive findings.</p>
-          <p><strong>Grade C:</strong> Limited human trials or mixed results.</p>
-          <p><strong>Grade D:</strong> Only mechanistic/animal data. No human trials.</p>
-          <p><strong>Grade F:</strong> Human trials show no benefit.</p>
+          <p><strong>Strong:</strong> Multiple high-quality human trials with consistent findings.</p>
+          <p><strong>Moderate:</strong> Several human trials with generally positive findings.</p>
+          <p><strong>Limited:</strong> Few human trials, small samples, or mixed results.</p>
+          <p><strong>Mechanism:</strong> Only mechanistic or animal data. No solid human trials.</p>
           <div className="pt-2">
             <Link href="/info/methodology/" className="text-sm font-bold text-brand-700 transition hover:text-brand-800">
               Full methodology →


### PR DESCRIPTION
## Summary

- `/evidence/evidence-checker/` rendered all 565 compound rows in one flat list (~37,000px tall) with no search or filter despite the page title promising both. The directory is now collapsible per-letter sections (native `details`/`summary`), cutting default page height to ~4,500px (−88%).
- **Crawl-safe:** all compound links remain server-rendered in the static HTML — verified 568 `/compounds/` hrefs in the raw response before hydration, matching the old page.
- Adds a name search box and evidence-tier filter chips with counts; filtering switches to a flat result list with a live status line and empty state.
- Badges now key off `evidence_tier` (four clean values) instead of the free-text `evidence_grade`. The old `TIER_COLORS` map referenced tier names that don't exist in the data ("Mechanism Only", "Insufficient Evidence"), so 159 "Mechanistic Evidence" rows fell through to the gray fallback, and free-text grades produced badges like "B FOR PCOS; D FOR CORE GOALS". Badge colors follow the site evidence palette (strong=emerald, moderate=blue, limited=amber, mechanism=slate) using color families the dark-mode overrides already remap.
- Legend updated to describe the four tiers actually shown; alphabet nav expands the target letter; `#letter-X` deep links open their section on load.
- Server payload slimmed: the unused `summary` field is no longer loaded or serialized.

## Verification

- [x] `npm run lint`
- [x] `npm run typecheck` + `npm run test` (570 tests pass)
- [x] `npm run validate:static-export` (PASS)
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs
- [x] no generated file corruption

## Risk Notes

- Exercised in the running app: default height measured, letter expand via alphabet nav, search ("magnes" → 7 results), tier filter (Strong → 76, matching data distribution), light and dark themes screenshotted. Without JS, native `details` toggling still works and all content is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxEFZMijgejnWWJbwJwPGR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxEFZMijgejnWWJbwJwPGR)_