### PR TITLE
Canonicalize guide structured-data routes

### DIFF
--- a/app/guides/[slug]/page.tsx
+++ b/app/guides/[slug]/page.tsx
@@ -142,7 +142,7 @@ export default async function GuidePage({ params }: Props) {
         )}
         <nav className="flex flex-wrap gap-4 text-sm font-semibold text-brand-700" aria-label="Guide support links">
           <Link href="/guides/" className="hover:text-brand-800">All guides</Link>
-          <Link href="/guides/" className="hover:text-brand-800">Articles</Link>
+          <Link href="/guides/" className="hover:text-brand-800">Guides</Link>
           <Link href="/safety-checker/" className="hover:text-brand-800">Safety checker</Link>
         </nav>
       </div>

--- a/app/guides/adhd/best-magnesium-supplement-for-adhd/page.tsx
+++ b/app/guides/adhd/best-magnesium-supplement-for-adhd/page.tsx
@@ -81,14 +81,14 @@ const MAGNESIUM_REFERENCES = [
 
 export default function BestMagnesiumForAdhdPage() {
   const breadcrumbLd = breadcrumbJsonLd([
-    { name: 'Articles', url: 'https://thehippiescientist.net/articles' },
-    { name: TITLE, url: `https://thehippiescientist.net/articles/${SLUG}` },
+    { name: 'Guides', url: 'https://thehippiescientist.net/guides/' },
+    { name: TITLE, url: `https://thehippiescientist.net/guides/adhd/${SLUG}/` },
   ])
   const articleLd = blogJsonLd(
     { title: TITLE, slug: SLUG, date: DATE, description: DESCRIPTION },
-    `/articles/${SLUG}`,
+    `/guides/adhd/${SLUG}/`,
   )
-  const faqLd = faqPageJsonLd({ pagePath: `/articles/${SLUG}`, questions: FAQS })
+  const faqLd = faqPageJsonLd({ pagePath: `/guides/adhd/${SLUG}/`, questions: FAQS })
 
   return (
     <article className="mx-auto max-w-5xl space-y-0 px-4 pb-20 pt-6 sm:px-6 lg:px-8">
@@ -97,7 +97,7 @@ export default function BestMagnesiumForAdhdPage() {
       {faqLd && <JsonLd schema={faqLd} />}
 
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
-        <Link href="/guides/" className="transition hover:text-ink">Articles</Link>
+        <Link href="/guides/" className="transition hover:text-ink">Guides</Link>
         <span>/</span>
         <span className="text-ink line-clamp-1">{TITLE}</span>
       </nav>
@@ -579,7 +579,7 @@ export default function BestMagnesiumForAdhdPage() {
 
       <div className="mt-8">
         <Link href="/guides/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
-          ← Back to Articles
+          ← Back to Guides
         </Link>
       </div>
     </article>

--- a/app/guides/adhd/l-theanine-magnesium-adhd-stack/page.tsx
+++ b/app/guides/adhd/l-theanine-magnesium-adhd-stack/page.tsx
@@ -74,14 +74,14 @@ const L_THEANINE_MAGNESIUM_ADHD_STACK_REFS = [
 
 export default function LTheanineMagnesiumAdhdStackPage() {
   const breadcrumbLd = breadcrumbJsonLd([
-    { name: 'Articles', url: 'https://thehippiescientist.net/articles' },
-    { name: TITLE, url: `https://thehippiescientist.net/articles/${SLUG}` },
+    { name: 'Guides', url: 'https://thehippiescientist.net/guides/' },
+    { name: TITLE, url: `https://thehippiescientist.net/guides/adhd/${SLUG}/` },
   ])
   const articleLd = blogJsonLd(
     { title: TITLE, slug: SLUG, date: DATE, description: DESCRIPTION },
-    `/articles/${SLUG}`,
+    `/guides/adhd/${SLUG}/`,
   )
-  const faqLd = faqPageJsonLd({ pagePath: `/articles/${SLUG}`, questions: FAQS })
+  const faqLd = faqPageJsonLd({ pagePath: `/guides/adhd/${SLUG}/`, questions: FAQS })
 
   return (
     <article className="mx-auto max-w-5xl space-y-0 px-4 pb-20 pt-6 sm:px-6 lg:px-8">
@@ -91,7 +91,7 @@ export default function LTheanineMagnesiumAdhdStackPage() {
 
       {/* Breadcrumb */}
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
-        <Link href="/guides/" className="transition hover:text-ink">Articles</Link>
+        <Link href="/guides/" className="transition hover:text-ink">Guides</Link>
         <span>/</span>
         <span className="text-ink line-clamp-1">{TITLE}</span>
       </nav>
@@ -496,7 +496,7 @@ export default function LTheanineMagnesiumAdhdStackPage() {
 
       <div className="mt-8">
         <Link href="/guides/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
-          ← Back to Articles
+          ← Back to Guides
         </Link>
       </div>
       <References refs={L_THEANINE_MAGNESIUM_ADHD_STACK_REFS} />

--- a/app/guides/adhd/magnesium-glycinate-vs-citrate-for-adhd/page.tsx
+++ b/app/guides/adhd/magnesium-glycinate-vs-citrate-for-adhd/page.tsx
@@ -74,14 +74,14 @@ const MAGNESIUM_GLYCINATE_VS_CITRATE_FOR_ADHD_REFS = [
 
 export default function MagnesiumGlycinateCitrateAdhdPage() {
   const breadcrumbLd = breadcrumbJsonLd([
-    { name: 'Articles', url: 'https://thehippiescientist.net/articles' },
-    { name: TITLE, url: `https://thehippiescientist.net/articles/${SLUG}` },
+    { name: 'Guides', url: 'https://thehippiescientist.net/guides/' },
+    { name: TITLE, url: `https://thehippiescientist.net/guides/adhd/${SLUG}/` },
   ])
   const articleLd = blogJsonLd(
     { title: TITLE, slug: SLUG, date: DATE, description: DESCRIPTION },
-    `/articles/${SLUG}`,
+    `/guides/adhd/${SLUG}/`,
   )
-  const faqLd = faqPageJsonLd({ pagePath: `/articles/${SLUG}`, questions: FAQS })
+  const faqLd = faqPageJsonLd({ pagePath: `/guides/adhd/${SLUG}/`, questions: FAQS })
 
   return (
     <article className="mx-auto max-w-5xl space-y-0 px-4 pb-20 pt-6 sm:px-6 lg:px-8">
@@ -91,7 +91,7 @@ export default function MagnesiumGlycinateCitrateAdhdPage() {
 
       {/* Breadcrumb */}
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
-        <Link href="/guides/" className="transition hover:text-ink">Articles</Link>
+        <Link href="/guides/" className="transition hover:text-ink">Guides</Link>
         <span>/</span>
         <span className="text-ink line-clamp-1">{TITLE}</span>
       </nav>
@@ -473,7 +473,7 @@ export default function MagnesiumGlycinateCitrateAdhdPage() {
 
       <div className="mt-8">
         <Link href="/guides/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
-          ← Back to Articles
+          ← Back to Guides
         </Link>
       </div>
       <References refs={MAGNESIUM_GLYCINATE_VS_CITRATE_FOR_ADHD_REFS} />

--- a/app/guides/anxiety/ashwagandha-for-anxiety/page.tsx
+++ b/app/guides/anxiety/ashwagandha-for-anxiety/page.tsx
@@ -67,15 +67,15 @@ export default function AshwagandhaForAnxietyPage() {
   const pageBreadcrumb = breadcrumbJsonLd([
     { name: 'Home', url: 'https://thehippiescientist.net' },
     { name: 'Anxiety', url: 'https://thehippiescientist.net/guides/anxiety/natural-anxiety-relief/' },
-    { name: TITLE, url: `https://thehippiescientist.net/articles/${SLUG}` },
+    { name: TITLE, url: `https://thehippiescientist.net/guides/anxiety/${SLUG}/` },
   ])
 
   const articleLd = blogJsonLd(
     { title: TITLE, slug: SLUG, date: DATE, description: DESCRIPTION },
-    `/articles/${SLUG}`,
+    `/guides/anxiety/${SLUG}/`,
   )
 
-  const faqLd = faqPageJsonLd({ pagePath: `/articles/${SLUG}`, questions: FAQS })
+  const faqLd = faqPageJsonLd({ pagePath: `/guides/anxiety/${SLUG}/`, questions: FAQS })
 
   return (
     <>

--- a/app/guides/anxiety/cbd-vs-ashwagandha-for-anxiety/page.tsx
+++ b/app/guides/anxiety/cbd-vs-ashwagandha-for-anxiety/page.tsx
@@ -62,15 +62,15 @@ export default function CbdVsAshwagandhaForAnxietyPage() {
   const pageBreadcrumb = breadcrumbJsonLd([
     { name: 'Home', url: 'https://thehippiescientist.net' },
     { name: 'Anxiety', url: 'https://thehippiescientist.net/guides/anxiety/natural-anxiety-relief/' },
-    { name: TITLE, url: `https://thehippiescientist.net/articles/${SLUG}` },
+    { name: TITLE, url: `https://thehippiescientist.net/guides/anxiety/${SLUG}/` },
   ])
 
   const articleLd = blogJsonLd(
     { title: TITLE, slug: SLUG, date: DATE, description: DESCRIPTION },
-    `/articles/${SLUG}`,
+    `/guides/anxiety/${SLUG}/`,
   )
 
-  const faqLd = faqPageJsonLd({ pagePath: `/articles/${SLUG}`, questions: FAQS })
+  const faqLd = faqPageJsonLd({ pagePath: `/guides/anxiety/${SLUG}/`, questions: FAQS })
 
   return (
     <>

--- a/app/guides/anxiety/l-theanine-for-anxiety/page.tsx
+++ b/app/guides/anxiety/l-theanine-for-anxiety/page.tsx
@@ -94,15 +94,15 @@ export default function LTheanineForAnxietyPage() {
   const pageBreadcrumb = breadcrumbJsonLd([
     { name: 'Home', url: 'https://thehippiescientist.net' },
     { name: 'Anxiety', url: 'https://thehippiescientist.net/guides/anxiety/natural-anxiety-relief/' },
-    { name: TITLE, url: `https://thehippiescientist.net/articles/${SLUG}` },
+    { name: TITLE, url: `https://thehippiescientist.net/guides/anxiety/${SLUG}/` },
   ])
 
   const articleLd = blogJsonLd(
     { title: TITLE, slug: SLUG, date: DATE, description: DESCRIPTION },
-    `/articles/${SLUG}`,
+    `/guides/anxiety/${SLUG}/`,
   )
 
-  const faqLd = faqPageJsonLd({ pagePath: `/articles/${SLUG}`, questions: FAQS })
+  const faqLd = faqPageJsonLd({ pagePath: `/guides/anxiety/${SLUG}/`, questions: FAQS })
 
   return (
     <>

--- a/app/guides/anxiety/natural-anxiety-relief/page.tsx
+++ b/app/guides/anxiety/natural-anxiety-relief/page.tsx
@@ -70,16 +70,16 @@ const FAQS = [
 
 export default function NaturalAnxietyReliefPage() {
   const pageBreadcrumb = breadcrumbJsonLd([
-    { name: 'Articles', url: 'https://thehippiescientist.net/articles' },
-    { name: TITLE, url: `https://thehippiescientist.net/articles/${SLUG}` },
+    { name: 'Guides', url: 'https://thehippiescientist.net/guides/' },
+    { name: TITLE, url: `https://thehippiescientist.net/guides/anxiety/${SLUG}/` },
   ])
 
   const articleLd = blogJsonLd(
     { title: TITLE, slug: SLUG, date: DATE, description: DESCRIPTION },
-    `/articles/${SLUG}`,
+    `/guides/anxiety/${SLUG}/`,
   )
 
-  const faqLd = faqPageJsonLd({ pagePath: `/articles/${SLUG}`, questions: FAQS })
+  const faqLd = faqPageJsonLd({ pagePath: `/guides/anxiety/${SLUG}/`, questions: FAQS })
 
   return (
     <article className="mx-auto max-w-5xl space-y-0 px-4 pb-20 pt-6 sm:px-6 lg:px-8">
@@ -93,7 +93,7 @@ export default function NaturalAnxietyReliefPage() {
       {/* Breadcrumb */}
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
         <Link href="/guides/" className="transition hover:text-ink">
-          Articles
+          Guides
         </Link>
         <span>/</span>
         <span className="text-ink line-clamp-1">{TITLE}</span>
@@ -1500,7 +1500,7 @@ export default function NaturalAnxietyReliefPage() {
 
       <div className="mt-8">
         <Link href="/guides/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
-          ← Back to Articles
+          ← Back to Guides
         </Link>
       </div>
     </article>

--- a/app/guides/focus/l-theanine-without-caffeine/page.tsx
+++ b/app/guides/focus/l-theanine-without-caffeine/page.tsx
@@ -91,14 +91,14 @@ export default function LTheanineWithoutCaffeinePage() {
     ? [L_THEANINE_100MG_BUDGET_PRODUCT, ...lTheanineProducts.products.filter((product) => product.slot !== 'budget')]
     : []
   const breadcrumbLd = breadcrumbJsonLd([
-    { name: 'Articles', url: 'https://thehippiescientist.net/articles' },
-    { name: TITLE, url: `https://thehippiescientist.net/articles/${SLUG}` },
+    { name: 'Guides', url: 'https://thehippiescientist.net/guides/' },
+    { name: TITLE, url: `https://thehippiescientist.net/guides/focus/${SLUG}/` },
   ])
   const articleLd = blogJsonLd(
     { title: TITLE, slug: SLUG, date: DATE, description: DESCRIPTION },
-    `/articles/${SLUG}`,
+    `/guides/focus/${SLUG}/`,
   )
-  const faqLd = faqPageJsonLd({ pagePath: `/articles/${SLUG}`, questions: FAQS })
+  const faqLd = faqPageJsonLd({ pagePath: `/guides/focus/${SLUG}/`, questions: FAQS })
 
   return (
     <article className="mx-auto max-w-5xl space-y-0 px-4 pb-20 pt-6 sm:px-6 lg:px-8">
@@ -107,7 +107,7 @@ export default function LTheanineWithoutCaffeinePage() {
       {faqLd && <JsonLd schema={faqLd} />}
 
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
-        <Link href="/guides/" className="transition hover:text-ink">Articles</Link>
+        <Link href="/guides/" className="transition hover:text-ink">Guides</Link>
         <span>/</span>
         <span className="text-ink line-clamp-1">{TITLE}</span>
       </nav>
@@ -562,7 +562,7 @@ export default function LTheanineWithoutCaffeinePage() {
 
       <div className="mt-8">
         <Link href="/guides/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
-          ← Back to Articles
+          ← Back to Guides
         </Link>
       </div>
       <References refs={L_THEANINE_WITHOUT_CAFFEINE_REFS} />

--- a/app/guides/herbs/ashwagandha/page.tsx
+++ b/app/guides/herbs/ashwagandha/page.tsx
@@ -75,16 +75,16 @@ const FAQS = [
 
 export default function AshwagandhaArticlePage() {
   const pageBreadcrumb = breadcrumbJsonLd([
-    { name: 'Articles', url: 'https://thehippiescientist.net/articles' },
-    { name: TITLE, url: `https://thehippiescientist.net/articles/${SLUG}` },
+    { name: 'Guides', url: 'https://thehippiescientist.net/guides/' },
+    { name: TITLE, url: `https://thehippiescientist.net/guides/herbs/${SLUG}/` },
   ])
 
   const articleLd = blogJsonLd(
     { title: TITLE, slug: SLUG, date: DATE, description: DESCRIPTION },
-    `/articles/${SLUG}`,
+    `/guides/herbs/${SLUG}/`,
   )
 
-  const faqLd = faqPageJsonLd({ pagePath: `/articles/${SLUG}`, questions: FAQS })
+  const faqLd = faqPageJsonLd({ pagePath: `/guides/herbs/${SLUG}/`, questions: FAQS })
 
   return (
     <article className="mx-auto max-w-5xl space-y-0 px-4 pb-20 pt-6 sm:px-6 lg:px-8">
@@ -98,7 +98,7 @@ export default function AshwagandhaArticlePage() {
       {/* Breadcrumb */}
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
         <Link href="/guides/" className="transition hover:text-ink">
-          Articles
+          Guides
         </Link>
         <span>/</span>
         <span className="text-ink line-clamp-1">{TITLE}</span>
@@ -1027,7 +1027,7 @@ export default function AshwagandhaArticlePage() {
 
       <div className="mt-8">
         <Link href="/guides/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
-          ← Back to Articles
+          ← Back to Guides
         </Link>
       </div>
     </article>

--- a/app/guides/herbs/l-theanine/page.tsx
+++ b/app/guides/herbs/l-theanine/page.tsx
@@ -75,16 +75,16 @@ const FAQS = [
 
 export default function LTheanineArticlePage() {
   const pageBreadcrumb = breadcrumbJsonLd([
-    { name: 'Articles', url: 'https://thehippiescientist.net/articles' },
-    { name: TITLE, url: `https://thehippiescientist.net/articles/${SLUG}` },
+    { name: 'Guides', url: 'https://thehippiescientist.net/guides/' },
+    { name: TITLE, url: `https://thehippiescientist.net/guides/herbs/${SLUG}/` },
   ])
 
   const articleLd = blogJsonLd(
     { title: TITLE, slug: SLUG, date: DATE, description: DESCRIPTION },
-    `/articles/${SLUG}`,
+    `/guides/herbs/${SLUG}/`,
   )
 
-  const faqLd = faqPageJsonLd({ pagePath: `/articles/${SLUG}`, questions: FAQS })
+  const faqLd = faqPageJsonLd({ pagePath: `/guides/herbs/${SLUG}/`, questions: FAQS })
 
   return (
     <article className="mx-auto max-w-5xl space-y-0 px-4 pb-20 pt-6 sm:px-6 lg:px-8">
@@ -98,7 +98,7 @@ export default function LTheanineArticlePage() {
       {/* Breadcrumb */}
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
         <Link href="/guides/" className="transition hover:text-ink">
-          Articles
+          Guides
         </Link>
         <span>/</span>
         <span className="text-ink line-clamp-1">{TITLE}</span>
@@ -1037,7 +1037,7 @@ export default function LTheanineArticlePage() {
 
       <div className="mt-8">
         <Link href="/guides/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
-          ← Back to Articles
+          ← Back to Guides
         </Link>
       </div>
     </article>

--- a/app/guides/sleep/ashwagandha-for-sleep/page.tsx
+++ b/app/guides/sleep/ashwagandha-for-sleep/page.tsx
@@ -72,16 +72,16 @@ const ASHWAGANDHA_FOR_SLEEP_REFS = [
 
 export default function AshwagandhaForSleepPage() {
   const pageBreadcrumb = breadcrumbJsonLd([
-    { name: 'Articles', url: 'https://thehippiescientist.net/articles' },
-    { name: TITLE, url: `https://thehippiescientist.net/articles/${SLUG}` },
+    { name: 'Guides', url: 'https://thehippiescientist.net/guides/' },
+    { name: TITLE, url: `https://thehippiescientist.net/guides/sleep/${SLUG}/` },
   ])
 
   const articleLd = blogJsonLd(
     { title: TITLE, slug: SLUG, date: DATE, description: DESCRIPTION },
-    `/articles/${SLUG}`,
+    `/guides/sleep/${SLUG}/`,
   )
 
-  const faqLd = faqPageJsonLd({ pagePath: `/articles/${SLUG}`, questions: FAQS })
+  const faqLd = faqPageJsonLd({ pagePath: `/guides/sleep/${SLUG}/`, questions: FAQS })
 
   return (
     <article className="mx-auto max-w-5xl space-y-0 px-4 pb-20 pt-6 sm:px-6 lg:px-8">
@@ -98,7 +98,7 @@ export default function AshwagandhaForSleepPage() {
       {/* Breadcrumb */}
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
         <Link href="/guides/" className="transition hover:text-ink">
-          Articles
+          Guides
         </Link>
         <span>/</span>
         <span className="text-ink line-clamp-1">{TITLE}</span>
@@ -1006,7 +1006,7 @@ export default function AshwagandhaForSleepPage() {
 
       <div className="mt-8">
         <Link href="/guides/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
-          ← Back to Articles
+          ← Back to Guides
         </Link>
       </div>
     </article>

--- a/app/guides/sleep/ashwagandha-vs-magnesium-for-sleep/page.tsx
+++ b/app/guides/sleep/ashwagandha-vs-magnesium-for-sleep/page.tsx
@@ -79,16 +79,16 @@ const ASHWAGANDHA_VS_MAGNESIUM_FOR_SLEEP_REFS = [
 
 export default function AshwagandhaVsMagnesiumForSleepPage() {
   const pageBreadcrumb = breadcrumbJsonLd([
-    { name: 'Articles', url: 'https://thehippiescientist.net/articles' },
-    { name: TITLE, url: `https://thehippiescientist.net/articles/${SLUG}` },
+    { name: 'Guides', url: 'https://thehippiescientist.net/guides/' },
+    { name: TITLE, url: `https://thehippiescientist.net/guides/sleep/${SLUG}/` },
   ])
 
   const articleLd = blogJsonLd(
     { title: TITLE, slug: SLUG, date: DATE, description: DESCRIPTION },
-    `/articles/${SLUG}`,
+    `/guides/sleep/${SLUG}/`,
   )
 
-  const faqLd = faqPageJsonLd({ pagePath: `/articles/${SLUG}`, questions: FAQS })
+  const faqLd = faqPageJsonLd({ pagePath: `/guides/sleep/${SLUG}/`, questions: FAQS })
 
   return (
     <article className="mx-auto max-w-5xl space-y-0 px-4 pb-20 pt-6 sm:px-6 lg:px-8">
@@ -105,7 +105,7 @@ export default function AshwagandhaVsMagnesiumForSleepPage() {
       {/* Breadcrumb */}
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
         <Link href="/guides/" className="transition hover:text-ink">
-          Articles
+          Guides
         </Link>
         <span>/</span>
         <span className="text-ink line-clamp-1">{TITLE}</span>
@@ -1186,7 +1186,7 @@ export default function AshwagandhaVsMagnesiumForSleepPage() {
 
       <div className="mt-8">
         <Link href="/guides/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
-          ← Back to Articles
+          ← Back to Guides
         </Link>
       </div>
     </article>

--- a/app/guides/sleep/best-herbs-for-sleep/page.tsx
+++ b/app/guides/sleep/best-herbs-for-sleep/page.tsx
@@ -70,16 +70,16 @@ const FAQS = [
 
 export default function BestHerbsForSleepPage() {
   const pageBreadcrumb = breadcrumbJsonLd([
-    { name: 'Articles', url: 'https://thehippiescientist.net/articles' },
-    { name: TITLE, url: `https://thehippiescientist.net/articles/${SLUG}` },
+    { name: 'Guides', url: 'https://thehippiescientist.net/guides/' },
+    { name: TITLE, url: `https://thehippiescientist.net/guides/sleep/${SLUG}/` },
   ])
 
   const articleLd = blogJsonLd(
     { title: TITLE, slug: SLUG, date: DATE, description: DESCRIPTION },
-    `/articles/${SLUG}`,
+    `/guides/sleep/${SLUG}/`,
   )
 
-  const faqLd = faqPageJsonLd({ pagePath: `/articles/${SLUG}`, questions: FAQS })
+  const faqLd = faqPageJsonLd({ pagePath: `/guides/sleep/${SLUG}/`, questions: FAQS })
 
   return (
     <article className="mx-auto max-w-5xl space-y-0 px-4 pb-20 pt-6 sm:px-6 lg:px-8">
@@ -93,7 +93,7 @@ export default function BestHerbsForSleepPage() {
       {/* Breadcrumb */}
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
         <Link href="/guides/" className="transition hover:text-ink">
-          Articles
+          Guides
         </Link>
         <span>/</span>
         <span className="text-ink line-clamp-1">{TITLE}</span>
@@ -1178,7 +1178,7 @@ export default function BestHerbsForSleepPage() {
 
       <div className="mt-8">
         <Link href="/guides/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
-          ← Back to Articles
+          ← Back to Guides
         </Link>
       </div>
     </article>

--- a/app/guides/sleep/l-theanine-for-sleep/page.tsx
+++ b/app/guides/sleep/l-theanine-for-sleep/page.tsx
@@ -70,16 +70,16 @@ const FAQS = [
 
 export default function LTheanineForSleepPage() {
   const pageBreadcrumb = breadcrumbJsonLd([
-    { name: 'Articles', url: 'https://thehippiescientist.net/articles' },
-    { name: TITLE, url: `https://thehippiescientist.net/articles/${SLUG}` },
+    { name: 'Guides', url: 'https://thehippiescientist.net/guides/' },
+    { name: TITLE, url: `https://thehippiescientist.net/guides/sleep/${SLUG}/` },
   ])
 
   const articleLd = blogJsonLd(
     { title: TITLE, slug: SLUG, date: DATE, description: DESCRIPTION },
-    `/articles/${SLUG}`,
+    `/guides/sleep/${SLUG}/`,
   )
 
-  const faqLd = faqPageJsonLd({ pagePath: `/articles/${SLUG}`, questions: FAQS })
+  const faqLd = faqPageJsonLd({ pagePath: `/guides/sleep/${SLUG}/`, questions: FAQS })
 
   return (
     <article className="mx-auto max-w-5xl space-y-0 px-4 pb-20 pt-6 sm:px-6 lg:px-8">
@@ -93,7 +93,7 @@ export default function LTheanineForSleepPage() {
       {/* Breadcrumb */}
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
         <Link href="/guides/" className="transition hover:text-ink">
-          Articles
+          Guides
         </Link>
         <span>/</span>
         <span className="text-ink line-clamp-1">{TITLE}</span>
@@ -1371,7 +1371,7 @@ export default function LTheanineForSleepPage() {
 
       <div className="mt-8">
         <Link href="/guides/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
-          ← Back to Articles
+          ← Back to Guides
         </Link>
       </div>
     </article>

--- a/app/guides/sleep/magnesium-types-for-sleep/page.tsx
+++ b/app/guides/sleep/magnesium-types-for-sleep/page.tsx
@@ -70,16 +70,16 @@ const FAQS = [
 
 export default function MagnesiumTypesForSleepPage() {
   const pageBreadcrumb = breadcrumbJsonLd([
-    { name: 'Articles', url: 'https://thehippiescientist.net/articles' },
-    { name: TITLE, url: `https://thehippiescientist.net/articles/${SLUG}` },
+    { name: 'Guides', url: 'https://thehippiescientist.net/guides/' },
+    { name: TITLE, url: `https://thehippiescientist.net/guides/sleep/${SLUG}/` },
   ])
 
   const articleLd = blogJsonLd(
     { title: TITLE, slug: SLUG, date: DATE, description: DESCRIPTION },
-    `/articles/${SLUG}`,
+    `/guides/sleep/${SLUG}/`,
   )
 
-  const faqLd = faqPageJsonLd({ pagePath: `/articles/${SLUG}`, questions: FAQS })
+  const faqLd = faqPageJsonLd({ pagePath: `/guides/sleep/${SLUG}/`, questions: FAQS })
 
   return (
     <article className="mx-auto max-w-5xl space-y-0 px-4 pb-20 pt-6 sm:px-6 lg:px-8">
@@ -93,7 +93,7 @@ export default function MagnesiumTypesForSleepPage() {
       {/* Breadcrumb */}
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
         <Link href="/guides/" className="transition hover:text-ink">
-          Articles
+          Guides
         </Link>
         <span>/</span>
         <span className="text-ink line-clamp-1">{TITLE}</span>
@@ -1224,7 +1224,7 @@ export default function MagnesiumTypesForSleepPage() {
 
       <div className="mt-8">
         <Link href="/guides/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
-          ← Back to Articles
+          ← Back to Guides
         </Link>
       </div>
     </article>

--- a/app/guides/sleep/sleep-stack-guide/page.tsx
+++ b/app/guides/sleep/sleep-stack-guide/page.tsx
@@ -70,16 +70,16 @@ const FAQS = [
 
 export default function SleepStackGuidePage() {
   const pageBreadcrumb = breadcrumbJsonLd([
-    { name: 'Articles', url: 'https://thehippiescientist.net/articles' },
-    { name: TITLE, url: `https://thehippiescientist.net/articles/${SLUG}` },
+    { name: 'Guides', url: 'https://thehippiescientist.net/guides/' },
+    { name: TITLE, url: `https://thehippiescientist.net/guides/sleep/${SLUG}/` },
   ])
 
   const articleLd = blogJsonLd(
     { title: TITLE, slug: SLUG, date: DATE, description: DESCRIPTION },
-    `/articles/${SLUG}`,
+    `/guides/sleep/${SLUG}/`,
   )
 
-  const faqLd = faqPageJsonLd({ pagePath: `/articles/${SLUG}`, questions: FAQS })
+  const faqLd = faqPageJsonLd({ pagePath: `/guides/sleep/${SLUG}/`, questions: FAQS })
 
   return (
     <article className="mx-auto max-w-5xl space-y-0 px-4 pb-20 pt-6 sm:px-6 lg:px-8">
@@ -93,7 +93,7 @@ export default function SleepStackGuidePage() {
       {/* Breadcrumb */}
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
         <Link href="/guides/" className="transition hover:text-ink">
-          Articles
+          Guides
         </Link>
         <span>/</span>
         <span className="text-ink line-clamp-1">{TITLE}</span>
@@ -1651,7 +1651,7 @@ export default function SleepStackGuidePage() {
 
       <div className="mt-8">
         <Link href="/guides/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
-          ← Back to Articles
+          ← Back to Guides
         </Link>
       </div>
     </article>

--- a/scripts/ci/validate-route-seo.mjs
+++ b/scripts/ci/validate-route-seo.mjs
@@ -62,6 +62,13 @@ const warnings = []
 
 for (const r of routes) {
   if (!r.route.startsWith('/')) errors.push(`Invalid route path ${r.route} from ${r.file}`)
+
+  if (r.route.startsWith('/guides/')) {
+    const pageSource = read(r.file)
+    if (pageSource.includes('articles/${SLUG}')) {
+      errors.push(`Guide route contains legacy /articles structured-data URL: ${r.route} (${r.file})`)
+    }
+  }
 }
 for (const r of dynamicRoutes) if (!r.gsp) errors.push(`Dynamic route missing generateStaticParams: ${r.route} (${r.file})`)
 


### PR DESCRIPTION
## What changed

- corrected article, FAQ, and breadcrumb JSON-LD URLs on 16 guide pages so they use each page's canonical `/guides/*` route instead of the legacy `/articles/*` namespace
- aligned visible guide breadcrumbs and return links with the current guide information architecture
- extended the route SEO validator to reject legacy `articles/${SLUG}` schema URLs inside guide pages

## Why

The affected pages declared canonical `/guides/*` metadata while their structured data identified a different legacy `/articles/*` URL. Aligning those signals reduces entity ambiguity for search engines and keeps users oriented within the current guide library.

## Validation

- `npm run validate:route-seo`
- `npm run typecheck`
- `npm run check:fast`
- `npm run build`
- `npm run verify:output`
- rendered HTML assertion across all 16 affected pages: expected canonical guide schema URL present and legacy article schema URL absent
