### PR TITLE
Route unpublished alkaloid profiles to live authority articles

### DIFF
--- a/public/redirect-overrides/seo-csv-400-2026-07-08.txt
+++ b/public/redirect-overrides/seo-csv-400-2026-07-08.txt
@@ -29,3 +29,5 @@
 /compounds/citicoline/ /compounds/cdp-choline/ 301
 /state-of-supplement-evidence-2026/ /articles/state-of-supplement-evidence-2026/ 301
 /education/insomnia/ /guides/sleep/ 301
+/compounds/mitragynine/ /articles/mitragynine/ 301
+/compounds/7-hydroxymitragynine/ /articles/7-hydroxymitragynine/ 301

--- a/scripts/seo/repair-broken-canonicals.mjs
+++ b/scripts/seo/repair-broken-canonicals.mjs
@@ -27,6 +27,8 @@ const INTERNAL_LINK_REPLACEMENTS = new Map([
   ['/compounds/citicoline/', '/compounds/cdp-choline/'],
   ['/state-of-supplement-evidence-2026/', '/articles/state-of-supplement-evidence-2026/'],
   ['/education/insomnia/', '/guides/sleep/'],
+  ['/compounds/mitragynine/', '/articles/mitragynine/'],
+  ['/compounds/7-hydroxymitragynine/', '/articles/7-hydroxymitragynine/'],
 ])
 
 const UNPUBLISHED_PROFILE_TARGETS = new Set([
@@ -34,8 +36,6 @@ const UNPUBLISHED_PROFILE_TARGETS = new Set([
   '/compounds/harmaline/',
   '/compounds/harmine/',
   '/compounds/kratom/',
-  '/compounds/mitragynine/',
-  '/compounds/7-hydroxymitragynine/',
 ])
 
 function* walkHtmlFiles(dir) {
@@ -100,7 +100,7 @@ function repairInternalLinks(html) {
     }
   }
 
-  next = next.replace(/<a\b([^>]*\bhref=(["'])(\/compounds\/(?:dmt|harmaline|harmine|kratom|mitragynine|7-hydroxymitragynine)\/)\2[^>]*)>([\s\S]*?)<\/a>/gi, (match, _attrs, _quote, href, innerHtml) => {
+  next = next.replace(/<a\b([^>]*\bhref=(["'])(\/compounds\/(?:dmt|harmaline|harmine|kratom)\/)\2[^>]*)>([\s\S]*?)<\/a>/gi, (match, _attrs, _quote, href, innerHtml) => {
     if (!UNPUBLISHED_PROFILE_TARGETS.has(href)) return match
     changedLinks += 1
     return innerHtml


### PR DESCRIPTION
## What this improves

- Redirects `/compounds/mitragynine/` to the published `/articles/mitragynine/` authority page.
- Redirects `/compounds/7-hydroxymitragynine/` to the published `/articles/7-hydroxymitragynine/` authority page.
- Rewrites internal links to those canonical article destinations during static export instead of removing the links entirely.
- Keeps truly unpublished DMT, harmine, harmaline, and kratom profile links suppressed.

## Why

The first indexation cleanup correctly removed broken links, but these two subjects already have substantial live articles. Preserving those links strengthens crawl paths and topical authority while eliminating 404 targets.