### PR TITLE
Add FC-004 25B-NBOMe blotter case

### DIFF
--- a/content/articles/failure-chains-25b-nbome-blotter.mdx
+++ b/content/articles/failure-chains-25b-nbome-blotter.mdx
@@ -1,0 +1,227 @@
+---
+title: "FC-004: When Blotter Wasn't LSD — The 25B-NBOMe Seizure Case"
+description: "A forensic reconstruction of a severe 25B-NBOMe poisoning in a teenager who swallowed blotter sold as LSD, developed repeated seizures, respiratory failure, rhabdomyolysis, and acute kidney injury, and survived intensive care."
+date: "2026-07-29"
+lastUpdated: "2026-07-29"
+slug: "failure-chains-25b-nbome-blotter"
+category: "Harm Reduction"
+tags: ["Failure Chains", "FC-004", "25B-NBOMe", "NBOMe", "LSD", "blotter", "seizures", "rhabdomyolysis", "acute kidney injury", "drug checking", "harm reduction", "case study"]
+readingTime: 13
+evidenceGrade: "Moderate for the incident: a peer-reviewed clinical report with specialized toxicological identification, supported by a broader literature of analytically confirmed NBOMe poisonings"
+author: "The Hippie Scientist"
+references:
+  - title: "Beware of Blotting Paper Hallucinogens: Severe Toxicity with NBOMes"
+    authors: "Isbister GK, Poklis A, Poklis JL, Grice J"
+    year: "2015"
+    pmid: ""
+    url: "https://www.mja.com.au/journal/2015/203/6/beware-blotting-paper-hallucinogens-severe-toxicity-nbomes"
+  - title: "Toxicities Associated with NBOMe Ingestion—A Novel Class of Potent Hallucinogens: A Review of the Literature"
+    authors: "Suzuki J, Dekker MA, Valenti ES, et al."
+    year: "2015"
+    pmid: "25659919"
+    url: "https://pmc.ncbi.nlm.nih.gov/articles/PMC4355190/"
+  - title: "A Case of 25I-NBOMe (25-I) Intoxication: A New Potent 5-HT2A Agonist Designer Drug"
+    authors: "Rutherfoord Rose S, Poklis JL, Poklis A"
+    year: "2013"
+    pmid: "23473462"
+    url: "https://pmc.ncbi.nlm.nih.gov/articles/PMC4002208/"
+---
+
+<FailureChainCaseFile
+  caseId="FC-004"
+  incident="25B-NBOMe blotter sold as LSD"
+  reported="Rural New South Wales, 2014 case"
+  outcome="Four seizures, respiratory failure, severe acidosis, rhabdomyolysis, and acute kidney injury; survived"
+  primaryFailure="A familiar delivery format was treated as proof of chemical identity"
+  preventability="High"
+  medicalSeverity="Critical"
+  documentationConfidence="High"
+  documentation="Peer-reviewed clinical report with specialized toxicological identification of 25B-NBOMe"
+  steps={[
+    'Blotter paper was represented as LSD',
+    'The familiar format supplied false identity confidence',
+    'A 16-year-old swallowed the blotter while camping with friends',
+    'Repeated seizures developed before and after hospital arrival',
+    'Respiratory failure and profound acidosis required intubation and mechanical ventilation',
+    'Severe muscle breakdown and acute kidney injury followed',
+    'Specialized testing identified 25B-NBOMe; the patient survived after intensive care',
+  ]}
+/>
+
+> **Safety note:** This is a medical case reconstruction, not dosing guidance. A seizure, collapse, extreme agitation, dangerous overheating, breathing difficulty, blue or very pale skin, severe muscle rigidity, chest pain, or inability to wake someone after a drug exposure is an emergency. Contact emergency services and a poison center immediately.
+
+## Executive Summary
+
+A 16-year-old camping with friends in rural New South Wales swallowed red blotter paper sold as LSD. He experienced three seizures before reaching hospital and a fourth after arrival. His breathing failed badly enough to produce profound respiratory acidosis, and clinicians sedated, paralyzed, intubated, and mechanically ventilated him. Over the following hours, severe muscle breakdown and acute kidney injury developed. Specialized toxicology identified 25B-NBOMe rather than LSD [1].
+
+The case is memorable because almost nothing about the object looked unusual. It was a small square of blotter—the delivery format culturally associated with LSD.
+
+But blotter is paper. It is not a chemical identity test.
+
+The central failure was **format substitution**: a familiar carrier silently imported assumptions about the molecule, expected dose range, time course, and medical risk. Once the paper was accepted as proof of LSD, the label no longer needed to be spoken aloud. The object itself did the persuading.
+
+## The Story
+
+The patient reportedly took blotter while camping with friends. He believed it was LSD [1].
+
+Before reaching medical care, he had three generalized seizures. A fourth occurred after arrival at the emergency department. His condition required aggressive airway management and mechanical ventilation.
+
+The report documented a blood pH of 6.93 with marked carbon-dioxide retention. That degree of acidemia signals a life-threatening physiological crisis. In this setting, repeated convulsions, impaired ventilation, and respiratory failure were not peripheral complications of a difficult psychedelic experience. They were the emergency.
+
+The injury continued after seizure control. His creatine kinase rose to 34,778 U/L, consistent with severe rhabdomyolysis. Damaged muscle cells release intracellular contents into circulation, which can disrupt electrolytes and injure the kidneys. The patient developed acute kidney injury but ultimately recovered and left hospital after five days [1].
+
+Specialized analysis identified 25B-NBOMe.
+
+The difference between the believed drug and the detected drug matters because these compounds are not interchangeable variations of the same risk profile. LSD can produce profound psychological effects and dangerous behavior, but severe NBOMe poisonings have repeatedly included seizures, hyperthermia, hypertension, intense agitation, muscle breakdown, kidney injury, coma, and death [2].
+
+## What the Source Documented
+
+### Documented
+
+The case report supports the following:
+
+- a 16-year-old swallowed red blotter believed to be LSD,
+- three seizures occurred before hospital arrival and a fourth afterward,
+- profound respiratory acidosis developed,
+- clinicians used sedation, neuromuscular paralysis, intubation, and mechanical ventilation,
+- creatine kinase rose to 34,778 U/L,
+- acute kidney injury occurred,
+- specialized toxicological testing identified 25B-NBOMe,
+- and the patient survived, leaving hospital after five days [1].
+
+### Inferred
+
+The strongest inference is that the blotter format created identity confidence. The paper looked compatible with LSD, so the ordinary visual cue did not warn the patient or his friends that the compound might have a substantially different toxicity profile.
+
+It is also reasonable to infer that early symptoms may initially have been interpreted through the category of a psychedelic experience rather than a rapidly escalating toxicological emergency. The published report does not provide a detailed account of the friends' interpretations, so that point should remain an inference rather than a quote placed into their mouths.
+
+### Uncertain
+
+The source does not establish:
+
+- the exact quantity of 25B-NBOMe on the blotter,
+- whether distribution across the paper was uniform,
+- the manufacturing or distribution chain,
+- whether any additional compounds were present below the limits of testing,
+- the exact interval between ingestion and each seizure,
+- or how representative this case is of all exposures to the compound.
+
+A confirmed molecule does not magically fill every gap in the history.
+
+## Why NBOMe Compounds Can Look Like LSD but Behave Differently
+
+NBOMe compounds are potent serotonergic hallucinogens, commonly described as strong agonists at the serotonin 5-HT2A receptor. That receptor activity can produce intense alterations in perception and cognition, but the clinical syndrome reported in serious poisonings extends well beyond hallucination.
+
+Published cases and reviews describe combinations of:
+
+- severe agitation,
+- panic and disorganized behavior,
+- hypertension and rapid heart rate,
+- hyperthermia,
+- generalized seizures,
+- metabolic acidosis,
+- rhabdomyolysis,
+- acute kidney injury,
+- coma,
+- traumatic injury,
+- and death [2, 3].
+
+The exact pathway from receptor activation to each systemic complication is not a single neat arrow. Seizures generate enormous muscular activity. Agitation and rigidity can raise temperature. Hyperthermia and prolonged muscle contraction worsen rhabdomyolysis. Muscle-cell breakdown can burden the kidneys. Impaired breathing or prolonged convulsions can drive acidosis. Several processes can reinforce one another at once.
+
+That is why describing the event as “too much serotonin” is insufficient. The receptor-level description matters, but the dangerous clinical reality is a network failure involving the brain, muscles, temperature regulation, circulation, breathing, and kidneys.
+
+## The Failure Chain
+
+### 1. A delivery format became an identity claim
+
+Blotter is strongly associated with LSD in popular culture. That association can become so automatic that the paper itself functions like a label.
+
+### 2. The format imported the wrong expectations
+
+Believing the substance was LSD shaped expectations about potency, onset, duration, and likely complications. Those expectations were attached to the carrier rather than verified against the chemical.
+
+### 3. Severe toxicity emerged rapidly
+
+Repeated seizures moved the event out of the category of an ordinary psychedelic crisis and into critical toxicology.
+
+### 4. Convulsions and ventilatory failure amplified injury
+
+Respiratory failure produced profound acidosis. Repeated intense muscle activity contributed to rhabdomyolysis, which then threatened kidney function.
+
+### 5. Definitive identity required specialized testing
+
+Routine emergency toxicology screens often do not identify novel hallucinogens. Clinicians initially treat physiology—seizures, airway failure, overheating, shock, muscle injury—while analytical confirmation may arrive later.
+
+## Blotter Is Packaging, Not Proof
+
+A tablet press does not prove that a tablet contains the expected medicine. A powder's color does not identify it. A plant's common name does not establish its alkaloid content. Blotter follows the same rule.
+
+The carrier can tell you something about how a substance was distributed. It cannot establish:
+
+- which molecule is present,
+- how much is present,
+- whether multiple compounds are present,
+- whether concentration is uniform,
+- or whether the seller's description is accurate.
+
+This is a recurring cognitive shortcut: familiar packaging makes uncertain contents feel known.
+
+The brain loves a costume. Toxicology remains stubbornly interested in the actor underneath.
+
+## Emergency Response
+
+There is no simple bedside antidote that identifies and reverses an NBOMe exposure. Treatment is driven by the patient's condition.
+
+Critical care may include:
+
+- rapid benzodiazepine treatment for seizures and severe agitation,
+- airway protection and mechanical ventilation,
+- active temperature management,
+- continuous cardiovascular monitoring,
+- intravenous fluids,
+- serial electrolyte, kidney-function, and creatine-kinase testing,
+- monitoring for rhabdomyolysis and compartment complications,
+- and management of trauma or organ injury.
+
+A seizure after a supposed psychedelic exposure should never be dismissed as an intense trip. Repeated seizures, abnormal breathing, severe rigidity, extreme temperature, cyanosis, collapse, or persistent unresponsiveness require immediate emergency care.
+
+The stated identity should be communicated honestly but with uncertainty: “It was sold as LSD on blotter; the actual compound is unknown.” That is more useful than presenting the seller's claim as a laboratory result.
+
+## Could This Have Been Prevented?
+
+**Preventability: high.**
+
+The case depended on an identity substitution that was invisible to ordinary visual inspection. Avoiding unknown blotter would have prevented this specific exposure. Independent analytical testing might have identified that the sample was not LSD, although no consumer method can guarantee purity, dose uniformity, or complete safety.
+
+The deeper preventability question is systemic. When several highly potent compounds can be distributed on the same carrier, a market based on appearance and trust creates predictable opportunities for substitution.
+
+The broad lesson is:
+
+> A familiar drug format can conceal an unfamiliar toxicology.
+
+## Evidence Quality and Uncertainty
+
+The incident is unusually well documented for an illicit-drug poisoning because the report includes severe objective clinical findings and specialized identification of 25B-NBOMe [1]. That supports high confidence in the core case.
+
+The broader NBOMe literature consists largely of case reports, case series, poison-center data, and retrospective reviews [2]. Those sources are strong for identifying possible severe outcomes but weak for estimating the probability of those outcomes among all users. Mild exposures are less likely to reach publication, while the total number of exposures is unknown.
+
+The appropriate conclusion is therefore:
+
+- **High confidence** that this patient experienced severe 25B-NBOMe poisoning substantially as reported.
+- **Moderate confidence** in the broader description of recurring NBOMe toxicity patterns.
+- **Low confidence** in any claim about the percentage of exposures that become critical.
+
+## Bigger Questions
+
+- Why do people trust a familiar carrier more than an unfamiliar chemical name?
+- What rapid hospital tests could identify novel hallucinogens early enough to affect monitoring decisions?
+- How can public warnings distinguish severe toxic syndromes from moral panic?
+- Which consumer-testing methods are best at distinguishing LSD from NBOMe compounds, and where do those methods fail?
+- How should emergency clinicians communicate uncertainty when the only initial identity information comes from a seller or a friend?
+
+## Related Reading
+
+- [FC-001: Injected Mushroom Tea and the ICU Case Behind “Mushrooms in His Blood”](/articles/failure-chains-injected-mushroom-tea/)
+- [FC-002: The Illicit Opioid Batch That Produced Permanent Parkinsonism](/articles/failure-chains-mptp-parkinsonism/)
+- [FC-003: Oklahoma's Bromo-DragonFLY Poisoning and the False-Identity Failure Chain](/articles/failure-chains-oklahoma-bromo-dragonfly/)
+- [When the Label Lies: Eight Hallucinogen Disasters and the Failure Chains Behind Them](/articles/psychedelic-disasters-mislabeled-drugs/)


### PR DESCRIPTION
## Summary

- publish `FC-004`, a forensic reconstruction of a severe 25B-NBOMe poisoning involving blotter sold as LSD
- center the failure chain on familiar packaging being mistaken for chemical identity
- document repeated seizures, respiratory failure, profound acidosis, rhabdomyolysis, acute kidney injury, and survival
- distinguish documented findings, causal inference, and unresolved dose and supply-chain details
- explain the broader NBOMe toxicology pattern without treating every exposure as equally severe
- cross-link FC-001 through FC-003 and the broader hallucinogen disaster overview

## Evidence base

- Isbister et al. (2015), Medical Journal of Australia
- Suzuki et al. (2015), PMID 25659919
- Rutherfoord Rose et al. (2013), PMID 23473462

## Editorial safeguards

- does not provide dosing or preparation instructions
- does not treat blotter appearance as evidence of identity
- avoids estimating the frequency of critical poisoning from case reports
- labels exact dose, distribution uniformity, and supply-chain history as uncertain
- treats seizures and respiratory failure as medical emergencies rather than an unusually intense trip