### PR TITLE
Fix content-audit word-count blind spot on data-driven guide hubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ dist-clean/*
 # Build reports / temp artifacts
 *_REPORT.md
 *_NOTES.md
+!docs/LOOP_NOTES.md
 *.md.bak
 *_patch.json
 *_merged.json

--- a/docs/LOOP_NOTES.md
+++ b/docs/LOOP_NOTES.md
@@ -1,0 +1,35 @@
+# Loop Notes
+
+Notes for future autonomous enhancement iterations — recurring friction, false positives, and tooling gaps discovered while working the loop.
+
+---
+
+## 2026-07-13 — `audit:content` word-count false positive on data-driven hub pages
+
+`scripts/content-audit.mjs`'s `countWords()` stripped every `{...}` block
+before counting words. That's correct for JSX interpolation, but the
+`guides/*` hub pages (adhd, anxiety, best, compare, focus, herbs, sleep)
+render their copy from typed data arrays — e.g.
+`{ problem: 'Racing thoughts at bedtime', why: '...', cta: '...' }` — so
+all of that user-facing prose lives inside `{}` and was being discarded
+before the word count ran. Every one of the 7 hub pages was flagged
+`thin_page` every run, regardless of actual content quality, because the
+metric literally couldn't see their content model.
+
+Fixed by extracting string-literal values for a known set of prose keys
+(`title`, `desc`, `description`, `problem`, `why`, `cta`, `body`,
+`caution`, `bestFor`, `fit`, `label`, `goal`, `role`, `summary`, `name`,
+`kind`, `sub`, `eyebrow`, `text`, `note`, `question`, `answer`) before the
+blanket brace-strip, and counting those alongside JSX text nodes.
+
+Result: `guides/best`, `guides/herbs`, `guides/sleep` now correctly clear
+the 500-word threshold. `guides/adhd`, `guides/anxiety`, `guides/compare`,
+`guides/focus` still read thin (378–421 words) — that's a much more
+trustworthy signal now and a reasonable next target, but wasn't tackled
+this cycle to keep the change scoped and verifiable.
+
+Takeaway for future cycles: if a hub/index page under `app/guides/*` is
+built on the `DecisionRouter` / `GuideCardGrid` data-array pattern, don't
+trust a stale `thin_page` reading without rerunning `audit:content` after
+confirming the word-count method actually parses that page's content
+shape — the audit is a heuristic over raw source, not the rendered DOM.

--- a/scripts/content-audit.mjs
+++ b/scripts/content-audit.mjs
@@ -62,14 +62,32 @@ function collectPages() {
 
 // ─── Word count ───────────────────────────────────────────────────────────────
 
+// Object-literal keys that hold user-facing copy in data-driven hub/card
+// components (e.g. GUIDES.map(...), DecisionRouter items, GuideCardGrid
+// cards). Blanket-stripping every `{...}` block below would otherwise
+// discard this prose entirely and make data-driven pages look thin even
+// when the rendered page has substantial text.
+const PROSE_KEYS = /\b(title|desc|description|problem|why|cta|body|caution|bestFor|fit|label|goal|role|summary|name|kind|sub|eyebrow|text|note|question|answer)\s*:\s*(['"`])((?:(?!\2)[^\\]|\\.)*)\2/g
+
 function countWords(source) {
-  // Strip JSX/HTML tags, imports, JS keywords, template strings
-  const stripped = source
+  const withoutImports = source
     .replace(/import\s+.*?from\s+['"][^'"]+['"]/g, '')
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/\{[^}]*\}/g, ' ')
     .replace(/\/\/.*$/gm, '')
     .replace(/\/\*[\s\S]*?\*\//g, '')
+
+  let proseLiterals = ''
+  let match
+  PROSE_KEYS.lastIndex = 0
+  while ((match = PROSE_KEYS.exec(withoutImports))) {
+    proseLiterals += ' ' + match[3]
+  }
+
+  // Strip JSX/HTML tags and remaining braces (interpolation, non-prose objects)
+  const jsxText = withoutImports
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\{[^}]*\}/g, ' ')
+
+  const stripped = (jsxText + ' ' + proseLiterals)
     .replace(/[^a-zA-Z\s'-]/g, ' ')
     .replace(/\s+/g, ' ')
     .trim()


### PR DESCRIPTION
## Summary

- `scripts/content-audit.mjs`'s `countWords()` blanket-stripped every `{...}` block before counting words. That's correct for JSX interpolation, but the 7 `guides/*` hub pages (adhd, anxiety, best, compare, focus, herbs, sleep) render their copy from typed data arrays consumed by `DecisionRouter`/`GuideCardGrid` — e.g. `{ problem: '...', why: '...', cta: '...' }` — so all of that user-facing prose lived inside `{}` and was silently discarded before the word count ran. Every one of the 7 hub pages was flagged `thin_page` on every audit run, independent of actual content quality.
- Fixed by extracting string-literal values for a known set of prose keys (`title`, `desc`, `description`, `problem`, `why`, `cta`, `body`, `caution`, `bestFor`, `fit`, `label`, `goal`, `role`, `summary`, `name`, `kind`, `sub`, `eyebrow`, `text`, `note`, `question`, `answer`) before the blanket brace-strip, and counting those alongside JSX text nodes.
- Result: `guides/best`, `guides/herbs`, `guides/sleep` now correctly clear the 500-word threshold. `guides/adhd`, `guides/anxiety`, `guides/compare`, `guides/focus` still read thin (378–421 words) — a much more trustworthy signal now, and a reasonable target for a future content pass.
- Added `docs/LOOP_NOTES.md` documenting the finding, and excepted it from the `*_NOTES.md` gitignore rule (it was previously being silently dropped by every fresh clone, defeating its purpose as a persistent note for future sessions).

## Verification

- [x] `npm run lint`
- [x] `npm run check`
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs
- [x] no generated file corruption
- [x] static export compatible
- [x] `npx vitest run` — 573/573 passing

## Risk Notes

- `audit:content` is warning-only (always exits 0) — this change affects reporting accuracy only, no build/runtime behavior.
- Scoped strictly to the audit script's word-counting heuristic; no application code changed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CGXzSDqEdbiE3aySALm3xa)_