### PR TITLE
Fix Windows content audit entrypoint

### DIFF
--- a/scripts/content-audit.mjs
+++ b/scripts/content-audit.mjs
@@ -608,8 +608,17 @@ function run() {
   process.exit(0)
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+function isMainModule(entryPath, moduleUrl = import.meta.url) {
+  if (!entryPath) return false
+  try {
+    return fs.realpathSync(entryPath) === fs.realpathSync(fileURLToPath(moduleUrl))
+  } catch {
+    return false
+  }
+}
+
+if (isMainModule(process.argv[1])) {
   run()
 }
 
-export { countWords }
+export { countWords, isMainModule }

--- a/scripts/content-audit.test.mjs
+++ b/scripts/content-audit.test.mjs
@@ -3,7 +3,15 @@ import os from 'os'
 import path from 'path'
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { countWords } from './content-audit.mjs'
+import { countWords, isMainModule } from './content-audit.mjs'
+
+describe('CLI entrypoint detection', () => {
+  it('recognizes a relative Windows-compatible script path as the main module', () => {
+    expect(isMainModule('scripts/content-audit.mjs')).toBe(true)
+    expect(isMainModule('scripts/content-audit.test.mjs')).toBe(false)
+    expect(isMainModule(undefined)).toBe(false)
+  })
+})
 
 describe('countWords', () => {
   it('counts inline JSX text and PROSE_KEYS object-literal values', () => {


### PR DESCRIPTION
## What changed

- Replace the Windows-incompatible content-audit entrypoint comparison with a real-path comparison.
- Export the entrypoint helper and add regression coverage for relative CLI paths.

## Why

`npm run audit:content` silently skipped execution on Windows because `import.meta.url` was compared with `file://${process.argv[1]}` while `process.argv[1]` was relative. The command appeared successful but left stale reports behind, creating false content-prioritization signals.

## Impact

The audit now runs on Windows and refreshes both health reports. The current run audits 8 pages and reports no thin pages, missing metadata, broken links, orphan pages, duplicate slugs, or hardcoded affiliate tags.

## Validation

- `npx vitest run scripts/content-audit.test.mjs` — 4 tests passed
- `npm run audit:content` — 8 pages audited, 0 issues
- `npm run check:fast` — passed
