### PR TITLE
Add FC-003 Oklahoma Bromo-DragonFLY case

### DIFF
--- a/content/articles/failure-chains-oklahoma-bromo-dragonfly.mdx
+++ b/content/articles/failure-chains-oklahoma-bromo-dragonfly.mdx
@@ -1,0 +1,243 @@
+---
+title: "FC-003: Oklahoma's Bromo-DragonFLY Poisoning and the False-Identity Failure Chain"
+description: "A forensic reconstruction of the 2011 Konawa, Oklahoma poisoning in which material represented as 2C-E was reported to be Bromo-DragonFLY, leaving eight people critically ill and two dead."
+date: "2026-07-29"
+lastUpdated: "2026-07-29"
+slug: "failure-chains-oklahoma-bromo-dragonfly"
+category: "Harm Reduction"
+tags: ["Failure Chains", "FC-003", "Bromo-DragonFLY", "2C-E", "research chemicals", "mislabeling", "delayed onset", "seizures", "drug checking", "Oklahoma", "harm reduction", "case study"]
+readingTime: 14
+evidenceGrade: "Moderate for the incident: court and government records support the outbreak and reported identity mismatch, while individual exposure quantities and complete analytical documentation remain limited in the public record"
+author: "The Hippie Scientist"
+references:
+  - title: "Probable Cause Affidavit: State of Oklahoma v. Cody Glenn Weddle"
+    authors: "Pontotoc County District Court and Oklahoma State Bureau of Investigation"
+    year: "2011"
+    pmid: ""
+    url: "https://s3.amazonaws.com/content.newsok.com/documents/2ce0001.pdf"
+  - title: "Bill Expanding First-Degree Murder Charges in Designer Drug Deaths Becomes Law"
+    authors: "Oklahoma State Senate"
+    year: "2012"
+    pmid: ""
+    url: "https://oksenate.gov/press-releases/bill-expanding-first-degree-murder-charges-designer-drug-deaths-becomes-law"
+  - title: "Delayed Onset of Seizures and Toxicity Associated with Recreational Use of Bromo-dragonFLY"
+    authors: "Wood DM, Looker JJ, Shaikh L, et al."
+    year: "2009"
+    pmid: "19876858"
+    url: "https://pubmed.ncbi.nlm.nih.gov/19876858/"
+  - title: "A Fatal Poisoning Involving Bromo-Dragonfly"
+    authors: "Andreasen MF, Telving R, Birkler RID, Schumacher B, Johannsen M"
+    year: "2009"
+    pmid: "19091499"
+    url: "https://pubmed.ncbi.nlm.nih.gov/19091499/"
+---
+
+<FailureChainCaseFile
+  caseId="FC-003"
+  incident="Konawa, Oklahoma Bromo-DragonFLY poisoning"
+  reported="May 2011"
+  outcome="Eight severe poisonings; two deaths and six survivors"
+  primaryFailure="A dosing plan for one chemical was applied to material later reported to be a substantially different and unusually potent compound"
+  preventability="Very high"
+  medicalSeverity="Critical"
+  documentationConfidence="Moderate"
+  documentation="Court records and government reporting, supported by peer-reviewed toxicology literature on Bromo-DragonFLY"
+  steps={[
+    'Powder obtained through an online research-chemical supply chain was represented as 2C-E',
+    'The material was dissolved and portioned using assumptions appropriate to the stated identity',
+    'Measured liquid created an appearance of precision while the starting identity remained unverified',
+    'Multiple people consumed portions from the same preparation',
+    'Severe toxicity developed, including seizures, agitation, cardiovascular stress, and critical illness',
+    'Eight people were affected; two died',
+  ]}
+/>
+
+> **Safety note:** This article reconstructs a fatal poisoning and does not provide preparation or dosing instructions. Seizure, collapse, extreme agitation, dangerous overheating, chest pain, severe limb pain or discoloration, breathing difficulty, or inability to wake someone after a drug exposure is an emergency. Contact emergency services and a poison center immediately.
+
+## Executive Summary
+
+In May 2011, eight young adults near Konawa, Oklahoma became severely ill after consuming a liquid prepared from powder reportedly purchased as 2C-E. Two died. Oklahoma officials later stated that the material was Bromo-DragonFLY rather than 2C-E [1, 2].
+
+The event is often summarized as a simple overdose. That description misses the central structure of the failure.
+
+The group reportedly used a method intended to make dosing more consistent: powder was dissolved into a known volume of water and liquid portions were measured. The method could only control distribution of whatever was actually in the container. It could not verify chemical identity.
+
+Once the starting label was false, every downstream calculation inherited the error.
+
+This case is therefore not a story about measurement being useless. It is a story about **precision without verification**. A carefully measured quantity of the wrong chemical remains the wrong chemical.
+
+## The Story
+
+According to a probable-cause affidavit, powder ordered online and represented as 2C-E was mixed into water. The affidavit describes one gram being dissolved into one liter, after which liquid portions were distributed among members of the group [1].
+
+That procedure would appear orderly. It converts a powder into a liquid concentration and can reduce variation between portions. But it depends on several hidden assumptions:
+
+- the powder is the chemical named on the label,
+- the powder's purity is known,
+- the material is evenly distributed,
+- the intended concentration is appropriate for that chemical,
+- and the measuring tools are accurate enough for the consequences involved.
+
+The first assumption failed.
+
+Oklahoma authorities later reported that the material was Bromo-DragonFLY, not 2C-E [2]. The distinction was not academic. Bromo-DragonFLY has a markedly different potency, onset, duration, and toxicological profile.
+
+In the early hours of May 7, 2011, eight people became critically ill. One person died that day, and a second died several days later. Six survived [1, 2]. Public accounts describe a chaotic medical emergency involving seizures and profound toxicity.
+
+The publicly available record does not establish a reliable individual dose for each person. Nor does it fully document the powder's purity, whether the liquid remained uniformly mixed, or exactly how much each person consumed. Those uncertainties prevent responsible reconstruction of a precise exposure multiplier.
+
+What can be stated confidently is simpler and more important:
+
+> The preparation was designed around the identity and expected potency of one drug, while the material was reported to be another.
+
+## What the Sources Document
+
+### Documented
+
+The available court and government records support the following points:
+
+- powder was obtained through an online supply chain and represented as 2C-E,
+- the powder was dissolved in water and distributed as measured liquid portions,
+- eight people became severely ill near Konawa,
+- two people died,
+- and Oklahoma officials later reported Bromo-DragonFLY as the substance involved [1, 2].
+
+Peer-reviewed literature independently establishes that analytically confirmed Bromo-DragonFLY exposure has been associated with delayed severe agitation, hallucinations, tonic-clonic seizures, prolonged toxicity, and death [3, 4].
+
+### Inferred
+
+The strongest inference is that the identity mismatch converted a seemingly controlled dosing procedure into a mass exposure to an unintended compound.
+
+It is also reasonable to infer that liquid measurement increased confidence. Once the group believed the concentration had been calculated, each measured portion may have felt more trustworthy than an unmeasured powder. The procedure reduced one form of uncertainty while leaving the most important uncertainty untouched.
+
+### Uncertain
+
+The public record does not establish with sufficient clarity:
+
+- the exact dose consumed by each person,
+- the complete analytical chain used for the Oklahoma material,
+- the powder's purity and homogeneity,
+- the degree to which individual redosing occurred,
+- the contribution of any co-exposures,
+- or why some members survived while two died.
+
+These gaps are not invitations to manufacture a dramatic exact dose. They are part of the case.
+
+## Why Bromo-DragonFLY Was Such a Dangerous Substitution
+
+Bromo-DragonFLY is a highly potent serotonergic hallucinogen with strong activity at serotonin 5-HT2 receptors. Its structure constrains part of the molecule into a rigid configuration, contributing to unusually strong and prolonged receptor interactions.
+
+Its risk is not limited to altered perception. Reported poisonings have included:
+
+- severe agitation,
+- hallucinations,
+- tonic-clonic seizures,
+- hypertension and tachycardia,
+- prolonged sympathomimetic stress,
+- intense vasoconstriction,
+- tissue ischemia,
+- organ injury,
+- and death [3, 4].
+
+A confirmed 2009 case described delayed severe agitation and seizures after exposure, demonstrating that an initially quiet period does not reliably indicate safety [3]. A separate forensic report documented a fatal poisoning in an 18-year-old woman, with Bromo-DragonFLY identified and quantified in biological specimens [4].
+
+Delayed onset is particularly dangerous in an informal setting. People commonly use the passage of time as a crude measurement tool: if little has happened, they may conclude that the material is weak or the dose was too small. With a slow-building, long-lasting compound, that conclusion can arrive before the first exposure has fully declared itself.
+
+## The Failure Chain
+
+### 1. A commercial label substituted for chemical verification
+
+The name supplied by a vendor became the foundation for every later decision. The container carried information, but not proof.
+
+### 2. A familiar drug name imported the wrong potency assumptions
+
+The group reportedly planned around 2C-E. Even perfect arithmetic cannot protect against a compound whose activity and hazard profile differ substantially from the one used in the calculation.
+
+### 3. Liquid measurement created precision downstream of an unverified premise
+
+Dissolving material can make portions more consistent. It cannot identify the material. The method answered, “How much of this solution is in the cup?” It did not answer, “What chemical is in the solution?”
+
+### 4. Shared preparation amplified a single upstream error
+
+Because several people consumed from the same batch, one false identity propagated across the group. The mistake was not repeated independently eight times. It was centralized, then distributed.
+
+### 5. Delayed and prolonged toxicity reduced the usefulness of subjective feedback
+
+A slow onset can disguise the seriousness of an exposure. By the time severe effects appear, additional portions may already have been consumed and the chemical may continue acting for many hours.
+
+### 6. Clinicians faced an emerging-drug emergency with incomplete information
+
+When the stated identity is wrong, emergency teams may initially receive a history that points toward the wrong expected timeline and complications. Treatment remains supportive, but toxicological uncertainty complicates anticipation and monitoring.
+
+## Precision Is Not the Same as Accuracy
+
+This case is an unusually clear demonstration of the difference.
+
+**Precision** means repeated measurements are consistent with one another.
+
+**Accuracy** means the measurement corresponds to reality.
+
+A liquid method can produce precise portions from an inaccurately identified starting material. The portions may be very similar to each other while all being dangerously wrong.
+
+The lesson generalizes beyond drugs. Laboratory science, medicine, engineering, and statistics all contain versions of this failure: a sophisticated method applied to a false premise can generate results that look impressively orderly.
+
+The polished spreadsheet does not save the bad input. Science has a cruel little sense of humor about that.
+
+## Emergency Response
+
+There is no specific antidote that simply reverses Bromo-DragonFLY exposure. Emergency care focuses on the complications that are present or developing.
+
+Depending on the presentation, clinicians may need to provide:
+
+- rapid seizure control,
+- sedation for dangerous agitation,
+- airway and breathing support,
+- temperature management,
+- cardiovascular monitoring,
+- laboratory monitoring for muscle breakdown and organ injury,
+- repeated assessment of circulation to the limbs,
+- and prolonged observation because toxicity may be delayed and persistent.
+
+Severe pain, pallor, blue discoloration, cold extremities, weak pulses, or worsening numbness can signal dangerous loss of blood flow. Those findings are not merely uncomfortable psychedelic effects.
+
+The most important prehospital information is the honest timeline: what was reportedly taken, when, how much uncertainty exists, whether anyone redosed, and whether others from the same batch are becoming ill.
+
+## Could This Have Been Prevented?
+
+**Preventability: very high.**
+
+The exact medical course of each affected person could not have been predicted. The larger event depended on a preventable system failure: unverified chemical identity was treated as established fact before a potent material was prepared for a group.
+
+No single consumer-level test can guarantee purity or safety. Testing methods have detection limits, mixtures can confuse interpretation, and a sample may not represent an entire batch. But the complete absence of independent identity verification leaves the vendor label as the only barrier between one compound and another.
+
+The broad prevention lesson is:
+
+> Measurement controls quantity only after identity is known well enough for quantity to mean something.
+
+## Evidence Quality and Uncertainty
+
+The Oklahoma incident is supported by a probable-cause affidavit and subsequent Oklahoma government reporting [1, 2]. These sources are valuable for reconstructing the event and legal response, but they are not a detailed peer-reviewed toxicology publication.
+
+The strongest clinical claims about Bromo-DragonFLY come from separate analytically confirmed case reports [3, 4]. Those reports establish that the compound can produce delayed seizures, severe prolonged toxicity, and fatal poisoning. They do not independently prove every detail of the Oklahoma exposure.
+
+The evidence therefore supports a layered conclusion:
+
+- **High confidence** that a severe group poisoning occurred and two people died.
+- **Moderate confidence** in the publicly reported 2C-E-to-Bromo-DragonFLY identity mismatch.
+- **Low confidence** in any precise reconstruction of individual doses or purity.
+
+That is enough to understand the failure chain without pretending the missing laboratory file is sitting under the couch.
+
+## Bigger Questions
+
+- How should identity confidence be communicated when a chemical passes through multiple anonymous suppliers?
+- Why does a precise measuring ritual create such powerful psychological reassurance?
+- What analytical evidence should governments release after a novel-drug outbreak so later reporting can be independently assessed?
+- How can emergency departments receive faster alerts when multiple patients may share an emerging compound?
+- Which harms are best prevented by individual testing, supply-chain accountability, public alerts, or some combination of all three?
+
+## Related Reading
+
+- [FC-001: Injected Mushroom Tea and the ICU Case Behind “Mushrooms in His Blood”](/articles/failure-chains-injected-mushroom-tea/)
+- [FC-002: The Illicit Opioid Batch That Produced Permanent Parkinsonism](/articles/failure-chains-mptp-parkinsonism/)
+- [When the Label Lies: Eight Hallucinogen Disasters and the Failure Chains Behind Them](/articles/psychedelic-disasters-mislabeled-drugs/)


### PR DESCRIPTION
## Summary

- publish `FC-003`, a forensic reconstruction of the 2011 Konawa, Oklahoma poisoning
- explain how material represented as 2C-E was reported to be Bromo-DragonFLY
- center the case on precision without identity verification
- distinguish documented facts, inference, and unresolved analytical details
- explain delayed onset, seizures, vasoconstriction, prolonged toxicity, and emergency implications
- cross-link FC-001, FC-002, and the broader hallucinogen disaster overview

## Evidence base

- 2011 probable-cause affidavit
- 2012 Oklahoma Senate reporting
- Wood et al. (2009), PMID 19876858
- Andreasen et al. (2009), PMID 19091499

## Editorial safeguards

- does not reconstruct operational dosing instructions
- avoids unsupported exact dose multipliers
- labels the public analytical record as incomplete
- separates general Bromo-DragonFLY toxicology from claims specific to Oklahoma
- emphasizes that consistent measurement cannot rescue a false chemical identity