### PR TITLE
Add AI-citation quick-answer summaries to 2 more compare pages

### DIFF
--- a/app/guides/compare/kanna-vs-ssris/page.tsx
+++ b/app/guides/compare/kanna-vs-ssris/page.tsx
@@ -13,6 +13,7 @@ import FAQSchema from '@/components/seo/FAQSchema'
 import References from '@/components/References'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
+import CitationReadySummary from '@/components/seo/CitationReadySummary'
 import COAList from '../../../../src/components/coa/COAList'
 import type { COADocument } from '../../../../src/types/coa'
 
@@ -102,6 +103,19 @@ export default function KannaVsSSRIsPage() {
         </figure>
       </section>
 
+      <CitationReadySummary
+        answer="Kanna and SSRIs both act on serotonin, but they are not comparable options — kanna is an under-studied traditional serotonin-reuptake-inhibiting herb with no standardized dosing or long-term safety data, while SSRIs are extensively studied prescription medications. Combining them risks serotonin syndrome, a potentially life-threatening condition."
+        bestFor={[
+          'Kanna: traditional short-term mood support in people not taking any serotonergic medication.',
+          'SSRIs: clinically diagnosed depression or anxiety requiring medically supervised, titrated treatment.',
+          'Neither together: combining kanna with SSRIs, SNRIs, MAOIs, tramadol, or St. John\'s Wort due to serotonin syndrome risk.',
+        ]}
+        evidenceLevel="SSRIs have decades of large-scale clinical trial data. Kanna's serotonin-reuptake-inhibiting and PDE4-inhibiting activity is supported by small human and preclinical studies, but potency, selectivity, and long-term effects are not well-characterized."
+        safetyNote="Anyone taking an SSRI, SNRI, MAOI, tramadol, or other serotonergic medication should not use kanna. Watch for serotonin syndrome symptoms (agitation, rapid heart rate, high blood pressure, muscle rigidity, hyperthermia) and seek emergency care if they occur."
+        notClaiming="This page is not claiming kanna is a safe or effective substitute for prescribed antidepressants."
+        referencesHref="#references"
+      />
+
       <section className="grid gap-6 lg:grid-cols-2">
         <div className="card-premium p-6 space-y-4">
           <p className="eyebrow-label">Ethnobotanical System</p>
@@ -151,6 +165,7 @@ export default function KannaVsSSRIsPage() {
         <div className="mt-4 flex flex-wrap gap-3">
           <Link href="/learn/serotonin/" className="rounded-full bg-red-100 px-3 py-1.5 text-xs font-bold text-red-800">Serotonin Pathway</Link>
           <Link href="/learn/serotonergic-stacking-risks/" className="rounded-full bg-red-100 px-3 py-1.5 text-xs font-bold text-red-800">Serotonergic Risks</Link>
+          <Link href="/safety-checker/" className="rounded-full bg-red-100 px-3 py-1.5 text-xs font-bold text-red-800">Check Your Medication Interactions</Link>
         </div>
       </section>
 

--- a/app/guides/compare/melatonin-vs-valerian-vs-magnesium-for-sleep/page.tsx
+++ b/app/guides/compare/melatonin-vs-valerian-vs-magnesium-for-sleep/page.tsx
@@ -11,6 +11,7 @@ export const metadata: Metadata = buildPageMetadata({
 import Link from 'next/link'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
+import CitationReadySummary from '@/components/seo/CitationReadySummary'
 import AffiliateDisclosure from '../../../../components/AffiliateDisclosure'
 import { EnhancedEmailCapture } from '@/components/monetization/EnhancedEmailCapture'
 import FAQSchema from '@/components/seo/FAQSchema'
@@ -81,6 +82,19 @@ export default function MelatoninVsValerianVsMagnesiumForSleepPage() {
           </figcaption>
         </figure>
       </section>
+
+      <CitationReadySummary
+        answer="Melatonin, valerian root, and magnesium support sleep in different ways: melatonin shifts circadian timing for people who aren't tired at bedtime, valerian root builds cumulative GABA-related relaxation over 2-4 weeks, and magnesium (especially glycinate) supports baseline physical relaxation and muscle tension release."
+        bestFor={[
+          'Melatonin: shifted sleep schedules, jet lag, or trouble feeling tired at the desired bedtime.',
+          'Valerian root: mild bedtime restlessness, taken consistently for cumulative benefit rather than as a one-off.',
+          'Magnesium glycinate: physical tension, muscle soreness, or general nightly wind-down support.',
+        ]}
+        evidenceLevel="Melatonin has strong evidence for shifting sleep timing. Valerian root and magnesium have limited-to-moderate evidence from smaller trials for sleep quality and latency."
+        safetyNote="Valerian root should never be combined with prescription sedatives, benzodiazepines, or alcohol. Magnesium requires caution in kidney disease. Melatonin may warrant caution with autoimmune conditions and can cause next-day grogginess at high doses."
+        notClaiming="This page is not claiming any of these three is a replacement for treating a diagnosed sleep disorder."
+        referencesHref="#references"
+      />
 
       {/* 3-Column Core Comparison Cards */}
       <section className="grid gap-6 lg:grid-cols-3">
@@ -254,6 +268,10 @@ export default function MelatoninVsValerianVsMagnesiumForSleepPage() {
               <strong>Magnesium</strong> requires caution in kidney disease. Excess magnesium is filtered by the kidneys, so impaired renal clearance can lead to severe accumulation.
             </li>
           </ul>
+          <div className="flex flex-wrap gap-3 pt-2">
+            <Link href="/safety-checker/" className="chip-readable">Check Your Medication Interactions</Link>
+            <Link href="/info/dosing/" className="chip-readable">Dosing Guidance</Link>
+          </div>
         </div>
       </section>
 

--- a/docs/LOOP_NOTES.md
+++ b/docs/LOOP_NOTES.md
@@ -1961,3 +1961,39 @@ index: false }` before assuming the flagged content gap is real — noindex
 routes (interactive tools, dynamic pickers, preview/draft pages) are a
 recurring blind spot for content-quality audits that only look at prose
 patterns, not indexing intent.
+
+## 2026-07-14 (later) — Closed 2 more `audit:ai-citations` compare-page gaps (6 → 4 remaining)
+
+Continued the `/guides/compare/*` `CitationReadySummary` thread from the
+prior entry, picking the two shortest of the six remaining flagged pages
+(`kanna-vs-ssris`, 207 lines; `melatonin-vs-valerian-vs-magnesium-for-sleep`,
+356 lines) per that entry's own "shortest/least risky first" ordering.
+Checked `list_pull_requests` first — 12 open PRs, none touching compare
+pages or this audit script, clear to work.
+
+Added a `CitationReadySummary` to each following the established prop
+pattern (`answer`, `bestFor`, `evidenceLevel`, `safetyNote`, `notClaiming`,
+`referencesHref="#references"`), written entirely from claims already on
+each page (the existing serotonin-syndrome warning block on the kanna page,
+the existing head-to-head table and safety-cautions list on the
+melatonin/valerian/magnesium page) — no new research introduced. Both pages
+were also missing the audit's methodology/disclaimer/safety/dosing support
+link, so added a `/safety-checker/` link to each (kanna page's existing red
+safety-warning chip row; melatonin/valerian/magnesium page's safety-cautions
+section, plus a second `/info/dosing/` link there since it already had the
+UI room for two chips).
+
+Re-ran `audit:ai-citations`: 6 flagged pages → 4
+(`ashwagandha-vs-l-theanine-vs-magnesium`, `berberine-vs-metformin`,
+`curcumin-vs-boswellia-vs-omega-3` — quick-answer only, `sleep-herbs-vs-
+melatonin`). `npm run check` passed clean (typecheck + lint + article
+quality + `data:build:core` + validate-data-files). Final diff: exactly the
+2 page files; `public/data/_meta/build-info.json` timestamp reverted as
+usual.
+
+**Takeaway for future cycles:** the remaining 4 pages get longer and more
+claim-dense (367–688 lines), so writing their summaries will take more care
+to stay grounded in existing page content rather than introducing new
+claims — same discipline as this cycle and the last, just slower per page.
+`sleep-herbs-vs-melatonin` (688 lines, the longest) is probably worth
+splitting into its own cycle rather than pairing it with another page.


### PR DESCRIPTION
## Summary

- Add a `CitationReadySummary` block (quick answer, best-fit, evidence level, safety note, references link) to `/guides/compare/kanna-vs-ssris/` and `/guides/compare/melatonin-vs-valerian-vs-magnesium-for-sleep/`, following the pattern already used on `caffeine-vs-l-theanine` and `melatonin-vs-magnesium`.
- Add a `/safety-checker/` link to both pages (plus `/info/dosing/` on the sleep-comparison page) so each also clears `audit:ai-citations`'s methodology/disclaimer/safety/dosing support-link check.
- All summary text is drawn from claims already present on each page (existing serotonin-syndrome warning, existing head-to-head comparison table and safety-cautions list) — no new claims introduced.
- Append a `docs/LOOP_NOTES.md` entry recording progress on the `audit:ai-citations` compare-page thread (6 flagged pages → 4 remaining).

## Verification

- [x] `npm run lint`
- [x] `npm run check`
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs
- [x] no generated file corruption
- [x] static export compatible
- [x] `npm run audit:ai-citations` — both pages no longer flagged

## Risk Notes

- Additive only; no existing claims changed, no routes renamed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HWgPf5uitaDogf1P7pzGqs)_