### PR TITLE
Rebuild best nootropics guide around outcome-specific evidence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,22 @@
 
 Older `/articles/*`, `/goals/*`, `/stacks/*`, top-level `/compare/*`, and top-level `/best-supplements-for-*` URLs should be treated as legacy compatibility/redirect surfaces unless explicitly reactivated. Prefer linking to the current `/guides/*` taxonomy. See `docs/site-organization.md`.
 
+## Evidence-first decision pages
+
+Before editing a best-of guide, comparison, stack, condition-adjacent page, or any route that helps a reader decide what to take or buy, read `docs/content-quality/evidence-first-decision-page-standard.md`.
+
+Required practices:
+
+- Separate outcomes that are not interchangeable: acute attention, long-term memory, fatigue, sleep, deficiency correction, symptom scales, and biomarkers require different claims.
+- State the studied population, comparator, product or extract, duration, and directness boundary.
+- Include null, negative, contradictory, subgroup-only, and non-replicated evidence—not only studies that support the ranking.
+- Treat trial doses and timelines as study context, not universal protocols.
+- Do not convert mechanism, observational association, preclinical findings, or an adjacent population into direct treatment evidence.
+- Disclose meaningful product funding, investigator conflicts, and lack of independent replication when they affect interpretation.
+- Set evidence order before product availability or commission; broad comparisons should not monetize only one ranked option without an explicit reason.
+- Consolidate overlapping routes when they serve the same reader job, and protect the decision with redirects, documentation, and regression tests.
+- Add route-specific tests for the exact overclaim, dose, monetization, or canonical pattern removed during the upgrade.
+
 ## Data pipeline
 - Primary source: `data-sources/herb_monograph_master.xlsx`. The workbook is editable — edit it to make broad/structured content changes, then run `npm run data:build`.
 - Generated JSON lives in `public/data/`. You may also edit these files directly to fix or patch content, but for larger changes prefer the workbook so edits are not lost on the next regeneration.

--- a/app/__tests__/best-nootropics-focus-calibration.test.ts
+++ b/app/__tests__/best-nootropics-focus-calibration.test.ts
@@ -1,0 +1,73 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const PAGE = 'app/guides/focus/best-nootropics-for-focus/page.tsx'
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+}
+
+describe('best nootropics for focus evidence calibration', () => {
+  it('separates acute attention, long-term memory, fatigue, and population-specific evidence', () => {
+    const source = read(PAGE)
+
+    expect(source).toContain('Short-term alertness during a demanding task')
+    expect(source).toContain('Memory over months rather than same-day focus')
+    expect(source).toContain('Age-associated memory complaint')
+    expect(source).toContain('Concentration that collapses with stress or fatigue')
+    expect(source).toContain('A positive memory result in older adults is not proof of acute attention')
+  })
+
+  it('does not restore protocol-like dosing or single-ingredient commercial bias', () => {
+    const source = read(PAGE)
+
+    expect(source).not.toContain('getRevenueProductSet')
+    expect(source).not.toContain('RecommendationSection')
+    expect(source).not.toContain('AffiliateDisclosure')
+    expect(source).not.toContain('A conservative starting point is')
+    expect(source).not.toContain('Common supplemental doses are')
+    expect(source).toContain('A dose in a trial is not a universal recommendation')
+  })
+
+  it('includes positive, null, negative, and conflict-aware evidence', () => {
+    const source = read(PAGE)
+
+    expect(source).toContain('confidence intervals often showed uncertainty')
+    expect(source).toContain('fatigue changes that favored placebo')
+    expect(source).toContain('null and limited negative findings')
+    expect(source).toContain('manufacturer-affiliated trial')
+    expect(source).toContain('Product-specific funding and investigator conflicts')
+  })
+
+  it('anchors every ranked ingredient in relevant human evidence', () => {
+    const source = read(PAGE)
+
+    for (const pmid of [
+      '40314930',
+      '42410082',
+      '22747190',
+      '41678913',
+      '33978188',
+      '22643043',
+      '25268730',
+      '38004235',
+      '40276537',
+      '18616866',
+      '40213691',
+    ]) {
+      expect(source).toContain(pmid)
+    }
+  })
+
+  it('preserves FAQ schema, email capture, internal pathways, and safety review', () => {
+    const source = read(PAGE)
+
+    expect(source).toContain('faqs={FAQS}')
+    expect(source).toContain('location="guides-best-nootropics-for-focus"')
+    expect(source).toContain('/guides/focus/')
+    expect(source).toContain('/guides/adhd/adhd-supplements/')
+    expect(source).toContain('/safety-checker/')
+    expect(source).toContain('Define the stop rule')
+  })
+})

--- a/app/__tests__/evidence-first-agent-guidance.test.ts
+++ b/app/__tests__/evidence-first-agent-guidance.test.ts
@@ -1,0 +1,30 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+}
+
+describe('evidence-first agent guidance', () => {
+  it('keeps the decision-page standard discoverable from AGENTS.md', () => {
+    const agents = read('AGENTS.md')
+
+    expect(agents).toContain('## Evidence-first decision pages')
+    expect(agents).toContain('docs/content-quality/evidence-first-decision-page-standard.md')
+    expect(agents).toContain('Include null, negative, contradictory')
+    expect(agents).toContain('Treat trial doses and timelines as study context')
+    expect(agents).toContain('broad comparisons should not monetize only one ranked option')
+  })
+
+  it('preserves the core evidence, commercial, and canonical rules in the standard', () => {
+    const standard = read('docs/content-quality/evidence-first-decision-page-standard.md')
+
+    expect(standard).toContain('## Directness ladder')
+    expect(standard).toContain('## Negative-evidence requirement')
+    expect(standard).toContain('## Commercial-neutrality rules')
+    expect(standard).toContain('## Canonical and cannibalization rule')
+    expect(standard).toContain('A combination product cannot prove the contribution of one component')
+    expect(standard).toContain('Affiliate disclosure does not repair biased evidence architecture')
+  })
+})

--- a/app/guides/focus/best-nootropics-for-focus/page.tsx
+++ b/app/guides/focus/best-nootropics-for-focus/page.tsx
@@ -2,157 +2,325 @@ import type { Metadata } from 'next'
 import Image from 'next/image'
 import Link from 'next/link'
 import StructuredData from '@/components/StructuredData'
-import { SITE_URL } from '@/lib/navigation-config'
 import { ArticleLayout, TableOfContents } from '@/components/articles'
 import type { Heading } from '@/components/articles'
-import { getRevenueProductSet } from '@/config/revenue-products'
-import RecommendationSection from '@/components/RecommendationSection'
-import AffiliateDisclosure from '@/components/AffiliateDisclosure'
 import EmailCapture from '@/components/EmailCapture'
 import References from '@/components/References'
+import ResponsiveTable from '@/components/ui/ResponsiveTable'
+import { buildPageMetadata, SITE_URL } from '@/src/lib/seo'
 
-const PAGE_URL = `${SITE_URL}/guides/focus/best-nootropics-for-focus`
+const PATH = '/guides/focus/best-nootropics-for-focus'
+const TITLE = 'Best Nootropics for Focus: Evidence by Goal'
+const DESCRIPTION =
+  'Compare focus nootropics by the outcome actually studied: acute attention, long-term memory, stress-related fatigue, or population-specific memory support—with safety and evidence limits.'
 
-export const metadata: Metadata = {
-  title: 'Best Nootropics for Focus: Choose by Attention, Fatigue or Memory',
-  description:
-    'Compare nootropics by the problem you actually want to solve: immediate attention, stress-related fatigue, or longer-term memory support. Evidence, safety, doses, and buying guidance.',
-  alternates: { canonical: '/guides/focus/best-nootropics-for-focus/' },
-  openGraph: {
-    title: 'Best Nootropics for Focus: Choose by Attention, Fatigue or Memory',
-    description:
-      'A practical evidence-based guide to choosing nootropics for immediate attention, stress-related fatigue, or longer-term memory support.',
-    url: '/guides/focus/best-nootropics-for-focus/',
-    type: 'article',
-    images: ['/og-default.jpg'],
+export const metadata: Metadata = buildPageMetadata({
+  title: TITLE,
+  description: DESCRIPTION,
+  path: PATH,
+  image: '/images/guides/best-nootropics-for-focus.jpg',
+  openGraphType: 'article',
+})
+
+const HEADINGS: Heading[] = [
+  { id: 'quick-answer', text: 'Quick answer', level: 2 },
+  { id: 'decision-map', text: 'Choose by the real outcome', level: 2 },
+  { id: 'evidence-profiles', text: 'Evidence profiles', level: 2 },
+  { id: 'study-context', text: 'Study context, not protocols', level: 2 },
+  { id: 'trial-design', text: 'How to test one safely', level: 2 },
+  { id: 'product-quality', text: 'Product-quality checklist', level: 2 },
+  { id: 'faq', text: 'Frequently asked questions', level: 2 },
+]
+
+const FAQS = [
+  {
+    question: 'What is the best nootropic for focus?',
+    answer:
+      'There is no universal winner. For a short demanding task, already-tolerated caffeine—sometimes paired with L-theanine—has the most direct acute attention evidence, but effects are small or task-specific and caffeine can worsen sleep, anxiety, blood pressure, and palpitations. Bacopa is better framed as a long-term memory option, not an immediate focus aid. The other ingredients on this page remain more population-specific or experimental.',
   },
-}
+  {
+    question: 'Do natural nootropics reliably improve attention in healthy adults?',
+    answer:
+      'Not reliably. A 2025 network meta-analysis of natural extracts found that none significantly outperformed placebo for attention in healthy adults. Individual trials can report positive tasks or subgroups, but that is different from a dependable, broad focus effect.',
+  },
+  {
+    question: 'Can nootropics replace ADHD medication or assessment?',
+    answer:
+      'No. A supplement guide for healthy-adult cognition does not establish treatment for ADHD, depression, anxiety, sleep disorders, or another medical cause of persistent concentration problems. Do not use a stack to delay appropriate assessment or prescribed care.',
+  },
+  {
+    question: 'Should I combine several nootropics?',
+    answer:
+      'Starting several products together makes benefits, side effects, and interactions difficult to attribute. Define one measurable target, establish a baseline, change one variable, and set a review and stop date before considering another ingredient.',
+  },
+  {
+    question: 'How long do nootropics take to work?',
+    answer:
+      'It depends on the studied outcome. Caffeine and L-theanine trials usually measure effects within hours. Bacopa memory trials generally run about 12 weeks. Citicoline, lion’s mane, rhodiola, and phosphatidylserine findings come from different populations, products, and durations, so a universal timeline is not evidence-based.',
+  },
+  {
+    question: 'What is the safest nootropic?',
+    answer:
+      'There is no universally safest option. Risk depends on dose, product identity, caffeine sensitivity, cardiovascular and mood history, allergies, pregnancy, medications, sleep, and whether the ingredient is being combined with other stimulating or sedating products.',
+  },
+]
 
-const FOCUS_NOOTROPICS = [
+const DECISION_ROWS = [
+  [
+    'Short-term alertness during a demanding task',
+    'Caffeine, optionally paired with L-theanine when caffeine is already tolerated',
+    'Selected acute attention and reaction-time outcomes in healthy adults',
+    'The effect is task-specific; L-theanine does not erase caffeine-related sleep, anxiety, heart-rate, or blood-pressure risk.',
+  ],
+  [
+    'Memory over months rather than same-day focus',
+    'Bacopa monnieri',
+    'The clearest signal is memory free recall after sustained use',
+    'Evidence for attention and broader cognitive enhancement is weaker; extracts and bacoside standardization vary.',
+  ],
+  [
+    'Age-associated memory complaint',
+    'Citicoline may be considered as a population-specific option',
+    'A positive randomized trial exists in adults ages 50–85 with age-associated memory impairment',
+    'That manufacturer-affiliated trial does not establish an immediate focus benefit in healthy young adults.',
+  ],
+  [
+    'Concentration that collapses with stress or fatigue',
+    'Address sleep, workload, mood, medical causes, and stimulant load first',
+    'Rhodiola research is contradictory and methodologically limited',
+    'A placebo-controlled trial in nursing students found fatigue outcomes favoring placebo.',
+  ],
+  [
+    'Experimental mushroom-based cognitive support',
+    'Lion’s mane',
+    'Small pilot trials report isolated positive tasks or trends',
+    'Samples are small, findings are mixed, and product composition is not interchangeable across fruiting-body and mycelium extracts.',
+  ],
+  [
+    'Stress-buffering or older-adult memory context',
+    'Phosphatidylserine',
+    'Small studies and combination products provide limited population-specific signals',
+    'The evidence does not support ranking standalone phosphatidylserine as a reliable general focus enhancer.',
+  ],
+] as const
+
+const NOOTROPICS = [
   {
     name: 'L-Theanine + Caffeine',
-    mechanism: 'Caffeine increases alertness while L-theanine may reduce some caffeine-related tension and support attention during demanding tasks.',
-    evidence: 'Moderate — several small crossover trials support short-term attention and reaction-time benefits, but results and doses vary',
-    dose: 'A conservative starting point is L-theanine 100–200 mg with caffeine 25–50 mg; adjust only after assessing sensitivity',
-    safety: 'Caffeine can worsen anxiety, palpitations, blood pressure, and sleep. Avoid treating the combination as automatically safe because it is widely sold.',
-    bestFor: 'Short-term alertness and attention when caffeine is already tolerated',
-    href: '/compounds/l-theanine',
-    badge: 'Best acute evidence',
-    timeframe: 'Acute (about 30–60 minutes)',
-  },
-  {
-    name: 'Citicoline (CDP-Choline)',
-    mechanism: 'Provides choline used in phospholipid and acetylcholine pathways; human evidence is stronger in older or clinically studied populations than in healthy young adults.',
-    evidence: 'Limited–moderate — some attention and memory findings, but broad “cognitive enhancement” claims outrun the healthy-adult evidence',
-    dose: 'Common supplemental doses are 250–500 mg daily; use the lowest practical dose and reassess rather than automatically escalating',
-    safety: 'Usually well tolerated, but headache, GI symptoms, restlessness, and insomnia can occur. Medication interactions still deserve review.',
-    bestFor: 'A cautious trial when longer-term attention or memory support is the goal—not an immediate stimulant-like effect',
-    href: '/compounds/cdp-choline',
-    badge: 'Conditional',
-    timeframe: 'Days to weeks',
+    href: '/guides/focus/l-theanine-without-caffeine/',
+    label: 'Most defensible acute option',
+    role: 'Selected short-term attention, alertness, and reaction-time tasks in healthy adults.',
+    evidence:
+      'A 2025 systematic review included 50 randomized trials and found small-to-moderate differences on selected outcomes, while confidence intervals often showed uncertainty about direction or magnitude. A separate 2026 L-theanine meta-analysis reported an acute choice-reaction-time benefit, but its clinical relevance outside test settings remains uncertain.',
+    boundary:
+      'The evidence is not ADHD treatment evidence, not proof of all-day productivity, and not proof that L-theanine neutralizes caffeine side effects. Several tea and branded-ingredient studies have industry involvement, which belongs in the interpretation.',
+    studyContext:
+      'Trials use different caffeine-to-theanine ratios and usually assess performance within one or two hours. Those study doses should not be converted into a universal daily stack.',
+    safety:
+      'Caffeine can worsen insomnia, anxiety, tremor, reflux, palpitations, and blood pressure. Count coffee, tea, energy drinks, pre-workout, medications, and supplements together.',
   },
   {
     name: 'Bacopa Monnieri',
-    mechanism: 'Bacopa is studied mainly for memory acquisition and recall over repeated use, not as a same-day focus booster.',
-    evidence: 'Moderate for selected memory outcomes after sustained use; much weaker as a direct treatment for everyday inattention',
-    dose: 'Use a standardized extract that states bacoside content; trial doses vary, and benefits are generally assessed over 8–12 weeks',
-    safety: 'GI upset is common enough to matter, and some people report fatigue or sedation. Review thyroid, cholinergic, and medication concerns before use.',
-    bestFor: 'Longer-term memory and learning goals when delayed onset is acceptable',
-    href: '/herbs/bacopa',
-    badge: 'Memory—not acute focus',
-    timeframe: 'Usually 8–12 weeks',
+    href: '/herbs/bacopa/',
+    label: 'Memory—not acute focus',
+    role: 'Long-term memory acquisition and free recall when a delayed evaluation period is acceptable.',
+    evidence:
+      'A systematic review of six randomized trials found that all studies lasted 12 weeks and that the most consistent positive findings were in memory free recall. Evidence for other cognitive domains was sparse. A newer network meta-analysis in healthy adults expands the evidence base but does not turn bacopa into a same-day attention aid.',
+    boundary:
+      'Bacopa should not be marketed as a stimulant-like focus booster. Benefits depend on extract identity, population, outcome, and sustained adherence; newer positive branded-extract trials do not automatically generalize to every bottle.',
+    studyContext:
+      'Historical trials commonly used standardized extracts for roughly 12 weeks. The extract and bacoside profile matter more than copying one milligram number across products.',
+    safety:
+      'GI effects are common enough to affect adherence. Fatigue or sedation can occur. Review thyroid, cholinergic, pregnancy, and medication context before use.',
   },
   {
-    name: "Lion's Mane (Hericium erinaceus)",
-    mechanism: 'Preclinical work is interesting, but human studies are small and mostly address mood or cognition in selected populations.',
-    evidence: 'Emerging — not enough evidence to rank it as a reliable focus enhancer for healthy adults',
-    dose: 'Products vary widely by fruiting body, mycelium, extraction method, and beta-glucan testing, so label quality matters more than a universal dose',
-    safety: 'Avoid with mushroom allergy; stop for allergic symptoms or unexpected respiratory or skin reactions. Long-term extract data remain limited.',
-    bestFor: 'People comfortable with an experimental, slow-build option rather than a proven attention aid',
-    href: '/herbs/hericium-erinaceus',
-    badge: 'Emerging',
-    timeframe: 'Weeks, if any benefit occurs',
+    name: 'Citicoline (CDP-Choline)',
+    href: '/compounds/cdp-choline/',
+    label: 'Population-specific',
+    role: 'Memory support in selected older or clinically studied populations—not an immediate stimulant substitute.',
+    evidence:
+      'A randomized trial in 100 adults ages 50–85 with age-associated memory impairment reported memory benefits after 12 weeks. The investigators included employees or partners of the branded citicoline manufacturer, and the population was not healthy young adults seeking sharper same-day focus.',
+    boundary:
+      'Choline-pathway plausibility is not enough to claim broad cognitive enhancement. Evidence for healthy young adults, persistent inattention, and acute work performance is much thinner than product marketing implies.',
+    studyContext:
+      'Use the population, duration, branded ingredient, and measured memory outcomes as context—not as a universal protocol.',
+    safety:
+      'Headache, GI symptoms, restlessness, and insomnia can occur. Avoid casually stacking multiple cholinergic products, and review medication or neurologic context with a clinician.',
   },
   {
     name: 'Rhodiola Rosea',
-    mechanism: 'Rhodiola may reduce perceived fatigue and support performance under stress, which can indirectly improve concentration.',
-    evidence: 'Limited–moderate — more convincing for stress-related fatigue than for improving baseline attention in rested adults',
-    dose: 'Trials commonly use standardized extracts in the morning; product standardization and individual stimulation response matter',
-    safety: 'Can feel activating and may worsen agitation or sleep. Review psychiatric medications and bipolar-spectrum risk with a clinician.',
-    bestFor: 'Focus that breaks down mainly during fatigue, burnout, or acute stress',
-    href: '/herbs/rhodiola',
-    badge: 'Best for fatigue pattern',
-    timeframe: 'Hours to weeks',
+    href: '/herbs/rhodiola/',
+    label: 'Contradictory fatigue evidence',
+    role: 'An experimental option when perceived stress or fatigue—not baseline attention—is the clearly defined target.',
+    evidence:
+      'A systematic review found contradictory results and judged all included fatigue studies to have high risk of bias or reporting problems. A later randomized trial in nursing students found fatigue changes that favored placebo rather than rhodiola.',
+    boundary:
+      'Rhodiola is not a reliably proven focus enhancer. Exercise-performance findings and preclinical memory mechanisms do not establish better concentration during ordinary cognitive work.',
+    studyContext:
+      'Products differ in extract composition and rosavin/salidroside standardization, making cross-product dose claims unreliable.',
+    safety:
+      'It can feel activating and may worsen agitation or sleep. Review bipolar-spectrum risk, psychiatric medication, blood pressure, and stimulant combinations.',
   },
   {
-    name: 'Phosphatidylserine (PS)',
-    mechanism: 'A membrane phospholipid studied mainly in age-related cognitive concerns and stress-response research.',
-    evidence: 'Limited–moderate in selected older-adult or stress contexts; sparse evidence for noticeable focus gains in healthy young adults',
-    dose: 'Common research doses fall around 100–300 mg daily, but product source and indication should guide any trial',
-    safety: 'Usually tolerated; GI effects and insomnia can occur. Check source allergens and medication compatibility.',
-    bestFor: 'Older adults or stress-related cognitive complaints—not a first-line acute focus supplement',
-    href: '/compounds/phosphatidylserine',
-    badge: 'Population-specific',
-    timeframe: 'Several weeks',
+    name: 'Lion’s Mane (Hericium erinaceus)',
+    href: '/herbs/lions-mane/',
+    label: 'Early and experimental',
+    role: 'A research-stage option for people comfortable with uncertain, product-specific evidence.',
+    evidence:
+      'A 2023 pilot trial in 41 healthy adults found one faster Stroop outcome and a trend toward lower stress, alongside null and limited negative findings. A newer acute crossover study included only 18 healthy younger adults. These are useful signals for future research, not a reliable ranking claim.',
+    boundary:
+      'Fruiting-body, mycelium, erinacine, hericenone, and extraction differences matter. Preclinical neurotrophic mechanisms and dementia studies cannot be silently converted into a healthy-adult focus promise.',
+    studyContext:
+      'The human studies use different preparations and durations. “Lion’s mane” on a front label does not show equivalence to a studied extract.',
+    safety:
+      'Avoid with mushroom allergy and stop for allergic, respiratory, or skin symptoms. Long-term extract and medication-interaction data remain limited.',
   },
-]
+  {
+    name: 'Phosphatidylserine',
+    href: '/compounds/phosphatidylserine/',
+    label: 'Product- and population-specific',
+    role: 'Stress-response or memory questions in selected populations rather than broad everyday focus enhancement.',
+    evidence:
+      'Small studies have examined induced stress, older adults with memory complaints, or formulas that combine phosphatidylserine with other active ingredients. One induced-stress study included only 16 healthy participants. Combination trials cannot isolate phosphatidylserine’s contribution.',
+    boundary:
+      'Membrane biology and stress-hormone findings do not establish a dependable attention benefit. Source material, combination ingredients, age, and baseline impairment change what a result can mean.',
+    studyContext:
+      'Do not copy doses from combination products as though they were standalone phosphatidylserine trials.',
+    safety:
+      'GI effects and insomnia are possible. Check soy or other source allergens and review anticoagulant, cholinergic, and medication context.',
+  },
+] as const
 
-const HEADINGS: Heading[] = [
-  { id: 'choose-by-problem', text: 'Choose by the real problem', level: 2 },
-  { id: 'profiles', text: 'Nootropic-by-nootropic review', level: 2 },
-  { id: 'trial-one-at-a-time', text: 'How to test one safely', level: 2 },
-  { id: 'buyer-checklist', text: 'Buyer checklist', level: 2 },
-]
+const TRIAL_STEPS = [
+  [
+    'Name one outcome',
+    'Use a measurable target such as reaction time on a defined task, fatigue during a recurring shift, or delayed memory recall—not “optimize my brain.”',
+  ],
+  [
+    'Record the baseline',
+    'Track the target, sleep, caffeine intake, anxiety, and adverse symptoms before changing anything. Otherwise normal variation can look like an effect.',
+  ],
+  [
+    'Change one variable',
+    'A multi-ingredient stack prevents attribution and can hide excess caffeine, overlapping stimulation, sedation, or cholinergic effects.',
+  ],
+  [
+    'Match the review date to the evidence',
+    'Acute caffeine/theanine questions can be evaluated quickly. A bacopa memory question requires a much longer window. Do not use one timeline for every ingredient.',
+  ],
+  [
+    'Define the stop rule',
+    'Stop for concerning cardiovascular, allergic, GI, sleep, or mood effects, and end a trial that produces no meaningful benefit by the review date.',
+  ],
+] as const
 
-const BEST_NOOTROPICS_FOR_FOCUS_REFS = [
-  { n: 1, text: 'Pase MP, et al. (2012). Bacopa monnieri for cognition. J Altern Complement Med, 18(7): 647-652.', url: 'https://pubmed.ncbi.nlm.nih.gov/22747190/' },
-  { n: 2, text: 'Haskell CF, et al. (2008). L-theanine and cognition. Biol Psychol, 77(2): 113-122.', url: 'https://pubmed.ncbi.nlm.nih.gov/18006208/' },
-]
+const REFERENCES = [
+  {
+    n: 1,
+    text: 'Payne ER, et al. Tea, L-theanine, and L-theanine plus caffeine for cognition, sleep, and mood: systematic review and meta-analysis. 2025. PMID: 40314930.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/40314930/',
+  },
+  {
+    n: 2,
+    text: 'Gerolymos C, et al. Cognitive and affective effects of L-theanine: systematic review and meta-analysis of 31 randomized trials. 2026. PMID: 42410082.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/42410082/',
+  },
+  {
+    n: 3,
+    text: 'Pase MP, et al. Cognitive-enhancing effects of Bacopa monnieri: systematic review of randomized controlled human trials. 2012. PMID: 22747190.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/22747190/',
+  },
+  {
+    n: 4,
+    text: 'Comparative effects of Bacopa monnieri and Ginkgo biloba on cognitive functions: systematic review and network meta-analysis. 2026. PMID: 41678913.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/41678913/',
+  },
+  {
+    n: 5,
+    text: 'Nakazaki E, et al. Citicoline and memory function in healthy older adults: randomized placebo-controlled trial. 2021. PMID: 33978188.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/33978188/',
+  },
+  {
+    n: 6,
+    text: 'Ishaque S, et al. Rhodiola rosea for physical and mental fatigue: systematic review. 2012. PMID: 22643043.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/22643043/',
+  },
+  {
+    n: 7,
+    text: 'Punja S, et al. Rhodiola rosea for mental and physical fatigue in nursing students: randomized controlled trial. 2014. PMID: 25268730.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/25268730/',
+  },
+  {
+    n: 8,
+    text: 'Docherty S, et al. Acute and chronic lion’s mane supplementation in young adults: double-blind pilot study. 2023. PMID: 38004235.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/38004235/',
+  },
+  {
+    n: 9,
+    text: 'Acute effects of a standardized lion’s mane extract on cognition and mood in healthy younger adults: randomized crossover study. 2025. PMID: 40276537.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/40276537/',
+  },
+  {
+    n: 10,
+    text: 'Baumeister J, et al. Phosphatidylserine, cognitive performance, and cortical activity after induced stress. 2008. PMID: 18616866.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/18616866/',
+  },
+  {
+    n: 11,
+    text: 'Effects of natural extracts on cognitive function in healthy adults: systematic review and network meta-analysis. 2025. PMID: 40213691.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/40213691/',
+  },
+] as const
 
 export default function BestNootropicsForFocusPage() {
   const toc = <TableOfContents headings={HEADINGS} />
-  const lTheanineProducts = getRevenueProductSet('l-theanine')
 
   return (
     <ArticleLayout toc={toc} zone="supplement">
       <StructuredData
-        pageUrl={PAGE_URL}
-        headline="Best Nootropics for Focus: Choose by Attention, Fatigue or Memory"
-        description="Evidence-based guide to choosing nootropics for immediate attention, stress-related fatigue, or longer-term memory support, with safety and buying guidance."
+        pageUrl={`${SITE_URL}${PATH}`}
+        headline={TITLE}
+        description={DESCRIPTION}
         datePublished="2026-06-16"
-        dateModified="2026-07-16"
+        dateModified="2026-08-02"
+        image={`${SITE_URL}/images/guides/best-nootropics-for-focus.jpg`}
+        faqs={FAQS}
         breadcrumbs={[
           { label: 'Home', href: '/' },
-          { label: 'Guides', href: '/guides' },
-          { label: 'Best Nootropics for Focus', href: '/guides/focus/best-nootropics-for-focus' },
+          { label: 'Guides', href: '/guides/' },
+          { label: 'Focus Guides', href: '/guides/focus/' },
+          { label: 'Best Nootropics for Focus', href: PATH },
         ]}
       />
 
-      <div className="space-y-14">
-        <AffiliateDisclosure variant="compact" className="mb-6" />
-
+      <div className="space-y-12">
         <section className="rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-10">
-          <p className="eyebrow-label">Focus nootropics guide</p>
-          <h1 className="mt-3 text-3xl font-bold tracking-tight text-ink sm:text-4xl">
-            Best Nootropics for Focus
+          <p className="eyebrow-label">Outcome-specific evidence guide</p>
+          <h1 className="mt-3 font-display text-3xl font-bold leading-tight tracking-tight text-ink sm:text-5xl">
+            Best Nootropics for Focus?
           </h1>
-          <p className="mt-4 text-sm leading-7 text-muted sm:text-base">
-            The best option depends on what “focus” means in your case. Short-term alertness, stress-related
-            mental fatigue, and long-term memory are different targets, and no supplement reliably fixes all
-            three. Start by identifying the bottleneck, then test one ingredient at a time.
+          <p className="mt-4 max-w-3xl text-base leading-7 text-muted">
+            “Focus” can mean acute alertness, memory over months, resistance to fatigue, or concentration that is
+            being disrupted by sleep, anxiety, ADHD, medication, or illness. Those are different problems. This
+            guide ranks the decision confidence—not the marketing excitement—behind six common options.
           </p>
-          <div className="mt-5 rounded-xl border border-brand-100 bg-brand-50/60 p-4 text-sm text-brand-900">
-            <strong>Quick answer:</strong> L-theanine with a small, already-tolerated caffeine dose has the
-            clearest short-term attention evidence. Rhodiola is more relevant when stress and fatigue are the
-            main problem. Bacopa is a slow memory option—not a same-day focus booster. Lion&apos;s mane,
-            citicoline, and phosphatidylserine are more conditional than marketing usually suggests.
+          <div className="mt-5 flex flex-wrap gap-3 text-xs font-semibold">
+            <Link href="/guides/focus/" className="text-brand-700 hover:underline">
+              Focus evidence hub →
+            </Link>
+            <Link href="/guides/focus-without-caffeine-crash/" className="text-brand-700 hover:underline">
+              Caffeine-crash alternatives →
+            </Link>
+            <Link href="/guides/adhd/adhd-supplements/" className="text-brand-700 hover:underline">
+              ADHD evidence boundary →
+            </Link>
           </div>
 
-          <figure className="mt-6">
+          <figure className="mt-7">
             <div className="overflow-hidden rounded-2xl border border-brand-900/10 bg-white shadow-sm">
               <Image
                 src="/images/guides/best-nootropics-for-focus.jpg"
-                alt="Nootropics for focus including capsules, lion's mane mushroom, and green tea"
+                alt="Nootropic ingredients arranged for an evidence comparison by attention, fatigue, and memory outcome"
                 width={1536}
                 height={1024}
                 priority
@@ -160,134 +328,210 @@ export default function BestNootropicsForFocusPage() {
               />
             </div>
             <figcaption className="mt-3 text-center text-sm text-muted">
-              Match the ingredient to the actual attention, fatigue, or memory problem.
+              Match the ingredient to the measured outcome—not the word “nootropic” on the label.
             </figcaption>
           </figure>
         </section>
 
-        <section id="choose-by-problem" className="scroll-mt-20 space-y-4">
-          <p className="eyebrow-label">Decision framework</p>
-          <h2 className="text-2xl font-semibold tracking-tight text-ink">Choose by the real problem</h2>
-          <div className="grid gap-4 sm:grid-cols-2">
+        <section id="quick-answer" className="scroll-mt-20 rounded-[1.65rem] border border-brand-200 bg-brand-50/60 p-6 shadow-sm sm:p-8">
+          <p className="eyebrow-label">Quick answer</p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
+            The strongest option depends on whether the target is attention or memory
+          </h2>
+          <p className="mt-3 text-sm leading-7 text-muted sm:text-base">
+            For selected short-term attention tasks, already-tolerated caffeine—sometimes paired with
+            L-theanine—has the clearest direct evidence, but effects are limited and caffeine risk still applies.
+            Bacopa has a better long-term memory case than an acute-focus case. Citicoline is population-specific.
+            Rhodiola, lion’s mane, and phosphatidylserine remain too inconsistent or indirect to call reliable
+            general focus enhancers.
+          </p>
+          <div className="mt-5 grid gap-3 sm:grid-cols-3">
             {[
-              {
-                problem: 'I need short-term alertness',
-                answer: 'Consider a low caffeine dose, optionally paired with L-theanine, only if caffeine is already well tolerated.',
-              },
-              {
-                problem: 'Stress or fatigue destroys my concentration',
-                answer: 'Rhodiola may be more relevant than memory-oriented supplements, but sleep debt and burnout still come first.',
-              },
-              {
-                problem: 'I want better memory over months',
-                answer: 'Bacopa is the clearest slow-build candidate here, with GI and sedation tradeoffs.',
-              },
-              {
-                problem: 'My focus problems are persistent or severe',
-                answer: 'Do not use a supplement stack to delay assessment for sleep disorders, anxiety, depression, ADHD, medication effects, or medical causes.',
-              },
-            ].map((item) => (
-              <div key={item.problem} className="rounded-2xl border border-brand-900/10 bg-white/90 p-5 shadow-sm">
-                <p className="text-sm font-semibold text-ink">{item.problem}</p>
-                <p className="mt-2 text-sm leading-6 text-muted">{item.answer}</p>
+              ['Acute task', 'Caffeine ± L-theanine, only when caffeine is already tolerated and sleep cost is counted.'],
+              ['Memory over months', 'Bacopa has the clearest sustained-memory rationale, not a same-day productivity effect.'],
+              ['Persistent concentration problems', 'Assess sleep, mood, ADHD, medication, substance use, and medical causes before building a stack.'],
+            ].map(([title, copy]) => (
+              <div key={title} className="rounded-xl border border-brand-900/10 bg-white/80 p-4">
+                <h3 className="text-sm font-semibold text-ink">{title}</h3>
+                <p className="mt-2 text-xs leading-6 text-muted">{copy}</p>
               </div>
             ))}
           </div>
         </section>
 
-        <section id="profiles" className="scroll-mt-20 space-y-6">
-          <div>
-            <p className="eyebrow-label">Evidence profiles</p>
-            <h2 className="mt-1 text-2xl font-semibold tracking-tight text-ink">
-              Nootropic-by-nootropic review
+        <section id="decision-map" className="scroll-mt-20 space-y-5">
+          <div className="max-w-3xl">
+            <p className="eyebrow-label">Decision map</p>
+            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
+              Choose by the real outcome
             </h2>
+            <p className="mt-3 text-sm leading-7 text-muted">
+              A positive memory result in older adults is not proof of acute attention in a younger adult. A
+              stress-hormone result is not automatically a focus result. A single positive computer task does not
+              establish a broad productivity effect.
+            </p>
           </div>
-
-          <div className="overflow-x-auto rounded-[1.65rem] border border-brand-900/10 bg-white shadow-sm">
-            <table className="w-full min-w-[560px] border-collapse text-sm">
-              <thead>
-                <tr className="border-b border-brand-900/10 bg-brand-50/50">
-                  <th className="p-4 text-left font-semibold text-ink">Nootropic</th>
-                  <th className="p-4 text-left font-semibold text-ink">Best-fit target</th>
-                  <th className="p-4 text-left font-semibold text-ink">Expected timescale</th>
+          <ResponsiveTable label="Nootropic decision map by focus-related outcome">
+            <table className="min-w-[1040px] w-full text-left text-sm">
+              <thead className="bg-brand-50/80">
+                <tr className="border-b border-brand-900/10">
+                  {['Actual target', 'Most relevant option', 'What the evidence addresses', 'Boundary'].map((heading) => (
+                    <th key={heading} className="px-4 py-3 text-xs font-bold uppercase tracking-[0.12em] text-brand-900">
+                      {heading}
+                    </th>
+                  ))}
                 </tr>
               </thead>
-              <tbody className="divide-y divide-brand-900/10">
-                {FOCUS_NOOTROPICS.map((n) => (
-                  <tr key={n.name}>
-                    <td className="p-4 font-medium text-ink">{n.name}</td>
-                    <td className="p-4 text-muted">{n.badge}</td>
-                    <td className="p-4 text-muted">{n.timeframe}</td>
+              <tbody className="divide-y divide-brand-900/10 bg-white">
+                {DECISION_ROWS.map(([target, option, evidence, boundary]) => (
+                  <tr key={target} className="align-top">
+                    <td className="px-4 py-4 font-semibold text-ink">{target}</td>
+                    <td className="px-4 py-4 text-muted">{option}</td>
+                    <td className="px-4 py-4 text-muted">{evidence}</td>
+                    <td className="px-4 py-4 text-muted">{boundary}</td>
                   </tr>
                 ))}
               </tbody>
             </table>
+          </ResponsiveTable>
+        </section>
+
+        <section id="evidence-profiles" className="scroll-mt-20 space-y-6">
+          <div className="max-w-3xl">
+            <p className="eyebrow-label">Evidence profiles</p>
+            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
+              Six popular options, without pretending they answer the same question
+            </h2>
           </div>
 
           <div className="space-y-5">
-            {FOCUS_NOOTROPICS.map((n) => (
-              <div key={n.name} className="rounded-[1.65rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm">
-                <div className="flex flex-wrap items-start justify-between gap-2">
-                  <Link href={n.href} className="text-xl font-semibold text-brand-800 hover:underline">
-                    {n.name}
+            {NOOTROPICS.map((item) => (
+              <article key={item.name} className="rounded-[1.65rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <Link href={item.href} className="text-xl font-semibold text-brand-800 hover:underline">
+                    {item.name}
                   </Link>
-                  <span className="rounded-full bg-brand-50 px-3 py-0.5 text-xs font-semibold text-brand-800">
-                    {n.badge}
+                  <span className="rounded-full bg-brand-50 px-3 py-1 text-xs font-semibold text-brand-800">
+                    {item.label}
                   </span>
                 </div>
-                <div className="mt-4 grid gap-3 text-sm sm:grid-cols-2">
-                  <div><p className="font-semibold text-ink">What it may do</p><p className="mt-0.5 text-muted">{n.mechanism}</p></div>
-                  <div><p className="font-semibold text-ink">Best for</p><p className="mt-0.5 text-muted">{n.bestFor}</p></div>
-                  <div><p className="font-semibold text-ink">Evidence</p><p className="mt-0.5 text-muted">{n.evidence}</p></div>
-                  <div><p className="font-semibold text-ink">Typical trial approach</p><p className="mt-0.5 text-muted">{n.dose}</p></div>
-                  <div className="sm:col-span-2"><p className="font-semibold text-ink">Safety</p><p className="mt-0.5 text-muted">{n.safety}</p></div>
+                <p className="mt-3 text-sm font-medium leading-6 text-ink">{item.role}</p>
+                <div className="mt-4 grid gap-4 text-sm md:grid-cols-2">
+                  <div>
+                    <h3 className="font-semibold text-ink">What the evidence shows</h3>
+                    <p className="mt-2 leading-7 text-muted">{item.evidence}</p>
+                  </div>
+                  <div>
+                    <h3 className="font-semibold text-ink">What it does not show</h3>
+                    <p className="mt-2 leading-7 text-muted">{item.boundary}</p>
+                  </div>
+                  <div>
+                    <h3 className="font-semibold text-ink">Study context</h3>
+                    <p className="mt-2 leading-7 text-muted">{item.studyContext}</p>
+                  </div>
+                  <div>
+                    <h3 className="font-semibold text-ink">Safety lens</h3>
+                    <p className="mt-2 leading-7 text-muted">{item.safety}</p>
+                  </div>
                 </div>
-                <Link href={n.href} className="mt-4 inline-block text-xs font-semibold text-brand-700 hover:underline">
-                  Full profile →
+                <Link href={item.href} className="mt-4 inline-flex text-xs font-semibold text-brand-700 hover:underline">
+                  Open related profile or guide →
                 </Link>
-              </div>
+              </article>
             ))}
           </div>
         </section>
 
-        <section id="trial-one-at-a-time" className="scroll-mt-20 space-y-4">
-          <p className="eyebrow-label">Avoid stack confusion</p>
-          <h2 className="text-2xl font-semibold tracking-tight text-ink">How to test one safely</h2>
-          <div className="rounded-[1.65rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm">
-            <ol className="space-y-3 text-sm leading-6 text-muted">
-              <li><strong className="text-ink">1. Define one outcome.</strong> Pick attention span, fatigue, or memory—not a vague goal of “better cognition.”</li>
-              <li><strong className="text-ink">2. Start with one ingredient.</strong> Multi-product stacks make benefits, side effects, and interactions impossible to attribute.</li>
-              <li><strong className="text-ink">3. Use a realistic timeframe.</strong> Do not judge bacopa after three days or keep taking an acute stimulant combination for months without reassessment.</li>
-              <li><strong className="text-ink">4. Track sleep and anxiety.</strong> A product that improves alertness while damaging sleep can worsen overall focus.</li>
-              <li><strong className="text-ink">5. Stop for adverse effects.</strong> Palpitations, agitation, allergic symptoms, severe GI effects, or meaningful mood changes are not signs to “push through.”</li>
-            </ol>
+        <section id="study-context" className="scroll-mt-20 rounded-[1.65rem] border border-amber-900/15 bg-amber-50/70 p-6 shadow-sm sm:p-8">
+          <p className="text-xs font-bold uppercase tracking-[0.14em] text-amber-800">Study context—not protocols</p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-amber-950">
+            A dose in a trial is not a universal recommendation
+          </h2>
+          <div className="mt-4 space-y-4 text-sm leading-7 text-amber-950/90">
+            <p>
+              Nootropic studies use different extracts, branded ingredients, populations, durations, cognitive
+              batteries, caffeine backgrounds, and inclusion criteria. Copying one study dose while changing the
+              product, goal, age group, or health context breaks the link to the evidence.
+            </p>
+            <p>
+              This matters especially for bacopa standardization, lion’s mane fruiting-body versus mycelium
+              preparations, rhodiola rosavin and salidroside profiles, branded citicoline, phosphatidylserine
+              combination products, and caffeine that is already being consumed from other sources.
+            </p>
+            <p>
+              Product-specific funding and investigator conflicts do not automatically invalidate a result, but
+              they increase the value of independent replication. A buying guide should disclose that uncertainty
+              instead of converting the newest positive trial into a category-wide promise.
+            </p>
           </div>
         </section>
 
-        <section id="buyer-checklist" className="scroll-mt-20 space-y-4">
-          <p className="eyebrow-label">Before product picks</p>
-          <h2 className="text-2xl font-semibold tracking-tight text-ink">Buyer checklist</h2>
-          <div className="grid gap-4 sm:grid-cols-2">
+        <section id="trial-design" className="scroll-mt-20 space-y-5">
+          <div className="max-w-3xl">
+            <p className="eyebrow-label">N-of-1 discipline</p>
+            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
+              How to test one safely
+            </h2>
+          </div>
+          <ol className="space-y-4">
+            {TRIAL_STEPS.map(([title, copy], index) => (
+              <li key={title} className="rounded-2xl border border-brand-900/10 bg-white/90 p-5 shadow-sm">
+                <div className="flex gap-4">
+                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-brand-100 text-sm font-bold text-brand-800">
+                    {index + 1}
+                  </span>
+                  <div>
+                    <h3 className="font-semibold text-ink">{title}</h3>
+                    <p className="mt-2 text-sm leading-6 text-muted">{copy}</p>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ol>
+        </section>
+
+        <section id="product-quality" className="scroll-mt-20 rounded-[1.65rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+          <p className="eyebrow-label">Before buying</p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
+            Product-quality checklist
+          </h2>
+          <div className="mt-5 grid gap-4 sm:grid-cols-2">
             {[
-              'Prefer a clearly disclosed single-ingredient dose over a proprietary blend.',
-              'Look for independent identity and contaminant testing—not only “made in a GMP facility.”',
-              'Check the active standardization that matches the research, such as bacosides for bacopa.',
-              'Avoid products that combine stimulants, herbs, and choline sources before you know how each affects you.',
-              'Compare serving size and active amount; a large capsule count does not equal a meaningful dose.',
-              'Review medications, pregnancy, cardiovascular risk, mood history, and sleep problems before buying.',
+              'Prefer a clearly disclosed single ingredient before a proprietary “focus matrix.”',
+              'Match the extract or active standardization to the research instead of assuming the plant name is enough.',
+              'Look for independent identity, potency, microbial, heavy-metal, and contaminant testing—not only a GMP logo.',
+              'Count caffeine from every source and avoid hidden stimulant ingredients such as guarana or concentrated tea extracts.',
+              'Check source allergens and distinguish fruiting body, mycelium, phospholipid source, and branded ingredient where relevant.',
+              'Reject medication-replacement, guaranteed-IQ, instant-memory, or universal “clinically proven” claims.',
             ].map((item) => (
-              <div key={item} className="rounded-2xl border border-brand-900/10 bg-white/90 p-5 text-sm leading-6 text-muted shadow-sm">
+              <div key={item} className="rounded-2xl border border-brand-900/10 bg-brand-50/30 p-5 text-sm leading-6 text-muted">
                 {item}
               </div>
             ))}
           </div>
+          <div className="mt-5 flex flex-wrap gap-4 text-sm font-semibold">
+            <Link href="/learn/product-quality/" className="text-brand-700 hover:underline">
+              Product-quality basics →
+            </Link>
+            <Link href="/safety-checker/" className="text-brand-700 hover:underline">
+              Check interaction pathways →
+            </Link>
+          </div>
         </section>
 
-        <References refs={BEST_NOOTROPICS_FOR_FOCUS_REFS} />
+        <section id="faq" className="scroll-mt-20 rounded-[1.65rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+          <h2 className="text-2xl font-semibold tracking-tight text-ink">Frequently asked questions</h2>
+          <div className="mt-5 divide-y divide-brand-900/10">
+            {FAQS.map((faq) => (
+              <div key={faq.question} className="py-5 first:pt-0 last:pb-0">
+                <h3 className="font-semibold text-ink">{faq.question}</h3>
+                <p className="mt-2 text-sm leading-7 text-muted">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </section>
 
-        {lTheanineProducts && (
-          <RecommendationSection products={lTheanineProducts.products} />
-        )}
+        <References refs={[...REFERENCES]} />
 
         <EmailCapture location="guides-best-nootropics-for-focus" className="mt-6" />
 
@@ -299,6 +543,12 @@ export default function BestNootropicsForFocusPage() {
           <Link href="/guides/compare/caffeine-vs-l-theanine-vs-bacopa-for-focus/" className="hover:text-brand-800">Caffeine vs L-Theanine vs Bacopa →</Link>
           <Link href="/guides/" className="hover:text-brand-800">All Guides →</Link>
         </nav>
+
+        <p className="text-xs leading-6 text-muted">
+          This guide is educational and does not diagnose or treat ADHD, cognitive impairment, fatigue, anxiety,
+          depression, or a sleep disorder. Review persistent concentration changes, pregnancy, cardiovascular or
+          mood conditions, and medication combinations with a qualified clinician or pharmacist.
+        </p>
       </div>
     </ArticleLayout>
   )

--- a/docs/content-quality/best-nootropics-focus-upgrade-2026-08-02.md
+++ b/docs/content-quality/best-nootropics-focus-upgrade-2026-08-02.md
@@ -1,0 +1,62 @@
+# Best Nootropics for Focus — Evidence Upgrade
+
+Date: 2026-08-02  
+Route: `/guides/focus/best-nootropics-for-focus/`
+
+## Why this page was prioritized
+
+The route has strong commercial and decision intent, supports the broader focus cluster, and can route readers toward ingredient profiles and comparison pages. The previous version had six ranked ingredients but only two references, mixed acute attention with long-term memory and stress-fatigue outcomes, and supplied protocol-like dose language despite population and product differences.
+
+It also displayed a governed L-theanine product module while comparing six options. Even when the products themselves are valid, monetizing only one ranked ingredient creates a structural incentive that can influence prominence and wording.
+
+## New editorial job
+
+The page now answers one question: **which ingredient, if any, matches the outcome that was actually studied?**
+
+The decision model separates:
+
+1. selected acute attention tasks;
+2. long-term memory and free recall;
+3. age-associated memory complaints;
+4. stress-related fatigue;
+5. experimental mushroom research;
+6. product- and population-specific stress or memory evidence.
+
+## Major evidence corrections
+
+- L-theanine plus caffeine is framed as the most defensible acute option only when caffeine is already tolerated; task specificity, uncertain confidence intervals, caffeine risk, and industry involvement remain visible.
+- Bacopa is framed as a sustained memory option rather than a same-day attention booster.
+- Citicoline is tied to its studied older-adult memory population and manufacturer-affiliated evidence rather than generalized to healthy young adults.
+- Rhodiola includes the contradictory systematic-review conclusion and the randomized nursing-student trial that favored placebo on fatigue outcomes.
+- Lion’s mane includes small sample sizes, null findings, product differences, and the inability to translate preclinical neurotrophic mechanisms into a reliable focus claim.
+- Phosphatidylserine is limited to small, product-specific, combination, stress, or older-adult contexts.
+- A recent network meta-analysis finding that no natural extract significantly outperformed placebo for attention in healthy adults is used as a category-level reality check.
+
+## Dose and product policy
+
+The page no longer gives a universal starting protocol. Study doses and durations are treated as context because extracts, branded ingredients, populations, cognitive tests, and background caffeine differ.
+
+The single L-theanine recommendation module and affiliate disclosure were removed from this broad comparison. Commercial decisions remain available on dedicated ingredient or buying pages where the product set matches the reader’s intent.
+
+## Regression controls
+
+`app/__tests__/best-nootropics-focus-calibration.test.ts` prevents:
+
+- collapse of distinct cognitive outcomes into one ranking;
+- restoration of protocol-like starting doses;
+- restoration of one-ingredient commercial bias;
+- removal of negative, null, or conflict-aware evidence;
+- loss of the expanded human reference set;
+- loss of FAQ schema, safety pathways, email capture, and one-change-at-a-time trial design.
+
+## Measurement
+
+Evaluate the route on:
+
+- impressions and clicks for “best nootropics for focus,” “nootropics that work,” and ingredient-comparison queries;
+- CTR changes from the more honest title and immediate answer;
+- entrances into the focus hub, caffeine-crash guide, ADHD hub, safety checker, and individual profiles;
+- scroll depth through the decision map and evidence profiles;
+- email-capture conversion;
+- reduced cannibalization with narrower ingredient and comparison pages;
+- whether product clicks shift appropriately to dedicated buying pages rather than disappearing from the cluster.

--- a/docs/content-quality/evidence-first-decision-page-standard.md
+++ b/docs/content-quality/evidence-first-decision-page-standard.md
@@ -1,0 +1,105 @@
+# Evidence-First Decision Page Standard
+
+Use this standard for best-of guides, supplement comparisons, stacks, condition-adjacent pages, and any route that helps a reader decide what to take or buy.
+
+## Core principle
+
+A decision page does not rank ingredient popularity. It maps a clearly defined reader problem to the closest directly studied outcome while keeping population, comparator, product, duration, uncertainty, safety, and commercial incentives visible.
+
+## Required evidence questions
+
+For every ranked ingredient or intervention, answer:
+
+1. **What exact outcome was measured?** Attention, reaction time, free recall, sleep onset, fatigue, symptom scale, laboratory marker, or another endpoint are not interchangeable.
+2. **Who was studied?** Healthy young adults, older adults with memory complaints, children with ADHD, people with deficiency, and clinical populations support different claims.
+3. **What was the comparator?** Placebo, active treatment, baseline, another ingredient, or no control changes confidence.
+4. **Was the ingredient tested alone?** A combination product cannot prove the contribution of one component.
+5. **Was the product equivalent?** Extract, standardization, plant part, salt, branded ingredient, dose form, and manufacturing quality can limit generalization.
+6. **How large and durable was the effect?** Statistical significance on one task is not a broad, clinically meaningful benefit.
+7. **What did not improve?** Include null outcomes, negative trials, inconsistent domains, and subgroup-only findings.
+8. **What are the bias signals?** Report small samples, high risk of bias, product funding, investigator conflicts, selective outcomes, and lack of independent replication.
+9. **What is the safety boundary?** Include age, pregnancy, kidney/liver, cardiovascular, mood, allergy, medication, stimulant, sedative, and cumulative-dose context as relevant.
+
+## Directness ladder
+
+Rank confidence by claim directness, not by excitement:
+
+1. direct randomized evidence for the exact outcome and population;
+2. systematic review or meta-analysis of sufficiently comparable direct trials;
+3. randomized evidence in a related population or adjacent outcome;
+4. observational association;
+5. mechanistic or biomarker evidence;
+6. preclinical evidence;
+7. traditional use or marketing rationale.
+
+Do not silently move a claim upward. Mechanism can explain a hypothesis; it cannot establish a clinical outcome.
+
+## Dose and timeline policy
+
+- Label trial doses and durations as **study context**, not instructions.
+- Do not create a universal starting protocol from heterogeneous studies.
+- Do not copy a pediatric, older-adult, deficient, clinical, or branded-product dose into a general recommendation.
+- Distinguish total compound weight from active or elemental amount.
+- Count cumulative exposure from food, drinks, medications, and other supplements when relevant.
+- A review date must match the studied timeframe; acute and chronic interventions cannot share one expected timeline.
+
+## Negative-evidence requirement
+
+A high-quality decision page must actively look for:
+
+- trials that favored placebo or an active comparator;
+- outcomes that did not improve;
+- systematic reviews concluding evidence is contradictory or inadequate;
+- confidence intervals that include trivial or uncertain effects;
+- studies that failed to replicate earlier positive findings;
+- evidence that applies only to a subgroup or secondary endpoint.
+
+Negative or null evidence is not a footnote. It helps define the decision boundary.
+
+## Commercial-neutrality rules
+
+- Evidence order is determined before product availability or commission.
+- A broad comparison should not monetize only one ranked option unless the page explicitly explains why commercial coverage is asymmetric.
+- Prefer product modules on dedicated buying pages where the reader has already chosen the ingredient category.
+- Do not let a revenue product set create or strengthen an efficacy ranking.
+- Product criteria must address identity, active amount, standardization, contaminants, third-party testing, allergens, and hidden stimulant or sedative ingredients.
+- Affiliate disclosure does not repair biased evidence architecture.
+
+## Page architecture
+
+A strong decision page normally contains:
+
+1. an immediate answer with the main evidence boundary;
+2. a decision map organized by real outcome or context;
+3. item-level evidence profiles with “shows” and “does not show” sections;
+4. study-context and dose-boundary language;
+5. safety, medication, and stop rules;
+6. a one-change-at-a-time trial framework when self-monitoring is appropriate;
+7. links to narrower evidence, safety, and buying pages;
+8. FAQ schema that repeats the calibrated answer rather than introducing stronger claims;
+9. primary or authoritative references sufficient for every ranked option;
+10. regression tests against the exact claim and commercial patterns removed during the upgrade.
+
+## Canonical and cannibalization rule
+
+Two pages should remain separate only when they serve materially different reader jobs. Different titles, templates, or monetization modules do not create different intent.
+
+Consolidate when pages substantially overlap in:
+
+- target query and immediate answer;
+- compared ingredients or products;
+- evidence and safety questions;
+- conversion action;
+- internal-link role.
+
+A consolidation must update internal links, add permanent redirects for all aliases, remove the retired route, document canonical ownership, and add tests preventing recreation.
+
+## Implemented examples
+
+- `/guides/adhd/adhd-supplements/`
+- `/guides/adhd/best-magnesium-supplement-for-adhd/`
+- `/guides/adhd/magnesium-glycinate-vs-citrate-for-adhd/`
+- `/guides/adhd/l-theanine-magnesium-adhd-stack/`
+- `/guides/focus/best-nootropics-for-focus/`
+
+Each upgraded page has route-specific regression coverage under `app/__tests__/`.


### PR DESCRIPTION
## What changed

- rebuilt `/guides/focus/best-nootropics-for-focus/` around acute attention, long-term memory, age-associated memory, stress-fatigue, and experimental evidence
- expanded the human evidence set from 2 references to 11, including 2025–2026 reviews
- added positive, null, negative, population-specific, product-specific, funding, and conflict context
- removed protocol-like starting doses
- removed the lone L-theanine product module from the six-option comparison
- added FAQ schema, product-quality rules, trial design, safety pathways, documentation, and regression tests
- added a reusable evidence-first decision-page standard and linked it from `AGENTS.md`

## Why

The prior page mixed different cognitive outcomes into one ranking, used only two references for six ingredients, and monetized only one option. The rewrite maps each ingredient to the outcome and population actually studied, while keeping uncertainty and negative evidence visible.

## Validation expected

- lint and TypeScript
- Vitest and accessibility gate
- static export and production build
- route SEO coverage
- site health, Fast UI, and Lighthouse
