### PR TITLE
Polish mobile recommendation browsing

### DIFF
--- a/components/AffiliateProductCard.tsx
+++ b/components/AffiliateProductCard.tsx
@@ -55,8 +55,8 @@ export default function AffiliateProductCard({ product, compact = false }: Affil
             alt={title}
             width={400}
             height={300}
-            sizes="(max-width: 768px) 100vw, 33vw"
-            quality={85}
+            sizes="(max-width: 767px) 272px, (max-width: 1024px) 33vw, 320px"
+            quality={78}
             decoding="async"
             className="h-full w-full object-cover"
           />
@@ -83,6 +83,7 @@ export default function AffiliateProductCard({ product, compact = false }: Affil
             href={affiliateUrl}
             target='_blank'
             rel={getOutboundLinkRel(true)}
+            aria-label={`${ctaLabel} for ${title} (opens in a new tab)`}
             onClick={() => trackRevenueEvent({
               kind: 'recommendation_click',
               location: product.trackingLocation || 'recommendation-section',

--- a/components/RecommendationSection.tsx
+++ b/components/RecommendationSection.tsx
@@ -1,6 +1,7 @@
 import AffiliateDisclosure from './AffiliateDisclosure'
 import AffiliateProductCard, { type AffiliateProduct } from './AffiliateProductCard'
 import WhyWeRecommend from '../src/components/monetization/WhyWeRecommend'
+import HorizontalCardRail from './ui/HorizontalCardRail'
 
 export type RecommendationSlot = 'budget' | 'overall' | 'premium'
 
@@ -39,15 +40,15 @@ export default function RecommendationSection({
   return (
     <section className='card-premium p-4 sm:p-5'>
       <div className='max-w-3xl'>
-        <p className='eyebrow-label'>Affiliate-ready sourcing</p>
+        <p className='eyebrow-label'>Sourcing options</p>
         <h2 className='mt-1 text-lg font-semibold text-ink'>{title}</h2>
         <p className='mt-1 text-sm leading-6 text-muted'>{description}</p>
         <AffiliateDisclosure variant='compact' className='mt-2' />
       </div>
 
-      <div className='mt-4 flex gap-3 overflow-x-auto pb-2 [-webkit-overflow-scrolling:touch] [scrollbar-width:thin] md:grid md:grid-cols-3 md:gap-4 md:overflow-visible md:pb-0'>
+      <HorizontalCardRail label={`${title} options`}>
         {ordered.map((product) => (
-          <div key={`${product.slot}-${product.title || product.name}`} className='flex w-[16rem] shrink-0 flex-col gap-2 md:w-auto md:shrink'>
+          <div key={`${product.slot}-${product.title || product.name}`} className='flex h-full flex-col gap-2'>
             <p className='text-xs font-bold uppercase tracking-[0.16em] text-brand-700 dark:text-brand-200'>{slotLabels[product.slot]}</p>
             <AffiliateProductCard
               product={{
@@ -59,7 +60,7 @@ export default function RecommendationSection({
             />
           </div>
         ))}
-      </div>
+      </HorizontalCardRail>
 
       <WhyWeRecommend className='mt-4' />
     </section>

--- a/components/StackRecommendationSection.tsx
+++ b/components/StackRecommendationSection.tsx
@@ -1,6 +1,7 @@
 import AffiliateDisclosure from './AffiliateDisclosure'
 import AffiliateProductCard from './AffiliateProductCard'
 import type { StackRecommendation } from '../src/lib/recommendation-engine'
+import HorizontalCardRail from './ui/HorizontalCardRail'
 
 interface StackRecommendationSectionProps {
   productName: string
@@ -14,7 +15,7 @@ export default function StackRecommendationSection({
   if (!recommendations.length) return null
 
   return (
-    <section className='rounded-[1.5rem] border border-brand-900/10 bg-white/80 p-4 shadow-sm sm:p-5'>
+    <section className='rounded-[1.5rem] border border-brand-900/10 bg-white/80 p-4 shadow-sm sm:p-5 dark:border-white/10 dark:bg-white/5'>
       <div className='max-w-3xl'>
         <p className='text-xs font-bold uppercase tracking-[0.18em] text-brand-700'>Supplement stacking</p>
         <h2 className='mt-1 text-lg font-semibold text-ink'>Stack {productName} With</h2>
@@ -24,10 +25,10 @@ export default function StackRecommendationSection({
         <AffiliateDisclosure variant='compact' className='mt-2' />
       </div>
 
-      <div className='mt-4 flex gap-3 overflow-x-auto pb-2 [-webkit-overflow-scrolling:touch] [scrollbar-width:thin] md:grid md:grid-cols-3 md:gap-4 md:overflow-visible md:pb-0'>
+      <HorizontalCardRail label={`Stack recommendations for ${productName}`}>
         {recommendations.map((rec) => (
-          <div key={rec.targetSlug} className='flex w-[16rem] shrink-0 flex-col gap-2 md:w-auto md:shrink'>
-            <p className='text-xs font-bold uppercase tracking-[0.16em] text-brand-700'>Pairs well</p>
+          <div key={rec.targetSlug} className='flex h-full flex-col gap-2'>
+            <p className='text-xs font-bold uppercase tracking-[0.16em] text-brand-700 dark:text-brand-200'>Pairs well</p>
             <AffiliateProductCard
               product={{
                 ...rec.product,
@@ -38,7 +39,7 @@ export default function StackRecommendationSection({
             />
           </div>
         ))}
-      </div>
+      </HorizontalCardRail>
     </section>
   )
 }

--- a/components/__tests__/AffiliateProductCard.regional.test.tsx
+++ b/components/__tests__/AffiliateProductCard.regional.test.tsx
@@ -63,4 +63,22 @@ describe('AffiliateProductCard regional URLs', () => {
       'sponsored nofollow noopener noreferrer',
     )
   })
+
+  it('announces the product and new-tab behavior on the outbound action', () => {
+    render(
+      <AffiliateProductCard
+        product={{
+          title: 'Test Saffron',
+          ctaLabel: 'View retailer',
+          affiliateUrl: 'https://www.amazon.com/test-saffron',
+        }}
+      />,
+    )
+
+    expect(
+      screen.getByRole('link', {
+        name: 'View retailer for Test Saffron (opens in a new tab)',
+      }),
+    ).toBeVisible()
+  })
 })

--- a/components/ui/HorizontalCardRail.tsx
+++ b/components/ui/HorizontalCardRail.tsx
@@ -1,0 +1,46 @@
+/* eslint-disable jsx-a11y/no-noninteractive-tabindex -- Horizontally scrollable card rails must be keyboard reachable. */
+import { Children, type ReactNode } from 'react'
+
+type HorizontalCardRailProps = {
+  children: ReactNode
+  label: string
+  className?: string
+}
+
+export default function HorizontalCardRail({
+  children,
+  label,
+  className = '',
+}: HorizontalCardRailProps) {
+  const items = Children.toArray(children)
+
+  if (items.length === 0) return null
+
+  return (
+    <div className={`mt-4 ${className}`}>
+      {items.length > 1 ? (
+        <p
+          aria-hidden="true"
+          className="mb-2 flex items-center justify-end gap-1 text-[0.68rem] font-semibold text-muted md:hidden"
+        >
+          Swipe to compare <span className="text-brand-700">→</span>
+        </p>
+      ) : null}
+
+      <ul
+        aria-label={label}
+        tabIndex={0}
+        className="flex list-none snap-x snap-mandatory scroll-px-1 gap-3 overflow-x-auto overscroll-x-contain pb-2 [scrollbar-width:thin] focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40 md:grid md:grid-cols-3 md:gap-4 md:overflow-visible md:pb-0 md:focus-visible:ring-0"
+      >
+        {items.map((item, index) => (
+          <li
+            key={index}
+            className="flex w-[calc(100%-1rem)] min-w-0 max-w-[17rem] shrink-0 snap-start flex-col md:w-auto md:max-w-none"
+          >
+            {item}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/components/ui/__tests__/HorizontalCardRail.test.tsx
+++ b/components/ui/__tests__/HorizontalCardRail.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, within } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import HorizontalCardRail from '../HorizontalCardRail'
+
+describe('HorizontalCardRail', () => {
+  it('makes multiple mobile cards a labeled, keyboard-reachable snap rail', () => {
+    render(
+      <HorizontalCardRail label="Product recommendation options">
+        <article>Budget option</article>
+        <article>Premium option</article>
+      </HorizontalCardRail>,
+    )
+
+    const rail = screen.getByRole('list', { name: 'Product recommendation options' })
+
+    expect(rail).toHaveAttribute('tabindex', '0')
+    expect(rail.className).toContain('overflow-x-auto')
+    expect(rail.className).toContain('snap-x')
+    expect(within(rail).getAllByRole('listitem')).toHaveLength(2)
+    expect(screen.getByText('Swipe to compare')).toBeVisible()
+  })
+
+  it('omits the swipe cue when there is only one card', () => {
+    render(
+      <HorizontalCardRail label="Single recommendation">
+        <article>Only option</article>
+      </HorizontalCardRail>,
+    )
+
+    expect(screen.queryByText('Swipe to compare')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- introduce a reusable, labeled card rail for recommendation and stack sections
- make mobile recommendation browsing keyboard reachable, snap-aligned, and visually cued
- preserve a non-scrolling three-column comparison grid on larger screens
- clarify the section eyebrow from internal jargon to “Sourcing options”
- announce product identity and new-tab behavior on outbound actions
- reduce requested affiliate-card image candidates on mobile and improve stack-section dark mode

## Growth and affiliate-readiness impact
This improves a live high-intent surface reused across herb, compound, comparison, and guide pages. Visitors can more easily discover and compare all available sourcing options on small screens, while existing disclosure, sponsored-link semantics, and revenue-event tracking remain intact. No affiliate programs, links, tracking IDs, claims, policies, or integrations are added.

## Validation
- targeted ESLint
- 11 focused/accessibility tests
- `npm run typecheck`
- `npx next build` (1,192 static pages)
- `npm run verify:postbuild` (706 sitemap URLs; affiliate-link audit passed)
- exported-page QA at 320px and 1440px plus dark mode

The browser QA caught and corrected an initial viewport-relative card width before this PR was opened.