### PR TITLE
Refresh magnesium glycinate guide with direct 2025 trial

### DIFF
--- a/content/articles/magnesium-glycinate.md
+++ b/content/articles/magnesium-glycinate.md
@@ -239,7 +239,7 @@ So the defensible statement is:
 
 For most people, the decision is less glamorous: choose a product that clearly lists **elemental magnesium**, is affordable enough to use consistently, and does not cause unacceptable GI effects.
 
-Deeper comparison: [Magnesium glycinate vs magnesium oxide](/comparisons/magnesium-glycinate-vs-magnesium-oxide/).
+For a broader comparison, see the [Magnesium Types Guide](/guides/other/magnesium-types-guide/).
 
 ---
 
@@ -433,7 +433,7 @@ Glycinate may be preferred when citrate causes loose stool, while citrate can be
     { ifYouWant: 'to compare glycinate with L-threonate', goTo: 'Glycinate vs L-Threonate for Sleep', href: '/guides/sleep/magnesium-glycinate-vs-l-threonate-for-sleep/' },
     { ifYouWant: 'to evaluate a magnesium plus L-theanine stack', goTo: 'Magnesium + L-Theanine Sleep Stack', href: '/articles/magnesium-l-theanine-sleep-stack/' },
     { ifYouWant: 'a wider insomnia decision guide', goTo: 'Sleep Guide', href: '/guides/sleep/' },
-    { ifYouWant: 'to compare glycinate with oxide', goTo: 'Magnesium Glycinate vs Magnesium Oxide', href: '/comparisons/magnesium-glycinate-vs-magnesium-oxide/' },
+    { ifYouWant: 'to compare magnesium with ashwagandha for sleep', goTo: 'Ashwagandha vs Magnesium for Sleep', href: '/guides/sleep/ashwagandha-vs-magnesium-for-sleep/' },
   ]}
 />
 

--- a/content/articles/magnesium-glycinate.md
+++ b/content/articles/magnesium-glycinate.md
@@ -1,513 +1,447 @@
 ---
 slug: magnesium-glycinate
-title: "Magnesium Glycinate: Sleep, Anxiety & Stress — What the Evidence Shows"
-description: "Evidence-based guide to magnesium glycinate for sleep, anxiety, and stress. Covers dosage (200-400 mg), GABA mechanisms, forms comparison, and what clinical trials actually found."
+title: "Magnesium Glycinate for Sleep: Benefits, Dose & 2025 Trial"
+description: "A 2026 evidence review of magnesium glycinate and bisglycinate for sleep, anxiety, dosage, absorption, side effects, kidney safety, and medication interactions."
 date: '2026-06-06'
-updatedAt: '2026-07-06'
-lastReviewed: '2026-07-06'
+updatedAt: '2026-08-01'
+lastReviewed: '2026-08-01'
 author: Will
 category: Anxiety & Sleep
 keywords:
   - magnesium glycinate
-  - magnesium for sleep
-  - magnesium for anxiety
+  - magnesium bisglycinate
+  - magnesium glycinate for sleep
+  - magnesium glycinate dosage
   - magnesium glycinate benefits
-  - magnesium dosage
-  - GABA receptor
-  - magnesium deficiency
-  - sleep supplement
-  - magnesium forms comparison
+  - magnesium for anxiety
+  - elemental magnesium
+  - magnesium glycinate side effects
   - magnesium glycinate vs citrate
 featured_image: ''
 tags:
   - magnesium
   - sleep
   - anxiety
-  - stress
+  - safety
   - evidence review
 profile_status: published
-ai_assisted: false
+ai_assisted: true
 faqs:
-  - question: "What is magnesium glycinate best used for?"
-    answer: "Magnesium glycinate is best for stress-related insomnia, nighttime muscle tension and jaw clenching, mild anxiety, and correcting the dietary magnesium shortfall that affects more than half of US adults. It is the preferred form for sleep and anxiety because it absorbs well without the laxative effect of oxide or citrate."
+  - question: "Does magnesium glycinate actually help sleep?"
+    answer: "Possibly, but the average effect appears modest. In a 2025 randomized trial, 250 mg of elemental magnesium as bisglycinate for four weeks produced a small additional improvement in insomnia-severity scores compared with placebo. The study did not show that magnesium glycinate works like a sleeping pill or treats chronic insomnia."
   - question: "How much magnesium glycinate should I take for sleep?"
-    answer: "The clinically effective range is 200-400 mg of elemental magnesium, taken 30-60 minutes before bed. Dose by the elemental magnesium number in the Supplement Facts panel, not the larger compound weight on the front of the bottle."
-  - question: "Does magnesium glycinate help anxiety and stress?"
-    answer: "For mild anxiety, the evidence is moderate: a systematic review found 12 of 18 trials showed reduced anxiety, strongest at 200-400 mg/day for at least four weeks and in people with low magnesium status. It works best as a low-risk adjunct, not a replacement for treatment of a diagnosed anxiety disorder."
+    answer: "The direct 2025 magnesium-bisglycinate trial used 250 mg of elemental magnesium daily. A cautious self-test often starts around 100–200 mg elemental magnesium in the evening. The adult upper limit is 350 mg per day from supplements and medications unless a clinician recommends more."
+  - question: "Is magnesium glycinate better than other forms for sleep?"
+    answer: "That has not been proven. Glycinate has one direct sleep trial and is often chosen for tolerability, but comparative human evidence showing it is more effective or better absorbed than citrate, chloride, or other soluble forms is limited."
+  - question: "Does magnesium glycinate help anxiety?"
+    answer: "Magnesium supplements may improve mild self-reported anxiety in some studies, particularly when magnesium intake or status is low. However, trials use different salts, doses, populations, and combination products, so the evidence should not be treated as proof that magnesium glycinate treats an anxiety disorder."
   - question: "How long does magnesium glycinate take to work?"
-    answer: "Some people notice easier sleep on the first night thanks to the glycine component. Anxiety and stress benefits usually take 2-4 weeks as tissue magnesium stores replete. If nothing changes after four weeks, magnesium deficiency may not be your main issue."
-  - question: "Why glycinate instead of other forms of magnesium?"
-    answer: "Glycinate is absorbed through amino-acid transport pathways, so it delivers high absorption with minimal laxative effect even at 400 mg elemental. The glycine it is bound to is also a calming neurotransmitter that independently supports sleep, making the chelate uniquely suited to sleep and anxiety."
-  - question: "Who should avoid magnesium glycinate?"
-    answer: "People with chronic kidney disease (GFR under 30), myasthenia gravis, or high-grade heart block should avoid supplemental magnesium without medical supervision, because the kidney clears magnesium and impaired clearance raises the risk of hypermagnesemia."
+    answer: "There is no well-established first-night timeline. The direct bisglycinate sleep trial measured a modest benefit after four weeks. Track a consistent dose for about two to four weeks rather than assuming a strong effect within an hour."
+  - question: "Who should be careful with magnesium glycinate?"
+    answer: "People with impaired kidney function need medical guidance because reduced magnesium clearance can cause toxicity. Magnesium also interferes with absorption of tetracycline and quinolone antibiotics and oral bisphosphonates, so dosing separation is important."
 references:
-  - title: "The effect of magnesium supplementation on primary insomnia in elderly: A double-blind placebo-controlled clinical trial"
-    authors: "Abbasi B, Kimiagar M, Sadeghniiat K, Shirazi MM, Hedayati M, Rashidkhani B"
-    year: "2012"
-    pmid: "22163214"
-    url: "https://pubmed.ncbi.nlm.nih.gov/22163214/"
+  - title: "Magnesium Bisglycinate Supplementation in Healthy Adults Reporting Poor Sleep: A Randomized, Placebo-Controlled Trial"
+    authors: "Schuster J, Cycelskij I, Lopresti A, Hahn A"
+    year: "2025"
+    pmid: "40918053"
+    doi: "10.2147/NSS.S524348"
+    url: "https://pubmed.ncbi.nlm.nih.gov/40918053/"
+  - title: "Examining the Effects of Supplemental Magnesium on Self-Reported Anxiety and Sleep Quality: A Systematic Review"
+    authors: "Rawji A, Peltier MR, Mourtzanakis K, et al."
+    year: "2024"
+    pmid: "38817505"
+    doi: "10.7759/cureus.59317"
+    url: "https://pubmed.ncbi.nlm.nih.gov/38817505/"
+  - title: "Oral magnesium supplementation for insomnia in older adults: a Systematic Review and Meta-Analysis"
+    authors: "Mah J, Pitre T"
+    year: "2021"
+    pmid: "33865376"
+    doi: "10.1186/s12906-021-03297-z"
+    url: "https://pubmed.ncbi.nlm.nih.gov/33865376/"
   - title: "The Effects of Magnesium Supplementation on Subjective Anxiety and Stress—A Systematic Review"
     authors: "Boyle NB, Lawton C, Dye L"
     year: "2017"
     pmid: "28352141"
+    doi: "10.3390/nu9050429"
     url: "https://pubmed.ncbi.nlm.nih.gov/28352141/"
-  - title: "Magnesium in Man: Implications for Health and Disease"
-    authors: "de Baaij JHF, Hoenderop JGJ, Bindels RJM"
-    year: "2015"
-    pmid: "26404370"
-    url: "https://pubmed.ncbi.nlm.nih.gov/26404370/"
-  - title: "Magnesium Status and Stress: The Vicious Circle Concept Revisited"
-    authors: "Pickering G, Mazur A, Trousselard M, Bienkowski P, Yaltsewa N, Amessou M, Noah L, Pouteau E"
-    year: "2020"
-    pmid: "33260549"
-    url: "https://pubmed.ncbi.nlm.nih.gov/33260549/"
-  - title: "Rapid recovery from major depression using magnesium treatment"
-    authors: "Eby GA, Eby KL"
-    year: "2006"
-    pmid: "16542786"
-    url: "https://pubmed.ncbi.nlm.nih.gov/16542786/"
-  - title: "Role of magnesium supplementation in the treatment of depression: A randomized clinical trial"
-    authors: "Tarleton EK, Littenberg B, MacLean CD, Kennedy AG, Daley C"
-    year: "2017"
-    pmid: "28526025"
-    url: "https://pubmed.ncbi.nlm.nih.gov/28526025/"
-  - title: "Oral magnesium supplementation for insomnia in older adults: a Systematic Review and Meta-Analysis"
-    authors: "Mah J, Pitre T"
-    year: "2021"
-    pmid: "31552798"
-    url: "https://pubmed.ncbi.nlm.nih.gov/31552798/"
-  - title: "Suboptimal magnesium status in the United States: are the health consequences underestimated?"
-    authors: "Rosanoff A, Weaver CM, Rude RK"
-    year: "2012"
-    pmid: "25540137"
-    url: "https://pubmed.ncbi.nlm.nih.gov/25540137/"
-  - title: "Effects of magnesium supplementation on blood pressure: a meta-analysis of randomized double-blind placebo-controlled trials"
-    authors: "Zhang X, Li Y, Del Gobbo LC, Rosanoff A, Wang J, Zhang W, Song Y"
-    year: "2016"
-    pmid: "26936737"
-    url: "https://pubmed.ncbi.nlm.nih.gov/26936737/"
-  - title: "Prophylaxis of migraine with oral magnesium: results from a prospective, multi-center, placebo-controlled and double-blind randomized study"
-    authors: "Peikert A, Wilimzig C, Köhne-Volland R"
-    year: "1996"
-    pmid: "22426836"
-    url: "https://pubmed.ncbi.nlm.nih.gov/22426836/"
   - title: "Bioavailability of magnesium diglycinate vs magnesium oxide in patients with ileal resection"
     authors: "Lindberg JS, Zobitz MM, Poindexter JR, Pak CY"
     year: "1990"
     pmid: "2407766"
     url: "https://pubmed.ncbi.nlm.nih.gov/2407766/"
-  - title: "Vitamin D and magnesium: a bidirectional relationship essential for human health"
-    authors: "Uwitonze AM, Razzaque MS"
-    year: "2018"
-    pmid: "29480918"
-    url: "https://pubmed.ncbi.nlm.nih.gov/29480918/"
-  - title: "Oral magnesium successfully relieves premenstrual mood changes"
-    authors: "Facchinetti F, Borella P, Sances G, Fioroni L, Nappi RE, Genazzani AR"
-    year: "1991"
-    pmid: "2067759"
-    url: "https://pubmed.ncbi.nlm.nih.gov/2067759/"
-  - title: "Oral magnesium supplementation improves insulin sensitivity and metabolic control in type 2 diabetic subjects: a randomized double-blind controlled trial"
-    authors: "Rodríguez-Morán M, Guerrero-Romero F"
-    year: "2003"
-    pmid: "12663588"
-    url: "https://pubmed.ncbi.nlm.nih.gov/12663588/"
+  - title: "Magnesium Fact Sheet for Health Professionals"
+    authors: "NIH Office of Dietary Supplements"
+    year: "2026"
+    url: "https://ods.od.nih.gov/factsheets/Magnesium-HealthProfessional/"
 ---
 
 <ScientificVerdict
-  recommendation="Yes"
-  bestFor="Stress-related insomnia|Nighttime muscle tension or jaw clenching|Mild anxiety|A likely dietary magnesium shortfall"
-  notFor="A fast, same-night sleeping pill|Severe or primary insomnia (sleep apnea, restless legs)|Kidney disease without medical supervision"
-  confidence="Moderate"
-  onset="Glycine calm within ~1 hr; full effect over 2–4 weeks"
+  recommendation="Consider"
+  bestFor="A four-week trial for mild self-reported sleep difficulty|Correcting low dietary magnesium intake|People who want a non-sedating option with realistic expectations"
+  notFor="Treating chronic insomnia or an anxiety disorder|Replacing evaluation for sleep apnea or restless legs|Kidney disease without medical guidance"
+  confidence="Limited–Moderate"
+  onset="No proven first-night effect"
   evaluationWindow="2–4 weeks"
 >
-Magnesium glycinate is a low-risk, well-absorbed first pick for stress- and tension-related sleep problems. It is not a sedative — it works best when a deficiency or an overactive nervous system is part of the picture, and it pairs well with better sleep habits rather than replacing them.
+Magnesium glycinate is reasonable to test, but the evidence is much narrower than the marketing. A 2025 randomized trial found a **small** improvement in insomnia severity after four weeks at 250 mg elemental magnesium daily. Evidence for anxiety is mixed and mostly evaluates magnesium generally—not glycinate specifically. The form may be convenient and tolerable, but superiority over other soluble magnesium salts has not been established.
 </ScientificVerdict>
 
 ## At a Glance
 
-Magnesium is a cofactor for over 300 enzymatic reactions — including several directly involved in sleep regulation, stress response, and neurotransmitter function. Yet national dietary surveys consistently find that 50–60% of US adults consume less than the Estimated Average Requirement ([Rosanoff 2012](#ref-25540137)). Magnesium glycinate (magnesium chelated to the amino acid glycine) is the preferred form for neurological and sleep applications because it delivers high absorption with minimal GI side effects — and glycine itself is an inhibitory neurotransmitter that independently improves sleep quality.
+Magnesium is an essential mineral involved in nerve signaling, muscle function, energy metabolism, glucose control, blood pressure, and hundreds of enzyme systems. That broad biological importance does **not** mean every magnesium supplement reliably improves sleep, anxiety, cramps, or stress.
 
-| Question | Answer |
+| Question | Evidence-based answer |
 |---|---|
-| Best fit | Stress-related insomnia, muscle tension, jaw clenching, anxiety, probable dietary deficiency |
-| Evidence level | Moderate for sleep quality and anxiety reduction |
-| Typical dose | 200–400 mg **elemental** magnesium, 30–60 min before bed |
-| Why glycinate specifically? | High absorption (25–40%), minimal laxative effect, glycine adds independent sleep benefit |
-| Onset | Some notice sleep improvement night 1; full effects over 2–4 weeks as intracellular stores replete |
-| Main caution | Kidney disease (GFR < 30 mL/min) — avoid without medical supervision |
-| Cost | $10–20/month at effective doses — one of the most affordable evidence-based sleep supplements |
-
+| Best-supported glycinate result | Small improvement in insomnia-severity scores after four weeks |
+| Direct trial dose | 250 mg **elemental magnesium** daily |
+| Sleep evidence overall | Suggestive, but heterogeneous and often low quality |
+| Anxiety evidence | Mixed; no strong glycinate-specific treatment evidence |
+| Better absorbed than oxide? | Possibly in some settings, but the classic comparison was in people with ileal resection |
+| Better than citrate for sleep? | Not established in head-to-head trials |
+| First-night effect | Not proven |
+| Main safety issue | Reduced kidney function and excessive supplemental dosing |
+| Major interactions | Tetracycline/quinolone antibiotics and oral bisphosphonates |
+| Adult supplemental upper limit | 350 mg/day from supplements and medications unless medically directed |
 
 ![Magnesium Glycinate](/images/guides/magnesium-for-sleep.jpg)
 
 ---
 
-## What to Expect: A Detailed Timeline
+## The Newest Direct Evidence: What the 2025 Trial Found
 
-Magnesium glycinate corrects a nutritional deficiency — not a neurotransmitter imbalance targeted by a drug. That means the timeline reflects gradual tissue repletion rather than acute pharmacology.
+The most relevant study is a 2025 randomized, double-blind, placebo-controlled trial of **155 adults aged 18–65** who reported poor sleep. Participants received either placebo or magnesium bisglycinate providing **250 mg of elemental magnesium daily** for four weeks.
 
-| Timeframe | What you might notice | What's happening physiologically |
-|-----------|----------------------|--------------------------------|
-| **Night 1** | Mild relaxation within ~1 hour. Some people fall asleep faster. The glycine component provides acute calming — this is the fastest-acting element. | Glycine binds to glycine receptors in the brainstem and spinal cord, producing mild inhibitory signaling. Magnesium begins distributing to extracellular fluid. |
-| **Week 1** | Sleep onset improves. Less muscle tension at night — jaw unclenching, shoulders dropping. If loose stool occurs, reduce dose (this is rarer with glycinate than with other forms but can happen at higher doses). | Intracellular magnesium levels begin rising. NMDA receptor blockade increases, reducing nocturnal neural excitability. |
-| **Week 2–4** | Sleep quality consolidates. Fewer 3 AM awakenings — magnesium's GABA-enhancing effects help maintain sleep architecture through the night. Morning anxiety may decrease as HPA axis tone normalizes. Those with genuine magnesium deficiency see the biggest changes here. | Tissue magnesium stores approach repletion. GABA-A receptor density normalizes. Cortisol diurnal rhythm begins to re-establish healthy pattern. |
-| **Month 2+** | Effects plateau at whatever level your individual magnesium status supports. Some taper to a lower maintenance dose (100–200 mg). Those combining with L-theanine or ashwagandha may notice synergistic effects. | Magnesium homeostasis is achieved. Further supplementation maintains rather than increases status. |
+### Result
 
-> **If you feel nothing after 4 weeks:** you may not be magnesium deficient. Magnesium works best when there's an actual deficiency to correct — it's not a drug that overrides normal physiology. Consider whether your sleep issue is behavioral (caffeine timing, screen use, inconsistent schedule), environmental (noise, light, temperature), or pathological (sleep apnea, restless legs). A magnesium RBC (red blood cell) test can confirm deficiency more reliably than serum magnesium, which is tightly regulated.
+Insomnia Severity Index scores improved in both groups:
 
-## What Magnesium Glycinate Actually Feels Like
+- Magnesium bisglycinate: **−3.9 points**
+- Placebo: **−2.3 points**
+- Between-group result: statistically significant at **p = 0.049**
+- Effect size: **small** (**Cohen’s d = 0.2**)
 
-Magnesium glycinate is subtle — more like a gentle nudge toward relaxation than a shove into sleep. Unlike sedative-hypnotics that impose sleep, magnesium enables the physiological conditions your body needs to transition naturally.
+That supports a possible benefit. It does not support calling magnesium glycinate a powerful sleep aid.
 
-People who benefit describe it as:
+### Important limitations
 
-- "I still need to wind down, but once I'm in bed, I actually stay asleep through the night"
-- "My jaw isn't clenched when I wake up anymore — I didn't even realize I was doing it"
-- "That 3 AM anxious awakening with a racing heart stopped happening within the first week"
-- "I didn't think it was working until I ran out and my sleep fell apart within 3 days"
+- Sleep was primarily assessed by questionnaire rather than polysomnography.
+- The placebo group improved substantially.
+- The average extra benefit was small.
+- The trial lasted only four weeks.
+- Participants had self-reported poor sleep, not necessarily a diagnosed sleep disorder.
+- Exploratory results suggested larger improvement among people with lower dietary magnesium intake, but that subgroup finding needs confirmation.
+- One author disclosed leadership of a contract research organization that receives nutraceutical-industry funding, and the studied supplement was manufactured by a commercial brand.
 
-**What it is not:**
-- A sleeping pill — won't override caffeine, acute stress, or a racing mind
-- A sedative — won't make you drowsy during the day at therapeutic doses
-- A quick fix — correcting a mineral deficiency takes weeks, not hours
-- A substitute for sleep hygiene — it enables better sleep physiology; it doesn't manufacture sleep from nothing
-
----
-
-## Best Use Cases
-
-Magnesium glycinate is a foundational, low-cost pick for a few clear situations:
-
-- **Stress-related insomnia** — trouble falling or staying asleep when you're wound up. It pairs naturally with a full [sleep](/guides/sleep/) routine.
-- **Nighttime muscle tension** — jaw clenching, tight shoulders, or leg cramps that surface at night.
-- **Mild [anxiety](/guides/anxiety/) and everyday [stress](/guides/best/supplements-for-stress/)** — especially if your diet is low in magnesium, which is common.
-- **Correcting a likely dietary shortfall** — more than half of US adults fall short of the recommended magnesium intake.
-
-It is not a focus or energy supplement, and it won't override caffeine, acute stress, or a sleep disorder like apnea.
-
-## For Sleep
-
-- **Strength of evidence:** Moderate — RCTs and meta-analyses in insomnia ([Abbasi 2012](#ref-22163214), [Mah 2021](#ref-31552798))
-- **Protocol:** 200–400 mg elemental magnesium (as glycinate), 30–60 minutes before bed
-- **What to track:** Time to fall asleep, 3 AM awakenings, nighttime jaw/muscle tension, morning grogginess (there should be none)
-- **Expected result:** Easier sleep onset and steadier sleep through the night, building over 2–4 weeks
-
-The [glycine](/compounds/glycine/) bound to the magnesium is itself a calming neurotransmitter that lowers core body temperature and supports sleep, which is why glycinate outperforms other forms here. For a ready-made combination, see the [magnesium + L-theanine sleep stack](/articles/magnesium-l-theanine-sleep-stack/), and the full [sleep guide](/guides/sleep/) for the wider toolkit.
-
-## For Anxiety & Stress
-
-- **Strength of evidence:** Moderate for mild anxiety; strongest when magnesium status is low
-- **Protocol:** 200 mg morning + 200 mg evening for daytime coverage, or a single evening dose
-- **What to track:** Baseline tension, stress reactivity, sleep knock-on effects
-- **Expected result:** A gradual easing of everyday [stress](/guides/best/supplements-for-stress/) and mild [anxiety](/guides/anxiety/) over 4+ weeks — a low-risk adjunct, not a replacement for treating a diagnosed anxiety disorder
-
-A systematic review found reduced anxiety in 12 of 18 trials, strongest at 200–400 mg/day for at least four weeks ([Boyle 2017](#ref-28352141)). Because magnesium and cortisol deplete each other in a feedback loop ([Pickering 2020](#ref-33260549)), correcting a shortfall can help settle an overactive stress response. For chronic, cortisol-driven stress, it stacks well with [ashwagandha](/articles/ashwagandha/); for acute, in-the-moment nerves, pair it with fast-acting [L-theanine](/articles/l-theanine/).
-
----
-
-## The Clinical Evidence: Study-by-Study
-
-> **Key finding:** Multiple RCTs and meta-analyses show magnesium improves sleep latency, sleep efficiency, and anxiety scores. Effect sizes are moderate but clinically meaningful — comparable to the benefits of improved sleep hygiene or low-dose melatonin — without dependency, tolerance, or morning hangover.
-
-### Evidence Summary Table
-
-| Study | Design | n | Population | Duration | Dose/Form | Primary Outcomes | Quality |
-|---|---|---|---|---|---|---|---|
-| [Abbasi 2012](#ref-22163214) | RCT, DB, PC | 46 | Elderly with primary insomnia (mean age 65) | 8 weeks | 500 mg elemental (oxide) | Sleep latency –17 min; sleep efficiency ↑; insomnia severity ↓; cortisol ↓; melatonin ↑ | **Moderate** |
-| [Mah 2021](#ref-31552798) | Meta-analysis | ~400 pooled | Older adults with insomnia | 4–8 weeks | Mixed forms | Sleep efficiency ↑; sleep onset latency ↓; early morning awakening ↓; ISI scores ↓ | **Moderate** |
-| [Boyle 2017](#ref-28352141) | Systematic review | ~2,000 pooled | Mixed populations | 4–12 weeks | Mixed forms | 12/18 studies: anxiety significantly ↓; strongest at 200–400 mg/day × 4+ weeks | **Moderate** |
-| [Tarleton 2017](#ref-28526025) | RCT, crossover | 126 | Adults with mild-moderate depression + low Mg intake | 6 weeks per phase | 248 mg elemental (chloride) | PHQ-9 depression scores –6.0 points vs –0.9 placebo (P<0.001); effect within 2 weeks | **Moderate-high** |
-| [Pickering 2020](#ref-33260549) | Narrative review | N/A | Stressed populations | N/A | Mixed | Confirmed bidirectional Mg-cortisol relationship; stress depletes Mg, low Mg amplifies stress | **Moderate** (mechanistic) |
-
-### The Landmark Sleep Trial: Abbasi 2012
-
-46 Iranian adults (mean age 65) with clinically documented primary insomnia were randomized to 500 mg elemental magnesium daily (as magnesium oxide) or placebo for 8 weeks. This is the most rigorous single-trial evidence for magnesium as a sleep intervention.
-
-Results:
-- **Sleep onset latency:** Reduced by a mean of 17.3 minutes in the magnesium group
-- **Sleep efficiency:** Significantly improved (percentage of time in bed actually asleep)
-- **Total sleep time:** Increased significantly
-- **Serum cortisol:** Decreased significantly — consistent with HPA axis modulation
-- **Serum renin:** Decreased — further supporting reduced sympathetic activation
-- **Serum melatonin:** Increased — magnesium is a cofactor for enzymes in melatonin synthesis
-- **Insomnia Severity Index:** Significantly improved
-
-Methodological note: This trial used **magnesium oxide** — the form with the worst absorption (~4%). Head-to-head bioavailability work found the diglycinate (glycinate) chelate is absorbed substantially better than oxide ([Lindberg 1990](#ref-2407766)). The fact that significant effects were achieved despite poor bioavailability strongly suggests a glycinate formulation at equivalent elemental doses would produce equal or superior results. This is the most common critique of the magnesium sleep literature: the best-designed trials used the worst-absorbed form.
-
-### Anxiety: Boyle 2017 Systematic Review
-
-Boyle, Lawton, and Dye systematically reviewed 18 randomized studies examining magnesium supplementation and anxiety. Key findings:
-
-- **12 of 18 studies** showed significant anxiety reduction with magnesium
-- The most consistent effects came from **200–400 mg/day for 4+ weeks**
-- Benefits were most pronounced in populations with probable or documented magnesium deficiency
-- Effect sizes were moderate — not comparable to prescription anxiolytics, but clinically meaningful as a low-risk adjunct
-- Heterogeneity in magnesium forms, doses, populations, and outcome measures limited meta-analytic pooling
-
-The review concluded that magnesium supplementation "may be beneficial for mild anxiety" and is "a reasonable low-risk adjunct" particularly for individuals with dietary deficiency — a conclusion that accurately reflects both the evidence and the appropriate clinical positioning.
-
-### Depression: Tarleton 2017 Crossover Trial
-
-126 American adults with mild-to-moderate depression (PHQ-9 scores 5–19) and self-reported low dietary magnesium intake were randomized in a crossover design to 248 mg elemental magnesium daily (as magnesium chloride) or placebo for 6 weeks per phase.
-
-Key results:
-- **PHQ-9 scores:** Decreased by 6.0 points during the magnesium phase vs. 0.9 points during placebo (P < 0.001)
-- **Effect onset:** Measurable improvements within 2 weeks — faster than the typical 4–6 week antidepressant onset
-- **Effect independence:** Benefits did not differ by baseline magnesium status, age, sex, or concurrent antidepressant use
-- **Tolerability:** Magnesium chloride was well-tolerated at 248 mg/day; GI side effects were minimal
-
-This is one of the more methodologically robust nutrient-mood trials. The crossover design (each participant serves as their own control) eliminates between-subject variability. The rapid onset (2 weeks) is mechanistically consistent with NMDA receptor modulation — the same mechanism through which ketamine produces rapid antidepressant effects, albeit at a much lower magnitude.
-
-### The Deficiency Problem: Rosanoff 2012
-
-Rosanoff, Weaver, and Rude conducted a sweeping analysis of NHANES dietary data spanning four decades. Their findings are the epidemiological foundation for magnesium supplementation:
-
-- **>50% of US adults** consume less magnesium than the Estimated Average Requirement
-- Large segments of adolescents, elderly, and female populations consume only **60–70% of the EAR**
-- Population magnesium intake has trended **steadily downward** over 40 years, tracking the rise of processed-food diets
-- Modern agricultural soil depletion has reduced magnesium content in crops by an estimated 15–25% compared to mid-20th century values
-- Refined grains lose up to **80%** of their magnesium content during processing
-
-The clinical implication: most people considering magnesium supplementation are not taking a drug — they're correcting a genuine nutritional gap. This fundamentally changes the risk-benefit calculus compared to pharmacological sleep or anxiety interventions.
-
-<EvidenceConfidence
-  grade="Moderate"
-  whyNotHigher={['The strongest sleep and anxiety effects are in people who were low in magnesium to begin with', 'Trials use different forms, doses, and populations, and many are small', 'Little head-to-head data compares glycinate specifically against other forms']}
-  whyNotLower={['Multiple human trials support benefits for sleep quality and stress', 'The biological role of magnesium in the nervous system is well understood', 'Deficiency is genuinely common, and the safety and cost profile is very favorable']}
-  practicalTakeaway="A low-risk, affordable first step worth a 2–4 week trial — especially if your diet is light on magnesium. It supports better sleep habits rather than replacing them, and it is not a treatment for primary insomnia or a diagnosed anxiety disorder."
+<RealityCheck
+  title="What the trial means in real life"
+  expectations={['A strong sedative effect on the first night', 'Guaranteed deeper sleep', 'A cure for chronic insomnia']}
+  reality={['A small average improvement over four weeks', 'Some people may respond more than others', 'Low magnesium intake may matter, but the subgroup result is not definitive']}
+  bottomLine="Magnesium glycinate is a reasonable experiment, not a replacement for diagnosing why sleep is poor."
 />
 
 ---
 
-<CollapsibleDetails title="How It Works — Complete Mechanism (tap to expand)" defaultOpen={false}>
+## Does Magnesium Glycinate Help Sleep?
 
-## How It Works: The Complete Mechanism
+### The honest answer
 
-Magnesium influences sleep and anxiety through four interconnected mechanisms, each operating on a different timescale and biological level.
+**Maybe, modestly.**
 
-### 1. GABA-A Receptor Potentiation
+A 2021 meta-analysis in older adults found that oral magnesium shortened sleep-onset latency by about 17 minutes, but it included only three small trials, all with moderate-to-high risk of bias, and rated the evidence low to very low quality. Those studies did not establish that glycinate was the best form.
 
-Gamma-aminobutyric acid (GABA) is the brain's primary inhibitory neurotransmitter. GABA-A receptors are ligand-gated chloride channels — when activated, chloride ions flow into the neuron, hyperpolarizing the membrane and reducing the probability of firing. This is the same receptor system targeted by benzodiazepines, barbiturates, alcohol, and most prescription sleep medications.
+A 2024 systematic review found that five of eight included sleep studies reported improvement in at least one outcome. However, doses, salts, populations, durations, and co-ingredients differed enough that firm conclusions were not possible.
 
-Magnesium enhances GABAergic signaling through two routes:
-- **Direct allosteric potentiation:** Magnesium ions bind to a site on the GABA-A receptor complex distinct from the benzodiazepine binding site, increasing chloride conductance at physiological concentrations
-- **Receptor density preservation:** In animal models, magnesium deficiency leads to measurable reductions in GABA-A receptor density in the hippocampus and cortex; repletion normalizes receptor expression
+The 2025 bisglycinate trial improves the formulation-specific evidence, but one small-effect trial is not enough to declare glycinate the “gold standard.”
 
-The anxiolytic effects of magnesium in rodent behavioral models (elevated plus maze, light-dark box) are blocked by bicuculline (a GABA-A antagonist), confirming GABAergic dependence. The glycine component of magnesium glycinate provides complementary inhibitory signaling through glycine receptors in the brainstem and spinal cord — a distinct mechanism that partially explains why the glycinate form is particularly effective for sleep.
+### What has not been established
 
-### 2. NMDA Receptor Blockade
+Current human evidence does not prove that magnesium glycinate:
 
-At resting membrane potentials, a magnesium ion sits within the NMDA glutamate receptor ion channel, physically blocking calcium and sodium influx. This voltage-dependent Mg²⁺ block is a critical brake on excitatory neurotransmission.
+- reliably works within 30–60 minutes;
+- prevents 3 a.m. awakenings;
+- normalizes sleep architecture;
+- increases slow-wave sleep;
+- lowers nighttime cortisol in typical users;
+- produces a clinically meaningful glycine effect at ordinary product doses;
+- outperforms citrate, chloride, malate, or threonate for sleep;
+- treats sleep apnea, restless legs syndrome, or chronic insomnia.
 
-When magnesium levels fall, the NMDA block weakens, lowering the threshold for glutamate-driven excitation. This manifests as:
-- Increased neuronal firing at rest (racing thoughts, hyperarousal)
-- Heightened anxiety and exaggerated stress reactivity
-- Reduced slow-wave sleep — which depends on thalamocortical NMDA rhythm regulation
-- Chronic overactivation → neuroinflammation and oxidative stress
+### Who may be more likely to benefit
 
-The NMDA-modulating dimension of magnesium has gained attention because ketamine — a non-competitive NMDA antagonist — produces rapid antidepressant effects through this same pathway. Magnesium's NMDA blockade at physiological concentrations is far weaker than ketamine's, but it operates continuously rather than acutely, providing tonic inhibition rather than phasic blockade.
+A trial may make more sense when one or more of these apply:
 
-### 3. HPA Axis and Cortisol Regulation
+- Dietary magnesium intake is low.
+- A medication or medical condition increases magnesium loss.
+- Sleep difficulty is mild rather than severe.
+- The goal is a subtle improvement rather than sedation.
+- The person can test one variable consistently for several weeks.
 
-Magnesium and cortisol are locked in a bidirectional vicious cycle:
-- **Stress → cortisol release →** cortisol increases renal magnesium excretion
-- **Magnesium depletion →** impaired negative feedback on CRH release in the hypothalamus → further HPA axis activation → more cortisol → more magnesium loss
-
-Breaking this cycle requires adequate magnesium to restore the negative feedback sensitivity. The paraventricular nucleus of the hypothalamus contains magnesium-dependent enzymes that regulate corticotropin-releasing hormone (CRH) release. When magnesium is sufficient, CRH release is appropriately suppressed at the end of a stress response. When magnesium is deficient, CRH continues to be released, sustaining the HPA activation.
-
-This mechanism explains why magnesium benefits often emerge over weeks rather than hours: tissue magnesium stores must be repleted before HPA axis tone can normalize.
-
-### 4. Muscle Relaxation via Calcium Channel Blockade
-
-Magnesium acts as a physiological calcium channel antagonist in both vascular smooth muscle and skeletal muscle. In skeletal muscle, calcium influx triggers the actin-myosin cross-bridge cycling that produces contraction. Magnesium competitively inhibits calcium entry, reducing baseline muscle tone.
-
-This is why magnesium glycinate users frequently report reduced jaw clenching, shoulder tension, and nocturnal muscle cramps — effects that are mechanistically distinct from the central nervous system actions described above and complement them in a sleep context.
-
-### Why Glycinate Specifically?
-
-The glycine molecule bound to magnesium in the glycinate chelate is not pharmacologically inert. Glycine is:
-- An **inhibitory neurotransmitter** at strychnine-sensitive glycine receptors in the spinal cord and brainstem
-- A **co-agonist** at NMDA receptors (facilitatory in forebrain, but the net effect of glycine at supplemental doses is calming)
-- Demonstrated in small Japanese RCTs to **lower core body temperature and improve subjective sleep quality** at doses of 1–3 g
-
-When you take 400 mg of elemental magnesium as magnesium glycinate, you're also consuming approximately 2–3 g of [glycine](/compounds/glycine/). This dual action — magnesium's GABAergic and NMDA-modulating effects plus glycine's independent sleep-promoting effects — makes the glycinate chelate uniquely suited for sleep applications.
-
-</CollapsibleDetails>
-
-## Forms Comparison: Every Magnesium, Ranked
-
-| Form | Elemental Mg % | Absorption | GI Tolerability | Best Clinical Use | Cost |
-|---|---|---|---|---|---|
-| **Magnesium glycinate** | ~14–18% | Very good (25–40%) | **Excellent** — minimal laxative effect even at 400 mg elemental | Sleep, anxiety, stress, PMS, migraine prophylaxis, high-dose sustained use | $$ |
-| Magnesium threonate | ~7–8% | Good (brain-targeted) | Good | Cognitive function, hippocampal plasticity; crosses BBB more effectively in animal models | $$$$ |
-| Magnesium taurate | ~9% | Good | Very good | Cardiovascular; taurine adds cardioprotective effects | $$$ |
-| Magnesium malate | ~11% | Good | Good | Muscle fatigue, fibromyalgia; malic acid supports ATP production | $$ |
-| Magnesium citrate | ~16% | Good (20–30%) | Moderate (laxative at >200 mg) | Constipation; budget option if GI tolerated | $ |
-| Magnesium chloride | ~12% | Good | Moderate | Topical (spray, bath); oral use in some clinical trials | $ |
-| Magnesium oxide | ~60% | **Poor (≤4%)** | Poor (strong laxative) | Constipation only; do not use for sleep — bioavailability too low | $ |
-| Magnesium sulfate | ~10% | Poor orally | Poor (strong laxative) | IV (eclampsia, arrhythmia); Epsom salt baths (transdermal absorption debated) | $ |
-
-**The practical hierarchy for sleep and anxiety:**
-1. **Glycinate** — gold standard. Best absorption-to-tolerability ratio. Glycine synergy.
-2. **Threonate** — interesting for cognition but significantly more expensive per mg of elemental magnesium. Animal data on brain penetration is impressive; human comparative sleep data vs. glycinate is limited.
-3. **Citrate** — reasonable budget alternative if you can tolerate the GI effects at effective doses (200+ mg elemental)
-4. **Everything else** — not optimized for sleep. Oxide is effectively useless for this purpose despite being the most common form in drugstore "magnesium" products.
+Persistent loud snoring, witnessed pauses in breathing, severe daytime sleepiness, uncomfortable leg urges, or months of insomnia deserve evaluation rather than another supplement stack.
 
 ---
 
-## Dosage and Timing
+## Anxiety and Stress: Keep the Claim Form-Agnostic
 
-### How Much to Take
+Magnesium and stress biology are linked, and several supplementation studies report improvements in self-rated anxiety or stress. Still, the literature has recurring problems:
 
-The effective range from clinical trials: **200–400 mg elemental magnesium per day**. Since magnesium glycinate is ~14–18% elemental magnesium by weight, this translates to:
+- Many trials are small.
+- Some combine magnesium with vitamin B6 or other active ingredients.
+- Different magnesium salts are treated as interchangeable.
+- Baseline magnesium status is often not measured well.
+- Anxiety outcomes are usually secondary or self-reported.
+- Diagnosed anxiety disorders are not the same as everyday stress.
 
-| Target elemental dose | Magnesium glycinate (compound weight) | Typical capsule equivalent |
+The 2017 systematic review found suggestive benefit but concluded that existing evidence quality was poor. The 2024 review was somewhat more positive, yet still emphasized heterogeneity and the need for larger randomized trials.
+
+**Practical framing:** magnesium glycinate may be a low-risk adjunct for mild symptoms in someone with low intake, but it should not be described as a treatment for generalized anxiety, panic disorder, obsessive-compulsive disorder, or trauma-related symptoms.
+
+---
+
+## Why Glycinate Specifically?
+
+“Magnesium glycinate” and “magnesium bisglycinate” usually refer to magnesium bound to glycine. The names are often used interchangeably, although product chemistry and the amount of unreacted or “buffered” material can vary.
+
+### What supports choosing it
+
+- It now has one direct randomized sleep trial.
+- Many users choose it because they find it easier on the stomach.
+- It supplies a meaningful amount of magnesium without being marketed primarily as a laxative.
+- It is widely available and easy to dose by elemental magnesium.
+
+### What does not support calling it superior
+
+The often-cited 1990 bioavailability study compared magnesium diglycinate with oxide in **patients with ileal resection**. That is useful evidence for a malabsorption setting, but it cannot establish a universal absorption percentage or prove superiority in healthy adults.
+
+Laboratory digestion studies can estimate magnesium release from products, but in-vitro release is not the same as human absorption, symptom improvement, or better sleep.
+
+The claim that glycinate uses a special amino-acid pathway and therefore avoids diarrhea at high doses is plausible, yet robust head-to-head human tolerability trials are sparse.
+
+### The “glycine synergy” problem
+
+Standalone glycine sleep studies commonly use gram-level doses. The amount of glycine delivered by a magnesium glycinate product depends on the exact compound and serving, and there is little direct evidence separating the effect of the glycine ligand from the magnesium itself.
+
+So the defensible statement is:
+
+> Glycine may contribute, but the size and clinical importance of that contribution have not been demonstrated in magnesium-glycinate trials.
+
+---
+
+## Comparing Common Magnesium Forms
+
+| Form | What is reasonably supported | What is often overstated |
 |---|---|---|
-| 200 mg | ~1,100–1,400 mg | 1–2 capsules |
-| 300 mg | ~1,700–2,100 mg | 2–3 capsules |
-| 400 mg | ~2,200–2,900 mg | 3–4 capsules |
+| **Glycinate / bisglycinate** | Direct 2025 sleep trial; commonly chosen for tolerability | Proven best absorption, no diarrhea, unique sleep synergy |
+| **Citrate** | Soluble and generally better absorbed than oxide; can loosen stool | Automatically inferior for sleep |
+| **Oxide** | High elemental percentage; useful in some laxative/antacid contexts | “Only 4% absorbed” as a universal fixed number |
+| **Chloride / lactate / aspartate** | Soluble forms with evidence of reasonable absorption | Automatically worse because they sound less premium |
+| **L-threonate** | Some emerging human sleep/cognition studies | Proven superior brain delivery or better sleep than glycinate in humans |
+| **Malate / taurate** | Chemically plausible uses | Form-specific clinical benefits that exceed the magnesium evidence |
 
-**How to read labels:** Many magnesium glycinate products list the compound weight on the front (e.g., "1,000 mg magnesium glycinate") and the elemental magnesium in the Supplement Facts panel (e.g., "Magnesium (as magnesium glycinate) 140 mg"). Dose based on the **elemental** number, not the compound weight.
+For most people, the decision is less glamorous: choose a product that clearly lists **elemental magnesium**, is affordable enough to use consistently, and does not cause unacceptable GI effects.
 
-### Timing Protocol
+Deeper comparison: [Magnesium glycinate vs magnesium oxide](/comparisons/magnesium-glycinate-vs-magnesium-oxide/).
 
-| Goal | Protocol | Rationale |
-|---|---|---|
-| **Sleep onset difficulty** | 200–400 mg elemental, 30–60 min before bed | Glycine component works within 30–60 min; magnesium's GABAergic effects support sleep architecture through the night |
-| **Sleep maintenance (3 AM awakenings)** | 200–400 mg elemental with dinner (1–2 hours before bed) | Earlier dosing allows magnesium to reach peak CNS concentrations by the time nocturnal awakenings typically occur |
-| **Daytime anxiety** | 200 mg morning + 200 mg evening | Split dosing provides more consistent GABAergic and NMDA-modulating tone throughout the day |
-| **Muscle tension / jaw clenching** | 200–400 mg evening dose | Magnesium's calcium-channel-blocking effect reduces baseline muscle tone during sleep when clenching occurs |
+---
 
-### Starting Protocol
+## Dose: Elemental Magnesium Is the Number That Matters
 
-**Week 1:** Start at 200 mg elemental magnesium (as glycinate) with dinner or 30–60 minutes before bed. This allows assessment of individual GI tolerability and initial sleep response.
+The front of a bottle may say “2,000 mg magnesium glycinate,” while the Supplement Facts panel shows only 200–300 mg of actual magnesium. Dose by the line that says **Magnesium — X mg**, not by the chelate’s total compound weight.
 
-**Week 2:** Increase to 400 mg if 200 mg was well-tolerated and sleep response was partial. If morning grogginess occurs, move the dose earlier (with dinner rather than right before bed).
+### A conservative self-test
 
-**Week 4:** Assess. If sleep has improved meaningfully, maintain at the effective dose. If no improvement, magnesium deficiency is unlikely to be the primary driver of your sleep issue — consider behavioral interventions, sleep study (if apnea is suspected), or other supplement pathways.
+| Step | Elemental magnesium | Timing | Purpose |
+|---|---:|---|---|
+| Start | 100–200 mg/day | With dinner or in the evening | Check GI and individual response |
+| Direct-trial target | 250 mg/day | Use consistently | Matches the 2025 bisglycinate study |
+| Reassess | After 2–4 weeks | Same dose and routine | Decide whether the change is meaningful |
+| Higher dosing | Above 350 mg/day from supplements | Clinician-guided | Exceeds the adult supplemental UL |
+
+The U.S. adult Tolerable Upper Intake Level is **350 mg/day from supplements and medications**. It does not include magnesium naturally present in food. The UL was set mainly around diarrhea and GI effects, not because 351 mg is suddenly toxic; nevertheless, routinely recommending 400 mg to everyone ignores the established limit and differences in kidney function, medication use, and total intake.
+
+### Timing
+
+The direct trial tested daily use, not a precise bedtime pharmacology window. Taking it with dinner or later in the evening is reasonable for convenience, but evidence does not establish that 30, 60, or 120 minutes before bed is uniquely effective.
+
+Food may improve stomach comfort. Consistency matters more than chasing an exact clock time.
 
 <CommonMistakes
   items={[
-    { mistake: 'Buying magnesium oxide for sleep', whyItMatters: "Oxide is the most common drugstore form but is barely absorbed (~4%) and mostly acts as a laxative.", betterApproach: 'Choose glycinate (or citrate if budget-limited) and dose by elemental magnesium.' },
-    { mistake: 'Dosing by the big number on the front of the bottle', whyItMatters: '"1,000 mg magnesium glycinate" may contain only ~140 mg of actual elemental magnesium.', betterApproach: 'Read the Supplement Facts panel and target 200–400 mg elemental.' },
-    { mistake: 'Quitting after two or three nights', whyItMatters: 'Beyond the first-night glycine calm, the real benefits build as tissue stores replete over weeks.', betterApproach: 'Give it a consistent 2–4 week trial before judging it.' },
-    { mistake: 'Expecting a sleeping-pill effect', whyItMatters: 'Magnesium enables better sleep physiology; it will not override caffeine, stress, or a sleep disorder.', betterApproach: 'Pair it with sleep hygiene and match it to tension/deficiency-driven sleep problems.' },
+    { mistake: 'Dosing by the large front-label number', whyItMatters: 'That number may be the full chelate weight rather than elemental magnesium.', betterApproach: 'Use the elemental magnesium amount in Supplement Facts.' },
+    { mistake: 'Jumping straight to 400 mg', whyItMatters: 'That exceeds the adult supplemental UL and raises the chance of GI effects.', betterApproach: 'Start around 100–200 mg and only increase with a clear reason.' },
+    { mistake: 'Expecting a first-night knockout effect', whyItMatters: 'The direct trial found a small average change after four weeks.', betterApproach: 'Track sleep consistently for two to four weeks.' },
+    { mistake: 'Assuming glycinate is proven superior', whyItMatters: 'Head-to-head clinical evidence is sparse.', betterApproach: 'Choose based on elemental dose, tolerability, cost, and evidence—not form mythology.' },
   ]}
 />
 
 ---
 
-## Beyond Sleep & Anxiety: Magnesium's Full Application Spectrum
+## How to Test It Without Fooling Yourself
 
-Magnesium glycinate's benefits extend past sleep and anxiety, but these are secondary applications with varying evidence strength.
+Sleep naturally varies from night to night, and buying a new supplement can create expectation effects. Use a small personal protocol:
 
-| Application | Evidence | Protocol | Magnitude of Effect |
-|---|---|---|---|
-| **Blood pressure** | Meta-analysis of 34 RCTs ([Zhang 2016](#ref-26936737)): –2.0 mmHg systolic, –1.8 diastolic at 368 mg/day median dose | 300–400 mg/day for 3+ months | Modest but real — a 2 mmHg population-wide systolic reduction would reduce stroke mortality ~10% |
-| **Migraine prevention** | [Peikert 1996](#ref-22426836) (RCT, n=81): attack frequency –41.6% vs –15.8% placebo at 3 months | 400–600 mg/day elemental | Comparable to some prescription preventives; American Academy of Neurology and American Headache Society recommend as first-line option |
-| **Depression (mild-moderate)** | [Tarleton 2017](#ref-28526025) (crossover, n=126): PHQ-9 –6.0 points vs –0.9 placebo at 6 weeks | 248 mg/day elemental | Effect size comparable to some SSRIs in mild depression; onset within 2 weeks |
-| **PMS** | [Facchinetti 1991](#ref-2067759) (RCT): significant mood symptom reduction | 200–400 mg/day throughout cycle | Addresses anxiety, sleep, and mood symptoms simultaneously in PMS-overlap populations |
-| **Exercise recovery** | Athletes lose magnesium through sweat and urine and have 10–20% higher requirements; supplementation may lower post-exercise cortisol | 300–400 mg/day | Evidence is preliminary and mostly in athletes with low baseline status |
-| **Insulin sensitivity** | [Rodríguez-Morán & Guerrero-Romero 2003](#ref-12663588) (RCT in T2DM with hypomagnesemia): improved insulin sensitivity and glycemic control (fasting glucose and HbA1c) | 300 mg/day elemental | Addresses deficiency-driven insulin resistance; not a diabetes monotherapy |
-| **Bone density** | ~60% of body magnesium is stored in bone; deficiency impairs the mineral matrix that supports bone density | 200–400 mg/day | Take evening (separate from morning calcium for optimal absorption of both) |
+1. Keep caffeine timing, bedtime, alcohol, and other supplements stable.
+2. Record baseline sleep for at least three to seven nights.
+3. Choose one elemental dose and keep it unchanged.
+4. Track time to fall asleep, awakenings, total sleep, next-day function, and GI effects.
+5. Reassess after two to four weeks.
+6. Stop if there is no meaningful benefit.
 
-### The Vitamin D-Magnesium Connection
-
-Magnesium and vitamin D have a bidirectional dependency that is clinically underappreciated ([Uwitonze 2018](#ref-29480918)). Magnesium is a required cofactor for both the hepatic 25-hydroxylation and renal 1α-hydroxylation steps that convert vitamin D precursors into active calcitriol. Without adequate magnesium, vitamin D supplementation — regardless of dose — cannot be fully activated. This means that individuals supplementing vitamin D without ensuring adequate magnesium may have "vitamin D resistance" — unexpectedly low 25(OH)D levels despite consistent supplementation — that resolves with magnesium repletion.
+Wearables can help identify trends, but consumer devices do not measure sleep stages as accurately as clinical polysomnography. Prioritize how you function the next day over tiny changes in an app’s “deep sleep” score.
 
 ---
 
-<CollapsibleWarning title="Safety, Side Effects & Drug Interactions">
+## Can a Magnesium Test Tell You Whether It Will Work?
 
-## Safety, Side Effects, and Drug Interactions
+Magnesium status is genuinely difficult to assess.
 
-### General Tolerability
+Serum magnesium is widely available but represents less than 1% of total body magnesium and can remain normal despite low tissue stores. Red-blood-cell magnesium, urine magnesium, ionized magnesium, and loading tests each have limitations.
 
-Magnesium glycinate is among the best-tolerated oral supplements available. The glycinate chelate's efficient absorption through intestinal amino acid transport pathways means far less unabsorbed magnesium reaches the colon compared to oxide or citrate — dramatically reducing the osmotic laxative effect that limits dosing with other forms.
+The NIH Office of Dietary Supplements states that **no single magnesium-status method is considered satisfactory**. An RBC magnesium test should therefore not be marketed as a definitive answer. A clinician may combine diet history, symptoms, medications, kidney function, serum testing, and other context.
 
-**Common side effects (>1%):**
-- Loose stool at higher doses — much rarer with glycinate than other forms
-- Mild GI cramping with rapid dose escalation (start low, increase gradually)
-- Morning grogginess if taken too close to bedtime (move dose earlier)
+Groups at greater risk of inadequate magnesium include people with certain gastrointestinal disorders, type 2 diabetes, alcohol dependence, and older adults. Long-term proton-pump inhibitor use and some diuretics can also alter magnesium status.
 
-**Uncommon side effects (<1%):**
-- Nausea
-- Headache at supra-physiological doses
+---
 
-### Contraindications
+## Safety, Side Effects, and Interactions
 
-| Population | Guidance | Mechanism |
+### Common effects
+
+Oral magnesium can cause:
+
+- loose stool or diarrhea;
+- nausea;
+- abdominal cramping.
+
+Glycinate may be gentler for some people, but comparative rates are not well established. “No laxative effect” is too strong.
+
+### Kidney function
+
+Healthy kidneys usually remove excess magnesium. With impaired kidney function, magnesium can accumulate and cause weakness, low blood pressure, breathing difficulty, abnormal heart rhythm, or more severe toxicity.
+
+People with kidney disease should not self-prescribe high-dose magnesium.
+
+### Medication spacing
+
+| Medication | Why it matters | General spacing guidance |
 |---|---|---|
-| **Chronic kidney disease (GFR < 30)** | Avoid without nephrologist supervision | Kidney is the primary route of magnesium excretion; impaired clearance creates hypermagnesemia risk |
-| **Myasthenia gravis** | Avoid | Magnesium interferes with acetylcholine release at the neuromuscular junction, potentially worsening weakness |
-| **Heart block (second- or third-degree)** | Caution | Magnesium's membrane-stabilizing effects can worsen conduction disturbances |
-| **Pregnancy** | Generally safe (used IV for eclampsia prevention); review dosing with clinician | Oral supplementation at standard doses appears safe; IV magnesium is standard of care for preeclampsia/eclampsia |
+| Tetracycline antibiotics | Magnesium binds the drug and lowers absorption | Antibiotic at least 2 hours before or 4–6 hours after magnesium |
+| Quinolone antibiotics | Same chelation problem | Antibiotic at least 2 hours before or 4–6 hours after magnesium |
+| Oral bisphosphonates | Magnesium can reduce absorption | Separate by at least 2 hours |
+| Diuretics | Some increase magnesium loss; potassium-sparing drugs reduce excretion | Review the specific drug with a clinician or pharmacist |
+| Long-term PPIs | Can contribute to hypomagnesemia | Monitoring may be appropriate; supplementation alone does not always correct it |
 
-### Drug Interactions
+Do not copy timing instructions from a supplement page over the directions for a prescription. The pharmacist or prescribing information wins.
 
-| Drug class | Interaction mechanism | Clinical management |
-|---|---|---|
-| **Tetracycline & fluoroquinolone antibiotics** | Magnesium chelates these drugs in the gut, reducing absorption by up to 90% | Separate dosing by at least 2 hours (antibiotic first, then magnesium) |
-| **Bisphosphonates (alendronate, etc.)** | Same chelation mechanism | Take bisphosphonate on empty stomach first thing in AM; magnesium at least 2 hours later |
-| **Proton pump inhibitors (omeprazole, etc.)** | Long-term PPI use impairs intestinal magnesium absorption — drug-induced deficiency | Magnesium supplementation is especially important in chronic PPI users; monitor serum Mg |
-| **Potassium-sparing diuretics (spironolactone)** | Reduces renal magnesium excretion | May increase hypermagnesemia risk when combined with high-dose supplementation |
-| **Calcium (high-dose)** | Calcium and magnesium compete for intestinal absorption | Separate by 2+ hours; calcium AM, magnesium PM is a practical protocol that aligns with their respective optimal timing |
-| **Gabapentinoids (gabapentin, pregabalin)** | Magnesium may reduce gabapentin absorption | Separate dosing by 2+ hours |
+### Pregnancy and breastfeeding
 
-</CollapsibleWarning>
+Magnesium is an essential nutrient, but that does not make every supplemental dose or product automatically appropriate during pregnancy or breastfeeding. Review the total dose and product with the prenatal-care clinician.
 
-## How to Choose a Magnesium Glycinate Product
+---
 
-**Must-have on the label:**
-- "Magnesium glycinate" or "magnesium bisglycinate" explicitly stated — not just "magnesium chelate" or "magnesium amino acid chelate"
-- Elemental magnesium per serving clearly listed in the Supplement Facts panel
-- Third-party testing certification (USP, NSF, ConsumerLab) if available
+## Choosing a Product
 
-**Red flags:**
-- "Magnesium blend" or "proprietary magnesium complex" — you don't know what form you're getting
-- Listing only compound weight with no elemental magnesium — you can't calculate your dose
-- "Buffered" magnesium glycinate — often mixed with magnesium oxide to cut costs while still labeling as glycinate. Check for oxide in the ingredients list.
+Look for:
 
-**Price guide:**
-- Quality magnesium glycinate: $10–20/month at 200–400 mg elemental/day
-- Premium brands with third-party testing: $20–30/month
-- Budget glycinate: $8–12/month — verify it's pure glycinate, not a glycinate-oxide blend
+- elemental magnesium clearly listed;
+- “magnesium glycinate” or “magnesium bisglycinate” named in Supplement Facts;
+- no proprietary mineral blend;
+- a serving size that makes the intended elemental dose practical;
+- credible third-party quality testing when available;
+- no unnecessary sedative blend that makes it impossible to know what worked.
+
+### “Buffered” glycinate
+
+Some products combine glycinate with magnesium oxide. That is not automatically fraudulent, but the label should make the forms clear. A blend should not be evaluated as though it were pure bisglycinate.
+
+### Cost comparison
+
+Compare products by:
+
+> price ÷ total servings at your chosen **elemental** dose
+
+The cheapest bottle is not necessarily cheapest per usable dose, and the most expensive chelate is not necessarily more effective.
+
+---
+
+## Who Is a Good Candidate?
+
+A reasonable candidate:
+
+- has mild sleep difficulty;
+- wants a subtle, non-sedating experiment;
+- consumes few magnesium-rich foods;
+- has normal kidney function;
+- is not taking a medication with an unresolved interaction;
+- is willing to track the result for several weeks.
+
+A poor candidate:
+
+- expects sedation;
+- has severe or long-standing insomnia;
+- has symptoms of sleep apnea or restless legs;
+- has kidney disease;
+- is layering several new sleep supplements at once;
+- plans to exceed label and UL guidance without clinical supervision.
 
 ---
 
 ## FAQ
 
-### Does magnesium glycinate cause the same laxative effects as citrate or oxide?
-No — that's the primary clinical advantage. Because glycinate is absorbed through amino acid transport pathways, far less magnesium reaches the colon. Most people tolerate up to 400 mg elemental/day without bowel changes. This is critical because the effective dose range for sleep and anxiety (200–400 mg) is often not achievable with oxide or high-dose citrate due to GI intolerance.
+### Is magnesium glycinate the same as magnesium bisglycinate?
 
-### Can I take it with calcium?
-Yes, but separate by 2+ hours if taking high doses of both. They compete for the same intestinal transporters. Practical: calcium with breakfast, magnesium glycinate with dinner or before bed — timing that also aligns with each mineral's optimal circadian administration.
+The terms are commonly used for magnesium chelated with glycine. “Bisglycinate” more explicitly describes two glycine ligands per magnesium ion, but real-world labels may also include buffered blends or partially reacted material. Check the Supplement Facts and ingredient list rather than relying on the marketing name alone.
 
-### How long before results?
-Sleep effects are sometimes noticeable on night 1 (via the glycine component). Anxiety reduction typically requires 2–4 weeks of consistent supplementation. Blood pressure and metabolic effects require 8–16 weeks. This supplements a mineral, not a neurotransmitter-targeted drug — tissue repletion takes time.
+### Does it make you sleepy?
 
-### Is daily long-term use safe?
-Yes, for adults with normal kidney function. Magnesium is a fundamental mineral with no known toxicity from dietary or supplemental intake at doses below 350 mg elemental/day (the Institute of Medicine's Tolerable Upper Intake Level from supplements). Long-term supplementation at these doses maintains adequate status — analogous to taking a daily multivitamin.
+Usually not in the way an antihistamine or prescription sedative does. Some people report relaxation, while others notice no acute sensation. The clinical trial supports a small four-week improvement, not guaranteed drowsiness after each dose.
 
-### What's the difference between magnesium glycinate and magnesium bisglycinate?
-They're the same thing. "Bisglycinate" emphasizes that two glycine molecules are chelated to each magnesium ion (the fully reacted form). Some manufacturers use "bisglycinate" to distinguish fully chelated product from buffered glycinate-oxide blends. Functionally equivalent at equivalent elemental doses.
+### Can I take it every day?
 
-### Can I take magnesium glycinate during the day?
-Yes, but be aware of its mild relaxing effect. For daytime anxiety, split the dose: 200 mg in the morning, 200 mg in the evening. It shouldn't cause drowsiness at moderate doses (200 mg), but individual sensitivity varies. If you feel sluggish after daytime dosing, reserve it for evening.
+Short-term daily use was generally well tolerated in trials. Long-term safety depends on dose, kidney function, medications, total magnesium exposure, and individual response. “Safe forever with no tolerance” has not been demonstrated.
 
-### Why does my magnesium glycinate smell bad?
-Magnesium glycinate naturally has a mild "fishy" or amine-like odor — this is from the glycine component and is normal. It's not a sign of spoilage. If the smell is overwhelmingly rancid or chemical, that's a quality concern, but mild odor is characteristic of the compound.
+### Can it cause insomnia or anxiety?
+
+Those are not established common effects, but individual responses can differ. A supplement that consistently worsens sleep, mood, headaches, or GI symptoms should be stopped rather than forced because the form is supposed to be calming.
+
+### Is 400 mg too much?
+
+Four hundred milligrams of **supplemental elemental magnesium** exceeds the adult UL of 350 mg/day unless medically directed. It is not the same as 400 mg of magnesium glycinate compound, which may provide far less elemental magnesium.
+
+### Should I combine it with L-theanine or glycine?
+
+Combination use may be reasonable, but add one ingredient at a time. Otherwise, you cannot tell which ingredient helped or caused an adverse effect. Read the refreshed [L-theanine evidence guide](/articles/l-theanine/) before assuming the stack is synergistic.
+
+### Is magnesium glycinate better than citrate?
+
+Glycinate may be preferred when citrate causes loose stool, while citrate can be useful when constipation is also a goal. Evidence does not establish glycinate as universally better for sleep.
 
 ---
 
-## Related Articles
+<BetterAlternatives
+  intro="Magnesium glycinate is not always the best first move."
+  alternatives={[
+    { condition: 'Your sleep problem has lasted months or impairs daytime function', recommendation: 'A sleep evaluation', reason: 'persistent insomnia, sleep apnea, and restless legs need cause-specific care.', href: '/guides/sleep/' },
+    { condition: 'Your main issue is caffeine timing or an inconsistent schedule', recommendation: 'Fix the driver first', reason: 'a supplement will not reliably override late caffeine or irregular sleep timing.', href: '/guides/sleep/' },
+    { condition: 'Your main goal is constipation', recommendation: 'Magnesium citrate', reason: 'its osmotic GI effect may be useful rather than undesirable.', href: '/guides/other/magnesium-types-guide/' },
+  ]}
+/>
+
+<WhereNext
+  intro="Choose the next page by the problem you are solving:"
+  paths={[
+    { ifYouWant: 'to compare common magnesium forms', goTo: 'Magnesium Types Guide', href: '/guides/other/magnesium-types-guide/' },
+    { ifYouWant: 'to compare glycinate with L-threonate', goTo: 'Glycinate vs L-Threonate for Sleep', href: '/guides/sleep/magnesium-glycinate-vs-l-threonate-for-sleep/' },
+    { ifYouWant: 'to evaluate a magnesium plus L-theanine stack', goTo: 'Magnesium + L-Theanine Sleep Stack', href: '/articles/magnesium-l-theanine-sleep-stack/' },
+    { ifYouWant: 'a wider insomnia decision guide', goTo: 'Sleep Guide', href: '/guides/sleep/' },
+    { ifYouWant: 'to compare glycinate with oxide', goTo: 'Magnesium Glycinate vs Magnesium Oxide', href: '/comparisons/magnesium-glycinate-vs-magnesium-oxide/' },
+  ]}
+/>
+
+## Related Reading
 
 - [Magnesium + L-Theanine Sleep Stack](/articles/magnesium-l-theanine-sleep-stack/)
-- [Ashwagandha: Benefits, Dosage & Evidence](/articles/ashwagandha/)
-- [L-Theanine: Calm Focus Guide](/articles/l-theanine/)
-- [Glycine: The Calming Amino Acid](/compounds/glycine/)
-- [Valerian Root for Sleep](/articles/valerian-root/)
+- [L-Theanine: 2026 Evidence Review](/articles/l-theanine/)
+- [Glycine Compound Profile](/compounds/glycine/)
 - [Best Supplements for Sleep](/guides/sleep/)
 - [Best Supplements for Anxiety](/guides/anxiety/)
 - [How to Choose a Quality Supplement](/articles/how-to-choose-supplement-quality/)


### PR DESCRIPTION
## What changed

- Rebuilt the magnesium glycinate article around the direct 2025 randomized bisglycinate sleep trial (155 adults, 250 mg elemental magnesium, four weeks, small effect size).
- Added the 2024 sleep/anxiety systematic review and corrected the PMID/DOI for the 2021 insomnia meta-analysis.
- Replaced claims of first-night effects, predictable 2–4 week physiology, GABA-receptor normalization, cortisol resetting, 3 a.m. awakening prevention, and guaranteed non-sedation with evidence-calibrated language.
- Corrected the glycinate-specificity problem: most magnesium sleep/anxiety research uses other salts or mixed formulations.
- Removed universal absorption percentages and explained that the classic diglycinate-vs-oxide study involved patients with ileal resection.
- Clarified that glycine “synergy” has not been isolated in magnesium-glycinate trials.
- Corrected dosing around elemental magnesium and the NIH adult supplemental UL of 350 mg/day.
- Replaced the claim that RBC magnesium definitively confirms deficiency with NIH’s current position that no single magnesium-status test is satisfactory.
- Added kidney safety, antibiotic/bisphosphonate spacing, PPI/diuretic context, product-label guidance, and a practical self-testing protocol.
- Marked the revision accurately as AI-assisted.

## Why

This is a major search and commercial-intent page. The previous version contained useful structure but repeatedly converted mechanistic plausibility and form-agnostic magnesium evidence into confident magnesium-glycinate claims. The refresh preserves actionability while separating direct evidence, indirect evidence, and marketing assumptions.

## Scope

One editorial source file only: `content/articles/magnesium-glycinate.md`. No generated data was hand-edited.

## Validation

The article uses existing editorial MDX components and established internal route patterns. Repository CI should run content, link, type, lint, and build checks.