### PR TITLE
Add standing audit script for severity-token-only compound contraindications

### DIFF
--- a/docs/LOOP_NOTES.md
+++ b/docs/LOOP_NOTES.md
@@ -1629,3 +1629,64 @@ initial `data:build:core`, again after `npm run check` re-ran it internally).
 should remain** (63 minus this cycle's 6) — re-run the detection query fresh next
 cycle rather than trusting this count, and check open PRs' touched files first given
 how much concurrent activity this thread continues to attract.
+
+---
+
+## 2026-07-14 (later) — Built the standing `audit:severity-tokens` script; skipped content fill this cycle due to heavy in-flight concurrency
+
+At least six entries above independently flagged the same thing: the
+"token-only `contraindications_or_flags`" detection query (bare severity/
+category tokens like `moderate`, `kidney`, `pregnancy,liver,kidney` passing
+the naive non-empty check) was hand-rolled from scratch in nearly every
+cycle that touched this thread, with two entries explicitly recommending it
+become a standing script instead. Checking `list_pull_requests` at the start
+of this cycle found 3 open PRs already active on this exact thread (#2263,
+#2262, #2260, plus #2242 recomputing indexability scores on related
+compounds) — picking yet another 5-6 slugs risked a fourth concurrent
+collision on top of the ones already documented at length above, for
+diminishing marginal value. Built the tooling fix instead, per this
+prompt's own self-improvement allowance.
+
+Added `scripts/audit-severity-token-contraindications.mjs`
+(`npm run audit:severity-tokens`), matching the existing
+`audit-safety-fill-rate.mjs`/`audit-risk-tag-collisions.mjs` conventions
+(same `Entity_Master` sheet resolution, same `assertWorkbookExists` guard).
+Exports `classifyContraindicationValue()` — EMPTY / TOKEN_ONLY / PROSE — and
+cross-references `public/data/compounds.json` for
+`runtime_export_decision === 'full_public_runtime'` so the report only
+surfaces gaps on live, indexed pages, not the full workbook population.
+TOKEN_ONLY is defined precisely as: every comma/semicolon-separated
+fragment matches `/^[a-z][a-z_]*$/i` (no whitespace) — a single real prose
+fragment among several tokens correctly classifies the whole value as
+PROSE, so it won't false-positive on a mixed legitimate value. Added
+`scripts/audit-severity-token-contraindications.test.mjs` covering all
+three classifications plus the mixed-value edge case.
+
+Ran it against the live workbook: **62 `full_public_runtime` compounds
+currently have a gap** (44 with variant/component-cluster slugs the prior
+entries repeatedly and deliberately skipped for the same undecided
+variant-naming-policy reason — `betaine`/`betaine-hcl`/`betaine-anhydrous`/
+`betaine-nitrate`, `taurine-blend`/`taurine-sleep`, `probiotics` and its
+strain variants, `atractylenolide-i/ii/iii`, `gingerol`/`gingerols`,
+`ginkgolide-b`/`ginkgolides`, `inositol-sleep`/`inositol-hexanicotinate`,
+boswellic-acid variants, `maca-root-extract`/`macamides`,
+`garlic-aged-extract`/`aged-garlic-extract` — plus `aucubin`, the
+already-documented deferred case). This confirms the script produces the
+same shape of list prior cycles derived by hand, and is ready to save the
+next several cycles from re-deriving it.
+
+Confirmed via `list_pull_requests` — the same standing-script gap this
+cycle closed is exactly what earlier entries called out as unaddressed:
+"consider building the standing script... before hand-rolling the query
+yet again." Also confirmed the variant-naming-policy question (should
+`betaine`, `betaine-hcl`, `betaine-anhydrous`, and `betaine-nitrate` share
+one sourced contraindications clause or each get independently sourced
+text?) is still open after ~8 entries mentioning it — worth a human
+decision before a future cycle either fills all variants identically or
+keeps skipping them indefinitely.
+
+`npm run lint`, `npm run typecheck`, and the full Vitest suite (592/592,
+now including the 5 new test cases) all passed clean. No workbook or
+`public/data` changes this cycle — diff is exactly the two new script
+files plus one `package.json` line, zero collision risk with any in-flight
+PR.

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "audit:source-of-truth": "STRICT_SOURCE_AUDIT=true node scripts/data/audit-source-of-truth.mjs",
     "audit:safety": "node scripts/audit-safety-fill-rate.mjs",
     "audit:risk-tag-collisions": "node scripts/audit-risk-tag-collisions.mjs",
+    "audit:severity-tokens": "node scripts/audit-severity-token-contraindications.mjs",
     "audit:duplicates": "node scripts/audit/find-duplicate-slugs.mjs",
     "audit:content-gaps": "node scripts/audit/content-gap-report.mjs",
     "audit:sitemap": "node scripts/audit/validate-sitemap-canonicals.mjs",

--- a/scripts/audit-severity-token-contraindications.mjs
+++ b/scripts/audit-severity-token-contraindications.mjs
@@ -118,7 +118,9 @@ async function main() {
   console.log(lines.join('\n'))
 }
 
-main().catch((error) => {
-  console.error(error)
-  process.exit(1)
-})
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })
+}

--- a/scripts/audit-severity-token-contraindications.mjs
+++ b/scripts/audit-severity-token-contraindications.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+// Standing script for a query that has been hand-rolled from scratch in
+// numerous separate enrichment cycles (see docs/LOOP_NOTES.md, the
+// "severity-tier-only compound contraindications" thread): a population of
+// compounds whose `contraindications_or_flags` workbook cell holds a bare
+// severity/category token (e.g. "moderate", "kidney", "pregnancy,liver")
+// instead of real sourced safety prose. Non-empty tokens like this pass the
+// naive "is this field filled?" check in `audit-safety-fill-rate.mjs`, so
+// they only ever surfaced via a one-off regex query re-derived by hand each
+// cycle. This script formalizes that query so future cycles can just run it.
+import { assertWorkbookExists, resolveWorkbookPath } from './workbook-source.mjs'
+import { getSheet, readWorkbook, sheetToRows } from './data/workbook-parser.mjs'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+const ENTITY_SHEET_CANDIDATES = ['Entity_Master', 'Sheet7']
+
+function clean(value) {
+  return String(value ?? '').trim()
+}
+
+function slugFor(row, index) {
+  return (
+    clean(row.slug) ||
+    clean(row.canonical_slug) ||
+    clean(row.canonicalCompoundId) ||
+    clean(row.compoundName) ||
+    clean(row.name) ||
+    `compound-${index + 1}`
+  )
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+}
+
+// A "token" fragment is a bare identifier with no whitespace — real prose
+// clauses are always multi-word sentences. A value only counts as
+// TOKEN_ONLY when every comma/semicolon-separated fragment matches this
+// shape; a single stray real clause among several tokens is enough to
+// classify the whole value as PROSE.
+const TOKEN_FRAGMENT = /^[a-z][a-z_]*$/i
+
+export function classifyContraindicationValue(rawValue) {
+  const value = clean(rawValue)
+  if (!value) return 'EMPTY'
+  const fragments = value
+    .split(/[,;]+/)
+    .map((fragment) => fragment.trim())
+    .filter(Boolean)
+  if (fragments.length > 0 && fragments.every((fragment) => TOKEN_FRAGMENT.test(fragment))) {
+    return 'TOKEN_ONLY'
+  }
+  return 'PROSE'
+}
+
+function resolveSheetName(workbook, candidates) {
+  return candidates.find((candidate) => getSheet(workbook, candidate)) || null
+}
+
+async function loadRuntimeExportDecisions(repoRoot) {
+  const compoundsPath = path.join(repoRoot, 'public', 'data', 'compounds.json')
+  const raw = await readFile(compoundsPath, 'utf8')
+  const compounds = JSON.parse(raw)
+  const bySlug = new Map()
+  for (const compound of compounds) {
+    if (compound?.slug) bySlug.set(compound.slug, compound.runtime_export_decision ?? null)
+  }
+  return bySlug
+}
+
+async function main() {
+  const repoRoot = process.cwd()
+  const workbookPath = resolveWorkbookPath(repoRoot)
+  assertWorkbookExists(workbookPath)
+  const workbook = await readWorkbook(workbookPath)
+
+  const entitySheetName = resolveSheetName(workbook, ENTITY_SHEET_CANDIDATES)
+  if (!entitySheetName) {
+    throw new Error(
+      `[audit:severity-tokens] could not find the entity sheet — tried ${ENTITY_SHEET_CANDIDATES.join(', ')}`,
+    )
+  }
+  const rows = sheetToRows(getSheet(workbook, entitySheetName)).filter(
+    (row) => clean(row.entity_type).toLowerCase() === 'compound',
+  )
+
+  const runtimeDecisions = await loadRuntimeExportDecisions(repoRoot)
+
+  const records = rows.map((row, index) => {
+    const slug = slugFor(row, index)
+    return {
+      slug,
+      value: clean(row.contraindications_or_flags),
+      status: classifyContraindicationValue(row.contraindications_or_flags),
+      runtimeExportDecision: runtimeDecisions.get(slug) ?? null,
+    }
+  })
+
+  const gaps = records.filter((record) => record.status !== 'PROSE')
+  const fullPublicGaps = gaps
+    .filter((record) => record.runtimeExportDecision === 'full_public_runtime')
+    .sort((a, b) => a.slug.localeCompare(b.slug))
+
+  const lines = [
+    'SEVERITY-TOKEN / EMPTY CONTRAINDICATIONS REPORT',
+    '================================================',
+    `Total compounds in workbook: ${records.length}`,
+    `Empty contraindications_or_flags: ${gaps.filter((r) => r.status === 'EMPTY').length}`,
+    `Token-only contraindications_or_flags: ${gaps.filter((r) => r.status === 'TOKEN_ONLY').length}`,
+    `Real prose: ${records.length - gaps.length}`,
+    '',
+    `full_public_runtime compounds with a gap (empty or token-only): ${fullPublicGaps.length}`,
+    ...fullPublicGaps.map((record) => `  ${record.slug} — ${record.status}${record.value ? ` (${record.value})` : ''}`),
+  ]
+
+  console.log(lines.join('\n'))
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/scripts/audit-severity-token-contraindications.test.mjs
+++ b/scripts/audit-severity-token-contraindications.test.mjs
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { classifyContraindicationValue } from './audit-severity-token-contraindications.mjs'
+
+describe('classifyContraindicationValue', () => {
+  it('classifies an empty value as EMPTY', () => {
+    expect(classifyContraindicationValue('')).toBe('EMPTY')
+    expect(classifyContraindicationValue('   ')).toBe('EMPTY')
+    expect(classifyContraindicationValue(undefined)).toBe('EMPTY')
+  })
+
+  it('classifies a bare single token as TOKEN_ONLY', () => {
+    expect(classifyContraindicationValue('moderate')).toBe('TOKEN_ONLY')
+    expect(classifyContraindicationValue('kidney')).toBe('TOKEN_ONLY')
+    expect(classifyContraindicationValue('low_to_moderate')).toBe('TOKEN_ONLY')
+  })
+
+  it('classifies comma/semicolon-separated bare tokens as TOKEN_ONLY', () => {
+    expect(classifyContraindicationValue('pregnancy,liver,kidney')).toBe('TOKEN_ONLY')
+    expect(classifyContraindicationValue('pregnancy; liver; kidney')).toBe('TOKEN_ONLY')
+  })
+
+  it('classifies real sourced prose as PROSE', () => {
+    expect(
+      classifyContraindicationValue(
+        'Avoid with warfarin due to a documented bleeding-risk interaction; discontinue before any procedure requiring general anesthesia.',
+      ),
+    ).toBe('PROSE')
+  })
+
+  it('classifies a value with a mix of tokens and prose as PROSE', () => {
+    expect(classifyContraindicationValue('pregnancy; avoid in patients with a history of seizures')).toBe('PROSE')
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `scripts/audit-severity-token-contraindications.mjs` (`npm run audit:severity-tokens`), a standing script that detects compounds whose `contraindications_or_flags` workbook cell holds a bare severity/category token (e.g. `moderate`, `kidney`, `pregnancy,liver,kidney`) instead of real sourced safety prose, cross-referenced against `public/data/compounds.json` for `runtime_export_decision === 'full_public_runtime'` (i.e. gaps that are actually live on indexed pages).
- This formalizes a query that has been hand-rolled from scratch in numerous separate autonomous enrichment cycles (documented at length in `docs/LOOP_NOTES.md`), with prior cycles explicitly recommending it become a standing script instead of re-derived by hand each time.
- Exports `classifyContraindicationValue()` (EMPTY / TOKEN_ONLY / PROSE) with a small test suite (`scripts/audit-severity-token-contraindications.test.mjs`).
- No workbook or `public/data` changes — this is tooling only.

No content fill this cycle: at the time of writing, 3 open PRs (#2263, #2262, #2260) were already actively working the same compound-contraindications-fill thread, plus #2242 on related indexability recomputation. Adding a tooling fix with zero collision risk was higher-ROI than risking a fourth concurrent collision on the same handful of compound slugs.

## Verification

- [x] `npm run lint`
- [x] `npm run check`
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs
- [x] no generated file corruption
- [x] static export compatible (no build-affecting changes)

## Risk Notes

- Pure addition (new script + test + one `package.json` line + a `docs/LOOP_NOTES.md` entry). No existing behavior changed.


---
_Generated by [Claude Code](https://claude.ai/code/session_016haF4gAp1av2qQxNS7X43i)_