### PR TITLE
Add eight hallucinogen disaster case studies

### DIFF
--- a/content/articles/psychedelic-disasters-mislabeled-drugs.mdx
+++ b/content/articles/psychedelic-disasters-mislabeled-drugs.mdx
@@ -1,0 +1,251 @@
+---
+title: "When the Label Lies: Three Psychedelic Disasters and the Failure Chains Behind Them"
+description: "A documented case-study review of the 2011 Oklahoma Bromo-DragonFLY poisoning, a 25B-NBOMe blotter emergency, and the 1967 DOM/STP outbreak—showing how misidentification, potency mismatch, delayed onset, and weak information systems turn drug use into disaster."
+date: "2026-07-28"
+lastUpdated: "2026-07-28"
+slug: "psychedelic-disasters-mislabeled-drugs"
+category: "Harm Reduction"
+tags: ["psychedelics", "hallucinogens", "Bromo-DragonFLY", "NBOMe", "DOM", "STP", "drug checking", "harm reduction", "case studies"]
+readingTime: 16
+evidenceGrade: "Moderate for the documented incidents; limited by incomplete public records and retrospective reporting"
+author: "The Hippie Scientist"
+references:
+  - title: "Probable Cause Affidavit: State of Oklahoma v. Cody Glenn Weddle"
+    authors: "Pontotoc County District Court and Oklahoma State Bureau of Investigation"
+    year: "2011"
+    pmid: ""
+    url: "https://s3.amazonaws.com/content.newsok.com/documents/2ce0001.pdf"
+  - title: "Bill Expanding First-Degree Murder Charges in Designer Drug Deaths Becomes Law"
+    authors: "Oklahoma State Senate"
+    year: "2012"
+    pmid: ""
+    url: "https://oksenate.gov/press-releases/bill-expanding-first-degree-murder-charges-designer-drug-deaths-becomes-law"
+  - title: "Delayed Onset of Seizures and Toxicity Associated with Recreational Use of Bromo-DragonFLY"
+    authors: "Wood DM, et al."
+    year: "2009"
+    pmid: "19876858"
+    url: "https://pubmed.ncbi.nlm.nih.gov/19876858/"
+  - title: "A Fatal Poisoning Involving Bromo-Dragonfly"
+    authors: "Andreasen MF, et al."
+    year: "2009"
+    pmid: "19091499"
+    url: "https://pubmed.ncbi.nlm.nih.gov/19091499/"
+  - title: "Beware of Blotting Paper Hallucinogens: Severe Toxicity with NBOMes"
+    authors: "Isbister GK, Poklis A, Poklis JL, Grice J"
+    year: "2015"
+    pmid: ""
+    url: "https://www.mja.com.au/journal/2015/203/6/beware-blotting-paper-hallucinogens-severe-toxicity-nbomes"
+  - title: "Toxicities Associated with NBOMe Ingestion—A Novel Class of Potent Hallucinogens: A Review of the Literature"
+    authors: "Suzuki J, et al."
+    year: "2015"
+    pmid: "25659919"
+    url: "https://pmc.ncbi.nlm.nih.gov/articles/PMC4355190/"
+  - title: "The Origin of 2,5-Dimethoxy-4-Methylamphetamine (DOM, STP)"
+    authors: "Trout K, Daley PF"
+    year: "2024"
+    pmid: ""
+    url: "https://analyticalsciencejournals.onlinelibrary.wiley.com/doi/10.1002/dta.3667"
+  - title: "Effects and Risks Associated with Novel Psychoactive Substances: Mislabeling and Sale as Bath Salts, Spice, and Research Chemicals"
+    authors: "Hohmann N, et al."
+    year: "2014"
+    pmid: ""
+    url: "https://pmc.ncbi.nlm.nih.gov/articles/PMC3965957/"
+  - title: "When Good Times Go Bad: Managing Legal High Complications in the Emergency Department"
+    authors: "Gray R, Bressington D, Hughes E, Ivanecka A"
+    year: "2017"
+    pmid: ""
+    url: "https://pmc.ncbi.nlm.nih.gov/articles/PMC5741979/"
+---
+
+> **Safety note:** These are historical toxicology case studies, not dosing guidance. A seizure, collapse, severe agitation, overheating, chest pain, breathing difficulty, blue or very pale skin, extreme confusion, or inability to wake someone after a drug exposure is an emergency. Contact emergency services and a poison center rather than waiting for the experience to pass.
+
+## Executive Summary
+
+The most frightening hallucinogen disasters are not always caused by someone knowingly choosing an extreme dose. Sometimes the person has the wrong chemical, the wrong potency assumption, the wrong timeline, or all three at once.
+
+This article examines three documented incidents:
+
+1. **Konawa, Oklahoma, 2011:** a liquid believed to contain 2C-E was later reported to contain Bromo-DragonFLY, a substantially more potent and unusually long-lasting psychedelic. Eight young adults became severely ill; two died.
+2. **Rural New South Wales, 2014:** a 16-year-old swallowed blotter sold as LSD and developed repeated seizures, respiratory failure, severe acidosis, muscle breakdown, and kidney injury. Laboratory testing identified 25B-NBOMe.
+3. **San Francisco, 1967:** high-dose DOM tablets, sold under the name STP, spread through the Summer of Love. Slow onset encouraged redosing, while the long duration and unfamiliar effects sent dozens of people to clinics and hospitals.
+
+The chemicals and circumstances differed, but the underlying failure pattern was remarkably consistent: **identity uncertainty, potency mismatch, delayed effects, false confidence, and medical systems forced to react before the substance was known.**
+
+## The Three Incidents at a Glance
+
+| Incident | What users believed | What was involved | Main failure | Outcome |
+|---|---|---|---|---|
+| Oklahoma, 2011 | 2C-E | Bromo-DragonFLY was later reported by officials | A dosing plan built for the wrong chemical | Eight severely affected; two deaths |
+| New South Wales, 2014 | LSD blotter | 25B-NBOMe confirmed in blood | The familiar blotter format falsely signaled LSD | Four seizures, intensive care, organ injury; survival |
+| San Francisco, 1967 | A new psychedelic called STP | DOM in unusually strong tablets | Slow onset encouraged redosing; duration was underestimated | Dozens sought medical help; no confirmed DOM deaths |
+
+## Case One: The 2011 Oklahoma Bromo-DragonFLY Poisoning
+
+### A measurement system built on a false identity
+
+According to the probable-cause affidavit, powder ordered online and labeled as 2C-E was dissolved into water. The affidavit describes one gram being mixed into one liter, followed by distribution in measured liquid portions [1]. On paper, that can look more deliberate than eyeballing powder: liquid measurement is often assumed to create consistency.
+
+But consistency is only useful when the starting information is correct.
+
+The group apparently believed it was handling 2C-E, a psychedelic generally discussed on a milligram scale. Officials later reported that laboratory testing identified Bromo-DragonFLY instead [2]. Bromo-DragonFLY is active at much smaller quantities, can have a delayed onset, and has been associated with prolonged agitation, seizures, cardiovascular stress, severe vasoconstriction, tissue injury, organ failure, and death [3, 4, 9].
+
+That means the participants were not merely inaccurate by a small percentage. They may have been applying a milligram-scale plan to a chemical with a dramatically different potency and toxicity profile.
+
+### The emergency
+
+In the early hours of May 7, 2011, emergency responders were called to a gathering near Konawa. Eight young adults became severely ill. Contemporary accounts described repeated seizures and extreme distress. One person died that day, and a second died several days later. Six survived [1, 2].
+
+The first public reports referred to 2C-E because that was the identity believed by the people involved and recorded in early investigative documents. The later Bromo-DragonFLY identification changed the interpretation of the entire event.
+
+### Why adding more water did not make the dose smaller
+
+A recurring misunderstanding in liquid dosing is the difference between **concentration** and **total amount**. Adding a measured portion to a larger drink lowers the concentration in each mouthful, but it does not remove any drug. If the entire drink is consumed, the total amount remains the same.
+
+The more fundamental problem in Oklahoma was upstream of the arithmetic. Even perfectly measured liquid portions cannot compensate for a mislabeled starting material. The procedure can distribute the wrong chemical very evenly.
+
+### What is well established—and what remains uncertain
+
+The affidavit supports the basic preparation and distribution sequence [1]. The deaths, the legislative response, and the later identification of Bromo-DragonFLY were publicly documented [2]. However, the exact quantity swallowed by each person, the purity of the powder, and how evenly it dissolved were not established in the public record with enough precision to reconstruct individual doses confidently.
+
+That matters because sensational retellings often turn uncertain estimates into exact facts. The defensible conclusion is narrower and stronger: **the identity was wrong, the potency assumptions were therefore wrong, and the resulting exposures were catastrophic.**
+
+## Case Two: The 25B-NBOMe Blotter Sold as LSD
+
+### A familiar object carried an unfamiliar risk
+
+In late 2014, a 16-year-old in rural New South Wales swallowed red blotter paper while camping with friends. He believed it was LSD [5]. The physical format reinforced that belief: for decades, small decorated paper squares had been associated with LSD.
+
+Blotter, however, is a delivery material—not a chemical identification method.
+
+The teenager experienced three seizures before reaching the emergency department and a fourth approximately an hour after arrival. His level of consciousness was severely reduced. A venous blood gas showed profound acidosis with a pH of 6.93 and extreme carbon-dioxide retention, indicating that ventilation had failed during the crisis [5].
+
+Doctors administered emergency sedation, paralyzed and intubated him, mechanically ventilated him, and transferred him to intensive care.
+
+### The injury continued after the seizures stopped
+
+The immediate neurological emergency was followed by **rhabdomyolysis**, the breakdown of skeletal muscle. His creatine kinase rose to 34,778 U/L, and laboratory findings showed acute kidney injury. He ultimately recovered and was discharged after five days [5].
+
+Specialized testing detected 25B-NBOMe in his blood. Routine hospital drug screens generally do not identify many NBOMe compounds, so clinicians often have to treat the visible syndrome—seizures, agitation, overheating, cardiovascular instability, muscle breakdown—before knowing the exact agent.
+
+### Why NBOMe substitution is especially dangerous
+
+NBOMe compounds are potent serotonin 5-HT2A receptor agonists. They can produce psychedelic effects, but severe poisonings have included violent agitation, seizures, hyperthermia, hypertension, tachycardia, rhabdomyolysis, kidney injury, coma, self-injury, and death [6].
+
+A review of analytically confirmed cases found a striking rate of intensive-care treatment and seizures [6]. The problem was not that the blotter looked suspicious. It was that it looked ordinary.
+
+The format created confidence that the supply chain had not earned.
+
+## Case Three: The 1967 DOM/STP Outbreak
+
+### A new drug arrives during the Summer of Love
+
+In June 1967, tablets containing DOM appeared in San Francisco under the street name **STP**, commonly expanded as “Serenity, Tranquility and Peace.” DOM had been synthesized and studied by Alexander Shulgin, but it was poorly understood by the public, emergency clinicians, and most underground distributors.
+
+At a summer-solstice gathering in Golden Gate Park, Owsley Stanley distributed a large number of tablets. Historical numbers vary, and later retellings often inflated the scale. A detailed 2024 reconstruction concludes that tablets around 10 milligrams—and some reportedly stronger—entered circulation [7]. Those amounts were substantially above the low-dose range explored in the earliest informal human work.
+
+### The delayed-onset trap
+
+DOM can take much longer than expected to build toward its peak. People familiar with faster-onset psychedelics sometimes interpreted the delay as evidence that the tablet was weak and took another.
+
+The sequence was simple and dangerous:
+
+1. Take a tablet.
+2. Feel less than expected after an hour or two.
+3. Take another.
+4. The first tablet continues rising.
+5. The second rises behind it.
+
+By the time the user realized the first dose was active, the second could no longer be taken back.
+
+### A long experience becomes a medical crisis
+
+DOM can produce an exceptionally prolonged psychedelic and stimulant-like state. High-dose users reported overwhelming sensory changes, panic, depersonalization, insomnia, and the fear that the experience would never end. Dozens sought help from the Haight-Ashbury Free Medical Clinic and San Francisco General Hospital [7]. Some required sedation or hospitalization for severe psychiatric disturbance.
+
+The recent historical review emphasizes that older stories contain exaggerations and contradictions. There were no confirmed deaths directly attributed to the 1967 DOM outbreak, and many people used the drug without presenting for medical care [7]. Still, it was a genuine public-health failure: unusually strong tablets, unfamiliar pharmacology, slow onset, prolonged duration, widespread distribution, and clinicians initially unsure what “STP” even was.
+
+### One constructive consequence
+
+Early rumors claimed that chlorpromazine would make DOM reactions worse. Later evidence did not support that simple warning, but the controversy helped push crisis responders toward calmer, less coercive management: reduced stimulation, reassurance, observation, and medication only when clinically necessary [7].
+
+In other words, a misinformation crisis accidentally accelerated a more humane model of psychedelic emergency care.
+
+## The Shared Failure Chain
+
+These incidents were separated by decades, countries, and chemical classes. The repeating architecture is more important than the individual drug names.
+
+### 1. The claimed identity was treated as a fact
+
+In Oklahoma, the powder was labeled as 2C-E. In Australia, blotter was assumed to be LSD. In San Francisco, people received STP without meaningful knowledge of DOM’s dose-response curve or duration.
+
+An illicit label is a claim, not an analytical result.
+
+### 2. The potency assumptions belonged to another substance
+
+A dose that might be ordinary for one compound can be extreme for another. This is why substitution among visually identical powders or blotters is not a minor quality-control problem. It can move the user across orders of magnitude.
+
+### 3. Delayed onset encouraged additional consumption
+
+Both Bromo-DragonFLY and DOM can develop slowly. The absence of early effects can be misread as product weakness rather than pharmacokinetics. Redosing turns uncertainty into accumulation.
+
+### 4. Measurement created false confidence
+
+The Oklahoma group used liquid measurement. The Australian teenager had a standardized-looking blotter square. The San Francisco tablets appeared to be discrete units.
+
+Each object looked measurable. None of that proved identity, purity, or appropriate potency.
+
+### 5. Several people were exposed before the danger was understood
+
+Group consumption compresses the warning window. When several people take material from the same batch at roughly the same time, one person’s adverse reaction may not begin early enough to warn the others.
+
+### 6. Emergency medicine started with incomplete information
+
+Routine toxicology panels do not identify every novel psychoactive substance. Clinicians often must stabilize seizures, temperature, breathing, circulation, and agitation before confirmatory testing is available—or without ever receiving confirmation [5, 6, 9].
+
+## What Drug Checking and Regulation Can Change
+
+These stories support a strong criticism of an entirely underground market. Prohibition does not eliminate demand, but it can eliminate or weaken the infrastructure that normally makes a chemical product legible:
+
+- verified identity;
+- batch records;
+- standardized concentration;
+- contamination screening;
+- enforceable labeling;
+- adverse-event reporting;
+- recalls;
+- rapid public warnings;
+- accountability for manufacturing failures.
+
+Drug checking can sometimes identify unexpected substances and reduce the information gap. A regulated framework could add manufacturing standards, traceability, age restrictions, professional screening, and clearer education.
+
+But neither testing nor regulation makes every hallucinogen safe. Analytical methods can miss compounds, mixtures may be uneven, and accurately identified substances can still cause panic, psychosis-like states, seizures, cardiovascular complications, accidents, or psychiatric destabilization. Bromo-DragonFLY would remain dangerous even in a perfectly labeled vial.
+
+The realistic goal is not zero risk. It is replacing avoidable uncertainty with better information and faster intervention.
+
+## Emergency Lessons That Do Not Depend on Knowing the Drug
+
+When the chemical identity is uncertain, the observable symptoms matter more than guessing the name.
+
+Seek emergency help for:
+
+- any seizure;
+- collapse or loss of consciousness;
+- inability to wake the person;
+- severe breathing difficulty;
+- chest pain or extreme heart rate;
+- dangerous overheating;
+- blue, gray, unusually pale, or cold extremities;
+- severe confusion, violence, or behavior creating immediate danger;
+- persistent vomiting with reduced consciousness;
+- intense muscle rigidity or prolonged uncontrolled movement.
+
+Do not let a severely affected person drive, wander away, or remain alone. Give responders the packaging, blotter, powder, messages, or vendor information if available. A wrong guess about the substance is less useful than an honest description of what was taken, when, and what symptoms followed.
+
+## Bottom Line
+
+The Oklahoma Bromo-DragonFLY deaths, the Australian 25B-NBOMe emergency, and the 1967 DOM outbreak were not identical events. One involved fatal misidentification, one involved “LSD” blotter containing a more toxic substitute, and one involved a known drug distributed at poorly understood strengths with a dangerously slow onset.
+
+Together, they demonstrate a single principle:
+
+> **A precise measurement of an unknown chemical is still an unknown exposure.**
+
+The paper square, tablet, label, online listing, and seller’s confidence are not analytical evidence. When identity, potency, and timing are uncertain, even behavior that feels careful can rest on a completely false foundation.

--- a/content/articles/psychedelic-disasters-mislabeled-drugs.mdx
+++ b/content/articles/psychedelic-disasters-mislabeled-drugs.mdx
@@ -1,13 +1,13 @@
 ---
-title: "When the Label Lies: Four Psychedelic Disasters and the Failure Chains Behind Them"
-description: "A documented case-study review of the Oklahoma Bromo-DragonFLY poisoning, a 25B-NBOMe blotter emergency, the 1967 DOM/STP outbreak, and a 1972 massive LSD overdose—showing how misidentification, potency mismatch, delayed onset, and weak information systems turn drug use into disaster."
+title: "When the Label Lies: Eight Hallucinogen Disasters and the Failure Chains Behind Them"
+description: "Eight documented toxicology case studies involving Bromo-DragonFLY, NBOMe and NBOH compounds, DOM/STP, LSD, ibogaine, and Datura—examining misidentification, delayed onset, cardiac toxicity, delirium, and failures of underground drug information."
 date: "2026-07-28"
 lastUpdated: "2026-07-28"
 slug: "psychedelic-disasters-mislabeled-drugs"
 category: "Harm Reduction"
-tags: ["psychedelics", "hallucinogens", "Bromo-DragonFLY", "NBOMe", "DOM", "STP", "LSD", "overdose", "drug checking", "harm reduction", "case studies"]
-readingTime: 20
-evidenceGrade: "Moderate for the documented incidents; limited by incomplete public records and retrospective reporting"
+tags: ["psychedelics", "hallucinogens", "Bromo-DragonFLY", "NBOMe", "NBOH", "DOM", "STP", "LSD", "ibogaine", "Datura", "drug checking", "harm reduction", "case studies"]
+readingTime: 32
+evidenceGrade: "Moderate for the documented incidents; limited by case-report design, incomplete public records, and retrospective historical reporting"
 author: "The Hippie Scientist"
 references:
   - title: "Probable Cause Affidavit: State of Oklahoma v. Cody Glenn Weddle"
@@ -45,246 +45,242 @@ references:
     year: "2024"
     pmid: ""
     url: "https://analyticalsciencejournals.onlinelibrary.wiley.com/doi/10.1002/dta.3667"
-  - title: "Effects and Risks Associated with Novel Psychoactive Substances: Mislabeling and Sale as Bath Salts, Spice, and Research Chemicals"
-    authors: "Hohmann N, et al."
-    year: "2014"
-    pmid: ""
-    url: "https://pmc.ncbi.nlm.nih.gov/articles/PMC3965957/"
-  - title: "When Good Times Go Bad: Managing Legal High Complications in the Emergency Department"
-    authors: "Gray R, Bressington D, Hughes E, Ivanecka A"
-    year: "2017"
-    pmid: ""
-    url: "https://pmc.ncbi.nlm.nih.gov/articles/PMC5741979/"
   - title: "Coma, Hyperthermia and Bleeding Associated with Massive LSD Overdose: A Report of Eight Cases"
     authors: "Klock JC, Boerner U, Becker CE"
     year: "1974"
     pmid: "4816396"
     url: "https://pmc.ncbi.nlm.nih.gov/articles/PMC1129381/"
+  - title: "A Case of 25I-NBOMe (25-I) Intoxication: A New Potent 5-HT2A Agonist Designer Drug"
+    authors: "Rutherfoord Rose S, Poklis JL, Poklis A"
+    year: "2013"
+    pmid: "23473462"
+    url: "https://pmc.ncbi.nlm.nih.gov/articles/PMC4002208/"
+  - title: "A Cluster of 25B-NBOH Poisonings Following Exposure to Powder Sold as Lysergic Acid Diethylamide (LSD)"
+    authors: "Ivory ST, Rotella JA, Schumann J, Greene SL"
+    year: "2022"
+    pmid: "35343858"
+    url: "https://pubmed.ncbi.nlm.nih.gov/35343858/"
+  - title: "Toxicokinetics of Ibogaine and Noribogaine in a Patient with Prolonged Multiple Cardiac Arrhythmias after Ingestion of Internet Purchased Ibogaine"
+    authors: "Henstra M, et al."
+    year: "2017"
+    pmid: "28489458"
+    url: "https://pubmed.ncbi.nlm.nih.gov/28489458/"
+  - title: "Cardiac Arrest after Ibogaine Intoxication"
+    authors: "Steinberg C, Deyell MW"
+    year: "2018"
+    pmid: "30167018"
+    url: "https://pmc.ncbi.nlm.nih.gov/articles/PMC6111465/"
+  - title: "Teenagers with Jimson Weed (Datura stramonium) Poisoning"
+    authors: "Spina SP, Taddei A"
+    year: "2007"
+    pmid: "18072995"
+    url: "https://pubmed.ncbi.nlm.nih.gov/18072995/"
+  - title: "Jimson 'Loco' Weed Abuse in Adolescents"
+    authors: "Shervette RE III, Schydlower M, Lampe RM, Fearnow RG"
+    year: "1979"
+    pmid: "440859"
+    url: "https://pubmed.ncbi.nlm.nih.gov/440859/"
 ---
 
-> **Safety note:** These are historical toxicology case studies, not dosing guidance. A seizure, collapse, severe agitation, overheating, chest pain, breathing difficulty, blue or very pale skin, extreme confusion, or inability to wake someone after a drug exposure is an emergency. Contact emergency services and a poison center rather than waiting for the experience to pass.
+> **Safety note:** These are historical toxicology case studies, not dosing guidance. A seizure, collapse, severe agitation, dangerous overheating, chest pain, breathing difficulty, blue or very pale skin, extreme confusion, or inability to wake someone after a drug exposure is an emergency. Contact emergency services and a poison center rather than waiting for the experience to pass.
 
 ## Executive Summary
 
-The most frightening hallucinogen disasters are not always caused by someone knowingly choosing an extreme dose. Sometimes the person has the wrong chemical, the wrong potency assumption, the wrong timeline, or all three at once.
+Hallucinogen disasters are not all variations of a “bad trip.” Some begin with a false label. Others begin with delayed onset, a powder that resembles another drug, a plant whose delirium is mistaken for psychedelic insight, or a compound whose cardiac toxicity persists long after its subjective effects should have ended.
 
-This article examines four documented incidents:
+This review examines eight documented incidents:
 
-1. **Konawa, Oklahoma, 2011:** a liquid believed to contain 2C-E was later reported to contain Bromo-DragonFLY, a substantially more potent and unusually long-lasting psychedelic. Eight young adults became severely ill; two died.
-2. **Rural New South Wales, 2014:** a 16-year-old swallowed blotter sold as LSD and developed repeated seizures, respiratory failure, severe acidosis, muscle breakdown, and kidney injury. Laboratory testing identified 25B-NBOMe.
-3. **San Francisco, 1967:** high-dose DOM tablets, sold under the name STP, spread through the Summer of Love. Slow onset encouraged redosing, while the long duration and unfamiliar effects sent dozens of people to clinics and hospitals.
-4. **San Francisco, 1972:** eight adults inhaled pure LSD tartrate powder after mistaking it for cocaine. They developed vomiting, collapse, hyperthermia, coma, respiratory arrest, and bleeding abnormalities; all survived with supportive care.
+1. **Konawa, Oklahoma, 2011:** liquid believed to contain 2C-E was later reported to contain Bromo-DragonFLY. Eight young adults became severely ill; two died.
+2. **Rural New South Wales, 2014:** a 16-year-old swallowed blotter sold as LSD and developed four seizures, respiratory failure, severe acidosis, rhabdomyolysis, and kidney injury. Testing identified 25B-NBOMe.
+3. **San Francisco, 1967:** unusually strong DOM tablets circulated as STP. Slow onset encouraged redosing and the prolonged experience sent dozens of people to clinics and hospitals.
+4. **San Francisco, 1972:** eight adults inhaled pure LSD tartrate after mistaking the powder for cocaine. Five became comatose; complications included hyperthermia, respiratory arrest, vomiting, and bleeding abnormalities. All survived.
+5. **United States, 2013:** an 18-year-old intoxicated with 25I-NBOMe jumped from a moving car and remained intermittently aggressive for nearly two days.
+6. **Australia, 2022 report:** five people encountered powder sold as “powdered LSD.” It contained 25B-NBOH; one patient developed status epilepticus requiring intubation.
+7. **Ibogaine cardiac cases:** internet-purchased or high-dose ibogaine produced profound QT prolongation, torsades de pointes, ventricular flutter, defibrillation, and rhythm instability lasting up to 12 days.
+8. **Datura poisonings:** teenagers seeking hallucinations developed anticholinergic delirium, combativeness, incoherent speech, and loss of reality testing after swallowing hundreds of jimsonweed seeds.
 
-The chemicals and circumstances differed, but the underlying failure pattern was remarkably consistent: **identity uncertainty, potency mismatch, delayed effects, false confidence, and medical systems forced to react before the substance was known.**
+The shared lesson is not that every psychoactive substance has the same risk. It is that **identity, potency, time course, and toxicological profile matter more than the name, artwork, container, seller confidence, or apparent precision of the dose.**
 
-## The Four Incidents at a Glance
+## Eight Incidents at a Glance
 
-| Incident | What users believed | What was involved | Main failure | Outcome |
+| Incident | What users believed | What was involved | Primary failure | Outcome |
 |---|---|---|---|---|
-| Oklahoma, 2011 | 2C-E | Bromo-DragonFLY was later reported by officials | A dosing plan built for the wrong chemical | Eight severely affected; two deaths |
-| New South Wales, 2014 | LSD blotter | 25B-NBOMe confirmed in blood | The familiar blotter format falsely signaled LSD | Four seizures, intensive care, organ injury; survival |
-| San Francisco, 1967 | A new psychedelic called STP | DOM in unusually strong tablets | Slow onset encouraged redosing; duration was underestimated | Dozens sought medical help; no confirmed DOM deaths |
-| San Francisco, 1972 | Cocaine | Pure LSD tartrate powder | A cocaine-sized amount of an ultra-potent psychedelic | Eight critical poisonings; all survived with supportive care |
+| Oklahoma, 2011 | 2C-E | Bromo-DragonFLY was later reported | Dosing plan built for the wrong chemical | Eight severe poisonings; two deaths |
+| New South Wales, 2014 | LSD blotter | 25B-NBOMe | Familiar format falsely signaled LSD | Four seizures, ICU care, organ injury; survival |
+| San Francisco, 1967 | STP with poorly understood properties | DOM in strong tablets | Slow onset and underestimated duration | Dozens sought medical help |
+| San Francisco, 1972 | Cocaine | Pure LSD tartrate powder | Cocaine-sized quantity of a microgram-active drug | Eight critical poisonings; all survived |
+| United States, 2013 | 25I-NBOMe | Confirmed 25I-NBOMe | Severe behavioral toxicity and impaired judgment | Jump from moving car; 48-hour recovery |
+| Australia, party cluster | “Powdered LSD” | 25B-NBOH | Powder form enabled excessive exposure | Status epilepticus, intubation, kidney injury |
+| Ibogaine cases | Anti-addiction treatment or visionary drug | Ibogaine and long-lived noribogaine | Prolonged cardiac repolarization toxicity | Torsades, ventricular flutter, defibrillation |
+| Datura cases | A hallucinogenic plant experience | Atropine/scopolamine-containing seeds | Delirium mistaken for a psychedelic state | Restraints, sedation, hospitalization |
 
 ## Case One: The 2011 Oklahoma Bromo-DragonFLY Poisoning
 
-### A measurement system built on a false identity
+### A careful-looking method built on a false identity
 
-According to the probable-cause affidavit, powder ordered online and labeled as 2C-E was dissolved into water. The affidavit describes one gram being mixed into one liter, followed by distribution in measured liquid portions [1]. On paper, that can look more deliberate than eyeballing powder: liquid measurement is often assumed to create consistency.
+According to a probable-cause affidavit, powder ordered online and labeled as 2C-E was dissolved into water. One gram was reportedly mixed into one liter, after which measured liquid portions were distributed [1].
 
-But consistency is only useful when the starting information is correct.
+Liquid measurement can reduce inconsistency only when the starting material is correctly identified and its concentration is known. Here, officials later reported that the material was Bromo-DragonFLY rather than 2C-E [2].
 
-The group apparently believed it was handling 2C-E, a psychedelic generally discussed on a milligram scale. Officials later reported that laboratory testing identified Bromo-DragonFLY instead [2]. Bromo-DragonFLY is active at much smaller quantities, can have a delayed onset, and has been associated with prolonged agitation, seizures, cardiovascular stress, severe vasoconstriction, tissue injury, organ failure, and death [3, 4, 9].
+The potency mismatch was not trivial. The group appears to have planned around a milligram-scale psychedelic. Bromo-DragonFLY can be active at much smaller quantities and has been associated with delayed onset, seizures, prolonged agitation, cardiovascular stress, severe vasoconstriction, tissue injury, organ failure, and death [3, 4].
 
-That means the participants were not merely inaccurate by a small percentage. They may have been applying a milligram-scale plan to a chemical with a dramatically different potency and toxicity profile.
+### The emergency and the uncertainty
 
-### The emergency
+Eight young adults became severely ill near Konawa in the early hours of May 7, 2011. One died that day and another several days later. Six survived [1, 2].
 
-In the early hours of May 7, 2011, emergency responders were called to a gathering near Konawa. Eight young adults became severely ill. Contemporary accounts described repeated seizures and extreme distress. One person died that day, and a second died several days later. Six survived [1, 2].
+The exact quantity swallowed by each person, the powder’s purity, and the uniformity of the solution were not publicly established well enough to reconstruct individual doses. The most defensible conclusion is therefore not a dramatic exact multiplier. It is simpler: **the chemical identity was wrong, so every downstream dosing assumption was wrong.**
 
-The first public reports referred to 2C-E because that was the identity believed by the people involved and recorded in early investigative documents. The later Bromo-DragonFLY identification changed the interpretation of the entire event.
+Adding more water would have lowered concentration per mouthful, but it would not have reduced the total amount in a finished drink. Measurement precision cannot rescue false source information.
 
-### Why adding more water did not make the dose smaller
+## Case Two: 25B-NBOMe Blotter Sold as LSD
 
-A recurring misunderstanding in liquid dosing is the difference between **concentration** and **total amount**. Adding a measured portion to a larger drink lowers the concentration in each mouthful, but it does not remove any drug. If the entire drink is consumed, the total amount remains the same.
+A 16-year-old camping with friends in rural New South Wales swallowed red blotter paper he believed was LSD [5]. He experienced three seizures before reaching the emergency department and a fourth after arrival.
 
-The more fundamental problem in Oklahoma was upstream of the arithmetic. Even perfectly measured liquid portions cannot compensate for a mislabeled starting material. The procedure can distribute the wrong chemical very evenly.
+His blood pH fell to 6.93, accompanied by severe carbon-dioxide retention—evidence of profound ventilatory failure during the crisis. Clinicians sedated, paralyzed, intubated, and mechanically ventilated him.
 
-### What is well established—and what remains uncertain
+The injury continued after seizure control. His creatine kinase climbed to 34,778 U/L, indicating severe rhabdomyolysis, and he developed acute kidney injury. Specialized analysis identified 25B-NBOMe. He recovered and left the hospital after five days [5].
 
-The affidavit supports the basic preparation and distribution sequence [1]. The deaths, the legislative response, and the later identification of Bromo-DragonFLY were publicly documented [2]. However, the exact quantity swallowed by each person, the purity of the powder, and how evenly it dissolved were not established in the public record with enough precision to reconstruct individual doses confidently.
-
-That matters because sensational retellings often turn uncertain estimates into exact facts. The defensible conclusion is narrower and stronger: **the identity was wrong, the potency assumptions were therefore wrong, and the resulting exposures were catastrophic.**
-
-## Case Two: The 25B-NBOMe Blotter Sold as LSD
-
-### A familiar object carried an unfamiliar risk
-
-In late 2014, a 16-year-old in rural New South Wales swallowed red blotter paper while camping with friends. He believed it was LSD [5]. The physical format reinforced that belief: for decades, small decorated paper squares had been associated with LSD.
-
-Blotter, however, is a delivery material—not a chemical identification method.
-
-The teenager experienced three seizures before reaching the emergency department and a fourth approximately an hour after arrival. His level of consciousness was severely reduced. A venous blood gas showed profound acidosis with a pH of 6.93 and extreme carbon-dioxide retention, indicating that ventilation had failed during the crisis [5].
-
-Doctors administered emergency sedation, paralyzed and intubated him, mechanically ventilated him, and transferred him to intensive care.
-
-### The injury continued after the seizures stopped
-
-The immediate neurological emergency was followed by **rhabdomyolysis**, the breakdown of skeletal muscle. His creatine kinase rose to 34,778 U/L, and laboratory findings showed acute kidney injury. He ultimately recovered and was discharged after five days [5].
-
-Specialized testing detected 25B-NBOMe in his blood. Routine hospital drug screens generally do not identify many NBOMe compounds, so clinicians often have to treat the visible syndrome—seizures, agitation, overheating, cardiovascular instability, muscle breakdown—before knowing the exact agent.
-
-### Why NBOMe substitution is especially dangerous
-
-NBOMe compounds are potent serotonin 5-HT2A receptor agonists. They can produce psychedelic effects, but severe poisonings have included violent agitation, seizures, hyperthermia, hypertension, tachycardia, rhabdomyolysis, kidney injury, coma, self-injury, and death [6].
-
-A review of analytically confirmed cases found a striking rate of intensive-care treatment and seizures [6]. The problem was not that the blotter looked suspicious. It was that it looked ordinary.
-
-The format created confidence that the supply chain had not earned.
+Blotter is a delivery material, not a chemical identity test. This case was dangerous precisely because the square looked ordinary. Reviews of confirmed NBOMe poisonings describe seizures, hyperthermia, hypertension, agitation, muscle breakdown, kidney injury, coma, self-injury, and death [6].
 
 ## Case Three: The 1967 DOM/STP Outbreak
 
-### A new drug arrives during the Summer of Love
+In June 1967, DOM tablets circulated in San Francisco under the name STP, often expanded as “Serenity, Tranquility and Peace.” The compound was unfamiliar to most users and clinicians, and historical accounts indicate that tablets around 10 milligrams—and some reportedly stronger—entered circulation [7].
 
-In June 1967, tablets containing DOM appeared in San Francisco under the street name **STP**, commonly expanded as “Serenity, Tranquility and Peace.” DOM had been synthesized and studied by Alexander Shulgin, but it was poorly understood by the public, emergency clinicians, and most underground distributors.
+DOM can build slowly and last far longer than many users expected. People accustomed to a faster onset sometimes interpreted the quiet first hours as evidence of weak material and took another tablet. When the first dose continued rising and the second followed behind it, the experience could become overwhelmingly intense and prolonged.
 
-At a summer-solstice gathering in Golden Gate Park, Owsley Stanley distributed a large number of tablets. Historical numbers vary, and later retellings often inflated the scale. A detailed 2024 reconstruction concludes that tablets around 10 milligrams—and some reportedly stronger—entered circulation [7]. Those amounts were substantially above the low-dose range explored in the earliest informal human work.
+Dozens reportedly sought help from the Haight-Ashbury Free Medical Clinic and San Francisco General Hospital. Some required sedation or hospitalization for severe psychiatric disturbance. No confirmed deaths were directly attributed to the outbreak, and later retellings often inflated the scale, but the event remains a classic information failure: strong tablets, delayed onset, long duration, mass distribution, and doctors initially uncertain what “STP” meant [7].
 
-### The delayed-onset trap
+The outbreak also helped push crisis care toward quieter surroundings, reassurance, observation, and less reflexively coercive treatment—an important improvement born from an otherwise chaotic episode.
 
-DOM can take much longer than expected to build toward its peak. People familiar with faster-onset psychedelics sometimes interpreted the delay as evidence that the tablet was weak and took another.
+## Case Four: Eight People Mistake Pure LSD Powder for Cocaine
 
-The sequence was simple and dangerous:
+On July 29, 1972, four women and four men arrived at San Francisco General Hospital after inhaling a white powder they believed was cocaine. It was pure LSD tartrate [8].
 
-1. Take a tablet.
-2. Feel less than expected after an hour or two.
-3. Take another.
-4. The first tablet continues rising.
-5. The second rises behind it.
+This was the inverse of the familiar “fake acid” story. The chemical really was LSD, but the group handled it as though it were a substance normally consumed in visible powder-sized amounts.
 
-By the time the user realized the first dose was active, the second could no longer be taken back.
+Within minutes, vomiting, collapse, extreme agitation, and altered consciousness appeared. Five patients became comatose. Reported complications included hyperthermia, respiratory arrest, and mild generalized bleeding. Laboratory testing showed platelet dysfunction in all eight, and LSD was measured in serum and stomach contents at concentrations rarely encountered clinically [8].
 
-### A long experience becomes a medical crisis
+No antidote could switch the exposure off. Treatment consisted of respiratory and cardiovascular support, cooling, monitoring, and management of complications. Remarkably, all eight survived.
 
-DOM can produce an exceptionally prolonged psychedelic and stimulant-like state. High-dose users reported overwhelming sensory changes, panic, depersonalization, insomnia, and the fear that the experience would never end. Dozens sought help from the Haight-Ashbury Free Medical Clinic and San Francisco General Hospital [7]. Some required sedation or hospitalization for severe psychiatric disturbance.
+The case should not be used to claim that massive LSD exposure is harmless. It documented life-threatening systemic toxicity. Its lesson is that a powder’s appearance can import the dosage assumptions of an entirely different drug.
 
-The recent historical review emphasizes that older stories contain exaggerations and contradictions. There were no confirmed deaths directly attributed to the 1967 DOM outbreak, and many people used the drug without presenting for medical care [7]. Still, it was a genuine public-health failure: unusually strong tablets, unfamiliar pharmacology, slow onset, prolonged duration, widespread distribution, and clinicians initially unsure what “STP” even was.
+## Case Five: The 25I-NBOMe Jump from a Moving Car
 
-### One constructive consequence
+An 18-year-old arrived at an emergency department with severe agitation and hallucinations after jumping from a moving car. His heart rate was approximately 150 to 160 beats per minute, and his blood pressure was markedly elevated [9].
 
-Early rumors claimed that chlorpromazine would make DOM reactions worse. Later evidence did not support that simple warning, but the controversy helped push crisis responders toward calmer, less coercive management: reduced stimulation, reassurance, observation, and medication only when clinically necessary [7].
+He required physical restraints and intravenous lorazepam. His vital signs gradually normalized, but episodes of aggression continued during a recovery lasting roughly 48 hours. Toxicological analysis quantified 25I-NBOMe in his serum [9].
 
-In other words, a misinformation crisis accidentally accelerated a more humane model of psychedelic emergency care.
+This case illustrates a risk that laboratory values alone do not capture: **behavioral toxicity**. A drug can transform perception and threat assessment so radically that an immediately dangerous action feels necessary or sensible. The medical crisis may begin with trauma, exposure, wandering, drowning, or confrontation before the chemical toxicity is even recognized.
 
-## Case Four: The 1972 San Francisco Massive LSD Overdose
+## Case Six: “Powdered LSD” That Was Actually 25B-NBOH
 
-### The inverse of the usual substitution story
+Five patients presented after exposure to powder sold as “powdered LSD” at a party. Chemical analysis identified 25B-NBOH, a potent hallucinogenic phenethylamine related to the NBOMe family [10].
 
-On July 29, 1972, four women and four men between 19 and 39 years old arrived at San Francisco General Hospital after a remarkable identification error. According to the published case report, the group had used a small amount of cocaine after a dinner party and then inhaled a quantity of white powder they also believed was cocaine. The second powder was pure D-lysergic acid diethylamide tartrate—LSD [10].
+A 24-year-old who swallowed the powder developed dilated pupils, tachycardia, hypertension, and severe agitation requiring injected sedation. A 22-year-old who inhaled it developed status epilepticus—a prolonged seizure emergency—and required intubation.
 
-Most substitution disasters involve a dangerous compound being sold as LSD. This was the reverse: the chemical really was LSD, but its appearance led the group to handle it as though it were a drug ordinarily consumed in visible powder-sized amounts.
+Both severely affected patients developed acute kidney injury; one developed rhabdomyolysis. Three others experienced milder hallucinations. Acute toxicity resolved within approximately 12 hours [10].
 
-The authors did not establish a precise absorbed dose for each patient. Claims that translate the exposure into an exact number of blotter “hits” are therefore more certain than the evidence permits. What the report does establish is that all eight inhaled large amounts of pure LSD powder and became critically ill.
+The powder format matters. Ultra-potent compounds are often placed on blotter partly because a visible scoop or line can represent far too much material. Calling an unknown powder “LSD” did more than misname it; it encouraged users to borrow the handling assumptions of a different substance.
 
-### A rapid critical-care emergency
+## Case Seven: Ibogaine and the Heart That Would Not Reset
 
-The patients were seen within approximately 15 minutes of the exposure. Vomiting and collapse occurred alongside signs of extreme sympathetic activation. Reported complications included hyperthermia, coma, and respiratory arrest [10].
+Ibogaine occupies a complicated cultural space: psychedelic, traditional plant alkaloid, and unapproved anti-addiction intervention. Its most alarming documented risk is not simply psychological distress but prolonged electrical instability of the heart.
 
-Several patients also developed mild generalized bleeding, while laboratory testing showed evidence of platelet dysfunction in all eight. LSD was measured in serum and stomach contents at concentrations rarely encountered in clinical practice [10].
+In one case involving internet-purchased ibogaine, a patient’s corrected QT interval reached 647 milliseconds. He developed atrial tachycardia, ventricular tachycardia, and torsades de pointes. QT prolongation persisted for 12 days—well after parent ibogaine levels had fallen—implicating the long-lasting metabolite noribogaine [11].
 
-This was not simply an exceptionally intense psychedelic experience. It was a life-threatening systemic poisoning requiring emergency monitoring and support of breathing, temperature, circulation, and other complications.
+A separate case involved a 61-year-old man who developed ventricular flutter at approximately 270 beats per minute and required emergency defibrillation. His QT interval took seven days to normalize [12].
 
-### The improbable outcome
+This creates a uniquely deceptive timeline: the visionary or intoxicating phase may be ending while the cardiac danger remains. Unlike a brief panic reaction, the risk can persist across many sleep cycles and requires prolonged medical monitoring.
 
-There was no antidote that could switch the exposure off. Clinicians used supportive care while the patients’ bodies cleared the drug.
+Ibogaine’s case also exposes the limits of framing psychoactive substances only by their subjective experience. A person may feel mentally clearer while their cardiac repolarization remains dangerously abnormal.
 
-All eight survived [10].
+## Case Eight: Datura and the Difference Between Hallucination and Delirium
 
-That outcome is medically striking, but it should not be converted into the claim that massive LSD exposure is harmless. The same case documented coma, respiratory arrest, dangerous overheating, collapse, vomiting, and abnormal bleeding. Survival depended on rapid access to hospital care.
+Two teenagers intentionally swallowed several hundred seeds from *Datura stramonium*, or jimsonweed, seeking hallucinogenic effects. They arrived with visual hallucinations, profound disorientation, incomprehensible speech, dilated pupils, and severe combativeness. Both required physical restraints until sedation was achieved [13].
 
-### Why this case belongs with the others
+Datura is better described as a **deliriant** than a classic psychedelic. Its atropine- and scopolamine-like compounds impair the brain systems needed to distinguish internal events from external reality. A person may speak with nonexistent people, manipulate imaginary objects, wander into danger, or fight rescuers without recognizing that the experience is drug-induced.
 
-The Oklahoma incident involved careful-looking liquid measurements applied to the wrong drug. The Australian case involved blotter that visually implied LSD but contained 25B-NBOMe. The 1972 case shows the opposite visual trap: an unidentified white powder was treated like cocaine even though it was an ultra-potent psychedelic active at far smaller quantities.
+A historical review of 29 adolescent hospitalizations following intentional jimsonweed ingestion found that every patient had hallucinations, dilated pupils, and disorientation. Five developed urinary retention severe enough to require catheterization. All recovered, but the average hospitalization lasted nearly two days [14].
 
-The shared problem was not simply recklessness. It was **an appearance being mistaken for an identity, followed by a quantity assumption borrowed from the wrong chemical.**
+Calling Datura a “natural hallucinogen” obscures the central danger. Natural origin says nothing about predictability, therapeutic margin, or the ability to retain insight.
 
-## The Shared Failure Chain
+## The Shared Failure Chains
 
-These incidents were separated by decades, countries, and chemical classes. The repeating architecture is more important than the individual drug names.
+### 1. Appearance and format became counterfeit evidence
 
-### 1. The claimed identity was treated as a fact
+Blotter was assumed to mean LSD. White powder was assumed to mean cocaine. A standardized-looking tablet implied a manageable unit. A plant was assumed to offer a gentler “natural” experience.
 
-In Oklahoma, the powder was labeled as 2C-E. In Australia, blotter was assumed to be LSD. In 1967 San Francisco, people received STP without meaningful knowledge of DOM’s dose-response curve or duration. In 1972, pure LSD powder was mistaken for cocaine.
+None of those appearances established identity or safety.
 
-An illicit label—or a familiar-looking object—is a claim, not an analytical result.
+### 2. Potency assumptions were borrowed from the wrong substance
 
-### 2. The potency assumptions belonged to another substance
+The Oklahoma group used a plan intended for 2C-E. The 1972 group handled LSD like cocaine. The 25B-NBOH cluster handled an ultra-potent compound as a visible powder.
 
-A dose that might be ordinary for one compound can be extreme for another. This is why substitution among visually identical powders or blotters is not a minor quality-control problem. It can move the user across orders of magnitude.
+When two substances differ by orders of magnitude, a small identification error becomes an enormous exposure error.
 
-### 3. Delayed onset encouraged additional consumption
+### 3. Delayed onset encouraged accumulation
 
-Both Bromo-DragonFLY and DOM can develop slowly. The absence of early effects can be misread as product weakness rather than pharmacokinetics. Redosing turns uncertainty into accumulation.
+Bromo-DragonFLY and DOM can develop slowly. Lack of early effect may be misread as weak material rather than delayed pharmacokinetics. By the time the first dose declares itself, additional doses cannot be taken back.
 
-### 4. Format and measurement created false confidence
+### 4. The danger was sometimes behavioral rather than purely biochemical
 
-The Oklahoma group used liquid measurement. The Australian teenager had a standardized-looking blotter square. The 1967 DOM appeared in discrete tablets. The 1972 group encountered a white powder that visually resembled another drug.
+The 25I-NBOMe patient jumped from a moving vehicle. Datura intoxication produced delirium and combativeness. A person can be medically endangered through impaired judgment even before temperature, heart rhythm, kidney function, or seizure activity becomes abnormal.
 
-Each object looked familiar or measurable. None of that proved identity, purity, or appropriate potency.
+### 5. Toxicity outlasted the expected “trip”
 
-### 5. Several people were exposed before the danger was understood
+Ibogaine-related QT prolongation persisted for seven to 12 days. DOM experiences lasted far longer than many users anticipated. Prolonged metabolites and receptor effects can make subjective recovery a poor guide to medical recovery.
 
-Group consumption compresses the warning window. When several people take material from the same batch at roughly the same time, one person’s adverse reaction may not begin early enough to warn the others.
+### 6. Group exposure compressed the warning window
 
-### 6. Emergency medicine started with incomplete information
+When several people consume the same material around the same time, the first severe reaction may begin too late to warn everyone else. Shared confidence amplifies rather than corrects the original mistake.
 
-Routine toxicology panels do not identify every novel psychoactive substance. Clinicians often must stabilize seizures, temperature, breathing, circulation, and agitation before confirmatory testing is available—or without ever receiving confirmation [5, 6, 9].
+### 7. Emergency medicine began with incomplete information
+
+Routine toxicology panels cannot identify every novel psychoactive substance. Clinicians often must control seizures, temperature, breathing, circulation, agitation, and trauma before confirmatory testing exists—or without ever receiving a definitive identification.
 
 ## What Drug Checking and Regulation Can Change
 
-These stories support a strong criticism of an entirely underground market. Prohibition does not eliminate demand, but it can eliminate or weaken the infrastructure that normally makes a chemical product legible:
+These cases support a strong criticism of an entirely underground market. Prohibition does not eliminate demand, but it can weaken the infrastructure that normally makes a chemical product legible:
 
 - verified identity;
-- batch records;
+- batch records and traceability;
 - standardized concentration;
 - contamination screening;
 - enforceable labeling;
 - adverse-event reporting;
-- recalls;
-- rapid public warnings;
-- accountability for manufacturing failures.
+- recalls and rapid public warnings;
+- accountability for manufacturing or distribution failures.
 
-Drug checking can sometimes identify unexpected substances and reduce the information gap. A regulated framework could add manufacturing standards, traceability, age restrictions, professional screening, and clearer education.
+Drug checking can sometimes identify unexpected compounds and narrow the information gap. A regulated framework could add manufacturing standards, age restrictions, screening, and clearer education.
 
-But neither testing nor regulation makes every hallucinogen safe. Analytical methods can miss compounds, mixtures may be uneven, and accurately identified substances can still cause panic, psychosis-like states, seizures, cardiovascular complications, accidents, or psychiatric destabilization. Bromo-DragonFLY would remain dangerous even in a perfectly labeled vial.
+But neither testing nor regulation makes every hallucinogen safe. Analytical methods have limits, mixtures can be uneven, and accurately identified substances can still cause panic, delirium, seizures, cardiovascular complications, trauma, or psychiatric destabilization. Ibogaine would still affect cardiac ion channels; Datura would still produce anticholinergic delirium; Bromo-DragonFLY would remain unusually potent and vasoconstrictive.
 
-The realistic goal is not zero risk. It is replacing avoidable uncertainty with better information and faster intervention.
+The realistic goal is not zero risk. It is replacing avoidable uncertainty with better information, earlier recognition, and faster intervention.
 
 ## Emergency Lessons That Do Not Depend on Knowing the Drug
 
-When the chemical identity is uncertain, the observable symptoms matter more than guessing the name.
+When chemical identity is uncertain, symptoms matter more than guessing the name.
 
 Seek emergency help for:
 
-- any seizure;
-- collapse or loss of consciousness;
-- inability to wake the person;
+- any seizure or repeated uncontrolled movement;
+- collapse, loss of consciousness, or inability to wake the person;
 - severe breathing difficulty;
-- chest pain or extreme heart rate;
+- chest pain, fainting, or an extreme or irregular heart rate;
 - dangerous overheating;
-- blue, gray, unusually pale, or cold extremities;
-- severe confusion, violence, or behavior creating immediate danger;
+- blue, gray, unusually pale, or cold skin or extremities;
+- severe confusion, delirium, violence, or behavior creating immediate danger;
 - persistent vomiting with reduced consciousness;
-- intense muscle rigidity or prolonged uncontrolled movement.
+- muscle rigidity, profound weakness, or dark urine after severe agitation or seizures.
 
-Do not let a severely affected person drive, wander away, or remain alone. Give responders the packaging, blotter, powder, messages, or vendor information if available. A wrong guess about the substance is less useful than an honest description of what was taken, when, and what symptoms followed.
+Do not let a severely affected person drive, wander away, or remain alone. Give responders any packaging, blotter, powder, messages, product listings, or vendor information available. An honest timeline is more useful than a confident but unverified drug name.
 
 ## Bottom Line
 
-The Oklahoma Bromo-DragonFLY deaths, the Australian 25B-NBOMe emergency, the 1967 DOM outbreak, and the 1972 massive LSD poisoning were not identical events. One involved fatal misidentification, one involved “LSD” blotter containing a more toxic substitute, one involved a known drug distributed at poorly understood strengths with a dangerously slow onset, and one involved pure LSD mistaken for a powder normally consumed at vastly larger amounts.
+These eight incidents span different decades, countries, chemical classes, and patterns of use. Some involved substitution. Some involved delayed onset. Some involved cardiac toxicity, prolonged seizures, or delirium. One involved genuine LSD mistaken for cocaine; another involved a compound sold as “powdered LSD” that was not LSD at all.
 
-Together, they demonstrate a single principle:
+Together, they demonstrate a durable principle:
 
-> **A precise measurement—or a familiar appearance—does not establish chemical identity.**
+> **A precise measurement—or a familiar appearance—does not establish chemical identity, potency, or safety.**
 
-The paper square, tablet, powder, label, online listing, and seller’s confidence are not analytical evidence. When identity, potency, and timing are uncertain, even behavior that feels careful can rest on a completely false foundation.
+The paper square, tablet, powder, plant, label, online listing, and seller’s confidence are not analytical evidence. When identity, time course, and toxicology are uncertain, behavior that feels careful can still rest on a false foundation.

--- a/content/articles/psychedelic-disasters-mislabeled-drugs.mdx
+++ b/content/articles/psychedelic-disasters-mislabeled-drugs.mdx
@@ -1,12 +1,12 @@
 ---
-title: "When the Label Lies: Three Psychedelic Disasters and the Failure Chains Behind Them"
-description: "A documented case-study review of the 2011 Oklahoma Bromo-DragonFLY poisoning, a 25B-NBOMe blotter emergency, and the 1967 DOM/STP outbreak—showing how misidentification, potency mismatch, delayed onset, and weak information systems turn drug use into disaster."
+title: "When the Label Lies: Four Psychedelic Disasters and the Failure Chains Behind Them"
+description: "A documented case-study review of the Oklahoma Bromo-DragonFLY poisoning, a 25B-NBOMe blotter emergency, the 1967 DOM/STP outbreak, and a 1972 massive LSD overdose—showing how misidentification, potency mismatch, delayed onset, and weak information systems turn drug use into disaster."
 date: "2026-07-28"
 lastUpdated: "2026-07-28"
 slug: "psychedelic-disasters-mislabeled-drugs"
 category: "Harm Reduction"
-tags: ["psychedelics", "hallucinogens", "Bromo-DragonFLY", "NBOMe", "DOM", "STP", "drug checking", "harm reduction", "case studies"]
-readingTime: 16
+tags: ["psychedelics", "hallucinogens", "Bromo-DragonFLY", "NBOMe", "DOM", "STP", "LSD", "overdose", "drug checking", "harm reduction", "case studies"]
+readingTime: 20
 evidenceGrade: "Moderate for the documented incidents; limited by incomplete public records and retrospective reporting"
 author: "The Hippie Scientist"
 references:
@@ -55,6 +55,11 @@ references:
     year: "2017"
     pmid: ""
     url: "https://pmc.ncbi.nlm.nih.gov/articles/PMC5741979/"
+  - title: "Coma, Hyperthermia and Bleeding Associated with Massive LSD Overdose: A Report of Eight Cases"
+    authors: "Klock JC, Boerner U, Becker CE"
+    year: "1974"
+    pmid: "4816396"
+    url: "https://pmc.ncbi.nlm.nih.gov/articles/PMC1129381/"
 ---
 
 > **Safety note:** These are historical toxicology case studies, not dosing guidance. A seizure, collapse, severe agitation, overheating, chest pain, breathing difficulty, blue or very pale skin, extreme confusion, or inability to wake someone after a drug exposure is an emergency. Contact emergency services and a poison center rather than waiting for the experience to pass.
@@ -63,21 +68,23 @@ references:
 
 The most frightening hallucinogen disasters are not always caused by someone knowingly choosing an extreme dose. Sometimes the person has the wrong chemical, the wrong potency assumption, the wrong timeline, or all three at once.
 
-This article examines three documented incidents:
+This article examines four documented incidents:
 
 1. **Konawa, Oklahoma, 2011:** a liquid believed to contain 2C-E was later reported to contain Bromo-DragonFLY, a substantially more potent and unusually long-lasting psychedelic. Eight young adults became severely ill; two died.
 2. **Rural New South Wales, 2014:** a 16-year-old swallowed blotter sold as LSD and developed repeated seizures, respiratory failure, severe acidosis, muscle breakdown, and kidney injury. Laboratory testing identified 25B-NBOMe.
 3. **San Francisco, 1967:** high-dose DOM tablets, sold under the name STP, spread through the Summer of Love. Slow onset encouraged redosing, while the long duration and unfamiliar effects sent dozens of people to clinics and hospitals.
+4. **San Francisco, 1972:** eight adults inhaled pure LSD tartrate powder after mistaking it for cocaine. They developed vomiting, collapse, hyperthermia, coma, respiratory arrest, and bleeding abnormalities; all survived with supportive care.
 
 The chemicals and circumstances differed, but the underlying failure pattern was remarkably consistent: **identity uncertainty, potency mismatch, delayed effects, false confidence, and medical systems forced to react before the substance was known.**
 
-## The Three Incidents at a Glance
+## The Four Incidents at a Glance
 
 | Incident | What users believed | What was involved | Main failure | Outcome |
 |---|---|---|---|---|
 | Oklahoma, 2011 | 2C-E | Bromo-DragonFLY was later reported by officials | A dosing plan built for the wrong chemical | Eight severely affected; two deaths |
 | New South Wales, 2014 | LSD blotter | 25B-NBOMe confirmed in blood | The familiar blotter format falsely signaled LSD | Four seizures, intensive care, organ injury; survival |
 | San Francisco, 1967 | A new psychedelic called STP | DOM in unusually strong tablets | Slow onset encouraged redosing; duration was underestimated | Dozens sought medical help; no confirmed DOM deaths |
+| San Francisco, 1972 | Cocaine | Pure LSD tartrate powder | A cocaine-sized amount of an ultra-potent psychedelic | Eight critical poisonings; all survived with supportive care |
 
 ## Case One: The 2011 Oklahoma Bromo-DragonFLY Poisoning
 
@@ -169,15 +176,47 @@ Early rumors claimed that chlorpromazine would make DOM reactions worse. Later e
 
 In other words, a misinformation crisis accidentally accelerated a more humane model of psychedelic emergency care.
 
+## Case Four: The 1972 San Francisco Massive LSD Overdose
+
+### The inverse of the usual substitution story
+
+On July 29, 1972, four women and four men between 19 and 39 years old arrived at San Francisco General Hospital after a remarkable identification error. According to the published case report, the group had used a small amount of cocaine after a dinner party and then inhaled a quantity of white powder they also believed was cocaine. The second powder was pure D-lysergic acid diethylamide tartrate—LSD [10].
+
+Most substitution disasters involve a dangerous compound being sold as LSD. This was the reverse: the chemical really was LSD, but its appearance led the group to handle it as though it were a drug ordinarily consumed in visible powder-sized amounts.
+
+The authors did not establish a precise absorbed dose for each patient. Claims that translate the exposure into an exact number of blotter “hits” are therefore more certain than the evidence permits. What the report does establish is that all eight inhaled large amounts of pure LSD powder and became critically ill.
+
+### A rapid critical-care emergency
+
+The patients were seen within approximately 15 minutes of the exposure. Vomiting and collapse occurred alongside signs of extreme sympathetic activation. Reported complications included hyperthermia, coma, and respiratory arrest [10].
+
+Several patients also developed mild generalized bleeding, while laboratory testing showed evidence of platelet dysfunction in all eight. LSD was measured in serum and stomach contents at concentrations rarely encountered in clinical practice [10].
+
+This was not simply an exceptionally intense psychedelic experience. It was a life-threatening systemic poisoning requiring emergency monitoring and support of breathing, temperature, circulation, and other complications.
+
+### The improbable outcome
+
+There was no antidote that could switch the exposure off. Clinicians used supportive care while the patients’ bodies cleared the drug.
+
+All eight survived [10].
+
+That outcome is medically striking, but it should not be converted into the claim that massive LSD exposure is harmless. The same case documented coma, respiratory arrest, dangerous overheating, collapse, vomiting, and abnormal bleeding. Survival depended on rapid access to hospital care.
+
+### Why this case belongs with the others
+
+The Oklahoma incident involved careful-looking liquid measurements applied to the wrong drug. The Australian case involved blotter that visually implied LSD but contained 25B-NBOMe. The 1972 case shows the opposite visual trap: an unidentified white powder was treated like cocaine even though it was an ultra-potent psychedelic active at far smaller quantities.
+
+The shared problem was not simply recklessness. It was **an appearance being mistaken for an identity, followed by a quantity assumption borrowed from the wrong chemical.**
+
 ## The Shared Failure Chain
 
 These incidents were separated by decades, countries, and chemical classes. The repeating architecture is more important than the individual drug names.
 
 ### 1. The claimed identity was treated as a fact
 
-In Oklahoma, the powder was labeled as 2C-E. In Australia, blotter was assumed to be LSD. In San Francisco, people received STP without meaningful knowledge of DOM’s dose-response curve or duration.
+In Oklahoma, the powder was labeled as 2C-E. In Australia, blotter was assumed to be LSD. In 1967 San Francisco, people received STP without meaningful knowledge of DOM’s dose-response curve or duration. In 1972, pure LSD powder was mistaken for cocaine.
 
-An illicit label is a claim, not an analytical result.
+An illicit label—or a familiar-looking object—is a claim, not an analytical result.
 
 ### 2. The potency assumptions belonged to another substance
 
@@ -187,11 +226,11 @@ A dose that might be ordinary for one compound can be extreme for another. This 
 
 Both Bromo-DragonFLY and DOM can develop slowly. The absence of early effects can be misread as product weakness rather than pharmacokinetics. Redosing turns uncertainty into accumulation.
 
-### 4. Measurement created false confidence
+### 4. Format and measurement created false confidence
 
-The Oklahoma group used liquid measurement. The Australian teenager had a standardized-looking blotter square. The San Francisco tablets appeared to be discrete units.
+The Oklahoma group used liquid measurement. The Australian teenager had a standardized-looking blotter square. The 1967 DOM appeared in discrete tablets. The 1972 group encountered a white powder that visually resembled another drug.
 
-Each object looked measurable. None of that proved identity, purity, or appropriate potency.
+Each object looked familiar or measurable. None of that proved identity, purity, or appropriate potency.
 
 ### 5. Several people were exposed before the danger was understood
 
@@ -242,10 +281,10 @@ Do not let a severely affected person drive, wander away, or remain alone. Give 
 
 ## Bottom Line
 
-The Oklahoma Bromo-DragonFLY deaths, the Australian 25B-NBOMe emergency, and the 1967 DOM outbreak were not identical events. One involved fatal misidentification, one involved “LSD” blotter containing a more toxic substitute, and one involved a known drug distributed at poorly understood strengths with a dangerously slow onset.
+The Oklahoma Bromo-DragonFLY deaths, the Australian 25B-NBOMe emergency, the 1967 DOM outbreak, and the 1972 massive LSD poisoning were not identical events. One involved fatal misidentification, one involved “LSD” blotter containing a more toxic substitute, one involved a known drug distributed at poorly understood strengths with a dangerously slow onset, and one involved pure LSD mistaken for a powder normally consumed at vastly larger amounts.
 
 Together, they demonstrate a single principle:
 
-> **A precise measurement of an unknown chemical is still an unknown exposure.**
+> **A precise measurement—or a familiar appearance—does not establish chemical identity.**
 
-The paper square, tablet, label, online listing, and seller’s confidence are not analytical evidence. When identity, potency, and timing are uncertain, even behavior that feels careful can rest on a completely false foundation.
+The paper square, tablet, powder, label, online listing, and seller’s confidence are not analytical evidence. When identity, potency, and timing are uncertain, even behavior that feels careful can rest on a completely false foundation.


### PR DESCRIPTION
## Summary

Adds a long-form, evidence-cited harm-reduction article covering eight documented hallucinogen disasters:

- the 2011 Oklahoma Bromo-DragonFLY/2C-E misidentification poisoning;
- a 2014 Australian 25B-NBOMe blotter poisoning sold as LSD;
- the 1967 San Francisco DOM/STP outbreak;
- the 1972 San Francisco mass poisoning in which eight adults inhaled pure LSD powder after mistaking it for cocaine;
- a confirmed 25I-NBOMe intoxication involving a jump from a moving car;
- a five-patient 25B-NBOH cluster involving powder sold as “powdered LSD”;
- two ibogaine cardiac-toxicity cases involving prolonged QT abnormalities, ventricular arrhythmias, and defibrillation;
- documented adolescent Datura poisonings illustrating anticholinergic delirium rather than a classic psychedelic state.

The article was comprehensively revised to compare misidentification, potency mismatch, delayed onset, behavioral toxicity, prolonged cardiac risk, delirium, and incomplete clinical information without becoming a dosing guide.

## Integration

The file lives in `content/articles`, so the existing content-collections pipeline publishes it at `/articles/psychedelic-disasters-mislabeled-drugs/` and includes it in the Articles index.

## Safety and sourcing

- Includes a prominent emergency safety notice and symptom-based escalation guidance.
- Separates documented facts from uncertain or exaggerated retellings.
- Includes fourteen court, government, historical, and peer-reviewed references.
- Expands the shared-failure analysis and regulation/drug-checking discussion.