### PR TITLE
Add citation metadata and curated article relationships

### DIFF
--- a/app/articles/[slug]/page.tsx
+++ b/app/articles/[slug]/page.tsx
@@ -7,6 +7,7 @@ import ArticleMdx from '@/components/articles/ArticleMdx'
 import Breadcrumbs from '@/components/ui/Breadcrumbs'
 import JsonLd from '@/components/seo/JsonLd'
 import ContentCards from '@/components/content/ContentCards'
+import { normalizeCitationMetadata, resolveRelatedArticles } from '@/src/lib/article-citation-metadata'
 import { SITE_URL, compactMetaTitle } from '../../../src/lib/seo'
 
 const articlePages = [...allArticleMonographs, ...allBlogPosts]
@@ -46,15 +47,13 @@ export default async function ArticleMonographPage({ params }: PageProps) {
   const page = articlePages.find((item) => item.slug === slug)
   if (!page) notFound()
 
-  const relatedPages = articlePages.filter((item) => item.slug !== page.slug && item.category === page.category)
+  const relatedPages = resolveRelatedArticles(page, articlePages)
+  const { keyTakeaways, citationQuestions, canonicalConcepts } = normalizeCitationMetadata(page)
 
-  // Trust/E-E-A-T fields exist only on article monographs, not blog posts.
   const author = 'author' in page ? page.author : undefined
   const reviewedBy = 'reviewedBy' in page && page.reviewedBy ? page.reviewedBy : undefined
   const reviewerCredential =
     'reviewerCredential' in page && page.reviewerCredential ? page.reviewerCredential : undefined
-  // Only surfaced when a page carries an explicit review date — "updated" is
-  // not the same as "reviewed", so we never infer this from lastUpdated.
   const lastReviewed = 'lastReviewed' in page && page.lastReviewed ? page.lastReviewed : undefined
   const reviewerLabel = reviewedBy
     ? `${reviewedBy}${reviewerCredential ? `, ${reviewerCredential}` : ''}`
@@ -71,6 +70,7 @@ export default async function ArticleMonographPage({ params }: PageProps) {
     image: `${SITE_URL}/og-default.jpg`,
     keywords: page.tags,
     articleSection: page.category,
+    ...(canonicalConcepts.length > 0 ? { about: canonicalConcepts } : {}),
     author: author
       ? { '@type': 'Person', name: author }
       : { '@type': 'Organization', name: 'The Hippie Scientist', url: SITE_URL },
@@ -85,7 +85,20 @@ export default async function ArticleMonographPage({ params }: PageProps) {
     })),
   }
 
-  // Emitted only when there is real review/citation substance to attest to.
+  const takeawaySchema =
+    keyTakeaways.length > 0
+      ? {
+          '@context': 'https://schema.org',
+          '@type': 'ItemList',
+          name: `${page.title}: Scientific Takeaways`,
+          itemListElement: keyTakeaways.map((takeaway, index) => ({
+            '@type': 'ListItem',
+            position: index + 1,
+            name: takeaway,
+          })),
+        }
+      : null
+
   const medicalPageSchema =
     lastReviewed || page.references.length > 0
       ? {
@@ -94,7 +107,13 @@ export default async function ArticleMonographPage({ params }: PageProps) {
           url: `${SITE_URL}/articles/${page.slug}/`,
           ...(lastReviewed ? { lastReviewed } : {}),
           ...(reviewerLabel
-            ? { reviewedBy: { '@type': 'Person', name: reviewedBy, ...(reviewerCredential ? { honorificSuffix: reviewerCredential } : {}) } }
+            ? {
+                reviewedBy: {
+                  '@type': 'Person',
+                  name: reviewedBy,
+                  ...(reviewerCredential ? { honorificSuffix: reviewerCredential } : {}),
+                },
+              }
             : {}),
         }
       : null
@@ -103,6 +122,7 @@ export default async function ArticleMonographPage({ params }: PageProps) {
     <article className="mx-auto max-w-5xl px-4 pb-20 pt-6 sm:px-6 lg:px-8">
       <JsonLd schema={articleSchema} />
       {medicalPageSchema ? <JsonLd schema={medicalPageSchema} /> : null}
+      {takeawaySchema ? <JsonLd schema={takeawaySchema} /> : null}
 
       <Breadcrumbs
         items={[
@@ -126,16 +146,16 @@ export default async function ArticleMonographPage({ params }: PageProps) {
             Updated {page.lastUpdated}
           </time>
           <span className="text-muted">·</span>
-          <span className="text-muted">{typeof page.readingTime === 'number' ? `${page.readingTime} min read` : page.readingTime}</span>
+          <span className="text-muted">
+            {typeof page.readingTime === 'number' ? `${page.readingTime} min read` : page.readingTime}
+          </span>
         </div>
 
         <h1 className="mt-4 max-w-[22ch] font-display text-2xl font-bold leading-[1.08] text-ink sm:text-4xl lg:text-5xl">
           {page.title}
         </h1>
 
-        <p className="mt-4 max-w-3xl text-base leading-7 text-muted">
-          {page.description}
-        </p>
+        <p className="mt-4 max-w-3xl text-base leading-7 text-muted">{page.description}</p>
 
         <div className="mt-5 flex flex-wrap items-center gap-x-3 gap-y-1.5 border-t border-brand-900/10 pt-4 text-xs text-muted">
           {author ? (
@@ -173,6 +193,37 @@ export default async function ArticleMonographPage({ params }: PageProps) {
           </Link>
         </div>
       </header>
+
+      {citationQuestions.length > 0 ? (
+        <section aria-labelledby="citation-questions-title" className="mt-6 rounded-2xl border border-brand-900/10 bg-white p-5">
+          <h2 id="citation-questions-title" className="text-lg font-bold text-ink">
+            Questions this page answers
+          </h2>
+          <ul className="mt-3 grid gap-2 text-sm leading-6 text-muted sm:grid-cols-2">
+            {citationQuestions.map((question) => (
+              <li key={question} className="border-l-2 border-brand-700/30 pl-3">
+                {question}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      {keyTakeaways.length > 0 ? (
+        <section aria-labelledby="metadata-takeaways-title" className="mt-6 rounded-2xl border border-brand-900/10 bg-brand-50/50 p-5">
+          <h2 id="metadata-takeaways-title" className="text-lg font-bold text-ink">
+            Scientific takeaways
+          </h2>
+          <ul className="mt-3 space-y-2 text-sm leading-6 text-muted">
+            {keyTakeaways.map((takeaway) => (
+              <li key={takeaway} className="flex gap-3">
+                <span aria-hidden="true" className="font-bold text-brand-700">•</span>
+                <span>{takeaway}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
 
       <div className="mt-6">
         <ContentCards>

--- a/content-collections.ts
+++ b/content-collections.ts
@@ -39,20 +39,18 @@ const articleMonographs = defineCollection({
     evidenceGrade: z.string().min(1).optional(),
     evidence_grade: z.string().min(1).optional(),
     author: z.string().optional(),
-    // Optional trust/E-E-A-T signals. `reviewedBy`/`reviewerCredential` are
-    // only rendered when a real reviewer is supplied — never fabricate one.
     reviewedBy: z.string().optional(),
     reviewerCredential: z.string().optional(),
     lastReviewed: z.string().regex(isoDatePattern).optional(),
     faqs: z.array(articleFaqSchema).default([]),
     references: z.array(articleReferenceSchema).default([]),
+    relatedSlugs: z.array(z.string().regex(slugPattern)).default([]),
+    keyTakeaways: z.array(z.string().min(1)).max(8).default([]),
+    citationQuestions: z.array(z.string().min(1)).max(12).default([]),
+    canonicalConcepts: z.array(z.string().min(1)).max(20).default([]),
     content: z.string(),
   }),
   transform: async (document, context) => {
-    // Plain-markdown articles (.md) may contain literal `<` (e.g. "<5% oral",
-    // "<1%") that MDX's JSX parser misreads as a malformed tag start. Escape
-    // any `<` not immediately followed by a tag-name character, `/`, or `!`
-    // so it renders as literal text instead of failing the MDX compile.
     const sanitizedDocument = {
       ...document,
       content: document.content.replace(/<(?![a-zA-Z/!])/g, '&lt;'),
@@ -108,6 +106,10 @@ const blogPosts = defineCollection({
       readingTime: `${estimatedMinutes} min read`,
       evidenceGrade: '',
       references: [],
+      relatedSlugs: [],
+      keyTakeaways: [],
+      citationQuestions: [],
+      canonicalConcepts: [],
       body,
       url: `/articles/${document.slug}`,
     }

--- a/src/lib/__tests__/article-citation-metadata.test.ts
+++ b/src/lib/__tests__/article-citation-metadata.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  normalizeCitationMetadata,
+  resolveRelatedArticles,
+} from '../article-citation-metadata'
+
+describe('resolveRelatedArticles', () => {
+  const articles = [
+    { slug: 'current', category: 'Harm Reduction', relatedSlugs: ['curated-two', 'curated-one'] },
+    { slug: 'curated-one', category: 'Neuroscience' },
+    { slug: 'curated-two', category: 'History' },
+    { slug: 'fallback-one', category: 'Harm Reduction' },
+    { slug: 'fallback-two', category: 'Harm Reduction' },
+  ]
+
+  it('preserves curated order before category fallbacks', () => {
+    expect(resolveRelatedArticles(articles[0], articles).map((article) => article.slug)).toEqual([
+      'curated-two',
+      'curated-one',
+      'fallback-one',
+      'fallback-two',
+    ])
+  })
+
+  it('ignores missing and self-referential slugs', () => {
+    const current = {
+      slug: 'current',
+      category: 'Harm Reduction',
+      relatedSlugs: ['missing', 'current', 'curated-one'],
+    }
+
+    expect(resolveRelatedArticles(current, articles, 2).map((article) => article.slug)).toEqual([
+      'curated-one',
+      'fallback-one',
+    ])
+  })
+})
+
+describe('normalizeCitationMetadata', () => {
+  it('returns stable empty arrays for optional metadata', () => {
+    expect(normalizeCitationMetadata({})).toEqual({
+      keyTakeaways: [],
+      citationQuestions: [],
+      canonicalConcepts: [],
+    })
+  })
+})

--- a/src/lib/article-citation-metadata.ts
+++ b/src/lib/article-citation-metadata.ts
@@ -1,0 +1,40 @@
+export type ArticleRelationshipRecord = {
+  slug: string
+  category: string
+  relatedSlugs?: string[]
+}
+
+export type ArticleCitationMetadata = {
+  keyTakeaways?: string[]
+  citationQuestions?: string[]
+  canonicalConcepts?: string[]
+}
+
+export function resolveRelatedArticles<T extends ArticleRelationshipRecord>(
+  current: T,
+  articles: T[],
+  limit = 6
+): T[] {
+  const bySlug = new Map(articles.map((article) => [article.slug, article]))
+  const curated = (current.relatedSlugs ?? [])
+    .map((slug) => bySlug.get(slug))
+    .filter((article): article is T => Boolean(article) && article.slug !== current.slug)
+
+  const seen = new Set(curated.map((article) => article.slug))
+  const fallback = articles.filter(
+    (article) =>
+      article.slug !== current.slug &&
+      article.category === current.category &&
+      !seen.has(article.slug)
+  )
+
+  return [...curated, ...fallback].slice(0, limit)
+}
+
+export function normalizeCitationMetadata(metadata: ArticleCitationMetadata) {
+  return {
+    keyTakeaways: metadata.keyTakeaways ?? [],
+    citationQuestions: metadata.citationQuestions ?? [],
+    canonicalConcepts: metadata.canonicalConcepts ?? [],
+  }
+}

--- a/src/lib/article-citation-metadata.ts
+++ b/src/lib/article-citation-metadata.ts
@@ -10,6 +10,13 @@ export type ArticleCitationMetadata = {
   canonicalConcepts?: string[]
 }
 
+function isRelatedArticle<T extends ArticleRelationshipRecord>(
+  article: T | undefined,
+  currentSlug: string
+): article is T {
+  return article !== undefined && article.slug !== currentSlug
+}
+
 export function resolveRelatedArticles<T extends ArticleRelationshipRecord>(
   current: T,
   articles: T[],
@@ -18,7 +25,7 @@ export function resolveRelatedArticles<T extends ArticleRelationshipRecord>(
   const bySlug = new Map(articles.map((article) => [article.slug, article]))
   const curated = (current.relatedSlugs ?? [])
     .map((slug) => bySlug.get(slug))
-    .filter((article): article is T => Boolean(article) && article.slug !== current.slug)
+    .filter((article): article is T => isRelatedArticle(article, current.slug))
 
   const seen = new Set(curated.map((article) => article.slug))
   const fallback = articles.filter(


### PR DESCRIPTION
## Summary

Second citation-growth architecture batch:

- add optional article frontmatter for `relatedSlugs`, `keyTakeaways`, `citationQuestions`, and `canonicalConcepts`
- provide stable defaults for blog posts so article rendering has one metadata contract
- add a tested resolver that preserves curated related-article order, ignores invalid/self links, and fills remaining slots with category matches
- render visible questions answered and scientific takeaways when metadata is supplied
- emit `ItemList` structured data only for visible takeaways
- add normalized concepts to Article structured data through `about`
- cap automatic related articles at six instead of rendering every article in a category

## Safeguards

- all new fields are optional and backward-compatible
- structured data mirrors visible page content
- curated links take precedence without disabling sensible fallbacks
- unresolved related slugs fail soft rather than breaking a page
- review metadata remains separate and is never inferred

## Validation

- helper behavior is covered with Vitest
- existing articles do not need immediate migration
- the next batch can migrate Failure Chains and introduce the first canonical definition pages