### PR TITLE
Fix semantic comparison link guard

### DIFF
--- a/app/__tests__/compare-link-integrity.test.ts
+++ b/app/__tests__/compare-link-integrity.test.ts
@@ -4,6 +4,7 @@ import { isBuiltComparisonSlug } from '@/lib/comparison-utils'
 import { buildComparisonRecommendations } from '@/lib/semantic/buildComparisonRecommendations'
 import { getComparisonCandidates } from '@/lib/semantic-runtime'
 import { buildCompareCTA } from '@/lib/conversion-aware-layouts'
+import { buildSemanticLinkSuggestions } from '@/lib/semantic-internal-linking'
 
 /**
  * Guards against the regression that produced a large "Not found (404)" cluster
@@ -64,6 +65,35 @@ describe('compare link integrity', () => {
       expect(candidate.href.startsWith('/guides/compare/')).toBe(true)
       expect(isBuiltComparisonSlug(compareSlug(candidate.href))).toBe(true)
     }
+  })
+
+
+  it('buildSemanticLinkSuggestions keeps built comparisons and drops unbuilt comparisons', () => {
+    const source = {
+      slug: 'ashwagandha',
+      name: 'Ashwagandha',
+      effects: ['stress'],
+      mechanisms: ['cortisol'],
+    }
+
+    const suggestions = buildSemanticLinkSuggestions(source, [
+      {
+        slug: 'rhodiola-vs-ashwagandha',
+        name: 'Rhodiola vs Ashwagandha',
+        entityType: 'compare',
+        effects: ['stress'],
+        mechanisms: ['cortisol'],
+      },
+      {
+        slug: 'ashwagandha-vs-random-unbuilt-topic',
+        name: 'Ashwagandha vs Random Unbuilt Topic',
+        entityType: 'compare',
+        effects: ['stress'],
+        mechanisms: ['cortisol'],
+      },
+    ])
+
+    expect(suggestions.map((item) => item.href)).toEqual(['/guides/compare/rhodiola-vs-ashwagandha'])
   })
 
   it('buildCompareCTA falls back to the /guides/compare hub for unbuilt topics', () => {

--- a/lib/semantic-internal-linking.ts
+++ b/lib/semantic-internal-linking.ts
@@ -12,6 +12,10 @@ function normalize(value: unknown) {
   return text(value).toLowerCase().trim()
 }
 
+function compareSlugFromHref(href: string) {
+  return String(href || '').trim().replace(/^\/(?:guides\/)?compare\//, '').replace(/\/$/, '')
+}
+
 export function buildSemanticLinkSuggestions(source: Record<string, unknown>, candidates: Record<string, unknown>[] = [], limit = 12): SemanticLinkSuggestion[] {
   const sourceSignals = unique([
     source?.slug,
@@ -69,7 +73,7 @@ export function buildSemanticLinkSuggestions(source: Record<string, unknown>, ca
     .filter((item) => item.score > 0)
     // Never surface a comparison link unless that comparison page is built;
     // an unbuilt /guides/compare/ slug 404s under static export.
-    .filter((item) => item.type !== 'compare' || isBuiltComparisonSlug(text(item.href).replace(/^\/compare\//, '')))
+    .filter((item) => item.type !== 'compare' || isBuiltComparisonSlug(compareSlugFromHref(item.href)))
     .sort((a, b) => b.score - a.score || a.label.localeCompare(b.label))
     .slice(0, limit)
     .map(({ score: _score, ...item }) => item)


### PR DESCRIPTION
### Motivation
- Prevent valid built `/guides/compare/<slug>` suggestions from being dropped and ensure unbuilt comparison candidates are never surfaced (which previously led to phantom /guides/compare/* 404s under static export).
- Add regression coverage so the semantic internal-link generator is explicitly tested to keep built comparisons and drop unbuilt ones.

### Description
- Add `compareSlugFromHref` helper in `lib/semantic-internal-linking.ts` to reliably extract the comparison slug from candidate hrefs before validation.
- Use the new helper when filtering compare-type suggestions so `isBuiltComparisonSlug` receives the canonical slug instead of the full href.
- Add a test in `app/__tests__/compare-link-integrity.test.ts` that asserts `buildSemanticLinkSuggestions` retains a built comparison suggestion and drops an unbuilt one.

### Testing
- Ran the focused test suite with `npm test -- app/__tests__/compare-link-integrity.test.ts` and all tests passed.
- Ran type checking and linting with `npm run typecheck` and `npm run lint:nocache`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55039464c88323a547d6db4d84c91b)