### PR TITLE
Add FC-002 MPTP parkinsonism case

### DIFF
--- a/content/articles/failure-chains-mptp-parkinsonism.mdx
+++ b/content/articles/failure-chains-mptp-parkinsonism.mdx
@@ -1,0 +1,246 @@
+---
+title: "FC-002: The Illicit Opioid Batch That Produced Permanent Parkinsonism"
+description: "A forensic reconstruction of the MPTP poisoning cluster in which a contaminant from illicit meperidine-analog synthesis caused abrupt, severe, and lasting parkinsonism—and transformed Parkinson's research."
+date: "2026-07-28"
+lastUpdated: "2026-07-28"
+slug: "failure-chains-mptp-parkinsonism"
+category: "Harm Reduction"
+tags: ["Failure Chains", "FC-002", "MPTP", "MPP+", "parkinsonism", "dopamine", "substantia nigra", "MPPP", "opioids", "illicit synthesis", "neurotoxicity", "case study"]
+readingTime: 14
+evidenceGrade: "Strong for the core incident: multiple peer-reviewed human case reports and follow-up series with analytical identification, consistent clinical findings, and convergent mechanistic research"
+author: "The Hippie Scientist"
+references:
+  - title: "Chronic Parkinsonism in Humans Due to a Product of Meperidine-Analog Synthesis"
+    authors: "Langston JW, Ballard P, Tetrud JW, Irwin I"
+    year: "1983"
+    pmid: "6823561"
+    url: "https://pubmed.ncbi.nlm.nih.gov/6823561/"
+  - title: "Permanent Human Parkinsonism Due to 1-Methyl-4-Phenyl-1,2,3,6-Tetrahydropyridine (MPTP): Seven Cases"
+    authors: "Ballard PA, Tetrud JW, Langston JW"
+    year: "1985"
+    pmid: "3874373"
+    url: "https://pubmed.ncbi.nlm.nih.gov/3874373/"
+  - title: "Parkinsonism Induced by MPTP: Implications for Treatment and the Pathogenesis of Parkinson's Disease"
+    authors: "Langston JW, Ballard P"
+    year: "1984"
+    pmid: "6608979"
+    url: "https://pubmed.ncbi.nlm.nih.gov/6608979/"
+  - title: "Pargyline Prevents MPTP-Induced Parkinsonism in Primates"
+    authors: "Langston JW, Irwin I, Langston EB, Forno LS"
+    year: "1984"
+    pmid: "6332378"
+    url: "https://pubmed.ncbi.nlm.nih.gov/6332378/"
+  - title: "MPTP Parkinsonism and Implications for Understanding Parkinson's Disease"
+    authors: "AlShimemeri S, Di Luca DG, Fox SH"
+    year: "2022"
+    pmid: "35005064"
+    url: "https://pubmed.ncbi.nlm.nih.gov/35005064/"
+---
+
+<FailureChainCaseFile
+  caseId="FC-002"
+  incident="MPTP-contaminated illicit opioid"
+  reported="Cluster recognized in 1982; landmark report published in 1983"
+  outcome="Abrupt, severe, and persistent parkinsonism in young adults; symptoms improved with dopaminergic treatment but remained chronic"
+  primaryFailure="A neurotoxic synthesis byproduct entered an illicit injectable drug supply"
+  preventability="High"
+  medicalSeverity="Critical"
+  documentationConfidence="Strong"
+  documentation="Multiple peer-reviewed human reports, analytical identification, longitudinal follow-up, and convergent animal and biochemical research"
+  steps={[
+    'An illicit meperidine analog was synthesized outside pharmaceutical controls',
+    'The process produced or retained the contaminant MPTP',
+    'The material was sold and injected as an opioid-like drug',
+    'Users developed profound immobility, rigidity, tremor, and impaired speech over a short period',
+    'Chemical analysis linked the batch to MPTP exposure',
+    'MPTP was metabolically converted to MPP+, selectively injuring nigrostriatal dopamine neurons',
+    'The resulting parkinsonism persisted and required long-term dopaminergic treatment',
+  ]}
+/>
+
+> **Safety note:** This is a historical neurotoxicology case, not chemistry or administration guidance. Sudden severe stiffness, inability to move, marked slowing, altered consciousness, breathing difficulty, collapse, or unusual neurologic symptoms after a drug exposure are emergencies. Contact emergency services and a poison center immediately.
+
+## Executive Summary
+
+In the early 1980s, several young adults in Northern California developed a syndrome that looked like advanced Parkinson's disease appearing almost overnight. They became profoundly slow or nearly motionless, rigid, quiet, and unable to initiate ordinary movement. Some were initially mistaken for people with severe psychiatric illness because they appeared awake but scarcely responsive.
+
+The common factor was an illicit injectable drug intended to resemble a meperidine-related opioid. Chemical analysis found that the material contained **MPTP**, a synthesis byproduct capable of producing selective and lasting injury to dopamine neurons in the substantia nigra [1].
+
+The result was not temporary intoxication. Seven patients described in follow-up literature developed chronic, severe parkinsonism. Levodopa and bromocriptine could improve symptoms, but treatment soon produced many of the same complications seen in Parkinson's disease, including dyskinesias, wearing-off, and on-off fluctuations [2, 3].
+
+The case became one of the most consequential accidents in modern neuroscience. A contaminated street drug harmed real people permanently, while revealing a reproducible route to parkinsonism that reshaped research into dopamine neurons, mitochondrial injury, environmental neurotoxins, and Parkinson's disease.
+
+## The Story
+
+The cluster was medically strange from the beginning. Parkinson's disease ordinarily develops gradually and is far more common later in life. These patients were young, and the change was abrupt.
+
+They showed severe bradykinesia—extreme slowness and difficulty initiating movement—along with rigidity, flexed posture, reduced facial expression, impaired speech, and in some cases tremor. The clinical picture resembled advanced Parkinson's disease much more than ordinary opioid intoxication.
+
+A crucial clue came from the drug supply. According to the 1983 report, four people developed marked parkinsonism after intravenous use of an illicitly manufactured substance. Analysis of material associated with two patients found that it consisted primarily of MPTP, with only trace amounts of the intended meperidine analog MPPP [1].
+
+That finding reversed the assumed roles of product and impurity. The opioid-like target compound was barely present. The contaminant dominated the sample.
+
+The pattern was not entirely without precedent. A 1979 report had described chronic parkinsonism after injection of illicit meperidine analogs, though the responsible chemical had not then been established. The later California cluster supplied enough clinical and chemical evidence to identify MPTP as the likely cause.
+
+Follow-up of seven patients showed that the syndrome was not transient. Their parkinsonism remained severe and chronic. Dopamine-replacement treatment helped, but within months several developed dyskinesias and fluctuations between mobile and immobile states [2, 3]. Those treatment complications had often been attributed to long disease duration or years of levodopa exposure. The MPTP cases showed that severe loss of the nigrostriatal dopamine system itself could produce them much sooner.
+
+## What the Sources Documented
+
+### Documented
+
+The human literature documented:
+
+- abrupt severe parkinsonism in young adults after repeated use of an illicit injectable drug,
+- analytical identification of MPTP in material linked to affected patients,
+- a clinical syndrome closely resembling Parkinson's disease,
+- chronic persistence rather than simple recovery after intoxication,
+- symptomatic improvement with levodopa and dopamine agonist treatment,
+- and early development of treatment-related dyskinesias and motor fluctuations [1–3].
+
+### Inferred
+
+The strongest causal inference is that MPTP exposure produced the parkinsonism. The unusual cluster, common exposure, analytical identification, selective clinical syndrome, persistence, and later experimental replication make this far stronger than a mere temporal association.
+
+It is also reasonable to infer that uncontrolled synthesis and absent batch testing allowed the contaminant to become the principal product delivered to users.
+
+### Uncertain
+
+The published record does not establish with precision:
+
+- the exact dose each person received,
+- the concentration of MPTP in every exposure,
+- whether all affected individuals used material from one production batch,
+- every step in the illicit synthesis process,
+- or why severity differed among individuals.
+
+Historical retellings sometimes compress the cluster into one dramatic batch made by one clearly identified chemist. The medical evidence is stronger on the exposure and syndrome than on every detail of the underground supply chain.
+
+## The Pharmacology
+
+MPTP is dangerous partly because it is not the final toxin acting inside dopamine neurons. It crosses into the brain and is metabolized, involving monoamine oxidase, into **MPP+** [4].
+
+MPP+ is then concentrated by the dopamine transporter inside neurons of the nigrostriatal pathway. Within those cells, it disrupts mitochondrial energy production, particularly complex I activity. The affected neurons are unusually important for initiating and smoothly regulating movement.
+
+This selectivity explains the clinical picture. The patients did not simply develop diffuse brain failure. They developed a syndrome dominated by loss of dopaminergic movement control: slowness, rigidity, impaired postural control, reduced spontaneous movement, and related motor features.
+
+The basal ganglia can be thought of as a set of interacting circuits that help the brain release, scale, and stop movement. Dopamine from the substantia nigra adjusts those circuits. When that signal collapses, knowing that you want to move is no longer enough to make movement begin normally.
+
+The effect can look almost paradoxical from the outside: a person may be conscious, able to understand speech, and physically capable of contracting muscles, yet remain nearly frozen because the machinery for selecting and initiating movement has been devastated.
+
+## Why This Was Not an Ordinary Opioid Overdose
+
+An opioid overdose primarily threatens consciousness and breathing through opioid receptor activity. Its immediate danger is often respiratory depression.
+
+The MPTP cluster followed a different failure mode. The intended drug category shaped users' expectations, but the lasting injury came from an unrelated neurotoxic contaminant. Survival of the initial exposure did not mean the danger had passed. The central outcome was selective destruction of a movement-related neural system.
+
+This distinction matters because drug names can conceal manufacturing history. Two powders sold under the same street identity may carry radically different risks if one contains an unexpected synthesis byproduct.
+
+## Failure-Chain Analysis
+
+### 1. An improvised synthesis replaced pharmaceutical manufacturing
+
+Controlled drug production includes defined procedures, validated purification, analytical release testing, documentation, and rejection of failed batches. Illicit production may reproduce the target structure imperfectly while omitting the systems designed to catch toxic byproducts.
+
+### 2. A small chemical change created a different biological problem
+
+The intended product was an opioid analog. MPTP was not simply a weaker or stronger version of that opioid. It was a compound with a distinct capacity for selective dopaminergic neurotoxicity.
+
+### 3. The contaminant became the product
+
+Analysis reported in the original cluster found primarily MPTP and only trace MPPP in material associated with two patients [1]. This was not a minor impurity riding beside a mostly correct drug. The manufacturing failure appears to have inverted the batch.
+
+### 4. Injection delivered the material efficiently
+
+Intravenous use removed barriers that might otherwise have limited or delayed exposure. It did not create MPTP's neurotoxicity, but it made systemic delivery direct and reliable.
+
+### 5. Early presentation was easy to misread
+
+Profound immobility, reduced speech, and flat expression can resemble catatonia, severe depression, sedation, or deliberate noncooperation. The patients' age made ordinary Parkinson's disease seem improbable.
+
+### 6. The injury outlasted the drug
+
+The molecule did not need to remain in circulation for the disability to continue. Once dopamine neurons were destroyed, the resulting circuit failure became chronic.
+
+The complete chain was therefore:
+
+> uncontrolled synthesis → neurotoxic byproduct → absent analytical testing → injection → selective neuronal injury → permanent movement disorder
+
+## Emergency and Clinical Response
+
+There was no antidote capable of restoring neurons already lost. Clinical care focused on recognizing the syndrome, supporting patients, and replacing missing dopaminergic signaling.
+
+Levodopa and dopamine agonists improved movement in the reported patients [2, 3]. That response reinforced the conclusion that the core deficit involved the nigrostriatal dopamine system.
+
+The response also taught an uncomfortable lesson: symptomatic improvement is not the same as reversal of injury. Medication could help remaining circuits function, but it did not erase the underlying neuronal loss. Several patients developed dyskinesias and motor fluctuations within months [2].
+
+For emergency clinicians, the case supports a broad rule. A known drug category should not narrow the diagnosis too quickly. Sudden neurologic syndromes after an illicit exposure may reflect contaminants, byproducts, adulterants, hypoxia, infection, vascular injury, or mechanisms unrelated to the drug the patient believed they used.
+
+## Could This Have Been Prevented?
+
+**Preventability: high.**
+
+The human poisonings depended on a preventable manufacturing and quality-control failure: a highly neurotoxic compound entered a drug supply without analytical detection.
+
+At the individual level, the precise danger would have been nearly impossible for users to infer from appearance or expected effects. MPTP cannot be reliably identified by sight, smell, confidence in the seller, or ordinary dose familiarity.
+
+At the system level, the prevention opportunities were substantial:
+
+- validated synthesis and purification,
+- analytical identity and purity testing,
+- rejection of contaminated batches,
+- rapid communication after unusual neurologic cases,
+- and access to drug-checking systems capable of identifying unexpected compounds.
+
+The case therefore resists a simplistic lesson such as “users should have been more careful.” The decisive information was chemical information they did not possess.
+
+## What Medicine Learned
+
+The MPTP disaster became scientifically transformative for several reasons.
+
+First, it showed that a relatively selective chemical injury could reproduce much of the motor syndrome of Parkinson's disease in humans.
+
+Second, researchers reproduced the syndrome in nonhuman primates, creating a powerful experimental model [4, 5]. That model helped investigators study basal-ganglia circuitry, dopamine replacement, motor complications, mitochondrial dysfunction, and later surgical approaches.
+
+Third, MPTP intensified the search for environmental contributors to Parkinson's disease. MPTP itself is not established as the ordinary cause of Parkinson's disease, and the induced syndrome is not identical to every aspect of the naturally occurring disease. But it demonstrated that an external chemical can selectively devastate the same neural pathway.
+
+The scientific value does not redeem the human harm. It does explain why this obscure illicit-drug cluster became a landmark in neurology.
+
+## Evidence Quality and Uncertainty
+
+The core event is unusually well supported for a historical poisoning cluster.
+
+Strengths include:
+
+- multiple affected patients with a distinctive shared syndrome,
+- analytical identification of MPTP in associated drug material,
+- longitudinal clinical follow-up,
+- consistent response to dopaminergic treatment,
+- experimental reproduction in primates,
+- and biochemical clarification of conversion from MPTP to MPP+ [1–5].
+
+Limitations remain:
+
+- incomplete reconstruction of the illicit manufacturing and distribution chain,
+- uncertain individual exposure quantities,
+- small patient numbers,
+- and differences between MPTP-induced parkinsonism and the full pathology of idiopathic Parkinson's disease.
+
+The appropriate confidence statement is:
+
+- **Strong confidence that MPTP caused the reported chronic parkinsonism.**
+- **Moderate confidence in detailed reconstructions of exactly how each illicit batch was produced and distributed.**
+- **Low confidence in claims that MPTP fully explains ordinary Parkinson's disease.**
+
+## Bigger Questions
+
+- Why are substantia-nigra dopamine neurons especially vulnerable to mitochondrial toxicants?
+- Which features of Parkinson's disease can MPTP model faithfully, and which does it miss?
+- How often have rare toxic contaminants produced permanent neurologic injury without ever being chemically identified?
+- Can drug-checking systems realistically detect obscure synthesis byproducts before a cluster appears?
+- How should medicine preserve the scientific lessons of a disaster without turning harmed patients into mere characters in a discovery story?
+
+## Related Reading
+
+Start with [FC-001: Injected Mushroom Tea and the ICU Case Behind “Mushrooms in His Blood”](/articles/failure-chains-injected-mushroom-tea/) for another case in which the route and formulation—not ordinary psychedelic pharmacology—dominated the medical outcome.
+
+For the wider pattern of misidentification, delayed onset, delirium, cardiac toxicity, and hidden toxicology, see [When the Label Lies: Eight Hallucinogen Disasters and the Failure Chains Behind Them](/articles/psychedelic-disasters-mislabeled-drugs/).


### PR DESCRIPTION
## Summary

- publish `FC-002`, a forensic reconstruction of the MPTP poisoning cluster
- explain how a contaminant from illicit meperidine-analog synthesis produced abrupt and persistent parkinsonism
- separate documented human findings, causal inference, and unresolved supply-chain details
- explain conversion of MPTP to MPP+, selective nigrostriatal injury, and the role of mitochondrial complex I
- show how the disaster transformed Parkinson's disease research without treating the harmed patients as a discovery prop
- cross-link the new case to FC-001 and the broader hallucinogen disaster overview

## Evidence base

Primary and near-primary sources include:

- Langston et al. (1983), PMID 6823561
- Ballard et al. (1985), PMID 3874373
- Langston & Ballard (1984), PMID 6608979
- Langston et al. (1984), PMID 6332378
- AlShimemeri et al. (2022), PMID 35005064

## Editorial safeguards

- avoids synthesis instructions and operational chemistry details
- does not overstate MPTP as the cause of ordinary Parkinson's disease
- labels uncertainty around exact doses, production steps, and distribution history
- places the main preventability burden on manufacturing and analytical-control failure rather than hindsight blame of users