### PR TITLE
Connect l-theanine-for-anxiety to curated product picks

### DIFF
--- a/app/guides/anxiety/l-theanine-for-anxiety/page.tsx
+++ b/app/guides/anxiety/l-theanine-for-anxiety/page.tsx
@@ -8,6 +8,8 @@ import EmailCapture from '@/components/EmailCapture'
 import NewsletterCtaBlock from '@/components/NewsletterCtaBlock'
 import LastUpdatedBadge from '../../../../src/components/editorial/LastUpdatedBadge'
 import { AFFILIATE_TAGS } from '@/config/affiliate'
+import { getRevenueProductSet } from '@/config/revenue-products'
+import RecommendationSection from '@/components/RecommendationSection'
 
 const SLUG = 'l-theanine-for-anxiety'
 const TITLE = 'L-Theanine for Anxiety: Benefits, Dosage, Safety, and Research Review'
@@ -384,6 +386,8 @@ export default function LTheanineForAnxietyPage() {
             </ul>
           </div>
         </section>
+
+        <RecommendationSection products={getRevenueProductSet('l-theanine')?.products ?? []} />
 
         <div className="my-12">
           <NewsletterCtaBlock />


### PR DESCRIPTION
## Summary

- `/guides/anxiety/l-theanine-for-anxiety` was the #1-ranked page in `high-roi-content-opportunities` audit, flagged for missing a `RecommendationSection`. It only had ad-hoc Amazon search-query cards instead of the shared curated `l-theanine` product set (`config/revenue-products.ts`) that other optimized anxiety-cluster pages (e.g. `ashwagandha-for-anxiety`) already use.
- Added `RecommendationSection` wired to `getRevenueProductSet('l-theanine')`, appended after the existing buyer-guide section, matching the established sibling-page convention.

## Verification

- [x] `npm run lint`
- [x] `npm run check`
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs (build-timestamp diff reverted)
- [x] no generated file corruption
- [x] static export compatible
- [x] `npx vitest run` — 643/643 passed
- [x] re-ran `node scripts/audit/high-roi-content-opportunities.mjs` — page no longer appears in top opportunities

## Risk Notes

- Additive-only change (4 lines): one import pair and one new section. No existing content removed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PBhJTfnFVn3t6ZqULyBU28)_