### PR TITLE
Add context-matched product modules across high-ROI guide tier

### DIFF
--- a/app/guides/adhd/best-magnesium-supplement-for-adhd/page.tsx
+++ b/app/guides/adhd/best-magnesium-supplement-for-adhd/page.tsx
@@ -1,4 +1,6 @@
 import Link from 'next/link'
+import RecommendationSection from '@/components/RecommendationSection'
+import { getRevenueProductSet } from '@/config/revenue-products'
 import Image from 'next/image'
 import JsonLd from '@/components/seo/JsonLd'
 import type { Metadata } from 'next'
@@ -519,6 +521,9 @@ export default function BestMagnesiumForAdhdPage() {
 
           </section>
 
+      <div className="max-w-4xl">
+        <RecommendationSection products={getRevenueProductSet('magnesium')?.products ?? []} />
+      </div>
           <EmailCapture
             headline="Get the ADHD supplement checklist"
             description="Evidence-first supplement updates, buying guides, and ADHD research notes."

--- a/app/guides/adhd/l-theanine-magnesium-adhd-stack/page.tsx
+++ b/app/guides/adhd/l-theanine-magnesium-adhd-stack/page.tsx
@@ -1,4 +1,6 @@
 import Link from 'next/link'
+import RecommendationSection from '@/components/RecommendationSection'
+import { getRevenueProductSet } from '@/config/revenue-products'
 import Image from 'next/image'
 import JsonLd from '@/components/seo/JsonLd'
 import type { Metadata } from 'next'
@@ -435,6 +437,9 @@ export default function LTheanineMagnesiumAdhdStackPage() {
 
           </section>
 
+      <div className="max-w-4xl">
+        <RecommendationSection products={getRevenueProductSet('l-theanine')?.products ?? []} />
+      </div>
           <EmailCapture
             headline="Get the ADHD supplement checklist"
             description="Evidence-first supplement updates, stack guides, and ADHD research notes. No diagnosis or personal medical advice."

--- a/app/guides/compare/caffeine-vs-l-theanine/page.tsx
+++ b/app/guides/compare/caffeine-vs-l-theanine/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next'
+import RecommendationSection from '@/components/RecommendationSection'
+import { getRevenueProductSet } from '@/config/revenue-products'
 import Link from 'next/link'
 import { buildPageMetadata } from '../../../../src/lib/seo'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
@@ -204,6 +206,9 @@ export default function CaffeineVsLTheaninePage() {
         </div>
       </section>
 
+      <div className="max-w-4xl">
+        <RecommendationSection products={getRevenueProductSet('l-theanine')?.products ?? []} />
+      </div>
       <References refs={CAFFEINE_VS_L_THEANINE_REFS} />
     </div>
   )

--- a/app/guides/herbs/kava/page.tsx
+++ b/app/guides/herbs/kava/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next'
+import RecommendationSection from '@/components/RecommendationSection'
+import { getRevenueProductSet } from '@/config/revenue-products'
 import Link from 'next/link'
 import Image from 'next/image'
 import { buildPageMetadata } from '../../../../src/lib/seo'
@@ -282,6 +284,9 @@ export default function KavaGuidePage() {
         <Link href="/herbs/" className="font-medium text-brand-700 hover:text-brand-800 hover:underline">Herb Library →</Link>
       </div>
       </div>{/* end space-y-8 */}
+      <div className="max-w-4xl">
+        <RecommendationSection products={getRevenueProductSet('kava')?.products ?? []} />
+      </div>
       <References refs={KAVA_REFS} />
     </ArticleLayout>
   )

--- a/app/guides/other/berberine-weight-loss/page.tsx
+++ b/app/guides/other/berberine-weight-loss/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next'
+import RecommendationSection from '@/components/RecommendationSection'
+import { getRevenueProductSet } from '@/config/revenue-products'
 import Link from 'next/link'
 import Image from 'next/image'
 import { buildPageMetadata } from '../../../../src/lib/seo'
@@ -78,6 +80,9 @@ export default function BerberineWeightLossPage() {
         <p className="text-sm leading-7 text-muted">Berberine at 1,000-1,500 mg/day produces modest, statistically significant weight loss (~2 kg) in people with metabolic syndrome [1]. It is a reasonable supplement for prediabetes and insulin resistance. It is not &ldquo;nature&rsquo;s Ozempic&rdquo; — semaglutide produces 5-7x more weight loss through a completely different mechanism. The comparison is misleading and does a disservice to both compounds. Berberine has drug interaction risks that GLP-1 agonists do not — disclose it to your prescriber [3].</p>
       </section>
       <References refs={BERBERINE_REFS} />
+      <div className="max-w-4xl">
+        <RecommendationSection products={getRevenueProductSet('berberine')?.products ?? []} />
+      </div>
       <EmailCapture headline="Get evidence reviews like this" description="Berberine, weight loss, Ozempic — evidence, not hype." ctaLabel="Get the evidence" location="guide-berberine-weight-loss" />
       <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between"><Link href="/guides/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">← Back to guides</Link><Link href="/herbs/" className="text-sm font-bold text-brand-800 hover:underline">Herb library →</Link></div>
     </div>

--- a/app/guides/other/collagen-supplements/page.tsx
+++ b/app/guides/other/collagen-supplements/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next'
+import RecommendationSection from '@/components/RecommendationSection'
+import { getRevenueProductSet } from '@/config/revenue-products'
 import Link from 'next/link'
 import Image from 'next/image'
 import { buildPageMetadata } from '../../../../src/lib/seo'
@@ -83,6 +85,9 @@ export default function CollagenGuidePage() {
         <Ref n={9} text="ConsumerLab.com (2023). Collagen Supplements Review: per-gram cost ranges from $0.07 to $25+." url="https://www.consumerlab.com/reviews/collagen-supplements-review/collagen/" />
         <Ref n={10} text="Choi FD, et al. (2019). Oral collagen supplementation: systematic review of dermatological applications. J Drugs Dermatol, 18(1): 9-16." url="https://pubmed.ncbi.nlm.nih.gov/30681787/" />
       </ol></section>
+      <div className="max-w-4xl">
+        <RecommendationSection products={getRevenueProductSet('collagen')?.products ?? []} />
+      </div>
       <EmailCapture headline="Get evidence reviews like this" description="10 cited studies per guide. No hype." ctaLabel="Get the evidence" location="guide-collagen" />
       <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between"><Link href="/guides/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">← Back to guides</Link><Link href="/herbs/" className="text-sm font-bold text-brand-800 hover:underline">Herb library →</Link></div>
     </div>

--- a/app/guides/other/coq10-guide/page.tsx
+++ b/app/guides/other/coq10-guide/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next'
+import RecommendationSection from '@/components/RecommendationSection'
+import { getRevenueProductSet } from '@/config/revenue-products'
 import Link from 'next/link'
 import Image from 'next/image'
 import { buildPageMetadata } from '../../../../src/lib/seo'
@@ -50,6 +52,9 @@ export default function CoQ10Page() {
 
       <section className="card-premium p-6 space-y-4"><h2 className="text-2xl font-semibold">Bottom line</h2><p className="text-sm leading-7 text-muted">CoQ10 is one of the few supplements with a mortality benefit in a specific population — heart failure [1]. For statin myalgia, it is worth a 4-week trial [2]. For young healthy adults, skip it. Ubiquinone at 200-300 mg/day with a fat-containing meal is the most cost-effective approach for most people. This is a supplement where the evidence is unusually strong for specific medical uses and unusually weak for general wellness. Take it if you have a reason — not because the bottle says "heart health."</p></section>
       <References refs={COQ10_REFS} />
+      <div className="max-w-4xl">
+        <RecommendationSection products={getRevenueProductSet('coenzyme-q10')?.products ?? []} />
+      </div>
       <EmailCapture headline="Get evidence reviews like this" description="CoQ10, heart failure, statins — evidence over marketing." ctaLabel="Get the evidence" location="guide-coq10" />
       <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between"><Link href="/guides/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">← Back to guides</Link><Link href="/herbs/" className="text-sm font-bold text-brand-800 hover:underline">Herb library →</Link></div>
     </div>

--- a/app/guides/other/creatine-brain-health/page.tsx
+++ b/app/guides/other/creatine-brain-health/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next'
+import RecommendationSection from '@/components/RecommendationSection'
+import { getRevenueProductSet } from '@/config/revenue-products'
 import Link from 'next/link'
 import Image from 'next/image'
 import { buildPageMetadata } from '../../../../src/lib/seo'
@@ -76,6 +78,9 @@ export default function CreatineBrainPage() {
 
       <section className="card-premium p-6 space-y-4 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">Bottom line</h2><p className="text-sm leading-7 text-muted">Creatine for brain health is one of the more promising — and surprisingly underdiscussed — supplement applications. The evidence is strongest for sleep deprivation [1,2,7], emerging for menopause [4] and depression augmentation [6], and weak for healthy young adults. At $0.10-0.20/day with decades of safety data, creatine is a low-risk, evidence-informed cognitive support — particularly for women in perimenopause, older adults, and anyone facing sleep loss. It will not make you smarter. It may help your brain function when the energy demands are high.</p></section>
       <References refs={CREATINE_BRAIN_REFS} />
+      <div className="max-w-4xl">
+        <RecommendationSection products={getRevenueProductSet('creatine')?.products ?? []} />
+      </div>
       <EmailCapture headline="Get evidence reviews like this" description="Creatine, menopause, brain health — we track the evidence." ctaLabel="Get the evidence" location="guide-creatine-brain" />
       <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between"><Link href="/guides/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">← Back to guides</Link><Link href="/herbs/" className="text-sm font-bold text-brand-800 hover:underline">Herb library →</Link></div>
     </div>

--- a/app/guides/other/curcumin-absorption-guide/page.tsx
+++ b/app/guides/other/curcumin-absorption-guide/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next'
+import RecommendationSection from '@/components/RecommendationSection'
+import { getRevenueProductSet } from '@/config/revenue-products'
 import Link from 'next/link'
 import Image from 'next/image'
 import { buildPageMetadata } from '../../../../src/lib/seo'
@@ -50,6 +52,9 @@ export default function CurcuminAbsorptionPage() {
 
       <section className="card-premium p-6 space-y-4"><h2 className="text-2xl font-semibold">Bottom line</h2><p className="text-sm leading-7 text-muted">The curcumin absorption problem is solved — but only if you buy the right formulation. Standard curcumin without bioavailability enhancement is a waste of money [1]. Curcumin + piperine (20x absorption) is the best value [2]. Phytosomes are slightly better at a premium [3]. Whichever you choose, the effective dose is 500-1,500 mg/day of enhanced curcumin. This is one of the few supplement categories where the formulation matters more than the dose.</p></section>
       <References refs={CURCUMIN_REFS} />
+      <div className="max-w-4xl">
+        <RecommendationSection products={getRevenueProductSet('turmeric')?.products ?? []} />
+      </div>
       <EmailCapture headline="Get evidence reviews like this" description="Curcumin absorption — the formulation matters more than the dose." ctaLabel="Get the evidence" location="guide-curcumin" />
       <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between"><Link href="/guides/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">← Back to guides</Link><Link href="/herbs/" className="text-sm font-bold text-brand-800 hover:underline">Herb library →</Link></div>
     </div>

--- a/app/guides/other/glutathione-nac-guide/page.tsx
+++ b/app/guides/other/glutathione-nac-guide/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next'
+import RecommendationSection from '@/components/RecommendationSection'
+import { getRevenueProductSet } from '@/config/revenue-products'
 import Link from 'next/link'
 import Image from 'next/image'
 import { buildPageMetadata } from '../../../../src/lib/seo'
@@ -51,6 +53,9 @@ export default function GlutathioneNACPage() {
 
       <section className="card-premium p-6 space-y-4"><h2 className="text-2xl font-semibold">Bottom line</h2><p className="text-sm leading-7 text-muted">NAC at 600-1,200 mg/day is the evidence-based way to support glutathione levels [1]. It has specific clinical evidence for COPD [2] and OCD [3] — but for most people, it is not a necessary supplement. Skip oral glutathione supplements — they are poorly absorbed and overpriced. If you drink alcohol regularly, have a respiratory condition, or take medications metabolized by the liver, NAC is worth discussing with your doctor. For everyone else, your body produces all the glutathione it needs from a normal diet [4].</p></section>
       <References refs={NAC_REFS} />
+      <div className="max-w-4xl">
+        <RecommendationSection products={getRevenueProductSet('nac')?.products ?? []} />
+      </div>
       <EmailCapture headline="Get evidence reviews like this" description="NAC, glutathione, antioxidants — evidence over marketing." ctaLabel="Get the evidence" location="guide-nac" />
       <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between"><Link href="/guides/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">← Back to guides</Link><Link href="/herbs/" className="text-sm font-bold text-brand-800 hover:underline">Herb library →</Link></div>
     </div>

--- a/app/guides/other/green-tea-egcg-guide/page.tsx
+++ b/app/guides/other/green-tea-egcg-guide/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next'
+import RecommendationSection from '@/components/RecommendationSection'
+import { getRevenueProductSet } from '@/config/revenue-products'
 import Link from 'next/link'
 import Image from 'next/image'
 import { buildPageMetadata } from '../../../../src/lib/seo'
@@ -49,6 +51,9 @@ export default function GreenTeaEGCGPage() {
 
       <section className="card-premium p-6 space-y-4"><h2 className="text-2xl font-semibold">Bottom line</h2><p className="text-sm leading-7 text-muted">Green tea is a healthy beverage. Green tea extract is a concentrated supplement with a documented, dose-dependent liver injury risk [2]. The weight loss effect is too small to justify the risk at high doses [1]. Drink matcha for the best combination of catechins, L-theanine, and safety. If you take extract, stay under 400 mg EGCG/day with food. The green tea story is a perfect example of why "natural" does not mean "safe at any dose."</p></section>
       <References refs={GREENTEA_REFS} />
+      <div className="max-w-4xl">
+        <RecommendationSection products={getRevenueProductSet('green-tea-extract')?.products ?? []} />
+      </div>
       <EmailCapture headline="Get evidence reviews like this" description="Green tea, EGCG, liver safety — evidence over marketing." ctaLabel="Get the evidence" location="guide-green-tea" />
       <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between"><Link href="/guides/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">← Back to guides</Link><Link href="/herbs/" className="text-sm font-bold text-brand-800 hover:underline">Herb library →</Link></div>
     </div>

--- a/app/guides/other/iron-supplement-guide/page.tsx
+++ b/app/guides/other/iron-supplement-guide/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next'
+import RecommendationSection from '@/components/RecommendationSection'
+import { getRevenueProductSet } from '@/config/revenue-products'
 import Link from 'next/link'
 import Image from 'next/image'
 import { buildPageMetadata } from '../../../../src/lib/seo'
@@ -49,6 +51,9 @@ export default function IronSupplementPage() {
 
       <section className="card-premium p-6 space-y-4"><h2 className="text-2xl font-semibold">Bottom line</h2><p className="text-sm leading-7 text-muted">Iron is not a general wellness supplement — it is a deficiency correction tool. Test before supplementing. Bisglycinate at 25-50 mg every other day + vitamin C is the best-tolerated, best-absorbed approach for most people [1,2]. Men and postmenopausal women should rarely supplement iron without confirmed deficiency. The risks of iron overload (oxidative damage, organ dysfunction) outweigh the benefits in iron-replete individuals [3].</p></section>
       <References refs={IRON_REFS} />
+      <div className="max-w-4xl">
+        <RecommendationSection products={getRevenueProductSet('iron')?.products ?? []} />
+      </div>
       <EmailCapture headline="Get evidence reviews like this" description="Iron, deficiency, forms — evidence over guesswork." ctaLabel="Get the evidence" location="guide-iron" />
       <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between"><Link href="/guides/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">← Back to guides</Link><Link href="/herbs/" className="text-sm font-bold text-brand-800 hover:underline">Herb library →</Link></div>
     </div>

--- a/app/guides/other/lions-mane-guide/page.tsx
+++ b/app/guides/other/lions-mane-guide/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next'
+import RecommendationSection from '@/components/RecommendationSection'
+import { getRevenueProductSet } from '@/config/revenue-products'
 import Link from 'next/link'
 import Image from 'next/image'
 import { buildPageMetadata } from '../../../../src/lib/seo'
@@ -55,6 +57,9 @@ export default function LionsManePage() {
 
       <section className="card-premium p-6 space-y-4 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">Bottom line</h2><p className="text-sm leading-7 text-muted">Lion&apos;s mane is the most scientifically interesting nootropic mushroom — the NGF mechanism is unique and well-established [2]. Human evidence is preliminary but directionally positive [1]. At $15-30/month with an excellent safety profile, it is a reasonable cognitive support supplement — particularly for older adults concerned about cognitive decline. For healthy young adults, the evidence is weaker. Quality matters enormously — most commercial products are myceliated grain with minimal actual mushroom content.</p></section>
       <References refs={LIONSMANE_REFS} />
+      <div className="max-w-4xl">
+        <RecommendationSection products={getRevenueProductSet('lions-mane')?.products ?? []} />
+      </div>
       <EmailCapture headline="Get evidence reviews like this" description="Lion\'s mane, NGF, cognition — evidence over marketing." ctaLabel="Get the evidence" location="guide-lions-mane" />
       <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between"><Link href="/guides/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">← Back to guides</Link><Link href="/herbs/" className="text-sm font-bold text-brand-800 hover:underline">Herb library →</Link></div>
     </div>

--- a/app/guides/other/melatonin-dosage-guide/page.tsx
+++ b/app/guides/other/melatonin-dosage-guide/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next'
+import RecommendationSection from '@/components/RecommendationSection'
+import { getRevenueProductSet } from '@/config/revenue-products'
 import Link from 'next/link'
 import Image from 'next/image'
 import { buildPageMetadata } from '../../../../src/lib/seo'
@@ -51,6 +53,9 @@ export default function MelatoninDosingPage() {
 
       <section className="card-premium p-6 space-y-4"><h2 className="text-2xl font-semibold">Bottom line</h2><p className="text-sm leading-7 text-muted">Most melatonin is overdosed at 3-10 mg. The evidence supports 0.3-1 mg for sleep onset [1,2]. Higher doses do not work better — they just cause more side effects. If your melatonin gives you morning grogginess, reduce the dose, not increase it. The best value: buy 1 mg tablets and break them in half. Or buy liquid melatonin and measure 0.3-0.5 mg. This will cost $5-10/month and work as well as the 10 mg capsules that cost 3x more with 3x the side effects.</p></section>
       <References refs={MELATONIN_REFS} />
+      <div className="max-w-4xl">
+        <RecommendationSection products={getRevenueProductSet('melatonin')?.products ?? []} />
+      </div>
       <EmailCapture headline="Get evidence reviews like this" description="Melatonin dosing — less is more." ctaLabel="Get the evidence" location="guide-melatonin-dosing" />
       <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between"><Link href="/guides/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">← Back to guides</Link><Link href="/herbs/" className="text-sm font-bold text-brand-800 hover:underline">Herb library →</Link></div>
     </div>

--- a/app/guides/other/omega-3-quality-guide/page.tsx
+++ b/app/guides/other/omega-3-quality-guide/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next'
+import RecommendationSection from '@/components/RecommendationSection'
+import { getRevenueProductSet } from '@/config/revenue-products'
 import Link from 'next/link'
 import Image from 'next/image'
 import { buildPageMetadata } from '../../../../src/lib/seo'
@@ -57,6 +59,9 @@ export default function Omega3QualityPage() {
 
       <section className="card-premium p-6 space-y-4 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">Bottom line</h2><p className="text-sm leading-7 text-muted">Omega-3 supplements are one of the most evidence-supported categories in nutrition [1,3]. The quality variation is enormous — from 30% concentration drugstore brands to 90%+ pharmaceutical-grade products. For most people: choose a triglyceride-form fish oil at 60%+ EPA+DHA, verified by third-party testing, stored properly. Algae oil is an excellent DHA source for vegetarians. Krill oil is overpriced — no outcome benefit over standard fish oil despite phospholipid marketing. Brands that publish IFOS reports: Nordic Naturals, Wiley's, Viva Naturals, Sports Research.</p></section>
       <References refs={OMEGA3_REFS} />
+      <div className="max-w-4xl">
+        <RecommendationSection products={getRevenueProductSet('omega-3')?.products ?? []} />
+      </div>
       <EmailCapture headline="Get evidence reviews like this" description="Omega-3 quality, EPA/DHA, rTG vs EE — evidence, not marketing." ctaLabel="Get the evidence" location="guide-omega3" />
       <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between"><Link href="/guides/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">← Back to guides</Link><Link href="/herbs/" className="text-sm font-bold text-brand-800 hover:underline">Herb library →</Link></div>
     </div>

--- a/app/guides/other/saffron-supplement/page.tsx
+++ b/app/guides/other/saffron-supplement/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next'
+import RecommendationSection from '@/components/RecommendationSection'
+import { getRevenueProductSet } from '@/config/revenue-products'
 import Link from 'next/link'
 import Image from 'next/image'
 import { buildPageMetadata } from '../../../../src/lib/seo'
@@ -60,6 +62,9 @@ export default function SaffronPage() {
 
       <section className="card-premium p-6 space-y-4"><h2 className="text-2xl font-semibold">Bottom line</h2><p className="text-sm leading-7 text-muted">Saffron is one of the most evidence-supported herbal antidepressants — the head-to-head data against fluoxetine is unusual for a botanical supplement [1,5]. However, the evidence comes primarily from small Iranian trials and needs independent replication. For mild-moderate depression, saffron extract at 30 mg/day is a reasonable, evidence-informed option — with prescriber oversight and careful attention to serotonergic drug interactions. At $15-30/month, it is less expensive than many prescription antidepressants and has fewer side effects at studied doses.</p></section>
       <References refs={SAFFRON_REFS} />
+      <div className="max-w-4xl">
+        <RecommendationSection products={getRevenueProductSet('saffron')?.products ?? []} />
+      </div>
       <EmailCapture headline="Get evidence reviews like this" description="Saffron, depression, mood — evidence over trends." ctaLabel="Get the evidence" location="guide-saffron" />
       <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between"><Link href="/guides/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">← Back to guides</Link><Link href="/herbs/" className="text-sm font-bold text-brand-800 hover:underline">Herb library →</Link></div>
     </div>

--- a/app/guides/other/vitamin-d-k2-guide/page.tsx
+++ b/app/guides/other/vitamin-d-k2-guide/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next'
+import RecommendationSection from '@/components/RecommendationSection'
+import { getRevenueProductSet } from '@/config/revenue-products'
 import Link from 'next/link'
 import Image from 'next/image'
 import { buildPageMetadata } from '../../../../src/lib/seo'
@@ -55,6 +57,9 @@ export default function VitaminDK2Page() {
 
       <section className="card-premium p-6 space-y-4 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">Bottom line</h2><p className="text-sm leading-7 text-muted">Vitamin D3 (2,000-5,000 IU) + K2 MK-7 (90-200 mcg) is the most logical daily supplement pairing after a multivitamin. The deficiency rates are high, the safety margins are wide, the cost is low ($10-18/month for both), and the mechanistic rationale is strong. Test vitamin D annually. If your levels are below 30 ng/mL, supplement aggressively under medical guidance. Above 40 ng/mL is optimal for most people. K2 may be particularly important for postmenopausal women, people with family history of cardiovascular disease, and anyone taking calcium supplements.</p></section>
       <References refs={VITD_REFS} />
+      <div className="max-w-4xl">
+        <RecommendationSection products={getRevenueProductSet('vitamin-d')?.products ?? []} />
+      </div>
       <EmailCapture headline="Get evidence reviews like this" description="Vitamin D, K2, dosing, deficiency — evidence over marketing." ctaLabel="Get the evidence" location="guide-vitamin-d-k2" />
       <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between"><Link href="/guides/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">← Back to guides</Link><Link href="/herbs/" className="text-sm font-bold text-brand-800 hover:underline">Herb library →</Link></div>
     </div>

--- a/app/guides/other/zinc-supplement-guide/page.tsx
+++ b/app/guides/other/zinc-supplement-guide/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next'
+import RecommendationSection from '@/components/RecommendationSection'
+import { getRevenueProductSet } from '@/config/revenue-products'
 import Link from 'next/link'
 import Image from 'next/image'
 import { buildPageMetadata } from '../../../../src/lib/seo'
@@ -56,6 +58,9 @@ export default function ZincPage() {
 
       <section className="card-premium p-6 space-y-4 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">Bottom line</h2><p className="text-sm leading-7 text-muted">Zinc picolinate or citrate at 15-25 mg/day is the best general supplementation strategy. Test levels if you suspect deficiency (vegetarian, GI disorder, elderly, pregnant). For colds: zinc acetate lozenges at 75-100 mg/day. Avoid oxide. Pair long-term zinc with copper. Total cost: $3-8/month for quality zinc — one of the best values in supplementation.</p></section>
       <References refs={ZINC_REFS} />
+      <div className="max-w-4xl">
+        <RecommendationSection products={getRevenueProductSet('zinc')?.products ?? []} />
+      </div>
       <EmailCapture headline="Get evidence reviews like this" description="Zinc forms, dosing, colds — evidence, not marketing." ctaLabel="Get the evidence" location="guide-zinc" />
       <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between"><Link href="/guides/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">← Back to guides</Link><Link href="/herbs/" className="text-sm font-bold text-brand-800 hover:underline">Herb library →</Link></div>
     </div>

--- a/app/guides/sleep/glycine-for-sleep/page.tsx
+++ b/app/guides/sleep/glycine-for-sleep/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { SITE_URL } from '@/src/lib/seo'
+import RecommendationSection from '@/components/RecommendationSection'
+import { getRevenueProductSet } from '@/config/revenue-products'
 
 const path = '/guides/sleep/glycine-for-sleep/'
 
@@ -167,6 +169,8 @@ export default function Page() {
             </div>
           </section>
         ))}
+
+        <RecommendationSection products={getRevenueProductSet('glycine')?.products ?? []} />
 
         <section className="rounded-2xl border border-emerald-800/15 bg-emerald-50/70 p-6 shadow-sm dark:border-white/10 dark:bg-[var(--surface-subtle)]">
           <h2 className="text-xl font-semibold text-ink dark:text-[var(--text-primary)]">Next comparison</h2>

--- a/app/guides/sleep/magnesium-glycinate-vs-l-threonate-for-sleep/page.tsx
+++ b/app/guides/sleep/magnesium-glycinate-vs-l-threonate-for-sleep/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { SITE_URL } from '@/src/lib/seo'
+import RecommendationSection from '@/components/RecommendationSection'
+import { getRevenueProductSet } from '@/config/revenue-products'
 
 const path = '/guides/sleep/magnesium-glycinate-vs-l-threonate-for-sleep/'
 
@@ -179,6 +181,8 @@ export default function Page() {
             </div>
           </section>
         ))}
+
+        <RecommendationSection products={getRevenueProductSet('magnesium')?.products ?? []} />
 
         <section className="rounded-2xl border border-emerald-800/15 bg-emerald-50/70 p-6 shadow-sm dark:border-white/10 dark:bg-[var(--surface-subtle)]">
           <h2 className="text-xl font-semibold text-ink dark:text-[var(--text-primary)]">Clean next step</h2>


### PR DESCRIPTION
## Summary

Second pass over the high-ROI content audit (`scripts/audit/high-roi-content-opportunities.mjs`). Closes the **dominant monetization gap** — missing `RecommendationSection` + revenue-product connection — on **20 genuinely commercial single-ingredient guides**, each wired to its context-matched, pre-approved revenue-product set.

## Pages upgraded (module now present, verified via re-run audit)

| Product set | Routes |
|---|---|
| glycine / magnesium / melatonin | `glycine-for-sleep`, `magnesium-glycinate-vs-l-threonate-for-sleep`, `best-magnesium-supplement-for-adhd`, `melatonin-dosage-guide` |
| l-theanine | `l-theanine-magnesium-adhd-stack`, `caffeine-vs-l-theanine` |
| kava | `guides/herbs/kava` |
| single-ingredient guides | `collagen-supplements`, `lions-mane-guide`, `omega-3-quality-guide`, `saffron-supplement`, `creatine-brain-health`, `green-tea-egcg-guide`, `iron-supplement-guide`, `curcumin-absorption-guide`, `vitamin-d-k2-guide`, `berberine-weight-loss`, `zinc-supplement-guide`, `coq10-guide`, `glutathione-nac-guide` |

## Deliberately excluded (adding an affiliate module would be inappropriate)

- `/learn/*` educational pages, hub/index and dynamic routes, `/info/*` pages
- Prescription / peptide pages (semaglutide, tirzepatide, bpc-157, pt-141, …)
- Multi-ingredient roundups without a single matching approved set
- Drug/alcohol-comparison pages (`kanna-vs-ssris`, `kava-vs-alcohol`)
- Shared-component / alias pages (would require a broad component rewrite, against the audit guardrails)

Remaining answer-first / decision-framework / FAQ / evidence gaps on other pages require **genuine per-page authoring** and were intentionally left for targeted follow-up rather than templated fill.

## Safety & validation

- All product sets are the existing approved, restricted-ingredient-guarded sets in `config/revenue-products.ts`; **no new affiliate literals** introduced.
- `npm run typecheck` — pass · `eslint` on all 20 files — clean · `npm run validate:evidence-language` — pass (0 critical)
- Re-ran the audit: `hasRecommendation = true` on all 20 routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BonLgZZcGRqec2J7ZzeMT6)_