### PR TITLE
Fix stale guides core-route verification

### DIFF
--- a/scripts/verify-core-routes.mjs
+++ b/scripts/verify-core-routes.mjs
@@ -76,7 +76,7 @@ const routeContentExpectations = [
   },
   {
     route: '/guides',
-    required: ['Supplement Guides', 'Browse by database'],
+    required: ['Evidence Library', 'Browse the reference databases'],
     forbidden: [LOADING_SENTINEL, 'Find the right supplement path for your goals.'],
   },
 ]


### PR DESCRIPTION
### Fix
Update `scripts/verify-core-routes.mjs` so `/guides` is validated against the current Evidence Library copy instead of the retired Supplement Guides copy.

### Root cause
The production build succeeded, but `verify:postbuild` failed because the verifier still required:
- `Supplement Guides`
- `Browse by database`

The current page renders:
- `Evidence Library`
- `Browse the reference databases`

This is a test expectation update only; no user-facing page behavior changes.