### PR TITLE
Improve mental health guide hub

### DIFF
--- a/app/__tests__/mental-health-navigation.test.ts
+++ b/app/__tests__/mental-health-navigation.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { generateNavigationSchema } from '@/components/NavigationSchema'
+import { primaryNavigation } from '@/lib/primary-navigation'
+import { SITE_URL } from '@/lib/navigation-config'
+
+describe('mental health navigation discovery', () => {
+  it('surfaces the mental health hub under Guides', () => {
+    const guides = primaryNavigation.find((item) => item.href === '/guides')
+
+    expect(guides?.children).toContainEqual(expect.objectContaining({
+      label: 'Mental Health',
+      href: '/guides/mental-health',
+    }))
+  })
+
+  it('includes the mental health hub in navigation structured data', () => {
+    const schema = generateNavigationSchema()
+
+    expect(schema.hasPart).toContainEqual({
+      '@type': 'WebPage',
+      name: 'Mental Health',
+      url: `${SITE_URL}/guides/mental-health`,
+    })
+  })
+})

--- a/app/guides/mental-health/page.tsx
+++ b/app/guides/mental-health/page.tsx
@@ -19,6 +19,12 @@ const HUB_PATH = '/guides/mental-health'
 const HUB_TITLE = 'Mental Health Guides: OCD and Personality Disorders'
 const HUB_DESCRIPTION = 'Citation-rich, evidence-based guides to OCD, BPD, and all ten DSM-5-TR personality disorders, with diagnosis, differential diagnosis, treatment, safety, and stigma context.'
 
+const SOURCE_LINKS = {
+  nimhOcd: 'https://www.nimh.nih.gov/health/topics/obsessive-compulsive-disorder-ocd',
+  apaPersonalityDisorders: 'https://www.psychiatry.org/patients-families/personality-disorders/what-are-personality-disorders',
+  whoIc11: 'https://www.who.int/publications/i/item/9789240077263',
+} as const
+
 const baseMetadata = buildPageMetadata({
   title: HUB_TITLE,
   description: HUB_DESCRIPTION,
@@ -123,7 +129,7 @@ export default function MentalHealthGuidesHub() {
     }),
     '@id': collectionId,
     inLanguage: 'en-US',
-    dateModified: '2026-07-13',
+    dateModified: '2026-07-15',
     about: [
       { '@type': 'MedicalCondition', name: 'Obsessive-compulsive disorder', alternateName: 'OCD' },
       { '@type': 'MedicalCondition', name: 'Borderline personality disorder', alternateName: 'BPD' },
@@ -151,10 +157,55 @@ export default function MentalHealthGuidesHub() {
         </p>
       </header>
 
+      <section className="mt-7 rounded-2xl border border-brand-700/20 bg-brand-50/60 p-5 sm:p-6" aria-labelledby="quick-answer">
+        <h2 id="quick-answer" className="text-xl font-bold text-ink">Quick answer: choose the guide that matches the question</h2>
+        <p className="mt-3 max-w-4xl leading-7 text-muted">
+          Start with the <Link href={`${HUB_PATH}/personality-disorders-overview/`} className="font-semibold text-brand-700 hover:underline">personality-disorders overview</Link> for classification and assessment basics. Use the <Link href={`${HUB_PATH}/obsessive-compulsive-disorder/`} className="font-semibold text-brand-700 hover:underline">OCD guide</Link> for intrusive obsessions, compulsions, and evidence-based treatment, or the <Link href={`${HUB_PATH}/obsessive-compulsive-personality-disorder/`} className="font-semibold text-brand-700 hover:underline">OCPD guide</Link> for enduring perfectionism, order, and control. OCD and OCPD are different diagnoses, although they can occur together.
+        </p>
+        <p className="mt-3 max-w-4xl text-sm leading-6 text-muted">
+          These guides can explain diagnostic concepts and treatment evidence. They cannot determine whether you or someone else has a disorder; diagnosis requires an individualized clinical assessment.
+        </p>
+      </section>
+
+      <section className="mt-10" aria-labelledby="key-differences">
+        <div className="max-w-3xl">
+          <h2 id="key-differences" className="text-2xl font-bold text-ink">OCD, OCPD, and personality disorders: key differences</h2>
+          <p className="mt-2 leading-7 text-muted">The shortest useful distinction is what kind of pattern is being assessed—not whether someone is merely neat, difficult, anxious, or perfectionistic.</p>
+        </div>
+        <div className="mt-5 overflow-x-auto rounded-2xl border border-brand-900/10 bg-white">
+          <table className="min-w-[46rem] w-full border-collapse text-left text-sm">
+            <thead className="bg-brand-50/70 text-ink">
+              <tr>
+                <th scope="col" className="px-4 py-3 font-bold">Topic</th>
+                <th scope="col" className="px-4 py-3 font-bold">Core clinical focus</th>
+                <th scope="col" className="px-4 py-3 font-bold">Best starting guide</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-brand-900/10 text-muted">
+              <tr>
+                <th scope="row" className="px-4 py-4 align-top font-bold text-ink">OCD</th>
+                <td className="px-4 py-4 align-top leading-6">Unwanted, recurring obsessions, compulsions, or both that are time-consuming, distressing, or interfere with daily life. <a href={SOURCE_LINKS.nimhOcd} className="font-semibold text-brand-700 hover:underline">NIMH overview</a></td>
+                <td className="px-4 py-4 align-top"><Link href={`${HUB_PATH}/obsessive-compulsive-disorder/`} className="font-semibold text-brand-700 hover:underline">OCD guide →</Link></td>
+              </tr>
+              <tr>
+                <th scope="row" className="px-4 py-4 align-top font-bold text-ink">OCPD</th>
+                <td className="px-4 py-4 align-top leading-6">An enduring personality pattern involving orderliness, perfectionism, and control. It is not the same diagnosis as OCD. <a href={SOURCE_LINKS.apaPersonalityDisorders} className="font-semibold text-brand-700 hover:underline">APA overview</a></td>
+                <td className="px-4 py-4 align-top"><Link href={`${HUB_PATH}/obsessive-compulsive-personality-disorder/`} className="font-semibold text-brand-700 hover:underline">OCPD guide →</Link></td>
+              </tr>
+              <tr>
+                <th scope="row" className="px-4 py-4 align-top font-bold text-ink">Personality disorders</th>
+                <td className="px-4 py-4 align-top leading-6">Persistent patterns involving how a person experiences themselves and relates to others, assessed across time, settings, functioning, culture, and development. DSM-5-TR and ICD-11 organize these diagnoses differently.</td>
+                <td className="px-4 py-4 align-top"><Link href={`${HUB_PATH}/personality-disorders-overview/`} className="font-semibold text-brand-700 hover:underline">Overview →</Link></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
       <section className="mt-7 rounded-2xl border border-brand-900/10 bg-brand-50/60 p-5 sm:p-6" aria-labelledby="editorial-standard">
         <h2 id="editorial-standard" className="text-lg font-bold text-ink">How these pages were verified</h2>
         <p className="mt-2 max-w-4xl text-sm leading-6 text-muted">
-          Claims are cited inline and linked to full references. Sources prioritize official clinical guidance, government health agencies, DSM-5-TR and ICD-11 materials, systematic reviews, meta-analyses, randomized trials, and peer-reviewed clinical reviews. All evidence was reviewed July 13, 2026.
+          Claims are cited inline and linked to full references. Sources prioritize official clinical guidance, government health agencies, DSM-5-TR and ICD-11 materials, systematic reviews, meta-analyses, randomized trials, and peer-reviewed clinical reviews. All evidence was reviewed July 15, 2026.
         </p>
         <p className="mt-3 max-w-4xl text-sm leading-6 text-muted">
           These pages are educational and cannot diagnose the reader or an absent third party. They also do not present herbs or supplements as replacements for psychotherapy, psychiatric care, or crisis treatment.
@@ -199,6 +250,27 @@ export default function MentalHealthGuidesHub() {
         <div className="mt-5 flex flex-wrap gap-3">
           <Link href="/info/methodology/" className="rounded-full bg-brand-700 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-brand-800">Read our methodology</Link>
           <Link href="/info/disclaimer/" className="rounded-full border border-brand-700 px-5 py-2.5 text-sm font-semibold text-brand-700 transition hover:bg-brand-50">Medical disclaimer</Link>
+        </div>
+      </section>
+
+      <section className="mt-10 grid gap-6 lg:grid-cols-2" aria-label="Sources and related education">
+        <div className="rounded-2xl border border-brand-900/10 bg-white p-6">
+          <h2 className="text-xl font-bold text-ink">Authoritative starting sources</h2>
+          <p className="mt-2 text-sm leading-6 text-muted">Individual guides include claim-level citations and full reference lists. These primary sources anchor the library’s definitions and classification context.</p>
+          <ul className="mt-4 space-y-3 text-sm leading-6">
+            <li><a href={SOURCE_LINKS.nimhOcd} className="font-semibold text-brand-700 hover:underline">National Institute of Mental Health: OCD</a></li>
+            <li><a href={SOURCE_LINKS.apaPersonalityDisorders} className="font-semibold text-brand-700 hover:underline">American Psychiatric Association: personality disorders</a></li>
+            <li><a href={SOURCE_LINKS.whoIc11} className="font-semibold text-brand-700 hover:underline">World Health Organization: ICD-11 clinical descriptions and diagnostic requirements</a></li>
+          </ul>
+        </div>
+        <div className="rounded-2xl border border-brand-900/10 bg-white p-6">
+          <h2 className="text-xl font-bold text-ink">Related education</h2>
+          <p className="mt-2 text-sm leading-6 text-muted">Use these explainers to evaluate evidence and understand overlapping processes without treating neuroscience as a diagnosis.</p>
+          <ul className="mt-4 space-y-3 text-sm leading-6">
+            <li><Link href="/learn/evidence-literacy/" className="font-semibold text-brand-700 hover:underline">Evidence literacy: how to assess a health claim →</Link></li>
+            <li><Link href="/learn/how-emotional-regulation-works/" className="font-semibold text-brand-700 hover:underline">How emotional regulation works →</Link></li>
+            <li><Link href="/learn/why-studies-conflict/" className="font-semibold text-brand-700 hover:underline">Why studies conflict →</Link></li>
+          </ul>
         </div>
       </section>
     </main>


### PR DESCRIPTION
## What changed

- Adds a direct-answer guide selector to the mental-health hub.
- Adds an accessible OCD/OCPD/personality-disorder comparison table.
- Links hub-level definitions to NIMH, APA, and WHO primary sources.
- Adds relevant internal education links and updates the evidence review date.
- Retains a navigation discovery regression test.

## Why

The hub had strong safety framing and complete article coverage, but users had to infer where to start. The new decision support makes the key distinctions immediately scannable and improves source transparency and internal discovery.

## Validation

- ESLint passed for the changed page.
- TypeScript passed.
- Mental-health navigation tests passed (2/2).
- Production static-export build passed all 20 steps.
- `npm run verify:output` passed.