### PR TITLE
Add AI-citation quick-answer summaries to 2 compare pages; fix noindex audit false positive

### DIFF
--- a/app/guides/compare/kava-vs-alcohol/page.tsx
+++ b/app/guides/compare/kava-vs-alcohol/page.tsx
@@ -13,6 +13,7 @@ import FAQSchema from '@/components/seo/FAQSchema'
 import References from '@/components/References'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
+import CitationReadySummary from '@/components/seo/CitationReadySummary'
 
 const KAVA_VS_ALCOHOL_REFS = [
   { n: 1, text: 'Sarris J, et al. (2013). Kava in the treatment of generalized anxiety disorder. J Clin Psychopharmacol, 33(5): 643-648.', url: 'https://pubmed.ncbi.nlm.nih.gov/23942365/' },
@@ -68,6 +69,19 @@ export default function KavaVsAlcoholPage() {
           </figcaption>
         </figure>
       </section>
+
+      <CitationReadySummary
+        answer="Kava produces relaxation with less cognitive impairment and a lower dependence risk than alcohol, but it is not risk-free — liver safety depends on using noble cultivars and avoiding contaminants."
+        bestFor={[
+          'Kava: relaxation and anxiolysis while keeping mental clarity, in a harm-reduction or social-alternative context.',
+          'Alcohol: broadly familiar and legal, but carries well-documented dependence, liver, and cognitive-impairment risks with regular use.',
+          'Neither: combining kava and alcohol, since both affect GABA signaling and can amplify sedation and liver strain.',
+        ]}
+        evidenceLevel="Clinical trials support kava for short-term anxiety reduction; liver-safety data is stronger for noble cultivars and traditional water extracts than for ethanol-based extracts or non-noble (tudei) kava."
+        safetyNote="Avoid combining kava with alcohol or other sedatives. Anyone with existing liver conditions, or taking hepatically-metabolized medications, should avoid kava or discuss it with a clinician first."
+        notClaiming="This page is not claiming kava is a safe substitute for alcohol use disorder treatment or that it is risk-free for the liver."
+        referencesHref="#references"
+      />
 
       <section className="grid gap-6 lg:grid-cols-2">
         <div className="card-premium p-6 space-y-4">
@@ -179,6 +193,14 @@ export default function KavaVsAlcoholPage() {
 
           <Link href="/learn/gaba/" className="chip-readable">
             GABA Pathway
+          </Link>
+
+          <Link href="/safety-checker/" className="chip-readable">
+            Safety Checker
+          </Link>
+
+          <Link href="/info/dosing/" className="chip-readable">
+            Dosing Guide
           </Link>
         </div>
       </section>

--- a/app/guides/compare/rhodiola-vs-ashwagandha/page.tsx
+++ b/app/guides/compare/rhodiola-vs-ashwagandha/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { buildPageMetadata } from '../../../../src/lib/seo'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
+import CitationReadySummary from '@/components/seo/CitationReadySummary'
 import AffiliateDisclosure from '../../../../components/AffiliateDisclosure'
 import { EnhancedEmailCapture } from '@/components/monetization/EnhancedEmailCapture'
 import { RelatedDiscoveryWidget } from '@/components/monetization/RelatedDiscoveryWidget'
@@ -78,6 +79,19 @@ export default function RhodiolaVsAshwagandhaComparePage() {
         </figure>
       </section>
 
+      <CitationReadySummary
+        answer="Rhodiola is usually the better fit for mental fatigue, overextended days, and daytime output. Ashwagandha is usually the better fit for ongoing stress load, evening wind-down, and calming an overstimulated nervous system."
+        bestFor={[
+          'Rhodiola: mental fatigue, burnout-adjacent exhaustion, and stress resilience without sedation.',
+          'Ashwagandha: steady stress support, evening settling, and situations where calm matters more than activation.',
+          'Together: rhodiola in the morning for output, ashwagandha at night for wind-down — a common, well-tolerated pairing.',
+        ]}
+        evidenceLevel="Human trials support rhodiola for stress-related fatigue and ashwagandha for perceived stress and anxiety, though effect sizes are modest and study quality varies."
+        safetyNote="Rhodiola can feel overstimulating for some people and is best avoided late in the day. Ashwagandha may affect thyroid hormone levels and should be reviewed with a clinician during pregnancy or with thyroid or autoimmune conditions."
+        notClaiming="This page is not claiming rhodiola or ashwagandha treats clinical burnout, generalized anxiety disorder, or diagnosed thyroid conditions."
+        referencesHref="#references"
+      />
+
       <AffiliateDisclosure />
 
       <section className="grid gap-6 lg:grid-cols-2">
@@ -140,7 +154,14 @@ export default function RhodiolaVsAshwagandhaComparePage() {
         href={revenueProducts[0]?.affiliateUrl || '#'}
       />
 
-      <section className="card-premium p-6 space-y-4 max-w-4xl mb-8"><h2 className="text-2xl font-semibold tracking-tight text-ink">How to choose</h2><p className="text-sm leading-7 text-muted">Ask yourself: am I wired or tired? If you feel anxious, overstimulated, and cannot wind down at night — ashwagandha (calming). If you feel exhausted, unmotivated, and burned out — rhodiola (stimulating). If both: ashwagandha at night, rhodiola in the morning — this is a common and well-tolerated stack. Start with one for 2-4 weeks before adding the other. Do not expect acute effects — adaptogens work cumulatively. If you feel nothing after 4 weeks, the adaptogen is likely not a fit for your stress pattern.</p></section>
+      <section className="card-premium p-6 space-y-4 max-w-4xl mb-8">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">How to choose</h2>
+        <p className="text-sm leading-7 text-muted">Ask yourself: am I wired or tired? If you feel anxious, overstimulated, and cannot wind down at night — ashwagandha (calming). If you feel exhausted, unmotivated, and burned out — rhodiola (stimulating). If both: ashwagandha at night, rhodiola in the morning — this is a common and well-tolerated stack. Start with one for 2-4 weeks before adding the other. Do not expect acute effects — adaptogens work cumulatively. If you feel nothing after 4 weeks, the adaptogen is likely not a fit for your stress pattern.</p>
+        <div className="flex flex-wrap gap-3">
+          <Link href="/info/dosing/" className="chip-readable text-xs font-bold">Review dosing basics</Link>
+          <Link href="/safety-checker/" className="chip-readable text-xs font-bold">Check safety context</Link>
+        </div>
+      </section>
 
       <References refs={RHODIOLA_VS_ASHWAGANDHA_REFS} />
     </div>

--- a/docs/LOOP_NOTES.md
+++ b/docs/LOOP_NOTES.md
@@ -1898,3 +1898,66 @@ affected) and its AI-entity-completeness score (average 16/100 across all
 856 profiles, 0 scoring 80+) are large, mostly-untouched surfaces — a good
 candidate for the next cycle to scope out, but too broad to fix in one pass
 without picking a narrow, well-justified slice first.
+
+---
+
+## 2026-07-14 (later still) — Closed 3 of the 9 `audit:ai-citations` compare-page warnings; found a real audit false positive along the way
+
+Followed up on the prior entry's pointer toward `audit:ai-citations`'s 9
+flagged `/guides/compare/*` pages. `list_pull_requests` showed 6 open PRs
+already on the contraindications thread (#2277, #2274, #2263, #2262, #2260,
+#2259) plus #2272/#2270/#2257/#2249/#2242 on other threads — none touching
+compare pages or this audit, so it was clear to work.
+
+One of the 9 flagged pages, `/guides/compare/dynamic/`, turned out to be a
+false positive: it's the interactive "pick any two items" comparison tool,
+explicitly marked `robots: { index: false, follow: true }` in its
+`buildPageMetadata` call, so it's deliberately excluded from search/AI
+indexing and was never a real citation target. The audit script
+(`scripts/ci/audit-ai-citation-readiness.mjs`) had no concept of noindex
+pages and flagged it for missing quick-answer/support-link signals anyway.
+Added an `isNoindexPage()` check (`robots:\s*{[^}]*index:\s*false` against
+the page source) that short-circuits `auditPage()` with zero warnings —
+cheap, targeted, and correctly leaves all 8 real indexed pages fully
+audited.
+
+The other two tractable targets, `/guides/compare/rhodiola-vs-ashwagandha/`
+and `/guides/compare/kava-vs-alcohol/` (148 and 188 lines — the two
+shortest of the 8 real flagged pages), had genuine gaps: no
+`CitationReadySummary` component (the "quick answer" block AI answer
+engines look for) and no link to `/safety-checker/` or `/info/dosing/`.
+Added a `CitationReadySummary` to each, following the exact prop pattern
+already used on the passing `caffeine-vs-l-theanine` and
+`melatonin-vs-magnesium` pages (`answer`, `bestFor`, `evidenceLevel`,
+`safetyNote`, `notClaiming`, `referencesHref="#references"` — the
+`References` component already renders `id="references"` on both pages, so
+no new anchor was needed), plus `chip-readable` links to `/safety-checker/`
+and `/info/dosing/` in each page's existing safety/how-to-choose section.
+No new claims were introduced — the summary text was written from content
+already present on each page (fatigue-vs-stress framing on the rhodiola
+page, GABA/liver-safety framing on the kava page) plus the existing
+reference list, not new research.
+
+Re-ran `audit:ai-citations`: 9 flagged pages → 6. `npm run check` (typecheck
++ lint + article-quality + profile-verdicts + claim-discipline +
+safety-visibility + blog/article build + `data:build:core` +
+validate-data-files) passed clean, plus `a11y.test.tsx` (5/5). Final diff:
+exactly 3 files (2 compare pages + the audit script), `public/data/_meta/
+build-info.json` timestamp reverted as usual.
+
+**6 real gaps remain** on `/guides/compare/*`:
+`ashwagandha-vs-l-theanine-vs-magnesium`, `berberine-vs-metformin`,
+`curcumin-vs-boswellia-vs-omega-3` (quick-answer only — already has a
+support link), `kanna-vs-ssris`, `melatonin-vs-valerian-vs-magnesium-for-
+sleep`, `sleep-herbs-vs-melatonin` — all longer, more claim-dense pages
+(207–688 lines) than this cycle's two targets, so writing their
+`CitationReadySummary` text will take more care to stay grounded in each
+page's existing evidence rather than introducing new claims. Good next
+targets, roughly in that length order (shortest/least risky first).
+
+**Takeaway for future cycles:** when an audit's `false` count looks
+surprising for a route, check whether that route carries `robots: {
+index: false }` before assuming the flagged content gap is real — noindex
+routes (interactive tools, dynamic pickers, preview/draft pages) are a
+recurring blind spot for content-quality audits that only look at prose
+patterns, not indexing intent.

--- a/scripts/ci/audit-ai-citation-readiness.mjs
+++ b/scripts/ci/audit-ai-citation-readiness.mjs
@@ -43,9 +43,15 @@ function hasNoncanonicalCompareLink(source) {
     || /url:\s*["'`]https:\/\/thehippiescientist\.net\/compare(?:\/|["'`])/.test(source)
 }
 
+function isNoindexPage(source) {
+  return /robots:\s*{[^}]*index:\s*false/.test(source)
+}
+
 function auditPage({ slug, file }) {
   const source = readFileSync(file, 'utf8')
   const warnings = []
+
+  if (isNoindexPage(source)) return { slug, file: path.relative(ROOT, file), warnings }
 
   if (!hasCanonicalComparePath(source, slug)) warnings.push('missing explicit /guides/compare/* canonical path')
   if (!/<h1[\s>]/.test(source)) warnings.push('missing visible H1')


### PR DESCRIPTION
## Summary

- `/guides/compare/rhodiola-vs-ashwagandha/` and `/guides/compare/kava-vs-alcohol/` were missing a `CitationReadySummary` "quick answer" block and a safety/dosing support link — both signals `audit:ai-citations` checks for AI answer-engine citation readiness. Added both to each page, following the pattern already used on the passing `caffeine-vs-l-theanine` and `melatonin-vs-magnesium` pages; summary text is drawn from content already on each page, no new claims introduced.
- `scripts/ci/audit-ai-citation-readiness.mjs` was flagging `/guides/compare/dynamic/` for the same gaps even though that page is the interactive comparison tool and is explicitly `robots: { index: false }` — never a real citation target. Added an `isNoindexPage()` short-circuit so noindex routes are no longer audited for content-quality signals they don't need.
- `docs/LOOP_NOTES.md`: documented the remaining 6 flagged compare pages and the noindex blind spot for the next autonomous iteration.

Net effect: `audit:ai-citations` advisory warnings dropped from 9 flagged pages to 6.

## Verification

- [x] `npm run lint`
- [x] `npm run check`
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs (build-timestamp reverted)
- [x] no generated file corruption
- [x] static export compatible
- [x] `npx vitest run app/__tests__/a11y.test.tsx` (5/5 passed)

## Risk Notes

- Purely additive content + one script-level audit refinement; no routes renamed, no data files hand-edited.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PJWcASkp5kYG3Z7f7Y2Z8B)_