### PR TITLE
Prevent stale detail overlays from replacing canonical trust fields

### DIFF
--- a/lib/__tests__/runtime-record-resolver.test.mjs
+++ b/lib/__tests__/runtime-record-resolver.test.mjs
@@ -18,6 +18,19 @@ const canonical = {
   sitemap_included: true,
 }
 
+const standardRecord = {
+  slug: 'standard-record',
+  runtime_export_decision: 'full_public_runtime',
+  safety: 'Canonical safety statement.',
+  contraindications: ['Serotonergic medications'],
+  interactions: ['SSRIs'],
+  evidence_tier: 'Moderate Human Evidence',
+  indexability_status: 'PUBLISH',
+  robots: 'index,follow',
+  sitemap_included: true,
+  summary: 'Canonical summary.',
+}
+
 describe('cluster-member runtime record resolver', () => {
   it('inherits valid canonical values and renderer aliases', () => {
     const result = resolveRuntimeRecordLayers(canonical, [{ slug: canonical.slug }])
@@ -59,5 +72,48 @@ describe('cluster-member runtime record resolver', () => {
 
   it('normalizes duplicate values deterministically', () => {
     expect(normalizeRuntimeList(['Nausea', ' nausea ', 'Headache', '', 'unknown'])).toEqual(['Nausea', 'Headache'])
+  })
+})
+
+describe('standard runtime record resolver', () => {
+  it('prevents stale detail overlays from replacing canonical trust fields', () => {
+    const result = resolveRuntimeRecordLayers(standardRecord, [{
+      slug: standardRecord.slug,
+      safetyNotes: 'Generally well tolerated for most users.',
+      contraindications: [],
+      interactions: ['Outdated interaction'],
+      evidence_tier: 'Unknown',
+      robots: 'noindex,follow',
+      sitemap_included: false,
+    }])
+
+    expect(result.safety).toBe(standardRecord.safety)
+    expect(result.contraindications).toEqual(standardRecord.contraindications)
+    expect(result.interactions).toEqual(standardRecord.interactions)
+    expect(result.evidence_tier).toBe(standardRecord.evidence_tier)
+    expect(result.robots).toBe(standardRecord.robots)
+    expect(result.sitemap_included).toBe(true)
+  })
+
+  it('still accepts meaningful presentation enrichment from detail records', () => {
+    const result = resolveRuntimeRecordLayers(standardRecord, [{
+      slug: standardRecord.slug,
+      summary: 'Expanded detail summary.',
+      dosage: '200 mg with food',
+    }])
+
+    expect(result.summary).toBe('Expanded detail summary.')
+    expect(result.dosage).toBe('200 mg with food')
+  })
+
+  it('allows a deliberate trust-field override only when explicitly approved', () => {
+    const result = resolveRuntimeRecordLayers(standardRecord, [{
+      slug: standardRecord.slug,
+      contraindications: ['Updated reviewed contraindication'],
+    }], {
+      approvedTrustOverrides: ['contraindications'],
+    })
+
+    expect(result.contraindications).toEqual(['Updated reviewed contraindication'])
   })
 })

--- a/lib/runtime-record-resolver.mjs
+++ b/lib/runtime-record-resolver.mjs
@@ -87,24 +87,21 @@ export function resolveTrustValue(canonicalValue, localValue, options = {}) {
 
 export function resolveRuntimeRecordLayers(base, layers = [], options = {}) {
   if (!base || typeof base !== 'object' || Array.isArray(base)) {
-    throw new Error('Cluster-member runtime inheritance requires a canonical core record')
+    throw new Error('Runtime inheritance requires a canonical core record')
   }
 
   const slug = text(base.slug)
-  if (!slug) throw new Error('Cluster-member runtime inheritance requires a canonical slug')
-
-  if (base.runtime_export_decision !== CLUSTER_MEMBER_RUNTIME_DECISION) {
-    return Object.assign({}, base, ...layers.filter(layer => layer && typeof layer === 'object' && !Array.isArray(layer)))
-  }
+  if (!slug) throw new Error('Runtime inheritance requires a canonical slug')
 
   const approved = new Set((options.approvedTrustOverrides || []).map(canonicalField))
   const resolved = { ...base }
+  const isClusterMember = base.runtime_export_decision === CLUSTER_MEMBER_RUNTIME_DECISION
 
   for (const layer of layers) {
     if (!layer || typeof layer !== 'object' || Array.isArray(layer)) continue
     const layerSlug = text(layer.slug || layer.id)
     if (layerSlug && layerSlug !== slug) {
-      throw new Error(`Cluster-member overlay ${layerSlug} does not match canonical slug ${slug}`)
+      throw new Error(`Runtime overlay ${layerSlug} does not match canonical slug ${slug}`)
     }
 
     for (const [field, value] of Object.entries(layer)) {
@@ -124,17 +121,22 @@ export function resolveRuntimeRecordLayers(base, layers = [], options = {}) {
     if (Array.isArray(resolved[field])) resolved[field] = normalizeRuntimeList(resolved[field])
   }
 
-  const safety = resolveTrustValue(undefined, resolved.safety || base.safety || base.runtime_safety, { field: 'safety', allowLocal: true })
-  if (safety !== undefined) {
-    resolved.safety = safety
-    resolved.runtime_safety = safety
-    resolved.safetyNotes = safety
-    resolved.safety_notes = safety
-  } else {
-    delete resolved.safety
-    delete resolved.runtime_safety
-    delete resolved.safetyNotes
-    delete resolved.safety_notes
+  // Cluster-member records require renderer aliases to inherit from the
+  // canonical safety field. Non-cluster records keep their existing aliases,
+  // while stale overlays are prevented from replacing canonical safety above.
+  if (isClusterMember) {
+    const safety = resolveTrustValue(undefined, resolved.safety || base.safety || base.runtime_safety, { field: 'safety', allowLocal: true })
+    if (safety !== undefined) {
+      resolved.safety = safety
+      resolved.runtime_safety = safety
+      resolved.safetyNotes = safety
+      resolved.safety_notes = safety
+    } else {
+      delete resolved.safety
+      delete resolved.runtime_safety
+      delete resolved.safetyNotes
+      delete resolved.safety_notes
+    }
   }
 
   return resolved


### PR DESCRIPTION
## Summary

- Fixes the root cause behind stale `herbs-detail` / `compounds-detail` safety overlays.
- Canonical trust fields are now protected for all runtime records, not only cluster members.
- Detail and summary layers may still enrich presentation fields such as summaries and dosage, but cannot silently replace canonical contraindications, interactions, safety, evidence tier, indexability, robots, or sitemap state.
- Explicit reviewed overrides remain possible through `approvedTrustOverrides`.
- Adds regression coverage for standard records, stale empty arrays, stale interactions, indexability overrides, normal presentation enrichment, and explicit approved overrides.

## Why this is high ROI

The prior repair tooling could detect and regenerate stale detail files, but the same drift could recur after any future enrichment. This changes runtime resolution itself so newer canonical safety content reaches live pages even before generated detail snapshots are refreshed.

## Scope

- `lib/runtime-record-resolver.mjs`
- `lib/__tests__/runtime-record-resolver.test.mjs`

No workbook, generated data, routes, or page content changed.