### PR TITLE
Build the /goals hub and the berberine-vs-inositol comparison

### DIFF
--- a/app/goals/[slug]/page.tsx
+++ b/app/goals/[slug]/page.tsx
@@ -1,0 +1,229 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+
+import { goals, type Goal } from '@/data/goals'
+import { getGoalContentExtension } from '@/data/goal-content'
+import { getGoalStartHereLinks } from '@/lib/goal-start-here-links'
+import GoalStartHereLinks from '@/components/goals/GoalStartHereLinks'
+import GoalContentDepth from '@/src/components/goals/GoalContentDepth'
+import GoalHubSections from '@/src/components/goals/GoalHubSections'
+import { getGoalHubLinks } from '@/src/lib/goal-hub-links'
+import SchemaOrg from '@/components/SchemaOrg'
+import Disclaimer from '@/src/components/Disclaimer'
+import { breadcrumbJsonLd, faqPageJsonLd, SITE_URL } from '@/src/lib/seo'
+
+type PageProps = {
+  params: Promise<{ slug: string }>
+}
+
+function getGoal(slug: string): Goal | undefined {
+  return goals.find((goal) => goal.slug === slug)
+}
+
+export function generateStaticParams() {
+  return goals.map((goal) => ({ slug: goal.slug }))
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params
+  const goal = getGoal(slug)
+  if (!goal) return { title: 'Goal Not Found', robots: { index: false, follow: true } }
+
+  const canonical = `${SITE_URL}/goals/${goal.slug}/`
+  const title = `${goal.title}: Compare Options by Fit, Onset & Evidence`
+  const description = goal.description
+
+  return {
+    title,
+    description,
+    alternates: { canonical },
+    openGraph: {
+      title: goal.title,
+      description,
+      url: canonical,
+      type: 'article',
+      images: ['/og-default.jpg'],
+    },
+  }
+}
+
+export default async function GoalPage({ params }: PageProps) {
+  const { slug } = await params
+  const goal = getGoal(slug)
+  if (!goal) notFound()
+
+  const goalPath = `/goals/${goal.slug}/`
+  const extension = getGoalContentExtension(goal.slug)
+  const startHereLinks = getGoalStartHereLinks(goal.slug)
+  const { stack, compares, seoEntry } = getGoalHubLinks(goal.slug)
+
+  const breadcrumbs = breadcrumbJsonLd([
+    { name: 'Home', url: `${SITE_URL}/` },
+    { name: 'Goals', url: `${SITE_URL}/goals/` },
+    { name: goal.title, url: `${SITE_URL}${goalPath}` },
+  ])
+  const faq = extension?.faqItems.length
+    ? faqPageJsonLd({
+        pagePath: goalPath,
+        questions: extension.faqItems.map((item) => ({
+          question: item.question,
+          answer: item.answer,
+        })),
+      })
+    : null
+
+  const relatedGoals = goal.relatedGoals
+    .map((relatedSlug) => getGoal(relatedSlug))
+    .filter((related): related is Goal => Boolean(related))
+
+  return (
+    <div className="container-page space-y-10 py-10">
+      <SchemaOrg schema={breadcrumbs} />
+      {faq ? <SchemaOrg schema={faq} /> : null}
+
+      <nav aria-label="Breadcrumb" className="text-sm text-muted">
+        <ol className="flex flex-wrap items-center gap-2">
+          <li>
+            <Link href="/" className="hover:underline">
+              Home
+            </Link>
+          </li>
+          <li aria-hidden="true">/</li>
+          <li>
+            <Link href="/goals/" className="hover:underline">
+              Goals
+            </Link>
+          </li>
+          <li aria-hidden="true">/</li>
+          <li className="font-medium text-ink">{goal.title}</li>
+        </ol>
+      </nav>
+
+      <header className="max-w-3xl space-y-4">
+        <p className="eyebrow-label">{goal.eyebrow}</p>
+        <h1 className="text-4xl font-bold tracking-tight text-ink sm:text-5xl">{goal.title}</h1>
+        <p className="text-lg leading-8 text-muted">{goal.description}</p>
+      </header>
+
+      {goal.quickPicks.length > 0 ? (
+        <section className="card-premium p-5 sm:p-8">
+          <p className="eyebrow-label">Quick picks</p>
+          <h2 className="mt-2 text-2xl font-semibold text-ink">Match your situation</h2>
+          <ul className="mt-6 grid gap-3 sm:grid-cols-3">
+            {goal.quickPicks.map((pick) => (
+              <li
+                key={`${pick.slug}-${pick.need}`}
+                className="rounded-2xl border border-brand-900/10 bg-white/70 p-4 dark:border-white/10 dark:bg-white/5"
+              >
+                <p className="text-xs font-semibold uppercase tracking-wider text-muted">
+                  {pick.need}
+                </p>
+                <p className="mt-2 text-base font-semibold text-brand-800 dark:text-brand-100">
+                  {pick.option}
+                </p>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      <section className="card-premium p-5 sm:p-8">
+        <h2 className="text-2xl font-semibold text-ink">Options compared</h2>
+        <p className="mt-2 text-sm leading-6 text-muted">
+          Sorted by how people usually approach this goal. &ldquo;Why people stop&rdquo; is included
+          because the reason a supplement gets abandoned is usually more useful than its best-case
+          claim.
+        </p>
+        <div className="mt-6 overflow-x-auto">
+          <table className="min-w-full border-collapse text-left text-sm">
+            <thead>
+              <tr className="border-b border-brand-900/10">
+                <th className="py-3 pr-4 text-xs font-bold uppercase tracking-wider text-ink">
+                  Option
+                </th>
+                <th className="py-3 pr-4 text-xs font-bold uppercase tracking-wider text-ink">
+                  Best for
+                </th>
+                <th className="py-3 pr-4 text-xs font-bold uppercase tracking-wider text-ink">
+                  Onset
+                </th>
+                <th className="py-3 pr-4 text-xs font-bold uppercase tracking-wider text-ink">
+                  Evidence
+                </th>
+                <th className="py-3 pr-4 text-xs font-bold uppercase tracking-wider text-ink">
+                  Risk
+                </th>
+                <th className="py-3 text-xs font-bold uppercase tracking-wider text-ink">
+                  Why people stop
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {goal.options.map((option) => (
+                <tr
+                  key={option.slug}
+                  className="border-b border-brand-900/5 align-top last:border-0"
+                >
+                  <td className="py-3 pr-4 font-semibold text-ink">{option.name}</td>
+                  <td className="py-3 pr-4 text-muted">{option.bestFor}</td>
+                  <td className="py-3 pr-4 text-muted">{option.speed}</td>
+                  <td className="py-3 pr-4 text-muted">{option.evidence}</td>
+                  <td className="py-3 pr-4 text-muted">{option.risk}</td>
+                  <td className="py-3 text-muted">{option.whyPeopleStop}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <ul className="mt-6 space-y-3">
+          {goal.options.map((option) => (
+            <li
+              key={`${option.slug}-detail`}
+              className="rounded-2xl border border-brand-900/10 bg-white/70 p-4 text-sm dark:border-white/10 dark:bg-white/5"
+            >
+              <p className="font-semibold text-ink">{option.name}</p>
+              <p className="mt-2 leading-6 text-muted">
+                <span className="font-semibold text-ink">Avoid if:</span> {option.avoidIf}
+              </p>
+              <p className="mt-1 leading-6 text-muted">
+                <span className="font-semibold text-ink">Form:</span> {option.form}
+              </p>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <GoalStartHereLinks links={startHereLinks} />
+
+      {extension ? <GoalContentDepth content={extension} /> : null}
+
+      <GoalHubSections
+        goalSlug={goal.slug}
+        stack={stack}
+        compares={compares}
+        seoEntry={seoEntry}
+      />
+
+      {relatedGoals.length > 0 ? (
+        <section className="card-premium p-5 sm:p-8">
+          <h2 className="text-xl font-semibold text-ink">Related goals</h2>
+          <ul className="mt-4 flex flex-wrap gap-3">
+            {relatedGoals.map((related) => (
+              <li key={related.slug}>
+                <Link
+                  href={`/goals/${related.slug}/`}
+                  className="inline-flex rounded-full border border-brand-900/15 bg-white px-4 py-2 text-sm font-medium text-ink transition hover:border-brand-700/30 dark:border-white/10 dark:bg-white/5"
+                >
+                  {related.title} →
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      <Disclaimer />
+    </div>
+  )
+}

--- a/app/goals/page.tsx
+++ b/app/goals/page.tsx
@@ -1,0 +1,62 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+import { goals } from '@/data/goals'
+import { SITE_URL } from '@/src/lib/seo'
+
+export const metadata: Metadata = {
+  title: 'Supplement Goals: Compare Options by What You Want to Fix',
+  description:
+    'Start from the outcome, not the ingredient. Each goal guide compares the common options by fit, onset, evidence quality, risk, and why people stop taking them.',
+  alternates: { canonical: `${SITE_URL}/goals/` },
+  openGraph: {
+    title: 'Supplement Goals',
+    description:
+      'Compare supplement options by goal — fit, onset, evidence quality, and risk profile for each.',
+    url: `${SITE_URL}/goals/`,
+    type: 'website',
+    images: ['/og-default.jpg'],
+  },
+}
+
+export default function GoalsIndexPage() {
+  return (
+    <div className="container-page space-y-10 py-10">
+      <header className="max-w-3xl space-y-4">
+        <p className="eyebrow-label">Goal guides</p>
+        <h1 className="text-4xl font-bold tracking-tight text-ink sm:text-5xl">
+          Start from the goal, not the ingredient
+        </h1>
+        <p className="text-lg leading-8 text-muted">
+          Most supplement research starts with a product name. These guides start with the outcome
+          you are after and compare the common options by practical fit, likely onset, evidence
+          quality, and the risks worth knowing before you start. Educational context only — not
+          medical advice.
+        </p>
+      </header>
+
+      <section>
+        <h2 className="sr-only">All goal guides</h2>
+        <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {goals.map((goal) => (
+            <li key={goal.slug}>
+              <Link
+                href={`/goals/${goal.slug}/`}
+                className="card-premium block h-full p-5 transition hover:border-brand-700/20 hover:shadow-sm"
+              >
+                <p className="text-[10px] font-bold uppercase tracking-wider text-brand-700 dark:text-brand-200">
+                  {goal.eyebrow}
+                </p>
+                <h3 className="mt-2 text-lg font-semibold text-ink">{goal.title}</h3>
+                <p className="mt-2 line-clamp-3 text-sm leading-6 text-muted">{goal.description}</p>
+                <p className="mt-3 text-xs font-semibold text-brand-800 dark:text-brand-100">
+                  {goal.options.length} options compared →
+                </p>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  )
+}

--- a/app/guides/compare/berberine-vs-inositol/page.tsx
+++ b/app/guides/compare/berberine-vs-inositol/page.tsx
@@ -1,0 +1,283 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+import { buildPageMetadata } from '../../../../src/lib/seo'
+import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
+import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
+import CitationReadySummary from '@/components/seo/CitationReadySummary'
+import FAQSchema from '@/components/seo/FAQSchema'
+import References from '@/components/References'
+import AffiliateDisclosure from '../../../../components/AffiliateDisclosure'
+import Disclaimer from '../../../../src/components/Disclaimer'
+
+// Both queries this page targets ("berberine vs inositol", "inositol vs berberine")
+// were landing on /guides/compare/berberine-vs-metformin/ via a redirect — a page
+// about a different comparison entirely.
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Berberine vs Inositol: Which Is Better for Blood Sugar?',
+  description:
+    'Berberine and inositol both improve insulin sensitivity by different mechanisms. Which fits blood sugar, which fits PCOS, how they dose, and where the evidence is strongest.',
+  path: '/guides/compare/berberine-vs-inositol/',
+})
+
+// Berberine references are the vetted set already cited on the berberine-vs-metformin
+// page. Inositol references are the PMIDs carried in the site's own claims registry
+// (public/data/claims.json) for the inositol / myo-inositol profiles.
+const BERBERINE_VS_INOSITOL_REFS = [
+  {
+    n: 1,
+    text: 'Yin J, et al. (2012). Efficacy of berberine in patients with type 2 diabetes. Metabolism, 57(5): 712-717.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/18442639/',
+  },
+  {
+    n: 2,
+    text: 'Lan J, et al. (2015). Meta-analysis of berberine in the treatment of type 2 diabetes. J Ethnopharmacol, 161: 69-81.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/25498346/',
+  },
+  {
+    n: 3,
+    text: 'Guo Y, et al. (2012). Repeated administration of berberine inhibits cytochromes P450. Eur J Pharmacol, 685(1-3): 116-122.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/21575678/',
+  },
+  {
+    n: 4,
+    text: 'Systematic review and meta-analysis of inositol in polycystic ovary syndrome and related metabolic outcomes (PubMed 29498933).',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/29498933/',
+  },
+  {
+    n: 5,
+    text: 'Systematic review of myo-inositol and D-chiro-inositol in metabolic and hormonal outcomes (PubMed 34078260).',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/34078260/',
+  },
+]
+
+const COMPARISON_ROWS = [
+  {
+    dimension: 'Primary mechanism',
+    berberine: 'AMPK activation; reduces hepatic glucose output and improves peripheral glucose uptake.',
+    inositol: 'Acts as a second messenger in the insulin signalling pathway rather than acting on AMPK.',
+  },
+  {
+    dimension: 'Strongest evidence base',
+    berberine: 'Type 2 diabetes and general glycaemic control, in RCTs and meta-analysis.',
+    inositol: 'Polycystic ovary syndrome and its associated insulin resistance, in RCT meta-analysis.',
+  },
+  {
+    dimension: 'Typical study duration',
+    berberine: 'Mostly under three months; long-term outcome data are not available.',
+    inositol: 'Commonly three to six months in PCOS trials.',
+  },
+  {
+    dimension: 'Tolerability',
+    berberine: 'Gastrointestinal effects are the most commonly reported adverse events.',
+    inositol: 'Generally well tolerated; mild GI upset, sleepiness, or dizziness at high intakes.',
+  },
+  {
+    dimension: 'Drug-interaction load',
+    berberine:
+      'Meaningful. Repeated dosing inhibited CYP2D6, CYP2C9, and CYP3A4, and a clinical cyclosporine interaction is documented.',
+    inositol: 'Low. May affect blood-glucose control in diabetes or hypoglycaemia.',
+  },
+  {
+    dimension: 'Key contraindications',
+    berberine:
+      'Pregnancy, breastfeeding, and infants — berberine can displace bilirubin and poses a kernicterus risk.',
+    inositol:
+      'Bipolar disorder without clinician supervision; pregnancy safety data are insufficient given a theoretical uterine-contraction risk at high doses.',
+  },
+]
+
+export default function BerberineVsInositolPage() {
+  return (
+    <div className="container-page space-y-10 py-10">
+      <AuthorityJsonLd
+        title="Berberine vs Inositol"
+        description="Evidence-graded comparison of berberine and inositol for insulin sensitivity, blood sugar, and PCOS-related metabolic outcomes."
+        url="https://thehippiescientist.net/guides/compare/berberine-vs-inositol/"
+        type="Article"
+      />
+
+      <AuthorityBreadcrumbs
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Compare', href: '/guides/compare/' },
+          { label: 'Berberine vs Inositol' },
+        ]}
+      />
+
+      <section className="max-w-4xl space-y-5">
+        <p className="eyebrow-label">Educational Comparison · Metabolic Cluster</p>
+        <h1 className="text-4xl font-bold tracking-tight text-ink sm:text-5xl">
+          Berberine vs Inositol: Which Is Better for Blood Sugar?
+        </h1>
+        <p className="text-lg leading-8 text-muted">
+          These two get compared because both improve insulin sensitivity, but they are not
+          interchangeable. They act through different pathways, their evidence bases sit in
+          different populations, and they carry very different interaction risk. The useful question
+          is not which is stronger — it is which one matches your situation.
+        </p>
+      </section>
+
+      <CitationReadySummary
+        answer="Berberine and inositol both support insulin sensitivity, but through different mechanisms and with evidence concentrated in different populations. Berberine activates AMPK and has its strongest evidence in type 2 diabetes glycaemic control, with meta-analysis support but mostly short trials and no long-term outcome data. Inositol acts as a second messenger in insulin signalling and has its strongest evidence in polycystic ovary syndrome and the insulin resistance associated with it. Berberine carries a substantially higher drug-interaction burden."
+        bestFor={[
+          'Berberine: blood-sugar and lipid support in insulin resistance or the prediabetes range, for someone not on interacting medication.',
+          'Inositol: PCOS-associated insulin resistance, or where a low interaction burden and better tolerability matter more than maximal glycaemic effect.',
+          'Neither as a substitute for prescribed diabetes medication without clinician oversight.',
+        ]}
+        evidenceLevel="Berberine has multiple positive RCTs and a meta-analysis in type 2 diabetes, but trials are mostly under three months with no cardiovascular or mortality endpoints. Inositol has RCT meta-analysis support in PCOS; evidence outside PCOS and metabolic outcomes is thinner."
+        safetyNote="Berberine inhibited CYP2D6, CYP2C9, and CYP3A4 on repeated human dosing and has a documented clinical cyclosporine interaction; it is contraindicated in pregnancy, breastfeeding, and infants. Inositol can trigger manic episodes in bipolar disorder and should only be used under clinician supervision in that population. Either may affect blood-glucose control in people already treating diabetes."
+        notClaiming="This page is not claiming either supplement treats diabetes or PCOS, or that either can replace prescribed medication."
+        referencesHref="#references"
+      />
+
+      <section className="card-premium p-6 sm:p-8">
+        <h2 className="text-2xl font-semibold text-ink">Side by side</h2>
+        <div className="mt-6 overflow-x-auto">
+          <table className="min-w-full border-collapse text-left text-sm">
+            <thead>
+              <tr className="border-b border-brand-900/10">
+                <th className="py-3 pr-4 text-xs font-bold uppercase tracking-wider text-ink">
+                  Dimension
+                </th>
+                <th className="py-3 pr-4 text-xs font-bold uppercase tracking-wider text-ink">
+                  Berberine
+                </th>
+                <th className="py-3 text-xs font-bold uppercase tracking-wider text-ink">
+                  Inositol
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {COMPARISON_ROWS.map((row) => (
+                <tr
+                  key={row.dimension}
+                  className="border-b border-brand-900/5 align-top last:border-0"
+                >
+                  <td className="py-3 pr-4 font-semibold text-ink">{row.dimension}</td>
+                  <td className="py-3 pr-4 text-muted">{row.berberine}</td>
+                  <td className="py-3 text-muted">{row.inositol}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="card-premium space-y-4 p-6 sm:p-8">
+        <h2 className="text-2xl font-semibold text-ink">Where each one has the better case</h2>
+        <div className="space-y-4 text-sm leading-7 text-muted">
+          <p>
+            <span className="font-semibold text-ink">Berberine</span> has the more direct glycaemic
+            evidence. Randomised trials and a meta-analysis in type 2 diabetes report reductions in
+            fasting glucose and HbA1c.<sup>[1][2]</sup> The catch is duration and interaction load:
+            most trials run under three months, so there is no evidence about long-term outcomes,
+            and repeated dosing inhibits several cytochrome P450 enzymes, which matters for anyone
+            on regular medication.<sup>[3]</sup>
+          </p>
+          <p>
+            <span className="font-semibold text-ink">Inositol</span> has its strongest support in
+            polycystic ovary syndrome, where meta-analysis of randomised trials covers insulin
+            resistance and hormonal outcomes.<sup>[4][5]</sup> It is generally better tolerated and
+            carries far less interaction risk. Its evidence is narrower — it is well studied in PCOS
+            and metabolic contexts, and thinner elsewhere.
+          </p>
+          <p>
+            If the goal is blood sugar and there is no PCOS context, berberine has the more relevant
+            evidence. If the context is PCOS-associated insulin resistance, or if tolerability and
+            drug interactions are the binding constraint, inositol is the better-matched option.
+            Anyone already on diabetes medication should treat either as a conversation to have with
+            a clinician rather than a decision to make alone.
+          </p>
+        </div>
+      </section>
+
+      <section className="card-premium space-y-4 p-6 sm:p-8">
+        <h2 className="text-2xl font-semibold text-ink">Read the full profiles</h2>
+        <ul className="grid gap-3 sm:grid-cols-2">
+          <li>
+            <Link
+              href="/compounds/berberine/"
+              className="block rounded-2xl border border-brand-900/10 bg-white/70 p-4 transition hover:border-brand-700/20 hover:bg-white hover:shadow-sm dark:border-white/10 dark:bg-white/5"
+            >
+              <span className="font-semibold text-brand-800 dark:text-brand-100">Berberine →</span>
+              <span className="mt-2 block text-xs leading-relaxed text-muted">
+                Mechanism, RCT data, dosing, interaction detail, and safety context.
+              </span>
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="/compounds/inositol/"
+              className="block rounded-2xl border border-brand-900/10 bg-white/70 p-4 transition hover:border-brand-700/20 hover:bg-white hover:shadow-sm dark:border-white/10 dark:bg-white/5"
+            >
+              <span className="font-semibold text-brand-800 dark:text-brand-100">Inositol →</span>
+              <span className="mt-2 block text-xs leading-relaxed text-muted">
+                Insulin signalling role, PCOS and metabolic evidence, dosing, and safety context.
+              </span>
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="/guides/compare/berberine-vs-metformin/"
+              className="block rounded-2xl border border-brand-900/10 bg-white/70 p-4 transition hover:border-brand-700/20 hover:bg-white hover:shadow-sm dark:border-white/10 dark:bg-white/5"
+            >
+              <span className="font-semibold text-brand-800 dark:text-brand-100">
+                Berberine vs Metformin →
+              </span>
+              <span className="mt-2 block text-xs leading-relaxed text-muted">
+                How berberine compares against the first-line prescription option.
+              </span>
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="/guides/compare/"
+              className="block rounded-2xl border border-brand-900/10 bg-white/70 p-4 transition hover:border-brand-700/20 hover:bg-white hover:shadow-sm dark:border-white/10 dark:bg-white/5"
+            >
+              <span className="font-semibold text-brand-800 dark:text-brand-100">
+                All comparisons →
+              </span>
+              <span className="mt-2 block text-xs leading-relaxed text-muted">
+                Every head-to-head comparison on the site.
+              </span>
+            </Link>
+          </li>
+        </ul>
+      </section>
+
+      <FAQSchema
+        pagePath="/guides/compare/berberine-vs-inositol/"
+        questions={[
+          {
+            question: 'Is berberine or inositol better for blood sugar?',
+            answer:
+              'For blood sugar specifically, berberine has the more direct evidence — randomised trials and a meta-analysis in type 2 diabetes report reductions in fasting glucose and HbA1c. Inositol’s strongest evidence sits in polycystic ovary syndrome and the insulin resistance associated with it, rather than in general glycaemic control.',
+          },
+          {
+            question: 'Can you take berberine and inositol together?',
+            answer:
+              'They act through different pathways, so combining them is not mechanistically contradictory, but there is little trial evidence for the combination and both can affect blood-glucose control. Anyone on diabetes medication, or on drugs metabolised by CYP3A4, CYP2D6, or CYP2C9, should review the combination with a clinician before starting.',
+          },
+          {
+            question: 'Which one is safer?',
+            answer:
+              'Inositol has the lower risk profile for most people: it is generally well tolerated and carries far less drug-interaction burden. Berberine inhibits several cytochrome P450 enzymes on repeated dosing and is contraindicated in pregnancy, breastfeeding, and infants. Inositol should only be used under clinician supervision by people with bipolar disorder.',
+          },
+          {
+            question: 'Which is better for PCOS?',
+            answer:
+              'Inositol. Its randomised-trial and meta-analysis evidence is concentrated in polycystic ovary syndrome and the insulin resistance associated with it, which is not the population berberine has been most studied in.',
+          },
+        ]}
+      />
+
+      <div className="space-y-3">
+        <AffiliateDisclosure />
+        <Disclaimer />
+      </div>
+
+      <References refs={BERBERINE_VS_INOSITOL_REFS} />
+    </div>
+  )
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -463,6 +463,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     route(normalizeSitemapUrl('/evidence/evidence-report'), 'monthly', 0.6),
     route(normalizeSitemapUrl('/safety-checker'), 'monthly', 0.8),
     route(normalizeSitemapUrl('/info/supplement-safety-checklist'), 'monthly', 0.8),
+    route(normalizeSitemapUrl('/goals'), 'monthly', 0.8),
     route(normalizeSitemapUrl('/herbs'), 'weekly', 0.8),
     route(normalizeSitemapUrl('/compounds'), 'weekly', 0.8),
     route(normalizeSitemapUrl('/articles'), 'daily', 0.7),

--- a/lib/comparison-utils.ts
+++ b/lib/comparison-utils.ts
@@ -17,6 +17,7 @@
  */
 export const BUILT_COMPARE_SLUGS = [
   'ashwagandha-vs-l-theanine-vs-magnesium',
+  'berberine-vs-inositol',
   'berberine-vs-metformin',
   'caffeine-vs-l-theanine',
   'caffeine-vs-l-theanine-vs-bacopa-for-focus',

--- a/public/_redirects
+++ b/public/_redirects
@@ -14,8 +14,8 @@ https://www.thehippiescientist.net/guides/best-supplements-for-joint-support htt
 https://www.thehippiescientist.net/guides/best-supplements-for-joint-support/ https://thehippiescientist.net/guides/best/supplements-for-joint-support/ 301
 https://www.thehippiescientist.net/compare/creatine-vs-beta-alanine https://thehippiescientist.net/guides/compare/ 301
 https://www.thehippiescientist.net/compare/creatine-vs-beta-alanine/ https://thehippiescientist.net/guides/compare/ 301
-https://www.thehippiescientist.net/compare/berberine-vs-inositol https://thehippiescientist.net/guides/compare/berberine-vs-metformin/ 301
-https://www.thehippiescientist.net/compare/berberine-vs-inositol/ https://thehippiescientist.net/guides/compare/berberine-vs-metformin/ 301
+https://www.thehippiescientist.net/compare/berberine-vs-inositol https://thehippiescientist.net/guides/compare/berberine-vs-inositol/ 301
+https://www.thehippiescientist.net/compare/berberine-vs-inositol/ https://thehippiescientist.net/guides/compare/berberine-vs-inositol/ 301
 https://www.thehippiescientist.net/herbs/guayusa https://thehippiescientist.net/herbs/guayusa/ 301
 https://www.thehippiescientist.net/herbs/guayusa/ https://thehippiescientist.net/herbs/guayusa/ 301
 https://www.thehippiescientist.net/herbs/agarikon https://thehippiescientist.net/herbs/agarikon/ 301
@@ -38,6 +38,9 @@ https://www.thehippiescientist.net/best-supplements-for-fat-loss https://thehipp
 https://www.thehippiescientist.net/best-supplements-for-fat-loss/ https://thehippiescientist.net/guides/best/supplements-for-fat-loss/ 301
 https://www.thehippiescientist.net/best-supplements-for-focus https://thehippiescientist.net/guides/focus/best-supplements-for-focus/ 301
 https://www.thehippiescientist.net/best-supplements-for-focus/ https://thehippiescientist.net/guides/focus/best-supplements-for-focus/ 301
+
+https://www.thehippiescientist.net/goals https://thehippiescientist.net/goals/ 301
+https://www.thehippiescientist.net/goals/ https://thehippiescientist.net/goals/ 301
 
 # Canonical: non-www
 https://www.thehippiescientist.net/* https://thehippiescientist.net/:splat 301
@@ -250,8 +253,8 @@ https://www.thehippiescientist.net/* https://thehippiescientist.net/:splat 301
 /compare/melatonin-vs-magnesium/ /guides/compare/melatonin-vs-magnesium/ 301
 /compare/sleep-herbs-vs-melatonin /guides/compare/sleep-herbs-vs-melatonin/ 301
 /compare/sleep-herbs-vs-melatonin/ /guides/compare/sleep-herbs-vs-melatonin/ 301
-/compare/berberine-vs-inositol /guides/compare/berberine-vs-metformin/ 301
-/compare/berberine-vs-inositol/ /guides/compare/berberine-vs-metformin/ 301
+/compare/berberine-vs-inositol /guides/compare/berberine-vs-inositol/ 301
+/compare/berberine-vs-inositol/ /guides/compare/berberine-vs-inositol/ 301
 # Earns GSC impressions on "zinc or magnesium" but has no page and no rule, so it
 # has been serving a hard 404 to a query with demand. Route it to the comparison
 # hub until a real magnesium-vs-zinc page exists.
@@ -290,13 +293,11 @@ https://www.thehippiescientist.net/* https://thehippiescientist.net/:splat 301
 /compare/ashwagandha-vs-rhodiola/ /guides/compare/rhodiola-vs-ashwagandha/ 301
 /compare/ashwagandha-vs-rhodiola-for-stress /guides/compare/rhodiola-vs-ashwagandha/ 301
 /compare/ashwagandha-vs-rhodiola-for-stress/ /guides/compare/rhodiola-vs-ashwagandha/ 301
-# /goals/ is documented as a route contract but has no app/goals route, so these
-# all 301d into a 404. Pointed at the topic hubs that actually build.
-/best-for /guides/ 301
-/best-for/ /guides/ 301
-/best-for/sleep-support /guides/sleep/ 301
-/best-for/sleep-support/ /guides/sleep/ 301
-/best-for/non-stimulant-focus /guides/focus/ 301
-/best-for/non-stimulant-focus/ /guides/focus/ 301
-/best-for/non-sedating-calm /guides/anxiety/ 301
-/best-for/non-sedating-calm/ /guides/anxiety/ 301
+/best-for /goals/ 301
+/best-for/ /goals/ 301
+/best-for/sleep-support /goals/sleep/ 301
+/best-for/sleep-support/ /goals/sleep/ 301
+/best-for/non-stimulant-focus /goals/focus/ 301
+/best-for/non-stimulant-focus/ /goals/focus/ 301
+/best-for/non-sedating-calm /goals/anxiety/ 301
+/best-for/non-sedating-calm/ /goals/anxiety/ 301

--- a/public/redirect-overrides/000-semrush-broken-internal-links-2026-07-08.txt
+++ b/public/redirect-overrides/000-semrush-broken-internal-links-2026-07-08.txt
@@ -1,22 +1,18 @@
+# /goals/* rules removed: the goal hub routes now exist (app/goals/[slug]).
+# They were added when /goals/ 404d; redirecting them away now would orphan
+# ~6,000 internal links from the pages they are supposed to reach.
 # Semrush internal broken links export: www.thehippiescientist.net_internal_broken_links_20260708.csv
 # 3,826 broken-link instances collapsed to 308 unique 404 targets.
 # Counts are preserved in comments for future prioritization; build script emits slash/non-slash variants.
 # 374 broken-link instances
-/goals/anxiety/ /guides/anxiety/ 301
 # 365 broken-link instances
-/goals/blood-pressure/ /guides/best/supplements-for-blood-pressure/ 301
 # 286 broken-link instances
-/goals/cognition/ /guides/focus/ 301
 # 226 broken-link instances
-/goals/energy/ /guides/other/supplements-for-brain-fog-and-fatigue/ 301
 # 190 broken-link instances
-/goals/stress/ /guides/anxiety/best-supplements-for-stress/ 301
 # 175 broken-link instances
-/goals/fat-loss/ /guides/best/supplements-for-fat-loss/ 301
 # 168 broken-link instances
 /herbs/angelica-sinensis/ /herbs/dong-quai/ 301
 # 160 broken-link instances
-/goals/inflammation/ /learn/inflammation/ 301
 # 158 broken-link instances
 /herbs/astragalus-membranaceus/ /herbs/astragalus/ 301
 # 127 broken-link instances
@@ -24,7 +20,6 @@
 # 121 broken-link instances
 /herbs/valeriana-officinalis/ /herbs/valerian/ 301
 # 95 broken-link instances
-/goals/recovery/ /guides/best/supplements-for-joint-support/ 301
 # 85 broken-link instances
 /herbs/angelica-root/ /herbs/angelica-archangelica/ 301
 # 84 broken-link instances
@@ -36,21 +31,16 @@
 # 77 broken-link instances
 /herbs/ganoderma-lucidum/ /herbs/reishi/ 301
 # 75 broken-link instances
-/goals/sleep/ /guides/sleep/ 301
 # 73 broken-link instances
 /herbs/berberis-vulgaris/ /herbs/berberis/ 301
 # 70 broken-link instances
 /herbs/coptis-chinensis/ /herbs/coptis/ 301
 # 57 broken-link instances
-/goals/gut-health/ /guides/best/supplements-for-gut-health/ 301
 # 48 broken-link instances
-/goals/focus/ /guides/focus/ 301
 # 46 broken-link instances
 /herbs/berberis-aristata/ /herbs/berberis/ 301
 # 41 broken-link instances
-/goals/pain/ /guides/best/supplements-for-joint-support/ 301
 # 40 broken-link instances
-/goals/joint-support/ /guides/best/supplements-for-joint-support/ 301
 # 33 broken-link instances
 /herbs/atractylodes-macrocephala/ /herbs/atractylodes/ 301
 # 30 broken-link instances
@@ -92,7 +82,6 @@
 # 4 broken-link instances
 /guides/adhd/l-theanine-without-caffeine/ /guides/focus/l-theanine-without-caffeine/ 301
 # 4 broken-link instances
-/compare/berberine-vs-inositol/ /guides/compare/ 301
 # 3 broken-link instances
 /compare/alpha-lipoic-acid-vs-berberine-hcl/ /guides/compare/ 301
 # 3 broken-link instances
@@ -316,7 +305,6 @@
 # 1 broken-link instances
 /guides/compare/bacopa-vs-rhodiola/ /guides/compare/ 301
 # 1 broken-link instances
-/guides/compare/berberine-vs-inositol/ /guides/compare/ 301
 # 1 broken-link instances
 /guides/compare/caffeine-vs-theanine/ /guides/compare/ 301
 # 1 broken-link instances

--- a/public/redirect-overrides/001-semrush-http-4xx-2026-07-08.txt
+++ b/public/redirect-overrides/001-semrush-http-4xx-2026-07-08.txt
@@ -1,3 +1,6 @@
+# /goals/* rules removed: the goal hub routes now exist (app/goals/[slug]).
+# They were added when /goals/ 404d; redirecting them away now would orphan
+# ~6,000 internal links from the pages they are supposed to reach.
 # Full Semrush HTTP 4XX export: www.thehippiescientist.net_http_4xx_client_errors_20260708.csv
 # 392 exact 404 URLs from the export. Build script emits slash/non-slash variants.
 /articles/alpha-gpc-and-adhd/ /guides/adhd/alpha-gpc-and-adhd/ 301
@@ -24,19 +27,6 @@
 /education/how-focus-and-motivation-work/ /learn/how-focus-and-motivation-work/ 301
 /education/why-fatigue-is-biologically-complex/ /learn/why-fatigue-is-biologically-complex/ 301
 /evidence/ /evidence/evidence-checker/ 301
-/goals/anxiety/ /guides/anxiety/ 301
-/goals/blood-pressure/ /guides/best/supplements-for-blood-pressure/ 301
-/goals/cognition/ /guides/focus/ 301
-/goals/energy/ /guides/other/supplements-for-brain-fog-and-fatigue/ 301
-/goals/fat-loss/ /guides/best/supplements-for-fat-loss/ 301
-/goals/focus/ /guides/focus/ 301
-/goals/gut-health/ /guides/best/supplements-for-gut-health/ 301
-/goals/inflammation/ /learn/inflammation/ 301
-/goals/joint-support/ /guides/best/supplements-for-joint-support/ 301
-/goals/pain/ /guides/best/supplements-for-joint-support/ 301
-/goals/recovery/ /guides/best/supplements-for-joint-support/ 301
-/goals/sleep/ /guides/sleep/ 301
-/goals/stress/ /guides/anxiety/best-supplements-for-stress/ 301
 /guides/adhd/l-theanine-vs-caffeine-for-focus/ /guides/focus/l-theanine-vs-caffeine-for-focus/ 301
 /guides/adhd/l-theanine-without-caffeine/ /guides/focus/l-theanine-without-caffeine/ 301
 /guides/best-adaptogens-for-stress/ /guides/anxiety/best-adaptogens-for-stress/ 301

--- a/public/redirect-overrides/seo-csv-400-2026-07-08.txt
+++ b/public/redirect-overrides/seo-csv-400-2026-07-08.txt
@@ -6,7 +6,6 @@
 /guides/compare/creatine-vs-beta-alanine/ /guides/compare/ 301
 /guides/compare/curcumin-vs-boswellia/ /guides/compare/curcumin-vs-boswellia-vs-omega-3/ 301
 /guides/compare/creatine-vs-bcaa/ /guides/compare/ 301
-/guides/compare/berberine-vs-inositol/ /guides/compare/ 301
 /guides/compare/bacopa-vs-rhodiola/ /guides/focus/best-nootropics-for-focus/ 301
 /guides/compare/cordyceps-vs-beta-alanine/ /guides/compare/ 301
 /guides/compare/hawthorn-vs-coq10/ /guides/best/supplements-for-blood-pressure/ 301

--- a/scripts/verify-redirects.mjs
+++ b/scripts/verify-redirects.mjs
@@ -156,5 +156,57 @@ if (targetsMissingPages.length) {
   process.exit(1)
 }
 
+// A URL cannot be both advertised as canonical in the sitemap and redirected
+// away. This happens when a redirect is added to paper over a 404 and the page
+// is built later: `public/redirect-overrides/*` rules are *prepended* to
+// out/_redirects, so they win over everything and silently orphan the new page.
+const sitemapPath = path.join(staticDir, 'sitemap.xml')
+if (fs.existsSync(sitemapPath)) {
+  const sitemapXml = fs.readFileSync(sitemapPath, 'utf8')
+  const sitemapPaths = new Set(
+    [...sitemapXml.matchAll(/<loc>(.*?)<\/loc>/g)].map((match) => {
+      try {
+        return new URL(match[1].trim()).pathname.replace(/\/+$/, '') || '/'
+      } catch {
+        return ''
+      }
+    }),
+  )
+
+  const shadowed = []
+  for (const line of lines) {
+    const [source, target = ''] = line.split(/\s+/)
+    if (source.includes('*') || !source.startsWith('/')) continue
+
+    const normalized = source.replace(/\/+$/, '') || '/'
+    if (!sitemapPaths.has(normalized)) continue
+
+    // A rule that only adds the trailing slash is the canonicalization itself
+    // (`/safety-checker -> /safety-checker/`), not a redirect away from the page.
+    let targetPath = target
+    if (/^https?:\/\//i.test(target)) {
+      try {
+        targetPath = new URL(target).pathname
+      } catch {
+        targetPath = target
+      }
+    }
+    if ((targetPath.replace(/\/+$/, '') || '/') === normalized) continue
+
+    shadowed.push(line)
+  }
+
+  if (shadowed.length) {
+    console.error(
+      `[verify-redirects] ${shadowed.length} sitemap URL(s) are also redirect sources — they would 301 away from a page listed as canonical:`,
+    )
+    for (const rule of shadowed.slice(0, 25)) {
+      console.error(`[verify-redirects]   ${rule}`)
+    }
+    process.exit(1)
+  }
+}
+
 console.log(`[verify-redirects] OK: ${requiredRedirects.length} required rules verified`)
 console.log(`[verify-redirects] OK: all ${lines.length} redirect targets resolve to exported pages`)
+console.log('[verify-redirects] OK: no sitemap URL is shadowed by a redirect')

--- a/src/lib/index-allowlist.ts
+++ b/src/lib/index-allowlist.ts
@@ -7,6 +7,7 @@ export const CORE_INDEXABLE_ROUTES = [
   '/info/dosing',
   '/evidence/evidence-digest',
   '/info/faq',
+  '/goals',
   '/guides',
   '/herbs',
   '/learn',


### PR DESCRIPTION
## Summary

Follow-up to #2377, which flagged three items as needing a decision. Two turned out to be defects worth fixing; the third I am recommending against.

- **`/goals` was 404ing behind ~6,000 internal links.** `CLAUDE.md` lists `/goals/:slug` as a stable route contract and `data/goals.ts` holds 15 fully-authored goal guides, but `app/goals/` has never existed in this repo's history. Everything around it was already built — the data, `GoalHubSections`, `GoalContentDepth`, `GoalStartHereLinks`, `goal-hub-links`, `goal-start-here-links` — so the route was the only missing piece. Meanwhile **6,163 internal links across 811 built pages** pointed into `/goals/`, and 77 pages put `https://thehippiescientist.net/goals/` in their JSON-LD breadcrumbs. Every one resolved to a 404.
- **The existing mitigation made it worse, not better.** Semrush caught this on 2026-07-08 and the fix was to add `/goals/*` rules to `public/redirect-overrides`, sending each goal URL to a guide hub. That stopped the 404s, but sent every link to a page whose content did not match its anchor text, and left the goal data as dead code. This commit removes those 26 rules. Removing them is not optional: `apply-redirect-overrides.mjs` **prepends** overrides to `out/_redirects`, so leaving them would 301 away the 15 pages this adds and orphan them.
- **`berberine-vs-inositol` now exists.** Both "berberine vs inositol" and "inositol vs berberine" earn impressions at position 46–60, and both redirected to `/guides/compare/berberine-vs-metformin/` — a page about a different comparison. A title change cannot fix a topic mismatch, so this adds the real page and repoints the redirects at it. Berberine claims reuse the citations already vetted on the metformin page; inositol claims cite the PMIDs the site's own `claims.json` carries for the inositol profiles, described only as far as those records support.
- **Guard against the class of bug.** Both cases were the same shape: a redirect added to paper over a 404, left in place after the page was built, silently orphaning it. `verify-redirects.mjs` now fails when a URL listed in the sitemap is also a redirect source, excluding trailing-slash canonicalization rules.

| Check | Before | After |
|---|---|---|
| Internal `/goals/` links resolving | 0 of 6,163 | 6,163 of 6,163 |
| Goal pages built / indexable / in sitemap | 0 | 15 / 15 / 15 |
| Redirect rules 301ing away a built goal page | 26 | 0 |
| `/guides/compare/berberine-vs-inositol/` | redirected to a different comparison | real page, indexable, FAQ schema |

### Saw palmetto — recommending no change

The third item from #2377. Promoting `/herbs/saw-palmetto/` over the binomial would need `runtime_export_decision` edited in the workbook, a column `apply-workbook-patch.mjs` deliberately holds for human review. The gain is a better URL slug; the page's title, H1, and body already lead with "Saw Palmetto" after #2377. That is a weak reason to route around a governance gate, so it is left as-is. Happy to do it if you'd rather — it's your call, not a blocker.

## Verification

- [x] `npm run lint`
- [x] `npm run check`
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs
- [x] no generated file corruption
- [x] static export compatible

Also run: `npm run typecheck`, `npm run test` (119 files, 700 tests), and a clean build.

`verify-redirects` and `audit-profile-robots` were run against `out/` **after** applying the redirect overrides the way `build:deploy` does. That is the step my local build skipped last time, and it is how the `/compounds/bcaas -> /goals/energy/` failure reached CI on #2377. All 1368 merged rules resolve to exported pages, and nothing in the sitemap is shadowed.

## Risk Notes

- **This reverses a deliberate SEO mitigation.** The `/goals/*` override rules were added on purpose in July to stop 404s. Building the route is the better fix, but if `/goals/` is meant to stay retired, this is the change to reject — and then the ~6,000 internal links and the JSON-LD breadcrumbs should be repointed instead, because the redirect-only state serves neither users nor crawlers well.
- **15 new indexable URLs.** They are templated from `data/goals.ts` rather than hand-written prose. The data is substantive (each option carries best-for, onset, evidence, risk, avoid-if, form, and why-people-stop), but this is a real expansion of the indexable surface on a site whose governance posture is otherwise conservative. Worth a look before merge if that trade-off matters.
- **New health-comparison content.** The berberine-vs-inositol page makes evidence claims. Every claim traces to a citation already in the repo; no citation was reconstructed from memory. Still worth an editorial read.
- **`verify-redirects` is stricter now.** The sitemap-shadowing check could fail future builds where a redirect legitimately overlaps a sitemap URL. I found no such case, but it is a new way for CI to go red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdE7aAye6fYdf1X94fFKET

---
_Generated by [Claude Code](https://claude.ai/code/session_01DdE7aAye6fYdf1X94fFKET)_