### PR TITLE
Normalize canonical author identity

### DIFF
--- a/app/__tests__/author-page.test.ts
+++ b/app/__tests__/author-page.test.ts
@@ -10,4 +10,28 @@ describe('Author page', () => {
     expect(source).toContain('Oak Ridge, Tennessee')
     expect(source).toContain('father of two little girls')
   })
+
+  it('keeps active bylines and schema helpers aligned with the canonical author profile', () => {
+    const identityFiles = [
+      'components/StructuredData.tsx',
+      'components/blog/BlogPostPage.tsx',
+      'lib/structured-data.ts',
+      'src/lib/seo.ts',
+      'app/guides/sleep/best-supplements-for-sleep/page.tsx',
+      'app/guides/sleep/best-natural-sleep-aids-that-work/page.tsx',
+      'app/guides/other/healthy-dipping-tobacco-alternatives/page.tsx',
+      'app/guides/anxiety/best-herbs-for-stress-and-anxiety-at-night/page.tsx',
+      'app/guides/anxiety/best-supplements-for-overthinking/page.tsx',
+      'app/guides/anxiety/how-to-lower-cortisol-naturally/page.tsx',
+      'app/guides/focus/focus-without-caffeine-crash/page.tsx',
+    ]
+    const sources = identityFiles
+      .map((file) => readFileSync(join(process.cwd(), file), 'utf8'))
+      .join('\n')
+
+    expect(sources).not.toContain('Will Thomas')
+    expect(sources).not.toContain('href="/author/"')
+    expect(sources).toContain('Willie B. Randolph III')
+    expect(sources).toContain('/info/author/')
+  })
 })

--- a/app/guides/anxiety/best-herbs-for-stress-and-anxiety-at-night/page.tsx
+++ b/app/guides/anxiety/best-herbs-for-stress-and-anxiety-at-night/page.tsx
@@ -95,8 +95,8 @@ export default function Page() {
             Best Herbs for Stress and Anxiety at Night
           </h1>
           <p className="mt-2 text-xs text-muted">
-            Written and reviewed by{' '}
-            <Link href="/author/" className="font-medium text-brand-700 hover:underline">Will Thomas</Link>
+            Written and edited by{' '}
+            <Link href="/info/author/" rel="author" className="font-medium text-brand-700 hover:underline">Willie B. Randolph III</Link>
             {' '}· Last updated June 2026
           </p>
           <p className="detail-reading mt-4 text-muted">

--- a/app/guides/anxiety/best-supplements-for-overthinking/page.tsx
+++ b/app/guides/anxiety/best-supplements-for-overthinking/page.tsx
@@ -95,8 +95,8 @@ export default function Page() {
             Best Supplements for Overthinking
           </h1>
           <p className="mt-2 text-xs text-muted">
-            Written and reviewed by{' '}
-            <Link href="/author/" className="font-medium text-brand-700 hover:underline">Will Thomas</Link>
+            Written and edited by{' '}
+            <Link href="/info/author/" rel="author" className="font-medium text-brand-700 hover:underline">Willie B. Randolph III</Link>
             {' '}· Last updated June 2026
           </p>
           <p className="detail-reading mt-4 text-muted">

--- a/app/guides/anxiety/how-to-lower-cortisol-naturally/page.tsx
+++ b/app/guides/anxiety/how-to-lower-cortisol-naturally/page.tsx
@@ -94,8 +94,8 @@ export default function Page() {
             How to Lower Cortisol Naturally
           </h1>
           <p className="mt-2 text-xs text-muted">
-            Written and reviewed by{' '}
-            <Link href="/author/" className="font-medium text-brand-700 hover:underline">Will Thomas</Link>
+            Written and edited by{' '}
+            <Link href="/info/author/" rel="author" className="font-medium text-brand-700 hover:underline">Willie B. Randolph III</Link>
             {' '}· Last updated June 2026
           </p>
           <p className="detail-reading mt-4 text-muted">

--- a/app/guides/focus/focus-without-caffeine-crash/page.tsx
+++ b/app/guides/focus/focus-without-caffeine-crash/page.tsx
@@ -96,8 +96,8 @@ export default function Page() {
             Focus Without the Caffeine Crash
           </h1>
           <p className="mt-2 text-xs text-muted">
-            Written and reviewed by{' '}
-            <Link href="/author/" className="font-medium text-brand-700 hover:underline">Will Thomas</Link>
+            Written and edited by{' '}
+            <Link href="/info/author/" rel="author" className="font-medium text-brand-700 hover:underline">Willie B. Randolph III</Link>
             {' '}· Last updated June 2026
           </p>
           <p className="detail-reading mt-4 text-muted">

--- a/app/guides/other/healthy-dipping-tobacco-alternatives/page.tsx
+++ b/app/guides/other/healthy-dipping-tobacco-alternatives/page.tsx
@@ -172,8 +172,8 @@ export default function Page() {
             Healthy Alternatives to Dipping Tobacco
           </h1>
           <p className="mt-2 text-xs text-muted">
-            Written and reviewed by{' '}
-            <Link href="/author/" className="font-medium text-brand-700 hover:underline">Will Thomas</Link>
+            Written and edited by{' '}
+            <Link href="/info/author/" rel="author" className="font-medium text-brand-700 hover:underline">Willie B. Randolph III</Link>
             {' '}· Last updated July 2026
           </p>
           <p className="detail-reading mt-4 text-muted">

--- a/app/guides/sleep/best-natural-sleep-aids-that-work/page.tsx
+++ b/app/guides/sleep/best-natural-sleep-aids-that-work/page.tsx
@@ -99,8 +99,8 @@ export default function Page() {
             Best Natural Sleep Aids That Actually Work
           </h1>
           <p className="mt-2 text-xs text-muted">
-            Written and reviewed by{' '}
-            <Link href="/author/" className="font-medium text-brand-700 hover:underline">Will Thomas</Link>
+            Written and edited by{' '}
+            <Link href="/info/author/" rel="author" className="font-medium text-brand-700 hover:underline">Willie B. Randolph III</Link>
             {' '}· Last updated June 2026
           </p>
           <p className="detail-reading mt-4 text-muted">

--- a/app/guides/sleep/best-supplements-for-sleep/page.tsx
+++ b/app/guides/sleep/best-supplements-for-sleep/page.tsx
@@ -180,8 +180,8 @@ export default function BestSupplementsForSleepPage() {
             Best Supplements for Sleep
           </h1>
           <p className="mt-2 text-xs text-muted">
-            Written and reviewed by{' '}
-            <Link href="/author/" className="font-medium text-brand-700 hover:underline">Will Thomas</Link>
+            Written and edited by{' '}
+            <Link href="/info/author/" rel="author" className="font-medium text-brand-700 hover:underline">Willie B. Randolph III</Link>
             {' '}· Last updated June 26, 2026
           </p>
           <p className="mt-4 text-sm leading-7 text-muted sm:text-base">

--- a/components/StructuredData.tsx
+++ b/components/StructuredData.tsx
@@ -2,7 +2,7 @@ import JsonLd from './seo/JsonLd'
 
 const SITE_URL = 'https://thehippiescientist.net'
 const SITE_NAME = 'The Hippie Scientist'
-const DEFAULT_AUTHOR = 'Will Thomas'
+const DEFAULT_AUTHOR = 'Willie B. Randolph III'
 const MIN_FAQ_SCHEMA_ITEMS = 2
 
 const FAQ_FALLBACK_ANSWER_PREFIXES = [
@@ -104,7 +104,7 @@ export default function StructuredData({
       author: {
         '@type': 'Person',
         name: authorName,
-        url: `${SITE_URL}/info/about/`,
+        url: `${SITE_URL}/info/author/`,
       },
       publisher: {
         '@type': 'Organization',

--- a/components/blog/BlogPostPage.tsx
+++ b/components/blog/BlogPostPage.tsx
@@ -49,7 +49,7 @@ export async function generateMetadata({ params }: BlogRouteProps) {
 
   return {
     ...meta,
-    authors: [{ name: 'Will', url: 'https://thehippiescientist.net/info/about' }],
+    authors: [{ name: 'Willie B. Randolph III', url: 'https://thehippiescientist.net/info/author/' }],
     alternates: { canonical: path },
     robots: shouldNoindexBlogPost(post) ? { index: false, follow: true } : undefined,
   }
@@ -137,8 +137,8 @@ export default async function BlogPostPage({ params }: BlogRouteProps) {
         <h1 className="mt-4 heading-premium max-w-4xl">{post.title}</h1>
         <p className="mt-3 text-sm text-muted">
           By{' '}
-          <Link href="/info/about/" rel="author" className="font-medium text-ink hover:underline">
-            Will
+          <Link href="/info/author/" rel="author" className="font-medium text-ink hover:underline">
+            Willie B. Randolph III
           </Link>
         </p>
         <div className="mt-3">

--- a/lib/structured-data.ts
+++ b/lib/structured-data.ts
@@ -49,8 +49,8 @@ export function buildArticleSchema(post: Record<string, unknown>) {
     url: url,
     author: {
       '@type': 'Person',
-      name: 'Will Thomas',
-      url: 'https://thehippiescientist.net/info/about/'
+      name: 'Willie B. Randolph III',
+      url: 'https://thehippiescientist.net/info/author/'
     },
     publisher: {
       '@type': 'Organization',

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -645,8 +645,8 @@ export function blogJsonLd(post: BlogJsonLdPost, path: string) {
     image: imageUrl,
     author: {
       '@type': 'Person',
-      name: 'Will Thomas',
-      url: `${SITE_URL}/info/about/`,
+      name: 'Willie B. Randolph III',
+      url: `${SITE_URL}/info/author/`,
     },
     publisher: {
       '@type': 'Organization',


### PR DESCRIPTION
## What changed

- Normalizes active schema helpers, blog metadata, and visible guide bylines to Willie B. Randolph III.
- Points author signals to the canonical `/info/author/` profile.
- Replaces unsupported “written and reviewed by” wording with “written and edited by.”
- Adds a regression test covering active author identity surfaces.

## Why

Conflicting author names and an obsolete `/author/` link weakened transparency across YMYL pages. Schema, metadata, and visible attribution now agree with the canonical author profile without implying independent medical review.

## Validation

- ESLint passed across all changed TypeScript and TSX files.
- TypeScript passed.
- Author identity tests passed (2/2).
- `git diff --check` passed.