### PR TITLE
Measure qualified recommendation impressions

### DIFF
--- a/components/AffiliateProductBox.tsx
+++ b/components/AffiliateProductBox.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import RevenueImpressionTracker from './RevenueImpressionTracker'
 import { trackRevenueEvent } from '../src/lib/revenue-tracking'
 
 export interface AffiliateEntry {
@@ -36,43 +37,50 @@ export default function AffiliateProductBox({ slug, products, heading = 'Recomme
           const displayTitle = product.title || product.name || 'Supplement option'
           const url = product.affiliateUrl!
           return (
-            <article
+            <RevenueImpressionTracker
               key={product.slot}
-              className="flex flex-col rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm"
+              className="h-full"
+              location="affiliate-product-box"
+              label={displayTitle}
+              productSlug={slug}
+              productSlot={product.slot}
+              productAsin={product.asin}
             >
-              <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">
-                {SLOT_LABELS[product.slot] ?? product.slot}
-              </p>
-              {product.brand && (
-                <p className="mt-0.5 text-xs font-semibold text-muted">{product.brand}</p>
-              )}
-              <h3 className="mt-2 text-sm font-semibold text-ink leading-5">{displayTitle}</h3>
-              {product.rationale && (
-                <p className="mt-2 text-xs leading-5 text-muted flex-1">{product.rationale}</p>
-              )}
-              <a
-                href={url}
-                target="_blank"
-                rel="nofollow sponsored noopener noreferrer"
-                data-revenue-tracked="true"
-                data-ingredient={slug}
-                data-product-slot={product.slot}
-                data-product-asin={product.asin || undefined}
-                data-tracking-location="affiliate-product-box"
-                onClick={() => trackRevenueEvent({
-                  kind: 'recommendation_click',
-                  location: 'affiliate-product-box',
-                  label: displayTitle || slug,
-                  target: url,
-                  productSlug: slug,
-                  productSlot: product.slot,
-                  productAsin: product.asin,
-                })}
-                className="mt-4 inline-flex min-h-10 w-full items-center justify-center rounded-full bg-brand-950 px-4 py-2 text-xs font-bold text-white transition hover:bg-brand-900"
-              >
-                View on Amazon →
-              </a>
-            </article>
+              <article className="flex h-full flex-col rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm">
+                <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">
+                  {SLOT_LABELS[product.slot] ?? product.slot}
+                </p>
+                {product.brand && (
+                  <p className="mt-0.5 text-xs font-semibold text-muted">{product.brand}</p>
+                )}
+                <h3 className="mt-2 text-sm font-semibold text-ink leading-5">{displayTitle}</h3>
+                {product.rationale && (
+                  <p className="mt-2 text-xs leading-5 text-muted flex-1">{product.rationale}</p>
+                )}
+                <a
+                  href={url}
+                  target="_blank"
+                  rel="nofollow sponsored noopener noreferrer"
+                  data-revenue-tracked="true"
+                  data-ingredient={slug}
+                  data-product-slot={product.slot}
+                  data-product-asin={product.asin || undefined}
+                  data-tracking-location="affiliate-product-box"
+                  onClick={() => trackRevenueEvent({
+                    kind: 'recommendation_click',
+                    location: 'affiliate-product-box',
+                    label: displayTitle || slug,
+                    target: url,
+                    productSlug: slug,
+                    productSlot: product.slot,
+                    productAsin: product.asin,
+                  })}
+                  className="mt-4 inline-flex min-h-10 w-full items-center justify-center rounded-full bg-brand-950 px-4 py-2 text-xs font-bold text-white transition hover:bg-brand-900"
+                >
+                  View on Amazon →
+                </a>
+              </article>
+            </RevenueImpressionTracker>
           )
         })}
       </div>

--- a/components/RecommendationSection.tsx
+++ b/components/RecommendationSection.tsx
@@ -1,5 +1,6 @@
 import AffiliateDisclosure from './AffiliateDisclosure'
 import AffiliateProductCard, { type AffiliateProduct } from './AffiliateProductCard'
+import RevenueImpressionTracker from './RevenueImpressionTracker'
 import WhyWeRecommend from '../src/components/monetization/WhyWeRecommend'
 import HorizontalCardRail from './ui/HorizontalCardRail'
 
@@ -51,21 +52,35 @@ export default function RecommendationSection({
       </div>
 
       <HorizontalCardRail label={`${title} options`}>
-        {ordered.map((product) => (
-          <div key={`${product.slot}-${product.title || product.name}`} className='flex h-full flex-col gap-2'>
-            <p className='text-xs font-bold uppercase tracking-[0.16em] text-brand-700 dark:text-brand-200'>{slotLabels[product.slot]}</p>
-            <AffiliateProductCard
-              product={{
-                ...product,
-                preferredRegion: product.preferredRegion ?? preferredRegion,
-                trackingLocation: product.trackingLocation ?? trackingLocation,
-                trackingProductSlug: product.trackingProductSlug ?? trackingProductSlug,
-                trackingSlot: product.trackingSlot ?? product.slot,
-              }}
-              compact
-            />
-          </div>
-        ))}
+        {ordered.map((product) => {
+          const productTitle = product.title || product.name || `${slotLabels[product.slot]} option`
+          const productSlug = product.trackingProductSlug ?? trackingProductSlug
+          const productLocation = product.trackingLocation ?? trackingLocation
+
+          return (
+            <RevenueImpressionTracker
+              key={`${product.slot}-${productTitle}`}
+              className='flex h-full flex-col gap-2'
+              location={productLocation}
+              label={productTitle}
+              productSlug={productSlug}
+              productSlot={product.trackingSlot ?? product.slot}
+              productAsin={product.asin}
+            >
+              <p className='text-xs font-bold uppercase tracking-[0.16em] text-brand-700 dark:text-brand-200'>{slotLabels[product.slot]}</p>
+              <AffiliateProductCard
+                product={{
+                  ...product,
+                  preferredRegion: product.preferredRegion ?? preferredRegion,
+                  trackingLocation: productLocation,
+                  trackingProductSlug: productSlug,
+                  trackingSlot: product.trackingSlot ?? product.slot,
+                }}
+                compact
+              />
+            </RevenueImpressionTracker>
+          )
+        })}
       </HorizontalCardRail>
 
       <WhyWeRecommend className='mt-4' />

--- a/components/RevenueImpressionTracker.tsx
+++ b/components/RevenueImpressionTracker.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { useEffect, useRef, type ReactNode } from 'react'
-import { CONSENT_GRANTED_EVENT, getConsent } from '@/src/lib/consent'
-import { trackRevenueEvent } from '@/src/lib/revenue-tracking'
+import { CONSENT_GRANTED_EVENT, getConsent } from '../src/lib/consent'
+import { trackRevenueEvent } from '../src/lib/revenue-tracking'
 
 export const RECOMMENDATION_IMPRESSION_THRESHOLD = 0.5
 export const RECOMMENDATION_IMPRESSION_DELAY_MS = 1000

--- a/components/RevenueImpressionTracker.tsx
+++ b/components/RevenueImpressionTracker.tsx
@@ -1,0 +1,107 @@
+'use client'
+
+import { useEffect, useRef, type ReactNode } from 'react'
+import { CONSENT_GRANTED_EVENT, getConsent } from '@/src/lib/consent'
+import { trackRevenueEvent } from '@/src/lib/revenue-tracking'
+
+export const RECOMMENDATION_IMPRESSION_THRESHOLD = 0.5
+export const RECOMMENDATION_IMPRESSION_DELAY_MS = 1000
+
+type RevenueImpressionTrackerProps = {
+  children: ReactNode
+  location: string
+  label: string
+  productSlug?: string
+  productSlot?: string
+  productAsin?: string
+  className?: string
+}
+
+export default function RevenueImpressionTracker({
+  children,
+  location,
+  label,
+  productSlug,
+  productSlot,
+  productAsin,
+  className,
+}: RevenueImpressionTrackerProps) {
+  const elementRef = useRef<HTMLDivElement>(null)
+  const visibleRef = useRef(false)
+  const trackedRef = useRef(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    const element = elementRef.current
+    if (!element || typeof IntersectionObserver === 'undefined') return
+
+    const clearPending = () => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+    }
+
+    const scheduleQualifiedImpression = () => {
+      clearPending()
+      if (trackedRef.current || !visibleRef.current || getConsent() !== 'granted') return
+
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null
+        if (trackedRef.current || !visibleRef.current || getConsent() !== 'granted') return
+
+        trackedRef.current = true
+        trackRevenueEvent({
+          kind: 'recommendation_impression',
+          location,
+          label,
+          productSlug,
+          productSlot,
+          productAsin,
+        })
+      }, RECOMMENDATION_IMPRESSION_DELAY_MS)
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        visibleRef.current = Boolean(
+          entry?.isIntersecting && entry.intersectionRatio >= RECOMMENDATION_IMPRESSION_THRESHOLD,
+        )
+
+        if (visibleRef.current) {
+          scheduleQualifiedImpression()
+        } else {
+          clearPending()
+        }
+      },
+      { threshold: [0, RECOMMENDATION_IMPRESSION_THRESHOLD, 1] },
+    )
+
+    const handleConsentChange = () => {
+      if (visibleRef.current) scheduleQualifiedImpression()
+    }
+
+    observer.observe(element)
+    window.addEventListener(CONSENT_GRANTED_EVENT, handleConsentChange)
+
+    return () => {
+      clearPending()
+      observer.disconnect()
+      window.removeEventListener(CONSENT_GRANTED_EVENT, handleConsentChange)
+    }
+  }, [label, location, productAsin, productSlot, productSlug])
+
+  return (
+    <div
+      ref={elementRef}
+      className={className}
+      data-revenue-impression-tracker="true"
+      data-ingredient={productSlug || undefined}
+      data-product-slot={productSlot || undefined}
+      data-product-asin={productAsin || undefined}
+      data-tracking-location={location}
+    >
+      {children}
+    </div>
+  )
+}

--- a/components/__tests__/RevenueImpressionTracker.test.tsx
+++ b/components/__tests__/RevenueImpressionTracker.test.tsx
@@ -11,12 +11,12 @@ const mocks = vi.hoisted(() => ({
   trackRevenueEvent: vi.fn(),
 }))
 
-vi.mock('@/src/lib/consent', () => ({
+vi.mock('../../src/lib/consent', () => ({
   CONSENT_GRANTED_EVENT: 'hs:consent-granted',
   getConsent: mocks.getConsent,
 }))
 
-vi.mock('@/src/lib/revenue-tracking', () => ({
+vi.mock('../../src/lib/revenue-tracking', () => ({
   trackRevenueEvent: mocks.trackRevenueEvent,
 }))
 

--- a/components/__tests__/RevenueImpressionTracker.test.tsx
+++ b/components/__tests__/RevenueImpressionTracker.test.tsx
@@ -1,0 +1,139 @@
+import { act, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import RevenueImpressionTracker, {
+  RECOMMENDATION_IMPRESSION_DELAY_MS,
+  RECOMMENDATION_IMPRESSION_THRESHOLD,
+} from '../RevenueImpressionTracker'
+
+const mocks = vi.hoisted(() => ({
+  getConsent: vi.fn(),
+  trackRevenueEvent: vi.fn(),
+}))
+
+vi.mock('@/src/lib/consent', () => ({
+  CONSENT_GRANTED_EVENT: 'hs:consent-granted',
+  getConsent: mocks.getConsent,
+}))
+
+vi.mock('@/src/lib/revenue-tracking', () => ({
+  trackRevenueEvent: mocks.trackRevenueEvent,
+}))
+
+let observerCallback: IntersectionObserverCallback
+
+class MockIntersectionObserver implements IntersectionObserver {
+  readonly root = null
+  readonly rootMargin = '0px'
+  readonly thresholds = [0, RECOMMENDATION_IMPRESSION_THRESHOLD, 1]
+
+  constructor(callback: IntersectionObserverCallback) {
+    observerCallback = callback
+  }
+
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+  takeRecords = vi.fn(() => [])
+}
+
+function setVisibility(isIntersecting: boolean, intersectionRatio: number) {
+  const target = document.querySelector('[data-revenue-impression-tracker="true"]') as Element
+
+  act(() => {
+    observerCallback(
+      [
+        {
+          isIntersecting,
+          intersectionRatio,
+          target,
+        } as IntersectionObserverEntry,
+      ],
+      {} as IntersectionObserver,
+    )
+  })
+}
+
+function renderTracker() {
+  return render(
+    <RevenueImpressionTracker
+      location="recommendation-section"
+      label="Magnesium glycinate"
+      productSlug="magnesium"
+      productSlot="overall"
+      productAsin="B000000000"
+    >
+      <p>Product card</p>
+    </RevenueImpressionTracker>,
+  )
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.stubGlobal('IntersectionObserver', MockIntersectionObserver)
+  mocks.getConsent.mockReturnValue('granted')
+  mocks.trackRevenueEvent.mockReset()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  mocks.getConsent.mockReset()
+})
+
+describe('RevenueImpressionTracker', () => {
+  it('tracks after at least half the product is visible for one second', () => {
+    renderTracker()
+    setVisibility(true, RECOMMENDATION_IMPRESSION_THRESHOLD)
+
+    act(() => vi.advanceTimersByTime(RECOMMENDATION_IMPRESSION_DELAY_MS - 1))
+    expect(mocks.trackRevenueEvent).not.toHaveBeenCalled()
+
+    act(() => vi.advanceTimersByTime(1))
+    expect(mocks.trackRevenueEvent).toHaveBeenCalledWith({
+      kind: 'recommendation_impression',
+      location: 'recommendation-section',
+      label: 'Magnesium glycinate',
+      productSlug: 'magnesium',
+      productSlot: 'overall',
+      productAsin: 'B000000000',
+    })
+  })
+
+  it('does not count products that remain below the visibility threshold', () => {
+    renderTracker()
+    setVisibility(true, RECOMMENDATION_IMPRESSION_THRESHOLD - 0.01)
+
+    act(() => vi.advanceTimersByTime(RECOMMENDATION_IMPRESSION_DELAY_MS * 2))
+    expect(mocks.trackRevenueEvent).not.toHaveBeenCalled()
+  })
+
+  it('waits for consent when a product is already visible', () => {
+    mocks.getConsent.mockReturnValue(null)
+    renderTracker()
+    setVisibility(true, 1)
+
+    act(() => vi.advanceTimersByTime(RECOMMENDATION_IMPRESSION_DELAY_MS * 2))
+    expect(mocks.trackRevenueEvent).not.toHaveBeenCalled()
+
+    mocks.getConsent.mockReturnValue('granted')
+    act(() => {
+      window.dispatchEvent(new CustomEvent('hs:consent-granted'))
+      vi.advanceTimersByTime(RECOMMENDATION_IMPRESSION_DELAY_MS)
+    })
+
+    expect(mocks.trackRevenueEvent).toHaveBeenCalledTimes(1)
+  })
+
+  it('counts a product only once per mounted recommendation', () => {
+    renderTracker()
+    setVisibility(true, 1)
+    act(() => vi.advanceTimersByTime(RECOMMENDATION_IMPRESSION_DELAY_MS))
+
+    setVisibility(false, 0)
+    setVisibility(true, 1)
+    act(() => vi.advanceTimersByTime(RECOMMENDATION_IMPRESSION_DELAY_MS * 2))
+
+    expect(mocks.trackRevenueEvent).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/lib/__tests__/revenue-tracking.test.ts
+++ b/src/lib/__tests__/revenue-tracking.test.ts
@@ -11,6 +11,7 @@ import {
 
 describe('revenue tracking', () => {
   it('normalizes supported revenue event kinds', () => {
+    expect(normalizeRevenueEventKind('recommendation_impression')).toBe('recommendation_impression')
     expect(normalizeRevenueEventKind('recommendation_click')).toBe('recommendation_click')
     expect(normalizeRevenueEventKind('affiliate_click')).toBe('affiliate_click')
     expect(normalizeRevenueEventKind('cta_click')).toBe('cta_click')
@@ -70,5 +71,37 @@ describe('revenue tracking', () => {
       scrollDepth: '50-74',
     })
     expect(event.occurredAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+
+  it('uses the same dimensions for recommendation impressions and clicks', () => {
+    const impression = buildRevenueEvent(
+      {
+        kind: 'recommendation_impression',
+        location: 'compare-recommendation',
+        label: 'Magnesium glycinate',
+        productSlug: 'magnesium',
+        productSlot: 'overall',
+        productAsin: 'B000000000',
+      },
+      {
+        pagePath: '/guides/compare/magnesium-vs-melatonin/',
+        viewportWidth: 1440,
+        viewportHeight: 900,
+        scrollY: 1200,
+        documentHeight: 3000,
+      },
+    )
+
+    expect(impression).toMatchObject({
+      kind: 'recommendation_impression',
+      location: 'compare-recommendation',
+      label: 'Magnesium glycinate',
+      routeFamily: 'comparison',
+      productSlug: 'magnesium',
+      productSlot: 'overall',
+      productAsin: 'B000000000',
+      deviceType: 'desktop',
+      scrollDepth: '50-74',
+    })
   })
 })

--- a/src/lib/revenue-tracking.ts
+++ b/src/lib/revenue-tracking.ts
@@ -1,6 +1,11 @@
 import { getConsent } from './consent'
 
-export type RevenueEventKind = 'recommendation_click' | 'affiliate_click' | 'cta_click' | 'email_signup_attempt'
+export type RevenueEventKind =
+  | 'recommendation_impression'
+  | 'recommendation_click'
+  | 'affiliate_click'
+  | 'cta_click'
+  | 'email_signup_attempt'
 
 export type RevenueRouteFamily =
   | 'home'
@@ -55,6 +60,7 @@ export type RevenueEvent = {
 
 export function normalizeRevenueEventKind(kind: string): RevenueEventKind {
   if (
+    kind === 'recommendation_impression' ||
     kind === 'recommendation_click' ||
     kind === 'affiliate_click' ||
     kind === 'cta_click' ||
@@ -193,13 +199,12 @@ export function trackProfileView(profileName: string, profileType: string) {
 }
 
 export function trackRecommendationImpression(sourceProduct: string, recommendedProducts: string[]) {
-  if (typeof window !== 'undefined' && window.gtag && getConsent() === 'granted') {
-    window.gtag('event', 'recommendation_impression', {
-      source_product: sourceProduct,
-      recommended_products: recommendedProducts.join(','),
-      count: recommendedProducts.length,
-    })
-  }
+  trackRevenueEvent({
+    kind: 'recommendation_impression',
+    location: 'legacy-recommendation-impression',
+    label: recommendedProducts.join(',') || sourceProduct,
+    productSlug: sourceProduct,
+  })
 }
 
 export function trackStackView(stackName: string, products: string[]) {


### PR DESCRIPTION
## Why this is the next highest-ROI upgrade

PR #2375 made affiliate clicks attributable by page, route family, ingredient, product slot, device, and scroll depth. Click totals alone still cannot show conversion efficiency because there was no denominator: a module with 20 clicks from 100 views is far stronger than one with 20 clicks from 10,000 views.

This adds qualified product-card impressions so recommendation CTR can be calculated using the same dimensions as clicks.

## What changed

- add a reusable client-side impression tracker for recommendation cards
- count an impression only when at least 50% of a card remains visible for one continuous second
- wait for explicit analytics consent, including when consent is granted while a card is already visible
- count each mounted product recommendation only once
- emit `recommendation_impression` through the existing consent-gated revenue event pipeline
- attach the same page, route family, product slug, slot, ASIN, device, and scroll-depth context used by recommendation clicks
- cover both the primary `RecommendationSection` rail and the legacy `AffiliateProductBox`
- route the older aggregate recommendation-impression helper through the unified event model
- use the repository-approved production import boundary enforced by output governance

## Expected payoff

GA4 can now compare `recommendation_click` against `recommendation_impression` by route, module, ingredient, product tier, device, and scroll depth. That makes it possible to distinguish high-traffic modules from genuinely persuasive ones and prioritize layout, product, and content improvements using CTR rather than raw click volume.

## Scope and privacy

- no new products, destinations, claims, routes, or visible marketing elements
- no user-identifying fields
- no analytics delivery before consent
- no impression for below-threshold or briefly visible cards

## Validation

All required suites passed on final head `df66281ba75f99078bba56266d53acc15016dce0`:

- CI quality gate: lint, TypeScript, 700 Vitest/accessibility tests, canonical data validation, workbook guards, runtime trust audit, production build, output governance, SEO route coverage, and security audit
- Build Check
- Site Health Check
- Fast UI Check
- Lighthouse CI

Focused coverage includes visibility threshold, one-second dwell time, consent-after-visibility, per-mount deduplication, and impression/click payload parity.