### PR TITLE
Add Failure Chains case system and FC-001

### DIFF
--- a/components/failure-chains/FailureChainCaseFile.tsx
+++ b/components/failure-chains/FailureChainCaseFile.tsx
@@ -1,0 +1,118 @@
+type Preventability = 'Low' | 'Moderate' | 'High' | 'Very high' | 'Unknown'
+type MedicalSeverity = 'Moderate' | 'Severe' | 'Critical' | 'Fatal'
+type DocumentationConfidence = 'Low' | 'Moderate' | 'High'
+
+interface FailureChainCaseFileProps {
+  caseId: string
+  incident: string
+  reported: string
+  outcome: string
+  primaryFailure: string
+  preventability: Preventability
+  medicalSeverity: MedicalSeverity
+  documentationConfidence: DocumentationConfidence
+  documentation: string
+  steps: string[]
+}
+
+const severityClasses: Record<MedicalSeverity, string> = {
+  Moderate: 'border-amber-700/20 bg-amber-50 text-amber-900',
+  Severe: 'border-orange-700/20 bg-orange-50 text-orange-900',
+  Critical: 'border-red-700/20 bg-red-50 text-red-900',
+  Fatal: 'border-red-900/25 bg-red-100 text-red-950',
+}
+
+const preventabilityClasses: Record<Preventability, string> = {
+  Low: 'border-slate-700/20 bg-slate-50 text-slate-800',
+  Moderate: 'border-amber-700/20 bg-amber-50 text-amber-900',
+  High: 'border-orange-700/20 bg-orange-50 text-orange-900',
+  'Very high': 'border-red-700/20 bg-red-50 text-red-900',
+  Unknown: 'border-slate-700/20 bg-slate-50 text-slate-800',
+}
+
+const confidenceClasses: Record<DocumentationConfidence, string> = {
+  Low: 'border-slate-700/20 bg-slate-50 text-slate-800',
+  Moderate: 'border-amber-700/20 bg-amber-50 text-amber-900',
+  High: 'border-emerald-700/20 bg-emerald-50 text-emerald-900',
+}
+
+function Detail({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-2xl border border-brand-900/10 bg-[var(--surface-subtle)] p-4">
+      <dt className="text-xs font-bold uppercase tracking-wider text-muted">{label}</dt>
+      <dd className="mt-2 text-sm font-semibold leading-6 text-ink">{value}</dd>
+    </div>
+  )
+}
+
+export default function FailureChainCaseFile({
+  caseId,
+  incident,
+  reported,
+  outcome,
+  primaryFailure,
+  preventability,
+  medicalSeverity,
+  documentationConfidence,
+  documentation,
+  steps,
+}: FailureChainCaseFileProps) {
+  const headingId = `failure-chain-${caseId.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`
+
+  return (
+    <section aria-labelledby={headingId} className="card-premium overflow-hidden p-5 sm:p-6">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="rounded-full border border-brand-700/20 bg-brand-50 px-3 py-1 text-xs font-bold uppercase tracking-wider text-brand-800">
+          {caseId}
+        </span>
+        <span className={`rounded-full border px-3 py-1 text-xs font-bold ${severityClasses[medicalSeverity]}`}>
+          Severity: {medicalSeverity}
+        </span>
+        <span className={`rounded-full border px-3 py-1 text-xs font-bold ${preventabilityClasses[preventability]}`}>
+          Preventability: {preventability}
+        </span>
+        <span className={`rounded-full border px-3 py-1 text-xs font-bold ${confidenceClasses[documentationConfidence]}`}>
+          Documentation: {documentationConfidence}
+        </span>
+      </div>
+
+      <div className="mt-5 max-w-3xl">
+        <p className="eyebrow-label">Failure Chains case file</p>
+        <h2 id={headingId} className="mt-2 text-2xl font-bold tracking-tight text-ink sm:text-3xl">
+          {incident}
+        </h2>
+        <p className="mt-2 text-sm font-semibold text-muted">{reported}</p>
+      </div>
+
+      <dl className="mt-6 grid gap-3 sm:grid-cols-2">
+        <Detail label="Outcome" value={outcome} />
+        <Detail label="Primary failure" value={primaryFailure} />
+        <Detail label="Source basis" value={documentation} />
+        <Detail
+          label="Editorial reading"
+          value="The chain describes this incident; it is not a frequency estimate for all exposures."
+        />
+      </dl>
+
+      <div className="mt-7 border-t border-brand-900/10 pt-6">
+        <h3 className="text-lg font-bold text-ink">Failure chain</h3>
+        <ol className="mt-5 space-y-0" aria-label={`${caseId} failure chain`}>
+          {steps.map((step, index) => (
+            <li
+              key={`${caseId}-${index}-${step}`}
+              className="relative border-l-2 border-brand-700/20 pb-5 pl-7 last:border-transparent last:pb-0"
+            >
+              <span
+                aria-hidden="true"
+                className="absolute -left-3 top-0 flex h-6 w-6 items-center justify-center rounded-full border border-brand-700/25 bg-white text-xs font-bold text-brand-800"
+              >
+                {index + 1}
+              </span>
+              <p className="text-sm font-medium leading-6 text-ink">{step}</p>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </section>
+  )
+}

--- a/components/failure-chains/__tests__/FailureChainCaseFile.test.tsx
+++ b/components/failure-chains/__tests__/FailureChainCaseFile.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import FailureChainCaseFile from '../FailureChainCaseFile'
+
+const steps = [
+  'Research was interpreted as support for unsupervised self-treatment',
+  'Nonsterile biological material was injected',
+  'Bloodstream infection and multiorgan failure developed',
+]
+
+describe('FailureChainCaseFile', () => {
+  it('renders the case identity, ratings, and source basis', () => {
+    render(
+      <FailureChainCaseFile
+        caseId="FC-001"
+        incident="Intravenous mushroom tea"
+        reported="Reported 2021"
+        outcome="Critical illness; survived"
+        primaryFailure="Injection of nonsterile biological material"
+        preventability="Very high"
+        medicalSeverity="Critical"
+        documentationConfidence="Moderate"
+        documentation="Single peer-reviewed case report"
+        steps={steps}
+      />
+    )
+
+    expect(screen.getByRole('heading', { name: 'Intravenous mushroom tea' })).toBeInTheDocument()
+    expect(screen.getByText('FC-001')).toBeInTheDocument()
+    expect(screen.getByText('Severity: Critical')).toBeInTheDocument()
+    expect(screen.getByText('Preventability: Very high')).toBeInTheDocument()
+    expect(screen.getByText('Documentation: Moderate')).toBeInTheDocument()
+    expect(screen.getByText('Single peer-reviewed case report')).toBeInTheDocument()
+  })
+
+  it('renders the failure chain as an ordered list', () => {
+    render(
+      <FailureChainCaseFile
+        caseId="FC-001"
+        incident="Intravenous mushroom tea"
+        reported="Reported 2021"
+        outcome="Critical illness; survived"
+        primaryFailure="Injection of nonsterile biological material"
+        preventability="Very high"
+        medicalSeverity="Critical"
+        documentationConfidence="Moderate"
+        documentation="Single peer-reviewed case report"
+        steps={steps}
+      />
+    )
+
+    const chain = screen.getByRole('list', { name: 'FC-001 failure chain' })
+    expect(chain).toBeInTheDocument()
+    expect(screen.getAllByRole('listitem')).toHaveLength(steps.length)
+    steps.forEach((step) => expect(screen.getByText(step)).toBeInTheDocument())
+  })
+})

--- a/content/articles/failure-chains-injected-mushroom-tea.mdx
+++ b/content/articles/failure-chains-injected-mushroom-tea.mdx
@@ -1,0 +1,227 @@
+---
+title: "FC-001: Injected Mushroom Tea and the ICU Case Behind 'Mushrooms in His Blood'"
+description: "A forensic reconstruction of a 2021 case report in which nonsterile mushroom tea was injected intravenously, followed by bacterial and fungal bloodstream infection, septic shock, respiratory failure, and multiorgan injury."
+date: "2026-07-28"
+lastUpdated: "2026-07-28"
+slug: "failure-chains-injected-mushroom-tea"
+category: "Harm Reduction"
+tags: ["Failure Chains", "FC-001", "psilocybin", "Psilocybe cubensis", "fungemia", "bacteremia", "sepsis", "intravenous injection", "route of administration", "harm reduction", "case study"]
+readingTime: 12
+evidenceGrade: "Moderate for the incident: one peer-reviewed case report with culture identification, limited by sparse microbiology methods, self-reported exposure details, and no independent reconstruction"
+author: "The Hippie Scientist"
+references:
+  - title: "A 'Trip' to the Intensive Care Unit: An Intravenous Injection of Psilocybin"
+    authors: "Giancola NB, Korson CJ, Caplan JP, McKnight CA"
+    year: "2021"
+    pmid: "34102133"
+    url: "https://pubmed.ncbi.nlm.nih.gov/34102133/"
+  - title: "Intravenous Mushroom Poisoning"
+    authors: "Curry SC, Rose MC"
+    year: "1985"
+    pmid: "4025991"
+    url: "https://pubmed.ncbi.nlm.nih.gov/4025991/"
+  - title: "Intravenous Injection of Mushrooms"
+    authors: "Sivyer G, Dorrington L"
+    year: "1984"
+    pmid: "6694611"
+    url: "https://pubmed.ncbi.nlm.nih.gov/6694611/"
+---
+
+<FailureChainCaseFile
+  caseId="FC-001"
+  incident="Intravenous mushroom tea"
+  reported="Reported in 2021"
+  outcome="Septic shock, respiratory failure, disseminated intravascular coagulation, and multiorgan injury; survived"
+  primaryFailure="Injection of nonsterile biological material directly into the bloodstream"
+  preventability="Very high"
+  medicalSeverity="Critical"
+  documentationConfidence="Moderate"
+  documentation="Single peer-reviewed case report with bacterial and fungal culture identification"
+  steps={[
+    'Therapeutic research was interpreted as support for unsupervised self-treatment',
+    'Whole mushroom material was boiled in water and passed through cotton, but not sterilized',
+    'The biological liquid was injected directly into a vein',
+    'Lethargy, jaundice, gastrointestinal illness, and confusion developed over several days',
+    'Bacteremia, fungemia, septic shock, respiratory failure, disordered clotting, and organ injury followed',
+    'Eight days of intensive care and 22 total hospital days led to survival',
+  ]}
+/>
+
+> **Safety note:** This is a documented medical case, not preparation or administration guidance. Confusion, jaundice, blue lips or nail beds, vomiting blood, severe weakness, breathing difficulty, collapse, or signs of shock after an injection or drug exposure are emergencies. Contact emergency services and a poison center immediately rather than waiting for the effects to pass.
+
+## Executive Summary
+
+The famous headline says that a man injected mushroom tea and then had “mushrooms growing in his blood.” The documented event was both less cartoonish and more medically serious.
+
+A 30-year-old man injected a homemade liquid prepared from *Psilocybe* mushrooms. Over the following days, he developed gastrointestinal illness, jaundice, confusion, shock, respiratory failure, abnormal clotting, kidney injury, and liver injury. Blood cultures grew a bacterium identified as *Brevibacillus* and a fungus identified as *Psilocybe cubensis*. He spent 22 days in the hospital, including eight days in intensive care, and survived [1].
+
+This was not primarily a conventional psilocybin overdose. Psilocybin's psychedelic pharmacology does not explain bacterial bloodstream infection, fungal culture growth, septic shock, or disseminated intravascular coagulation. The dominant failure was the **route**: nonsterile biological material was placed directly into the bloodstream, bypassing barriers that normally keep environmental organisms out.
+
+The case is valuable because it separates three things that are often blurred together:
+
+- a psychoactive molecule,
+- the biological material containing it,
+- and the route used to introduce that material into the body.
+
+Those are not interchangeable.
+
+## The Story
+
+The case report described a 30-year-old man with bipolar I disorder and a history of injection drug use. He had been reading about experimental psychedelic research while looking for ways to address depression and opioid dependence [1].
+
+The crucial misunderstanding was not merely that he believed psilocybin might have therapeutic potential. That question is being studied under controlled conditions. The failure was treating research on carefully prepared interventions as permission to improvise an injectable product from whole mushrooms.
+
+He boiled psilocybin-containing mushrooms in water, passed the resulting liquid through cotton, and injected it intravenously. Cotton can catch visible particles. It does not reliably remove bacteria, fungal cells, spores, dissolved contaminants, or toxins, and it does not convert a kitchen preparation into a sterile pharmaceutical product.
+
+Over the next several days, the man became lethargic and jaundiced. He developed diarrhea, nausea, and hematemesis—vomiting blood. His family eventually found him confused and brought him to an emergency department [1].
+
+On examination, he appeared severely ill. The report described dry mucous membranes, mild blue discoloration of the lips and nail beds, jaundiced skin, diffuse abdominal tenderness, low blood pressure, and confusion severe enough that he could not participate meaningfully in an interview.
+
+Laboratory testing showed abnormalities across several systems, including low platelets, electrolyte disturbances, acute kidney dysfunction, acute liver injury, and elevated cardiac enzymes. The electrocardiogram showed sinus tachycardia and early repolarization. The accumulating picture was not simply intoxication or a prolonged psychedelic experience. It was multiorgan failure.
+
+He was transferred to intensive care and treated with intravenous fluids, vasopressors to support blood pressure, broad-spectrum antibacterial drugs, and antifungal medication. His condition progressed to septic shock and acute respiratory failure. He required intubation on the second hospital day. He also developed disseminated intravascular coagulation, a dangerous state in which uncontrolled activation of clotting can produce both microscopic clots and severe bleeding. The report states that plasmapheresis was used [1].
+
+Blood cultures identified *Brevibacillus* bacteremia and growth identified as *Psilocybe cubensis* fungemia. He remained hospitalized for 22 days, eight of them in intensive care. At the time of publication, the authors reported that he remained on a prolonged regimen of antibacterial and antifungal therapy [1].
+
+## What the Source Documented
+
+### Documented
+
+The peer-reviewed report documented:
+
+- self-reported intravenous injection of a liquid made from psilocybin-containing mushrooms,
+- several days of progressive illness,
+- hypotension, confusion, cyanosis, jaundice, and abdominal tenderness,
+- kidney, liver, electrolyte, platelet, and cardiac-marker abnormalities,
+- septic shock and respiratory failure requiring intensive care and intubation,
+- disseminated intravascular coagulation,
+- blood cultures reported as *Brevibacillus* and *Psilocybe cubensis*,
+- and survival after a 22-day hospitalization [1].
+
+### Inferred
+
+The strongest inference is that direct inoculation of contaminated biological material drove the bloodstream infections and septic physiology. The timing, route, culture findings, and clinical syndrome all support that interpretation.
+
+It is also reasonable to infer that the cotton filtration step created false confidence. It reduced visible material without solving sterility.
+
+### Uncertain
+
+The brief report does not establish:
+
+- the exact quantity of mushroom material or psilocybin involved,
+- the organisms present in the liquid before injection,
+- whether contamination came from the mushrooms, water, preparation environment, cotton, syringe, skin, or several sources,
+- the detailed laboratory method used to identify the cultured fungus,
+- the exact contribution of the bacterium, fungus, inflammatory response, dehydration, and other factors to each organ injury,
+- or whether any acute psychedelic effects materially changed the subsequent clinical course.
+
+Those gaps matter. A memorable story is not permission to invent missing microbiology.
+
+## What “Mushrooms Growing in His Blood” Actually Means
+
+The popular phrase creates an image of mushroom caps or fruiting bodies sprouting inside veins. That is not what the case report described.
+
+A blood culture places a blood sample into conditions designed to reveal whether viable microorganisms are present. Organisms that reproduce in that laboratory culture can then be identified. In this case, the authors reported fungal growth identified as *Psilocybe cubensis* [1].
+
+That supports the presence of viable fungal material in the sampled blood. It does **not** mean that recognizable mushrooms were physically fruiting inside the patient's circulation.
+
+There is another reason to use careful wording: the published report is only two pages long and does not provide a detailed account of the fungal-identification method. The core claim is credible enough to report as the authors' finding, but the evidence does not justify embellishing it into a body-horror metaphor.
+
+The scientifically accurate version is already extraordinary:
+
+> Following injection of a homemade mushroom preparation, blood cultures grew organisms identified as a bacterium and the injected mushroom species.
+
+No tabloid garnish required.
+
+## Pharmacology and Toxicology
+
+Psilocybin is converted in the body to psilocin, which produces psychedelic effects largely through serotonin 5-HT2A receptor activity. That mechanism can alter perception, cognition, emotion, and sense of self. It does not produce *Brevibacillus* bacteremia.
+
+Researchers may administer purified compounds through routes chosen under strict protocols. A sterile, chemically characterized research formulation is fundamentally different from whole fungal tissue boiled in a nonsterile setting. Sharing the word “intravenous” does not make the exposures pharmacologically or microbiologically comparable.
+
+The gastrointestinal tract, skin, liver, and immune system provide layers of protection and processing. Intravenous injection bypasses several of those defenses and gives contaminants immediate access to circulation. Once organisms or microbial products enter the bloodstream, the immune response can become systemic. Blood vessels dilate, pressure falls, tissue perfusion fails, clotting becomes disordered, and organs begin to malfunction. That sequence is sepsis—not an unusually intense trip.
+
+Earlier literature shows that intravenous mushroom extracts had caused severe systemic illness before the 2021 report. A 1985 case described vomiting, severe muscle pain, extreme fever, low blood oxygen, and mild methemoglobinemia after intravenous exposure to a *Psilocybe* extract; the patient improved with supportive care [2]. A short 1984 report also documented intravenous mushroom injection [3].
+
+Those older cases do not prove that every event followed the same mechanism. They do show that this route had already produced medical emergencies and that the 2021 event was not the first warning.
+
+## Failure-Chain Analysis
+
+### 1. Therapeutic possibility became personal permission
+
+Research suggesting potential benefits under controlled conditions was translated into a do-it-yourself intervention. This is a common information failure: a finding about a molecule, formulation, population, and clinical setting is stripped of those boundaries.
+
+### 2. The molecule was confused with the organism
+
+Purified psilocybin is a chemical. A mushroom is living biological material containing many chemicals, cellular structures, microorganisms, and environmental contaminants. Extracting some compounds into water does not erase the rest of that biology.
+
+### 3. Filtration was confused with sterilization
+
+Removing visible particles can make a liquid look cleaner without making it microbiologically safe. Visual clarity is not evidence of sterility.
+
+### 4. Intravenous delivery removed the body's margin for error
+
+Swallowed contaminants face barriers and processing. Injected contaminants reach circulation directly. The route transformed a dubious preparation into a high-consequence exposure.
+
+### 5. Progressive illness unfolded over days
+
+The delay between injection and obvious collapse may have obscured the seriousness of the event. By the time emergency care began, multiple organ systems were already involved.
+
+No single receptor explains this chain. It was a translation failure, formulation failure, sterility failure, route failure, and delayed medical crisis stacked together.
+
+## Emergency Response
+
+Clinicians approached the patient as critically ill rather than assuming that confusion after a psychedelic exposure was merely psychiatric. That distinction was lifesaving.
+
+The medical response addressed the physiology that was failing:
+
+- fluids and vasopressors for shock,
+- antibacterial and antifungal treatment for suspected bloodstream infection,
+- airway and ventilatory support for respiratory failure,
+- intensive monitoring of kidney, liver, cardiac, electrolyte, platelet, and clotting abnormalities,
+- and treatment of disseminated intravascular coagulation [1].
+
+This is an important emergency-medicine lesson. When altered mental status appears alongside jaundice, cyanosis, bleeding, hypotension, fever, breathing difficulty, or organ injury, “bad trip” is not an adequate diagnosis. The psychoactive exposure may be only one part of the problem—or almost beside the point.
+
+## Could This Have Been Prevented?
+
+**Preventability: very high.**
+
+The critical event was not an unpredictable reaction at an ordinary route of exposure. It was direct injection of a nonsterile biological preparation. Avoiding that action would very probably have prevented the bacteremia, fungemia, and septic shock described in the report.
+
+That judgment does not mean every downstream detail was predictable. The exact organisms and organ complications were not. The high-level hazard was.
+
+The broad prevention lesson is simple:
+
+> Evidence that a psychoactive molecule may have therapeutic potential does not make homemade biological material safe for injection.
+
+## Evidence Quality and Uncertainty
+
+The 2021 source is a peer-reviewed case report, which is appropriate for documenting a rare event but weak for estimating frequency or proving general rules. Its strengths include a coherent clinical timeline, severe objective findings, intensive-care treatment, and reported bacterial and fungal culture identification [1].
+
+Its limitations include:
+
+- reliance on self-report for preparation and exposure history,
+- no retained sample of the injected liquid for analysis,
+- sparse description of microbiological identification methods,
+- no comparison group,
+- and no way to separate precisely the contribution of every infectious, toxic, inflammatory, and psychiatric factor.
+
+The earlier 1984 and 1985 reports strengthen the conclusion that intravenous mushroom preparations can produce severe systemic illness [2, 3]. They do not make the 2021 case common, nor do they establish the probability of a particular complication.
+
+The correct confidence statement is therefore two-part:
+
+- **Moderate confidence that the reported incident occurred substantially as described.**
+- **Low confidence in any claim about how often the same outcome would occur.**
+
+## Bigger Questions
+
+- How should researchers communicate promising therapeutic findings so readers do not mistake controlled formulations for interchangeable homemade products?
+- What minimum microbiology detail should unusual fungemia case reports publish to make species identification independently assessable?
+- Why does visible filtration feel intuitively equivalent to safety, even when microorganisms are invisible?
+- How can harm-reduction education discuss route-specific danger without accidentally supplying operational instructions?
+- How often do emergency clinicians encounter severe complications from improvised formulations that never become published case reports?
+
+## Related Reading
+
+For the broader pattern—misidentification, delayed onset, unusual routes, delirium, and hidden toxicology—see [When the Label Lies: Eight Hallucinogen Disasters and the Failure Chains Behind Them](/articles/psychedelic-disasters-mislabeled-drugs/).

--- a/docs/specs/failure-chains-case-system.md
+++ b/docs/specs/failure-chains-case-system.md
@@ -1,0 +1,240 @@
+# Failure Chains Case System Specification
+
+## 1. Purpose
+
+Failure Chains is a forensic case-study format for explaining how psychoactive-drug emergencies develop. Each entry reconstructs a documented incident, separates established facts from interpretation, explains the relevant pharmacology and toxicology, and identifies the sequence of conditions that turned an exposure into a medical crisis.
+
+The format should help a reader answer:
+
+> What happened, why did it happen, what remains uncertain, and what could prevent a similar outcome?
+
+Failure Chains is an educational and harm-reduction system. It is not dosing guidance, a substitute for emergency care, or a vehicle for sensational stories.
+
+## 2. Product goals
+
+1. **Make the causal sequence visible.** Readers should be able to understand the incident at a glance before reading the full reconstruction.
+2. **Standardize case reporting.** Every standalone case should use the same identifiers, summary fields, article anatomy, and evidence language.
+3. **Preserve uncertainty.** The presentation must distinguish documented findings, reasonable inference, and unresolved questions.
+4. **Teach systems thinking.** The focus is the chain of identity, route, dose, timing, biology, environment, and response failures—not moral blame.
+5. **Remain reusable in MDX.** Authors should be able to create a new case without writing page-specific React code.
+6. **Support future indexing.** Case metadata and terminology should be regular enough to power a Failure Atlas later.
+
+## 3. Non-goals
+
+The initial implementation does not include:
+
+- A searchable Failure Atlas database.
+- Automated extraction of failure-chain metadata from prose.
+- A new content collection or a dedicated `/failure-chains` route.
+- Clinical treatment protocols or personalized medical advice.
+- User-submitted case reports.
+- Numerical risk estimates inferred from individual case reports.
+
+Those features may be added after the editorial format is stable across several published entries.
+
+## 4. Case identity
+
+Standalone Failure Chains entries receive permanent identifiers in publication order.
+
+Format:
+
+```text
+FC-001
+FC-002
+FC-003
+```
+
+Rules:
+
+- The identifier belongs to the standalone case article, not to every incident mentioned in an overview article.
+- Identifiers are never reused, even when an article is retired or substantially revised.
+- Roundups and series overviews are not assigned a case number.
+- The case ID appears in the article title or opening case-file component and in the article tags.
+
+The existing eight-case article is treated as a series overview. The injected-mushroom-tea article becomes the first standalone entry, `FC-001`.
+
+## 5. Editorial contract
+
+Every standalone case must contain the following sections, although headings may be adjusted for readability.
+
+1. **Case file** — structured summary and visible failure chain.
+2. **Safety note** — emergency framing without operational drug-use guidance.
+3. **Executive summary** — the incident and central lesson in plain language.
+4. **The story** — chronological reconstruction.
+5. **What the source documented** — findings reported directly by the primary source.
+6. **Pharmacology and toxicology** — the mechanism relevant to the outcome.
+7. **Failure-chain analysis** — why the event escalated.
+8. **Emergency response** — what clinicians recognized and managed, described at an educational level.
+9. **Could it have been prevented?** — a direct, evidence-bounded answer.
+10. **Evidence quality and uncertainty** — limitations of the source record.
+11. **Bigger questions** — unanswered scientific, clinical, or policy questions.
+12. **References** — primary sources first.
+
+## 6. Case-file component contract
+
+The reusable `FailureChainCaseFile` MDX component is the visual entry point for a case.
+
+Required props:
+
+| Prop | Type | Purpose |
+| --- | --- | --- |
+| `caseId` | string | Permanent identifier, such as `FC-001`. |
+| `incident` | string | Short human-readable incident name. |
+| `reported` | string | Publication year or incident date when reliably known. |
+| `outcome` | string | Concise clinical or historical outcome. |
+| `primaryFailure` | string | The dominant preventable or causal failure. |
+| `preventability` | enum | `Low`, `Moderate`, `High`, `Very high`, or `Unknown`. |
+| `medicalSeverity` | enum | `Moderate`, `Severe`, `Critical`, or `Fatal`. |
+| `documentationConfidence` | enum | `Low`, `Moderate`, or `High`. |
+| `documentation` | string | Source basis, such as `Peer-reviewed case report`. |
+| `steps` | string[] | Ordered failure-chain steps. |
+
+Example:
+
+```mdx
+<FailureChainCaseFile
+  caseId="FC-001"
+  incident="Intravenous mushroom tea"
+  reported="Reported 2021"
+  outcome="Septic shock, respiratory failure, multiorgan injury; survived"
+  primaryFailure="Injection of nonsterile biological material"
+  preventability="Very high"
+  medicalSeverity="Critical"
+  documentationConfidence="Moderate"
+  documentation="Single peer-reviewed case report with culture confirmation"
+  steps={[
+    'Therapeutic research was interpreted as support for unsupervised self-treatment',
+    'Whole mushroom material was boiled and passed through cotton',
+    'The nonsterile liquid was injected intravenously',
+    'Bacterial and fungal material entered the bloodstream',
+    'Sepsis and multiorgan failure developed',
+    'Intensive-care treatment led to survival',
+  ]}
+/>
+```
+
+## 7. Evidence language
+
+Failure Chains articles should use three evidence categories in prose:
+
+- **Documented:** directly reported by the primary source or official record.
+- **Inferred:** a conclusion supported by the documented facts but not directly measured.
+- **Uncertain:** information the available record cannot establish.
+
+Examples:
+
+- Documented: blood cultures grew organisms identified as *Brevibacillus* and *Psilocybe cubensis*.
+- Inferred: injection of contaminated biological material was the dominant cause of sepsis.
+- Uncertain: the exact organisms present in the prepared liquid before injection and the precise contribution of each organism to each organ injury.
+
+A memorable headline must not be presented as more certain than the source. In particular, “mushrooms grew in his blood” should be explained as growth from blood cultures identified as *P. cubensis*, not literal mushroom fruiting bodies growing inside veins.
+
+## 8. Preventability rating
+
+Preventability is an editorial assessment, not a validated clinical score.
+
+| Rating | Meaning |
+| --- | --- |
+| Very high | Avoiding one clearly hazardous action would probably have prevented the event. |
+| High | Several known safeguards would likely have prevented or greatly reduced harm. |
+| Moderate | Important risks were modifiable, but individual biology or incomplete evidence limits certainty. |
+| Low | The event was difficult to anticipate or prevent with information reasonably available at the time. |
+| Unknown | The record is too incomplete to assess. |
+
+The article must explain the rating. The badge alone is not sufficient.
+
+## 9. Medical-severity rating
+
+Medical severity describes the documented outcome, not the inherent danger of every exposure to the substance.
+
+| Rating | Meaning |
+| --- | --- |
+| Moderate | Medical evaluation or treatment was required without major organ failure. |
+| Severe | Hospitalization, major physiologic disturbance, or substantial injury occurred. |
+| Critical | Intensive care, respiratory or cardiovascular support, seizures, shock, or multiorgan failure occurred. |
+| Fatal | One or more deaths were documented. |
+
+## 10. Documentation confidence
+
+Documentation confidence describes confidence in the incident reconstruction.
+
+| Rating | Meaning |
+| --- | --- |
+| High | Multiple converging primary sources, analytical confirmation, or detailed official records. |
+| Moderate | A credible primary report documents the core event, but important details or methods are missing. |
+| Low | The account relies heavily on retrospective reporting, incomplete records, or unverified self-report. |
+
+A single case report usually supports only limited generalization even when the incident itself is well documented.
+
+## 11. Safety and tone requirements
+
+- Do not provide preparation, dosing, injection, concealment, or procurement instructions.
+- Do not reproduce unnecessary quantities when they would function as operational guidance.
+- State emergency warning signs and direct readers toward emergency services and poison centers.
+- Avoid ridicule. Case subjects are people, not punch lines.
+- Avoid implying that one unusual case defines the ordinary risk profile of a compound.
+- Distinguish the intended psychoactive molecule from contamination, route-of-administration, and environmental hazards.
+- Use precise language for microbiology and toxicology; avoid tabloid phrasing unless the article is explicitly correcting it.
+
+## 12. Accessibility and presentation
+
+The case-file component must:
+
+- Use semantic section and ordered-list markup.
+- Expose a descriptive heading to screen readers.
+- Keep color as a secondary cue; all ratings must be written as text.
+- Render at narrow mobile widths without horizontal scrolling.
+- Avoid animation that is required to understand the chain.
+- Preserve readable contrast using the site's existing design tokens.
+
+## 13. Search and cross-linking
+
+Each article should include:
+
+- `Failure Chains` and its case ID in tags.
+- The primary compound, toxidrome, route, and major clinical syndrome in tags when applicable.
+- At least one internal link to a relevant overview, molecule page, toxicology concept, or related case when such a page exists.
+
+Future indexing should be able to group entries by:
+
+- Failure type: identity, dose, timing, route, interaction, environment, medical response.
+- Receptor or biological system.
+- Clinical syndrome.
+- Substance or class.
+- Outcome and severity.
+- Evidence type.
+
+## 14. Initial implementation
+
+The first implementation includes:
+
+1. `FailureChainCaseFile`, a reusable MDX component.
+2. Registration of the component in the global MDX component map.
+3. A copyable authoring template under `docs/templates`.
+4. One production article: `FC-001`, the injected-mushroom-tea ICU case.
+5. Component tests for the summary fields and ordered failure chain.
+
+## 15. Acceptance criteria
+
+The implementation is complete when:
+
+- A new MDX article can render a case file without local imports.
+- Required ratings are constrained by TypeScript unions.
+- The component uses semantic and accessible markup.
+- The component renders all summary fields and ordered steps on mobile and desktop layouts.
+- The article cites the 2021 primary case report and relevant earlier case literature.
+- The article explicitly distinguishes blood-culture growth from literal mushrooms growing in veins.
+- The article explains why the route and contamination—not simply psilocybin receptor pharmacology—drove the emergency.
+- Unit tests verify the core rendering contract.
+- Existing article and blog rendering remain unchanged.
+
+## 16. Future extensions
+
+After several entries establish stable terminology, consider:
+
+- Structured frontmatter for failure type, substances, toxidromes, and outcome.
+- A `/failure-chains` series landing page.
+- Case filters and the Failure Atlas.
+- Relationship cards linking cases that share a failure mechanism.
+- Machine-readable JSON-LD for case reports and medical concepts.
+- Editorial tooling that checks required sections and duplicate case IDs.

--- a/docs/templates/failure-chain-case.mdx
+++ b/docs/templates/failure-chain-case.mdx
@@ -1,0 +1,85 @@
+---
+title: "FC-XXX: [Case title]"
+description: "[One-sentence forensic summary of the incident, documented outcome, and central lesson.]"
+date: "YYYY-MM-DD"
+lastUpdated: "YYYY-MM-DD"
+slug: "failure-chains-[descriptive-slug]"
+category: "Harm Reduction"
+tags: ["Failure Chains", "FC-XXX", "case study", "harm reduction", "[substance]", "[syndrome]", "[failure type]"]
+readingTime: 10
+evidenceGrade: "[Concise description of evidence strength and limitations]"
+author: "The Hippie Scientist"
+references:
+  - title: "[Primary source title]"
+    authors: "[Authors]"
+    year: "[Year]"
+    pmid: "[PMID or empty string]"
+    url: "[Primary source URL]"
+---
+
+<FailureChainCaseFile
+  caseId="FC-XXX"
+  incident="[Short incident name]"
+  reported="[Incident date or reported year]"
+  outcome="[Concise outcome]"
+  primaryFailure="[Dominant failure]"
+  preventability="Unknown"
+  medicalSeverity="Severe"
+  documentationConfidence="Moderate"
+  documentation="[Primary source basis]"
+  steps={[
+    '[Initial condition or assumption]',
+    '[Escalating decision or exposure]',
+    '[Relevant pharmacological, toxicological, or environmental event]',
+    '[Medical crisis]',
+    '[Response and outcome]',
+  ]}
+/>
+
+> **Safety note:** This is a documented case analysis, not dosing or preparation guidance. [Add concise emergency warning signs relevant to the incident.] Contact emergency services and a poison center rather than waiting for severe symptoms to pass.
+
+## Executive Summary
+
+[Summarize the case, the main mechanism, and the lesson. Avoid suspense that hides medically important facts.]
+
+## The Story
+
+[Reconstruct the event chronologically. Protect dignity and avoid unnecessary operational detail.]
+
+## What the Source Documented
+
+Separate the record explicitly:
+
+- **Documented:** [Facts directly reported by the primary source.]
+- **Inferred:** [Conclusions strongly supported by those facts.]
+- **Uncertain:** [Details the record cannot establish.]
+
+## Pharmacology and Toxicology
+
+[Explain the mechanism that actually drove the emergency. Distinguish the intended psychoactive effect from contamination, route, interaction, or environmental hazards.]
+
+## Failure-Chain Analysis
+
+[Explain why the steps compounded. Do not simply repeat the visual chain.]
+
+## Emergency Response
+
+[Describe recognition, monitoring, and supportive care at an educational level. Do not present a home-treatment protocol.]
+
+## Could This Have Been Prevented?
+
+[State the preventability assessment directly and explain it.]
+
+## Evidence Quality and Uncertainty
+
+[Explain study design, confirmation methods, missing information, and limits on generalization.]
+
+## Bigger Questions
+
+- [Scientific or clinical question]
+- [Public-health or communication question]
+- [Unresolved evidentiary question]
+
+## Related Reading
+
+- [Relevant internal article](../[slug])

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -4,6 +4,7 @@ import EvidenceSummaryCard from '@/components/evidence/EvidenceSummaryCard'
 import ResearchLimitations from '@/components/evidence/ResearchLimitations'
 import MisconceptionCallout from '@/components/evidence/MisconceptionCallout'
 import SafetyNotice from '@/components/evidence/SafetyNotice'
+import FailureChainCaseFile from '@/components/failure-chains/FailureChainCaseFile'
 import { ComparisonTable } from '@/components/ComparisonTable'
 import { EvidenceNote } from '@/components/EvidenceNote'
 import { HarmReductionCallout } from '@/components/HarmReductionCallout'
@@ -91,6 +92,7 @@ const evidenceComponents = {
   ResearchLimitations,
   MisconceptionCallout,
   SafetyNotice,
+  FailureChainCaseFile,
   ComparisonTable,
   NPSDisclaimer,
   EvidenceNote,


### PR DESCRIPTION
## Summary

- specify the reusable Failure Chains editorial and UI contract
- add an accessible `FailureChainCaseFile` MDX component with constrained severity, preventability, and documentation ratings
- register the component globally for article MDX
- add a copyable authoring template
- publish `FC-001`, a primary-source-led reconstruction of the injected mushroom tea ICU case
- add component tests for the summary contract and ordered failure chain

## Editorial safeguards

- distinguishes documented facts, inference, and unresolved details
- explains that blood-culture growth is not literal mushroom fruiting inside veins
- identifies route and contamination as the dominant failure rather than presenting the event as a conventional psilocybin overdose
- avoids dosing and injection instructions while retaining the facts required to understand the case

## Sources

Primary references include:

- Giancola et al. (2021), PMID 34102133
- Curry & Rose (1985), PMID 4025991
- Sivyer & Dorrington (1984), PMID 6694611

## Validation

The implementation includes a Vitest/Testing Library test file. Repository CI should run the full content, lint, type, and test checks.