### PR TITLE
Scope base list spacing to block-flow lists; fit three-way comparison row on one line

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -291,8 +291,11 @@ html.theme-ready body * {
     @apply mt-4;
   }
 
-  ul,
-  ol {
+  /* Block-flow lists take their rhythm from child margins. Grid and flex lists
+     space themselves with `gap`, and a child margin there leaves every item but
+     the last shorter than its row track — so those opt out. */
+  ul:not([class~='grid'], [class~='inline-grid'], [class~='flex'], [class~='inline-flex']),
+  ol:not([class~='grid'], [class~='inline-grid'], [class~='flex'], [class~='inline-flex']) {
     @apply space-y-2.5;
   }
 

--- a/app/guides/compare/page.tsx
+++ b/app/guides/compare/page.tsx
@@ -278,7 +278,7 @@ export default async function ComparePage() {
               <h3 className="text-xs font-bold uppercase tracking-widest text-brand-700 dark:text-brand-200">{cat.label}</h3>
               <p className="mt-1 text-sm leading-6 text-muted">{cat.blurb}</p>
             </div>
-            <ul className="grid gap-3 space-y-0 sm:grid-cols-2 lg:grid-cols-4">
+            <ul className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
               {cat.pairs.map((pair) => (
                 <li key={pair.slug}>
                   <Link
@@ -298,7 +298,7 @@ export default async function ComparePage() {
       <PremiumCard as="section" className="p-5">
         <h2 className="text-xl font-semibold text-ink">More comparison starting points</h2>
         <p className="mt-2 text-sm leading-6 text-muted">Flagship pages with the most detailed evidence breakdowns.</p>
-        <ul className="mt-4 grid gap-2 space-y-0 text-sm leading-6 text-muted sm:grid-cols-2">
+        <ul className="mt-4 grid gap-2 text-sm leading-6 text-muted sm:grid-cols-2">
           {popularComparisonPairs.map(pair => (
             <li key={pair.href}>
               <Link href={pair.href} className="font-semibold text-brand-800 hover:underline dark:text-brand-100 dark:hover:text-white">{pair.label}</Link>

--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -373,40 +373,34 @@ export default function HomepageV2() {
 
             <div className='@container mt-7 space-y-3.5'>
               {comparisonLinks.map((comparison) => {
-                // A three-way comparison does not fit on one line in a narrow card, and
-                // wrapping strands a lone "vs" on the second line. Below ~30rem of card
-                // width these stack into an aligned column instead; above it they read
-                // inline like the two-way rows.
+                // A three-way comparison is too wide for one line at the card's normal
+                // type size, so it runs at a reduced scale that steps back up as the
+                // card widens (see .hs-vs--multi). Only the very narrowest phones still
+                // fall back to a stacked column.
                 const isMultiWay = comparison.parts.length > 2
                 return (
                 <Link
                   key={comparison.href}
                   href={comparison.href}
                   data-tone={comparison.tone}
-                  className='hs-vs group focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--tone)] focus-visible:ring-offset-2'
+                  className={`hs-vs group${isMultiWay ? ' hs-vs--multi' : ''} focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--tone)] focus-visible:ring-offset-2`}
                 >
                   <span
                     className={
                       isMultiWay
-                        ? 'flex min-w-0 flex-1 flex-col items-start gap-y-1.5 @min-[30rem]:flex-row @min-[30rem]:flex-wrap @min-[30rem]:items-center @min-[30rem]:gap-x-2.5'
+                        ? 'hs-vs-parts'
                         : 'flex min-w-0 flex-1 flex-wrap items-center gap-x-2.5 gap-y-1.5'
                     }
                   >
                     {comparison.parts.map((part, index) => (
-                      <span key={part} className='flex items-center gap-2.5'>
-                        {/* Keeps the first name aligned with the ones below it while stacked. */}
-                        {isMultiWay && index === 0 ? (
-                          <span
-                            aria-hidden='true'
-                            className='h-[1.7rem] w-[1.7rem] shrink-0 @min-[30rem]:hidden'
-                          />
-                        ) : null}
+                      <span
+                        key={part}
+                        className={isMultiWay ? 'hs-vs-part' : 'flex items-center gap-2.5'}
+                      >
                         {index > 0 ? <span className='hs-vs-mark'>vs</span> : null}
                         <span
                           className={
-                            isMultiWay
-                              ? 'hs-vs-name text-[1.02rem]'
-                              : 'hs-vs-name text-[1.02rem] sm:text-[1.1rem]'
+                            isMultiWay ? 'hs-vs-name' : 'hs-vs-name text-[1.02rem] sm:text-[1.1rem]'
                           }
                         >
                           {part}

--- a/styles/homepage-editorial-redesign.css
+++ b/styles/homepage-editorial-redesign.css
@@ -726,6 +726,106 @@
   line-height: 1.2;
 }
 
+/* Three-or-more-way rows: the names cannot fit one card line at the normal type
+   size, so they run smaller and step back up at each container width that can
+   afford it. The list wrapper carries `@container`, so these queries measure the
+   card itself rather than the viewport. Under ~20.5rem there is no legible size
+   that fits, so the names stack into an aligned column instead of wrapping and
+   stranding a lone "vs" mark on the second line. */
+.hs-vs-parts {
+  display: flex;
+  flex: 1 1 auto;
+  min-width: 0;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.4rem;
+}
+
+.hs-vs-part {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+/* Aligns the first name with the ones stacked below it. */
+.hs-vs-part:first-child {
+  padding-inline-start: 1.6rem;
+}
+
+.hs-vs--multi .hs-vs-name {
+  font-size: 0.68rem;
+}
+
+.hs-vs--multi .hs-vs-mark {
+  width: 1.2rem;
+  height: 1.2rem;
+  font-size: 0.5rem;
+}
+
+@container (min-width: 20.5rem) {
+  .hs-vs-parts {
+    flex-direction: row;
+    flex-wrap: nowrap;
+    align-items: center;
+  }
+
+  .hs-vs-part:first-child {
+    padding-inline-start: 0;
+  }
+}
+
+@container (min-width: 21.5rem) {
+  .hs-vs--multi .hs-vs-name {
+    font-size: 0.72rem;
+  }
+
+  .hs-vs--multi .hs-vs-mark {
+    width: 1.25rem;
+    height: 1.25rem;
+    font-size: 0.52rem;
+  }
+}
+
+@container (min-width: 25rem) {
+  .hs-vs-parts,
+  .hs-vs-part {
+    gap: 0.5rem;
+  }
+
+  .hs-vs--multi .hs-vs-name {
+    font-size: 0.86rem;
+  }
+
+  .hs-vs--multi .hs-vs-mark {
+    width: 1.45rem;
+    height: 1.45rem;
+    font-size: 0.58rem;
+  }
+}
+
+@container (min-width: 26rem) {
+  .hs-vs--multi .hs-vs-name {
+    font-size: 0.92rem;
+  }
+}
+
+@container (min-width: 29rem) {
+  .hs-vs-parts,
+  .hs-vs-part {
+    gap: 0.625rem;
+  }
+
+  .hs-vs--multi .hs-vs-name {
+    font-size: 1.02rem;
+  }
+
+  .hs-vs--multi .hs-vs-mark {
+    width: 1.7rem;
+    height: 1.7rem;
+    font-size: 0.68rem;
+  }
+}
+
 /* The "vs" mark between the two names. */
 .hs-vs-mark {
   display: inline-flex;


### PR DESCRIPTION
## Summary

- **Global list spacing.** The base rule in `app/globals.css` applied `space-y-2.5` to every `ul`/`ol`, including grid and flex lists that already space themselves with `gap`. On those, the child margin left every item but the last shorter than its row track, so the last card in each row rendered taller than its neighbours. Grid and flex lists now opt out via a token-based `:not()`. Checked before changing it: all 30 grid/flex `ul`s in the codebase declare the display token at base **and** set their own `gap`, and none become grid/flex only at a breakpoint — so nothing loses spacing. Verified across 10 routes: 11 grid/flex lists, 0 still carrying a stray child margin; 31 block-flow lists, all still spaced.
- Removed the local `space-y-0` workaround on the compare hub, since the global fix now covers it. Card rows there remain even (70/70/70/70 per row).
- **Three-way comparison row on the homepage.** `Ashwagandha vs L-theanine vs Magnesium` no longer fits its card at the normal type size, so it ran at a reduced scale that steps back up as the card widens (`.hs-vs--multi`, driven by container queries on the card, not the viewport). It now reads on one line from 375px up. The stacked column is kept only as the fallback for the narrowest phones, where no legible size fits.

Measured (card width → font size → lines):

| Viewport | Card | Font | Lines |
|---|---|---|---|
| 320px | 280px | 10.9px | 3 (stacked fallback) |
| 360px | 320px | 10.9px | 3 (stacked fallback) |
| 375px | 335px | 10.9px | **1** |
| 390px | 350px | 11.5px | **1** |
| 640px | 576px | 16.3px | **1** |
| 1024px | 440px | 14.7px | **1** |
| 1280px | 504px | 16.3px | **1** |

No content overflow at any width. Two-way rows are untouched.

## Verification

- [x] `npm run lint`
- [x] `npm run check`
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs (only the `build-info.json` timestamp, reverted)
- [x] no generated file corruption
- [x] static export compatible — CSS and markup only

Also run: `npm run typecheck` clean, `npm run test` 700/700 across 119 files. Layout verified in a browser at 320/360/375/390/430/640/768/1024/1280/1536px.

## Risk Notes

- The list-spacing rule is base-layer and site-wide. The exclusion keys on class tokens (`grid`, `flex`, `inline-grid`, `inline-flex`), so a list that becomes a grid through a plain CSS class rather than a utility would still carry the stray margin. None exist today, but that is the blind spot.
- At 390px the three-way row's type is 11.5px against 16.3px on the two-way rows beside it — a deliberate trade to keep it on one line, and the visible cost of that choice.
- Pre-existing and untouched: the homepage has horizontal overflow at 768–834px (`scrollWidth` 815 vs 768). Confirmed present on `main` before these changes; worth a separate fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_013MZGLbtRWFs2Y6BSiAJYy7)_