### PR TITLE
Document substring-collision risk-tag bug in loop notes

### DIFF
--- a/docs/LOOP_NOTES.md
+++ b/docs/LOOP_NOTES.md
@@ -370,3 +370,26 @@ more `full_public_runtime` compounds with empty `contraindications_or_flags`
 — the next enrichment cycle should re-run `npm run audit:safety` fresh
 rather than assuming this list, since new compounds may have been promoted
 to `full_public_runtime` or added since this entry.
+
+**Post-merge addendum:** the repo's automated `chatgpt-codex-connector`
+PR review caught a real bug in this batch before merge: the
+`ginsenoside-rg3` clause used the phrase "cesarean delivery", and
+`deriveInteractionData()`'s hepatic keyword list (`['hepat','liver']` in
+`scripts/data/build-interaction-data.mjs`) matches via plain
+`String.includes()` with no word-boundary check — "delivery" contains
+"liver" as a literal substring, so the derived `entity_risk_tags.json`
+falsely labeled this compound's pregnancy/bleeding caution as a hepatic
+risk too. Fixed by rewording to "cesarean section childbirth" (verified
+against a throwaway keyword-matcher simulation) rather than touching the
+shared matcher, to keep the fix scoped to this PR. Takeaway for future
+cycles: the keyword matcher has *no word-boundary protection at all* —
+before writing any `contraindications_or_flags` clause, mentally (or via
+a quick `node -e` check) scan it for the substrings `hepat`, `liver`,
+`kidney`, `renal`, `allerg`, `thyroid`, `bleeding`, `surgery`,
+`pregnan`, `breastfeed`, `lactation`, `sedat`, `glucose`, `hypoglyc`,
+`diabet`, `hypotens`, `hypertens`, `seroton`, `immunosuppress` appearing
+*inside an unrelated word* (like "delivery" → "liver", or "regeneration"
+→ "renal"-adjacent near-misses) — not just for the intended keyword
+matches. This is a standing landmine in the matcher itself and worth
+fixing properly (word-boundary regex) in a future cycle if it keeps
+tripping up enrichment batches.


### PR DESCRIPTION
## Summary

- Docs-only follow-up to #2226. Appends a `docs/LOOP_NOTES.md` addendum documenting the false-positive `hepatic` risk tag that the Codex PR review caught on that PR (a "cesarean delivery" → "liver" substring collision in `deriveInteractionData()`'s naive keyword matcher).
- No data or code changes — this only records the finding and takeaway for future enrichment cycles.

## Verification

- [x] `npm run lint` (not applicable — no code changed)
- [x] `npm run check` (not applicable — docs-only)
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs
- [x] no generated file corruption
- [x] static export compatible (no runtime code touched)

## Risk Notes

- Zero risk: single markdown file, additive only.


---
_Generated by [Claude Code](https://claude.ai/code/session_013BYCf6pNDd1ibug7U9xBf2)_