### PR TITLE
Add audit:patch-flagged-slugs to check workbook-patch holds before content edits

### DIFF
--- a/docs/LOOP_NOTES.md
+++ b/docs/LOOP_NOTES.md
@@ -2781,3 +2781,72 @@ workbook-patches file wasn't picked up) — investigate the mismatch, don't
 assume the slug is fair game again. Genuinely new abstention decisions
 (new patch files, same shape) will be picked up automatically with no
 further tooling work needed.
+
+---
+
+## 2026-07-16 (later) — Added `npm run audit:patch-flagged-slugs`, a general-purpose complement to the `audit:safety` abstention filter above
+
+Fresh cold session. `npm run audit:safety` showed no new unblocked target
+beyond the same ~14 variant-cluster gaps the last several entries already
+documented as blocked on the workbook-patch collision described just above.
+Rather than re-attempt that content (still blocked, still needs a human
+naming-policy call) or route around it again, picked up the standing tooling
+gap the last entry explicitly flagged for "whichever future cycle picks up
+tooling work next": there was no script to check
+`data-sources/workbook-patches/*.json` for a `requires_human_review: true`
+hold on a slug *before* drafting content for it — only after-the-fact, when
+CI's `validate-workbook-patches` check happened to fail.
+
+Added `scripts/audit-patch-flagged-slugs.mjs` (`npm run
+audit:patch-flagged-slugs -- <slug> [slug...]`): scans every `status:
+"applied"` file in `data-sources/workbook-patches/`, reports any `changes[]`
+entry touching the requested slug(s), and exits non-zero specifically when
+any hit has `requires_human_review: true`. Verified it reproduces the exact
+incident from the "Skipped a creatine/creatine-hcl/creatine-monohydrate..."
+entry above byte-for-byte: running it against `creatine creatine-hcl
+creatine-monohydrate` surfaces the same 6 flagged changes from
+`trust-completeness-batch-4-primary-runtime-2026-07-15.json` (blank
+`contraindications_or_flags`, populated `runtime_safety`, same rationale
+text) that cycle had to discover manually after already drafting and
+opening a PR. Running it against an unrelated slug (`ashwagandha`) with no
+patch history correctly reports a clean pass. Extracted the matching logic
+into an exported pure function (`findFlaggedChanges`) so it's unit-tested
+(`scripts/audit-patch-flagged-slugs.test.mjs`, 6 cases: flags a
+`requires_human_review` hit, ignores non-matching slugs, ignores
+non-`applied` patch status, still surfaces non-flagged hits as
+informational context, matches across multiple files/slugs, and returns
+empty for no patches) rather than only exercised by hand against the live
+(and mutable) `data-sources/workbook-patches/` directory.
+
+**Standing instruction for future cycles:** per the process-gap note in the
+entry above, run `npm run audit:patch-flagged-slugs -- <slug1> <slug2> ...`
+for every target slug *before* drafting any new `contraindications_or_flags`
+/ `safety_notes` / `runtime_safety` content — not just before opening a PR —
+and treat a non-zero exit (a `requires_human_review` hold) as a skip on that
+slug/column, not a staleness bug to fix. This does not by itself resolve the
+14 blocked variant-cluster gaps or the naming-policy question from the
+entries above; it only makes the existing "check workbook-patches first"
+habit a one-line command instead of a manual `grep`.
+
+`npm run check` (typecheck + lint + `data:build:core`) passed. Diff: 1 new
+script, 1 new test file, 1 `package.json` script entry, this note — no
+workbook or `public/data` changes this cycle.
+
+**Note on overlap with the entry directly above (`loadDeliberateAbstentions()`
+in `audit-safety-fill-rate.mjs`):** both this script and that change were
+written independently, in parallel cycles, against the same recurring
+request in this file, and rebasing this branch onto the merged result of
+that one surfaced the duplication. They are not redundant, so both were
+kept: `loadDeliberateAbstentions()` is scoped specifically to
+`contraindications_or_flags` being cleared to empty and runs automatically
+inside the `audit:safety` report, which is exactly right for "which of the
+top-20 fill-rate gaps are actually settled." `audit-patch-flagged-slugs.mjs`
+is column-agnostic, takes an explicit slug list, and is meant to be run
+proactively for *any* slug/column a cycle is about to touch — including
+slugs that are already `FILLED` in the current report but where a cycle
+wants to edit `runtime_safety` or a different field, which
+`loadDeliberateAbstentions()`'s `PRIMARY_ONLY`-only scope wouldn't catch.
+Future cycles: prefer `audit:safety`'s abstention section for "is this
+top-20 gap real," and reach for `audit:patch-flagged-slugs` before editing
+any specific slug's safety-adjacent fields, regardless of its current fill
+status.

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "audit:severity-tokens": "node scripts/audit-severity-token-contraindications.mjs",
     "audit:cluster-member-trust": "node scripts/audit-cluster-member-trust.mjs",
     "audit:cluster-member-trust:strict": "node scripts/audit-cluster-member-trust.mjs --strict",
+    "audit:patch-flagged-slugs": "node scripts/audit-patch-flagged-slugs.mjs",
     "validate:cluster-member-export": "node scripts/ci/validate-cluster-member-export.mjs",
     "audit:duplicates": "node scripts/audit/find-duplicate-slugs.mjs",
     "audit:content-gaps": "node scripts/audit/content-gap-report.mjs",

--- a/scripts/audit-patch-flagged-slugs.mjs
+++ b/scripts/audit-patch-flagged-slugs.mjs
@@ -21,6 +21,30 @@ const __dirname = path.dirname(__filename)
 const repoRoot = path.resolve(__dirname, '..')
 const patchDir = path.join(repoRoot, 'data-sources/workbook-patches')
 
+// Reads and parses every *.json patch file in `dir`. Fails closed: this is a
+// pre-drafting safety gate, so a file we can't read or parse must not be
+// silently dropped — it could be the one file recording the human-review
+// hold a cycle is trying to check for. Throws listing every bad file rather
+// than reporting a false-clear "no history found."
+export function loadPatchesByFile(dir) {
+  const patchesByFile = {}
+  const unreadable = []
+  for (const name of fs.readdirSync(dir).filter((n) => n.endsWith('.json')).sort()) {
+    try {
+      patchesByFile[name] = JSON.parse(fs.readFileSync(path.join(dir, name), 'utf8'))
+    } catch (error) {
+      unreadable.push(`${name}: ${error.message}`)
+    }
+  }
+  if (unreadable.length > 0) {
+    throw new Error(
+      `Could not read/parse ${unreadable.length} workbook-patch file(s), so a human-review hold could be hidden in one of them:\n` +
+        unreadable.map((line) => `  - ${line}`).join('\n'),
+    )
+  }
+  return patchesByFile
+}
+
 // Pure: given { fileName -> parsed patch JSON } and a list of target slugs,
 // return every `changes[]` entry across `status: "applied"` patch files that
 // touches one of those slugs.
@@ -50,14 +74,12 @@ function main() {
     process.exit(0)
   }
 
-  const patchFiles = fs.readdirSync(patchDir).filter((name) => name.endsWith('.json')).sort()
-  const patchesByFile = {}
-  for (const name of patchFiles) {
-    try {
-      patchesByFile[name] = JSON.parse(fs.readFileSync(path.join(patchDir, name), 'utf8'))
-    } catch {
-      // Skip unreadable/malformed patch files rather than fail the whole check.
-    }
+  let patchesByFile
+  try {
+    patchesByFile = loadPatchesByFile(patchDir)
+  } catch (error) {
+    console.error(`[audit:patch-flagged-slugs] FAIL: ${error.message}`)
+    process.exit(1)
   }
 
   const hits = findFlaggedChanges(patchesByFile, slugs)

--- a/scripts/audit-patch-flagged-slugs.mjs
+++ b/scripts/audit-patch-flagged-slugs.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// Checks whether any workbook-patch file in data-sources/workbook-patches/
+// already recorded a `requires_human_review: true` decision for one or more
+// slugs, before a cycle starts drafting new content for those slugs.
+//
+// This exists because a direct edit (e.g. via edit-entity-master-cell.mjs)
+// can silently reverse a deliberate, sourced, human-flagged patch decision
+// made through the separate workbook-patch pipeline on the same cell/column —
+// see docs/LOOP_NOTES.md, 2026-07-16 "Skipped a creatine/.../.../ contra-
+// indications fill" entry, for the incident this script is meant to prevent.
+// Run this for every target slug up front, before drafting content, not just
+// before opening a PR.
+//
+// Usage: node scripts/audit-patch-flagged-slugs.mjs <slug> [slug...]
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const repoRoot = path.resolve(__dirname, '..')
+const patchDir = path.join(repoRoot, 'data-sources/workbook-patches')
+
+// Pure: given { fileName -> parsed patch JSON } and a list of target slugs,
+// return every `changes[]` entry across `status: "applied"` patch files that
+// touches one of those slugs.
+export function findFlaggedChanges(patchesByFile, slugs) {
+  const slugSet = new Set(slugs)
+  const hits = []
+  for (const [file, patch] of Object.entries(patchesByFile)) {
+    if (!patch || patch.status !== 'applied' || !Array.isArray(patch.changes)) continue
+    for (const change of patch.changes) {
+      if (!change || !slugSet.has(change.slug)) continue
+      hits.push({ file, patchId: patch.id, ...change })
+    }
+  }
+  return hits
+}
+
+function main() {
+  const slugs = process.argv.slice(2).map((s) => s.trim()).filter(Boolean)
+
+  if (slugs.length === 0) {
+    console.error('Usage: node scripts/audit-patch-flagged-slugs.mjs <slug> [slug...]')
+    process.exit(1)
+  }
+
+  if (!fs.existsSync(patchDir)) {
+    console.log('[audit:patch-flagged-slugs] No workbook patch directory present — nothing to check.')
+    process.exit(0)
+  }
+
+  const patchFiles = fs.readdirSync(patchDir).filter((name) => name.endsWith('.json')).sort()
+  const patchesByFile = {}
+  for (const name of patchFiles) {
+    try {
+      patchesByFile[name] = JSON.parse(fs.readFileSync(path.join(patchDir, name), 'utf8'))
+    } catch {
+      // Skip unreadable/malformed patch files rather than fail the whole check.
+    }
+  }
+
+  const hits = findFlaggedChanges(patchesByFile, slugs)
+
+  if (hits.length === 0) {
+    console.log(`[audit:patch-flagged-slugs] No applied workbook-patch history found for: ${slugs.join(', ')}`)
+    process.exit(0)
+  }
+
+  const flagged = hits.filter((h) => h.requires_human_review === true)
+
+  console.log(`[audit:patch-flagged-slugs] Found ${hits.length} applied change(s) across ${new Set(hits.map((h) => h.file)).size} patch file(s) for: ${slugs.join(', ')}\n`)
+
+  for (const hit of hits) {
+    const marker = hit.requires_human_review === true ? 'REQUIRES HUMAN REVIEW' : 'informational'
+    console.log(`- [${marker}] ${hit.slug}.${hit.column} (${hit.file} / ${hit.patchId})`)
+    console.log(`    new_value: ${JSON.stringify(hit.new_value)}`)
+    if (hit.rationale) console.log(`    rationale: ${hit.rationale}`)
+    console.log('')
+  }
+
+  if (flagged.length > 0) {
+    console.log(
+      `[audit:patch-flagged-slugs] HOLD: ${flagged.length} change(s) above are flagged requires_human_review — ` +
+        'do not draft content that reverses these without a human decision. Skip the affected slug/column, ' +
+        "don't route around the flag.",
+    )
+    process.exit(2)
+  }
+
+  console.log('[audit:patch-flagged-slugs] PASS: no requires_human_review holds for these slugs.')
+  process.exit(0)
+}
+
+if (process.argv[1] === __filename) {
+  main()
+}

--- a/scripts/audit-patch-flagged-slugs.test.mjs
+++ b/scripts/audit-patch-flagged-slugs.test.mjs
@@ -1,5 +1,44 @@
-import { describe, expect, it } from 'vitest'
-import { findFlaggedChanges } from './audit-patch-flagged-slugs.mjs'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { findFlaggedChanges, loadPatchesByFile } from './audit-patch-flagged-slugs.mjs'
+
+const tempDirs = []
+function makeTempPatchDir(files) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'workbook-patches-test-'))
+  tempDirs.push(dir)
+  for (const [name, contents] of Object.entries(files)) {
+    fs.writeFileSync(path.join(dir, name), contents, 'utf8')
+  }
+  return dir
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    fs.rmSync(tempDirs.pop(), { recursive: true, force: true })
+  }
+})
+
+describe('loadPatchesByFile', () => {
+  it('parses every *.json file in the directory', () => {
+    const dir = makeTempPatchDir({
+      'a.json': JSON.stringify({ status: 'applied', changes: [] }),
+      'b.json': JSON.stringify({ status: 'proposal', changes: [] }),
+      'README.md': 'not json, and not a .json file, so must be ignored',
+    })
+    const patches = loadPatchesByFile(dir)
+    expect(Object.keys(patches).sort()).toEqual(['a.json', 'b.json'])
+  })
+
+  it('fails closed (throws) when a patch file cannot be parsed, instead of silently dropping it', () => {
+    const dir = makeTempPatchDir({
+      'a.json': JSON.stringify({ status: 'applied', changes: [] }),
+      'corrupt.json': '{not valid json',
+    })
+    expect(() => loadPatchesByFile(dir)).toThrowError(/corrupt\.json/)
+  })
+})
 
 describe('findFlaggedChanges', () => {
   it('flags an applied change with requires_human_review: true for a matching slug', () => {

--- a/scripts/audit-patch-flagged-slugs.test.mjs
+++ b/scripts/audit-patch-flagged-slugs.test.mjs
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { findFlaggedChanges } from './audit-patch-flagged-slugs.mjs'
+
+describe('findFlaggedChanges', () => {
+  it('flags an applied change with requires_human_review: true for a matching slug', () => {
+    const patchesByFile = {
+      'batch-1.json': {
+        id: 'batch-1',
+        status: 'applied',
+        changes: [
+          { slug: 'creatine', column: 'contraindications_or_flags', new_value: '', requires_human_review: true },
+        ],
+      },
+    }
+    const hits = findFlaggedChanges(patchesByFile, ['creatine'])
+    expect(hits).toHaveLength(1)
+    expect(hits[0]).toMatchObject({ file: 'batch-1.json', patchId: 'batch-1', slug: 'creatine', requires_human_review: true })
+  })
+
+  it('ignores changes for slugs not in the requested list', () => {
+    const patchesByFile = {
+      'batch-1.json': {
+        status: 'applied',
+        changes: [{ slug: 'ashwagandha', column: 'contraindications_or_flags', requires_human_review: true }],
+      },
+    }
+    expect(findFlaggedChanges(patchesByFile, ['creatine'])).toEqual([])
+  })
+
+  it('ignores changes from patches that are not status: "applied" (proposal/approved)', () => {
+    const patchesByFile = {
+      'batch-1.json': {
+        status: 'proposal',
+        changes: [{ slug: 'creatine', column: 'contraindications_or_flags', requires_human_review: true }],
+      },
+    }
+    expect(findFlaggedChanges(patchesByFile, ['creatine'])).toEqual([])
+  })
+
+  it('returns a hit even when requires_human_review is false, so callers can render informational context', () => {
+    const patchesByFile = {
+      'batch-1.json': {
+        status: 'applied',
+        changes: [{ slug: 'creatine', column: 'runtime_safety', new_value: 'x', requires_human_review: false }],
+      },
+    }
+    const hits = findFlaggedChanges(patchesByFile, ['creatine'])
+    expect(hits).toHaveLength(1)
+    expect(hits[0].requires_human_review).toBe(false)
+  })
+
+  it('matches across multiple patch files and multiple requested slugs', () => {
+    const patchesByFile = {
+      'batch-1.json': {
+        id: 'batch-1',
+        status: 'applied',
+        changes: [{ slug: 'creatine-hcl', column: 'contraindications_or_flags', requires_human_review: true }],
+      },
+      'batch-2.json': {
+        id: 'batch-2',
+        status: 'applied',
+        changes: [{ slug: 'creatine-monohydrate', column: 'runtime_safety', requires_human_review: true }],
+      },
+    }
+    const hits = findFlaggedChanges(patchesByFile, ['creatine-hcl', 'creatine-monohydrate'])
+    expect(hits).toHaveLength(2)
+    expect(hits.map((h) => h.file).sort()).toEqual(['batch-1.json', 'batch-2.json'])
+  })
+
+  it('returns no hits when no patches are present', () => {
+    expect(findFlaggedChanges({}, ['creatine'])).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `scripts/audit-patch-flagged-slugs.mjs` (`npm run audit:patch-flagged-slugs -- <slug> [slug...]`), which scans every `status: "applied"` file in `data-sources/workbook-patches/` and reports any recorded change touching the given slug(s), exiting non-zero when a hit is flagged `requires_human_review: true`.
- This closes a recurring process gap documented in `docs/LOOP_NOTES.md`: a direct workbook edit can silently reverse a sourced, human-reviewed decision recorded by the separate workbook-patch pipeline on the same cell, and previously the only way to catch that was after the fact when CI's `validate-workbook-patches` check happened to fail. Running this script against a target slug up front, before drafting content, surfaces the hold immediately — verified it reproduces byte-for-byte the exact incident recorded in the "Skipped a creatine/creatine-hcl/creatine-monohydrate contraindications fill" `LOOP_NOTES.md` entry.
- Matching logic is extracted into an exported pure function (`findFlaggedChanges`) with unit tests in `scripts/audit-patch-flagged-slugs.test.mjs` (6 cases), rather than only exercised against the live, mutable `data-sources/workbook-patches/` directory.
- No workbook or `public/data` changes in this PR.

## Verification

- [x] `npm run lint`
- [x] `npm run check`
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs
- [x] no generated file corruption
- [x] static export compatible (no route/build-config changes)

## Risk Notes

- Purely additive: one new script, one new test file, one `package.json` script entry, and a `docs/LOOP_NOTES.md` note. Does not change any existing script's behavior or any generated data.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hn1wC6NXo9KE4ZrTdEzgiE)_