### PR TITLE
Add a complete supplement topic guide hub

### DIFF
--- a/app/guides/other/__tests__/topic-guide-hub.test.ts
+++ b/app/guides/other/__tests__/topic-guide-hub.test.ts
@@ -1,0 +1,19 @@
+import { existsSync, readdirSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import { ALL_TOPIC_GUIDES } from '../topic-guides'
+
+describe('topic guide hub', () => {
+  it('links every published topic-guide route exactly once', () => {
+    const routeRoot = path.join(process.cwd(), 'app', 'guides', 'other')
+    const publishedRoutes = readdirSync(routeRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && existsSync(path.join(routeRoot, entry.name, 'page.tsx')))
+      .map((entry) => `/guides/other/${entry.name}/`)
+      .sort()
+    const hubRoutes = ALL_TOPIC_GUIDES.map((guide) => guide.href).sort()
+
+    expect(new Set(hubRoutes).size).toBe(hubRoutes.length)
+    expect(hubRoutes).toEqual(publishedRoutes)
+  })
+})

--- a/app/guides/other/__tests__/topic-guide-hub.test.ts
+++ b/app/guides/other/__tests__/topic-guide-hub.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 
@@ -15,5 +15,15 @@ describe('topic guide hub', () => {
 
     expect(new Set(hubRoutes).size).toBe(hubRoutes.length)
     expect(hubRoutes).toEqual(publishedRoutes)
+  })
+
+  it('is not shadowed by a legacy redirect override', () => {
+    const redirectRoot = path.join(process.cwd(), 'public', 'redirect-overrides')
+    const redirects = readdirSync(redirectRoot)
+      .filter((file) => file.endsWith('.txt'))
+      .flatMap((file) => readFileSync(path.join(redirectRoot, file), 'utf8').split(/\r?\n/))
+      .filter((line) => !line.trimStart().startsWith('#'))
+
+    expect(redirects.some((line) => /^\/guides\/other\/?\s/.test(line))).toBe(false)
   })
 })

--- a/app/guides/other/page.tsx
+++ b/app/guides/other/page.tsx
@@ -1,0 +1,105 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+import { GuideCardGrid } from '@/components/guides/GuideCardGrid'
+import { HubSectionHeading } from '@/components/guides/HubSectionHeading'
+import SchemaGraphScript from '@/components/seo/SchemaGraphScript'
+import { SITE_URL } from '@/src/lib/seo'
+import { buildGuideHubSchemaGraph } from '@/src/lib/schema-graph'
+
+import { ALL_TOPIC_GUIDES, TOPIC_GUIDE_GROUPS } from './topic-guides'
+
+const TITLE = 'Supplement Topic Guides'
+const DESCRIPTION =
+  'Browse evidence-first guides on supplement forms, popular categories, goal-based routines, advanced compounds, and harm reduction.'
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  alternates: { canonical: `${SITE_URL}/guides/other/` },
+  openGraph: {
+    title: `${TITLE} | The Hippie Scientist`,
+    description: DESCRIPTION,
+    url: `${SITE_URL}/guides/other/`,
+    type: 'website',
+    images: ['/og-default.jpg'],
+  },
+}
+
+export default function TopicGuideHub() {
+  const schemaGraph = buildGuideHubSchemaGraph({
+    path: '/guides/other/',
+    title: TITLE,
+    description: DESCRIPTION,
+    breadcrumbs: [
+      { name: 'Home', url: `${SITE_URL}/` },
+      { name: 'Guides', url: `${SITE_URL}/guides/` },
+      { name: 'Topic Guides', url: `${SITE_URL}/guides/other/` },
+    ],
+    itemListName: 'Supplement Topic Guides',
+    items: ALL_TOPIC_GUIDES.map((guide) => ({ name: guide.title, url: guide.href })),
+  })
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 pb-24 pt-8">
+      <SchemaGraphScript graph={schemaGraph} />
+
+      <nav className="mb-4 text-xs text-muted" aria-label="Topic guide breadcrumb">
+        <Link href="/guides/" className="hover:text-ink">Guides</Link>
+        <span className="mx-1.5">/</span>
+        <span className="font-medium text-ink">Topic guides</span>
+      </nav>
+
+      <header className="mb-10">
+        <p className="eyebrow-label">Evidence library</p>
+        <h1 className="mt-2 font-display text-3xl font-semibold tracking-tight text-ink sm:text-5xl">
+          Supplement Topic Guides
+        </h1>
+        <p className="mt-4 max-w-3xl text-lg leading-8 text-muted">
+          Find the question closest to yours—from choosing a magnesium form to understanding a
+          research peptide. These guides organize evidence, tradeoffs, safety context, and what
+          remains uncertain.
+        </p>
+      </header>
+
+      <nav aria-label="Topic guide sections" className="mb-14 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {TOPIC_GUIDE_GROUPS.map((group) => (
+          <a
+            key={group.id}
+            href={`#${group.id}`}
+            className="rounded-xl border border-brand-900/12 bg-white p-4 transition hover:border-brand-700/30 hover:bg-brand-50 dark:border-white/10 dark:bg-[var(--surface-card)] dark:hover:bg-white/10"
+          >
+            <span className="block text-[11px] font-bold uppercase tracking-widest text-brand-700">
+              {group.guides.length} guides
+            </span>
+            <span className="mt-1 block font-semibold text-ink">{group.eyebrow}</span>
+          </a>
+        ))}
+      </nav>
+
+      <div className="space-y-16">
+        {TOPIC_GUIDE_GROUPS.map((group) => (
+          <section key={group.id} id={group.id} className="scroll-mt-28">
+            <HubSectionHeading
+              eyebrow={group.eyebrow}
+              title={group.title}
+              sub={group.description}
+            />
+            <GuideCardGrid cards={group.guides} />
+          </section>
+        ))}
+      </div>
+
+      <aside className="mt-16 rounded-2xl border border-brand-900/12 bg-brand-50/60 p-6 dark:border-white/10 dark:bg-[var(--surface-subtle)]">
+        <h2 className="font-display text-xl font-semibold text-ink">Looking for a goal-specific guide?</h2>
+        <p className="mt-2 text-sm leading-7 text-muted">
+          ADHD, sleep, anxiety, focus, comparisons, and best-of guides have dedicated hubs with
+          shorter decision paths.
+        </p>
+        <Link href="/guides/" className="mt-4 inline-flex font-semibold text-brand-800 hover:underline">
+          Return to the full evidence library →
+        </Link>
+      </aside>
+    </div>
+  )
+}

--- a/app/guides/other/topic-guides.ts
+++ b/app/guides/other/topic-guides.ts
@@ -1,0 +1,96 @@
+import type { GuideCard } from '@/components/guides/GuideCardGrid'
+
+export type TopicGuideGroup = {
+  id: string
+  eyebrow: string
+  title: string
+  description: string
+  guides: GuideCard[]
+}
+
+export const TOPIC_GUIDE_GROUPS: TopicGuideGroup[] = [
+  {
+    id: 'forms-and-formulas',
+    eyebrow: 'Forms and formulas',
+    title: 'Choose the right version',
+    description:
+      'Use these when the ingredient is familiar but the form, dose, quality markers, or label is not.',
+    guides: [
+      { href: '/guides/other/b-complex-guide/', title: 'B-Complex Vitamins', desc: 'Compare the major B vitamins, common forms, and when supplementation is worth discussing.' },
+      { href: '/guides/other/curcumin-absorption-guide/', title: 'Curcumin Absorption', desc: 'Compare piperine, phytosome, and other formulation approaches.' },
+      { href: '/guides/other/electrolyte-supplements/', title: 'Electrolyte Supplements', desc: 'When electrolyte products may fit—and when water may be enough.' },
+      { href: '/guides/other/green-tea-egcg-guide/', title: 'Green Tea Extract and EGCG', desc: 'Review extract dosing, evidence context, and high-dose safety concerns.' },
+      { href: '/guides/other/glutathione-nac-guide/', title: 'NAC and Glutathione', desc: 'Understand how these related antioxidant pathways and supplements differ.' },
+      { href: '/guides/other/iron-supplement-guide/', title: 'Iron Supplements', desc: 'Compare common forms and why testing matters before supplementing.' },
+      { href: '/guides/other/magnesium-types-guide/', title: 'Magnesium Types Compared', desc: 'Match glycinate, citrate, threonate, oxide, and other forms to practical tradeoffs.' },
+      { href: '/guides/other/omega-3-quality-guide/', title: 'Omega-3 Quality Guide', desc: 'Read EPA/DHA labels, oil forms, oxidation signals, and quality markers.' },
+      { href: '/guides/other/protein-powder-guide/', title: 'Protein Powders Compared', desc: 'Compare whey, casein, plant, and collagen products by use case.' },
+      { href: '/guides/other/vitamin-d-k2-guide/', title: 'Vitamin D and K2', desc: 'Review evidence, dosing context, and the rationale behind combining them.' },
+      { href: '/guides/other/zinc-supplement-guide/', title: 'Zinc Supplements', desc: 'Compare common forms, dosing context, and long-term safety considerations.' },
+    ],
+  },
+  {
+    id: 'everyday-topics',
+    eyebrow: 'Everyday topics',
+    title: 'Evaluate popular supplement categories',
+    description:
+      'Evidence-first reviews for categories that attract strong marketing but still require careful product and goal matching.',
+    guides: [
+      { href: '/guides/other/apple-cider-vinegar/', title: 'Apple Cider Vinegar', desc: 'Separate evidence on blood sugar, weight, and digestion from trend claims.' },
+      { href: '/guides/other/bovine-colostrum/', title: 'Bovine Colostrum', desc: 'Review immune, gut, performance, and safety evidence behind the category.' },
+      { href: '/guides/other/collagen-supplements/', title: 'Collagen Supplements', desc: 'Compare evidence for skin, joints, bone, and muscle-related goals.' },
+      { href: '/guides/other/coq10-guide/', title: 'CoQ10', desc: 'Understand ubiquinone, ubiquinol, and the conditions where CoQ10 is most discussed.' },
+      { href: '/guides/other/creatine-brain-health/', title: 'Creatine for Brain Health', desc: 'Look beyond sports use to cognition, fatigue, and sleep-deprivation research.' },
+      { href: '/guides/other/functional-mushrooms-guide/', title: 'Functional Mushrooms Compared', desc: 'Compare lion’s mane, reishi, cordyceps, and other mushroom categories.' },
+      { href: '/guides/other/greens-powders/', title: 'Greens Powders', desc: 'Assess nutrient-filling evidence and the limits of broad wellness claims.' },
+      { href: '/guides/other/lions-mane-guide/', title: 'Lion’s Mane Mushroom', desc: 'Review cognition, mood, mechanism, dosing, and evidence limitations.' },
+      { href: '/guides/other/prebiotics/', title: 'Prebiotics', desc: 'Compare supplemental fibers with food sources and goal-specific evidence.' },
+      { href: '/guides/other/probiotic-strains-guide/', title: 'Probiotic Strains', desc: 'Choose by strain and use case instead of relying on CFU count alone.' },
+    ],
+  },
+  {
+    id: 'goals-and-routines',
+    eyebrow: 'Goals and routines',
+    title: 'Start with the outcome or decision',
+    description:
+      'Use these broader guides to compare options, plan a routine, or identify what should be checked first.',
+    guides: [
+      { href: '/guides/other/adaptogens-compared/', title: 'Adaptogens Compared', desc: 'Compare ashwagandha, rhodiola, holy basil, eleuthero, and schisandra.' },
+      { href: '/guides/other/anti-inflammatory-supplements/', title: 'Anti-Inflammatory Supplements', desc: 'Compare curcumin, omega-3, ginger, boswellia, and quercetin evidence.' },
+      { href: '/guides/other/berberine-weight-loss/', title: 'Berberine and Weight Loss', desc: 'Review clinical evidence, safety, and the limits of GLP-1 comparisons.' },
+      { href: '/guides/other/intermittent-fasting-supplements/', title: 'Supplements and Intermittent Fasting', desc: 'Check which products may support a fast and which change its purpose.' },
+      { href: '/guides/other/menopause-supplements/', title: 'Menopause Supplements', desc: 'Compare evidence for common symptom-focused supplement options.' },
+      { href: '/guides/other/nmn-supplements/', title: 'NMN Supplements', desc: 'Review human evidence, safety, and the gap between NAD+ and lifespan claims.' },
+      { href: '/guides/other/nootropic-stacking-guide/', title: 'Nootropic Stacking', desc: 'Build simpler combinations with mechanism, dosing, and interaction context.' },
+      { href: '/guides/other/saffron-supplement/', title: 'Saffron and Mood', desc: 'Review the mood evidence, safety context, and study limitations.' },
+      { href: '/guides/other/sleep-supplements-guide/', title: 'Sleep Supplements', desc: 'Compare melatonin, magnesium, L-theanine, glycine, valerian, and more.' },
+      { href: '/guides/other/supplement-stacking-safety/', title: 'Supplement Stacking Safety', desc: 'Check serotonergic, sedative, stimulant, and metabolic interaction patterns.' },
+      { href: '/guides/other/supplements-for-brain-fog-and-fatigue/', title: 'Brain Fog and Fatigue', desc: 'Start with likely causes and tradeoffs before choosing a supplement lane.' },
+      { href: '/guides/other/testosterone-supplements/', title: 'Testosterone Support Supplements', desc: 'Review evidence for common ingredients and the limits of “booster” products.' },
+    ],
+  },
+  {
+    id: 'advanced-and-harm-reduction',
+    eyebrow: 'Advanced and harm reduction',
+    title: 'Research higher-risk and regulated topics',
+    description:
+      'Educational context for prescription-adjacent compounds, research peptides, withdrawal, and harm reduction—not a purchase or self-treatment list.',
+    guides: [
+      { href: '/guides/other/bpc-157/', title: 'BPC-157', desc: 'Review preclinical evidence, safety uncertainty, and current legal context.' },
+      { href: '/guides/other/cjc-1295/', title: 'CJC-1295', desc: 'Understand the mechanism, research evidence, forms, and legal status.' },
+      { href: '/guides/other/ghk-cu/', title: 'GHK-Cu', desc: 'Separate topical cosmetic evidence from injectable and research-only use.' },
+      { href: '/guides/other/glp1-supplements/', title: 'Nutrition and Supplements on GLP-1s', desc: 'Review protein, hydration, and nutrient issues discussed with GLP-1 medications.' },
+      { href: '/guides/other/healthy-dipping-tobacco-alternatives/', title: 'Dipping Tobacco Alternatives', desc: 'Compare replacement paths through a harm-reduction and cardiovascular lens.' },
+      { href: '/guides/other/ipamorelin/', title: 'Ipamorelin', desc: 'Review mechanism, evidence limits, safety, and current legal context.' },
+      { href: '/guides/other/kratom-7oh-withdrawal-management/', title: 'Kratom 7-OH Withdrawal', desc: 'Evidence-informed harm reduction, symptom context, and routes to medical support.' },
+      { href: '/guides/other/psychedelic-adjacent-herbs/', title: 'Psychedelic-Adjacent Herbs', desc: 'Traditional and ritual botanicals viewed through a harm-reduction framework.' },
+      { href: '/guides/other/pt-141/', title: 'PT-141 (Bremelanotide)', desc: 'Distinguish the approved indication from off-label and research-only use.' },
+      { href: '/guides/other/semaglutide/', title: 'Semaglutide', desc: 'Evidence, mechanism, side effects, and brand-versus-compounded context.' },
+      { href: '/guides/other/tb-500/', title: 'TB-500', desc: 'Review repair research, evidence limits, safety, and legal status.' },
+      { href: '/guides/other/tirzepatide/', title: 'Tirzepatide', desc: 'Evidence, dual GIP/GLP-1 mechanism, side effects, and prescribing context.' },
+      { href: '/guides/other/melatonin-dosage-guide/', title: 'Melatonin Dosing', desc: 'Understand lower-dose evidence, timing, and common reasons for side effects.' },
+    ],
+  },
+]
+
+export const ALL_TOPIC_GUIDES = TOPIC_GUIDE_GROUPS.flatMap((group) => group.guides)

--- a/app/guides/page.tsx
+++ b/app/guides/page.tsx
@@ -80,11 +80,11 @@ const SECTIONS = [
     articles: ['Evidence literacy', 'How to read scientific studies', 'Neuroscience glossary', 'Interactions', 'Product quality'],
   },
   {
-    title: 'Other & Harm Reduction',
-    href: '/guides/other/healthy-dipping-tobacco-alternatives/',
-    desc: 'Evidence-informed guides that sit outside the main goal clusters, including tobacco replacement, peptides, and psychoactive harm reduction.',
+    title: 'Supplement Topic Guides',
+    href: '/guides/other/',
+    desc: 'Form and quality guides, popular supplement categories, goal-based routines, advanced compounds, and harm reduction — organized by the decision you are making.',
     color: 'border-l-stone-500',
-    articles: ['Dipping tobacco alternatives', 'Kratom 7-OH withdrawal', 'Psychedelic-adjacent herbs', 'Brain fog and fatigue'],
+    articles: ['Magnesium types', 'Omega-3 quality', 'Gut health', 'Stacking safety', 'Advanced research'],
   },
 ]
 

--- a/public/redirect-overrides/000-semrush-broken-internal-links-2026-07-08.txt
+++ b/public/redirect-overrides/000-semrush-broken-internal-links-2026-07-08.txt
@@ -59,8 +59,6 @@
 /guides/sleep-herbs-vs-melatonin/ /guides/compare/sleep-herbs-vs-melatonin/ 301
 # 10 broken-link instances
 /info/ /info/about/ 301
-# 9 broken-link instances
-/guides/other/ /guides/ 301
 # 8 broken-link instances
 /psychoactive/ /guides/other/psychedelic-adjacent-herbs/ 301
 # 7 broken-link instances

--- a/public/redirect-overrides/001-semrush-http-4xx-2026-07-08.txt
+++ b/public/redirect-overrides/001-semrush-http-4xx-2026-07-08.txt
@@ -336,7 +336,6 @@
 /guides/kratom-7oh-withdrawal-management/ /guides/other/kratom-7oh-withdrawal-management/ 301
 /guides/magnesium-for-sleep/ /guides/sleep/best-magnesium-for-sleep/ 301
 /guides/natural-alternatives-to-anxiety-medication/ /guides/anxiety/natural-alternatives-to-anxiety-medication/ 301
-/guides/other/ /guides/ 301
 /guides/passionflower/ /guides/herbs/passionflower/ 301
 /guides/rhodiola-complete-guide/ /guides/herbs/rhodiola-complete-guide/ 301
 /guides/rhodiola-energy/ /guides/herbs/rhodiola-energy/ 301


### PR DESCRIPTION
## Summary
- replace the evidence-library link to one miscellaneous article with a complete /guides/other/ topic hub
- organize all 46 existing topic guides into four decision-oriented lanes
- frame advanced and regulated topics as educational and harm-reduction content
- add a guard test so every published topic guide remains linked exactly once

## Impact
- reduces full-site orphan routes from 25 to 4 (only two crawlable routes remain)
- gives high-intent supplement, formulation, safety, and advanced-research content a coherent discovery path
- adds the new hub to the generated sitemap and CollectionPage/ItemList schema

## Validation
- targeted ESLint
- topic-route completeness test
- npm run typecheck
- Next static export (1,193 pages)
- npm run verify:postbuild (707 valid sitemap URLs)
- full HTML internal-link audit
- 320px mobile, desktop dark-mode, and anchor-navigation browser QA