### PR TITLE
Fix library pagination and polish index pages

### DIFF
--- a/app/compounds/CompoundsIndexClient.tsx
+++ b/app/compounds/CompoundsIndexClient.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Link from 'next/link'
+import { useSearchParams } from 'next/navigation'
 import { Suspense } from 'react'
 import { cleanSummary, formatDisplayLabel, isClean, list, text, unique } from '@/lib/display-utils'
 import { normalizeDecisionEvidence, normalizeDecisionSafety } from '@/lib/decision-primitives'
@@ -299,9 +300,10 @@ const browsePaths = [
   },
 ]
 
-export default function CompoundsIndexClient({ compounds: sourceCompounds, allCompounds, initialQuery = '', initialContext = '', paginated = false, page = 1, totalPages = 1}: { compounds: RuntimeRecord[]; allCompounds?: RuntimeRecord[]; initialQuery?: string; initialContext?: string; paginated?: boolean; page?: number; totalPages?: number }) {
-  const query = firstParam(initialQuery)
-  const context = firstParam(initialContext)
+export default function CompoundsIndexClient({ compounds: sourceCompounds, allCompounds, initialQuery = '', initialContext = '', paginated = false, page: _page = 1, totalPages: _totalPages = 1}: { compounds: RuntimeRecord[]; allCompounds?: RuntimeRecord[]; initialQuery?: string; initialContext?: string; paginated?: boolean; page?: number; totalPages?: number }) {
+  const urlParams = useSearchParams()
+  const query = urlParams?.get('q') || firstParam(initialQuery)
+  const context = urlParams?.get('context') || firstParam(initialContext)
   const activeFilter = filterOptions.some(option => option.value === context) ? context : 'all'
 
   const baseCompounds = [...(allCompounds || sourceCompounds)].sort((a: RuntimeRecord, b: RuntimeRecord) => scoreCompound(b) - scoreCompound(a))
@@ -341,7 +343,7 @@ export default function CompoundsIndexClient({ compounds: sourceCompounds, allCo
           </div>
         </section>
 
-        <section className="rounded-[0.85rem] border border-brand-900/10 bg-white/85 p-3 shadow-sm sm:p-4" aria-labelledby="compound-search-heading">
+        <section className="rounded-[0.85rem] border border-brand-900/10 bg-[var(--surface-card)] p-3 shadow-sm sm:p-4" aria-labelledby="compound-search-heading">
           <div className="flex flex-col gap-2 lg:flex-row lg:items-end lg:justify-between">
             <div className="max-w-2xl space-y-1.5">
               <p className="eyebrow-label">Search and filter</p>
@@ -358,10 +360,10 @@ export default function CompoundsIndexClient({ compounds: sourceCompounds, allCo
               type="search"
               defaultValue={query}
               placeholder="Search compound, mechanism, source herb, or safety note"
-              className="min-h-10 w-full rounded-full border border-brand-900/10 bg-white px-4 text-sm text-ink shadow-sm placeholder:text-muted/60 dark:placeholder:text-[var(--text-muted)]/50"
+              className="min-h-11 w-full rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 text-base text-ink shadow-sm placeholder:text-muted/60 focus:outline-none focus:ring-2 focus:ring-brand-700/30 dark:placeholder:text-[var(--text-muted)]/50"
             />
             {activeFilter !== 'all' ? <input type="hidden" name="context" value={activeFilter} /> : null}
-            <button type="submit" className="button-primary min-h-10 px-4 py-2">
+            <button type="submit" className="button-primary min-h-11 px-5 py-2.5 text-sm">
               Search
             </button>
           </form>
@@ -375,7 +377,7 @@ export default function CompoundsIndexClient({ compounds: sourceCompounds, allCo
           />
         </section>
 
-        <section className="rounded-[0.85rem] border border-brand-900/10 bg-white/75 p-3 shadow-sm">
+        <section className="rounded-[0.85rem] border border-brand-900/10 bg-[var(--surface-card)] p-3 shadow-sm">
           <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
             <div className="max-w-2xl space-y-1.5">
               <p className="eyebrow-label">Common starting points</p>
@@ -388,7 +390,7 @@ export default function CompoundsIndexClient({ compounds: sourceCompounds, allCo
               <Link
                 key={path.label}
                 href={path.href}
-                className="group rounded-[0.75rem] border border-brand-900/10 bg-white/85 p-2.5 shadow-sm transition hover:border-brand-700/20 hover:bg-white"
+                className="group rounded-[0.75rem] border border-brand-900/10 bg-[var(--surface-card)] p-2.5 shadow-sm transition hover:border-brand-700/20 hover:bg-[var(--surface-card-strong)]"
               >
                 <h3 className="text-base font-semibold tracking-tight text-ink transition group-hover:text-brand-800">{path.label}</h3>
                 <p className="mt-1 text-sm leading-5 text-muted">{path.description}</p>
@@ -447,9 +449,6 @@ export default function CompoundsIndexClient({ compounds: sourceCompounds, allCo
                   </div>
                 </Suspense>
               </section>
-            ) : null}
-            {paginated && !hasActiveFilters && totalPages > 1 ? (
-              <p className="text-sm text-muted">Showing page {page} of {totalPages}. Use previous/next links above for crawl-safe navigation.</p>
             ) : null}
           </>
         )}

--- a/app/compounds/page.tsx
+++ b/app/compounds/page.tsx
@@ -9,6 +9,7 @@ import { COMPOUNDS_PAGE_SIZE, paginateItems } from '@/lib/pagination'
 import { toLeanProfileIndexRecords } from '@/lib/profile-index-records'
 import CompoundsIndexClient from './CompoundsIndexClient'
 import type { RuntimeRecord } from '../../src/types/content'
+import Pagination from '@/components/Pagination'
 
 export const metadata: Metadata = buildPageMetadata({
   title: 'Compound Library',
@@ -43,6 +44,8 @@ export default async function CompoundsPage() {
         <p className="mt-2 text-sm font-semibold text-muted">Browsing {allCompounds.length} compounds</p>
       </section>
 
+      <Pagination basePath="/compounds" currentPage={1} totalPages={pageData.totalPages} itemLabel="Compound profiles" />
+
       {/* SEO-crawlable index (hidden from visual users, served to Googlebot) */}
       <nav aria-label="Compound profiles index" className="sr-only">
         <ul>
@@ -68,6 +71,7 @@ export default async function CompoundsPage() {
           totalPages={pageData.totalPages}
         />
       </Suspense>
+      <Pagination basePath="/compounds" currentPage={1} totalPages={pageData.totalPages} itemLabel="Compound profiles" />
     </div>
   )
 }

--- a/app/compounds/page/[page]/page.tsx
+++ b/app/compounds/page/[page]/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next'
-import Link from 'next/link'
 import { Suspense } from 'react'
 import { getAllCompounds } from '@/lib/server/runtime-data'
 import { getRuntimeVisibility } from '../../../../lib/runtime-visibility'
@@ -7,6 +6,7 @@ import { COMPOUNDS_PAGE_SIZE, clampPositiveInt, paginateItems } from '@/lib/pagi
 import { toLeanProfileIndexRecords } from '@/lib/profile-index-records'
 import CompoundsIndexClient from '../../CompoundsIndexClient'
 import type { RuntimeRecord } from '../../../../src/types/content'
+import Pagination from '@/components/Pagination'
 
 type P = {
   params: Promise<{ page: string }>
@@ -43,32 +43,18 @@ export default async function CompoundsPageN({ params }: P) {
   const leanPageItems = toLeanProfileIndexRecords(p.pageItems as RuntimeRecord[])
 
   return (
-    <div className="mx-auto max-w-6xl space-y-8 px-4 py-8 sm:py-10">
-      <header className="rounded-xl border border-brand-900/10 bg-white/85 p-4 shadow-sm sm:p-5">
+    <div className="mx-auto max-w-6xl space-y-6 px-4 py-6 sm:py-8">
+      <header className="hero-shell rounded-[0.95rem] border border-brand-900/10 px-4 py-5 shadow-sm sm:px-6 sm:py-6">
         <p className="eyebrow-label">Compound research library</p>
-        <h1 className="mt-2 font-display text-3xl font-semibold tracking-tight text-ink sm:text-4xl">
-          Compound Profiles &amp; Research Library — Page {p.currentPage}
+        <h1 className="mt-2 max-w-3xl text-balance font-display text-3xl font-semibold leading-[1.08] text-ink sm:text-5xl">
+          Compound Library <span className="text-muted">— Page {p.currentPage}</span>
         </h1>
-        <p className="mt-2 max-w-2xl text-sm leading-6 text-muted">
+        <p className="mt-2 max-w-2xl text-pretty text-sm leading-6 text-muted">
           Browse evidence, mechanism, and safety summaries for published compound profiles.
         </p>
       </header>
 
-      <nav className="rounded-xl border border-brand-900/10 bg-white/80 p-4 text-sm">
-        <p className="font-semibold">Page {p.currentPage} of {p.totalPages}</p>
-        <div className="mt-2 flex gap-4">
-          {p.hasPrev ? (
-            <Link rel="prev" href={p.currentPage === 2 ? '/compounds' : `/compounds/page/${p.currentPage - 1}`}>
-              ← Previous page
-            </Link>
-          ) : null}
-          {p.hasNext ? (
-            <Link rel="next" href={`/compounds/page/${p.currentPage + 1}`}>
-              Next page →
-            </Link>
-          ) : null}
-        </div>
-      </nav>
+      <Pagination basePath="/compounds" currentPage={p.currentPage} totalPages={p.totalPages} itemLabel="Compound profiles" />
 
       <Suspense fallback={null}>
         <CompoundsIndexClient
@@ -79,6 +65,7 @@ export default async function CompoundsPageN({ params }: P) {
           totalPages={p.totalPages}
         />
       </Suspense>
+      <Pagination basePath="/compounds" currentPage={p.currentPage} totalPages={p.totalPages} itemLabel="Compound profiles" />
     </div>
   )
 }

--- a/app/herbs/HerbsIndexClient.tsx
+++ b/app/herbs/HerbsIndexClient.tsx
@@ -305,7 +305,7 @@ const browsePaths = [
   },
 ]
 
-export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initialQuery = '', initialContext = '', paginated = false, page = 1, totalPages = 1}: { herbs: RuntimeRecord[]; allHerbs?: RuntimeRecord[]; initialQuery?: string; initialContext?: string; paginated?: boolean; page?: number; totalPages?: number }) {
+export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initialQuery = '', initialContext = '', paginated = false, page = 1, totalPages: _totalPages = 1}: { herbs: RuntimeRecord[]; allHerbs?: RuntimeRecord[]; initialQuery?: string; initialContext?: string; paginated?: boolean; page?: number; totalPages?: number }) {
   const urlParams = useSearchParams()
   const query = urlParams?.get('q') || firstParam(initialQuery)
   const context = urlParams?.get('context') || firstParam(initialContext)
@@ -477,9 +477,6 @@ export default function HerbsIndexClient({ herbs: sourceHerbs, allHerbs, initial
                   ))}
                 </div>
               </section>
-            ) : null}
-            {paginated && !hasActiveFilters && totalPages > 1 ? (
-              <p className="text-sm text-muted">Showing page {page} of {totalPages}. Use previous/next links above for crawl-safe navigation.</p>
             ) : null}
           </>
         )}

--- a/app/herbs/page.tsx
+++ b/app/herbs/page.tsx
@@ -11,6 +11,7 @@ import { formatDisplayLabel } from '@/lib/display-utils'
 import { isRedirectedDuplicate } from '@/lib/deprecated-herb-canonicals'
 import { toLeanProfileIndexRecords } from '@/lib/profile-index-records'
 import HerbsIndexClient from './HerbsIndexClient'
+import Pagination from '@/components/Pagination'
 
 export const metadata: Metadata = buildPageMetadata({
   title: 'Herb Profiles & Research Library',
@@ -57,18 +58,15 @@ export default async function HerbsPage() {
 
   return (
     <div className="mx-auto max-w-6xl space-y-5 px-4 py-4 sm:py-6">
-      <div className="space-y-1 pb-1">
+      <header className="hero-shell rounded-[0.95rem] border border-brand-900/10 px-4 py-5 shadow-sm sm:px-6 sm:py-6">
         <p className="eyebrow-label">Botanical Research Library</p>
-        <h1 className="text-3xl font-bold tracking-tight text-ink sm:text-4xl">Herb Profiles</h1>
-        <p className="text-sm text-muted">
+        <h1 className="mt-2 max-w-3xl text-balance font-display text-3xl font-semibold leading-[1.08] text-ink sm:text-5xl">Herb Profiles</h1>
+        <p className="mt-2 max-w-2xl text-pretty text-sm leading-6 text-muted">
           Mechanisms, safety notes, active compounds, and research context for {herbs.length} herbs — plain language, conservative claims.
         </p>
-      </div>
+      </header>
 
-      <nav className="flex items-center gap-3 border-y border-brand-900/10 py-3 text-sm" aria-label="Herb pagination">
-        <p className="font-semibold">Page 1 of {pageData.totalPages}</p>
-        {pageData.hasNext ? <Link rel="next" href="/herbs/page/2" className="font-semibold text-brand-800">Next page →</Link> : null}
-      </nav>
+      <Pagination basePath="/herbs" currentPage={1} totalPages={pageData.totalPages} itemLabel="Herb profiles" />
 
       <nav aria-label="Herb profiles index" className="sr-only">
         <ul>
@@ -100,6 +98,7 @@ export default async function HerbsPage() {
       <Suspense fallback={<HerbsLoadingSkeleton />}>
         <HerbsIndexClient herbs={leanPageItems} allHerbs={leanHerbs} paginated page={1} totalPages={pageData.totalPages} />
       </Suspense>
+      <Pagination basePath="/herbs" currentPage={1} totalPages={pageData.totalPages} itemLabel="Herb profiles" />
     </div>
   )
 }

--- a/app/herbs/page/[page]/page.tsx
+++ b/app/herbs/page/[page]/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next'
-import Link from 'next/link'
 import { Suspense } from 'react'
 import { getHerbSummaryIndex } from '../../../../src/lib/runtime-summary-indexes'
 import { getRuntimeVisibility } from '../../../../lib/runtime-visibility'
@@ -8,12 +7,20 @@ import { isRedirectedDuplicate } from '@/lib/deprecated-herb-canonicals'
 import { toLeanProfileIndexRecords } from '@/lib/profile-index-records'
 import HerbsIndexClient from '../../HerbsIndexClient'
 import type { RuntimeRecord } from '../../../../src/types/content'
+import { formatDisplayLabel } from '@/lib/display-utils'
+import Pagination from '@/components/Pagination'
 
 type P={params:Promise<{page:string}>}
 async function loadBrowseHerbs(): Promise<RuntimeRecord[]> {
   const all = (await getHerbSummaryIndex()) as RuntimeRecord[]
   const present = new Set(all.map((h) => String(h.slug || '')))
-  return all.filter((h) => h.slug && getRuntimeVisibility(h).canRender && !isRedirectedDuplicate(String(h.slug), present))
+  return all
+    .filter((h) => h.slug && getRuntimeVisibility(h).canRender && !isRedirectedDuplicate(String(h.slug), present))
+    .sort((a, b) => {
+      const aName = formatDisplayLabel(a.displayName) || formatDisplayLabel(a.name) || formatDisplayLabel(a.slug)
+      const bName = formatDisplayLabel(b.displayName) || formatDisplayLabel(b.name) || formatDisplayLabel(b.slug)
+      return aName.localeCompare(bName)
+    })
 }
 export async function generateStaticParams(){ const herbs=await loadBrowseHerbs(); const total=Math.max(1,Math.ceil(herbs.length/HERBS_PAGE_SIZE)); return Array.from({length:Math.max(total-1,0)},(_,i)=>({page:String(i+2)})) }
 export async function generateMetadata({ params }: P): Promise<Metadata> {
@@ -44,21 +51,16 @@ export default async function HerbsPageN({params}:P){
   const leanPageItems = toLeanProfileIndexRecords(p.pageItems as RuntimeRecord[])
   return (
     <div className="mx-auto max-w-6xl space-y-5 px-4 py-4 sm:py-6">
-      <div className="space-y-1 pb-1">
+      <header className="hero-shell rounded-[0.95rem] border border-brand-900/10 px-4 py-5 shadow-sm sm:px-6 sm:py-6">
         <p className="eyebrow-label">Botanical Research Library</p>
-        <h1 className="text-3xl font-bold tracking-tight text-ink sm:text-4xl">Herb Profiles (Page {p.currentPage})</h1>
-        <p className="text-sm text-muted">Mechanisms, safety notes, active compounds, and research context for {herbs.length} herbs — page {p.currentPage} of {p.totalPages}.</p>
-      </div>
-      <nav className="rounded-[0.8rem] border border-brand-900/10 bg-white/80 p-3 text-sm">
-        <p className="font-semibold">Page {p.currentPage} of {p.totalPages}</p>
-        <div className="mt-2 flex gap-4">
-          {p.hasPrev ? <Link rel="prev" href={p.currentPage===2?'/herbs':`/herbs/page/${p.currentPage-1}`}>← Previous page</Link> : null}
-          {p.hasNext ? <Link rel="next" href={`/herbs/page/${p.currentPage+1}`}>Next page →</Link> : null}
-        </div>
-      </nav>
+        <h1 className="mt-2 max-w-3xl text-balance font-display text-3xl font-semibold leading-[1.08] text-ink sm:text-5xl">Herb Profiles <span className="text-muted">— Page {p.currentPage}</span></h1>
+        <p className="mt-2 max-w-2xl text-pretty text-sm leading-6 text-muted">Mechanisms, safety notes, active compounds, and research context for {herbs.length} herbs.</p>
+      </header>
+      <Pagination basePath="/herbs" currentPage={p.currentPage} totalPages={p.totalPages} itemLabel="Herb profiles" />
       <Suspense fallback={<HerbsPageSkeleton />}>
         <HerbsIndexClient herbs={leanPageItems} allHerbs={leanHerbs} paginated page={p.currentPage} totalPages={p.totalPages} />
       </Suspense>
+      <Pagination basePath="/herbs" currentPage={p.currentPage} totalPages={p.totalPages} itemLabel="Herb profiles" />
     </div>
   )
 }

--- a/components/Pagination.tsx
+++ b/components/Pagination.tsx
@@ -1,0 +1,67 @@
+import Link from 'next/link'
+
+type PaginationProps = {
+  basePath: string
+  currentPage: number
+  totalPages: number
+  itemLabel: string
+}
+
+function pageHref(basePath: string, page: number) {
+  return page === 1 ? basePath : `${basePath}/page/${page}`
+}
+
+function visiblePages(currentPage: number, totalPages: number) {
+  const pages = new Set([1, totalPages])
+  for (let page = currentPage - 1; page <= currentPage + 1; page += 1) {
+    if (page > 0 && page <= totalPages) pages.add(page)
+  }
+  return [...pages].sort((a, b) => a - b)
+}
+
+export default function Pagination({ basePath, currentPage, totalPages, itemLabel }: PaginationProps) {
+  if (totalPages <= 1) return null
+
+  const pages = visiblePages(currentPage, totalPages)
+  const linkClass = 'inline-flex min-h-10 min-w-10 items-center justify-center rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-3 text-sm font-semibold text-ink shadow-sm transition hover:border-brand-700/30 hover:bg-[var(--surface-card-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40'
+
+  return (
+    <nav
+      aria-label={`${itemLabel} pagination`}
+      className="flex flex-col gap-3 rounded-[0.9rem] border border-brand-900/10 bg-[var(--surface-card)] p-3 shadow-sm sm:flex-row sm:items-center sm:justify-between sm:p-4"
+    >
+      <p className="text-sm font-semibold tabular-nums text-muted">
+        Page <span className="text-ink">{currentPage}</span> of {totalPages}
+      </p>
+
+      <div className="flex flex-wrap items-center gap-1.5">
+        {currentPage > 1 ? (
+          <Link rel="prev" href={pageHref(basePath, currentPage - 1)} className={linkClass} aria-label="Go to previous page">
+            <span aria-hidden="true">←</span><span className="ml-1.5 hidden sm:inline">Previous</span>
+          </Link>
+        ) : null}
+
+        {pages.map((page, index) => (
+          <span key={page} className="contents">
+            {index > 0 && page - pages[index - 1] > 1 ? <span className="px-1 text-muted" aria-hidden="true">…</span> : null}
+            {page === currentPage ? (
+              <span aria-current="page" className="inline-flex min-h-10 min-w-10 items-center justify-center rounded-full bg-brand-800 px-3 text-sm font-bold text-white shadow-sm">
+                <span className="sr-only">Page </span>{page}
+              </span>
+            ) : (
+              <Link href={pageHref(basePath, page)} className={linkClass} aria-label={`Go to page ${page}`}>
+                {page}
+              </Link>
+            )}
+          </span>
+        ))}
+
+        {currentPage < totalPages ? (
+          <Link rel="next" href={pageHref(basePath, currentPage + 1)} className={linkClass} aria-label="Go to next page">
+            <span className="mr-1.5 hidden sm:inline">Next</span><span aria-hidden="true">→</span>
+          </Link>
+        ) : null}
+      </div>
+    </nav>
+  )
+}


### PR DESCRIPTION
## What changed

- fixes herb pagination ordering so page boundaries do not overlap or omit profiles
- adds reusable, accessible numbered navigation above and below herb and compound indexes
- fixes compound search and filters reading URL parameters
- polishes library typography, spacing, touch targets, focus states, and dark-mode surfaces

## Root cause

The first herb page sorted records before slicing, while later pages sliced the unsorted source. Compound search also rendered submitted URL parameters without reading them in the client.

## Validation

- focused ESLint passed
- TypeScript passed
- production static export passed (1,172 pages)
- diff whitespace validation passed

## Test note

The rendering suite contains one pre-existing stale expectation for a removed `Herbal research library` heading; the other rendering tests passed.