### PR TITLE
Remove stale ashitaba-extract safety exception entry

### DIFF
--- a/data-sources/safety-evidence-limited-exceptions.json
+++ b/data-sources/safety-evidence-limited-exceptions.json
@@ -8,7 +8,6 @@
     {"slug":"acetyl-11-keto-beta-boswellic-acid","batch":"safety-coverage-batch-2-2026-07-15","reason":"Human evidence concerns an AKBA-enriched extract, not isolated-compound contraindications.","evidence":["PMID:18667054"]},
     {"slug":"alpha-asarone","batch":"safety-coverage-batch-2-2026-07-15","reason":"Human safety is unknown; preclinical toxicology cannot define a human contraindication.","evidence":["10.1002/jat.4112"]},
     {"slug":"alpha-mangostin","batch":"safety-coverage-batch-2-2026-07-15","reason":"Systematic toxicity evidence is preclinical and cannot establish human organ-specific contraindications.","evidence":["10.1016/j.heliyon.2023.e16045"]},
-    {"slug":"ashitaba-extract","batch":"safety-coverage-batch-2-2026-07-15","reason":"Limited human studies reported mild or no events but did not establish a categorical contraindication.","evidence":["10.1016/j.heliyon.2024.e24119"]},
     {"slug":"atractylenolide-i","batch":"safety-coverage-batch-2-2026-07-15","reason":"Evidence is primarily preclinical and does not define human contraindications.","evidence":["PMID:34269984"]},
     {"slug":"atractylenolide-ii","batch":"safety-coverage-batch-2-2026-07-15","reason":"Evidence is primarily preclinical and does not define human contraindications.","evidence":["PMID:34269984"]},
     {"slug":"atractylenolide-iii","batch":"safety-coverage-batch-2-2026-07-15","reason":"Evidence is primarily preclinical and does not define human contraindications.","evidence":["PMID:34269984"]},

--- a/docs/LOOP_NOTES.md
+++ b/docs/LOOP_NOTES.md
@@ -4066,3 +4066,49 @@ prior entry — most of it is now redundant work superseded by intervening
 batches, but the general technique here (diff the branch's generated
 output against current `main`, not the branch itself, and check it against
 *every* governance ledger before writing) is the reusable part.
+
+---
+
+## 2026-07-20 — Closed the standalone `ashitaba-extract` stale-exception gap flagged by the prior entry
+
+Fresh cold session, picked up the one open thread the prior (batch 7) entry
+explicitly deferred: `npm run audit:severity-tokens` failed on `main` with
+`evidence-limited exceptions no longer match a full-public gap:
+ashitaba-extract`. Confirmed directly against the workbook
+(`edit-entity-master-cell.mjs --slug ashitaba-extract --column
+contraindications_or_flags --value x --dry-run`) that the cell already holds
+4 clauses of real sourced prose (coumarin/anticoagulant interaction,
+photosensitization, long-term-use and pregnancy/breastfeeding cautions) —
+some later batch filled it for real after the 2026-07-15
+`safety-coverage-batch-2` review recorded it as a deliberate "leave empty,
+evidence is too limited" exception. The exception enum in
+`data-sources/safety-evidence-limited-exceptions.json` was never removed
+once the gap it described stopped existing, so the audit's
+`staleExceptions` check (added specifically to catch this class of drift,
+per the entries above) correctly hard-failed.
+
+Fix was a one-line removal of the stale `ashitaba-extract` entry from the
+exceptions file — no workbook edit, no new safety claim, nothing that
+touches any of the three governance ledgers documented in the entry above
+beyond removing a now-false record from one of them. Verified: `npm run
+audit:severity-tokens` now reports `Remaining actionable full_public_runtime
+gaps: 0` (was throwing before), `node scripts/ci/validate-workbook-patches.mjs`
+still passes (7/7), `npm run audit:risk-tag-collisions` still clean, and
+`npm run check` (typecheck + lint + article-quality + claim-discipline +
+safety-visibility + `data:build:core`) passes end-to-end. Diff scope: just
+the one exceptions-file line (`build-info.json` timestamp reverted).
+
+Takeaway: `audit:severity-tokens`'s `staleExceptions` check is a real,
+useful drift detector, but it isn't wired into `check`/`check:full` (same
+gap as `audit:risk-tag-collisions` and `audit:safety` before it) so a
+legitimate content fill that closes a documented exception's gap will sit
+unnoticed until someone runs the audit by hand. Worth a future cycle
+running `npm run audit:severity-tokens` as a standing part of `check` (it's
+fast — single workbook read, no network) so this class of staleness surfaces
+immediately instead of waiting for a dedicated triage cycle to notice it.
+
+The 32-PR backlog (oldest from 2026-06-22, unchanged in count since the
+prior entry) is still open and still worth a human or future cycle's triage
+— this cycle deliberately did not touch it, since closing/merging PRs this
+session didn't open falls outside what this autonomous run is scoped to do
+without a human confirming first.


### PR DESCRIPTION
## Summary

- `npm run audit:severity-tokens` was hard-failing on `main` with `evidence-limited exceptions no longer match a full-public gap: ashitaba-extract`.
- The workbook's `contraindications_or_flags` for `ashitaba-extract` was filled with real sourced prose (coumarin/anticoagulant interaction, photosensitization, long-term-use and pregnancy/breastfeeding cautions) by a later enrichment batch, after `safety-coverage-batch-2-2026-07-15` had recorded a "leave empty — evidence too limited" exception for it. The exception record was never cleaned up once the gap it described stopped existing.
- Removed the now-stale `ashitaba-extract` entry from `data-sources/safety-evidence-limited-exceptions.json`. No workbook edit, no new safety claim — just dropping a false record from the exceptions ledger.

## Verification

- [x] `npm run lint`
- [x] `npm run check`
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs (only the disposable `build-info.json` timestamp, reverted)
- [x] no generated file corruption
- [x] static export compatible
- [x] `node scripts/ci/validate-workbook-patches.mjs` (7/7 pass)
- [x] `npm run audit:risk-tag-collisions` (clean)
- [x] `npm run audit:severity-tokens` (now reports `Remaining actionable full_public_runtime gaps: 0`, was throwing before)

## Risk Notes

- Zero-risk data-governance cleanup: no safety text changed, only a stale "intentionally empty" exception record removed to match reality.


---
_Generated by [Claude Code](https://claude.ai/code/session_0152tun5knAyt1Ubtp3fA5wB)_