### PR TITLE
Add audit:risk-tag-collisions guard for keyword-substring false positives

### DIFF
--- a/docs/LOOP_NOTES.md
+++ b/docs/LOOP_NOTES.md
@@ -393,3 +393,41 @@ a quick `node -e` check) scan it for the substrings `hepat`, `liver`,
 matches. This is a standing landmine in the matcher itself and worth
 fixing properly (word-boundary regex) in a future cycle if it keeps
 tripping up enrichment batches.
+
+---
+
+## 2026-07-13 — Added `audit:risk-tag-collisions` guard for the substring-collision bug class above, instead of touching the matcher
+
+Followed up on the previous entry's "worth fixing properly" note, but
+concluded a blanket word-boundary regex fix on `deriveInteractionData()`
+itself would be the wrong move: a full scan of every `contraindications_or_flags`
+value in the live workbook (881 Entity_Master rows, not just the
+`full_public_runtime` subset in `public/data`) found 124 matches where the
+matched keyword is immediately preceded by a letter — but on inspection
+*every single one* is a legitimate compound medical term formed by gluing a
+prefix straight onto the keyword with no separator (`antidiabetic` →
+`diabet`, `antihypertensive` → `hypertens`, `hyperthyroidism` → `thyroid`,
+etc.). A naive "require a non-letter before the match" fix would have
+silently dropped the `blood_glucose`/`blood_pressure`/`thyroid` risk tags on
+all 124 of those real entities — a much bigger regression than the one
+collision bug it would have fixed. Safety-critical derived data like this
+needs a human (or at least a scoped, reviewable allowlist) in the loop, not
+a blanket regex change in a single autonomous cycle.
+
+Instead added `scripts/audit-risk-tag-collisions.mjs` (`npm run
+audit:risk-tag-collisions`), which runs the exact same `KEYWORDS` table
+(now exported from `build-interaction-data.mjs` instead of duplicated) over
+every workbook row and flags only matches preceded by a letter that does
+*not* form one of a small curated `ALLOWED_PREFIXES` (`anti`, `hyper`,
+`hypo`, `para`, `non`, `pre`, `post`, `sub`, `poly`, `dys`, `over`, `under`,
+`co`, `re`). Verified it reports zero findings against the current
+workbook (i.e. all 124 real matches are covered by the allowlist) and, via
+`scripts/audit-risk-tag-collisions.test.mjs`, that it correctly flags the
+exact `"cesarean delivery"` → `liver` collision the prior cycle's PR review
+caught by hand. It's informational (exit 0) by default — pass `--strict`
+for a hard-fail exit code once the allowlist has proven itself over more
+cycles — and is *not* wired into `check`/`check:full` yet for the same
+reason. Future cycles: run `npm run audit:risk-tag-collisions` after
+editing any `contraindications_or_flags` clause instead of eyeballing the
+keyword list by hand; if it flags a genuine new compound term, extend
+`ALLOWED_PREFIXES` rather than reword the clause.

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "data:ci": "node scripts/data/validate-canonical.mjs && node scripts/data/build-sqlite.mjs && node scripts/data/canonical/__tests__/graph-smoke.mjs && node scripts/data/export-site-data.mjs && node scripts/ci/validate-generated-freshness.mjs",
     "audit:source-of-truth": "STRICT_SOURCE_AUDIT=true node scripts/data/audit-source-of-truth.mjs",
     "audit:safety": "node scripts/audit-safety-fill-rate.mjs",
+    "audit:risk-tag-collisions": "node scripts/audit-risk-tag-collisions.mjs",
     "audit:duplicates": "node scripts/audit/find-duplicate-slugs.mjs",
     "audit:content-gaps": "node scripts/audit/content-gap-report.mjs",
     "audit:sitemap": "node scripts/audit/validate-sitemap-canonicals.mjs",

--- a/scripts/audit-risk-tag-collisions.mjs
+++ b/scripts/audit-risk-tag-collisions.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+
+// Guards against a real bug class found in production data (see
+// docs/LOOP_NOTES.md, 2026-07-13): deriveInteractionData() in
+// scripts/data/build-interaction-data.mjs matches risk keywords via plain
+// String.includes(), with no word-boundary check. A keyword that happens to
+// be a complete word (e.g. "liver") can match as a substring of an unrelated
+// word (e.g. "delivery"), silently mislabeling an entity's risk mechanism.
+//
+// Legitimate matches are routinely formed by a medical prefix glued directly
+// onto the keyword with no separator (e.g. "antidiabetic" -> "diabet",
+// "hypertension" -> "hypertens") — those must NOT be flagged. This script
+// flags only matches preceded by a letter that does NOT form one of those
+// known-safe prefixes, so it can run over the real workbook with zero
+// expected findings today and catch new collisions introduced by future
+// enrichment edits before they reach entity_risk_tags.json.
+//
+// Informational by default (exit 0) since prefix curation is inherently
+// incomplete; pass --strict to exit 1 on any finding (e.g. for a future,
+// deliberate CI gate once the allowlist has proven itself over time).
+
+import { assertWorkbookExists, resolveWorkbookPath } from './workbook-source.mjs'
+import { getSheet, readWorkbook, sheetToRows } from './data/workbook-parser.mjs'
+import { KEYWORDS } from './data/build-interaction-data.mjs'
+
+const ENTITY_SHEET_CANDIDATES = ['Entity_Master', 'Sheet7']
+
+// Prefixes that legitimately glue onto a keyword stem with no separator.
+// Extend this list (not the matcher) when a new legitimate compound term
+// is found — do not weaken the boundary check itself.
+const ALLOWED_PREFIXES = [
+  'anti', 'hyper', 'hypo', 'para', 'non', 'pre', 'post',
+  'sub', 'poly', 'dys', 'over', 'under', 'co', 're',
+]
+
+function clean(value) {
+  return String(value ?? '').trim()
+}
+
+function splitFlags(v) {
+  return v == null ? [] : String(v).split(/[;,]/).map((s) => s.trim()).filter(Boolean)
+}
+
+export function findSuspectMatches(phrase) {
+  const pl = phrase.toLowerCase()
+  const suspects = []
+  for (const [mech, keys] of Object.entries(KEYWORDS)) {
+    for (const key of keys) {
+      let from = 0
+      let idx
+      while ((idx = pl.indexOf(key, from)) !== -1) {
+        from = idx + 1
+        const before = idx > 0 ? pl[idx - 1] : ''
+        if (/[a-z]/.test(before)) {
+          let start = idx
+          while (start > 0 && /[a-z]/.test(pl[start - 1])) start--
+          const prefix = pl.slice(start, idx)
+          if (!ALLOWED_PREFIXES.includes(prefix)) {
+            suspects.push({ mech, key, prefix, phrase })
+          }
+        }
+      }
+    }
+  }
+  return suspects
+}
+
+async function main() {
+  const strict = process.argv.includes('--strict')
+  const workbookPath = resolveWorkbookPath(process.cwd())
+  assertWorkbookExists(workbookPath)
+  const wb = await readWorkbook(workbookPath)
+
+  const sheetName = ENTITY_SHEET_CANDIDATES.find((c) => getSheet(wb, c))
+  if (!sheetName) {
+    console.error(`[audit:risk-tag-collisions] missing required sheet: ${ENTITY_SHEET_CANDIDATES.join(' or ')}`)
+    process.exit(1)
+  }
+  const rows = sheetToRows(getSheet(wb, sheetName))
+
+  const findings = []
+  for (const row of rows) {
+    const slug = clean(row.slug)
+    for (const phrase of splitFlags(row.contraindications_or_flags)) {
+      for (const suspect of findSuspectMatches(phrase)) {
+        findings.push({ slug, ...suspect })
+      }
+    }
+  }
+
+  if (findings.length === 0) {
+    console.log('[audit:risk-tag-collisions] clean — no unboundaried keyword matches found in contraindications_or_flags')
+    process.exit(0)
+  }
+
+  console.log(`[audit:risk-tag-collisions] ${findings.length} potential substring-collision false positive(s):\n`)
+  for (const f of findings) {
+    console.log(`  ${f.slug} — mechanism "${f.mech}" matched "${f.key}" via prefix "${f.prefix}" in: "${f.phrase}"`)
+  }
+  console.log('\nIf a finding is a genuine new compound term (e.g. a novel medical prefix), add the prefix to')
+  console.log('ALLOWED_PREFIXES in this script. Otherwise, reword the clause in the workbook to break the collision')
+  console.log('(see docs/LOOP_NOTES.md, 2026-07-13 post-merge addendum, for a worked example).')
+
+  process.exit(strict ? 1 : 0)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}

--- a/scripts/audit-risk-tag-collisions.test.mjs
+++ b/scripts/audit-risk-tag-collisions.test.mjs
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { findSuspectMatches } from './audit-risk-tag-collisions.mjs'
+
+describe('findSuspectMatches', () => {
+  it('flags a keyword matched as a substring of an unrelated word (the real bug it guards against)', () => {
+    const suspects = findSuspectMatches('caution around cesarean delivery')
+    expect(suspects).toHaveLength(1)
+    expect(suspects[0]).toMatchObject({ mech: 'hepatic', key: 'liver', prefix: 'de' })
+  })
+
+  it('does not flag a keyword at the start of a phrase', () => {
+    expect(findSuspectMatches('liver disease caution')).toEqual([])
+  })
+
+  it('does not flag a keyword glued to a known-safe medical prefix', () => {
+    expect(findSuspectMatches('interaction concern with antidiabetic medicines')).toEqual([])
+    expect(findSuspectMatches('caution with antihypertensive medications')).toEqual([])
+    expect(findSuspectMatches('hyperthyroidism or hypothyroidism caution')).toEqual([])
+  })
+
+  it('flags a keyword glued to an unrecognized prefix', () => {
+    const suspects = findSuspectMatches('unrenal finding of no clinical relevance')
+    expect(suspects).toHaveLength(1)
+    expect(suspects[0]).toMatchObject({ mech: 'renal', key: 'renal', prefix: 'un' })
+  })
+
+  it('returns no suspects for a phrase with no keyword matches at all', () => {
+    expect(findSuspectMatches('generally well tolerated at typical doses')).toEqual([])
+  })
+})

--- a/scripts/data/build-interaction-data.mjs
+++ b/scripts/data/build-interaction-data.mjs
@@ -5,7 +5,7 @@
 import { readFileSync } from 'node:fs';
 import { writeFileSync } from 'node:fs';
 
-const KEYWORDS = {
+export const KEYWORDS = {
   serotonergic:      ['seroton','ssri','snri','maoi'],
   anticoagulant:     ['anticoagul','antiplatelet','bleeding','pre-surgery','surgery'],
   cns_sedation:      ['sedat','cns depress','drowsi'],


### PR DESCRIPTION
## Summary

- `deriveInteractionData()` (`scripts/data/build-interaction-data.mjs`) matches risk keywords via plain `String.includes()` with no word-boundary check. A prior cycle's PR review caught this by hand: `"cesarean delivery"` mislabeled a compound as a hepatic risk because `"liver"` is a substring of `"delivery"` (see `docs/LOOP_NOTES.md`, 2026-07-13 post-merge addendum).
- Investigated fixing the matcher directly with a blanket word-boundary regex, but a full scan of the live workbook (881 `Entity_Master` rows) found 124 matches where the keyword is preceded by a letter — and every one is a *legitimate* compound medical term (`antidiabetic` → `diabet`, `antihypertensive` → `hypertens`, `hyperthyroidism` → `thyroid`, etc.). A naive boundary fix would have silently dropped real `blood_glucose`/`blood_pressure`/`thyroid` risk tags on all 124 of those entities — a much bigger regression than the bug it fixes. Safety-critical derived data like this needs a curated, reviewable check rather than a blanket regex change.
- Added `scripts/audit-risk-tag-collisions.mjs` (`npm run audit:risk-tag-collisions`), which reuses the exact same `KEYWORDS` table (now exported from `build-interaction-data.mjs` instead of duplicated) and flags only matches preceded by a letter that doesn't form one of a small curated `ALLOWED_PREFIXES` list. Verified it reports zero findings against the current workbook, and added `scripts/audit-risk-tag-collisions.test.mjs` covering the exact collision case that was found previously, plus the allowlist behavior.
- Informational only (exit 0) by default — not wired into `check`/`check:full` yet, pending the allowlist proving itself over more cycles. Documented in `docs/LOOP_NOTES.md` for future cycles.

## Verification

- [x] `npm run lint`
- [x] `npm run check`
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs (build-timestamp diff reverted)
- [x] no generated file corruption
- [x] static export compatible (no runtime code touched — script only reads the workbook at build/audit time)
- [x] `npm run test` (578 tests passed)

## Risk Notes

- Pure addition: one `export` keyword added to an existing constant, one new standalone script, one new test file, one new npm script entry. No existing derivation behavior changed, no existing output data changed (confirmed identical edge/tag counts before and after).


---
_Generated by [Claude Code](https://claude.ai/code/session_01PBP1f6Bvxhjdwk7JXvSiH6)_