### PR TITLE
Add a science-first alkaloid directory

### DIFF
--- a/app/guides/other/alkaloids-on-amazon/AlkaloidDirectory.tsx
+++ b/app/guides/other/alkaloids-on-amazon/AlkaloidDirectory.tsx
@@ -1,0 +1,198 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+
+import { FilterChip } from '@/components/search/search-ui'
+
+import type { AlkaloidDirectoryEntry } from './alkaloids'
+
+type Filter = 'all' | 'human' | 'higher' | 'botanical' | 'isolated'
+
+const FILTERS: Array<{ id: Filter; label: string }> = [
+  { id: 'all', label: 'All entries' },
+  { id: 'human', label: 'Human evidence' },
+  { id: 'higher', label: 'Higher caution' },
+  { id: 'botanical', label: 'Botanicals' },
+  { id: 'isolated', label: 'Isolated compounds' },
+]
+
+const SAFETY_STYLES = {
+  standard:
+    'border-emerald-700/20 bg-emerald-50 text-emerald-900 dark:border-emerald-400/25 dark:bg-emerald-950/40 dark:text-emerald-200',
+  interaction:
+    'border-amber-700/20 bg-amber-50 text-amber-950 dark:border-amber-400/25 dark:bg-amber-950/35 dark:text-amber-200',
+  higher:
+    'border-rose-700/20 bg-rose-50 text-rose-950 dark:border-rose-400/25 dark:bg-rose-950/35 dark:text-rose-200',
+} as const
+
+function matchesFilter(entry: AlkaloidDirectoryEntry, filter: Filter) {
+  if (filter === 'all') return true
+  if (filter === 'human') return entry.evidenceBand === 'human'
+  if (filter === 'higher') return entry.safetyTier === 'higher'
+  return entry.formats.includes(filter)
+}
+
+export default function AlkaloidDirectory({ entries }: { entries: AlkaloidDirectoryEntry[] }) {
+  const [filter, setFilter] = useState<Filter>('all')
+  const [query, setQuery] = useState('')
+
+  const filteredEntries = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase()
+
+    return entries.filter((entry) => {
+      if (!matchesFilter(entry, filter)) return false
+      if (!normalizedQuery) return true
+
+      return [
+        entry.name,
+        entry.identity,
+        entry.alkaloids,
+        entry.classification,
+        entry.safetyLabel,
+      ].some((value) => value.toLowerCase().includes(normalizedQuery))
+    })
+  }, [entries, filter, query])
+
+  return (
+    <section id="directory" className="scroll-mt-24">
+      <div className="rounded-3xl border border-brand-900/12 bg-[var(--surface-card)] p-5 shadow-sm sm:p-7">
+        <div className="max-w-3xl">
+          <p className="eyebrow-label">Ingredient directory</p>
+          <h2 className="mt-2 font-display text-3xl font-semibold tracking-tight text-ink">
+            Compare the chemistry before the catalog
+          </h2>
+          <p className="mt-3 text-sm leading-7 text-muted">
+            Evidence labels describe the kind of research available—not a recommendation. Higher-caution
+            entries stay visible because hiding risk would make this directory less useful.
+          </p>
+        </div>
+
+        <div className="mt-6 grid gap-5 lg:grid-cols-[minmax(0,1fr)_18rem] lg:items-end">
+          <fieldset>
+            <legend className="mb-2 text-sm font-semibold text-ink">Filter the directory</legend>
+            <div className="flex flex-wrap gap-2">
+              {FILTERS.map((option) => (
+                <FilterChip
+                  key={option.id}
+                  label={option.label}
+                  active={filter === option.id}
+                  count={entries.filter((entry) => matchesFilter(entry, option.id)).length}
+                  onClick={() => setFilter(option.id)}
+                />
+              ))}
+            </div>
+          </fieldset>
+
+          <label className="block">
+            <span className="mb-2 block text-sm font-semibold text-ink">Search names or classes</span>
+            <input
+              type="search"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Try “isoquinoline”"
+              className="min-h-11 w-full rounded-xl border border-brand-900/15 bg-[var(--surface)] px-4 py-2 text-base text-ink outline-none transition placeholder:text-muted focus:border-brand-700 focus:ring-2 focus:ring-brand-700/20"
+            />
+          </label>
+        </div>
+      </div>
+
+      <p className="my-5 text-sm text-muted" role="status" aria-live="polite">
+        Showing {filteredEntries.length} of {entries.length} entries.
+      </p>
+
+      {filteredEntries.length ? (
+        <div className="grid gap-5 lg:grid-cols-2">
+          {filteredEntries.map((entry) => (
+            <article
+              key={entry.id}
+              id={entry.id}
+              className="scroll-mt-28 rounded-3xl border border-brand-900/12 bg-[var(--surface-card)] p-5 shadow-[0_8px_28px_rgba(13,23,18,0.05)] sm:p-6"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <h3 className="font-display text-2xl font-semibold text-ink">{entry.name}</h3>
+                  <p className="mt-1 text-sm italic leading-6 text-muted">{entry.identity}</p>
+                </div>
+                <span
+                  className={`inline-flex rounded-full border px-3 py-1 text-xs font-bold ${SAFETY_STYLES[entry.safetyTier]}`}
+                >
+                  {entry.safetyLabel}
+                </span>
+              </div>
+
+              <dl className="mt-5 grid gap-3 rounded-2xl border border-brand-900/8 bg-[var(--surface-subtle)] p-4 text-sm">
+                <div>
+                  <dt className="text-xs font-bold uppercase tracking-wider text-muted">Named alkaloid(s)</dt>
+                  <dd className="mt-1 font-medium text-ink">{entry.alkaloids}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs font-bold uppercase tracking-wider text-muted">Chemical class</dt>
+                  <dd className="mt-1 font-medium text-ink">{entry.classification}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs font-bold uppercase tracking-wider text-muted">Evidence signal</dt>
+                  <dd className="mt-1 font-medium text-ink">{entry.evidenceLabel}</dd>
+                </div>
+              </dl>
+
+              <div className="mt-5 rounded-2xl border border-rose-900/10 bg-rose-50/55 p-4 text-sm leading-6 text-rose-950 dark:border-rose-400/20 dark:bg-rose-950/25 dark:text-rose-100">
+                <strong>Safety read:</strong> {entry.safetySummary}
+              </div>
+
+              <details className="group mt-4 rounded-2xl border border-brand-900/10">
+                <summary className="cursor-pointer list-none px-4 py-3 text-sm font-semibold text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/30">
+                  <span className="flex items-center justify-between gap-3">
+                    Evidence by source type
+                    <span aria-hidden="true" className="text-brand-700 transition group-open:rotate-45">＋</span>
+                  </span>
+                </summary>
+                <div className="space-y-4 border-t border-brand-900/8 px-4 py-4 text-sm leading-6 text-muted">
+                  <p><strong className="text-ink">Human:</strong> {entry.humanEvidence}</p>
+                  <p><strong className="text-ink">Traditional context:</strong> {entry.traditionalEvidence}</p>
+                  <p><strong className="text-ink">Mechanistic/preclinical:</strong> {entry.mechanisticEvidence}</p>
+                </div>
+              </details>
+
+              <div className="mt-5">
+                <h4 className="text-sm font-semibold text-ink">What the label must make clear</h4>
+                <ul className="mt-2 space-y-2 text-sm leading-6 text-muted">
+                  {entry.labelChecks.map((check) => (
+                    <li key={check} className="flex gap-2">
+                      <span aria-hidden="true" className="mt-0.5 text-brand-700">✓</span>
+                      <span>{check}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              <div className="mt-5 flex flex-wrap gap-x-4 gap-y-2 border-t border-brand-900/8 pt-4 text-sm">
+                {entry.internalLinks.map((link) => (
+                  <a key={link.href} href={link.href} className="font-semibold text-brand-800 hover:underline">
+                    {link.label} →
+                  </a>
+                ))}
+                <a href={`#ref-${entry.references[0]}`} className="font-semibold text-muted hover:text-ink hover:underline">
+                  Source{entry.references.length > 1 ? 's' : ''} [{entry.references.join(', ')}]
+                </a>
+              </div>
+            </article>
+          ))}
+        </div>
+      ) : (
+        <div className="rounded-2xl border border-dashed border-brand-900/20 p-8 text-center">
+          <p className="font-semibold text-ink">No entries match those filters.</p>
+          <button
+            type="button"
+            className="mt-3 font-semibold text-brand-800 hover:underline"
+            onClick={() => {
+              setFilter('all')
+              setQuery('')
+            }}
+          >
+            Clear filters
+          </button>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/app/guides/other/alkaloids-on-amazon/__tests__/alkaloids.test.ts
+++ b/app/guides/other/alkaloids-on-amazon/__tests__/alkaloids.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  ALKALOID_DIRECTORY,
+  COMMONLY_MISTAKEN_FOR_ALKALOIDS,
+  HIGHER_CAUTION_IDS,
+  PRODUCT_SCREENING_CRITERIA,
+} from '../alkaloids'
+
+describe('alkaloid commerce-readiness data', () => {
+  it('keeps required higher-caution entries conservative', () => {
+    const higherCautionIds = ALKALOID_DIRECTORY
+      .filter((entry) => entry.safetyTier === 'higher')
+      .map((entry) => entry.id)
+      .sort()
+
+    expect(higherCautionIds).toEqual([...HIGHER_CAUTION_IDS].sort())
+    for (const entry of ALKALOID_DIRECTORY.filter((item) => item.safetyTier === 'higher')) {
+      expect(entry.safetyLabel).toBe('Higher caution')
+      expect(entry.safetySummary.length).toBeGreaterThan(80)
+    }
+  })
+
+  it('does not misclassify L-theanine as an alkaloid', () => {
+    expect(ALKALOID_DIRECTORY.some((entry) => entry.id === 'l-theanine')).toBe(false)
+    expect(COMMONLY_MISTAKEN_FOR_ALKALOIDS).toContainEqual(
+      expect.objectContaining({
+        name: 'L-theanine',
+        classification: expect.stringContaining('not an alkaloid'),
+      }),
+    )
+  })
+
+  it('contains no commerce activation fields and covers every screening requirement', () => {
+    const serialized = JSON.stringify(ALKALOID_DIRECTORY).toLowerCase()
+
+    expect(serialized).not.toContain('affiliateurl')
+    expect(serialized).not.toContain('trackingid')
+    expect(serialized).not.toContain('merchant')
+    expect(serialized).not.toContain('"price"')
+    expect(PRODUCT_SCREENING_CRITERIA.map((criterion) => criterion.title)).toEqual([
+      'Botanical identity',
+      'Plant part',
+      'Standardization',
+      'Supplement Facts',
+      'Responsible manufacturer',
+      'COA and testing',
+      'No opaque blends',
+      'No high-risk positioning',
+    ])
+  })
+
+  it('keeps blue lotus and cat’s claw out of withdrawal substitution guidance', () => {
+    const blueLotus = ALKALOID_DIRECTORY.find((entry) => entry.id === 'blue-lotus')
+    const catsClaw = ALKALOID_DIRECTORY.find((entry) => entry.id === 'cats-claw')
+
+    expect(blueLotus?.safetySummary).toContain('Reject')
+    expect(blueLotus?.safetySummary).toContain('substitution')
+    expect(catsClaw?.humanEvidence).toContain('no reliable human evidence')
+    expect(catsClaw?.labelChecks.join(' ')).toContain('No withdrawal')
+  })
+})

--- a/app/guides/other/alkaloids-on-amazon/alkaloids.ts
+++ b/app/guides/other/alkaloids-on-amazon/alkaloids.ts
@@ -1,0 +1,342 @@
+export type AlkaloidEvidenceBand = 'human' | 'limited' | 'traditional'
+export type AlkaloidFormat = 'botanical' | 'isolated'
+export type AlkaloidSafetyTier = 'standard' | 'interaction' | 'higher'
+
+export type AlkaloidDirectoryEntry = {
+  id: string
+  name: string
+  identity: string
+  alkaloids: string
+  classification: string
+  formats: AlkaloidFormat[]
+  evidenceBand: AlkaloidEvidenceBand
+  evidenceLabel: string
+  humanEvidence: string
+  traditionalEvidence: string
+  mechanisticEvidence: string
+  safetyTier: AlkaloidSafetyTier
+  safetyLabel: string
+  safetySummary: string
+  labelChecks: string[]
+  internalLinks: Array<{ label: string; href: string }>
+  references: number[]
+}
+
+export const ALKALOID_DIRECTORY: AlkaloidDirectoryEntry[] = [
+  {
+    id: 'caffeine',
+    name: 'Caffeine',
+    identity: 'Caffeine from coffee, tea, guarana, kola nut, or yerba maté—or isolated caffeine',
+    alkaloids: 'Caffeine',
+    classification: 'Methylxanthine (purine alkaloid)',
+    formats: ['botanical', 'isolated'],
+    evidenceBand: 'human',
+    evidenceLabel: 'Substantial human evidence',
+    humanEvidence:
+      'Acute alertness and performance effects are well studied in people. Evidence for weight loss or broad “metabolism” promises is much less useful and often comes from multi-ingredient products.',
+    traditionalEvidence:
+      'Caffeinated plants have long food and beverage histories, but that does not make concentrated extracts equivalent to tea or coffee.',
+    mechanisticEvidence:
+      'Adenosine-receptor antagonism explains stimulation; tolerance, sleep timing, total daily exposure, and stimulant stacking shape the practical risk.',
+    safetyTier: 'standard',
+    safetyLabel: 'Dose and stacking matter',
+    safetySummary:
+      'Check the total caffeine from every source. Extra caution is warranted with anxiety, sleep disruption, pregnancy, cardiovascular sensitivity, and other stimulants.',
+    labelChecks: ['Exact caffeine amount per serving', 'All botanical caffeine sources disclosed', 'No stimulant blend hiding the total dose'],
+    internalLinks: [
+      { label: 'Caffeine profile', href: '/compounds/caffeine/' },
+      { label: 'Caffeine vs. L-theanine', href: '/guides/compare/caffeine-vs-l-theanine/' },
+    ],
+    references: [4],
+  },
+  {
+    id: 'berberine',
+    name: 'Berberine',
+    identity: 'An isolated constituent found in barberry, goldenseal, Oregon grape, and related plants',
+    alkaloids: 'Berberine',
+    classification: 'Isoquinoline alkaloid',
+    formats: ['isolated', 'botanical'],
+    evidenceBand: 'human',
+    evidenceLabel: 'Human evidence, interaction-heavy',
+    humanEvidence:
+      'Human trials and reviews report changes in some glucose and lipid markers, but study quality and populations vary. This is not evidence that berberine replaces prescribed treatment.',
+    traditionalEvidence:
+      'Berberine-containing plants have histories in several medical traditions; modern isolated products are a different exposure from traditional preparations.',
+    mechanisticEvidence:
+      'Multiple metabolic enzymes, transporters, and signaling pathways have been studied. The same breadth helps explain why medication interactions deserve prominent attention.',
+    safetyTier: 'interaction',
+    safetyLabel: 'Interaction caution',
+    safetySummary:
+      'Medication review is important. Avoid during pregnancy, breastfeeding, and infancy; gastrointestinal effects are common in clinical use.',
+    labelChecks: ['Chemical form stated clearly', 'Amount per serving is visible', 'No “natural GLP-1” or medication-replacement positioning'],
+    internalLinks: [
+      { label: 'Berberine profile', href: '/compounds/berberine/' },
+      { label: 'Berberine evidence guide', href: '/guides/other/berberine-weight-loss/' },
+    ],
+    references: [13],
+  },
+  {
+    id: 'theobromine',
+    name: 'Theobromine',
+    identity: 'A constituent of cacao; also used as an isolated ingredient in some formulas',
+    alkaloids: 'Theobromine',
+    classification: 'Methylxanthine (purine alkaloid)',
+    formats: ['botanical', 'isolated'],
+    evidenceBand: 'limited',
+    evidenceLabel: 'Limited use-specific human evidence',
+    humanEvidence:
+      'Human exposure through cacao is familiar, but that does not establish a benefit for concentrated standalone products or multi-ingredient “energy” formulas.',
+    traditionalEvidence:
+      'Cacao has a long food and ceremonial history. Historical use should not be used as a dose or efficacy claim for extracts.',
+    mechanisticEvidence:
+      'Theobromine is pharmacologically related to caffeine but has a different stimulant and cardiovascular profile.',
+    safetyTier: 'standard',
+    safetyLabel: 'Concentration matters',
+    safetySummary:
+      'Concentrated products should not be treated like ordinary chocolate. Check for added caffeine and consider cardiovascular or sleep sensitivity.',
+    labelChecks: ['Theobromine amount stated', 'Added caffeine separated from the total', 'No proprietary “energy matrix”'],
+    internalLinks: [{ label: 'Supplement stacking safety', href: '/guides/other/supplement-stacking-safety/' }],
+    references: [2, 4],
+  },
+  {
+    id: 'california-poppy',
+    name: 'California poppy',
+    identity: 'Eschscholzia californica aerial parts—not Papaver somniferum',
+    alkaloids: 'Protopine and related isoquinoline alkaloids',
+    classification: 'Botanical source of isoquinoline alkaloids',
+    formats: ['botanical'],
+    evidenceBand: 'traditional',
+    evidenceLabel: 'Traditional use; limited clinical evidence',
+    humanEvidence:
+      'Clinical evidence is too limited to make confident sleep, anxiety, pain, or withdrawal claims.',
+    traditionalEvidence:
+      'European herbal assessments recognize a history of traditional use, which is not the same as strong clinical proof.',
+    mechanisticEvidence:
+      'Alkaloid and sedative-pathway findings are largely preclinical and do not establish an opioid-like effect in people.',
+    safetyTier: 'interaction',
+    safetyLabel: 'Sedative-interaction caution',
+    safetySummary:
+      'Do not confuse this plant with opium poppy. Avoid stacking sedating botanicals with alcohol, sleep medicines, or other central nervous system depressants without clinical guidance.',
+    labelChecks: ['Botanical name: Eschscholzia californica', 'Aerial plant part identified', 'No “herbal opioid” or withdrawal positioning'],
+    internalLinks: [
+      { label: 'Sleep supplement guide', href: '/guides/other/sleep-supplements-guide/' },
+      { label: 'Site safety checker', href: '/safety-checker/' },
+    ],
+    references: [9, 10],
+  },
+  {
+    id: 'blue-lotus',
+    name: 'Blue lotus',
+    identity: 'Nymphaea caerulea—not sacred lotus (Nelumbo nucifera)',
+    alkaloids: 'Nuciferine and related aporphine alkaloids',
+    classification: 'Aporphine alkaloids in a botanical product',
+    formats: ['botanical'],
+    evidenceBand: 'traditional',
+    evidenceLabel: 'Mostly traditional, chemical, and case-report evidence',
+    humanEvidence:
+      'There are no robust human trials supporting general wellness, sleep, or withdrawal uses. Published clinical literature includes a small toxicity case series rather than efficacy evidence.',
+    traditionalEvidence:
+      'Historical and ritual associations are often repeated online, but they do not establish modern product identity, dose, or clinical benefit.',
+    mechanisticEvidence:
+      'Receptor findings and constituent chemistry are hypothesis-generating; they do not predict a reliable effect from an unverified extract.',
+    safetyTier: 'higher',
+    safetyLabel: 'Higher caution',
+    safetySummary:
+      'Sedation and perceptual disturbances have been reported. Reject vaping, smoking, “legal high,” extreme-extract, or kratom/7-OH substitution positioning.',
+    labelChecks: ['Botanical name: Nymphaea caerulea', 'Plant part and extraction ratio disclosed', 'Identity and contaminant COA available'],
+    internalLinks: [{ label: 'Psychedelic-adjacent herb safety guide', href: '/guides/other/psychedelic-adjacent-herbs/' }],
+    references: [8],
+  },
+  {
+    id: 'huperzine-a',
+    name: 'Huperzine A',
+    identity: 'An isolated Lycopodium alkaloid associated with Huperzia serrata',
+    alkaloids: 'Huperzine A',
+    classification: 'Lycopodium alkaloid; acetylcholinesterase inhibitor',
+    formats: ['isolated'],
+    evidenceBand: 'limited',
+    evidenceLabel: 'Clinical-context evidence; uncertain general use',
+    humanEvidence:
+      'Trials and reviews mostly concern dementia-related clinical contexts. Reviews flag heterogeneous, low-quality primary studies, so they do not support casual memory-enhancement claims for healthy shoppers.',
+    traditionalEvidence:
+      'Traditional plant use does not map cleanly onto a measured isolated compound.',
+    mechanisticEvidence:
+      'Acetylcholinesterase inhibition is pharmacologically meaningful and makes cholinergic stacking a safety issue, not a reason to assume cognitive benefit.',
+    safetyTier: 'higher',
+    safetyLabel: 'Higher caution',
+    safetySummary:
+      'Avoid self-directed stacking with other cholinergic ingredients or medicines. Pregnancy, heart-rate concerns, and medication use call for clinician review.',
+    labelChecks: ['Huperzine A amount shown in micrograms', 'No hidden cholinergic blend', 'No disease-treatment or “limitless” claims'],
+    internalLinks: [
+      { label: 'Nootropic stacking guide', href: '/guides/other/nootropic-stacking-guide/' },
+      { label: 'Site safety checker', href: '/safety-checker/' },
+    ],
+    references: [7],
+  },
+  {
+    id: 'bitter-orange',
+    name: 'Bitter orange',
+    identity: 'Citrus aurantium fruit or extract',
+    alkaloids: 'p-Synephrine and related protoalkaloids',
+    classification: 'Protoalkaloid / sympathomimetic amine (classification varies)',
+    formats: ['botanical', 'isolated'],
+    evidenceBand: 'limited',
+    evidenceLabel: 'Small, confounded human studies',
+    humanEvidence:
+      'Weight-loss studies are generally small, short, and frequently use multi-ingredient formulas, making benefit and safety difficult to attribute to bitter orange.',
+    traditionalEvidence:
+      'Traditional citrus use is not evidence for concentrated stimulant-style extracts.',
+    mechanisticEvidence:
+      'Adrenergic activity raises practical questions about heart rate, blood pressure, and combination with caffeine or other stimulants.',
+    safetyTier: 'higher',
+    safetyLabel: 'Higher caution',
+    safetySummary:
+      'Reject stimulant stacks, especially products that obscure caffeine or make rapid weight-loss claims. Cardiovascular conditions and medication use require clinician review.',
+    labelChecks: ['Citrus aurantium and plant part identified', 'p-Synephrine amount and standardization visible', 'Total caffeine disclosed'],
+    internalLinks: [
+      { label: 'Stimulant-free focus guide', href: '/guides/focus/focus-without-caffeine-crash/' },
+      { label: 'Supplement stacking safety', href: '/guides/other/supplement-stacking-safety/' },
+    ],
+    references: [4, 5],
+  },
+  {
+    id: 'yohimbe',
+    name: 'Yohimbe',
+    identity: 'Pausinystalia yohimbe bark or a yohimbine-standardized extract',
+    alkaloids: 'Yohimbine and related indole alkaloids',
+    classification: 'Indole alkaloids in a botanical stimulant',
+    formats: ['botanical', 'isolated'],
+    evidenceBand: 'limited',
+    evidenceLabel: 'Little supplement efficacy evidence; documented risk',
+    humanEvidence:
+      'NCCIH reports very little research in people on yohimbe supplements and insufficient evidence for health uses. Product analyses have also found major yohimbine-label variability.',
+    traditionalEvidence:
+      'Traditional use does not resolve modern extract potency, adulteration, or medication-interaction concerns.',
+    mechanisticEvidence:
+      'Adrenergic effects are consistent with anxiety, blood-pressure, heart-rate, and stimulant-stacking concerns.',
+    safetyTier: 'higher',
+    safetyLabel: 'Higher caution',
+    safetySummary:
+      'Associated risks include blood-pressure problems, arrhythmia, heart attack, and seizures. Avoid sexual-enhancement, rapid-fat-loss, and stimulant-stack positioning.',
+    labelChecks: ['Botanical identity and bark stated', 'Yohimbine amount verified independently', 'No proprietary sexual-enhancement blend'],
+    internalLinks: [
+      { label: 'Serotonin and MAOI safety context', href: '/learn/serotonin-syndrome-supplements/' },
+      { label: 'Site safety checker', href: '/safety-checker/' },
+    ],
+    references: [6, 15],
+  },
+  {
+    id: 'corydalis',
+    name: 'Corydalis',
+    identity: 'Corydalis yanhusuo rhizome; species and plant part are essential',
+    alkaloids: 'Tetrahydropalmatine and related isoquinoline alkaloids',
+    classification: 'Isoquinoline alkaloids in a traditional botanical',
+    formats: ['botanical'],
+    evidenceBand: 'traditional',
+    evidenceLabel: 'Traditional and preclinical evidence dominate',
+    humanEvidence:
+      'Human evidence is not strong enough for confident pain, sleep, or withdrawal recommendations. A recent product analysis found large alkaloid variability and a possible enriched/adulterated sample.',
+    traditionalEvidence:
+      'Corydalis rhizome has traditional use in Chinese medicine; that history does not validate an unidentified powder or unusually concentrated extract.',
+    mechanisticEvidence:
+      'Dopamine and other receptor findings are preclinical and should not be translated into opioid-substitution or analgesic promises.',
+    safetyTier: 'higher',
+    safetyLabel: 'Higher caution',
+    safetySummary:
+      'Reject products without species, rhizome identity, alkaloid testing, and contaminant testing. Avoid sedative stacking and self-treatment positioning.',
+    labelChecks: ['Species: Corydalis yanhusuo', 'Rhizome identified', 'Alkaloid profile and contaminant COA available'],
+    internalLinks: [
+      { label: 'Corydalis profile', href: '/herbs/corydalis/' },
+      { label: 'Site safety checker', href: '/safety-checker/' },
+    ],
+    references: [11],
+  },
+  {
+    id: 'cats-claw',
+    name: 'Cat’s claw',
+    identity: 'Uncaria tomentosa or Uncaria guianensis—not similarly named herbs',
+    alkaloids: 'Pentacyclic and tetracyclic oxindole alkaloids',
+    classification: 'Oxindole alkaloids in a botanical product',
+    formats: ['botanical'],
+    evidenceBand: 'limited',
+    evidenceLabel: 'Very limited high-quality human evidence',
+    humanEvidence:
+      'NCCIH finds no conclusive human evidence for a health purpose. There is no reliable human evidence supporting cat’s claw as a kratom or 7-OH withdrawal aid.',
+    traditionalEvidence:
+      'Amazonian traditional use is culturally important context, but it is not proof for modern disease, pain, or withdrawal claims.',
+    mechanisticEvidence:
+      'Immune and inflammatory findings do not establish a clinically meaningful outcome and may matter for autoimmune or medication safety.',
+    safetyTier: 'interaction',
+    safetyLabel: 'Interaction caution',
+    safetySummary:
+      'Use extra caution with autoimmune disease, pregnancy, anticoagulant or antiplatelet drugs, blood-pressure drugs, and surgery.',
+    labelChecks: ['Uncaria species named', 'Bark or root plant part identified', 'No withdrawal, detox, or immune-disease claims'],
+    internalLinks: [
+      { label: 'Evidence-methodology guide', href: '/info/methodology/' },
+      { label: 'Site safety checker', href: '/safety-checker/' },
+    ],
+    references: [12],
+  },
+]
+
+export const HIGHER_CAUTION_IDS = [
+  'blue-lotus',
+  'huperzine-a',
+  'bitter-orange',
+  'yohimbe',
+  'corydalis',
+] as const
+export const COMMONLY_MISTAKEN_FOR_ALKALOIDS = [
+  {
+    name: 'L-theanine',
+    classification: 'A non-protein amino acid found in tea—not an alkaloid.',
+    href: '/compounds/l-theanine/',
+  },
+  {
+    name: 'L-tyrosine',
+    classification: 'An amino acid—not an alkaloid.',
+  },
+  {
+    name: '5-HTP',
+    classification: 'An amino-acid derivative and serotonin precursor—not an alkaloid.',
+  },
+  {
+    name: 'Taurine',
+    classification: 'An amino sulfonic acid—not an alkaloid.',
+  },
+] as const
+
+export const PRODUCT_SCREENING_CRITERIA = [
+  {
+    title: 'Botanical identity',
+    detail: 'Require the full Latin binomial; reject common-name-only labels where plants can be confused.',
+  },
+  {
+    title: 'Plant part',
+    detail: 'Bark, rhizome, aerial parts, leaf, seed, and flower are not interchangeable.',
+  },
+  {
+    title: 'Standardization',
+    detail: 'The named marker, percentage, and actual amount per serving should all be visible.',
+  },
+  {
+    title: 'Supplement Facts',
+    detail: 'Every active ingredient and amount should be readable before purchase.',
+  },
+  {
+    title: 'Responsible manufacturer',
+    detail: 'Look for a traceable company, lot number, contact path, and manufacturing-quality information.',
+  },
+  {
+    title: 'COA and testing',
+    detail: 'Prefer lot-specific identity, potency, heavy-metal, microbial, and adulterant testing from an independent laboratory.',
+  },
+  {
+    title: 'No opaque blends',
+    detail: 'Reject proprietary blends that hide the amount of the alkaloid source or accompanying stimulants and sedatives.',
+  },
+  {
+    title: 'No high-risk positioning',
+    detail: 'Reject vaping, smoking, “legal high,” detox, withdrawal-substitute, rapid-weight-loss, or drug-like marketing.',
+  },
+] as const

--- a/app/guides/other/alkaloids-on-amazon/page.tsx
+++ b/app/guides/other/alkaloids-on-amazon/page.tsx
@@ -1,0 +1,373 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+import FAQAccordion from '@/components/FAQAccordion'
+import SchemaGraphScript from '@/components/seo/SchemaGraphScript'
+import FaqJsonLd from '@/components/seo/FaqJsonLd'
+import { SITE_URL } from '@/src/lib/seo'
+import { buildGuideHubSchemaGraph } from '@/src/lib/schema-graph'
+
+import AlkaloidDirectory from './AlkaloidDirectory'
+import {
+  ALKALOID_DIRECTORY,
+  COMMONLY_MISTAKEN_FOR_ALKALOIDS,
+  PRODUCT_SCREENING_CRITERIA,
+} from './alkaloids'
+
+const PATH = '/guides/other/alkaloids-on-amazon/'
+const TITLE = 'Alkaloids on Amazon: A Science-First Supplement Directory'
+const DESCRIPTION =
+  'A safety-first directory of naturally occurring alkaloids discussed in online supplement shopping, with evidence types, taxonomy checks, and product-screening criteria—not product endorsements.'
+
+const FAQS = [
+  {
+    question: 'What is an alkaloid?',
+    answer:
+      'Alkaloid is a broad chemistry term for naturally occurring nitrogen-containing compounds, many of which have meaningful biological activity. The category includes several chemical families, so sharing the label “alkaloid” does not mean two ingredients work alike or carry the same risk.',
+  },
+  {
+    question: 'Is L-theanine an alkaloid?',
+    answer:
+      'No. L-theanine is a non-protein amino acid found in tea. It is often grouped with caffeine in supplement discussions, but caffeine is a methylxanthine alkaloid and L-theanine is not.',
+  },
+  {
+    question: 'Is California poppy the same plant as opium poppy?',
+    answer:
+      'No. California poppy is Eschscholzia californica. Opium poppy is Papaver somniferum, the source of opium alkaloids such as morphine and codeine. A responsible California poppy label should state Eschscholzia californica and the plant part.',
+  },
+  {
+    question: 'Are the ingredients on this page currently sold on Amazon?',
+    answer:
+      'This page does not verify or monitor current Amazon listings, prices, sellers, or availability. Marketplace inventory changes quickly. Every product would need a separate identity, label, testing, manufacturer, claims, and catalog review before it could be considered for a recommendation.',
+  },
+  {
+    question: 'Does a higher-caution label mean an ingredient is illegal?',
+    answer:
+      'No. The label reflects evidence uncertainty, pharmacology, interaction potential, product variability, or reported harms; it is not a legal-status determination. Laws and marketplace policies vary by place and can change.',
+  },
+  {
+    question: 'Can blue lotus or cat’s claw replace kratom or 7-OH during withdrawal?',
+    answer:
+      'There is no reliable human evidence supporting either as a kratom or 7-OH withdrawal treatment or substitute. This page provides no substitution protocol. People experiencing withdrawal or concerning symptoms should seek qualified medical or addiction care.',
+  },
+]
+
+const REFERENCES = [
+  {
+    n: 1,
+    label: 'PubChem. L-Theanine compound summary.',
+    url: 'https://pubchem.ncbi.nlm.nih.gov/compound/L-Theanine',
+  },
+  {
+    n: 2,
+    label: 'U.S. Food and Drug Administration. FDA 101: Dietary Supplements.',
+    url: 'https://www.fda.gov/consumers/consumer-updates/fda-101-dietary-supplements',
+  },
+  {
+    n: 3,
+    label: 'U.S. Food and Drug Administration. Dietary supplement current good manufacturing practices.',
+    url: 'https://www.fda.gov/food/dietary-supplements-guidance-documents-regulatory-information/backgrounder-final-rule-current-good-manufacturing-practices-cgmps-dietary-supplements',
+  },
+  {
+    n: 4,
+    label: 'NIH Office of Dietary Supplements. Dietary Supplements for Weight Loss: Health Professional Fact Sheet.',
+    url: 'https://ods.od.nih.gov/factsheets/WeightLoss-HealthProfessional/',
+  },
+  {
+    n: 5,
+    label: 'National Center for Complementary and Integrative Health. Bitter Orange: Usefulness and Safety.',
+    url: 'https://www.nccih.nih.gov/health/bitter-orange',
+  },
+  {
+    n: 6,
+    label: 'National Center for Complementary and Integrative Health. Yohimbe: Usefulness and Safety.',
+    url: 'https://www.nccih.nih.gov/health/yohimbe',
+  },
+  {
+    n: 7,
+    label: 'Wang J, et al. The effects of Huperzine A on dementia and mild cognitive impairment: an overview of systematic reviews. 2021.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/33851462/',
+  },
+  {
+    n: 8,
+    label: 'Schimpf M, et al. Toxicity From Blue Lotus After Ingestion or Inhalation: A Case Series. Military Medicine. 2023.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/34345890/',
+  },
+  {
+    n: 9,
+    label: 'European Medicines Agency. Eschscholziae herba (California poppy) assessment resources.',
+    url: 'https://www.ema.europa.eu/en/medicines/herbal/eschscholziae-herba',
+  },
+  {
+    n: 10,
+    label: 'U.S. Drug Enforcement Administration. Opium fact sheet (Papaver somniferum).',
+    url: 'https://www.dea.gov/factsheets/opium',
+  },
+  {
+    n: 11,
+    label: 'Eisenreich W, et al. Large variability in the alkaloid content of Corydalis yanhusuo dietary supplements. 2025.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/39881869/',
+  },
+  {
+    n: 12,
+    label: 'National Center for Complementary and Integrative Health. Cat’s Claw: Usefulness and Safety.',
+    url: 'https://www.nccih.nih.gov/health/cats-claw',
+  },
+  {
+    n: 13,
+    label: 'National Center for Complementary and Integrative Health. Diabetes and Dietary Supplements (berberine evidence and safety).',
+    url: 'https://www.nccih.nih.gov/health/diabetes-and-dietary-supplements-what-you-need-to-know',
+  },
+  {
+    n: 14,
+    label: 'U.S. Food and Drug Administration. Avoiding Products Contaminated with Hidden Ingredients.',
+    url: 'https://www.fda.gov/drugs/medication-health-fraud/avoiding-products-contaminated-hidden-ingredients',
+  },
+  {
+    n: 15,
+    label: 'U.S. Food and Drug Administration. Sexual Enhancement and Energy Product Notifications.',
+    url: 'https://www.fda.gov/drugs/medication-health-fraud-notifications/sexual-enhancement-and-energy-product-notifications',
+  },
+]
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  alternates: { canonical: `${SITE_URL}${PATH}` },
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    url: `${SITE_URL}${PATH}`,
+    type: 'article',
+    images: ['/og-default.jpg'],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: TITLE,
+    description: DESCRIPTION,
+  },
+}
+
+export default function AlkaloidsOnAmazonPage() {
+  const schemaGraph = buildGuideHubSchemaGraph({
+    path: PATH,
+    title: TITLE,
+    description: DESCRIPTION,
+    breadcrumbs: [
+      { name: 'Home', url: `${SITE_URL}/` },
+      { name: 'Guides', url: `${SITE_URL}/guides/` },
+      { name: 'Topic Guides', url: `${SITE_URL}/guides/other/` },
+      { name: 'Alkaloids on Amazon', url: `${SITE_URL}${PATH}` },
+    ],
+    itemListName: 'Naturally occurring alkaloid supplement categories',
+    items: ALKALOID_DIRECTORY.map((entry) => ({
+      name: entry.name,
+      url: `${PATH}#${entry.id}`,
+    })),
+  })
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 pb-24 pt-8 sm:px-6">
+      <SchemaGraphScript graph={schemaGraph} />
+      <FaqJsonLd items={FAQS} />
+
+      <nav className="mb-5 text-xs text-muted" aria-label="Breadcrumb">
+        <Link href="/guides/" className="hover:text-ink">Guides</Link>
+        <span className="mx-1.5">/</span>
+        <Link href="/guides/other/" className="hover:text-ink">Topic guides</Link>
+        <span className="mx-1.5">/</span>
+        <span className="font-medium text-ink">Alkaloids on Amazon</span>
+      </nav>
+
+      <header className="relative overflow-hidden rounded-[2rem] border border-brand-900/12 bg-[linear-gradient(135deg,var(--surface-card),var(--surface-subtle))] p-6 shadow-sm sm:p-10 lg:p-12">
+        <div aria-hidden="true" className="absolute -right-16 -top-20 h-64 w-64 rounded-full bg-brand-600/10 blur-3xl" />
+        <div className="relative max-w-4xl">
+          <p className="eyebrow-label">Chemistry before commerce</p>
+          <h1 className="mt-3 font-display text-4xl font-semibold tracking-tight text-ink sm:text-6xl">
+            Alkaloids on Amazon
+          </h1>
+          <p className="mt-4 max-w-3xl text-lg leading-8 text-muted sm:text-xl">
+            A science-first directory for understanding naturally occurring alkaloids that appear in
+            online supplement conversations—without pretending a marketplace listing proves identity,
+            evidence, safety, or quality.
+          </p>
+
+          <div className="mt-7 flex flex-wrap gap-3">
+            <a
+              href="#directory"
+              className="inline-flex min-h-11 items-center rounded-full bg-brand-800 px-5 py-2.5 font-semibold text-white shadow-sm transition hover:bg-brand-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-700 focus-visible:ring-offset-2 dark:bg-brand-600 dark:text-[#07150c]"
+            >
+              Explore the directory
+            </a>
+            <a
+              href="#screening-checklist"
+              className="inline-flex min-h-11 items-center rounded-full border border-brand-900/15 bg-[var(--surface-card)] px-5 py-2.5 font-semibold text-ink transition hover:border-brand-700/35 hover:text-brand-800"
+            >
+              Use the screening checklist
+            </a>
+          </div>
+        </div>
+      </header>
+
+      <section className="mt-6 rounded-2xl border border-amber-900/15 bg-amber-50/70 p-5 text-sm leading-7 text-amber-950 dark:border-amber-400/20 dark:bg-amber-950/30 dark:text-amber-100">
+        <p className="text-xs font-bold uppercase tracking-widest">Commerce status: research only</p>
+        <p className="mt-2">
+          This page has no affiliate links, merchant links, ranked products, prices, or verified
+          availability claims. Product recommendations remain intentionally inactive until a current
+          catalog, label, testing, manufacturer, claims, disclosure, legal, privacy, and tracking review
+          is complete.
+        </p>
+        <Link href="/info/affiliate-disclosure/" className="mt-2 inline-flex font-semibold underline decoration-current/30 underline-offset-4">
+          Read the site’s affiliate and editorial policy
+        </Link>
+      </section>
+
+      <section className="my-12 grid gap-5 lg:grid-cols-3">
+        <article className="rounded-2xl border border-brand-900/10 bg-[var(--surface-card)] p-5">
+          <p className="text-xs font-bold uppercase tracking-wider text-brand-700">1 · Identity</p>
+          <h2 className="mt-2 text-xl font-semibold text-ink">The name is not enough</h2>
+          <p className="mt-2 text-sm leading-7 text-muted">
+            “Poppy,” “lotus,” and “cat’s claw” can each hide a species problem. Start with the Latin
+            binomial and plant part before considering evidence.
+          </p>
+        </article>
+        <article className="rounded-2xl border border-brand-900/10 bg-[var(--surface-card)] p-5">
+          <p className="text-xs font-bold uppercase tracking-wider text-brand-700">2 · Evidence</p>
+          <h2 className="mt-2 text-xl font-semibold text-ink">Separate the evidence lanes</h2>
+          <p className="mt-2 text-sm leading-7 text-muted">
+            Human outcomes, traditional use, receptor mechanisms, and animal studies answer different
+            questions. This directory never treats them as interchangeable.
+          </p>
+        </article>
+        <article className="rounded-2xl border border-brand-900/10 bg-[var(--surface-card)] p-5">
+          <p className="text-xs font-bold uppercase tracking-wider text-brand-700">3 · Product</p>
+          <h2 className="mt-2 text-xl font-semibold text-ink">A listing is not verification</h2>
+          <p className="mt-2 text-sm leading-7 text-muted">
+            FDA does not approve dietary supplements for safety and effectiveness before sale. Labels,
+            testing, claims, and manufacturers require their own review. [2, 3]
+          </p>
+        </article>
+      </section>
+
+      <aside className="mb-12 rounded-3xl border-2 border-rose-800/20 bg-rose-50/70 p-5 sm:p-7 dark:border-rose-400/25 dark:bg-rose-950/30">
+        <p className="text-xs font-bold uppercase tracking-widest text-rose-800 dark:text-rose-200">
+          Not a kratom or 7-OH withdrawal guide
+        </p>
+        <h2 className="mt-2 text-2xl font-semibold text-rose-950 dark:text-rose-100">
+          Curiosity is not evidence of a safe substitute
+        </h2>
+        <p className="mt-3 max-w-4xl text-sm leading-7 text-rose-950/85 dark:text-rose-100/85">
+          Blue lotus and cat’s claw are sometimes discussed in communities where people are reducing or
+          stopping kratom or concentrated 7-OH. Reliable human evidence does not support either as a
+          withdrawal treatment or replacement, and this page offers no substitution instructions. If
+          you are experiencing withdrawal or concerning symptoms, seek qualified medical or addiction
+          care. Severe or rapidly worsening symptoms need urgent evaluation.
+        </p>
+        <div className="mt-4 flex flex-wrap gap-x-5 gap-y-2 text-sm font-semibold">
+          <Link href="/guides/other/kratom-7oh-withdrawal-management/" className="text-rose-900 underline underline-offset-4 dark:text-rose-200">
+            Read the separate harm-reduction guide
+          </Link>
+          <Link href="/info/disclaimer/" className="text-rose-900 underline underline-offset-4 dark:text-rose-200">
+            Health information disclaimer
+          </Link>
+        </div>
+      </aside>
+
+      <AlkaloidDirectory entries={ALKALOID_DIRECTORY} />
+
+      <section id="screening-checklist" className="mt-16 scroll-mt-24">
+        <div className="max-w-3xl">
+          <p className="eyebrow-label">Affiliate-readiness gate</p>
+          <h2 className="mt-2 font-display text-3xl font-semibold tracking-tight text-ink sm:text-4xl">
+            Product-screening criteria
+          </h2>
+          <p className="mt-3 text-base leading-8 text-muted">
+            These are inclusion gates, not quality decorations. A future catalog entry should fail
+            closed when identity, dose, testing, manufacturer, or positioning cannot be verified.
+          </p>
+        </div>
+        <ol className="mt-7 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {PRODUCT_SCREENING_CRITERIA.map((criterion, index) => (
+            <li key={criterion.title} className="rounded-2xl border border-brand-900/10 bg-[var(--surface-card)] p-5">
+              <span className="text-xs font-bold text-brand-700">{String(index + 1).padStart(2, '0')}</span>
+              <h3 className="mt-2 font-semibold text-ink">{criterion.title}</h3>
+              <p className="mt-2 text-sm leading-6 text-muted">{criterion.detail}</p>
+            </li>
+          ))}
+        </ol>
+        <p className="mt-5 text-sm leading-7 text-muted">
+          Also check FDA’s current health-fraud notifications, especially for sexual enhancement,
+          weight loss, energy, pain, bodybuilding, and sleep products, where hidden ingredients are a
+          documented concern. [14, 15]
+        </p>
+      </section>
+
+      <section className="mt-16 rounded-3xl border border-sky-900/12 bg-sky-50/60 p-6 sm:p-8 dark:border-sky-400/20 dark:bg-sky-950/25">
+        <p className="text-xs font-bold uppercase tracking-widest text-sky-800 dark:text-sky-200">
+          Taxonomy check
+        </p>
+        <h2 className="mt-2 font-display text-3xl font-semibold text-sky-950 dark:text-sky-100">
+          Commonly mistaken for alkaloids
+        </h2>
+        <p className="mt-3 max-w-3xl text-sm leading-7 text-sky-950/80 dark:text-sky-100/80">
+          Nitrogen-containing or “nootropic” does not automatically mean alkaloid. L-theanine is the
+          most important correction for this shopping context. [1]
+        </p>
+        <div className="mt-6 grid gap-3 sm:grid-cols-2">
+          {COMMONLY_MISTAKEN_FOR_ALKALOIDS.map((item) => (
+            <article key={item.name} className="rounded-2xl border border-sky-900/10 bg-[var(--surface-card)] p-4">
+              <h3 className="font-semibold text-ink">{item.name}</h3>
+              <p className="mt-1 text-sm leading-6 text-muted">{item.classification}</p>
+              {'href' in item ? (
+                <Link href={item.href} className="mt-2 inline-flex text-sm font-semibold text-brand-800 hover:underline">
+                  Read the compound profile →
+                </Link>
+              ) : null}
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="mt-16" id="faq">
+        <FAQAccordion faqs={FAQS} heading="Questions this directory should answer" />
+      </section>
+
+      <section id="references" aria-label="References" className="mt-12 rounded-3xl border border-brand-900/10 bg-[var(--surface-card)] p-6 sm:p-8">
+        <h2 className="font-display text-2xl font-semibold text-ink">References and regulatory sources</h2>
+        <p className="mt-2 text-sm leading-7 text-muted">
+          Primary research is used where available; federal and European public-health sources support
+          taxonomy, regulation, and safety interpretation.
+        </p>
+        <ol className="mt-5 space-y-3 text-sm leading-6 text-muted">
+          {REFERENCES.map((reference) => (
+            <li key={reference.n} id={`ref-${reference.n}`} className="scroll-mt-24">
+              <span className="font-semibold text-ink">[{reference.n}]</span>{' '}
+              {reference.label}{' '}
+              <a
+                href={reference.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-semibold text-brand-800 underline decoration-brand-700/25 underline-offset-3 hover:decoration-brand-700"
+              >
+                View source
+              </a>
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      <aside className="mt-12 rounded-2xl border border-brand-900/12 bg-brand-50/60 p-6 dark:border-white/10 dark:bg-[var(--surface-subtle)]">
+        <h2 className="font-display text-xl font-semibold text-ink">Continue with evidence, not a cart</h2>
+        <p className="mt-2 max-w-3xl text-sm leading-7 text-muted">
+          Use the full topic library for deeper safety, comparison, and supplement-label guides. This
+          directory is educational and does not diagnose, treat, or recommend a product.
+        </p>
+        <div className="mt-4 flex flex-wrap gap-x-5 gap-y-2 text-sm font-semibold">
+          <Link href="/guides/other/" className="text-brand-800 hover:underline">Browse topic guides →</Link>
+          <Link href="/info/methodology/" className="text-brand-800 hover:underline">How evidence is graded →</Link>
+          <Link href="/safety-checker/" className="text-brand-800 hover:underline">Use the safety checker →</Link>
+        </div>
+      </aside>
+    </div>
+  )
+}

--- a/app/guides/other/topic-guides.ts
+++ b/app/guides/other/topic-guides.ts
@@ -36,6 +36,7 @@ export const TOPIC_GUIDE_GROUPS: TopicGuideGroup[] = [
     description:
       'Evidence-first reviews for categories that attract strong marketing but still require careful product and goal matching.',
     guides: [
+      { href: '/guides/other/alkaloids-on-amazon/', title: 'Alkaloids on Amazon', desc: 'Identify alkaloid supplement categories, separate evidence types, and screen labels without product endorsements.' },
       { href: '/guides/other/apple-cider-vinegar/', title: 'Apple Cider Vinegar', desc: 'Separate evidence on blood sugar, weight, and digestion from trend claims.' },
       { href: '/guides/other/bovine-colostrum/', title: 'Bovine Colostrum', desc: 'Review immune, gut, performance, and safety evidence behind the category.' },
       { href: '/guides/other/collagen-supplements/', title: 'Collagen Supplements', desc: 'Compare evidence for skin, joints, bone, and muscle-related goals.' },

--- a/public/_redirects
+++ b/public/_redirects
@@ -213,6 +213,8 @@ https://www.thehippiescientist.net/* https://thehippiescientist.net/:splat 301
 /best-nootropics-for-focus /guides/focus/best-nootropics-for-focus/ 301
 /best-adaptogens-for-stress /guides/anxiety/best-adaptogens-for-stress/ 301
 /natural-testosterone-boosters /guides/other/testosterone-supplements/ 301
+/alkaloids-on-amazon /guides/other/alkaloids-on-amazon/ 301
+/alkaloids-on-amazon/ /guides/other/alkaloids-on-amazon/ 301
 /comparisons/rhodiola-vs-ashwagandha /compare/rhodiola-vs-ashwagandha/ 301
 /compare/ashwagandha-vs-rhodiola /compare/rhodiola-vs-ashwagandha/ 301
 /compare/ashwagandha-vs-rhodiola-for-stress /compare/rhodiola-vs-ashwagandha/ 301


### PR DESCRIPTION
## What changed
- adds a static, filterable science-first directory at `/guides/other/alkaloids-on-amazon/`
- separates human, traditional, and mechanistic evidence and applies conservative safety labels
- adds product-screening criteria, a no-commerce status notice, and explicit kratom/7-OH substitution guardrails
- distinguishes California poppy from opium poppy and keeps L-theanine in a clearly labeled non-alkaloid section
- links the page from the topic guide hub and redirects the short route to the canonical URL
- adds focused data-contract tests

## Why
This creates a high-curiosity discovery surface and affiliate-ready information architecture without activating commerce, making unverified marketplace claims, or offering medical/substitution guidance.

## Validation
- targeted ESLint
- targeted Vitest: 4 tests passed
- `npm run typecheck`
- `npm run check:fast`
- `npm run build`: 1,194 static pages, structured-data regression checks, 745 sitemap URLs, Pagefind index
- `npm run verify:output`
- responsive desktop/mobile and light/dark browser QA

## Deferred intentionally
No affiliate links, tracking IDs, merchant/product rankings, pricing, availability claims, or policy changes are included. Commerce activation still requires a verified catalog, approved program/IDs, and disclosure/legal/privacy review.