### PR TITLE
Fix mobile privacy banner and borders

### DIFF
--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -167,7 +167,7 @@ export default function HomepageV2() {
         </section>
 
         <section className='grid gap-5 lg:grid-cols-[1.15fr_0.85fr]'>
-          <div className='editorial-card-strong border-x-0 p-5 sm:rounded-[2rem] sm:border-x sm:p-8'>
+          <div className='editorial-card-strong rounded-[2rem] p-5 sm:p-8'>
             <p className='editorial-eyebrow'>Smarter choices</p>
             <div className='mt-3 flex items-start justify-between gap-4'>
               <SectionHeader
@@ -195,7 +195,7 @@ export default function HomepageV2() {
             </Link>
           </div>
 
-          <div className='editorial-card border-x-0 p-5 sm:rounded-[2rem] sm:border-x sm:p-8'>
+          <div className='editorial-card rounded-[2rem] p-5 sm:p-8'>
             <p className='editorial-eyebrow'>Safety first</p>
             <SectionHeader
               title='Use the safety tools'
@@ -221,7 +221,7 @@ export default function HomepageV2() {
           </div>
         </section>
 
-        <section id='choose-a-path' className='editorial-card border-x-0 p-5 scroll-mt-24 sm:rounded-[2rem] sm:border-x sm:p-8'>
+        <section id='choose-a-path' className='editorial-card rounded-[2rem] p-5 scroll-mt-24 sm:p-8'>
           <div className='flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between'>
             <SectionHeader
               title='Choose one path'

--- a/src/components/ConsentBanner.tsx
+++ b/src/components/ConsentBanner.tsx
@@ -26,22 +26,27 @@ export default function ConsentBanner() {
   const dnt = getSystemNoTracking()
 
   return (
-    <div className='fixed inset-x-0 bottom-0 z-50 p-1 sm:p-1.5'>
-      <div className='mx-auto max-w-3xl rounded-lg border border-white/10 bg-black/50 px-3 py-2 text-xs text-white/80 backdrop-blur-sm'>
-        <div className='flex items-center justify-between gap-2'>
-          <p className='min-w-0 truncate leading-tight text-white/75'>
+    <div className='fixed inset-x-0 bottom-[calc(env(safe-area-inset-bottom)+5.25rem)] z-[100] px-3 md:bottom-0 md:px-4 md:pb-4'>
+      <div
+        role='region'
+        aria-label='Privacy notice'
+        className='mx-auto max-w-3xl rounded-2xl border border-white/20 bg-[#123c2f]/95 px-4 py-3 text-sm text-white shadow-[0_10px_35px_rgba(18,60,47,0.28)] backdrop-blur-md'
+      >
+        <div className='flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between'>
+          <p className='min-w-0 leading-snug text-white/90'>
             We use privacy-friendly analytics.{' '}
-            <Link className='underline' to='/info/privacy'>
-              Privacy
+            <Link className='font-semibold text-white underline underline-offset-2 hover:text-white' to='/info/privacy'>
+              Read our privacy policy
             </Link>
             .
             {dnt && (
               <span className='ml-1 text-amber-300'>DNT/GPC detected: tracking stays off.</span>
             )}
           </p>
-          <div className='flex shrink-0 items-center gap-2'>
+          <div className='flex shrink-0 items-center justify-end gap-2'>
             <button
-              className='text-[11px] text-white/60 underline underline-offset-2 transition-colors hover:text-white/80'
+              type='button'
+              className='inline-flex min-h-11 items-center justify-center rounded-lg px-3 text-sm font-semibold text-white/85 underline underline-offset-2 transition-colors hover:bg-white/10 hover:text-white'
               onClick={() => {
                 setConsent('denied')
                 setShow(false)
@@ -50,7 +55,8 @@ export default function ConsentBanner() {
               Decline
             </button>
             <button
-              className='rounded-md border border-lime-300/20 bg-gradient-to-r from-lime-400/25 to-cyan-400/15 px-2 py-1 text-[11px] font-medium text-lime-200 transition-all duration-200 hover:from-lime-400/35 hover:to-cyan-400/25'
+              type='button'
+              className='inline-flex min-h-11 items-center justify-center rounded-lg border border-[#d8c08d]/50 bg-[#fffdf8] px-4 text-sm font-bold text-[#123c2f] transition-colors hover:bg-[#f5efe2]'
               onClick={() => {
                 setConsent('granted')
                 setShow(false)

--- a/styles/editorial-botanical-refresh.css
+++ b/styles/editorial-botanical-refresh.css
@@ -255,9 +255,9 @@ html:not(.dark) body {
 }
 
 .editorial-mobile-dock {
-  border: 1px solid rgba(18, 60, 47, 0.10);
+  border: 1px solid rgba(18, 60, 47, 0.16);
   background: rgba(255, 253, 248, 0.98);
-  box-shadow: none;
+  box-shadow: 0 -6px 24px rgba(58, 45, 24, 0.10);
   backdrop-filter: blur(14px);
 }
 


### PR DESCRIPTION
## What changed

- move the mobile privacy notice above the floating navigation with a clear gap
- restore rounded borders on the homepage’s main mobile cards
- strengthen the floating dock border and add a subtle shadow

## Why

The privacy notice still overlapped the mobile dock, and a previous mobile cleanup explicitly removed horizontal card borders.

## Validation

- `npm run typecheck`
- targeted ESLint for the edited TSX files
- `git diff --check`