### PR TITLE
Fix false positives in audit:curated-indexable for deliberate governance holds

### DIFF
--- a/docs/LOOP_NOTES.md
+++ b/docs/LOOP_NOTES.md
@@ -1690,3 +1690,72 @@ now including the 5 new test cases) all passed clean. No workbook or
 `public/data` changes this cycle — diff is exactly the two new script
 files plus one `package.json` line, zero collision risk with any in-flight
 PR.
+
+---
+
+## 2026-07-14 (later still) — Fixed `audit:curated-indexable`'s false positives on deliberate governance holds
+
+PR #2270 (open, unmerged as of this cycle) fixed a real leaked-template-text
+bug on `ginger`/`peppermint` that `npm run audit:curated-indexable` caught,
+but its own description flagged 3 more of that audit's 10 reported
+"regressions" — `black-cohosh`, `phosphatidylcholine`, `acetyl-l-carnitine`
+— as false positives: deliberate governance holds (`hidden_until_grounded` /
+`research_only`), not bugs, and explicitly left them untouched. The PR
+suggested as a next step: "either clear the 3 remaining holds or teach the
+guard to distinguish intentional holds from regressions, then wire
+`audit:curated-indexable` into `check:full`." Since #2270 was already
+mid-flight on the real bug, this cycle picked up the second half instead —
+the audit-accuracy fix is orthogonal and doesn't collide.
+
+Traced why these 3 are safe to hold rather than a live SEO bug first, since
+`src/lib/index-allowlist.ts`'s curated slugs get special-cased in both
+`src/lib/seo.ts` (`shouldIndexRoute`) and `app/sitemap.ts` (`addRoute`) —
+worth confirming the "curated" bypass doesn't actually override a real
+noindex before treating the audit's failure as cosmetic. It doesn't:
+`shouldIndexRoute`'s curated-allowlist bypass only fires when the noindex
+signal is `sitemap_included=false` or `indexability_status=NEEDS_REVIEW`;
+`hasNoindexSignal()` returns `robots=noindex` first for any of these 3
+records (checked before it even reaches the `indexability_status`/
+`runtime_export_decision` branches), which isn't in the bypass list — so
+the live page's `<meta name="robots">` and the generated sitemap.xml both
+correctly stay excluded. The audit script's failure was a pure false
+positive in its own reporting, not a symptom of a real indexing bug.
+
+Fixed `scripts/audit/verify-curated-indexable.mjs` by adding
+`isKnownGovernanceHold(rec)`: a curated slug that fails the PUBLISH check is
+only a reported regression if its `indexability_reasons` don't already
+explain it as a deliberate hold (`noindex-decision:*` — the hard-block path
+in `scripts/data/indexability-policy.mjs`'s `NOINDEX_DECISIONS`; or
+`profile-status:(research_only|minimal|draft|archived)`) **and** its
+robots/`sitemap_included` fields are actually internally consistent with
+that hold (noindex robots + sitemap excluded) — a bare matching reason
+string alone doesn't suffice, since that would risk masking a genuine
+inconsistency rather than confirming a real hold. Verified against the live
+`ginger`/`peppermint` records that this doesn't accidentally swallow real
+regressions: their reasons are `profile-status:partial` /
+`summary-too-thin`, neither of which matches the hold pattern, so both
+still correctly fail. Added
+`scripts/audit/verify-curated-indexable.test.mjs` (5 cases: hard
+noindex-decision hold, research_only hold, plain content regression not
+swallowed, a hold-shaped reason rejected when robots/sitemap are
+inconsistent with it, and a missing record) and wrapped the script's CLI
+body in an `import.meta.url` guard (matching the
+`audit-severity-token-contraindications.mjs` convention) so the test file
+can import `isKnownGovernanceHold` without triggering the script's own
+`process.exit(1)`.
+
+Re-ran the audit after the fix: 3 of the original 10 problems now correctly
+report as informational holds; the 2 real `ginger`/`peppermint` regressions
+(subject of #2270) still fail as expected, so this fix does not make
+`audit:curated-indexable` misleadingly green while a real bug is still on
+`main` — **deliberately did not wire it into `check`/`check:full` this
+cycle**, since doing so today would hard-fail the gate on #2270's
+still-open bug. Once #2270 merges, a future cycle should wire
+`npm run audit:curated-indexable` into `check:full` (per the original
+suggestion) now that the false-positive class is fixed and re-verify a
+clean run first.
+
+`npm run lint`, `npm run typecheck`, and the full Vitest suite all pass.
+Diff is exactly the one script + its new test file, zero workbook/
+`public/data` changes, zero collision risk with #2270 or any other in-flight
+PR.

--- a/scripts/audit/verify-curated-indexable.mjs
+++ b/scripts/audit/verify-curated-indexable.mjs
@@ -64,16 +64,46 @@ function loadFlat(file) {
   return Array.isArray(parsed) ? parsed : [];
 }
 
+// A curated slug that fails the PUBLISH check is a real regression only if
+// nothing in scripts/data/indexability-policy.mjs's own reasons explain it as
+// a deliberate governance decision (e.g. `hidden_until_grounded`,
+// `research_only`) rather than a content bug. Restrict to reasons whose
+// `finish()`-produced robots/sitemap_included state actually matches what a
+// real hold looks like — a stray reason string alone (without the matching
+// noindex robots + excluded sitemap state) doesn't count, since that would
+// just be masking a genuine inconsistency instead of a real hold.
+const GOVERNANCE_HOLD_REASON_PATTERN =
+  /^(noindex-decision:|profile-status:(research_only|minimal|draft|archived))/;
+
+export function isKnownGovernanceHold(rec) {
+  if (!rec) return false;
+  const reasons = Array.isArray(rec.indexability_reasons) ? rec.indexability_reasons : [];
+  const hasGovernanceReason = reasons.some((r) => GOVERNANCE_HOLD_REASON_PATTERN.test(String(r)));
+  if (!hasGovernanceReason) return false;
+  const robotsNoindex = String(rec.robots || '').toLowerCase().includes('noindex');
+  const sitemapExcluded = rec.sitemap_included !== true;
+  return robotsNoindex && sitemapExcluded;
+}
+
 function check(list, slugs, kind) {
   const bySlug = new Map(list.map((r) => [r?.slug, r]));
   const problems = [];
+  const holds = [];
   for (const slug of slugs) {
     const rec = bySlug.get(slug);
     if (!rec) {
       problems.push({ slug, issue: 'missing_from_data' });
       continue;
     }
-    if (String(rec.indexability_status || '').toUpperCase() !== 'PUBLISH') {
+    const wrongStatus = String(rec.indexability_status || '').toUpperCase() !== 'PUBLISH';
+    const wrongSitemap = rec.sitemap_included !== true;
+    if (!wrongStatus && !wrongSitemap) continue;
+
+    if (isKnownGovernanceHold(rec)) {
+      holds.push({ slug, actual: rec.indexability_status, reasons: rec.indexability_reasons });
+      continue;
+    }
+    if (wrongStatus) {
       problems.push({
         slug,
         issue: 'wrong_indexability_status',
@@ -81,31 +111,42 @@ function check(list, slugs, kind) {
         reasons: rec.indexability_reasons,
       });
     }
-    if (rec.sitemap_included !== true) {
+    if (wrongSitemap) {
       problems.push({ slug, issue: 'sitemap_included_false', actual: rec.sitemap_included });
     }
   }
-  return { kind, problems };
-}const herbs = loadFlat('herbs.json');
-const compounds = loadFlat('compounds.json');
+  return { kind, problems, holds };
+}
 
-const herbReport = check(herbs, CURATED_INDEXABLE_HERB_SLUGS, 'herbs');
-const compoundReport = check(compounds, CURATED_INDEXABLE_COMPOUND_SLUGS, 'compounds');
+function main() {
+  const herbs = loadFlat('herbs.json');
+  const compounds = loadFlat('compounds.json');
 
-const totalProblems =
-  herbReport.problems.length + compoundReport.problems.length;
+  const herbReport = check(herbs, CURATED_INDEXABLE_HERB_SLUGS, 'herbs');
+  const compoundReport = check(compounds, CURATED_INDEXABLE_COMPOUND_SLUGS, 'compounds');
 
-for (const r of [herbReport, compoundReport]) {
-  if (r.problems.length === 0) {
-    console.log(`[verify-curated-indexable] ${r.kind}: all curated slugs are PUBLISH + sitemap_included ✅`);
-  } else {
-    console.log(`[verify-curated-indexable] ${r.kind}: ${r.problems.length} problems:`);
-    for (const p of r.problems) console.log(`  - ${p.slug}: ${p.issue} ${p.actual ? `(actual=${p.actual})` : ''}`);
+  const totalProblems =
+    herbReport.problems.length + compoundReport.problems.length;
+
+  for (const r of [herbReport, compoundReport]) {
+    if (r.problems.length === 0) {
+      console.log(`[verify-curated-indexable] ${r.kind}: all curated slugs are PUBLISH + sitemap_included ✅`);
+    } else {
+      console.log(`[verify-curated-indexable] ${r.kind}: ${r.problems.length} problems:`);
+      for (const p of r.problems) console.log(`  - ${p.slug}: ${p.issue} ${p.actual ? `(actual=${p.actual})` : ''}`);
+    }
+    for (const h of r.holds) {
+      console.log(`  (known governance hold, not a regression) ${h.slug}: actual=${h.actual} reasons=${JSON.stringify(h.reasons)}`);
+    }
   }
+
+  if (totalProblems > 0) {
+    console.error(`\n[verify-curated-indexable] FAILED: ${totalProblems} curated slug(s) regressed. Fix the governance overlay or workbook before deploying.`);
+    process.exit(1);
+  }
+  console.log('\n[verify-curated-indexable] OK');
 }
 
-if (totalProblems > 0) {
-  console.error(`\n[verify-curated-indexable] FAILED: ${totalProblems} curated slug(s) regressed. Fix the governance overlay or workbook before deploying.`);
-  process.exit(1);
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
 }
-console.log('\n[verify-curated-indexable] OK');

--- a/scripts/audit/verify-curated-indexable.test.mjs
+++ b/scripts/audit/verify-curated-indexable.test.mjs
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { isKnownGovernanceHold } from './verify-curated-indexable.mjs'
+
+describe('isKnownGovernanceHold', () => {
+  it('recognizes a hidden_until_grounded noindex decision as a known hold', () => {
+    expect(
+      isKnownGovernanceHold({
+        indexability_status: 'NOINDEX',
+        robots: 'noindex,follow',
+        sitemap_included: false,
+        indexability_reasons: ['noindex-decision:hidden_until_grounded'],
+      }),
+    ).toBe(true)
+  })
+
+  it('recognizes a research_only profile status as a known hold', () => {
+    expect(
+      isKnownGovernanceHold({
+        indexability_status: 'NEEDS_REVIEW',
+        robots: 'noindex,follow',
+        sitemap_included: false,
+        indexability_reasons: ['profile-status:research_only', 'non-publishable-profile-status'],
+      }),
+    ).toBe(true)
+  })
+
+  it('does not treat a plain content-quality regression as a known hold', () => {
+    expect(
+      isKnownGovernanceHold({
+        indexability_status: 'NEEDS_REVIEW',
+        robots: 'noindex,follow',
+        sitemap_included: false,
+        indexability_reasons: ['profile-status:partial', 'summary-too-thin', 'summary-quality-missing'],
+      }),
+    ).toBe(false)
+  })
+
+  it('does not treat a governance-shaped reason as a hold if robots/sitemap are inconsistent with it', () => {
+    // A stray reason string alone isn't enough — the robots/sitemap_included
+    // state must actually match what a real hold produces, otherwise this
+    // would mask a genuine data inconsistency instead of a real editorial hold.
+    expect(
+      isKnownGovernanceHold({
+        indexability_status: 'PUBLISH',
+        robots: 'index,follow',
+        sitemap_included: true,
+        indexability_reasons: ['noindex-decision:hidden_until_grounded'],
+      }),
+    ).toBe(false)
+  })
+
+  it('returns false for a missing record', () => {
+    expect(isKnownGovernanceHold(null)).toBe(false)
+    expect(isKnownGovernanceHold(undefined)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- `npm run audit:curated-indexable` (a regression guard checking that editor-curated high-traffic herb/compound slugs stay indexable) reports 10 "regressed" slugs on `main`. PR #2270 (open, unmerged) found 2 of those (`ginger`, `peppermint`) are a real leaked-template-text bug, but explicitly flagged the other 3 (`black-cohosh`, `phosphatidylcholine`, `acetyl-l-carnitine`) as deliberate governance holds (`hidden_until_grounded` / `research_only`) rather than bugs, and suggested as a follow-up: "teach the guard to distinguish intentional holds from regressions, then wire `audit:curated-indexable` into `check:full`."
- Verified this isn't masking a live SEO bug first: `src/lib/index-allowlist.ts`'s curated slugs get a bypass in both `src/lib/seo.ts` (`shouldIndexRoute`) and `app/sitemap.ts` (`addRoute`), but that bypass only fires for `sitemap_included=false` / `indexability_status=NEEDS_REVIEW` signals — `hasNoindexSignal()` returns `robots=noindex` first for all 3 of these records, which isn't bypassable, so the live page's robots meta and the generated sitemap.xml both correctly stay excluded. The audit's failure is a pure reporting false positive, not a symptom of a real indexing bug.
- Added `isKnownGovernanceHold(rec)` to `scripts/audit/verify-curated-indexable.mjs`: a curated slug that fails the PUBLISH check is only reported as a regression if its `indexability_reasons` don't already explain it as a deliberate hold (`noindex-decision:*` or `profile-status:(research_only|minimal|draft|archived)`) **and** its robots/`sitemap_included` fields are internally consistent with that hold — a bare matching reason string alone isn't enough, to avoid masking a genuine inconsistency.
- Verified this doesn't swallow real regressions: `ginger`/`peppermint`'s actual reasons (`profile-status:partial`, `summary-too-thin`) don't match the hold pattern, so both still correctly fail.
- Added `scripts/audit/verify-curated-indexable.test.mjs` (5 cases) and wrapped the script's CLI body behind an `import.meta.url` guard (matching `audit-severity-token-contraindications.mjs`'s convention) so the test can import the classifier without triggering `process.exit(1)`.
- **Deliberately did not wire this into `check`/`check:full` yet** — `ginger`/`peppermint` are still real, unfixed regressions on `main` until #2270 merges, and wiring it in now would hard-fail the gate on an unrelated in-flight bug. Left a note in `docs/LOOP_NOTES.md` for a follow-up cycle to wire it in once #2270 merges.

## Verification

- [x] `npm run lint`
- [x] `npm run check`
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs (none — no workbook/data changes this PR)
- [x] no generated file corruption
- [x] static export compatible (no route/config changes)

## Risk Notes

- Pure tooling change: one audit script + its new test file + a `docs/LOOP_NOTES.md` entry. No workbook, `public/data`, or app code touched.
- The audit is still not wired into any CI gate, so this carries zero build-breaking risk on its own.


---
_Generated by [Claude Code](https://claude.ai/code/session_011uYcxbwVk1mxVuuinaazkC)_