### PR TITLE
Add focus ADHD article source guardrails

### DIFF
--- a/app/__tests__/focus-adhd-articles.test.ts
+++ b/app/__tests__/focus-adhd-articles.test.ts
@@ -1,0 +1,32 @@
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import { focusAdhdArticles, getFocusAdhdArticle } from '../../lib/focus-adhd-articles'
+
+const editorialScaffoldPattern = /\b(?:TODO|FIXME|TBD|PLACEHOLDER|DRAFT NOTE|EDITOR NOTE)\b|##\s+(?:Related Articles|Internal Linking Recommendations)\b/i
+
+describe('focus ADHD article sources', () => {
+  it('points every sourced focus article at an existing markdown file', () => {
+    const missingSources = focusAdhdArticles
+      .filter((article) => article.source)
+      .filter((article) => !existsSync(path.join(process.cwd(), article.source as string)))
+      .map((article) => `${article.slug}: ${article.source}`)
+
+    expect(missingSources).toEqual([])
+  })
+
+  it('does not expose editorial scaffold text in rendered article bodies', () => {
+    const leakedScaffold = focusAdhdArticles
+      .map((article) => {
+        const rendered = getFocusAdhdArticle(article.slug)
+        return {
+          slug: article.slug,
+          match: rendered?.body.match(editorialScaffoldPattern)?.[0] ?? null,
+        }
+      })
+      .filter((result) => result.match)
+
+    expect(leakedScaffold).toEqual([])
+  })
+})


### PR DESCRIPTION
### Motivation
- Ensure the focus/ADHD editorial content configuration references existing source files to avoid runtime missing-source issues.
- Prevent accidental publication of editorial scaffold text (TODOs, placeholders, planning sections) in rendered article bodies.

### Description
- Add a Vitest file `app/__tests__/focus-adhd-articles.test.ts` that asserts every `focusAdhdArticles` entry with a `source` points to an existing markdown file.
- Add a regression assertion in the same test that `getFocusAdhdArticle(...)` output does not contain editorial scaffold markers like `TODO`, `FIXME`, `PLACEHOLDER`, or terminal planning sections (`Related Articles`, `Internal Linking Recommendations`).

### Testing
- Ran `npm run test -- app/__tests__/focus-adhd-articles.test.ts` and the new test file passed (2 tests, 2 passed).
- Ran `npm run typecheck` and `npm run lint:nocache` and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55067ec5a88323afddf290d18d8c6f)