### PR TITLE
Add CitationReadySummary to ashwagandha-vs-l-theanine-vs-magnesium compare page

### DIFF
--- a/app/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium/page.tsx
+++ b/app/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium/page.tsx
@@ -14,6 +14,7 @@ import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
 import AffiliateDisclosure from '../../../../components/AffiliateDisclosure'
 import { EnhancedEmailCapture } from '@/components/monetization/EnhancedEmailCapture'
 import FAQSchema from '@/components/seo/FAQSchema'
+import CitationReadySummary from '@/components/seo/CitationReadySummary'
 import { RelatedDiscoveryWidget } from '@/components/monetization/RelatedDiscoveryWidget'
 import RecommendationSection from '@/components/RecommendationSection'
 import { getRevenueProductSet } from '@/config/revenue-products'
@@ -82,6 +83,19 @@ export default function AshwagandhaVsLTheanineVsMagnesiumPage() {
           </figcaption>
         </figure>
       </section>
+
+      <CitationReadySummary
+        answer="Ashwagandha is usually the better fit for chronic, cortisol-driven stress that builds up over weeks and needs 2-8 weeks of daily use to shift. L-theanine is usually the better fit for acute, situational stress or racing thoughts, working within 30-90 minutes. Magnesium glycinate is usually the better fit for physical muscle tension and evening wind-down."
+        bestFor={[
+          'Ashwagandha: long-term daily resilience for chronic, generalized stress and cortisol regulation.',
+          'L-theanine: fast-acting daytime calm for acute stress, jitters, or racing thoughts.',
+          'Magnesium glycinate: physical tension, muscle cramps, and baseline mineral deficiency, especially in the evening.',
+        ]}
+        evidenceLevel="Ashwagandha has moderate-to-strong randomized-trial evidence for stress and anxiety; L-theanine has moderate evidence for acute stress response; magnesium has limited-to-moderate evidence, strongest for people with a baseline deficiency."
+        safetyNote="Ashwagandha can affect thyroid hormone and immune activity — avoid with hyperthyroidism, autoimmune conditions, or pregnancy. L-theanine can lower blood pressure. Magnesium relies on kidney clearance and should be used cautiously with kidney disease."
+        notClaiming="This page is not claiming any of the three treats a diagnosed anxiety disorder, replaces prescribed treatment, or is safe to combine without checking your own medication and health history."
+        referencesHref="#references"
+      />
 
       {/* 3-Column Core Comparison Cards */}
       <section className="grid gap-6 lg:grid-cols-3">
@@ -255,6 +269,10 @@ export default function AshwagandhaVsLTheanineVsMagnesiumPage() {
               <strong>Magnesium</strong> relies heavily on kidney clearance. If you have any history of kidney disease or renal impairment, supplementing magnesium can cause dangerous buildup (hypermagnesemia).
             </li>
           </ul>
+          <div className="flex flex-wrap gap-3 pt-2">
+            <Link href="/safety-checker/" className="chip-readable">Check Your Medication Interactions</Link>
+            <Link href="/info/dosing/" className="chip-readable">Dosing Guidance</Link>
+          </div>
         </div>
       </section>
 

--- a/docs/LOOP_NOTES.md
+++ b/docs/LOOP_NOTES.md
@@ -2079,3 +2079,37 @@ made the check net-negative (audit fatigue) had it shipped as-is. The
 remaining `rhodiola-extract-shr5` finding is a fine target for a future
 contraindications-thread cycle once the current pile of open PRs on that file
 has thinned out.
+
+---
+
+## 2026-07-14 (later still) — Closed 1 more `audit:ai-citations` compare-page gap (4 → 3 remaining)
+
+`list_pull_requests` showed 37 open PRs, none touching `/guides/compare/*`
+or the AI-citation audit script — clear to continue this thread. Picked
+`ashwagandha-vs-l-theanine-vs-magnesium` (367 lines), the shortest of the
+4 remaining flagged pages, per the prior entry's own risk ordering.
+
+Added a `CitationReadySummary` (same established prop pattern: `answer`,
+`bestFor`, `evidenceLevel`, `safetyNote`, `notClaiming`,
+`referencesHref="#references"`) written entirely from claims already on
+the page — the existing head-to-head comparison table and the three
+scenario cards. No new research introduced. The page's existing "Safety &
+Clinical Cautions" section had no support link, so added
+`/safety-checker/` and `/info/dosing/` chip links there, matching the
+pattern used on `melatonin-vs-valerian-vs-magnesium-for-sleep`.
+
+Re-ran `audit:ai-citations`: 4 flagged pages → 3 (`berberine-vs-metformin`,
+`curcumin-vs-boswellia-vs-omega-3` — quick-answer only, `sleep-herbs-vs-
+melatonin`). `npm run check` passed clean, plus `a11y.test.tsx` (5/5).
+Final diff: exactly the 1 page file; `public/data/_meta/build-info.json`
+timestamp reverted as usual.
+
+**3 real gaps remain**, all longer/more claim-dense than this cycle's
+target: `berberine-vs-metformin` (527 lines — a herb/drug-interaction
+comparison page, so its summary needs extra care to state the interaction
+risk without overclaiming), `curcumin-vs-boswellia-vs-omega-3` (391 lines,
+quick-answer only — no support-link gap, so a smaller fix), and
+`sleep-herbs-vs-melatonin` (688 lines, the longest — still probably worth
+its own cycle per the prior entry). `curcumin-vs-boswellia-vs-omega-3` is
+likely the next-lowest-risk pick since it only needs one component added,
+not two content additions.


### PR DESCRIPTION
## Summary

- Closed an `audit:ai-citations` advisory gap on `/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium/`: added a `CitationReadySummary` block (the "quick answer" component AI answer engines look for) grounded entirely in claims already present on the page — the existing head-to-head comparison table and the three stress-scenario cards. No new research introduced.
- Added `/safety-checker/` and `/info/dosing/` support links to the page's existing "Safety & Clinical Cautions" section, matching the pattern already used on other compare pages.
- Continues a multi-cycle thread tracked in `docs/LOOP_NOTES.md`; 3 flagged compare pages remain (`berberine-vs-metformin`, `curcumin-vs-boswellia-vs-omega-3`, `sleep-herbs-vs-melatonin`).

## Verification

- [x] `npm run lint`
- [x] `npm run check`
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs (build-info.json timestamp reverted)
- [x] no generated file corruption
- [x] static export compatible
- [x] `npx vitest run app/__tests__/a11y.test.tsx` (5/5 passed)
- [x] `npm run audit:ai-citations` confirms the gap is closed (4 flagged pages → 3)

## Risk Notes

- Single-file diff, additive only. No claims beyond what the page already stated.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TBjaGT1cpx8EpPXXTPJFpc)_