### PR TITLE
Canonicalize compare hub links

### DIFF
--- a/app/__tests__/compare-link-integrity.test.ts
+++ b/app/__tests__/compare-link-integrity.test.ts
@@ -18,7 +18,7 @@ import { buildCompareCTA } from '@/lib/conversion-aware-layouts'
  */
 
 function compareSlug(href: string): string {
-  return href.replace(/^\/compare\//, '').replace(/\/$/, '')
+  return href.replace(/^\/(?:guides\/)?compare\//, '').replace(/\/$/, '')
 }
 
 describe('compare link integrity', () => {
@@ -66,13 +66,13 @@ describe('compare link integrity', () => {
     }
   })
 
-  it('buildCompareCTA falls back to the /compare hub for unbuilt topics', () => {
+  it('buildCompareCTA falls back to the /guides/compare hub for unbuilt topics', () => {
     const cta = buildCompareCTA({ name: 'Sleep Herbs', slug: 'sleep-herbs' })
     // Either the comparison hub, or a genuinely built comparison page.
-    if (cta.href !== '/compare') {
+    if (cta.href !== '/guides/compare') {
       expect(isBuiltComparisonSlug(compareSlug(cta.href))).toBe(true)
     } else {
-      expect(cta.href).toBe('/compare')
+      expect(cta.href).toBe('/guides/compare')
     }
   })
 })

--- a/app/__tests__/route-integrity.test.ts
+++ b/app/__tests__/route-integrity.test.ts
@@ -42,7 +42,7 @@ describe('Route Integrity Test', () => {
       '/herbs', '/herbs/',
       '/compounds', '/compounds/',
       '/articles', '/articles/',
-      '/compare', '/guides/compare/',
+      '/guides/compare', '/guides/compare/',
       '/stacks', '/stacks/',
       '/goals', '/goals/',
     ]

--- a/app/compounds/CompoundsIndexClient.tsx
+++ b/app/compounds/CompoundsIndexClient.tsx
@@ -324,7 +324,7 @@ const browsePaths = [
   },
   {
     label: 'Compare options',
-    href: '/compare',
+    href: '/guides/compare',
     description: 'Review alternatives without treating compound lists as recommendations.',
   },
 ]

--- a/app/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium/page.tsx
+++ b/app/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium/page.tsx
@@ -50,7 +50,7 @@ export default function AshwagandhaVsLTheanineVsMagnesiumPage() {
       <AuthorityBreadcrumbs
         items={[
           { label: 'Home', href: '/' },
-          { label: 'Compare', href: '/compare' },
+          { label: 'Compare', href: '/guides/compare' },
           { label: 'Ashwagandha vs L-Theanine vs Magnesium' },
         ]}
       />

--- a/app/guides/compare/berberine-vs-metformin/page.tsx
+++ b/app/guides/compare/berberine-vs-metformin/page.tsx
@@ -46,7 +46,7 @@ export default function BerberineVsMetforminPage() {
       <AuthorityBreadcrumbs
         items={[
           { label: 'Home', href: '/' },
-          { label: 'Compare', href: '/compare' },
+          { label: 'Compare', href: '/guides/compare' },
           { label: 'Berberine vs Metformin' },
         ]}
       />

--- a/app/guides/compare/curcumin-vs-boswellia-vs-omega-3/page.tsx
+++ b/app/guides/compare/curcumin-vs-boswellia-vs-omega-3/page.tsx
@@ -48,7 +48,7 @@ export default function CurcuminVsBoswelliaVsOmega3Page() {
       <AuthorityBreadcrumbs
         items={[
           { label: 'Home', href: '/' },
-          { label: 'Compare', href: '/compare' },
+          { label: 'Compare', href: '/guides/compare' },
           { label: 'Curcumin vs Boswellia vs Omega-3' },
         ]}
       />

--- a/app/guides/compare/kanna-vs-ssris/page.tsx
+++ b/app/guides/compare/kanna-vs-ssris/page.tsx
@@ -67,7 +67,7 @@ export default function KannaVsSSRIsPage() {
       <AuthorityBreadcrumbs
         items={[
           { label: 'Home', href: '/' },
-          { label: 'Compare', href: '/compare' },
+          { label: 'Compare', href: '/guides/compare' },
           { label: 'Kanna vs SSRIs' },
         ]}
       />

--- a/app/guides/compare/kava-vs-alcohol/page.tsx
+++ b/app/guides/compare/kava-vs-alcohol/page.tsx
@@ -36,7 +36,7 @@ export default function KavaVsAlcoholPage() {
       <AuthorityBreadcrumbs
         items={[
           { label: 'Home', href: '/' },
-          { label: 'Compare', href: '/compare' },
+          { label: 'Compare', href: '/guides/compare' },
           { label: 'Kava vs Alcohol' },
         ]}
       />

--- a/app/guides/compare/melatonin-vs-valerian-vs-magnesium-for-sleep/page.tsx
+++ b/app/guides/compare/melatonin-vs-valerian-vs-magnesium-for-sleep/page.tsx
@@ -48,7 +48,7 @@ export default function MelatoninVsValerianVsMagnesiumForSleepPage() {
       <AuthorityBreadcrumbs
         items={[
           { label: 'Home', href: '/' },
-          { label: 'Compare', href: '/compare' },
+          { label: 'Compare', href: '/guides/compare' },
           { label: 'Melatonin vs Valerian vs Magnesium for Sleep' },
         ]}
       />

--- a/app/guides/compare/rhodiola-vs-ashwagandha/page.tsx
+++ b/app/guides/compare/rhodiola-vs-ashwagandha/page.tsx
@@ -46,7 +46,7 @@ export default function RhodiolaVsAshwagandhaComparePage() {
       <AuthorityBreadcrumbs
         items={[
           { label: 'Home', href: '/' },
-          { label: 'Compare', href: '/compare' },
+          { label: 'Compare', href: '/guides/compare' },
           { label: 'Rhodiola vs Ashwagandha' },
         ]}
       />

--- a/app/guides/compare/sleep-herbs-vs-melatonin/page.tsx
+++ b/app/guides/compare/sleep-herbs-vs-melatonin/page.tsx
@@ -51,7 +51,7 @@ export default function SleepHerbsVsMelatoninComparePage() {
       <AuthorityBreadcrumbs
         items={[
           { label: 'Home', href: '/' },
-          { label: 'Compare', href: '/compare' },
+          { label: 'Compare', href: '/guides/compare' },
           { label: 'Sleep Herbs vs Melatonin' },
         ]}
       />

--- a/app/search/SearchClient.tsx
+++ b/app/search/SearchClient.tsx
@@ -132,11 +132,11 @@ const discoveryFilters: IntentPrompt[] = [
 
 const crossContentLinks: { goals: DiscoveryLink[]; compare: DiscoveryLink[]; learn: DiscoveryLink[] } = {
   goals: [
-    { label: 'Sleep support goals', href: '/guides/sleep-support', description: 'Start with outcome constraints before profile selection.' },
+    { label: 'Sleep support goals', href: '/guides/sleep', description: 'Start with outcome constraints before profile selection.' },
     { label: 'Non-stimulant focus goals', href: '/guides/focus', description: 'Build focus plans with lower stimulation load.' },
   ],
   compare: [
-    { label: 'Comparison table', href: '/compare', description: 'Contrast common strategy patterns first.' },
+    { label: 'Comparison table', href: '/guides/compare', description: 'Contrast common strategy patterns first.' },
     { label: 'L-theanine vs magnesium', href: '/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium', description: 'Compare calming support styles with practical tradeoffs.' },
   ],
   learn: [

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -329,7 +329,7 @@ function isAllowedRouteManifestEntry(routeStr: string): boolean {
     '/stacks',
     '/guides',
     '/learn',
-    '/compare',
+    '/guides/compare',
     '/tools',
     '/info/dosing',
     '/info/affiliate-disclosure',

--- a/lib/canonical-route-taxonomy.ts
+++ b/lib/canonical-route-taxonomy.ts
@@ -2,7 +2,7 @@ import { text } from '@/lib/display-utils'
 
 export const canonicalRouteFamilies = {
   guides: '/guides',
-  compare: '/compare',
+  compare: '/guides/compare',
   ecosystems: '/ecosystems',
   herbs: '/herbs',
   compounds: '/compounds',

--- a/lib/conversion-aware-layouts.ts
+++ b/lib/conversion-aware-layouts.ts
@@ -50,7 +50,7 @@ export function buildCompareCTA(record: Record<string, unknown>): ConversionCTA 
 
   // A topic name is not a comparison slug, so only deep-link when a built page
   // exists; otherwise route to the comparison hub instead of a 404.
-  const href = isBuiltComparisonSlug(topicSlug) ? `/guides/compare/${topicSlug}` : '/compare'
+  const href = isBuiltComparisonSlug(topicSlug) ? `/guides/compare/${topicSlug}` : '/guides/compare'
 
   return {
     label: `Compare ${topic} alternatives`,
@@ -79,7 +79,7 @@ export function buildContinuationCTA(record: Record<string, unknown>): Conversio
     href: semantic.recommendedRouteType === 'ecosystem'
       ? '/explore/ecosystems'
       : semantic.recommendedRouteType === 'compare'
-        ? '/compare'
+        ? '/guides/compare'
         : '/explore',
     description: 'Follow adjacent evidence, pathway, and ecosystem relationships.',
     tone: 'explore',

--- a/lib/homepage-messaging.ts
+++ b/lib/homepage-messaging.ts
@@ -8,7 +8,7 @@ export const homepageMessaging = {
   },
   secondaryCTA: {
     label: 'Compare Supplements',
-    href: '/compare',
+    href: '/guides/compare',
   },
   sections: {
     exploreByGoal: 'Explore by goal',
@@ -32,7 +32,7 @@ export const mobileNavigationItems = [
   {
     label: 'Compare',
     icon: 'GitCompare',
-    href: '/compare',
+    href: '/guides/compare',
   },
   {
     label: 'Explore',

--- a/public/_redirects
+++ b/public/_redirects
@@ -27,6 +27,10 @@ https://www.thehippiescientist.net/* https://thehippiescientist.net/:splat 301
 
 /atom.xml /feed.xml 301
 
+# Legacy comparison hub alias.
+/compare /guides/compare/ 301
+/compare/ /guides/compare/ 301
+
 # Required legacy aliases checked by verify-redirects.
 /natural-anxiolytics-beyond-ashwagandha /guides/natural-anxiolytics-beyond-ashwagandha/ 301
 /psychedelic-adjacent-herbs /guides/psychedelic-adjacent-herbs/ 301


### PR DESCRIPTION
### Motivation
- Prevent legacy `/compare` link leakage and 404s by standardizing internal references to the canonical compare hub at `/guides/compare`.
- Keep discovery and navigation links accurate (including a stale `/guides/sleep-support` reference) to preserve UX and SEO continuity.
- Preserve legacy traffic and external links by adding redirects from the old `/compare` paths to the canonical hub.

### Description
- Point high-visibility CTAs and navigation to the canonical compare hub by updating `lib/homepage-messaging.ts` and the mobile nav to use `'/guides/compare'` instead of `'/compare'`.
- Canonicalize compare routing in helpers and layout logic by updating `lib/canonical-route-taxonomy.ts` and `lib/conversion-aware-layouts.ts` so `compare` maps to `'/guides/compare'` and fallback CTAs route to `'/guides/compare'`.
- Update discovery/search and compound browse links by changing `app/search/SearchClient.tsx` and `app/compounds/CompoundsIndexClient.tsx` to reference `'/guides/sleep'` and `'/guides/compare'` respectively.
- Update compare article breadcrumbs and related pages under `app/guides/compare/*` to use `'/guides/compare'` links and adjust `app/sitemap.ts` to include the canonical compare hub as an allowed static route.
- Add legacy redirect entries in `public/_redirects` to map `/compare` and `/compare/` to `/guides/compare/` so old links and SEO signals are preserved.
- Adjust route/link integrity tests (`app/__tests__/compare-link-integrity.test.ts` and `app/__tests__/route-integrity.test.ts`) to assert canonical `/guides/compare` behavior and to avoid emitting unbuilt comparison slugs.

### Testing
- Ran unit tests `npx vitest run app/__tests__/compare-link-integrity.test.ts app/__tests__/route-integrity.test.ts` and both test files passed.
- Ran type checking with `npm run typecheck` and it completed successfully with no errors.
- Ran linter with `npm run lint` and it completed successfully with no warnings.
- Ran `npm run verify:redirects` which flagged a missing `out/_redirects` (expected in a static export), so redirect verification produced a warning in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54fc0cf4f88323add6d1db2d42b0a6)