### PR TITLE
Redesign the neuroplasticity article for mobile reading

### DIFF
--- a/app/learn/how-learning-affects-neuroplasticity/page.tsx
+++ b/app/learn/how-learning-affects-neuroplasticity/page.tsx
@@ -1,266 +1,393 @@
 import type { Metadata } from 'next'
-import { buildPageMetadata } from '../../../src/lib/seo'
 import Link from 'next/link'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
-import EvidenceSummaryCard from '@/components/evidence/EvidenceSummaryCard'
-import MisconceptionCallout from '@/components/evidence/MisconceptionCallout'
-import ResearchLimitations from '@/components/evidence/ResearchLimitations'
-import ReferencedStudies from '@/components/evidence/ReferencedStudies'
-import SafetyNotice from '@/components/evidence/SafetyNotice'
 import References from '@/components/References'
-export const metadata: Metadata = buildPageMetadata({
-  title: "How Learning Affects Neuroplasticity",
-  description: "Educational exploration of neuroplasticity, learning systems, cognition continuity, recovery biology, and adaptive nervous-system signaling.",
-  path: "/learn/how-learning-affects-neuroplasticity/",
-})
+import { buildPageMetadata } from '../../../src/lib/seo'
 
+export const metadata: Metadata = buildPageMetadata({
+  title: 'How Learning Affects Neuroplasticity',
+  description:
+    'Educational exploration of neuroplasticity, learning systems, cognition continuity, recovery biology, and adaptive nervous-system signaling.',
+  path: '/learn/how-learning-affects-neuroplasticity/',
+})
 
 const mechanisms = [
   {
-    title: 'Learning and Adaptation',
-    body: 'Neuroplasticity discussions commonly involve learning continuity, sensory integration, attentional regulation, memory formation, environmental adaptation, repetition systems, and cognition resilience.',
+    title: 'Learning and adaptation',
+    body: 'Neuroplasticity discussions commonly involve learning continuity, sensory integration, attentional regulation, memory formation, environmental adaptation, repetition systems, and cognitive resilience.',
   },
   {
-    title: 'Sleep and Recovery Biology',
+    title: 'Sleep and recovery biology',
     body: 'Sleep architecture, nervous-system restoration, stress recovery, emotional regulation, and recovery-oriented neurobiology are frequently discussed in relation to neuroplastic adaptation systems.',
   },
   {
-    title: 'Stress and Cognitive Flexibility',
-    body: 'Chronic stress burden, emotional exhaustion, burnout physiology, fatigue systems, and nervous-system overload may influence learning quality, cognitive flexibility, attentional continuity, and recovery-oriented cognition systems.',
+    title: 'Stress and cognitive flexibility',
+    body: 'Chronic stress burden, emotional exhaustion, burnout physiology, fatigue, and nervous-system overload may influence learning quality, cognitive flexibility, attentional continuity, and recovery.',
   },
 ]
 
+const evidenceSignals = [
+  {
+    label: 'Human evidence',
+    body: 'Learning repetition, attentional engagement, sleep continuity, recovery biology, and emotional salience are consistently associated with memory formation and adaptive cognition.',
+  },
+  {
+    label: 'Research signal',
+    body: 'Mechanistic models commonly involve glutamatergic signaling, synaptic adaptation, reinforcement systems, stress physiology, and sleep-related consolidation pathways.',
+  },
+  {
+    label: 'Practical constraint',
+    body: 'Chronic sleep disruption, severe stress, emotional exhaustion, and nervous-system overload may interfere with learning continuity and adaptive cognitive performance.',
+  },
+]
+
+const adaptiveSystems = [
+  'Learning reinforcement systems',
+  'Sleep-dependent consolidation',
+  'Attention and cognitive continuity',
+  'Emotional salience processing',
+  'Stress-adaptation interaction',
+]
+
+const evidenceLimits = [
+  'Human adaptation is biologically complex',
+  'Mechanisms can be oversimplified online',
+  'Individual variability is substantial',
+  'Laboratory findings may not translate cleanly',
+  'Sleep and stress can confound outcomes',
+]
+
 const relatedSystems = [
-  {
-    href: '/learn/how-memory-formation-works',
-    title: 'Memory Formation',
-  },
-  {
-    href: '/learn/how-focus-and-motivation-work',
-    title: 'Focus and Motivation',
-  },
-  {
-    href: '/learn/how-sleep-affects-neurochemistry',
-    title: 'Sleep Neurochemistry',
-  },
-  {
-    href: '/learn/glutamate',
-    title: 'Glutamate Pathway',
-  },
+  { href: '/learn/how-memory-formation-works', title: 'Memory formation' },
+  { href: '/learn/how-focus-and-motivation-work', title: 'Focus and motivation' },
+  { href: '/learn/how-sleep-affects-neurochemistry', title: 'Sleep neurochemistry' },
+  { href: '/learn/glutamate', title: 'Glutamate pathway' },
 ]
 
 const faqItems = [
   {
     question: 'What is neuroplasticity?',
     answer:
-      'Neuroplasticity generally refers to the nervous system’s ability to adapt through learning, repetition, environmental interaction, recovery processes, and changing patterns of neural activity associated with cognition continuity and behavior.',
+      'Neuroplasticity generally refers to the nervous system’s ability to adapt through learning, repetition, environmental interaction, recovery processes, and changing patterns of neural activity associated with cognition and behavior.',
   },
   {
     question: 'Can neuroplasticity happen throughout life?',
     answer:
-      'Yes. Neuroplasticity-related processes may continue throughout life, though learning quality, stress burden, sleep continuity, recovery biology, emotional regulation, and aging-related physiology may influence adaptation capacity.',
+      'Yes. Neuroplasticity-related processes may continue throughout life, although learning quality, stress burden, sleep continuity, recovery biology, emotional regulation, and aging-related physiology may influence adaptation capacity.',
   },
   {
     question: 'Is neuroplasticity unlimited?',
     answer:
-      'No. Online discussions sometimes exaggerate neuroplasticity narratives. Human adaptation systems involve biological constraints, recovery limitations, environmental influences, stress physiology, and substantial individual variability.',
+      'No. Human adaptation involves biological constraints, recovery limitations, environmental influences, stress physiology, and substantial individual variability. “Rewire your brain instantly” claims are misleading.',
   },
 ]
 
+const keyTakeaways = [
+  'Change is usually gradual and repetition-dependent.',
+  'Attention, emotion, sleep, and recovery shape learning.',
+  'Stress can reduce flexibility and consolidation quality.',
+  'Mechanistic findings do not guarantee real-world outcomes.',
+]
+
 const HOW_LEARNING_AFFECTS_NEUROPLASTICITY_REFS = [
-  { n: 1, text: 'Diamond A. (2013). Executive functions. Annu Rev Psychol, 64: 135-168.', url: 'https://pubmed.ncbi.nlm.nih.gov/23020641/' },
-  { n: 2, text: 'Posner MI, Petersen SE. (1990). The attention system of the human brain. Annu Rev Neurosci, 13: 25-42.', url: 'https://pubmed.ncbi.nlm.nih.gov/2183676/' },
+  {
+    n: 1,
+    text: 'Diamond A. (2013). Executive functions. Annu Rev Psychol, 64: 135-168.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/23020641/',
+  },
+  {
+    n: 2,
+    text: 'Posner MI, Petersen SE. (1990). The attention system of the human brain. Annu Rev Neurosci, 13: 25-42.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/2183676/',
+  },
+]
+
+const jumpLinks = [
+  { href: '#overview', label: 'Overview' },
+  { href: '#systems', label: 'Learning systems' },
+  { href: '#evidence', label: 'Evidence' },
+  { href: '#limits', label: 'Limits & safety' },
+  { href: '#questions', label: 'Questions' },
 ]
 
 export default function NeuroplasticityEducationPage() {
   return (
-    <div className="container-page py-10 space-y-12">
+    <div className='container-page py-8 sm:py-12'>
       <AuthorityJsonLd
-        title="How Learning Affects Neuroplasticity"
-        description="Educational exploration of neuroplasticity, learning systems, cognition continuity, recovery biology, and adaptive nervous-system signaling."
-        url="https://thehippiescientist.net/learn/how-learning-affects-neuroplasticity"
-        type="Article"
+        title='How Learning Affects Neuroplasticity'
+        description='Educational exploration of neuroplasticity, learning systems, cognition continuity, recovery biology, and adaptive nervous-system signaling.'
+        url='https://thehippiescientist.net/learn/how-learning-affects-neuroplasticity'
+        type='Article'
         faqItems={faqItems}
       />
 
-      <AuthorityBreadcrumbs
-        items={[
-          { label: 'Home', href: '/' },
-          { label: 'Education', href: '/learn' },
-          { label: 'How Learning Affects Neuroplasticity' },
-        ]}
-      />
+      <article className='mx-auto max-w-6xl'>
+        <AuthorityBreadcrumbs
+          items={[
+            { label: 'Home', href: '/' },
+            { label: 'Education', href: '/learn' },
+            { label: 'How Learning Affects Neuroplasticity' },
+          ]}
+        />
 
-      <section className="space-y-6 max-w-4xl">
-        <div className="space-y-3">
-          <p className="eyebrow-label">Educational Supernode</p>
-
-          <h1 className="font-display text-3xl font-bold tracking-tight text-ink sm:text-4xl lg:text-5xl">
-            How Learning Affects Neuroplasticity
-          </h1>
-        </div>
-
-        <p className="text-xl leading-9 text-muted">
-          Neuroplasticity involves adaptive nervous-system processes associated with learning continuity, memory formation, sensory integration, attentional regulation, cognition resilience, behavioral adaptation, and environmental interaction.
-        </p>
-
-        <p className="text-base leading-8 text-[#5c6b63]">
-          Educational neuroplasticity discussions commonly intersect with glutamatergic signaling, sleep-dependent recovery systems, stress physiology, emotional regulation, repetition-based learning, executive-function continuity, and adaptive neurobiology.
-        </p>
-      </section>
-
-      <MisconceptionCallout
-        myth="Neuroplasticity means the brain can instantly rewire itself without limits"
-        reality="Human neuroplasticity involves gradual adaptive processes influenced by repetition, recovery biology, sleep continuity, emotional state, environmental context, stress burden, cognition resilience, and biological constraints."
-      />
-
-      <EvidenceSummaryCard
-        title="Neuroplasticity and adaptive cognition systems"
-        evidenceLevel="Strong"
-        humanEvidence="Human research strongly associates learning repetition, attentional engagement, sleep continuity, recovery biology, and emotional salience with adaptive cognition systems and memory formation."
-        mechanisticEvidence="Mechanistic models commonly involve glutamatergic signaling, synaptic adaptation, learning-dependent reinforcement systems, stress physiology, and sleep-related consolidation pathways."
-        safetyProfile="Chronic sleep disruption, burnout, severe stress burden, emotional exhaustion, and nervous-system overload may negatively influence adaptive cognition systems and learning continuity."
-      />
-
-      <section className="grid gap-6 lg:grid-cols-3">
-        {mechanisms.map((mechanism) => (
-          <div key={mechanism.title} className="card-premium p-6 space-y-4">
-            <h2 className="text-2xl font-semibold tracking-tight text-ink">
-              {mechanism.title}
-            </h2>
-
-            <p className="text-sm leading-7 text-muted">
-              {mechanism.body}
+        <header className='grid gap-8 border-b border-[var(--border-soft)] pb-10 pt-6 sm:pb-14 lg:grid-cols-[minmax(0,1fr)_18rem] lg:items-end'>
+          <div className='max-w-3xl'>
+            <p className='eyebrow-label'>Learning science · Evidence overview</p>
+            <h1 className='mt-4 max-w-[15ch] font-display text-4xl font-semibold leading-[1.02] tracking-[-0.025em] text-ink sm:text-5xl lg:text-[3.75rem]'>
+              How Learning Affects Neuroplasticity
+            </h1>
+            <p className='mt-6 max-w-[66ch] text-lg leading-8 text-muted sm:text-xl sm:leading-9'>
+              Neuroplasticity is the nervous system’s capacity to adapt. Learning can help shape that adaptation, but the process depends on repetition, attention, emotion, sleep, recovery, and biological limits.
             </p>
           </div>
-        ))}
-      </section>
 
-      <section className="card-premium p-8 space-y-6">
-        <div className="space-y-2 max-w-3xl">
-          <p className="eyebrow-label">Systems Biology Context</p>
+          <aside className='border-l-2 border-[#b88a42]/55 pl-5'>
+            <p className='text-xs font-extrabold uppercase tracking-[0.17em] text-[#8a6a38] dark:text-[var(--accent-gold)]'>
+              In one minute
+            </p>
+            <p className='mt-3 text-sm leading-7 text-muted'>
+              The brain does not “rewire” on command. Durable adaptation is generally gradual, context-dependent, and supported by repeated practice plus adequate recovery.
+            </p>
+          </aside>
+        </header>
 
-          <h2 className="text-3xl font-semibold tracking-tight text-ink">
-            Neuroplasticity depends on recovery-oriented learning systems
-          </h2>
-
-          <p className="text-base leading-8 text-muted">
-            Learning quality and adaptive cognition may be influenced by sleep continuity, stress resilience, attentional filtering, emotional salience, recovery biology, environmental context, repetition systems, and nervous-system flexibility.
-          </p>
-        </div>
-
-        <div className="grid gap-5 lg:grid-cols-2">
-          <div className="rounded-3xl border border-black/5 bg-white/60 p-6 space-y-3">
-            <h3 className="text-xl font-semibold text-ink">
-              Commonly discussed adaptive systems
-            </h3>
-
-            <ul className="space-y-2 text-sm leading-7 text-muted">
-              <li>• Learning reinforcement systems</li>
-              <li>• Sleep-dependent consolidation</li>
-              <li>• Attention and cognition continuity</li>
-              <li>• Emotional salience processing</li>
-              <li>• Stress-adaptation interaction</li>
-            </ul>
-          </div>
-
-          <div className="rounded-3xl border border-black/5 bg-white/60 p-6 space-y-3">
-            <h3 className="text-xl font-semibold text-ink">
-              Major evidence limitations
-            </h3>
-
-            <ul className="space-y-2 text-sm leading-7 text-muted">
-              <li>• Human adaptation complexity</li>
-              <li>• Mechanistic oversimplification risk</li>
-              <li>• Individual variability</li>
-              <li>• Translational limitations</li>
-              <li>• Recovery-system confounding factors</li>
-            </ul>
-          </div>
-        </div>
-      </section>
-
-      <SafetyNotice>
-        Persistent cognitive decline, major burnout symptoms, chronic sleep disruption, severe emotional distress, or significant neurological symptoms should be evaluated appropriately. Educational content is not a substitute for individualized medical care.
-      </SafetyNotice>
-
-      <ResearchLimitations
-        limitations={[
-          'Neuroplasticity remains biologically complex and incompletely understood.',
-          'Mechanistic findings may not directly predict real-world learning outcomes.',
-          'Online neuroplasticity discussions frequently exaggerate adaptability claims.',
-          'Human cognition systems involve substantial environmental and psychological variability.',
-        ]}
-      />
-
-      <section className="space-y-6">
-        <div className="space-y-2">
-          <p className="eyebrow-label">Educational FAQ</p>
-
-          <h2 className="text-3xl font-semibold tracking-tight text-ink">
-            Common neuroplasticity questions
-          </h2>
-        </div>
-
-        <div className="grid gap-5">
-          {faqItems.map((item) => (
-            <div key={item.question} className="card-premium p-6 space-y-3">
-              <h3 className="text-xl font-semibold tracking-tight text-ink">
-                {item.question}
-              </h3>
-
-              <p className="text-sm leading-7 text-muted">
-                {item.answer}
-              </p>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      <section className="space-y-5">
-        <div className="space-y-2">
-          <p className="eyebrow-label">Related Educational Systems</p>
-
-          <h2 className="text-3xl font-semibold tracking-tight text-ink">
-            Continue exploring adaptive cognition systems
-          </h2>
-        </div>
-
-        <div className="grid gap-5 lg:grid-cols-2">
-          {relatedSystems.map((system) => (
-            <Link
-              key={system.href}
-              href={system.href}
-              className="card-premium p-6 transition motion-safe:hover:-translate-y-0.5"
+        <nav
+          aria-label='Article sections'
+          className='-mx-4 flex gap-2 overflow-x-auto border-b border-[var(--border-soft)] px-4 py-4 sm:mx-0 sm:flex-wrap sm:px-0'
+        >
+          {jumpLinks.map((item) => (
+            <a
+              key={item.href}
+              href={item.href}
+              className='shrink-0 rounded-full border border-[var(--border-soft)] bg-[var(--surface-card)] px-3.5 py-2 text-xs font-bold text-ink transition hover:border-[#b88a42]/45 hover:text-ink'
             >
-              <div className="space-y-3">
-                <p className="eyebrow-label">Related System</p>
-
-                <h3 className="text-2xl font-semibold tracking-tight text-ink">
-                  {system.title}
-                </h3>
-              </div>
-            </Link>
+              {item.label}
+            </a>
           ))}
-        </div>
-      </section>
+        </nav>
 
-      <ReferencedStudies
-        studies={[
-          {
-            title: 'National Institute of Neurological Disorders and Stroke',
-            href: 'https://www.ninds.nih.gov/',
-            source: 'NINDS',
-          },
-          {
-            title: 'PubMed Neuroplasticity Research',
-            href: 'https://pubmed.ncbi.nlm.nih.gov/',
-            source: 'NIH / PubMed',
-          },
-        ]}
-      />
-      <References refs={HOW_LEARNING_AFFECTS_NEUROPLASTICITY_REFS} />
+        <div className='mt-10 grid gap-12 lg:grid-cols-[minmax(0,1fr)_17rem] lg:gap-16'>
+          <div className='min-w-0 space-y-16'>
+            <section id='overview' className='scroll-mt-28'>
+              <p className='eyebrow-label'>Start with the definition</p>
+              <h2 className='mt-3 max-w-2xl text-3xl font-semibold tracking-tight text-ink sm:text-4xl'>
+                Neuroplasticity is adaptation—not magic.
+              </h2>
+              <div className='mt-6 max-w-[72ch] space-y-5 text-base leading-8 text-muted sm:text-[1.05rem]'>
+                <p>
+                  Neuroplasticity involves adaptive nervous-system processes associated with learning, memory formation, sensory integration, attentional regulation, behavior, and environmental interaction.
+                </p>
+                <p>
+                  These processes intersect with glutamatergic signaling, sleep-dependent recovery, stress physiology, emotional regulation, repetition-based learning, executive function, and broader adaptive neurobiology.
+                </p>
+              </div>
+
+              <div className='mt-8 border-l-4 border-[#b88a42] pl-5 sm:pl-6'>
+                <p className='text-xs font-extrabold uppercase tracking-[0.16em] text-[#8a6a38] dark:text-[var(--accent-gold)]'>
+                  Common misconception
+                </p>
+                <h3 className='mt-2 max-w-2xl text-xl font-semibold text-ink sm:text-2xl'>
+                  “The brain can instantly rewire itself without limits.”
+                </h3>
+                <p className='mt-3 max-w-[68ch] text-sm leading-7 text-muted sm:text-base'>
+                  Human neuroplasticity is typically gradual and influenced by repetition, recovery, sleep, emotional state, environmental context, stress burden, and biological constraints.
+                </p>
+              </div>
+            </section>
+
+            <section id='systems' className='scroll-mt-28'>
+              <p className='eyebrow-label'>Three interacting systems</p>
+              <h2 className='mt-3 text-3xl font-semibold tracking-tight text-ink sm:text-4xl'>
+                Learning does not happen in isolation.
+              </h2>
+              <div className='mt-7 divide-y divide-[var(--border-soft)] border-y border-[var(--border-soft)]'>
+                {mechanisms.map((mechanism, index) => (
+                  <div key={mechanism.title} className='grid gap-3 py-7 sm:grid-cols-[3rem_1fr] sm:gap-5'>
+                    <span className='font-display text-3xl font-semibold text-[#b88a42]' aria-hidden='true'>
+                      {String(index + 1).padStart(2, '0')}
+                    </span>
+                    <div>
+                      <h3 className='text-xl font-semibold text-ink sm:text-2xl'>{mechanism.title}</h3>
+                      <p className='mt-3 max-w-[68ch] text-sm leading-7 text-muted sm:text-base'>
+                        {mechanism.body}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            <section id='evidence' className='scroll-mt-28'>
+              <div className='rounded-[1.25rem] border border-[var(--border-soft)] bg-[var(--surface-subtle)] p-5 sm:p-8'>
+                <div className='flex flex-wrap items-center justify-between gap-3'>
+                  <div>
+                    <p className='eyebrow-label'>Evidence snapshot</p>
+                    <h2 className='mt-2 text-2xl font-semibold tracking-tight text-ink sm:text-3xl'>
+                      Adaptive cognition and learning
+                    </h2>
+                  </div>
+                  <span className='rounded-full border border-emerald-700/20 bg-emerald-50/60 px-3 py-1.5 text-xs font-extrabold uppercase tracking-[0.12em] text-emerald-800 dark:text-emerald-100'>
+                    Strong signal
+                  </span>
+                </div>
+
+                <div className='mt-7 divide-y divide-[var(--border-soft)]'>
+                  {evidenceSignals.map((signal) => (
+                    <div key={signal.label} className='grid gap-2 py-5 first:pt-0 last:pb-0 sm:grid-cols-[9rem_1fr] sm:gap-6'>
+                      <h3 className='text-sm font-bold text-ink'>{signal.label}</h3>
+                      <p className='text-sm leading-7 text-muted'>{signal.body}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </section>
+
+            <section className='scroll-mt-28'>
+              <p className='eyebrow-label'>Systems biology context</p>
+              <h2 className='mt-3 max-w-3xl text-3xl font-semibold tracking-tight text-ink sm:text-4xl'>
+                Recovery helps determine whether learning sticks.
+              </h2>
+              <p className='mt-5 max-w-[72ch] text-base leading-8 text-muted'>
+                Learning quality and adaptive cognition may be influenced by sleep continuity, stress resilience, attentional filtering, emotional salience, environmental context, repetition, and nervous-system flexibility.
+              </p>
+
+              <div className='mt-8 grid gap-8 border-y border-[var(--border-soft)] py-8 sm:grid-cols-2'>
+                <div>
+                  <h3 className='text-lg font-semibold text-ink'>Adaptive systems commonly discussed</h3>
+                  <ul className='mt-4 space-y-3'>
+                    {adaptiveSystems.map((item) => (
+                      <li key={item} className='flex gap-3 text-sm leading-6 text-muted'>
+                        <span className='mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-[#b88a42]' aria-hidden='true' />
+                        <span>{item}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+                <div>
+                  <h3 className='text-lg font-semibold text-ink'>What the evidence cannot simplify</h3>
+                  <ul className='mt-4 space-y-3'>
+                    {evidenceLimits.map((item) => (
+                      <li key={item} className='flex gap-3 text-sm leading-6 text-muted'>
+                        <span className='mt-2 h-1.5 w-1.5 shrink-0 rounded-full border border-[#b88a42]' aria-hidden='true' />
+                        <span>{item}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            </section>
+
+            <section id='limits' className='scroll-mt-28'>
+              <p className='eyebrow-label'>Limits and safety</p>
+              <h2 className='mt-3 text-3xl font-semibold tracking-tight text-ink sm:text-4xl'>
+                Keep the neuroscience in proportion.
+              </h2>
+
+              <div className='mt-7 grid gap-5 sm:grid-cols-2'>
+                <div className='border-l-2 border-amber-600/60 pl-5'>
+                  <h3 className='text-lg font-semibold text-ink'>Research limitations</h3>
+                  <ul className='mt-4 space-y-3 text-sm leading-7 text-muted'>
+                    <li>Neuroplasticity remains biologically complex and incompletely understood.</li>
+                    <li>Mechanistic findings may not directly predict real-world learning outcomes.</li>
+                    <li>Human cognition varies substantially across people and environments.</li>
+                  </ul>
+                </div>
+
+                <div className='border-l-2 border-rose-600/50 pl-5'>
+                  <h3 className='text-lg font-semibold text-ink'>When to seek evaluation</h3>
+                  <p className='mt-4 text-sm leading-7 text-muted'>
+                    Persistent cognitive decline, major burnout symptoms, chronic sleep disruption, severe emotional distress, or significant neurological symptoms deserve appropriate professional evaluation. This page is educational, not individualized medical care.
+                  </p>
+                </div>
+              </div>
+            </section>
+
+            <section id='questions' className='scroll-mt-28'>
+              <p className='eyebrow-label'>Common questions</p>
+              <h2 className='mt-3 text-3xl font-semibold tracking-tight text-ink sm:text-4xl'>
+                Neuroplasticity, without the hype
+              </h2>
+              <div className='mt-6 border-t border-[var(--border-soft)]'>
+                {faqItems.map((item) => (
+                  <details
+                    key={item.question}
+                    className='!rounded-none !border-x-0 !border-t-0 !border-b !border-[var(--border-soft)] !bg-transparent !px-0 !py-5 !shadow-none'
+                  >
+                    <summary className='pr-4 text-base font-semibold text-ink sm:text-lg'>{item.question}</summary>
+                    <p className='max-w-[70ch] text-sm leading-7 text-muted sm:text-base'>{item.answer}</p>
+                  </details>
+                ))}
+              </div>
+            </section>
+
+            <section>
+              <p className='eyebrow-label'>Continue learning</p>
+              <h2 className='mt-3 text-3xl font-semibold tracking-tight text-ink sm:text-4xl'>
+                Follow the connected systems
+              </h2>
+              <div className='mt-6 grid border-t border-[var(--border-soft)] sm:grid-cols-2'>
+                {relatedSystems.map((system) => (
+                  <Link
+                    key={system.href}
+                    href={system.href}
+                    className='group flex items-center justify-between gap-4 border-b border-[var(--border-soft)] py-5 pr-3 text-base font-semibold text-ink sm:odd:pr-7 sm:even:border-l sm:even:pl-7'
+                  >
+                    <span>{system.title}</span>
+                    <span className='text-[#b88a42] transition-transform group-hover:translate-x-1' aria-hidden='true'>→</span>
+                  </Link>
+                ))}
+              </div>
+            </section>
+
+            <div className='[&>section]:max-w-none'>
+              <References refs={HOW_LEARNING_AFFECTS_NEUROPLASTICITY_REFS} />
+            </div>
+          </div>
+
+          <aside className='hidden lg:block'>
+            <div className='sticky top-28 space-y-7'>
+              <section>
+                <p className='text-xs font-extrabold uppercase tracking-[0.16em] text-[#8a6a38] dark:text-[var(--accent-gold)]'>
+                  On this page
+                </p>
+                <nav className='mt-3 border-l border-[var(--border-soft)]' aria-label='Desktop article sections'>
+                  {jumpLinks.map((item) => (
+                    <a
+                      key={item.href}
+                      href={item.href}
+                      className='block border-l-2 border-transparent px-4 py-2 text-sm font-medium text-muted transition hover:border-[#b88a42] hover:text-ink'
+                    >
+                      {item.label}
+                    </a>
+                  ))}
+                </nav>
+              </section>
+
+              <section className='rounded-[1rem] border border-[var(--border-soft)] bg-[var(--surface-card)] p-5'>
+                <p className='text-xs font-extrabold uppercase tracking-[0.16em] text-[#8a6a38] dark:text-[var(--accent-gold)]'>
+                  Key takeaways
+                </p>
+                <ul className='mt-4 space-y-3'>
+                  {keyTakeaways.map((item) => (
+                    <li key={item} className='flex gap-2.5 text-xs leading-6 text-muted'>
+                      <span className='mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-[#b88a42]' aria-hidden='true' />
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+
+              <Link
+                href='/learn/'
+                className='inline-flex text-sm font-bold text-brand-700 hover:text-brand-800'
+              >
+                Browse the learning library →
+              </Link>
+            </div>
+          </aside>
+        </div>
+      </article>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Rebuilds `/learn/how-learning-affects-neuroplasticity/` from a long stack of visually identical cards into a calmer editorial reading experience, with particular attention to the cramped dark-mode mobile layout shown in the screenshot.

## What changed

- Replaced the full-page card stack with a typography-first article layout
- Added a stronger, cleaner opening section with a concise one-minute explanation
- Added compact jump links for long-page navigation
- Converted the three core mechanisms into numbered editorial sections separated by dividers
- Consolidated evidence into one structured snapshot instead of nested cards
- Reorganized adaptive systems and evidence limits into lightweight lists
- Replaced large safety and limitation cards with restrained callouts
- Converted FAQs into collapsible rows to reduce mobile page length
- Replaced related-content cards with a compact linked list
- Added a desktop-only sticky article outline and key-takeaway panel
- Preserved metadata, FAQ structured data, references, content meaning, and all linked routes

## Scope

- One page changed
- No global styles, routes, navigation, shared components, or content data were altered

## Risk

Low-to-moderate visual change isolated to one educational article. Full build, UI, and accessibility checks should run before merge.