### PR TITLE
Improve compound browse index stability

### DIFF
--- a/app/compounds/page.tsx
+++ b/app/compounds/page.tsx
@@ -7,6 +7,7 @@ import { getRuntimeVisibility } from '../../lib/runtime-visibility'
 import { buildPageMetadata } from '../../src/lib/seo'
 import { COMPOUNDS_PAGE_SIZE, paginateItems } from '@/lib/pagination'
 import { toLeanProfileIndexRecords } from '@/lib/profile-index-records'
+import { formatDisplayLabel } from '@/lib/display-utils'
 import CompoundsIndexClient from './CompoundsIndexClient'
 import type { RuntimeRecord } from '../../src/types/content'
 import Pagination from '@/components/Pagination'
@@ -20,11 +21,25 @@ export const metadata: Metadata = buildPageMetadata({
 
 export const dynamic = 'force-static'
 
+function getCompoundName(compound: RuntimeRecord) {
+  return (
+    formatDisplayLabel(compound.displayName) ||
+    formatDisplayLabel(compound.name) ||
+    formatDisplayLabel(compound.compoundName) ||
+    formatDisplayLabel(compound.canonicalCompoundName) ||
+    formatDisplayLabel(compound.slug)
+  )
+}
+
+function loadBrowseCompounds(records: RuntimeRecord[]) {
+  return records
+    .filter((compound) => compound?.slug && getRuntimeVisibility(compound).canRender)
+    .sort((a, b) => getCompoundName(a).localeCompare(getCompoundName(b)))
+}
+
 export default async function CompoundsPage() {
   const raw = await getAllCompounds()
-  const allCompounds = (raw as unknown as RuntimeRecord[]).filter(
-    (c) => c?.slug && getRuntimeVisibility(c).canRender,
-  )
+  const allCompounds = loadBrowseCompounds(raw as unknown as RuntimeRecord[])
 
   const pageData = paginateItems(allCompounds, 1, COMPOUNDS_PAGE_SIZE)
   const leanCompounds = toLeanProfileIndexRecords(allCompounds)
@@ -51,7 +66,7 @@ export default async function CompoundsPage() {
         <ul>
           {allCompounds.map((c) => (
             <li key={c.slug}>
-              <Link href={`/compounds/${c.slug}`}>{String(c.name || c.slug)}</Link>
+              <Link href={`/compounds/${c.slug}`}>{getCompoundName(c)}</Link>
             </li>
           ))}
         </ul>

--- a/app/compounds/page/[page]/page.tsx
+++ b/app/compounds/page/[page]/page.tsx
@@ -4,6 +4,8 @@ import { getAllCompounds } from '@/lib/server/runtime-data'
 import { getRuntimeVisibility } from '../../../../lib/runtime-visibility'
 import { COMPOUNDS_PAGE_SIZE, clampPositiveInt, paginateItems } from '@/lib/pagination'
 import { toLeanProfileIndexRecords } from '@/lib/profile-index-records'
+import { formatDisplayLabel } from '@/lib/display-utils'
+import Link from 'next/link'
 import CompoundsIndexClient from '../../CompoundsIndexClient'
 import type { RuntimeRecord } from '../../../../src/types/content'
 import Pagination from '@/components/Pagination'
@@ -12,9 +14,24 @@ type P = {
   params: Promise<{ page: string }>
 }
 
+function getCompoundName(compound: RuntimeRecord) {
+  return (
+    formatDisplayLabel(compound.displayName) ||
+    formatDisplayLabel(compound.name) ||
+    formatDisplayLabel(compound.compoundName) ||
+    formatDisplayLabel(compound.canonicalCompoundName) ||
+    formatDisplayLabel(compound.slug)
+  )
+}
+
+async function loadBrowseCompounds(): Promise<RuntimeRecord[]> {
+  return ((await getAllCompounds()) as unknown as RuntimeRecord[])
+    .filter((compound) => compound?.slug && getRuntimeVisibility(compound).canRender)
+    .sort((a, b) => getCompoundName(a).localeCompare(getCompoundName(b)))
+}
+
 export async function generateStaticParams() {
-  const compounds = ((await getAllCompounds()) as unknown as RuntimeRecord[])
-    .filter((compound) => getRuntimeVisibility(compound).canRender)
+  const compounds = await loadBrowseCompounds()
   const total = Math.max(1, Math.ceil(compounds.length / COMPOUNDS_PAGE_SIZE))
 
   return Array.from({ length: Math.max(total - 1, 0) }, (_, i) => ({
@@ -36,8 +53,7 @@ export async function generateMetadata({ params }: P): Promise<Metadata> {
 
 export default async function CompoundsPageN({ params }: P) {
   const n = clampPositiveInt((await params).page, 2)
-  const runtime = (await getAllCompounds()) as unknown as RuntimeRecord[]
-  const compounds = runtime.filter((compound) => compound?.slug && getRuntimeVisibility(compound).canRender)
+  const compounds = await loadBrowseCompounds()
   const p = paginateItems(compounds, n, COMPOUNDS_PAGE_SIZE)
   const leanCompounds = toLeanProfileIndexRecords(compounds)
   const leanPageItems = toLeanProfileIndexRecords(p.pageItems as RuntimeRecord[])
@@ -55,6 +71,16 @@ export default async function CompoundsPageN({ params }: P) {
       </header>
 
       <Pagination basePath="/compounds" currentPage={p.currentPage} totalPages={p.totalPages} itemLabel="Compound profiles" />
+
+      <nav aria-label="Compound profiles on this page" className="sr-only">
+        <ul>
+          {p.pageItems.map((compound) => (
+            <li key={compound.slug}>
+              <Link href={`/compounds/${compound.slug}`}>{getCompoundName(compound)}</Link>
+            </li>
+          ))}
+        </ul>
+      </nav>
 
       <Suspense fallback={null}>
         <CompoundsIndexClient


### PR DESCRIPTION
### Motivation
- Ensure the `/compounds` browse pages have stable, reader-friendly ordering and consistent paginated membership by sorting compounds by a normalized display label before pagination.
- Improve the SEO-crawlable link index and accessibility by using formatted labels instead of raw names/slugs for hidden crawl lists.
- Align compound browse behavior with the herb library patterns for predictable page membership and crawlability.

### Description
- Added `getCompoundName` and `loadBrowseCompounds` helpers and imported `formatDisplayLabel` to normalize and sort compound records before pagination in `app/compounds/page.tsx` and `app/compounds/page/[page]/page.tsx`.
- Replaced ad-hoc filtering with `loadBrowseCompounds(...)` so the listing is filtered for `slug` + `getRuntimeVisibility(...).canRender` and then consistently sorted by formatted label.
- Replaced raw `String(name || slug)` links with `getCompoundName(...)` in the SEO-crawlable index and added a screen-reader-only, crawlable link list for each paginated compound page.
- Updated `generateStaticParams` and paginated page logic to use the sorted compound list so page composition is stable across builds.

### Testing
- Ran `npm run typecheck` which passed successfully.
- Ran `npm run lint -- --no-cache app/compounds/page.tsx app/compounds/page/[page]/page.tsx` which passed with no lint errors.
- Ran `npm run validate:route-seo` which passed and confirmed route checks.
- Ran `git diff --check` (and pre-commit checks) with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54e840c09c83239a5d4cd7c81f864f)