### PR TITLE
Premium design system, phase 0/1: promote the homepage foundation site-wide

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -32,6 +32,7 @@ import '@/styles/editorial-botanical-refresh.css'
 import '@/styles/homepage-hero-signal-upgrade.css'
 import '@/styles/editorial-content-surfaces.css'
 import '@/styles/homepage-editorial-redesign.css'
+import '@/styles/premium-foundation.css'
 
 const HOME_TITLE = 'The Hippie Scientist | Supplement Research'
 
@@ -92,7 +93,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           Skip to main content
         </a>
         <DarkModeProvider>
-          <div className='min-h-screen bg-background text-ink transition-colors duration-300'>
+          <div className='hs-shell min-h-screen bg-background text-ink transition-colors duration-300'>
             <header>
               <Navigation />
             </header>

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -127,10 +127,16 @@ export function Navigation() {
               const childGroups = groupChildren(link.children)
               const isMegaMenu = childGroups.length > 1
               const active = isPrimaryActive(link)
+              // The panel is centred on its trigger, not on the viewport, so a
+              // width capped only at 100vw still runs off the right edge on the
+              // narrower desktop widths. Keep it small enough to clear the edge
+              // from wherever its trigger sits, and open it up from lg.
               const menuWidth = childGroups.length === 2
-                ? 'w-[min(46rem,calc(100vw-2rem))]'
-                : 'w-[min(58rem,calc(100vw-2rem))]'
-              const menuGrid = childGroups.length === 2 ? 'grid-cols-2' : 'grid-cols-3'
+                ? 'w-[min(26rem,calc(100vw-2rem))] lg:w-[min(46rem,calc(100vw-2rem))]'
+                : 'w-[min(30rem,calc(100vw-2rem))] lg:w-[min(58rem,calc(100vw-2rem))]'
+              const menuGrid = childGroups.length === 2
+                ? 'grid-cols-1 lg:grid-cols-2'
+                : 'grid-cols-2 lg:grid-cols-3'
 
               return (
                 <div key={link.href} className='group relative'>

--- a/styles/homepage-editorial-redesign.css
+++ b/styles/homepage-editorial-redesign.css
@@ -4,46 +4,15 @@
    Everything here is scoped under .hs-home so shared editorial-* surfaces used
    by other routes are untouched. */
 
+/* The --hs-* palette, elevation, and hairline tokens now live at the document
+   root in styles/premium-foundation.css so every route shares them. What stays
+   here is the homepage's own ground and stacking context. */
 .hs-home {
-  --hs-gold: #b88a42;
-  --hs-gold-bright: #c99a4e;
-  --hs-gold-soft: #e2cba3;
-  --hs-ink: #10352a;
-  --hs-ink-soft: #315f50;
-  --hs-body: #4a5b52;
-  --hs-hairline: rgba(18, 60, 47, 0.12);
-  --hs-hairline-strong: rgba(18, 60, 47, 0.2);
-  --hs-surface: #fffdf8;
-  --hs-surface-2: rgba(255, 253, 248, 0.72);
-  --hs-lift: 0 1px 2px rgba(46, 38, 20, 0.05), 0 12px 32px -12px rgba(46, 38, 20, 0.16);
-  --hs-lift-hover: 0 2px 4px rgba(46, 38, 20, 0.06), 0 26px 56px -18px rgba(46, 38, 20, 0.26);
-
   position: relative;
   isolation: isolate;
   overflow: clip;
   color: var(--hs-body);
-  background:
-    radial-gradient(120% 60% at 50% -10%, rgba(203, 220, 200, 0.6), transparent 60%),
-    linear-gradient(180deg, #fffdf8 0%, #fbf8f1 30%, #f8f3e8 100%);
-}
-
-.dark .hs-home {
-  --hs-gold: #d9b271;
-  --hs-gold-bright: #e8c98f;
-  --hs-gold-soft: rgba(217, 178, 113, 0.28);
-  --hs-ink: #f3f0e6;
-  --hs-ink-soft: #a9c9b5;
-  --hs-body: #b6c7bb;
-  --hs-hairline: rgba(180, 210, 190, 0.16);
-  --hs-hairline-strong: rgba(180, 210, 190, 0.3);
-  --hs-surface: #16291f;
-  --hs-surface-2: rgba(24, 43, 33, 0.6);
-  --hs-lift: 0 1px 0 rgba(255, 255, 255, 0.05) inset, 0 16px 40px -16px rgba(0, 0, 0, 0.7);
-  --hs-lift-hover: 0 1px 0 rgba(255, 255, 255, 0.09) inset, 0 30px 64px -20px rgba(0, 0, 0, 0.85);
-
-  background:
-    radial-gradient(120% 55% at 50% -8%, rgba(46, 96, 74, 0.42), transparent 62%),
-    linear-gradient(180deg, #0a1610 0%, #081410 45%, #0a1712 100%);
+  background: var(--hs-canvas);
 }
 
 /* Fine botanical dot field, faded out below the hero. */

--- a/styles/premium-foundation.css
+++ b/styles/premium-foundation.css
@@ -1,0 +1,118 @@
+/* Premium foundation — the homepage design language, promoted site-wide.
+ *
+ * The homepage system in styles/homepage-editorial-redesign.css was written
+ * scoped to .hs-home so it could not leak into other routes. That scoping is
+ * what kept the rest of the site on an older, flatter surface vocabulary.
+ *
+ * This file lifts the palette, elevation, and hairline tokens to the document
+ * root so every route can build on them, and paints the same warm canvas
+ * behind the whole app. Component-level surfaces (cards, chips, eyebrows,
+ * buttons) are adopted in a later pass; this file changes only the ground
+ * they sit on.
+ *
+ * Load order matters: this is imported last in app/layout.tsx so it settles
+ * the cascade against the older layers that also touch these hooks.
+ */
+
+:root {
+  --hs-gold: #b88a42;
+  --hs-gold-bright: #c99a4e;
+  --hs-gold-soft: #e2cba3;
+  --hs-ink: #10352a;
+  --hs-ink-soft: #315f50;
+  --hs-body: #4a5b52;
+  --hs-hairline: rgba(18, 60, 47, 0.12);
+  --hs-hairline-strong: rgba(18, 60, 47, 0.2);
+  --hs-surface: #fffdf8;
+  --hs-surface-2: rgba(255, 253, 248, 0.72);
+  --hs-lift: 0 1px 2px rgba(46, 38, 20, 0.05), 0 12px 32px -12px rgba(46, 38, 20, 0.16);
+  --hs-lift-hover: 0 2px 4px rgba(46, 38, 20, 0.06), 0 26px 56px -18px rgba(46, 38, 20, 0.26);
+
+  /* Canvas washes, kept as tokens so a route can opt into a different ground. */
+  --hs-canvas: radial-gradient(120% 60% at 50% -10%, rgba(203, 220, 200, 0.6), transparent 60%),
+    linear-gradient(180deg, #fffdf8 0%, #fbf8f1 30%, #f8f3e8 100%);
+  --hs-dot: rgba(18, 60, 47, 0.14);
+  --hs-dot-opacity: 0.5;
+}
+
+html.dark {
+  --hs-gold: #d9b271;
+  --hs-gold-bright: #e8c98f;
+  --hs-gold-soft: rgba(217, 178, 113, 0.28);
+  --hs-ink: #f3f0e6;
+  --hs-ink-soft: #a9c9b5;
+  --hs-body: #b6c7bb;
+  --hs-hairline: rgba(180, 210, 190, 0.16);
+  --hs-hairline-strong: rgba(180, 210, 190, 0.3);
+  --hs-surface: #16291f;
+  --hs-surface-2: rgba(24, 43, 33, 0.6);
+  --hs-lift: 0 1px 0 rgba(255, 255, 255, 0.05) inset, 0 16px 40px -16px rgba(0, 0, 0, 0.7);
+  --hs-lift-hover: 0 1px 0 rgba(255, 255, 255, 0.09) inset, 0 30px 64px -20px rgba(0, 0, 0, 0.85);
+
+  --hs-canvas: radial-gradient(120% 55% at 50% -8%, rgba(46, 96, 74, 0.42), transparent 62%),
+    linear-gradient(180deg, #0a1610 0%, #081410 45%, #0a1712 100%);
+  --hs-dot: rgba(190, 224, 202, 0.16);
+  --hs-dot-opacity: 0.4;
+}
+
+/* ---------- Page canvas ---------- */
+
+/* The app shell owns the ground for every route. `isolation` makes it the
+   stacking context the dot field sits in, so the field paints above the
+   shell's own background but stays behind all content. */
+.hs-shell {
+  position: relative;
+  isolation: isolate;
+  background: var(--hs-canvas);
+}
+
+/* Fine botanical dot field, fading out down the first screenful — the same
+   treatment the homepage hero sits on. Decorative only. */
+.hs-shell::before {
+  content: '';
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 90rem;
+  z-index: -1;
+  pointer-events: none;
+  opacity: var(--hs-dot-opacity);
+  background-image: radial-gradient(circle at 1px 1px, var(--hs-dot) 1px, transparent 0);
+  background-size: 34px 34px;
+  mask-image: linear-gradient(to bottom, #000 0%, transparent 42%);
+}
+
+/* The homepage paints its own identical canvas inside the shell; skip the
+   second dot field so the texture does not double up there. */
+.hs-shell:has(.hs-home)::before {
+  content: none;
+}
+
+/* styles/editorial-global-tokens.css painted <main> a flat #fbf8f1, which sat
+   on top of the shell and hid the canvas on every route but the homepage. The
+   shell owns the ground now, so main stays transparent. */
+html:not(.dark) main,
+html.dark main {
+  background-color: transparent;
+}
+
+/* ---------- Measure and rhythm ---------- */
+
+/* The homepage reads at 72rem with a wider gutter; the rest of the site was
+   set to 80rem with a tighter one, which is what made those pages feel less
+   composed at desktop widths. One measure now. */
+.container-page {
+  max-width: 72rem;
+  padding-inline: 1.25rem;
+}
+
+@media (min-width: 640px) {
+  .container-page {
+    padding-inline: 2rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .container-page {
+    padding-inline: 2.5rem;
+  }
+}


### PR DESCRIPTION
## Summary

First slice of applying the homepage's visual system to the rest of the site. This changes the ground every route sits on; component surfaces come next.

- **Tokens promoted.** The `--hs-*` palette, elevation, and hairline tokens were scoped to `.hs-home`, which is precisely what kept every other route on the older, flatter vocabulary. They now live at the document root in a new `styles/premium-foundation.css`; `.hs-home` keeps only its own ground and stacking context, so there is one source of truth instead of two copies.
- **Canvas site-wide.** The app shell (`.hs-shell`, added to the layout wrapper) paints the warm gradient and the fading botanical dot field for every route, light and dark.
- **Unblocked it.** `<main>` was painting a flat `#fbf8f1` from `editorial-global-tokens.css` directly over the canvas, so the change was invisible everywhere but the homepage. `main` is transparent now and the shell owns the ground.
- **One measure.** `container-page` moves from 80rem with a tight gutter to the homepage's 72rem and gutter scale, which is what made those pages feel less composed at desktop widths.
- **Fixed the 768–1023px horizontal overflow** flagged in the last PR. The nav mega-menu is centred on its trigger, so a width capped only at `100vw` still ran past the right edge; it opens narrower below `lg` and full width from `lg`.

## Verification

- [x] `npm run lint`
- [x] `npm run check`
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs (only the `build-info.json` timestamp, reverted)
- [x] no generated file corruption
- [x] static export compatible — CSS, one class on the layout wrapper, one nav width change

Built a route sweep for this work: **25 routes × 3 widths × 2 themes = 150 checks**, asserting load status and horizontal overflow with screenshots per route. Result: 0 failed loads, 0 overflow (was 2 routes overflowing before the nav fix). Canvas and dot field confirmed rendering in both themes; dark mode verified against the real theme provider rather than just `prefers-color-scheme`. `npm run typecheck` clean, `npm run test` 700/700.

## Risk Notes

- `main { background-color: transparent }` is the highest-risk line here: any page that relied on main's opaque fill for contrast now sits on the canvas instead. The canvas is within a shade of the colour it replaced (`#fffdf8`→`#f8f3e8` vs `#fbf8f1`), and the sweep found no contrast or layout fallout, but it is a site-wide change.
- The visible effect varies by route. Pages already carrying `editorial-*` treatment barely change; pages using `container-page` shift noticeably because of the new measure. That is expected at this phase — the jump in polish lands in phase 2 when cards, chips, eyebrows, and buttons adopt the `hs-` surfaces.
- The sweep harness lives outside the repo for now. Adding Playwright as a devDependency plus a CI job is a separate call, since it affects CI time and cost — worth deciding before phase 2, which touches 616 card instances.

---
_Generated by [Claude Code](https://claude.ai/code/session_013MZGLbtRWFs2Y6BSiAJYy7)_