### PR TITLE
Begin citation growth architecture

### DIFF
--- a/components/editorial/ScientificTakeaways.tsx
+++ b/components/editorial/ScientificTakeaways.tsx
@@ -1,0 +1,53 @@
+type Confidence = 'High' | 'Moderate' | 'Limited'
+
+type Takeaway = {
+  claim: string
+  confidence?: Confidence
+  context?: string
+}
+
+type ScientificTakeawaysProps = {
+  title?: string
+  summary?: string
+  items: Takeaway[]
+}
+
+const confidenceClasses: Record<Confidence, string> = {
+  High: 'border-emerald-700/20 bg-emerald-50 text-emerald-900',
+  Moderate: 'border-amber-700/20 bg-amber-50 text-amber-900',
+  Limited: 'border-rose-700/20 bg-rose-50 text-rose-900',
+}
+
+export default function ScientificTakeaways({
+  title = 'Scientific Takeaways',
+  summary,
+  items,
+}: ScientificTakeawaysProps) {
+  if (!items.length) return null
+
+  return (
+    <aside aria-labelledby="scientific-takeaways-title" className="my-8 rounded-3xl border border-brand-900/15 bg-brand-50/60 p-5 sm:p-6">
+      <p className="text-xs font-bold uppercase tracking-[0.16em] text-brand-700">Citation-ready summary</p>
+      <h2 id="scientific-takeaways-title" className="mt-2 text-2xl font-bold tracking-tight text-ink">
+        {title}
+      </h2>
+      {summary ? <p className="mt-3 max-w-3xl text-sm leading-6 text-muted">{summary}</p> : null}
+
+      <ul className="mt-5 space-y-3">
+        {items.map((item, index) => (
+          <li key={`${item.claim}-${index}`} className="rounded-2xl border border-brand-900/10 bg-white/80 p-4">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <p className="min-w-0 flex-1 text-sm font-semibold leading-6 text-ink">{item.claim}</p>
+              {item.confidence ? (
+                <span className={`shrink-0 rounded-full border px-2.5 py-1 text-xs font-bold ${confidenceClasses[item.confidence]}`}>
+                  {item.confidence} confidence
+                </span>
+              ) : null}
+            </div>
+            {item.context ? <p className="mt-2 text-sm leading-6 text-muted">{item.context}</p> : null}
+          </li>
+        ))}
+      </ul>
+    </aside>
+  )
+}

--- a/components/editorial/ScientificTakeaways.tsx
+++ b/components/editorial/ScientificTakeaways.tsx
@@ -1,3 +1,5 @@
+import { useId } from 'react'
+
 type Confidence = 'High' | 'Moderate' | 'Limited'
 
 type Takeaway = {
@@ -23,12 +25,15 @@ export default function ScientificTakeaways({
   summary,
   items,
 }: ScientificTakeawaysProps) {
+  const generatedId = useId()
+  const headingId = `scientific-takeaways-${generatedId.replace(/:/g, '')}`
+
   if (!items.length) return null
 
   return (
-    <aside aria-labelledby="scientific-takeaways-title" className="my-8 rounded-3xl border border-brand-900/15 bg-brand-50/60 p-5 sm:p-6">
+    <aside aria-labelledby={headingId} className="my-8 rounded-3xl border border-brand-900/15 bg-brand-50/60 p-5 sm:p-6">
       <p className="text-xs font-bold uppercase tracking-[0.16em] text-brand-700">Citation-ready summary</p>
-      <h2 id="scientific-takeaways-title" className="mt-2 text-2xl font-bold tracking-tight text-ink">
+      <h2 id={headingId} className="mt-2 text-2xl font-bold tracking-tight text-ink">
         {title}
       </h2>
       {summary ? <p className="mt-3 max-w-3xl text-sm leading-6 text-muted">{summary}</p> : null}

--- a/components/editorial/__tests__/ScientificTakeaways.test.tsx
+++ b/components/editorial/__tests__/ScientificTakeaways.test.tsx
@@ -30,6 +30,23 @@ describe('ScientificTakeaways', () => {
     expect(screen.getByText('The carrier can contain several potent compounds.')).toBeInTheDocument()
   })
 
+  it('uses unique accessible heading IDs for multiple blocks', () => {
+    render(
+      <>
+        <ScientificTakeaways title="Mechanism" items={[{ claim: 'First claim.' }]} />
+        <ScientificTakeaways title="Clinical meaning" items={[{ claim: 'Second claim.' }]} />
+      </>
+    )
+
+    const headings = screen.getAllByRole('heading')
+    const headingIds = headings.map((heading) => heading.id)
+    const asides = screen.getAllByRole('complementary')
+
+    expect(new Set(headingIds).size).toBe(headingIds.length)
+    expect(asides[0]).toHaveAttribute('aria-labelledby', headings[0].id)
+    expect(asides[1]).toHaveAttribute('aria-labelledby', headings[1].id)
+  })
+
   it('renders nothing when no takeaways are supplied', () => {
     const { container } = render(<ScientificTakeaways items={[]} />)
     expect(container.firstChild).toBeNull()

--- a/components/editorial/__tests__/ScientificTakeaways.test.tsx
+++ b/components/editorial/__tests__/ScientificTakeaways.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import ScientificTakeaways from '../ScientificTakeaways'
+
+describe('ScientificTakeaways', () => {
+  it('renders atomic claims, confidence, and qualifying context', () => {
+    render(
+      <ScientificTakeaways
+        summary="What the evidence supports."
+        items={[
+          {
+            claim: 'Blotter paper does not establish chemical identity.',
+            confidence: 'High',
+            context: 'The carrier can contain several potent compounds.',
+          },
+          {
+            claim: 'Case reports cannot estimate the frequency of critical poisoning.',
+            confidence: 'Moderate',
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByRole('heading', { name: 'Scientific Takeaways' })).toBeInTheDocument()
+    expect(screen.getByText('What the evidence supports.')).toBeInTheDocument()
+    expect(screen.getByText('Blotter paper does not establish chemical identity.')).toBeInTheDocument()
+    expect(screen.getByText('High confidence')).toBeInTheDocument()
+    expect(screen.getByText('The carrier can contain several potent compounds.')).toBeInTheDocument()
+  })
+
+  it('renders nothing when no takeaways are supplied', () => {
+    const { container } = render(<ScientificTakeaways items={[]} />)
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/docs/specs/citation-growth-architecture.md
+++ b/docs/specs/citation-growth-architecture.md
@@ -1,0 +1,141 @@
+# Citation Growth Architecture
+
+## Purpose
+
+Turn The Hippie Scientist from a collection of strong pages into an interconnected, citation-ready scientific knowledge system. The goal is durable growth in cited pages and citations by making claims easier to discover, verify, extract, and connect without weakening scientific nuance.
+
+## Principles
+
+1. **Answer first, evidence immediately behind it.** Pages should state the defensible answer early, then show mechanism, limitations, and sources.
+2. **One canonical concept per reusable page.** Repeated explanations such as vasoconstriction, rhabdomyolysis, delirium, and 5-HT2A agonism should eventually resolve to dedicated hub pages.
+3. **Claims must carry uncertainty.** High, moderate, and limited confidence labels describe evidence strength, not certainty of individual outcomes.
+4. **Internal links should represent scientific relationships.** Links should connect molecule → receptor → physiological process → clinical consequence → case study.
+5. **Primary literature remains the trust anchor.** PMID, DOI, year, authors, and source URLs should be retained whenever available.
+6. **No extraction bait.** Citation-ready summaries must remain accurate when quoted out of context.
+
+## Content Primitives
+
+### Scientific Takeaways
+
+A reusable MDX component containing three to six atomic claims. Each claim may include:
+
+- confidence level,
+- a short qualifying context,
+- language that remains defensible when extracted independently.
+
+Do not use this block for promotional conclusions or unsupported recommendations.
+
+### Definition Pages
+
+Definition pages should answer one canonical question, such as:
+
+- What is rhabdomyolysis?
+- What is receptor agonism?
+- Why can vasoconstriction cause ischemia?
+- What distinguishes delirium from a psychedelic state?
+
+Each definition page should include a concise definition, mechanism, why it matters, common misconceptions, related molecules and cases, evidence limitations, and sources.
+
+### Cornerstone Hubs
+
+Cornerstone hubs organize clusters rather than duplicating every child page. Initial candidates:
+
+- Psychedelic toxicology
+- Hallucinogen emergencies
+- Serotonin and 5-HT receptors
+- Dopamine and movement
+- NMDA receptors and dissociation
+- Drug-induced hyperthermia
+
+### Failure Chains
+
+Failure Chains remain forensic case studies. Each should link outward to the canonical pages for the molecule, receptor or pathway, physiological complications, and related cases.
+
+## Article Metadata Contract
+
+Future article metadata should support:
+
+- `relatedSlugs`: intentionally curated article relationships,
+- `keyTakeaways`: short atomic claims,
+- `citationQuestions`: user questions the page directly answers,
+- `canonicalConcepts`: normalized concepts for graph generation,
+- `lastReviewed`: a genuine review date only,
+- `evidenceGrade`: concise evidence-level language.
+
+Metadata must never imply a review or credential that did not occur.
+
+## Internal-Linking Rules
+
+1. Prefer a specific canonical concept page over a generic category page.
+2. Add links where the relationship is meaningful in the sentence; avoid keyword stuffing.
+3. A mature article should generally connect to:
+   - two to five canonical concepts,
+   - one or more molecule or receptor pages,
+   - two or more related articles or cases.
+4. Hub pages should link down to every major child page; child pages should link back to their hub.
+5. Broken, redirected, and orphaned links remain CI failures or audit findings.
+
+## Structured Data
+
+Article pages should continue emitting Article and MedicalWebPage data only when supported. Planned additions:
+
+- FAQPage only when the FAQ is visibly rendered,
+- DefinedTerm for canonical definitions,
+- ItemList for visible takeaways where useful,
+- explicit citation entries using source URLs and identifiers,
+- BreadcrumbList through existing breadcrumb infrastructure.
+
+Structured data must describe visible content and may not manufacture hidden claims.
+
+## Measurement
+
+Track monthly:
+
+- total citations,
+- cited pages,
+- citations per cited page,
+- number of new pages first cited,
+- citation concentration among the top ten pages,
+- orphan-page count,
+- average intentional internal links per cornerstone article,
+- percentage of articles with primary references,
+- percentage of articles with visible takeaways and uncertainty language.
+
+A healthy system increases cited pages without allowing one page to dominate all citations.
+
+## Rollout
+
+### Phase 1 — Extraction primitives
+
+- Scientific Takeaways component
+- authoring template
+- metadata contract
+- citation-readiness audit
+
+### Phase 2 — Canonical concepts
+
+- launch the first ten definition pages
+- connect existing Failure Chains to those concepts
+- create the psychedelic toxicology cornerstone hub
+
+### Phase 3 — Knowledge graph
+
+- normalize concepts in frontmatter or generated data
+- generate related-content edges
+- add orphan and link-density auditing
+- expose browsable concept relationships
+
+### Phase 4 — Continuous optimization
+
+- review Bing citation exports monthly
+- identify pages with impressions but no citations
+- improve answer-first summaries and source coverage
+- expand clusters based on real citation demand rather than raw publishing volume
+
+## Acceptance Criteria for Phase 1
+
+- MDX authors can add a visible, accessible Scientific Takeaways block without imports.
+- The component supports optional confidence and context per claim.
+- A copyable authoring template exists.
+- The architecture clearly separates current implementation from later graph and hub work.
+- Existing content continues to compile without adopting the new fields immediately.

--- a/docs/templates/scientific-takeaways.mdx
+++ b/docs/templates/scientific-takeaways.mdx
@@ -1,0 +1,35 @@
+## Scientific Takeaways authoring template
+
+Use three to six claims that can stand alone without losing their scientific qualification.
+
+```mdx
+<ScientificTakeaways
+  summary="A one-sentence statement describing what this block covers and what it does not establish."
+  items={[
+    {
+      claim: 'State one precise, defensible scientific conclusion.',
+      confidence: 'High',
+      context: 'Explain the evidence boundary or the population to which the claim applies.',
+    },
+    {
+      claim: 'Separate a well-supported mechanism from a less certain clinical inference.',
+      confidence: 'Moderate',
+      context: 'Case reports can document possibility but usually cannot estimate frequency.',
+    },
+    {
+      claim: 'Name the important unresolved question rather than smoothing it over.',
+      confidence: 'Limited',
+      context: 'Describe exactly what evidence is missing.',
+    },
+  ]}
+/>
+```
+
+## Rules
+
+- Prefer one claim per item.
+- Avoid vague claims such as “more research is needed” without saying what is unknown.
+- Do not convert association into causation.
+- Do not use confidence labels to describe personal certainty; they describe the evidence supporting the claim.
+- Ensure the claim remains accurate when quoted without the surrounding article.
+- Put operational safety instructions in a dedicated safety block, not in the takeaways component.

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -21,6 +21,7 @@ import BetterAlternatives from '@/components/editorial/BetterAlternatives'
 import WhereNext from '@/components/editorial/WhereNext'
 import EvidenceConfidence from '@/components/editorial/EvidenceConfidence'
 import EditorialNote from '@/components/editorial/EditorialNote'
+import ScientificTakeaways from '@/components/editorial/ScientificTakeaways'
 
 type MDXComponents = Record<string, ComponentType<Record<string, unknown>>>
 type MdxTableProps = Record<string, unknown> & { children?: ReactNode }
@@ -111,6 +112,7 @@ const evidenceComponents = {
   WhereNext,
   EvidenceConfidence,
   EditorialNote,
+  ScientificTakeaways,
   table: MdxTable,
   a: MdxAnchor,
 } as unknown as MDXComponents


### PR DESCRIPTION
## Summary

This is the first implementation batch for turning the site into a citation-oriented scientific knowledge system rather than applying isolated SEO tweaks.

- add a full citation-growth architecture specification
- add a reusable, accessible `ScientificTakeaways` MDX component for atomic citation-ready claims
- support optional evidence-confidence labels and qualifying context per takeaway
- register the component globally for article MDX
- add a copyable authoring template with claim-discipline rules
- add component tests for content, confidence labels, context, and empty-state behavior

## Why this batch comes first

The broader roadmap includes canonical definition pages, cornerstone hubs, normalized concept metadata, graph-generated relationships, structured data, and citation-readiness auditing. Those systems need a stable editorial primitive before we migrate existing articles or generate links at scale.

`ScientificTakeaways` creates that primitive while remaining opt-in and backward-compatible.

## Editorial safeguards

- extracted claims must remain accurate outside the article
- confidence describes evidence strength, not author certainty
- association must not be rewritten as causation
- vague “more research is needed” claims require a specific unresolved question
- safety instructions remain in dedicated safety blocks

## Validation

- added Vitest and Testing Library coverage
- no existing content is required to adopt the component immediately
- no schema or route behavior is changed in this first batch