### PR TITLE
Replace zinc-and-ADHD placeholder with full evidence-based article

### DIFF
--- a/docs/content/focus-cluster/zinc-and-adhd.md
+++ b/docs/content/focus-cluster/zinc-and-adhd.md
@@ -1,6 +1,6 @@
 ---
 title: "Zinc and ADHD: Deficiency, Hyperactivity, Attention, and Supplementation"
-seoTitle: "Zinc and ADHD: Deficiency, Hyperactivity, Attention, and Supplementation"
+seoTitle: "Zinc and ADHD: Deficiency, Attention and Safety"
 metaDescription: "Evidence-based review of zinc and ADHD. Covers deficiency, hyperactivity, attention, stimulant response, dosing, safety, and copper balance."
 primaryKeyword: "zinc ADHD"
 secondaryKeywords:
@@ -10,12 +10,118 @@ secondaryKeywords:
   - "zinc children ADHD"
   - "zinc and hyperactivity"
   - "zinc stimulant response ADHD"
-status: "draft-source"
+status: "published"
 cluster: "focus-adhd"
 ---
 
-# Zinc and ADHD: What the Research Shows About Symptoms, Deficiency, Supplementation, and Cognitive Function
+# Zinc and ADHD: What the Research Shows About Deficiency, Supplementation, and Attention
 
-Updated source article replacing prior published-route source. Includes expanded sections on dopamine modulation, stimulant response, deficiency assessment, copper balance, supplementation trials, evidence grading, forms, dosing, safety, FAQ, and internal cluster linking.
+## Quick Answer
 
-(Full article content supplied in workflow session and committed as source-document replacement.)
+Zinc is an essential mineral involved in dopamine metabolism, neurotransmitter signaling, and the regulation of the transporter that clears dopamine from the synapse. Because dopamine is central to attention and impulse control, zinc has been studied as a possible support for ADHD.
+
+The evidence is mixed but points in a consistent direction: zinc deficiency is more common in some people with ADHD, and correcting a genuine deficiency may modestly help symptoms or improve the response to stimulant medication. Zinc is not a treatment for ADHD on its own, and adding zinc when levels are already adequate has not been shown to improve attention.
+
+Zinc is best thought of as a deficiency-correction tool, not a stimulant substitute. If a blood test shows low zinc, supplementation is reasonable and well-supported. If levels are normal, the expected benefit is small.
+
+## Best For / Not Best For
+
+Zinc may be worth considering when:
+
+- A blood test shows low or low-normal zinc, or the diet is genuinely low in zinc
+- Diet is limited (restricted eating, low animal-protein intake, or high phytate intake)
+- The goal is to correct a deficiency that could be worsening focus, sleep, or mood
+- Supplementation is used as one part of a broader plan alongside sleep, nutrition, and medical care
+- Use in children is guided by a clinician who can check levels and dosing
+
+Zinc is not a good fit when:
+
+- Zinc levels are already normal and the aim is to boost attention beyond baseline
+- It is being used as a replacement for evidence-based ADHD care
+- High doses are taken long-term without monitoring copper status
+- The plan is to stack several minerals at once and guess what is helping
+
+## What Zinc Is
+
+Zinc is an essential trace mineral the body cannot make or store in large amounts, so a steady dietary supply is needed. It is a cofactor for hundreds of enzymes and is involved in immune function, wound healing, growth, taste, and the synthesis and regulation of neurotransmitters.
+
+Dietary zinc comes mainly from oysters, red meat, poultry, beans, nuts, seeds, and whole grains. Plant sources contain phytates that reduce zinc absorption, which is one reason low intake can appear in restricted or largely plant-based diets. Zinc status is often assessed with serum or plasma zinc, though these markers have limitations and can be affected by inflammation, recent meals, and time of day.
+
+## How Zinc Works in ADHD
+
+Zinc's relevance to ADHD centers on dopamine. Zinc helps regulate the dopamine transporter, the protein that removes dopamine from the synapse — the same target that stimulant medications act on. Zinc is also a cofactor for enzymes involved in making neurotransmitters and in metabolizing fatty acids and melatonin, both of which are relevant to attention and sleep.
+
+The important nuance is that ADHD is not caused by simple zinc deficiency. Low zinc may worsen symptoms or reduce how well the system responds to treatment, but correcting it does not resolve the underlying condition. The strongest rationale for zinc is repletion: restoring an adequate level so that dopamine signaling, sleep, and overall function are not held back by a nutrient gap.
+
+## What the Evidence Says
+
+Several lines of research connect zinc and ADHD:
+
+- **Deficiency association.** Multiple studies report lower average zinc levels in children with ADHD compared with peers, though not every study agrees and populations differ widely. Deficiency appears more likely in regions and diets where zinc intake is generally low.
+- **Supplementation trials.** Randomized trials of zinc as a standalone therapy have shown small and inconsistent benefits. Some found modest improvements in hyperactivity and impulsivity; others found little effect, particularly in well-nourished populations.
+- **Stimulant response.** A notable line of evidence suggests zinc may work best as an adjunct: adding zinc alongside stimulant medication has, in some trials, been associated with a lower effective medication dose or slightly improved response. This fits the mechanism, since zinc and stimulants both influence the dopamine transporter.
+
+The overall picture is that zinc is most useful when a deficiency exists. In people with adequate zinc, the benefit is generally small. This is why testing before supplementing is more rational than blanket use. For a broader look at which nutrients matter, see [nutrient deficiencies and ADHD](/guides/adhd/nutrient-deficiencies-and-adhd/) and [ADHD blood tests](/guides/adhd/adhd-blood-tests/).
+
+## Zinc Deficiency and Assessment
+
+Zinc deficiency can be hard to pin down because standard blood markers are imperfect. Serum or plasma zinc is the most common test, but it can be lowered by inflammation, infection, stress, and recent food intake, and it does not always reflect tissue stores. Despite these limits, a clearly low result is meaningful and worth acting on.
+
+Practical signals that zinc may be worth checking include a restricted or largely plant-based diet, frequent illness, poor wound healing, reduced sense of taste or smell, or poor appetite. In the context of ADHD, testing zinc alongside iron/ferritin, vitamin D, and magnesium gives a fuller nutritional picture than checking any one marker alone.
+
+## Copper Balance and Long-Term Use
+
+Zinc and copper compete for absorption, and sustained high-dose zinc can lower copper levels over time, potentially causing anemia or neurological problems. This is the single most important safety consideration for ongoing zinc use.
+
+Short-term repletion at modest doses is low-risk. Long-term or higher-dose supplementation should be monitored, and some clinicians recommend a small amount of copper alongside extended zinc use. This is a decision to make with a healthcare provider rather than by self-directed high dosing.
+
+## Forms and Dosing
+
+Common supplemental forms include zinc gluconate, zinc citrate, zinc picolinate, zinc bisglycinate, and zinc sulfate. Absorption differences between well-formulated products are modest; tolerability and cost often matter more than the specific salt. Zinc sulfate is the most likely to cause stomach upset.
+
+General principles rather than a prescription:
+
+- Supplemental doses in ADHD studies have typically fallen in a modest daily range, well below levels that risk copper depletion in the short term.
+- Taking zinc with food reduces nausea, though very high-phytate meals can lower absorption.
+- Dosing for children should always be set by a clinician, since needs and safe ranges differ by age and weight.
+
+Because appropriate dosing depends on age, diet, measured levels, and other supplements, individual dosing is best confirmed with a healthcare provider — especially for children and anyone taking medication.
+
+## Side Effects and Safety
+
+At modest doses zinc is generally well tolerated. The most common short-term side effect is stomach upset or nausea, especially on an empty stomach or with zinc sulfate. Key safety points:
+
+- **Copper depletion** is the main long-term risk of higher-dose supplementation.
+- **Excess zinc** can impair immune function rather than help it — more is not better.
+- **Medication interactions** exist: zinc can reduce absorption of some antibiotics and can be affected by certain diuretics, so timing and clinician input matter.
+- **Pregnancy, nursing, and pediatric use** require professional guidance on dose.
+
+If you are combining zinc with other calming, stimulating, or mineral supplements, it is worth reviewing the overall stack for overlap and interactions. The [ADHD stack guide](/guides/adhd/adhd-stack-guide/) covers how to combine supports without overstacking.
+
+## Practical Decision Framework
+
+A reasonable, evidence-aligned approach to zinc and ADHD:
+
+1. **Check before supplementing.** Ask about testing zinc, ideally alongside ferritin, vitamin D, and magnesium, rather than guessing.
+2. **Treat a real deficiency.** If levels are low, repletion is well-supported and low-risk in the short term.
+3. **Set modest expectations if levels are normal.** Benefit from adding zinc to an already-adequate diet is small.
+4. **Use it as an adjunct, not a replacement.** Zinc may support the response to established care; it does not substitute for it.
+5. **Monitor long-term use.** Watch copper status and involve a clinician for extended or higher-dose supplementation.
+
+## FAQ
+
+**Does zinc help ADHD?** It may modestly help when a genuine deficiency exists, and it may support the response to stimulant medication. In people with normal zinc levels, the benefit is generally small.
+
+**Should I get tested before taking zinc?** Testing is the more rational path, especially because the clearest benefit is in correcting a measured deficiency. Testing zinc alongside iron, vitamin D, and magnesium gives a fuller picture.
+
+**Can zinc replace ADHD medication?** No. Zinc is a nutrient-repletion tool, not a treatment for ADHD, and should not replace evidence-based care.
+
+**Is zinc safe to take long-term?** Modest short-term use is low-risk. Long-term or higher-dose use can deplete copper and should be monitored by a clinician.
+
+**Which form of zinc is best?** Differences between well-formulated forms are small. Zinc bisglycinate, citrate, and picolinate are generally well tolerated; zinc sulfate is more likely to cause stomach upset.
+
+## Conclusion
+
+Zinc has a real but limited role in ADHD. It matters most as a way to correct a deficiency that could be holding back dopamine signaling, sleep, and overall function — and possibly as an adjunct that supports the response to established treatment. It is not a stimulant substitute, and adding it when levels are already adequate offers little.
+
+The most useful next step is testing rather than guessing. If zinc is low, correcting it is sensible and safe in the short term; if it is normal, attention is better spent on sleep, nutrition, medication fit, and the other supports that carry stronger evidence. For related nutrients, see [nutrient deficiencies and ADHD](/guides/adhd/nutrient-deficiencies-and-adhd/), [iron, ferritin, and ADHD](/guides/adhd/iron-ferritin-and-adhd/), and the evidence-graded overview in [best supplements for ADHD](/guides/adhd/best-supplements-for-adhd/).

--- a/lib/focus-adhd-articles.ts
+++ b/lib/focus-adhd-articles.ts
@@ -122,8 +122,8 @@ export const focusAdhdArticles: FocusAdhdArticle[] = [
     description: 'Evidence-based review of zinc and ADHD. Covers deficiency, hyperactivity, attention, stimulant response, dosing, safety, and copper balance.',
     category: 'Nutrient Deficiencies',
     tags: ['Focus', 'ADHD', 'Nutrient Deficiencies', 'Supplement Evidence'],
-    date: '2026-06-11',
-    readingTime: '11 min read',
+    date: '2026-07-12',
+    readingTime: '8 min read',
   },
   {
     slug: 'iron-ferritin-and-adhd',


### PR DESCRIPTION
## Summary

- The `/guides/adhd/zinc-and-adhd/` route was serving a ~130-word source placeholder ("Full article content supplied in workflow session…") instead of real content, while every sibling ADHD article had 1,700–8,000 words.
- Replaces the stub in `docs/content/focus-cluster/zinc-and-adhd.md` with a complete ~1,600-word evidence-based article: dopamine/transporter mechanism, deficiency association, supplementation trials, the stimulant-response adjunct angle, deficiency assessment, copper-balance safety, forms/dosing, a practical decision framework, and FAQ.
- Adds internal links to five related ADHD cluster guides (nutrient deficiencies, blood tests, stack guide, iron/ferritin, best supplements).
- Updates the reading-time estimate in `lib/focus-adhd-articles.ts` to match the new length and flips the article `status` to published.

## Verification

- [x] `npm run check` (typecheck + lint + article quality + data:build:core) — exit 0
- [x] Content loader verified to render the full 1,583-word body (no placeholder text)
- [x] All five internal-link routes confirmed to exist
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs (reverted the disposable build-info timestamp)
- [x] no generated file corruption
- [x] static export compatible (markdown source + existing article renderer)

## Risk Notes

- Content-only change on an existing route: swaps placeholder text for a full article and adjusts one registry entry's reading time. No routing, layout, or component changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DvQwaiUDnVbvWH4WDaL51h

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvQwaiUDnVbvWH4WDaL51h)_