### PR TITLE
Catch semantically-loose keyword matches in audit:risk-tag-collisions

### DIFF
--- a/docs/LOOP_NOTES.md
+++ b/docs/LOOP_NOTES.md
@@ -1997,3 +1997,85 @@ to stay grounded in existing page content rather than introducing new
 claims — same discipline as this cycle and the last, just slower per page.
 `sleep-herbs-vs-melatonin` (688 lines, the longest) is probably worth
 splitting into its own cycle rather than pairing it with another page.
+
+---
+
+## 2026-07-14 (later still) — Closed the gap PR #2274 found: taught `audit:risk-tag-collisions` to catch semantically-loose keyword matches, not just substring collisions
+
+Fresh cold session. Checked `list_pull_requests` first: 6 open PRs already on
+the compound `contraindications_or_flags` thread (#2277, #2274, #2263, #2262,
+#2260, #2259), all touching the same binary `.xlsx` workbook — a high
+collision-risk surface for another 6-compound batch, and #2274's own notes
+(read via `get_files`) flagged a concrete, still-unaddressed tooling gap
+instead: a real bug survived that thread's entire validation pipeline and had
+to be caught by an external GitHub review bot. Picked the tooling fix over
+another data batch — narrower blast radius, no `.xlsx` merge-conflict risk,
+and it benefits every future cycle on that thread, not just this one.
+
+The bug: `deriveInteractionData()` (`scripts/data/build-interaction-data.mjs`)
+matches `contraindications_or_flags` text against `KEYWORDS` via plain
+substring search. `catuaba`'s clause "discontinue before scheduled surgery due
+to an unstudied interaction with anesthesia" contains the word `surgery`,
+which is in `KEYWORDS.anticoagulant` — so catuaba got silently tagged an
+anticoagulant/bleeding-risk compound and paired into bleeding-risk interaction
+edges with every other anticoagulant-tagged entity, even though the clause
+never mentions bleeding. The existing `findSuspectMatches()` in
+`scripts/audit-risk-tag-collisions.mjs` only catches *substring* collisions
+(a keyword glued to an unrelated word, e.g. "delivery" containing "liver") —
+it does nothing for a clean, correctly word-boundaried whole-word match that
+is simply semantically unrelated to the mechanism it triggers. `surgery` is
+broad by design (`KEYWORDS.anticoagulant` needs it for the common, legitimate
+"discontinue before surgery due to bleeding risk" clause) but clinicians also
+cite surgery for sedation, anesthesia-interaction, or general-precaution
+reasons that have nothing to do with clotting.
+
+Added `findWeakCorroborationMatches()` alongside `findSuspectMatches()` in the
+same script: for keywords broad enough to need it (currently just
+`surgery`/`pre-surgery` under the `anticoagulant` mechanism), flag a clause
+only when it's an *explanatory* sentence — one with an explicit "due to" /
+"because (of)" causal reason — and that stated reason doesn't corroborate
+bleeding (no `bleed`/`clot`/`coagul`/`platelet`/`inr`/`hemorrhage`/etc.
+nearby). First draft required corroboration anywhere in the clause and was
+wrong: run against the real workbook it flagged 14 entries (`allium-sativum`,
+`angelica-sinensis`, `chuanxiong`, `damiana`, `danshen`, `dong-quai`,
+`feverfew`, `garlic`, `japanese-knotweed`, `notoginseng`,
+`valeriana-officinalis`, `ajoene`, `allicin`, `rhodiola-extract-shr5`) — every
+one a false positive, because this dataset's established convention for
+well-documented antiplatelet/anticoagulant herbs is a short standalone flag
+token ("pre-surgery", "upcoming surgery", "scheduled surgery") with the
+mechanism established by the herb's known pharmacology, not restated in every
+token. Narrowing to "only flag clauses that state an explicit reason" dropped
+that to a single real remaining finding: `rhodiola-extract-shr5`'s
+"discontinue before surgery or other medical procedures due to limited
+interaction data" — a legitimately vague, non-bleeding-specific stated
+reason, left as a documented finding for a future cycle rather than fixed
+here (fixing it means editing the workbook, which reopens the same
+`.xlsx`-merge-conflict risk this cycle was chosen specifically to avoid).
+
+Wired the new check into the same script's `main()` as a second, separately
+labeled report section (still informational-by-default, `--strict` opts into
+exit 1, matching the existing check's convention). Added
+`findWeakCorroborationMatches` tests mirroring the existing test file's
+pattern, including one that locks in the real catuaba bug as a regression
+test and one confirming the bare-flag-token false-positive class stays
+unflagged. `npm run audit:risk-tag-collisions` now reports both sections
+cleanly against the real workbook (0 substring collisions, 1 documented weak-
+corroboration finding). `npm run lint`, `npm run typecheck`, and the full
+Vitest suite (596/596, up from 592 — the 4 new tests) all passed. Diff is
+exactly 2 files (the script + its test file) — no workbook, no `public/data`
+touched, so no `data:build`/`data:validate`/`guard:source-of-truth` round-trip
+was needed this cycle.
+
+**Takeaway for future cycles:** when the same data-enrichment thread has 5+
+concurrent open PRs all touching the same binary workbook file, a tooling fix
+that closes a gap one of those PRs already found (and documented in its own
+LOOP_NOTES entry) is often better ROI than adding another data batch to the
+pile — zero collision risk, and it protects every PR still in flight on that
+thread, not just future ones. Also: when writing a corroboration/context
+heuristic like this one, always dry-run it against the *entire* real dataset
+before trusting it, not just hand-picked examples — the first draft's 14
+false positives on legitimate, well-sourced antiplatelet-herb data would have
+made the check net-negative (audit fatigue) had it shipped as-is. The
+remaining `rhodiola-extract-shr5` finding is a fine target for a future
+contraindications-thread cycle once the current pile of open PRs on that file
+has thinned out.

--- a/scripts/audit-risk-tag-collisions.mjs
+++ b/scripts/audit-risk-tag-collisions.mjs
@@ -65,6 +65,58 @@ export function findSuspectMatches(phrase) {
   return suspects
 }
 
+// Second bug class, found by an external reviewer (see docs/LOOP_NOTES.md,
+// 2026-07-14, PR #2274): a keyword can be a clean, correctly word-boundaried
+// whole-word match and still be semantically unrelated to the mechanism it
+// triggers. `surgery` is in KEYWORDS.anticoagulant because "discontinue
+// before surgery due to bleeding risk" is a common, legitimate clause — but
+// clinicians also cite surgery for sedation, anesthesia-interaction, or
+// general-precaution reasons that have nothing to do with bleeding. That
+// shipped as a real bug: catuaba's "discontinue before scheduled surgery due
+// to an unstudied interaction with anesthesia" clause was silently tagged an
+// anticoagulant/bleeding risk. findSuspectMatches() cannot catch this — the
+// match isn't a substring collision, it's a semantically loose keyword.
+//
+// A first version of this check required a corroborating term (e.g. "bleed",
+// "clot") anywhere in the same clause — but the real workbook's established
+// convention is short standalone flags like "pre-surgery" or "upcoming
+// surgery" (no restated mechanism) for well-documented antiplatelet herbs
+// (garlic, danshen, notoginseng, ...), so that version flagged 14 legitimate
+// entries as false positives on real data. Only flag an *explanatory*
+// clause — one that explicitly gives an causal reason via "due to"/"because
+// of" — where that stated reason doesn't corroborate bleeding. A bare flag
+// token with no stated reason is left alone; that's the dataset's normal
+// shorthand, not a bug.
+const CORROBORATION_REQUIRED = {
+  anticoagulant: {
+    keys: ['surgery', 'pre-surgery'],
+    corroborators: [
+      'bleed', 'clot', 'coagul', 'platelet', 'inr', 'hemorrhage', 'haemorrhage',
+      'blood-thinning', 'blood thinning', 'thin the blood', 'thins the blood',
+    ],
+  },
+}
+const REASON_MARKERS = ['due to', 'because of', 'because ']
+
+export function findWeakCorroborationMatches(phrase) {
+  const pl = phrase.toLowerCase()
+  const suspects = []
+  for (const [mech, { keys, corroborators }] of Object.entries(CORROBORATION_REQUIRED)) {
+    const matchedKey = keys.find((k) => pl.includes(k))
+    if (!matchedKey) continue
+    const reasonIdx = Math.min(
+      ...REASON_MARKERS.map((m) => pl.indexOf(m)).filter((i) => i !== -1),
+      Infinity
+    )
+    if (!Number.isFinite(reasonIdx)) continue // bare flag token, no stated reason — established shorthand, not a bug
+    const stated = pl.slice(reasonIdx)
+    if (!corroborators.some((c) => stated.includes(c))) {
+      suspects.push({ mech, key: matchedKey, phrase })
+    }
+  }
+  return suspects
+}
+
 async function main() {
   const strict = process.argv.includes('--strict')
   const workbookPath = resolveWorkbookPath(process.cwd())
@@ -79,29 +131,45 @@ async function main() {
   const rows = sheetToRows(getSheet(wb, sheetName))
 
   const findings = []
+  const weakFindings = []
   for (const row of rows) {
     const slug = clean(row.slug)
     for (const phrase of splitFlags(row.contraindications_or_flags)) {
       for (const suspect of findSuspectMatches(phrase)) {
         findings.push({ slug, ...suspect })
       }
+      for (const suspect of findWeakCorroborationMatches(phrase)) {
+        weakFindings.push({ slug, ...suspect })
+      }
     }
   }
 
   if (findings.length === 0) {
     console.log('[audit:risk-tag-collisions] clean — no unboundaried keyword matches found in contraindications_or_flags')
-    process.exit(0)
+  } else {
+    console.log(`[audit:risk-tag-collisions] ${findings.length} potential substring-collision false positive(s):\n`)
+    for (const f of findings) {
+      console.log(`  ${f.slug} — mechanism "${f.mech}" matched "${f.key}" via prefix "${f.prefix}" in: "${f.phrase}"`)
+    }
+    console.log('\nIf a finding is a genuine new compound term (e.g. a novel medical prefix), add the prefix to')
+    console.log('ALLOWED_PREFIXES in this script. Otherwise, reword the clause in the workbook to break the collision')
+    console.log('(see docs/LOOP_NOTES.md, 2026-07-13 post-merge addendum, for a worked example).')
   }
 
-  console.log(`[audit:risk-tag-collisions] ${findings.length} potential substring-collision false positive(s):\n`)
-  for (const f of findings) {
-    console.log(`  ${f.slug} — mechanism "${f.mech}" matched "${f.key}" via prefix "${f.prefix}" in: "${f.phrase}"`)
+  if (weakFindings.length === 0) {
+    console.log('[audit:risk-tag-collisions] clean — no weak-corroboration keyword matches found in contraindications_or_flags')
+  } else {
+    console.log(`\n[audit:risk-tag-collisions] ${weakFindings.length} weak-corroboration false positive(s):\n`)
+    for (const f of weakFindings) {
+      console.log(`  ${f.slug} — mechanism "${f.mech}" matched "${f.key}" with no corroborating term in: "${f.phrase}"`)
+    }
+    console.log('\nThe clause matches a mechanism keyword that is broad enough to appear in unrelated contexts (e.g.')
+    console.log('"surgery" cited for sedation/anesthesia reasons, not bleeding risk). Reword the clause to either name')
+    console.log('the real mechanism explicitly, or add a corroborating term so the tag is intentional, not accidental')
+    console.log('(see docs/LOOP_NOTES.md, 2026-07-14, PR #2274, for the production bug this guards against).')
   }
-  console.log('\nIf a finding is a genuine new compound term (e.g. a novel medical prefix), add the prefix to')
-  console.log('ALLOWED_PREFIXES in this script. Otherwise, reword the clause in the workbook to break the collision')
-  console.log('(see docs/LOOP_NOTES.md, 2026-07-13 post-merge addendum, for a worked example).')
 
-  process.exit(strict ? 1 : 0)
+  process.exit(strict && (findings.length > 0 || weakFindings.length > 0) ? 1 : 0)
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/scripts/audit-risk-tag-collisions.test.mjs
+++ b/scripts/audit-risk-tag-collisions.test.mjs
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { findSuspectMatches } from './audit-risk-tag-collisions.mjs'
+import { findSuspectMatches, findWeakCorroborationMatches } from './audit-risk-tag-collisions.mjs'
 
 describe('findSuspectMatches', () => {
   it('flags a keyword matched as a substring of an unrelated word (the real bug it guards against)', () => {
@@ -26,5 +26,35 @@ describe('findSuspectMatches', () => {
 
   it('returns no suspects for a phrase with no keyword matches at all', () => {
     expect(findSuspectMatches('generally well tolerated at typical doses')).toEqual([])
+  })
+})
+
+describe('findWeakCorroborationMatches', () => {
+  it('flags the real production bug: "surgery" cited for a non-bleeding reason', () => {
+    const suspects = findWeakCorroborationMatches(
+      'discontinue before scheduled surgery due to an unstudied interaction with anesthesia'
+    )
+    expect(suspects).toHaveLength(1)
+    expect(suspects[0]).toMatchObject({ mech: 'anticoagulant', key: 'surgery' })
+  })
+
+  it('does not flag "surgery" when the clause corroborates the bleeding-risk mechanism', () => {
+    expect(
+      findWeakCorroborationMatches('discontinue before surgery due to increased bleeding risk')
+    ).toEqual([])
+    expect(
+      findWeakCorroborationMatches('may increase bleeding risk with anticoagulants/antiplatelets')
+    ).toEqual([])
+  })
+
+  it('does not flag a bare "surgery" flag token with no stated reason (the dataset\'s normal shorthand)', () => {
+    expect(findWeakCorroborationMatches('pre-surgery')).toEqual([])
+    expect(findWeakCorroborationMatches('upcoming surgery')).toEqual([])
+    expect(findWeakCorroborationMatches('planned surgery')).toEqual([])
+    expect(findWeakCorroborationMatches('scheduled surgery')).toEqual([])
+  })
+
+  it('returns no suspects for a phrase with no weak-keyword matches at all', () => {
+    expect(findWeakCorroborationMatches('generally well tolerated at typical doses')).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary

- `deriveInteractionData()` tags `contraindications_or_flags` text into risk-mechanism interaction edges via plain substring matching on `KEYWORDS`. A clause can match a keyword as a clean, correctly word-boundaried whole word and still be semantically unrelated to the mechanism it triggers — e.g. "surgery" cited for an anesthesia-interaction reason, not bleeding risk, still gets tagged `anticoagulant`. This shipped as a real bug (compound `catuaba`, caught by external review in PR #2274, still open) that the existing `findSuspectMatches()` substring-collision check can't catch — the match isn't a substring collision, it's a semantically loose keyword.
- Adds `findWeakCorroborationMatches()` to `scripts/audit-risk-tag-collisions.mjs`: flags an *explanatory* clause (one with an explicit "due to"/"because" causal reason) whose stated reason doesn't corroborate the matched keyword's mechanism, while leaving the dataset's established bare-flag-token shorthand ("pre-surgery", "upcoming surgery") alone.
- An unscoped first draft (require corroboration anywhere in the clause) flagged 14 false positives when run against the real workbook — all legitimate antiplatelet-herb entries (garlic, danshen, notoginseng, etc.) using the dataset's normal short-flag-token convention. Narrowed to only flag clauses with an explicit stated reason, leaving a single genuine finding (`rhodiola-extract-shr5`) documented in `docs/LOOP_NOTES.md` for a future cycle.
- Wired into the same script's `main()` as a second, separately labeled report section — informational by default, `--strict` opts into a nonzero exit, matching the existing check's convention. Added regression tests, including one that locks in the real `catuaba` bug case.
- No workbook or `public/data` changes — this is a pure tooling/validation fix, chosen specifically to avoid adding to the `.xlsx` merge-conflict pile from the ~6 other open PRs currently enriching `contraindications_or_flags`.

## Verification

- [x] `npm run lint`
- [x] `npm run check`
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs
- [x] no generated file corruption
- [x] static export compatible (no app/build config touched)
- [x] `npx vitest run` — 596/596 passed (592 + 4 new)
- [x] `npm run audit:risk-tag-collisions` — clean on substring collisions, 1 documented weak-corroboration finding on real data

## Risk Notes

- Additive-only change to an informational (non-CI-blocking) audit script and its test file; no runtime/app code paths touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nrmbhb1ccHxF2m94R1EinX)_