### PR TITLE
Fix audit:safety silently reporting 0/0 due to stale sheet names

### DIFF
--- a/docs/LOOP_NOTES.md
+++ b/docs/LOOP_NOTES.md
@@ -33,3 +33,53 @@ built on the `DecisionRouter` / `GuideCardGrid` data-array pattern, don't
 trust a stale `thin_page` reading without rerunning `audit:content` after
 confirming the word-count method actually parses that page's content
 shape — the audit is a heuristic over raw source, not the rendered DOM.
+
+---
+
+## 2026-07-13 — `audit:safety` was silently broken (0/0), masking a real compound-safety gap
+
+`scripts/audit-safety-fill-rate.mjs` hard-coded `SHEETS = { herbs: 'Herb
+Master V3', compounds: 'Compound Master V3' }`. Those sheets don't exist
+in the current workbook — herbs and compounds were consolidated onto one
+`Entity_Master` sheet (distinguished by an `entity_type` column) at some
+earlier migration. Every run of `npm run audit:safety` silently printed
+`0 filled / 0 total (0%)` for both, with no error — `getSheet()` just
+returns `null` for an unknown sheet name and the script treats that as
+"zero rows" rather than failing loudly. This was easy to miss because
+the command still exits 0 and prints a well-formed-looking report.
+
+Contrast with `scripts/data/build-runtime-from-workbook.mjs`, which reads
+sheets via a *candidate-name list* (`['Herb Master V3', 'Herb
+Monographs', 'Site Export Herbs']` etc., falling back to `Entity_Master`)
+— that script degrades gracefully across the schema migration. The audit
+script had no such fallback, so it just went quiet instead of failing.
+
+Fixed by pointing `audit-safety-fill-rate.mjs` at `Entity_Master`,
+filtering rows by `entity_type`, and reading safety completeness off
+`contraindications_or_flags` (the field that actually carries structured
+safety content now; the old `safety_level` enum no longer exists —
+`safety_notes` is free text and is ~100% filled everywhere so it isn't a
+useful completeness signal on its own).
+
+Real result after the fix: **herbs are 292/293 (100%) filled, but
+compounds are only 314/588 (53%) filled** — 274 compound rows have empty
+`contraindications_or_flags`, each carrying a boilerplate `safety_notes`
+placeholder ("Safety notes are not source-complete in this workbook row;
+avoid broad safety claims and hold for interaction, population, and
+formulation review."). That's a legitimate, large content gap, but too
+large and too safety-sensitive to hand-author in one small verifiable
+batch without real per-compound sourcing — flagging it here as the
+highest-ROI target for a future enrichment cycle: pick a handful of the
+274 (prioritize by traffic/sitemap priority once that's wired up — the
+"TOP 20 MISSING" ranking in this script's own output is still a flat
+`priority: 0.9` stub, not real traffic data) and source real
+contraindication/interaction data per compound rather than batch-filling.
+
+Takeaway for future cycles: any script that resolves a workbook sheet by
+a single hard-coded name (not a candidate list through
+`scripts/data/workbook-parser.mjs` conventions) is one workbook migration
+away from silently reporting empty/zero and looking healthy. When an
+audit reports a suspiciously round or empty number, check whether its
+`SHEETS`/`getSheet()` reference still matches current `Entity_Master`
+sheet names before trusting the number — don't assume 0/0 means "no
+issues."

--- a/scripts/audit-safety-fill-rate.mjs
+++ b/scripts/audit-safety-fill-rate.mjs
@@ -3,9 +3,16 @@
 import { assertWorkbookExists, resolveWorkbookPath } from './workbook-source.mjs'
 import { getSheet, readWorkbook, sheetToRows } from './data/workbook-parser.mjs'
 
-const SHEETS = {
-  herbs: 'Herb Master V3',
-  compounds: 'Compound Master V3',
+// Current workbook schema (see docs/workbook-only-data-contract.md) keeps herbs
+// and compounds together on one unified sheet, distinguished by entity_type.
+// There is no per-entity-type "safety_level" enum anymore — safety completeness
+// is tracked via the free-text contraindications_or_flags column, backed by
+// safety_notes. Legacy field names are still checked as a fallback in case a
+// future workbook revision reintroduces a dedicated enum column.
+const ENTITY_SHEET = 'Entity_Master'
+const ENTITY_TYPES = {
+  herbs: 'herb',
+  compounds: 'compound',
 }
 
 function clean(value) {
@@ -28,7 +35,14 @@ function slugFor(row, fallbackPrefix, index) {
 }
 
 function safetyValue(row) {
-  return clean(row.safety_level || row['safety level'] || row.safety || row.safety_rating || row.safetyRating)
+  return clean(
+    row.contraindications_or_flags ||
+      row.safety_level ||
+      row['safety level'] ||
+      row.safety ||
+      row.safety_rating ||
+      row.safetyRating,
+  )
 }
 
 function classifySafety(value) {
@@ -95,9 +109,10 @@ async function main() {
   const workbookPath = resolveWorkbookPath(repoRoot)
   assertWorkbookExists(workbookPath)
   const workbook = await readWorkbook(workbookPath)
+  const entityRows = sheetToRows(getSheet(workbook, ENTITY_SHEET))
 
-  const herbRows = sheetToRows(getSheet(workbook, SHEETS.herbs))
-  const compoundRows = sheetToRows(getSheet(workbook, SHEETS.compounds))
+  const herbRows = entityRows.filter((row) => clean(row.entity_type).toLowerCase() === ENTITY_TYPES.herbs)
+  const compoundRows = entityRows.filter((row) => clean(row.entity_type).toLowerCase() === ENTITY_TYPES.compounds)
   const report = linesForReport(
     summarize(herbRows, 'herb'),
     summarize(compoundRows, 'compound'),

--- a/scripts/audit-safety-fill-rate.mjs
+++ b/scripts/audit-safety-fill-rate.mjs
@@ -9,10 +9,25 @@ import { getSheet, readWorkbook, sheetToRows } from './data/workbook-parser.mjs'
 // is tracked via the free-text contraindications_or_flags column, backed by
 // safety_notes. Legacy field names are still checked as a fallback in case a
 // future workbook revision reintroduces a dedicated enum column.
-const ENTITY_SHEET = 'Entity_Master'
+//
+// Sheet name resolution mirrors scripts/data/build-runtime-from-workbook.mjs's
+// candidate-list approach: the unified sheet is sometimes saved under the
+// 'Sheet7' alias, and older workbooks may still carry the pre-consolidation
+// split herb/compound sheets. Resolving via a single hard-coded name here
+// previously caused a silent 0/0 report (see docs/LOOP_NOTES.md) — any sheet
+// this script can't find must fail loudly instead of reporting zero rows.
+const ENTITY_SHEET_CANDIDATES = ['Entity_Master', 'Sheet7']
+const LEGACY_SHEET_CANDIDATES = {
+  herbs: ['Herb Master V3', 'Herb Monographs', 'Site Export Herbs'],
+  compounds: ['Compound Master V3', 'Site Export Compounds'],
+}
 const ENTITY_TYPES = {
   herbs: 'herb',
   compounds: 'compound',
+}
+
+function resolveSheetName(workbook, candidates) {
+  return candidates.find((candidate) => getSheet(workbook, candidate)) || null
 }
 
 function clean(value) {
@@ -104,15 +119,31 @@ function linesForReport(herbSummary, compoundSummary) {
   ]
 }
 
+function resolveRows(workbook, type) {
+  const entitySheetName = resolveSheetName(workbook, ENTITY_SHEET_CANDIDATES)
+  if (entitySheetName) {
+    const entityRows = sheetToRows(getSheet(workbook, entitySheetName))
+    return entityRows.filter((row) => clean(row.entity_type).toLowerCase() === ENTITY_TYPES[type])
+  }
+
+  const legacySheetName = resolveSheetName(workbook, LEGACY_SHEET_CANDIDATES[type])
+  if (legacySheetName) {
+    return sheetToRows(getSheet(workbook, legacySheetName))
+  }
+
+  throw new Error(
+    `[audit:safety] could not find a ${type} sheet — tried ${[...ENTITY_SHEET_CANDIDATES, ...LEGACY_SHEET_CANDIDATES[type]].join(', ')}`,
+  )
+}
+
 async function main() {
   const repoRoot = process.cwd()
   const workbookPath = resolveWorkbookPath(repoRoot)
   assertWorkbookExists(workbookPath)
   const workbook = await readWorkbook(workbookPath)
-  const entityRows = sheetToRows(getSheet(workbook, ENTITY_SHEET))
 
-  const herbRows = entityRows.filter((row) => clean(row.entity_type).toLowerCase() === ENTITY_TYPES.herbs)
-  const compoundRows = entityRows.filter((row) => clean(row.entity_type).toLowerCase() === ENTITY_TYPES.compounds)
+  const herbRows = resolveRows(workbook, 'herbs')
+  const compoundRows = resolveRows(workbook, 'compounds')
   const report = linesForReport(
     summarize(herbRows, 'herb'),
     summarize(compoundRows, 'compound'),


### PR DESCRIPTION
## Summary

- `scripts/audit-safety-fill-rate.mjs` hard-coded sheet names (`Herb Master V3`, `Compound Master V3`) that no longer exist — herbs and compounds now live on a unified `Entity_Master` sheet distinguished by `entity_type`. `getSheet()` silently returned `null` for both, so every run printed `0 filled / 0 total (0%)` and exited 0, looking healthy while reporting nothing.
- Fixed the audit to read `Entity_Master`, filter by `entity_type`, and classify safety fill status using `contraindications_or_flags` (the field that now carries structured safety content — the old `safety_level` enum is gone, and `safety_notes` free text is ~100% filled everywhere so it isn't a useful completeness signal).
- Real numbers now surfaced: **herbs 292/293 (100%) filled, compounds only 314/588 (53%) filled** — logged the 274-compound gap and a general "stale hard-coded sheet name" pattern warning in `docs/LOOP_NOTES.md` for future enrichment cycles. Not fixing the underlying compound data gap in this PR — it's large and safety-sensitive, needs per-compound sourcing rather than a batch fill.

## Verification

- [x] `npm run lint`
- [x] `npm run check`
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs (only a build-timestamp diff, discarded)
- [x] no generated file corruption
- [x] static export compatible (script-only change, not part of the build/export path)

## Risk Notes

- Script-only change to a standalone diagnostic (`npm run audit:safety`), not wired into `check`/`check:full` CI gates. No workbook or `public/data` edits.


---
_Generated by [Claude Code](https://claude.ai/code/session_017gP1jHucBBFX9RYJYM6ESz)_