### PR TITLE
High ROI: optimize magnesium vs melatonin comparison

### DIFF
--- a/app/guides/sleep/magnesium-vs-melatonin/page.tsx
+++ b/app/guides/sleep/magnesium-vs-melatonin/page.tsx
@@ -1,36 +1,56 @@
-import Link from 'next/link';
-import Image from 'next/image';
-import { SeoEntryPage, generateSeoEntryMetadata } from '../../../seo-entry-pages';
-import StructuredData from '@/components/StructuredData';
-import { ArticleLayout, TableOfContents } from '@/components/articles';
-import type { Heading } from '@/components/articles';
-import { getRevenueProductSet } from '@/config/revenue-products';
-import RecommendationSection from '@/components/RecommendationSection';
-import AffiliateDisclosure from '@/components/AffiliateDisclosure';
-import EmailCapture from '@/components/EmailCapture';
+import Link from 'next/link'
+import Image from 'next/image'
+import { SeoEntryPage, generateSeoEntryMetadata } from '../../../seo-entry-pages'
+import StructuredData from '@/components/StructuredData'
+import { ArticleLayout, TableOfContents } from '@/components/articles'
+import type { Heading } from '@/components/articles'
+import { getRevenueProductSet } from '@/config/revenue-products'
+import RecommendationSection from '@/components/RecommendationSection'
+import AffiliateDisclosure from '@/components/AffiliateDisclosure'
+import EmailCapture from '@/components/EmailCapture'
 import References from '@/components/References'
 import ComparisonVerdict from '@/components/editorial/ComparisonVerdict'
 
 const CANONICAL_PATH = '/guides/sleep/magnesium-vs-melatonin/'
-const route = 'guides/magnesium-vs-melatonin';
-const PAGE_URL = 'https://thehippiescientist.net/guides/sleep/magnesium-vs-melatonin';
+const route = 'guides/magnesium-vs-melatonin'
+const PAGE_URL = 'https://thehippiescientist.net/guides/sleep/magnesium-vs-melatonin'
 
 export const metadata = {
   ...generateSeoEntryMetadata(route, CANONICAL_PATH),
+  title: 'Magnesium vs Melatonin for Sleep: Which Fits Your Problem?',
+  description:
+    'Magnesium and melatonin solve different sleep problems. Compare evidence, timing, safety, product selection, and when neither is the right answer.',
   robots: { index: true, follow: true },
-};
+}
 
 const HEADINGS: Heading[] = [
-  { id: 'comparison', text: 'Quick Comparison at a Glance', level: 2 },
-  { id: 'mechanism', text: 'How They Work', level: 2 },
-  { id: 'decision', text: 'Decision Framework', level: 2 },
-  { id: 'routine', text: 'Example Evening Routine', level: 2 },
-  { id: 'bottom-line', text: 'Bottom Line', level: 2 },
+  { id: 'comparison', text: 'Magnesium vs melatonin at a glance', level: 2 },
+  { id: 'mechanism', text: 'How they differ', level: 2 },
+  { id: 'decision', text: 'Choose by sleep problem', level: 2 },
+  { id: 'buying', text: 'What to look for when buying magnesium', level: 2 },
+  { id: 'safety', text: 'Safety and when neither fits', level: 2 },
+  { id: 'bottom-line', text: 'Bottom line', level: 2 },
 ]
 
 const MAGNESIUM_VS_MELATONIN_REFS = [
-  { n: 1, text: 'Abbasi B, et al. (2012). Magnesium and insomnia. J Res Med Sci, 17(12): 1161-1169.', url: 'https://pubmed.ncbi.nlm.nih.gov/23853635/' },
-  { n: 2, text: 'Ferracioli-Oda E, et al. (2013). Melatonin for sleep. PLoS ONE, 8(5): e63773.', url: 'https://pubmed.ncbi.nlm.nih.gov/23691095/' },
+  {
+    n: 1,
+    text: 'Abbasi B, et al. (2012). Magnesium and insomnia. J Res Med Sci, 17(12): 1161-1169.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/23853635/',
+  },
+  {
+    n: 2,
+    text: 'Ferracioli-Oda E, et al. (2013). Melatonin for sleep. PLoS ONE, 8(5): e63773.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/23691095/',
+  },
+]
+
+const BUYING_CHECKLIST = [
+  'Check the elemental magnesium amount, not only the weight of the full compound.',
+  'Choose a clearly labeled form. Glycinate or bisglycinate is often selected for tolerability; oxide is more likely to cause gastrointestinal effects.',
+  'Avoid proprietary blends that hide the amount of each ingredient.',
+  'Prefer a single-ingredient product before trying a multi-supplement sleep blend.',
+  'Review kidney disease and medication cautions before using supplemental magnesium.',
 ]
 
 export default function MagnesiumVsMelatoninGuidePage() {
@@ -42,14 +62,14 @@ export default function MagnesiumVsMelatoninGuidePage() {
       <AffiliateDisclosure variant="compact" className="mb-6" />
       <StructuredData
         pageUrl={PAGE_URL}
-        headline="Magnesium vs Melatonin for Sleep: Evidence-Based Comparison"
-        description="Nuanced comparison of magnesium and melatonin for sleep support. Mechanisms, timing, dosing, safety, decision framework, and when stacking makes sense."
+        headline="Magnesium vs Melatonin for Sleep: Which Fits Your Problem?"
+        description="Evidence-based comparison of magnesium and melatonin for sleep timing, relaxation, safety, and product selection."
         datePublished="2026-06-14"
-        dateModified="2026-06-14"
+        dateModified="2026-07-16"
         breadcrumbs={[
           { label: 'Home', href: '/' },
           { label: 'Guides', href: '/guides' },
-          { label: 'Magnesium vs Melatonin', href: '/guides/sleep/magnesium-vs-melatonin' },
+          { label: 'Magnesium vs Melatonin', href: CANONICAL_PATH },
         ]}
       />
 
@@ -57,171 +77,177 @@ export default function MagnesiumVsMelatoninGuidePage() {
         optionA="Magnesium"
         optionB="Melatonin"
         chooseA={[
-          'Muscle tension or trouble winding down',
-          'You suspect a low magnesium intake (common)',
-          'You want sleep-quality support, not just faster onset',
+          'Muscle tension, restlessness, or difficulty physically winding down',
+          'Low magnesium intake or deficiency risk may be part of the problem',
+          'You want to test a relaxation-oriented option rather than alter sleep timing',
         ]}
         chooseB={[
-          'A circadian / timing problem — jet lag, shift work, delayed sleep phase',
-          'You mainly struggle to fall asleep at the desired hour',
-          'You need it only occasionally, for a schedule shift',
+          'Jet lag, shift work, or a delayed sleep schedule',
+          'You become sleepy later than the bedtime you need',
+          'The main problem is circadian timing rather than physical tension',
         ]}
-        useBoth={['Both relaxation and timing are issues — take magnesium in the evening and low-dose melatonin 30–120 min before your target bedtime.']}
-        avoidBoth={['Loud snoring with daytime exhaustion (possible sleep apnea) or chronic insomnia — see a clinician; neither supplement fixes these.']}
+        useBoth={[
+          'Do not start both at once. Test one ingredient first so you can identify benefit, side effects, and the lowest useful dose.',
+        ]}
+        avoidBoth={[
+          'Loud snoring, breathing pauses, persistent daytime sleepiness, restless legs, or chronic insomnia need clinical evaluation rather than another supplement.',
+        ]}
         winners={[
-          { label: 'Fastest to act', winner: 'Melatonin' },
-          { label: 'Best for muscle tension', winner: 'Magnesium' },
-          { label: 'Best for jet lag / timing', winner: 'Melatonin' },
-          { label: 'Best safety for nightly use', winner: 'Magnesium', note: 'no morning grog' },
+          { label: 'Best for circadian timing', winner: 'Melatonin' },
+          { label: 'Best for jet lag', winner: 'Melatonin' },
+          { label: 'Best when low magnesium is plausible', winner: 'Magnesium' },
+          { label: 'Best for universal insomnia relief', winner: 'Neither', note: 'match the cause first' },
         ]}
       >
-        They solve different problems — magnesium calms the body and nervous system; melatonin shifts your clock. Most people should start with whichever matches the list above, and many combine them.
+        <strong>Quick answer:</strong> melatonin is mainly a timing signal; magnesium is a conditional relaxation option whose sleep benefit is more plausible when intake is low, deficiency risk exists, or physical tension overlaps with poor sleep. Neither is a general-purpose fix for every kind of insomnia.
       </ComparisonVerdict>
 
       <SeoEntryPage route={route} canonicalPath={CANONICAL_PATH} />
 
-      {magnesiumProducts && (
-      <>
-        <References refs={MAGNESIUM_VS_MELATONIN_REFS} />
-          <RecommendationSection products={magnesiumProducts.products} />
-      </>
-      )}
-
-      <EmailCapture location="guides-magnesium-vs-melatonin" className="mt-6" />
-
       <div className="space-y-12">
-
-        {/* Quick Comparison Table */}
         <section id="comparison" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mb-4">Quick Comparison at a Glance</h2>
+          <h2 className="mb-4 text-2xl font-semibold text-ink">Magnesium vs melatonin at a glance</h2>
           <div className="overflow-x-auto rounded-[1.65rem] border border-brand-900/10 bg-white shadow-sm">
-            <table className="min-w-[720px] w-full text-sm border-collapse">
+            <table className="w-full min-w-[720px] border-collapse text-sm">
               <thead>
                 <tr className="border-b border-brand-900/10 bg-brand-50/50">
-                  <th className="text-left p-4 font-semibold text-ink">Aspect</th>
-                  <th className="text-left p-4 font-semibold text-ink">Magnesium</th>
-                  <th className="text-left p-4 font-semibold text-ink">Melatonin</th>
+                  <th className="p-4 text-left font-semibold text-ink">Question</th>
+                  <th className="p-4 text-left font-semibold text-ink">Magnesium</th>
+                  <th className="p-4 text-left font-semibold text-ink">Melatonin</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-brand-900/10">
                 <tr>
-                  <td className="p-4 font-medium text-ink">Primary mechanisms</td>
-                  <td className="p-4 text-muted">NMDA receptor antagonism + GABA support, muscle relaxation</td>
-                  <td className="p-4 text-muted">MT1/MT2 receptor activation in SCN for circadian signaling</td>
+                  <td className="p-4 font-medium text-ink">What does it primarily target?</td>
+                  <td className="p-4 text-muted">Magnesium status, neuromuscular function, and relaxation</td>
+                  <td className="p-4 text-muted">Circadian signaling and sleep timing</td>
                 </tr>
                 <tr>
-                  <td className="p-4 font-medium text-ink">Best suited for</td>
-                  <td className="p-4 text-muted">Relaxation, muscle tension, possible deficiency, sleep quality</td>
-                  <td className="p-4 text-muted">Sleep onset latency, jet lag, delayed sleep phase, schedule shifts</td>
+                  <td className="p-4 font-medium text-ink">Best fit</td>
+                  <td className="p-4 text-muted">Possible low intake, physical tension, or restlessness</td>
+                  <td className="p-4 text-muted">Jet lag, delayed sleep phase, shift work, or schedule changes</td>
                 </tr>
                 <tr>
-                  <td className="p-4 font-medium text-ink">Evidence context</td>
-                  <td className="p-4 text-muted">B-C overall; stronger in deficient or older adults</td>
-                  <td className="p-4 text-muted">B for specific circadian/onset uses</td>
+                  <td className="p-4 font-medium text-ink">Evidence boundary</td>
+                  <td className="p-4 text-muted">Not consistently proven as a broad insomnia treatment in healthy adults</td>
+                  <td className="p-4 text-muted">More convincing for timing and modest sleep-onset effects than for all-night sleep quality</td>
                 </tr>
                 <tr>
-                  <td className="p-4 font-medium text-ink">Typical timing</td>
-                  <td className="p-4 text-muted">Evening use; benefits often build over days to weeks</td>
-                  <td className="p-4 text-muted">30–120 min before desired bedtime (timing is critical)</td>
+                  <td className="p-4 font-medium text-ink">Main practical risk</td>
+                  <td className="p-4 text-muted">GI effects, medication absorption issues, and kidney-disease concerns</td>
+                  <td className="p-4 text-muted">Poor timing, next-day drowsiness, vivid dreams, and medication interactions</td>
                 </tr>
               </tbody>
             </table>
           </div>
         </section>
 
-        {/* Mechanisms + Visual */}
         <section id="mechanism" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mb-4">How They Work</h2>
+          <h2 className="mb-4 text-2xl font-semibold text-ink">How they differ</h2>
           <div className="grid gap-6 md:grid-cols-2">
             <div className="card-premium p-6">
-              <h3 className="font-semibold text-xl mb-3">Magnesium</h3>
-              <p className="text-muted">Acts as an NMDA receptor antagonist and supports GABAergic tone. This helps reduce neuronal excitability while promoting muscle relaxation. Benefits are often more noticeable when addressing suboptimal magnesium status.</p>
+              <h3 className="mb-3 text-xl font-semibold">Magnesium</h3>
+              <p className="text-muted">
+                Magnesium participates in nervous-system and muscle function. That makes it biologically relevant to relaxation, but mechanism alone does not prove that supplementation improves insomnia. The strongest rationale is when low intake, deficiency risk, older age, or physical tension is part of the picture.
+              </p>
             </div>
             <div className="card-premium p-6">
-              <h3 className="font-semibold text-xl mb-3">Melatonin</h3>
-              <p className="text-muted">Activates MT1 and MT2 receptors in the suprachiasmatic nucleus (SCN). It primarily helps align circadian timing and reduce the time it takes to fall asleep.</p>
+              <h3 className="mb-3 text-xl font-semibold">Melatonin</h3>
+              <p className="text-muted">
+                Melatonin is a circadian signal produced by the body at night. Supplemental melatonin can shift or reinforce sleep timing, which is why it fits jet lag and delayed schedules better than vague complaints of poor sleep quality.
+              </p>
             </div>
           </div>
 
           <figure className="my-8">
-            <div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white">
+            <div className="overflow-hidden rounded-2xl border border-brand-900/10 bg-white shadow-sm">
               <Image
                 src="/images/guides/magnesium-melatonin-mechanisms.jpg"
                 alt="Diagram comparing magnesium and melatonin mechanisms for sleep support"
                 width={1176}
                 height={784}
-                className="w-full h-auto"
+                className="h-auto w-full"
               />
             </div>
             <figcaption className="mt-3 text-center text-sm text-muted">
-              Magnesium primarily supports relaxation and sleep quality. Melatonin primarily aids sleep timing and onset via circadian signaling.
+              Magnesium is a conditional relaxation option; melatonin is primarily a sleep-timing signal.
             </figcaption>
           </figure>
         </section>
 
-        {/* Decision Framework + Visual */}
         <section id="decision" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mb-4">Decision Framework</h2>
+          <h2 className="mb-4 text-2xl font-semibold text-ink">Choose by sleep problem</h2>
           <div className="space-y-4 text-muted">
             <div className="card-premium p-5">
-              <p><strong>Lean toward magnesium first if:</strong> Muscle tension, difficulty winding down, or possible low magnesium status is the main issue.</p>
+              <p><strong>Choose magnesium first:</strong> when physical tension, low dietary intake, or deficiency risk is plausible. Treat it as a targeted trial, not a guaranteed sedative.</p>
             </div>
             <div className="card-premium p-5">
-              <p><strong>Lean toward melatonin first if:</strong> Clear circadian or timing problems (jet lag, delayed sleep phase, or difficulty falling asleep at the desired hour).</p>
+              <p><strong>Choose melatonin first:</strong> when your clock is shifted and you are trying to sleep earlier than your body naturally becomes sleepy.</p>
             </div>
             <div className="card-premium p-5">
-              <p><strong>Consider both / thoughtful stacking if:</strong> Overlapping factors exist. Many people combine them successfully when attention is paid to timing and dose.</p>
+              <p><strong>Choose neither first:</strong> when the problem is breathing disruption, pain, restless legs, medication effects, heavy caffeine use, alcohol-related sleep fragmentation, or persistent insomnia.</p>
             </div>
           </div>
 
-          <figure className="my-8 max-w-2xl mx-auto">
-            <div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white">
+          <figure className="my-8 mx-auto max-w-2xl">
+            <div className="overflow-hidden rounded-2xl border border-brand-900/10 bg-white shadow-sm">
               <Image
                 src="/images/guides/magnesium-melatonin-decision.jpg"
                 alt="Decision flowchart for choosing magnesium vs melatonin"
                 width={784}
                 height={1176}
                 priority
-                className="w-full h-auto"
+                className="h-auto w-full"
               />
             </div>
             <figcaption className="mt-3 text-center text-sm text-muted">
-              Use the compare tool for deeper evidence context.
+              Match the supplement to the bottleneck rather than choosing the more popular product.
             </figcaption>
           </figure>
         </section>
 
-        {/* Evening Routine Visual */}
-        <section id="routine" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mb-4">Example Evening Routine</h2>
-          <figure>
-            <div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white">
-              <Image
-                src="/images/guides/evening-sleep-routine.jpg"
-                alt="Sample evening timeline for magnesium and melatonin"
-                width={1176}
-                height={784}
-                className="w-full h-auto"
-              />
-            </div>
-            <figcaption className="mt-3 text-center text-sm text-muted">
-              Adjust timing and doses based on your personal response.
-            </figcaption>
-          </figure>
+        <section id="buying" className="scroll-mt-20 rounded-[1.65rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm">
+          <p className="eyebrow-label">Buyer checklist</p>
+          <h2 className="mt-1 text-2xl font-semibold text-ink">What to look for when buying magnesium</h2>
+          <ul className="mt-5 space-y-3 text-sm leading-7 text-muted">
+            {BUYING_CHECKLIST.map((item) => (
+              <li key={item} className="flex gap-3">
+                <span aria-hidden="true" className="font-bold text-brand-700">✓</span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
         </section>
+
+        {magnesiumProducts && (
+          <RecommendationSection products={magnesiumProducts.products} />
+        )}
+
+        <section id="safety" className="scroll-mt-20 rounded-[1.65rem] border border-amber-200 bg-amber-50/70 p-6">
+          <h2 className="text-xl font-semibold text-amber-950">Safety and when neither fits</h2>
+          <div className="mt-4 space-y-3 text-sm leading-7 text-amber-950/85">
+            <p><strong>Magnesium:</strong> supplemental forms can cause diarrhea or cramping, may affect absorption of some medicines, and require extra caution with impaired kidney function.</p>
+            <p><strong>Melatonin:</strong> can cause next-day drowsiness and may interact with anticoagulants, sedatives, anticonvulsants, immunosuppressants, and other medicines.</p>
+            <p><strong>Do not use stacking as the default:</strong> starting two products together makes it harder to tell which one helped or caused side effects.</p>
+          </div>
+        </section>
+
+        <References refs={MAGNESIUM_VS_MELATONIN_REFS} />
 
         <section id="bottom-line" className="scroll-mt-20 rounded-2xl border border-brand-900/10 bg-white/90 p-6">
-          <h2 className="text-xl font-semibold text-ink mb-3">Bottom Line</h2>
+          <h2 className="mb-3 text-xl font-semibold text-ink">Bottom line</h2>
           <p className="text-muted">
-            Magnesium and melatonin are complementary tools. Choose emphasis based on whether your main need is relaxation/quality support or circadian timing/onset. Thoughtful stacking is common. Prioritize sleep hygiene and use the compare tool for deeper evidence views.
+            Pick melatonin for a timing problem. Consider magnesium when low intake or physical tension plausibly contributes. Start with one intervention, use the lowest practical dose, and reassess the underlying cause when sleep problems persist.
           </p>
           <div className="mt-4 flex flex-wrap gap-4 text-sm">
-            <Link href="/guides/sleep/magnesium-vs-melatonin/" className="font-semibold text-emerald-700 hover:underline">Open side-by-side compare →</Link>
+            <Link href="/guides/sleep/best-supplements-for-sleep/" className="font-semibold text-emerald-700 hover:underline">Compare more sleep options →</Link>
             <Link href="/compounds/magnesium/" className="font-semibold text-emerald-700 hover:underline">Magnesium profile →</Link>
             <Link href="/compounds/melatonin/" className="font-semibold text-emerald-700 hover:underline">Melatonin profile →</Link>
           </div>
         </section>
       </div>
+
+      <EmailCapture location="guides-magnesium-vs-melatonin" className="mt-6" />
     </ArticleLayout>
-  );
+  )
 }


### PR DESCRIPTION
## What changed

- Reframe the comparison around the visitor's actual sleep bottleneck: circadian timing, possible low magnesium status, physical tension, or a problem neither supplement addresses.
- Replace casual stacking language with a single-ingredient-first boundary.
- Move the magnesium recommendation module after the decision framework and a practical buyer checklist.
- Improve title, description, quick answer, structured-data freshness, and internal next-step links.
- Remove the self-referential bottom link and send visitors into the broader sleep guide plus the two supporting profiles.

## Why this is high ROI

This route has direct comparison intent, strong supporting profiles, and an existing monetization module. The previous version exposed the affiliate products before the page had earned the recommendation and presented combining both products as routine. The new flow answers the query first, helps the reader choose, teaches them how to evaluate a product, and only then presents product options.

## Evidence and trust corrections

- Magnesium is no longer presented as broadly effective for healthy sleepers.
- Melatonin is framed primarily as a circadian-timing signal.
- Mechanistic plausibility is separated from proven insomnia benefit.
- Stacking is no longer the default recommendation.
- Medication, kidney-function, and persistent-insomnia cautions are more visible.

## Validation

- Single page-component change.
- No workbook, generated data, routing, schema, or affiliate configuration changes.
- Normal repository checks should run before or immediately after merge.