### PR TITLE
Measure the shared App Router payload

### DIFF
--- a/docs/performance/budgets-log.md
+++ b/docs/performance/budgets-log.md
@@ -1,9 +1,10 @@
 # Performance Budgets Log
   
-Generated on 2026-07-03T12:51:46.646Z
+Generated on 2026-08-01T13:15:48.457Z
 
 | Metric | Actual Size | Budget Size | Status |
 | :--- | :--- | :--- | :--- |
-| Largest JSON (compounds.json) | 1883.11 KB | 2560.00 KB | Pass |
-| Search Index (search-index.json) | 741.60 KB | 1024.00 KB | Pass |
-| Total Search/Index Payload | 1489.22 KB | 2048.00 KB | Pass |
+| Largest JSON (compounds.json) | 1949.40 KB | 2560.00 KB | Pass |
+| Search Index (search-index.json) | 784.53 KB | 1024.00 KB | Pass |
+| Total Search/Index Payload | 1532.15 KB | 2048.00 KB | Pass |
+| App Router shared JS (gzip) | 100.36 KB | 120.00 KB | Pass |

--- a/docs/performance/budgets.md
+++ b/docs/performance/budgets.md
@@ -11,7 +11,7 @@ The build pipeline enforces size limits using `scripts/report-performance-budget
 | **Max Single JSON File** | `2.5 MB` | The absolute maximum size for any individual JSON database file under `public/data/` (e.g. `compounds.json`, `herbs.json`). |
 | **Search Index Payload** | `1.0 MB` | The limit for the client-side search index (`search-index.json`). |
 | **Total Indexing Payload** | `2.0 MB` | The combined limit of the search index and summary JSONs (`herbs-summary.json` + `compounds-summary.json`) that are loaded on listing/search hubs. |
-| **Next.js Core JS Bundle** | `350 KB` | The combined size of Next.js core client bundles (`main`, `framework`, `webpack`, and `polyfills`). |
+| **App Router Shared JS** | `120 KB gzip` | The compressed modern runtime chunks from Next.js `rootMainFiles` that are shared by every App Router route. The legacy Pages Router runtime and `nomodule` polyfill are excluded because they are not part of this shared payload. |
 
 ## Lazy Loading and Optimization Guidelines
 

--- a/scripts/report-performance-budget.mjs
+++ b/scripts/report-performance-budget.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import fs from 'node:fs'
 import path from 'node:path'
+import { gzipSync } from 'node:zlib'
 
 const ROOT = process.cwd()
 
@@ -15,14 +16,42 @@ const BUDGETS = {
   // Max total search/index data payload (search-index + summaries)
   maxTotalIndexPayload: 2.0 * 1024 * 1024, // 2.0 MB (sums up to ~1.5MB currently)
   
-  // Max size of the main Next.js entry JS bundle (main chunk, framework, webpack)
-  maxMainJsBundle: 350 * 1024, // 350 KB
+  // Max gzip transfer size of the modern App Router runtime shared by every route
+  maxAppRouterSharedJsGzip: 120 * 1024, // 120 KB
 }
 
 function getFileSize(filePath) {
   try {
     const stats = fs.statSync(filePath)
     return stats.size
+  } catch {
+    return 0
+  }
+}
+
+function getGzipSize(filePath) {
+  try {
+    return gzipSync(fs.readFileSync(filePath)).byteLength
+  } catch {
+    return 0
+  }
+}
+
+function getAppRouterSharedJsSize(outDir) {
+  const manifestPath = path.join(ROOT, '.next', 'build-manifest.json')
+
+  try {
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+    const sharedFiles = Array.isArray(manifest.rootMainFiles)
+      ? manifest.rootMainFiles.filter(file => file.endsWith('.js'))
+      : []
+
+    if (sharedFiles.length === 0) return 0
+
+    const sizes = sharedFiles.map(file => getGzipSize(path.join(outDir, '_next', file)))
+    if (sizes.some(size => size === 0)) return 0
+
+    return sizes.reduce((total, size) => total + size, 0)
   } catch {
     return 0
   }
@@ -56,25 +85,17 @@ function main() {
   metrics.push({ name: 'Search Index (search-index.json)', size: searchIndexSize, budget: BUDGETS.maxSearchIndex })
   metrics.push({ name: 'Total Search/Index Payload', size: totalIndexPayload, budget: BUDGETS.maxTotalIndexPayload })
 
-  // 2. Audit Client JS Bundle sizes (if out/ exists)
+  // 2. Audit the compressed App Router runtime loaded by every modern site route.
+  // build-manifest.json is authoritative here; filename matching also counts the
+  // legacy Pages Router runtime and nomodule polyfill, which visitors do not load
+  // as the shared App Router payload.
   if (fs.existsSync(outDir)) {
-    const chunksDir = path.join(outDir, '_next', 'static', 'chunks')
-    let mainJsSize = 0
-
-    if (fs.existsSync(chunksDir)) {
-      const files = fs.readdirSync(chunksDir)
-      // Find core Next.js chunk sizes (main, framework, webpack, polyfills)
-      const coreFiles = files.filter(f => 
-        (f.startsWith('main-') || f.startsWith('framework-') || f.startsWith('webpack-') || f.startsWith('polyfills-')) && 
-        f.endsWith('.js')
-      )
-
-      for (const file of coreFiles) {
-        mainJsSize += getFileSize(path.join(chunksDir, file))
-      }
-    }
-
-    metrics.push({ name: 'Main JS Bundle (Next.js core)', size: mainJsSize, budget: BUDGETS.maxMainJsBundle })
+    metrics.push({
+      name: 'App Router shared JS (gzip)',
+      size: getAppRouterSharedJsSize(outDir),
+      budget: BUDGETS.maxAppRouterSharedJsGzip,
+      required: true,
+    })
   } else {
     console.log('[performance-budget] out/ directory not found. Skipping JS bundle size audit (run npm run build first).')
   }
@@ -87,6 +108,10 @@ function main() {
   for (const m of metrics) {
     if (m.size === 0) {
       console.log(`| ${m.name} | N/A | ${formatSize(m.budget)} | ⚠️ Missing |`)
+      if (m.required) {
+        errors.push(`${m.name} could not be measured from the App Router build manifest and exported chunks.`)
+        failed = true
+      }
       continue
     }
 


### PR DESCRIPTION
## What changed

- Measure the gzip transfer size of Next.js App Router `rootMainFiles` instead of summing legacy filename patterns.
- Exclude the Pages Router-only runtime and `nomodule` polyfill from the shared App Router metric.
- Tighten the shared payload target from an ineffective 350 KB raw limit to 120 KB gzip and fail when required chunks cannot be measured.
- Refresh the checked-in performance budget log from the current default-branch build.

## Why

The existing check reported a 367.88 KB warning by combining scripts that are not the shared payload used by modern site routes. Next.js reports 102 KB shared by all App Router routes; the corrected check independently measures 100.36 KB gzip. This makes future performance alerts accurate and actionable.

## Validation

- `node --check scripts/report-performance-budget.mjs`
- Positive budget check: 100.36 KB / 120 KB, pass
- Negative missing-chunk test: expected exit 1
- `npm run check:ui`
- `npm run verify:output`
- Clean production baseline build: `npm run build`