### PR TITLE
Distinguish deliberate safety-flag abstentions from real gaps in audit:safety

### DIFF
--- a/docs/LOOP_NOTES.md
+++ b/docs/LOOP_NOTES.md
@@ -2707,3 +2707,77 @@ omega-3 trio, `creatine-beta-alanine`) were not checked against
 `workbook-patches/` this cycle — do that check first, per the above, before
 trusting the naming-policy resolution proposed in the prior entry applies
 cleanly to any of them.
+
+---
+
+## 2026-07-16 (later still) — Built the standing `audit:patch-flagged-slugs`-equivalent this entry called for: taught `audit:safety` to separate deliberate abstentions from real gaps
+
+Fresh cold session. `npm run audit:safety`'s "TOP 20 SAFETY COVERAGE GAPS"
+still opened with the same ~14 `priority=95` compounds the last 3 entries
+above have each independently re-investigated and correctly declined to
+fill (`bacopaside-ii`, the curcuminoid pair, `caffeine-l-theanine`, the
+omega-3 trio, `creatine*`, etc.). Manually grepped
+`data-sources/workbook-patches/*.json` for each, per the standing habit —
+every single one hit an **applied**, `requires_human_review: true` change
+that had already, deliberately, cleared `contraindications_or_flags` to
+`''` because the cited evidence (often a whole-extract trial) can't support
+a categorical contraindication for an isolated constituent or
+single-ingredient product. Went one level further this time and checked the
+next tier down too (the `priority=67` betaine cluster, `boswellia-akba-
+standardized`, etc., never discussed in this file before) — same pattern,
+same same-week batches (`safety-coverage-batch-1/2-2026-07-15.json`,
+`trust-completeness-batch-1/2-2026-07-15.json`). Every top-20 entry was a
+settled decision, not a gap.
+
+**This is the exact recurring-friction pattern this file's own prior entry
+flagged as worth a standing script for** ("a legitimate high-ROI target...
+`audit:patch-flagged-slugs <slug1> <slug2> ...` that a cycle runs before
+starting to draft any contraindications content at all"). Rather than a
+separate script needing a slug list fed in by hand each cycle, built it
+directly into `scripts/audit-safety-fill-rate.mjs` (the tool that surfaces
+the slugs in the first place) so it runs automatically with zero per-cycle
+setup — same shape as the existing precedent at
+`scripts/audit/verify-curated-indexable.mjs`'s `isDeliberateHold()`, which
+already solved this identical problem for indexability governance holds.
+
+Added `loadDeliberateAbstentions()`: scans `data-sources/workbook-patches/
+*.json`, and for every `status: "applied"` patch, records any change where
+`column` matches `contraindications_or_flags` (or a legacy variant),
+`new_value` is empty, and `requires_human_review` is `true`. `summarize()`
+now tags each `PRIMARY_ONLY` record with the matching patch file if its
+slug is in that set. The report's "TOP 20" list now excludes tagged
+records entirely and instead prints them under a new, explicitly
+non-actionable `DELIBERATE ABSTENTIONS` section naming the patch file each
+one came from, so a future cycle can go verify the rationale directly
+instead of re-deriving it from scratch.
+
+**Effect, verified by re-running `audit:safety` before/after:** 51 of the
+283 `primary_only` records across both tiers turned out to be settled
+abstentions (14 `priority=95` + the `priority=67` betaine/boswellia cluster
++ ~30 more never previously surfaced in this file, e.g. `gingerols`,
+`ginkgolides`, `maca-root-extract`, `atractylenolide-i/ii/iii`,
+`guggulsterone`). The "TOP 20" list is now genuinely actionable for the
+first time: all `priority=5` obscure-tail compounds
+(`23-epi-26-deoxyactein`, `5-meo-dmt`, `7-hydroxymitragynine`, etc.) that
+were previously invisible behind the same ~20 settled high-priority slugs
+every cycle re-discovered.
+
+Added 3 test cases to `scripts/audit-safety-fill-rate.test.mjs` (applied +
+human-reviewed blank-flags change is caught; proposal-status/non-flags-
+column/no-human-review changes are correctly ignored; `summarize()` still
+reports `PRIMARY_ONLY` status for an abstained record — this is about
+what's *actionable*, not changing the underlying fill-rate math). Full
+gate green: `typecheck`, `lint`, `npm run test` (635/635), `npm run check`
+(including a `data:build:core` regen — diffed clean, only the disposable
+`build-info.json` timestamp changed, reverted before commit). No workbook
+edit, no `public/data` change — this cycle is a tooling-only PR.
+
+**Takeaway for future cycles:** the `priority=95`/`priority=67` gaps this
+file has spent 4 entries manually re-litigating should no longer appear in
+`audit:safety`'s top-20 at all. If they reappear, something regressed this
+new check (e.g. a workbook edit changed `contraindications_or_flags` back
+to non-empty without updating/removing the stale patch record, or a new
+workbook-patches file wasn't picked up) — investigate the mismatch, don't
+assume the slug is fair game again. Genuinely new abstention decisions
+(new patch files, same shape) will be picked up automatically with no
+further tooling work needed.

--- a/scripts/audit-safety-fill-rate.mjs
+++ b/scripts/audit-safety-fill-rate.mjs
@@ -2,6 +2,8 @@
 
 import { assertWorkbookExists, resolveWorkbookPath } from './workbook-source.mjs'
 import { getSheet, readWorkbook, sheetToRows } from './data/workbook-parser.mjs'
+import fs from 'node:fs'
+import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { CLUSTER_MEMBER_RUNTIME_DECISION } from '../config/cluster-member-runtime-trust.mjs'
 
@@ -108,18 +110,63 @@ function pct(filled, total) {
   return total > 0 ? `${Math.round((filled / total) * 100)}%` : '0%'
 }
 
-export function summarize(rows, type) {
+// A PRIMARY_ONLY gap (safety_notes/runtime_safety filled, contraindications_or_flags
+// blank) is not always an oversight. Reviewed enrichment cycles have deliberately
+// cleared that column for isolated constituents/single-ingredient products where the
+// cited evidence (e.g. a whole-extract trial) can't support a categorical
+// contraindication for the specific product — recording the decision as an *applied*,
+// human-review-flagged change in data-sources/workbook-patches/. Without cross-checking
+// those patches, every autonomous cycle re-discovers the same ~20 slugs, re-derives the
+// same "don't fabricate a contraindication" conclusion, and burns a full investigation
+// on already-settled ground (see docs/LOOP_NOTES.md, 2026-07-16 entries on the
+// `creatine`/`bacopaside-ii`/betaine-cluster gaps). Mirror how
+// scripts/audit/verify-curated-indexable.mjs's isDeliberateHold() separates deliberate
+// governance holds from real regressions: print these as informational, not actionable.
+const WORKBOOK_PATCHES_DIR = path.join(process.cwd(), 'data-sources/workbook-patches')
+const FLAGS_COLUMN_PATTERN = /^contraindications([_ ]or[_ ]flags)?$/i
+
+export function loadDeliberateAbstentions(dir = WORKBOOK_PATCHES_DIR) {
+  const abstentions = new Map()
+  if (!fs.existsSync(dir)) return abstentions
+
+  for (const file of fs.readdirSync(dir)) {
+    if (!file.endsWith('.json')) continue
+    let patch
+    try {
+      patch = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf8'))
+    } catch {
+      continue
+    }
+    if (patch?.status !== 'applied') continue
+
+    for (const change of patch.changes ?? []) {
+      const slug = clean(change.slug)
+      const isFlagsColumn = FLAGS_COLUMN_PATTERN.test(clean(change.column))
+      const clearedFlag = isFlagsColumn && clean(change.new_value) === ''
+      if (slug && clearedFlag && change.requires_human_review) {
+        abstentions.set(slug, { patchFile: file, rationale: clean(change.rationale) })
+      }
+    }
+  }
+  return abstentions
+}
+
+export function summarize(rows, type, abstentions = new Map()) {
   const records = rows.map((row, index) => {
     const context = safetyContext(row)
+    const slug = slugFor(row, type, index)
+    const status = classifySafety(context)
+    const abstention = status === 'PRIMARY_ONLY' ? abstentions.get(slug) : undefined
     return {
-      slug: slugFor(row, type, index),
+      slug,
       type,
       priority: Number(first(row, ['recommendation_weight', 'discovery_weight'])) || 0,
       isPublic: /^public$/i.test(clean(row.public_search_visibility)),
       isIndexable: /^index$/i.test(clean(row.seo_indexing_recommendation)),
       ...context,
-      status: classifySafety(context),
+      status,
       runtimeTrustStatus: classifyRuntimeTrust(row),
+      deliberateAbstention: abstention ?? null,
     }
   })
 
@@ -144,7 +191,7 @@ function linesForReport(herbSummary, compoundSummary) {
   const clusterRuntime = allRecords.filter(record => record.runtimeTrustStatus !== 'NOT_TARGETED')
   const clusterRuntimeComplete = clusterRuntime.filter(record => record.runtimeTrustStatus === 'RUNTIME_TRUST_COMPLETE').length
   const clusterRuntimeGaps = clusterRuntime.filter(record => record.runtimeTrustStatus !== 'RUNTIME_TRUST_COMPLETE')
-  const gaps = allRecords
+  const incomplete = allRecords
     .filter((record) => record.status !== 'FILLED')
     .sort((a, b) =>
       Number(b.isPublic) - Number(a.isPublic) ||
@@ -153,7 +200,8 @@ function linesForReport(herbSummary, compoundSummary) {
       a.type.localeCompare(b.type) ||
       a.slug.localeCompare(b.slug),
     )
-    .slice(0, 20)
+  const heldAbstentions = incomplete.filter((record) => record.deliberateAbstention)
+  const gaps = incomplete.filter((record) => !record.deliberateAbstention).slice(0, 20)
 
   return [
     'SAFETY FILL RATE REPORT',
@@ -170,6 +218,11 @@ function linesForReport(herbSummary, compoundSummary) {
     ...(gaps.length
       ? gaps.map((record) => `${record.slug} ${record.type} ${record.status.toLowerCase()} priority=${record.priority}`)
       : ['None']),
+    '',
+    `DELIBERATE ABSTENTIONS — contraindications_or_flags intentionally left blank per an applied, human-review-flagged workbook patch (not actionable; do not re-fill without new evidence): ${heldAbstentions.length}`,
+    ...(heldAbstentions.length
+      ? heldAbstentions.map((record) => `  ${record.slug} ${record.type} (${record.deliberateAbstention.patchFile})`)
+      : []),
     '',
     'COVERAGE DISTRIBUTION:',
     ...distribution(allRecords, (record) => record.status.toLowerCase()).map(([value, count]) => `${value}: ${count}`),
@@ -205,8 +258,9 @@ export async function auditSafetyFillRate(repoRoot = process.cwd()) {
 
   const herbRows = resolveRows(workbook, 'herbs')
   const compoundRows = resolveRows(workbook, 'compounds')
-  const herbSummary = summarize(herbRows, 'herb')
-  const compoundSummary = summarize(compoundRows, 'compound')
+  const abstentions = loadDeliberateAbstentions()
+  const herbSummary = summarize(herbRows, 'herb', abstentions)
+  const compoundSummary = summarize(compoundRows, 'compound', abstentions)
   const report = linesForReport(herbSummary, compoundSummary)
 
   return { herbSummary, compoundSummary, lines: report }

--- a/scripts/audit-safety-fill-rate.test.mjs
+++ b/scripts/audit-safety-fill-rate.test.mjs
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { classifyRuntimeTrust } from './audit-safety-fill-rate.mjs'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { classifyRuntimeTrust, loadDeliberateAbstentions, summarize } from './audit-safety-fill-rate.mjs'
 
 const historicalSlugs = [
   'green-tea-egcg-isolated',
@@ -34,5 +37,80 @@ describe('safety fill-rate runtime classification', () => {
       runtime_safety: '',
       safety_notes: 'Source narrative.',
     })).toBe('SOURCE_ONLY_NOT_RUNTIME')
+  })
+})
+
+describe('deliberate abstention detection', () => {
+  function withPatchFixture(patches, fn) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'workbook-patches-'))
+    try {
+      for (const [name, contents] of Object.entries(patches)) {
+        fs.writeFileSync(path.join(dir, name), JSON.stringify(contents))
+      }
+      return fn(dir)
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  }
+
+  it('treats an applied, human-review-flagged blank-flags change as a deliberate abstention', () => {
+    withPatchFixture(
+      {
+        'batch.json': {
+          status: 'applied',
+          changes: [
+            {
+              slug: 'bacopaside-ii',
+              column: 'contraindications_or_flags',
+              new_value: '',
+              requires_human_review: true,
+              rationale: 'Whole-extract trials cannot establish an isolated-constituent contraindication.',
+            },
+          ],
+        },
+      },
+      (dir) => {
+        const abstentions = loadDeliberateAbstentions(dir)
+        expect(abstentions.get('bacopaside-ii')?.patchFile).toBe('batch.json')
+      },
+    )
+  })
+
+  it('ignores proposal-status patches, non-flags columns, and changes without human review', () => {
+    withPatchFixture(
+      {
+        'batch.json': {
+          status: 'proposal',
+          changes: [{ slug: 'a', column: 'contraindications_or_flags', new_value: '', requires_human_review: true }],
+        },
+        'batch2.json': {
+          status: 'applied',
+          changes: [
+            { slug: 'b', column: 'safety_notes', new_value: '', requires_human_review: true },
+            { slug: 'c', column: 'contraindications_or_flags', new_value: '', requires_human_review: false },
+            { slug: 'd', column: 'contraindications_or_flags', new_value: 'pregnancy', requires_human_review: true },
+          ],
+        },
+      },
+      (dir) => {
+        expect(loadDeliberateAbstentions(dir).size).toBe(0)
+      },
+    )
+  })
+
+  it('excludes a deliberate abstention from summarize gaps but keeps it visible as PRIMARY_ONLY', () => {
+    const abstentions = new Map([['betaine', { patchFile: 'safety-coverage-batch-1-2026-07-15.json', rationale: 'insufficient product-specific evidence' }]])
+    const rows = [
+      { slug: 'betaine', safety_notes: 'Human intervention data were limited.' },
+      { slug: 'some-untouched-compound', safety_notes: 'Narrative present.' },
+    ]
+    const { records } = summarize(rows, 'compound', abstentions)
+    const betaine = records.find((r) => r.slug === 'betaine')
+    const untouched = records.find((r) => r.slug === 'some-untouched-compound')
+
+    expect(betaine.status).toBe('PRIMARY_ONLY')
+    expect(betaine.deliberateAbstention?.patchFile).toBe('safety-coverage-batch-1-2026-07-15.json')
+    expect(untouched.status).toBe('PRIMARY_ONLY')
+    expect(untouched.deliberateAbstention).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

- `npm run audit:safety`'s "TOP 20 SAFETY COVERAGE GAPS" list has repeatedly resurfaced the same ~20 compound slugs across multiple prior autonomous enrichment cycles (`bacopaside-ii`, the curcuminoid pair, `caffeine-l-theanine`, the omega-3 trio, `creatine*`, the betaine cluster, `boswellia-akba-standardized`, etc. — see `docs/LOOP_NOTES.md`). Checking `data-sources/workbook-patches/*.json` for each confirms every single one is a **settled, sourced decision**: an applied, `requires_human_review: true` patch already cleared `contraindications_or_flags` to blank because the cited evidence (often a whole-extract trial) can't support a categorical contraindication for an isolated constituent or single-ingredient product. Without cross-checking those patches, every cycle re-derives the same "don't fabricate a contraindication" conclusion from scratch instead of doing new enrichment work.
- Added `loadDeliberateAbstentions()` to `scripts/audit-safety-fill-rate.mjs`, which cross-references `data-sources/workbook-patches/*.json` for applied, human-review-flagged changes that intentionally blanked `contraindications_or_flags` — mirroring the existing `isDeliberateHold()` pattern already used in `scripts/audit/verify-curated-indexable.mjs` for a structurally identical problem (governance holds vs. real regressions).
- Matching records are now excluded from the actionable top-20 list and instead printed under a new, explicitly non-actionable `DELIBERATE ABSTENTIONS` section naming the patch file each came from, so a future cycle can go verify the rationale instead of re-investigating it. Re-running the audit before/after shows 51 of 283 `primary_only` records were settled abstentions; the top-20 list now surfaces genuinely untouched low-priority tail compounds for the first time.
- No workbook edit and no `public/data` change — this is a tooling-only PR (`data:build:core` was run as part of `npm run check` and diffed clean except a disposable `build-info.json` timestamp, which was reverted before committing).

## Verification

- [x] `npm run lint`
- [x] `npm run check` (typecheck + lint + article/claim/safety validators + `data:build:core` + data-file validation)
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs
- [x] no generated file corruption
- [x] static export compatible (no build-config or runtime changes)
- [x] `npm run test` — 635/635 passing, including 3 new test cases for the new logic

## Risk Notes

- Pure script/test/docs change — no data pipeline output, workbook, or production route is touched.
- Checked open PRs for collisions on `scripts/audit-safety-fill-rate.mjs` — none found.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xa8adqBDFEf16W91fTRf7F)_