### PR TITLE
Correct cluster trust completion report file list

### DIFF
--- a/docs/trust-completeness-cluster-member-runtime-completion-2026-07-15.md
+++ b/docs/trust-completeness-cluster-member-runtime-completion-2026-07-15.md
@@ -85,7 +85,7 @@ The previous fill-rate audit inspected only workbook-local safety text and class
 - Build/search/audit: runtime workbook builder, search builder, cluster trust audit, safety fill-rate audit, strict CI/deploy wiring
 - Routes/rendering: compound/herb formatters, compound route/sitemap/redirect contracts, metadata audit, redirect verifier, content-depth injector, built-export validator
 - Tests: resolver, runtime boundary, cluster audit, safety-audit false-positive fixtures
-- Documentation: this report and synchronized internal-link/topic-cluster outputs
+- Documentation: this completion report
 
 ## Tests added
 


### PR DESCRIPTION
Correct the completion report's files-changed section after the final diff audit. Unrelated generated internal-link and topic-cluster outputs were intentionally pruned from PR #2301 and should not be listed as changed.