### PR TITLE
Teach audit:curated-indexable to distinguish governance holds from regressions

### DIFF
--- a/docs/LOOP_NOTES.md
+++ b/docs/LOOP_NOTES.md
@@ -2113,3 +2113,79 @@ quick-answer only — no support-link gap, so a smaller fix), and
 its own cycle per the prior entry). `curcumin-vs-boswellia-vs-omega-3` is
 likely the next-lowest-risk pick since it only needs one component added,
 not two content additions.
+
+---
+
+## 2026-07-14 (later still) — Taught `audit:curated-indexable` to distinguish deliberate governance holds from real regressions; two big findings for future cycles
+
+Fresh cold session. `list_pull_requests` showed 37 open PRs — the
+AI-citation compare-page thread (prior two entries) turned out to be fully
+claimed already: `curcumin-vs-boswellia-vs-omega-3` had an open PR (#2282,
+not yet merged) and `sleep-herbs-vs-melatonin` had already merged (#2284)
+in the few minutes before this session started. Re-running
+`audit:ai-citations` locally showed 1 flagged page, which matched #2282's
+in-flight work, not a fresh gap — don't trust a locally-run advisory audit
+against a stale `origin/main` fetch without cross-checking open PR titles
+first; the numbers can look like "one gap left" when it's actually "one PR
+away from landing."
+
+**Finding #1 (acted on this cycle):** PR #2270 (open, unmerged) fixed a
+real leaked-template-placeholder bug on 8 flagship herb summaries and left
+a documented next step: `npm run audit:curated-indexable` (a regression
+guard added at some point, never wired into CI) was reporting 10 problems,
+but 3 of those (`black-cohosh`, `phosphatidylcholine`, `acetyl-l-carnitine`)
+are *deliberate* governance holds (`hidden_until_grounded` /
+`research_only` profile status pending stronger evidence grounding), not
+regressions — the script had no way to tell the two apart. Fixed by adding
+`isDeliberateHold()` to `scripts/audit/verify-curated-indexable.mjs`,
+matching on the same `noindex-decision:*` / `profile-status:*` reason
+strings that `scripts/data/indexability-policy.mjs` already writes into
+`indexability_reasons` (kept in lockstep via a comment, same convention
+the file already uses for the curated-slug-list duplication). Deliberate
+holds now print as an informational, non-failing section; genuine
+regressions (currently `ginger` and `peppermint` — the exact 2 slugs
+#2270's own diff fixes) still fail the script correctly. Verified against
+current `public/data`: 10 problems → 4 real problems + 6 holds correctly
+separated.
+
+**Did NOT wire it into `check`/`check:fast` this cycle** even though
+that was the natural next step and the code fully supports it now — doing
+so today would make `npm run check` fail for everyone on `main` until
+#2270 merges, since `ginger`/`peppermint` are a real, currently-live
+regression on production main (not yet fixed there). Wiring a guard into
+the standard gate while it's certain to fail on `main` is worse than not
+wiring it. **Next cycle: once #2270 merges, wire
+`node scripts/audit/verify-curated-indexable.mjs` into the `check:fast`
+script chain** (right after `validate-data-files.mjs` — it's a cheap
+read-two-JSON-files check with no build cost) so this class of bug can't
+silently ship again.
+
+**Finding #2 (documented, not acted on — needs a human decision):** the
+compound-`contraindications_or_flags` safety-gap thread (5+ concurrent
+PRs — #2260, #2262, #2263, #2274, #2277 — all editing
+`data-sources/herb_monograph_master.xlsx` independently) has started
+producing real merge conflicts now that some of them have merged: checked
+#2277's `pull_request_read` and its `mergeable_state` is `"dirty"` against
+current `main`. Binary `.xlsx` conflicts can't be resolved by GitHub's
+web merge UI — someone has to manually re-derive the diff (re-run the
+surgical `edit-entity-master-cell.mjs` edits against a fresh base) or the
+PR is effectively dead weight sitting in the open-PR list. This wasn't
+something a single cycle could safely fix (rebasing another
+already-authored PR's branch on top of newly-merged history, without
+being able to verify the rebase preserves that PR's exact intended cell
+edits, felt too risky to do unattended), so it's left as a documented
+finding rather than an action.
+
+**Takeaway for future cycles:** (1) when a thread you're about to continue
+already merged or has an open PR covering the exact target you're eyeing,
+`list_pull_requests` + a title scan catches it in seconds — do that before
+re-running the audit locally, since a stale local `main` can make a
+claimed gap look like a fresh one. (2) Before adding yet another PR to the
+compound-contraindications-workbook pile, check a sample of the existing
+open ones' `mergeable_state` first — if several are already `dirty`, the
+thread needs a rebase/consolidation pass more than another new batch, and
+piling on makes the eventual untangling worse, not better. (3) A CI/audit
+guard is only safe to wire into the standard gate once it's green against
+current `main` — a guard that's correct-but-currently-failing belongs in
+LOOP_NOTES as "wire this in once PR #NNNN lands," not directly into
+`check`.

--- a/scripts/audit/verify-curated-indexable.mjs
+++ b/scripts/audit/verify-curated-indexable.mjs
@@ -57,6 +57,28 @@ const CURATED_INDEXABLE_COMPOUND_SLUGS = [
   'huperzine-a',
 ];
 
+// A curated slug dropping out of PUBLISH is only a *regression* if nothing
+// deliberately put it there. `indexability-policy.mjs` records an explicit
+// governance decision in `indexability_reasons` whenever a profile is held
+// back on purpose (e.g. `hidden_until_grounded` pending stronger evidence
+// grounding, or a `research_only` profile status). Mirror those two reason
+// families here — keep in lockstep with NOINDEX_DECISIONS and the
+// research_only/minimal profile-status handling in
+// scripts/data/indexability-policy.mjs — so an editor's deliberate hold
+// doesn't get flagged as a false-positive "regression" every run.
+const DELIBERATE_HOLD_DECISIONS = ['hidden_until_grounded', 'research_archive_runtime'];
+const DELIBERATE_HOLD_PROFILE_STATUSES = ['research_only', 'minimal'];
+
+function isDeliberateHold(rec) {
+  const reasons = Array.isArray(rec?.indexability_reasons) ? rec.indexability_reasons : [];
+  return reasons.some((reason) => {
+    const [key, value] = String(reason).split(':');
+    if (key === 'noindex-decision' && DELIBERATE_HOLD_DECISIONS.includes(value)) return true;
+    if (key === 'profile-status' && DELIBERATE_HOLD_PROFILE_STATUSES.includes(value)) return true;
+    return false;
+  });
+}
+
 function loadFlat(file) {
   const p = path.join(DATA_DIR, file);
   if (!fs.existsSync(p)) return [];
@@ -67,33 +89,41 @@ function loadFlat(file) {
 function check(list, slugs, kind) {
   const bySlug = new Map(list.map((r) => [r?.slug, r]));
   const problems = [];
+  const holds = [];
   for (const slug of slugs) {
     const rec = bySlug.get(slug);
     if (!rec) {
       problems.push({ slug, issue: 'missing_from_data' });
       continue;
     }
+    const bucket = isDeliberateHold(rec) ? holds : problems;
+    const issuePrefix = bucket === holds ? 'known_governance_hold' : null;
     if (String(rec.indexability_status || '').toUpperCase() !== 'PUBLISH') {
-      problems.push({
+      bucket.push({
         slug,
-        issue: 'wrong_indexability_status',
+        issue: issuePrefix ?? 'wrong_indexability_status',
         actual: rec.indexability_status,
         reasons: rec.indexability_reasons,
       });
     }
     if (rec.sitemap_included !== true) {
-      problems.push({ slug, issue: 'sitemap_included_false', actual: rec.sitemap_included });
+      bucket.push({
+        slug,
+        issue: issuePrefix ?? 'sitemap_included_false',
+        actual: rec.sitemap_included,
+      });
     }
   }
-  return { kind, problems };
-}const herbs = loadFlat('herbs.json');
+  return { kind, problems, holds };
+}
+const herbs = loadFlat('herbs.json');
 const compounds = loadFlat('compounds.json');
 
 const herbReport = check(herbs, CURATED_INDEXABLE_HERB_SLUGS, 'herbs');
 const compoundReport = check(compounds, CURATED_INDEXABLE_COMPOUND_SLUGS, 'compounds');
 
-const totalProblems =
-  herbReport.problems.length + compoundReport.problems.length;
+const totalProblems = herbReport.problems.length + compoundReport.problems.length;
+const totalHolds = herbReport.holds.length + compoundReport.holds.length;
 
 for (const r of [herbReport, compoundReport]) {
   if (r.problems.length === 0) {
@@ -102,10 +132,14 @@ for (const r of [herbReport, compoundReport]) {
     console.log(`[verify-curated-indexable] ${r.kind}: ${r.problems.length} problems:`);
     for (const p of r.problems) console.log(`  - ${p.slug}: ${p.issue} ${p.actual ? `(actual=${p.actual})` : ''}`);
   }
+  if (r.holds.length > 0) {
+    console.log(`[verify-curated-indexable] ${r.kind}: ${r.holds.length} deliberate governance hold(s) (not counted as a regression):`);
+    for (const p of r.holds) console.log(`  - ${p.slug}: held back by ${JSON.stringify(p.reasons ?? p.actual)}`);
+  }
 }
 
 if (totalProblems > 0) {
-  console.error(`\n[verify-curated-indexable] FAILED: ${totalProblems} curated slug(s) regressed. Fix the governance overlay or workbook before deploying.`);
+  console.error(`\n[verify-curated-indexable] FAILED: ${totalProblems} curated slug(s) regressed${totalHolds > 0 ? ` (${totalHolds} more excluded as deliberate governance holds)` : ''}. Fix the governance overlay or workbook before deploying.`);
   process.exit(1);
 }
-console.log('\n[verify-curated-indexable] OK');
+console.log(`\n[verify-curated-indexable] OK${totalHolds > 0 ? ` (${totalHolds} deliberate governance hold(s) excluded)` : ''}`);


### PR DESCRIPTION
## Summary

- `npm run audit:curated-indexable` (a regression guard checking editor-curated high-traffic herb/compound slugs stay `PUBLISH` + sitemap-included) reports 10 problems against current `main`, but 3 of those slugs (`black-cohosh`, `phosphatidylcholine`, `acetyl-l-carnitine`) are *deliberately* held back by the governance overlay (`hidden_until_grounded` / `research_only` profile status pending stronger evidence grounding) — not regressions. The script had no way to distinguish the two, a gap flagged as a documented next step in PR #2270.
- Added `isDeliberateHold()` to `scripts/audit/verify-curated-indexable.mjs`, matching the `noindex-decision:*` / `profile-status:*` reason strings that `scripts/data/indexability-policy.mjs` already writes into `indexability_reasons` (kept in lockstep via comment, same convention this file already uses for its curated-slug-list duplication).
- Deliberate holds now print as an informational, non-failing section. Genuine regressions (`ginger`, `peppermint` — a real leaked-template-placeholder bug on live, indexed pages, fixed by the separate open PR #2270) still correctly fail the script.
- Documented two findings in `docs/LOOP_NOTES.md` for future cycles: (1) this guard should get wired into `check:fast` once #2270 merges and clears the ginger/peppermint regression — not done in this PR since that would make `npm run check` fail on current `main` for an unrelated, already-tracked issue; (2) the concurrent compound-`contraindications_or_flags` safety-gap PR thread has started hitting real merge conflicts on the shared `.xlsx` workbook (`#2277`'s `mergeable_state` is `dirty`), worth a rebase/consolidation pass before more PRs pile onto it.

## Verification

- [x] `npm run lint`
- [x] `npm run check`
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs (`build-info.json` timestamp reverted)
- [x] no generated file corruption
- [x] static export compatible (script-only change, no app code touched)

## Risk Notes

- Script-only change to an audit tool, not wired into any CI gate in this PR — zero blast radius on the build or deploy.
- No workbook or `public/data` edits.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WRZdE8Y8u9YsX18NoE2yV8)_