### PR TITLE
Rebuild high-intent ADHD magnesium guides around current evidence

### DIFF
--- a/app/__tests__/adhd-magnesium-evidence-calibration.test.ts
+++ b/app/__tests__/adhd-magnesium-evidence-calibration.test.ts
@@ -49,4 +49,12 @@ describe('ADHD magnesium evidence calibration', () => {
     expect(comparison).toContain('Symmetrical comparison')
     expect(comparison).toContain('Glycinate vs citrate without the marketing shortcuts')
   })
+
+  it('labels government and DOI references accurately instead of calling every source PubMed', () => {
+    const references = read('components/References.tsx')
+
+    expect(references).toContain("url.includes('pubmed.ncbi.nlm.nih.gov')")
+    expect(references).toContain("url.includes('doi.org')")
+    expect(references).toContain("return 'Source →'")
+  })
 })

--- a/app/__tests__/adhd-magnesium-evidence-calibration.test.ts
+++ b/app/__tests__/adhd-magnesium-evidence-calibration.test.ts
@@ -32,7 +32,7 @@ describe('ADHD magnesium evidence calibration', () => {
   it('does not restore categorical form superiority or unsupported dose claims', () => {
     const combined = `${read(BUYING_GUIDE)}\n${read(COMPARISON)}`
 
-    expect(combined).toContain('no magnesium form has been proven best for core ADHD symptoms')
+    expect(combined.toLowerCase()).toContain('no magnesium form has been proven best for core adhd symptoms')
     expect(combined).toContain('There is no direct ADHD head-to-head trial')
     expect(combined).not.toContain('Magnesium Glycinate — The Best First Choice')
     expect(combined).not.toContain('poor absorption (~4% bioavailability)')

--- a/app/__tests__/adhd-magnesium-evidence-calibration.test.ts
+++ b/app/__tests__/adhd-magnesium-evidence-calibration.test.ts
@@ -1,0 +1,52 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+}
+
+const BUYING_GUIDE = 'app/guides/adhd/best-magnesium-supplement-for-adhd/page.tsx'
+const COMPARISON = 'app/guides/adhd/magnesium-glycinate-vs-citrate-for-adhd/page.tsx'
+
+describe('ADHD magnesium evidence calibration', () => {
+  it('keeps both stable high-intent routes evidence-first and source-backed', () => {
+    const buyingGuide = read(BUYING_GUIDE)
+    const comparison = read(COMPARISON)
+
+    expect(buyingGuide).toContain("const PATH = '/guides/adhd/best-magnesium-supplement-for-adhd'")
+    expect(comparison).toContain("const PATH = '/guides/adhd/magnesium-glycinate-vs-citrate-for-adhd'")
+
+    for (const source of [buyingGuide, comparison]) {
+      expect(source).toContain('40918053')
+      expect(source).toContain('23808779')
+      expect(source).toContain('30496768')
+      expect(source).toContain('ods.od.nih.gov/factsheets/Magnesium-HealthProfessional')
+      expect(source).toContain("getRevenueProductSet('magnesium')")
+      expect(source).toContain('<AffiliateDisclosure')
+      expect(source).not.toContain('amazon.com/s?k=')
+      expect(source).not.toContain('AFFILIATE_TAGS')
+    }
+  })
+
+  it('does not restore categorical form superiority or unsupported dose claims', () => {
+    const combined = `${read(BUYING_GUIDE)}\n${read(COMPARISON)}`
+
+    expect(combined).toContain('no magnesium form has been proven best for core ADHD symptoms')
+    expect(combined).toContain('There is no direct ADHD head-to-head trial')
+    expect(combined).not.toContain('Magnesium Glycinate — The Best First Choice')
+    expect(combined).not.toContain('poor absorption (~4% bioavailability)')
+    expect(combined).not.toContain('200–400 mg of elemental magnesium daily')
+    expect(combined).not.toContain('glycine component adds mild calming support')
+  })
+
+  it('separates the two pages by searcher decision', () => {
+    const buyingGuide = read(BUYING_GUIDE)
+    const comparison = read(COMPARISON)
+
+    expect(buyingGuide).toContain('How to read the label')
+    expect(buyingGuide).toContain('Compare elemental magnesium per serving')
+    expect(comparison).toContain('Symmetrical comparison')
+    expect(comparison).toContain('Glycinate vs citrate without the marketing shortcuts')
+  })
+})

--- a/app/guides/adhd/best-magnesium-supplement-for-adhd/page.tsx
+++ b/app/guides/adhd/best-magnesium-supplement-for-adhd/page.tsx
@@ -1,587 +1,418 @@
-import Link from 'next/link'
-import RecommendationSection from '@/components/RecommendationSection'
-import { getRevenueProductSet } from '@/config/revenue-products'
-import Image from 'next/image'
-import JsonLd from '@/components/seo/JsonLd'
 import type { Metadata } from 'next'
-import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd, compactMetaTitle } from '../../../../src/lib/seo'
-import LastUpdatedBadge from '../../../../src/components/editorial/LastUpdatedBadge'
+import Image from 'next/image'
+import Link from 'next/link'
+import AffiliateDisclosure from '@/components/AffiliateDisclosure'
+import { ArticleLayout, TableOfContents } from '@/components/articles'
+import type { Heading } from '@/components/articles'
+import RecommendationSection from '@/components/RecommendationSection'
+import References from '@/components/References'
+import StructuredData from '@/components/StructuredData'
 import ResponsiveTable from '@/components/ui/ResponsiveTable'
-import SafetyNotice from '@/components/evidence/SafetyNotice'
-import EmailCapture from '@/components/EmailCapture'
-import NewsletterCtaBlock from '@/components/NewsletterCtaBlock'
-import PathwayDiagram from '@/components/PathwayDiagram'
-import EvidenceLegend from '@/components/EvidenceLegend'
-import { pathwayDiagrams } from '@/lib/pathway-data'
-import { AFFILIATE_TAGS } from '@/config/affiliate'
+import { getRevenueProductSet } from '@/config/revenue-products'
+import { SITE_URL } from '@/lib/navigation-config'
 
-const SLUG = 'best-magnesium-supplement-for-adhd'
-const TITLE = 'Best Magnesium Supplement for ADHD: Which Form, What Dose, and What to Look For'
+const PATH = '/guides/adhd/best-magnesium-supplement-for-adhd'
+const PAGE_URL = `${SITE_URL}${PATH}`
+const TITLE = 'Best Magnesium Supplement for ADHD? Evidence & Buying Guide'
 const DESCRIPTION =
-  'Practical buying guide to magnesium supplements for ADHD. Covers the best forms (glycinate, citrate, threonate), what to ignore (oxide), how to read labels, dose ranges, and what to expect.'
-const DATE = '2026-06-12'
-const AUTHOR = 'Will'
-const READING_TIME = '9 min read'
-const TAGS = ['magnesium', 'ADHD', 'buying guide', 'sleep', 'supplements']
-const CATEGORY = 'Buying Guide'
+  'No magnesium form has been proven best for core ADHD symptoms. Compare glycinate, citrate, oxide, and threonate by evidence, tolerability, label quality, safety, and cost.'
 
-export const metadata: Metadata = buildPageMetadata({
-  title: compactMetaTitle(TITLE),
+export const metadata: Metadata = {
+  title: TITLE,
   description: DESCRIPTION,
-  path: `/guides/adhd/${SLUG}`,
-  openGraphType: 'article',
-})
+  alternates: { canonical: `${PATH}/` },
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    url: `${PATH}/`,
+    type: 'article',
+    images: ['/images/guides/best-magnesium-supplement-for-adhd.jpg'],
+  },
+}
+
+const HEADINGS: Heading[] = [
+  { id: 'quick-answer', text: 'Quick answer', level: 2 },
+  { id: 'choose-by-goal', text: 'Choose by the real goal', level: 2 },
+  { id: 'form-comparison', text: 'Magnesium form comparison', level: 2 },
+  { id: 'adhd-evidence', text: 'What the ADHD evidence shows', level: 2 },
+  { id: 'label-checklist', text: 'How to read the label', level: 2 },
+  { id: 'safety', text: 'Dose and safety guardrails', level: 2 },
+  { id: 'faq', text: 'Frequently asked questions', level: 2 },
+]
+
+const FORM_ROWS = [
+  {
+    form: 'Glycinate / bisglycinate',
+    directAdhdEvidence: 'No form-specific ADHD trial showing superiority',
+    usefulContext:
+      'A reasonable option when a person values a non-laxative-style product or is also evaluating sleep. A 2025 trial in adults with poor sleep found a small benefit from 250 mg elemental magnesium daily, but it was not an ADHD study.',
+    buyingNote: 'Check the elemental magnesium amount; do not assume the chelate weight is the dose.',
+  },
+  {
+    form: 'Citrate',
+    directAdhdEvidence: 'No evidence that citrate treats ADHD better or worse than glycinate',
+    usefulContext:
+      'NIH notes that citrate is absorbed more completely than oxide in small studies. It can also loosen stools, which may be useful or unwanted depending on the person.',
+    buyingNote: 'Often lower cost; start by judging tolerance rather than chasing an ADHD-specific claim.',
+  },
+  {
+    form: 'Oxide',
+    directAdhdEvidence: 'No credible ADHD-specific advantage',
+    usefulContext:
+      'Usually inexpensive and high in elemental magnesium by weight, but NIH summarizes lower absorption than several more soluble forms and more frequent GI effects.',
+    buyingNote: 'Not automatically dangerous or useless, but usually a weaker first choice for routine repletion.',
+  },
+  {
+    form: 'L-threonate',
+    directAdhdEvidence: 'No direct ADHD head-to-head evidence against glycinate or citrate',
+    usefulContext:
+      'Premium brain-targeting claims rely heavily on mechanistic and non-ADHD evidence. A higher price does not establish a better ADHD outcome.',
+    buyingNote: 'Pay only for a clearly defined reason—not for the word “brain” on the front label.',
+  },
+] as const
 
 const FAQS = [
   {
     question: 'What is the best magnesium supplement for ADHD?',
     answer:
-      'Magnesium glycinate is the most recommended form for ADHD-related use. It combines good bioavailability with gentle GI tolerability and the mild calming effect of glycine — making it suitable for evening use to support sleep and reduce hyperactivation. It is more expensive than citrate but worth it as a starting point. For budget-conscious buyers, magnesium citrate is a reasonable second choice at lower doses.',
+      'No magnesium form has been proven best for core ADHD symptoms. Glycinate or citrate can both be reasonable practical choices. The better option depends on elemental dose, GI tolerance, cost, constipation, sleep goals, kidney health, medications, and whether low intake or deficiency is actually plausible.',
   },
   {
-    question: 'How much magnesium should I take for ADHD?',
+    question: 'Does magnesium improve ADHD symptoms?',
     answer:
-      'Most research in ADHD populations uses 200–400 mg of elemental magnesium daily. For adults starting glycinate, 200 mg elemental magnesium before bed is a reasonable starting dose. Elemental magnesium content is not the same as the product weight on the label — a product labeled "400 mg magnesium glycinate" typically contains only 60–80 mg of elemental magnesium. Always check the "Supplement Facts" label for elemental magnesium per serving.',
+      'The direct treatment evidence is weak. A 2013 systematic review found no well-controlled randomized double-blind magnesium trial for ADHD and no magnesium-monotherapy evidence. Observational meta-analyses have reported lower magnesium levels in children with ADHD, but an association does not prove that supplementation improves core symptoms.',
   },
   {
-    question: 'Should I take magnesium with food or without for ADHD?',
+    question: 'Is magnesium glycinate better than citrate for ADHD?',
     answer:
-      'Taking magnesium with a small meal or snack is generally recommended — this reduces the chance of nausea (which is uncommon but possible) and may improve absorption compared to a completely empty stomach. Magnesium glycinate is tolerant to be taken with or without food, unlike some other mineral supplements.',
+      'There is no direct ADHD head-to-head trial showing that glycinate is better. Glycinate is often selected for perceived GI tolerability or sleep-oriented use, while citrate is often selected for lower cost or when a laxative effect would be acceptable. Those are practical tradeoffs, not proof of superior ADHD efficacy.',
   },
   {
-    question: 'Is magnesium threonate worth the extra cost for ADHD?',
+    question: 'How much magnesium should an adult take for ADHD?',
     answer:
-      'Magnesium threonate has been promoted as superior for brain health due to animal studies suggesting greater brain penetration. Human ADHD-specific trials comparing threonate to glycinate are very limited. At 3–4x the cost of glycinate and with no convincing comparative ADHD evidence, threonate is not the best starting choice. Try glycinate for 4–6 weeks first. If well-tolerated but insufficient, threonate may be worth exploring.',
+      'There is no established ADHD-specific dose. Read the Supplement Facts panel for elemental magnesium. The NIH adult upper limit is 350 mg per day from supplements and medications unless a clinician recommends otherwise; magnesium naturally present in food is not included in that limit.',
   },
   {
-    question: 'Can my child with ADHD take magnesium?',
+    question: 'Can children with ADHD take magnesium?',
     answer:
-      'Magnesium supplementation in children with ADHD has been studied, and several trials in pediatric populations show improvements in hyperactivity, emotional dysregulation, and sleep — particularly in children with confirmed low magnesium levels. However, pediatric dosing is different from adult dosing (typically 100–200 mg elemental depending on age and weight), and supplementation in children should be discussed with a pediatrician before starting.',
+      'Children should not be placed on an adult supplement protocol. NIH supplemental upper limits vary by age, and kidney disease, GI conditions, diet, and medications can change the risk. A pediatric clinician should guide whether supplementation and testing are appropriate.',
   },
   {
-    question: 'How long before bed should I take magnesium for ADHD?',
+    question: 'Can a normal serum magnesium result rule out low magnesium status?',
     answer:
-      'Taking magnesium 30–60 minutes before bed is a commonly used timing for sleep and evening calm support. This allows time for absorption before the intended sleep-support effects are most useful. Some people prefer taking it earlier in the evening as part of a wind-down routine — this is also fine for most forms including glycinate.',
+      'No. NIH notes that serum magnesium is the most common test but does not closely reflect total-body or tissue magnesium, and no single assessment method is considered satisfactory. Laboratory results need clinical and dietary context.',
   },
 ]
 
-const MAGNESIUM_EVIDENCE_ROWS = [
-  ['Glycinate / bisglycinate', 'Best first choice', 'Well tolerated; useful when sleep tension or low intake is part of the picture', '100-300 mg elemental magnesium, often evening', 'Separate from some antibiotics and thyroid medication; avoid unsupervised use with kidney disease'],
-  ['Citrate', 'Budget alternative', 'Reasonable absorption and cost, but more laxative at higher doses', '100-200 mg elemental to start', 'Loose stools are the main limiting factor'],
-  ['L-threonate', 'Premium / not first-line', 'Interesting brain-bioavailability marketing, but limited ADHD-specific comparative evidence', 'Use label dosing; elemental magnesium is usually lower', 'High cost and limited direct evidence'],
-  ['Malate', 'Daytime option', 'Sometimes used when fatigue is prominent; less calming than glycinate', '100-300 mg elemental, often earlier in the day', 'Can feel less sleep-oriented for sensitive users'],
-  ['Oxide', 'Not recommended for ADHD goals', 'High elemental percentage but poor practical absorption and more laxative effect', 'Do not use as the primary form for ADHD sleep/calm goals', 'Often appears in cheap formulas'],
-] as const
-
-const MAGNESIUM_REFERENCES = [
-  ['Nutrition in ADHD review', 'https://pmc.ncbi.nlm.nih.gov/articles/PMC10444659/'],
-  ['Mineral status in ADHD review', 'https://www.mdpi.com/1420-3049/25/19/4440'],
-  ['Iron and zinc ADHD systematic review context', 'https://pmc.ncbi.nlm.nih.gov/articles/PMC8618748/'],
+const REFERENCES = [
+  {
+    n: 1,
+    text: 'NIH Office of Dietary Supplements. Magnesium: Fact Sheet for Health Professionals.',
+    url: 'https://ods.od.nih.gov/factsheets/Magnesium-HealthProfessional/',
+  },
+  {
+    n: 2,
+    text: 'Schuster J, et al. Magnesium bisglycinate supplementation in healthy adults reporting poor sleep: randomized placebo-controlled trial. 2025. PMID: 40918053.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/40918053/',
+  },
+  {
+    n: 3,
+    text: 'Ghanizadeh A. A systematic review of magnesium therapy for treating attention deficit hyperactivity disorder. 2013. PMID: 23808779.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/23808779/',
+  },
+  {
+    n: 4,
+    text: 'Huang YH, et al. Magnesium levels in children with ADHD: systematic review and meta-analysis. 2019. PMID: 30496768.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/30496768/',
+  },
 ] as const
 
 export default function BestMagnesiumForAdhdPage() {
-  const breadcrumbLd = breadcrumbJsonLd([
-    { name: 'Guides', url: 'https://thehippiescientist.net/guides/' },
-    { name: TITLE, url: `https://thehippiescientist.net/guides/adhd/${SLUG}/` },
-  ])
-  const articleLd = blogJsonLd(
-    { title: TITLE, slug: SLUG, date: DATE, description: DESCRIPTION },
-    `/guides/adhd/${SLUG}/`,
-  )
-  const faqLd = faqPageJsonLd({ pagePath: `/guides/adhd/${SLUG}/`, questions: FAQS })
+  const toc = <TableOfContents headings={HEADINGS} />
+  const magnesiumProducts = getRevenueProductSet('magnesium')
 
   return (
-    <article className="mx-auto max-w-5xl space-y-0 px-4 pb-20 pt-6 sm:px-6 lg:px-8">
-      <JsonLd schema={articleLd} />
-      <JsonLd schema={breadcrumbLd} />
-      {faqLd && <JsonLd schema={faqLd} />}
+    <ArticleLayout toc={toc} zone="supplement">
+      <StructuredData
+        pageUrl={PAGE_URL}
+        headline={TITLE}
+        description={DESCRIPTION}
+        datePublished="2026-06-12"
+        dateModified="2026-08-02"
+        image={`${SITE_URL}/images/guides/best-magnesium-supplement-for-adhd.jpg`}
+        faqs={FAQS}
+        breadcrumbs={[
+          { label: 'Home', href: '/' },
+          { label: 'ADHD Guides', href: '/guides/adhd/' },
+          { label: 'Magnesium Buying Guide', href: PATH },
+        ]}
+        zone="monetized"
+      />
 
-      <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
-        <Link href="/guides/" className="transition hover:text-ink">Guides</Link>
-        <span>/</span>
-        <span className="text-ink line-clamp-1">{TITLE}</span>
-      </nav>
+      <div className="space-y-12">
+        <AffiliateDisclosure variant="compact" />
 
-      <section className="rounded-[1.5rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8 lg:p-10">
-        <div className="flex flex-wrap items-center gap-2 text-xs">
-          <span className="rounded-full border border-brand-900/10 bg-brand-50 px-2.5 py-0.5 font-bold uppercase tracking-wider text-brand-800">
-            {CATEGORY}
-          </span>
-          {TAGS.slice(0, 3).map((tag) => (
-            <span key={tag} className="rounded-full border border-brand-900/10 bg-white px-2.5 py-0.5 font-semibold text-muted capitalize">
-              {tag}
-            </span>
-          ))}
-          <span className="text-muted">June 12, 2026</span>
-          <span className="text-muted">·</span>
-          <span className="text-muted">{READING_TIME}</span>
-        </div>
-        <h1 className="mt-4 font-display text-3xl font-bold leading-tight tracking-tight text-ink sm:text-4xl lg:text-5xl">
-          {TITLE}
-        </h1>
-        <p className="mt-2 text-sm text-muted">
-          By{' '}
-          <Link href="/info/about/" rel="author" className="font-medium text-ink hover:underline">
-            {AUTHOR}
-          </Link>
-        </p>
-        <div className="mt-3">
-          <LastUpdatedBadge date={DATE} label="Last updated" />
-        </div>
-        <p className="mt-4 max-w-3xl text-base leading-7 text-muted">{DESCRIPTION}</p>
-
-        <figure className="mt-6">
-          <div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white">
-            <Image
-              src="/images/guides/best-magnesium-supplement-for-adhd.jpg"
-              alt="Magnesium glycinate capsules and powder — choosing the best magnesium supplement for ADHD"
-              width={1536}
-              height={1024}
-              priority
-              className="w-full h-auto"
-            />
+        <section className="rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-10">
+          <p className="eyebrow-label">Evidence-calibrated buying guide</p>
+          <h1 className="mt-3 font-display text-3xl font-bold leading-tight tracking-tight text-ink sm:text-5xl">
+            Best Magnesium Supplement for ADHD?
+          </h1>
+          <p className="mt-4 max-w-3xl text-base leading-7 text-muted">
+            The honest answer is less dramatic than most product pages: no magnesium form has been proven
+            best for core ADHD symptoms. The useful buying decision is to match the form to the reason for
+            taking magnesium, then verify elemental dose, tolerability, medication timing, and safety.
+          </p>
+          <div className="mt-5 flex flex-wrap gap-3 text-xs font-semibold">
+            <Link href="/guides/adhd/magnesium-glycinate-vs-citrate-for-adhd/" className="text-brand-700 hover:underline">
+              Glycinate vs citrate →
+            </Link>
+            <Link href="/guides/adhd/adhd-supplements/" className="text-brand-700 hover:underline">
+              ADHD supplement evidence hub →
+            </Link>
           </div>
-          <figcaption className="mt-3 text-center text-sm text-muted">
-            Magnesium glycinate is often the best-tolerated form for calm and focus in ADHD.
-          </figcaption>
-        </figure>
-      </section>
 
-      <div className="mt-4 rounded-[1rem] border border-brand-900/10 bg-brand-50/60 px-5 py-3 text-xs leading-6 text-muted">
-        <strong className="text-ink">Affiliate disclosure:</strong> This article contains affiliate
-        links. Purchases may earn us a commission at no additional cost to you. All recommendations
-        are based on evidence and dose ranges reviewed on this page.
-      </div>
+          <figure className="mt-7">
+            <div className="overflow-hidden rounded-2xl border border-brand-900/10 bg-white shadow-sm">
+              <Image
+                src="/images/guides/best-magnesium-supplement-for-adhd.jpg"
+                alt="Magnesium supplement bottles and capsules arranged for a label-comparison guide"
+                width={1536}
+                height={1024}
+                priority
+                className="h-auto w-full"
+              />
+            </div>
+            <figcaption className="mt-3 text-center text-sm text-muted">
+              Choose by evidence, elemental dose, and fit—not by an ADHD claim on the bottle.
+            </figcaption>
+          </figure>
+        </section>
 
-      <div className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1fr)_240px]">
-        <div className="space-y-6">
+        <section id="quick-answer" className="scroll-mt-20 rounded-[1.65rem] border border-brand-200 bg-brand-50/60 p-6 shadow-sm sm:p-8">
+          <p className="eyebrow-label">Quick answer</p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
+            Glycinate is a practical option, not a proven ADHD winner
+          </h2>
+          <p className="mt-3 text-sm leading-7 text-muted sm:text-base">
+            For a general supplement trial, glycinate or citrate are usually easier to justify than an
+            expensive “brain magnesium” product. Glycinate has one recent non-ADHD sleep trial with a small
+            effect; citrate has established practical absorption advantages over oxide. Neither form has
+            been shown to outperform the other for attention, hyperactivity, impulsivity, or executive
+            function.
+          </p>
+          <div className="mt-5 grid gap-3 sm:grid-cols-3">
+            {[
+              ['Best evidence boundary', 'Magnesium is not an evidence-based replacement for ADHD medication, therapy, sleep care, or assessment.'],
+              ['Best shopping rule', 'Compare elemental magnesium per serving, not the large compound weight printed on the front.'],
+              ['Best risk control', 'Avoid unsupervised use with impaired kidney function and check medication spacing.'],
+            ].map(([label, copy]) => (
+              <div key={label} className="rounded-xl border border-brand-900/10 bg-white/80 p-4">
+                <h3 className="text-sm font-semibold text-ink">{label}</h3>
+                <p className="mt-2 text-xs leading-6 text-muted">{copy}</p>
+              </div>
+            ))}
+          </div>
+        </section>
 
-          {/* Top Pick Box */}
-          <section className="rounded-[1rem] border border-emerald-200 bg-emerald-50/60 p-6 shadow-sm sm:p-8">
-            <p className="text-[10px] font-bold uppercase tracking-wider text-emerald-700">Top Pick for ADHD</p>
+        <section id="choose-by-goal" className="scroll-mt-20 space-y-5">
+          <div>
+            <p className="eyebrow-label">Decision framework</p>
+            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">Choose by the real goal</h2>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {[
+              {
+                goal: 'Low intake or clinician concern',
+                answer:
+                  'Food intake, GI history, medications, and clinical assessment matter more than choosing a trendy chelate. Use a form that delivers a clear elemental dose and is tolerated.',
+              },
+              {
+                goal: 'Poor sleep is the actual target',
+                answer:
+                  'Bisglycinate has a recent four-week trial in adults with poor sleep, but the benefit was small and the participants were not selected for ADHD.',
+              },
+              {
+                goal: 'Constipation is also present',
+                answer:
+                  'Citrate may be a more useful fit because it can loosen stools. That same effect makes it a poor fit for someone prone to diarrhea.',
+              },
+              {
+                goal: 'Core ADHD symptoms are the target',
+                answer:
+                  'Do not expect form selection to create a medication-like effect. The direct magnesium-treatment evidence for ADHD remains inadequate.',
+              },
+            ].map((item) => (
+              <div key={item.goal} className="rounded-2xl border border-brand-900/10 bg-white/90 p-5 shadow-sm">
+                <h3 className="text-base font-semibold text-ink">{item.goal}</h3>
+                <p className="mt-2 text-sm leading-6 text-muted">{item.answer}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section id="form-comparison" className="scroll-mt-20 space-y-5">
+          <div>
+            <p className="eyebrow-label">Form comparison</p>
             <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
-              Magnesium Glycinate — The Best First Choice
+              What each form can—and cannot—claim
             </h2>
-            <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
-              For most adults and children with ADHD, <strong>magnesium glycinate</strong> is the best
-              starting point. It has high bioavailability, excellent GI tolerability, and the glycine
-              component adds mild calming support that aligns well with ADHD-related sleep difficulty and
-              evening hyperactivation.
-            </p>
-            <ul className="mt-3 ml-5 space-y-1 list-disc text-[1.01rem] leading-[1.85] text-muted">
-              <li><strong>Target dose:</strong> 200–300 mg elemental magnesium before bed</li>
-              <li><strong>When to take it:</strong> 30–60 minutes before sleep</li>
-              <li><strong>What to look for on the label:</strong> &ldquo;Magnesium glycinate&rdquo; or &ldquo;magnesium bisglycinate&rdquo;; elemental magnesium listed in Supplement Facts</li>
-              <li><strong>What to avoid:</strong> Magnesium oxide — poor absorption (~4% bioavailability)</li>
-            </ul>
-            <a
-              href={`https://www.amazon.com/s?k=magnesium+glycinate+adhd+sleep&tag=${AFFILIATE_TAGS.amazon}`}
-              target="_blank"
-              rel="noopener noreferrer sponsored"
-              className="mt-4 inline-flex items-center gap-1.5 rounded-full bg-emerald-700 px-5 py-2 text-sm font-bold text-white transition hover:bg-emerald-800"
-            >
-              Find Magnesium Glycinate on Amazon →
-            </a>
-          </section>
-
-          <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8 space-y-8">
-
-            <div id="how-magnesium-works">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                Why Magnesium for ADHD?
-              </h2>
-              <PathwayDiagram data={pathwayDiagrams['magnesium-adhd']} />
-              <p className="mt-4 text-[1.01rem] leading-[1.85] text-muted">
-                Magnesium plays a key role in regulating neural excitability via NMDA receptor blockade.
-                In ADHD, neural over-excitation contributes to hyperactivity, impulsivity, and difficulty
-                with emotional regulation. Magnesium deficiency — more common in ADHD than the general
-                population — may exacerbate these symptoms. Correcting it is one of the more
-                evidence-backed reasons to use magnesium in ADHD.
-              </p>
-              <EvidenceLegend highlightTier="moderate" className="mt-4" />
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            <div id="evidence-synthesis">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                Magnesium + ADHD Evidence: What This Buying Guide Assumes
-              </h2>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                Magnesium makes the most sense when there is low intake, a documented low level, sleep disruption,
-                muscle tension, or evening hyperarousal. It should not be framed as a standalone ADHD treatment.
-                Human ADHD research is mixed and often confounded by baseline nutrient status, so product choice
-                matters less than choosing a tolerable form, checking elemental dose, and avoiding broad claims.
-              </p>
-              <ResponsiveTable label="Magnesium form evidence and safety comparison" className="mt-4">
-                <table className="min-w-[760px] w-full text-sm">
-                  <thead>
-                    <tr className="border-b border-brand-900/10">
-                      {['Form', 'Verdict', 'Best fit', 'Dose range', 'Safety note'].map((h) => (
-                        <th key={h} className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">{h}</th>
-                      ))}
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-brand-900/5">
-                    {MAGNESIUM_EVIDENCE_ROWS.map(([form, verdict, fit, dose, safety]) => (
-                      <tr key={form} className="align-top">
-                        <td className="py-3 pr-4 font-semibold text-ink">{form}</td>
-                        <td className="py-3 pr-4 text-muted">{verdict}</td>
-                        <td className="py-3 pr-4 text-muted">{fit}</td>
-                        <td className="py-3 pr-4 text-muted">{dose}</td>
-                        <td className="py-3 text-muted">{safety}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </ResponsiveTable>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            <div id="deficiency-and-dosing">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                Deficiency Clues, Age Context, and Timing
-              </h2>
-              <div className="grid gap-4 sm:grid-cols-2">
-                <div className="rounded-[1rem] border border-brand-900/10 bg-brand-50/50 p-5">
-                  <h3 className="font-semibold text-ink">Signs to discuss with a clinician</h3>
-                  <ul className="mt-2 ml-5 list-disc space-y-1.5 text-sm leading-6 text-muted">
-                    <li>Low dietary magnesium intake, restrictive diet, or frequent GI losses.</li>
-                    <li>Muscle cramps, restless sleep, or tension that overlaps with low intake.</li>
-                    <li>Medication, kidney, or GI history that changes mineral handling.</li>
-                  </ul>
-                </div>
-                <div className="rounded-[1rem] border border-amber-900/10 bg-amber-50/70 p-5">
-                  <h3 className="font-semibold text-amber-950">Children and teens</h3>
-                  <p className="mt-2 text-sm leading-6 text-amber-900/90">
-                    Pediatric magnesium dosing should be individualized by a pediatrician. Do not copy adult
-                    doses for children, and do not use magnesium to replace behavioral care, school support,
-                    sleep evaluation, or prescribed ADHD treatment.
-                  </p>
-                </div>
-              </div>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Form Rankings */}
-            <div id="form-rankings">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                Magnesium Forms Ranked for ADHD
-              </h2>
-              <div className="space-y-3">
-                {[
-                  {
-                    rank: '1',
-                    name: 'Magnesium Glycinate (Bisglycinate)',
-                    verdict: 'Best Choice',
-                    verdictClass: 'bg-emerald-50 border-emerald-200 text-emerald-800',
-                    desc: 'High absorption, gentle GI profile, glycine adds calming co-benefit. Best for sleep and evening calm support in ADHD.',
-                    query: 'magnesium+glycinate+bisglycinate+sleep',
-                  },
-                  {
-                    rank: '2',
-                    name: 'Magnesium Citrate',
-                    verdict: 'Good Alternative',
-                    verdictClass: 'bg-blue-50 border-blue-200 text-blue-800',
-                    desc: 'Good absorption, widely available, lower cost. Laxative effect at higher doses — start at 150–200 mg elemental.',
-                    query: 'magnesium+citrate+supplement+sleep',
-                  },
-                  {
-                    rank: '3',
-                    name: 'Magnesium L-Threonate',
-                    verdict: 'Premium / Unproven for ADHD',
-                    verdictClass: 'bg-amber-50 border-amber-200 text-amber-800',
-                    desc: 'Marketed for brain penetration. Animal data is interesting but human ADHD trials vs glycinate are limited. 3–4x the cost. Try glycinate first.',
-                    query: 'magnesium+threonate+cognitive',
-                  },
-                  {
-                    rank: '4',
-                    name: 'Magnesium Malate',
-                    verdict: 'Decent Option',
-                    verdictClass: 'bg-slate-50 border-slate-200 text-slate-700',
-                    desc: 'Good tolerance, reasonable absorption. Often used for energy and fatigue. Less calming co-benefit than glycinate. Valid choice if glycinate is unavailable.',
-                    query: 'magnesium+malate+supplement',
-                  },
-                  {
-                    rank: '✕',
-                    name: 'Magnesium Oxide',
-                    verdict: 'Avoid',
-                    verdictClass: 'bg-red-50 border-red-200 text-red-800',
-                    desc: '~4% bioavailability. Almost entirely passes through as a laxative. Very common in cheap supplements — check your label and avoid this form for ADHD use.',
-                    query: 'magnesium+glycinate+not+oxide',
-                  },
-                ].map(({ rank, name, verdict, verdictClass, desc, query }) => (
-                  <div key={name} className="flex gap-4 rounded-[1rem] border border-brand-900/10 bg-brand-50/20 p-4">
-                    <span className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-brand-900 text-xs font-bold text-white">
-                      {rank}
-                    </span>
-                    <div className="min-w-0 flex-1">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <p className="font-semibold text-ink">{name}</p>
-                        <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-bold ${verdictClass}`}>
-                          {verdict}
-                        </span>
-                      </div>
-                      <p className="mt-1 text-sm leading-6 text-muted">{desc}</p>
-                      {rank !== '✕' && (
-                        <a
-                          href={`https://www.amazon.com/s?k=${query}&tag=${AFFILIATE_TAGS.amazon}`}
-                          target="_blank"
-                          rel="noopener noreferrer sponsored"
-                          className="mt-2 inline-flex items-center gap-1 text-xs font-semibold text-brand-700 hover:text-brand-800 hover:underline"
-                        >
-                          View on Amazon →
-                        </a>
-                      )}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Label Reading Guide */}
-            <div id="label-guide">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                How to Read a Magnesium Label
-              </h2>
-              <div className="rounded-[1rem] border border-brand-900/10 bg-brand-50/60 p-5">
-                <p className="font-semibold text-ink">The most common labeling confusion:</p>
-                <p className="mt-2 text-sm leading-6 text-muted">
-                  A product labeled &ldquo;Magnesium Glycinate 400mg&rdquo; does NOT mean you are getting
-                  400mg of elemental magnesium. The 400mg is the weight of the entire compound (magnesium
-                  + glycine). The actual elemental magnesium is typically <strong>60–80mg per tablet</strong>.
-                </p>
-                <p className="mt-3 text-sm leading-6 text-muted">
-                  Always look at the <strong>Supplement Facts panel</strong> for the line that reads:
-                  &ldquo;Magnesium [as magnesium glycinate] — Xmg&rdquo;. That &ldquo;Xmg&rdquo; is the
-                  elemental dose. If you want 200mg elemental magnesium per day, you may need 3–4 tablets
-                  of a standard glycinate product.
-                </p>
-              </div>
-              <ResponsiveTable label="Magnesium form comparison by elemental content" className="mt-4">
-                <table className="min-w-[520px] w-full text-sm">
-                  <thead>
-                    <tr className="border-b border-brand-900/10">
-                      {['Form', 'Typical Elemental %', 'Dose to Hit 200mg Elemental', 'GI Risk'].map((h) => (
-                        <th key={h} className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">{h}</th>
-                      ))}
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-brand-900/5">
-                    {[
-                      ['Glycinate', '~14–18%', '2–4 standard capsules', 'Very low'],
-                      ['Citrate', '~16%', '2–3 capsules', 'Moderate at high doses'],
-                      ['Threonate', '~8%', '3–4 capsules', 'Low'],
-                      ['Oxide', '~60%', '1 capsule (but ~4% absorbed)', 'High laxative effect'],
-                    ].map(([form, pct, dose, gi]) => (
-                      <tr key={form as string} className="align-top">
-                        <td className="py-3 pr-4 font-medium text-ink">{form}</td>
-                        <td className="py-3 pr-4 text-muted">{pct}</td>
-                        <td className="py-3 pr-4 text-muted">{dose}</td>
-                        <td className="py-3 text-muted">{gi}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </ResponsiveTable>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Products */}
-            <div id="products">
-              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">Recommended Products</h2>
-              <p className="mb-4 text-[1.01rem] leading-[1.85] text-muted">
-                These searches reflect the forms and dose ranges most consistent with the ADHD evidence
-                reviewed on this page. Prices and availability vary.
-              </p>
-              <div className="grid gap-4 sm:grid-cols-2">
-                {[
-                  {
-                    eyebrow: '#1 Pick — Sleep + Calm',
-                    name: 'Magnesium Glycinate (200–400mg elemental)',
-                    desc: 'Best first purchase. Look for products listing 100–200mg elemental magnesium per serving in the Supplement Facts panel.',
-                    query: 'magnesium+glycinate+200mg+elemental+adhd+sleep',
-                    cta: 'Find on Amazon →',
-                  },
-                  {
-                    eyebrow: 'Budget Pick',
-                    name: 'Magnesium Citrate',
-                    desc: 'Solid absorption at lower cost. Stay at 150–200mg elemental per dose to minimize loose-stool effect.',
-                    query: 'magnesium+citrate+150mg+200mg+sleep',
-                    cta: 'Find on Amazon →',
-                  },
-                  {
-                    eyebrow: 'For Combining',
-                    name: 'L-Theanine + Magnesium Stack',
-                    desc: 'For adults who want both mental and physical calm support. Verify dose amounts on the label.',
-                    query: 'l-theanine+magnesium+glycinate+sleep+calm+adhd',
-                    cta: 'View combo options →',
-                  },
-                  {
-                    eyebrow: 'Kids ADHD (consult doctor first)',
-                    name: 'Magnesium Glycinate — Pediatric Dose',
-                    desc: 'Lower-dose options for children. Pediatric dosing should be guided by a clinician — do not use adult doses in children.',
-                    query: 'magnesium+glycinate+kids+children+100mg',
-                    cta: 'View options →',
-                  },
-                ].map(({ eyebrow, name, desc, query, cta }) => (
-                  <div key={name} className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
-                    <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">{eyebrow}</p>
-                    <p className="font-semibold text-ink">{name}</p>
-                    <p className="mt-1 text-xs leading-5 text-muted">{desc}</p>
-                    <a
-                      href={`https://www.amazon.com/s?k=${query}&tag=${AFFILIATE_TAGS.amazon}`}
-                      target="_blank"
-                      rel="noopener noreferrer sponsored"
-                      className="mt-3 inline-flex items-center gap-1 rounded-full bg-brand-950 px-4 py-1.5 text-xs font-bold text-white transition hover:bg-brand-900"
-                    >
-                      {cta}
-                    </a>
-                  </div>
-                ))}
-              </div>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            <div id="safety">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Safety Checklist</h2>
-              <SafetyNotice title="Magnesium Safety — ADHD Use">
-                <ul className="ml-5 space-y-1.5 list-disc">
-                  {[
-                    ['Upper limit for supplements: 350 mg/day elemental', 'This applies to supplemental magnesium only. Food-derived magnesium is not counted. Do not routinely exceed 350 mg supplemental without medical advice.'],
-                    ['Kidney disease: Do not supplement without guidance', 'Magnesium is cleared by the kidneys. Impaired clearance can lead to toxicity. Always consult your nephrologist or GP first.'],
-                    ['ADHD medications: No established interaction', 'No known interaction with methylphenidate, amphetamine salts, or atomoxetine. Inform your prescriber you are supplementing.'],
-                    ['Children: Get pediatric dosing advice', 'Research in children exists, but adult doses are not appropriate for children. Discuss with a pediatrician before supplementing.'],
-                    ['Do not use oxide', 'Magnesium oxide is mainly a laxative and delivers very little bioavailable magnesium. Check your labels carefully.'],
-                    ['Drug interactions', 'Magnesium can reduce absorption of some antibiotics, bisphosphonates, and may interact with blood pressure medications. Take 2+ hours apart from these.'],
-                  ].map(([bold, text]) => (
-                    <li key={bold as string}><strong>{bold as string}.</strong> {text as string}</li>
+          </div>
+          <ResponsiveTable label="Magnesium forms for ADHD buying decisions">
+            <table className="min-w-[900px] w-full text-left text-sm">
+              <thead className="bg-brand-50/80">
+                <tr className="border-b border-brand-900/10">
+                  {['Form', 'Direct ADHD evidence', 'Useful context', 'Buying note'].map((heading) => (
+                    <th key={heading} className="px-4 py-3 text-xs font-bold uppercase tracking-[0.12em] text-brand-900">
+                      {heading}
+                    </th>
                   ))}
-                </ul>
-              </SafetyNotice>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            <div id="references">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">References</h2>
-              <ul className="space-y-2 text-sm leading-6">
-                {MAGNESIUM_REFERENCES.map(([label, href]) => (
-                  <li key={href}>
-                    <a href={href} target="_blank" rel="noopener noreferrer" className="font-semibold text-brand-700 hover:underline">
-                      {label}
-                    </a>
-                  </li>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-brand-900/10 bg-white">
+                {FORM_ROWS.map((row) => (
+                  <tr key={row.form} className="align-top">
+                    <td className="px-4 py-4 font-semibold text-ink">{row.form}</td>
+                    <td className="px-4 py-4 text-muted">{row.directAdhdEvidence}</td>
+                    <td className="px-4 py-4 text-muted">{row.usefulContext}</td>
+                    <td className="px-4 py-4 text-muted">{row.buyingNote}</td>
+                  </tr>
                 ))}
-              </ul>
-            </div>
+              </tbody>
+            </table>
+          </ResponsiveTable>
+        </section>
 
-            <hr className="border-brand-900/10" />
+        <section id="adhd-evidence" className="scroll-mt-20 rounded-[1.65rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+          <p className="eyebrow-label">Evidence boundary</p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
+            Lower magnesium status is not the same as a proven treatment
+          </h2>
+          <div className="mt-4 space-y-4 text-sm leading-7 text-muted sm:text-base">
+            <p>
+              Meta-analyses have reported lower serum, blood, or hair magnesium measures in children with
+              ADHD than in controls. That is an observational association with substantial uncertainty; it
+              does not establish that low magnesium causes ADHD or that a supplement improves symptoms.
+            </p>
+            <p>
+              The dedicated systematic review of magnesium treatment found only six intervention studies,
+              no randomized double-blind controlled trial, and no magnesium-monotherapy study. The evidence
+              was not strong enough to recommend magnesium as an ADHD treatment.
+            </p>
+            <p>
+              The newer bisglycinate trial is useful for a narrower question. In 155 adults reporting poor
+              sleep, 250 mg elemental magnesium daily for four weeks produced a statistically significant but
+              small improvement in insomnia severity. It did not test ADHD symptoms or compare magnesium forms.
+            </p>
+          </div>
+        </section>
 
-            <div id="faq">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Frequently Asked Questions</h2>
-              <div className="space-y-4">
-                {FAQS.map((faq, i) => (
-                  <div key={i} className="rounded-[0.75rem] border border-brand-900/10 bg-brand-50/40 p-4">
-                    <h3 className="font-semibold text-ink">{faq.question}</h3>
-                    <p className="mt-2 text-sm leading-7 text-muted">{faq.answer}</p>
-                  </div>
-                ))}
+        <section id="label-checklist" className="scroll-mt-20 space-y-5">
+          <div>
+            <p className="eyebrow-label">Buyer checklist</p>
+            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">How to read the label</h2>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            {[
+              ['Find elemental magnesium', 'The Supplement Facts panel reports elemental magnesium. The front-label chelate weight can be much larger and is not the dose that counts.'],
+              ['Prefer a simple formula', 'A single-ingredient product makes benefits and side effects easier to attribute than an ADHD blend with stimulants, herbs, or undisclosed amounts.'],
+              ['Check serving size', 'A bottle can advertise a dose that requires several capsules. Compare elemental magnesium per full serving and per dollar.'],
+              ['Ignore unsupported superiority language', '“Brain-penetrating,” “ADHD formula,” and “maximum absorption” are marketing claims unless the exact product and outcome were tested.'],
+              ['Look for independent quality signals', 'Third-party verification can reduce identity and contamination uncertainty, but it does not prove the supplement works for ADHD.'],
+              ['Audit the whole routine', 'Count magnesium from other supplements, antacids, and laxatives before adding another product.'],
+            ].map(([title, copy]) => (
+              <div key={title} className="rounded-2xl border border-brand-900/10 bg-white/90 p-5 shadow-sm">
+                <h3 className="font-semibold text-ink">{title}</h3>
+                <p className="mt-2 text-sm leading-6 text-muted">{copy}</p>
               </div>
+            ))}
+          </div>
+        </section>
+
+        <section id="safety" className="scroll-mt-20 rounded-[1.65rem] border border-amber-900/15 bg-amber-50/70 p-6 shadow-sm sm:p-8">
+          <p className="text-xs font-bold uppercase tracking-[0.14em] text-amber-800">Safety first</p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-amber-950">
+            Dose and medication guardrails
+          </h2>
+          <ul className="mt-4 space-y-3 text-sm leading-7 text-amber-950/90">
+            <li>
+              <strong>There is no established ADHD dose.</strong> The NIH adult upper limit is 350 mg/day
+              from supplements and medications unless a clinician directs otherwise. Food magnesium is not
+              included in that limit.
+            </li>
+            <li>
+              <strong>Children have age-specific limits.</strong> Do not copy an adult protocol for a child;
+              pediatric dosing and the reason for supplementation require clinical review.
+            </li>
+            <li>
+              <strong>Kidney function matters.</strong> Impaired renal function raises the risk of magnesium
+              accumulation and toxicity.
+            </li>
+            <li>
+              <strong>Medication timing matters.</strong> Magnesium can reduce absorption of oral
+              bisphosphonates and can bind tetracycline or quinolone antibiotics. Follow the medication label
+              or pharmacist’s spacing instructions.
+            </li>
+            <li>
+              <strong>GI symptoms are dose-limiting information.</strong> Diarrhea, nausea, or cramping are
+              reasons to stop escalating and reassess the form, dose, and need.
+            </li>
+          </ul>
+        </section>
+
+        {magnesiumProducts && (
+          <section className="space-y-4">
+            <div className="max-w-3xl">
+              <p className="eyebrow-label">Product filter</p>
+              <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
+                Compare products only after choosing the role
+              </h2>
+              <p className="mt-3 text-sm leading-7 text-muted">
+                The product set below is for comparing label clarity and formulation. It is not a ranking of
+                ADHD treatments, and a product appearance here does not establish that it improves attention.
+              </p>
             </div>
-
-            <hr className="border-brand-900/10" />
-
-            <div id="related">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Related Articles</h2>
-              <div className="grid gap-3 sm:grid-cols-2">
-                {[
-                  ['/guides/adhd/magnesium-for-adhd/', 'ADHD Cluster', 'Magnesium for ADHD', 'Full evidence review.'],
-                  ['/guides/adhd/best-supplements-for-adhd/', 'Cornerstone', 'Best Supplements for ADHD', 'Evidence-ranked guide.'],
-                  ['/guides/adhd/magnesium-glycinate-vs-citrate-for-adhd', 'ADHD Cluster', 'Glycinate vs Citrate for ADHD', 'Form comparison.'],
-                  ['/guides/adhd/l-theanine-magnesium-adhd-stack', 'Stack Guide', 'L-Theanine + Magnesium Stack', 'How to combine the two.'],
-                  ['/guides/adhd/sleep-and-adhd', 'Sleep + ADHD', 'Sleep and ADHD', 'Why sleep is critical in ADHD.'],
-                  ['/guides/adhd/adhd-stack-guide', 'ADHD Cluster', 'ADHD Stack Guide', 'Full supplement stacking guide.'],
-                ].map(([href, eyebrow, label, desc]) => (
-                  <Link key={href as string} href={href as string}
-                    className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30">
-                    <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">{eyebrow}</p>
-                    <p className="font-semibold text-ink transition group-hover:text-brand-700">{label}</p>
-                    <p className="mt-1 text-xs text-muted">{desc}</p>
-                  </Link>
-                ))}
-              </div>
-            </div>
-
+            <RecommendationSection products={magnesiumProducts.products} />
           </section>
+        )}
 
-      <div className="max-w-4xl">
-        <RecommendationSection products={getRevenueProductSet('magnesium')?.products ?? []} />
-      </div>
-          <EmailCapture
-            headline="Get the ADHD supplement checklist"
-            description="Evidence-first supplement updates, buying guides, and ADHD research notes."
-            ctaLabel="Get Checklist"
-            location={`article-${SLUG}`}
-          />
-          <NewsletterCtaBlock
-            title="Continue with the newsletter archive"
-            description="Short notes built for cautious supplement decisions."
-            location={`article-${SLUG}-newsletter`}
-          />
-        </div>
-
-        {/* Sidebar */}
-        <aside className="space-y-4 lg:sticky lg:top-24 lg:self-start">
-          <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
-            <p className="text-[10px] font-bold uppercase tracking-wider text-muted">In this article</p>
-            <nav className="mt-3 space-y-1.5" aria-label="Article sections">
-              {[
-                ['#how-magnesium-works', 'Why Magnesium?'],
-                ['#form-rankings', 'Form Rankings'],
-                ['#label-guide', 'Reading Labels'],
-                ['#products', 'Product Picks'],
-                ['#safety', 'Safety Checklist'],
-                ['#faq', 'FAQ'],
-              ].map(([href, label]) => (
-                <a key={href} href={href as string}
-                  className="block text-sm text-brand-700 hover:text-brand-800 hover:underline">
-                  {label}
-                </a>
-              ))}
-            </nav>
+        <section className="rounded-[1.65rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm">
+          <h2 className="text-xl font-semibold text-ink">Continue the decision</h2>
+          <div className="mt-4 grid gap-3 sm:grid-cols-2">
+            <Link href="/guides/adhd/magnesium-glycinate-vs-citrate-for-adhd/" className="rounded-xl border border-brand-900/10 p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/30 hover:underline">
+              Compare glycinate and citrate directly →
+            </Link>
+            <Link href="/guides/sleep/magnesium-types-for-sleep/" className="rounded-xl border border-brand-900/10 p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/30 hover:underline">
+              Choose magnesium by sleep goal →
+            </Link>
+            <Link href="/guides/adhd/iron-ferritin-and-adhd/" className="rounded-xl border border-brand-900/10 p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/30 hover:underline">
+              Understand deficiency-first ADHD support →
+            </Link>
+            <Link href="/compounds/magnesium/" className="rounded-xl border border-brand-900/10 p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/30 hover:underline">
+              Read the magnesium compound profile →
+            </Link>
           </div>
-          <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
-            <p className="text-[10px] font-bold uppercase tracking-wider text-muted">ADHD cluster</p>
-            <div className="mt-3 space-y-2">
-              {[
-                ['/guides/adhd/best-supplements-for-adhd/', 'Best supplements for ADHD →'],
-                ['/guides/adhd/magnesium-for-adhd/', 'Magnesium for ADHD →'],
-                ['/guides/adhd/l-theanine-magnesium-adhd-stack', 'L-Theanine + Magnesium Stack →'],
-                ['/guides/adhd/adhd-stack-guide', 'ADHD stack guide →'],
-                ['/guides/focus', 'Focus goal hub →'],
-              ].map(([href, label]) => (
-                <Link key={href as string} href={href as string}
-                  className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline">
-                  {label}
-                </Link>
-              ))}
-            </div>
-          </div>
-        </aside>
-      </div>
+        </section>
 
-      <div className="mt-8">
-        <Link href="/guides/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
-          ← Back to Guides
-        </Link>
+        <section id="faq" className="scroll-mt-20 rounded-[1.65rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+          <h2 className="text-2xl font-semibold tracking-tight text-ink">Frequently asked questions</h2>
+          <div className="mt-5 divide-y divide-brand-900/10">
+            {FAQS.map((faq) => (
+              <div key={faq.question} className="py-5 first:pt-0 last:pb-0">
+                <h3 className="font-semibold text-ink">{faq.question}</h3>
+                <p className="mt-2 text-sm leading-7 text-muted">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <References refs={[...REFERENCES]} />
+
+        <p className="text-xs leading-6 text-muted">
+          This guide is educational and does not diagnose magnesium deficiency or recommend magnesium as a
+          treatment for ADHD. Discuss persistent attention problems, sleep disruption, pediatric use, kidney
+          disease, pregnancy, and medication interactions with a qualified clinician or pharmacist.
+        </p>
       </div>
-    </article>
+    </ArticleLayout>
   )
 }

--- a/app/guides/adhd/magnesium-glycinate-vs-citrate-for-adhd/page.tsx
+++ b/app/guides/adhd/magnesium-glycinate-vs-citrate-for-adhd/page.tsx
@@ -1,482 +1,406 @@
-import Link from 'next/link'
-import Image from 'next/image'
-import JsonLd from '@/components/seo/JsonLd'
 import type { Metadata } from 'next'
-import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd, compactMetaTitle } from '../../../../src/lib/seo'
-import LastUpdatedBadge from '../../../../src/components/editorial/LastUpdatedBadge'
-import ResponsiveTable from '@/components/ui/ResponsiveTable'
-import SafetyNotice from '@/components/evidence/SafetyNotice'
-import EvidenceSummaryCard from '@/components/evidence/EvidenceSummaryCard'
-import EmailCapture from '@/components/EmailCapture'
-import NewsletterCtaBlock from '@/components/NewsletterCtaBlock'
-import PathwayDiagram from '@/components/PathwayDiagram'
-import EvidenceLegend from '@/components/EvidenceLegend'
-import { pathwayDiagrams } from '@/lib/pathway-data'
-import References from '@/components/References'
+import Image from 'next/image'
+import Link from 'next/link'
+import AffiliateDisclosure from '@/components/AffiliateDisclosure'
+import { ArticleLayout, TableOfContents } from '@/components/articles'
+import type { Heading } from '@/components/articles'
 import RecommendationSection from '@/components/RecommendationSection'
+import References from '@/components/References'
+import StructuredData from '@/components/StructuredData'
+import ResponsiveTable from '@/components/ui/ResponsiveTable'
 import { getRevenueProductSet } from '@/config/revenue-products'
+import { SITE_URL } from '@/lib/navigation-config'
 
-const SLUG = 'magnesium-glycinate-vs-citrate-for-adhd'
-const TITLE = 'Magnesium Glycinate vs Citrate for ADHD: Which Form Works Better?'
+const PATH = '/guides/adhd/magnesium-glycinate-vs-citrate-for-adhd'
+const PAGE_URL = `${SITE_URL}${PATH}`
+const TITLE = 'Magnesium Glycinate vs Citrate for ADHD: Evidence & Tradeoffs'
 const DESCRIPTION =
-  'Evidence-based comparison of magnesium glycinate and citrate for ADHD. Covers absorption, sleep support, calming effects, GI tolerability, dosage, and practical product guidance.'
-const DATE = '2026-06-12'
-const AUTHOR = 'Will'
-const READING_TIME = '11 min read'
-const TAGS = ['magnesium', 'ADHD', 'focus', 'sleep', 'minerals']
-const CATEGORY = 'Supplement Evidence'
+  'Compare magnesium glycinate and citrate for ADHD without the marketing shortcuts. Direct ADHD evidence, sleep context, absorption, GI effects, labels, safety, and cost.'
 
-export const metadata: Metadata = buildPageMetadata({
-  title: compactMetaTitle(TITLE),
+export const metadata: Metadata = {
+  title: TITLE,
   description: DESCRIPTION,
-  path: `/guides/adhd/${SLUG}`,
-  openGraphType: 'article',
-})
+  alternates: { canonical: `${PATH}/` },
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    url: `${PATH}/`,
+    type: 'article',
+    images: ['/images/guides/magnesium-glycinate-vs-citrate-for-adhd.jpg'],
+  },
+}
+
+const HEADINGS: Heading[] = [
+  { id: 'verdict', text: 'Quick verdict', level: 2 },
+  { id: 'comparison', text: 'Side-by-side comparison', level: 2 },
+  { id: 'claim-check', text: 'Claim check', level: 2 },
+  { id: 'choose', text: 'How to choose', level: 2 },
+  { id: 'dose-safety', text: 'Dose and safety', level: 2 },
+  { id: 'faq', text: 'Frequently asked questions', level: 2 },
+]
+
+const COMPARISON_ROWS = [
+  ['Direct ADHD evidence', 'No form-specific ADHD trial showing benefit or superiority', 'No form-specific ADHD trial showing benefit or superiority'],
+  ['Sleep evidence', 'One 2025 placebo-controlled trial in adults with poor sleep found a small benefit from bisglycinate; it was not an ADHD trial', 'No comparable ADHD or direct glycinate-vs-citrate sleep trial'],
+  ['Absorption evidence', 'No authoritative evidence that glycinate is uniquely best for ADHD', 'NIH summarizes citrate as more completely absorbed than oxide in small studies; that does not prove superiority to glycinate'],
+  ['GI fit', 'Often chosen by people trying to avoid a laxative-style product, but individual tolerance varies', 'Can loosen stools; useful when constipation is part of the picture and less useful when diarrhea is a risk'],
+  ['Cost', 'Usually higher', 'Usually lower'],
+  ['Best practical use', 'A simple trial when sleep or perceived GI tolerance is the main reason for the form choice', 'A cost-conscious repletion option or a form that may also help constipation'],
+  ['What it cannot claim', 'Proven calm-focus synergy or better ADHD symptom control', 'Proven ADHD efficacy or equal benefit at every dose'],
+] as const
 
 const FAQS = [
   {
     question: 'Is magnesium glycinate or citrate better for ADHD?',
     answer:
-      'Magnesium glycinate is generally considered the better first choice for ADHD-related use. The glycine component adds mild calming support, it is gentler on the digestive system, and it is well-absorbed. Citrate is a reasonable alternative with good absorption at a lower price point, but it has a stronger laxative effect at higher doses. For sleep support, glycinate is typically preferred. For general magnesium repletion at a lower cost, citrate is acceptable.',
+      'Neither has been proven better for ADHD. There is no direct ADHD head-to-head trial. Glycinate may be a practical fit when sleep or perceived GI tolerance matters; citrate may be a practical fit when cost or constipation matters. Those are use-case differences, not evidence of superior ADHD symptom control.',
   },
   {
-    question: 'Can magnesium help ADHD symptoms directly?',
+    question: 'Does the glycine in magnesium glycinate make it better for focus or calm?',
     answer:
-      'The evidence for magnesium improving core ADHD symptoms (inattention, hyperactivity) is primarily in populations with documented magnesium deficiency — which is more common in ADHD than the general population. Correcting a deficiency may improve symptoms by normalizing nervous system excitability. Using magnesium as a primary ADHD treatment in a non-deficient person has weaker supporting evidence. Testing serum magnesium levels before supplementing is reasonable.',
+      'That claim is plausible but unproven. The effect of glycine has not been isolated in a magnesium-glycinate ADHD trial, so the combined product cannot be assumed to provide a special calm-focus effect beyond magnesium itself.',
   },
   {
-    question: 'What dose of magnesium glycinate for ADHD?',
+    question: 'Is citrate absorbed better than glycinate?',
     answer:
-      'Common supplemental doses are 200–400 mg elemental magnesium daily. For ADHD specifically, many practitioners use 200–300 mg elemental magnesium glycinate taken in the evening. Start at the lower end and increase gradually. Note that "magnesium glycinate 400 mg" on a label refers to the total salt weight, not elemental magnesium — check the label for elemental magnesium content, which is typically 60–75 mg per 400 mg serving of the chelate.',
+      'NIH summarizes small studies showing citrate is absorbed more completely than oxide and sulfate. That is not the same as a direct citrate-versus-glycinate comparison, and it does not establish that citrate produces better ADHD or sleep outcomes.',
   },
   {
-    question: 'Can I take magnesium glycinate every night for ADHD?',
+    question: 'Which form is less likely to cause diarrhea?',
     answer:
-      'Daily evening use is a common pattern and is generally considered reasonable for healthy adults within typical supplemental dose ranges. Long-term formal safety data for high-dose supplementation is limited, but magnesium at physiological doses has a good safety record. Avoid exceeding the tolerable upper intake level of 350 mg supplemental magnesium per day from supplements (dietary magnesium is not counted in this limit). If you have kidney disease or take medications, consult a clinician first.',
+      'Citrate can have a more noticeable laxative effect, but GI response varies by dose, serving size, diet, and individual sensitivity. A lower elemental dose can matter as much as the form name.',
   },
   {
-    question: 'Does magnesium citrate have a laxative effect at ADHD doses?',
+    question: 'What dose should I use for ADHD?',
     answer:
-      'At typical ADHD supplemental doses (150–200 mg elemental magnesium), GI effects are mild for most people. Magnesium citrate has a stronger osmotic laxative effect than glycinate at equal elemental doses, particularly above 200–300 mg. If loose stools occur with citrate, switching to glycinate or reducing the dose usually resolves the issue. Some people find citrate useful for constipation as a side benefit; for others it is a reason to use glycinate instead.',
+      'There is no established ADHD-specific dose for either form. Read the label for elemental magnesium rather than the total chelate weight. The NIH adult upper limit is 350 mg per day from supplements and medications unless a clinician recommends otherwise.',
   },
   {
-    question: 'Is magnesium threonate better than glycinate for ADHD?',
+    question: 'Should I test magnesium before choosing a form?',
     answer:
-      'Magnesium threonate (L-threonate) is marketed for brain health due to animal data suggesting greater brain penetration. Human trial data for threonate vs glycinate in ADHD specifically is very limited. It is substantially more expensive than glycinate. For most people starting magnesium supplementation for ADHD, glycinate is the most practical first choice: better evidence, better cost, and a strong safety profile. Threonate may be worth exploring if glycinate does not produce results after a fair trial.',
+      'Clinical context can be useful, but no single magnesium test is definitive. NIH notes that serum magnesium is commonly measured yet does not closely reflect total-body or tissue status. Diet, symptoms, medical history, medications, and laboratory findings may all matter.',
   },
 ]
 
-const MAGNESIUM_GLYCINATE_VS_CITRATE_FOR_ADHD_REFS = [
-  { n: 1, text: 'Starobrat-Hermelin B, Kozielec T. (1997). Magnesium in ADHD. Magnes Res, 10(2): 149-156.', url: 'https://pubmed.ncbi.nlm.nih.gov/9368238/' },
-  { n: 2, text: 'Mousain-Bosc M, et al. (2006). Magnesium-B6 supplementation in ADHD. Magnes Res, 19(1): 46-52.', url: 'https://pubmed.ncbi.nlm.nih.gov/16846101/' },
-  { n: 3, text: 'Abbasi B, et al. (2012). Magnesium and sleep. J Res Med Sci, 17(12): 1161-1169.', url: 'https://pubmed.ncbi.nlm.nih.gov/23853635/' },
-]
+const REFERENCES = [
+  {
+    n: 1,
+    text: 'NIH Office of Dietary Supplements. Magnesium: Fact Sheet for Health Professionals.',
+    url: 'https://ods.od.nih.gov/factsheets/Magnesium-HealthProfessional/',
+  },
+  {
+    n: 2,
+    text: 'Schuster J, et al. Magnesium bisglycinate supplementation in healthy adults reporting poor sleep: randomized placebo-controlled trial. 2025. PMID: 40918053.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/40918053/',
+  },
+  {
+    n: 3,
+    text: 'Ghanizadeh A. A systematic review of magnesium therapy for treating attention deficit hyperactivity disorder. 2013. PMID: 23808779.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/23808779/',
+  },
+  {
+    n: 4,
+    text: 'Huang YH, et al. Magnesium levels in children with ADHD: systematic review and meta-analysis. 2019. PMID: 30496768.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/30496768/',
+  },
+] as const
 
-export default function MagnesiumGlycinateCitrateAdhdPage() {
-  const breadcrumbLd = breadcrumbJsonLd([
-    { name: 'Guides', url: 'https://thehippiescientist.net/guides/' },
-    { name: TITLE, url: `https://thehippiescientist.net/guides/adhd/${SLUG}/` },
-  ])
-  const articleLd = blogJsonLd(
-    { title: TITLE, slug: SLUG, date: DATE, description: DESCRIPTION },
-    `/guides/adhd/${SLUG}/`,
-  )
-  const faqLd = faqPageJsonLd({ pagePath: `/guides/adhd/${SLUG}/`, questions: FAQS })
+export default function MagnesiumGlycinateVsCitrateForAdhdPage() {
+  const toc = <TableOfContents headings={HEADINGS} />
+  const magnesiumProducts = getRevenueProductSet('magnesium')
 
   return (
-    <article className="mx-auto max-w-5xl space-y-0 px-4 pb-20 pt-6 sm:px-6 lg:px-8">
-      <JsonLd schema={articleLd} />
-      <JsonLd schema={breadcrumbLd} />
-      {faqLd && <JsonLd schema={faqLd} />}
+    <ArticleLayout toc={toc} zone="supplement">
+      <StructuredData
+        pageUrl={PAGE_URL}
+        headline={TITLE}
+        description={DESCRIPTION}
+        datePublished="2026-06-12"
+        dateModified="2026-08-02"
+        image={`${SITE_URL}/images/guides/magnesium-glycinate-vs-citrate-for-adhd.jpg`}
+        faqs={FAQS}
+        breadcrumbs={[
+          { label: 'Home', href: '/' },
+          { label: 'ADHD Guides', href: '/guides/adhd/' },
+          { label: 'Glycinate vs Citrate', href: PATH },
+        ]}
+        zone="monetized"
+      />
 
-      {/* Breadcrumb */}
-      <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
-        <Link href="/guides/" className="transition hover:text-ink">Guides</Link>
-        <span>/</span>
-        <span className="text-ink line-clamp-1">{TITLE}</span>
-      </nav>
+      <div className="space-y-12">
+        <AffiliateDisclosure variant="compact" />
 
-      {/* Hero */}
-      <section className="rounded-[1.5rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8 lg:p-10">
-        <div className="flex flex-wrap items-center gap-2 text-xs">
-          <span className="rounded-full border border-brand-900/10 bg-brand-50 px-2.5 py-0.5 font-bold uppercase tracking-wider text-brand-800">
-            {CATEGORY}
-          </span>
-          {TAGS.slice(0, 3).map((tag) => (
-            <span key={tag} className="rounded-full border border-brand-900/10 bg-white px-2.5 py-0.5 font-semibold text-muted capitalize">
-              {tag}
-            </span>
-          ))}
-          <span className="text-muted">June 12, 2026</span>
-          <span className="text-muted">·</span>
-          <span className="text-muted">{READING_TIME}</span>
-        </div>
-
-        <h1 className="mt-4 font-display text-3xl font-bold leading-tight tracking-tight text-ink sm:text-4xl lg:text-5xl">
-          {TITLE}
-        </h1>
-        <p className="mt-2 text-sm text-muted">
-          By{' '}
-          <Link href="/info/about/" rel="author" className="font-medium text-ink hover:underline">
-            {AUTHOR}
-          </Link>
-        </p>
-        <div className="mt-3">
-          <LastUpdatedBadge date={DATE} label="Last updated" />
-        </div>
-        <p className="mt-4 max-w-3xl text-base leading-7 text-muted">{DESCRIPTION}</p>
-
-        <figure className="mt-6">
-          <div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white">
-            <Image
-              src="/images/guides/magnesium-glycinate-vs-citrate-for-adhd.jpg"
-              alt="Magnesium glycinate and magnesium citrate supplements compared for ADHD"
-              width={1536}
-              height={1024}
-              priority
-              className="w-full h-auto"
-            />
+        <section className="rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-10">
+          <p className="eyebrow-label">Symmetrical comparison</p>
+          <h1 className="mt-3 font-display text-3xl font-bold leading-tight tracking-tight text-ink sm:text-5xl">
+            Magnesium Glycinate vs Citrate for ADHD
+          </h1>
+          <p className="mt-4 max-w-3xl text-base leading-7 text-muted">
+            There is no direct ADHD head-to-head trial showing that glycinate beats citrate. The useful
+            comparison is practical: sleep context, GI response, constipation, cost, elemental dose, and
+            medication safety. This page keeps those tradeoffs separate from claims about treating ADHD.
+          </p>
+          <div className="mt-5 flex flex-wrap gap-3 text-xs font-semibold">
+            <Link href="/guides/adhd/best-magnesium-supplement-for-adhd/" className="text-brand-700 hover:underline">
+              Magnesium buying guide →
+            </Link>
+            <Link href="/guides/sleep/magnesium-types-for-sleep/" className="text-brand-700 hover:underline">
+              Compare forms for sleep →
+            </Link>
           </div>
-          <figcaption className="mt-3 text-center text-sm text-muted">
-            Glycinate vs citrate — the two magnesium forms most relevant to ADHD.
-          </figcaption>
-        </figure>
-      </section>
 
-      {/* Disclosure */}
-      <div className="mt-4 rounded-[1rem] border border-brand-900/10 bg-brand-50/60 px-5 py-3 text-xs leading-6 text-muted">
-        <strong className="text-ink">Affiliate disclosure:</strong> This article contains affiliate
-        links. If you purchase through these links, we may earn a commission at no additional cost to
-        you. We only link to forms and dose ranges consistent with the research reviewed on this page.
-      </div>
-
-      {/* Body + sidebar */}
-      <div className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1fr)_240px]">
-        <div className="space-y-6">
-
-          {/* Quick Verdict */}
-          <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
-            <p className="eyebrow-label">Quick Verdict</p>
-            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
-              Glycinate or Citrate — Which Wins for ADHD?
-            </h2>
-            <ul className="mt-4 space-y-2">
-              {[
-                ['Glycinate is the better first choice for ADHD', 'The glycine component adds mild calming support, GI tolerance is better, and it\'s well-suited for evening use.'],
-                ['Citrate is a reasonable budget alternative', 'Similar elemental absorption at lower cost, but more laxative potential at higher doses.'],
-                ['Both forms help correct magnesium deficiency', 'Deficiency is more common in ADHD and correcting it may reduce hyperactivation and support sleep.'],
-                ['Neither is a primary ADHD treatment', 'Evidence for direct ADHD symptom improvement is strongest in deficient populations — not as a standalone stimulant replacement.'],
-              ].map(([bold, rest]) => (
-                <li key={bold as string} className="flex gap-2 text-[1.01rem] leading-[1.85] text-muted">
-                  <span className="mt-1 flex-shrink-0 text-brand-700">▸</span>
-                  <span><strong>{bold as string}.</strong> {rest as string}</span>
-                </li>
-              ))}
-            </ul>
-          </section>
-
-          {/* Main content */}
-          <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8 space-y-8">
-
-            <div id="why-form-matters">
-              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">
-                Why the Form of Magnesium Matters for ADHD
-              </h2>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                Not all magnesium supplements deliver the same amount of usable magnesium to your cells.
-                Bioavailability — how much is absorbed in the gut and reaches tissues — varies significantly
-                by form. For ADHD specifically, additional factors matter: whether the chelating agent has
-                its own neurological effect (glycine does), how the supplement affects digestion, and
-                whether the timing suits sleep support.
-              </p>
-              <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
-                <strong>Magnesium glycinate</strong> is magnesium chelated to glycine, an amino acid that
-                acts as an inhibitory neurotransmitter in the central nervous system. Glycine itself has
-                evidence for sleep quality support and may add a calming effect beyond what magnesium alone
-                provides — making glycinate a natural fit for ADHD-related sleep difficulties and evening
-                calming support.
-              </p>
-              <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
-                <strong>Magnesium citrate</strong> is magnesium bound to citric acid. It has good
-                bioavailability and is substantially cheaper than glycinate, but the citrate form has
-                a stronger osmotic effect in the gut — meaning it draws water into the intestines, which
-                can cause loose stools at higher doses. At typical supplemental doses for ADHD (150–200 mg
-                elemental), this is usually mild, but it is a meaningful difference for sensitive users.
-              </p>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Mechanism */}
-            <div id="mechanism">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                How Magnesium Works in the Brain
-              </h2>
-              <PathwayDiagram data={pathwayDiagrams['magnesium-adhd']} />
-              <p className="mt-4 text-[1.01rem] leading-[1.85] text-muted">
-                Magnesium&apos;s primary role in neural excitability is as a voltage-dependent blocker of
-                NMDA receptors — the &ldquo;volume knob&rdquo; for excitatory signaling in the brain. When
-                magnesium levels are adequate, NMDA receptors require stronger signals to activate, which
-                reduces neural hyperactivation. This is particularly relevant for ADHD, where
-                hyperactivation and sensory overload are common presentations.
-              </p>
-              <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
-                Magnesium also supports GABA activity (the brain&apos;s primary inhibitory
-                neurotransmitter), which contributes to its calming and sleep-supporting properties. GABA
-                dysregulation is implicated in anxiety and sleep problems commonly co-occurring with ADHD.
-              </p>
-              <EvidenceLegend highlightTier="moderate" className="mt-4" />
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Evidence */}
-            <div id="evidence">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                Evidence Summary
-              </h2>
-              <EvidenceSummaryCard
-                title="Magnesium &amp; ADHD Symptoms"
-                evidenceLevel="Moderate"
-                humanEvidence="Several controlled trials show improvements in ADHD-related hyperactivity, emotional dysregulation, and sleep — particularly in children and adults with confirmed low magnesium status. Effects are most consistent in deficient populations; evidence in magnesium-replete individuals is weaker. Form comparison trials (glycinate vs citrate specifically for ADHD) are limited."
-                mechanisticEvidence="NMDA receptor blockade by magnesium is well-established in preclinical literature. The connection to ADHD is biologically plausible: NMDA hyperactivation is proposed to contribute to impulsivity and executive dysfunction. GABA support via magnesium provides additional rationale for sleep and calming effects."
-                safetyProfile="Well-tolerated at supplemental doses. Main risks: laxative effect (dose-dependent, stronger with citrate), hypotension at very high doses, contraindication in severe kidney disease. Avoid magnesium oxide — poor bioavailability and significant GI effects."
+          <figure className="mt-7">
+            <div className="overflow-hidden rounded-2xl border border-brand-900/10 bg-white shadow-sm">
+              <Image
+                src="/images/guides/magnesium-glycinate-vs-citrate-for-adhd.jpg"
+                alt="Magnesium glycinate and citrate bottles compared side by side"
+                width={1536}
+                height={1024}
+                priority
+                className="h-auto w-full"
               />
             </div>
+            <figcaption className="mt-3 text-center text-sm text-muted">
+              A form decision should be based on tradeoffs—not an unsupported ADHD winner.
+            </figcaption>
+          </figure>
+        </section>
 
-            <hr className="border-brand-900/10" />
-
-            {/* Comparison Table */}
-            <div id="comparison">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                Glycinate vs Citrate: Side-by-Side
-              </h2>
-              <ResponsiveTable label="Magnesium glycinate vs citrate comparison for ADHD">
-                <table className="min-w-[600px] w-full text-sm">
-                  <thead>
-                    <tr className="border-b border-brand-900/10">
-                      {['Factor', 'Glycinate', 'Citrate'].map((h) => (
-                        <th key={h} className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">{h}</th>
-                      ))}
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-brand-900/5">
-                    {[
-                      ['Absorption', 'High — chelated form bypasses some GI barriers', 'Good — soluble salt, solid bioavailability'],
-                      ['GI tolerance', 'Excellent — rarely causes loose stools', 'Moderate — laxative effect above ~200 mg elemental'],
-                      ['Glycine co-factor', 'Yes — glycine adds mild calming + sleep support', 'No — citrate is neutral, no added CNS effect'],
-                      ['Cost', '$$–$$$ — premium form', '$ — widely available, lower cost'],
-                      ['Best for ADHD sleep', '★★★ First choice', '★★ Acceptable alternative'],
-                      ['Best for ADHD calm focus', '★★★ First choice', '★★ Good if tolerated'],
-                      ['Best for deficiency correction', '★★★', '★★★ (both equally effective)'],
-                      ['Avoid at high doses?', 'No special concern', 'Yes — GI effects above 300 mg elemental/day'],
-                    ].map(([factor, glycinate, citrate]) => (
-                      <tr key={factor as string} className="align-top">
-                        <td className="py-3 pr-4 font-medium text-ink">{factor}</td>
-                        <td className="py-3 pr-4 text-muted">{glycinate}</td>
-                        <td className="py-3 text-muted">{citrate}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </ResponsiveTable>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Dosage */}
-            <div id="dosage">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                Dosage Guide for ADHD
-              </h2>
-              <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-5 shadow-sm">
-                <p className="mb-3 text-[10px] font-bold uppercase tracking-wider text-muted">
-                  Magnesium Dosage Reference — ADHD Use
-                </p>
-                <ResponsiveTable label="Magnesium dosage for ADHD">
-                  <table className="min-w-[520px] w-full text-sm">
-                    <thead>
-                      <tr className="border-b border-brand-900/10">
-                        {['Use Case', 'Form', 'Elemental Dose', 'Timing'].map((h) => (
-                          <th key={h} className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">{h}</th>
-                        ))}
-                      </tr>
-                    </thead>
-                    <tbody className="divide-y divide-brand-900/5">
-                      {[
-                        ['Sleep + calm support', 'Glycinate', '200–300 mg', '30–60 min before bed'],
-                        ['General repletion', 'Glycinate or Citrate', '200–400 mg', 'Evening, with food'],
-                        ['Budget option', 'Citrate', '150–250 mg', 'Evening — start low'],
-                        ['Deficiency correction', 'Either', '200–400 mg', 'As directed by clinician'],
-                      ].map(([use, form, dose, timing]) => (
-                        <tr key={use as string} className="align-top">
-                          <td className="py-3 pr-4 font-medium text-ink">{use}</td>
-                          <td className="py-3 pr-4 text-muted">{form}</td>
-                          <td className="py-3 pr-4 text-muted">{dose}</td>
-                          <td className="py-3 text-muted">{timing}</td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </ResponsiveTable>
-                <p className="mt-3 text-xs text-muted">
-                  Check product labels for elemental magnesium content — the chelate weight shown on the
-                  label is not the same as elemental magnesium. A product showing &ldquo;400 mg magnesium
-                  glycinate&rdquo; typically provides 60–80 mg of elemental magnesium per tablet.
-                </p>
+        <section id="verdict" className="scroll-mt-20 rounded-[1.65rem] border border-brand-200 bg-brand-50/60 p-6 shadow-sm sm:p-8">
+          <p className="eyebrow-label">Quick verdict</p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
+            Glycinate for sleep-oriented fit; citrate for cost or constipation
+          </h2>
+          <p className="mt-3 text-sm leading-7 text-muted sm:text-base">
+            That is a shopping shortcut, not an efficacy ranking. Glycinate has a small recent sleep signal
+            in non-ADHD adults. Citrate has practical absorption evidence relative to oxide and a more useful
+            laxative effect for some people. Neither has demonstrated superior control of inattention,
+            hyperactivity, impulsivity, or executive dysfunction.
+          </p>
+          <div className="mt-5 grid gap-3 md:grid-cols-3">
+            {[
+              ['Choose glycinate when', 'You want a simple, sleep-oriented trial and are willing to pay more without assuming ADHD superiority.'],
+              ['Choose citrate when', 'Lower cost or constipation matters and a looser-stool effect would not be a problem.'],
+              ['Choose neither yet when', 'Kidney disease, medication interactions, unexplained symptoms, or a child’s dosing make clinical review the next step.'],
+            ].map(([title, copy]) => (
+              <div key={title} className="rounded-xl border border-brand-900/10 bg-white/80 p-4">
+                <h3 className="text-sm font-semibold text-ink">{title}</h3>
+                <p className="mt-2 text-xs leading-6 text-muted">{copy}</p>
               </div>
-            </div>
+            ))}
+          </div>
+        </section>
 
-            <hr className="border-brand-900/10" />
-
-            {/* Products */}
-            <div id="products">
-              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">
-                Product Recommendations
-              </h2>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                These picks favor glycinate-chelated forms with clearly labeled elemental magnesium,
-                consistent with the comparison above. Avoid magnesium oxide — poor bioavailability and
-                a stronger laxative effect make it a weak fit for ADHD-related use.
-              </p>
-              <div className="mt-4">
-                <RecommendationSection products={getRevenueProductSet('magnesium')?.products ?? []} />
-              </div>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Safety */}
-            <div id="safety">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Safety</h2>
-              <SafetyNotice title="Safety Summary — Magnesium for ADHD">
-                <ul className="ml-5 space-y-1.5 list-disc">
-                  {[
-                    ['Generally safe at supplemental doses', 'Magnesium from food and supplements at physiological amounts is well-tolerated in healthy adults and children.'],
-                    ['Tolerable upper level: 350 mg/day supplemental', 'This limit applies to magnesium from supplements only. Dietary magnesium from food is not counted. Exceeding this level increases risk of adverse effects including diarrhea.'],
-                    ['Kidney disease caution', 'Magnesium is renally cleared. Impaired kidney function can lead to magnesium accumulation. Do not supplement without clinician guidance if you have chronic kidney disease.'],
-                    ['Drug interactions', 'Magnesium can reduce absorption of tetracycline and quinolone antibiotics, some bisphosphonates, and may interact with blood pressure medications. Take at least 2 hours apart from these drugs.'],
-                    ['ADHD medications', 'No established interaction between supplemental magnesium and stimulant ADHD medications. Some practitioners use magnesium alongside methylphenidate to potentially reduce side effects — discuss with your prescribing clinician.'],
-                    ['Avoid oxide form', 'Magnesium oxide is poorly absorbed and acts primarily as a laxative. It is not appropriate for ADHD-related supplementation goals.'],
-                  ].map(([bold, text]) => (
-                    <li key={bold as string}>
-                      <strong>{bold as string}.</strong> {text as string}
-                    </li>
+        <section id="comparison" className="scroll-mt-20 space-y-5">
+          <div>
+            <p className="eyebrow-label">Side by side</p>
+            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
+              Glycinate vs citrate without the marketing shortcuts
+            </h2>
+          </div>
+          <ResponsiveTable label="Magnesium glycinate and citrate comparison for ADHD-related decisions">
+            <table className="min-w-[850px] w-full text-left text-sm">
+              <thead className="bg-brand-50/80">
+                <tr className="border-b border-brand-900/10">
+                  {['Question', 'Glycinate / bisglycinate', 'Citrate'].map((heading) => (
+                    <th key={heading} className="px-4 py-3 text-xs font-bold uppercase tracking-[0.12em] text-brand-900">
+                      {heading}
+                    </th>
                   ))}
-                </ul>
-              </SafetyNotice>
-            </div>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-brand-900/10 bg-white">
+                {COMPARISON_ROWS.map(([question, glycinate, citrate]) => (
+                  <tr key={question} className="align-top">
+                    <td className="px-4 py-4 font-semibold text-ink">{question}</td>
+                    <td className="px-4 py-4 text-muted">{glycinate}</td>
+                    <td className="px-4 py-4 text-muted">{citrate}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </ResponsiveTable>
+        </section>
 
-            <hr className="border-brand-900/10" />
+        <section id="claim-check" className="scroll-mt-20 space-y-5">
+          <div>
+            <p className="eyebrow-label">Claim check</p>
+            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
+              Four claims that need a reality check
+            </h2>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            {[
+              {
+                claim: '“Glycinate is best for ADHD.”',
+                verdict: 'Unsupported',
+                explanation:
+                  'No direct ADHD comparison establishes a winning form. Choosing glycinate for sleep context or tolerance is different from claiming better ADHD efficacy.',
+              },
+              {
+                claim: '“The glycine creates calm-focus synergy.”',
+                verdict: 'Not isolated',
+                explanation:
+                  'The glycine contribution has not been separated from magnesium in an ADHD trial. Mechanistic plausibility should not be presented as a demonstrated clinical effect.',
+              },
+              {
+                claim: '“A normal serum test means magnesium is fine.”',
+                verdict: 'Too simple',
+                explanation:
+                  'Serum magnesium is commonly used but does not closely reflect total-body or tissue magnesium. NIH states that no single assessment method is satisfactory.',
+              },
+              {
+                claim: '“Lower magnesium in ADHD proves supplementation works.”',
+                verdict: 'Association, not treatment evidence',
+                explanation:
+                  'Observational meta-analyses can identify group differences, but they cannot prove causation or establish that supplementation improves symptoms.',
+              },
+            ].map((item) => (
+              <div key={item.claim} className="rounded-2xl border border-brand-900/10 bg-white/90 p-5 shadow-sm">
+                <p className="text-xs font-bold uppercase tracking-[0.12em] text-brand-700">{item.verdict}</p>
+                <h3 className="mt-2 text-base font-semibold text-ink">{item.claim}</h3>
+                <p className="mt-2 text-sm leading-6 text-muted">{item.explanation}</p>
+              </div>
+            ))}
+          </div>
+        </section>
 
-            {/* FAQ */}
-            <div id="faq">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                Frequently Asked Questions
-              </h2>
-              <div className="space-y-4">
-                {FAQS.map((faq, i) => (
-                  <div key={i} className="rounded-[0.75rem] border border-brand-900/10 bg-brand-50/40 p-4">
-                    <h3 className="font-semibold text-ink">{faq.question}</h3>
-                    <p className="mt-2 text-sm leading-7 text-muted">{faq.answer}</p>
+        <section className="rounded-[1.65rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+          <p className="eyebrow-label">Evidence boundary</p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
+            What the current research actually supports
+          </h2>
+          <div className="mt-4 space-y-4 text-sm leading-7 text-muted sm:text-base">
+            <p>
+              The ADHD treatment literature remains inadequate. A systematic review found no randomized
+              double-blind magnesium trial and no magnesium-monotherapy study for ADHD. That means neither
+              glycinate nor citrate can be ranked as an evidence-based ADHD treatment.
+            </p>
+            <p>
+              The 2025 bisglycinate trial enrolled 155 adults with self-reported poor sleep, used 250 mg
+              elemental magnesium daily for four weeks, and found a small improvement in insomnia severity.
+              It did not recruit an ADHD population, measure core ADHD outcomes, or compare citrate.
+            </p>
+            <p>
+              NIH’s form discussion is narrower: more soluble forms such as citrate are absorbed more
+              completely than oxide in small studies. It does not identify a universally superior form for
+              ADHD, sleep, anxiety, or cognition.
+            </p>
+          </div>
+        </section>
+
+        <section id="choose" className="scroll-mt-20 space-y-5">
+          <div>
+            <p className="eyebrow-label">Decision path</p>
+            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">How to choose in practice</h2>
+          </div>
+          <ol className="space-y-4">
+            {[
+              ['Define the actual target', 'Separate core ADHD symptoms from poor sleep, constipation, low dietary intake, muscle tension, or another reason for considering magnesium.'],
+              ['Check the elemental dose', 'Compare the Supplement Facts panel, not the front-label compound weight. A lower, clearly labeled serving is easier to evaluate.'],
+              ['Pick one form', 'Do not start glycinate, citrate, and a multi-ingredient ADHD blend together. One change makes benefit and side effects interpretable.'],
+              ['Track the matching outcome', 'For a sleep-oriented trial, track sleep onset and next-day function. For constipation, track stool changes. Do not redefine any vague change as improved ADHD.'],
+              ['Stop for poor fit', 'Persistent diarrhea, nausea, cramping, unusual weakness, or other concerning symptoms are reasons to stop and seek clinical advice—not to keep escalating.'],
+            ].map(([title, copy], index) => (
+              <li key={title} className="rounded-2xl border border-brand-900/10 bg-white/90 p-5 shadow-sm">
+                <div className="flex gap-4">
+                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-brand-100 text-sm font-bold text-brand-800">
+                    {index + 1}
+                  </span>
+                  <div>
+                    <h3 className="font-semibold text-ink">{title}</h3>
+                    <p className="mt-2 text-sm leading-6 text-muted">{copy}</p>
                   </div>
-                ))}
-              </div>
+                </div>
+              </li>
+            ))}
+          </ol>
+        </section>
+
+        <section id="dose-safety" className="scroll-mt-20 rounded-[1.65rem] border border-amber-900/15 bg-amber-50/70 p-6 shadow-sm sm:p-8">
+          <p className="text-xs font-bold uppercase tracking-[0.14em] text-amber-800">Dose and safety</p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-amber-950">
+            The form name does not remove the guardrails
+          </h2>
+          <ul className="mt-4 space-y-3 text-sm leading-7 text-amber-950/90">
+            <li>
+              <strong>No ADHD-specific dose is established.</strong> The adult upper limit is 350 mg/day
+              from supplements and medications unless a clinician recommends otherwise.
+            </li>
+            <li>
+              <strong>Children need pediatric guidance.</strong> Supplemental upper limits vary by age, and
+              an adult dose should not be copied for a child with ADHD.
+            </li>
+            <li>
+              <strong>Kidney impairment increases risk.</strong> Reduced magnesium clearance can lead to
+              accumulation and toxicity.
+            </li>
+            <li>
+              <strong>Magnesium can interfere with medicines.</strong> It can reduce absorption of oral
+              bisphosphonates and bind tetracycline or quinolone antibiotics. Follow pharmacist or label
+              spacing instructions.
+            </li>
+            <li>
+              <strong>Count other sources.</strong> Antacids, laxatives, multivitamins, and sleep products can
+              already contain magnesium.
+            </li>
+          </ul>
+        </section>
+
+        {magnesiumProducts && (
+          <section className="space-y-4">
+            <div className="max-w-3xl">
+              <p className="eyebrow-label">Product comparison</p>
+              <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
+                Compare labels after choosing the tradeoff
+              </h2>
+              <p className="mt-3 text-sm leading-7 text-muted">
+                Use the product set to compare elemental dose, serving size, formulation, and cost. It is not
+                evidence that any listed product treats ADHD or that glycinate is clinically superior.
+              </p>
             </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Related */}
-            <div id="related">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Related Articles</h2>
-              <div className="grid gap-3 sm:grid-cols-2">
-                {[
-                  ['/guides/adhd/magnesium-for-adhd/', 'ADHD Cluster', 'Magnesium for ADHD', 'Evidence review, forms, sleep, and practical use.'],
-                  ['/guides/adhd/best-supplements-for-adhd/', 'ADHD Cornerstone', 'Best Supplements for ADHD', 'Evidence-ranked guide covering all key ADHD supplements.'],
-                  ['/guides/adhd/l-theanine-magnesium-adhd-stack', 'ADHD Cluster', 'L-Theanine + Magnesium Stack', 'How to combine L-theanine and magnesium for ADHD.'],
-                  ['/guides/adhd/best-magnesium-supplement-for-adhd', 'Buying Guide', 'Best Magnesium Supplement for ADHD', 'Which product to buy first — form, dose, and practical guidance.'],
-                  ['/guides/adhd/adhd-stack-guide', 'ADHD Cluster', 'ADHD Stack Guide', 'How to build a safe, evidence-based ADHD supplement stack.'],
-                  ['/guides/adhd/l-theanine-for-adhd/', 'ADHD Cluster', 'L-Theanine for ADHD', 'Evidence on attention, sleep, and emotional regulation.'],
-                  ['/guides/adhd/sleep-and-adhd', 'Sleep + ADHD', 'Sleep and ADHD', 'Why sleep issues are common in ADHD and how to address them.'],
-                  ['/guides/focus', 'Goal Hub', 'Focus Goal Hub', 'Compare all focus supplements side by side.'],
-                ].map(([href, eyebrow, label, desc]) => (
-                  <Link key={href as string} href={href as string}
-                    className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30">
-                    <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">{eyebrow}</p>
-                    <p className="font-semibold text-ink transition group-hover:text-brand-700">{label}</p>
-                    <p className="mt-1 text-xs text-muted">{desc}</p>
-                  </Link>
-                ))}
-              </div>
-            </div>
-
+            <RecommendationSection products={magnesiumProducts.products} />
           </section>
+        )}
 
-          <EmailCapture
-            headline="Get the ADHD supplement checklist"
-            description="Evidence-first supplement updates, safety context, and ADHD research notes. No diagnosis or personal medical advice."
-            ctaLabel="Get Checklist"
-            location={`article-${SLUG}`}
-          />
-
-          <NewsletterCtaBlock
-            title="Continue with the newsletter archive"
-            description="Short notes built for cautious supplement decisions."
-            location={`article-${SLUG}-newsletter`}
-          />
-        </div>
-
-        {/* Sidebar */}
-        <aside className="space-y-4 lg:sticky lg:top-24 lg:self-start">
-          <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
-            <p className="text-[10px] font-bold uppercase tracking-wider text-muted">In this article</p>
-            <nav className="mt-3 space-y-1.5" aria-label="Article sections">
-              {[
-                ['#why-form-matters', 'Why Form Matters'],
-                ['#mechanism', 'How Magnesium Works'],
-                ['#evidence', 'Evidence Summary'],
-                ['#comparison', 'Glycinate vs Citrate'],
-                ['#dosage', 'Dosage Guide'],
-                ['#products', 'Product Picks'],
-                ['#safety', 'Safety'],
-                ['#faq', 'FAQ'],
-                ['#related', 'Related Articles'],
-              ].map(([href, label]) => (
-                <a key={href} href={href as string}
-                  className="block text-sm text-brand-700 hover:text-brand-800 hover:underline">
-                  {label}
-                </a>
-              ))}
-            </nav>
+        <section className="rounded-[1.65rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm">
+          <h2 className="text-xl font-semibold text-ink">Related evidence paths</h2>
+          <div className="mt-4 grid gap-3 sm:grid-cols-2">
+            <Link href="/guides/adhd/best-magnesium-supplement-for-adhd/" className="rounded-xl border border-brand-900/10 p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/30 hover:underline">
+              Use the full magnesium buying checklist →
+            </Link>
+            <Link href="/guides/adhd/adhd-supplements/" className="rounded-xl border border-brand-900/10 p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/30 hover:underline">
+              Compare magnesium with other ADHD adjuncts →
+            </Link>
+            <Link href="/guides/sleep/magnesium-types-for-sleep/" className="rounded-xl border border-brand-900/10 p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/30 hover:underline">
+              Compare magnesium forms for sleep →
+            </Link>
+            <Link href="/compounds/magnesium/" className="rounded-xl border border-brand-900/10 p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/30 hover:underline">
+              Read the magnesium compound profile →
+            </Link>
           </div>
+        </section>
 
-          <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
-            <p className="text-[10px] font-bold uppercase tracking-wider text-muted">ADHD cluster</p>
-            <div className="mt-3 space-y-2">
-              {[
-                ['/guides/adhd/best-supplements-for-adhd/', 'Best supplements for ADHD →'],
-                ['/guides/adhd/magnesium-for-adhd/', 'Magnesium for ADHD →'],
-                ['/guides/adhd/l-theanine-for-adhd/', 'L-Theanine for ADHD →'],
-                ['/guides/adhd/adhd-stack-guide', 'ADHD stack guide →'],
-                ['/guides/adhd/sleep-and-adhd', 'Sleep and ADHD →'],
-                ['/guides/focus', 'Focus goal hub →'],
-              ].map(([href, label]) => (
-                <Link key={href as string} href={href as string}
-                  className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline">
-                  {label}
-                </Link>
-              ))}
-            </div>
+        <section id="faq" className="scroll-mt-20 rounded-[1.65rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+          <h2 className="text-2xl font-semibold tracking-tight text-ink">Frequently asked questions</h2>
+          <div className="mt-5 divide-y divide-brand-900/10">
+            {FAQS.map((faq) => (
+              <div key={faq.question} className="py-5 first:pt-0 last:pb-0">
+                <h3 className="font-semibold text-ink">{faq.question}</h3>
+                <p className="mt-2 text-sm leading-7 text-muted">{faq.answer}</p>
+              </div>
+            ))}
           </div>
-        </aside>
-      </div>
+        </section>
 
-      <div className="mt-8">
-        <Link href="/guides/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
-          ← Back to Guides
-        </Link>
+        <References refs={[...REFERENCES]} />
+
+        <p className="text-xs leading-6 text-muted">
+          This comparison is educational. It does not diagnose magnesium deficiency or recommend magnesium
+          as a treatment for ADHD. Discuss pediatric use, pregnancy, kidney disease, persistent symptoms, and
+          medication interactions with a qualified clinician or pharmacist.
+        </p>
       </div>
-      <References refs={MAGNESIUM_GLYCINATE_VS_CITRATE_FOR_ADHD_REFS} />
-    </article>
+    </ArticleLayout>
   )
 }

--- a/components/References.tsx
+++ b/components/References.tsx
@@ -10,6 +10,12 @@ export type Ref = {
   doi?: string
 }
 
+function sourceLabel(url: string): string {
+  if (url.includes('pubmed.ncbi.nlm.nih.gov')) return 'PubMed →'
+  if (url.includes('doi.org')) return 'DOI →'
+  return 'Source →'
+}
+
 export default function References({ refs }: { refs: Ref[] }) {
   return (
     <section id="references" aria-label="References" className="card-premium p-6 space-y-3 max-w-4xl">
@@ -29,7 +35,7 @@ export default function References({ refs }: { refs: Ref[] }) {
               <>
                 {' '}
                 <a href={ref.url} target="_blank" rel="noopener noreferrer" itemProp="url" className="text-brand-700 underline hover:text-brand-800">
-                  PubMed →
+                  {sourceLabel(ref.url)}
                 </a>
               </>
             ) : null}

--- a/docs/content/high-potential-page-quality-pass-2026-08-02.md
+++ b/docs/content/high-potential-page-quality-pass-2026-08-02.md
@@ -1,0 +1,54 @@
+# High-potential page quality pass
+
+Date: August 2, 2026
+
+## Scope
+
+Identify the strongest remaining existing-page opportunities after the five-guide batch merged in PRs #2401 and #2402, then improve the pages where commercial intent and trust risk overlap most heavily.
+
+The uploaded Bing performance CSVs were not available through the current repository or file connector during this pass, so this ranking uses the current `main` branch, the repository's high-ROI opportunity rules, cluster role, commercial intent, content differentiation, and severity of evidence/safety gaps. Re-rank with route-level impressions, clicks, CTR, and conversions when those exports are available in the active workspace.
+
+## Priority ranking
+
+| Rank | Route | Why it has upside | Main quality risk | Action |
+|---:|---|---|---|---|
+| 1 | `/guides/adhd/best-magnesium-supplement-for-adhd/` | Strong buying intent, ADHD cluster authority, product-module potential, and multiple supporting routes | Presented glycinate as the proven best ADHD form; used unsupported ADHD-specific dosing, timing, glycine-synergy, and absorption certainty | Rebuilt in this branch |
+| 2 | `/guides/adhd/magnesium-glycinate-vs-citrate-for-adhd/` | Exact comparison intent and natural path into the buying guide | Claimed a winner despite no direct ADHD head-to-head trial; comparison was asymmetrical and risked cannibalizing the buying guide | Rebuilt in this branch |
+| 3 | `/guides/adhd/adhd-supplements/` | Pillar route with the strongest internal-link leverage in the ADHD cluster | Evidence tiers and several mechanism statements remain more confident than the underlying ADHD evidence | Next editorial target |
+| 4 | `/guides/adhd/l-theanine-magnesium-adhd-stack/` | High stack intent and natural commercial path | Combination language can imply synergy without isolating either ingredient or the stack | Review after the two magnesium pages deploy |
+| 5 | `/guides/focus/best-nootropics-for-focus/` | Broad high-value focus query with multiple profile and product paths | Strong structure already; main gap is source depth and route-level performance validation rather than a fundamental rewrite | Protect, measure, then selectively deepen |
+
+## Changes completed
+
+### Best magnesium supplement for ADHD
+
+- Preserved the stable route and core keyword intent.
+- Changed the answer from “glycinate wins” to “no form is proven best for core ADHD symptoms.”
+- Separated core ADHD treatment claims from sleep, constipation, low intake, and tolerability decisions.
+- Replaced the hardcoded generic Amazon search with the governed magnesium recommendation set.
+- Added an answer-first block, decision framework, symmetrical form table, buyer checklist, FAQ schema, stronger internal links, and visible safety guardrails.
+- Corrected label guidance to emphasize elemental magnesium.
+- Corrected status-testing language: serum magnesium is common but no single assessment method is definitive.
+- Added current NIH guidance, the 2025 bisglycinate sleep RCT, the ADHD magnesium treatment systematic review, and the magnesium-status meta-analysis.
+
+### Magnesium glycinate vs citrate for ADHD
+
+- Preserved the comparison URL and search intent.
+- Reframed the page around the absence of a direct ADHD head-to-head trial.
+- Made the comparison symmetrical across evidence, sleep context, absorption, GI fit, cost, practical use, and unsupported claims.
+- Removed form-superiority, glycine-synergy, universal timing, and ADHD-dose certainty.
+- Differentiated the route from the buying guide: this page answers “which tradeoff fits?” while the buying guide answers “how do I choose and read a product?”
+- Retained one governed product module after evidence and safety context.
+
+## Measurement plan
+
+After deployment, track these routes separately for at least 14 days:
+
+- organic impressions, clicks, CTR, and average position;
+- guide-to-guide and guide-to-profile clicks;
+- affiliate outbound CTR;
+- engagement with the product module;
+- email or checklist conversion where present;
+- query overlap between the buying guide and comparison page.
+
+If both pages receive impressions for the same query but one consistently underperforms, adjust title and introduction language before considering consolidation. Do not create another magnesium-for-ADHD URL.


### PR DESCRIPTION
## What changed

- ranked the strongest remaining existing-page opportunities after PRs #2401 and #2402
- rebuilt `/guides/adhd/best-magnesium-supplement-for-adhd/` as a label, fit, safety, and buying-decision guide
- rebuilt `/guides/adhd/magnesium-glycinate-vs-citrate-for-adhd/` as a symmetrical tradeoff comparison
- removed unsupported form superiority, ADHD-specific dose/timing certainty, isolated glycine-synergy claims, and the hardcoded generic Amazon search
- added current NIH magnesium guidance, the 2025 bisglycinate sleep RCT, the ADHD magnesium treatment systematic review, and magnesium-status meta-analysis
- retained stable routes and one governed magnesium recommendation module per page after evidence and safety context
- added regression coverage and documented the next ranked targets

## Why these pages

Both routes have high commercial and comparison intent, strong ADHD-cluster internal-link value, and a meaningful trust gap. The old pages confidently selected glycinate as the ADHD winner despite no direct ADHD head-to-head trial and limited magnesium-treatment evidence.

## Validation built into the branch

- stable route assertions
- primary/authoritative source assertions
- no generic Amazon search or hardcoded affiliate tag
- no restoration of the old categorical winner, 4% absorption, ADHD-dose, or glycine-synergy claims
- distinct searcher decisions for the buying guide and comparison page

CI should run the repository's content, type, lint, test, and static-export checks.