### PR TITLE
Add CollectionPage + BreadcrumbList structured data to guide hub pages

### DIFF
--- a/app/guides/adhd/page.tsx
+++ b/app/guides/adhd/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { SITE_URL } from '@/src/lib/seo'
 import References from '@/components/References'
+import SchemaGraphScript from '@/components/seo/SchemaGraphScript'
+import { buildGuideHubSchemaGraph } from '../../../src/lib/schema-graph'
 
 export const metadata: Metadata = {
   title: 'ADHD Supplement Guides & Research',
@@ -47,8 +49,23 @@ const ADHD_REFS = [
 ]
 
 export default function AdhdGuideIndex() {
+  const schemaGraph = buildGuideHubSchemaGraph({
+    path: '/guides/adhd/',
+    title: 'ADHD Supplement Guides & Research',
+    description:
+      'Evidence-based guides on ADHD supplements, nutrient deficiencies, and medication context. Magnesium, omega-3, L-theanine, iron, zinc, and more.',
+    breadcrumbs: [
+      { name: 'Home', url: `${SITE_URL}/` },
+      { name: 'Guides', url: `${SITE_URL}/guides/` },
+      { name: 'ADHD', url: `${SITE_URL}/guides/adhd/` },
+    ],
+    itemListName: 'ADHD Supplement Guides',
+    items: GUIDES.map((g) => ({ name: g.title, url: `/guides/adhd/${g.slug}/` })),
+  })
+
   return (
     <div className="mx-auto max-w-4xl px-4 pb-24 pt-8">
+      <SchemaGraphScript graph={schemaGraph} />
       <nav className="text-xs text-muted mb-4">
         <Link href="/guides/" className="hover:text-ink">Guides</Link>
         <span className="mx-1.5">/</span>

--- a/app/guides/anxiety/page.tsx
+++ b/app/guides/anxiety/page.tsx
@@ -4,6 +4,8 @@ import { SITE_URL } from '@/src/lib/seo'
 import { HubSectionHeading } from '@/components/guides/HubSectionHeading'
 import { DecisionRouter, type IntentRoute } from '@/components/guides/DecisionRouter'
 import { GuideCardGrid, type GuideCard } from '@/components/guides/GuideCardGrid'
+import SchemaGraphScript from '@/components/seo/SchemaGraphScript'
+import { buildGuideHubSchemaGraph } from '../../../src/lib/schema-graph'
 
 export const metadata: Metadata = {
   title: 'Anxiety & Stress Supplement Guides',
@@ -130,8 +132,23 @@ const ALL_GUIDES = [
 ]
 
 export default function AnxietyGuideIndex() {
+  const schemaGraph = buildGuideHubSchemaGraph({
+    path: '/guides/anxiety/',
+    title: 'Anxiety & Stress Supplement Guides',
+    description:
+      'Choose the right natural support based on the kind of anxiety or stress you have — overthinking, situational nerves, chronic stress, or nighttime worry.',
+    breadcrumbs: [
+      { name: 'Home', url: `${SITE_URL}/` },
+      { name: 'Guides', url: `${SITE_URL}/guides/` },
+      { name: 'Anxiety & Stress', url: `${SITE_URL}/guides/anxiety/` },
+    ],
+    itemListName: 'Anxiety & Stress Supplement Guides',
+    items: ALL_GUIDES.map((g) => ({ name: g.title, url: `/guides/anxiety/${g.slug}/` })),
+  })
+
   return (
     <div className="mx-auto max-w-4xl px-4 pb-24 pt-8">
+      <SchemaGraphScript graph={schemaGraph} />
       <nav className="mb-4 text-xs text-muted">
         <Link href="/guides/" className="hover:text-ink">
           Guides

--- a/app/guides/best/page.tsx
+++ b/app/guides/best/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
-import { buildPageMetadata } from '@/src/lib/seo'
+import { buildPageMetadata, SITE_URL } from '@/src/lib/seo'
+import SchemaGraphScript from '@/components/seo/SchemaGraphScript'
+import { buildGuideHubSchemaGraph } from '../../../src/lib/schema-graph'
 
 export const metadata: Metadata = buildPageMetadata({
   title: 'Best Supplement Guides by Goal',
@@ -77,8 +79,23 @@ const workflows = [
 ]
 
 export default function BestSupplementGuidesHub() {
+  const schemaGraph = buildGuideHubSchemaGraph({
+    path: '/guides/best/',
+    title: 'Best Supplement Guides by Goal',
+    description:
+      'Browse evidence-informed best supplement guides for ADHD, stress, blood pressure, fat loss, gut health, and joint support, with safety-first decision context.',
+    breadcrumbs: [
+      { name: 'Home', url: `${SITE_URL}/` },
+      { name: 'Guides', url: `${SITE_URL}/guides/` },
+      { name: 'Best Supplement Guides', url: `${SITE_URL}/guides/best/` },
+    ],
+    itemListName: 'Best Supplement Guides by Goal',
+    items: bestGuides.map((g) => ({ name: g.title, url: g.href })),
+  })
+
   return (
     <div className="mx-auto max-w-6xl space-y-10 px-4 pb-24 pt-8 sm:pt-10">
+      <SchemaGraphScript graph={schemaGraph} />
       <header className="rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8 dark:border-white/10 dark:bg-white/5">
         <p className="text-sm font-semibold uppercase tracking-[0.18em] text-brand-700 dark:text-brand-200">
           Curated supplement guides

--- a/app/guides/focus/page.tsx
+++ b/app/guides/focus/page.tsx
@@ -4,6 +4,8 @@ import { SITE_URL } from '@/src/lib/seo'
 import { HubSectionHeading } from '@/components/guides/HubSectionHeading'
 import { DecisionRouter, type IntentRoute } from '@/components/guides/DecisionRouter'
 import { GuideCardGrid, type GuideCard } from '@/components/guides/GuideCardGrid'
+import SchemaGraphScript from '@/components/seo/SchemaGraphScript'
+import { buildGuideHubSchemaGraph } from '../../../src/lib/schema-graph'
 
 export const metadata: Metadata = {
   title: 'Focus & Cognition Supplement Guides',
@@ -112,8 +114,23 @@ const ALL_GUIDES = [
 ]
 
 export default function FocusGuideIndex() {
+  const schemaGraph = buildGuideHubSchemaGraph({
+    path: '/guides/focus/',
+    title: 'Focus & Cognition Supplement Guides',
+    description:
+      'Match the right focus support to why your attention slips — energy crashes, caffeine jitters, or slow-building memory.',
+    breadcrumbs: [
+      { name: 'Home', url: `${SITE_URL}/` },
+      { name: 'Guides', url: `${SITE_URL}/guides/` },
+      { name: 'Focus & Cognition', url: `${SITE_URL}/guides/focus/` },
+    ],
+    itemListName: 'Focus & Cognition Supplement Guides',
+    items: ALL_GUIDES.map((g) => ({ name: g.title, url: `/guides/focus/${g.slug}/` })),
+  })
+
   return (
     <div className="mx-auto max-w-4xl px-4 pb-24 pt-8">
+      <SchemaGraphScript graph={schemaGraph} />
       <nav className="mb-4 text-xs text-muted">
         <Link href="/guides/" className="hover:text-ink">
           Guides

--- a/app/guides/herbs/page.tsx
+++ b/app/guides/herbs/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { SITE_URL } from '@/src/lib/seo'
+import SchemaGraphScript from '@/components/seo/SchemaGraphScript'
+import { buildGuideHubSchemaGraph } from '../../../src/lib/schema-graph'
 
 export const metadata: Metadata = {
   title: 'Herb Deep-Dive Guides',
@@ -112,8 +114,23 @@ const readingWorkflow = [
 ]
 
 export default function HerbsGuideIndex() {
+  const schemaGraph = buildGuideHubSchemaGraph({
+    path: '/guides/herbs/',
+    title: 'Herb Deep-Dive Guides',
+    description:
+      'Herb deep-dive guide hub covering evidence, safety, dosing, product quality, and practical fit for ashwagandha, kava, passionflower, rhodiola, turmeric, elderberry, and more.',
+    breadcrumbs: [
+      { name: 'Home', url: `${SITE_URL}/` },
+      { name: 'Guides', url: `${SITE_URL}/guides/` },
+      { name: 'Herb Profiles', url: `${SITE_URL}/guides/herbs/` },
+    ],
+    itemListName: 'Herb Deep-Dive Guides',
+    items: GUIDES.map((g) => ({ name: g.title, url: `/guides/herbs/${g.slug}/` })),
+  })
+
   return (
     <div className="mx-auto max-w-6xl space-y-10 px-4 pb-24 pt-8 sm:pt-10">
+      <SchemaGraphScript graph={schemaGraph} />
       <nav className="text-xs text-muted">
         <Link href="/guides/" className="hover:text-ink">Guides</Link>
         <span className="mx-1.5">/</span>

--- a/app/guides/sleep/page.tsx
+++ b/app/guides/sleep/page.tsx
@@ -4,6 +4,8 @@ import { SITE_URL } from '@/src/lib/seo'
 import { HubSectionHeading } from '@/components/guides/HubSectionHeading'
 import { DecisionRouter, type IntentRoute } from '@/components/guides/DecisionRouter'
 import { GuideCardGrid, type GuideCard } from '@/components/guides/GuideCardGrid'
+import SchemaGraphScript from '@/components/seo/SchemaGraphScript'
+import { buildGuideHubSchemaGraph } from '../../../src/lib/schema-graph'
 
 export const metadata: Metadata = {
   title: 'Sleep Supplement Guides & Natural Sleep Aids',
@@ -176,8 +178,23 @@ const DEPTH_LINKS = [
 ]
 
 export default function SleepGuideIndex() {
+  const schemaGraph = buildGuideHubSchemaGraph({
+    path: '/guides/sleep/',
+    title: 'Sleep Supplement Guides & Natural Sleep Aids',
+    description:
+      'Choose the right natural sleep support based on what is actually keeping you awake — racing thoughts, physical tension, stress, or timing.',
+    breadcrumbs: [
+      { name: 'Home', url: `${SITE_URL}/` },
+      { name: 'Guides', url: `${SITE_URL}/guides/` },
+      { name: 'Sleep', url: `${SITE_URL}/guides/sleep/` },
+    ],
+    itemListName: 'Sleep Supplement Guides',
+    items: ALL_GUIDES.map((g) => ({ name: g.title, url: `/guides/sleep/${g.slug}/` })),
+  })
+
   return (
     <div className="mx-auto max-w-4xl px-4 pb-24 pt-8">
+      <SchemaGraphScript graph={schemaGraph} />
       <nav className="mb-4 text-xs text-muted">
         <Link href="/guides/" className="hover:text-ink">
           Guides

--- a/src/lib/schema-graph.ts
+++ b/src/lib/schema-graph.ts
@@ -352,6 +352,50 @@ export function buildCompareHubSchemaGraph(args: {
   return buildSchemaGraph([webpage, breadcrumb, itemList])
 }
 
+export function buildGuideHubSchemaGraph(args: {
+  path: string
+  title: string
+  description: string
+  breadcrumbs: Array<{ name: string; url: string }>
+  itemListName: string
+  items: Array<{ name: string; url: string }>
+}) {
+  const canonical = normalizeCanonical(toAbsoluteUrl(args.path))
+  const webpageId = `${canonical}#webpage`
+  const breadcrumbId = `${canonical}#breadcrumb`
+  const itemListId = `${canonical}#item-list`
+
+  const webpage = {
+    '@type': 'CollectionPage',
+    '@id': webpageId,
+    name: args.title,
+    description: args.description,
+    url: canonical,
+    isPartOf: { '@type': 'WebSite', name: 'The Hippie Scientist', url: SITE_URL },
+    breadcrumb: { '@id': breadcrumbId },
+    mainEntity: { '@id': itemListId },
+  }
+
+  const breadcrumb = {
+    ...stripSchemaContext(breadcrumbJsonLd(args.breadcrumbs, { id: breadcrumbId })),
+    '@id': breadcrumbId,
+  }
+
+  const itemList = {
+    ...stripSchemaContext(
+      itemListJsonLd({
+        id: itemListId,
+        name: args.itemListName,
+        path: args.path,
+        items: args.items,
+      }),
+    ),
+    isPartOf: { '@id': webpageId },
+  }
+
+  return buildSchemaGraph([webpage, breadcrumb, itemList])
+}
+
 export function buildCompareDetailSchemaGraph(args: {
   path: string
   title: string


### PR DESCRIPTION
## Summary

- Only `/guides/compare` emitted JSON-LD among the guide hub pages; the six other hubs had no structured data.
- Adds a generic `buildGuideHubSchemaGraph` to `src/lib/schema-graph.ts` (CollectionPage + BreadcrumbList + ItemList graph, mirroring the existing compare-hub pattern).
- Wires it into `/guides/adhd`, `/guides/anxiety`, `/guides/best`, `/guides/focus`, `/guides/herbs`, and `/guides/sleep` via the existing `SchemaGraphScript` component.

## Verification

- [x] `npm run lint`
- [x] `npm run typecheck` + full Vitest suite (88 files, 570 tests passing)
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs
- [x] no generated file corruption
- [x] static export compatible (server-rendered JSON-LD only, no runtime features)

## Risk Notes

- Purely additive `<script type="application/ld+json">` output on six hub pages; no visual or routing changes. Sample graph output was rendered and inspected for valid absolute URLs and `@id` cross-references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DvQwaiUDnVbvWH4WDaL51h

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvQwaiUDnVbvWH4WDaL51h)_