### PR TITLE
Resolve #2319 safely on current main

### DIFF
--- a/scripts/ci/guard-detail-additive-freshness.mjs
+++ b/scripts/ci/guard-detail-additive-freshness.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { KEYWORDS } from '../data/build-interaction-data.mjs'
+import { CLUSTER_MEMBER_RUNTIME_DECISION } from '../../config/cluster-member-runtime-trust.mjs'
+
+const __filename = fileURLToPath(import.meta.url)
+const repoRoot = path.resolve(path.dirname(__filename), '../..')
+const dataDir = path.join(repoRoot, 'public/data')
+const ADDITIVE_MECHS = new Set(['serotonergic', 'anticoagulant', 'cns_sedation', 'blood_glucose', 'blood_pressure'])
+
+function loadFlatList(fileName) {
+  const parsed = JSON.parse(fs.readFileSync(path.join(dataDir, fileName), 'utf8'))
+  return Array.isArray(parsed) ? parsed : Object.values(parsed).find(Array.isArray) || []
+}
+
+function makeDetailReader(detailDirName) {
+  const dir = path.join(dataDir, detailDirName)
+  return (slug) => {
+    const file = path.join(dir, `${slug}.json`)
+    if (!fs.existsSync(file)) return null
+    return JSON.parse(fs.readFileSync(file, 'utf8'))
+  }
+}
+
+export function findStaleDetailRecords(flatRecords, tagsBySlug, readDetail) {
+  const findings = []
+  for (const record of flatRecords) {
+    if (!record?.slug || record.runtime_export_decision === CLUSTER_MEMBER_RUNTIME_DECISION) continue
+    const detail = readDetail(record.slug)
+    if (!detail || !('contraindications' in detail)) continue
+    const detailList = Array.isArray(detail.contraindications) ? detail.contraindications : []
+
+    if (detailList.length === 0) {
+      if (Array.isArray(record.contraindications) && record.contraindications.length > 0) {
+        findings.push({ slug: record.slug, reason: 'empty_override', missing: [] })
+      }
+      continue
+    }
+
+    const additiveMechs = (tagsBySlug[record.slug] || [])
+      .filter((tag) => tag.pair_behavior === 'additive' && ADDITIVE_MECHS.has(tag.risk_mechanism))
+      .map((tag) => tag.risk_mechanism)
+    if (additiveMechs.length === 0) continue
+
+    const detailText = detailList.join(' ').toLowerCase()
+    const missing = additiveMechs.filter((mechanism) => !KEYWORDS[mechanism].some((keyword) => detailText.includes(keyword)))
+    if (missing.length > 0) findings.push({ slug: record.slug, reason: 'stale_mechanism', missing })
+  }
+  return findings
+}
+
+function main() {
+  const herbs = loadFlatList('herbs.json')
+  const compounds = loadFlatList('compounds.json')
+  const tagsBySlug = JSON.parse(fs.readFileSync(path.join(dataDir, 'entity_risk_tags.json'), 'utf8'))
+  const findings = [
+    ...findStaleDetailRecords(herbs, tagsBySlug, makeDetailReader('herbs-detail')),
+    ...findStaleDetailRecords(compounds, tagsBySlug, makeDetailReader('compounds-detail')),
+  ]
+
+  if (findings.length === 0) {
+    console.log('[guard:detail-additive-freshness] PASS: no stale detail safety overrides found.')
+    return
+  }
+
+  console.error(`[guard:detail-additive-freshness] FAIL: ${findings.length} stale detail override(s):`)
+  for (const finding of findings) {
+    const reason = finding.reason === 'empty_override'
+      ? 'empty contraindications array overrides a non-empty flat record'
+      : `missing additive mechanism(s): ${finding.missing.join(', ')}`
+    console.error(`  - ${finding.slug}: ${reason}`)
+  }
+  console.error('\nFix with: npm run data:backfill-detail-additive-mechanisms')
+  process.exit(1)
+}
+
+if (process.argv[1] === __filename) main()

--- a/scripts/ci/guard-detail-additive-freshness.test.mjs
+++ b/scripts/ci/guard-detail-additive-freshness.test.mjs
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { findStaleDetailRecords } from './guard-detail-additive-freshness.mjs'
+
+const TAGS = {
+  'herb-a': [{ risk_mechanism: 'serotonergic', pair_behavior: 'additive' }],
+  'herb-b': [{ risk_mechanism: 'anticoagulant', pair_behavior: 'additive' }],
+}
+
+const readerFor = (records) => (slug) => records[slug] ?? null
+
+describe('findStaleDetailRecords', () => {
+  it('flags a missing additive mechanism', () => {
+    const flat = [{ slug: 'herb-a', contraindications: ['serotonin syndrome with SSRIs'] }]
+    const findings = findStaleDetailRecords(flat, TAGS, readerFor({ 'herb-a': { contraindications: ['pregnancy'] } }))
+    expect(findings).toEqual([{ slug: 'herb-a', reason: 'stale_mechanism', missing: ['serotonergic'] }])
+  })
+
+  it('passes when detail content includes the mechanism', () => {
+    const flat = [{ slug: 'herb-a', contraindications: ['serotonin syndrome with SSRIs'] }]
+    expect(findStaleDetailRecords(flat, TAGS, readerFor({ 'herb-a': { contraindications: ['serotonin syndrome with SSRIs'] } }))).toEqual([])
+  })
+
+  it('flags an empty override', () => {
+    const flat = [{ slug: 'herb-b', contraindications: ['bleeding risk with anticoagulants'] }]
+    expect(findStaleDetailRecords(flat, TAGS, readerFor({ 'herb-b': { contraindications: [] } }))).toEqual([
+      { slug: 'herb-b', reason: 'empty_override', missing: [] },
+    ])
+  })
+
+  it('ignores absent detail files and absent contraindications keys', () => {
+    const flat = [{ slug: 'herb-a', contraindications: ['serotonin syndrome with SSRIs'] }]
+    expect(findStaleDetailRecords(flat, TAGS, readerFor({}))).toEqual([])
+    expect(findStaleDetailRecords(flat, TAGS, readerFor({ 'herb-a': { dosage: '500 mg' } }))).toEqual([])
+  })
+
+  it('skips cluster-member records', () => {
+    const flat = [{ slug: 'herb-a', runtime_export_decision: 'cluster_member_runtime', contraindications: ['serotonin syndrome'] }]
+    expect(findStaleDetailRecords(flat, TAGS, readerFor({ 'herb-a': { contraindications: [] } }))).toEqual([])
+  })
+})

--- a/scripts/data/backfill-detail-additive-mechanisms.mjs
+++ b/scripts/data/backfill-detail-additive-mechanisms.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { findStaleDetailRecords } from '../ci/guard-detail-additive-freshness.mjs'
+
+const __filename = fileURLToPath(import.meta.url)
+const repoRoot = path.resolve(path.dirname(__filename), '../..')
+const dataDir = path.join(repoRoot, 'public/data')
+const dryRun = process.argv.includes('--dry-run')
+
+function loadFlatList(fileName) {
+  const parsed = JSON.parse(fs.readFileSync(path.join(dataDir, fileName), 'utf8'))
+  return Array.isArray(parsed) ? parsed : Object.values(parsed).find(Array.isArray) || []
+}
+
+function detailPath(detailDirName, slug) {
+  return path.join(dataDir, detailDirName, `${slug}.json`)
+}
+
+export function unionLists(detailList, flatList) {
+  const seen = new Set(detailList.map((item) => String(item).toLowerCase().trim()))
+  const merged = [...detailList]
+  for (const item of flatList) {
+    const key = String(item).toLowerCase().trim()
+    if (!key || seen.has(key)) continue
+    seen.add(key)
+    merged.push(item)
+  }
+  return merged
+}
+
+function fixGroup(flatFileName, detailDirName, tagsBySlug) {
+  const flatList = loadFlatList(flatFileName)
+  const readDetail = (slug) => {
+    const file = detailPath(detailDirName, slug)
+    return fs.existsSync(file) ? JSON.parse(fs.readFileSync(file, 'utf8')) : null
+  }
+  const findings = findStaleDetailRecords(flatList, tagsBySlug, readDetail)
+  const flatBySlug = new Map(flatList.map((record) => [record.slug, record]))
+
+  for (const finding of findings) {
+    const file = detailPath(detailDirName, finding.slug)
+    const detail = JSON.parse(fs.readFileSync(file, 'utf8'))
+    const flatRecord = flatBySlug.get(finding.slug)
+    const flatListValue = Array.isArray(flatRecord?.contraindications) ? flatRecord.contraindications : []
+    const detailListValue = Array.isArray(detail.contraindications) ? detail.contraindications : []
+    const merged = unionLists(detailListValue, flatListValue)
+    detail.contraindications = merged
+    console.log(`  ${finding.slug}: ${detailListValue.length} -> ${merged.length}`)
+    if (!dryRun) fs.writeFileSync(file, `${JSON.stringify(detail, null, 2)}\n`)
+  }
+
+  return findings.length
+}
+
+function main() {
+  const tagsBySlug = JSON.parse(fs.readFileSync(path.join(dataDir, 'entity_risk_tags.json'), 'utf8'))
+  const herbCount = fixGroup('herbs.json', 'herbs-detail', tagsBySlug)
+  const compoundCount = fixGroup('compounds.json', 'compounds-detail', tagsBySlug)
+  console.log(`[backfill-detail-additive-mechanisms] ${herbCount + compoundCount} file(s) ${dryRun ? 'would be ' : ''}updated.`)
+}
+
+if (process.argv[1] === __filename) main()


### PR DESCRIPTION
## What changed

- Rebuild the reusable stale-detail detection and repair tooling from PR #2319 on top of current `main`.
- Preserve all safety/profile updates merged after #2319 opened.
- Add a guard that detects detail JSON overriding newer additive-mechanism contraindications from flat runtime records.
- Add a union-based backfill tool that preserves both detail-specific and flat-record safety prose without deleting either source.
- Add focused regression tests.

## Conflict resolution

The original PR changed 150+ generated detail JSON files that have since been updated by multiple safety-enrichment merges. Those snapshots were deliberately not copied forward because doing so could overwrite newer content. This replacement carries forward the reusable code and tests only; the backfill should be run from current `main` so its generated changes are based on the latest records.

## Supersedes

Supersedes conflicted PR #2319.