### PR TITLE
SEO: canonicalize L-tyrosine under compounds

### DIFF
--- a/lib/deprecated-herb-canonicals.ts
+++ b/lib/deprecated-herb-canonicals.ts
@@ -2,6 +2,10 @@
 // profile (see public/_redirects and app/sitemap.ts). Source slugs are
 // excluded from generateStaticParams and from the /herbs browse/index
 // artifacts so the site never links to a redirected URL.
+//
+// Most targets are canonical herb slugs. Cross-taxonomy entries (currently
+// tyrosine) are paired with an explicit public/_redirects rule to the correct
+// compound URL and are always hidden from herb browse/index artifacts.
 export const DEPRECATED_HERB_CANONICALS: Record<string, string> = {
   'allium-sativum': 'garlic',
   'valeriana-officinalis': 'valerian',
@@ -20,15 +24,20 @@ export const DEPRECATED_HERB_CANONICALS: Record<string, string> = {
   'atractylodes-macrocephala': 'atractylodes',
   'angelica-sinensis': 'dong-quai',
   'angelica-root': 'angelica-archangelica',
+  // L-tyrosine is an amino-acid compound, not a botanical profile.
+  tyrosine: 'l-tyrosine',
 }
+
+const CROSS_TAXONOMY_REDIRECT_SLUGS = new Set(['tyrosine'])
 
 // True when `slug` redirects to a canonical that exists as its own record in
 // `presentSlugs` — i.e. the redirect source is a duplicate that should be
 // hidden from browse/index listings. Alias-served pairs whose target is not a
 // separate record (e.g. passionflower, kava) are kept so their profile stays
-// visible in the browse grid.
+// visible in the browse grid. Cross-taxonomy sources are always hidden.
 export function isRedirectedDuplicate(slug: string | undefined | null, presentSlugs: Set<string>): boolean {
   if (!slug) return false
+  if (CROSS_TAXONOMY_REDIRECT_SLUGS.has(slug)) return true
   const target = DEPRECATED_HERB_CANONICALS[slug]
   return !!target && presentSlugs.has(target)
 }

--- a/public/_redirects
+++ b/public/_redirects
@@ -82,6 +82,11 @@ https://www.thehippiescientist.net/* https://thehippiescientist.net/:splat 301
 /compounds/trans-resveratrol /herbs/resveratrol/ 301
 /herbs/ashwagandha-withania-somnifera /herbs/ashwagandha/ 301
 /herbs/ashwagandha-withania-somnifera/ /herbs/ashwagandha/ 301
+
+# Cross-taxonomy canonical: L-tyrosine is an amino-acid compound, not an herb.
+/herbs/tyrosine /compounds/l-tyrosine/ 301
+/herbs/tyrosine/ /compounds/l-tyrosine/ 301
+
 /safety-checker /safety-checker/ 301
 /safety /safety-checker/ 301
 /safety/ /safety-checker/ 301

--- a/src/lib/__tests__/tyrosine-canonical.test.ts
+++ b/src/lib/__tests__/tyrosine-canonical.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import {
+  DEPRECATED_HERB_CANONICALS,
+  isRedirectedDuplicate,
+} from '../../../lib/deprecated-herb-canonicals'
+
+describe('L-tyrosine canonical taxonomy', () => {
+  it('removes the legacy herb record from herb browse and static route generation', () => {
+    expect(DEPRECATED_HERB_CANONICALS.tyrosine).toBe('l-tyrosine')
+    expect(isRedirectedDuplicate('tyrosine', new Set(['tyrosine']))).toBe(true)
+  })
+
+  it('redirects both herb URL variants directly to the compound canonical', () => {
+    const redirects = readFileSync(path.join(process.cwd(), 'public/_redirects'), 'utf8')
+
+    expect(redirects).toContain('/herbs/tyrosine /compounds/l-tyrosine/ 301')
+    expect(redirects).toContain('/herbs/tyrosine/ /compounds/l-tyrosine/ 301')
+  })
+})


### PR DESCRIPTION
## What changed
- Redirect `/herbs/tyrosine` and `/herbs/tyrosine/` directly to `/compounds/l-tyrosine/`
- Exclude the legacy tyrosine herb record from static generation and herb browse/index artifacts
- Add regression tests for route governance and both redirect variants

## Why
The live site exposes L-tyrosine in both herb and compound taxonomies. Consolidating to the compound profile removes duplicate/cross-taxonomy indexing signals, concentrates authority on one canonical URL, and prevents the herb library from linking to a redirected page.

## Validation
- Diff reviewed: 3 files, 37 additions, 1 deletion
- CI requested for repository test/build/SEO checks