### PR TITLE
SEO: emit hreflang alternates site-wide

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,8 @@
 import type { Metadata } from 'next'
 import HomepageV2 from '@/components/homepage-v2'
 import { buildPageMetadata } from '../src/lib/seo'
-import { getCurrentLocaleAlternates } from '../src/lib/international-seo'
 
-const homepageLocaleAlternates = Object.fromEntries(
-  getCurrentLocaleAlternates('/').map((alternate) => [alternate.locale, alternate.url]),
-)
-
-const homepageMetadata = buildPageMetadata({
+export const metadata: Metadata = buildPageMetadata({
   title: 'The Hippie Scientist: Evidence & Safety for Supplements',
   description:
     'Compare evidence-based plant medicine, herbs, and supplements by goal. Explore human clinical trial evidence, biological mechanisms, and drug interactions for sleep, anxiety, focus, and stress.',
@@ -26,14 +21,6 @@ const homepageMetadata = buildPageMetadata({
   path: '/',
   openGraphType: 'website',
 })
-
-export const metadata: Metadata = {
-  ...homepageMetadata,
-  alternates: {
-    ...homepageMetadata.alternates,
-    languages: homepageLocaleAlternates,
-  },
-}
 
 export default function Page() {
   return <HomepageV2 />

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { formatDisplayLabel, list } from '@/lib/display-utils'
 import { getEvidenceLabel } from '@/lib/evidence'
 import { SITE_URL, SITE_NAME } from './site'
+import { getCurrentLocaleAlternates } from './international-seo'
 import {
   CORE_INDEXABLE_ROUTES,
   CURATED_INDEXABLE_COMPOUND_SLUGS,
@@ -176,11 +177,14 @@ export function buildPageMetadata({
   const meta = buildMeta({ title, description, path, image, keepQueryParams })
   const fullTitle = title || DEFAULT_TITLE
   const fullDesc = description || DEFAULT_DESCRIPTION
+  const languageAlternates = Object.fromEntries(
+    getCurrentLocaleAlternates(path).map((alternate) => [alternate.locale, alternate.url]),
+  )
   return {
     title: fullTitle,
     description: fullDesc,
     keywords,
-    alternates: { canonical: meta.url },
+    alternates: { canonical: meta.url, languages: languageAlternates },
     openGraph: {
       title: fullTitle,
       description: fullDesc,


### PR DESCRIPTION
## Summary

Centralizes the `en-US` / `x-default` hreflang alternates in `buildPageMetadata` so every page built through it advertises `rel="alternate" hreflang` links — not just the homepage.

Previously only `app/page.tsx` merged the language alternates in by hand; every other indexable route (herbs, compounds, articles, guides, learn, etc.) emitted a canonical link with **no** hreflang, weakening the international/canonical signal for the bulk of the site. Since profile pages flow through `generateDetailMetadata` → `buildPageMetadata` with their canonical path, they now emit hreflang pointing at the canonical URL.

## Changes

- `src/lib/seo.ts` — `buildPageMetadata` now attaches `alternates.languages` (en-US + x-default) alongside the existing canonical.
- `app/page.tsx` — simplified to rely on the centralized behavior instead of manually merging the alternates.

## Verification

- `npm run typecheck` — passes
- `npm run lint` — passes (zero warnings)
- `npx vitest run` on `seo`, `international-seo`, `metadata-engine` suites — 21 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrcXf5XTYUR26XbmcCYSDA

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrcXf5XTYUR26XbmcCYSDA)_