### PR TITLE
Refine the homepage and give the lower sections colour

### DIFF
--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -1,9 +1,11 @@
 import Link from 'next/link'
 import {
   ArrowRight,
+  Atom,
   BookOpen,
   Cloud,
   FlaskConical,
+  ListChecks,
   Moon,
   Leaf,
   Search,
@@ -55,19 +57,29 @@ const trustItems = [
 ]
 
 const popularProfiles = [
-  { href: '/herbs/ashwagandha/', label: 'Ashwagandha', type: 'Herb' },
-  { href: '/herbs/rhodiola/', label: 'Rhodiola', type: 'Herb' },
-  { href: '/compounds/magnesium/', label: 'Magnesium', type: 'Compound' },
-  { href: '/compounds/l-theanine/', label: 'L-theanine', type: 'Compound' },
-  { href: '/compounds/melatonin/', label: 'Melatonin', type: 'Compound' },
+  { href: '/herbs/ashwagandha/', label: 'Ashwagandha', type: 'Herb', tone: 'amber' },
+  { href: '/herbs/rhodiola/', label: 'Rhodiola', type: 'Herb', tone: 'rose' },
+  { href: '/compounds/magnesium/', label: 'Magnesium', type: 'Compound', tone: 'blue' },
+  { href: '/compounds/l-theanine/', label: 'L-theanine', type: 'Compound', tone: 'green' },
+  { href: '/compounds/melatonin/', label: 'Melatonin', type: 'Compound', tone: 'indigo' },
+  { href: '/herbs/valerian/', label: 'Valerian', type: 'Herb', tone: 'violet' },
 ]
 
 const comparisonLinks = [
-  { href: '/guides/compare/melatonin-vs-magnesium/', title: 'Melatonin vs magnesium' },
-  { href: '/guides/compare/rhodiola-vs-ashwagandha/', title: 'Rhodiola vs ashwagandha' },
+  {
+    href: '/guides/compare/melatonin-vs-magnesium/',
+    parts: ['Melatonin', 'Magnesium'],
+    tone: 'indigo',
+  },
+  {
+    href: '/guides/compare/rhodiola-vs-ashwagandha/',
+    parts: ['Rhodiola', 'Ashwagandha'],
+    tone: 'rose',
+  },
   {
     href: '/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium/',
-    title: 'Ashwagandha vs L-theanine vs magnesium',
+    parts: ['Ashwagandha', 'L-theanine', 'Magnesium'],
+    tone: 'amber',
   },
 ]
 
@@ -76,18 +88,39 @@ const toolLinks = [
     href: '/safety-checker/',
     title: 'Safety interaction checker',
     description: 'Screen combinations for overlapping cautions before stacking.',
+    icon: ShieldCheck,
+    tone: 'rose',
   },
   {
     href: '/evidence/evidence-checker/',
     title: 'Evidence lookup',
     description: 'Filter compounds by clinical evidence strength and research context.',
+    icon: FlaskConical,
+    tone: 'teal',
   },
   {
     href: '/info/supplement-safety-checklist/',
     title: 'Supplement safety checklist',
     description: 'Five practical questions to ask before comparing products or buying.',
+    icon: ListChecks,
+    tone: 'amber',
   },
 ]
+
+// Tone per article category so the cards carry colour rather than reading as a
+// row of identical dark panels.
+const CATEGORY_TONES: Record<string, string> = {
+  'metabolic health': 'amber',
+  'cognitive health': 'blue',
+  'anxiety & sleep': 'indigo',
+  'mental health': 'violet',
+  general: 'green',
+}
+
+function categoryTone(category?: string): string {
+  if (!category) return 'green'
+  return CATEGORY_TONES[category.toLowerCase()] || 'teal'
+}
 
 const methodSteps = [
   {
@@ -157,18 +190,18 @@ export default function HomepageV2() {
     <div className='hs-home'>
       <div className='mx-auto max-w-6xl px-5 sm:px-8 lg:px-10'>
         {/* ---------------- Hero ---------------- */}
-        <section className='hs-hero pb-14 pt-12 sm:pb-20 sm:pt-16 lg:pt-20'>
+        <section className='hs-hero pb-10 pt-8 sm:pb-20 sm:pt-16 lg:pt-20'>
           <div className='grid items-center gap-12 lg:grid-cols-[1.08fr_0.92fr] lg:gap-10'>
             <div>
               <p className='hs-eyebrow'>Evidence-based supplement guidance</p>
 
-              <h1 className='hs-display mt-7 max-w-[15ch] text-[3rem] leading-[0.98] sm:text-[4.4rem] lg:text-[5.1rem]'>
-                Herbs &amp; supplements, <span className='hs-accent'>actually explained.</span>
+              <h1 className='hs-display mt-6 max-w-[17ch] text-[2.9rem] leading-[1.02] sm:mt-7 sm:max-w-[14ch] sm:text-[4.2rem] lg:text-[4.9rem]'>
+                Feel Better <span className='hs-accent'>Without Guessing</span>
               </h1>
 
-              <p className='hs-lede mt-7 max-w-xl text-lg leading-8 sm:text-xl sm:leading-9'>
-                Start with your goal. Compare the human evidence, the mechanism, the dose, and the safety —
-                without the marketing.
+              <p className='hs-lede mt-6 max-w-xl text-[1.05rem] leading-[1.65] sm:mt-7 sm:text-xl sm:leading-9'>
+                Compare herbs and supplements on human evidence, mechanism, dose, and safety — so you can
+                start with your goal instead of the marketing.
               </p>
 
               <div className='mt-9 flex flex-col gap-3 sm:flex-row sm:items-center'>
@@ -205,13 +238,17 @@ export default function HomepageV2() {
           </div>
 
           {/* Real counts from the generated build report — credibility without a card. */}
-          <dl className='mt-12 flex flex-wrap items-baseline gap-x-8 gap-y-3'>
+          {/* Three across on a phone with the label stacked, so the row never
+              breaks 2 + 1; inline once there is width for it. */}
+          <dl className='mt-10 grid grid-cols-3 gap-x-4 sm:mt-12 sm:flex sm:flex-wrap sm:items-baseline sm:gap-x-8'>
             {heroStats.map((stat) => (
-              <div key={stat.label} className='flex items-baseline gap-2'>
+              <div key={stat.label} className='sm:flex sm:items-baseline sm:gap-2'>
                 <dt className='sr-only'>{stat.label}</dt>
-                <dd className='flex items-baseline gap-2'>
-                  <span className='hs-stat-num text-2xl sm:text-[1.75rem]'>{stat.value}</span>
-                  <span className='text-sm text-[color:var(--hs-body)]'>{stat.label}</span>
+                <dd className='sm:flex sm:items-baseline sm:gap-2'>
+                  <span className='hs-stat-num block text-[1.6rem] sm:inline sm:text-[1.75rem]'>{stat.value}</span>
+                  <span className='mt-0.5 block text-[0.78rem] leading-[1.3] text-[color:var(--hs-body)] sm:mt-0 sm:inline sm:text-sm'>
+                    {stat.label}
+                  </span>
                 </dd>
               </div>
             ))}
@@ -238,7 +275,7 @@ export default function HomepageV2() {
         </section>
 
         {/* ---------------- Goal paths — the colour anchor ---------------- */}
-        <section id='choose-a-path' className='scroll-mt-24 py-14 sm:py-20'>
+        <section id='choose-a-path' className='scroll-mt-24 py-11 sm:py-20'>
           <SectionHeader
             eyebrow='Start here'
             title={
@@ -251,7 +288,7 @@ export default function HomepageV2() {
             size='lg'
           />
 
-          <div className='mt-10 grid grid-cols-2 gap-3.5 sm:gap-5 lg:grid-cols-4'>
+          <div className='mt-8 grid grid-cols-2 gap-3.5 sm:mt-10 sm:gap-5 lg:grid-cols-4'>
             {heroGoals.map((goal) => {
               const Icon = goal.icon
               return (
@@ -282,30 +319,35 @@ export default function HomepageV2() {
         <hr className='hs-divider' />
 
         {/* ---------------- Popular starting points ---------------- */}
-        <section className='py-14 sm:py-20'>
+        <section className='py-11 sm:py-20'>
           <SectionHeader
             eyebrow='Popular starting points'
             title='Look up a familiar name'
             subtitle='These are the most common first searches — not endorsements. Each profile opens with evidence, mechanism, dosing context, and safety.'
           />
 
-          <div className='mt-9 flex flex-wrap gap-3'>
-            {popularProfiles.map((profile) => (
-              <Link
-                key={profile.href}
-                href={profile.href}
-                className='hs-chip group inline-flex items-center gap-2.5 px-5 py-3 text-sm font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--hs-gold)] focus-visible:ring-offset-2'
-              >
-                <span>{profile.label}</span>
-                <span className='text-[0.62rem] font-semibold uppercase tracking-[0.14em] text-[color:var(--hs-body)]'>
-                  {profile.type}
-                </span>
-                <ArrowRight
-                  className='h-3.5 w-3.5 transition group-hover:translate-x-0.5'
-                  aria-hidden='true'
-                />
-              </Link>
-            ))}
+          {/* A specimen shelf: one jewel tone per entry so the row reads as a
+              collection rather than six identical grey pills. */}
+          <div className='mt-8 grid grid-cols-2 gap-3 sm:mt-10 sm:grid-cols-3 sm:gap-4 lg:grid-cols-6'>
+            {popularProfiles.map((profile) => {
+              const Icon = profile.type === 'Herb' ? Leaf : Atom
+              return (
+                <Link
+                  key={profile.href}
+                  href={profile.href}
+                  data-tone={profile.tone}
+                  className='hs-specimen group focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--tone)] focus-visible:ring-offset-2'
+                >
+                  <span className='hs-specimen-icon'>
+                    <Icon className='h-[1.15rem] w-[1.15rem]' aria-hidden='true' strokeWidth={1.7} />
+                  </span>
+                  <span className='block'>
+                    <span className='hs-specimen-name block text-[1.02rem] leading-tight'>{profile.label}</span>
+                    <span className='hs-specimen-type mt-1.5 block'>{profile.type}</span>
+                  </span>
+                </Link>
+              )
+            })}
           </div>
 
           <div className='mt-8 flex flex-wrap gap-x-8 gap-y-3'>
@@ -321,7 +363,7 @@ export default function HomepageV2() {
         <hr className='hs-divider' />
 
         {/* ---------------- Decide / check — hairline lists, no nested tiles ---------------- */}
-        <section className='grid gap-12 py-14 sm:py-20 lg:grid-cols-2 lg:gap-16'>
+        <section className='grid gap-11 py-11 sm:gap-12 sm:py-20 lg:grid-cols-2 lg:gap-16'>
           <div>
             <p className='hs-eyebrow'>Make a decision</p>
             <h2 className='hs-display mt-4 text-[1.9rem] sm:text-[2.35rem]'>Compare before you choose</h2>
@@ -329,15 +371,26 @@ export default function HomepageV2() {
               Side-by-side guides for when the real question is which option fits your situation.
             </p>
 
-            <div className='hs-rows mt-7'>
+            <div className='mt-7 space-y-3.5'>
               {comparisonLinks.map((comparison) => (
                 <Link
                   key={comparison.href}
                   href={comparison.href}
-                  className='hs-row py-4 text-[0.95rem] font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--hs-gold)]'
+                  data-tone={comparison.tone}
+                  className='hs-vs group focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--tone)] focus-visible:ring-offset-2'
                 >
-                  <span>{comparison.title}</span>
-                  <ArrowRight className='h-4 w-4 shrink-0' aria-hidden='true' />
+                  <span className='flex flex-1 flex-wrap items-center gap-x-2.5 gap-y-1.5'>
+                    {comparison.parts.map((part, index) => (
+                      <span key={part} className='flex items-center gap-2.5'>
+                        {index > 0 ? <span className='hs-vs-mark'>vs</span> : null}
+                        <span className='hs-vs-name text-[1.02rem] sm:text-[1.1rem]'>{part}</span>
+                      </span>
+                    ))}
+                  </span>
+                  <ArrowRight
+                    className='h-4 w-4 shrink-0 text-[color:var(--tone-ink)] transition'
+                    aria-hidden='true'
+                  />
                 </Link>
               ))}
             </div>
@@ -354,20 +407,32 @@ export default function HomepageV2() {
               Check interactions, evidence strength, and buying basics before combining or purchasing anything.
             </p>
 
-            <div className='hs-rows mt-7'>
-              {toolLinks.map((tool) => (
-                <Link
-                  key={tool.href}
-                  href={tool.href}
-                  className='hs-row py-4 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--hs-gold)]'
-                >
-                  <span>
-                    <span className='block text-[0.95rem] font-bold'>{tool.title}</span>
-                    <span className='hs-row-sub mt-1 block text-[0.82rem] leading-5'>{tool.description}</span>
-                  </span>
-                  <ArrowRight className='h-4 w-4 shrink-0' aria-hidden='true' />
-                </Link>
-              ))}
+            <div className='mt-7 space-y-3.5'>
+              {toolLinks.map((tool) => {
+                const Icon = tool.icon
+                return (
+                  <Link
+                    key={tool.href}
+                    href={tool.href}
+                    data-tone={tool.tone}
+                    className='hs-tool group focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--tone)] focus-visible:ring-offset-2'
+                  >
+                    <span className='hs-tool-icon'>
+                      <Icon className='h-[1.2rem] w-[1.2rem]' aria-hidden='true' strokeWidth={1.7} />
+                    </span>
+                    <span className='min-w-0 flex-1'>
+                      <span className='hs-tool-title block text-[0.95rem]'>{tool.title}</span>
+                      <span className='hs-row-sub mt-1.5 block text-[0.82rem] leading-[1.5]'>
+                        {tool.description}
+                      </span>
+                    </span>
+                    <ArrowRight
+                      className='hs-go mt-0.5 h-4 w-4 shrink-0 text-[color:var(--tone-ink)] transition'
+                      aria-hidden='true'
+                    />
+                  </Link>
+                )
+              })}
             </div>
           </div>
         </section>
@@ -376,7 +441,7 @@ export default function HomepageV2() {
         {latestArticles.length > 0 && (
           <>
             <hr className='hs-divider' />
-            <section className='py-14 sm:py-20'>
+            <section className='py-11 sm:py-20'>
               <SectionHeader
                 eyebrow='Fresh from the library'
                 title='Latest guides & research'
@@ -384,12 +449,13 @@ export default function HomepageV2() {
                 action={{ href: '/guides/', label: 'Browse the library' }}
               />
 
-              <div className='mt-10 grid gap-5 sm:grid-cols-2 lg:grid-cols-3'>
+              <div className='mt-8 grid gap-4 sm:mt-10 sm:gap-5 sm:grid-cols-2 lg:grid-cols-3'>
                 {latestArticles.map((article: any) => (
                   <Link
                     key={article.slug}
                     href={`/articles/${article.slug}/`}
-                    className='hs-article group flex flex-col gap-3.5 p-6 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--hs-gold)] focus-visible:ring-offset-2'
+                    data-tone={categoryTone(article.category)}
+                    className='hs-article group flex flex-col p-5 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--tone)] focus-visible:ring-offset-2 sm:p-6'
                   >
                     <div className='flex flex-wrap items-center gap-2'>
                       {article.category ? (
@@ -401,13 +467,15 @@ export default function HomepageV2() {
                         <span className='text-[0.72rem] text-[color:var(--hs-body)]'>{article.readingTime}</span>
                       ) : null}
                     </div>
-                    <h3 className='hs-article-title text-[1.2rem] leading-snug'>{article.title}</h3>
+                    {/* These articles carry no excerpt, so the title has to hold the
+                        card on its own — keep it large and the gaps tight. */}
+                    <h3 className='hs-article-title mt-3.5 text-[1.22rem] leading-[1.3]'>{article.title}</h3>
                     {article.excerpt ? (
-                      <p className='line-clamp-3 text-[0.85rem] leading-6 text-[color:var(--hs-body)]'>
+                      <p className='mt-2.5 line-clamp-3 text-[0.85rem] leading-6 text-[color:var(--hs-body)]'>
                         {article.excerpt}
                       </p>
                     ) : null}
-                    <span className='hs-link mt-auto pt-1 text-[0.8rem]'>
+                    <span className='hs-link mt-4 text-[0.8rem] sm:mt-auto sm:pt-4'>
                       Read <ArrowRight className='h-3.5 w-3.5' aria-hidden='true' />
                     </span>
                   </Link>
@@ -419,8 +487,8 @@ export default function HomepageV2() {
       </div>
 
       {/* ---------------- Full-bleed methodology band — the page's closing moment ---------------- */}
-      <section className='hs-method mt-6 py-16 sm:py-24'>
-        <div className='mx-auto grid max-w-6xl gap-12 px-5 sm:px-8 lg:grid-cols-[0.85fr_1.15fr] lg:gap-20 lg:px-10'>
+      <section className='hs-method py-14 sm:py-24'>
+        <div className='mx-auto grid max-w-6xl gap-10 px-5 sm:gap-12 sm:px-8 lg:grid-cols-[0.85fr_1.15fr] lg:gap-20 lg:px-10'>
           <div>
             <p className='hs-eyebrow'>How the site works</p>
             <h2 className='hs-display mt-5 text-[2.2rem] sm:text-[2.9rem]'>
@@ -434,13 +502,14 @@ export default function HomepageV2() {
             </Link>
           </div>
 
-          <ol className='space-y-0'>
+          <ol className='relative space-y-0'>
+            <Leaf className='hs-method-mark' aria-hidden='true' strokeWidth={0.6} />
             {methodSteps.map((step) => (
-              <li key={step.num} className='hs-step flex gap-6 py-6 sm:gap-8'>
-                <span className='hs-step-num shrink-0 text-[1.6rem] sm:text-[2rem]'>{step.num}</span>
-                <div>
-                  <h3 className='text-base font-bold text-[#fffdf8] sm:text-lg'>{step.title}</h3>
-                  <p className='mt-2 text-[0.88rem] leading-6 text-[#b8c9bd]'>{step.body}</p>
+              <li key={step.num} className='hs-step flex items-start gap-5 py-7 sm:gap-8'>
+                <span className='hs-step-num text-[2.6rem] sm:text-[3.4rem]'>{step.num}</span>
+                <div className='pt-1 sm:pt-2'>
+                  <h3 className='text-[1.05rem] font-bold text-[#fffdf8] sm:text-lg'>{step.title}</h3>
+                  <p className='mt-2 text-[0.88rem] leading-[1.6] text-[#b8c9bd]'>{step.body}</p>
                 </div>
               </li>
             ))}

--- a/styles/homepage-editorial-redesign.css
+++ b/styles/homepage-editorial-redesign.css
@@ -103,6 +103,19 @@
   opacity: 0.55;
 }
 
+/* The longest eyebrow runs edge-to-edge on a phone; ease the tracking and rule. */
+@media (max-width: 480px) {
+  .hs-eyebrow {
+    gap: 0.5rem;
+    font-size: 0.64rem;
+    letter-spacing: 0.15em;
+  }
+
+  .hs-eyebrow::before {
+    width: 1.1rem;
+  }
+}
+
 .hs-lede {
   color: var(--hs-body);
   text-wrap: pretty;
@@ -508,6 +521,304 @@
   --tone-ink: #ecc98d;
 }
 
+/* Extended jewel palette so the lower half of the page carries colour too. */
+[data-tone='amber'] {
+  --tone: #c2913f;
+  --tone-ink: #8a6318;
+}
+[data-tone='rose'] {
+  --tone: #c2607a;
+  --tone-ink: #9c3f58;
+}
+[data-tone='blue'] {
+  --tone: #4a86c4;
+  --tone-ink: #2b6099;
+}
+[data-tone='green'] {
+  --tone: #4f9e6d;
+  --tone-ink: #2f7a4c;
+}
+[data-tone='indigo'] {
+  --tone: #7c73d6;
+  --tone-ink: #5a51b5;
+}
+[data-tone='violet'] {
+  --tone: #a06bc8;
+  --tone-ink: #7c46a5;
+}
+[data-tone='teal'] {
+  --tone: #3f97a8;
+  --tone-ink: #24707f;
+}
+
+.dark [data-tone='amber'] {
+  --tone: #d7a94f;
+  --tone-ink: #ecc98d;
+}
+.dark [data-tone='rose'] {
+  --tone: #d97e96;
+  --tone-ink: #f0aebd;
+}
+.dark [data-tone='blue'] {
+  --tone: #64a2dc;
+  --tone-ink: #a2cbee;
+}
+.dark [data-tone='green'] {
+  --tone: #5cb37c;
+  --tone-ink: #8fd3a7;
+}
+.dark [data-tone='indigo'] {
+  --tone: #8b82e6;
+  --tone-ink: #b6afef;
+}
+.dark [data-tone='violet'] {
+  --tone: #b98ada;
+  --tone-ink: #d5b6ea;
+}
+.dark [data-tone='teal'] {
+  --tone: #49aabd;
+  --tone-ink: #86d2e0;
+}
+
+/* ---------- Specimen tiles (popular starting points) ---------- */
+
+.hs-specimen {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  border: 1px solid color-mix(in srgb, var(--tone) 28%, transparent);
+  border-radius: 1.15rem;
+  padding: 1rem;
+  background:
+    linear-gradient(155deg, color-mix(in srgb, var(--tone) 15%, transparent), transparent 70%),
+    var(--hs-surface);
+  box-shadow: var(--hs-lift);
+  transition:
+    transform 260ms cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 260ms ease,
+    border-color 260ms ease;
+}
+
+.dark .hs-specimen {
+  background:
+    linear-gradient(155deg, color-mix(in srgb, var(--tone) 28%, transparent), transparent 72%),
+    var(--hs-surface);
+}
+
+.hs-specimen::after {
+  content: '';
+  position: absolute;
+  z-index: -1;
+  right: -40%;
+  top: -60%;
+  width: 9rem;
+  height: 9rem;
+  border-radius: 50%;
+  opacity: 0.45;
+  filter: blur(22px);
+  background: radial-gradient(circle, color-mix(in srgb, var(--tone) 55%, transparent), transparent 70%);
+  transition: opacity 300ms ease, transform 420ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.hs-specimen:hover {
+  transform: translateY(-4px);
+  border-color: color-mix(in srgb, var(--tone) 58%, transparent);
+  box-shadow: var(--hs-lift-hover);
+}
+
+.hs-specimen:hover::after {
+  opacity: 0.9;
+  transform: scale(1.25);
+}
+
+.hs-specimen-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.4rem;
+  height: 2.4rem;
+  border: 1px solid color-mix(in srgb, var(--tone) 36%, transparent);
+  border-radius: 0.8rem;
+  color: var(--tone-ink);
+  background: color-mix(in srgb, var(--tone) 17%, var(--hs-surface));
+}
+
+.hs-specimen-name {
+  color: var(--hs-ink);
+  font-family: var(--font-fraunces), Fraunces, Georgia, serif;
+  font-weight: 620;
+  letter-spacing: -0.018em;
+}
+
+.hs-specimen-type {
+  color: var(--tone-ink);
+  font-size: 0.6rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+/* ---------- Versus cards (comparisons) ---------- */
+
+.hs-vs {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  border: 1px solid color-mix(in srgb, var(--tone) 26%, transparent);
+  border-radius: 1.15rem;
+  padding: 1.05rem 1.15rem;
+  background:
+    linear-gradient(100deg, color-mix(in srgb, var(--tone) 14%, transparent), transparent 58%),
+    var(--hs-surface);
+  box-shadow: var(--hs-lift);
+  transition:
+    transform 260ms cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 260ms ease,
+    border-color 260ms ease;
+}
+
+.dark .hs-vs {
+  background:
+    linear-gradient(100deg, color-mix(in srgb, var(--tone) 26%, transparent), transparent 62%),
+    var(--hs-surface);
+}
+
+.hs-vs::after {
+  content: '';
+  position: absolute;
+  z-index: -1;
+  left: -10%;
+  top: -120%;
+  width: 12rem;
+  height: 12rem;
+  border-radius: 50%;
+  opacity: 0.4;
+  filter: blur(26px);
+  background: radial-gradient(circle, color-mix(in srgb, var(--tone) 50%, transparent), transparent 70%);
+  transition: opacity 300ms ease;
+}
+
+.hs-vs:hover {
+  transform: translateY(-3px);
+  border-color: color-mix(in srgb, var(--tone) 55%, transparent);
+  box-shadow: var(--hs-lift-hover);
+}
+
+.hs-vs:hover::after {
+  opacity: 0.85;
+}
+
+.hs-vs:hover svg {
+  transform: translateX(4px);
+}
+
+.hs-vs-name {
+  color: var(--hs-ink);
+  font-family: var(--font-fraunces), Fraunces, Georgia, serif;
+  font-weight: 615;
+  letter-spacing: -0.018em;
+  line-height: 1.2;
+}
+
+/* The "vs" mark between the two names. */
+.hs-vs-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 1.7rem;
+  height: 1.7rem;
+  border: 1px solid color-mix(in srgb, var(--hs-gold) 45%, transparent);
+  border-radius: 50%;
+  color: var(--hs-gold-bright);
+  background: color-mix(in srgb, var(--hs-gold) 12%, var(--hs-surface));
+  font-family: var(--font-fraunces), Fraunces, Georgia, serif;
+  font-size: 0.68rem;
+  font-style: italic;
+  font-weight: 600;
+  line-height: 1;
+}
+
+/* ---------- Tool panels (safety tools) ---------- */
+
+.hs-tool {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  display: flex;
+  gap: 0.95rem;
+  border: 1px solid color-mix(in srgb, var(--tone) 24%, transparent);
+  border-radius: 1.15rem;
+  padding: 1.15rem;
+  background:
+    linear-gradient(150deg, color-mix(in srgb, var(--tone) 13%, transparent), transparent 66%),
+    var(--hs-surface);
+  box-shadow: var(--hs-lift);
+  transition:
+    transform 260ms cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 260ms ease,
+    border-color 260ms ease;
+}
+
+.dark .hs-tool {
+  background:
+    linear-gradient(150deg, color-mix(in srgb, var(--tone) 25%, transparent), transparent 68%),
+    var(--hs-surface);
+}
+
+.hs-tool::after {
+  content: '';
+  position: absolute;
+  z-index: -1;
+  right: -25%;
+  bottom: -120%;
+  width: 12rem;
+  height: 12rem;
+  border-radius: 50%;
+  opacity: 0.4;
+  filter: blur(26px);
+  background: radial-gradient(circle, color-mix(in srgb, var(--tone) 50%, transparent), transparent 70%);
+  transition: opacity 300ms ease;
+}
+
+.hs-tool:hover {
+  transform: translateY(-3px);
+  border-color: color-mix(in srgb, var(--tone) 52%, transparent);
+  box-shadow: var(--hs-lift-hover);
+}
+
+.hs-tool:hover::after {
+  opacity: 0.85;
+}
+
+.hs-tool:hover svg.hs-go {
+  transform: translateX(4px);
+}
+
+.hs-tool-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 2.6rem;
+  height: 2.6rem;
+  border: 1px solid color-mix(in srgb, var(--tone) 34%, transparent);
+  border-radius: 0.85rem;
+  color: var(--tone-ink);
+  background: color-mix(in srgb, var(--tone) 16%, var(--hs-surface));
+}
+
+.hs-tool-title {
+  color: var(--hs-ink);
+  font-weight: 700;
+}
+
 /* ---------- Chips ---------- */
 
 .hs-chip {
@@ -572,6 +883,12 @@
   transform: translateX(4px);
 }
 
+/* The list's closing rule sits a short distance below the section divider and
+   reads as a doubled line; let the divider terminate the list instead. */
+.hs-row:last-child {
+  border-bottom: 0;
+}
+
 .hs-row-sub {
   color: var(--hs-body);
 }
@@ -595,24 +912,51 @@
     border-color 260ms ease;
 }
 
+/* Always-on tone accent along the top edge, brightened on hover. */
 .hs-article::before {
   content: '';
   position: absolute;
   inset: 0 0 auto 0;
   height: 3px;
-  background: linear-gradient(90deg, var(--hs-gold), transparent);
-  opacity: 0;
+  background: linear-gradient(90deg, var(--tone), color-mix(in srgb, var(--tone) 20%, transparent) 55%, transparent);
+  opacity: 0.75;
   transition: opacity 260ms ease;
 }
 
+.hs-article::after {
+  content: '';
+  position: absolute;
+  z-index: -1;
+  right: -30%;
+  top: -50%;
+  width: 13rem;
+  height: 13rem;
+  border-radius: 50%;
+  opacity: 0.32;
+  filter: blur(26px);
+  background: radial-gradient(circle, color-mix(in srgb, var(--tone) 50%, transparent), transparent 70%);
+  transition: opacity 320ms ease, transform 420ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
 .hs-article:hover {
-  transform: translateY(-4px);
-  border-color: var(--hs-gold-soft);
+  transform: translateY(-5px);
+  border-color: color-mix(in srgb, var(--tone) 48%, transparent);
   box-shadow: var(--hs-lift-hover);
 }
 
 .hs-article:hover::before {
   opacity: 1;
+}
+
+.hs-article:hover::after {
+  opacity: 0.8;
+  transform: scale(1.2);
+}
+
+.hs-article .hs-tag {
+  border-color: color-mix(in srgb, var(--tone) 34%, transparent);
+  background: color-mix(in srgb, var(--tone) 13%, transparent);
+  color: var(--tone-ink);
 }
 
 .hs-article-title {
@@ -638,9 +982,12 @@
   border-top: 1px solid rgba(217, 178, 113, 0.28);
   border-bottom: 1px solid rgba(217, 178, 113, 0.18);
   color: #e8ece3;
+  /* First layer eases the band out of the page canvas so the top edge reads as a
+     transition rather than a hard seam against the near-black background. */
   background:
-    radial-gradient(70% 110% at 8% -10%, rgba(56, 116, 90, 0.42), transparent 58%),
-    linear-gradient(160deg, #10382b 0%, #0c2a20 52%, #081d17 100%);
+    linear-gradient(180deg, rgba(8, 20, 16, 0.9) 0%, rgba(8, 20, 16, 0.35) 7%, transparent 16%),
+    radial-gradient(85% 70% at 22% 0%, rgba(56, 116, 90, 0.34), transparent 62%),
+    linear-gradient(168deg, #10382b 0%, #0c2a20 52%, #081d17 100%);
 }
 
 .hs-method::before {
@@ -664,15 +1011,56 @@
 }
 
 .hs-step {
+  position: relative;
   border-top: 1px solid rgba(226, 203, 163, 0.22);
+  transition: border-color 240ms ease;
 }
 
+.hs-step:hover {
+  border-color: rgba(226, 203, 163, 0.5);
+}
+
+/* Oversized gold numerals with a metallic gradient — the band's focal detail. */
 .hs-step-num {
-  color: rgba(226, 203, 163, 0.85);
+  flex: 0 0 auto;
+  background: linear-gradient(150deg, #f4e0bb 0%, #d9b271 45%, #a9803c 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
   font-family: var(--font-fraunces), Fraunces, Georgia, serif;
-  font-weight: 600;
+  font-weight: 620;
   font-variant-numeric: tabular-nums;
-  letter-spacing: -0.02em;
+  letter-spacing: -0.045em;
+  line-height: 0.9;
+  opacity: 0.92;
+  transition: opacity 240ms ease;
+}
+
+.hs-step:hover .hs-step-num {
+  opacity: 1;
+}
+
+/* Botanical watermark behind the step list. */
+.hs-method-mark {
+  position: absolute;
+  z-index: -1;
+  right: -3rem;
+  bottom: -4rem;
+  width: 22rem;
+  height: 22rem;
+  pointer-events: none;
+  opacity: 0.09;
+  color: #e2cba3;
+}
+
+@media (max-width: 1023px) {
+  .hs-method-mark {
+    right: -6rem;
+    bottom: -6rem;
+    width: 17rem;
+    height: 17rem;
+    opacity: 0.07;
+  }
 }
 
 .hs-method-link {


### PR DESCRIPTION
## Summary

Follow-up to #2386, driven by screenshots from a real device. Removing the nested card chrome fixed the clutter, but it left the bottom two thirds of the page flat — plain text lists and grey panels on a near-black canvas, with all the colour concentrated in the hero and the goal grid.

**Hero copy**

- Headline is now "Feel Better Without Guessing", with "Without Guessing" carrying the gold italic accent. The lede was rewritten to pick up "herbs and supplements" so the hero prose keeps the terms the old headline held.

**Carry colour through the rest of the page**

- Added a jewel palette (amber, rose, blue, green, indigo, violet, teal) alongside the existing goal tones.
- Popular starting points became a specimen shelf — one tone per entry, with a leaf mark for herbs and an atom mark for compounds — instead of six identical grey pills.
- Comparisons became versus cards: both names set in the display serif, separated by a gold "vs" mark, on a toned gradient.
- Safety tools each get a toned icon panel.
- Article cards take a tone from their category, with an always-on accent along the top edge and a matching category chip.
- The methodology band gets oversized numerals in a metallic gold gradient plus a botanical watermark.

**Layout problems visible on device**

- The popular-profile chips wrapped into a ragged staircase — two on the first row, then one per row, with a large empty right side. They are a grid now, so they align.
- The hero stat row broke 2 + 1; it is three across with stacked labels on a phone.
- Section padding was 56px top and bottom, doubling to 112px at every boundary. Down to 44px on mobile, unchanged from `sm` up.
- Article cards left a void because none of the three latest articles carry an excerpt. Tightened so the title holds the card on its own.
- The methodology band met the canvas at a hard seam; it now eases in over the first 16% of its height.
- A list's closing rule sat just above a section divider and read as a doubled line. The divider terminates the list instead.
- Eased eyebrow tracking under 480px, where the longest one ran edge to edge.
- Added Valerian as a sixth popular profile so the grid squares off instead of leaving an empty cell.

## Verification

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs — only `components/homepage-v2.tsx` and `styles/homepage-editorial-redesign.css` changed
- [x] no generated file corruption
- [x] static export compatible — 696 files scanned, no violations

Additionally:

- [x] `npm run test` — 119 files, 700 tests passing
- [x] axe (`color-contrast`, `link-name`, `heading-order`, `landmark-one-main`, `region`) against the live render in light and dark at 430px and 1440px — no violations. This was the main risk, since every tone introduces new tinted text on a tinted background.

## Risk Notes

- Homepage-only. No data, routing, or metadata changes.
- The h1 no longer contains "herbs" or "supplements". Both terms remain in the hero lede, the eyebrow, the page `<title>`, and the meta description, so the change is to the visible headline rather than to the page's indexed terms — but it is a deliberate voice change worth being aware of.
- Tones lean on `color-mix()`. Supported in all current evergreen browsers; older engines fall back to no tint, leaving every surface legible on its base colour.
- The `vs` mark is real text rather than `aria-hidden`, so each comparison link still reads as "Melatonin vs Magnesium" to a screen reader.
- All new CSS remains scoped under `.hs-home`; shared `editorial-*` surfaces used by other routes are untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wi3o6eVum24UxHkkPRcUBv)_