### PR TITLE
Consolidate legacy guide links

### DIFF
--- a/lib/collections.ts
+++ b/lib/collections.ts
@@ -63,7 +63,7 @@ export const scientificCollections: ScientificCollection[] = [
     related: [
       { title: 'Best-Studied Sleep Compounds', href: '/guides/sleep', description: 'Sleep and relaxation records that often overlap with stress physiology.' },
       { title: 'GABA Pathways', href: '/learn/gaba', description: 'Calming pathway records related to inhibitory tone and relaxation.' },
-      { title: 'Stress Goal Guide', href: '/best-supplements-for-stress', description: 'Intent-oriented stress support navigation from the goal layer.' },
+      { title: 'Stress Goal Guide', href: '/guides/best/supplements-for-stress', description: 'Intent-oriented stress support navigation from the goal layer.' },
       { title: 'Natural Anxiolytics', href: '/guides/anxiety/natural-anxiolytics-beyond-ashwagandha', description: 'Broader harm-aware discovery for calming botanicals beyond one headline herb.' },
     ],
   },
@@ -79,9 +79,9 @@ export const scientificCollections: ScientificCollection[] = [
     chips: ['Acetylcholine', 'Memory', 'Focus', 'Neuro signaling', 'Cognition'],
     related: [
       { title: 'Dopamine Pathways', href: '/learn/dopamine', description: 'Cognition and attention records with dopaminergic or motivation-adjacent signals.' },
-      { title: 'Focus Supplements', href: '/best-supplements-for-focus', description: 'Intent entry page for focus-oriented supplement discovery.' },
+      { title: 'Focus Supplements', href: '/guides/focus/best-supplements-for-focus', description: 'Intent entry page for focus-oriented supplement discovery.' },
       { title: 'Cognition Compounds', href: '/guides/focus', description: 'Goal-oriented discovery for cognition, attention, and memory signals.' },
-      { title: 'Brain Fog Guide', href: '/guides/supplements-for-brain-fog-and-fatigue', description: 'Decision-oriented discovery for cognitive clarity intent.' },
+      { title: 'Brain Fog Guide', href: '/guides/other/supplements-for-brain-fog-and-fatigue', description: 'Decision-oriented discovery for cognitive clarity intent.' },
     ],
   },
   {
@@ -97,8 +97,8 @@ export const scientificCollections: ScientificCollection[] = [
     related: [
       { title: 'Inflammation Pathways', href: '/learn/inflammation', description: 'Pathway hub for inflammatory, immune, oxidative, and antioxidant records.' },
       { title: 'Recovery Support', href: '/guides/sleep', description: 'Recovery signals that can overlap with inflammatory and oxidative-stress context.' },
-      { title: 'Joint Support Supplements', href: '/best-supplements-for-joint-support', description: 'Intent entry page for joint-support discovery.' },
-      { title: 'Gut Health Supplements', href: '/best-supplements-for-gut-health', description: 'Adjacent discovery for immune and inflammation-adjacent wellness intent.' },
+      { title: 'Joint Support Supplements', href: '/guides/best/supplements-for-joint-support', description: 'Intent entry page for joint-support discovery.' },
+      { title: 'Gut Health Supplements', href: '/guides/best/supplements-for-gut-health', description: 'Adjacent discovery for immune and inflammation-adjacent wellness intent.' },
     ],
   },
 ]

--- a/lib/ecosystem-context.ts
+++ b/lib/ecosystem-context.ts
@@ -29,7 +29,7 @@ export const topicClusters: TopicCluster[] = [
   {
     slug: 'metabolism',
     label: 'Metabolism',
-    href: '/best-supplements-for-fat-loss',
+    href: '/guides/best/supplements-for-fat-loss',
     description: 'Energy balance, glucose context, body-composition research, and metabolic resilience signals.',
     systems: ['Energy balance', 'Glucose context', 'Body composition'],
     keywords: ['metabolism', 'metabolic', 'glucose', 'insulin', 'fat', 'weight'],
@@ -37,7 +37,7 @@ export const topicClusters: TopicCluster[] = [
   {
     slug: 'stress-response',
     label: 'Stress response',
-    href: '/best-supplements-for-stress',
+    href: '/guides/best/supplements-for-stress',
     description: 'HPA-axis language, adaptation, calm, sleep overlap, and nervous-system resilience.',
     systems: ['HPA axis', 'Adaptation', 'Calm'],
     keywords: ['stress', 'cortisol', 'adaptogen', 'anxiety', 'calm', 'relaxation'],
@@ -53,7 +53,7 @@ export const topicClusters: TopicCluster[] = [
   {
     slug: 'mitochondrial-function',
     label: 'Mitochondrial function',
-    href: '/performance-supplements',
+    href: '/guides/other/supplements-for-brain-fog-and-fatigue',
     description: 'Cellular energy, fatigue, exercise performance, and recovery-adjacent mechanism context.',
     systems: ['Cellular energy', 'Fatigue', 'Performance'],
     keywords: ['mitochondria', 'mitochondrial', 'atp', 'energy', 'fatigue', 'performance'],
@@ -85,7 +85,7 @@ export const topicClusters: TopicCluster[] = [
   {
     slug: 'cardiovascular-function',
     label: 'Cardiovascular function',
-    href: '/best-supplements-for-blood-pressure',
+    href: '/guides/best/supplements-for-blood-pressure',
     description: 'Blood-pressure context, vascular tone, circulation, metabolic overlap, and endothelial themes.',
     systems: ['Vascular tone', 'Circulation', 'Blood pressure'],
     keywords: ['cardio', 'vascular', 'blood pressure', 'circulation', 'heart', 'endothelial'],

--- a/lib/goal-start-here-links.ts
+++ b/lib/goal-start-here-links.ts
@@ -48,7 +48,7 @@ export const GOAL_START_HERE_LINKS: Record<string, GoalStartHereLink[]> = {
     {
       role: 'Beginner guide',
       title: 'Best supplements for stress',
-      href: '/best-supplements-for-stress/',
+      href: '/guides/best/supplements-for-stress/',
       note: 'A broad entry point for comparing calming support, adaptogens, and safety flags.',
     },
     {

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -160,32 +160,32 @@ const FOCUS_CLUSTER_KEYWORDS = /\b(adhd|attention|focus|concentration|cognition|
 export const focusClusterSeeAlsoLinks: FocusClusterLink[] = [
   {
     title: 'Best Supplements for ADHD',
-    href: '/best-supplements-for-adhd/',
+    href: '/guides/adhd/best-supplements-for-adhd/',
     description: 'Cluster overview for ADHD-adjacent supplement questions.',
   },
   {
     title: 'Omega-3 for ADHD',
-    href: '/omega-3-for-adhd/',
+    href: '/guides/adhd/omega-3-and-adhd/',
     description: 'EPA/DHA context for attention-support research.',
   },
   {
     title: 'Magnesium for ADHD',
-    href: '/magnesium-for-adhd/',
+    href: '/guides/adhd/magnesium-for-adhd/',
     description: 'Magnesium status, sleep, and focus-adjacent framing.',
   },
   {
     title: 'L-Theanine for ADHD',
-    href: '/l-theanine-for-adhd/',
+    href: '/guides/adhd/l-theanine-for-adhd/',
     description: 'Calm-focus positioning without stimulant claims.',
   },
   {
     title: 'Citicoline vs Alpha-GPC',
-    href: '/citicoline-vs-alpha-gpc/',
+    href: '/guides/adhd/citicoline-vs-alpha-gpc/',
     description: 'Choline donor comparison for focus stacks.',
   },
   {
     title: 'Best Supplements for Focus Without Caffeine',
-    href: '/best-supplements-for-focus-without-caffeine',
+    href: '/guides/focus/focus-without-caffeine-crash/',
     description: 'Non-caffeine focus options and tradeoffs.',
   },
 ]
@@ -532,7 +532,7 @@ export function buildFocusClusterBreadcrumb(args: {
       { '@type': 'ListItem', position: 1, name: 'Home', item: `${SITE_URL}/` },
       { '@type': 'ListItem', position: 2, name: 'Goals', item: `${SITE_URL}/goals/` },
       { '@type': 'ListItem', position: 3, name: 'Focus', item: `${SITE_URL}/guides/focus/` },
-      { '@type': 'ListItem', position: 4, name: 'Focus & ADHD cluster', item: `${SITE_URL}/best-supplements-for-adhd/` },
+      { '@type': 'ListItem', position: 4, name: 'Focus & ADHD cluster', item: `${SITE_URL}/guides/adhd/best-supplements-for-adhd/` },
       { '@type': 'ListItem', position: 5, name: args.currentName, item: currentUrl },
     ],
   }

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,6 +1,6 @@
 # GSC redirect cleanup (2026-07-03): preserve workbook www URLs to canonical paths.
 https://www.thehippiescientist.net/goals/ https://thehippiescientist.net/goals/ 301
-https://www.thehippiescientist.net/guides/supplements-for-brain-fog-and-fatigue/ https://thehippiescientist.net/guides/other/supplements-for-brain-fog-and-fatigue/ 301
+https://www.thehippiescientist.net/guides/other/supplements-for-brain-fog-and-fatigue/ https://thehippiescientist.net/guides/other/supplements-for-brain-fog-and-fatigue/ 301
 https://www.thehippiescientist.net/ https://thehippiescientist.net/ 301
 https://www.thehippiescientist.net/guides/sleep-herbs-vs-melatonin/ https://thehippiescientist.net/guides/sleep/sleep-herbs-vs-melatonin/ 301
 https://www.thehippiescientist.net/guides/best-supplements-for-gut-health/ https://thehippiescientist.net/guides/best/supplements-for-gut-health/ 301
@@ -140,6 +140,19 @@ https://www.thehippiescientist.net/* https://thehippiescientist.net/:splat 301
 /articles/ashwagandha/ /guides/herbs/ashwagandha/ 301
 /articles/l-theanine /guides/herbs/l-theanine/ 301
 /articles/l-theanine/ /guides/herbs/l-theanine/ 301
+
+# Legacy best-of entry points consolidated under guide taxonomy.
+/best-supplements-for-stress /guides/best/supplements-for-stress/ 301
+/best-supplements-for-stress/ /guides/best/supplements-for-stress/ 301
+/best-supplements-for-gut-health /guides/best/supplements-for-gut-health/ 301
+/best-supplements-for-gut-health/ /guides/best/supplements-for-gut-health/ 301
+/best-supplements-for-blood-pressure /guides/best/supplements-for-blood-pressure/ 301
+/best-supplements-for-blood-pressure/ /guides/best/supplements-for-blood-pressure/ 301
+/best-supplements-for-joint-support /guides/best/supplements-for-joint-support/ 301
+/best-supplements-for-joint-support/ /guides/best/supplements-for-joint-support/ 301
+/performance-supplements /guides/other/supplements-for-brain-fog-and-fatigue/ 301
+/performance-supplements/ /guides/other/supplements-for-brain-fog-and-fatigue/ 301
+
 /best-supplements-for-sleep /guides/sleep/best-supplements-for-sleep/ 301
 /best-supplements-for-sleep/ /guides/sleep/best-supplements-for-sleep/ 301
 /best-herbs-for-anxiety /guides/anxiety/best-herbs-for-anxiety/ 301
@@ -188,11 +201,11 @@ https://www.thehippiescientist.net/* https://thehippiescientist.net/:splat 301
 # Articles style category legacy redirect (field-notes → nootropics)
 /articles/style/field-notes /articles/style/nootropics/ 301
 /articles/style/field-notes/ /articles/style/nootropics/ 301
-/best-herbs-for-anxiety /guides/best-herbs-for-anxiety/ 301
+/best-herbs-for-anxiety /guides/anxiety/best-herbs-for-anxiety/ 301
 /herbs-for-sleep /articles/best-herbs-for-sleep/ 301
-/best-nootropics-for-focus /guides/best-nootropics-for-focus/ 301
-/best-adaptogens-for-stress /guides/best-adaptogens-for-stress/ 301
-/natural-testosterone-boosters /guides/natural-testosterone-boosters/ 301
+/best-nootropics-for-focus /guides/focus/best-nootropics-for-focus/ 301
+/best-adaptogens-for-stress /guides/anxiety/best-adaptogens-for-stress/ 301
+/natural-testosterone-boosters /guides/other/testosterone-supplements/ 301
 /comparisons/rhodiola-vs-ashwagandha /compare/rhodiola-vs-ashwagandha/ 301
 /compare/ashwagandha-vs-rhodiola /compare/rhodiola-vs-ashwagandha/ 301
 /compare/ashwagandha-vs-rhodiola-for-stress /compare/rhodiola-vs-ashwagandha/ 301


### PR DESCRIPTION
### Motivation
- Align in-code navigation and semantic hub links with the current canonical guide taxonomy to avoid redirect hops and stale top-level aliases.
- Preserve SEO and existing traffic by adding explicit redirects for legacy "best-of" and performance entry points when canonical paths were introduced.
- Make minimal, surgical changes limited to navigation/redirect surfaces so route stability and static-export behavior are maintained.

### Description
- Updated topic cluster links in `lib/ecosystem-context.ts` to point at canonical guide routes (metabolism, stress, mitochondrial, cardiovascular entries). 
- Updated collection related links in `lib/collections.ts` and the stress goal starter in `lib/goal-start-here-links.ts` to use canonical `/guides/...` paths instead of legacy top-level aliases. 
- Rewrote focus/ADHD see-also links and breadcrumb structured-data in `lib/schema.ts` to reference `/guides/adhd/...` and `/guides/focus/...` routes. 
- Added explicit legacy redirects to `public/_redirects` for high-intent entry points (e.g. `/best-supplements-for-stress`, `/performance-supplements`) and corrected several duplicate legacy redirect targets.

### Testing
- Ran `npm run typecheck` which completed successfully. 
- Ran `npm run lint` which completed successfully. 
- Ran `git diff --check` which reported no whitespace/merge issues. 
- Ran `npm run verify:redirects` which was blocked in this environment because `out/_redirects` (build output) is not present, so final redirect publish validation requires a static export build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54f32161fc8323934b207de6a2e499)