### PR TITLE
Unify guides and learning under an Evidence Library

### DIFF
--- a/app/guides/page.tsx
+++ b/app/guides/page.tsx
@@ -3,12 +3,12 @@ import Link from 'next/link'
 import { SITE_URL } from '@/lib/navigation-config'
 
 export const metadata: Metadata = {
-  title: 'Evidence-Based Guides — Supplements & Mental Health',
-  description: 'Evidence-based guides to ADHD, sleep, anxiety, stress, focus, mental health, OCD, personality disorders, and individual herbs and supplements.',
+  title: 'Evidence Library — Supplements, Science & Mental Health',
+  description: 'One evidence library for guides, articles, and explainers covering ADHD, sleep, anxiety, focus, mental health, herbs, supplements, and research literacy.',
   alternates: { canonical: `${SITE_URL}/guides/` },
   openGraph: {
-    title: 'Evidence-Based Guides — The Hippie Scientist',
-    description: 'Browse citation-rich guides to supplements, health goals, OCD, personality disorders, safety, and treatment evidence.',
+    title: 'Evidence Library — The Hippie Scientist',
+    description: 'Browse citation-rich guides, mental health explainers, supplement comparisons, and science foundations in one organized library.',
     url: `${SITE_URL}/guides/`,
     type: 'website',
     images: ['/og-default.jpg'],
@@ -16,6 +16,13 @@ export const metadata: Metadata = {
 }
 
 const SECTIONS = [
+  {
+    title: 'Mental Health',
+    href: '/guides/mental-health/',
+    desc: 'OCD, BPD, and every named DSM-5-TR personality disorder — citation-rich guides covering diagnosis, differential diagnosis, treatment, safety, and stigma.',
+    color: 'border-l-cyan-600',
+    articles: ['OCD', 'Borderline personality disorder', 'Personality disorders overview', 'OCD vs OCPD', 'Avoidant personality disorder'],
+  },
   {
     title: 'ADHD',
     href: '/guides/adhd/',
@@ -38,13 +45,6 @@ const SECTIONS = [
     articles: ['Best herbs for anxiety', 'Best adaptogens for stress', 'How to lower cortisol', 'Ashwagandha for anxiety', 'L-theanine for calm'],
   },
   {
-    title: 'Mental Health',
-    href: '/guides/mental-health/',
-    desc: 'OCD, BPD, and every named DSM-5-TR personality disorder — citation-rich guides covering diagnosis, differential diagnosis, treatment, safety, and stigma.',
-    color: 'border-l-cyan-600',
-    articles: ['OCD', 'Borderline personality disorder', 'Personality disorders overview', 'OCD vs OCPD', 'Avoidant personality disorder'],
-  },
-  {
     title: 'Focus & Cognition',
     href: '/guides/focus/',
     desc: 'Nootropics, focus stacks, and cognitive enhancement — 6 guides on getting more from your brain.',
@@ -52,7 +52,7 @@ const SECTIONS = [
     articles: ['Best nootropics for focus', 'Focus without caffeine crash', 'L-theanine vs caffeine', 'Best focus supplements'],
   },
   {
-    title: 'Herb Profiles',
+    title: 'Herb Guides',
     href: '/guides/herbs/',
     desc: 'Deep-dive monographs on individual herbs — ashwagandha, kava, passionflower, rhodiola, turmeric.',
     color: 'border-l-green-600',
@@ -73,6 +73,13 @@ const SECTIONS = [
     articles: ['Best for blood pressure', 'Best for fat loss', 'Best for joint support', 'Best for gut health'],
   },
   {
+    title: 'Science Foundations',
+    href: '/learn/',
+    desc: 'Research literacy, neuroscience, interactions, and product quality explainers that make the rest of the library easier to evaluate.',
+    color: 'border-l-teal-600',
+    articles: ['Evidence literacy', 'How to read scientific studies', 'Neuroscience glossary', 'Interactions', 'Product quality'],
+  },
+  {
     title: 'Other & Harm Reduction',
     href: '/guides/other/healthy-dipping-tobacco-alternatives/',
     desc: 'Evidence-informed guides that sit outside the main goal clusters, including tobacco replacement, peptides, and psychoactive harm reduction.',
@@ -81,13 +88,13 @@ const SECTIONS = [
   },
 ]
 
-export default function GuidesHub() {
+export default function LibraryHub() {
   return (
     <div className="mx-auto max-w-5xl px-4 pb-24 pt-8">
       <header className="mb-12">
-        <h1 className="text-3xl font-bold text-ink sm:text-4xl">Supplement Guides &amp; Mental Health</h1>
+        <h1 className="text-3xl font-bold text-ink sm:text-4xl">Evidence Library</h1>
         <p className="mt-3 max-w-2xl text-lg text-muted">
-          Citation-rich guides organized by health goal and topic. Published research, visible references, safety context, and no bro-science.
+          Guides, articles, mental health explainers, comparisons, and science foundations — organized as one connected library instead of separate content silos.
         </p>
       </header>
 
@@ -110,8 +117,8 @@ export default function GuidesHub() {
       </div>
 
       <div className="mt-16 rounded-2xl border border-brand-900/10 bg-brand-50/50 p-8 text-center">
-        <h2 className="text-xl font-bold text-ink">Browse by database</h2>
-        <p className="mt-2 text-muted">Prefer to search structured data? Explore 290 herbs and 557 active compounds.</p>
+        <h2 className="text-xl font-bold text-ink">Browse the reference databases</h2>
+        <p className="mt-2 text-muted">Prefer structured profiles? Explore 290 herbs and 557 active compounds.</p>
         <div className="mt-4 flex justify-center gap-3">
           <Link href="/herbs/" className="rounded-full bg-brand-700 px-6 py-2.5 text-sm font-semibold text-white transition hover:bg-brand-800">Browse Herbs →</Link>
           <Link href="/compounds/" className="rounded-full border border-brand-700 px-6 py-2.5 text-sm font-semibold text-brand-700 transition hover:bg-brand-50">Browse Compounds →</Link>

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -6,13 +6,26 @@ import { usePathname } from 'next/navigation'
 import { Leaf, Menu, X } from 'lucide-react'
 import { GlobalSearchModal } from './search/GlobalSearchModal'
 import DarkModeToggle from './DarkModeToggle'
-import { mainNavigation } from '@/lib/navigation-config'
+import { primaryNavigation, type PrimaryNavigationItem } from '@/lib/primary-navigation'
 
-const primaryLinks = mainNavigation
+const primaryLinks = primaryNavigation
 
 function toCanonicalHref(href: string) {
   if (!href || href === '/' || href.includes('?') || href.includes('#')) return href
   return href.endsWith('/') ? href : `${href}/`
+}
+
+function groupChildren(children: PrimaryNavigationItem[] = []) {
+  const groups = new Map<string, PrimaryNavigationItem[]>()
+
+  for (const child of children) {
+    const section = child.section || ''
+    const existing = groups.get(section) || []
+    existing.push(child)
+    groups.set(section, existing)
+  }
+
+  return Array.from(groups.entries()).map(([section, items]) => ({ section, items }))
 }
 
 export function Navigation() {
@@ -35,11 +48,28 @@ export function Navigation() {
     return () => window.removeEventListener('keydown', onKey)
   }, [mobileOpen])
 
-  const isActive = (href: string) => {
-    if (href === '/') return pathname === '/'
-    if (href === '/guides') return pathname === '/guides' || pathname.startsWith('/guides/')
-    if (href === '/learn') return pathname === '/learn' || pathname.startsWith('/learn/') || pathname.startsWith('/novel-psychoactive-substances')
-    if (href === '/safety-checker') return pathname === '/safety-checker' || pathname.startsWith('/evidence/') || pathname.startsWith('/info/dosing') || pathname.startsWith('/info/supplement-safety-checklist')
+  const isPrimaryActive = (link: PrimaryNavigationItem) => {
+    if (link.label === 'Library') {
+      return pathname === '/guides'
+        || pathname.startsWith('/guides/')
+        || pathname === '/learn'
+        || pathname.startsWith('/learn/')
+        || pathname.startsWith('/novel-psychoactive-substances')
+    }
+
+    if (link.href === '/safety-checker') {
+      return pathname === '/safety-checker'
+        || pathname.startsWith('/evidence/')
+        || pathname.startsWith('/info/dosing')
+        || pathname.startsWith('/info/supplement-safety-checklist')
+        || pathname.startsWith('/info/infographics')
+    }
+
+    return pathname === link.href || pathname.startsWith(link.href + '/')
+  }
+
+  const isChildActive = (href: string) => {
+    if (href === '/guides' || href === '/learn') return pathname === href
     return pathname === href || pathname.startsWith(href + '/')
   }
 
@@ -68,15 +98,18 @@ export function Navigation() {
           <div className='hidden items-center gap-6 text-sm md:flex lg:gap-8'>
             {primaryLinks.map((link) => {
               const hasChildren = Boolean(link.children?.length)
+              const childGroups = groupChildren(link.children)
+              const isMegaMenu = childGroups.length > 1
+              const active = isPrimaryActive(link)
 
               return (
                 <div key={link.href} className='group relative'>
                   <Link
                     href={toCanonicalHref(link.href)}
-                    aria-current={isActive(link.href) ? 'page' : undefined}
+                    aria-current={active ? 'page' : undefined}
                     aria-haspopup={hasChildren ? 'true' : undefined}
                     className={`relative flex items-center gap-1 py-2 font-semibold transition-colors ${
-                      isActive(link.href)
+                      active
                         ? 'text-[#123c2f] after:absolute after:inset-x-0 after:-bottom-0.5 after:h-0.5 after:rounded-full after:bg-[#b88a42] dark:text-[var(--text-primary)]'
                         : 'text-[#44544d] hover:text-[#123c2f] dark:text-[var(--text-secondary)] dark:hover:text-[var(--text-primary)]'
                     }`}
@@ -90,20 +123,33 @@ export function Navigation() {
                   </Link>
 
                   {hasChildren ? (
-                    <div className='invisible absolute left-1/2 top-full z-50 w-72 -translate-x-1/2 pt-3 opacity-0 transition duration-150 ease-out group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100'>
-                      <div className='overflow-hidden rounded-3xl border border-[#123c2f]/10 bg-[#fffdf8] p-2 shadow-[0_18px_48px_rgba(45,35,19,0.14)] ring-1 ring-white/60 dark:border-[var(--border-strong)] dark:bg-[var(--surface-card-strong)] dark:ring-white/5'>
-                        {link.children?.map((child) => (
-                          <Link
-                            key={child.href}
-                            href={toCanonicalHref(child.href)}
-                            aria-current={isActive(child.href) ? 'page' : undefined}
-                            className='block rounded-2xl px-4 py-3 transition hover:bg-[#f5efe2] focus-visible:bg-[#f5efe2] focus-visible:outline-none dark:hover:bg-[var(--surface-subtle)] dark:focus-visible:bg-[var(--surface-subtle)]'
-                          >
-                            <span className='block text-sm font-semibold text-[#123c2f] dark:text-[var(--text-primary)]'>{child.label}</span>
-                            {child.description ? (
-                              <span className='mt-1 block text-xs leading-snug text-[#526159] dark:text-[var(--text-secondary)]'>{child.description}</span>
+                    <div
+                      className={`invisible absolute left-1/2 top-full z-50 -translate-x-1/2 pt-3 opacity-0 transition duration-150 ease-out group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100 ${
+                        isMegaMenu ? 'w-[min(58rem,calc(100vw-2rem))]' : 'w-72'
+                      }`}
+                    >
+                      <div className={`overflow-hidden rounded-3xl border border-[#123c2f]/10 bg-[#fffdf8] shadow-[0_18px_48px_rgba(45,35,19,0.14)] ring-1 ring-white/60 dark:border-[var(--border-strong)] dark:bg-[var(--surface-card-strong)] dark:ring-white/5 ${isMegaMenu ? 'grid grid-cols-3 gap-2 p-3' : 'p-2'}`}>
+                        {childGroups.map(({ section, items }) => (
+                          <div key={section || 'links'} className={isMegaMenu ? 'rounded-2xl bg-[#f8f3e8]/55 p-2 dark:bg-[var(--surface-subtle)]' : ''}>
+                            {section ? (
+                              <p className='px-3 pb-1 pt-2 text-[0.68rem] font-extrabold uppercase tracking-[0.16em] text-[#8a6a38] dark:text-[var(--accent-gold)]'>
+                                {section}
+                              </p>
                             ) : null}
-                          </Link>
+                            {items.map((child) => (
+                              <Link
+                                key={child.href}
+                                href={toCanonicalHref(child.href)}
+                                aria-current={isChildActive(child.href) ? 'page' : undefined}
+                                className='block rounded-2xl px-3 py-2.5 transition hover:bg-[#f5efe2] focus-visible:bg-[#f5efe2] focus-visible:outline-none dark:hover:bg-[var(--surface-card)] dark:focus-visible:bg-[var(--surface-card)]'
+                              >
+                                <span className='block text-sm font-semibold text-[#123c2f] dark:text-[var(--text-primary)]'>{child.label}</span>
+                                {child.description ? (
+                                  <span className='mt-1 block text-xs leading-snug text-[#526159] dark:text-[var(--text-secondary)]'>{child.description}</span>
+                                ) : null}
+                              </Link>
+                            ))}
+                          </div>
                         ))}
                       </div>
                     </div>
@@ -160,37 +206,51 @@ export function Navigation() {
             </div>
 
             <nav className='flex flex-col gap-2 text-base' aria-label='Mobile primary links'>
-              {primaryLinks.map((link) => (
-                <div key={link.href}>
-                  <Link
-                    href={toCanonicalHref(link.href)}
-                    onClick={closeMobile}
-                    aria-current={isActive(link.href) ? 'page' : undefined}
-                    className={`block rounded-2xl px-4 py-3.5 font-semibold transition ${
-                      isActive(link.href)
-                        ? 'border border-[#b88a42]/20 bg-[#f5efe2] text-[#123c2f] shadow-sm dark:border-[var(--border-strong)] dark:bg-[var(--surface-subtle)] dark:text-[var(--text-primary)]'
-                        : 'text-[#33433c] hover:bg-[#f5efe2]/70 hover:text-[#123c2f] dark:text-[var(--text-secondary)] dark:hover:bg-[var(--surface-subtle)] dark:hover:text-[var(--text-primary)]'
-                    }`}
-                  >
-                    {link.label}
-                  </Link>
-                  {link.children && link.children.length > 0 ? (
-                    <div className='ml-4 mt-2 border-l border-[#123c2f]/10 pl-3 dark:border-[var(--border-soft)]'>
-                      {link.children.map((child) => (
-                        <Link
-                          key={child.href}
-                          href={toCanonicalHref(child.href)}
-                          onClick={closeMobile}
-                          aria-current={isActive(child.href) ? 'page' : undefined}
-                          className='block rounded-xl px-3 py-2.5 text-sm font-medium text-[#526159] transition hover:bg-[#f5efe2]/65 hover:text-[#123c2f] dark:text-[var(--text-secondary)] dark:hover:bg-[var(--surface-subtle)] dark:hover:text-[var(--text-primary)]'
-                        >
-                          {child.label}
-                        </Link>
-                      ))}
-                    </div>
-                  ) : null}
-                </div>
-              ))}
+              {primaryLinks.map((link) => {
+                const childGroups = groupChildren(link.children)
+                const active = isPrimaryActive(link)
+
+                return (
+                  <div key={link.href}>
+                    <Link
+                      href={toCanonicalHref(link.href)}
+                      onClick={closeMobile}
+                      aria-current={active ? 'page' : undefined}
+                      className={`block rounded-2xl px-4 py-3.5 font-semibold transition ${
+                        active
+                          ? 'border border-[#b88a42]/20 bg-[#f5efe2] text-[#123c2f] shadow-sm dark:border-[var(--border-strong)] dark:bg-[var(--surface-subtle)] dark:text-[var(--text-primary)]'
+                          : 'text-[#33433c] hover:bg-[#f5efe2]/70 hover:text-[#123c2f] dark:text-[var(--text-secondary)] dark:hover:bg-[var(--surface-subtle)] dark:hover:text-[var(--text-primary)]'
+                      }`}
+                    >
+                      {link.label}
+                    </Link>
+                    {childGroups.length > 0 ? (
+                      <div className='ml-4 mt-2 border-l border-[#123c2f]/10 pl-3 dark:border-[var(--border-soft)]'>
+                        {childGroups.map(({ section, items }) => (
+                          <div key={section || 'links'} className={section ? 'pb-2' : ''}>
+                            {section ? (
+                              <p className='px-3 pb-1 pt-3 text-[0.66rem] font-extrabold uppercase tracking-[0.15em] text-[#8a6a38] dark:text-[var(--accent-gold)]'>
+                                {section}
+                              </p>
+                            ) : null}
+                            {items.map((child) => (
+                              <Link
+                                key={child.href}
+                                href={toCanonicalHref(child.href)}
+                                onClick={closeMobile}
+                                aria-current={isChildActive(child.href) ? 'page' : undefined}
+                                className='block rounded-xl px-3 py-2.5 text-sm font-medium text-[#526159] transition hover:bg-[#f5efe2]/65 hover:text-[#123c2f] dark:text-[var(--text-secondary)] dark:hover:bg-[var(--surface-subtle)] dark:hover:text-[var(--text-primary)]'
+                              >
+                                {child.label}
+                              </Link>
+                            ))}
+                          </div>
+                        ))}
+                      </div>
+                    ) : null}
+                  </div>
+                )
+              })}
 
               <div className='my-2 h-px bg-[#123c2f]/10 dark:bg-[var(--border-soft)]' />
               <div className='flex items-center justify-between rounded-2xl border border-[#123c2f]/10 bg-[#f5efe2]/65 px-4 py-3 dark:border-[var(--border-soft)] dark:bg-[var(--surface-subtle)]'>

--- a/components/NavigationSchema.tsx
+++ b/components/NavigationSchema.tsx
@@ -9,7 +9,8 @@
  * @component
  */
 
-import { mainNavigation, SITE_URL } from '@/lib/navigation-config'
+import { SITE_URL } from '@/lib/navigation-config'
+import { primaryNavigation } from '@/lib/primary-navigation'
 import { serializeJsonLd } from '@/src/lib/schema-injector'
 
 /**
@@ -27,7 +28,7 @@ function generateNavigationSchema() {
    * Flatten hierarchical navigation into flat array for schema
    */
   const flattenNav = (
-    items: typeof mainNavigation
+    items: typeof primaryNavigation
   ): Array<{ label: string; href: string }> => {
     const result: Array<{ label: string; href: string }> = []
 
@@ -41,7 +42,7 @@ function generateNavigationSchema() {
     return result
   }
 
-  const flatItems = flattenNav(mainNavigation)
+  const flatItems = flattenNav(primaryNavigation)
 
   for (const item of flatItems) {
     hasPart.push({

--- a/lib/primary-navigation.ts
+++ b/lib/primary-navigation.ts
@@ -1,0 +1,67 @@
+export interface PrimaryNavigationItem {
+  label: string
+  href: string
+  description?: string
+  children?: PrimaryNavigationItem[]
+  section?: string
+}
+
+export const primaryNavigation: PrimaryNavigationItem[] = [
+  {
+    label: 'Herbs',
+    href: '/herbs',
+    description: 'Evidence-graded herb profiles — effects, safety, dosing, and pharmacology',
+    children: [
+      { label: 'Browse all herbs', href: '/herbs', description: 'Alphabetical herb database with evidence and safety summaries' },
+      { label: 'Herb guides', href: '/guides/herbs', description: 'Editorial herb explainers and practical use guides' },
+      { label: 'Compare herbs', href: '/guides/compare', description: 'Side-by-side tradeoffs for popular botanicals and supplements' },
+    ],
+  },
+  {
+    label: 'Compounds',
+    href: '/compounds',
+    description: 'Evidence-graded compound profiles with mechanisms, safety context, and research summaries',
+    children: [
+      { label: 'Browse all compounds', href: '/compounds', description: 'Active compounds, nutrients, and standardized extracts' },
+      { label: 'Evidence lookup', href: '/evidence/evidence-checker', description: 'Filter compounds by clinical evidence grade' },
+      { label: 'Dosing guide', href: '/info/dosing', description: 'Bioavailability, timing, stacking, and dose realism basics' },
+    ],
+  },
+  {
+    label: 'Library',
+    href: '/guides',
+    description: 'Guides, articles, and science explainers organized in one library',
+    children: [
+      { section: 'Browse by topic', label: 'Mental Health', href: '/guides/mental-health', description: 'OCD, personality disorders, treatment evidence, safety, and stigma' },
+      { section: 'Browse by topic', label: 'ADHD', href: '/guides/adhd', description: 'Attention, executive function, nutrients, and treatment context' },
+      { section: 'Browse by topic', label: 'Sleep', href: '/guides/sleep', description: 'Sleep aids, melatonin alternatives, and sleep hygiene' },
+      { section: 'Browse by topic', label: 'Anxiety & Stress', href: '/guides/anxiety', description: 'Adaptogens, anxiolytics, and stress-management evidence' },
+      { section: 'Browse by topic', label: 'Focus & Cognition', href: '/guides/focus', description: 'Nootropics, focus stacks, and cognitive performance' },
+      { section: 'Practical content', label: 'All guides', href: '/guides', description: 'Browse the complete problem-solving guide library' },
+      { section: 'Practical content', label: 'Herb guides', href: '/guides/herbs', description: 'Deep dives on individual herbs and botanicals' },
+      { section: 'Practical content', label: 'Comparisons', href: '/guides/compare', description: 'Side-by-side supplement and compound tradeoffs' },
+      { section: 'Practical content', label: 'Best supplements', href: '/guides/best', description: 'Curated recommendations organized by need' },
+      { section: 'Science foundations', label: 'Learning library', href: '/learn', description: 'Evidence, neurochemistry, safety, and research explainers' },
+      { section: 'Science foundations', label: 'Evidence literacy', href: '/learn/evidence-literacy', description: 'Interpret supplement research without the hype' },
+      { section: 'Science foundations', label: 'How to read studies', href: '/learn/how-to-read-scientific-studies', description: 'Trial design, endpoints, bias, and practical interpretation' },
+      { section: 'Science foundations', label: 'Neuroscience glossary', href: '/learn/neuroscience-glossary', description: 'Plain-English brain and receptor terminology' },
+      { section: 'Science foundations', label: 'Interactions', href: '/learn/interactions', description: 'Why herb-drug and supplement interactions matter' },
+      { section: 'Science foundations', label: 'Product quality', href: '/learn/product-quality', description: 'Labels, standardization, testing, and quality signals' },
+      { section: 'Science foundations', label: 'Novel psychoactives', href: '/novel-psychoactive-substances', description: 'Harm-reduction profiles for emerging substances' },
+    ],
+  },
+  {
+    label: 'Tools',
+    href: '/safety-checker',
+    description: 'Safety checkers, evidence lookup, and practical resources',
+    children: [
+      { label: 'Safety checker', href: '/safety-checker', description: 'Herb-drug interaction and contraindication lookup' },
+      { label: 'Evidence lookup', href: '/evidence/evidence-checker', description: 'Search compounds by clinical evidence grade' },
+      { label: 'Evidence report', href: '/evidence/evidence-report', description: 'State of Supplement Evidence — annual research review' },
+      { label: 'Evidence digest', href: '/evidence/evidence-digest', description: 'Recent human-trial highlights and research summaries' },
+      { label: 'Dosing guide', href: '/info/dosing', description: 'Bioavailability, timing, and stacking guidelines' },
+      { label: 'Supplement checklist', href: '/info/supplement-safety-checklist', description: 'What to verify before buying any supplement' },
+      { label: 'Infographics', href: '/info/infographics', description: 'Shareable evidence-based supplement visuals' },
+    ],
+  },
+]

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { BookOpen, FlaskConical, Leaf, Scale, Search, Shapes } from 'lucide-react'
+import { BookOpen, Brain, Leaf, Scale, Search, Shapes } from 'lucide-react'
 import { Link } from '../lib/router-compat'
 import ConsentManager from './ConsentManager'
 import { onOpenConsent } from '../lib/consentBus'
@@ -9,18 +9,19 @@ import { isAnalyticsRouteEnabled } from '../lib/analyticsAccess'
 import { PUBLIC_ROUTES } from '../lib/public-routes'
 
 const exploreLinks = [
-  { href: PUBLIC_ROUTES.guides, label: 'All Guides', Icon: BookOpen },
+  { href: PUBLIC_ROUTES.guides, label: 'Library', Icon: BookOpen },
+  { href: '/guides/mental-health/', label: 'Mental Health', Icon: Brain },
   { href: PUBLIC_ROUTES.herbs, label: 'Herb Database', Icon: Leaf },
   { href: PUBLIC_ROUTES.compounds, label: 'Compounds', Icon: Shapes },
   { href: '/guides/compare/', label: 'Compare', Icon: Scale },
-  { href: '/learn/', label: 'Learn the Science', Icon: FlaskConical },
   { href: '/search/', label: 'Search', Icon: Search },
 ]
 
 const priorityGoalLinks = [
+  { href: '/guides/mental-health/', label: 'Mental Health' },
   { href: '/guides/sleep/', label: 'Sleep' },
-  { href: '/guides/anxiety/', label: 'Stress' },
-  { href: '/guides/anxiety/', label: 'Anxiety' },
+  { href: '/guides/adhd/', label: 'ADHD' },
+  { href: '/guides/anxiety/', label: 'Anxiety & Stress' },
   { href: '/guides/focus/', label: 'Focus' },
 ]
 
@@ -121,7 +122,7 @@ export default function Footer() {
 
             <div className='mt-8 grid gap-7 sm:grid-cols-3'>
               <div>
-                <h3 className='text-xs font-extrabold uppercase tracking-[0.15em] text-[#315f50] dark:text-[#8dc49a]'>Popular goals</h3>
+                <h3 className='text-xs font-extrabold uppercase tracking-[0.15em] text-[#315f50] dark:text-[#8dc49a]'>Popular topics</h3>
                 <ul className='mt-3 space-y-2'>
                   {priorityGoalLinks.map((link) => (
                     <li key={`${link.href}-${link.label}`}>


### PR DESCRIPTION
### What changed
- Replaced separate Guides and Learn top-level navigation with one `Library` entry.
- Added a three-column desktop mega-menu organized into Browse by topic, Practical content, and Science foundations.
- Mirrored the same hierarchy in mobile navigation.
- Moved Mental Health to the first topic position for stronger discoverability.
- Updated the `/guides/` hub to present as the Evidence Library and added Science Foundations as a first-class section.
- Updated the footer and navigation JSON-LD to use the unified structure.

### Why
The existing Guides/Learn split made related articles and explainers feel like separate products. This creates one coherent content destination while keeping Herbs, Compounds, and Tools distinct.

### Validation
- Branch is cleanly based on current `main` with no divergence.
- GitHub Actions should run the repository typecheck, lint, tests, and build checks.