### PR TITLE
Premium design system phase 2: shared surfaces, plus a corner mobile nav widget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ docs/internal/
 
 # Agent metadata harvester cache (auto-generated, regenerates on each run)
 agent/cache/
+.visual-sweep/

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -33,6 +33,7 @@ import '@/styles/homepage-hero-signal-upgrade.css'
 import '@/styles/editorial-content-surfaces.css'
 import '@/styles/homepage-editorial-redesign.css'
 import '@/styles/premium-foundation.css'
+import '@/styles/premium-surfaces.css'
 
 const HOME_TITLE = 'The Hippie Scientist | Supplement Research'
 
@@ -101,7 +102,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             <main
               id='main-content'
               data-pagefind-body
-              className='pb-[calc(env(safe-area-inset-bottom)+6rem)] md:pb-8'
+              className='pb-[calc(env(safe-area-inset-bottom)+2rem)] md:pb-8'
               tabIndex={-1}
             >
               <GlobalTOC />

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -123,6 +123,21 @@ export default [
     },
   },
   {
+    // Browser-driving dev tools: the callbacks passed to page.evaluate() are
+    // serialised and run in the page, so they legitimately use DOM globals.
+    files: ['scripts/dev/**/*.{js,mjs,cjs}'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+        ...globals.browser,
+        ...globals.es2022,
+      },
+    },
+    rules: {
+      'no-empty': ['error', { allowEmptyCatch: true }],
+    },
+  },
+  {
     files: ['tools/**/*.{js,mjs,cjs,ts,tsx}', '**/*.config.{js,mjs,cjs,ts}'],
     languageOptions: {
       globals: {

--- a/scripts/ci/validate-direct-dependencies.mjs
+++ b/scripts/ci/validate-direct-dependencies.mjs
@@ -5,7 +5,11 @@ import { builtinModules } from 'node:module'
 
 const experimentalBuiltins = ['node:sqlite']
 const builtinSet = new Set([...builtinModules, ...builtinModules.map(m => `node:${m}`), ...experimentalBuiltins])
-const optionalProbes = new Set(['exceljs', 'glob', 'react-plotly.js'])
+// Packages a script may import without the repo depending on them. `playwright`
+// backs the on-demand tools in scripts/dev/, which are run by hand against a
+// dev server (`npm i --no-save playwright`) and never by the build or CI, so it
+// is deliberately absent from package.json.
+const optionalProbes = new Set(['exceljs', 'glob', 'react-plotly.js', 'playwright'])
 const generatedImports = new Set(['content-collections'])
 const sourceRoots = ['app', 'components', 'src', 'lib', 'scripts', 'data', 'config']
 const sourceFiles = ['next.config.mjs', 'tailwind.config.ts', 'postcss.config.js']

--- a/scripts/dev/contrast-audit.mjs
+++ b/scripts/dev/contrast-audit.mjs
@@ -1,0 +1,64 @@
+/**
+ * Contrast audit — walks a route set in both themes and reports the worst
+ * text-contrast ratio for eyebrows, body copy, and headings, compositing
+ * translucent and oklab backgrounds through a canvas so the numbers reflect
+ * what is actually rendered.
+ *
+ * Run it before and after a colour change and compare: the useful signal is
+ * which rows moved, not the absolute floor. Text over photographs reads low
+ * here because the image is invisible to the compositing walk.
+ *
+ *   npm run dev
+ *   npm i --no-save playwright && node scripts/dev/contrast-audit.mjs
+ */
+import { chromium } from 'playwright'
+const ROUTES = ['/', '/herbs/ashwagandha/', '/compounds/l-theanine/', '/guides/', '/guides/compare/',
+  '/library/', '/goals/sleep/', '/articles/', '/safety-checker/', '/info/about/', '/learn/', '/evidence/evidence-report/']
+const browser = await chromium.launch({ ...(process.env.CHROMIUM_PATH ? { executablePath: process.env.CHROMIUM_PATH } : {}) })
+const rows = []
+for (const theme of ['light', 'dark']) {
+  const ctx = await browser.newContext({ viewport: { width: 1280, height: 1000 }, colorScheme: theme })
+  await ctx.addInitScript((t) => { try { localStorage.setItem('theme', t) } catch {} }, theme)
+  const page = await ctx.newPage()
+  for (const r of ROUTES) {
+    const resp = await page.goto(`http://localhost:3000${r}`, { waitUntil: 'domcontentloaded', timeout: 120000 }).catch(() => null)
+    if (!resp || !resp.ok()) continue
+    await page.waitForTimeout(450)
+    const out = await page.evaluate(() => {
+      // Composite any CSS colour (oklab, alpha, hsl...) onto a base via canvas.
+      const cv = document.createElement('canvas'); cv.width = cv.height = 1
+      const c2 = cv.getContext('2d', { willReadFrequently: true })
+      const paint = (colors) => {
+        c2.clearRect(0, 0, 1, 1)
+        c2.fillStyle = '#ffffff'; c2.fillRect(0, 0, 1, 1)
+        for (const col of colors) { c2.fillStyle = col; c2.fillRect(0, 0, 1, 1) }
+        const d = c2.getImageData(0, 0, 1, 1).data
+        return [d[0], d[1], d[2]]
+      }
+      const lum = ([r, g, b]) => { const f = (v) => { const s = v / 255; return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4) }; return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b) }
+      const bgStack = (el) => { const st = []; for (let n = el; n; n = n.parentElement) { const bg = getComputedStyle(n).backgroundColor; if (bg && bg !== 'rgba(0, 0, 0, 0)') st.unshift(bg) } return st }
+      const ratio = (fg, bgs) => { const b = paint(bgs); const f = paint([...bgs, fg]); const l1 = lum(f), l2 = lum(b); return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05) }
+      const check = (sel) => {
+        let worst = 99, n = 0, worstText = ''
+        for (const el of [...document.querySelectorAll(sel)].slice(0, 30)) {
+          if (!el.textContent.trim()) continue
+          const cr = ratio(getComputedStyle(el).color, bgStack(el))
+          if (cr < worst) { worst = cr; worstText = el.textContent.trim().slice(0, 24) }
+          n++
+        }
+        return { n, worst: n ? Number(worst.toFixed(2)) : null, worstText }
+      }
+      return { eyebrow: check('.eyebrow-label, .section-label'), body: check('main p'), heads: check('main h2, main h3') }
+    })
+    rows.push({ r, theme, ...out })
+  }
+  await page.close(); await ctx.close()
+}
+await browser.close()
+let fails = 0
+for (const x of rows) {
+  const bad = [x.eyebrow, x.body, x.heads].some((m) => m.worst !== null && m.worst < 4.5)
+  if (bad) fails++
+  console.log(`${bad ? 'FAIL' : ' ok '} ${x.theme.padEnd(5)} ${x.r.padEnd(30)} eyebrow=${x.eyebrow.worst ?? '-'} body=${x.body.worst ?? '-'} heads=${x.heads.worst ?? '-'}${bad ? '  <- ' + [x.eyebrow, x.body, x.heads].filter((m) => m.worst !== null && m.worst < 4.5).map((m) => `"${m.worstText}"`).join(' ') : ''}`)
+}
+console.log(`\nrows below 4.5:1 -> ${fails}`)

--- a/scripts/dev/visual-sweep.mjs
+++ b/scripts/dev/visual-sweep.mjs
@@ -1,0 +1,69 @@
+/**
+ * Visual sweep — loads a representative route set at three widths in both
+ * themes and reports failed loads, horizontal overflow, and a screenshot per
+ * route. Used to check design changes that touch shared surfaces.
+ *
+ * Not wired into CI: it needs a browser, and this repo already runs a
+ * production build, fast-ui-check, and Lighthouse per PR. Run it on demand.
+ *
+ *   npm run dev
+ *   npm i --no-save playwright && node scripts/dev/visual-sweep.mjs before
+ *   ...make changes...
+ *   node scripts/dev/visual-sweep.mjs after
+ *
+ * Screenshots and report.json land in .visual-sweep/<tag>/.
+ */
+import { chromium } from 'playwright'
+import { mkdirSync, writeFileSync } from 'node:fs'
+
+const ROUTES = [
+  '/', '/herbs/', '/herbs/ashwagandha/', '/compounds/', '/compounds/l-theanine/',
+  '/guides/', '/guides/compare/', '/guides/compare/rhodiola-vs-ashwagandha/',
+  '/guides/sleep/', '/goals/sleep/', '/library/', '/articles/', '/learn/',
+  '/safety-checker/', '/evidence/evidence-report/', '/search/',
+  '/info/about/', '/info/faq/', '/info/methodology/', '/info/privacy/',
+  '/guides/mental-health/', '/guides/anxiety/', '/novel-psychoactive-substances/',
+  '/guides/other/', '/evidence/evidence-checker/',
+]
+const WIDTHS = [390, 768, 1280]
+const tag = process.argv[2] || 'base'
+const dir = `${process.cwd()}/.visual-sweep/${tag}`
+mkdirSync(dir, { recursive: true })
+
+const browser = await chromium.launch({ ...(process.env.CHROMIUM_PATH ? { executablePath: process.env.CHROMIUM_PATH } : {}) })
+const report = []
+for (const theme of ['light', 'dark']) {
+  for (const w of WIDTHS) {
+    const page = await browser.newPage({ viewport: { width: w, height: 900 }, colorScheme: theme })
+    for (const route of ROUTES) {
+      const resp = await page.goto(`http://localhost:3000${route}`, { waitUntil: 'domcontentloaded', timeout: 120000 }).catch(() => null)
+      if (!resp || !resp.ok()) { report.push({ route, w, theme, status: resp ? resp.status() : 'ERR' }); continue }
+      await page.waitForTimeout(350)
+      const m = await page.evaluate(() => {
+        const de = document.documentElement
+        const body = document.body
+        const bodyBg = getComputedStyle(body).backgroundColor
+        const p = document.querySelector('main p, p')
+        return {
+          overflow: de.scrollWidth - de.clientWidth,
+          bodyBg,
+          textColor: p ? getComputedStyle(p).color : null,
+          h1: (document.querySelector('h1')?.textContent || '').trim().slice(0, 40),
+        }
+      })
+      report.push({ route, w, theme, ...m })
+      if (w === 1280 && theme === 'light') {
+        await page.screenshot({ path: `${dir}/${route.replace(/\//g, '_') || 'home'}.png` })
+      }
+    }
+    await page.close()
+  }
+}
+await browser.close()
+writeFileSync(`${dir}/report.json`, JSON.stringify(report, null, 1))
+const over = report.filter((r) => r.overflow > 0)
+const errs = report.filter((r) => r.status)
+console.log(`routes=${ROUTES.length} widths=${WIDTHS.length} themes=2 checks=${report.length}`)
+console.log(`failed loads: ${errs.length}`, errs.slice(0, 8).map((e) => `${e.route}@${e.status}`).join(', '))
+console.log(`horizontal overflow: ${over.length}`)
+for (const o of over.slice(0, 12)) console.log(`  ${o.route} @${o.w} ${o.theme}: +${o.overflow}px`)

--- a/src/components/ScrollToTopButton.tsx
+++ b/src/components/ScrollToTopButton.tsx
@@ -16,7 +16,7 @@ export default function ScrollToTopButton() {
     <button
       type="button"
       onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-      className={`fixed bottom-[5.25rem] right-3 z-[85] min-h-10 min-w-10 rounded-full border border-brand-900/15 bg-[var(--surface-card-strong)] p-2 text-brand-800 shadow-sm backdrop-blur transition-all motion-safe:hover:scale-105 md:bottom-8 md:right-6 md:flex ${visible ? 'opacity-100' : 'pointer-events-none opacity-0'}`}
+      className={`fixed bottom-[calc(env(safe-area-inset-bottom)+0.75rem)] right-3 z-[85] min-h-10 min-w-10 rounded-full border border-brand-900/15 bg-[var(--surface-card-strong)] p-2 text-brand-800 shadow-sm backdrop-blur transition-all motion-safe:hover:scale-105 md:bottom-8 md:right-6 md:flex ${visible ? 'opacity-100' : 'pointer-events-none opacity-0'}`}
       aria-label='Scroll to top'
     >
       <ArrowUp aria-hidden="true" className="h-5 w-5" />

--- a/src/components/mobile-bottom-nav.tsx
+++ b/src/components/mobile-bottom-nav.tsx
@@ -2,7 +2,8 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { BookOpenCheck, Leaf, Library, Newspaper, Search } from 'lucide-react'
+import { useEffect, useId, useRef, useState } from 'react'
+import { BookOpenCheck, Compass, Leaf, Library, Newspaper, Search, X } from 'lucide-react'
 
 export const mobileBottomNavItems = [
   { href: '/library', label: 'Explore', Icon: Library },
@@ -17,49 +18,104 @@ function toCanonicalHref(href: string) {
   return href.endsWith('/') ? href : `${href}/`
 }
 
+/**
+ * Mobile navigation as a corner widget rather than a docked bar.
+ *
+ * The bar version held a strip of the viewport on every page and every scroll
+ * position. This collapses to a single button in the bottom-left corner and
+ * opens the same destinations on demand, so reading space stays with the page.
+ */
 export default function MobileBottomNav() {
   const pathname = usePathname() || '/'
+  const [open, setOpen] = useState(false)
+  const panelId = useId()
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
+  const panelRef = useRef<HTMLDivElement | null>(null)
+
+  // Close on route change so the panel never survives a navigation.
+  useEffect(() => {
+    setOpen(false)
+  }, [pathname])
+
+  useEffect(() => {
+    if (!open) return
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        event.stopPropagation()
+        setOpen(false)
+        triggerRef.current?.focus()
+      }
+    }
+
+    function onPointerDown(event: PointerEvent) {
+      const target = event.target as Node
+      if (panelRef.current?.contains(target) || triggerRef.current?.contains(target)) return
+      setOpen(false)
+    }
+
+    document.addEventListener('keydown', onKeyDown)
+    document.addEventListener('pointerdown', onPointerDown)
+    // Move focus into the panel so keyboard and screen-reader users land there.
+    panelRef.current?.querySelector<HTMLAnchorElement>('a')?.focus()
+
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+      document.removeEventListener('pointerdown', onPointerDown)
+    }
+  }, [open])
 
   return (
-    <nav
-      aria-label='Primary mobile navigation'
-      className='editorial-mobile-dock mobile-bottom-nav fixed inset-x-3 bottom-[calc(env(safe-area-inset-bottom)+0.5rem)] z-[90] mx-auto max-w-[34rem] overflow-hidden rounded-[1.25rem] md:hidden'
-    >
-      <div className='flex items-center gap-0.5 px-1 py-1'>
-        {mobileBottomNavItems.map((item) => {
-          const active = pathname === item.href || pathname.startsWith(`${item.href}/`)
-          const isSearch = item.label === 'Search'
-          const Icon = item.Icon
+    <div className='mobile-bottom-nav pointer-events-none fixed bottom-[calc(env(safe-area-inset-bottom)+0.75rem)] left-3 z-[90] flex flex-col items-start gap-2 md:hidden'>
+      <div
+        id={panelId}
+        ref={panelRef}
+        hidden={!open}
+        className='pointer-events-auto w-[13.5rem] origin-bottom-left overflow-hidden rounded-[1.25rem] border border-[color:var(--hs-hairline-strong)] bg-[color:var(--hs-surface)] p-1.5 shadow-[var(--hs-lift-hover)] motion-safe:animate-[hs-widget-in_160ms_cubic-bezier(0.22,1,0.36,1)]'
+      >
+        <nav aria-label='Primary mobile navigation'>
+          <ul className='flex flex-col gap-0.5'>
+            {mobileBottomNavItems.map((item) => {
+              const active = pathname === item.href || pathname.startsWith(`${item.href}/`)
+              const Icon = item.Icon
 
-          return (
-            <Link
-              key={item.href}
-              href={toCanonicalHref(item.href)}
-              aria-current={active ? 'page' : undefined}
-              className={`group relative flex min-h-[2.9rem] min-w-0 flex-1 flex-col items-center justify-center gap-0.5 rounded-xl px-0.5 text-center transition ${
-                active && !isSearch
-                  ? 'text-[#123c2f] dark:text-[var(--text-primary)]'
-                  : 'text-[#526159] hover:text-[#123c2f] dark:text-[var(--text-secondary)] dark:hover:text-[var(--text-primary)]'
-              }`}
-            >
-              <span
-                className={`inline-flex items-center justify-center transition ${
-                  isSearch
-                    ? 'editorial-mobile-search h-8 w-10 rounded-full'
-                    : active
-                      ? 'h-7 w-9 rounded-full bg-[#dfe9dc] dark:bg-[rgba(255,255,255,0.09)]'
-                      : 'h-7 w-9 rounded-full'
-                }`}
-              >
-                <Icon aria-hidden='true' className='h-5 w-5' strokeWidth={active || isSearch ? 2.2 : 1.8} />
-              </span>
-              <span className={`max-w-full whitespace-nowrap text-[0.69rem] leading-none ${active ? 'font-bold' : 'font-semibold'}`}>
-                {item.label}
-              </span>
-            </Link>
-          )
-        })}
+              return (
+                <li key={item.href}>
+                  <Link
+                    href={toCanonicalHref(item.href)}
+                    aria-current={active ? 'page' : undefined}
+                    onClick={() => setOpen(false)}
+                    className={`flex min-h-11 items-center gap-3 rounded-xl px-3 text-sm transition ${
+                      active
+                        ? 'bg-[color:color-mix(in_srgb,var(--tone)_16%,transparent)] font-bold text-[color:var(--hs-ink)]'
+                        : 'font-semibold text-[color:var(--hs-body)] hover:bg-[color:color-mix(in_srgb,var(--tone)_10%,transparent)] hover:text-[color:var(--hs-ink)]'
+                    }`}
+                  >
+                    <Icon aria-hidden='true' className='h-[1.15rem] w-[1.15rem] shrink-0' strokeWidth={active ? 2.2 : 1.8} />
+                    {item.label}
+                  </Link>
+                </li>
+              )
+            })}
+          </ul>
+        </nav>
       </div>
-    </nav>
+
+      <button
+        ref={triggerRef}
+        type='button'
+        onClick={() => setOpen((value) => !value)}
+        aria-expanded={open}
+        aria-controls={panelId}
+        aria-label={open ? 'Close navigation menu' : 'Open navigation menu'}
+        className='pointer-events-auto inline-flex h-13 w-13 min-h-12 min-w-12 items-center justify-center rounded-full border border-[color:var(--hs-hairline-strong)] bg-[color:var(--hs-surface)] text-[color:var(--hs-ink)] shadow-[var(--hs-lift)] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--hs-gold)] focus-visible:ring-offset-2 motion-safe:active:scale-95'
+      >
+        {open ? (
+          <X aria-hidden='true' className='h-5 w-5' strokeWidth={2} />
+        ) : (
+          <Compass aria-hidden='true' className='h-5 w-5' strokeWidth={1.9} />
+        )}
+      </button>
+    </div>
   )
 }

--- a/styles/premium-surfaces.css
+++ b/styles/premium-surfaces.css
@@ -1,0 +1,253 @@
+/* Premium surfaces — phase 2 of promoting the homepage design language.
+ *
+ * Phase 0/1 (styles/premium-foundation.css) gave every route the homepage's
+ * tokens and canvas. This file moves the shared component surfaces onto the
+ * same vocabulary: the elevation model from .hs-goal, the eyebrow with its
+ * rule, the pill chip, and the two button treatments.
+ *
+ * On specificity: .card-premium and .eyebrow-label are each defined in six or
+ * seven of the older stylesheets, some scoped like `.library-index-page
+ * .card-premium` (0,2,0) and some like `html:not(.dark) :where(.card-premium)`
+ * (0,1,1). Repeating the class raises these rules above that range without an
+ * arms race of ever-longer selectors. It is deliberate, and it goes away when
+ * those older layers are collapsed.
+ */
+
+:root {
+  /* Tone drives the per-surface wash. Routes override it; this is the default. */
+  --tone: #3f7c4a;
+  --tone-ink: #1f4d29;
+
+  /* --hs-gold is a decoration colour: it clears 3:1 against the canvas as a
+     rule or border, but only ~2.9:1 as text, which fails WCAG AA. Text that
+     wants to read as gold uses this darker cut (~5:1) instead. */
+  --hs-gold-ink: #7a5620;
+}
+
+html.dark {
+  --tone: #78a380;
+  --tone-ink: #a9c9b5;
+  --hs-gold-ink: #d9b271;
+}
+
+/* Per-family tone, applied through the wrappers that already exist. Anything
+   without a hook keeps the default green. A route-family attribute on the
+   shell would let this cover every template; that is a follow-up. */
+.library-index-page {
+  --tone: #5c4db8;
+  --tone-ink: #4a3da3;
+}
+
+html.dark .library-index-page {
+  --tone: #a89dcc;
+  --tone-ink: #c3bce0;
+}
+
+.goal-decision-experience {
+  --tone: #2563eb;
+  --tone-ink: #1d4fd8;
+}
+
+html.dark .goal-decision-experience {
+  --tone: #7ea6f5;
+  --tone-ink: #a8c4f8;
+}
+
+/* ---------- Cards ---------- */
+
+html .card-premium.card-premium,
+html .scientific-card.scientific-card,
+html .library-card-premium.library-card-premium {
+  border: 1px solid color-mix(in srgb, var(--tone) 22%, transparent);
+  border-radius: 1.25rem;
+  background:
+    linear-gradient(160deg, color-mix(in srgb, var(--tone) 9%, transparent), transparent 62%),
+    var(--hs-surface);
+  box-shadow: var(--hs-lift);
+  transition:
+    transform 260ms cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 260ms ease,
+    border-color 260ms ease;
+}
+
+/* Dark surfaces swallow a 9% wash, so the tint is pushed harder there — the
+   same correction the homepage goal cards make. */
+html.dark .card-premium.card-premium,
+html.dark .scientific-card.scientific-card,
+html.dark .library-card-premium.library-card-premium {
+  border-color: color-mix(in srgb, var(--tone) 28%, transparent);
+  background:
+    linear-gradient(158deg, color-mix(in srgb, var(--tone) 20%, transparent), transparent 68%),
+    var(--hs-surface);
+}
+
+/* Only lift cards that are actually interactive; a static content panel that
+   rises on hover reads as broken. */
+html a.card-premium.card-premium:hover,
+html a .card-premium.card-premium:hover,
+html button.card-premium.card-premium:hover,
+html .card-premium.card-premium:has(> a):hover,
+html .library-card-premium.library-card-premium:hover {
+  transform: translateY(-3px);
+  border-color: color-mix(in srgb, var(--tone) 48%, transparent);
+  box-shadow: var(--hs-lift-hover);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html .card-premium.card-premium,
+  html .scientific-card.scientific-card,
+  html .library-card-premium.library-card-premium {
+    transition: none;
+  }
+
+  html a.card-premium.card-premium:hover,
+  html .library-card-premium.library-card-premium:hover {
+    transform: none;
+  }
+}
+
+/* ---------- Eyebrows ---------- */
+
+html .eyebrow-label.eyebrow-label,
+html .section-label.section-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  color: var(--hs-gold-ink);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.2em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+/* The short rule that opens every homepage section label. */
+html .eyebrow-label.eyebrow-label::before,
+html .section-label.section-label::before {
+  content: '';
+  width: 1.6rem;
+  height: 1px;
+  flex: 0 0 auto;
+  background: currentColor;
+  opacity: 0.55;
+}
+
+@media (max-width: 480px) {
+  html .eyebrow-label.eyebrow-label,
+  html .section-label.section-label {
+    gap: 0.5rem;
+    font-size: 0.64rem;
+    letter-spacing: 0.15em;
+  }
+
+  html .eyebrow-label.eyebrow-label::before,
+  html .section-label.section-label::before {
+    width: 1.1rem;
+  }
+}
+
+/* ---------- Chips ---------- */
+
+html .chip-readable.chip-readable {
+  border: 1px solid var(--hs-hairline);
+  border-radius: 999px;
+  background: var(--hs-surface);
+  color: var(--hs-ink);
+  box-shadow: var(--hs-lift);
+  transition:
+    transform 200ms cubic-bezier(0.22, 1, 0.36, 1),
+    border-color 200ms ease,
+    box-shadow 200ms ease;
+}
+
+html a.chip-readable.chip-readable:hover,
+html button.chip-readable.chip-readable:hover {
+  transform: translateY(-2px);
+  border-color: var(--hs-gold);
+  box-shadow: var(--hs-lift-hover);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html .chip-readable.chip-readable {
+    transition: none;
+  }
+
+  html a.chip-readable.chip-readable:hover,
+  html button.chip-readable.chip-readable:hover {
+    transform: none;
+  }
+}
+
+/* ---------- Buttons ---------- */
+
+html .button-primary.button-primary {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(18, 60, 47, 0.9);
+  background: linear-gradient(140deg, #1c5241 0%, #123c2f 55%, #0f3227 100%);
+  color: #fffdf8;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.14) inset,
+    0 14px 30px -12px rgba(18, 60, 47, 0.7);
+}
+
+html.dark .button-primary.button-primary {
+  border-color: rgba(217, 178, 113, 0.42);
+  background: linear-gradient(140deg, #256a52 0%, #17493a 55%, #123c2f 100%);
+}
+
+html .button-primary.button-primary:hover {
+  transform: translateY(-2px);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.18) inset,
+    0 20px 40px -12px rgba(18, 60, 47, 0.6);
+}
+
+html .button-secondary.button-secondary {
+  border: 1px solid var(--hs-hairline-strong);
+  background: var(--hs-surface-2);
+  color: var(--hs-ink);
+  backdrop-filter: blur(10px);
+}
+
+html .button-secondary.button-secondary:hover {
+  transform: translateY(-2px);
+  border-color: var(--hs-gold);
+  background: var(--hs-surface);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html .button-primary.button-primary:hover,
+  html .button-secondary.button-secondary:hover {
+    transform: none;
+  }
+}
+
+/* ---------- Dividers ---------- */
+
+html main hr {
+  border: 0;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    var(--hs-hairline-strong) 12%,
+    var(--hs-hairline-strong) 88%,
+    transparent
+  );
+}
+
+/* ---------- Mobile navigation widget ---------- */
+
+/* The corner widget grows from its trigger rather than sliding in from an
+   edge, so the button reads as the thing that opened it. */
+@keyframes hs-widget-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}


### PR DESCRIPTION
## Summary

Two changes.

**Phase 2 — shared surfaces.** Cards, eyebrows, chips, buttons, and dividers adopt the homepage elevation model, hairlines, and tone wash. This reaches most of the site through four hooks rather than 267 page files: `card-premium` (616 uses), `eyebrow-label` (609), `chip-readable` (177), and the two button classes. Tone is extended site-wide with a green default and per-family overrides where stable wrappers exist.

The contrast problem this surfaced: the homepage gold reads at only **~2.9:1 as text** on the canvas, so applying it to 609 eyebrows unchanged would have multiplied a WCAG AA failure. Gold text now uses a darker cut (`--hs-gold-ink`); `--hs-gold` stays for rules and borders, where the 3:1 non-text threshold applies.

Contrast audit, 12 routes × both themes, before → after:

| | Baseline | After |
|---|---|---|
| Rows below 4.5:1 | 7 | **4** |
| `/library/` eyebrow | 2.87 | **6.1** |
| `/goals/sleep/` eyebrow | 2.93 | **6.23** |
| `/learn/` eyebrow | 2.93 | **6.23** |
| `/safety-checker/` eyebrow | 3.11 | **6.6** |

The 4 remaining rows are all pre-existing text over photography, unchanged by this PR. Only interactive cards lift on hover, and every transform is disabled under `prefers-reduced-motion`.

**Mobile navigation.** The docked bottom bar held a strip of every mobile viewport at every scroll position. It is now a 52px button in the bottom-left corner that opens the same five destinations on demand. `aria-expanded` and `aria-controls` on the trigger, focus moves into the panel on open, Escape closes and restores focus, outside pointer-down closes, route change closes. With the bar gone, `main` reclaims the 6rem of bottom padding it reserved (now 2rem) and the scroll-to-top button drops to the edge it used to clear.

Also adds the two verification harnesses as on-demand dev scripts under `scripts/dev/`. They stay out of CI deliberately — this repo already runs a production build, fast-ui-check, and Lighthouse per PR, and adding a browser download to every run is a poor trade.

## Verification

- [x] `npm run lint`
- [x] `npm run check`
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs (only the `build-info.json` timestamp, reverted)
- [x] no generated file corruption
- [x] static export compatible — CSS, one client component, no new server features

Route sweep: 25 routes × 3 widths × 2 themes = 150 checks, 0 failed loads, 0 horizontal overflow. Widget behaviour asserted in both themes: 52×52 target, `aria-expanded` toggles, focus enters the panel, Escape restores focus to the trigger. `npm run typecheck` clean, `npm run test` 700/700.

## Risk Notes

- Phase 2 rules repeat their class (`.card-premium.card-premium`) to clear the six or seven older definitions of the same hooks. It is deliberate and commented; it disappears when those layers are collapsed in phase 4.
- Tone currently covers the library and goal wrappers only. Full per-family colour needs a route-family attribute on the shell — a small follow-up, not a blocker.
- The nav change is a behaviour change, not just styling: destinations that were one tap away are now two. That is the trade for the reclaimed space, and worth a look on a real device before it is considered settled.

---
_Generated by [Claude Code](https://claude.ai/code/session_013MZGLbtRWFs2Y6BSiAJYy7)_