### PR TITLE
Author content upgrades on top commercial roundup guides

### DIFF
--- a/app/guides/other/anti-inflammatory-supplements/page.tsx
+++ b/app/guides/other/anti-inflammatory-supplements/page.tsx
@@ -7,6 +7,8 @@ import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
 import FAQSchema from '@/components/seo/FAQSchema'
 import References from '@/components/References'
 import EmailCapture from '../../../../components/EmailCapture'
+import RecommendationSection from '@/components/RecommendationSection'
+import { getRevenueProductSet } from '@/config/revenue-products'
 
 export const metadata: Metadata = buildPageMetadata({
   title: 'Anti-Inflammatory Supplements: Evidence Review (2026)',
@@ -58,6 +60,37 @@ export default function AntiInflammatoryPage() {
       <section className="card-premium p-6 space-y-4 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">Bottom line</h2><p className="text-sm leading-7 text-muted">Omega-3 fatty acids at 2-4 g EPA+DHA/day and curcumin at 500-1,500 mg/day (with bioavailability enhancement) are the two best-evidenced anti-inflammatory supplements [1,2]. They work through different pathways and can be safely combined. Ginger and boswellia are second-line options with specific use cases. No supplement replaces the anti-inflammatory effect of weight loss, exercise, sleep, and a whole-foods diet — but for people with chronic inflammatory conditions, this stack is one of the most evidence-supported interventions in the supplement world.</p></section>
 
       <section className="card-premium p-6 space-y-4 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">When to take each one</h2><p className="text-sm leading-7 text-muted"><strong>Omega-3:</strong> With food (fat improves absorption). Split dose morning/evening to reduce fish burps. <strong>Curcumin:</strong> With food + black pepper (piperine) or as phytosome formulation. Morning or midday — some report mild stimulating effects. <strong>Ginger:</strong> With or without food. Before exercise for muscle soreness prevention. <strong>Boswellia:</strong> With food. Morning and evening (split dose). <strong>Quercetin:</strong> With food (fat-soluble). Morning — may be mildly stimulating. Separate from iron supplements by 2 hours (quercetin chelates iron). Do not take all five at once — start with omega-3 + curcumin, assess for 4 weeks, then add ginger or boswellia if needed.</p></section>
+      <section className="card-premium p-6 space-y-4 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">Frequently asked questions</h2>
+        <div className="space-y-4">
+          {FAQS.map((faq) => (
+            <div key={faq.question} className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+              <h3 className="font-semibold text-ink">{faq.question}</h3>
+              <p className="mt-2 text-sm leading-7 text-muted">{faq.answer}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="card-premium p-6 space-y-3 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">Related reading</h2>
+        <p className="text-sm leading-7 text-muted">Go deeper on the two best-evidenced picks and the ingredients in the stack:</p>
+        <ul className="grid gap-2 sm:grid-cols-2 text-sm font-semibold text-brand-800">
+          <li><Link href="/guides/other/curcumin-absorption-guide/" className="hover:underline">Curcumin absorption guide →</Link></li>
+          <li><Link href="/guides/other/omega-3-quality-guide/" className="hover:underline">Omega-3 quality guide →</Link></li>
+          <li><Link href="/herbs/turmeric/" className="hover:underline">Turmeric herb profile →</Link></li>
+          <li><Link href="/herbs/ginger/" className="hover:underline">Ginger herb profile →</Link></li>
+          <li><Link href="/compounds/omega-3-epa/" className="hover:underline">Omega-3 (EPA) compound profile →</Link></li>
+          <li><Link href="/guides/best/supplements-for-joint-support/" className="hover:underline">Best supplements for joint support →</Link></li>
+        </ul>
+      </section>
+
+      <div className="max-w-4xl">
+        <RecommendationSection
+          title="Curcumin (turmeric) product picks"
+          description="Curcumin is the flagship, best-evidenced anti-inflammatory in this guide — pair it with a high-EPA omega-3 as the core stack. These are sourcing starting points; a formulation with piperine or a phytosome carrier matters more than brand, and the bleeding-risk and dose notes above still apply."
+          products={getRevenueProductSet('turmeric')?.products ?? []}
+        />
+      </div>
+
       <References refs={ANTI_INFLAM_REFS} />
       <EmailCapture headline="Get evidence reviews like this" description="Anti-inflammatory, omega-3, curcumin — evidence, not hype." ctaLabel="Get the evidence" location="guide-anti-inflammatory" />
       <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between"><Link href="/guides/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">← Back to guides</Link><Link href="/herbs/" className="text-sm font-bold text-brand-800 hover:underline">Herb library →</Link></div>

--- a/app/guides/other/menopause-supplements/page.tsx
+++ b/app/guides/other/menopause-supplements/page.tsx
@@ -7,6 +7,8 @@ import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
 import FAQSchema from '@/components/seo/FAQSchema'
 import References from '@/components/References'
 import EmailCapture from '../../../../components/EmailCapture'
+import RecommendationSection from '@/components/RecommendationSection'
+import { getRevenueProductSet } from '@/config/revenue-products'
 
 export const metadata: Metadata = buildPageMetadata({
   title: 'Menopause Supplements: Evidence Review (2026 Guide)',
@@ -76,6 +78,37 @@ export default function MenopauseSupplementsPage() {
       <section className="card-premium p-6 space-y-4 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">Why menopause creates unique supplement needs</h2><p className="text-sm leading-7 text-muted">The 2026 Cambridge UK Biobank study (n=125,000) confirmed menopause is linked to reductions in grey matter volume in the hippocampus, entorhinal cortex, and anterior cingulate — regions involved in memory, emotion, and attention. Estrogen plays a critical role in brain glucose metabolism, creatine synthesis, and bone turnover. As it declines, the brain becomes less efficient at generating energy, contributing to brain fog and cognitive fatigue. HRT addresses some of these deficits but does not fully reverse grey matter changes. This is where targeted supplementation — particularly creatine for brain energetics and vitamin D for bone — has a plausible biological rationale.</p></section>
 
       <section className="card-premium p-6 space-y-4 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">Bottom line</h2><p className="text-sm leading-7 text-muted">Creatine at 3-5 g/day is the strongest evidence-based supplement for menopausal brain fog and muscle preservation [1,2,8]. Soy isoflavones modestly reduce hot flashes [3]. Vitamin D + calcium protect bones [4]. Magnesium supports sleep [5]. Most other menopause supplements lack rigorous evidence — and none replace the evidence base for HRT when it is clinically appropriate [7]. If you choose to supplement, start with creatine and vitamin D: well-studied, safe, inexpensive, and supported by plausible mechanisms. Track symptoms for 8-12 weeks before adding anything else.</p></section>
+      <section className="card-premium p-6 space-y-4 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">Frequently asked questions</h2>
+        <div className="space-y-4">
+          {FAQS.map((faq) => (
+            <div key={faq.question} className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+              <h3 className="font-semibold text-ink">{faq.question}</h3>
+              <p className="mt-2 text-sm leading-7 text-muted">{faq.answer}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="card-premium p-6 space-y-3 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">Related reading</h2>
+        <p className="text-sm leading-7 text-muted">Go deeper on the core stack ingredients:</p>
+        <ul className="grid gap-2 sm:grid-cols-2 text-sm font-semibold text-brand-800">
+          <li><Link href="/guides/other/creatine-brain-health/" className="hover:underline">Creatine for brain health →</Link></li>
+          <li><Link href="/compounds/creatine/" className="hover:underline">Creatine compound profile →</Link></li>
+          <li><Link href="/guides/other/vitamin-d-k2-guide/" className="hover:underline">Vitamin D + K2 guide →</Link></li>
+          <li><Link href="/compounds/magnesium-glycinate/" className="hover:underline">Magnesium glycinate profile →</Link></li>
+          <li><Link href="/herbs/black-cohosh/" className="hover:underline">Black cohosh herb profile →</Link></li>
+          <li><Link href="/guides/other/magnesium-types-guide/" className="hover:underline">Magnesium types guide →</Link></li>
+        </ul>
+      </section>
+
+      <div className="max-w-4xl">
+        <RecommendationSection
+          title="Creatine product picks"
+          description="Creatine monohydrate is the best-evidenced pick in this guide for menopausal brain fog and muscle preservation — start here rather than with black cohosh. These are sourcing starting points; plain creatine monohydrate is the studied form, and the dosing and HRT-disclosure notes above still apply."
+          products={getRevenueProductSet('creatine')?.products ?? []}
+        />
+      </div>
+
       <References refs={MENOPAUSE_REFS} />
       <EmailCapture headline="Get evidence reviews like this" description="We track claims against clinical evidence. No hype, no influencer talking points." ctaLabel="Get the evidence" location="guide-menopause" />
       <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between"><Link href="/guides/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">← Back to guides</Link><Link href="/herbs/" className="text-sm font-bold text-brand-800 hover:underline">Herb library →</Link></div>

--- a/app/guides/other/prebiotics/page.tsx
+++ b/app/guides/other/prebiotics/page.tsx
@@ -71,6 +71,26 @@ export default function PrebioticsGuide() {
         <Ref n={7} text="Robertson MD, et al. (2005). Resistant starch improves insulin sensitivity in healthy subjects. Diabetologia, 48(6): 1218-1225." url="https://pubmed.ncbi.nlm.nih.gov/15778869/" />
         <Ref n={8} text="Deehan EC, et al. (2020). Precision microbiome modulation with discrete dietary fiber structures. Cell Host Microbe, 27(3): 389-404." url="https://pubmed.ncbi.nlm.nih.gov/32101703/" />
       </ol></section>
+      <section className="card-premium p-6 space-y-4 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">Frequently asked questions</h2>
+        <div className="space-y-4">
+          {FAQS.map((faq) => (
+            <div key={faq.question} className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+              <h3 className="font-semibold text-ink">{faq.question}</h3>
+              <p className="mt-2 text-sm leading-7 text-muted">{faq.answer}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="card-premium p-6 space-y-3 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">Related reading</h2>
+        <p className="text-sm leading-7 text-muted">Prebiotics feed the bacteria; probiotics seed them. Round out the gut picture:</p>
+        <ul className="grid gap-2 sm:grid-cols-2 text-sm font-semibold text-brand-800">
+          <li><Link href="/guides/other/probiotic-strains-guide/" className="hover:underline">Probiotic strains guide →</Link></li>
+          <li><Link href="/guides/best/supplements-for-gut-health/" className="hover:underline">Best supplements for gut health →</Link></li>
+          <li><Link href="/herbs/garlic/" className="hover:underline">Garlic herb profile →</Link></li>
+        </ul>
+      </section>
+
       <EmailCapture headline="Get evidence reviews like this" description="8 cited studies. No hype." ctaLabel="Get the evidence" location="guide-prebiotics" />
       <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between"><Link href="/guides/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">← Back to guides</Link><Link href="/herbs/" className="text-sm font-bold text-brand-800 hover:underline">Herb library →</Link></div>
     </div>

--- a/app/guides/other/probiotic-strains-guide/page.tsx
+++ b/app/guides/other/probiotic-strains-guide/page.tsx
@@ -6,6 +6,8 @@ import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
 import FAQSchema from '@/components/seo/FAQSchema'
 import References from '@/components/References'
+import RecommendationSection from '@/components/RecommendationSection'
+import { getRevenueProductSet } from '@/config/revenue-products'
 import EmailCapture from '../../../../components/EmailCapture'
 
 export const metadata: Metadata = buildPageMetadata({
@@ -57,6 +59,33 @@ export default function ProbioticStrainsPage() {
         <div className="mt-3 p-3 rounded-lg bg-white border border-brand-200"><p className="text-xs font-semibold text-ink">The probiotic rule:</p><p className="mt-1 text-xs leading-5 text-muted">Match strain to condition. Separate from antibiotics by 2-3 hours. Continue 1-2 weeks after antibiotics. Give 4-8 weeks to assess effect. If no benefit by week 8, the strain is not a match for your microbiome. Fermented foods (yogurt, kefir, kimchi) provide diverse bacteria plus metabolites — a better foundation than any single supplement [4].</p></div></section>
 
       <section className="card-premium p-6 space-y-4 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">Bottom line</h2><p className="text-sm leading-7 text-muted">Probiotics work — for specific conditions with specific strains at studied doses. The evidence is strongest for antibiotic-associated diarrhea (NNT=13), IBS, and traveler&rsquo;s diarrhea [1,2,3]. For general gut health, fermented foods and a high-fiber diet provide greater benefit at lower cost than any supplement [4]. When buying: look for named strains (not just species), studied CFU ranges, and third-party verification. Avoid proprietary blends that hide individual strain amounts. The best probiotic is the one matched to your specific condition — not the one with the biggest number on the bottle.</p></section>
+      <section className="card-premium p-6 space-y-4 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">Frequently asked questions</h2>
+        <div className="space-y-4">
+          {FAQS.map((faq) => (
+            <div key={faq.question} className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+              <h3 className="font-semibold text-ink">{faq.question}</h3>
+              <p className="mt-2 text-sm leading-7 text-muted">{faq.answer}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="card-premium p-6 space-y-3 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">Related reading</h2>
+        <p className="text-sm leading-7 text-muted">Round out the gut-health picture:</p>
+        <ul className="grid gap-2 sm:grid-cols-2 text-sm font-semibold text-brand-800">
+          <li><Link href="/guides/other/prebiotics/" className="hover:underline">Prebiotics: evidence &amp; types →</Link></li>
+          <li><Link href="/guides/best/supplements-for-gut-health/" className="hover:underline">Best supplements for gut health →</Link></li>
+        </ul>
+      </section>
+
+      <div className="max-w-4xl">
+        <RecommendationSection
+          title="Probiotic product picks"
+          description="Buy on named strain and studied CFU, not the biggest number on the bottle — match the strain to your condition using the selector above. These are sourcing starting points; a strain with clinical evidence for your specific issue beats a generic high-CFU blend."
+          products={getRevenueProductSet('probiotics')?.products ?? []}
+        />
+      </div>
+
       <References refs={PROBIOTIC_REFS} />
       <EmailCapture headline="Get evidence reviews like this" description="Probiotic strains, IBS, diarrhea — evidence, not CFU marketing." ctaLabel="Get the evidence" location="guide-probiotics" />
       <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between"><Link href="/guides/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">← Back to guides</Link><Link href="/herbs/" className="text-sm font-bold text-brand-800 hover:underline">Herb library →</Link></div>

--- a/app/guides/other/sleep-supplements-guide/page.tsx
+++ b/app/guides/other/sleep-supplements-guide/page.tsx
@@ -6,6 +6,8 @@ import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
 import FAQSchema from '@/components/seo/FAQSchema'
 import References from '@/components/References'
+import RecommendationSection from '@/components/RecommendationSection'
+import { getRevenueProductSet } from '@/config/revenue-products'
 import EmailCapture from '../../../../components/EmailCapture'
 
 export const metadata: Metadata = buildPageMetadata({
@@ -41,7 +43,7 @@ export default function SleepSupplementsPage() {
 
       <section className="card-premium p-6 space-y-4"><h2 className="text-2xl font-semibold">Quick answer</h2><p className="text-sm leading-7 text-muted"><strong>Match the supplement to your sleep problem, not the marketing.</strong> For sleep onset (can&apos;t fall asleep): low-dose melatonin (0.3-1 mg) or L-theanine (200 mg). For sleep maintenance (can&apos;t stay asleep): magnesium glycinate (200-400 mg). For racing mind: L-theanine + magnesium. For circadian disruption (jet lag, shift work): melatonin [2]. Avoid diphenhydramine (Benadryl/ZzzQuil) for regular use — it causes tolerance and next-day impairment. Sleep hygiene (consistent schedule, dark room, no screens) has stronger evidence than any supplement [1].</p></section>
 
-      <section className="card-premium p-6 space-y-4 max-w-4xl border-l-4 border-brand-700 bg-brand-50/30"><p className="text-xs font-bold uppercase tracking-wider text-brand-700">At a Glance · Sleep Supplement Selector</p><div className="overflow-x-auto"><table className="min-w-full text-sm"><thead><tr className="border-b"><th className="text-left py-2 pr-4 font-semibold text-ink">Sleep Problem</th><th className="text-left py-2 pr-4 font-semibold text-ink">Best Supplement</th><th className="text-left py-2 pr-4 font-semibold text-ink">Dose</th><th className="text-left py-2 font-semibold text-ink">Timing</th></tr></thead><tbody className="text-muted">
+      <section className="card-premium p-6 space-y-4 max-w-4xl border-l-4 border-brand-700 bg-brand-50/30"><p className="text-xs font-bold uppercase tracking-wider text-brand-700">At a Glance · Sleep Supplement Selector</p><p className="text-sm leading-7 text-muted">Use this as a simple decision framework: identify which sleep problem best describes you, then choose the option matched to it below.</p><div className="overflow-x-auto"><table className="min-w-full text-sm"><thead><tr className="border-b"><th className="text-left py-2 pr-4 font-semibold text-ink">Sleep Problem</th><th className="text-left py-2 pr-4 font-semibold text-ink">Best Supplement</th><th className="text-left py-2 pr-4 font-semibold text-ink">Dose</th><th className="text-left py-2 font-semibold text-ink">Timing</th></tr></thead><tbody className="text-muted">
           <tr className="border-b"><td className="py-2 pr-4 font-medium text-ink">Can&apos;t fall asleep</td><td className="py-2 pr-4">Melatonin (0.3-1 mg)</td><td className="py-2 pr-4">0.3-1 mg</td><td className="py-2">1-2 hrs before bed</td></tr>
           <tr className="border-b"><td className="py-2 pr-4 font-medium text-ink">Can&apos;t stay asleep</td><td className="py-2 pr-4">Magnesium glycinate</td><td className="py-2 pr-4">200-400 mg</td><td className="py-2">Evening</td></tr>
           <tr className="border-b"><td className="py-2 pr-4 font-medium text-ink">Racing mind at night</td><td className="py-2 pr-4">L-Theanine</td><td className="py-2 pr-4">200 mg</td><td className="py-2">30-60 min before bed</td></tr>
@@ -52,6 +54,37 @@ export default function SleepSupplementsPage() {
       <section className="card-premium p-6 space-y-4 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">Bottom line</h2><p className="text-sm leading-7 text-muted">The best sleep supplements are matched to specific sleep problems: melatonin for timing issues, magnesium for tension-driven insomnia, L-theanine for racing mind. The combination of magnesium glycinate + L-theanine is the most broadly applicable, lowest-risk starting point. Avoid high-dose melatonin (over 1-3 mg) — the side effects (grogginess, vivid dreams) outweigh the benefits. Sleep hygiene (consistent schedule, dark cool room, no screens) has stronger evidence than any supplement [1]. Supplements support sleep — they do not replace the fundamentals.</p></section>
 
       <section className="card-premium p-6 space-y-4 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">How to build a sleep stack</h2><p className="text-sm leading-7 text-muted">Start with magnesium glycinate (200 mg) for one week. If sleep onset is the issue, add L-theanine (200 mg) 30-60 minutes before bed. If still struggling with onset, add low-dose melatonin (0.3 mg) — not 3-10 mg. If maintenance is the issue (waking at 3 AM), try glycine (3 g) before bed instead of melatonin. Do not add all three at once — you will not know what is working. Give each addition 5-7 nights before assessing. If nothing helps after 3 weeks of consistent sleep hygiene + supplements, see a sleep specialist — you may have sleep apnea, restless leg syndrome, or another condition that supplements cannot address.</p></section>
+      <section className="card-premium p-6 space-y-4 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">Frequently asked questions</h2>
+        <div className="space-y-4">
+          {FAQS.map((faq) => (
+            <div key={faq.question} className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+              <h3 className="font-semibold text-ink">{faq.question}</h3>
+              <p className="mt-2 text-sm leading-7 text-muted">{faq.answer}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="card-premium p-6 space-y-3 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">Related reading</h2>
+        <p className="text-sm leading-7 text-muted">Deeper guides for each part of a sleep stack:</p>
+        <ul className="grid gap-2 sm:grid-cols-2 text-sm font-semibold text-brand-800">
+          <li><Link href="/guides/sleep/best-natural-sleep-aids-that-work/" className="hover:underline">Best natural sleep aids that work →</Link></li>
+          <li><Link href="/guides/sleep/sleep-stack-guide/" className="hover:underline">How to build a sleep stack →</Link></li>
+          <li><Link href="/guides/other/melatonin-dosage-guide/" className="hover:underline">Melatonin dosage guide →</Link></li>
+          <li><Link href="/guides/other/magnesium-types-guide/" className="hover:underline">Magnesium types guide →</Link></li>
+          <li><Link href="/compounds/magnesium-glycinate/" className="hover:underline">Magnesium glycinate profile →</Link></li>
+          <li><Link href="/compounds/l-theanine/" className="hover:underline">L-theanine compound profile →</Link></li>
+        </ul>
+      </section>
+
+      <div className="max-w-4xl">
+        <RecommendationSection
+          title="Magnesium glycinate product picks"
+          description="Magnesium glycinate is the most broadly applicable, lowest-risk starting point in this guide. These are sourcing starting points; match the elemental dose and check kidney/medication precautions above before buying. For onset-timing problems, low-dose melatonin or L-theanine is the better first move."
+          products={getRevenueProductSet('magnesium')?.products ?? []}
+        />
+      </div>
+
       <References refs={SLEEP_REFS} />
       <EmailCapture headline="Get evidence reviews like this" description="Sleep supplements, melatonin, magnesium — evidence over marketing." ctaLabel="Get the evidence" location="guide-sleep" />
       <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between"><Link href="/guides/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">← Back to guides</Link><Link href="/herbs/" className="text-sm font-bold text-brand-800 hover:underline">Herb library →</Link></div>


### PR DESCRIPTION
## Summary

Third pass over the high-ROI content audit — this one is **genuine per-page content authoring** (not a mechanical module drop) on the highest-value multi-ingredient roundup guides. Each had strong body copy but only ~2 internal links, no product module, and a FAQ that was defined for JSON-LD yet **never rendered on the page**.

For each page I: rendered the existing FAQ block visibly, added a "Related reading" block of contextual links to supporting profiles/guides, and — only where a genuinely context-matched approved product set exists — added a flagship `RecommendationSection` keyed to the page's *own* strongest-evidence pick.

| Page | Flagship module | Gap |
|---|---|---|
| `anti-inflammatory-supplements` | curcumin / turmeric | 31 → **0** |
| `menopause-supplements` | creatine (the page's #1 pick, not black cohosh) | 31 → **0** |
| `sleep-supplements-guide` | magnesium glycinate + decision-framework framing | 38 → **0** |
| `probiotic-strains-guide` | probiotics (with "buy on strain, not CFU" caveat) | 31 → **0** |
| `prebiotics` | **none — intentionally** | 32 (FAQ + links added) |

## On `prebiotics`

No product module was added. The page deliberately separates *prebiotics* (fiber that feeds gut bacteria) from *probiotics* (live bacteria), and there is no approved single-ingredient prebiotic set. Dropping a probiotics module there would mislead readers, so I added only the visible FAQ and contextual links. Its audit gap stays non-zero by design — the honest outcome.

## Safety & validation

- All modules use existing approved, restricted-ingredient-guarded sets in `config/revenue-products.ts`; **no new affiliate literals**.
- Module descriptions preserve each page's safety framing (bleeding risk, HRT disclosure, kidney/medication precautions, strain-vs-CFU).
- `npm run typecheck` — pass · `eslint` on all files — clean · `npm run validate:evidence-language` — pass (0 critical)
- Re-ran the audit: four pages now `gap=0`; FAQ visible and links ≥4 on all five.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BonLgZZcGRqec2J7ZzeMT6)_