### PR TITLE
High ROI: serve full stress guide on canonical money-page route

### DIFF
--- a/app/guides/best/supplements-for-stress/page.tsx
+++ b/app/guides/best/supplements-for-stress/page.tsx
@@ -1,10 +1,22 @@
-import { SeoEntryPage, generateSeoEntryMetadata } from '../../../seo-entry-pages'
+import type { Metadata } from 'next'
+import BestSupplementsForStressPage from '../../anxiety/best-supplements-for-stress/page'
 
-const route = 'best-supplements-for-stress'
 const CANONICAL_PATH = '/guides/best/supplements-for-stress/'
 
-export const metadata = generateSeoEntryMetadata(route, CANONICAL_PATH)
-
-export default function Page(){
-  return <SeoEntryPage route={route} canonicalPath={CANONICAL_PATH} />
+export const metadata: Metadata = {
+  title: 'Best Supplements for Stress: Ashwagandha, Rhodiola, Magnesium & More',
+  description:
+    'Compare evidence-backed supplements for chronic stress, stress-related fatigue, poor sleep, and acute tension. Includes dosing, safety, and product-selection guidance.',
+  alternates: { canonical: CANONICAL_PATH },
+  robots: { index: true, follow: true },
+  openGraph: {
+    title: 'Best Supplements for Stress: Evidence-Based Guide',
+    description:
+      'Choose among ashwagandha, rhodiola, magnesium, L-theanine, and phosphatidylserine based on your stress pattern, timeline, and safety needs.',
+    url: CANONICAL_PATH,
+    type: 'article',
+    images: ['/og-default.jpg'],
+  },
 }
+
+export default BestSupplementsForStressPage


### PR DESCRIPTION
## Summary

- Replaces the thin `SeoEntryPage` shell at `/guides/best/supplements-for-stress/` with the existing full evidence-based stress supplements guide.
- Keeps `/guides/anxiety/best-supplements-for-stress/` as the `noindex` alias that canonicals to the money-page route.
- Gives the canonical route explicit index/follow metadata, stronger search copy, and matching Open Graph metadata.

## Why this is high ROI

The canonical commercial-intent URL was a thin generic entry page, while the richer guide with supplement profiles, decision framework, references, and product recommendations lived behind a `noindex` duplicate route. This consolidates ranking signals onto the stronger content without introducing a second indexed copy.

## Scope

- One route component only
- No workbook, generated data, affiliate configuration, or shared components changed
- Reuses an existing static-export-compatible page component

## Validation

Normal repository checks should run on the PR.