### PR TITLE
Close monetization gaps on high-ROI guide tier

### DIFF
--- a/app/guides/compare/sleep-herbs-vs-melatonin/page.tsx
+++ b/app/guides/compare/sleep-herbs-vs-melatonin/page.tsx
@@ -174,6 +174,18 @@ export default function SleepHerbsVsMelatoninComparePage() {
       <section className="card-premium p-6 space-y-5 max-w-5xl">
         <p className="eyebrow-label">Fast Decision</p>
         <h2 className="text-3xl font-semibold tracking-tight text-ink">Which one fits your sleep problem?</h2>
+        <div className="rounded-xl border-l-4 border-brand-700 bg-brand-50/40 p-4">
+          <p className="text-sm font-semibold text-ink">Bottom line — the fastest useful choice</p>
+          <p className="mt-1 text-sm leading-7 text-muted">
+            Reach for <strong>melatonin (0.3&ndash;1&nbsp;mg)</strong> only if your problem is timing &mdash;
+            jet lag, shift work, or a delayed sleep phase. For everything else, the higher-value starting
+            point is{' '}
+            <Link href="/compounds/magnesium-glycinate/" className="font-semibold text-brand-700 hover:underline">magnesium glycinate</Link>{' '}
+            for sleep depth and physical tension, or{' '}
+            <Link href="/compounds/l-theanine/" className="font-semibold text-brand-700 hover:underline">L-theanine</Link>{' '}
+            (100&ndash;200&nbsp;mg) for racing thoughts at bedtime. Save valerian for when those have not helped.
+          </p>
+        </div>
         <div className="overflow-x-auto">
           <table className="w-full min-w-[880px] text-sm text-left">
             <thead className="text-ink">

--- a/app/guides/other/adaptogens-compared/page.tsx
+++ b/app/guides/other/adaptogens-compared/page.tsx
@@ -7,6 +7,8 @@ import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
 import FAQSchema from '@/components/seo/FAQSchema'
 import References from '@/components/References'
 import EmailCapture from '../../../../components/EmailCapture'
+import RecommendationSection from '@/components/RecommendationSection'
+import { getRevenueProductSet } from '@/config/revenue-products'
 
 export const metadata: Metadata = buildPageMetadata({
   title: 'Adaptogens Compared: Ashwagandha, Rhodiola, Holy Basil & More (2026)',
@@ -61,13 +63,22 @@ export default function AdaptogensComparedPage() {
 
       <section className="card-premium p-6 space-y-5 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">The three stress patterns</h2>
         <div className="space-y-4">
-          <div className="p-4 rounded-xl bg-brand-50/60"><h3 className="font-semibold text-ink">Pattern 1: Wired but tired (high cortisol, anxious)</h3><p className="mt-2 text-sm leading-7 text-muted">You feel simultaneously exhausted and unable to relax. Cortisol is elevated, sleep is disrupted, and your mind races at night. <strong>Best fit: Ashwagandha.</strong> Reduces cortisol by 27% in clinical trials [2,5]. Take 240-600 mg in the evening. Monitor thyroid function if taken long-term. The calming effect builds over 2-4 weeks. Avoid rhodiola with this pattern — it will worsen the &ldquo;wired&rdquo; feeling.</p></div>
-          <div className="p-4 rounded-xl bg-brand-50/60"><h3 className="font-semibold text-ink">Pattern 2: Burned out and depleted (low cortisol, fatigued)</h3><p className="mt-2 text-sm leading-7 text-muted">You are exhausted, unmotivated, and struggling to get through the day. Stress has depleted your reserves rather than overactivating them. <strong>Best fit: Rhodiola.</strong> Improves mental and physical fatigue in multiple trials [4,6]. Take 200-400 mg in the morning. Do not take in the evening — it is stimulating. Effects appear within 1-2 weeks. If you also have anxiety, add ashwagandha in the evening.</p></div>
-          <div className="p-4 rounded-xl bg-brand-50/60"><h3 className="font-semibold text-ink">Pattern 3: General life stress (functional, managing)</h3><p className="mt-2 text-sm leading-7 text-muted">You are managing stress reasonably well but want additional support. No dominant symptom — just the cumulative wear of modern life. <strong>Best fit: Holy basil or ashwagandha at lower doses.</strong> Holy basil has anti-inflammatory and mild anxiolytic effects but less clinical trial data than ashwagandha. A morning holy basil tea is a gentle introduction to adaptogens. Ashwagandha at 120-240 mg is appropriate if sleep or anxiety are the primary concerns.</p></div>
+          <div className="p-4 rounded-xl bg-brand-50/60"><h3 className="font-semibold text-ink">Pattern 1: Wired but tired (high cortisol, anxious)</h3><p className="mt-2 text-sm leading-7 text-muted">You feel simultaneously exhausted and unable to relax. Cortisol is elevated, sleep is disrupted, and your mind races at night. <strong>Best fit: <Link href="/herbs/ashwagandha/" className="font-semibold text-brand-700 hover:underline">Ashwagandha</Link>.</strong> Reduces cortisol by 27% in clinical trials [2,5]. Take 240-600 mg in the evening. Monitor thyroid function if taken long-term. The calming effect builds over 2-4 weeks. Avoid rhodiola with this pattern — it will worsen the &ldquo;wired&rdquo; feeling.</p></div>
+          <div className="p-4 rounded-xl bg-brand-50/60"><h3 className="font-semibold text-ink">Pattern 2: Burned out and depleted (low cortisol, fatigued)</h3><p className="mt-2 text-sm leading-7 text-muted">You are exhausted, unmotivated, and struggling to get through the day. Stress has depleted your reserves rather than overactivating them. <strong>Best fit: <Link href="/herbs/rhodiola/" className="font-semibold text-brand-700 hover:underline">Rhodiola</Link>.</strong> Improves mental and physical fatigue in multiple trials [4,6]. Take 200-400 mg in the morning. Do not take in the evening — it is stimulating. Effects appear within 1-2 weeks. If you also have anxiety, add ashwagandha in the evening.</p></div>
+          <div className="p-4 rounded-xl bg-brand-50/60"><h3 className="font-semibold text-ink">Pattern 3: General life stress (functional, managing)</h3><p className="mt-2 text-sm leading-7 text-muted">You are managing stress reasonably well but want additional support. No dominant symptom — just the cumulative wear of modern life. <strong>Best fit: <Link href="/herbs/holy-basil/" className="font-semibold text-brand-700 hover:underline">Holy basil</Link> or ashwagandha at lower doses.</strong> Holy basil has anti-inflammatory and mild anxiolytic effects but less clinical trial data than ashwagandha. A morning holy basil tea is a gentle introduction to adaptogens. Ashwagandha at 120-240 mg is appropriate if sleep or anxiety are the primary concerns.</p></div>
         </div>
       </section>
 
       <section className="card-premium p-6 space-y-4 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">Bottom line</h2><p className="text-sm leading-7 text-muted">Adaptogens are not interchangeable. Match the herb to your stress pattern: <strong>ashwagandha for the anxious-overactivated</strong> [2,5], <strong>rhodiola for the fatigued-depleted</strong> [4,6], and <strong>holy basil for general maintenance</strong>. Start one at a time for 2-4 weeks before assessing. Most people benefit from ashwagandha first — it has the strongest evidence base and addresses the most common stress pattern. The adaptogen category is real, clinically relevant, and underutilized.</p></section>
+
+      <div className="max-w-4xl">
+        <RecommendationSection
+          title="Ashwagandha product picks"
+          description="Ashwagandha has the strongest evidence of the adaptogens compared here and fits the most common stress pattern. These are sourcing starting points — confirm dose, standardization, and fit for your situation, and review the safety notes above before buying."
+          products={getRevenueProductSet('ashwagandha')?.products ?? []}
+        />
+      </div>
+
       <References refs={ADAPTOGENS_REFS} />
       <EmailCapture headline="Get evidence reviews like this" description="Adaptogens, stacking safety, evidence — not marketing." ctaLabel="Get the evidence" location="guide-adaptogens" />
       <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between"><Link href="/guides/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">← Back to guides</Link><Link href="/herbs/" className="text-sm font-bold text-brand-800 hover:underline">Herb library →</Link></div>

--- a/app/guides/sleep/ashwagandha-vs-magnesium-for-sleep/page.tsx
+++ b/app/guides/sleep/ashwagandha-vs-magnesium-for-sleep/page.tsx
@@ -180,6 +180,27 @@ export default function AshwagandhaVsMagnesiumForSleepPage() {
         {/* Main content */}
         <div className="space-y-6">
 
+          {/* Fastest useful choice */}
+          <section className="rounded-[1rem] border border-brand-700/20 bg-brand-50/60 p-6 shadow-sm sm:p-8">
+            <p className="eyebrow-label">Fastest useful choice</p>
+            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
+              If you only try one tonight: magnesium glycinate
+            </h2>
+            <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
+              <strong>Magnesium glycinate is the faster, lower-friction starting point.</strong> It is
+              inexpensive, has a broad safety record, and can help with muscle tension and restlessness
+              within days. Ashwagandha is the better fit when stress is the main reason you cannot sleep,
+              but it typically needs 2&ndash;4 weeks of daily use to build an effect &mdash; so it is a
+              commitment, not a same-night fix. If you are unsure, start with{' '}
+              <Link href="/compounds/magnesium-glycinate/" className="font-semibold text-brand-700 hover:underline">magnesium glycinate</Link>{' '}
+              (100&ndash;300&nbsp;mg elemental, 30&ndash;60 minutes before bed), then add{' '}
+              <Link href="/herbs/ashwagandha/" className="font-semibold text-brand-700 hover:underline">ashwagandha</Link>{' '}
+              if stress-driven wakefulness persists. See the full{' '}
+              <Link href="/guides/sleep/best-natural-sleep-aids-that-work/" className="font-semibold text-brand-700 hover:underline">natural sleep aids guide</Link>{' '}
+              for how both fit a wider routine.
+            </p>
+          </section>
+
           {/* Quick Verdict */}
           <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
             <p className="eyebrow-label">Quick Verdict</p>


### PR DESCRIPTION
## Summary

Audited the high-ROI content tier via `scripts/audit/high-roi-content-opportunities.mjs` and repaired the top actionable pages, driving each one's monetization gap to **0** while preserving safety language and affiliate disclosures.

Per the audit playbook (`docs/high-roi-content-pass-2026-07-15.md`), the top five ranked routes were worked first; two (`ashwagandha-for-sleep`, `l-theanine-without-caffeine`) already had no gaps and were left untouched. The three actionable pages:

| Route | Before → After (gap) | Fix |
|---|---|---|
| `/guides/other/adaptogens-compared` | 31 → 0 | Added a context-matched ashwagandha `RecommendationSection` (strongest-evidence adaptogen, most common stress pattern) + contextual links to the ashwagandha, rhodiola, and holy-basil profiles |
| `/guides/sleep/ashwagandha-vs-magnesium-for-sleep` | 5 → 0 | Added an answer-first "fastest useful choice" block above the fold with contextual profile/guide links |
| `/guides/compare/sleep-herbs-vs-melatonin` | 5 → 0 | Added a one-glance "bottom line" recommendation above the decision table, linking magnesium glycinate and L-theanine profiles |

## Validation

- `npm run typecheck` — pass
- `eslint` on all three files — clean
- `npm run validate:evidence-language` — pass (0 critical)
- Re-ran the high-ROI audit: all three targets now report `gap=0` with no remaining actions

## Notes

- Product recommendation uses the existing approved `ashwagandha` revenue-product set; no new affiliate literals or restricted ingredients introduced.
- All internal-link targets verified to exist.
- Batch intentionally scoped to the top-five tier; lower-ranked pages left for a follow-up pass per the audit's stop condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BonLgZZcGRqec2J7ZzeMT6)_