### PR TITLE
Improve ADHD checklist discovery

### DIFF
--- a/app/guides/adhd/page.tsx
+++ b/app/guides/adhd/page.tsx
@@ -186,6 +186,28 @@ export default function AdhdGuideIndex() {
         </p>
       </header>
 
+      <aside className="mb-12 overflow-hidden rounded-2xl border border-brand-900/12 bg-gradient-to-br from-brand-50 to-white p-5 shadow-sm dark:border-white/10 dark:from-[var(--surface-card)] dark:to-[var(--surface-subtle)] sm:p-7">
+        <div className="grid gap-5 sm:grid-cols-[1fr_auto] sm:items-center">
+          <div>
+            <p className="eyebrow-label">Free printable tool</p>
+            <h2 className="mt-2 font-display text-2xl font-semibold tracking-tight text-ink">
+              Plan one careful change at a time
+            </h2>
+            <p className="mt-2 max-w-2xl text-sm leading-7 text-muted">
+              Use the ADHD Supplement Starter Checklist to record your baseline, review safety
+              questions, and track one change across four weeks. No signup is required to preview
+              or print it.
+            </p>
+          </div>
+          <Link
+            href="/lead-magnets/adhd-supplement-starter-checklist/"
+            className="button-primary inline-flex min-h-11 items-center justify-center px-5 py-3 text-center text-sm sm:whitespace-nowrap"
+          >
+            Open the checklist
+          </Link>
+        </div>
+      </aside>
+
       {/* Start Here — decision routing */}
       <section className="mb-12">
         <HubSectionHeading

--- a/components/ClickTracker.tsx
+++ b/components/ClickTracker.tsx
@@ -2,7 +2,12 @@
 
 import { useEffect, useRef } from 'react'
 import { usePathname } from 'next/navigation'
-import { getGuideTrackingContext, trackAffiliateClick, trackGuideView } from '@/lib/analytics'
+import {
+  getGuideTrackingContext,
+  trackAffiliateClick,
+  trackGuideView,
+  trackLeadMagnetClick,
+} from '@/lib/analytics'
 import { CONSENT_GRANTED_EVENT, getConsent } from '../src/lib/consent'
 import { loadAnalytics } from '../src/lib/loadAnalytics'
 
@@ -36,6 +41,14 @@ export default function ClickTracker() {
       if (!link) return
 
       const href = link.getAttribute('href') || ''
+      const leadMagnetMatch = href.match(/^\/lead-magnets\/([^/?#]+)/)
+
+      if (leadMagnetMatch && getConsent() === 'granted') {
+        trackLeadMagnetClick({
+          slug: leadMagnetMatch[1],
+          sourcePath: window.location.pathname,
+        })
+      }
       
       // Determine if it's an outbound / affiliate link
       const isAffiliate = 

--- a/components/__tests__/ClickTracker.test.tsx
+++ b/components/__tests__/ClickTracker.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render } from '@testing-library/react'
+import Link from 'next/link'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import ClickTracker from '../ClickTracker'
+
+const mocks = vi.hoisted(() => ({
+  getConsent: vi.fn(),
+  trackLeadMagnetClick: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/guides/adhd/',
+}))
+
+vi.mock('@/lib/analytics', () => ({
+  getGuideTrackingContext: () => null,
+  trackAffiliateClick: vi.fn(),
+  trackGuideView: vi.fn(),
+  trackLeadMagnetClick: mocks.trackLeadMagnetClick,
+}))
+
+vi.mock('@/src/lib/consent', () => ({
+  CONSENT_GRANTED_EVENT: 'consent-granted',
+  getConsent: mocks.getConsent,
+}))
+
+vi.mock('@/src/lib/loadAnalytics', () => ({
+  loadAnalytics: vi.fn(),
+}))
+
+afterEach(() => {
+  mocks.getConsent.mockReset()
+  mocks.trackLeadMagnetClick.mockReset()
+})
+
+describe('ClickTracker', () => {
+  it('tracks lead-magnet clicks after analytics consent', () => {
+    mocks.getConsent.mockReturnValue('granted')
+    render(
+      <>
+        <ClickTracker />
+        <Link href="/lead-magnets/adhd-supplement-starter-checklist/" onClick={(event) => event.preventDefault()}>
+          Open checklist
+        </Link>
+      </>,
+    )
+
+    fireEvent.click(document.querySelector('a')!)
+
+    expect(mocks.trackLeadMagnetClick).toHaveBeenCalledWith({
+      slug: 'adhd-supplement-starter-checklist',
+      sourcePath: '/',
+    })
+  })
+
+  it('does not track before analytics consent', () => {
+    mocks.getConsent.mockReturnValue('unknown')
+    render(
+      <>
+        <ClickTracker />
+        <Link href="/lead-magnets/adhd-supplement-starter-checklist/" onClick={(event) => event.preventDefault()}>
+          Open checklist
+        </Link>
+      </>,
+    )
+
+    fireEvent.click(document.querySelector('a')!)
+
+    expect(mocks.trackLeadMagnetClick).not.toHaveBeenCalled()
+  })
+})

--- a/components/articles/EmailCapture.tsx
+++ b/components/articles/EmailCapture.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { FormEvent, useId, useState } from 'react'
+import Link from 'next/link'
 import { trackEmailSignup } from '@/lib/analytics'
 
 type EmailCaptureProps = {
@@ -56,11 +57,18 @@ export default function EmailCapture({ title, description, ctaLabel, magnet }: E
   return (
     <aside className="my-10 rounded-3xl border border-brand-900/10 bg-brand-50/70 p-5 shadow-sm sm:p-7" aria-labelledby={titleId}>
       <div className="space-y-3">
-        <p className="eyebrow-label">Free checklist</p>
+        <p className="eyebrow-label">Free printable checklist</p>
         <h2 id={titleId} className="font-display text-2xl font-semibold tracking-tight text-ink sm:text-3xl">
           {title}
         </h2>
         <p className="max-w-2xl text-base leading-7 text-muted">{description}</p>
+        <p className="text-sm leading-6 text-muted">
+          Want to review it first?{' '}
+          <Link className="font-semibold text-brand-800 underline decoration-brand-700/35 underline-offset-4 hover:text-brand-900" href={CHECKLIST_URL}>
+            Preview and print the checklist
+          </Link>
+          .
+        </p>
       </div>
 
       {state === 'success' ? (

--- a/components/articles/__tests__/EmailCapture.test.tsx
+++ b/components/articles/__tests__/EmailCapture.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import EmailCapture from '../EmailCapture'
+
+describe('article EmailCapture', () => {
+  it('lets readers preview the public checklist before subscribing', () => {
+    render(
+      <EmailCapture
+        title="Get the ADHD Supplement Starter Checklist"
+        description="Track one change at a time."
+        ctaLabel="Send me the checklist"
+        magnet="adhd-supplement-starter-checklist"
+      />,
+    )
+
+    expect(screen.getByRole('link', { name: /preview and print the checklist/i })).toHaveAttribute(
+      'href',
+      '/lead-magnets/adhd-supplement-starter-checklist',
+    )
+    expect(screen.getByRole('button', { name: /send me the checklist/i })).toBeEnabled()
+  })
+})

--- a/lib/__tests__/analytics.test.ts
+++ b/lib/__tests__/analytics.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { getGuideTrackingContext, trackGuideView } from '../analytics'
+import { getGuideTrackingContext, trackGuideView, trackLeadMagnetClick } from '../analytics'
 
 afterEach(() => {
   delete (window as Window & { gtag?: unknown }).gtag
@@ -41,6 +41,21 @@ describe('guide analytics', () => {
       guide_slug: 'magnesium-for-sleep',
       guide_cluster: 'sleep',
       page_path: '/guides/sleep/magnesium-for-sleep/',
+    })
+  })
+
+  it('tracks a lead magnet with its source path', () => {
+    const gtag = vi.fn()
+    ;(window as Window & { gtag?: unknown }).gtag = gtag
+
+    trackLeadMagnetClick({
+      slug: 'adhd-supplement-starter-checklist',
+      sourcePath: '/guides/adhd/',
+    })
+
+    expect(gtag).toHaveBeenCalledWith('event', 'lead_magnet_click', {
+      lead_magnet_slug: 'adhd-supplement-starter-checklist',
+      source_path: '/guides/adhd/',
     })
   })
 })

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -2,7 +2,7 @@
 
 type Gtag = (
   command: 'event',
-  eventName: 'affiliate_click' | 'email_signup' | 'guide_view',
+  eventName: 'affiliate_click' | 'email_signup' | 'guide_view' | 'lead_magnet_click',
   params: Record<string, string | number | boolean | undefined>,
 ) => void
 
@@ -40,6 +40,17 @@ export function trackEmailSignup(params: { source: string }): void {
     })
   } catch {
     // Analytics must never block signup flow.
+  }
+}
+
+export function trackLeadMagnetClick(params: { slug: string; sourcePath: string }): void {
+  try {
+    getGtag()?.('event', 'lead_magnet_click', {
+      lead_magnet_slug: params.slug,
+      source_path: params.sourcePath,
+    })
+  } catch {
+    // Analytics must never block resource access.
   }
 }
 

--- a/scripts/ci/audit-internal-links.mjs
+++ b/scripts/ci/audit-internal-links.mjs
@@ -55,7 +55,8 @@ if (!FULL_HTML_AUDIT) {
 
 const routes=new Set(files.map(routeFromFile))
 const graph=new Map([...routes].map(r=>[r,new Set()]))
-const hrefRe=/href=["'](\/[^"'#\s>]+)["']/g
+const inboundGraph=new Map([...routes].map(r=>[r,new Set()]))
+const hrefRe=/href=["'](\/[^"'#\s>]*)["']/g
 const robotsNoindexRe=/<meta\b(?=[^>]*\bname=["']robots["'])(?=[^>]*\bcontent=["'][^"']*\bnoindex\b)[^>]*>/i
 
 function nonCanonicalInternalHref(href) {
@@ -109,7 +110,10 @@ async function run() {
         const nonCanonical = nonCanonicalInternalHref(h)
         if (nonCanonical) nonCanonicalInternalLinks.push({ source: route, ...nonCanonical })
         const t=h.split('?')[0].replace(/\/$/,'')||'/';
-        if(graph.has(t)) graph.get(route).add(t)
+        if(graph.has(t)) {
+          graph.get(route).add(t)
+          if (t !== route) inboundGraph.get(t).add(route)
+        }
       }
       const duration = Date.now() - start;
       if (duration > 100) {
@@ -118,13 +122,15 @@ async function run() {
     }))
   }
 
-  const orphan=[...graph.entries()].filter(([,o])=>o.size===0).map(([r])=>r)
-  const weak=[...graph.entries()].filter(([,o])=>o.size>0&&o.size<3).map(([r,o])=>({route:r,outbound:o.size}))
+  const orphan=[...inboundGraph.entries()].filter(([,incoming])=>incoming.size===0).map(([r])=>r)
+  const weak=[...inboundGraph.entries()]
+    .filter(([,incoming])=>incoming.size>0&&incoming.size<3)
+    .map(([r,incoming])=>({route:r,inbound:incoming.size}))
   const density=[...graph.entries()].map(([r,o])=>({route:r,outbound:o.size})).sort((a,b)=>b.outbound-a.outbound)
   const nonCanonicalSummary = summarizeNonCanonicalLinks(nonCanonicalInternalLinks)
   const report={generatedAt:new Date().toISOString(),totalRoutes:routes.size,orphanRoutes:orphan,weaklyConnected:weak,internalLinkDensity:density.slice(0,100),nonCanonicalInternalLinks,nonCanonicalSummary}
   fs.mkdirSync(path.join(root,'ops','reports'),{recursive:true}); fs.writeFileSync(path.join(root,'ops/reports/internal-link-report.json'),JSON.stringify(report,null,2));
-  const nonIndexable = orphan.filter(r => r === '/500' || r.startsWith('/_not-found') || r.startsWith('/sitemap.xml') || r.startsWith('/robots.txt') || r.startsWith('/opengraph-image') || r.startsWith('/twitter-image') || r.startsWith('/blogdata') || noindexRoutes.has(r))
+  const nonIndexable = orphan.filter(r => r === '/404' || r === '/500' || r.startsWith('/_not-found') || r.startsWith('/sitemap.xml') || r.startsWith('/robots.txt') || r.startsWith('/opengraph-image') || r.startsWith('/twitter-image') || r.startsWith('/blogdata') || noindexRoutes.has(r))
   const blockingOrphans = orphan.filter(r => !nonIndexable.includes(r))
   const topNonCanonicalSource = nonCanonicalSummary.topSourceRoutes[0]
   console.log(`internal-links: routes=${routes.size}, orphan=${orphan.length}, blockingOrphan=${blockingOrphans.length}, weak=${weak.length}, nonCanonical=${nonCanonicalInternalLinks.length}`)


### PR DESCRIPTION
## Summary
- surface the existing printable ADHD checklist on the ADHD guide hub and before article signup
- add consent-gated lead-magnet click measurement using the existing analytics layer
- fix the internal-link audit so orphan and weak-link reporting measures inbound links

## Validation
- targeted ESLint
- 8 focused Vitest tests
- npm run typecheck
- Next static export (1,192 pages)
- npm run verify:postbuild
- full HTML internal-link audit (checklist no longer orphaned)
- mobile 320px, desktop, and dark-mode browser QA