### PR TITLE
Rebuild L-theanine magnesium ADHD stack guide around direct evidence

### DIFF
--- a/app/__tests__/l-theanine-magnesium-stack-calibration.test.ts
+++ b/app/__tests__/l-theanine-magnesium-stack-calibration.test.ts
@@ -42,12 +42,12 @@ describe('L-theanine magnesium ADHD stack calibration', () => {
     expect(source).toContain('https://ods.od.nih.gov/factsheets/Magnesium-HealthProfessional/')
   })
 
-  it('routes commercial and medication decisions to narrower guides', () => {
+  it('routes ingredient and safety decisions to narrower guides', () => {
     const source = read(PAGE)
 
     expect(source).toContain('/guides/adhd/l-theanine-for-adhd/')
     expect(source).toContain('/guides/adhd/best-magnesium-supplement-for-adhd/')
-    expect(source).toContain('/guides/adhd/adhd-medication-supplement-interactions/')
+    expect(source).toContain('/guides/other/supplement-stacking-safety/')
     expect(source).toContain('/safety-checker/')
     expect(source).toContain('<AdhdInlineCta type="stack" />')
     expect(source).toContain('<AdhdInlineCta type="safety" />')

--- a/app/__tests__/l-theanine-magnesium-stack-calibration.test.ts
+++ b/app/__tests__/l-theanine-magnesium-stack-calibration.test.ts
@@ -1,0 +1,55 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const PAGE = 'app/guides/adhd/l-theanine-magnesium-adhd-stack/page.tsx'
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+}
+
+describe('L-theanine magnesium ADHD stack calibration', () => {
+  it('preserves the stable route and states the direct evidence boundary', () => {
+    const source = read(PAGE)
+
+    expect(source).toContain("const SLUG = 'l-theanine-magnesium-adhd-stack'")
+    expect(source).toContain('No direct ADHD trial shows that this two-ingredient stack is synergistic')
+    expect(source).toContain('The combination is untested for ADHD outcomes')
+    expect(source).toContain('There is no validated combination dose')
+  })
+
+  it('does not restore the old protocol, synergy, or generic affiliate claims', () => {
+    const source = read(PAGE)
+
+    expect(source).not.toContain('AFFILIATE_TAGS')
+    expect(source).not.toContain('amazon.com/s?k=')
+    expect(source).not.toContain('RecommendationSection')
+    expect(source).not.toContain('Magnesium Glycinate — The Best First Step')
+    expect(source).not.toContain('200–300 mg elemental')
+    expect(source).not.toContain('appropriate for use alongside ADHD medication')
+    expect(source).not.toContain('which is why combining them is additive rather than redundant')
+  })
+
+  it('anchors the page in ADHD-specific, current, and authoritative sources', () => {
+    const source = read(PAGE)
+
+    expect(source).toContain('22214254')
+    expect(source).toContain('23808779')
+    expect(source).toContain('30496768')
+    expect(source).toContain('42410082')
+    expect(source).toContain('40314930')
+    expect(source).toContain('35565828')
+    expect(source).toContain('https://ods.od.nih.gov/factsheets/Magnesium-HealthProfessional/')
+  })
+
+  it('routes commercial and medication decisions to narrower guides', () => {
+    const source = read(PAGE)
+
+    expect(source).toContain('/guides/adhd/l-theanine-for-adhd/')
+    expect(source).toContain('/guides/adhd/best-magnesium-supplement-for-adhd/')
+    expect(source).toContain('/guides/adhd/adhd-medication-supplement-interactions/')
+    expect(source).toContain('/safety-checker/')
+    expect(source).toContain('<AdhdInlineCta type="stack" />')
+    expect(source).toContain('<AdhdInlineCta type="safety" />')
+  })
+})

--- a/app/guides/adhd/l-theanine-magnesium-adhd-stack/page.tsx
+++ b/app/guides/adhd/l-theanine-magnesium-adhd-stack/page.tsx
@@ -223,8 +223,8 @@ export default function LTheanineMagnesiumAdhdStackPage() {
       title: TITLE,
       slug: SLUG,
       date: DATE_PUBLISHED,
+      updated: DATE_MODIFIED,
       description: DESCRIPTION,
-      dateModified: DATE_MODIFIED,
     },
     `${PATH}/`,
   )

--- a/app/guides/adhd/l-theanine-magnesium-adhd-stack/page.tsx
+++ b/app/guides/adhd/l-theanine-magnesium-adhd-stack/page.tsx
@@ -1,505 +1,528 @@
-import Link from 'next/link'
-import RecommendationSection from '@/components/RecommendationSection'
-import { getRevenueProductSet } from '@/config/revenue-products'
-import Image from 'next/image'
-import JsonLd from '@/components/seo/JsonLd'
 import type { Metadata } from 'next'
-import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd } from '../../../../src/lib/seo'
-import LastUpdatedBadge from '../../../../src/components/editorial/LastUpdatedBadge'
-import ResponsiveTable from '@/components/ui/ResponsiveTable'
-import SafetyNotice from '@/components/evidence/SafetyNotice'
-import EmailCapture from '@/components/EmailCapture'
-import NewsletterCtaBlock from '@/components/NewsletterCtaBlock'
-import PathwayDiagram from '@/components/PathwayDiagram'
-import EvidenceLegend from '@/components/EvidenceLegend'
-import { pathwayDiagrams } from '@/lib/pathway-data'
-import { AFFILIATE_TAGS } from '@/config/affiliate'
+import Image from 'next/image'
+import Link from 'next/link'
+import JsonLd from '@/components/seo/JsonLd'
+import { ArticleLayout, TableOfContents } from '@/components/articles'
+import type { Heading } from '@/components/articles'
+import { AdhdInlineCta } from '@/components/articles/AdhdMonetizationWidgets'
 import References from '@/components/References'
+import ResponsiveTable from '@/components/ui/ResponsiveTable'
+import {
+  blogJsonLd,
+  breadcrumbJsonLd,
+  buildPageMetadata,
+  faqPageJsonLd,
+} from '../../../../src/lib/seo'
 
 const SLUG = 'l-theanine-magnesium-adhd-stack'
-const TITLE = 'L-Theanine and Magnesium for ADHD: How to Stack Them Safely'
+const PATH = `/guides/adhd/${SLUG}`
+const TITLE = 'L-Theanine + Magnesium for ADHD? Evidence & Safety'
 const DESCRIPTION =
-  'Evidence-based guide to combining L-theanine and magnesium for ADHD. Covers mechanisms, synergy, safety, dosing order, timing, and drug interactions — including ADHD medication compatibility.'
-const DATE = '2026-06-12'
-const AUTHOR = 'Will'
-const READING_TIME = '10 min read'
-const TAGS = ['L-theanine', 'magnesium', 'ADHD', 'stacks', 'sleep']
-const CATEGORY = 'ADHD Stacks'
+  'Can L-theanine and magnesium be combined for ADHD? Review the direct evidence, sleep context, dose limits, medication uncertainties, and safer one-change-at-a-time trial design.'
+const DATE_PUBLISHED = '2026-06-12'
+const DATE_MODIFIED = '2026-08-02'
 
 export const metadata: Metadata = buildPageMetadata({
   title: TITLE,
   description: DESCRIPTION,
-  path: `/guides/adhd/${SLUG}`,
+  path: PATH,
   openGraphType: 'article',
 })
 
+const HEADINGS: Heading[] = [
+  { id: 'quick-answer', text: 'Quick answer', level: 2 },
+  { id: 'evidence', text: 'What the evidence shows', level: 2 },
+  { id: 'claim-check', text: 'Stack claim check', level: 2 },
+  { id: 'target', text: 'Choose the real target', level: 2 },
+  { id: 'trial-design', text: 'Safer trial design', level: 2 },
+  { id: 'dose-context', text: 'Dose context', level: 2 },
+  { id: 'safety', text: 'Safety and medications', level: 2 },
+  { id: 'faq', text: 'Frequently asked questions', level: 2 },
+]
+
 const FAQS = [
   {
-    question: 'Can I take L-theanine and magnesium together for ADHD?',
+    question: 'Do L-theanine and magnesium work better together for ADHD?',
     answer:
-      'For most healthy adults and children without relevant medical conditions, yes — combining L-theanine and magnesium is considered reasonable. They act through different mechanisms (L-theanine via alpha-wave induction and glutamate modulation; magnesium via NMDA blockade and GABA support), which means they are complementary rather than duplicative. No significant adverse interaction between the two has been established in available literature. Introduce one at a time before combining to identify which is producing which effect.',
+      'That has not been established. There is no direct ADHD trial comparing the combination with either ingredient alone or placebo. Mechanistic differences do not prove clinical synergy, and studies of multi-ingredient stress products cannot isolate the contribution of L-theanine plus magnesium.',
   },
   {
-    question: 'Does L-theanine make magnesium work better for ADHD?',
+    question: 'Can this stack improve core ADHD symptoms?',
     answer:
-      'Not through a direct pharmacological interaction — they do not amplify each other\'s absorption or binding. Rather, they address complementary aspects of ADHD-related difficulty: L-theanine works on mental calm and alpha-wave activity, while magnesium works on neural over-excitability and GABA pathways. Using both means broader coverage of the neurobiological targets relevant to ADHD hyperactivation and sleep difficulty.',
+      'Direct evidence is inadequate. The main ADHD-specific L-theanine trial measured sleep in boys and did not establish improvement in inattention, hyperactivity, impulsivity, or executive function. A magnesium systematic review found no well-controlled randomized double-blind trial and no magnesium-monotherapy study for ADHD.',
   },
   {
-    question: 'When should I take L-theanine and magnesium for ADHD?',
+    question: 'Can L-theanine and magnesium be taken together?',
     answer:
-      'Evening use is the most common pattern for both. L-theanine (100–200 mg) and magnesium glycinate (200–400 mg elemental) taken 30–60 minutes before bed supports ADHD-related sleep onset difficulties and evening hyperactivation. For daytime calm focus, L-theanine can also be taken in the morning or with a focus session — magnesium is typically reserved for evening because it may increase sedation when combined with other sleep cues.',
+      'No direct harmful interaction between the two has been established, but absence of a known interaction is not proof that the combination is safe for every person. Kidney function, age, pregnancy, medications, total magnesium exposure, blood pressure, sedation, and the reason for use all matter. A clinician or pharmacist should review pediatric use and medication combinations.',
   },
   {
-    question: 'Is this stack safe with ADHD medications?',
+    question: 'What dose should I use for an ADHD stack?',
     answer:
-      'No established adverse interaction between supplemental L-theanine or magnesium and common ADHD stimulants (methylphenidate, amphetamine salts) has been documented. Some practitioners use magnesium to support side-effect management in stimulant users. However, you should inform your prescribing clinician that you are using these supplements, particularly if you observe changes in medication response. Do not adjust medication timing or dose based on supplement use without medical guidance.',
+      'There is no established ADHD-specific or combination dose. The 2011 L-theanine trial used 400 mg daily in boys ages 8 to 12, but that study dose is not a general pediatric recommendation. NIH sets an adult upper limit of 350 mg daily for magnesium from supplements and medications unless a clinician directs otherwise; younger children have lower limits.',
   },
   {
-    question: 'How long does it take to notice effects from this stack?',
+    question: 'Is the combination safe with stimulant medication?',
     answer:
-      'L-theanine effects (if they occur) are often noticeable within the same day or evening — particularly the alpha-wave calming effect. Magnesium effects on sleep quality and neural excitability are more gradual: most users report noticing changes within 1–2 weeks of consistent daily use, with fuller effects developing at 4–6 weeks. If neither supplement produces any noticeable effect after 4–6 weeks of consistent use, reassess with a clinician — blood testing for magnesium status may be informative.',
+      'The pediatric L-theanine sleep trial stratified participants by stimulant use, but it was not designed or powered to prove interaction safety with every stimulant, dose, or patient profile. Do not treat “no established interaction” as guaranteed compatibility. Review the combination with the prescriber and do not change medication timing or dose based on supplement use.',
   },
   {
-    question: 'Should I start both supplements on the same day?',
+    question: 'Should both supplements be started at the same time?',
     answer:
-      'Starting them separately is strongly preferred. Begin one supplement, assess your response over 7–14 days, then add the second. If you start both simultaneously and experience an effect (positive or negative), you cannot determine which supplement is responsible. This makes it harder to optimise or troubleshoot. Starting separately also means smaller initial supplement burden and cleaner attribution of any side effects.',
+      'Starting both together makes benefit and side effects difficult to interpret. When a clinician agrees that a trial is reasonable, define one target, introduce one change, record a baseline, set a review date, and add a second product only if there is a clear reason.',
   },
 ]
 
-const L_THEANINE_MAGNESIUM_ADHD_STACK_REFS = [
-  { n: 1, text: 'Giesbrecht T, et al. (2010). L-theanine and caffeine on cognition. Nutr Neurosci, 13(6): 283-290.', url: 'https://pubmed.ncbi.nlm.nih.gov/21040626/' },
-  { n: 2, text: 'Starobrat-Hermelin B. (1998). Magnesium in ADHD children. Magnes Res, 11(1): 71-77.', url: 'https://pubmed.ncbi.nlm.nih.gov/9595557/' },
-  { n: 3, text: 'Haskell CF, et al. (2008). L-theanine and cognition. Biol Psychol, 77(2): 113-122.', url: 'https://pubmed.ncbi.nlm.nih.gov/18006208/' },
-]
+const EVIDENCE_ROWS = [
+  [
+    'L-theanine in ADHD',
+    'One six-week randomized trial in 98 boys ages 8–12 used 400 mg/day and found better sleep percentage and sleep efficiency on actigraphy.',
+    'It did not test the L-theanine + magnesium combination or establish improvement in core ADHD symptoms. Sleep latency was unchanged.',
+  ],
+  [
+    'Magnesium in ADHD',
+    'Observational meta-analyses report lower average magnesium measures in some children with ADHD.',
+    'Association does not prove causation or treatment benefit. The dedicated treatment review found no well-controlled double-blind trial and no magnesium-monotherapy study.',
+  ],
+  [
+    'L-theanine cognition',
+    'A 2026 meta-analysis across healthy and clinical populations reported some acute attention and reaction-time signals.',
+    'The evidence was not specific to ADHD, clinical relevance remained uncertain, and some stress findings were influenced by high-risk-of-bias studies.',
+  ],
+  [
+    'Combination evidence',
+    'A multi-ingredient product containing magnesium, B vitamins, rhodiola, and green-tea/L-theanine has been studied in stressed healthy adults.',
+    'That does not isolate L-theanine plus magnesium, does not establish synergy, and does not answer an ADHD treatment question.',
+  ],
+] as const
+
+const CLAIMS = [
+  {
+    claim: '“The two pathways are complementary, so the stack is additive.”',
+    verdict: 'Mechanism is not outcome evidence',
+    explanation:
+      'Different proposed pathways can justify a research question, but they cannot demonstrate that the combined clinical effect is larger, safer, or more useful than either ingredient alone.',
+  },
+  {
+    claim: '“Magnesium calms the body while L-theanine calms the mind.”',
+    verdict: 'Marketing shorthand',
+    explanation:
+      'This framing turns broad physiological roles into predictable person-level effects. Response varies, and neither ingredient has reliable evidence for that tidy division in ADHD.',
+  },
+  {
+    claim: '“No known interaction means stimulant compatibility.”',
+    verdict: 'Too strong',
+    explanation:
+      'A lack of published interaction evidence is not the same as a dedicated interaction study. Medication, cardiovascular, sleep, appetite, kidney, and blood-pressure context still require review.',
+  },
+  {
+    claim: '“A bedtime stack should work within four to six weeks.”',
+    verdict: 'Unsupported timeline',
+    explanation:
+      'There is no validated response timeline for the combination. A trial should be judged against a defined target and stopped when benefit is absent, side effects appear, or the rationale no longer holds.',
+  },
+] as const
+
+const TARGET_ROWS = [
+  [
+    'Core inattention, hyperactivity, or impulsivity',
+    'Do not use this stack as the primary treatment plan.',
+    'Evidence-based ADHD care, sleep assessment, and functional supports have stronger decision priority.',
+  ],
+  [
+    'Sleep efficiency or nighttime restlessness',
+    'L-theanine has one ADHD-specific sleep trial, but the result is narrow and not a combination result.',
+    'Track objective sleep timing, awakenings, and next-day function rather than vague “calm.”',
+  ],
+  [
+    'Low magnesium intake or deficiency concern',
+    'Evaluate diet, medications, GI history, and clinical context before selecting a form or dose.',
+    'Correcting a plausible gap is different from treating ADHD.',
+  ],
+  [
+    'Constipation',
+    'A magnesium form may be selected for its GI effect under appropriate guidance.',
+    'That use case does not require L-theanine and should not be reframed as an ADHD stack.',
+  ],
+  [
+    'Daytime “calm focus”',
+    'L-theanine research outside ADHD is mixed and often acute or conducted with caffeine.',
+    'Avoid promising a non-sedating focus effect or assuming general cognition studies transfer to ADHD.',
+  ],
+] as const
+
+const TRIAL_STEPS = [
+  [
+    'Define one target',
+    'Choose a measurable outcome such as sleep efficiency, sleep onset, constipation, or correction of low intake. “Better ADHD” is too broad to interpret.',
+  ],
+  [
+    'Review reasons not to self-test',
+    'Pause for clinician or pharmacist review when the user is a child, pregnant, has kidney disease, uses prescription medication, has low blood pressure, or already takes sedating products.',
+  ],
+  [
+    'Change one variable',
+    'Do not start L-theanine, magnesium, and a multi-ingredient sleep blend together. One change makes benefit and harm attributable.',
+  ],
+  [
+    'Record a baseline',
+    'Track the target before the trial. Without a baseline, normal variation can look like a supplement effect.',
+  ],
+  [
+    'Set a review and stop rule',
+    'Decide in advance when the trial ends, what counts as meaningful benefit, and which symptoms require stopping or medical advice.',
+  ],
+] as const
+
+const REFERENCES = [
+  {
+    n: 1,
+    text: 'Lyon MR, et al. L-theanine and objective sleep quality in boys with ADHD: randomized double-blind placebo-controlled trial. 2011. PMID: 22214254.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/22214254/',
+  },
+  {
+    n: 2,
+    text: 'Ghanizadeh A. A systematic review of magnesium therapy for treating ADHD. 2013. PMID: 23808779.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/23808779/',
+  },
+  {
+    n: 3,
+    text: 'Huang YH, et al. Magnesium levels in children with ADHD: systematic review and meta-analysis. 2019. PMID: 30496768.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/30496768/',
+  },
+  {
+    n: 4,
+    text: 'Gerolymos C, et al. Cognitive and affective effects of L-theanine: systematic review and meta-analysis of 31 randomized trials. 2026. PMID: 42410082.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/42410082/',
+  },
+  {
+    n: 5,
+    text: 'Payne ER, et al. Tea, L-theanine, and L-theanine plus caffeine for cognition, sleep, and mood: systematic review and meta-analysis. 2025. PMID: 40314930.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/40314930/',
+  },
+  {
+    n: 6,
+    text: 'Noah L, et al. Magnesium, B vitamins, rhodiola, and green tea/L-theanine in chronically stressed healthy adults: randomized placebo-controlled study. 2022. PMID: 35565828.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/35565828/',
+  },
+  {
+    n: 7,
+    text: 'NIH Office of Dietary Supplements. Magnesium: Fact Sheet for Health Professionals.',
+    url: 'https://ods.od.nih.gov/factsheets/Magnesium-HealthProfessional/',
+  },
+  {
+    n: 8,
+    text: 'Moshfeghinia R, et al. L-theanine supplementation in mental disorders: systematic review. 2024. PMID: 39633316.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/39633316/',
+  },
+] as const
 
 export default function LTheanineMagnesiumAdhdStackPage() {
+  const articleLd = blogJsonLd(
+    {
+      title: TITLE,
+      slug: SLUG,
+      date: DATE_PUBLISHED,
+      description: DESCRIPTION,
+      dateModified: DATE_MODIFIED,
+    },
+    `${PATH}/`,
+  )
   const breadcrumbLd = breadcrumbJsonLd([
     { name: 'Guides', url: 'https://thehippiescientist.net/guides/' },
-    { name: TITLE, url: `https://thehippiescientist.net/guides/adhd/${SLUG}/` },
+    { name: 'ADHD Guides', url: 'https://thehippiescientist.net/guides/adhd/' },
+    { name: TITLE, url: `https://thehippiescientist.net${PATH}/` },
   ])
-  const articleLd = blogJsonLd(
-    { title: TITLE, slug: SLUG, date: DATE, description: DESCRIPTION },
-    `/guides/adhd/${SLUG}/`,
-  )
-  const faqLd = faqPageJsonLd({ pagePath: `/guides/adhd/${SLUG}/`, questions: FAQS })
+  const faqLd = faqPageJsonLd({ pagePath: `${PATH}/`, questions: FAQS })
+  const toc = <TableOfContents headings={HEADINGS} />
 
   return (
-    <article className="mx-auto max-w-5xl space-y-0 px-4 pb-20 pt-6 sm:px-6 lg:px-8">
+    <ArticleLayout toc={toc} zone="supplement">
       <JsonLd schema={articleLd} />
       <JsonLd schema={breadcrumbLd} />
       {faqLd && <JsonLd schema={faqLd} />}
 
-      {/* Breadcrumb */}
-      <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
-        <Link href="/guides/" className="transition hover:text-ink">Guides</Link>
-        <span>/</span>
-        <span className="text-ink line-clamp-1">{TITLE}</span>
-      </nav>
-
-      {/* Hero */}
-      <section className="rounded-[1.5rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8 lg:p-10">
-        <div className="flex flex-wrap items-center gap-2 text-xs">
-          <span className="rounded-full border border-brand-900/10 bg-brand-50 px-2.5 py-0.5 font-bold uppercase tracking-wider text-brand-800">
-            {CATEGORY}
-          </span>
-          {TAGS.slice(0, 3).map((tag) => (
-            <span key={tag} className="rounded-full border border-brand-900/10 bg-white px-2.5 py-0.5 font-semibold text-muted capitalize">
-              {tag}
-            </span>
-          ))}
-          <span className="text-muted">June 12, 2026</span>
-          <span className="text-muted">·</span>
-          <span className="text-muted">{READING_TIME}</span>
-        </div>
-        <h1 className="mt-4 font-display text-3xl font-bold leading-tight tracking-tight text-ink sm:text-4xl lg:text-5xl">
-          {TITLE}
-        </h1>
-        <p className="mt-2 text-sm text-muted">
-          By{' '}
-          <Link href="/info/about/" rel="author" className="font-medium text-ink hover:underline">
-            {AUTHOR}
-          </Link>
-        </p>
-        <div className="mt-3">
-          <LastUpdatedBadge date={DATE} label="Last updated" />
-        </div>
-        <p className="mt-4 max-w-3xl text-base leading-7 text-muted">{DESCRIPTION}</p>
-
-        <figure className="mt-6">
-          <div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white">
-            <Image
-              src="/images/guides/l-theanine-magnesium-adhd-stack.jpg"
-              alt="L-theanine and magnesium supplements combined as a calming focus stack for ADHD"
-              width={1536}
-              height={1024}
-              priority
-              className="w-full h-auto"
-            />
+      <div className="space-y-12">
+        <section className="rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-10">
+          <p className="eyebrow-label">Combination evidence review</p>
+          <h1 className="mt-3 font-display text-3xl font-bold leading-tight tracking-tight text-ink sm:text-5xl">
+            L-Theanine + Magnesium for ADHD?
+          </h1>
+          <p className="mt-4 max-w-3xl text-base leading-7 text-muted">
+            No direct ADHD trial shows that this two-ingredient stack is synergistic, improves core symptoms, or
+            has a validated dose. The most defensible use is narrower: evaluate each ingredient against a
+            separate target, then avoid combining them unless both have a clear role.
+          </p>
+          <div className="mt-5 flex flex-wrap gap-3 text-xs font-semibold">
+            <Link href="/guides/adhd/l-theanine-for-adhd/" className="text-brand-700 hover:underline">
+              L-theanine evidence →
+            </Link>
+            <Link href="/guides/adhd/best-magnesium-supplement-for-adhd/" className="text-brand-700 hover:underline">
+              Magnesium decision guide →
+            </Link>
+            <Link href="/guides/adhd/adhd-stack-guide/" className="text-brand-700 hover:underline">
+              Safer stack framework →
+            </Link>
           </div>
-          <figcaption className="mt-3 text-center text-sm text-muted">
-            L-theanine plus magnesium — a low-risk calming stack often used for ADHD focus.
-          </figcaption>
-        </figure>
-      </section>
 
-      {/* Disclosure */}
-      <div className="mt-4 rounded-[1rem] border border-brand-900/10 bg-brand-50/60 px-5 py-3 text-xs leading-6 text-muted">
-        <strong className="text-ink">Affiliate disclosure:</strong> This article contains affiliate
-        links. We may earn a commission at no additional cost to you. We only link to products
-        consistent with the evidence and dose ranges reviewed on this page.
-      </div>
+          <figure className="mt-7">
+            <div className="overflow-hidden rounded-2xl border border-brand-900/10 bg-white shadow-sm">
+              <Image
+                src="/images/guides/l-theanine-magnesium-adhd-stack.jpg"
+                alt="L-theanine and magnesium supplements evaluated as separate parts of an ADHD-related sleep decision"
+                width={1536}
+                height={1024}
+                priority
+                className="h-auto w-full"
+              />
+            </div>
+            <figcaption className="mt-3 text-center text-sm text-muted">
+              Two plausible ingredients do not automatically create a proven stack.
+            </figcaption>
+          </figure>
+        </section>
 
-      <div className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1fr)_240px]">
-        <div className="space-y-6">
+        <section id="quick-answer" className="scroll-mt-20 rounded-[1.65rem] border border-brand-200 bg-brand-50/60 p-6 shadow-sm sm:p-8">
+          <p className="eyebrow-label">Quick answer</p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
+            The combination is untested for ADHD outcomes
+          </h2>
+          <p className="mt-3 text-sm leading-7 text-muted sm:text-base">
+            L-theanine has one ADHD-specific pediatric trial supporting a narrow sleep-efficiency outcome.
+            Magnesium has observational status findings but inadequate treatment evidence. No trial establishes
+            that taking them together improves attention, hyperactivity, impulsivity, executive function, or
+            sleep more than either ingredient alone.
+          </p>
+          <div className="mt-5 grid gap-3 sm:grid-cols-3">
+            {[
+              ['Best evidence boundary', 'Do not present this as an ADHD treatment or established synergy.'],
+              ['Best practical rule', 'Start with the target and test one ingredient at a time.'],
+              ['Best safety rule', 'Medication compatibility and pediatric dosing require clinical review.'],
+            ].map(([title, copy]) => (
+              <div key={title} className="rounded-xl border border-brand-900/10 bg-white/80 p-4">
+                <h3 className="text-sm font-semibold text-ink">{title}</h3>
+                <p className="mt-2 text-xs leading-6 text-muted">{copy}</p>
+              </div>
+            ))}
+          </div>
+        </section>
 
-          {/* Quick Verdict */}
-          <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
-            <p className="eyebrow-label">Quick Verdict</p>
+        <section id="evidence" className="scroll-mt-20 space-y-5">
+          <div className="max-w-3xl">
+            <p className="eyebrow-label">Evidence map</p>
             <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
-              Is This Stack Worth Trying for ADHD?
+              What each study can—and cannot—support
             </h2>
-            <ul className="mt-4 space-y-2">
-              {[
-                ['Safe to combine for most healthy adults', 'No established adverse interaction. Both are well-tolerated at supplemental doses.'],
-                ['Complementary mechanisms — not duplicative', 'L-theanine targets mental arousal and alpha waves; magnesium targets neural over-excitability and GABA. They cover different ground.'],
-                ['Best evidence is for individual components', 'Direct combination trials in ADHD are limited. Individual evidence for each compound is more robust.'],
-                ['Start one at a time — always', 'Introduce supplements separately over 1–2 weeks each to identify what works and attribute any effects correctly.'],
-              ].map(([bold, rest]) => (
-                <li key={bold as string} className="flex gap-2 text-[1.01rem] leading-[1.85] text-muted">
-                  <span className="mt-1 flex-shrink-0 text-brand-700">▸</span>
-                  <span><strong>{bold as string}.</strong> {rest as string}</span>
-                </li>
-              ))}
-            </ul>
-          </section>
-
-          <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8 space-y-8">
-
-            <div id="why-combine">
-              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">
-                Why Combine These Two for ADHD?
-              </h2>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                ADHD often involves hyperactivation across multiple dimensions: mental (racing thoughts,
-                difficulty quieting the mind), physical (motor restlessness), and neurochemical (imbalanced
-                excitatory/inhibitory signaling). A single supplement is unlikely to address all of these.
-              </p>
-              <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
-                L-theanine and magnesium together cover more of this territory than either alone:
-              </p>
-              <ul className="mt-3 ml-5 space-y-1 list-disc text-[1.01rem] leading-[1.85] text-muted">
-                <li>L-theanine for mental calm, alpha-wave induction, and reducing stress-driven mental arousal</li>
-                <li>Magnesium for neural excitability regulation (NMDA), muscle relaxation, GABA support, and sleep architecture</li>
-                <li>Both are non-stimulant, non-sedative at typical doses — appropriate for use alongside ADHD medication</li>
-              </ul>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Two mechanism diagrams */}
-            <div id="mechanisms">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                How Each Works — Separate Pathways
-              </h2>
-              <p className="mb-4 text-[1.01rem] leading-[1.85] text-muted">
-                These two pathways are distinct — they don&apos;t share primary receptors or neurotransmitters,
-                which is why combining them is additive rather than redundant.
-              </p>
-              <div className="space-y-4">
-                <div>
-                  <p className="mb-2 text-sm font-semibold text-ink">L-Theanine Pathway:</p>
-                  <PathwayDiagram data={pathwayDiagrams['l-theanine-focus']} />
-                </div>
-                <div>
-                  <p className="mb-2 text-sm font-semibold text-ink">Magnesium Pathway:</p>
-                  <PathwayDiagram data={pathwayDiagrams['magnesium-adhd']} />
-                </div>
-              </div>
-              <EvidenceLegend highlightTier="limited" className="mt-4" />
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Synergy table */}
-            <div id="synergy">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                Synergy Overview
-              </h2>
-              <ResponsiveTable label="L-theanine and magnesium synergy for ADHD">
-                <table className="min-w-[580px] w-full text-sm">
-                  <thead>
-                    <tr className="border-b border-brand-900/10">
-                      {['ADHD Challenge', 'L-Theanine Contribution', 'Magnesium Contribution'].map((h) => (
-                        <th key={h} className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">{h}</th>
-                      ))}
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-brand-900/5">
-                    {[
-                      ['Sleep onset', 'Mental quiet, reduced racing thoughts', 'NMDA calm, muscle relaxation, GABA support'],
-                      ['Evening hyperactivation', 'Alpha-wave induction, mental de-arousal', 'Neural excitability regulation'],
-                      ['Emotional dysregulation', 'Mild GABA modulation, stress attenuation', 'GABA support, potential cortisol-adjacent effects'],
-                      ['Daytime focus (L-theanine only)', '↑ Alpha, calm alertness without sedation', '(Not typically used in daytime)'],
-                      ['Physical restlessness', 'Limited direct effect', 'Muscle relaxation, magnesium\'s role in motor nerve conduction'],
-                    ].map(([challenge, lt, mg]) => (
-                      <tr key={challenge as string} className="align-top">
-                        <td className="py-3 pr-4 font-medium text-ink">{challenge}</td>
-                        <td className="py-3 pr-4 text-muted">{lt}</td>
-                        <td className="py-3 text-muted">{mg}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </ResponsiveTable>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* How to Stack */}
-            <div id="how-to-stack">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                How to Stack Them: A Practical Protocol
-              </h2>
-              <div className="space-y-4">
-                {[
-                  {
-                    step: '1',
-                    title: 'Start with magnesium glycinate alone',
-                    body: 'Week 1–2: Take 200 mg elemental magnesium glycinate 30–60 minutes before bed. Assess sleep quality and evening calm. Magnesium deficiency is common in ADHD, so this may produce noticeable results quickly.',
-                  },
-                  {
-                    step: '2',
-                    title: 'Evaluate and add L-theanine',
-                    body: 'If magnesium is producing benefit but you still notice mental racing or stress-driven arousal at bedtime, add L-theanine 100–200 mg at the same time (30–60 min before bed). Start at 100 mg.',
-                  },
-                  {
-                    step: '3',
-                    title: 'For daytime calm focus',
-                    body: 'L-theanine can also be used alone during the day (100–200 mg, standalone, caffeine-free) for calm alertness. Magnesium is typically not added to daytime stacks unless deficiency correction is the primary goal.',
-                  },
-                  {
-                    step: '4',
-                    title: 'Monitor and adjust',
-                    body: 'After 4–6 weeks on the full stack, assess whether both supplements are contributing. If results are good, continue. If sleep worsened or any side effects emerged, step back to one supplement and reassess.',
-                  },
-                ].map(({ step, title, body }) => (
-                  <div key={step} className="flex gap-4 rounded-[1rem] border border-brand-900/10 bg-brand-50/40 p-4">
-                    <span className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-brand-700 text-xs font-bold text-white">
-                      {step}
-                    </span>
-                    <div>
-                      <p className="font-semibold text-ink">{title}</p>
-                      <p className="mt-1 text-sm leading-6 text-muted">{body}</p>
-                    </div>
-                  </div>
-                ))}
-              </div>
-
-              <div className="mt-4 rounded-[1rem] border border-brand-900/10 bg-white/90 p-5 shadow-sm">
-                <p className="mb-3 text-[10px] font-bold uppercase tracking-wider text-muted">
-                  Stack Reference — Evening Protocol
-                </p>
-                <ResponsiveTable label="L-theanine magnesium stack dosage">
-                  <table className="min-w-[500px] w-full text-sm">
-                    <thead>
-                      <tr className="border-b border-brand-900/10">
-                        {['Supplement', 'Dose', 'Timing', 'Notes'].map((h) => (
-                          <th key={h} className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">{h}</th>
-                        ))}
-                      </tr>
-                    </thead>
-                    <tbody className="divide-y divide-brand-900/5">
-                      {[
-                        ['Magnesium Glycinate', '200–300 mg elemental', '30–60 min before bed', 'Introduce first; confirm tolerance'],
-                        ['L-Theanine', '100–200 mg', 'Same time as magnesium', 'Add after 1–2 weeks on Mg alone'],
-                      ].map(([supp, dose, timing, notes]) => (
-                        <tr key={supp as string} className="align-top">
-                          <td className="py-3 pr-4 font-medium text-ink">{supp}</td>
-                          <td className="py-3 pr-4 text-muted">{dose}</td>
-                          <td className="py-3 pr-4 text-muted">{timing}</td>
-                          <td className="py-3 text-muted">{notes}</td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </ResponsiveTable>
-              </div>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Products */}
-            <div id="products">
-              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">Product Options</h2>
-              <div className="grid gap-4 sm:grid-cols-2">
-                {[
-                  {
-                    eyebrow: 'Magnesium Glycinate',
-                    name: 'Magnesium Glycinate 400mg',
-                    desc: 'Best form for the stack. Check the elemental magnesium per serving on the label.',
-                    query: 'magnesium+glycinate+sleep+calm',
-                    cta: 'View on Amazon →',
-                  },
-                  {
-                    eyebrow: 'L-Theanine (Caffeine-Free)',
-                    name: 'L-Theanine 100–200mg',
-                    desc: 'Choose a standalone product without added caffeine. Look for "caffeine-free" clearly stated.',
-                    query: 'l-theanine+200mg+caffeine+free+sleep',
-                    cta: 'View on Amazon →',
-                  },
-                  {
-                    eyebrow: 'Combined Stack',
-                    name: 'L-Theanine + Magnesium Combo',
-                    desc: 'Pre-combined sleep stack products. Verify dose amounts match the ranges on this page.',
-                    query: 'l-theanine+magnesium+glycinate+sleep+stack',
-                    cta: 'View combo products →',
-                  },
-                ].map(({ eyebrow, name, desc, query, cta }) => (
-                  <div key={name} className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
-                    <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">{eyebrow}</p>
-                    <p className="font-semibold text-ink">{name}</p>
-                    <p className="mt-1 text-xs leading-5 text-muted">{desc}</p>
-                    <a
-                      href={`https://www.amazon.com/s?k=${query}&tag=${AFFILIATE_TAGS.amazon}`}
-                      target="_blank"
-                      rel="noopener noreferrer sponsored"
-                      className="mt-3 inline-flex items-center gap-1 rounded-full bg-brand-950 px-4 py-1.5 text-xs font-bold text-white transition hover:bg-brand-900"
-                    >
-                      {cta}
-                    </a>
-                  </div>
-                ))}
-              </div>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Safety */}
-            <div id="safety">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Safety and Interactions</h2>
-              <SafetyNotice title="Stack Safety — L-Theanine + Magnesium for ADHD">
-                <ul className="ml-5 space-y-1.5 list-disc">
-                  {[
-                    ['No established adverse L-theanine + magnesium interaction', 'No pharmacokinetic or pharmacodynamic interaction has been identified between supplemental L-theanine and magnesium in available literature.'],
-                    ['ADHD stimulant medications', 'No established interaction with methylphenidate or amphetamine salts. Inform your prescriber that you are supplementing; do not adjust medication dose based on supplement use.'],
-                    ['Sedative medications', 'Both L-theanine and magnesium have mild CNS-calming properties. Use caution when combining with benzodiazepines, z-drugs, or other sedative medications.'],
-                    ['Kidney disease', 'Magnesium is renally cleared. Do not supplement without clinician guidance if you have kidney impairment.'],
-                    ['Tolerable upper level for magnesium', 'Do not exceed 350 mg supplemental magnesium per day without medical oversight. This does not include dietary magnesium.'],
-                    ['Pregnancy and breastfeeding', 'Insufficient safety data for supplemental L-theanine. Supplemental magnesium may be appropriate in some cases — consult a clinician.'],
-                  ].map(([bold, text]) => (
-                    <li key={bold as string}>
-                      <strong>{bold as string}.</strong> {text as string}
-                    </li>
+          </div>
+          <ResponsiveTable label="Evidence for L-theanine and magnesium in ADHD-related decisions">
+            <table className="min-w-[900px] w-full text-left text-sm">
+              <thead className="bg-brand-50/80">
+                <tr className="border-b border-brand-900/10">
+                  {['Evidence area', 'What was observed', 'Boundary'].map((heading) => (
+                    <th key={heading} className="px-4 py-3 text-xs font-bold uppercase tracking-[0.12em] text-brand-900">
+                      {heading}
+                    </th>
                   ))}
-                </ul>
-              </SafetyNotice>
-            </div>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-brand-900/10 bg-white">
+                {EVIDENCE_ROWS.map(([area, observed, boundary]) => (
+                  <tr key={area} className="align-top">
+                    <td className="px-4 py-4 font-semibold text-ink">{area}</td>
+                    <td className="px-4 py-4 text-muted">{observed}</td>
+                    <td className="px-4 py-4 text-muted">{boundary}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </ResponsiveTable>
+        </section>
 
-            <hr className="border-brand-900/10" />
+        <section id="claim-check" className="scroll-mt-20 space-y-5">
+          <div>
+            <p className="eyebrow-label">Claim check</p>
+            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
+              Four shortcuts the evidence does not support
+            </h2>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            {CLAIMS.map((item) => (
+              <div key={item.claim} className="rounded-2xl border border-brand-900/10 bg-white/90 p-5 shadow-sm">
+                <p className="text-xs font-bold uppercase tracking-[0.12em] text-brand-700">{item.verdict}</p>
+                <h3 className="mt-2 text-base font-semibold text-ink">{item.claim}</h3>
+                <p className="mt-2 text-sm leading-6 text-muted">{item.explanation}</p>
+              </div>
+            ))}
+          </div>
+        </section>
 
-            {/* FAQ */}
-            <div id="faq">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Frequently Asked Questions</h2>
-              <div className="space-y-4">
-                {FAQS.map((faq, i) => (
-                  <div key={i} className="rounded-[0.75rem] border border-brand-900/10 bg-brand-50/40 p-4">
-                    <h3 className="font-semibold text-ink">{faq.question}</h3>
-                    <p className="mt-2 text-sm leading-7 text-muted">{faq.answer}</p>
+        <section id="target" className="scroll-mt-20 rounded-[1.65rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+          <p className="eyebrow-label">Decision framework</p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
+            Choose the real target before considering a stack
+          </h2>
+          <div className="mt-5">
+            <ResponsiveTable label="Targets for an L-theanine or magnesium trial">
+              <table className="min-w-[900px] w-full text-left text-sm">
+                <thead className="bg-brand-50/80">
+                  <tr className="border-b border-brand-900/10">
+                    {['Target', 'Evidence-calibrated decision', 'Tracking rule'].map((heading) => (
+                      <th key={heading} className="px-4 py-3 text-xs font-bold uppercase tracking-[0.12em] text-brand-900">
+                        {heading}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-brand-900/10 bg-white">
+                  {TARGET_ROWS.map(([target, decision, tracking]) => (
+                    <tr key={target} className="align-top">
+                      <td className="px-4 py-4 font-semibold text-ink">{target}</td>
+                      <td className="px-4 py-4 text-muted">{decision}</td>
+                      <td className="px-4 py-4 text-muted">{tracking}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </ResponsiveTable>
+          </div>
+        </section>
+
+        <AdhdInlineCta type="stack" />
+
+        <section id="trial-design" className="scroll-mt-20 space-y-5">
+          <div className="max-w-3xl">
+            <p className="eyebrow-label">N-of-1 design</p>
+            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
+              Make a trial interpretable before making it complicated
+            </h2>
+          </div>
+          <ol className="space-y-4">
+            {TRIAL_STEPS.map(([title, copy], index) => (
+              <li key={title} className="rounded-2xl border border-brand-900/10 bg-white/90 p-5 shadow-sm">
+                <div className="flex gap-4">
+                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-brand-100 text-sm font-bold text-brand-800">
+                    {index + 1}
+                  </span>
+                  <div>
+                    <h3 className="font-semibold text-ink">{title}</h3>
+                    <p className="mt-2 text-sm leading-6 text-muted">{copy}</p>
                   </div>
-                ))}
-              </div>
-            </div>
+                </div>
+              </li>
+            ))}
+          </ol>
+        </section>
 
-            <hr className="border-brand-900/10" />
-
-            <div id="related">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Related Articles</h2>
-              <div className="grid gap-3 sm:grid-cols-2">
-                {[
-                  ['/guides/adhd/best-supplements-for-adhd/', 'Cornerstone', 'Best Supplements for ADHD', 'Full evidence-ranked guide.'],
-                  ['/guides/adhd/magnesium-for-adhd/', 'ADHD Cluster', 'Magnesium for ADHD', 'Evidence review of magnesium for ADHD.'],
-                  ['/guides/adhd/l-theanine-for-adhd/', 'ADHD Cluster', 'L-Theanine for ADHD', 'Evidence review of L-theanine for ADHD.'],
-                  ['/guides/adhd/magnesium-glycinate-vs-citrate-for-adhd', 'ADHD Cluster', 'Glycinate vs Citrate for ADHD', 'Which magnesium form works best.'],
-                  ['/guides/adhd/best-magnesium-supplement-for-adhd', 'Buying Guide', 'Best Magnesium for ADHD', 'Which product to buy first.'],
-                  ['/guides/adhd/adhd-stack-guide', 'Stack Guide', 'ADHD Stack Guide', 'Full supplement stacking guide for ADHD.'],
-                  ['/guides/adhd/sleep-and-adhd', 'Sleep + ADHD', 'Sleep and ADHD', 'Why sleep matters so much in ADHD.'],
-                  ['/guides/focus', 'Goal Hub', 'Focus Goal Hub', 'Compare all focus supplements.'],
-                ].map(([href, eyebrow, label, desc]) => (
-                  <Link key={href as string} href={href as string}
-                    className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30">
-                    <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">{eyebrow}</p>
-                    <p className="font-semibold text-ink transition group-hover:text-brand-700">{label}</p>
-                    <p className="mt-1 text-xs text-muted">{desc}</p>
-                  </Link>
-                ))}
-              </div>
-            </div>
-
-          </section>
-
-      <div className="max-w-4xl">
-        <RecommendationSection products={getRevenueProductSet('l-theanine')?.products ?? []} />
-      </div>
-          <EmailCapture
-            headline="Get the ADHD supplement checklist"
-            description="Evidence-first supplement updates, stack guides, and ADHD research notes. No diagnosis or personal medical advice."
-            ctaLabel="Get Checklist"
-            location={`article-${SLUG}`}
-          />
-          <NewsletterCtaBlock
-            title="Continue with the newsletter archive"
-            description="Short notes built for cautious supplement decisions."
-            location={`article-${SLUG}-newsletter`}
-          />
-        </div>
-
-        {/* Sidebar */}
-        <aside className="space-y-4 lg:sticky lg:top-24 lg:self-start">
-          <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
-            <p className="text-[10px] font-bold uppercase tracking-wider text-muted">In this article</p>
-            <nav className="mt-3 space-y-1.5" aria-label="Article sections">
-              {[
-                ['#why-combine', 'Why Combine?'],
-                ['#mechanisms', 'Mechanisms'],
-                ['#synergy', 'Synergy Table'],
-                ['#how-to-stack', 'How to Stack'],
-                ['#products', 'Products'],
-                ['#safety', 'Safety'],
-                ['#faq', 'FAQ'],
-              ].map(([href, label]) => (
-                <a key={href} href={href as string}
-                  className="block text-sm text-brand-700 hover:text-brand-800 hover:underline">
-                  {label}
-                </a>
-              ))}
-            </nav>
+        <section id="dose-context" className="scroll-mt-20 rounded-[1.65rem] border border-amber-900/15 bg-amber-50/70 p-6 shadow-sm sm:p-8">
+          <p className="text-xs font-bold uppercase tracking-[0.14em] text-amber-800">Study context—not a protocol</p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-amber-950">
+            There is no validated combination dose
+          </h2>
+          <div className="mt-4 space-y-4 text-sm leading-7 text-amber-950/90">
+            <p>
+              The pediatric L-theanine trial used 400 mg daily, split between breakfast and after school, for six
+              weeks. That dose belongs in the study description; it should not be converted into a universal
+              bedtime recommendation or copied for a child without clinical guidance.
+            </p>
+            <p>
+              Magnesium labels report elemental magnesium, not total compound weight. NIH sets a 350 mg/day
+              upper limit from supplements and medications for adults and ages 9–18 unless a clinician directs
+              otherwise. Limits are 65 mg/day for ages 1–3 and 110 mg/day for ages 4–8. Food magnesium is not
+              included in those limits.
+            </p>
+            <p>
+              A “200–300 mg magnesium + 100–200 mg L-theanine” stack may look ordinary online, but it is not an
+              evidence-based ADHD protocol and can exceed age-specific magnesium limits. Product serving size,
+              other supplements, antacids, and laxatives must be counted.
+            </p>
           </div>
-          <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
-            <p className="text-[10px] font-bold uppercase tracking-wider text-muted">ADHD cluster</p>
-            <div className="mt-3 space-y-2">
-              {[
-                ['/guides/adhd/best-supplements-for-adhd/', 'Best supplements for ADHD →'],
-                ['/guides/adhd/magnesium-for-adhd/', 'Magnesium for ADHD →'],
-                ['/guides/adhd/l-theanine-for-adhd/', 'L-Theanine for ADHD →'],
-                ['/guides/adhd/adhd-stack-guide', 'ADHD stack guide →'],
-                ['/guides/adhd/adhd-supplements/', 'ADHD supplements guide →'],
-              ].map(([href, label]) => (
-                <Link key={href as string} href={href as string}
-                  className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline">
-                  {label}
-                </Link>
-              ))}
-            </div>
-          </div>
-        </aside>
-      </div>
+        </section>
 
-      <div className="mt-8">
-        <Link href="/guides/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
-          ← Back to Guides
-        </Link>
+        <section id="safety" className="scroll-mt-20 rounded-[1.65rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+          <p className="eyebrow-label">Safety and medications</p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
+            “No known interaction” is not a safety certificate
+          </h2>
+          <ul className="mt-5 space-y-3 text-sm leading-7 text-muted">
+            <li>
+              <strong>ADHD medication:</strong> The L-theanine sleep trial included stimulant and non-stimulant
+              users through stratified randomization, but it was not a dedicated interaction study. Review the
+              combination with the prescriber.
+            </li>
+            <li>
+              <strong>Kidney impairment:</strong> Reduced magnesium clearance raises the risk of accumulation and
+              toxicity. Do not self-supplement without medical guidance.
+            </li>
+            <li>
+              <strong>Medication absorption:</strong> Magnesium can interfere with oral bisphosphonates and bind
+              tetracycline or quinolone antibiotics. Follow the medicine label or pharmacist’s spacing advice.
+            </li>
+            <li>
+              <strong>Blood pressure and sedation:</strong> L-theanine data are limited across medication
+              combinations. Review use with blood-pressure drugs, sedatives, sleep medicines, alcohol, or other
+              calming supplements rather than assuming additive effects are harmless.
+            </li>
+            <li>
+              <strong>Children, pregnancy, and breastfeeding:</strong> Do not copy adult internet protocols.
+              Product quality, dose, indication, and medication context require clinician review.
+            </li>
+            <li>
+              <strong>Stop signals:</strong> Persistent diarrhea, vomiting, unusual weakness, dizziness, fainting,
+              breathing difficulty, marked sedation, worsening mood, or a concerning medication change require
+              stopping and appropriate medical advice.
+            </li>
+          </ul>
+          <div className="mt-5 flex flex-wrap gap-4 text-sm font-semibold">
+            <Link href="/safety-checker/" className="text-brand-700 hover:underline">
+              Check interaction pathways →
+            </Link>
+            <Link href="/guides/adhd/adhd-medication-supplement-interactions/" className="text-brand-700 hover:underline">
+              Medication interaction guide →
+            </Link>
+          </div>
+        </section>
+
+        <AdhdInlineCta type="safety" />
+
+        <section className="rounded-[1.65rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm">
+          <h2 className="text-xl font-semibold text-ink">Continue with the narrower decision</h2>
+          <div className="mt-4 grid gap-3 sm:grid-cols-2">
+            <Link href="/guides/adhd/l-theanine-for-adhd/" className="rounded-xl border border-brand-900/10 p-4 text-sm font-semibold text-brand-700 hover:underline">
+              Review L-theanine alone →
+            </Link>
+            <Link href="/guides/adhd/best-magnesium-supplement-for-adhd/" className="rounded-xl border border-brand-900/10 p-4 text-sm font-semibold text-brand-700 hover:underline">
+              Choose magnesium by role and label →
+            </Link>
+            <Link href="/guides/adhd/sleep-and-adhd/" className="rounded-xl border border-brand-900/10 p-4 text-sm font-semibold text-brand-700 hover:underline">
+              Separate sleep problems from ADHD →
+            </Link>
+            <Link href="/guides/adhd/adhd-supplements/" className="rounded-xl border border-brand-900/10 p-4 text-sm font-semibold text-brand-700 hover:underline">
+              Return to the evidence hub →
+            </Link>
+          </div>
+        </section>
+
+        <section id="faq" className="scroll-mt-20 rounded-[1.65rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+          <h2 className="text-2xl font-semibold tracking-tight text-ink">Frequently asked questions</h2>
+          <div className="mt-5 divide-y divide-brand-900/10">
+            {FAQS.map((faq) => (
+              <div key={faq.question} className="py-5 first:pt-0 last:pb-0">
+                <h3 className="font-semibold text-ink">{faq.question}</h3>
+                <p className="mt-2 text-sm leading-7 text-muted">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <References refs={[...REFERENCES]} />
+
+        <p className="text-xs leading-6 text-muted">
+          This guide is educational. It does not diagnose ADHD, magnesium deficiency, or a sleep disorder and
+          does not prescribe a supplement stack. Discuss pediatric use, pregnancy, kidney disease, persistent
+          sleep problems, low blood pressure, and medication combinations with a qualified clinician or
+          pharmacist.
+        </p>
       </div>
-      <References refs={L_THEANINE_MAGNESIUM_ADHD_STACK_REFS} />
-    </article>
+    </ArticleLayout>
   )
 }

--- a/app/guides/adhd/l-theanine-magnesium-adhd-stack/page.tsx
+++ b/app/guides/adhd/l-theanine-magnesium-adhd-stack/page.tsx
@@ -476,8 +476,8 @@ export default function LTheanineMagnesiumAdhdStackPage() {
             <Link href="/safety-checker/" className="text-brand-700 hover:underline">
               Check interaction pathways →
             </Link>
-            <Link href="/guides/adhd/adhd-medication-supplement-interactions/" className="text-brand-700 hover:underline">
-              Medication interaction guide →
+            <Link href="/guides/other/supplement-stacking-safety/" className="text-brand-700 hover:underline">
+              General stacking safety guide →
             </Link>
           </div>
         </section>


### PR DESCRIPTION
## What changed

- rebuilt `/guides/adhd/l-theanine-magnesium-adhd-stack/` as a combination-evidence and trial-design guide
- removed the old protocol framing, additive-synergy language, response timeline, and implied stimulant compatibility
- removed generic Amazon search cards and duplicate product monetization
- separated the ADHD-specific L-theanine sleep trial, magnesium status findings, general cognition evidence, and multi-ingredient combination research
- labeled study doses as study context rather than recommendations
- added age-specific NIH magnesium upper-limit context, kidney cautions, medication-absorption issues, and pediatric guardrails
- replaced “no known interaction” reassurance with a prescriber/pharmacist review framework
- routed readers to the individual L-theanine, magnesium, sleep, stack-safety, and safety-checker pages
- added regression tests preventing the old dose, synergy, and affiliate claims from returning

## Why this page

This high-intent stack page previously presented an untested combination as low-risk and complementary, prescribed a 200–300 mg elemental magnesium plus 100–200 mg L-theanine bedtime protocol, and implied compatibility with ADHD medication. The direct ADHD evidence does not support those conclusions: the L-theanine trial addressed narrow sleep outcomes, magnesium treatment evidence remains inadequate, and no trial establishes combination synergy or a validated ADHD dose.

## Validation expected

- lint and TypeScript
- Vitest and accessibility gate
- static export and production build
- route SEO coverage
- site health, Fast UI, and Lighthouse
