### PR TITLE
Record and fix the loop's silent auto-merge no-op bug

### DIFF
--- a/docs/LOOP_NOTES.md
+++ b/docs/LOOP_NOTES.md
@@ -3787,3 +3787,57 @@ selective detail-field syncing (diffing workbook vs. detail per field, not a
 full-record overwrite) or at least extend `validate-cluster-member-export.mjs`
 past its current 4 hardcoded slugs so a *new* placeholder-vs-workbook
 mismatch fails CI immediately instead of silently accumulating again.
+
+---
+
+## 2026-07-16 — the loop's own "auto-merge" step was silently no-op'ing; ~32 validated PRs never shipped
+
+Before starting this cycle's own work, checked the repo's open-PR queue
+(`list_pull_requests`) and found 33 open PRs, the oldest from 2026-06-22 —
+three-plus weeks of prior autonomous-cycle output that never reached `main`,
+despite every one of them describing a full local verification pass
+(`npm run check`, `data:validate`, `guard:source-of-truth`, full Vitest) in
+its own PR body.
+
+Root cause, confirmed directly: this environment has no `gh` CLI — only the
+`mcp__github__*` tool surface — and `enable_pr_auto_merge` (the tool a prior
+cycle would reach for to satisfy the outer routine's "enable auto-merge:
+`gh pr merge --auto`" instruction) **fails as soon as required checks have
+already finished**, returning `"The pull request is already in clean status
+... you can merge directly"` instead of doing anything. CI in this repo
+finishes in seconds (confirmed via `actions_list`: all 5 required checks on
+PR #2341 completed in the same few seconds as PR creation), so by the time a
+session gets around to the auto-merge call, checks have essentially always
+already finished — meaning `enable_pr_auto_merge` reliably errors out and
+does *not* merge the PR. If the calling session didn't specifically catch
+that error and fall back to a direct `merge_pull_request` call, the PR was
+left open with no further action — which is exactly the shape of every one
+of the 33 stuck PRs found this cycle.
+
+Verified the fix by hand: called `enable_pr_auto_merge` on the most recent
+PR (#2341, `mergeable_state: "clean"`), got the graceful-failure message
+above, then called `merge_pull_request` directly (`squash`) and it merged
+immediately with no further action needed.
+
+**Fix for future cycles:** at the "SHIP + AUTO-MERGE" step, don't rely on
+`enable_pr_auto_merge` alone. Instead: read the PR back
+(`pull_request_read` → `mergeable_state`) after opening it; if it's already
+`"clean"`, call `merge_pull_request` directly; only fall back to
+`enable_pr_auto_merge` (and only trust it silently) when the state is
+`"unstable"`/checks still pending. Treat any `enable_pr_auto_merge` error
+mentioning "already ... clean" as a signal to merge directly, not as
+terminal failure.
+
+**Backlog status:** merged #2341 directly this cycle as the one immediately
+enrichment-validated, single-most-recent PR. The other 32 remain open as of
+this cycle and were deliberately *not* bulk-merged — several are weeks old
+with `mergeable_state: "unknown"` (GitHub hasn't recomputed against current
+`main` yet, likely genuinely stale/conflicting by now), a few are Dependabot
+version bumps that can conflict with each other's lockfile diffs if merged
+out of order, one (#1886) is still a draft, and at least one prior PR's own
+description (#2262) notes finding redundant/overlapping work with another
+backlogged PR — i.e. this backlog likely contains internal duplicates that
+need triage, not a blind merge. A future cycle (or a human) should triage
+this list PR-by-PR: re-check `mergeable_state` fresh, rebase/close anything
+stale or superseded, and merge what's still clean, oldest-first so newer
+PRs' conflicts (if any) surface against an up-to-date base.


### PR DESCRIPTION
## Summary

- Found the open-PR queue at 33 PRs, oldest from 2026-06-22 — three-plus weeks of prior autonomous-cycle output that never reached `main`, despite each one describing a full passing local verification in its own PR body.
- Root cause: this environment has no `gh` CLI, only `mcp__github__*` tools, and `enable_pr_auto_merge` fails (instead of merging) once required checks have already finished — which is effectively always, since this repo's CI completes in seconds. Prior cycles evidently hit that graceful-failure error at the "enable auto-merge" step and stopped without falling back to a direct merge, leaving the PR open with no further action.
- Verified the diagnosis by hand: called `enable_pr_auto_merge` on PR #2341 (the most recent backlogged PR, `mergeable_state: "clean"`), got the "already clean, merge directly" error, then called `merge_pull_request` directly and it merged immediately.
- Merged #2341 directly this cycle as proof of the fix. Documented the root cause, the fix (check `mergeable_state` after opening a PR; merge directly when clean, only rely on `enable_pr_auto_merge` when checks are still pending), and the remaining 32-PR backlog status in `docs/LOOP_NOTES.md` so future cycles apply the fix and know the backlog needs PR-by-PR triage (stale bases, possible Dependabot lockfile conflicts, at least one known internal duplicate per PR #2262's own notes, one open draft) rather than a blind bulk merge.
- No app code, workbook, or `public/data` touched — docs-only change.

## Verification

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs (none — docs-only change)
- [x] no generated file corruption
- [x] static export compatible (no build config touched)

## Risk Notes

- Pure documentation change (`docs/LOOP_NOTES.md` only) — zero runtime/build risk on its own.
- The one production-affecting action this cycle was merging already-independently-validated PR #2341 directly (confirmed CI-green, `mergeable_state: "clean"`, no conflicts) — not a new/unreviewed change, just unblocking a stuck one.


---
_Generated by [Claude Code](https://claude.ai/code/session_01H5VdZa6iKKUF8C5Pdr9TE6)_