### PR TITLE
Fix indexation audit redirect chains, broken links, and long descriptions

### DIFF
--- a/functions/_shared/__tests__/legacy-compare.test.ts
+++ b/functions/_shared/__tests__/legacy-compare.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import { handleLegacyCompareRequest } from '../legacy-compare'
+
+describe('legacy comparison routing', () => {
+  it('redirects the legacy index to the comparison hub', () => {
+    const response = handleLegacyCompareRequest(
+      new Request('https://thehippiescientist.net/compare/'),
+      'compare',
+    )
+
+    expect(response.status).toBe(301)
+    expect(response.headers.get('location')).toBe('https://thehippiescientist.net/guides/compare/')
+  })
+
+  it('redirects a legacy slug only when a static comparison page exists', () => {
+    const response = handleLegacyCompareRequest(
+      new Request('https://thehippiescientist.net/compare/melatonin-vs-magnesium/'),
+      'compare',
+    )
+
+    expect(response.status).toBe(301)
+    expect(response.headers.get('location')).toBe(
+      'https://thehippiescientist.net/guides/compare/melatonin-vs-magnesium/',
+    )
+  })
+
+  it('maps known legacy aliases to their current canonical comparison', () => {
+    const response = handleLegacyCompareRequest(
+      new Request('https://thehippiescientist.net/comparisons/ashwagandha-vs-rhodiola/'),
+      'comparisons',
+    )
+
+    expect(response.status).toBe(301)
+    expect(response.headers.get('location')).toBe(
+      'https://thehippiescientist.net/guides/compare/rhodiola-vs-ashwagandha/',
+    )
+  })
+
+  it('returns 410 instead of redirecting a phantom comparison into a 404', () => {
+    const response = handleLegacyCompareRequest(
+      new Request('https://thehippiescientist.net/compare/nonexistent-vs-phantom/'),
+      'compare',
+    )
+
+    expect(response.status).toBe(410)
+    expect(response.headers.get('location')).toBeNull()
+    expect(response.headers.get('x-robots-tag')).toBe('noindex, nofollow')
+  })
+})

--- a/functions/_shared/legacy-compare.ts
+++ b/functions/_shared/legacy-compare.ts
@@ -1,0 +1,50 @@
+const BUILT_COMPARE_SLUGS = new Set([
+  'ashwagandha-vs-l-theanine-vs-magnesium',
+  'berberine-vs-inositol',
+  'berberine-vs-metformin',
+  'caffeine-vs-l-theanine',
+  'caffeine-vs-l-theanine-vs-bacopa-for-focus',
+  'curcumin-vs-boswellia-vs-omega-3',
+  'kanna-vs-ssris',
+  'kava-vs-alcohol',
+  'melatonin-vs-magnesium',
+  'melatonin-vs-valerian-vs-magnesium-for-sleep',
+  'rhodiola-vs-ashwagandha',
+  'sleep-herbs-vs-melatonin',
+])
+
+const LEGACY_COMPARE_ALIASES: Record<string, string> = {
+  'ashwagandha-vs-rhodiola': 'rhodiola-vs-ashwagandha',
+  'curcumin-vs-boswellia': 'curcumin-vs-boswellia-vs-omega-3',
+}
+
+function extractLegacySlug(pathname: string, legacyPrefix: string): string {
+  return pathname
+    .replace(new RegExp(`^/${legacyPrefix}/?`), '')
+    .replace(/^\/+|\/+$/g, '')
+}
+
+export function handleLegacyCompareRequest(request: Request, legacyPrefix: string): Response {
+  const url = new URL(request.url)
+  const legacySlug = extractLegacySlug(url.pathname, legacyPrefix)
+
+  if (!legacySlug) {
+    url.pathname = '/guides/compare/'
+    return Response.redirect(url.toString(), 301)
+  }
+
+  const targetSlug = LEGACY_COMPARE_ALIASES[legacySlug] || legacySlug
+  if (BUILT_COMPARE_SLUGS.has(targetSlug)) {
+    url.pathname = `/guides/compare/${targetSlug}/`
+    return Response.redirect(url.toString(), 301)
+  }
+
+  return new Response('This comparison page is no longer available.', {
+    status: 410,
+    headers: {
+      'Cache-Control': 'public, max-age=86400',
+      'Content-Type': 'text/plain; charset=utf-8',
+      'X-Robots-Tag': 'noindex, nofollow',
+    },
+  })
+}

--- a/functions/compare/[[path]].ts
+++ b/functions/compare/[[path]].ts
@@ -1,17 +1,9 @@
+import { handleLegacyCompareRequest } from '../_shared/legacy-compare'
+
 type PagesFunctionContext = {
   request: Request
 }
 
-function buildCompareTarget(request: Request, legacyPrefix: string): string {
-  const url = new URL(request.url)
-  const rest = url.pathname
-    .replace(new RegExp(`^/${legacyPrefix}/?`), '')
-    .replace(/^\/+|\/+$/g, '')
-
-  url.pathname = rest ? `/guides/compare/${rest}/` : '/guides/compare/'
-  return url.toString()
-}
-
 export const onRequest = async ({ request }: PagesFunctionContext): Promise<Response> => {
-  return Response.redirect(buildCompareTarget(request, 'compare'), 301)
+  return handleLegacyCompareRequest(request, 'compare')
 }

--- a/functions/comparisons/[[path]].ts
+++ b/functions/comparisons/[[path]].ts
@@ -1,17 +1,9 @@
+import { handleLegacyCompareRequest } from '../_shared/legacy-compare'
+
 type PagesFunctionContext = {
   request: Request
 }
 
-function buildCompareTarget(request: Request, legacyPrefix: string): string {
-  const url = new URL(request.url)
-  const rest = url.pathname
-    .replace(new RegExp(`^/${legacyPrefix}/?`), '')
-    .replace(/^\/+|\/+$/g, '')
-
-  url.pathname = rest ? `/guides/compare/${rest}/` : '/guides/compare/'
-  return url.toString()
-}
-
 export const onRequest = async ({ request }: PagesFunctionContext): Promise<Response> => {
-  return Response.redirect(buildCompareTarget(request, 'comparisons'), 301)
+  return handleLegacyCompareRequest(request, 'comparisons')
 }

--- a/public/redirect-overrides/seo-csv-400-2026-07-08.txt
+++ b/public/redirect-overrides/seo-csv-400-2026-07-08.txt
@@ -26,3 +26,6 @@
 /guides/compare/bacopa-vs-lions-mane/ /guides/focus/best-nootropics-for-focus/ 301
 /herbs/passiflora-incarnata/ /herbs/passionflower/ 301
 /guides/compare/caffeine-vs-theanine/ /guides/herbs/l-theanine/ 301
+/compounds/citicoline/ /compounds/cdp-choline/ 301
+/state-of-supplement-evidence-2026/ /articles/state-of-supplement-evidence-2026/ 301
+/education/insomnia/ /guides/sleep/ 301

--- a/scripts/seo/repair-broken-canonicals.mjs
+++ b/scripts/seo/repair-broken-canonicals.mjs
@@ -23,6 +23,21 @@ const CANONICAL_REPLACEMENTS = new Map([
   ['https://thehippiescientist.net/herbs/angelica-root/', 'https://thehippiescientist.net/herbs/angelica-archangelica/'],
 ])
 
+const INTERNAL_LINK_REPLACEMENTS = new Map([
+  ['/compounds/citicoline/', '/compounds/cdp-choline/'],
+  ['/state-of-supplement-evidence-2026/', '/articles/state-of-supplement-evidence-2026/'],
+  ['/education/insomnia/', '/guides/sleep/'],
+])
+
+const UNPUBLISHED_PROFILE_TARGETS = new Set([
+  '/compounds/dmt/',
+  '/compounds/harmaline/',
+  '/compounds/harmine/',
+  '/compounds/kratom/',
+  '/compounds/mitragynine/',
+  '/compounds/7-hydroxymitragynine/',
+])
+
 function* walkHtmlFiles(dir) {
   if (!fs.existsSync(dir)) return
 
@@ -70,6 +85,30 @@ function normalizeDescriptionTags(html) {
   return { html: next, changedTags }
 }
 
+function repairInternalLinks(html) {
+  let changedLinks = 0
+  let next = html
+
+  for (const [from, to] of INTERNAL_LINK_REPLACEMENTS) {
+    for (const quote of ['"', "'"]) {
+      const source = `href=${quote}${from}${quote}`
+      const target = `href=${quote}${to}${quote}`
+      if (!next.includes(source)) continue
+      const before = next
+      next = next.split(source).join(target)
+      changedLinks += before.split(source).length - 1
+    }
+  }
+
+  next = next.replace(/<a\b([^>]*\bhref=(["'])(\/compounds\/(?:dmt|harmaline|harmine|kratom|mitragynine|7-hydroxymitragynine)\/)\2[^>]*)>([\s\S]*?)<\/a>/gi, (match, _attrs, _quote, href, innerHtml) => {
+    if (!UNPUBLISHED_PROFILE_TARGETS.has(href)) return match
+    changedLinks += 1
+    return innerHtml
+  })
+
+  return { html: next, changedLinks }
+}
+
 if (!fs.existsSync(outDir)) {
   console.warn('[repair-broken-canonicals] out directory not found; skipping.')
   process.exit(0)
@@ -78,6 +117,7 @@ if (!fs.existsSync(outDir)) {
 let touchedFiles = 0
 let replacements = 0
 let normalizedDescriptionTags = 0
+let repairedInternalLinks = 0
 
 for (const filePath of walkHtmlFiles(outDir)) {
   const html = fs.readFileSync(filePath, 'utf8')
@@ -94,6 +134,10 @@ for (const filePath of walkHtmlFiles(outDir)) {
   next = normalizedDescriptions.html
   normalizedDescriptionTags += normalizedDescriptions.changedTags
 
+  const repairedLinks = repairInternalLinks(next)
+  next = repairedLinks.html
+  repairedInternalLinks += repairedLinks.changedLinks
+
   if (next !== html) {
     fs.writeFileSync(filePath, next)
     touchedFiles += 1
@@ -101,5 +145,5 @@ for (const filePath of walkHtmlFiles(outDir)) {
 }
 
 console.log(
-  `[repair-broken-canonicals] Rewrote ${replacements} canonical alias references and normalized ${normalizedDescriptionTags} description tags in ${touchedFiles} HTML files.`,
+  `[repair-broken-canonicals] Rewrote ${replacements} canonical alias references, normalized ${normalizedDescriptionTags} description tags, and repaired ${repairedInternalLinks} internal links in ${touchedFiles} HTML files.`,
 )

--- a/scripts/seo/repair-broken-canonicals.mjs
+++ b/scripts/seo/repair-broken-canonicals.mjs
@@ -3,6 +3,7 @@ import path from 'node:path'
 
 const root = process.cwd()
 const outDir = path.join(root, 'out')
+const MAX_META_DESCRIPTION_LENGTH = 155
 
 const CANONICAL_REPLACEMENTS = new Map([
   ['https://thehippiescientist.net/herbs/piper-methysticum/', 'https://thehippiescientist.net/herbs/kava/'],
@@ -35,6 +36,40 @@ function* walkHtmlFiles(dir) {
   }
 }
 
+function truncateMetaDescription(value) {
+  const normalized = value.replace(/\s+/g, ' ').trim()
+  if (normalized.length <= MAX_META_DESCRIPTION_LENGTH) return normalized
+
+  const targetLength = MAX_META_DESCRIPTION_LENGTH - 1
+  const candidate = normalized.slice(0, targetLength)
+  const lastSpace = candidate.lastIndexOf(' ')
+  let shortened = lastSpace >= 110 ? candidate.slice(0, lastSpace) : candidate
+
+  // Do not leave a partial HTML entity such as "&amp" at the cut boundary.
+  const lastAmpersand = shortened.lastIndexOf('&')
+  const lastSemicolon = shortened.lastIndexOf(';')
+  if (lastAmpersand > lastSemicolon) {
+    shortened = shortened.slice(0, lastAmpersand)
+  }
+
+  return `${shortened.trimEnd()}…`
+}
+
+function normalizeDescriptionTags(html) {
+  let changedTags = 0
+  const next = html.replace(/<meta\b[^>]*(?:(?:name|property)=["'](?:description|og:description|twitter:description)["'])[^>]*>/gi, tag => {
+    const normalizedTag = tag.replace(/content=(["'])(.*?)\1/i, (match, quote, value) => {
+      const normalized = truncateMetaDescription(value)
+      if (normalized === value) return match
+      changedTags += 1
+      return `content=${quote}${normalized}${quote}`
+    })
+    return normalizedTag
+  })
+
+  return { html: next, changedTags }
+}
+
 if (!fs.existsSync(outDir)) {
   console.warn('[repair-broken-canonicals] out directory not found; skipping.')
   process.exit(0)
@@ -42,6 +77,7 @@ if (!fs.existsSync(outDir)) {
 
 let touchedFiles = 0
 let replacements = 0
+let normalizedDescriptionTags = 0
 
 for (const filePath of walkHtmlFiles(outDir)) {
   const html = fs.readFileSync(filePath, 'utf8')
@@ -54,10 +90,16 @@ for (const filePath of walkHtmlFiles(outDir)) {
     replacements += before.split(from).length - 1
   }
 
+  const normalizedDescriptions = normalizeDescriptionTags(next)
+  next = normalizedDescriptions.html
+  normalizedDescriptionTags += normalizedDescriptions.changedTags
+
   if (next !== html) {
     fs.writeFileSync(filePath, next)
     touchedFiles += 1
   }
 }
 
-console.log(`[repair-broken-canonicals] Rewrote ${replacements} canonical alias references in ${touchedFiles} HTML files.`)
+console.log(
+  `[repair-broken-canonicals] Rewrote ${replacements} canonical alias references and normalized ${normalizedDescriptionTags} description tags in ${touchedFiles} HTML files.`,
+)


### PR DESCRIPTION
## What this fixes

- Stops the legacy `/compare/*` and `/comparisons/*` catch-all functions from blindly redirecting nonexistent comparisons into `/guides/compare/*` 404s.
- Preserves 301 redirects for the 12 comparison pages that are actually built, plus two known legacy aliases.
- Returns a direct `410 Gone` with `X-Robots-Tag: noindex, nofollow` for phantom comparison URLs so crawlers can retire them without wasting another redirect hop.
- Repairs the audited Citicoline, State of Supplement Evidence, and insomnia targets with exact canonical redirects.
- Rewrites those audited internal hrefs in exported HTML so crawlers see the canonical destination directly.
- Removes rendered links to unpublished DMT, harmine, harmaline, kratom, mitragynine, and 7-OH profiles instead of shipping links that resolve to 404.
- Caps exported standard, Open Graph, and Twitter descriptions at 155 characters during the existing post-export repair step.
- Adds regression tests for legacy comparison routing.

## Audit impact

This directly addresses the audit's large legacy comparison redirect-to-404 cluster, its listed internal broken-link targets, and the 125 overlong meta-description warnings after the next production export.

## Important boundary

The Ahrefs `blocked by robots.txt` and `uncrawled` CSV rows are overwhelmingly external Instagram/YouTube/Twitter/Amazon/NCBI URLs. Those are crawler restrictions on other domains, not defects this repository can fix. The GSC `crawled - currently not indexed` group also needs content/indexability review after these technical blockers are deployed; no code change can force Google to index a page.