### PR TITLE
Fix audit:content-gaps false-positive safety gaps on reviewed exceptions

### DIFF
--- a/docs/LOOP_NOTES.md
+++ b/docs/LOOP_NOTES.md
@@ -4112,3 +4112,65 @@ prior entry) is still open and still worth a human or future cycle's triage
 — this cycle deliberately did not touch it, since closing/merging PRs this
 session didn't open falls outside what this autonomous run is scoped to do
 without a human confirming first.
+
+---
+
+## 2026-07-27 — `audit:content-gaps`' top-20 high-traffic table was flagging 6 already-reviewed safety abstentions as fresh gaps
+
+Fresh cold session. `npm run audit:content-gaps` (`scripts/audit/content-gap-report.mjs`)
+is a *different* audit from `audit:severity-tokens`, computing its own
+"safety" completeness signal straight off `item.contraindications` with no
+knowledge of the two governance exception ledgers the repeated
+`contraindications_or_flags`-fill entries above (2026-07-13 through
+2026-07-16) built and rely on. Its top-20 highest-traffic table showed
+`ginger` (→`gingerol`), `holy-basil` (→`holy-basil-extract`), `l-theanine`
+(→`caffeine-l-theanine`), `creatine`, and `omega-3` (→`omega-3-dha-dominant`)
+all missing "safety" at 71% completeness — a tempting, obvious-looking
+worklist for exactly the kind of fill those prior cycles were doing.
+
+Checked all 6 against both ledgers before writing anything (the practice the
+2026-07-16 "batch 7" entry above established): every single one already has
+a dated, sourced, reviewed exception record in
+`data-sources/safety-evidence-limited-exceptions.json` or
+`-primary-runtime-exceptions.json` (e.g. `gingerol`: "Human pregnancy
+evidence concerns oral ginger preparations, not isolated gingerol"). Filling
+these would have silently reversed a prior human/agent-reviewed abstention
+decision — the exact failure mode the 2026-07-16 "reversed a same-week
+sourced patch decision" entry warned about, just approached from a
+different audit's blind spot this time.
+
+Fixed the audit instead of the (non-existent) content gap: `content-gap-
+report.mjs` now loads both exception ledgers and treats a slug's empty
+safety field as `DOCUMENTED_EXCEPTION` (excluded from `missingFields` and
+the completeness penalty, but still distinguished from a genuine `FILLED`
+in `details.safety`) rather than a plain `EMPTY` gap. Added a one-line
+summary-stats note reporting the exception count so the report stays
+transparent about what it's excluding and why. Re-ran the audit: all 5
+compounds above now show 86% (only genuinely-missing `interactions`
+remains); safety fill rate line now reads "67.8% (580/856); plus 56 slugs
+with a documented evidence-limited exception... not counted below as a
+gap" instead of silently undercounting. Exported `checkSafety` and the new
+`loadDocumentedSafetyExceptions` and added
+`scripts/audit/content-gap-report.test.mjs` (3 cases) so this stays
+regression-tested. Guarded the script's `runGapAnalysis()` call behind an
+`import.meta.url === file://${process.argv[1]}` check (existing repo
+pattern, e.g. `build-interaction-data.mjs`) so importing it for the test
+doesn't also run the full analysis as a side effect. `npm run check` and
+the full Vitest suite (658/658) pass; only the tracked-file diff is the
+script + its test (the `reports/content-gaps.*` outputs and
+`public/data/_meta/build-info.json` timestamp are gitignored/disposable and
+were left untouched).
+
+**Takeaway for future cycles:** this repo now has at least two audits
+computing a "safety completeness" signal from different data paths with
+different awareness of the exception ledgers —
+`audit:severity-tokens` (ledger-aware, `full_public_runtime` only) and
+`audit:content-gaps` (was ledger-blind, all profiles, drives the
+highest-traffic priority table). Before trusting *any* "missing safety"
+list from *any* script as a real worklist, check whether that specific
+script consults the ledgers — grep the script for `safety-evidence-
+limited` first, not just grep the target slug against the ledgers by hand
+every time. If a new completeness/gap script gets added later, wire it to
+`loadDocumentedSafetyExceptions()` (now exported from
+`scripts/audit/content-gap-report.mjs`) up front rather than rediscovering
+this same false-positive class a third time.

--- a/scripts/audit/content-gap-report.mjs
+++ b/scripts/audit/content-gap-report.mjs
@@ -27,7 +27,7 @@ function checkDescription(value) {
   return !placeholders.some(p => val.includes(p));
 }
 
-function checkSafety(value) {
+export function checkSafety(value) {
   const placeholders = [
     'needs review',
     'safety review pending',
@@ -106,6 +106,26 @@ function checkInteractions(item, interactionEdgesMap) {
   return Array.isArray(edges) && edges.length > 0;
 }
 
+// Slugs whose empty contraindications_or_flags field was already reviewed and
+// intentionally left blank (evidence doesn't support a categorical human
+// contraindication) — see docs/LOOP_NOTES.md's repeated findings that these
+// ledgers must be checked before treating an empty safety field as a gap.
+export function loadDocumentedSafetyExceptions() {
+  const ledgerPaths = [
+    'data-sources/safety-evidence-limited-exceptions.json',
+    'data-sources/safety-evidence-limited-primary-runtime-exceptions.json',
+  ];
+  const slugs = new Set();
+  for (const ledgerPath of ledgerPaths) {
+    if (!fs.existsSync(ledgerPath)) continue;
+    const parsed = JSON.parse(fs.readFileSync(ledgerPath, 'utf8'));
+    for (const entry of parsed.exceptions || []) {
+      if (entry.slug) slugs.add(entry.slug);
+    }
+  }
+  return slugs;
+}
+
 function runGapAnalysis() {
   const herbsPath = 'public/data/herbs.json';
   const compoundsPath = 'public/data/compounds.json';
@@ -121,9 +141,11 @@ function runGapAnalysis() {
   const interactionEdgesMap = fs.existsSync(interactionEdgesPath)
     ? JSON.parse(fs.readFileSync(interactionEdgesPath, 'utf8'))
     : {};
+  const documentedSafetyExceptions = loadDocumentedSafetyExceptions();
 
   const allProfiles = [];
   let safetyFilledCount = 0;
+  let safetyDocumentedExceptionCount = 0;
   let descriptionFilledCount = 0;
   let mechanismFilledCount = 0;
   let interactionsFilledCount = 0;
@@ -139,6 +161,7 @@ function runGapAnalysis() {
     items.forEach(item => {
       const descFilled = checkDescription(item.description);
       const safetyFilled = checkSafety(item.contraindications);
+      const safetyDocumentedException = !safetyFilled && documentedSafetyExceptions.has(item.slug);
       const evidenceFilled = checkEvidenceLevel(item);
       const mechFilled = checkMechanism(item);
       const bestForFilled = checkBestFor(item);
@@ -147,12 +170,13 @@ function runGapAnalysis() {
 
       if (descFilled) descriptionFilledCount++;
       if (safetyFilled) safetyFilledCount++;
+      if (safetyDocumentedException) safetyDocumentedExceptionCount++;
       if (mechFilled) mechanismFilledCount++;
       if (interactionsFilled) interactionsFilledCount++;
 
       const missing = [];
       if (!descFilled) missing.push('description');
-      if (!safetyFilled) missing.push('safety');
+      if (!safetyFilled && !safetyDocumentedException) missing.push('safety');
       if (!evidenceFilled) missing.push('evidence_level');
       if (!mechFilled) missing.push('mechanism');
       if (!bestForFilled) missing.push('best_for');
@@ -170,7 +194,7 @@ function runGapAnalysis() {
         missingFields: missing,
         details: {
           description: descFilled ? 'FILLED' : 'EMPTY',
-          safety: safetyFilled ? 'FILLED' : 'EMPTY',
+          safety: safetyFilled ? 'FILLED' : (safetyDocumentedException ? 'DOCUMENTED_EXCEPTION' : 'EMPTY'),
           evidence_level: evidenceFilled ? 'FILLED' : 'EMPTY',
           mechanism: mechFilled ? 'FILLED' : 'EMPTY',
           best_for: bestForFilled ? 'FILLED' : 'EMPTY',
@@ -230,7 +254,7 @@ Generated on: ${new Date().toISOString()}
 ## Summary Statistics
 
 - **Total Profiles Evaluated**: ${total}
-- **Safety Data Fill Rate**: ${pctSafety}% (${safetyFilledCount} / ${total})
+- **Safety Data Fill Rate**: ${pctSafety}% (${safetyFilledCount} / ${total}); plus ${safetyDocumentedExceptionCount} slug(s) with a documented evidence-limited exception (reviewed and intentionally left blank — see \`data-sources/safety-evidence-limited-exceptions.json\` and \`data-sources/safety-evidence-limited-primary-runtime-exceptions.json\`), not counted below as a "safety" gap
 - **Description Fill Rate**: ${pctDesc}% (${descriptionFilledCount} / ${total})
 - **Mechanism Fill Rate**: ${pctMech}% (${mechanismFilledCount} / ${total})
 - **Interactions Fill Rate**: ${pctInteractions}% (${interactionsFilledCount} / ${total}) — counts profiles with a derived interaction-graph entry in \`interaction_edges.json\` (the data source the live "Interactions" page section actually reads)
@@ -268,4 +292,6 @@ Here is the completeness audit for the top 20 highest-traffic priority slugs:
   console.log(`Wrote reports/content-gaps.md.`);
 }
 
-runGapAnalysis();
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runGapAnalysis();
+}

--- a/scripts/audit/content-gap-report.test.mjs
+++ b/scripts/audit/content-gap-report.test.mjs
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { checkSafety, loadDocumentedSafetyExceptions } from './content-gap-report.mjs'
+
+describe('content-gap-report safety checks', () => {
+  it('treats empty/placeholder contraindications as not filled', () => {
+    expect(checkSafety('')).toBe(false)
+    expect(checkSafety(undefined)).toBe(false)
+    expect(checkSafety('safety review pending')).toBe(false)
+    expect(checkSafety([])).toBe(false)
+  })
+
+  it('treats real prose as filled', () => {
+    expect(checkSafety('Avoid combining with anticoagulants.')).toBe(true)
+    expect(checkSafety(['Avoid combining with anticoagulants.'])).toBe(true)
+  })
+
+  it('loads documented evidence-limited safety exceptions from both governance ledgers', () => {
+    const slugs = loadDocumentedSafetyExceptions()
+    // These slugs are reviewed, deliberate abstentions recorded in
+    // data-sources/safety-evidence-limited*-exceptions.json — an empty
+    // contraindications_or_flags field for them is not a real content gap.
+    expect(slugs.has('gingerol')).toBe(true)
+    expect(slugs.has('creatine')).toBe(true)
+    expect(slugs.size).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Summary

- `scripts/audit/content-gap-report.mjs` computed "missing safety" straight from `item.contraindications`, with no awareness of the two governance exception ledgers (`data-sources/safety-evidence-limited-exceptions.json` and `-primary-runtime-exceptions.json`) that record deliberate, sourced decisions to leave a compound's `contraindications_or_flags` field empty.
- Its highest-traffic priority table was flagging `ginger` (→ `gingerol`), `holy-basil`, `l-theanine` (→ `caffeine-l-theanine`), `creatine`, and `omega-3` as having a safety gap — but each already has a reviewed, cited exception record explaining why no categorical contraindication is claimed. Filling these "gaps" would have silently reversed a prior evidence-based abstention decision.
- The script now loads both ledgers and marks those slugs as a distinct `DOCUMENTED_EXCEPTION` status (excluded from `missingFields`/completeness penalty, but still visibly different from a genuine `FILLED`), and reports the exception count in the summary stats instead of silently undercounting.
- Added `scripts/audit/content-gap-report.test.mjs` (3 cases) covering `checkSafety` and the new `loadDocumentedSafetyExceptions` loader, and guarded the script's top-level `runGapAnalysis()` call behind the repo's existing `import.meta.url === file://${process.argv[1]}` pattern so importing it for tests doesn't also run the full analysis.
- Logged the finding in `docs/LOOP_NOTES.md` for future autonomous cycles.

## Verification

- [x] `npm run lint`
- [x] `npm run check`
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs
- [x] no generated file corruption
- [x] static export compatible
- [x] full Vitest suite (658/658 passing)

## Risk Notes

- Purely additive to an advisory audit script (`audit:content-gaps` is non-blocking); no runtime/page code touched, no workbook edits, no `public/data` changes committed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ej9eKpucBPPLByMhVqbSM4)_