### PR TITLE
Fix mental health article authorship

### DIFF
--- a/app/__tests__/mental-health-navigation.test.ts
+++ b/app/__tests__/mental-health-navigation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { generateNavigationSchema } from '@/components/NavigationSchema'
+import { mentalHealthMetadata } from '@/components/articles/MentalHealthArticlePage'
 import { primaryNavigation } from '@/lib/primary-navigation'
 import { SITE_URL } from '@/lib/navigation-config'
 
@@ -22,5 +23,15 @@ describe('mental health navigation discovery', () => {
       name: 'Mental Health',
       url: `${SITE_URL}/guides/mental-health`,
     })
+  })
+
+  it('uses the verified author identity for mental health article metadata', () => {
+    const metadata = mentalHealthMetadata('obsessive-compulsive-disorder')
+
+    expect(metadata.authors).toEqual([{
+      name: 'Willie B. Randolph III',
+      url: `${SITE_URL}/info/author/`,
+    }])
+    expect(metadata.creator).toBe('Willie B. Randolph III')
   })
 })

--- a/components/articles/MentalHealthArticlePage.tsx
+++ b/components/articles/MentalHealthArticlePage.tsx
@@ -22,8 +22,15 @@ import {
 } from '@/src/lib/seo'
 
 const BASE_PATH = '/guides/mental-health'
-const AUTHOR_NAME = 'Will Thomas'
-const AUTHOR_URL = `${SITE_URL}/info/about/`
+const AUTHOR_NAME = 'Willie B. Randolph III'
+const AUTHOR_URL = `${SITE_URL}/info/author/`
+
+function formatReviewDate(date: string): string {
+  return new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'long',
+    timeZone: 'UTC',
+  }).format(new Date(`${date}T00:00:00Z`))
+}
 
 function citationNumbers(article: MentalHealthArticle): Map<string, number> {
   return new Map(article.references.map((reference, index) => [reference.id, index + 1]))
@@ -159,6 +166,11 @@ export default function MentalHealthArticlePage({ slug }: { slug: string }) {
     '@id': `${articleUrl}#article`,
     url: articleUrl,
     mainEntityOfPage: articleUrl,
+    author: {
+      '@type': 'Person',
+      name: AUTHOR_NAME,
+      url: AUTHOR_URL,
+    },
     image: {
       '@type': 'ImageObject',
       url: canonicalUrl(DEFAULT_OG_IMAGE),
@@ -229,6 +241,9 @@ export default function MentalHealthArticlePage({ slug }: { slug: string }) {
         <div className="mt-3">
           <LastUpdatedBadge date={article.dateReviewed} label="Evidence reviewed" />
         </div>
+        <p className="mt-3 text-sm text-muted">
+          Written and edited by <Link href="/info/author/" rel="author" className="font-semibold text-brand-700 hover:underline">{AUTHOR_NAME}</Link>
+        </p>
         <p className="mt-5 max-w-3xl text-lg leading-8 text-muted">{article.deck}</p>
       </header>
 
@@ -244,7 +259,7 @@ export default function MentalHealthArticlePage({ slug }: { slug: string }) {
           <div>
             <h2 id="source-standard" className="text-lg font-bold text-ink">Source and verification standard</h2>
             <p className="mt-1 max-w-3xl text-sm leading-6 text-muted">
-              Claims are linked to official guidance, government health sources, diagnostic manuals, systematic reviews, meta-analyses, randomized trials, and peer-reviewed clinical reviews. Evidence last reviewed July 13, 2026.
+              Claims are linked to official guidance, government health sources, diagnostic manuals, systematic reviews, meta-analyses, randomized trials, and peer-reviewed clinical reviews. Evidence last reviewed {formatReviewDate(article.dateReviewed)}.
             </p>
           </div>
           <a href="#references" className="text-sm font-bold text-brand-700 hover:text-brand-900">Jump to {article.references.length} references ↓</a>


### PR DESCRIPTION
## What changed

- Corrects the shared mental-health article author identity to Willie B. Randolph III.
- Links metadata and structured data to the verified author page.
- Adds a visible author byline to every mental-health guide.
- Renders each article's actual evidence-review date instead of a hardcoded date.
- Adds a regression test for mental-health metadata authorship.

## Why

The OCD guide and other mental-health articles had strong evidence content but conflicting authorship signals. The renderer named “Will Thomas,” while the hub and author profile identify Willie B. Randolph III. For YMYL content, visible and machine-readable accountability must agree.

## Validation

- ESLint passed for the shared renderer.
- TypeScript passed.
- Mental-health navigation/authorship tests passed (3/3).
- `git diff --check` passed.