### PR TITLE
Rebuild the homepage visual design

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,6 +31,7 @@ import '@/styles/editorial-global-tokens.css'
 import '@/styles/editorial-botanical-refresh.css'
 import '@/styles/homepage-hero-signal-upgrade.css'
 import '@/styles/editorial-content-surfaces.css'
+import '@/styles/homepage-editorial-redesign.css'
 
 const HOME_TITLE = 'The Hippie Scientist | Supplement Research'
 

--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -4,53 +4,54 @@ import {
   BookOpen,
   Cloud,
   FlaskConical,
-  Leaf,
-  Library,
   Moon,
+  Leaf,
   Search,
   ShieldCheck,
-  Sparkles,
   Zap,
 } from 'lucide-react'
 import articlesData from '@/data/articles/articles.json'
-
-type SectionHeaderProps = { title: string; subtitle?: string; as?: 'h2' | 'h3' }
+import buildReport from '@/public/data/build-report.json'
 
 const heroGoals = [
   {
     slug: 'sleep',
+    tone: 'sleep',
     title: 'Sleep',
     href: '/guides/sleep/',
     icon: Moon,
-    prompt: 'Compare sleep supports by timing, evidence, next-day effects, and safety.',
+    prompt: 'Compare sleep supports by timing, evidence, and next-day effects.',
   },
   {
     slug: 'stress',
+    tone: 'stress',
     title: 'Stress',
     href: '/guides/anxiety/',
     icon: Leaf,
-    prompt: 'Sort calming supports and adaptogens by symptom pattern and tradeoffs.',
+    prompt: 'Sort calming supports and adaptogens by symptom pattern.',
   },
   {
     slug: 'anxiety',
+    tone: 'anxiety',
     title: 'Anxiety',
     href: '/guides/anxiety/',
     icon: Cloud,
-    prompt: 'Research options for overthinking, tension, and calm without the hype.',
+    prompt: 'Research options for overthinking, tension, and calm — without hype.',
   },
   {
     slug: 'focus',
+    tone: 'focus',
     title: 'Focus',
     href: '/guides/focus/',
     icon: Zap,
-    prompt: 'Compare stimulant and non-stimulant approaches to attention and cognition.',
+    prompt: 'Weigh stimulant and non-stimulant approaches to attention.',
   },
 ]
 
 const trustItems = [
   { label: 'Evidence-first', body: 'Human research before marketing claims', icon: FlaskConical },
   { label: 'Safety aware', body: 'Interactions and contraindications stay visible', icon: ShieldCheck },
-  { label: 'Plain English', body: 'Clear conclusions with uncertainty intact', icon: BookOpen },
+  { label: 'Plain English', body: 'Clear conclusions with the uncertainty intact', icon: BookOpen },
 ]
 
 const popularProfiles = [
@@ -84,33 +85,63 @@ const toolLinks = [
   {
     href: '/info/supplement-safety-checklist/',
     title: 'Supplement safety checklist',
-    description: 'Use five practical questions before comparing products or buying.',
+    description: 'Five practical questions to ask before comparing products or buying.',
   },
 ]
 
-const CATEGORY_TAG_COLORS: Record<string, string> = {
-  'metabolic health':
-    'border-stone-300 bg-stone-100 text-stone-700 dark:border-stone-700 dark:bg-stone-800/30 dark:text-stone-200',
-  'cognitive health':
-    'border-emerald-300 bg-emerald-100 text-emerald-800 dark:border-emerald-700 dark:bg-emerald-800/20 dark:text-emerald-200',
-  'anxiety & sleep':
-    'border-violet-300 bg-violet-100 text-violet-800 dark:border-violet-700 dark:bg-violet-800/20 dark:text-violet-200',
-  general:
-    'border-amber-300 bg-amber-100 text-amber-800 dark:border-amber-700 dark:bg-amber-800/20 dark:text-amber-200',
+const methodSteps = [
+  {
+    num: '01',
+    title: 'Human evidence first',
+    body: 'Clinical trials in people lead. Cell and animal work is labelled as what it is — a hypothesis, not a result.',
+  },
+  {
+    num: '02',
+    title: 'Mechanism kept separate',
+    body: 'Biological plausibility gets its own section so a promising pathway never masquerades as a proven benefit.',
+  },
+  {
+    num: '03',
+    title: 'Safety before the verdict',
+    body: 'Interactions, contraindications, and dosing context appear before any conclusion about whether something is worth trying.',
+  },
+]
+
+const counts = buildReport.counts
+
+const heroStats = [
+  { value: `${counts.herbs}`, label: 'herb profiles' },
+  { value: `${counts.compounds}`, label: 'compound profiles' },
+  { value: `${counts.claims}`, label: 'sourced claims' },
+]
+
+type SectionHeaderProps = {
+  eyebrow?: string
+  title: React.ReactNode
+  subtitle?: string
+  action?: { href: string; label: string }
+  size?: 'md' | 'lg'
 }
 
-function categoryTagClass(category: string): string {
+function SectionHeader({ eyebrow, title, subtitle, action, size = 'md' }: SectionHeaderProps) {
   return (
-    CATEGORY_TAG_COLORS[category.toLowerCase()] ||
-    'border-brand-200 bg-brand-50 text-brand-700 dark:bg-[var(--surface-subtle)] dark:text-[var(--text-secondary)]'
-  )
-}
-
-function SectionHeader({ title, subtitle, as: HeadingTag = 'h2' }: SectionHeaderProps) {
-  return (
-    <div className='max-w-3xl space-y-2'>
-      <HeadingTag className='editorial-display text-[2rem] sm:text-[2.65rem]'>{title}</HeadingTag>
-      {subtitle ? <p className='max-w-2xl text-sm leading-6 text-muted sm:text-base sm:leading-7'>{subtitle}</p> : null}
+    <div className='flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between'>
+      <div className='max-w-2xl'>
+        {eyebrow ? <p className='hs-eyebrow'>{eyebrow}</p> : null}
+        <h2
+          className={`hs-display mt-4 ${
+            size === 'lg' ? 'text-[2.4rem] sm:text-[3.4rem]' : 'text-[2rem] sm:text-[2.6rem]'
+          }`}
+        >
+          {title}
+        </h2>
+        {subtitle ? <p className='hs-lede mt-4 text-[0.95rem] leading-7 sm:text-base'>{subtitle}</p> : null}
+      </div>
+      {action ? (
+        <Link href={action.href} className='hs-link shrink-0 text-sm'>
+          {action.label} <ArrowRight className='h-4 w-4' aria-hidden='true' />
+        </Link>
+      ) : null}
     </div>
   )
 }
@@ -123,97 +154,123 @@ export default function HomepageV2() {
     .slice(0, 3)
 
   return (
-    <div className='editorial-site-shell'>
-      <div className='relative mx-auto max-w-6xl space-y-6 px-4 pb-16 pt-4 sm:space-y-12 sm:px-6 sm:pb-20 sm:pt-8 lg:px-8'>
-        <section className='editorial-hero px-5 pb-0 pt-8 sm:px-10 sm:pt-12 lg:px-14 lg:pt-16'>
-          <div className='editorial-botanical-orbit' aria-hidden='true'>
-            <span />
-            <span />
-            <span />
-            <span />
-          </div>
+    <div className='hs-home'>
+      <div className='mx-auto max-w-6xl px-5 sm:px-8 lg:px-10'>
+        {/* ---------------- Hero ---------------- */}
+        <section className='hs-hero pb-14 pt-12 sm:pb-20 sm:pt-16 lg:pt-20'>
+          <div className='grid items-center gap-12 lg:grid-cols-[1.08fr_0.92fr] lg:gap-10'>
+            <div>
+              <p className='hs-eyebrow'>Evidence-based supplement guidance</p>
 
-          <div className='relative max-w-3xl pb-10 sm:pb-12 lg:pb-14'>
-            <p className='editorial-eyebrow'>Evidence-based supplement guidance</p>
-            <h1 className='editorial-display mt-4 max-w-[12ch] text-[2.55rem] sm:text-[4.6rem] lg:text-[5.6rem]'>
-              Herbs &amp; supplements, actually explained.
-            </h1>
-            <p className='mt-5 max-w-xl text-base leading-7 text-[#33433c] sm:mt-6 sm:text-lg sm:leading-8 dark:text-[var(--text-secondary)]'>
-              Start with your goal, then compare evidence, mechanisms, dosing context, and safety without marketing fluff.
-            </p>
+              <h1 className='hs-display mt-7 max-w-[15ch] text-[3rem] leading-[0.98] sm:text-[4.4rem] lg:text-[5.1rem]'>
+                Herbs &amp; supplements, <span className='hs-accent'>actually explained.</span>
+              </h1>
 
-            <div className='mt-7 flex flex-col gap-3 sm:mt-9 sm:flex-row sm:items-center'>
-              <Link
-                href='#choose-a-path'
-                className='editorial-cta inline-flex min-h-14 w-full max-w-md items-center justify-between rounded-full px-5 py-4 text-base font-bold transition duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#b88a42] focus-visible:ring-offset-2 sm:w-auto sm:px-7'
-              >
-                <span className='inline-flex items-center gap-3'>
-                  <Leaf className='h-5 w-5 text-[#dec69b]' aria-hidden='true' strokeWidth={1.8} />
+              <p className='hs-lede mt-7 max-w-xl text-lg leading-8 sm:text-xl sm:leading-9'>
+                Start with your goal. Compare the human evidence, the mechanism, the dose, and the safety —
+                without the marketing.
+              </p>
+
+              <div className='mt-9 flex flex-col gap-3 sm:flex-row sm:items-center'>
+                <Link
+                  href='#choose-a-path'
+                  className='hs-btn-primary inline-flex min-h-14 items-center justify-center gap-3 rounded-full px-7 py-4 text-base font-bold transition duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--hs-gold)] focus-visible:ring-offset-2'
+                >
+                  <Leaf className='h-5 w-5 text-[#e2cba3]' aria-hidden='true' strokeWidth={1.8} />
                   Choose a health goal
-                </span>
-                <ArrowRight className='h-5 w-5 text-[#dec69b]' aria-hidden='true' />
-              </Link>
-              <Link
-                href='/search/'
-                className='inline-flex min-h-14 w-full items-center justify-center gap-2 rounded-full border border-[#123c2f]/15 bg-[#fffdf8]/80 px-5 py-3.5 text-base font-bold text-[#123c2f] shadow-sm transition hover:border-[#b88a42]/35 hover:bg-[#f5efe2] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#b88a42] focus-visible:ring-offset-2 dark:border-[var(--border-strong)] dark:bg-[var(--surface-card)] dark:text-[var(--text-primary)] dark:hover:bg-[var(--surface-subtle)] sm:w-auto'
-              >
-                <Search className='h-5 w-5' aria-hidden='true' strokeWidth={1.8} />
-                Search by name
-              </Link>
+                  <ArrowRight className='h-5 w-5 text-[#e2cba3]' aria-hidden='true' />
+                </Link>
+                <Link
+                  href='/search/'
+                  className='hs-btn-ghost inline-flex min-h-14 items-center justify-center gap-2.5 rounded-full px-7 py-4 text-base font-bold transition duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--hs-gold)] focus-visible:ring-offset-2'
+                >
+                  <Search className='h-5 w-5' aria-hidden='true' strokeWidth={1.8} />
+                  Search by name
+                </Link>
+              </div>
+            </div>
+
+            <div className='hs-dial' aria-hidden='true'>
+              <div className='hs-dial-ring hs-dial-ring--outer' />
+              <div className='hs-dial-ring hs-dial-ring--mid' />
+              <div className='hs-dial-ring hs-dial-ring--inner' />
+              <div className='hs-dial-core'>
+                <Leaf className='h-14 w-14' strokeWidth={1.25} />
+              </div>
+              <span className='hs-dial-chip'>Human evidence</span>
+              <span className='hs-dial-chip'>Safety context</span>
+              <span className='hs-dial-chip'>Dose ranges</span>
+              <span className='hs-dial-chip'>Honest limits</span>
             </div>
           </div>
 
-          <div className='editorial-trust-strip -mx-5 grid grid-cols-1 gap-2 px-5 py-4 sm:-mx-10 sm:grid-cols-3 sm:px-10 lg:-mx-14 lg:px-14'>
+          {/* Real counts from the generated build report — credibility without a card. */}
+          <dl className='mt-12 flex flex-wrap items-baseline gap-x-8 gap-y-3'>
+            {heroStats.map((stat) => (
+              <div key={stat.label} className='flex items-baseline gap-2'>
+                <dt className='sr-only'>{stat.label}</dt>
+                <dd className='flex items-baseline gap-2'>
+                  <span className='hs-stat-num text-2xl sm:text-[1.75rem]'>{stat.value}</span>
+                  <span className='text-sm text-[color:var(--hs-body)]'>{stat.label}</span>
+                </dd>
+              </div>
+            ))}
+          </dl>
+
+          <dl className='hs-rail mt-10 grid grid-cols-1 gap-0 sm:grid-cols-3'>
             {trustItems.map((item) => {
               const Icon = item.icon
               return (
-                <div key={item.label} className='flex items-center gap-3 py-1'>
-                  <span className='editorial-icon-disc h-10 w-10 shrink-0'>
-                    <Icon className='h-5 w-5' aria-hidden='true' strokeWidth={1.8} />
-                  </span>
+                <div key={item.label} className='flex items-start gap-3 px-0 py-4 sm:px-6 sm:py-5 sm:first:pl-0'>
+                  <Icon
+                    className='mt-0.5 h-4 w-4 shrink-0 text-[color:var(--hs-gold)]'
+                    aria-hidden='true'
+                    strokeWidth={2}
+                  />
                   <div>
-                    <p className='text-sm font-bold text-[#123c2f] dark:text-[var(--text-primary)]'>{item.label}</p>
-                    <p className='text-xs text-muted'>{item.body}</p>
+                    <dt className='text-sm font-bold'>{item.label}</dt>
+                    <dd className='mt-1 text-[0.8rem] leading-5 text-[color:var(--hs-body)]'>{item.body}</dd>
                   </div>
                 </div>
               )
             })}
-          </div>
+          </dl>
         </section>
 
-        <section id='choose-a-path' className='editorial-card rounded-[2rem] p-5 scroll-mt-24 sm:p-8'>
-          <div className='flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between'>
-            <SectionHeader
-              title='Choose one path'
-              subtitle='Begin with the outcome you care about. Each hub narrows the options before sending you into individual profiles.'
-            />
-            <Link
-              href='/guides/'
-              className='inline-flex shrink-0 items-center gap-2 text-sm font-bold text-[#315f50] transition hover:text-[#123c2f] dark:text-[var(--accent-teal)]'
-            >
-              Browse all guides <ArrowRight className='h-4 w-4' aria-hidden='true' />
-            </Link>
-          </div>
+        {/* ---------------- Goal paths — the colour anchor ---------------- */}
+        <section id='choose-a-path' className='scroll-mt-24 py-14 sm:py-20'>
+          <SectionHeader
+            eyebrow='Start here'
+            title={
+              <>
+                Choose one <span className='hs-accent'>path</span>
+              </>
+            }
+            subtitle='Begin with the outcome you care about. Each hub narrows the field before sending you into individual profiles.'
+            action={{ href: '/guides/', label: 'Browse all guides' }}
+            size='lg'
+          />
 
-          <div className='mt-6 grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4'>
+          <div className='mt-10 grid grid-cols-2 gap-3.5 sm:gap-5 lg:grid-cols-4'>
             {heroGoals.map((goal) => {
               const Icon = goal.icon
               return (
                 <Link
                   key={goal.slug}
                   href={goal.href}
-                  className='editorial-link-tile group flex min-h-44 flex-col justify-between rounded-[1.4rem] p-4 transition duration-200 sm:min-h-52 sm:p-5'
+                  data-tone={goal.tone}
+                  className='hs-goal group flex min-h-[12.5rem] flex-col justify-between p-4 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--tone)] focus-visible:ring-offset-2 sm:min-h-[15rem] sm:p-6'
                 >
                   <div>
-                    <span className='editorial-icon-disc mb-3 h-11 w-11 sm:h-12 sm:w-12'>
-                      <Icon className='h-5 w-5 sm:h-6 sm:w-6' aria-hidden='true' strokeWidth={1.7} />
+                    <span className='hs-goal-icon h-11 w-11 sm:h-12 sm:w-12'>
+                      <Icon className='h-[1.2rem] w-[1.2rem] sm:h-[1.35rem] sm:w-[1.35rem]' aria-hidden='true' strokeWidth={1.8} />
                     </span>
-                    <h3 className='font-display text-xl font-semibold text-[#123c2f] dark:text-[var(--text-primary)] sm:text-2xl'>
-                      {goal.title}
-                    </h3>
-                    <p className='mt-2 text-[0.8rem] leading-5 text-muted sm:text-sm sm:leading-6'>{goal.prompt}</p>
+                    <h3 className='hs-goal-title mt-4 text-xl sm:mt-5 sm:text-[1.75rem]'>{goal.title}</h3>
+                    <p className='mt-2 text-[0.78rem] leading-[1.45] text-[color:var(--hs-body)] sm:mt-2.5 sm:text-[0.85rem] sm:leading-6'>
+                      {goal.prompt}
+                    </p>
                   </div>
-                  <span className='mt-4 inline-flex items-center gap-1.5 text-[0.8rem] font-bold text-[#315f50] transition group-hover:gap-2.5 dark:text-[var(--accent-teal)] sm:text-sm'>
+                  <span className='hs-goal-go mt-5 inline-flex items-center gap-2 text-[0.75rem] font-bold sm:mt-6 sm:text-[0.8rem]'>
                     Start here <ArrowRight className='h-3.5 w-3.5' aria-hidden='true' />
                   </span>
                 </Link>
@@ -222,190 +279,174 @@ export default function HomepageV2() {
           </div>
         </section>
 
-        <section className='editorial-card rounded-[2rem] p-5 sm:p-8'>
-          <div className='flex items-start justify-between gap-4'>
-            <div>
-              <p className='editorial-eyebrow'>Popular starting points</p>
-              <SectionHeader
-                title='Research a familiar supplement'
-                subtitle='These are common first searches, not endorsements. Open a profile for evidence, dosing context, mechanisms, and safety.'
-              />
-            </div>
-            <span className='editorial-icon-disc hidden h-14 w-14 shrink-0 sm:inline-flex'>
-              <Library className='h-6 w-6' aria-hidden='true' strokeWidth={1.7} />
-            </span>
-          </div>
+        <hr className='hs-divider' />
 
-          <div className='mt-6 flex flex-wrap gap-2.5'>
+        {/* ---------------- Popular starting points ---------------- */}
+        <section className='py-14 sm:py-20'>
+          <SectionHeader
+            eyebrow='Popular starting points'
+            title='Look up a familiar name'
+            subtitle='These are the most common first searches — not endorsements. Each profile opens with evidence, mechanism, dosing context, and safety.'
+          />
+
+          <div className='mt-9 flex flex-wrap gap-3'>
             {popularProfiles.map((profile) => (
               <Link
                 key={profile.href}
                 href={profile.href}
-                className='editorial-link-tile group inline-flex items-center gap-2 rounded-full px-4 py-2.5 text-sm font-bold text-[#123c2f] transition dark:text-[var(--text-primary)]'
+                className='hs-chip group inline-flex items-center gap-2.5 px-5 py-3 text-sm font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--hs-gold)] focus-visible:ring-offset-2'
               >
                 <span>{profile.label}</span>
-                <span className='text-[0.65rem] font-semibold uppercase tracking-wider text-muted'>{profile.type}</span>
-                <ArrowRight className='h-3.5 w-3.5 transition group-hover:translate-x-0.5' aria-hidden='true' />
+                <span className='text-[0.62rem] font-semibold uppercase tracking-[0.14em] text-[color:var(--hs-body)]'>
+                  {profile.type}
+                </span>
+                <ArrowRight
+                  className='h-3.5 w-3.5 transition group-hover:translate-x-0.5'
+                  aria-hidden='true'
+                />
               </Link>
             ))}
           </div>
 
-          <div className='mt-6 flex flex-wrap gap-x-5 gap-y-3'>
-            <Link
-              href='/herbs/'
-              className='inline-flex items-center gap-2 text-sm font-bold text-[#315f50] hover:text-[#123c2f] dark:text-[var(--accent-teal)]'
-            >
-              Browse all herbs <ArrowRight className='h-4 w-4' aria-hidden='true' />
+          <div className='mt-8 flex flex-wrap gap-x-8 gap-y-3'>
+            <Link href='/herbs/' className='hs-link text-sm'>
+              Browse all {counts.herbs} herbs <ArrowRight className='h-4 w-4' aria-hidden='true' />
             </Link>
-            <Link
-              href='/compounds/'
-              className='inline-flex items-center gap-2 text-sm font-bold text-[#315f50] hover:text-[#123c2f] dark:text-[var(--accent-teal)]'
-            >
-              Browse all compounds <ArrowRight className='h-4 w-4' aria-hidden='true' />
+            <Link href='/compounds/' className='hs-link text-sm'>
+              Browse all {counts.compounds} compounds <ArrowRight className='h-4 w-4' aria-hidden='true' />
             </Link>
           </div>
         </section>
 
-        <section className='grid gap-5 lg:grid-cols-2'>
-          <div className='editorial-card-strong rounded-[2rem] p-5 sm:p-8'>
-            <p className='editorial-eyebrow'>Make a decision</p>
-            <div className='mt-3 flex items-start justify-between gap-4'>
-              <SectionHeader
-                title='Compare before you choose'
-                subtitle='Use side-by-side guides when the real question is which option fits your situation better.'
-              />
-              <span className='editorial-icon-disc hidden h-14 w-14 shrink-0 sm:inline-flex'>
-                <Sparkles className='h-6 w-6' aria-hidden='true' strokeWidth={1.6} />
-              </span>
-            </div>
-            <div className='mt-6 space-y-3'>
+        <hr className='hs-divider' />
+
+        {/* ---------------- Decide / check — hairline lists, no nested tiles ---------------- */}
+        <section className='grid gap-12 py-14 sm:py-20 lg:grid-cols-2 lg:gap-16'>
+          <div>
+            <p className='hs-eyebrow'>Make a decision</p>
+            <h2 className='hs-display mt-4 text-[1.9rem] sm:text-[2.35rem]'>Compare before you choose</h2>
+            <p className='hs-lede mt-4 text-[0.95rem] leading-7'>
+              Side-by-side guides for when the real question is which option fits your situation.
+            </p>
+
+            <div className='hs-rows mt-7'>
               {comparisonLinks.map((comparison) => (
                 <Link
                   key={comparison.href}
                   href={comparison.href}
-                  className='editorial-link-tile group flex items-center justify-between rounded-2xl px-4 py-3.5 text-sm font-bold text-[#123c2f] transition duration-200 dark:text-[var(--text-primary)]'
+                  className='hs-row py-4 text-[0.95rem] font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--hs-gold)]'
                 >
                   <span>{comparison.title}</span>
-                  <ArrowRight className='h-4 w-4 shrink-0 transition group-hover:translate-x-1' aria-hidden='true' />
+                  <ArrowRight className='h-4 w-4 shrink-0' aria-hidden='true' />
                 </Link>
               ))}
             </div>
-            <Link
-              href='/guides/compare/'
-              className='mt-6 inline-flex items-center gap-2 text-sm font-bold text-[#315f50] transition hover:text-[#123c2f] dark:text-[var(--accent-teal)]'
-            >
+
+            <Link href='/guides/compare/' className='hs-link mt-7 text-sm'>
               Browse all comparisons <ArrowRight className='h-4 w-4' aria-hidden='true' />
             </Link>
           </div>
 
-          <div className='editorial-card rounded-[2rem] p-5 sm:p-8'>
-            <p className='editorial-eyebrow'>Check the downside</p>
-            <SectionHeader
-              title='Use the safety tools'
-              subtitle='Check interactions, evidence strength, and buying basics before combining or purchasing supplements.'
-            />
-            <div className='mt-6 space-y-3'>
+          <div>
+            <p className='hs-eyebrow'>Check the downside</p>
+            <h2 className='hs-display mt-4 text-[1.9rem] sm:text-[2.35rem]'>Use the safety tools</h2>
+            <p className='hs-lede mt-4 text-[0.95rem] leading-7'>
+              Check interactions, evidence strength, and buying basics before combining or purchasing anything.
+            </p>
+
+            <div className='hs-rows mt-7'>
               {toolLinks.map((tool) => (
                 <Link
                   key={tool.href}
                   href={tool.href}
-                  className='editorial-link-tile group block rounded-2xl p-4 transition duration-200'
+                  className='hs-row py-4 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--hs-gold)]'
                 >
-                  <div className='flex items-start justify-between gap-3'>
-                    <div>
-                      <h3 className='text-sm font-bold text-[#123c2f] dark:text-[var(--text-primary)]'>{tool.title}</h3>
-                      <p className='mt-1 text-sm leading-6 text-muted'>{tool.description}</p>
-                    </div>
-                    <ArrowRight
-                      className='mt-1 h-4 w-4 shrink-0 text-[#315f50] transition group-hover:translate-x-1 dark:text-[var(--accent-teal)]'
-                      aria-hidden='true'
-                    />
-                  </div>
+                  <span>
+                    <span className='block text-[0.95rem] font-bold'>{tool.title}</span>
+                    <span className='hs-row-sub mt-1 block text-[0.82rem] leading-5'>{tool.description}</span>
+                  </span>
+                  <ArrowRight className='h-4 w-4 shrink-0' aria-hidden='true' />
                 </Link>
               ))}
             </div>
           </div>
         </section>
 
+        {/* ---------------- Latest ---------------- */}
         {latestArticles.length > 0 && (
-          <section className='space-y-5'>
-            <div className='flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between'>
+          <>
+            <hr className='hs-divider' />
+            <section className='py-14 sm:py-20'>
               <SectionHeader
+                eyebrow='Fresh from the library'
                 title='Latest guides & research'
-                subtitle='A small, fresh set of practical explainers and evidence reviews — not another endless homepage feed.'
+                subtitle='A short, current set of practical explainers and evidence reviews — not an endless feed.'
+                action={{ href: '/guides/', label: 'Browse the library' }}
               />
-              <Link
-                href='/guides/'
-                className='inline-flex shrink-0 items-center gap-2 text-sm font-bold text-[#315f50] transition hover:text-[#123c2f] dark:text-[var(--accent-teal)]'
-              >
-                Browse the library <ArrowRight className='h-4 w-4' aria-hidden='true' />
-              </Link>
-            </div>
 
-            <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-3'>
-              {latestArticles.map((article: any) => (
-                <Link
-                  key={article.slug}
-                  href={`/articles/${article.slug}/`}
-                  className='editorial-card group flex flex-col gap-3 rounded-[1.4rem] p-5 transition duration-200 hover:-translate-y-1 hover:border-[#b88a42]/30'
-                >
-                  <div className='flex items-center gap-2'>
-                    {article.category ? (
-                      <span className={`rounded-full border px-2.5 py-0.5 text-[0.72rem] font-medium ${categoryTagClass(article.category)}`}>
-                        {article.category}
-                      </span>
+              <div className='mt-10 grid gap-5 sm:grid-cols-2 lg:grid-cols-3'>
+                {latestArticles.map((article: any) => (
+                  <Link
+                    key={article.slug}
+                    href={`/articles/${article.slug}/`}
+                    className='hs-article group flex flex-col gap-3.5 p-6 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--hs-gold)] focus-visible:ring-offset-2'
+                  >
+                    <div className='flex flex-wrap items-center gap-2'>
+                      {article.category ? (
+                        <span className='hs-tag px-2.5 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.1em]'>
+                          {article.category}
+                        </span>
+                      ) : null}
+                      {article.readingTime ? (
+                        <span className='text-[0.72rem] text-[color:var(--hs-body)]'>{article.readingTime}</span>
+                      ) : null}
+                    </div>
+                    <h3 className='hs-article-title text-[1.2rem] leading-snug'>{article.title}</h3>
+                    {article.excerpt ? (
+                      <p className='line-clamp-3 text-[0.85rem] leading-6 text-[color:var(--hs-body)]'>
+                        {article.excerpt}
+                      </p>
                     ) : null}
-                    {article.readingTime ? <span className='text-[0.72rem] text-muted'>{article.readingTime}</span> : null}
-                  </div>
-                  <h3 className='font-display text-lg font-semibold leading-snug text-[#123c2f] transition group-hover:text-[#315f50] dark:text-[var(--text-primary)]'>
-                    {article.title}
-                  </h3>
-                  {article.excerpt ? <p className='line-clamp-2 text-sm leading-6 text-muted'>{article.excerpt}</p> : null}
-                </Link>
-              ))}
-            </div>
-          </section>
-        )}
-
-        <section className='editorial-card-strong relative overflow-hidden rounded-[2rem] p-6 sm:p-9'>
-          <div className='editorial-botanical-orbit !-bottom-20 !-right-20 !opacity-40' aria-hidden='true'>
-            <span />
-            <span />
-            <span />
-            <span />
-          </div>
-          <div className='relative grid gap-7 lg:grid-cols-[0.9fr_1.1fr] lg:items-center'>
-            <div>
-              <p className='editorial-eyebrow'>How the site works</p>
-              <h2 className='editorial-display mt-3 text-[2.25rem] sm:text-[3rem]'>Evidence, safety, then a conclusion.</h2>
-              <p className='mt-4 max-w-lg text-sm leading-7 text-muted sm:text-base'>
-                Profiles separate human evidence, biological plausibility, dosing context, and safety so a promising mechanism never masquerades as a proven benefit.
-              </p>
-              <Link
-                href='/info/methodology/'
-                className='mt-5 inline-flex items-center gap-2 text-sm font-bold text-[#315f50] transition hover:text-[#123c2f] dark:text-[var(--accent-teal)]'
-              >
-                Read the evidence methodology <ArrowRight className='h-4 w-4' aria-hidden='true' />
-              </Link>
-            </div>
-
-            <div className='grid gap-3 sm:grid-cols-3'>
-              {trustItems.map((item) => {
-                const Icon = item.icon
-                return (
-                  <div key={item.label} className='editorial-link-tile rounded-[1.3rem] p-4'>
-                    <span className='editorial-icon-disc h-10 w-10'>
-                      <Icon className='h-5 w-5' aria-hidden='true' strokeWidth={1.8} />
+                    <span className='hs-link mt-auto pt-1 text-[0.8rem]'>
+                      Read <ArrowRight className='h-3.5 w-3.5' aria-hidden='true' />
                     </span>
-                    <p className='mt-3 text-sm font-bold text-[#123c2f] dark:text-[var(--text-primary)]'>{item.label}</p>
-                    <p className='mt-1 text-xs leading-5 text-muted'>{item.body}</p>
-                  </div>
-                )
-              })}
-            </div>
-          </div>
-        </section>
+                  </Link>
+                ))}
+              </div>
+            </section>
+          </>
+        )}
       </div>
+
+      {/* ---------------- Full-bleed methodology band — the page's closing moment ---------------- */}
+      <section className='hs-method mt-6 py-16 sm:py-24'>
+        <div className='mx-auto grid max-w-6xl gap-12 px-5 sm:px-8 lg:grid-cols-[0.85fr_1.15fr] lg:gap-20 lg:px-10'>
+          <div>
+            <p className='hs-eyebrow'>How the site works</p>
+            <h2 className='hs-display mt-5 text-[2.2rem] sm:text-[2.9rem]'>
+              Evidence, safety, <span className='hs-accent'>then a conclusion.</span>
+            </h2>
+            <p className='mt-5 max-w-md text-[0.95rem] leading-7 text-[#c3d2c7]'>
+              Every profile follows the same order, so you always know how much weight a claim actually carries.
+            </p>
+            <Link href='/info/methodology/' className='hs-method-link mt-7 inline-flex items-center gap-2 text-sm font-bold'>
+              Read the evidence methodology <ArrowRight className='h-4 w-4' aria-hidden='true' />
+            </Link>
+          </div>
+
+          <ol className='space-y-0'>
+            {methodSteps.map((step) => (
+              <li key={step.num} className='hs-step flex gap-6 py-6 sm:gap-8'>
+                <span className='hs-step-num shrink-0 text-[1.6rem] sm:text-[2rem]'>{step.num}</span>
+                <div>
+                  <h3 className='text-base font-bold text-[#fffdf8] sm:text-lg'>{step.title}</h3>
+                  <p className='mt-2 text-[0.88rem] leading-6 text-[#b8c9bd]'>{step.body}</p>
+                </div>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </section>
     </div>
   )
 }

--- a/components/search/GlobalSearchModal.tsx
+++ b/components/search/GlobalSearchModal.tsx
@@ -128,7 +128,7 @@ export function GlobalSearchModal() {
       >
         <Search className="h-4 w-4" aria-hidden="true" />
         <span className="hidden sm:inline">Search</span>
-        <kbd className="hidden rounded border border-brand-900/15 bg-brand-50/60 px-1.5 py-0.5 text-[10px] font-semibold text-ink/50 dark:border-[var(--border-soft)] dark:bg-[var(--surface-neutral)] dark:text-[var(--text-muted)] md:inline">
+        <kbd className="hidden rounded border border-brand-900/15 bg-brand-50/60 px-1.5 py-0.5 text-[10px] font-semibold text-ink/75 dark:border-[var(--border-soft)] dark:bg-[var(--surface-neutral)] dark:text-[var(--text-muted)] md:inline">
           ⌘K
         </kbd>
       </button>
@@ -172,7 +172,7 @@ export function GlobalSearchModal() {
                 placeholder="Search herbs, compounds, and education…"
                 className="min-h-14 w-full bg-transparent py-3 text-base text-ink outline-none placeholder:text-muted/60 dark:placeholder:text-[var(--text-muted)]/50"
               />
-              <kbd className="hidden shrink-0 rounded border border-brand-900/15 bg-brand-50/60 px-1.5 py-0.5 text-[10px] font-semibold text-ink/40 dark:border-[var(--border-soft)] dark:bg-[var(--surface-neutral)] dark:text-[var(--text-muted)] sm:inline">
+              <kbd className="hidden shrink-0 rounded border border-brand-900/15 bg-brand-50/60 px-1.5 py-0.5 text-[10px] font-semibold text-ink/75 dark:border-[var(--border-soft)] dark:bg-[var(--surface-neutral)] dark:text-[var(--text-muted)] sm:inline">
                 Esc
               </kbd>
             </div>

--- a/styles/homepage-editorial-redesign.css
+++ b/styles/homepage-editorial-redesign.css
@@ -1,0 +1,745 @@
+/* Homepage visual redesign — "botanical apothecary journal"
+   Goals: real elevation instead of card-on-card, colour per goal instead of a
+   monotone green field, generous rhythm, and one dark full-bleed moment.
+   Everything here is scoped under .hs-home so shared editorial-* surfaces used
+   by other routes are untouched. */
+
+.hs-home {
+  --hs-gold: #b88a42;
+  --hs-gold-bright: #c99a4e;
+  --hs-gold-soft: #e2cba3;
+  --hs-ink: #10352a;
+  --hs-ink-soft: #315f50;
+  --hs-body: #4a5b52;
+  --hs-hairline: rgba(18, 60, 47, 0.12);
+  --hs-hairline-strong: rgba(18, 60, 47, 0.2);
+  --hs-surface: #fffdf8;
+  --hs-surface-2: rgba(255, 253, 248, 0.72);
+  --hs-lift: 0 1px 2px rgba(46, 38, 20, 0.05), 0 12px 32px -12px rgba(46, 38, 20, 0.16);
+  --hs-lift-hover: 0 2px 4px rgba(46, 38, 20, 0.06), 0 26px 56px -18px rgba(46, 38, 20, 0.26);
+
+  position: relative;
+  isolation: isolate;
+  overflow: clip;
+  color: var(--hs-body);
+  background:
+    radial-gradient(120% 60% at 50% -10%, rgba(203, 220, 200, 0.6), transparent 60%),
+    linear-gradient(180deg, #fffdf8 0%, #fbf8f1 30%, #f8f3e8 100%);
+}
+
+.dark .hs-home {
+  --hs-gold: #d9b271;
+  --hs-gold-bright: #e8c98f;
+  --hs-gold-soft: rgba(217, 178, 113, 0.28);
+  --hs-ink: #f3f0e6;
+  --hs-ink-soft: #a9c9b5;
+  --hs-body: #b6c7bb;
+  --hs-hairline: rgba(180, 210, 190, 0.16);
+  --hs-hairline-strong: rgba(180, 210, 190, 0.3);
+  --hs-surface: #16291f;
+  --hs-surface-2: rgba(24, 43, 33, 0.6);
+  --hs-lift: 0 1px 0 rgba(255, 255, 255, 0.05) inset, 0 16px 40px -16px rgba(0, 0, 0, 0.7);
+  --hs-lift-hover: 0 1px 0 rgba(255, 255, 255, 0.09) inset, 0 30px 64px -20px rgba(0, 0, 0, 0.85);
+
+  background:
+    radial-gradient(120% 55% at 50% -8%, rgba(46, 96, 74, 0.42), transparent 62%),
+    linear-gradient(180deg, #0a1610 0%, #081410 45%, #0a1712 100%);
+}
+
+/* Fine botanical dot field, faded out below the hero. */
+.hs-home::before {
+  content: '';
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 90rem;
+  z-index: -1;
+  pointer-events: none;
+  opacity: 0.5;
+  background-image: radial-gradient(circle at 1px 1px, rgba(18, 60, 47, 0.14) 1px, transparent 0);
+  background-size: 34px 34px;
+  mask-image: linear-gradient(to bottom, #000 0%, transparent 42%);
+}
+
+.dark .hs-home::before {
+  opacity: 0.4;
+  background-image: radial-gradient(circle at 1px 1px, rgba(190, 224, 202, 0.16) 1px, transparent 0);
+}
+
+/* ---------- Type ---------- */
+
+.hs-display {
+  color: var(--hs-ink);
+  font-family: var(--font-fraunces), Fraunces, Georgia, serif;
+  font-weight: 640;
+  letter-spacing: -0.032em;
+  line-height: 1.02;
+  text-wrap: balance;
+}
+
+.hs-accent {
+  color: var(--hs-gold-bright);
+  font-style: italic;
+  font-weight: 560;
+}
+
+.hs-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  color: var(--hs-gold);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.2em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.hs-eyebrow::before {
+  content: '';
+  width: 1.6rem;
+  height: 1px;
+  flex: 0 0 auto;
+  background: currentColor;
+  opacity: 0.55;
+}
+
+.hs-lede {
+  color: var(--hs-body);
+  text-wrap: pretty;
+}
+
+/* ---------- Hero ---------- */
+
+.hs-hero {
+  position: relative;
+}
+
+/* Soft aurora bloom behind the headline. */
+.hs-hero::before {
+  content: '';
+  position: absolute;
+  z-index: -1;
+  left: -18%;
+  top: -22%;
+  width: 46rem;
+  height: 34rem;
+  pointer-events: none;
+  border-radius: 50%;
+  filter: blur(60px);
+  opacity: 0.5;
+  background: radial-gradient(circle at 40% 40%, rgba(148, 190, 160, 0.5), transparent 65%);
+}
+
+.dark .hs-hero::before {
+  opacity: 0.65;
+  background: radial-gradient(circle at 40% 40%, rgba(60, 122, 95, 0.5), transparent 65%);
+}
+
+/* Hero "evidence dial" — the page's single decorative focal point.
+   Purely presentational; the markup is aria-hidden. Desktop only. */
+
+.hs-dial {
+  position: relative;
+  display: none;
+  width: 100%;
+  max-width: 30rem;
+  margin-inline: auto;
+  aspect-ratio: 1;
+}
+
+@media (min-width: 1024px) {
+  .hs-dial {
+    display: block;
+  }
+}
+
+.hs-dial::before {
+  content: '';
+  position: absolute;
+  z-index: -1;
+  inset: 6%;
+  border-radius: 50%;
+  filter: blur(38px);
+  opacity: 0.7;
+  background: radial-gradient(circle at 45% 40%, rgba(139, 186, 155, 0.55), transparent 68%);
+}
+
+.dark .hs-dial::before {
+  opacity: 0.85;
+  background: radial-gradient(circle at 45% 40%, rgba(62, 132, 101, 0.6), transparent 68%);
+}
+
+.hs-dial-ring {
+  position: absolute;
+  border-radius: 50%;
+}
+
+/* Outer dashed measurement ring. */
+.hs-dial-ring--outer {
+  inset: 0;
+  border: 1px dashed color-mix(in srgb, var(--hs-gold) 42%, transparent);
+  opacity: 0.75;
+  animation: hs-dial-spin 90s linear infinite;
+}
+
+/* Mid ring carries a conic "evidence strength" arc. */
+.hs-dial-ring--mid {
+  inset: 11%;
+  border: 1px solid var(--hs-hairline-strong);
+  background: conic-gradient(
+    from 200deg,
+    color-mix(in srgb, var(--hs-gold) 58%, transparent) 0deg,
+    color-mix(in srgb, var(--hs-gold) 12%, transparent) 118deg,
+    transparent 150deg,
+    transparent 360deg
+  );
+  mask: radial-gradient(circle, transparent 0 calc(50% - 3px), #000 calc(50% - 3px) 50%, transparent 50%);
+}
+
+/* Inner tick ring. */
+.hs-dial-ring--inner {
+  inset: 22%;
+  border: 1px solid var(--hs-hairline);
+  background: repeating-conic-gradient(
+    from 0deg,
+    color-mix(in srgb, var(--hs-ink) 22%, transparent) 0deg 0.5deg,
+    transparent 0.5deg 15deg
+  );
+  mask: radial-gradient(circle, transparent 0 calc(50% - 9px), #000 calc(50% - 9px) 50%, transparent 50%);
+  opacity: 0.85;
+}
+
+.dark .hs-dial-ring--inner {
+  background: repeating-conic-gradient(
+    from 0deg,
+    rgba(198, 226, 208, 0.5) 0deg 0.5deg,
+    transparent 0.5deg 15deg
+  );
+}
+
+.hs-dial-core {
+  position: absolute;
+  inset: 33%;
+  display: grid;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--hs-gold) 34%, transparent);
+  border-radius: 50%;
+  color: var(--hs-gold-bright);
+  background:
+    radial-gradient(circle at 34% 26%, rgba(255, 255, 255, 0.96), rgba(238, 244, 235, 0.9) 55%, rgba(212, 228, 214, 0.9)),
+    var(--hs-surface);
+  box-shadow:
+    0 18px 44px -14px rgba(18, 60, 47, 0.42),
+    0 0 0 10px color-mix(in srgb, var(--hs-surface) 55%, transparent),
+    0 0 0 11px var(--hs-hairline);
+}
+
+.dark .hs-dial-core {
+  border-color: rgba(217, 178, 113, 0.5);
+  background:
+    radial-gradient(circle at 34% 26%, rgba(96, 152, 122, 0.95), rgba(38, 76, 59, 0.96) 58%, rgba(20, 44, 34, 0.98));
+  box-shadow:
+    0 18px 44px -12px rgba(0, 0, 0, 0.75),
+    0 0 34px -6px rgba(217, 178, 113, 0.22),
+    0 0 0 10px rgba(10, 22, 17, 0.7),
+    0 0 0 11px var(--hs-hairline);
+}
+
+/* Orbiting evidence chips. */
+.hs-dial-chip {
+  position: absolute;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  white-space: nowrap;
+  border: 1px solid var(--hs-hairline);
+  border-radius: 999px;
+  padding: 0.55rem 0.85rem;
+  color: var(--hs-ink);
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.005em;
+  background: var(--hs-surface);
+  box-shadow: var(--hs-lift);
+  backdrop-filter: blur(10px);
+  animation: hs-dial-float 8s ease-in-out infinite;
+}
+
+.hs-dial-chip::before {
+  content: '';
+  width: 0.45rem;
+  height: 0.45rem;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--hs-gold);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--hs-gold) 22%, transparent);
+}
+
+.hs-dial-chip:nth-of-type(1) {
+  left: -4%;
+  top: 17%;
+  animation-delay: -1.2s;
+}
+.hs-dial-chip:nth-of-type(2) {
+  right: -6%;
+  top: 30%;
+  animation-delay: -4.1s;
+}
+.hs-dial-chip:nth-of-type(3) {
+  left: 0%;
+  bottom: 22%;
+  animation-delay: -6.3s;
+}
+.hs-dial-chip:nth-of-type(4) {
+  right: -2%;
+  bottom: 12%;
+  animation-delay: -2.7s;
+}
+
+@keyframes hs-dial-float {
+  0%,
+  100% {
+    translate: 0 0;
+  }
+  50% {
+    translate: 0 -6px;
+  }
+}
+
+@keyframes hs-dial-spin {
+  to {
+    rotate: 360deg;
+  }
+}
+
+.hs-btn-primary {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(18, 60, 47, 0.9);
+  background: linear-gradient(140deg, #1c5241 0%, #123c2f 55%, #0f3227 100%);
+  color: #fffdf8;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.14) inset,
+    0 14px 30px -12px rgba(18, 60, 47, 0.7);
+}
+
+.dark .hs-btn-primary {
+  border-color: rgba(217, 178, 113, 0.42);
+  background: linear-gradient(140deg, #256a52 0%, #17493a 55%, #123c2f 100%);
+}
+
+.hs-btn-primary::after {
+  content: '';
+  position: absolute;
+  inset: -2px auto -2px -45%;
+  width: 32%;
+  transform: skewX(-18deg);
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.22), transparent);
+  transition: left 620ms ease;
+}
+
+.hs-btn-primary:hover {
+  transform: translateY(-2px);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.18) inset,
+    0 20px 40px -12px rgba(18, 60, 47, 0.6);
+}
+
+.hs-btn-primary:hover::after {
+  left: 120%;
+}
+
+.hs-btn-ghost {
+  border: 1px solid var(--hs-hairline-strong);
+  background: var(--hs-surface-2);
+  color: var(--hs-ink);
+  backdrop-filter: blur(10px);
+}
+
+.hs-btn-ghost:hover {
+  border-color: var(--hs-gold);
+  background: var(--hs-surface);
+  transform: translateY(-2px);
+}
+
+/* Hero credibility rail — plain text columns, no nested boxes. */
+.hs-rail {
+  border-top: 1px solid var(--hs-hairline);
+  border-bottom: 1px solid var(--hs-hairline);
+}
+
+.hs-rail > * + * {
+  border-top: 1px solid var(--hs-hairline);
+}
+
+@media (min-width: 640px) {
+  .hs-rail > * + * {
+    border-top: 0;
+    border-left: 1px solid var(--hs-hairline);
+  }
+}
+
+.hs-rail dt {
+  color: var(--hs-ink);
+}
+
+.hs-stat-num {
+  color: var(--hs-ink);
+  font-family: var(--font-fraunces), Fraunces, Georgia, serif;
+  font-weight: 640;
+  letter-spacing: -0.02em;
+}
+
+/* ---------- Goal cards — one hue each, the page's colour anchor ---------- */
+
+.hs-goal {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--tone) 26%, transparent);
+  border-radius: 1.5rem;
+  background:
+    linear-gradient(160deg, color-mix(in srgb, var(--tone) 13%, transparent), transparent 62%),
+    var(--hs-surface);
+  box-shadow: var(--hs-lift);
+  transition:
+    transform 260ms cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 260ms ease,
+    border-color 260ms ease;
+}
+
+/* Dark surfaces swallow a 13% wash, so push the tint harder there. */
+.dark .hs-goal {
+  border-color: color-mix(in srgb, var(--tone) 30%, transparent);
+  background:
+    linear-gradient(158deg, color-mix(in srgb, var(--tone) 26%, transparent), transparent 68%),
+    var(--hs-surface);
+}
+
+/* Colour bloom that grows on hover. */
+.hs-goal::after {
+  content: '';
+  position: absolute;
+  z-index: -1;
+  right: -30%;
+  bottom: -55%;
+  width: 16rem;
+  height: 16rem;
+  border-radius: 50%;
+  opacity: 0.5;
+  filter: blur(28px);
+  background: radial-gradient(circle, color-mix(in srgb, var(--tone) 42%, transparent), transparent 70%);
+  transition: opacity 320ms ease, transform 420ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.hs-goal:hover {
+  transform: translateY(-4px);
+  border-color: color-mix(in srgb, var(--tone) 52%, transparent);
+  box-shadow: var(--hs-lift-hover);
+}
+
+.hs-goal:hover::after {
+  opacity: 0.85;
+  transform: scale(1.18);
+}
+
+.hs-goal-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid color-mix(in srgb, var(--tone) 34%, transparent);
+  border-radius: 1rem;
+  background: color-mix(in srgb, var(--tone) 15%, var(--hs-surface));
+  color: var(--tone-ink);
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.5) inset;
+}
+
+.dark .hs-goal-icon {
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.07) inset;
+}
+
+.hs-goal-title {
+  color: var(--hs-ink);
+  font-family: var(--font-fraunces), Fraunces, Georgia, serif;
+  font-weight: 630;
+  letter-spacing: -0.025em;
+}
+
+.hs-goal-go {
+  color: var(--tone-ink);
+}
+
+.hs-goal:hover .hs-goal-go svg {
+  transform: translateX(4px);
+}
+
+/* Tones. --tone drives washes/borders, --tone-ink drives text/icons. */
+[data-tone='sleep'] {
+  --tone: #7c73d6;
+  --tone-ink: #5a51b5;
+}
+[data-tone='stress'] {
+  --tone: #4f9e6d;
+  --tone-ink: #2f7a4c;
+}
+[data-tone='anxiety'] {
+  --tone: #3f97a8;
+  --tone-ink: #24707f;
+}
+[data-tone='focus'] {
+  --tone: #c2913f;
+  --tone-ink: #966a1d;
+}
+
+.dark [data-tone='sleep'] {
+  --tone: #8b82e6;
+  --tone-ink: #b6afef;
+}
+.dark [data-tone='stress'] {
+  --tone: #5cb37c;
+  --tone-ink: #8fd3a7;
+}
+.dark [data-tone='anxiety'] {
+  --tone: #49aabd;
+  --tone-ink: #86d2e0;
+}
+.dark [data-tone='focus'] {
+  --tone: #d7a94f;
+  --tone-ink: #ecc98d;
+}
+
+/* ---------- Chips ---------- */
+
+.hs-chip {
+  border: 1px solid var(--hs-hairline);
+  border-radius: 999px;
+  background: var(--hs-surface);
+  color: var(--hs-ink);
+  box-shadow: var(--hs-lift);
+  transition:
+    transform 200ms cubic-bezier(0.22, 1, 0.36, 1),
+    border-color 200ms ease,
+    box-shadow 200ms ease;
+}
+
+.hs-chip:hover {
+  transform: translateY(-2px);
+  border-color: var(--hs-gold);
+  box-shadow: var(--hs-lift-hover);
+}
+
+/* ---------- Link rows — hairline list, no nested tiles ---------- */
+
+.hs-rows {
+  border-top: 1px solid var(--hs-hairline);
+}
+
+.hs-row {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid var(--hs-hairline);
+  color: var(--hs-ink);
+  transition: color 200ms ease, padding-left 240ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* Gold marker that slides in on hover instead of a box appearing. */
+.hs-row::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 12%;
+  bottom: 12%;
+  width: 2px;
+  border-radius: 2px;
+  background: var(--hs-gold);
+  opacity: 0;
+  transition: opacity 200ms ease;
+}
+
+.hs-row:hover {
+  padding-left: 0.9rem;
+  color: var(--hs-gold-bright);
+}
+
+.hs-row:hover::before {
+  opacity: 1;
+}
+
+.hs-row:hover svg {
+  transform: translateX(4px);
+}
+
+.hs-row-sub {
+  color: var(--hs-body);
+}
+
+.hs-row:hover .hs-row-sub {
+  color: var(--hs-body);
+}
+
+/* ---------- Article cards ---------- */
+
+.hs-article {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--hs-hairline);
+  border-radius: 1.25rem;
+  background: var(--hs-surface);
+  box-shadow: var(--hs-lift);
+  transition:
+    transform 260ms cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 260ms ease,
+    border-color 260ms ease;
+}
+
+.hs-article::before {
+  content: '';
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--hs-gold), transparent);
+  opacity: 0;
+  transition: opacity 260ms ease;
+}
+
+.hs-article:hover {
+  transform: translateY(-4px);
+  border-color: var(--hs-gold-soft);
+  box-shadow: var(--hs-lift-hover);
+}
+
+.hs-article:hover::before {
+  opacity: 1;
+}
+
+.hs-article-title {
+  color: var(--hs-ink);
+  font-family: var(--font-fraunces), Fraunces, Georgia, serif;
+  font-weight: 620;
+  letter-spacing: -0.02em;
+}
+
+.hs-tag {
+  border: 1px solid var(--hs-hairline);
+  border-radius: 999px;
+  background: var(--hs-surface-2);
+  color: var(--hs-body);
+}
+
+/* ---------- Dark full-bleed methodology band ---------- */
+
+.hs-method {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  border-top: 1px solid rgba(217, 178, 113, 0.28);
+  border-bottom: 1px solid rgba(217, 178, 113, 0.18);
+  color: #e8ece3;
+  background:
+    radial-gradient(70% 110% at 8% -10%, rgba(56, 116, 90, 0.42), transparent 58%),
+    linear-gradient(160deg, #10382b 0%, #0c2a20 52%, #081d17 100%);
+}
+
+.hs-method::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  opacity: 0.5;
+  background-image: radial-gradient(circle at 1px 1px, rgba(226, 203, 163, 0.16) 1px, transparent 0);
+  background-size: 38px 38px;
+  mask-image: radial-gradient(70% 90% at 80% 30%, #000, transparent 75%);
+}
+
+.hs-method .hs-display {
+  color: #fffdf8;
+}
+
+.hs-method .hs-eyebrow {
+  color: #e0c193;
+}
+
+.hs-step {
+  border-top: 1px solid rgba(226, 203, 163, 0.22);
+}
+
+.hs-step-num {
+  color: rgba(226, 203, 163, 0.85);
+  font-family: var(--font-fraunces), Fraunces, Georgia, serif;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+}
+
+.hs-method-link {
+  color: #f0dcb8;
+  border-bottom: 1px solid rgba(240, 220, 184, 0.35);
+  transition: border-color 200ms ease, color 200ms ease;
+}
+
+.hs-method-link:hover {
+  color: #fffdf8;
+  border-color: #fffdf8;
+}
+
+.hs-method-link:hover svg {
+  transform: translateX(4px);
+}
+
+/* ---------- Shared link affordance ---------- */
+
+.hs-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--hs-ink-soft);
+  font-weight: 700;
+  transition: color 200ms ease;
+}
+
+.hs-link:hover {
+  color: var(--hs-gold-bright);
+}
+
+.hs-link svg,
+.hs-row svg,
+.hs-goal-go svg,
+.hs-method-link svg {
+  transition: transform 240ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.hs-link:hover svg {
+  transform: translateX(4px);
+}
+
+/* Hairline section divider used between open bands. */
+.hs-divider {
+  height: 1px;
+  border: 0;
+  background: linear-gradient(90deg, var(--hs-hairline-strong), transparent 70%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hs-home *,
+  .hs-home *::before,
+  .hs-home *::after {
+    transition: none !important;
+    animation: none !important;
+  }
+
+  .hs-goal:hover,
+  .hs-article:hover,
+  .hs-chip:hover,
+  .hs-btn-primary:hover,
+  .hs-btn-ghost:hover {
+    transform: none;
+  }
+
+  .hs-row:hover {
+    padding-left: 0;
+  }
+}


### PR DESCRIPTION
## Summary

The homepage read as a blog index. The cause was structural: every section was an `editorial-card` panel containing more `editorial-link-tile` panels, and in dark mode all three layers sat within a few percent of each other — canvas `#0d1712`, section panel `rgba(24,45,36)`, tile `rgba(29,53,43)`. The result was a flat monotone green field with dozens of borders and no hierarchy. The trust triad (Evidence-first / Safety aware / Plain English) also rendered twice, once in the hero and again in the closing section, which reinforced the feed impression.

**Structure**

- Dropped the section-level card chrome. Sections are now open bands on the page canvas separated by hairline rules, so only genuinely interactive elements carry a surface. This removes roughly half the visible boxes.
- Replaced the nested comparison and safety-tool tiles with hairline list rows that reveal a gold marker on hover instead of materialising a panel.
- De-duplicated the trust triad. It now appears once in the hero as a plain text rail; the closing section became a numbered 01/02/03 methodology summary.
- The page ends on a full-bleed deep evergreen band so it has a visual full stop rather than trailing off into the footer.

**Colour and depth**

- Each goal gets its own hue — sleep/violet, stress/green, anxiety/teal, focus/amber — with a gradient wash and a bloom that grows on hover. This is the page's colour anchor and what breaks the monotone.
- Established a real elevation scale: deeper canvas so surfaces have room to lift, with a hairline top highlight in dark and warm shadow in light.

**Hero**

- Two-column layout with an "evidence dial" focal point at `lg` and up, filling the empty right half the previous hero left behind.
- "actually explained." set in italic gold. `text-wrap: balance` fixes the comma-orphan line break the old headline produced (it wrapped to `, actually`).
- Surfaces real herb/compound/claim counts read from the generated `public/data/build-report.json` rather than adding another card. That file is git-tracked and regenerated in pipeline step 2, before `next build`.

Also raises the search-hint `kbd` from `text-ink/50` to `/75`; at 2.81:1 it was the one colour-contrast violation axe found on the page. Pre-existing, unrelated to the redesign, but it sits in the header on every route.

All new CSS is scoped under `.hs-home` in a new `styles/homepage-editorial-redesign.css`, so the shared `editorial-*` classes other routes depend on are untouched.

## Verification

- [x] `npm run lint`
- [x] `npm run check`
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs
- [x] no generated file corruption
- [x] static export compatible

Additionally:

- [x] `npm run typecheck`
- [x] `npm run test` — 119 files, 700 tests passing
- [x] `npm run validate:static-export` — 696 files scanned, no violations
- [x] axe (`color-contrast`, `link-name`, `heading-order`, `landmark-one-main`, `region`) against the live render in light and dark at 430px and 1440px — no violations

`npm run check` regenerated only the `generatedAt` timestamp in `public/data/_meta/build-info.json`, which I reverted; no content drift.

## Risk Notes

- Homepage-only visual change. No data, routing, or metadata changes, so no redirect or SEO impact.
- New CSS is namespaced under `.hs-home`; shared `editorial-*` surfaces used by other routes are not modified. The two files touched outside the homepage are `app/layout.tsx` (one stylesheet import) and `GlobalSearchModal.tsx` (the contrast fix).
- The hero dial is decorative and `aria-hidden`, rendered only at `≥1024px`. Its slow rotation and float animations are disabled under `prefers-reduced-motion`.
- `.hs-home` uses `overflow: clip`, which clips the aurora and bloom decorations without creating a scroll container or breaking the in-page `#choose-a-path` anchor.
- Uses `color-mix()` for the goal tones. Supported in all current evergreen browsers; in anything older the tone washes degrade to no tint, leaving the cards legible on their base surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wi3o6eVum24UxHkkPRcUBv)_