### PR TITLE
Premium design system phases 3 and 4: typographic voice, and one owner per surface

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -392,20 +392,7 @@ html.dark ::selection {
 @layer components {
   .container-page {
     @apply mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8;
-  }
-
-  .card-premium {
-    background-color: #ffffff;
-    border: 1px solid rgba(13, 23, 18, 0.06);
-    @apply transition-all duration-300;
-    border-radius: var(--radius-card-premium);
-    box-shadow: var(--shadow-card-calm);
-  }
-
-  .card-premium:hover {
-    border-color: rgba(13, 23, 18, 0.10);
-    box-shadow: var(--shadow-card-calm-hover);
-  }
+  }    
 
   .hero-shell {
     background:
@@ -611,15 +598,7 @@ html.dark ::selection {
 
   .metadata-row {
     @apply flex flex-wrap items-center gap-2;
-  }
-
-  .section-frame {
-    background-color: #ffffff;
-    border: 1px solid rgba(13, 23, 18, 0.06);
-    @apply p-4 sm:p-5;
-    border-radius: var(--radius-card-premium);
-    box-shadow: var(--shadow-card-calm);
-  }
+  }  
 
   .muted-readable {
     @apply text-[#36483e];
@@ -634,21 +613,7 @@ html.dark ::selection {
 
   .eyebrow-label {
     @apply text-[0.78rem] font-semibold tracking-[0.03em] text-brand-700;
-  }
-
-  .surface-subtle {
-    background-color: var(--surface);
-    border: 1px solid rgba(13, 23, 18, 0.05);
-    @apply shadow-sm;
-    border-radius: var(--radius-card-premium);
-  }
-
-  .surface-depth {
-    background-color: var(--surface-elevated);
-    border: 1px solid rgba(13, 23, 18, 0.06);
-    border-radius: var(--radius-card-premium);
-    box-shadow: var(--shadow-card-calm);
-  }
+  }    
 
   .chip-readable {
     @apply inline-flex items-center rounded-full border border-brand-900/10 bg-white/80 px-2 py-0.5 text-[0.68rem] font-semibold leading-snug text-[#33443a];
@@ -682,17 +647,7 @@ html.dark ::selection {
 
   .safety-block {
     @apply rounded-card border border-amber-600/20 bg-amber-50/85 p-4 shadow-sm;
-  }
-
-  .button-primary {
-    @apply inline-flex items-center justify-center rounded-full bg-brand-700 px-4 py-2 text-sm font-semibold text-white transition-colors duration-200 hover:bg-brand-800 focus-visible:text-white;
-    box-shadow: var(--shadow-button-primary);
-  }
-
-  .button-secondary {
-    @apply inline-flex items-center justify-center rounded-full border border-brand-200 bg-white px-4 py-2 text-sm font-semibold text-brand-800 transition-colors duration-200 hover:border-brand-300 hover:bg-brand-50;
-    box-shadow: var(--shadow-button-secondary);
-  }
+  }    
 }
 
 /* Dark mode overrides for hardcoded light-mode text colors in prose/content components */
@@ -783,20 +738,14 @@ html.dark .content-prose blockquote {
   border-color: rgba(49, 75, 51, 0.18);
 }
 
-/* Dark-mode compatibility for legacy utility-heavy pages.
-   Keep this centralized so page contracts and generated content stay untouched. */
+/* Dark-mode compatibility for legacy utility-heavy pages, i.e. markup that
+   paints itself with bg-white utilities. The named card surfaces used to be
+   listed here too; they are owned by styles/premium-surfaces.css now. */
 html.dark :is(
-  .card-premium,
-  .section-frame,
-  .surface-subtle,
-  .surface-depth,
-  .scientific-card,
-  .mobile-reading-card,
   .compact-section,
   .compact-card,
   .semantic-rail-card,
   .accordion-readable,
-  .chip-readable,
   [class~="bg-white"],
   [class~="bg-white/50"],
   [class~="bg-white/60"],
@@ -1115,18 +1064,6 @@ html.dark :is(.identity-herb, .identity-compound, .identity-article, .identity-p
   background: var(--surface-card);
 }
 
-html.dark :is(.button-secondary) {
-  background-color: var(--surface-card);
-  color: var(--text-primary);
-  border-color: var(--border-soft);
-}
-
-html.dark :is(.button-primary) {
-  background-color: #78a380;
-  color: #07150c;
-  box-shadow: 0 2px 10px rgba(0,0,0,0.30);
-}
-
 html.dark :is(
   [class~="bg-brand-700"], [class~="bg-brand-800"], [class~="bg-brand-950"]
 ) {
@@ -1266,12 +1203,7 @@ html.dark :is(
   }
 }
 
-@layer components {
-  .scientific-card {
-    @apply block bg-white p-4 transition-all duration-200 hover:bg-brand-50/50;
-    border-radius: var(--radius-card-compact);
-    box-shadow: var(--shadow-card-calm);
-  }
+@layer components {  
 
   .scientific-card[data-evidence="strong"] {
     border-left: 3px solid var(--color-evidence-strong);
@@ -1315,12 +1247,7 @@ html.dark :is(
 
   .pull-quote-science {
     @apply rounded-[1rem] border-l-4 border-brand-700 bg-white/75 p-4 font-display text-xl font-semibold leading-snug tracking-tight text-ink shadow-sm;
-  }
-
-  .mobile-reading-card {
-    @apply border border-brand-900/10 bg-white/80 p-4 shadow-sm;
-    border-radius: var(--radius-card-compact);
-  }
+  }  
 
   .compact-section {
     @apply border border-brand-900/10 bg-white/75 p-3 shadow-sm sm:p-4;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -34,6 +34,7 @@ import '@/styles/editorial-content-surfaces.css'
 import '@/styles/homepage-editorial-redesign.css'
 import '@/styles/premium-foundation.css'
 import '@/styles/premium-surfaces.css'
+import '@/styles/premium-typography.css'
 
 const HOME_TITLE = 'The Hippie Scientist | Supplement Research'
 

--- a/styles/editorial-content-surfaces.css
+++ b/styles/editorial-content-surfaces.css
@@ -10,42 +10,6 @@ html:not(.dark) :where(
   .surface-subtle,
   .section-frame,
   .glass-card
-) {
-  border-color: rgba(18, 60, 47, 0.11);
-  background:
-    radial-gradient(circle at 100% 0%, rgba(203, 220, 200, 0.28), transparent 32%),
-    linear-gradient(145deg, rgba(255, 253, 248, 0.98), rgba(247, 241, 230, 0.88));
-  box-shadow:
-    0 16px 42px rgba(58, 45, 24, 0.075),
-    inset 0 1px 0 rgba(255, 255, 255, 0.88);
-}
-
-html:not(.dark) :where(
-  .library-card-premium,
-  .card-premium,
-  .scientific-card,
-  .surface-depth,
-  .surface-subtle,
-  .section-frame,
-  .glass-card
-):hover {
-  border-color: rgba(184, 138, 66, 0.28);
-  background:
-    radial-gradient(circle at 100% 0%, rgba(203, 220, 200, 0.34), transparent 34%),
-    linear-gradient(145deg, #fffdf8, #f8f2e7);
-  box-shadow:
-    0 20px 48px rgba(58, 45, 24, 0.10),
-    inset 0 1px 0 rgba(255, 255, 255, 0.92);
-}
-
-html:not(.dark) :where(
-  .library-card-premium,
-  .card-premium,
-  .scientific-card,
-  .surface-depth,
-  .surface-subtle,
-  .section-frame,
-  .glass-card
 ) :where(h2, h3) {
   color: var(--editorial-evergreen);
 }
@@ -62,13 +26,7 @@ html:not(.dark) :where(
   color: #526159;
 }
 
-html:not(.dark) .eyebrow-label {
-  color: var(--editorial-gold);
-  font-weight: 800;
-  letter-spacing: 0.14em;
-}
-
-html:not(.dark) :where(.identity-kicker, .chip-readable, .evidence-pill-strong, .evidence-pill-moderate) {
+html:not(.dark) :where(.identity-kicker, .evidence-pill-strong, .evidence-pill-moderate) {
   border-color: rgba(18, 60, 47, 0.10);
   background: linear-gradient(145deg, rgba(223, 233, 220, 0.78), rgba(255, 253, 248, 0.92));
   color: var(--editorial-evergreen);

--- a/styles/foundation-readability.css
+++ b/styles/foundation-readability.css
@@ -90,42 +90,7 @@ canvas {
 
 .content-prose li + li {
   margin-top: 0.45rem;
-}
-
-/* Improve visual separation without redesigning components. */
-.card-premium,
-.surface-depth,
-.surface-subtle,
-.section-frame,
-.glass-card,
-.mobile-reading-card,
-.scientific-card,
-.library-card-premium {
-  border-color: var(--scientific-border);
-  background-color: var(--paper-card);
-  box-shadow: var(--soft-lift-shadow);
-}
-
-.card-premium:hover,
-.scientific-card:hover,
-.library-card-premium:hover {
-  border-color: var(--scientific-border-strong);
-  box-shadow: var(--deep-lift-shadow);
-}
-
-.surface-depth,
-.section-frame,
-.glass-card {
-  background:
-    linear-gradient(180deg, var(--paper-card-strong), rgba(244, 247, 242, 0.82));
-}
-
-html.dark .surface-depth,
-html.dark .section-frame,
-html.dark .glass-card {
-  background:
-    linear-gradient(180deg, var(--paper-card-strong), rgba(17, 26, 20, 0.78));
-}
+}/* Improve visual separation without redesigning components. */
 
 .section-spacing {
   row-gap: clamp(2.75rem, 4.5vw, 5rem);
@@ -152,7 +117,6 @@ html.dark .glass-card {
 }
 
 .eyebrow,
-.eyebrow-label,
 .identity-kicker,
 .identity-meta {
   letter-spacing: 0.15em;
@@ -209,18 +173,7 @@ html.dark .glass-card {
 
   .hero-shell {
     border-radius: 1.6rem;
-  }
-
-  .card-premium,
-  .surface-depth,
-  .surface-subtle,
-  .section-frame,
-  .glass-card,
-  .mobile-reading-card,
-  .scientific-card,
-  .library-card-premium {
-    border-radius: 1.35rem;
-  }
+  }  
 }
 
 @media (max-width: 480px) {
@@ -348,8 +301,7 @@ html.dark .goal-decision-experience #safety-first article p {
   }
 
   .goal-decision-experience .hero-shell,
-  .goal-decision-experience .card-premium,
-  .goal-decision-experience #safety-first {
+.goal-decision-experience #safety-first {
     border-radius: 1.25rem;
   }
 

--- a/styles/herb-profile-polish.css
+++ b/styles/herb-profile-polish.css
@@ -10,8 +10,6 @@ main:has(nav[aria-label="Jump to profile sections"]) > div.mx-auto {
 
 main:has(nav[aria-label="Jump to profile sections"]) .hero-shell,
 #ashwagandha-stress-claim,
-#ashwagandha-stress-claim .card-premium,
-main:has(nav[aria-label="Jump to profile sections"]) .card-premium,
 main:has(nav[aria-label="Jump to profile sections"]) #quick-stats,
 main:has(nav[aria-label="Jump to profile sections"]) #compare,
 main:has(nav[aria-label="Jump to profile sections"]) section.rounded-2xl {
@@ -24,8 +22,6 @@ main:has(nav[aria-label="Jump to profile sections"]) section.rounded-2xl {
 
 html:not(.dark) main:has(nav[aria-label="Jump to profile sections"]) .hero-shell,
 html:not(.dark) #ashwagandha-stress-claim,
-html:not(.dark) #ashwagandha-stress-claim .card-premium,
-html:not(.dark) main:has(nav[aria-label="Jump to profile sections"]) .card-premium,
 html:not(.dark) main:has(nav[aria-label="Jump to profile sections"]) #quick-stats,
 html:not(.dark) main:has(nav[aria-label="Jump to profile sections"]) #compare,
 html:not(.dark) main:has(nav[aria-label="Jump to profile sections"]) section.rounded-2xl {
@@ -103,14 +99,10 @@ html:not(.dark) #ashwagandha-stress-claim .text-\[\#5f4a24\] {
   color: #4f6057;
 }
 
-main:has(nav[aria-label="Jump to profile sections"]) .eyebrow-label,
-#ashwagandha-stress-claim .eyebrow-label,
 #ashwagandha-stress-claim dt {
   color: #cbd8c0;
 }
 
-html:not(.dark) main:has(nav[aria-label="Jump to profile sections"]) .eyebrow-label,
-html:not(.dark) #ashwagandha-stress-claim .eyebrow-label,
 html:not(.dark) #ashwagandha-stress-claim dt {
   color: #314b33;
 }

--- a/styles/premium-cards.css
+++ b/styles/premium-cards.css
@@ -5,77 +5,11 @@
 .surface-subtle,
 .section-frame,
 .glass-card {
+  /* Structure only. The surface itself - background, border, radius, shadow,
+     transition - is owned by styles/premium-surfaces.css. */
   position: relative;
   overflow: hidden;
   isolation: isolate;
-
-  background:
-    linear-gradient(
-      180deg,
-      rgba(255,255,255,0.92) 0%,
-      rgba(255,252,246,0.84) 100%
-    );
-
-  backdrop-filter: blur(18px);
-  -webkit-backdrop-filter: blur(18px);
-
-  border-radius: var(--radius-card-premium, 1.65rem);
-  border: 1px solid rgba(29,74,47,0.09);
-
-  box-shadow:
-    0 14px 42px rgba(16,32,24,0.07),
-    0 2px 8px rgba(16,32,24,0.035);
-
-  transition:
-    transform .28s ease,
-    box-shadow .28s ease,
-    border-color .28s ease,
-    background .28s ease,
-    opacity .28s ease;
-}
-
-.library-card-premium::before,
-.card-premium::before,
-.scientific-card::before,
-.surface-depth::before,
-.section-frame::before,
-.glass-card::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-
-  background:
-    radial-gradient(
-      circle at top right,
-      rgba(154,191,132,0.08),
-      transparent 42%
-    );
-
-  opacity: 0.9;
-}
-
-.library-card-premium:hover,
-.card-premium:hover,
-.scientific-card:hover,
-.surface-depth:hover,
-.section-frame:hover,
-.glass-card:hover {
-  transform: translateY(-3px);
-
-  border-color: rgba(53,143,82,0.22);
-
-  box-shadow:
-    0 0 0 1px rgba(141,170,120,0.10),
-    0 20px 56px rgba(16,32,24,0.10),
-    0 4px 14px rgba(16,32,24,0.045);
-
-  background:
-    linear-gradient(
-      180deg,
-      rgba(255,255,255,0.96) 0%,
-      rgba(255,250,242,0.88) 100%
-    );
 }
 
 .library-card-premium h2,
@@ -144,7 +78,6 @@
   background: rgba(79,105,79,0.5);
 }
 
-.chip-readable,
 .evidence-pill-strong,
 .evidence-pill-moderate {
   display: inline-flex;
@@ -169,7 +102,6 @@
     color .22s ease;
 }
 
-.chip-readable:hover,
 .evidence-pill-strong:hover,
 .evidence-pill-moderate:hover {
   transform: translateY(-1px);
@@ -182,32 +114,6 @@
     min-height: 2.25rem;
     white-space: normal;
   }
-}
-
-.button-primary,
-.button-secondary {
-  transition:
-    transform .24s ease,
-    box-shadow .24s ease,
-    border-color .24s ease,
-    background .24s ease;
-}
-
-.button-primary:hover,
-.button-secondary:hover {
-  transform: translateY(-2px);
-}
-
-.button-primary:hover {
-  box-shadow:
-    0 16px 34px rgba(36,86,58,0.18),
-    inset 0 1px 0 rgba(255,255,255,0.16);
-}
-
-.button-secondary:hover {
-  box-shadow:
-    0 12px 30px rgba(16,32,24,0.08),
-    inset 0 1px 0 rgba(255,255,255,0.72);
 }
 
 .hero-shell {
@@ -257,29 +163,6 @@
     );
 }
 
-html.dark .library-card-premium,
-html.dark .card-premium,
-html.dark .scientific-card,
-html.dark .surface-depth,
-html.dark .surface-subtle,
-html.dark .section-frame,
-html.dark .glass-card {
-  background: var(--surface-card);
-  border-color: var(--border-soft);
-  box-shadow: var(--shadow-card-calm);
-}
-
-html.dark .library-card-premium:hover,
-html.dark .card-premium:hover,
-html.dark .scientific-card:hover,
-html.dark .surface-depth:hover,
-html.dark .section-frame:hover,
-html.dark .glass-card:hover {
-  background: var(--surface-card-strong);
-  border-color: var(--border-strong);
-  box-shadow: var(--shadow-card-calm-hover);
-}
-
 html.dark .library-card-premium h2,
 html.dark .library-card-premium h3,
 html.dark .card-premium h2,
@@ -301,7 +184,6 @@ html.dark .pull-quote-science {
 }
 
 html.dark .identity-kicker,
-html.dark .chip-readable,
 html.dark .evidence-pill-strong,
 html.dark .evidence-pill-moderate {
   background: var(--surface-subtle);
@@ -309,25 +191,7 @@ html.dark .evidence-pill-moderate {
   color: var(--text-primary);
 }
 
-@media (max-width: 768px) {
-  .library-card-premium,
-  .card-premium,
-  .scientific-card,
-  .surface-depth,
-  .surface-subtle,
-  .section-frame,
-  .glass-card {
-    border-radius: var(--radius-card-compact, 1.35rem);
-  }
-
-  .library-card-premium:hover,
-  .card-premium:hover,
-  .scientific-card:hover,
-  .surface-depth:hover,
-  .section-frame:hover,
-  .glass-card:hover {
-    transform: translateY(-2px);
-  }
+@media (max-width: 768px) {    
 
   .identity-meta,
   .identity-kicker {

--- a/styles/premium-library-polish.css
+++ b/styles/premium-library-polish.css
@@ -51,19 +51,6 @@ html:not(.dark) .goal-decision-experience {
   pointer-events: none;
 }
 
-.library-index-page .card-premium,
-.goal-decision-experience .card-premium {
-  position: relative;
-  overflow: hidden;
-  border-color: var(--polish-border);
-  background:
-    linear-gradient(180deg, var(--polish-card-bg-strong), var(--polish-card-bg));
-  box-shadow: var(--polish-shadow);
-}
-
-.library-index-page .card-premium:hover,
-.goal-decision-experience .card-premium:hover,
-.library-index-page .library-content-card:hover,
 .goal-decision-experience .goal-link-card:hover,
 .goal-decision-experience .goal-mini-card:hover {
   border-color: var(--polish-border-strong);
@@ -93,7 +80,6 @@ html:not(.dark) .goal-decision-experience {
 }
 
 .library-index-page .library-nav-card,
-.library-index-page .library-content-card,
 .goal-decision-experience .goal-link-card,
 .goal-decision-experience .goal-mini-card,
 .goal-decision-experience details,
@@ -105,7 +91,6 @@ html:not(.dark) .goal-decision-experience {
 }
 
 html:not(.dark) .library-index-page .library-nav-card,
-html:not(.dark) .library-index-page .library-content-card,
 html:not(.dark) .goal-decision-experience .goal-link-card,
 html:not(.dark) .goal-decision-experience .goal-mini-card,
 html:not(.dark) .goal-decision-experience details,
@@ -116,7 +101,6 @@ html:not(.dark) .goal-decision-experience #comparison-table .overflow-x-auto {
 }
 
 .library-index-page .library-nav-card,
-.library-index-page .library-content-card,
 .goal-decision-experience .goal-link-card,
 .goal-decision-experience .goal-mini-card {
   transition: transform 220ms ease, border-color 220ms ease, background 220ms ease, box-shadow 220ms ease;
@@ -126,16 +110,6 @@ html:not(.dark) .goal-decision-experience #comparison-table .overflow-x-auto {
 .goal-decision-experience .goal-mini-card h3,
 .goal-decision-experience .goal-link-card span:last-child {
   letter-spacing: -0.025em;
-}
-
-.library-index-page :is(.eyebrow-label, .section-label),
-.goal-decision-experience :is(.eyebrow-label, .section-label) {
-  color: #cbd8c0;
-}
-
-html:not(.dark) .library-index-page :is(.eyebrow-label, .section-label),
-html:not(.dark) .goal-decision-experience :is(.eyebrow-label, .section-label) {
-  color: #314b33;
 }
 
 .library-index-page p,
@@ -283,9 +257,8 @@ html:not(.dark) .library-index-page > section:last-child {
   }
 
   .library-index-page .library-nav-card,
-  .library-index-page .library-content-card,
-  .goal-decision-experience .goal-link-card,
-  .goal-decision-experience .goal-mini-card {
+.goal-decision-experience .goal-link-card,
+.goal-decision-experience .goal-mini-card {
     border-radius: 1rem;
   }
 }

--- a/styles/premium-surface-details.css
+++ b/styles/premium-surface-details.css
@@ -143,7 +143,6 @@ main summary {
 }
 
 /* Chips, pills, badges: add subtle luminosity and better contrast. */
-.chip-readable,
 .evidence-pill-strong,
 .evidence-pill-moderate,
 main :is([class*='rounded-full'][class*='text-']) {
@@ -151,7 +150,6 @@ main :is([class*='rounded-full'][class*='text-']) {
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.34);
 }
 
-html.dark .chip-readable,
 html.dark .evidence-pill-strong,
 html.dark .evidence-pill-moderate,
 html.dark main :is([class*='rounded-full'][class*='text-']) {

--- a/styles/premium-surfaces.css
+++ b/styles/premium-surfaces.css
@@ -5,12 +5,12 @@
  * same vocabulary: the elevation model from .hs-goal, the eyebrow with its
  * rule, the pill chip, and the two button treatments.
  *
- * On specificity: .card-premium and .eyebrow-label are each defined in six or
- * seven of the older stylesheets, some scoped like `.library-index-page
- * .card-premium` (0,2,0) and some like `html:not(.dark) :where(.card-premium)`
- * (0,1,1). Repeating the class raises these rules above that range without an
- * arms race of ever-longer selectors. It is deliberate, and it goes away when
- * those older layers are collapsed.
+ * This file owns those surfaces outright. The competing definitions that used
+ * to live in premium-cards, resonant-theme-lighting, editorial-content-surfaces,
+ * foundation-readability, premium-library-polish, and globals were removed in
+ * phase 4, so plain single-class selectors are enough here — no doubled classes
+ * and no specificity arms race. Keep it that way: style a card surface here,
+ * not in one of the older layers.
  */
 
 :root {
@@ -55,9 +55,15 @@ html.dark .goal-decision-experience {
 
 /* ---------- Cards ---------- */
 
-html .card-premium.card-premium,
-html .scientific-card.scientific-card,
-html .library-card-premium.library-card-premium {
+html .card-premium,
+html .scientific-card,
+html .library-card-premium,
+html .library-content-card,
+html .surface-depth,
+html .surface-subtle,
+html .section-frame,
+html .glass-card,
+html .mobile-reading-card {
   border: 1px solid color-mix(in srgb, var(--tone) 22%, transparent);
   border-radius: 1.25rem;
   background:
@@ -72,9 +78,15 @@ html .library-card-premium.library-card-premium {
 
 /* Dark surfaces swallow a 9% wash, so the tint is pushed harder there — the
    same correction the homepage goal cards make. */
-html.dark .card-premium.card-premium,
-html.dark .scientific-card.scientific-card,
-html.dark .library-card-premium.library-card-premium {
+html.dark .card-premium,
+html.dark .scientific-card,
+html.dark .library-card-premium,
+html.dark .library-content-card,
+html.dark .surface-depth,
+html.dark .surface-subtle,
+html.dark .section-frame,
+html.dark .glass-card,
+html.dark .mobile-reading-card {
   border-color: color-mix(in srgb, var(--tone) 28%, transparent);
   background:
     linear-gradient(158deg, color-mix(in srgb, var(--tone) 20%, transparent), transparent 68%),
@@ -83,33 +95,41 @@ html.dark .library-card-premium.library-card-premium {
 
 /* Only lift cards that are actually interactive; a static content panel that
    rises on hover reads as broken. */
-html a.card-premium.card-premium:hover,
-html a .card-premium.card-premium:hover,
-html button.card-premium.card-premium:hover,
-html .card-premium.card-premium:has(> a):hover,
-html .library-card-premium.library-card-premium:hover {
+html a.card-premium:hover,
+html a .card-premium:hover,
+html button.card-premium:hover,
+html .card-premium:has(> a):hover,
+html .library-card-premium:hover,
+html .library-content-card:hover {
   transform: translateY(-3px);
   border-color: color-mix(in srgb, var(--tone) 48%, transparent);
   box-shadow: var(--hs-lift-hover);
 }
 
 @media (prefers-reduced-motion: reduce) {
-  html .card-premium.card-premium,
-  html .scientific-card.scientific-card,
-  html .library-card-premium.library-card-premium {
+  html .card-premium,
+  html .scientific-card,
+  html .library-card-premium,
+  html .library-content-card,
+  html .surface-depth,
+  html .surface-subtle,
+  html .section-frame,
+  html .glass-card,
+  html .mobile-reading-card {
     transition: none;
   }
 
-  html a.card-premium.card-premium:hover,
-  html .library-card-premium.library-card-premium:hover {
+  html a.card-premium:hover,
+  html .library-card-premium:hover,
+  html .library-content-card:hover {
     transform: none;
   }
 }
 
 /* ---------- Eyebrows ---------- */
 
-html .eyebrow-label.eyebrow-label,
-html .section-label.section-label {
+html .eyebrow-label,
+html .section-label {
   display: inline-flex;
   align-items: center;
   gap: 0.6rem;
@@ -122,8 +142,8 @@ html .section-label.section-label {
 }
 
 /* The short rule that opens every homepage section label. */
-html .eyebrow-label.eyebrow-label::before,
-html .section-label.section-label::before {
+html .eyebrow-label::before,
+html .section-label::before {
   content: '';
   width: 1.6rem;
   height: 1px;
@@ -133,22 +153,22 @@ html .section-label.section-label::before {
 }
 
 @media (max-width: 480px) {
-  html .eyebrow-label.eyebrow-label,
-  html .section-label.section-label {
+  html .eyebrow-label,
+  html .section-label {
     gap: 0.5rem;
     font-size: 0.64rem;
     letter-spacing: 0.15em;
   }
 
-  html .eyebrow-label.eyebrow-label::before,
-  html .section-label.section-label::before {
+  html .eyebrow-label::before,
+  html .section-label::before {
     width: 1.1rem;
   }
 }
 
 /* ---------- Chips ---------- */
 
-html .chip-readable.chip-readable {
+html .chip-readable {
   border: 1px solid var(--hs-hairline);
   border-radius: 999px;
   background: var(--hs-surface);
@@ -160,27 +180,27 @@ html .chip-readable.chip-readable {
     box-shadow 200ms ease;
 }
 
-html a.chip-readable.chip-readable:hover,
-html button.chip-readable.chip-readable:hover {
+html a.chip-readable:hover,
+html button.chip-readable:hover {
   transform: translateY(-2px);
   border-color: var(--hs-gold);
   box-shadow: var(--hs-lift-hover);
 }
 
 @media (prefers-reduced-motion: reduce) {
-  html .chip-readable.chip-readable {
+  html .chip-readable {
     transition: none;
   }
 
-  html a.chip-readable.chip-readable:hover,
-  html button.chip-readable.chip-readable:hover {
+  html a.chip-readable:hover,
+  html button.chip-readable:hover {
     transform: none;
   }
 }
 
 /* ---------- Buttons ---------- */
 
-html .button-primary.button-primary {
+html .button-primary {
   position: relative;
   overflow: hidden;
   border: 1px solid rgba(18, 60, 47, 0.9);
@@ -191,34 +211,34 @@ html .button-primary.button-primary {
     0 14px 30px -12px rgba(18, 60, 47, 0.7);
 }
 
-html.dark .button-primary.button-primary {
+html.dark .button-primary {
   border-color: rgba(217, 178, 113, 0.42);
   background: linear-gradient(140deg, #256a52 0%, #17493a 55%, #123c2f 100%);
 }
 
-html .button-primary.button-primary:hover {
+html .button-primary:hover {
   transform: translateY(-2px);
   box-shadow:
     0 1px 0 rgba(255, 255, 255, 0.18) inset,
     0 20px 40px -12px rgba(18, 60, 47, 0.6);
 }
 
-html .button-secondary.button-secondary {
+html .button-secondary {
   border: 1px solid var(--hs-hairline-strong);
   background: var(--hs-surface-2);
   color: var(--hs-ink);
   backdrop-filter: blur(10px);
 }
 
-html .button-secondary.button-secondary:hover {
+html .button-secondary:hover {
   transform: translateY(-2px);
   border-color: var(--hs-gold);
   background: var(--hs-surface);
 }
 
 @media (prefers-reduced-motion: reduce) {
-  html .button-primary.button-primary:hover,
-  html .button-secondary.button-secondary:hover {
+  html .button-primary:hover,
+  html .button-secondary:hover {
     transform: none;
   }
 }

--- a/styles/premium-typography.css
+++ b/styles/premium-typography.css
@@ -1,0 +1,81 @@
+/* Premium typography — phase 3 of promoting the homepage design language.
+ *
+ * Phases 0-2 gave every route the homepage's tokens, canvas, and surfaces.
+ * What still separated a profile or hub page from the homepage was voice:
+ * headings in the body font, ledes at body size, and no rhythm between a
+ * section label and the heading it introduces.
+ *
+ * This sets voice, not scale. Pages size their own headings through utilities
+ * and the older readability layer, and those sizes are deliberate per template
+ * — so nothing here sets font-size on a heading. Family, tracking, wrap, and
+ * spacing only.
+ */
+
+html main :is(h1, h2, h3, h4) {
+  font-family: var(--font-fraunces), Fraunces, Georgia, serif;
+  color: var(--hs-ink);
+  text-wrap: balance;
+}
+
+html main h1 {
+  letter-spacing: -0.032em;
+  line-height: 1.02;
+}
+
+html main h2 {
+  letter-spacing: -0.028em;
+  line-height: 1.08;
+}
+
+html main :is(h3, h4) {
+  letter-spacing: -0.02em;
+  line-height: 1.18;
+}
+
+/* The opening paragraph under a page title carries the summary, so it reads a
+   step above body copy — the homepage lede treatment. */
+html main h1 + p {
+  color: var(--hs-body);
+  font-size: 1.05rem;
+  line-height: 1.65;
+  text-wrap: pretty;
+}
+
+@media (min-width: 640px) {
+  html main h1 + p {
+    font-size: 1.15rem;
+    line-height: 1.75;
+  }
+}
+
+/* An eyebrow introduces the heading beneath it; the default block margins let
+   them drift apart and read as two unrelated lines. */
+html main :is(.eyebrow-label, .section-label) + :is(h1, h2, h3) {
+  margin-top: 0.7rem;
+}
+
+/* Section rhythm. The homepage breathes at 2.75rem/5rem between sections; the
+   rest of the site inherited whatever each page happened to set. */
+html main .container-page > section + section,
+html main .container-page > .hs-section + .hs-section {
+  margin-top: 2.75rem;
+}
+
+@media (min-width: 640px) {
+  html main .container-page > section + section,
+  html main .container-page > .hs-section + .hs-section {
+    margin-top: 4rem;
+  }
+}
+
+/* Body links inside prose get the gold underline the homepage uses, rather
+   than the browser default sitting tight against the baseline. */
+html main p a[href]:not([class*='button']):not([class*='chip']) {
+  text-decoration-color: color-mix(in srgb, var(--hs-gold) 55%, transparent);
+  text-underline-offset: 0.18em;
+  transition: text-decoration-color 200ms ease;
+}
+
+html main p a[href]:not([class*='button']):not([class*='chip']):hover {
+  text-decoration-color: var(--hs-gold);
+}

--- a/styles/resonant-theme-lighting.css
+++ b/styles/resonant-theme-lighting.css
@@ -36,13 +36,7 @@ html.dark body {
   background: #0d1712;
 }
 
-.hero-shell,
-.card-premium,
-.surface-depth,
-.surface-subtle,
-.section-frame,
-.scientific-card,
-.library-card-premium {
+.hero-shell {
   position: relative;
   border-color: color-mix(in srgb, var(--border-soft) 72%, var(--resonance-emerald-strong));
   box-shadow: var(--resonance-card-shadow);
@@ -79,30 +73,6 @@ html.dark .hero-shell::before {
   z-index: 1;
 }
 
-.card-premium,
-.surface-depth,
-.surface-subtle,
-.section-frame,
-.scientific-card,
-.library-card-premium {
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(244, 247, 242, 0.82));
-}
-
-html.dark .card-premium,
-html.dark .surface-depth,
-html.dark .surface-subtle,
-html.dark .section-frame,
-html.dark .scientific-card,
-html.dark .library-card-premium {
-  background:
-    linear-gradient(180deg, rgba(26, 48, 40, 0.94), rgba(20, 38, 29, 0.9));
-}
-
-.card-premium:hover,
-.scientific-card:hover,
-.library-card-premium:hover,
-.library-content-card:hover,
 .goal-link-card:hover,
 .goal-mini-card:hover {
   border-color: color-mix(in srgb, var(--border-strong) 62%, var(--resonance-gold));
@@ -125,8 +95,6 @@ html.dark .identity-meta {
   text-shadow: 0 0 18px rgba(203, 216, 192, 0.16);
 }
 
-.button-primary,
-.hero-shell a[href]:not(.button-secondary),
 a.rounded-full.bg-brand-950,
 a.rounded-full.bg-brand-850,
 button.rounded-full.bg-brand-950,
@@ -171,12 +139,8 @@ button.rounded-full.border {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .card-premium:hover,
-  .scientific-card:hover,
-  .library-card-premium:hover,
-  .library-content-card:hover,
   .goal-link-card:hover,
-  .goal-mini-card:hover {
+.goal-mini-card:hover {
     transform: none !important;
   }
 }


### PR DESCRIPTION
## Summary

**Phase 3 — voice.** With tokens, canvas, and surfaces shared, what still read as a different site was typography: headings set in the body font at default tracking. Headings in `main` now take Fraunces with the homepage's tracking and balanced wrap, the paragraph under a page title reads as a lede, an eyebrow sits tight above the heading it introduces, sections inside `container-page` share one rhythm, and prose links get the gold underline.

Deliberately **no `font-size` on headings**. Templates size their own headings and those choices are per-template; this sets voice, not scale.

**Phase 4 — one owner per surface.** Each of `card-premium`, `eyebrow-label`, `chip-readable`, and the buttons was defined across six or seven stylesheets. That tangle is what forced the doubled-class selectors in phase 2. Now:

- `premium-surfaces.css` owns those surfaces outright, and the **doubled-class hack is gone** — plain single-class selectors.
- The older layers keep what is genuinely theirs: hero shells, evidence pills, identity rows, the profile-scoped mobile compaction, and the legacy dark-mode compat for `bg-white` utility markup.
- The new layer extends to the rest of the card family (`surface-depth`, `section-frame`, `glass-card`, `surface-subtle`, `mobile-reading-card`, `library-content-card`) so removing the old grouped rules left nothing unstyled.
- **Net 435 deletions against 83 insertions.**

Files still setting surface properties per hook, before → after: `card-premium` 7 → 2, `chip-readable` 4 → 2, `eyebrow-label` 3 → 1, buttons 4 → 1. What remains is scoped and intentional, not duplicate.

## Verification

- [x] `npm run lint`
- [x] `npm run check`
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs (only the `build-info.json` timestamp, reverted)
- [x] no generated file corruption
- [x] static export compatible — CSS only, plus one stylesheet import

Also ran `npm run verify:prebuild` — the chain that caught the last PR — clean. Route sweep after every step of the prune: 25 routes × 3 widths × 2 themes, 0 failed loads, 0 overflow. Phase 4 screenshots are pixel-identical to the pre-prune baseline, which is the point: the new layer was already winning, so this deletes dead weight rather than changing output. Contrast audit unchanged at 4 rows below AA, all pre-existing text over photography. `npm run typecheck` clean, `npm run test` 700/700.

## Risk Notes

- Phase 4 removed ~435 lines of live CSS. Parity is evidenced by screenshots across 25 routes in both themes, but the sweep does not cover every template — profile sub-pages, article layouts, and the tool clients are represented by samples, not exhaustively.
- Two rules were left alone on purpose: the profile-scoped mobile radius/padding in `herb-profile-polish.css` (a real template tweak, not duplication) and the legacy dark compat block in `globals.css` (still needed for utility-painted markup).
- Consolidating the remaining stylesheets into fewer *files* was not done. None is dead — each still owns real non-card styles — so merging them would be file shuffling with regression risk and no user-visible gain. The valuable half of phase 4, single ownership of the shared hooks, is complete.

---
_Generated by [Claude Code](https://claude.ai/code/session_013MZGLbtRWFs2Y6BSiAJYy7)_