### PR TITLE
Fix mobile overlays and duplicate herb navigation

### DIFF
--- a/app/guides/compare/melatonin-vs-magnesium/page.tsx
+++ b/app/guides/compare/melatonin-vs-magnesium/page.tsx
@@ -157,11 +157,16 @@ export default function MelatoninVsMagnesiumPage() {
       <section className="card-premium p-6 space-y-5">
         <p className="eyebrow-label">Decision table</p>
         <h2 className="text-3xl font-semibold tracking-tight text-ink">Melatonin vs magnesium glycinate: head-to-head</h2>
-        <div className="overflow-x-auto">
-          <table className="w-full min-w-[760px] text-left text-sm">
+        <div className="-mx-2 overflow-x-auto px-2 pb-2 [scrollbar-width:thin]">
+          <table className="w-full min-w-[760px] table-fixed border-collapse text-left text-sm">
+            <colgroup>
+              <col className="w-[22%]" />
+              <col className="w-[39%]" />
+              <col className="w-[39%]" />
+            </colgroup>
             <thead className="text-ink">
               <tr className="border-b border-black/10">
-                <th className="py-3 pr-4 text-xs font-bold uppercase tracking-wider">Question</th>
+                <th className="whitespace-nowrap py-3 pr-4 text-xs font-bold uppercase tracking-wider">Question</th>
                 <th className="py-3 pr-4 text-xs font-bold uppercase tracking-wider">Melatonin</th>
                 <th className="py-3 pr-4 text-xs font-bold uppercase tracking-wider">Magnesium glycinate</th>
               </tr>

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -555,13 +555,6 @@ export default async function HerbDetailPage({ params }: PageProps) {
 
       <div className="flex gap-8 items-start">
         <div className="flex-1 min-w-0 space-y-6">
-          {/* Header Breadcrumb - use only common name, not scientific name */}
-      <nav className="flex items-center gap-2 text-xs text-muted">
-        <Link href="/herbs/" className="transition hover:text-ink">Herbs</Link>
-        <span>/</span>
-        <span className="text-ink font-medium">{displayName}</span>
-      </nav>
-
       {/* Title Header — includes the quick-stat strip so the essentials fit in one screen */}
       <div id="overview" className="profile-hero hero-shell scroll-mt-24 rounded-[2rem] border border-brand-900/10 p-5 shadow-sm sm:p-6">
         <header className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_260px] lg:items-start">

--- a/components/conversion-sticky-cta.tsx
+++ b/components/conversion-sticky-cta.tsx
@@ -26,7 +26,7 @@ export default function ConversionStickyCTA({ brand, name, href }: Props) {
   return (
     <>
       {visible ? (
-        <div className="pointer-events-none fixed bottom-20 left-1/2 z-40 w-[calc(100%-2rem)] max-w-xl -translate-x-1/2 rounded-2xl bg-[#111a16] px-4 py-3 text-white shadow-2xl ring-1 ring-black/10 dark:bg-[#1a3028] dark:ring-white/10">
+        <div className="pointer-events-none fixed bottom-20 left-1/2 z-40 hidden w-[calc(100%-2rem)] max-w-xl -translate-x-1/2 rounded-2xl bg-[#111a16] px-4 py-3 text-white shadow-2xl ring-1 ring-black/10 dark:bg-[#1a3028] dark:ring-white/10 md:block">
           <div className="pointer-events-auto flex items-center justify-between gap-3">
             <div className="min-w-0">
               <p className="text-xs font-semibold uppercase tracking-wide text-white/60">Popular choice</p>
@@ -39,7 +39,7 @@ export default function ConversionStickyCTA({ brand, name, href }: Props) {
         </div>
       ) : null}
 
-      <div className="pointer-events-none fixed bottom-0 left-0 right-0 z-40 border-t border-neutral-200 bg-white/95 p-3 shadow-[0_-10px_30px_rgba(0,0,0,0.08)] backdrop-blur dark:border-[var(--border-soft)]">
+      <div className="pointer-events-none fixed bottom-0 left-0 right-0 z-40 hidden border-t border-neutral-200 bg-white/95 p-3 shadow-[0_-10px_30px_rgba(0,0,0,0.08)] backdrop-blur dark:border-[var(--border-soft)] md:block">
         <div className="pointer-events-auto mx-auto flex min-h-14 max-w-5xl items-center justify-between gap-3">
           <div className="min-w-0 text-sm">
             <p className="font-bold text-ink">Top pick</p>


### PR DESCRIPTION
## What changed
- hide the Popular choice and Top pick sticky overlays on mobile across all pages using the shared CTA
- remove the redundant breadcrumb from the shared herb profile template
- stabilize the melatonin-vs-magnesium comparison table columns and mobile scrolling

## Why
The sticky affiliate overlays obscured mobile content, herb profiles displayed duplicate breadcrumb navigation, and the comparison table header wrapped incorrectly on narrow screens.

## Validation
- `npm run typecheck`
- cached deployment checks passed until the production build encountered a local Windows `EPERM` lock on the pre-existing `out` directory
