### PR TITLE
Normalize internal links to trailing-slash canonical form

### DIFF
--- a/app/__tests__/a11y.test.tsx
+++ b/app/__tests__/a11y.test.tsx
@@ -32,7 +32,7 @@ describe('a11y (axe-core)', () => {
   it('DecisionProfileCard renders with semantic structure and no serious a11y violations', async () => {
     const { container } = render(
       <DecisionProfileCard
-        href="/herbs/ashwagandha"
+        href="/herbs/ashwagandha/"
         name="Ashwagandha"
         summary="Evidence summary for stress."
         bestFor="Stress support"
@@ -50,7 +50,7 @@ describe('a11y (axe-core)', () => {
   it('Profile card renders without evidence/safety boxes', async () => {
     const { container } = render(
       <DecisionProfileCard
-        href="/herbs/unknown"
+        href="/herbs/unknown/"
         name="Unknown Herb"
         summary="Profile summary."
         bestFor="General"

--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -374,7 +374,7 @@ function CompoundMdxPage({ page }: { page: (typeof allCompoundMdxPages)[number] 
           Educational disclaimer: this page is for evidence review and harm-reduction context only. It is not medical advice, legal advice, sourcing guidance, or a recommendation to use any opioid-acting kratom derivative.
           <div className="mt-3 flex flex-wrap gap-4 font-semibold text-brand-800">
             <Link href="/compounds/" className="hover:underline">Compounds library</Link>
-            <Link href="/compounds/7-hydroxymitragynine" className="hover:underline">7-OH article</Link>
+            <Link href="/compounds/7-hydroxymitragynine/" className="hover:underline">7-OH article</Link>
             <Link href="/safety-checker/" className="hover:underline">Safety checker</Link>
           </div>
         </footer>
@@ -900,7 +900,7 @@ export default async function CompoundPage({ params }: PageProps) {
             </p>
             <div className="mt-4 flex flex-wrap gap-3">
               <Link
-                href="/compounds/7-hydroxymitragynine"
+                href="/compounds/7-hydroxymitragynine/"
                 className="rounded-full border border-red-200 bg-red-50 px-4 py-2 text-sm font-bold text-red-950 hover:bg-red-100"
               >
                 Full evidence monograph →
@@ -912,7 +912,7 @@ export default async function CompoundPage({ params }: PageProps) {
                 Withdrawal management guide →
               </Link>
               <Link
-                href="/guides/other/kratom-7oh-withdrawal-management"
+                href="/guides/other/kratom-7oh-withdrawal-management/"
                 className="rounded-full border border-brand-900/10 bg-white px-4 py-2 text-sm font-bold text-brand-800 hover:bg-brand-50"
               >
                 Compare mitragynine vs 7-OH →
@@ -930,13 +930,13 @@ export default async function CompoundPage({ params }: PageProps) {
             </p>
             <div className="mt-4 flex flex-wrap gap-3">
               <Link
-                href="/compounds/mitragynine"
+                href="/compounds/mitragynine/"
                 className="rounded-full border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-bold text-amber-950 hover:bg-amber-100"
               >
                 Mitragynine monograph →
               </Link>
               <Link
-                href="/guides/other/kratom-7oh-withdrawal-management"
+                href="/guides/other/kratom-7oh-withdrawal-management/"
                 className="rounded-full border border-brand-900/10 bg-white px-4 py-2 text-sm font-bold text-brand-800 hover:bg-brand-50"
               >
                 Compare mitragynine vs 7-OH →

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -50,21 +50,21 @@ export default function ErrorPage({ error, reset }: ErrorPageProps) {
           </Link>
 
           <Link
-            href='/herbs'
+            href='/herbs/'
             className='button-secondary px-5 py-3 text-sm'
           >
             Herbs
           </Link>
 
           <Link
-            href='/articles'
+            href='/articles/'
             className='button-secondary px-5 py-3 text-sm'
           >
             Articles
           </Link>
 
           <Link
-            href='/compounds'
+            href='/compounds/'
             className='button-secondary px-5 py-3 text-sm'
           >
             Compounds

--- a/app/guides/adhd/adhd-supplements/page.tsx
+++ b/app/guides/adhd/adhd-supplements/page.tsx
@@ -149,7 +149,7 @@ export default function AdhdSupplementsHub() {
           <Link href="/guides/adhd/best-supplements-for-adhd/" className="text-brand-700 hover:text-brand-800 hover:underline">
             Read Pillar Review →
           </Link>
-          <Link href="/guides/adhd/adhd-stack-guide" className="text-brand-700 hover:text-brand-800 hover:underline">
+          <Link href="/guides/adhd/adhd-stack-guide/" className="text-brand-700 hover:text-brand-800 hover:underline">
             View Stack Builder Guide →
           </Link>
         </div>
@@ -377,19 +377,19 @@ export default function AdhdSupplementsHub() {
           <div className="rounded-xl border border-brand-900/5 bg-brand-50/30 p-4">
             <h3 className="font-semibold text-ink text-sm">L-Theanine for Calm</h3>
             <p className="mt-1.5 text-xs text-muted leading-relaxed">
-              Promotes alpha brain wave activity to quiet a racing mind at bedtime. Learn more in our guide on <Link href="/guides/sleep/l-theanine-for-sleep" className="font-semibold text-brand-700 hover:text-brand-800 hover:underline">L-Theanine for Sleep</Link>.
+              Promotes alpha brain wave activity to quiet a racing mind at bedtime. Learn more in our guide on <Link href="/guides/sleep/l-theanine-for-sleep/" className="font-semibold text-brand-700 hover:text-brand-800 hover:underline">L-Theanine for Sleep</Link>.
             </p>
           </div>
           <div className="rounded-xl border border-brand-900/5 bg-brand-50/30 p-4">
             <h3 className="font-semibold text-ink text-sm">Magnesium Selection</h3>
             <p className="mt-1.5 text-xs text-muted leading-relaxed">
-              Supports neuromuscular relaxation and GABA. It is vital to prioritize deficiency testing. Compare forms in our guide on <Link href="/guides/sleep/magnesium-types-for-sleep" className="font-semibold text-brand-700 hover:text-brand-800 hover:underline">Magnesium Types for Sleep</Link>.
+              Supports neuromuscular relaxation and GABA. It is vital to prioritize deficiency testing. Compare forms in our guide on <Link href="/guides/sleep/magnesium-types-for-sleep/" className="font-semibold text-brand-700 hover:text-brand-800 hover:underline">Magnesium Types for Sleep</Link>.
             </p>
           </div>
           <div className="rounded-xl border border-brand-900/5 bg-brand-50/30 p-4">
             <h3 className="font-semibold text-ink text-sm">Botanical Sleep Support</h3>
             <p className="mt-1.5 text-xs text-muted leading-relaxed">
-              Herbs like chamomile, lemon balm, or valerian are commonly used for general relaxation. Explore the research in <Link href="/guides/sleep/best-herbs-for-sleep" className="font-semibold text-brand-700 hover:text-brand-800 hover:underline">Best Herbs for Sleep</Link>.
+              Herbs like chamomile, lemon balm, or valerian are commonly used for general relaxation. Explore the research in <Link href="/guides/sleep/best-herbs-for-sleep/" className="font-semibold text-brand-700 hover:text-brand-800 hover:underline">Best Herbs for Sleep</Link>.
             </p>
           </div>
         </div>

--- a/app/guides/anxiety/anxiety-stack-guide/page.tsx
+++ b/app/guides/anxiety/anxiety-stack-guide/page.tsx
@@ -273,7 +273,7 @@ export default function AnxietyStackGuidePage() {
               This is a more comprehensive stack that addresses chronic stress (ashwagandha), mental tension (L-theanine), and physical relaxation/sleep (magnesium). It is best suited for people whose anxiety significantly impacts sleep.
             </p>
             <p>
-              See also: <Link href="/guides/sleep/sleep-stack-guide" className="text-primary underline">Sleep Stack Guide</Link> and <Link href="/guides/sleep/best-herbs-for-sleep" className="text-primary underline">Best Herbs for Sleep</Link>.
+              See also: <Link href="/guides/sleep/sleep-stack-guide/" className="text-primary underline">Sleep Stack Guide</Link> and <Link href="/guides/sleep/best-herbs-for-sleep/" className="text-primary underline">Best Herbs for Sleep</Link>.
             </p>
           </div>
         </section>
@@ -407,13 +407,13 @@ export default function AnxietyStackGuidePage() {
             <Link href="/guides/herbs/l-theanine/" className="block p-4 border rounded-lg hover:bg-muted transition-colors">
               L-Theanine: Full Guide
             </Link>
-            <Link href="/guides/anxiety/cbd-vs-ashwagandha-for-anxiety" className="block p-4 border rounded-lg hover:bg-muted transition-colors">
+            <Link href="/guides/anxiety/cbd-vs-ashwagandha-for-anxiety/" className="block p-4 border rounded-lg hover:bg-muted transition-colors">
               CBD vs Ashwagandha for Anxiety
             </Link>
-            <Link href="/guides/sleep/sleep-stack-guide" className="block p-4 border rounded-lg hover:bg-muted transition-colors">
+            <Link href="/guides/sleep/sleep-stack-guide/" className="block p-4 border rounded-lg hover:bg-muted transition-colors">
               Sleep Stack Guide
             </Link>
-            <Link href="/guides/anxiety" className="block p-4 border rounded-lg hover:bg-muted transition-colors">
+            <Link href="/guides/anxiety/" className="block p-4 border rounded-lg hover:bg-muted transition-colors">
               Anxiety Goal Hub
             </Link>
           </div>

--- a/app/guides/anxiety/ashwagandha-for-anxiety/page.tsx
+++ b/app/guides/anxiety/ashwagandha-for-anxiety/page.tsx
@@ -252,7 +252,7 @@ export default function AshwagandhaForAnxietyPage() {
             </p>
             <p>
               Many people use them together or at different times of day. See our comparison in the{' '}
-              <Link href="/guides/sleep/l-theanine-for-sleep" className="text-primary underline">L-Theanine for Sleep</Link>, the umbrella{' '}
+              <Link href="/guides/sleep/l-theanine-for-sleep/" className="text-primary underline">L-Theanine for Sleep</Link>, the umbrella{' '}
               <Link href="/guides/herbs/l-theanine/" className="text-primary underline">L-Theanine article</Link>, and the{' '}
               <Link href="/guides/anxiety/natural-anxiety-relief/" className="text-primary underline">Natural Anxiety Relief</Link>{' '}
               hub. For the full{' '}
@@ -276,7 +276,7 @@ export default function AshwagandhaForAnxietyPage() {
             <p>
               See related content:{' '}
               <Link href="/guides/sleep/magnesium-for-sleep/" className="text-primary underline">Magnesium for Sleep</Link> and{' '}
-              <Link href="/guides/sleep/best-herbs-for-sleep" className="text-primary underline">Best Herbs for Sleep</Link>.
+              <Link href="/guides/sleep/best-herbs-for-sleep/" className="text-primary underline">Best Herbs for Sleep</Link>.
             </p>
           </div>
         </section>
@@ -393,19 +393,19 @@ export default function AshwagandhaForAnxietyPage() {
             <Link href="/guides/anxiety/l-theanine-for-anxiety/" className="block p-4 border rounded-lg hover:bg-muted transition-colors">
               L-Theanine for Anxiety
             </Link>
-            <Link href="/guides/anxiety/cbd-vs-ashwagandha-for-anxiety" className="block p-4 border rounded-lg hover:bg-muted transition-colors">
+            <Link href="/guides/anxiety/cbd-vs-ashwagandha-for-anxiety/" className="block p-4 border rounded-lg hover:bg-muted transition-colors">
               CBD vs Ashwagandha for Anxiety
             </Link>
-            <Link href="/guides/anxiety/anxiety-stack-guide" className="block p-4 border rounded-lg hover:bg-muted transition-colors">
+            <Link href="/guides/anxiety/anxiety-stack-guide/" className="block p-4 border rounded-lg hover:bg-muted transition-colors">
               Anxiety Stack Guide
             </Link>
-            <Link href="/guides/sleep/ashwagandha-for-sleep" className="block p-4 border rounded-lg hover:bg-muted transition-colors">
+            <Link href="/guides/sleep/ashwagandha-for-sleep/" className="block p-4 border rounded-lg hover:bg-muted transition-colors">
               Ashwagandha for Sleep
             </Link>
             <Link href="/guides/herbs/l-theanine/" className="block p-4 border rounded-lg hover:bg-muted transition-colors">
               L-Theanine: Full Guide
             </Link>
-            <Link href="/guides/anxiety" className="block p-4 border rounded-lg hover:bg-muted transition-colors">
+            <Link href="/guides/anxiety/" className="block p-4 border rounded-lg hover:bg-muted transition-colors">
               Anxiety Goal Hub
             </Link>
           </div>

--- a/app/guides/anxiety/best-adaptogens-for-stress/page.tsx
+++ b/app/guides/anxiety/best-adaptogens-for-stress/page.tsx
@@ -171,7 +171,7 @@ export default function BestAdaptogensForStressPage() {
             — meaning fastest in the sense of "lowest time-to-meaningful-benefit," not acute effect.
             Allow 4–8 weeks of consistent daily use. It will not lower cortisol in an hour; that is
             not how adaptogens work. If you need something for an acute stress spike, see{' '}
-            <Link href="/compounds/l-theanine" className="font-semibold text-brand-700 hover:underline">
+            <Link href="/compounds/l-theanine/" className="font-semibold text-brand-700 hover:underline">
               L-theanine
             </Link>
             . For the deep dive, see the{' '}
@@ -274,11 +274,11 @@ export default function BestAdaptogensForStressPage() {
 
         {/* Related */}
         <nav className="flex flex-wrap gap-4 text-sm font-semibold text-brand-700">
-          <Link href="/guides/anxiety" className="hover:text-brand-800">Stress goal hub →</Link>
+          <Link href="/guides/anxiety/" className="hover:text-brand-800">Stress goal hub →</Link>
           <Link href="/guides/herbs/ashwagandha/" className="hover:text-brand-800">Ashwagandha Article →</Link>
           <Link href="/guides/best/supplements-for-stress/" className="hover:text-brand-800">Best Supplements for Stress →</Link>
-          <Link href="/guides/how-to-lower-cortisol-naturally" className="hover:text-brand-800">How to Lower Cortisol Naturally →</Link>
-          <Link href="/guides/compare/rhodiola-vs-ashwagandha" className="hover:text-brand-800">Rhodiola vs Ashwagandha →</Link>
+          <Link href="/guides/how-to-lower-cortisol-naturally/" className="hover:text-brand-800">How to Lower Cortisol Naturally →</Link>
+          <Link href="/guides/compare/rhodiola-vs-ashwagandha/" className="hover:text-brand-800">Rhodiola vs Ashwagandha →</Link>
           <Link href="/guides/rhodiola-complete-guide/" className="hover:text-brand-800">Complete Rhodiola Guide →</Link>
           <Link href="/guides/" className="hover:text-brand-800">All Guides →</Link>
         </nav>

--- a/app/guides/anxiety/best-herbs-for-anxiety/page.tsx
+++ b/app/guides/anxiety/best-herbs-for-anxiety/page.tsx
@@ -198,10 +198,10 @@ export default function BestHerbsForAnxietyPage() {
             <strong>Fastest useful choice:</strong> for chronic stress-related anxiety, start with{' '}
             <Link href="/guides/herbs/ashwagandha/" className="font-semibold text-brand-800 hover:underline">ashwagandha</Link>;
             for same-day calming, compare{' '}
-            <Link href="/herbs/passionflower" className="font-semibold text-brand-800 hover:underline">passionflower</Link>{' '}
-            or <Link href="/compounds/lavender" className="font-semibold text-brand-800 hover:underline">lavender/Silexan</Link>;
+            <Link href="/herbs/passionflower/" className="font-semibold text-brand-800 hover:underline">passionflower</Link>{' '}
+            or <Link href="/compounds/lavender/" className="font-semibold text-brand-800 hover:underline">lavender/Silexan</Link>;
             for higher-risk short-term use only, read the{' '}
-            <Link href="/guides/kava" className="font-semibold text-brand-800 hover:underline">kava safety guide</Link> first.
+            <Link href="/guides/kava/" className="font-semibold text-brand-800 hover:underline">kava safety guide</Link> first.
           </div>
 
           <figure className="mt-6">
@@ -391,12 +391,12 @@ export default function BestHerbsForAnxietyPage() {
 
         {/* Related guides */}
         <nav className="flex flex-wrap gap-4 text-sm font-semibold text-brand-700">
-          <Link href="/guides/anxiety" className="hover:text-brand-800">Anxiety goal hub →</Link>
+          <Link href="/guides/anxiety/" className="hover:text-brand-800">Anxiety goal hub →</Link>
           <Link href="/guides/herbs/ashwagandha/" className="hover:text-brand-800">Ashwagandha Evidence Guide →</Link>
-          <Link href="/guides/anxiety/natural-anxiolytics-beyond-ashwagandha" className="hover:text-brand-800">Anxiolytics Beyond Ashwagandha →</Link>
-          <Link href="/guides/natural-alternatives-to-anxiety-medication" className="hover:text-brand-800">Natural Alternatives to Anxiety Meds →</Link>
-          <Link href="/guides/kava" className="hover:text-brand-800">Kava Safety Guide →</Link>
-          <Link href="/guides/best-supplements-for-overthinking" className="hover:text-brand-800">Supplements for Overthinking →</Link>
+          <Link href="/guides/anxiety/natural-anxiolytics-beyond-ashwagandha/" className="hover:text-brand-800">Anxiolytics Beyond Ashwagandha →</Link>
+          <Link href="/guides/natural-alternatives-to-anxiety-medication/" className="hover:text-brand-800">Natural Alternatives to Anxiety Meds →</Link>
+          <Link href="/guides/kava/" className="hover:text-brand-800">Kava Safety Guide →</Link>
+          <Link href="/guides/best-supplements-for-overthinking/" className="hover:text-brand-800">Supplements for Overthinking →</Link>
           <Link href="/guides/" className="hover:text-brand-800">All Guides →</Link>
         </nav>
       </div>

--- a/app/guides/anxiety/best-herbs-for-stress-and-anxiety-at-night/page.tsx
+++ b/app/guides/anxiety/best-herbs-for-stress-and-anxiety-at-night/page.tsx
@@ -213,13 +213,13 @@ export default function Page() {
               restless sleep. It is one of the gentlest ways to take the edge off bedtime worry, used as a
               tea or extract. A practical first choice when the issue is anxiety rather than deep
               tiredness. See the dedicated{' '}
-              <Link href="/guides/passionflower" className="font-medium text-brand-700 hover:underline">passionflower guide</Link>.
+              <Link href="/guides/passionflower/" className="font-medium text-brand-700 hover:underline">passionflower guide</Link>.
             </p>
           </article>
 
           <article className="card-premium p-6">
             <h3 className="text-xl font-semibold text-brand-800">
-              <Link href="/herbs/melissa-officinalis" className="hover:underline">Lemon balm (Melissa)</Link>
+              <Link href="/herbs/melissa-officinalis/" className="hover:underline">Lemon balm (Melissa)</Link>
             </h3>
             <p className="mt-3 text-sm text-muted">
               A mild, pleasant calming herb with traditional and some clinical support for reducing
@@ -230,24 +230,24 @@ export default function Page() {
 
           <article className="card-premium p-6">
             <h3 className="text-xl font-semibold text-brand-800">
-              <Link href="/herbs/ashwagandha" className="hover:underline">Ashwagandha</Link>{' '}
+              <Link href="/herbs/ashwagandha/" className="hover:underline">Ashwagandha</Link>{' '}
               <span className="ml-2 rounded-full bg-brand-50 px-3 py-0.5 align-middle text-xs font-semibold text-brand-800">Best for &ldquo;wired but tired&rdquo;</span>
             </h3>
             <p className="mt-3 text-sm text-muted">
               The most clinically studied adaptogen for stress. By moderating the HPA axis and lowering
               cortisol, evening ashwagandha targets the root of stress-driven wakefulness rather than
               just sedating you. Allow 2–6 weeks of consistent use. Learn how it compares in{' '}
-              <Link href="/guides/compare/rhodiola-vs-ashwagandha" className="font-medium text-brand-700 hover:underline">rhodiola vs ashwagandha</Link>{' '}
+              <Link href="/guides/compare/rhodiola-vs-ashwagandha/" className="font-medium text-brand-700 hover:underline">rhodiola vs ashwagandha</Link>{' '}
               and our{' '}
-              <Link href="/guides/how-to-lower-cortisol-naturally" className="font-medium text-brand-700 hover:underline">how to lower cortisol naturally</Link>{' '}
+              <Link href="/guides/how-to-lower-cortisol-naturally/" className="font-medium text-brand-700 hover:underline">how to lower cortisol naturally</Link>{' '}
               guide.
             </p>
           </article>
 
           <article className="card-premium p-6">
             <h3 className="text-xl font-semibold text-brand-800">
-              <Link href="/herbs/magnolia-officinalis" className="hover:underline">Magnolia bark</Link> &amp;{' '}
-              <Link href="/herbs/valerian" className="hover:underline">valerian</Link>
+              <Link href="/herbs/magnolia-officinalis/" className="hover:underline">Magnolia bark</Link> &amp;{' '}
+              <Link href="/herbs/valerian/" className="hover:underline">valerian</Link>
             </h3>
             <p className="mt-3 text-sm text-muted">
               Magnolia&rsquo;s honokiol acts on GABA receptors and is used traditionally for evening
@@ -258,14 +258,14 @@ export default function Page() {
 
           <article className="card-premium p-6">
             <h3 className="text-xl font-semibold text-brand-800">
-              <Link href="/compounds/l-theanine" className="hover:underline">L-theanine</Link>{' '}
+              <Link href="/compounds/l-theanine/" className="hover:underline">L-theanine</Link>{' '}
               <span className="ml-2 rounded-full bg-brand-50 px-3 py-0.5 align-middle text-xs font-semibold text-brand-800">Fastest for racing thoughts</span>
             </h3>
             <p className="mt-3 text-sm text-muted">
               Not a herb but the most reliable fast-acting option for mental noise: 100–200&nbsp;mg quiets
               stress-driven arousal within an hour without sedation, and it stacks cleanly with magnesium
               or passionflower. See{' '}
-              <Link href="/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium" className="font-medium text-brand-700 hover:underline">L-theanine vs magnesium</Link>.
+              <Link href="/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium/" className="font-medium text-brand-700 hover:underline">L-theanine vs magnesium</Link>.
             </p>
           </article>
         </section>
@@ -323,11 +323,11 @@ export default function Page() {
           <h2 className="text-2xl font-semibold text-ink">Related guides &amp; comparisons</h2>
           <div className="grid gap-3 sm:grid-cols-2">
             <Link href="/guides/best-natural-sleep-aids-that-work/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Best Natural Sleep Aids That Work →</Link>
-            <Link href="/guides/anxiety/best-herbs-for-anxiety" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Best Herbs for Anxiety →</Link>
-            <Link href="/guides/how-to-lower-cortisol-naturally" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">How to Lower Cortisol Naturally →</Link>
-            <Link href="/guides/anxiety/natural-anxiolytics-beyond-ashwagandha" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Natural Anxiolytics Beyond Ashwagandha →</Link>
-            <Link href="/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Ashwagandha vs L-theanine vs Magnesium →</Link>
-            <Link href="/guides/anxiety" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">All Anxiety Guides →</Link>
+            <Link href="/guides/anxiety/best-herbs-for-anxiety/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Best Herbs for Anxiety →</Link>
+            <Link href="/guides/how-to-lower-cortisol-naturally/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">How to Lower Cortisol Naturally →</Link>
+            <Link href="/guides/anxiety/natural-anxiolytics-beyond-ashwagandha/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Natural Anxiolytics Beyond Ashwagandha →</Link>
+            <Link href="/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Ashwagandha vs L-theanine vs Magnesium →</Link>
+            <Link href="/guides/anxiety/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">All Anxiety Guides →</Link>
           </div>
         </section>
       </div>

--- a/app/guides/anxiety/best-supplements-for-overthinking/page.tsx
+++ b/app/guides/anxiety/best-supplements-for-overthinking/page.tsx
@@ -133,7 +133,7 @@ export default function Page() {
             effects typically within 30–60 minutes, no sedation, no dependency. It works by raising
             calming alpha-wave activity and dialing down anxious mental chatter. If overthinking
             peaks at night with physical tension, add{' '}
-            <Link href="/compounds/magnesium-glycinate" className="font-semibold text-brand-700 hover:underline">
+            <Link href="/compounds/magnesium-glycinate/" className="font-semibold text-brand-700 hover:underline">
               magnesium glycinate
             </Link>{' '}
             in the evening. See the{' '}
@@ -199,7 +199,7 @@ export default function Page() {
 
           <article className="card-premium p-6">
             <h3 className="text-xl font-semibold text-brand-800">
-              <Link href="/compounds/l-theanine" className="hover:underline">L-theanine</Link>{' '}
+              <Link href="/compounds/l-theanine/" className="hover:underline">L-theanine</Link>{' '}
               <span className="ml-2 rounded-full bg-brand-50 px-3 py-0.5 align-middle text-xs font-semibold text-brand-800">First choice</span>
             </h3>
             <p className="mt-3 text-sm text-muted">
@@ -207,13 +207,13 @@ export default function Page() {
               glutamate. Trials show reduced stress and a quieter, calmer focus without drowsiness. It is
               the cleanest way to take the volume down on mental chatter, and it pairs perfectly with
               magnesium. Compare them in{' '}
-              <Link href="/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium" className="font-medium text-brand-700 hover:underline">L-theanine vs magnesium</Link>.
+              <Link href="/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium/" className="font-medium text-brand-700 hover:underline">L-theanine vs magnesium</Link>.
             </p>
           </article>
 
           <article className="card-premium p-6">
             <h3 className="text-xl font-semibold text-brand-800">
-              <Link href="/compounds/magnesium-glycinate" className="hover:underline">Magnesium glycinate</Link>
+              <Link href="/compounds/magnesium-glycinate/" className="hover:underline">Magnesium glycinate</Link>
             </h3>
             <p className="mt-3 text-sm text-muted">
               Magnesium lowers nervous-system excitability and supports relaxation, and many people who
@@ -224,7 +224,7 @@ export default function Page() {
 
           <article className="card-premium p-6">
             <h3 className="text-xl font-semibold text-brand-800">
-              <Link href="/herbs/melissa-officinalis" className="hover:underline">Lemon balm &amp; saffron</Link>
+              <Link href="/herbs/melissa-officinalis/" className="hover:underline">Lemon balm &amp; saffron</Link>
             </h3>
             <p className="mt-3 text-sm text-muted">
               Lemon balm is a gentle calming herb with some trial support for reducing stress and
@@ -236,14 +236,14 @@ export default function Page() {
 
           <article className="card-premium p-6">
             <h3 className="text-xl font-semibold text-brand-800">
-              <Link href="/herbs/ashwagandha" className="hover:underline">Ashwagandha</Link>{' '}
+              <Link href="/herbs/ashwagandha/" className="hover:underline">Ashwagandha</Link>{' '}
               <span className="ml-2 rounded-full bg-brand-50 px-3 py-0.5 align-middle text-xs font-semibold text-brand-800">For chronic loops</span>
             </h3>
             <p className="mt-3 text-sm text-muted">
               When overthinking is really chronic stress wearing a different mask, ashwagandha addresses
               the root by lowering cortisol and perceived stress over 4–8 weeks. It will not stop a single
               spiral tonight, but it lowers the baseline that makes spirals more likely. See our{' '}
-              <Link href="/guides/how-to-lower-cortisol-naturally" className="font-medium text-brand-700 hover:underline">how to lower cortisol naturally</Link>{' '}
+              <Link href="/guides/how-to-lower-cortisol-naturally/" className="font-medium text-brand-700 hover:underline">how to lower cortisol naturally</Link>{' '}
               guide.
             </p>
           </article>
@@ -299,12 +299,12 @@ export default function Page() {
         <section className="space-y-4">
           <h2 className="text-2xl font-semibold text-ink">Related guides &amp; comparisons</h2>
           <div className="grid gap-3 sm:grid-cols-2">
-            <Link href="/guides/anxiety/best-herbs-for-anxiety" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Best Herbs for Anxiety →</Link>
-            <Link href="/guides/anxiety/natural-anxiolytics-beyond-ashwagandha" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Natural Anxiolytics Beyond Ashwagandha →</Link>
-            <Link href="/guides/best-herbs-for-stress-and-anxiety-at-night" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Best Herbs for Stress &amp; Anxiety at Night →</Link>
-            <Link href="/guides/how-to-lower-cortisol-naturally" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">How to Lower Cortisol Naturally →</Link>
-            <Link href="/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Ashwagandha vs L-theanine vs Magnesium →</Link>
-            <Link href="/guides/anxiety" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">All Anxiety Guides →</Link>
+            <Link href="/guides/anxiety/best-herbs-for-anxiety/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Best Herbs for Anxiety →</Link>
+            <Link href="/guides/anxiety/natural-anxiolytics-beyond-ashwagandha/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Natural Anxiolytics Beyond Ashwagandha →</Link>
+            <Link href="/guides/best-herbs-for-stress-and-anxiety-at-night/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Best Herbs for Stress &amp; Anxiety at Night →</Link>
+            <Link href="/guides/how-to-lower-cortisol-naturally/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">How to Lower Cortisol Naturally →</Link>
+            <Link href="/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Ashwagandha vs L-theanine vs Magnesium →</Link>
+            <Link href="/guides/anxiety/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">All Anxiety Guides →</Link>
           </div>
         </section>
       </div>

--- a/app/guides/anxiety/best-supplements-for-stress/page.tsx
+++ b/app/guides/anxiety/best-supplements-for-stress/page.tsx
@@ -132,7 +132,7 @@ export default function BestSupplementsForStressPage() {
             <strong>Fastest useful choice:</strong> for chronic daily stress, start with{' '}
             <Link href="/guides/herbs/ashwagandha/" className="font-semibold text-brand-800 hover:underline">ashwagandha</Link>;
             for pressure and fatigue, compare{' '}
-            <Link href="/herbs/rhodiola" className="font-semibold text-brand-800 hover:underline">rhodiola</Link>;
+            <Link href="/herbs/rhodiola/" className="font-semibold text-brand-800 hover:underline">rhodiola</Link>;
             for acute stress without sedation, start with{' '}
             <Link href="/guides/herbs/l-theanine/" className="font-semibold text-brand-800 hover:underline">L-theanine</Link>.
           </div>
@@ -235,8 +235,8 @@ export default function BestSupplementsForStressPage() {
         <nav className="flex flex-wrap gap-4 text-sm font-semibold text-brand-700">
           <Link href="/guides/herbs/ashwagandha/" className="hover:text-brand-800">Ashwagandha Evidence Guide →</Link>
           <Link href="/guides/herbs/l-theanine/" className="hover:text-brand-800">L-Theanine for Acute Stress →</Link>
-          <Link href="/guides/how-to-lower-cortisol-naturally" className="hover:text-brand-800">How to Lower Cortisol Naturally →</Link>
-          <Link href="/guides/compare/rhodiola-vs-ashwagandha" className="hover:text-brand-800">Rhodiola vs Ashwagandha →</Link>
+          <Link href="/guides/how-to-lower-cortisol-naturally/" className="hover:text-brand-800">How to Lower Cortisol Naturally →</Link>
+          <Link href="/guides/compare/rhodiola-vs-ashwagandha/" className="hover:text-brand-800">Rhodiola vs Ashwagandha →</Link>
           <Link href="/guides/rhodiola-complete-guide/" className="hover:text-brand-800">Complete Rhodiola Guide →</Link>
           <Link href="/guides/" className="hover:text-brand-800">All Guides →</Link>
         </nav>

--- a/app/guides/anxiety/cbd-vs-ashwagandha-for-anxiety/page.tsx
+++ b/app/guides/anxiety/cbd-vs-ashwagandha-for-anxiety/page.tsx
@@ -464,19 +464,19 @@ export default function CbdVsAshwagandhaForAnxietyPage() {
               L-Theanine for Anxiety
             </Link>
             <Link
-              href="/guides/anxiety/anxiety-stack-guide"
+              href="/guides/anxiety/anxiety-stack-guide/"
               className="block p-4 border rounded-lg hover:bg-muted transition-colors"
             >
               Anxiety Stack Guide
             </Link>
             <Link
-              href="/guides/sleep/ashwagandha-for-sleep"
+              href="/guides/sleep/ashwagandha-for-sleep/"
               className="block p-4 border rounded-lg hover:bg-muted transition-colors"
             >
               Ashwagandha for Sleep
             </Link>
             <Link
-              href="/guides/sleep/sleep-stack-guide"
+              href="/guides/sleep/sleep-stack-guide/"
               className="block p-4 border rounded-lg hover:bg-muted transition-colors"
             >
               Sleep Stack Guide

--- a/app/guides/anxiety/how-to-lower-cortisol-naturally/page.tsx
+++ b/app/guides/anxiety/how-to-lower-cortisol-naturally/page.tsx
@@ -132,12 +132,12 @@ export default function Page() {
             poor night measurably raises next-day cortisol, while a consistent sleep-and-wake schedule
             restores the natural morning-peak / evening-trough rhythm that supplements cannot replicate.
             For acute stress moments,{' '}
-            <Link href="/compounds/l-theanine" className="font-semibold text-brand-700 hover:underline">
+            <Link href="/compounds/l-theanine/" className="font-semibold text-brand-700 hover:underline">
               L-theanine
             </Link>{' '}
             (100&ndash;200&nbsp;mg) blunts cortisol within an hour. For chronic baseline elevation over
             weeks,{' '}
-            <Link href="/herbs/ashwagandha" className="font-semibold text-brand-700 hover:underline">
+            <Link href="/herbs/ashwagandha/" className="font-semibold text-brand-700 hover:underline">
               ashwagandha
             </Link>{' '}
             (300&ndash;600&nbsp;mg, KSM-66 or Sensoril) has the strongest supplement evidence.
@@ -211,7 +211,7 @@ export default function Page() {
 
           <article className="card-premium p-6">
             <h3 className="text-xl font-semibold text-brand-800">
-              <Link href="/herbs/ashwagandha" className="hover:underline">Ashwagandha</Link>{' '}
+              <Link href="/herbs/ashwagandha/" className="hover:underline">Ashwagandha</Link>{' '}
               <span className="ml-2 rounded-full bg-brand-50 px-3 py-0.5 align-middle text-xs font-semibold text-brand-800">Strongest evidence</span>
             </h3>
             <p className="mt-3 text-sm text-muted">
@@ -219,13 +219,13 @@ export default function Page() {
               stressed adults across randomized trials. Typical dose is 300–600&nbsp;mg of a standardized
               extract, given 4–8 weeks. It is the closest thing to a direct cortisol-lowering supplement —
               see how it stacks up in{' '}
-              <Link href="/guides/compare/rhodiola-vs-ashwagandha" className="font-medium text-brand-700 hover:underline">rhodiola vs ashwagandha</Link>.
+              <Link href="/guides/compare/rhodiola-vs-ashwagandha/" className="font-medium text-brand-700 hover:underline">rhodiola vs ashwagandha</Link>.
             </p>
           </article>
 
           <article className="card-premium p-6">
             <h3 className="text-xl font-semibold text-brand-800">
-              <Link href="/herbs/rhodiola" className="hover:underline">Rhodiola rosea</Link>
+              <Link href="/herbs/rhodiola/" className="hover:underline">Rhodiola rosea</Link>
             </h3>
             <p className="mt-3 text-sm text-muted">
               Rhodiola targets the <em>experience</em> of stress — fatigue, mental tiredness and burnout —
@@ -238,7 +238,7 @@ export default function Page() {
 
           <article className="card-premium p-6">
             <h3 className="text-xl font-semibold text-brand-800">
-              <Link href="/herbs/holy-basil" className="hover:underline">Holy basil (tulsi)</Link>
+              <Link href="/herbs/holy-basil/" className="hover:underline">Holy basil (tulsi)</Link>
             </h3>
             <p className="mt-3 text-sm text-muted">
               A traditional adaptogen with emerging trial support for reducing stress symptoms. A gentle,
@@ -248,15 +248,15 @@ export default function Page() {
 
           <article className="card-premium p-6">
             <h3 className="text-xl font-semibold text-brand-800">
-              <Link href="/compounds/magnesium-glycinate" className="hover:underline">Magnesium</Link> &amp;{' '}
-              <Link href="/compounds/l-theanine" className="hover:underline">L-theanine</Link>
+              <Link href="/compounds/magnesium-glycinate/" className="hover:underline">Magnesium</Link> &amp;{' '}
+              <Link href="/compounds/l-theanine/" className="hover:underline">L-theanine</Link>
             </h3>
             <p className="mt-3 text-sm text-muted">
               Magnesium supports HPA-axis regulation and is often depleted in stressed people; deficiency
               amplifies the stress response. L-theanine is the best acute tool, blunting cortisol and the
               feeling of stress within an hour without sedation. Together they cover the moment-to-moment
               side of stress while adaptogens work on the baseline. See{' '}
-              <Link href="/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium" className="font-medium text-brand-700 hover:underline">ashwagandha vs L-theanine vs magnesium</Link>.
+              <Link href="/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium/" className="font-medium text-brand-700 hover:underline">ashwagandha vs L-theanine vs magnesium</Link>.
             </p>
           </article>
         </section>
@@ -302,11 +302,11 @@ export default function Page() {
           <h2 className="text-2xl font-semibold text-ink">Related guides &amp; comparisons</h2>
           <div className="grid gap-3 sm:grid-cols-2">
             <Link href="/guides/best/supplements-for-stress/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Best Supplements for Stress →</Link>
-            <Link href="/guides/anxiety/best-adaptogens-for-stress" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Best Adaptogens for Stress →</Link>
-            <Link href="/guides/best-herbs-for-stress-and-anxiety-at-night" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Best Herbs for Stress &amp; Anxiety at Night →</Link>
+            <Link href="/guides/anxiety/best-adaptogens-for-stress/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Best Adaptogens for Stress →</Link>
+            <Link href="/guides/best-herbs-for-stress-and-anxiety-at-night/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Best Herbs for Stress &amp; Anxiety at Night →</Link>
             <Link href="/guides/rhodiola-complete-guide/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Complete Rhodiola Guide →</Link>
-            <Link href="/guides/compare/rhodiola-vs-ashwagandha" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Rhodiola vs Ashwagandha →</Link>
-            <Link href="/guides/anxiety" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">All Stress Guides →</Link>
+            <Link href="/guides/compare/rhodiola-vs-ashwagandha/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Rhodiola vs Ashwagandha →</Link>
+            <Link href="/guides/anxiety/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">All Stress Guides →</Link>
           </div>
         </section>
       </div>

--- a/app/guides/anxiety/l-theanine-for-anxiety/page.tsx
+++ b/app/guides/anxiety/l-theanine-for-anxiety/page.tsx
@@ -253,7 +253,7 @@ export default function LTheanineForAnxietyPage() {
                 Magnesium for Sleep
               </Link>
               , and{' '}
-              <Link href="/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium" className="text-primary underline">
+              <Link href="/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium/" className="text-primary underline">
                 L-Theanine vs Magnesium
               </Link>
               .
@@ -272,11 +272,11 @@ export default function LTheanineForAnxietyPage() {
             </p>
             <p>
               For sleep-specific context, read{' '}
-              <Link href="/guides/sleep/l-theanine-for-sleep" className="text-primary underline">
+              <Link href="/guides/sleep/l-theanine-for-sleep/" className="text-primary underline">
                 L-Theanine for Sleep
               </Link>
               {' '}and{' '}
-              <Link href="/guides/sleep/sleep-stack-guide" className="text-primary underline">
+              <Link href="/guides/sleep/sleep-stack-guide/" className="text-primary underline">
                 Sleep Stack Guide
               </Link>
               .

--- a/app/guides/anxiety/natural-alternatives-to-anxiety-medication/page.tsx
+++ b/app/guides/anxiety/natural-alternatives-to-anxiety-medication/page.tsx
@@ -61,8 +61,8 @@ export default function Page() {
       )}
       <EmailCapture location="guides-natural-alternatives-to-anxiety-medication" className="mt-6" />
       <div className="flex flex-wrap gap-4">
-        <Link href="/guides/anxiety/best-herbs-for-anxiety" className="text-sm font-medium text-emerald-700 hover:underline">Top anxiety herbs</Link>
-        <Link href="/guides/anxiety/natural-anxiolytics-beyond-ashwagandha" className="text-sm font-medium text-emerald-700 hover:underline">Natural anxiolytics cluster</Link>
+        <Link href="/guides/anxiety/best-herbs-for-anxiety/" className="text-sm font-medium text-emerald-700 hover:underline">Top anxiety herbs</Link>
+        <Link href="/guides/anxiety/natural-anxiolytics-beyond-ashwagandha/" className="text-sm font-medium text-emerald-700 hover:underline">Natural anxiolytics cluster</Link>
       </div>
     </ArticleLayout>
   )

--- a/app/guides/anxiety/natural-anxiety-relief/page.tsx
+++ b/app/guides/anxiety/natural-anxiety-relief/page.tsx
@@ -191,7 +191,7 @@ export default function NaturalAnxietyReliefPage() {
                 ashwagandha guide
               </Link>
               , and the{' '}
-              <Link href="/guides/anxiety/anxiety-stack-guide" className="font-semibold text-brand-700 hover:underline">
+              <Link href="/guides/anxiety/anxiety-stack-guide/" className="font-semibold text-brand-700 hover:underline">
                 anxiety stack guide
               </Link>
               .
@@ -332,7 +332,7 @@ export default function NaturalAnxietyReliefPage() {
                         <td className="py-3 pr-4 text-muted">Avoid with sedatives; caution in pregnancy</td>
                         <td className="py-3">
                           <Link
-                            href="/guides/passionflower"
+                            href="/guides/passionflower/"
                             className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
                           >
                             Full guide →
@@ -355,7 +355,7 @@ export default function NaturalAnxietyReliefPage() {
                         <td className="py-3 pr-4 text-muted">Hepatotoxicity risk; avoid with alcohol/sedatives</td>
                         <td className="py-3">
                           <Link
-                            href="/guides/kava"
+                            href="/guides/kava/"
                             className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
                           >
                             Full guide →
@@ -370,7 +370,7 @@ export default function NaturalAnxietyReliefPage() {
                         <td className="py-3 pr-4 text-muted">Sedation; avoid with CNS depressants</td>
                         <td className="py-3">
                           <Link
-                            href="/guides/sleep/best-herbs-for-sleep"
+                            href="/guides/sleep/best-herbs-for-sleep/"
                             className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
                           >
                             Sleep hub →
@@ -485,7 +485,7 @@ export default function NaturalAnxietyReliefPage() {
                   </p>
                   <p>
                     <Link
-                      href="/guides/sleep/ashwagandha-for-sleep"
+                      href="/guides/sleep/ashwagandha-for-sleep/"
                       className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
                     >
                       Related: Ashwagandha for Sleep →
@@ -534,7 +534,7 @@ export default function NaturalAnxietyReliefPage() {
                   </p>
                   <p>
                     <Link
-                      href="/guides/sleep/l-theanine-for-sleep"
+                      href="/guides/sleep/l-theanine-for-sleep/"
                       className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
                     >
                       Related: L-Theanine for Sleep →
@@ -728,7 +728,7 @@ export default function NaturalAnxietyReliefPage() {
                   <span className="mt-0.5 flex-shrink-0 text-brand-700">→</span>
                   <p className="text-[1.01rem] leading-[1.85] text-muted">
                     <strong>Chronic stress + poor sleep:</strong> Start with{' '}
-                    <Link href="/guides/sleep/ashwagandha-for-sleep" className="font-semibold text-brand-700 hover:underline">
+                    <Link href="/guides/sleep/ashwagandha-for-sleep/" className="font-semibold text-brand-700 hover:underline">
                       ashwagandha
                     </Link>{' '}
                     (KSM-66 or Sensoril, 300–600 mg/day). Allow 6–8 weeks. Consider adding{' '}
@@ -853,7 +853,7 @@ export default function NaturalAnxietyReliefPage() {
               </p>
               <div className="grid gap-3 sm:grid-cols-2">
                 <Link
-                  href="/guides/sleep/best-herbs-for-sleep"
+                  href="/guides/sleep/best-herbs-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-brand-50/40 p-4 transition hover:border-brand-700/30"
                 >
                   <p className="font-semibold text-ink transition group-hover:text-brand-700">
@@ -864,7 +864,7 @@ export default function NaturalAnxietyReliefPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/ashwagandha-for-sleep"
+                  href="/guides/sleep/ashwagandha-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-brand-50/40 p-4 transition hover:border-brand-700/30"
                 >
                   <p className="font-semibold text-ink transition group-hover:text-brand-700">
@@ -875,7 +875,7 @@ export default function NaturalAnxietyReliefPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/l-theanine-for-sleep"
+                  href="/guides/sleep/l-theanine-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-brand-50/40 p-4 transition hover:border-brand-700/30"
                 >
                   <p className="font-semibold text-ink transition group-hover:text-brand-700">
@@ -897,7 +897,7 @@ export default function NaturalAnxietyReliefPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/sleep-stack-guide"
+                  href="/guides/sleep/sleep-stack-guide/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-brand-50/40 p-4 transition hover:border-brand-700/30"
                 >
                   <p className="font-semibold text-ink transition group-hover:text-brand-700">
@@ -1120,7 +1120,7 @@ export default function NaturalAnxietyReliefPage() {
               </h2>
               <div className="grid gap-3 sm:grid-cols-2">
                 <Link
-                  href="/guides/sleep/best-herbs-for-sleep"
+                  href="/guides/sleep/best-herbs-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -1135,7 +1135,7 @@ export default function NaturalAnxietyReliefPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/ashwagandha-for-sleep"
+                  href="/guides/sleep/ashwagandha-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -1149,7 +1149,7 @@ export default function NaturalAnxietyReliefPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/l-theanine-for-sleep"
+                  href="/guides/sleep/l-theanine-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -1177,7 +1177,7 @@ export default function NaturalAnxietyReliefPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/sleep-stack-guide"
+                  href="/guides/sleep/sleep-stack-guide/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -1191,7 +1191,7 @@ export default function NaturalAnxietyReliefPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/anxiety/ashwagandha-for-anxiety"
+                  href="/guides/anxiety/ashwagandha-for-anxiety/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -1211,7 +1211,7 @@ export default function NaturalAnxietyReliefPage() {
                   <p className="mt-1 text-xs text-muted">Calm focus and racing thoughts without sedation.</p>
                 </Link>
                 <Link
-                  href="/guides/anxiety/anxiety-stack-guide"
+                  href="/guides/anxiety/anxiety-stack-guide/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -1386,7 +1386,7 @@ export default function NaturalAnxietyReliefPage() {
             </p>
             <div className="mt-3 space-y-2">
               <Link
-                href="/guides/anxiety/ashwagandha-for-anxiety"
+                href="/guides/anxiety/ashwagandha-for-anxiety/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Ashwagandha for anxiety →
@@ -1398,7 +1398,7 @@ export default function NaturalAnxietyReliefPage() {
                 L-theanine for anxiety →
               </Link>
               <Link
-                href="/guides/anxiety/anxiety-stack-guide"
+                href="/guides/anxiety/anxiety-stack-guide/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Anxiety stack guide →
@@ -1413,13 +1413,13 @@ export default function NaturalAnxietyReliefPage() {
             </p>
             <div className="mt-3 space-y-2">
               <Link
-                href="/guides/sleep/best-herbs-for-sleep"
+                href="/guides/sleep/best-herbs-for-sleep/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Best herbs for sleep →
               </Link>
               <Link
-                href="/guides/sleep/ashwagandha-for-sleep"
+                href="/guides/sleep/ashwagandha-for-sleep/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Ashwagandha for sleep →
@@ -1431,7 +1431,7 @@ export default function NaturalAnxietyReliefPage() {
                 Magnesium for sleep →
               </Link>
               <Link
-                href="/guides/sleep/sleep-stack-guide"
+                href="/guides/sleep/sleep-stack-guide/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Sleep stack guide →

--- a/app/guides/anxiety/natural-anxiolytics-beyond-ashwagandha/page.tsx
+++ b/app/guides/anxiety/natural-anxiolytics-beyond-ashwagandha/page.tsx
@@ -94,16 +94,16 @@ export default function NaturalAnxiolyticsPage() {
         </p>
 
         <div className="mt-6 flex flex-wrap gap-4 text-xs font-semibold uppercase tracking-[0.14em]">
-          <Link href="/herbs/ashwagandha" className="text-brand-700 hover:text-brand-800 hover:underline">
+          <Link href="/herbs/ashwagandha/" className="text-brand-700 hover:text-brand-800 hover:underline">
             Read Ashwagandha Profile →
           </Link>
-          <Link href="/guides/anxiety/best-herbs-for-anxiety" className="text-brand-700 hover:text-brand-800 hover:underline">
+          <Link href="/guides/anxiety/best-herbs-for-anxiety/" className="text-brand-700 hover:text-brand-800 hover:underline">
             Best Herbs for Anxiety Guide →
           </Link>
-          <Link href="/guides/compare/kanna-vs-ssris" className="text-brand-700 hover:text-brand-800 hover:underline">
+          <Link href="/guides/compare/kanna-vs-ssris/" className="text-brand-700 hover:text-brand-800 hover:underline">
             Kanna vs SSRIs Guide →
           </Link>
-          <Link href="/guides/compare/kava-vs-alcohol" className="text-brand-700 hover:text-brand-800 hover:underline">
+          <Link href="/guides/compare/kava-vs-alcohol/" className="text-brand-700 hover:text-brand-800 hover:underline">
             Kava vs Alcohol Guide →
           </Link>
         </div>

--- a/app/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium/page.tsx
+++ b/app/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium/page.tsx
@@ -96,7 +96,7 @@ export default function AshwagandhaVsLTheanineVsMagnesiumPage() {
             </p>
           </div>
           <div className="pt-4">
-            <Link href="/herbs/ashwagandha" className="chip-readable text-xs font-bold">
+            <Link href="/herbs/ashwagandha/" className="chip-readable text-xs font-bold">
               Explore Ashwagandha →
             </Link>
           </div>
@@ -113,7 +113,7 @@ export default function AshwagandhaVsLTheanineVsMagnesiumPage() {
             </p>
           </div>
           <div className="pt-4">
-            <Link href="/compounds/l-theanine" className="chip-readable text-xs font-bold">
+            <Link href="/compounds/l-theanine/" className="chip-readable text-xs font-bold">
               Explore L-Theanine →
             </Link>
           </div>
@@ -130,7 +130,7 @@ export default function AshwagandhaVsLTheanineVsMagnesiumPage() {
             </p>
           </div>
           <div className="pt-4">
-            <Link href="/compounds/magnesium" className="chip-readable text-xs font-bold">
+            <Link href="/compounds/magnesium/" className="chip-readable text-xs font-bold">
               Explore Magnesium →
             </Link>
           </div>

--- a/app/guides/compare/berberine-vs-metformin/page.tsx
+++ b/app/guides/compare/berberine-vs-metformin/page.tsx
@@ -101,7 +101,7 @@ export default function BerberineVsMetforminPage() {
             AMPK activation — the same upstream target as metformin. Also modulates the gut microbiome,
             inhibits PTP1B, and upregulates GLUT4. Available OTC; typically dosed 500mg three times daily.
           </p>
-          <Link href="/compounds/berberine" className="chip-readable">Explore Berberine</Link>
+          <Link href="/compounds/berberine/" className="chip-readable">Explore Berberine</Link>
         </div>
 
         <div className="card-premium p-6 space-y-4">
@@ -510,10 +510,10 @@ export default function BerberineVsMetforminPage() {
       </div>
 
       <div className="flex flex-wrap gap-3">
-        <Link href="/guides/compare/berberine-vs-metformin" className="chip-readable">Berberine vs Inositol</Link>
-        <Link href="/guides/compare/berberine-vs-metformin" className="chip-readable">Berberine vs Psyllium</Link>
-        <Link href="/guides/best/supplements-for-gut-health" className="chip-readable">Gut Health Goals</Link>
-        <Link href="/guides/best/supplements-for-fat-loss" className="chip-readable">Fat Loss Goals</Link>
+        <Link href="/guides/compare/berberine-vs-metformin/" className="chip-readable">Berberine vs Inositol</Link>
+        <Link href="/guides/compare/berberine-vs-metformin/" className="chip-readable">Berberine vs Psyllium</Link>
+        <Link href="/guides/best/supplements-for-gut-health/" className="chip-readable">Gut Health Goals</Link>
+        <Link href="/guides/best/supplements-for-fat-loss/" className="chip-readable">Fat Loss Goals</Link>
         <Link href="/guides/compare/" className="chip-readable">All Comparisons</Link>
       </div>
       <ConversionStickyCTA

--- a/app/guides/compare/caffeine-vs-l-theanine-vs-bacopa-for-focus/page.tsx
+++ b/app/guides/compare/caffeine-vs-l-theanine-vs-bacopa-for-focus/page.tsx
@@ -109,7 +109,7 @@ export default function CaffeineVsLTheanineVsBacopaForFocusPage() {
             </p>
           </div>
           <div className="pt-4">
-            <Link href="/compounds/caffeine" className="chip-readable text-xs font-bold">
+            <Link href="/compounds/caffeine/" className="chip-readable text-xs font-bold">
               Explore Caffeine →
             </Link>
           </div>
@@ -126,7 +126,7 @@ export default function CaffeineVsLTheanineVsBacopaForFocusPage() {
             </p>
           </div>
           <div className="pt-4">
-            <Link href="/compounds/l-theanine" className="chip-readable text-xs font-bold">
+            <Link href="/compounds/l-theanine/" className="chip-readable text-xs font-bold">
               Explore L-Theanine →
             </Link>
           </div>
@@ -143,7 +143,7 @@ export default function CaffeineVsLTheanineVsBacopaForFocusPage() {
             </p>
           </div>
           <div className="pt-4">
-            <Link href="/herbs/bacopa" className="chip-readable text-xs font-bold">
+            <Link href="/herbs/bacopa/" className="chip-readable text-xs font-bold">
               Explore Bacopa →
             </Link>
           </div>

--- a/app/guides/compare/curcumin-vs-boswellia-vs-omega-3/page.tsx
+++ b/app/guides/compare/curcumin-vs-boswellia-vs-omega-3/page.tsx
@@ -100,7 +100,7 @@ export default function CurcuminVsBoswelliaVsOmega3Page() {
             </p>
           </div>
           <div className="pt-4">
-            <Link href="/compounds/curcumin" className="chip-readable text-xs font-bold">
+            <Link href="/compounds/curcumin/" className="chip-readable text-xs font-bold">
               Explore Curcumin →
             </Link>
           </div>
@@ -119,7 +119,7 @@ export default function CurcuminVsBoswelliaVsOmega3Page() {
             </p>
           </div>
           <div className="pt-4">
-            <Link href="/compounds/boswellia" className="chip-readable text-xs font-bold">
+            <Link href="/compounds/boswellia/" className="chip-readable text-xs font-bold">
               Explore Boswellia →
             </Link>
           </div>
@@ -138,7 +138,7 @@ export default function CurcuminVsBoswelliaVsOmega3Page() {
             </p>
           </div>
           <div className="pt-4">
-            <Link href="/compounds/omega-3" className="chip-readable text-xs font-bold">
+            <Link href="/compounds/omega-3/" className="chip-readable text-xs font-bold">
               Explore Omega-3 →
             </Link>
           </div>

--- a/app/guides/compare/kanna-vs-ssris/page.tsx
+++ b/app/guides/compare/kanna-vs-ssris/page.tsx
@@ -109,7 +109,7 @@ export default function KannaVsSSRIsPage() {
           <p className="text-sm leading-7 text-muted">
             Kanna (Sceletium tortuosum) contains mesembrine and related alkaloids that act as serotonin reuptake inhibitors and PDE4 inhibitors. Traditional South African use includes mood elevation, stress reduction, and social bonding — but the pharmacology is under-studied compared to pharmaceutical antidepressants.
           </p>
-          <Link href="/herbs/kanna" className="chip-readable">Explore Kanna</Link>
+          <Link href="/herbs/kanna/" className="chip-readable">Explore Kanna</Link>
         </div>
 
         <div className="card-premium p-6 space-y-4">
@@ -149,8 +149,8 @@ export default function KannaVsSSRIsPage() {
           Kanna has serotonergic activity. Combining it with SSRIs, SNRIs, MAOIs, tramadol, St. John's Wort, or other serotonergic substances increases the risk of serotonin syndrome — a potentially life-threatening condition. Symptoms include agitation, confusion, rapid heart rate, high blood pressure, dilated pupils, muscle rigidity, and hyperthermia. If you take any serotonergic medication, do not use kanna.
         </p>
         <div className="mt-4 flex flex-wrap gap-3">
-          <Link href="/learn/serotonin" className="rounded-full bg-red-100 px-3 py-1.5 text-xs font-bold text-red-800">Serotonin Pathway</Link>
-          <Link href="/learn/serotonergic-stacking-risks" className="rounded-full bg-red-100 px-3 py-1.5 text-xs font-bold text-red-800">Serotonergic Risks</Link>
+          <Link href="/learn/serotonin/" className="rounded-full bg-red-100 px-3 py-1.5 text-xs font-bold text-red-800">Serotonin Pathway</Link>
+          <Link href="/learn/serotonergic-stacking-risks/" className="rounded-full bg-red-100 px-3 py-1.5 text-xs font-bold text-red-800">Serotonergic Risks</Link>
         </div>
       </section>
 
@@ -192,11 +192,11 @@ export default function KannaVsSSRIsPage() {
         </p>
 
         <div className="flex flex-wrap gap-3">
-          <Link href="/learn/serotonin" className="chip-readable">
+          <Link href="/learn/serotonin/" className="chip-readable">
             Serotonin Pathway
           </Link>
 
-          <Link href="/learn/serotonergic-stacking-risks" className="chip-readable">
+          <Link href="/learn/serotonergic-stacking-risks/" className="chip-readable">
             Serotonergic Risks
           </Link>
         </div>

--- a/app/guides/compare/kava-vs-alcohol/page.tsx
+++ b/app/guides/compare/kava-vs-alcohol/page.tsx
@@ -75,7 +75,7 @@ export default function KavaVsAlcoholPage() {
           <p className="text-sm leading-7 text-muted">
             Kava (Piper methysticum) modulates GABA-A receptors via kavalactones, producing relaxation without the cognitive impairment or dependence profile associated with alcohol. Traditional Pacific Island use spans centuries in social and ceremonial contexts.
           </p>
-          <Link href="/herbs/kava" className="chip-readable">
+          <Link href="/herbs/kava/" className="chip-readable">
             Explore Kava
           </Link>
         </div>
@@ -173,11 +173,11 @@ export default function KavaVsAlcoholPage() {
         </p>
 
         <div className="flex flex-wrap gap-3">
-          <Link href="/learn/harm-reduction" className="chip-readable">
+          <Link href="/learn/harm-reduction/" className="chip-readable">
             Harm Reduction
           </Link>
 
-          <Link href="/learn/gaba" className="chip-readable">
+          <Link href="/learn/gaba/" className="chip-readable">
             GABA Pathway
           </Link>
         </div>

--- a/app/guides/compare/melatonin-vs-valerian-vs-magnesium-for-sleep/page.tsx
+++ b/app/guides/compare/melatonin-vs-valerian-vs-magnesium-for-sleep/page.tsx
@@ -95,7 +95,7 @@ export default function MelatoninVsValerianVsMagnesiumForSleepPage() {
             </p>
           </div>
           <div className="pt-4">
-            <Link href="/compounds/melatonin" className="chip-readable text-xs font-bold">
+            <Link href="/compounds/melatonin/" className="chip-readable text-xs font-bold">
               Explore Melatonin →
             </Link>
           </div>
@@ -112,7 +112,7 @@ export default function MelatoninVsValerianVsMagnesiumForSleepPage() {
             </p>
           </div>
           <div className="pt-4">
-            <Link href="/herbs/valerian" className="chip-readable text-xs font-bold">
+            <Link href="/herbs/valerian/" className="chip-readable text-xs font-bold">
               Explore Valerian →
             </Link>
           </div>
@@ -129,7 +129,7 @@ export default function MelatoninVsValerianVsMagnesiumForSleepPage() {
             </p>
           </div>
           <div className="pt-4">
-            <Link href="/compounds/magnesium" className="chip-readable text-xs font-bold">
+            <Link href="/compounds/magnesium/" className="chip-readable text-xs font-bold">
               Explore Magnesium →
             </Link>
           </div>

--- a/app/guides/compare/rhodiola-vs-ashwagandha/page.tsx
+++ b/app/guides/compare/rhodiola-vs-ashwagandha/page.tsx
@@ -87,7 +87,7 @@ export default function RhodiolaVsAshwagandhaComparePage() {
           <p className="text-sm leading-7 text-muted">
             Better for mental fatigue, stress resilience, and daytime output when you do not want a sedating option.
           </p>
-          <Link href="/herbs/rhodiola" className="chip-readable text-xs font-bold">Explore Rhodiola →</Link>
+          <Link href="/herbs/rhodiola/" className="chip-readable text-xs font-bold">Explore Rhodiola →</Link>
         </article>
 
         <article className="card-premium p-6 space-y-4">
@@ -96,7 +96,7 @@ export default function RhodiolaVsAshwagandhaComparePage() {
           <p className="text-sm leading-7 text-muted">
             Better for steady stress support, evening settling, and routines where calm matters more than activation.
           </p>
-          <Link href="/herbs/ashwagandha" className="chip-readable text-xs font-bold">Explore Ashwagandha →</Link>
+          <Link href="/herbs/ashwagandha/" className="chip-readable text-xs font-bold">Explore Ashwagandha →</Link>
         </article>
       </section>
 

--- a/app/guides/compare/sleep-herbs-vs-melatonin/page.tsx
+++ b/app/guides/compare/sleep-herbs-vs-melatonin/page.tsx
@@ -112,7 +112,7 @@ export default function SleepHerbsVsMelatoninComparePage() {
             syndrome. At low doses (0.3–1 mg), it mimics physiological release without receptor
             downregulation.
           </p>
-          <Link href="/compounds/melatonin" className="chip-readable">Explore Melatonin</Link>
+          <Link href="/compounds/melatonin/" className="chip-readable">Explore Melatonin</Link>
         </div>
 
         <div className="card-premium p-6 space-y-4">
@@ -125,7 +125,7 @@ export default function SleepHerbsVsMelatoninComparePage() {
             depth. Most adults are below optimal intake. Magnesium glycinate is the preferred form for
             sleep due to high bioavailability and low GI impact.
           </p>
-          <Link href="/compounds/magnesium" className="chip-readable">Explore Magnesium</Link>
+          <Link href="/compounds/magnesium/" className="chip-readable">Explore Magnesium</Link>
         </div>
 
         <div className="card-premium p-6 space-y-4">
@@ -138,7 +138,7 @@ export default function SleepHerbsVsMelatoninComparePage() {
             for sleep onset when the problem is mental chatter rather than a shifted schedule or physical
             tension.
           </p>
-          <Link href="/compounds/l-theanine" className="chip-readable">Explore L-Theanine</Link>
+          <Link href="/compounds/l-theanine/" className="chip-readable">Explore L-Theanine</Link>
         </div>
 
         <div className="card-premium p-6 space-y-4">
@@ -151,7 +151,7 @@ export default function SleepHerbsVsMelatoninComparePage() {
             and effect sizes are often modest. It may be better tolerated in combination with hops or
             lemon balm than as a standalone option.
           </p>
-          <Link href="/herbs/valerian" className="chip-readable">Explore Valerian</Link>
+          <Link href="/herbs/valerian/" className="chip-readable">Explore Valerian</Link>
         </div>
       </section>
 
@@ -670,11 +670,11 @@ export default function SleepHerbsVsMelatoninComparePage() {
       </div>
 
       <div className="flex flex-wrap gap-3">
-        <Link href="/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium" className="chip-readable">L-Theanine vs Magnesium</Link>
-        <Link href="/guides/sleep/magnesium-types-for-sleep" className="chip-readable">Magnesium Glycinate vs L-Threonate</Link>
-        <Link href="/guides/sleep/magnesium-types-for-sleep" className="chip-readable">Magnesium Glycinate vs Oxide</Link>
-        <Link href="/guides/sleep" className="chip-readable">Sleep Goals</Link>
-        <Link href="/learn/gaba" className="chip-readable">GABA Pathway</Link>
+        <Link href="/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium/" className="chip-readable">L-Theanine vs Magnesium</Link>
+        <Link href="/guides/sleep/magnesium-types-for-sleep/" className="chip-readable">Magnesium Glycinate vs L-Threonate</Link>
+        <Link href="/guides/sleep/magnesium-types-for-sleep/" className="chip-readable">Magnesium Glycinate vs Oxide</Link>
+        <Link href="/guides/sleep/" className="chip-readable">Sleep Goals</Link>
+        <Link href="/learn/gaba/" className="chip-readable">GABA Pathway</Link>
         <Link href="/guides/compare/" className="chip-readable">All Comparisons</Link>
       </div>
       <ConversionStickyCTA

--- a/app/guides/focus/best-nootropics-for-focus/page.tsx
+++ b/app/guides/focus/best-nootropics-for-focus/page.tsx
@@ -295,11 +295,11 @@ export default function BestNootropicsForFocusPage() {
 
         {/* Related */}
         <nav className="flex flex-wrap gap-4 text-sm font-semibold text-brand-700">
-          <Link href="/guides/focus" className="hover:text-brand-800">Focus goal hub →</Link>
+          <Link href="/guides/focus/" className="hover:text-brand-800">Focus goal hub →</Link>
           <Link href="/guides/focus-without-caffeine-crash/" className="hover:text-brand-800">Focus Without the Caffeine Crash →</Link>
           <Link href="/guides/adhd/adhd-supplements/" className="hover:text-brand-800">ADHD Supplements Hub →</Link>
-          <Link href="/guides/supplements-for-brain-fog-and-fatigue" className="hover:text-brand-800">Brain Fog & Fatigue →</Link>
-          <Link href="/guides/compare/caffeine-vs-l-theanine-vs-bacopa-for-focus" className="hover:text-brand-800">Caffeine vs L-Theanine vs Bacopa →</Link>
+          <Link href="/guides/supplements-for-brain-fog-and-fatigue/" className="hover:text-brand-800">Brain Fog & Fatigue →</Link>
+          <Link href="/guides/compare/caffeine-vs-l-theanine-vs-bacopa-for-focus/" className="hover:text-brand-800">Caffeine vs L-Theanine vs Bacopa →</Link>
           <Link href="/guides/" className="hover:text-brand-800">All Guides →</Link>
         </nav>
       </div>

--- a/app/guides/focus/focus-without-caffeine-crash/page.tsx
+++ b/app/guides/focus/focus-without-caffeine-crash/page.tsx
@@ -178,11 +178,11 @@ export default function Page() {
               <p className="text-sm font-semibold text-ink">Go deeper</p>
               <p className="mt-2 text-sm text-muted">
                 Read the{' '}
-                <Link href="/compounds/l-theanine" className="font-medium text-brand-700 hover:underline">L-theanine</Link>{' '}
+                <Link href="/compounds/l-theanine/" className="font-medium text-brand-700 hover:underline">L-theanine</Link>{' '}
                 and{' '}
-                <Link href="/compounds/caffeine" className="font-medium text-brand-700 hover:underline">caffeine</Link>{' '}
+                <Link href="/compounds/caffeine/" className="font-medium text-brand-700 hover:underline">caffeine</Link>{' '}
                 profiles, or the{' '}
-                <Link href="/guides/compare/caffeine-vs-l-theanine-vs-bacopa-for-focus" className="font-medium text-brand-700 hover:underline">caffeine vs L-theanine vs bacopa</Link>{' '}
+                <Link href="/guides/compare/caffeine-vs-l-theanine-vs-bacopa-for-focus/" className="font-medium text-brand-700 hover:underline">caffeine vs L-theanine vs bacopa</Link>{' '}
                 comparison.
               </p>
             </div>
@@ -196,20 +196,20 @@ export default function Page() {
 
           <article className="card-premium p-6">
             <h3 className="text-xl font-semibold text-brand-800">
-              <Link href="/herbs/rhodiola" className="hover:underline">Rhodiola rosea</Link>
+              <Link href="/herbs/rhodiola/" className="hover:underline">Rhodiola rosea</Link>
             </h3>
             <p className="mt-3 text-sm text-muted">
               Best for mental fatigue and focus that fades under stress. Rhodiola supports stamina and
               concentration without a stimulant spike, taken in the morning at 200–400&nbsp;mg of a
               standardized extract. See the{' '}
-              <Link href="/guides/rhodiola-energy" className="font-medium text-brand-700 hover:underline">rhodiola for energy</Link>{' '}
+              <Link href="/guides/rhodiola-energy/" className="font-medium text-brand-700 hover:underline">rhodiola for energy</Link>{' '}
               guide.
             </p>
           </article>
 
           <article className="card-premium p-6">
             <h3 className="text-xl font-semibold text-brand-800">
-              <Link href="/herbs/bacopa" className="hover:underline">Bacopa monnieri</Link>
+              <Link href="/herbs/bacopa/" className="hover:underline">Bacopa monnieri</Link>
             </h3>
             <p className="mt-3 text-sm text-muted">
               A slow-burn nootropic with good evidence for memory and attention, but it works over weeks of
@@ -220,13 +220,13 @@ export default function Page() {
 
           <article className="card-premium p-6">
             <h3 className="text-xl font-semibold text-brand-800">
-              <Link href="/compounds/alpha-gpc" className="hover:underline">Alpha-GPC &amp; the cholinergic angle</Link>
+              <Link href="/compounds/alpha-gpc/" className="hover:underline">Alpha-GPC &amp; the cholinergic angle</Link>
             </h3>
             <p className="mt-3 text-sm text-muted">
               Choline donors like alpha-GPC support acetylcholine, a neurotransmitter central to attention.
               They can sharpen focus without stimulation, and some people pair a small dose with their
               focus block. Explore more in{' '}
-              <Link href="/guides/focus/best-nootropics-for-focus" className="font-medium text-brand-700 hover:underline">best nootropics for focus</Link>.
+              <Link href="/guides/focus/best-nootropics-for-focus/" className="font-medium text-brand-700 hover:underline">best nootropics for focus</Link>.
             </p>
           </article>
         </section>
@@ -280,12 +280,12 @@ export default function Page() {
         <section className="space-y-4">
           <h2 className="text-2xl font-semibold text-ink">Related guides &amp; comparisons</h2>
           <div className="grid gap-3 sm:grid-cols-2">
-            <Link href="/guides/focus/best-supplements-for-focus" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Best Supplements for Focus →</Link>
-            <Link href="/guides/focus/best-nootropics-for-focus" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Best Nootropics for Focus →</Link>
-            <Link href="/guides/supplements-for-brain-fog-and-fatigue" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Supplements for Brain Fog &amp; Fatigue →</Link>
-            <Link href="/guides/compare/caffeine-vs-l-theanine-vs-bacopa-for-focus" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Caffeine vs L-theanine vs Bacopa →</Link>
-            <Link href="/compounds/l-theanine" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">L-theanine Profile →</Link>
-            <Link href="/guides/focus" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">All Focus Guides →</Link>
+            <Link href="/guides/focus/best-supplements-for-focus/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Best Supplements for Focus →</Link>
+            <Link href="/guides/focus/best-nootropics-for-focus/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Best Nootropics for Focus →</Link>
+            <Link href="/guides/supplements-for-brain-fog-and-fatigue/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Supplements for Brain Fog &amp; Fatigue →</Link>
+            <Link href="/guides/compare/caffeine-vs-l-theanine-vs-bacopa-for-focus/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Caffeine vs L-theanine vs Bacopa →</Link>
+            <Link href="/compounds/l-theanine/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">L-theanine Profile →</Link>
+            <Link href="/guides/focus/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">All Focus Guides →</Link>
           </div>
         </section>
       </div>

--- a/app/guides/focus/l-theanine-without-caffeine/page.tsx
+++ b/app/guides/focus/l-theanine-without-caffeine/page.tsx
@@ -159,7 +159,7 @@ export default function LTheanineWithoutCaffeinePage() {
               stimulant-free ADHD focus.</strong> Effects within 30–60 minutes, no crash, no sleep
               disruption, no dependency. If 100&nbsp;mg is not enough, increase to 200&nbsp;mg before
               considering other compounds. For comparison with the caffeine combination, see{' '}
-              <Link href="/guides/focus/l-theanine-vs-caffeine-for-focus" className="font-semibold text-brand-700 hover:underline">
+              <Link href="/guides/focus/l-theanine-vs-caffeine-for-focus/" className="font-semibold text-brand-700 hover:underline">
                 L-Theanine vs Caffeine for Focus
               </Link>
               . For the broader evidence review, see the{' '}
@@ -315,7 +315,7 @@ export default function LTheanineWithoutCaffeinePage() {
               </p>
               <p className="mt-3 text-sm text-muted">
                 For the full comparison, see{' '}
-                <Link href="/guides/focus/l-theanine-vs-caffeine-for-focus"
+                <Link href="/guides/focus/l-theanine-vs-caffeine-for-focus/"
                   className="font-semibold text-brand-700 hover:underline">
                   L-Theanine vs Caffeine for Focus
                 </Link>.

--- a/app/guides/herbs/ashwagandha/page.tsx
+++ b/app/guides/herbs/ashwagandha/page.tsx
@@ -236,7 +236,7 @@ export default function AshwagandhaArticlePage() {
                 Whether you are considering ashwagandha for stress, anxiety, sleep, focus, or general
                 resilience, this hub will help you decide if it is right for you, what dose and form
                 to use, and what to expect over time. All claims are tied to primary studies or the{' '}
-                <Link href="/herbs/ashwagandha" className="font-semibold text-brand-700 hover:text-brand-800 hover:underline">
+                <Link href="/herbs/ashwagandha/" className="font-semibold text-brand-700 hover:text-brand-800 hover:underline">
                   Ashwagandha herb profile
                 </Link>
                 .
@@ -301,7 +301,7 @@ export default function AshwagandhaArticlePage() {
                       <td className="p-4 text-brand-700 font-medium">Strong</td>
                       <td className="p-4 text-muted">4–8 weeks</td>
                       <td className="p-4">
-                        <Link href="/guides/how-to-lower-cortisol-naturally" className="text-brand-700 hover:underline font-medium">
+                        <Link href="/guides/how-to-lower-cortisol-naturally/" className="text-brand-700 hover:underline font-medium">
                           Cortisol guide →
                         </Link>
                       </td>
@@ -321,7 +321,7 @@ export default function AshwagandhaArticlePage() {
                       <td className="p-4 text-brand-700 font-medium">Moderate</td>
                       <td className="p-4 text-muted">6–10 weeks</td>
                       <td className="p-4">
-                        <Link href="/guides/sleep/ashwagandha-for-sleep" className="text-brand-700 hover:underline font-medium">
+                        <Link href="/guides/sleep/ashwagandha-for-sleep/" className="text-brand-700 hover:underline font-medium">
                           Ashwagandha for sleep →
                         </Link>
                       </td>
@@ -331,7 +331,7 @@ export default function AshwagandhaArticlePage() {
                       <td className="p-4 text-muted">Emerging–Moderate</td>
                       <td className="p-4 text-muted">4–8 weeks</td>
                       <td className="p-4">
-                        <Link href="/guides/adhd/ashwagandha-for-adhd" className="text-brand-700 hover:underline font-medium">
+                        <Link href="/guides/adhd/ashwagandha-for-adhd/" className="text-brand-700 hover:underline font-medium">
                           Ashwagandha for ADHD/focus →
                         </Link>
                       </td>
@@ -352,7 +352,7 @@ export default function AshwagandhaArticlePage() {
                 For most readers, the right entry point is the chronic stress / cortisol evidence —
                 that is the strongest and most consistent body of research, and it underlies the
                 benefits seen in anxiety and sleep. If your primary goal is sleep, see the{' '}
-                <Link href="/guides/sleep/ashwagandha-for-sleep" className="font-semibold text-brand-700 hover:underline">
+                <Link href="/guides/sleep/ashwagandha-for-sleep/" className="font-semibold text-brand-700 hover:underline">
                   dedicated sleep article
                 </Link>
                 . If anxiety is primary, see the{' '}
@@ -360,11 +360,11 @@ export default function AshwagandhaArticlePage() {
                   anxiety article
                 </Link>
                 . If you want a head-to-head with magnesium, see{' '}
-                <Link href="/guides/sleep/ashwagandha-vs-magnesium-for-sleep" className="font-semibold text-brand-700 hover:underline">
+                <Link href="/guides/sleep/ashwagandha-vs-magnesium-for-sleep/" className="font-semibold text-brand-700 hover:underline">
                   ashwagandha vs magnesium for sleep
                 </Link>
                 . If you want the herb-level monograph, see{' '}
-                <Link href="/herbs/ashwagandha" className="font-semibold text-brand-700 hover:underline">
+                <Link href="/herbs/ashwagandha/" className="font-semibold text-brand-700 hover:underline">
                   the full Ashwagandha herb profile
                 </Link>
                 .
@@ -614,7 +614,7 @@ export default function AshwagandhaArticlePage() {
               <p className="mt-3 text-sm text-muted">
                 For a complete breakdown of adverse events, drug interactions, and contraindications,
                 see the{' '}
-                <Link href="/herbs/ashwagandha" className="font-semibold text-brand-700 hover:text-brand-800 hover:underline">
+                <Link href="/herbs/ashwagandha/" className="font-semibold text-brand-700 hover:text-brand-800 hover:underline">
                   full Ashwagandha safety profile
                 </Link>
                 .
@@ -651,7 +651,7 @@ export default function AshwagandhaArticlePage() {
                   <p className="mt-1 text-xs leading-5 text-muted">
                     Stress baseline (ashwagandha) plus evening relaxation and muscle tension
                     support (magnesium). Compare in{' '}
-                    <Link href="/guides/sleep/ashwagandha-vs-magnesium-for-sleep" className="font-semibold text-brand-700 hover:underline">
+                    <Link href="/guides/sleep/ashwagandha-vs-magnesium-for-sleep/" className="font-semibold text-brand-700 hover:underline">
                       ashwagandha vs magnesium for sleep
                     </Link>
                     .
@@ -722,7 +722,7 @@ export default function AshwagandhaArticlePage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/ashwagandha-for-sleep"
+                  href="/guides/sleep/ashwagandha-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -737,7 +737,7 @@ export default function AshwagandhaArticlePage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/adhd/ashwagandha-for-adhd"
+                  href="/guides/adhd/ashwagandha-for-adhd/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -752,7 +752,7 @@ export default function AshwagandhaArticlePage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/ashwagandha-vs-magnesium-for-sleep"
+                  href="/guides/sleep/ashwagandha-vs-magnesium-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -766,7 +766,7 @@ export default function AshwagandhaArticlePage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/anxiety/cbd-vs-ashwagandha-for-anxiety"
+                  href="/guides/anxiety/cbd-vs-ashwagandha-for-anxiety/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -781,7 +781,7 @@ export default function AshwagandhaArticlePage() {
                   </p>
                 </Link>
                 <Link
-                  href="/herbs/ashwagandha"
+                  href="/herbs/ashwagandha/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -991,7 +991,7 @@ export default function AshwagandhaArticlePage() {
                 Ashwagandha for anxiety →
               </Link>
               <Link
-                href="/guides/sleep/ashwagandha-for-sleep"
+                href="/guides/sleep/ashwagandha-for-sleep/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Ashwagandha for sleep →
@@ -1003,13 +1003,13 @@ export default function AshwagandhaArticlePage() {
                 L-theanine article →
               </Link>
               <Link
-                href="/herbs/ashwagandha"
+                href="/herbs/ashwagandha/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Ashwagandha herb profile →
               </Link>
               <Link
-                href="/guides/anxiety"
+                href="/guides/anxiety/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Stress goal hub →

--- a/app/guides/herbs/elderberry/page.tsx
+++ b/app/guides/herbs/elderberry/page.tsx
@@ -270,12 +270,12 @@ export default function ElderberryGuidePage() {
       <section className="space-y-3">
         <h2 className="text-xl font-semibold text-ink">Related Guides</h2>
         <div className="grid gap-3 sm:grid-cols-3">
-          <Link href="/guides/turmeric-curcumin" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+          <Link href="/guides/turmeric-curcumin/" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
             <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Guide</p>
             <p className="mt-1 text-sm font-semibold text-ink">Turmeric &amp; Curcumin</p>
             <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Anti-inflammatory evidence, bioavailability, and form comparison.</p>
           </Link>
-          <Link href="/guides/passionflower" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+          <Link href="/guides/passionflower/" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
             <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Guide</p>
             <p className="mt-1 text-sm font-semibold text-ink">Passionflower</p>
             <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Evidence for anxiety and sleep, with safety and dosing context.</p>

--- a/app/guides/herbs/kava/page.tsx
+++ b/app/guides/herbs/kava/page.tsx
@@ -258,17 +258,17 @@ export default function KavaGuidePage() {
           For most people managing anxiety, the options below have more favorable risk profiles than kava.
         </p>
         <div className="grid gap-3 sm:grid-cols-3">
-          <Link href="/guides/passionflower" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+          <Link href="/guides/passionflower/" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
             <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Guide</p>
             <p className="mt-1 text-sm font-semibold text-ink">Passionflower</p>
             <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Modest anxiety reduction with a more favorable safety profile.</p>
           </Link>
-          <Link href="/guides/anxiety/best-adaptogens-for-stress" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+          <Link href="/guides/anxiety/best-adaptogens-for-stress/" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
             <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Guide</p>
             <p className="mt-1 text-sm font-semibold text-ink">Ashwagandha & Adaptogens</p>
             <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Adaptogen with the strongest stress/anxiety evidence base.</p>
           </Link>
-          <Link href="/guides/anxiety/natural-anxiolytics-beyond-ashwagandha" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+          <Link href="/guides/anxiety/natural-anxiolytics-beyond-ashwagandha/" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
             <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Guide</p>
             <p className="mt-1 text-sm font-semibold text-ink">Natural Anxiolytics</p>
             <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Evidence-ranked anxiolytic options beyond the usual picks.</p>

--- a/app/guides/herbs/l-theanine/page.tsx
+++ b/app/guides/herbs/l-theanine/page.tsx
@@ -186,7 +186,7 @@ export default function LTheanineArticlePage() {
               increase to 200 mg before adding other compounds. The L-theanine + caffeine 2:1 stack
               is the most-studied nootropic combination in the literature and a natural upgrade if
               you also want alertness. See the{' '}
-              <Link href="/guides/focus/l-theanine-vs-caffeine-for-focus" className="font-semibold text-brand-700 hover:text-brand-800 hover:underline">
+              <Link href="/guides/focus/l-theanine-vs-caffeine-for-focus/" className="font-semibold text-brand-700 hover:text-brand-800 hover:underline">
                 head-to-head comparison
               </Link>
               .
@@ -261,7 +261,7 @@ export default function LTheanineArticlePage() {
               <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
                 For a complete breakdown of chemistry, mechanisms, and research across all uses,
                 see the{' '}
-                <Link href="/compounds/l-theanine" className="font-semibold text-brand-700 hover:text-brand-800 hover:underline">
+                <Link href="/compounds/l-theanine/" className="font-semibold text-brand-700 hover:text-brand-800 hover:underline">
                   L-theanine compound profile
                 </Link>
                 .
@@ -297,7 +297,7 @@ export default function LTheanineArticlePage() {
                       <td className="p-4 text-brand-700 font-medium">Strong</td>
                       <td className="p-4 text-muted">30–60 min</td>
                       <td className="p-4">
-                        <Link href="/guides/focus/l-theanine-vs-caffeine-for-focus" className="text-brand-700 hover:underline font-medium">
+                        <Link href="/guides/focus/l-theanine-vs-caffeine-for-focus/" className="text-brand-700 hover:underline font-medium">
                           vs Caffeine →
                         </Link>
                       </td>
@@ -317,7 +317,7 @@ export default function LTheanineArticlePage() {
                       <td className="p-4 text-brand-700 font-medium">Moderate</td>
                       <td className="p-4 text-muted">30–60 min</td>
                       <td className="p-4">
-                        <Link href="/guides/sleep/l-theanine-for-sleep" className="text-brand-700 hover:underline font-medium">
+                        <Link href="/guides/sleep/l-theanine-for-sleep/" className="text-brand-700 hover:underline font-medium">
                           L-theanine for sleep →
                         </Link>
                       </td>
@@ -352,15 +352,15 @@ export default function LTheanineArticlePage() {
                   anxiety deep-dive
                 </Link>
                 . If sleep is primary, see{' '}
-                <Link href="/guides/sleep/l-theanine-for-sleep" className="font-semibold text-brand-700 hover:underline">
+                <Link href="/guides/sleep/l-theanine-for-sleep/" className="font-semibold text-brand-700 hover:underline">
                   L-theanine for sleep
                 </Link>
                 . If you want a stack that combines L-theanine with magnesium, see the{' '}
-                <Link href="/guides/adhd/l-theanine-magnesium-adhd-stack" className="font-semibold text-brand-700 hover:underline">
+                <Link href="/guides/adhd/l-theanine-magnesium-adhd-stack/" className="font-semibold text-brand-700 hover:underline">
                   L-theanine + magnesium stack
                 </Link>
                 . For caffeine-free focus, see{' '}
-                <Link href="/guides/focus/l-theanine-without-caffeine" className="font-semibold text-brand-700 hover:underline">
+                <Link href="/guides/focus/l-theanine-without-caffeine/" className="font-semibold text-brand-700 hover:underline">
                   L-theanine without caffeine
                 </Link>
                 .
@@ -611,7 +611,7 @@ export default function LTheanineArticlePage() {
                 L-theanine has one of the cleanest safety profiles of any supplement reviewed on
                 this site. The main cautions are additive effects with sedatives and mild
                 blood-pressure reduction at higher chronic doses. For a complete breakdown, see the{' '}
-                <Link href="/compounds/l-theanine" className="font-semibold text-brand-700 hover:text-brand-800 hover:underline">
+                <Link href="/compounds/l-theanine/" className="font-semibold text-brand-700 hover:text-brand-800 hover:underline">
                   full L-theanine compound profile
                 </Link>
                 .
@@ -637,7 +637,7 @@ export default function LTheanineArticlePage() {
                   <p className="mt-1 text-xs leading-5 text-muted">
                     100–200 mg L-theanine with 50–100 mg caffeine (2:1 ratio). The most-studied
                     nootropic stack — calm focus without jitters. See{' '}
-                    <Link href="/guides/focus/l-theanine-vs-caffeine-for-focus" className="font-semibold text-brand-700 hover:underline">
+                    <Link href="/guides/focus/l-theanine-vs-caffeine-for-focus/" className="font-semibold text-brand-700 hover:underline">
                       head-to-head comparison
                     </Link>
                     .
@@ -648,7 +648,7 @@ export default function LTheanineArticlePage() {
                   <p className="mt-1 text-xs leading-5 text-muted">
                     Acute calming (L-theanine) plus evening muscle tension and nervous-system
                     support (magnesium). See the{' '}
-                    <Link href="/guides/adhd/l-theanine-magnesium-adhd-stack" className="font-semibold text-brand-700 hover:underline">
+                    <Link href="/guides/adhd/l-theanine-magnesium-adhd-stack/" className="font-semibold text-brand-700 hover:underline">
                       L-theanine + magnesium stack
                     </Link>
                     .
@@ -670,7 +670,7 @@ export default function LTheanineArticlePage() {
                   <p className="mt-1 text-xs leading-5 text-muted">
                     For sleep: L-theanine quiets racing thoughts; melatonin signals circadian
                     onset. Different mechanisms — complementary. See{' '}
-                    <Link href="/guides/sleep/l-theanine-for-sleep" className="font-semibold text-brand-700 hover:underline">
+                    <Link href="/guides/sleep/l-theanine-for-sleep/" className="font-semibold text-brand-700 hover:underline">
                       L-theanine for sleep
                     </Link>
                     .
@@ -729,7 +729,7 @@ export default function LTheanineArticlePage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/l-theanine-for-sleep"
+                  href="/guides/sleep/l-theanine-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -759,7 +759,7 @@ export default function LTheanineArticlePage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/focus/l-theanine-vs-caffeine-for-focus"
+                  href="/guides/focus/l-theanine-vs-caffeine-for-focus/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -773,7 +773,7 @@ export default function LTheanineArticlePage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/adhd/l-theanine-magnesium-adhd-stack"
+                  href="/guides/adhd/l-theanine-magnesium-adhd-stack/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -787,7 +787,7 @@ export default function LTheanineArticlePage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/focus/l-theanine-without-caffeine"
+                  href="/guides/focus/l-theanine-without-caffeine/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -989,7 +989,7 @@ export default function LTheanineArticlePage() {
                 L-theanine for anxiety →
               </Link>
               <Link
-                href="/guides/sleep/l-theanine-for-sleep"
+                href="/guides/sleep/l-theanine-for-sleep/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 L-theanine for sleep →
@@ -1007,19 +1007,19 @@ export default function LTheanineArticlePage() {
                 Ashwagandha article →
               </Link>
               <Link
-                href="/compounds/l-theanine"
+                href="/compounds/l-theanine/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 L-theanine compound profile →
               </Link>
               <Link
-                href="/guides/anxiety"
+                href="/guides/anxiety/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Anxiety goal hub →
               </Link>
               <Link
-                href="/guides/focus"
+                href="/guides/focus/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Focus goal hub →

--- a/app/guides/herbs/passionflower/page.tsx
+++ b/app/guides/herbs/passionflower/page.tsx
@@ -263,12 +263,12 @@ export default function PassionflowerGuidePage() {
             <p className="mt-1 text-sm font-semibold text-ink">Magnesium for Sleep</p>
             <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Forms, dosage, and evidence for magnesium as a sleep and anxiety support.</p>
           </Link>
-          <Link href="/guides/anxiety/natural-anxiolytics-beyond-ashwagandha" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+          <Link href="/guides/anxiety/natural-anxiolytics-beyond-ashwagandha/" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
             <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Guide</p>
             <p className="mt-1 text-sm font-semibold text-ink">Natural Anxiolytics</p>
             <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Evidence-ranked anxiolytic options beyond the usual picks.</p>
           </Link>
-          <Link href="/guides/sleep/best-herbs-for-sleep" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+          <Link href="/guides/sleep/best-herbs-for-sleep/" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
             <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Pillar</p>
             <p className="mt-1 text-sm font-semibold text-ink">Best Herbs for Sleep</p>
             <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Evidence-ranked guide to the most-studied natural sleep options.</p>

--- a/app/guides/herbs/rhodiola-complete-guide/page.tsx
+++ b/app/guides/herbs/rhodiola-complete-guide/page.tsx
@@ -172,10 +172,10 @@ export default function RhodiolaCompleteGuidePage() {
           most herbs, what the evidence supports, and how to dose it correctly — no hype, no filler.
         </p>
         <div className="mt-6 flex flex-wrap gap-4 text-xs font-semibold uppercase tracking-[0.14em]">
-          <Link href="/herbs/rhodiola" className="text-brand-700 hover:text-brand-800 hover:underline">
+          <Link href="/herbs/rhodiola/" className="text-brand-700 hover:text-brand-800 hover:underline">
             Rhodiola Herb Profile →
           </Link>
-          <Link href="/compounds/salidroside" className="text-brand-700 hover:text-brand-800 hover:underline">
+          <Link href="/compounds/salidroside/" className="text-brand-700 hover:text-brand-800 hover:underline">
             Salidroside Compound →
           </Link>
         </div>
@@ -311,17 +311,17 @@ export default function RhodiolaCompleteGuidePage() {
       <section className="space-y-3">
         <h2 className="text-xl font-semibold text-ink">Explore the Rhodiola Hub</h2>
         <div className="grid gap-3 sm:grid-cols-3">
-          <Link href="/guides/rhodiola-energy" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+          <Link href="/guides/rhodiola-energy/" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
             <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Guide</p>
             <p className="mt-1 text-sm font-semibold text-ink">Rhodiola for Energy</p>
             <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Sustained energy without the stimulant crash — and how it compares to caffeine.</p>
           </Link>
-          <Link href="/guides/rhodiola-extract-vs-powder" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+          <Link href="/guides/rhodiola-extract-vs-powder/" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
             <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Guide</p>
             <p className="mt-1 text-sm font-semibold text-ink">Extract vs Powder</p>
             <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Which form actually works — absorption, cost, and evidence compared.</p>
           </Link>
-          <Link href="/guides/rhodiola-sleep-stack" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+          <Link href="/guides/rhodiola-sleep-stack/" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
             <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Stack Guide</p>
             <p className="mt-1 text-sm font-semibold text-ink">Rhodiola + Magnesium for Sleep</p>
             <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">The adaptogen stack for the &quot;wired but tired&quot; cycle.</p>

--- a/app/guides/herbs/rhodiola-energy/page.tsx
+++ b/app/guides/herbs/rhodiola-energy/page.tsx
@@ -172,7 +172,7 @@ export default function RhodiolaEnergyGuidePage() {
           <Link href="/guides/rhodiola-complete-guide/" className="text-brand-700 hover:text-brand-800 hover:underline">
             Complete Rhodiola Guide →
           </Link>
-          <Link href="/herbs/rhodiola" className="text-brand-700 hover:text-brand-800 hover:underline">
+          <Link href="/herbs/rhodiola/" className="text-brand-700 hover:text-brand-800 hover:underline">
             Rhodiola Herb Profile →
           </Link>
         </div>
@@ -301,12 +301,12 @@ export default function RhodiolaEnergyGuidePage() {
             <p className="mt-1 text-sm font-semibold text-ink">Complete Rhodiola Guide</p>
             <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Forms, benefits, dosing, and the full evidence base in one place.</p>
           </Link>
-          <Link href="/guides/rhodiola-extract-vs-powder" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+          <Link href="/guides/rhodiola-extract-vs-powder/" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
             <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Guide</p>
             <p className="mt-1 text-sm font-semibold text-ink">Extract vs Powder</p>
             <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Which form actually works — absorption, dosing, and evidence compared.</p>
           </Link>
-          <Link href="/guides/rhodiola-sleep-stack" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+          <Link href="/guides/rhodiola-sleep-stack/" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
             <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Stack Guide</p>
             <p className="mt-1 text-sm font-semibold text-ink">Rhodiola + Magnesium for Sleep</p>
             <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">The adaptogen stack for the &quot;wired but tired&quot; cycle.</p>

--- a/app/guides/herbs/rhodiola-extract-vs-powder/page.tsx
+++ b/app/guides/herbs/rhodiola-extract-vs-powder/page.tsx
@@ -131,7 +131,7 @@ export default function RhodiolaExtractVsPowderGuidePage() {
           <Link href="/guides/rhodiola-complete-guide/" className="text-brand-700 hover:text-brand-800 hover:underline">
             Complete Rhodiola Guide →
           </Link>
-          <Link href="/herbs/rhodiola" className="text-brand-700 hover:text-brand-800 hover:underline">
+          <Link href="/herbs/rhodiola/" className="text-brand-700 hover:text-brand-800 hover:underline">
             Rhodiola Herb Profile →
           </Link>
         </div>
@@ -241,12 +241,12 @@ export default function RhodiolaExtractVsPowderGuidePage() {
             <p className="mt-1 text-sm font-semibold text-ink">Complete Rhodiola Guide</p>
             <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Forms, benefits, dosing, and the full evidence base in one place.</p>
           </Link>
-          <Link href="/guides/rhodiola-energy" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+          <Link href="/guides/rhodiola-energy/" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
             <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Guide</p>
             <p className="mt-1 text-sm font-semibold text-ink">Rhodiola for Energy</p>
             <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Sustained energy without the stimulant crash — research and dosing.</p>
           </Link>
-          <Link href="/guides/rhodiola-sleep-stack" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+          <Link href="/guides/rhodiola-sleep-stack/" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
             <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Stack Guide</p>
             <p className="mt-1 text-sm font-semibold text-ink">Rhodiola + Magnesium for Sleep</p>
             <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">The adaptogen stack for the &quot;wired but tired&quot; cycle.</p>

--- a/app/guides/herbs/turmeric-curcumin/page.tsx
+++ b/app/guides/herbs/turmeric-curcumin/page.tsx
@@ -210,13 +210,13 @@ export default function TurmericCurcuminGuidePage() {
         </p>
         <div className="mt-6 flex flex-wrap gap-4 text-xs font-semibold uppercase tracking-[0.14em]">
           <Link
-            href="/herbs/turmeric"
+            href="/herbs/turmeric/"
             className="text-brand-700 hover:text-brand-800 hover:underline"
           >
             Turmeric Herb Profile →
           </Link>
           <Link
-            href="/compounds/curcumin"
+            href="/compounds/curcumin/"
             className="text-brand-700 hover:text-brand-800 hover:underline"
           >
             Curcumin Compound Profile →
@@ -354,7 +354,7 @@ export default function TurmericCurcuminGuidePage() {
         <h2 className="text-xl font-semibold text-ink">Referenced Profiles</h2>
         <div className="grid gap-3 sm:grid-cols-3">
           <Link
-            href="/herbs/turmeric"
+            href="/herbs/turmeric/"
             className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white"
           >
             <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">
@@ -364,7 +364,7 @@ export default function TurmericCurcuminGuidePage() {
             <p className="mt-1 text-xs text-muted">Full herb profile with mechanism map and safety data</p>
           </Link>
           <Link
-            href="/compounds/curcumin"
+            href="/compounds/curcumin/"
             className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white"
           >
             <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">
@@ -374,7 +374,7 @@ export default function TurmericCurcuminGuidePage() {
             <p className="mt-1 text-xs text-muted">Molecular mechanism, evidence grading, and interaction data</p>
           </Link>
           <Link
-            href="/compounds/piperine"
+            href="/compounds/piperine/"
             className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white"
           >
             <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">

--- a/app/guides/other/bpc-157/page.tsx
+++ b/app/guides/other/bpc-157/page.tsx
@@ -155,7 +155,7 @@ export default function Page() {
 
       <div className="mt-8 flex gap-4 flex-wrap">
         <Link href="/guides/" className="text-sm font-medium text-emerald-700 hover:underline">Back to guides &rarr;</Link>
-        <Link href="/compounds/bpc-157" className="text-sm font-medium text-emerald-700 hover:underline">View BPC-157 compound profile &rarr;</Link>
+        <Link href="/compounds/bpc-157/" className="text-sm font-medium text-emerald-700 hover:underline">View BPC-157 compound profile &rarr;</Link>
         <Link href="/guides/other/tb-500/" className="text-sm font-medium text-emerald-700 hover:underline">Read the TB-500 guide &rarr;</Link>
 
       </div>

--- a/app/guides/other/cjc-1295/page.tsx
+++ b/app/guides/other/cjc-1295/page.tsx
@@ -147,7 +147,7 @@ export default function Page() {
 
       <div className="mt-8 flex gap-4 flex-wrap">
         <Link href="/guides/" className="text-sm font-medium text-emerald-700 hover:underline">Back to guides &rarr;</Link>
-        <Link href="/compounds/cjc-1295" className="text-sm font-medium text-emerald-700 hover:underline">View CJC-1295 compound profile &rarr;</Link>
+        <Link href="/compounds/cjc-1295/" className="text-sm font-medium text-emerald-700 hover:underline">View CJC-1295 compound profile &rarr;</Link>
         <Link href="/guides/other/ipamorelin/" className="text-sm font-medium text-emerald-700 hover:underline">Read the Ipamorelin guide &rarr;</Link>
 
       </div>

--- a/app/guides/other/ghk-cu/page.tsx
+++ b/app/guides/other/ghk-cu/page.tsx
@@ -140,7 +140,7 @@ export default function Page() {
 
       <div className="mt-8 flex gap-4 flex-wrap">
         <Link href="/guides/" className="text-sm font-medium text-emerald-700 hover:underline">Back to guides &rarr;</Link>
-        <Link href="/compounds/ghk-cu" className="text-sm font-medium text-emerald-700 hover:underline">View GHK-Cu compound profile &rarr;</Link>
+        <Link href="/compounds/ghk-cu/" className="text-sm font-medium text-emerald-700 hover:underline">View GHK-Cu compound profile &rarr;</Link>
 
       </div>
     </div>

--- a/app/guides/other/healthy-dipping-tobacco-alternatives/page.tsx
+++ b/app/guides/other/healthy-dipping-tobacco-alternatives/page.tsx
@@ -408,10 +408,10 @@ export default function Page() {
         <section className="space-y-4">
           <h2 className="text-2xl font-semibold text-ink">Related Hippie Scientist pages</h2>
           <div className="grid gap-3 sm:grid-cols-2">
-            <Link href="/compounds/nicotine" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Nicotine compound profile -&gt;</Link>
-            <Link href="/learn/inflammation" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Inflammation guide -&gt;</Link>
-            <Link href="/guides/best/supplements-for-blood-pressure" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Supplements for blood pressure -&gt;</Link>
-            <Link href="/guides/compare/curcumin-vs-boswellia-vs-omega-3" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Curcumin vs boswellia vs omega-3 -&gt;</Link>
+            <Link href="/compounds/nicotine/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Nicotine compound profile -&gt;</Link>
+            <Link href="/learn/inflammation/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Inflammation guide -&gt;</Link>
+            <Link href="/guides/best/supplements-for-blood-pressure/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Supplements for blood pressure -&gt;</Link>
+            <Link href="/guides/compare/curcumin-vs-boswellia-vs-omega-3/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Curcumin vs boswellia vs omega-3 -&gt;</Link>
           </div>
         </section>
       </div>

--- a/app/guides/other/ipamorelin/page.tsx
+++ b/app/guides/other/ipamorelin/page.tsx
@@ -147,7 +147,7 @@ export default function Page() {
 
       <div className="mt-8 flex gap-4 flex-wrap">
         <Link href="/guides/" className="text-sm font-medium text-emerald-700 hover:underline">Back to guides &rarr;</Link>
-        <Link href="/compounds/ipamorelin" className="text-sm font-medium text-emerald-700 hover:underline">View Ipamorelin compound profile &rarr;</Link>
+        <Link href="/compounds/ipamorelin/" className="text-sm font-medium text-emerald-700 hover:underline">View Ipamorelin compound profile &rarr;</Link>
         <Link href="/guides/other/cjc-1295/" className="text-sm font-medium text-emerald-700 hover:underline">Read the CJC-1295 guide &rarr;</Link>
 
       </div>

--- a/app/guides/other/kratom-7oh-withdrawal-management/page.tsx
+++ b/app/guides/other/kratom-7oh-withdrawal-management/page.tsx
@@ -86,7 +86,7 @@ export default function Page() {
         <div id="understanding" className="scroll-mt-20">
           <h2 className="text-2xl font-semibold text-ink mt-6 mb-4">Understanding 7-OH and Withdrawal</h2>
           <p className="text-muted leading-relaxed">
-            7-Hydroxymitragynine (7-OH) is a kratom alkaloid with mu-opioid receptor activity, similar in mechanism to pharmaceutical opioids but occurring naturally in Mitragyna speciosa leaves. Chronic 7-OH use can lead to physical dependence, resulting in withdrawal symptoms when discontinuing or reducing dosage. The intensity and duration of withdrawal depend on dose, frequency, duration of use, individual metabolism, and co-occurring conditions. For pharmacology and regulatory context, read the <Link href="/compounds/7-hydroxymitragynine" className="font-semibold text-brand-800 hover:underline">full 7-OH evidence monograph</Link>.
+            7-Hydroxymitragynine (7-OH) is a kratom alkaloid with mu-opioid receptor activity, similar in mechanism to pharmaceutical opioids but occurring naturally in Mitragyna speciosa leaves. Chronic 7-OH use can lead to physical dependence, resulting in withdrawal symptoms when discontinuing or reducing dosage. The intensity and duration of withdrawal depend on dose, frequency, duration of use, individual metabolism, and co-occurring conditions. For pharmacology and regulatory context, read the <Link href="/compounds/7-hydroxymitragynine/" className="font-semibold text-brand-800 hover:underline">full 7-OH evidence monograph</Link>.
           </p>
         </div>
 
@@ -329,12 +329,12 @@ export default function Page() {
 
       <div className="mt-8 flex gap-4 flex-wrap">
         <Link href="/guides/" className="text-sm font-medium text-emerald-700 hover:underline">Back to guides →</Link>
-        <Link href="/compounds/7-hydroxymitragynine" className="text-sm font-medium text-emerald-700 hover:underline">Read the 7-OH monograph →</Link>
-        <Link href="/compounds/mitragynine" className="text-sm font-medium text-emerald-700 hover:underline">Read the mitragynine monograph →</Link>
-        <Link href="/guides/other/kratom-7oh-withdrawal-management" className="text-sm font-medium text-emerald-700 hover:underline">Compare mitragynine vs 7-OH →</Link>
-        <Link href="/compounds/mitragynine" className="text-sm font-medium text-emerald-700 hover:underline">View mitragynine profile →</Link>
+        <Link href="/compounds/7-hydroxymitragynine/" className="text-sm font-medium text-emerald-700 hover:underline">Read the 7-OH monograph →</Link>
+        <Link href="/compounds/mitragynine/" className="text-sm font-medium text-emerald-700 hover:underline">Read the mitragynine monograph →</Link>
+        <Link href="/guides/other/kratom-7oh-withdrawal-management/" className="text-sm font-medium text-emerald-700 hover:underline">Compare mitragynine vs 7-OH →</Link>
+        <Link href="/compounds/mitragynine/" className="text-sm font-medium text-emerald-700 hover:underline">View mitragynine profile →</Link>
         <Link href="/compounds/kratom/" className="text-sm font-medium text-emerald-700 hover:underline">View kratom profile →</Link>
-        <Link href="/compounds/7-hydroxymitragynine" className="text-sm font-medium text-emerald-700 hover:underline">View 7-OH compound profile →</Link>
+        <Link href="/compounds/7-hydroxymitragynine/" className="text-sm font-medium text-emerald-700 hover:underline">View 7-OH compound profile →</Link>
       </div>
     </div>
     <References refs={KRATOM_7OH_WITHDRAWAL_MANAGEMENT_REFS} />

--- a/app/guides/other/psychedelic-adjacent-herbs/page.tsx
+++ b/app/guides/other/psychedelic-adjacent-herbs/page.tsx
@@ -69,10 +69,10 @@ export default function PsychedelicAdjacentHerbsPage() {
         </p>
 
         <div className="mt-6 flex flex-wrap gap-4 text-xs font-semibold uppercase tracking-[0.14em]">
-          <Link href="/learn/serotonergic-stacking-risks" className="text-brand-700 hover:text-brand-800 hover:underline">
+          <Link href="/learn/serotonergic-stacking-risks/" className="text-brand-700 hover:text-brand-800 hover:underline">
             Serotonergic Stacking Risks →
           </Link>
-          <Link href="/guides/compare/kanna-vs-ssris" className="text-brand-700 hover:text-brand-800 hover:underline">
+          <Link href="/guides/compare/kanna-vs-ssris/" className="text-brand-700 hover:text-brand-800 hover:underline">
             Kanna vs SSRIs Compare →
           </Link>
           <Link href="/info/disclaimer/" className="text-brand-700 hover:text-brand-800 hover:underline">

--- a/app/guides/other/pt-141/page.tsx
+++ b/app/guides/other/pt-141/page.tsx
@@ -137,7 +137,7 @@ export default function Page() {
 
       <div className="mt-8 flex gap-4 flex-wrap">
         <Link href="/guides/" className="text-sm font-medium text-emerald-700 hover:underline">Back to guides &rarr;</Link>
-        <Link href="/compounds/pt-141" className="text-sm font-medium text-emerald-700 hover:underline">View PT-141 compound profile &rarr;</Link>
+        <Link href="/compounds/pt-141/" className="text-sm font-medium text-emerald-700 hover:underline">View PT-141 compound profile &rarr;</Link>
 
       </div>
     </div>

--- a/app/guides/other/semaglutide/page.tsx
+++ b/app/guides/other/semaglutide/page.tsx
@@ -144,7 +144,7 @@ export default function Page() {
 
       <div className="mt-8 flex gap-4 flex-wrap">
         <Link href="/guides/" className="text-sm font-medium text-emerald-700 hover:underline">Back to guides &rarr;</Link>
-        <Link href="/compounds/semaglutide" className="text-sm font-medium text-emerald-700 hover:underline">View Semaglutide compound profile &rarr;</Link>
+        <Link href="/compounds/semaglutide/" className="text-sm font-medium text-emerald-700 hover:underline">View Semaglutide compound profile &rarr;</Link>
         <Link href="/guides/other/tirzepatide/" className="text-sm font-medium text-emerald-700 hover:underline">Read the Tirzepatide guide &rarr;</Link>
 
       </div>

--- a/app/guides/other/supplements-for-brain-fog-and-fatigue/page.tsx
+++ b/app/guides/other/supplements-for-brain-fog-and-fatigue/page.tsx
@@ -67,9 +67,9 @@ export default function Page() {
       <section className='card-premium p-6'>
         <h2 className='text-xl font-semibold text-ink'>Where to go next</h2>
         <div className='mt-4 flex flex-wrap gap-4'>
-          <Link href='/guides/other/supplements-for-brain-fog-and-fatigue' className='text-sm font-medium text-emerald-700 hover:underline'>Best supplements for brain fog</Link>
-          <Link href='/guides/other/supplements-for-brain-fog-and-fatigue' className='text-sm font-medium text-emerald-700 hover:underline'>Best supplements for fatigue</Link>
-          <Link href='/guides/focus/best-nootropics-for-focus' className='text-sm font-medium text-emerald-700 hover:underline'>Creatine vs caffeine</Link>
+          <Link href='/guides/other/supplements-for-brain-fog-and-fatigue/' className='text-sm font-medium text-emerald-700 hover:underline'>Best supplements for brain fog</Link>
+          <Link href='/guides/other/supplements-for-brain-fog-and-fatigue/' className='text-sm font-medium text-emerald-700 hover:underline'>Best supplements for fatigue</Link>
+          <Link href='/guides/focus/best-nootropics-for-focus/' className='text-sm font-medium text-emerald-700 hover:underline'>Creatine vs caffeine</Link>
         </div>
       </section>
     </ArticleLayout>

--- a/app/guides/other/tb-500/page.tsx
+++ b/app/guides/other/tb-500/page.tsx
@@ -147,7 +147,7 @@ export default function Page() {
 
       <div className="mt-8 flex gap-4 flex-wrap">
         <Link href="/guides/" className="text-sm font-medium text-emerald-700 hover:underline">Back to guides &rarr;</Link>
-        <Link href="/compounds/tb-500" className="text-sm font-medium text-emerald-700 hover:underline">View TB-500 compound profile &rarr;</Link>
+        <Link href="/compounds/tb-500/" className="text-sm font-medium text-emerald-700 hover:underline">View TB-500 compound profile &rarr;</Link>
         <Link href="/guides/other/bpc-157/" className="text-sm font-medium text-emerald-700 hover:underline">Read the BPC-157 guide &rarr;</Link>
 
       </div>

--- a/app/guides/other/tirzepatide/page.tsx
+++ b/app/guides/other/tirzepatide/page.tsx
@@ -140,7 +140,7 @@ export default function Page() {
 
       <div className="mt-8 flex gap-4 flex-wrap">
         <Link href="/guides/" className="text-sm font-medium text-emerald-700 hover:underline">Back to guides &rarr;</Link>
-        <Link href="/compounds/tirzepatide" className="text-sm font-medium text-emerald-700 hover:underline">View Tirzepatide compound profile &rarr;</Link>
+        <Link href="/compounds/tirzepatide/" className="text-sm font-medium text-emerald-700 hover:underline">View Tirzepatide compound profile &rarr;</Link>
         <Link href="/guides/other/semaglutide/" className="text-sm font-medium text-emerald-700 hover:underline">Read the Semaglutide guide &rarr;</Link>
 
       </div>

--- a/app/guides/sleep/ashwagandha-for-sleep/page.tsx
+++ b/app/guides/sleep/ashwagandha-for-sleep/page.tsx
@@ -189,7 +189,7 @@ export default function AshwagandhaForSleepPage() {
               an acute sleep aid. See the{' '}
               <Link href="/guides/herbs/ashwagandha/" className="font-semibold text-brand-700 hover:underline">full ashwagandha article</Link>{' '}
               and the{' '}
-              <Link href="/guides/sleep/best-herbs-for-sleep" className="font-semibold text-brand-700 hover:underline">best herbs for sleep hub</Link>.
+              <Link href="/guides/sleep/best-herbs-for-sleep/" className="font-semibold text-brand-700 hover:underline">best herbs for sleep hub</Link>.
             </p>
           </section>
 
@@ -232,7 +232,7 @@ export default function AshwagandhaForSleepPage() {
                 supplements, and flags the safety considerations that matter most for long-term use.
                 All claims are referenced to primary studies or the{' '}
                 <Link
-                  href="/herbs/ashwagandha"
+                  href="/herbs/ashwagandha/"
                   className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
                 >
                   Ashwagandha herb profile
@@ -269,7 +269,7 @@ export default function AshwagandhaForSleepPage() {
               <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
                 For a complete breakdown of chemistry, evidence, and uses beyond sleep, see the{' '}
                 <Link
-                  href="/herbs/ashwagandha"
+                  href="/herbs/ashwagandha/"
                   className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
                 >
                   full Ashwagandha herb profile
@@ -526,7 +526,7 @@ export default function AshwagandhaForSleepPage() {
               <p className="mt-3 text-sm text-muted">
                 See the{' '}
                 <Link
-                  href="/herbs/ashwagandha"
+                  href="/herbs/ashwagandha/"
                   className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
                 >
                   full Ashwagandha safety profile
@@ -598,7 +598,7 @@ export default function AshwagandhaForSleepPage() {
               <p className="mt-3 text-sm text-muted">
                 See the full{' '}
                 <Link
-                  href="/guides/sleep-herbs-vs-melatonin"
+                  href="/guides/sleep-herbs-vs-melatonin/"
                   className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
                 >
                   sleep herbs vs melatonin comparison
@@ -636,7 +636,7 @@ export default function AshwagandhaForSleepPage() {
               </h2>
               <div className="grid gap-3 sm:grid-cols-2">
                 <Link
-                  href="/guides/sleep/best-herbs-for-sleep"
+                  href="/guides/sleep/best-herbs-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -651,7 +651,7 @@ export default function AshwagandhaForSleepPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep-herbs-vs-melatonin"
+                  href="/guides/sleep-herbs-vs-melatonin/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -666,7 +666,7 @@ export default function AshwagandhaForSleepPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/herbs/ashwagandha"
+                  href="/herbs/ashwagandha/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -681,7 +681,7 @@ export default function AshwagandhaForSleepPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/anxiety/natural-anxiolytics-beyond-ashwagandha"
+                  href="/guides/anxiety/natural-anxiolytics-beyond-ashwagandha/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -696,7 +696,7 @@ export default function AshwagandhaForSleepPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/ashwagandha-vs-magnesium-for-sleep"
+                  href="/guides/sleep/ashwagandha-vs-magnesium-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -711,7 +711,7 @@ export default function AshwagandhaForSleepPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/l-theanine-for-sleep"
+                  href="/guides/sleep/l-theanine-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -768,7 +768,7 @@ export default function AshwagandhaForSleepPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep"
+                  href="/guides/sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -970,19 +970,19 @@ export default function AshwagandhaForSleepPage() {
             </p>
             <div className="mt-3 space-y-2">
               <Link
-                href="/herbs/ashwagandha"
+                href="/herbs/ashwagandha/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Ashwagandha herb profile →
               </Link>
               <Link
-                href="/guides/sleep-herbs-vs-melatonin"
+                href="/guides/sleep-herbs-vs-melatonin/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Sleep herbs vs melatonin →
               </Link>
               <Link
-                href="/guides/anxiety/natural-anxiolytics-beyond-ashwagandha"
+                href="/guides/anxiety/natural-anxiolytics-beyond-ashwagandha/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Natural anxiolytics →

--- a/app/guides/sleep/ashwagandha-vs-magnesium-for-sleep/page.tsx
+++ b/app/guides/sleep/ashwagandha-vs-magnesium-for-sleep/page.tsx
@@ -354,7 +354,7 @@ export default function AshwagandhaVsMagnesiumForSleepPage() {
                 For the full clinical evidence review, mechanisms, and dosage protocols for
                 ashwagandha as a sleep supplement, see the{' '}
                 <Link
-                  href="/guides/sleep/ashwagandha-for-sleep"
+                  href="/guides/sleep/ashwagandha-for-sleep/"
                   className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
                 >
                   Ashwagandha for Sleep article
@@ -418,7 +418,7 @@ export default function AshwagandhaVsMagnesiumForSleepPage() {
                 </Link>{' '}
                 and the{' '}
                 <Link
-                  href="/guides/sleep/magnesium-types-for-sleep"
+                  href="/guides/sleep/magnesium-types-for-sleep/"
                   className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
                 >
                   Magnesium Types for Sleep guide
@@ -825,7 +825,7 @@ export default function AshwagandhaVsMagnesiumForSleepPage() {
               </h2>
               <div className="grid gap-3 sm:grid-cols-2">
                 <Link
-                  href="/guides/sleep/ashwagandha-for-sleep"
+                  href="/guides/sleep/ashwagandha-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -855,7 +855,7 @@ export default function AshwagandhaVsMagnesiumForSleepPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/magnesium-types-for-sleep"
+                  href="/guides/sleep/magnesium-types-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -870,7 +870,7 @@ export default function AshwagandhaVsMagnesiumForSleepPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/best-herbs-for-sleep"
+                  href="/guides/sleep/best-herbs-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -885,7 +885,7 @@ export default function AshwagandhaVsMagnesiumForSleepPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/l-theanine-for-sleep"
+                  href="/guides/sleep/l-theanine-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -900,7 +900,7 @@ export default function AshwagandhaVsMagnesiumForSleepPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/sleep-stack-guide"
+                  href="/guides/sleep/sleep-stack-guide/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -1052,7 +1052,7 @@ export default function AshwagandhaVsMagnesiumForSleepPage() {
                 Ashwagandha safety references are shared
                 with the{' '}
                 <Link
-                  href="/guides/sleep/ashwagandha-for-sleep"
+                  href="/guides/sleep/ashwagandha-for-sleep/"
                   className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
                 >
                   Ashwagandha for Sleep article
@@ -1123,7 +1123,7 @@ export default function AshwagandhaVsMagnesiumForSleepPage() {
             </p>
             <div className="mt-3 space-y-2">
               <Link
-                href="/guides/sleep/ashwagandha-for-sleep"
+                href="/guides/sleep/ashwagandha-for-sleep/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Ashwagandha for sleep →
@@ -1135,19 +1135,19 @@ export default function AshwagandhaVsMagnesiumForSleepPage() {
                 Magnesium for sleep →
               </Link>
               <Link
-                href="/guides/sleep/magnesium-types-for-sleep"
+                href="/guides/sleep/magnesium-types-for-sleep/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Magnesium types for sleep →
               </Link>
               <Link
-                href="/guides/sleep/best-herbs-for-sleep"
+                href="/guides/sleep/best-herbs-for-sleep/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Best herbs for sleep →
               </Link>
               <Link
-                href="/guides/sleep-herbs-vs-melatonin"
+                href="/guides/sleep-herbs-vs-melatonin/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Sleep herbs vs melatonin →

--- a/app/guides/sleep/best-herbs-for-sleep/page.tsx
+++ b/app/guides/sleep/best-herbs-for-sleep/page.tsx
@@ -265,7 +265,7 @@ export default function BestHerbsForSleepPage() {
                         <td className="py-3 pr-4 text-muted">300–600 mg/day (KSM-66 or Sensoril), evening</td>
                         <td className="py-3">
                           <Link
-                            href="/guides/sleep/ashwagandha-for-sleep"
+                            href="/guides/sleep/ashwagandha-for-sleep/"
                             className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
                           >
                             Full guide →
@@ -280,7 +280,7 @@ export default function BestHerbsForSleepPage() {
                         <td className="py-3 pr-4 text-muted">100–200 mg, 30–60 min before bed</td>
                         <td className="py-3 text-xs">
                           <Link
-                            href="/guides/sleep/l-theanine-for-sleep"
+                            href="/guides/sleep/l-theanine-for-sleep/"
                             className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
                           >
                             Full guide →
@@ -470,7 +470,7 @@ export default function BestHerbsForSleepPage() {
                   </p>
                   <p>
                     <Link
-                      href="/guides/sleep/ashwagandha-for-sleep"
+                      href="/guides/sleep/ashwagandha-for-sleep/"
                       className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
                     >
                       Full guide: Ashwagandha for Sleep →
@@ -627,7 +627,7 @@ export default function BestHerbsForSleepPage() {
                     <strong>If stress is clearly the main sleep blocker</strong> — you find it hard
                     to wind down, your mind is active, or you notice elevated stress throughout the
                     day: try{' '}
-                    <Link href="/guides/sleep/ashwagandha-for-sleep" className="font-semibold text-brand-700 hover:underline">
+                    <Link href="/guides/sleep/ashwagandha-for-sleep/" className="font-semibold text-brand-700 hover:underline">
                       ashwagandha
                     </Link>{' '}
                     (KSM-66 or Sensoril, 300–600 mg/day). Allow 6–8 weeks.
@@ -812,7 +812,7 @@ export default function BestHerbsForSleepPage() {
               </h2>
               <div className="grid gap-3 sm:grid-cols-2">
                 <Link
-                  href="/guides/sleep/ashwagandha-for-sleep"
+                  href="/guides/sleep/ashwagandha-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -842,7 +842,7 @@ export default function BestHerbsForSleepPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/l-theanine-for-sleep"
+                  href="/guides/sleep/l-theanine-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -857,7 +857,7 @@ export default function BestHerbsForSleepPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/magnesium-types-for-sleep"
+                  href="/guides/sleep/magnesium-types-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -872,7 +872,7 @@ export default function BestHerbsForSleepPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/ashwagandha-vs-magnesium-for-sleep"
+                  href="/guides/sleep/ashwagandha-vs-magnesium-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -887,7 +887,7 @@ export default function BestHerbsForSleepPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/sleep-stack-guide"
+                  href="/guides/sleep/sleep-stack-guide/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -917,7 +917,7 @@ export default function BestHerbsForSleepPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/adhd/sleep-and-adhd"
+                  href="/guides/adhd/sleep-and-adhd/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -1107,13 +1107,13 @@ export default function BestHerbsForSleepPage() {
                 Magnesium for sleep →
               </Link>
               <Link
-                href="/guides/sleep/ashwagandha-for-sleep"
+                href="/guides/sleep/ashwagandha-for-sleep/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Ashwagandha for sleep →
               </Link>
               <Link
-                href="/guides/sleep-herbs-vs-melatonin"
+                href="/guides/sleep-herbs-vs-melatonin/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Sleep herbs vs melatonin →

--- a/app/guides/sleep/best-natural-sleep-aids-that-work/page.tsx
+++ b/app/guides/sleep/best-natural-sleep-aids-that-work/page.tsx
@@ -197,7 +197,7 @@ export default function Page() {
           <div className="space-y-3">
             <article className="card-premium p-6">
               <h3 className="text-xl font-semibold text-brand-800">
-                <Link href="/compounds/magnesium-glycinate" className="hover:underline">Magnesium glycinate</Link>{' '}
+                <Link href="/compounds/magnesium-glycinate/" className="hover:underline">Magnesium glycinate</Link>{' '}
                 <span className="ml-2 rounded-full bg-brand-50 px-3 py-0.5 align-middle text-xs font-semibold text-brand-800">Grade B · Foundation</span>
               </h3>
               <p className="mt-3 text-sm text-muted">
@@ -206,14 +206,14 @@ export default function Page() {
                 in stressed, high-caffeine populations. The glycinate form is well absorbed and gentle on
                 the gut. Typical evening dose is 200–400&nbsp;mg of elemental magnesium. It pairs naturally
                 with L-theanine; see{' '}
-                <Link href="/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium" className="font-medium text-brand-700 hover:underline">L-theanine vs magnesium</Link>{' '}
+                <Link href="/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium/" className="font-medium text-brand-700 hover:underline">L-theanine vs magnesium</Link>{' '}
                 for how to choose between or combine them.
               </p>
             </article>
 
             <article className="card-premium p-6">
               <h3 className="text-xl font-semibold text-brand-800">
-                <Link href="/compounds/l-theanine" className="hover:underline">L-theanine</Link>{' '}
+                <Link href="/compounds/l-theanine/" className="hover:underline">L-theanine</Link>{' '}
                 <span className="ml-2 rounded-full bg-brand-50 px-3 py-0.5 align-middle text-xs font-semibold text-brand-800">Grade B · Calm</span>
               </h3>
               <p className="mt-3 text-sm text-muted">
@@ -226,30 +226,30 @@ export default function Page() {
 
             <article className="card-premium p-6">
               <h3 className="text-xl font-semibold text-brand-800">
-                <Link href="/compounds/melatonin" className="hover:underline">Melatonin (low dose)</Link>{' '}
+                <Link href="/compounds/melatonin/" className="hover:underline">Melatonin (low dose)</Link>{' '}
                 <span className="ml-2 rounded-full bg-brand-50 px-3 py-0.5 align-middle text-xs font-semibold text-brand-800">Grade A (circadian)</span>
               </h3>
               <p className="mt-3 text-sm text-muted">
                 Melatonin is a circadian signal, not a knockout drug. It is strongly evidenced for jet
                 lag, shift work and delayed sleep phase, and moderately helpful for general sleep-onset
                 latency. Use 0.5–1&nbsp;mg — higher doses rarely help more and can cause grogginess. See{' '}
-                <Link href="/guides/compare/melatonin-vs-magnesium" className="font-medium text-brand-700 hover:underline">melatonin vs magnesium</Link>{' '}
+                <Link href="/guides/compare/melatonin-vs-magnesium/" className="font-medium text-brand-700 hover:underline">melatonin vs magnesium</Link>{' '}
                 and{' '}
-                <Link href="/guides/sleep/magnesium-vs-melatonin" className="font-medium text-brand-700 hover:underline">our magnesium vs melatonin guide</Link>{' '}
+                <Link href="/guides/sleep/magnesium-vs-melatonin/" className="font-medium text-brand-700 hover:underline">our magnesium vs melatonin guide</Link>{' '}
                 to decide which mechanism fits your problem.
               </p>
             </article>
 
             <article className="card-premium p-6">
               <h3 className="text-xl font-semibold text-brand-800">
-                <Link href="/herbs/valerian" className="hover:underline">Valerian root</Link>{' '}
+                <Link href="/herbs/valerian/" className="hover:underline">Valerian root</Link>{' '}
                 <span className="ml-2 rounded-full bg-brand-50 px-3 py-0.5 align-middle text-xs font-semibold text-brand-800">Grade C–B · Sedating</span>
               </h3>
               <p className="mt-3 text-sm text-muted">
                 Valerian acts on GABA-A receptors and has a genuine mild sedative effect, though trial
                 results are mixed and depend heavily on extract quality. It works best with consistent
                 use over a couple of weeks and pairs traditionally with{' '}
-                <Link href="/herbs/hops" className="font-medium text-brand-700 hover:underline">hops</Link>{' '}
+                <Link href="/herbs/hops/" className="font-medium text-brand-700 hover:underline">hops</Link>{' '}
                 and lemon balm. Avoid combining with alcohol or other sedatives.
               </p>
             </article>
@@ -263,7 +263,7 @@ export default function Page() {
                 Both raise GABA tone and have a long traditional record for anxiety-related, restless
                 sleep. The evidence base is smaller, but they are gentle, low-risk options for mild
                 difficulty winding down. Read the full{' '}
-                <Link href="/guides/passionflower" className="font-medium text-brand-700 hover:underline">passionflower guide</Link>{' '}
+                <Link href="/guides/passionflower/" className="font-medium text-brand-700 hover:underline">passionflower guide</Link>{' '}
                 for preparation and dosing.
               </p>
             </article>
@@ -340,12 +340,12 @@ export default function Page() {
         <section className="space-y-4">
           <h2 className="text-2xl font-semibold text-ink">Related guides &amp; comparisons</h2>
           <div className="grid gap-3 sm:grid-cols-2">
-            <Link href="/guides/sleep/best-supplements-for-sleep" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Best Supplements for Sleep →</Link>
+            <Link href="/guides/sleep/best-supplements-for-sleep/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Best Supplements for Sleep →</Link>
             <Link href="/guides/sleep/magnesium-for-sleep/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Magnesium for Sleep →</Link>
-            <Link href="/guides/best-herbs-for-stress-and-anxiety-at-night" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Best Herbs for Stress &amp; Anxiety at Night →</Link>
-            <Link href="/guides/compare/melatonin-vs-valerian-vs-magnesium-for-sleep" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Melatonin vs Valerian vs Magnesium →</Link>
-            <Link href="/guides/compare/sleep-herbs-vs-melatonin" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Sleep Herbs vs Melatonin →</Link>
-            <Link href="/guides/sleep" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">All Sleep Guides →</Link>
+            <Link href="/guides/best-herbs-for-stress-and-anxiety-at-night/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Best Herbs for Stress &amp; Anxiety at Night →</Link>
+            <Link href="/guides/compare/melatonin-vs-valerian-vs-magnesium-for-sleep/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Melatonin vs Valerian vs Magnesium →</Link>
+            <Link href="/guides/compare/sleep-herbs-vs-melatonin/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Sleep Herbs vs Melatonin →</Link>
+            <Link href="/guides/sleep/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">All Sleep Guides →</Link>
           </div>
         </section>
       </div>

--- a/app/guides/sleep/best-supplements-for-sleep/page.tsx
+++ b/app/guides/sleep/best-supplements-for-sleep/page.tsx
@@ -199,9 +199,9 @@ export default function BestSupplementsForSleepPage() {
             <strong>Fastest useful choice:</strong> for racing thoughts, start with{' '}
             <Link href="/guides/herbs/l-theanine/" className="font-semibold text-brand-800 hover:underline">L-theanine</Link>;
             for muscle tension or night waking, start with{' '}
-            <Link href="/compounds/magnesium-glycinate" className="font-semibold text-brand-800 hover:underline">magnesium glycinate</Link>;
+            <Link href="/compounds/magnesium-glycinate/" className="font-semibold text-brand-800 hover:underline">magnesium glycinate</Link>;
             for jet lag or a shifted sleep schedule, start with low-dose{' '}
-            <Link href="/compounds/melatonin" className="font-semibold text-brand-800 hover:underline">melatonin</Link>.
+            <Link href="/compounds/melatonin/" className="font-semibold text-brand-800 hover:underline">melatonin</Link>.
           </div>
 
         <figure className="mt-6">
@@ -397,10 +397,10 @@ export default function BestSupplementsForSleepPage() {
         {/* Related */}
         <nav className="flex flex-wrap gap-4 text-sm font-semibold text-brand-700">
           <Link href="/guides/herbs/l-theanine/" className="hover:text-brand-800">L-Theanine for Calm Sleep →</Link>
-          <Link href="/guides/sleep/magnesium-vs-melatonin" className="hover:text-brand-800">Magnesium vs Melatonin →</Link>
-          <Link href="/guides/compare/sleep-herbs-vs-melatonin" className="hover:text-brand-800">Sleep Herbs vs Melatonin →</Link>
+          <Link href="/guides/sleep/magnesium-vs-melatonin/" className="hover:text-brand-800">Magnesium vs Melatonin →</Link>
+          <Link href="/guides/compare/sleep-herbs-vs-melatonin/" className="hover:text-brand-800">Sleep Herbs vs Melatonin →</Link>
           <Link href="/guides/sleep/magnesium-for-sleep/" className="hover:text-brand-800">Magnesium for Sleep Guide →</Link>
-          <Link href="/guides/sleep/magnesium-types-for-sleep" className="hover:text-brand-800">Magnesium Types for Sleep →</Link>
+          <Link href="/guides/sleep/magnesium-types-for-sleep/" className="hover:text-brand-800">Magnesium Types for Sleep →</Link>
           <Link href="/guides/" className="hover:text-brand-800">All Guides →</Link>
         </nav>
       </div>

--- a/app/guides/sleep/l-theanine-for-sleep/page.tsx
+++ b/app/guides/sleep/l-theanine-for-sleep/page.tsx
@@ -547,7 +547,7 @@ export default function LTheanineForSleepPage() {
                 </Link>{' '}
                 and the{' '}
                 <Link
-                  href="/guides/sleep/magnesium-types-for-sleep"
+                  href="/guides/sleep/magnesium-types-for-sleep/"
                   className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
                 >
                   Magnesium Types for Sleep guide
@@ -645,14 +645,14 @@ export default function LTheanineForSleepPage() {
               <p className="mt-3 text-sm text-muted">
                 For the full clinical review of ashwagandha for sleep, see the{' '}
                 <Link
-                  href="/guides/sleep/ashwagandha-for-sleep"
+                  href="/guides/sleep/ashwagandha-for-sleep/"
                   className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
                 >
                   Ashwagandha for Sleep article
                 </Link>{' '}
                 and the{' '}
                 <Link
-                  href="/guides/sleep/ashwagandha-vs-magnesium-for-sleep"
+                  href="/guides/sleep/ashwagandha-vs-magnesium-for-sleep/"
                   className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
                 >
                   Ashwagandha vs Magnesium for Sleep comparison
@@ -1004,7 +1004,7 @@ export default function LTheanineForSleepPage() {
               </h2>
               <div className="grid gap-3 sm:grid-cols-2">
                 <Link
-                  href="/guides/sleep/best-herbs-for-sleep"
+                  href="/guides/sleep/best-herbs-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -1034,7 +1034,7 @@ export default function LTheanineForSleepPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/magnesium-types-for-sleep"
+                  href="/guides/sleep/magnesium-types-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -1049,7 +1049,7 @@ export default function LTheanineForSleepPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/ashwagandha-for-sleep"
+                  href="/guides/sleep/ashwagandha-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -1064,7 +1064,7 @@ export default function LTheanineForSleepPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/ashwagandha-vs-magnesium-for-sleep"
+                  href="/guides/sleep/ashwagandha-vs-magnesium-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -1079,7 +1079,7 @@ export default function LTheanineForSleepPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/sleep-stack-guide"
+                  href="/guides/sleep/sleep-stack-guide/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -1123,7 +1123,7 @@ export default function LTheanineForSleepPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/adhd/sleep-and-adhd"
+                  href="/guides/adhd/sleep-and-adhd/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -1258,7 +1258,7 @@ export default function LTheanineForSleepPage() {
                 </Link>
                 . Ashwagandha evidence references are shared with the{' '}
                 <Link
-                  href="/guides/sleep/ashwagandha-for-sleep"
+                  href="/guides/sleep/ashwagandha-for-sleep/"
                   className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
                 >
                   Ashwagandha for Sleep article
@@ -1323,7 +1323,7 @@ export default function LTheanineForSleepPage() {
             </p>
             <div className="mt-3 space-y-2">
               <Link
-                href="/guides/sleep/best-herbs-for-sleep"
+                href="/guides/sleep/best-herbs-for-sleep/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Best herbs for sleep →
@@ -1335,25 +1335,25 @@ export default function LTheanineForSleepPage() {
                 Magnesium for sleep →
               </Link>
               <Link
-                href="/guides/sleep/magnesium-types-for-sleep"
+                href="/guides/sleep/magnesium-types-for-sleep/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Magnesium types for sleep →
               </Link>
               <Link
-                href="/guides/sleep/ashwagandha-for-sleep"
+                href="/guides/sleep/ashwagandha-for-sleep/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Ashwagandha for sleep →
               </Link>
               <Link
-                href="/guides/sleep/ashwagandha-vs-magnesium-for-sleep"
+                href="/guides/sleep/ashwagandha-vs-magnesium-for-sleep/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Ashwagandha vs magnesium →
               </Link>
               <Link
-                href="/guides/sleep-herbs-vs-melatonin"
+                href="/guides/sleep-herbs-vs-melatonin/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Sleep herbs vs melatonin →

--- a/app/guides/sleep/magnesium-types-for-sleep/page.tsx
+++ b/app/guides/sleep/magnesium-types-for-sleep/page.tsx
@@ -898,7 +898,7 @@ export default function MagnesiumTypesForSleepPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/best-herbs-for-sleep"
+                  href="/guides/sleep/best-herbs-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -913,7 +913,7 @@ export default function MagnesiumTypesForSleepPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/ashwagandha-for-sleep"
+                  href="/guides/sleep/ashwagandha-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -928,7 +928,7 @@ export default function MagnesiumTypesForSleepPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/ashwagandha-vs-magnesium-for-sleep"
+                  href="/guides/sleep/ashwagandha-vs-magnesium-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -943,7 +943,7 @@ export default function MagnesiumTypesForSleepPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/sleep-stack-guide"
+                  href="/guides/sleep/sleep-stack-guide/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -958,7 +958,7 @@ export default function MagnesiumTypesForSleepPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/l-theanine-for-sleep"
+                  href="/guides/sleep/l-theanine-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -987,7 +987,7 @@ export default function MagnesiumTypesForSleepPage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/adhd/sleep-and-adhd"
+                  href="/guides/adhd/sleep-and-adhd/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -1147,19 +1147,19 @@ export default function MagnesiumTypesForSleepPage() {
                 Magnesium for sleep →
               </Link>
               <Link
-                href="/guides/sleep/best-herbs-for-sleep"
+                href="/guides/sleep/best-herbs-for-sleep/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Best herbs for sleep →
               </Link>
               <Link
-                href="/guides/sleep/ashwagandha-for-sleep"
+                href="/guides/sleep/ashwagandha-for-sleep/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Ashwagandha for sleep →
               </Link>
               <Link
-                href="/guides/sleep-herbs-vs-melatonin"
+                href="/guides/sleep-herbs-vs-melatonin/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Sleep herbs vs melatonin →

--- a/app/guides/sleep/magnesium-vs-melatonin/page.tsx
+++ b/app/guides/sleep/magnesium-vs-melatonin/page.tsx
@@ -216,9 +216,9 @@ export default function MagnesiumVsMelatoninGuidePage() {
             Magnesium and melatonin are complementary tools. Choose emphasis based on whether your main need is relaxation/quality support or circadian timing/onset. Thoughtful stacking is common. Prioritize sleep hygiene and use the compare tool for deeper evidence views.
           </p>
           <div className="mt-4 flex flex-wrap gap-4 text-sm">
-            <Link href="/guides/sleep/magnesium-vs-melatonin" className="font-semibold text-emerald-700 hover:underline">Open side-by-side compare →</Link>
-            <Link href="/compounds/magnesium" className="font-semibold text-emerald-700 hover:underline">Magnesium profile →</Link>
-            <Link href="/compounds/melatonin" className="font-semibold text-emerald-700 hover:underline">Melatonin profile →</Link>
+            <Link href="/guides/sleep/magnesium-vs-melatonin/" className="font-semibold text-emerald-700 hover:underline">Open side-by-side compare →</Link>
+            <Link href="/compounds/magnesium/" className="font-semibold text-emerald-700 hover:underline">Magnesium profile →</Link>
+            <Link href="/compounds/melatonin/" className="font-semibold text-emerald-700 hover:underline">Melatonin profile →</Link>
           </div>
         </section>
       </div>

--- a/app/guides/sleep/rhodiola-sleep-stack/page.tsx
+++ b/app/guides/sleep/rhodiola-sleep-stack/page.tsx
@@ -302,7 +302,7 @@ export default function RhodiolaSleepStackGuidePage() {
             <p className="mt-1 text-sm font-semibold text-ink">Magnesium for Sleep</p>
             <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Forms, dosage, and evidence for magnesium as a sleep and anxiety support.</p>
           </Link>
-          <Link href="/guides/sleep/best-herbs-for-sleep" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
+          <Link href="/guides/sleep/best-herbs-for-sleep/" className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white">
             <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">Pillar</p>
             <p className="mt-1 text-sm font-semibold text-ink">Best Herbs for Sleep</p>
             <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">Evidence-ranked guide to the most-studied natural sleep options.</p>

--- a/app/guides/sleep/sleep-herbs-vs-melatonin/page.tsx
+++ b/app/guides/sleep/sleep-herbs-vs-melatonin/page.tsx
@@ -94,13 +94,13 @@ export default function SleepHerbsVsMelatoninPage() {
         </p>
 
         <div className="mt-6 flex flex-wrap gap-4 text-xs font-semibold uppercase tracking-[0.14em]">
-          <Link href="/guides/compare/sleep-herbs-vs-melatonin" className="text-brand-700 hover:text-brand-800 hover:underline">
+          <Link href="/guides/compare/sleep-herbs-vs-melatonin/" className="text-brand-700 hover:text-brand-800 hover:underline">
             Full Evidence Comparison →
           </Link>
-          <Link href="/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium" className="text-brand-700 hover:text-brand-800 hover:underline">
+          <Link href="/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium/" className="text-brand-700 hover:text-brand-800 hover:underline">
             L-Theanine vs Magnesium →
           </Link>
-          <Link href="/guides/sleep/magnesium-vs-melatonin" className="text-brand-700 hover:text-brand-800 hover:underline">
+          <Link href="/guides/sleep/magnesium-vs-melatonin/" className="text-brand-700 hover:text-brand-800 hover:underline">
             Magnesium vs Melatonin Guide →
           </Link>
           <Link href="/best-supplements-for-sleep/" className="text-brand-700 hover:text-brand-800 hover:underline">

--- a/app/guides/sleep/sleep-stack-guide/page.tsx
+++ b/app/guides/sleep/sleep-stack-guide/page.tsx
@@ -293,7 +293,7 @@ export default function SleepStackGuidePage() {
                 </Link>{' '}
                 ·{' '}
                 <Link
-                  href="/guides/sleep/magnesium-types-for-sleep"
+                  href="/guides/sleep/magnesium-types-for-sleep/"
                   className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
                 >
                   Magnesium Types for Sleep
@@ -314,7 +314,7 @@ export default function SleepStackGuidePage() {
               <p className="mt-2 text-sm text-muted">
                 Full evidence review:{' '}
                 <Link
-                  href="/guides/sleep/l-theanine-for-sleep"
+                  href="/guides/sleep/l-theanine-for-sleep/"
                   className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
                 >
                   L-Theanine for Sleep
@@ -336,14 +336,14 @@ export default function SleepStackGuidePage() {
               <p className="mt-2 text-sm text-muted">
                 Full evidence review:{' '}
                 <Link
-                  href="/guides/sleep/ashwagandha-for-sleep"
+                  href="/guides/sleep/ashwagandha-for-sleep/"
                   className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
                 >
                   Ashwagandha for Sleep
                 </Link>{' '}
                 ·{' '}
                 <Link
-                  href="/guides/sleep/ashwagandha-vs-magnesium-for-sleep"
+                  href="/guides/sleep/ashwagandha-vs-magnesium-for-sleep/"
                   className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
                 >
                   Ashwagandha vs Magnesium
@@ -669,7 +669,7 @@ export default function SleepStackGuidePage() {
               <p className="mt-3 text-sm text-muted">
                 See the full comparison:{' '}
                 <Link
-                  href="/guides/sleep/ashwagandha-vs-magnesium-for-sleep"
+                  href="/guides/sleep/ashwagandha-vs-magnesium-for-sleep/"
                   className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
                 >
                   Ashwagandha vs Magnesium for Sleep
@@ -1228,7 +1228,7 @@ export default function SleepStackGuidePage() {
                       Add ashwagandha (KSM-66 or Sensoril) to magnesium. Commit to 6–8 weeks.
                       See{' '}
                       <Link
-                        href="/guides/sleep/ashwagandha-for-sleep"
+                        href="/guides/sleep/ashwagandha-for-sleep/"
                         className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
                       >
                         Ashwagandha for Sleep
@@ -1306,7 +1306,7 @@ export default function SleepStackGuidePage() {
               </h2>
               <div className="grid gap-3 sm:grid-cols-2">
                 <Link
-                  href="/guides/sleep/best-herbs-for-sleep"
+                  href="/guides/sleep/best-herbs-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -1336,7 +1336,7 @@ export default function SleepStackGuidePage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/magnesium-types-for-sleep"
+                  href="/guides/sleep/magnesium-types-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -1351,7 +1351,7 @@ export default function SleepStackGuidePage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/l-theanine-for-sleep"
+                  href="/guides/sleep/l-theanine-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -1366,7 +1366,7 @@ export default function SleepStackGuidePage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/ashwagandha-for-sleep"
+                  href="/guides/sleep/ashwagandha-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -1381,7 +1381,7 @@ export default function SleepStackGuidePage() {
                   </p>
                 </Link>
                 <Link
-                  href="/guides/sleep/ashwagandha-vs-magnesium-for-sleep"
+                  href="/guides/sleep/ashwagandha-vs-magnesium-for-sleep/"
                   className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
                 >
                   <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
@@ -1523,14 +1523,14 @@ export default function SleepStackGuidePage() {
                 </Link>
                 {', '}
                 <Link
-                  href="/guides/sleep/l-theanine-for-sleep"
+                  href="/guides/sleep/l-theanine-for-sleep/"
                   className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
                 >
                   L-Theanine for Sleep
                 </Link>
                 {', and '}
                 <Link
-                  href="/guides/sleep/ashwagandha-for-sleep"
+                  href="/guides/sleep/ashwagandha-for-sleep/"
                   className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
                 >
                   Ashwagandha for Sleep
@@ -1597,7 +1597,7 @@ export default function SleepStackGuidePage() {
             </p>
             <div className="mt-3 space-y-2">
               <Link
-                href="/guides/sleep/best-herbs-for-sleep"
+                href="/guides/sleep/best-herbs-for-sleep/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Best herbs for sleep →
@@ -1609,31 +1609,31 @@ export default function SleepStackGuidePage() {
                 Magnesium for sleep →
               </Link>
               <Link
-                href="/guides/sleep/magnesium-types-for-sleep"
+                href="/guides/sleep/magnesium-types-for-sleep/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Magnesium types for sleep →
               </Link>
               <Link
-                href="/guides/sleep/l-theanine-for-sleep"
+                href="/guides/sleep/l-theanine-for-sleep/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 L-Theanine for sleep →
               </Link>
               <Link
-                href="/guides/sleep/ashwagandha-for-sleep"
+                href="/guides/sleep/ashwagandha-for-sleep/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Ashwagandha for sleep →
               </Link>
               <Link
-                href="/guides/sleep/ashwagandha-vs-magnesium-for-sleep"
+                href="/guides/sleep/ashwagandha-vs-magnesium-for-sleep/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Ashwagandha vs magnesium →
               </Link>
               <Link
-                href="/guides/sleep-herbs-vs-melatonin"
+                href="/guides/sleep-herbs-vs-melatonin/"
                 className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
               >
                 Sleep herbs vs melatonin →

--- a/app/info/faq/page.tsx
+++ b/app/info/faq/page.tsx
@@ -88,21 +88,21 @@ export default function FaqPage() {
 
         <div className='mt-6 flex flex-wrap gap-3'>
           <Link
-            href='/info/about'
+            href='/info/about/'
             className='rounded-full bg-emerald-600 px-5 py-3 text-sm font-semibold text-white transition hover:bg-emerald-700 shadow-sm'
           >
             Read About
           </Link>
 
           <Link
-            href='/info/contact'
+            href='/info/contact/'
             className='rounded-full border border-stone-200 px-5 py-3 text-sm font-semibold text-stone-700 transition hover:bg-stone-50 hover:text-stone-900'
           >
             Contact
           </Link>
 
           <Link
-            href='/info/disclaimer'
+            href='/info/disclaimer/'
             className='rounded-full border border-stone-200 px-5 py-3 text-sm font-semibold text-stone-700 transition hover:bg-stone-50 hover:text-stone-900'
           >
             Disclaimer
@@ -151,7 +151,7 @@ export default function FaqPage() {
 
           <div className='mt-4 space-y-3'>
             <Link
-              href='/herbs'
+              href='/herbs/'
               className='block rounded-2xl border border-brand-900/10 px-4 py-4 transition hover:bg-stone-50/50 hover:border-brand-900/20'
             >
               <p className='text-sm font-semibold text-ink'>Herbs</p>
@@ -161,7 +161,7 @@ export default function FaqPage() {
             </Link>
 
             <Link
-              href='/compounds'
+              href='/compounds/'
               className='block rounded-2xl border border-brand-900/10 px-4 py-4 transition hover:bg-stone-50/50 hover:border-brand-900/20'
             >
               <p className='text-sm font-semibold text-ink'>Compounds</p>
@@ -171,7 +171,7 @@ export default function FaqPage() {
             </Link>
 
             <Link
-              href='/articles'
+              href='/articles/'
               className='block rounded-2xl border border-brand-900/10 px-4 py-4 transition hover:bg-stone-50/50 hover:border-brand-900/20'
             >
               <p className='text-sm font-semibold text-ink'>Articles</p>

--- a/app/info/methodology/page.tsx
+++ b/app/info/methodology/page.tsx
@@ -155,10 +155,10 @@ export default function MethodologyPage() {
           Our editorial grades are set solely by our research team based on peer-reviewed literature. While we use affiliate links to support our hosting costs, product placement has zero impact on evidence grades, safety warnings, or brand reviews. If an ingredient carries risk or fails clinical standards, we state it plainly.
         </p>
         <div className='pt-2 flex flex-wrap gap-4'>
-          <Link href='/info/affiliate-disclosure' className='text-sm font-semibold text-emerald-800 hover:underline'>
+          <Link href='/info/affiliate-disclosure/' className='text-sm font-semibold text-emerald-800 hover:underline'>
             Affiliate Disclosure →
           </Link>
-          <Link href='/info/disclaimer' className='text-sm font-semibold text-emerald-800 hover:underline'>
+          <Link href='/info/disclaimer/' className='text-sm font-semibold text-emerald-800 hover:underline'>
             Medical Disclaimer →
           </Link>
         </div>

--- a/app/learn/gaba/page.tsx
+++ b/app/learn/gaba/page.tsx
@@ -191,14 +191,14 @@ export default function GabaPathwayPage() {
 
         <div className="flex flex-wrap gap-3">
           <Link
-            href="/learn/gaba-vs-serotonin"
+            href="/learn/gaba-vs-serotonin/"
             className="chip-readable hover:bg-white transition"
           >
             GABA vs Serotonin
           </Link>
 
           <Link
-            href="/learn/calming"
+            href="/learn/calming/"
             className="chip-readable hover:bg-white transition"
           >
             Calming Psychoactives
@@ -212,7 +212,7 @@ export default function GabaPathwayPage() {
           </Link>
 
           <Link
-            href="/learn/harm-reduction"
+            href="/learn/harm-reduction/"
             className="chip-readable hover:bg-white transition"
           >
             GABAergic Safety

--- a/app/learn/page.tsx
+++ b/app/learn/page.tsx
@@ -331,14 +331,14 @@ export default function EducationHubPage() {
 
         <div className='flex flex-wrap gap-3'>
           <Link
-            href='/guides'
+            href='/guides/'
             className='rounded-full border border-brand-900/15 px-4 py-2 text-sm font-medium text-ink transition hover:bg-ink hover:text-white'
           >
             Explore Goal Guides
           </Link>
 
           <Link
-            href='/guides'
+            href='/guides/'
             className='rounded-full border border-brand-900/15 px-4 py-2 text-sm font-medium text-ink transition hover:bg-ink hover:text-white'
           >
             Browse all guides

--- a/app/learn/research-methodology/page.tsx
+++ b/app/learn/research-methodology/page.tsx
@@ -93,15 +93,15 @@ export default function ResearchMethodologyPage() {
         </div>
 
         <div className="flex flex-wrap gap-3">
-          <Link href="/learn/what-is-neuropharmacology" className="chip-readable">
+          <Link href="/learn/what-is-neuropharmacology/" className="chip-readable">
             Neuropharmacology
           </Link>
 
-          <Link href="/learn/harm-reduction" className="chip-readable">
+          <Link href="/learn/harm-reduction/" className="chip-readable">
             Harm Reduction
           </Link>
 
-          <Link href="/learn/how-herbal-psychoactives-differ-from-pharmaceuticals" className="chip-readable">
+          <Link href="/learn/how-herbal-psychoactives-differ-from-pharmaceuticals/" className="chip-readable">
             Herbal vs Pharmaceutical Systems
           </Link>
         </div>

--- a/app/learn/study-design-snapshot/page.tsx
+++ b/app/learn/study-design-snapshot/page.tsx
@@ -54,7 +54,7 @@ export default function StudyDesignSnapshotHubPage() {
           and tucks the &ldquo;why&rdquo; — trial design and limitations — into an optional,
           expandable panel. The same component is embeddable inside our structured education
           content. For the full methodology guide, see{' '}
-          <Link href="/learn/evidence-hierarchy" className="font-semibold text-brand-700 hover:text-brand-800">
+          <Link href="/learn/evidence-hierarchy/" className="font-semibold text-brand-700 hover:text-brand-800">
             Evidence Hierarchy
           </Link>
           .

--- a/app/learn/what-are-psychoactive-herbs/page.tsx
+++ b/app/learn/what-are-psychoactive-herbs/page.tsx
@@ -171,21 +171,21 @@ export default function WhatArePsychoactiveHerbsPage() {
 
         <div className="flex flex-wrap gap-3">
           <Link
-            href="/learn/harm-reduction"
+            href="/learn/harm-reduction/"
             className="chip-readable hover:bg-white transition"
           >
             Harm Reduction
           </Link>
 
           <Link
-            href="/learn/interactions"
+            href="/learn/interactions/"
             className="chip-readable hover:bg-white transition"
           >
             Interaction Guide
           </Link>
 
           <Link
-            href="/learn/serotonergic-stacking-risks"
+            href="/learn/serotonergic-stacking-risks/"
             className="chip-readable hover:bg-white transition"
           >
             Serotonergic Risks

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -37,21 +37,21 @@ export default function NotFound() {
           </Link>
 
           <Link
-            href='/herbs'
+            href='/herbs/'
             className='button-secondary px-5 py-3 text-sm'
           >
             Herbs
           </Link>
 
           <Link
-            href='/articles'
+            href='/articles/'
             className='button-secondary px-5 py-3 text-sm'
           >
             Articles
           </Link>
 
           <Link
-            href='/guides'
+            href='/guides/'
             className='button-secondary px-5 py-3 text-sm'
           >
             Goals

--- a/components/NewsletterSignup.tsx
+++ b/components/NewsletterSignup.tsx
@@ -93,7 +93,7 @@ export default function NewsletterSignup({
           <p className={`mt-3 text-sm leading-7 ${mutedColor}`}>{description}</p>
           <p className={`mt-2 text-xs leading-5 ${mutedColor}`}>
             {safetyChecklistLeadMagnet.privacyNote}{' '}
-            <Link href='/info/privacy' className={isFooter ? 'text-emerald-300 hover:underline' : 'text-brand-800 hover:underline'}>
+            <Link href='/info/privacy/' className={isFooter ? 'text-emerald-300 hover:underline' : 'text-brand-800 hover:underline'}>
               Privacy policy
             </Link>
             .
@@ -149,7 +149,7 @@ export default function NewsletterSignup({
             >
               {message}{' '}
               {status === 'success' ? (
-                <Link href='/info/supplement-safety-checklist' className={isFooter ? 'text-emerald-300 hover:underline' : 'text-brand-800 hover:underline'}>
+                <Link href='/info/supplement-safety-checklist/' className={isFooter ? 'text-emerald-300 hover:underline' : 'text-brand-800 hover:underline'}>
                   Open checklist
                 </Link>
               ) : null}

--- a/components/monetization/ProductTrustAffiliate.tsx
+++ b/components/monetization/ProductTrustAffiliate.tsx
@@ -69,7 +69,7 @@ export default function ProductTrustAffiliate({
       </a>
       <p className='mt-2 text-[10px] text-muted'>
         Affiliate link.{' '}
-        <Link href='/info/affiliate-disclosure' className='font-semibold text-emerald-800 hover:underline dark:text-brand-100'>
+        <Link href='/info/affiliate-disclosure/' className='font-semibold text-emerald-800 hover:underline dark:text-brand-100'>
           Disclosure
         </Link>
       </p>

--- a/components/monetization/SafetyChecklistPromo.tsx
+++ b/components/monetization/SafetyChecklistPromo.tsx
@@ -32,7 +32,7 @@ export default function SafetyChecklistPromo({
           One-page safety workflow: meds, dose, form, and stacking — not medical advice.
         </p>
         <Link
-          href='/info/supplement-safety-checklist'
+          href='/info/supplement-safety-checklist/'
           className='mt-4 inline-flex min-h-11 items-center justify-center rounded-full bg-brand-950 px-5 py-2.5 text-sm font-bold text-white hover:bg-brand-900 dark:bg-brand-200 dark:text-brand-950 dark:hover:bg-brand-100'
         >
           Get the free safety checklist →
@@ -66,7 +66,7 @@ export default function SafetyChecklistPromo({
             ))}
           </ul>
           <Link
-            href='/info/supplement-safety-checklist'
+            href='/info/supplement-safety-checklist/'
             className='mt-5 inline-flex text-sm font-bold text-brand-800 hover:underline dark:text-brand-100'
           >
             See what&apos;s inside the checklist →

--- a/components/monetization/__tests__/monetization.test.tsx
+++ b/components/monetization/__tests__/monetization.test.tsx
@@ -30,7 +30,7 @@ describe('monetization infrastructure', () => {
   })
 
   it('renders internal links without external rel attributes', () => {
-    render(<AffiliateLink href='/info/methodology'>Methodology</AffiliateLink>)
+    render(<AffiliateLink href='/info/methodology/'>Methodology</AffiliateLink>)
 
     const link = screen.getByRole('link', { name: /methodology/i })
 

--- a/src/components/monetization/WhyWeRecommend.tsx
+++ b/src/components/monetization/WhyWeRecommend.tsx
@@ -41,10 +41,10 @@ export default function WhyWeRecommend({
           ))}
         </ul>
         <div className='mt-3 flex flex-wrap gap-3 text-xs font-semibold'>
-          <Link href='/learn/product-quality' className='text-emerald-800 hover:underline'>
+          <Link href='/learn/product-quality/' className='text-emerald-800 hover:underline'>
             Product quality guide →
           </Link>
-          <Link href='/info/affiliate-disclosure' className='text-emerald-800 hover:underline'>
+          <Link href='/info/affiliate-disclosure/' className='text-emerald-800 hover:underline'>
             Affiliate disclosure →
           </Link>
         </div>


### PR DESCRIPTION
## Summary

- The site runs `trailingSlash: true`, so internal links written without a trailing slash 308-redirect before the real page loads — wasted crawl budget and an extra hop for users.
- Normalizes **390 literal internal `href` values across 74 files** to their canonical trailing-slash form, scoped to real route roots (`guides`, `compounds`, `herbs`, `learn`, `info`, `articles`).
- Every changed target was verified to resolve to an existing route (static page, dynamic `[slug]` route, or a `public/_redirects` rule); no double-slashes introduced.
- Purely mechanical/additive — no content, routing, or behavior changes.

## Verification

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] route/link integrity + monetization + a11y vitest suites pass
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs
- [x] no generated file corruption
- [x] static export compatible (link hrefs only)

## Risk Notes

- Low. Only appends a trailing slash to internal `href` string literals that already 308-redirect. All 112 distinct changed targets confirmed to resolve. No dynamic/template-literal hrefs touched.