### PR TITLE
Fix stale mobile nav assertion in route-consolidation-guardrails test

### DIFF
--- a/app/__tests__/route-consolidation-guardrails.test.ts
+++ b/app/__tests__/route-consolidation-guardrails.test.ts
@@ -30,7 +30,7 @@ describe('route consolidation guardrails', () => {
     const legacyPrefixes = ['/articles', '/compare', '/goals', '/stacks']
     const navHrefs = mobileBottomNavItems.map((item) => item.href)
 
-    expect(navHrefs).toEqual(['/guides', '/herbs', '/search', '/compounds', '/guides/best'])
+    expect(navHrefs).toEqual(['/library', '/herbs', '/search', '/compounds', '/guides/best'])
 
     for (const href of navHrefs) {
       expect(legacyPrefixes.some((legacyPrefix) => href === legacyPrefix || href.startsWith(`${legacyPrefix}/`))).toBe(false)


### PR DESCRIPTION
## Summary

- `app/__tests__/route-consolidation-guardrails.test.ts` still asserted the mobile bottom nav's first item was `/guides`, but that item was renamed to `/library` three commits ago on `main` (`Rename mobile bottom nav Guides label to Library` → `Add dedicated Library page route` → `Point mobile Library nav item to Library page`). The test was never updated, so `npm run test` currently fails on `main`.
- Confirmed `/library` is intentional and live (`app/library/page.tsx` exists, `src/components/mobile-bottom-nav.tsx` points there), so this is a one-line test-assertion fix, not a nav revert.

## Verification

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` — 584/584 passing (was 583/584 on `main`)
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs (no data files touched)
- [x] no generated file corruption (no generated files touched)
- [x] static export compatible (test-only change)

## Risk Notes

- Test-only change, no application code or data touched. Zero behavioral impact on the live site.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FEB5YVG1fwHx37TWm7bxb3)_