### PR TITLE
Fix duplicate breadcrumb navigation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1522,3 +1522,8 @@ html.dark :is(
     display: block;
   }
 }
+/* Page templates with their own breadcrumb trail take precedence over the
+   root-layout fallback, preventing two navigation trails from being shown. */
+body:has(#main-content nav[aria-label='Breadcrumb']) [data-global-breadcrumb] {
+  display: none;
+}

--- a/components/Breadcrumbs.tsx
+++ b/components/Breadcrumbs.tsx
@@ -55,7 +55,10 @@ export function Breadcrumbs({
   }
 
   return (
-    <div className="border-b border-brand-900/10 bg-[var(--surface)] dark:border-[var(--border-soft)] dark:bg-[var(--surface)]">
+    <div
+      data-global-breadcrumb
+      className="border-b border-brand-900/10 bg-[var(--surface)] dark:border-[var(--border-soft)] dark:bg-[var(--surface)]"
+    >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
         <AuthorityBreadcrumbs items={breadcrumbs.map(({ href, label }) => ({ href, label }))} />
       </div>


### PR DESCRIPTION
## What changed

- Marked the root-layout breadcrumb as a global fallback.
- Hide that fallback whenever a page template renders its own accessible breadcrumb trail.

## Why

Pages with template-owned breadcrumbs were showing two navigation trails on mobile. The page-owned trail now takes precedence while pages without one retain the global breadcrumb.

## Validation

- `npm run typecheck` passed in the source checkout.
- `git diff --check` passed against current `origin/main`.
