### PR TITLE
Connect magnesium-types-guide to curated magnesium product picks

### DIFF
--- a/app/guides/other/magnesium-types-guide/page.tsx
+++ b/app/guides/other/magnesium-types-guide/page.tsx
@@ -7,6 +7,8 @@ import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
 import FAQSchema from '@/components/seo/FAQSchema'
 import References from '@/components/References'
 import EmailCapture from '../../../../components/EmailCapture'
+import { getRevenueProductSet } from '@/config/revenue-products'
+import RecommendationSection from '@/components/RecommendationSection'
 
 export const metadata: Metadata = buildPageMetadata({
   title: 'Magnesium Types Compared: Which Form Is Best? (2026 Guide)',
@@ -35,6 +37,7 @@ const MAGNESIUM_TYPES_REFS = [
 ]
 
 export default function MagnesiumTypesPage() {
+  const magnesiumProducts = getRevenueProductSet('magnesium')
   return (
     <div className="container-page py-10 space-y-10">
       <AuthorityJsonLd title="Magnesium Types Compared" description="Glycinate, citrate, oxide, threonate — which magnesium is right for you?" url="https://thehippiescientist.net/guides/other/magnesium-types-guide" type="Article" />
@@ -65,6 +68,14 @@ export default function MagnesiumTypesPage() {
           <div className="p-4 rounded-xl bg-red-50/60"><h3 className="font-semibold text-ink">Oxide — Avoid</h3><p className="mt-2 text-sm leading-7 text-muted">The cheapest and most common form in drugstore supplements — and the worst. Bioavailability is ~4% [2], meaning 96% passes through unabsorbed. It will raise magnesium levels in severely deficient people at high doses, but glycinate or citrate achieve the same effect at lower doses with fewer GI effects. Save your money.</p></div>
         </div>
       </section>
+
+      {magnesiumProducts && (
+        <RecommendationSection
+          title="Magnesium glycinate picks"
+          description="Glycinate is the all-purpose winner from the comparison above — well-absorbed, well-tolerated, and useful for sleep, anxiety, and general supplementation. These are sourcing starting points, not medical recommendations."
+          products={magnesiumProducts.products}
+        />
+      )}
 
       <section className="card-premium p-6 space-y-4 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">The magnesium deficiency problem</h2><p className="text-sm leading-7 text-muted">Up to 50% of the US population consumes less than the EAR for magnesium [8]. Deficiency is associated with increased inflammation, poor sleep, anxiety, and cardiovascular risk. Processed food diets, soil depletion, and certain medications (PPIs, diuretics) all contribute. Most people would benefit from increasing magnesium intake through diet (leafy greens, nuts, seeds, legumes) or supplementation — and the form matters. Glycinate is the best general-purpose choice; citrate if constipation is a goal; threonate if you are specifically targeting brain health and can afford the premium.</p></section>
 


### PR DESCRIPTION
## Summary

- `/guides/other/magnesium-types-guide` was the #1 ranked page in `scripts/audit/high-roi-content-opportunities.mjs` (score 151, following the `l-theanine-without-caffeine` fix merged earlier this cycle) — high commercial intent, flagged for missing a context-matched `RecommendationSection`. The page's own "Bottom line" section already recommends magnesium glycinate as the best all-purpose choice, but had no product picks at all. Wired in the existing `RecommendationSection` + `getRevenueProductSet('magnesium')` module (already used on `magnesium-vs-melatonin` and other optimized sleep/anxiety pages), placed right after the "Evidence by form" section where the reader has just been walked through why glycinate is the recommended form.

## Verification

- [x] `npm run lint`
- [x] `npm run check` (typecheck + lint + article-quality/claim/safety validators + `data:build:core`)
- [x] `npx vitest run` — 643/643 passed
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs (only a disposable `build-info.json` timestamp, reverted before commit)
- [x] no generated file corruption
- [x] static export compatible (no server-only APIs used)

## Risk Notes

- Content-only change to one page component; no data pipeline or workbook changes.
- Re-ran `scripts/audit/high-roi-content-opportunities.mjs` after the change: this page's flag cleared, next-highest opportunity moved up.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rvw7yZX7PAKCFnVES6MS3Y)_