### PR TITLE
Add homepage safety checklist email capture

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import HomepageV2 from '@/components/homepage-v2'
+import HomepageEmailCapture from '@/components/HomepageEmailCapture'
 import { buildPageMetadata } from '../src/lib/seo'
 
 export const metadata: Metadata = buildPageMetadata({
@@ -23,5 +24,10 @@ export const metadata: Metadata = buildPageMetadata({
 })
 
 export default function Page() {
-  return <HomepageV2 />
+  return (
+    <>
+      <HomepageV2 />
+      <HomepageEmailCapture />
+    </>
+  )
 }

--- a/components/HomepageEmailCapture.tsx
+++ b/components/HomepageEmailCapture.tsx
@@ -1,0 +1,21 @@
+import NewsletterSignup from '@/components/NewsletterSignup'
+
+export default function HomepageEmailCapture() {
+  return (
+    <section
+      aria-label='Free supplement safety checklist'
+      className='border-t border-brand-900/10 bg-[#f5f1e8] py-12 dark:border-white/10 dark:bg-[#0d1713] sm:py-16'
+    >
+      <div className='mx-auto max-w-6xl px-5 sm:px-8 lg:px-10'>
+        <NewsletterSignup
+          title='Get the free 5-point supplement safety checklist'
+          description='Use it to screen dose clarity, interactions, product testing, and marketing red flags before you buy—plus get occasional evidence notes when important guides publish.'
+          ctaLabel='Send me the checklist'
+          location='homepage-safety-checklist'
+          variant='editorial'
+          className='mb-0'
+        />
+      </div>
+    </section>
+  )
+}

--- a/tests/homepage-safety-checklist.test.ts
+++ b/tests/homepage-safety-checklist.test.ts
@@ -1,0 +1,21 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+}
+
+describe('homepage safety checklist capture', () => {
+  it('keeps the owned-audience conversion surface on the homepage', () => {
+    const page = read('app/page.tsx')
+    const capture = read('components/HomepageEmailCapture.tsx')
+
+    expect(page).toContain("import HomepageEmailCapture from '@/components/HomepageEmailCapture'")
+    expect(page).toContain('<HomepageEmailCapture />')
+    expect(capture).toContain("location='homepage-safety-checklist'")
+    expect(capture).toContain("variant='editorial'")
+    expect(capture).toContain('Get the free 5-point supplement safety checklist')
+    expect(capture).toContain('Send me the checklist')
+  })
+})


### PR DESCRIPTION
## Why this is high ROI

The homepage currently routes visitors into the library but does not convert them into an owned audience. The newsletter backend, tracking, privacy copy, bot protection, and safety-checklist lead magnet already exist elsewhere in the site, so this adds a homepage conversion surface without introducing a new system.

## Changes

- Add a dedicated homepage safety-checklist capture section
- Reuse the existing `NewsletterSignup` component and editorial styling
- Track attribution with `homepage-safety-checklist`
- Add a regression test so the capture is not accidentally removed

## Expected impact

- More email subscribers from direct and organic homepage visits
- More repeat traffic when evidence notes and guides publish
- Better long-term monetization optionality without adding aggressive affiliate placement

## Verification

- Branch is based on current `main`
- Change is isolated to 3 files
- CI should run the existing lint, typecheck, test, and build checks