### PR TITLE
Refine mobile bottom navigation

### DIFF
--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -52,11 +52,11 @@ export function Navigation() {
       }`}
       aria-label='Primary'
     >
-      <div className='mx-auto max-w-7xl px-4 sm:px-6 lg:px-8'>
-        <div className='flex h-[4.35rem] items-center justify-between gap-3 sm:h-[4.8rem]'>
+      <div className='mx-auto max-w-7xl px-3 sm:px-6 lg:px-8'>
+        <div className='flex h-[4.35rem] items-center justify-between gap-2 sm:h-[4.8rem] sm:gap-3'>
           <Link
             href='/'
-            className='flex min-w-0 items-center gap-2.5 font-display text-[clamp(0.8rem,calc((100vw-15.2rem)/9.4),1rem)] font-semibold tracking-[-0.025em] text-[#123c2f] transition hover:text-[#315f50] dark:text-[var(--text-primary)] sm:text-[1.28rem]'
+            className='flex min-w-0 items-center gap-2 font-display text-[0.9rem] font-semibold tracking-[-0.025em] text-[#123c2f] transition hover:text-[#315f50] dark:text-[var(--text-primary)] sm:gap-2.5 sm:text-[1.28rem]'
             aria-label='The Hippie Scientist home'
           >
             <span className='editorial-icon-disc h-9 w-9 shrink-0 border-none bg-transparent shadow-none sm:h-10 sm:w-10'>

--- a/src/components/mobile-bottom-nav.tsx
+++ b/src/components/mobile-bottom-nav.tsx
@@ -23,9 +23,9 @@ export default function MobileBottomNav() {
   return (
     <nav
       aria-label='Primary mobile navigation'
-      className='editorial-mobile-dock mobile-bottom-nav fixed inset-x-2 bottom-[calc(env(safe-area-inset-bottom)+0.35rem)] z-[90] mx-auto max-w-[34rem] rounded-2xl md:hidden'
+      className='editorial-mobile-dock mobile-bottom-nav fixed inset-x-3 bottom-[calc(env(safe-area-inset-bottom)+0.5rem)] z-[90] mx-auto max-w-[34rem] overflow-hidden rounded-[1.25rem] md:hidden'
     >
-      <div className='flex items-center gap-0.5 px-1.5 py-1.5'>
+      <div className='flex items-center gap-0.5 px-1 py-1'>
         {mobileBottomNavItems.map((item) => {
           const active = pathname === item.href || pathname.startsWith(`${item.href}/`)
           const isSearch = item.label === 'Search'
@@ -36,7 +36,7 @@ export default function MobileBottomNav() {
               key={item.href}
               href={toCanonicalHref(item.href)}
               aria-current={active ? 'page' : undefined}
-              className={`group relative flex min-h-[3rem] min-w-0 flex-1 flex-col items-center justify-center gap-0.5 rounded-xl px-0.5 text-center transition ${
+              className={`group relative flex min-h-[2.9rem] min-w-0 flex-1 flex-col items-center justify-center gap-0.5 rounded-xl px-0.5 text-center transition ${
                 active && !isSearch
                   ? 'text-[#123c2f] dark:text-[var(--text-primary)]'
                   : 'text-[#526159] hover:text-[#123c2f] dark:text-[var(--text-secondary)] dark:hover:text-[var(--text-primary)]'

--- a/styles/editorial-botanical-refresh.css
+++ b/styles/editorial-botanical-refresh.css
@@ -255,17 +255,17 @@ html:not(.dark) body {
 }
 
 .editorial-mobile-dock {
-  border: 1px solid rgba(18, 60, 47, 0.12);
-  background: rgba(255, 253, 248, 0.94);
-  box-shadow: 0 -10px 36px rgba(58, 45, 24, 0.13);
-  backdrop-filter: blur(20px);
+  border: 1px solid rgba(18, 60, 47, 0.10);
+  background: rgba(255, 253, 248, 0.98);
+  box-shadow: none;
+  backdrop-filter: blur(14px);
 }
 
 .editorial-mobile-search {
   border: 1px solid rgba(222, 198, 155, 0.82);
   background: linear-gradient(145deg, #123c2f, #245846);
   color: #fffdf8;
-  box-shadow: 0 8px 22px rgba(18, 60, 47, 0.24);
+  box-shadow: 0 3px 10px rgba(18, 60, 47, 0.18);
 }
 
 @media (max-width: 767px) {


### PR DESCRIPTION
## What changed

- removed the oversized shadow around the mobile bottom navigation
- tightened the dock spacing and softened the search control elevation
- adjusted the mobile header so the full site name remains visible

## Why

The previous dock shadow rendered as a thick shaded frame on mobile Safari and made the navigation feel oversized.

## Validation

- npm run typecheck
- npx eslint components/Navigation.tsx src/components/mobile-bottom-nav.tsx
- verified at 390 x 844 with no horizontal overflow or console errors