### PR TITLE
Publish indexability promotion candidates from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,18 +93,23 @@ jobs:
         if: always()
         run: npm run audit:seo-reports
 
+      - name: Generate indexability candidate report
+        if: always()
+        run: npm run indexability:report
+
       - name: Audit internal links through redirects
         if: always()
         run: node scripts/ci/audit-internal-redirect-links.mjs
 
       - name: Upload SEO audit reports
-        if: always() && (hashFiles('public/data/reports/*.json') != '' || hashFiles('ops/reports/*.json') != '')
+        if: always() && (hashFiles('public/data/reports/*.json') != '' || hashFiles('ops/reports/*.json') != '' || hashFiles('ops/indexability-review/*.json') != '')
         uses: actions/upload-artifact@v4
         with:
           name: seo-audit-reports
           path: |
             public/data/reports/*.json
             ops/reports/*.json
+            ops/indexability-review/*.json
           if-no-files-found: ignore
 
       - name: Validate route SEO coverage
@@ -130,6 +135,6 @@ jobs:
           echo "## CI quality gate" >> "$GITHUB_STEP_SUMMARY"
           echo "- Purpose: enforce lint, typecheck, workbook/data correctness, build verification, and security audit" >> "$GITHUB_STEP_SUMMARY"
           echo "- Branch/ref: $GITHUB_REF" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Key commands: npm ci; npm run check:node; npm run validate:workbook-source; npm run validate:static-export; npm run routes:inventory; npm run lint; npm run typecheck; npm run data:build; npm run data:validate; npm run guard:source-of-truth; npm run build:deploy; npm run verify:output; npm run audit:seo-reports; node scripts/ci/audit-internal-redirect-links.mjs; npm run validate:route-seo; npm run audit:high" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Artifacts: seo-audit-reports; npm-audit-after" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Key commands: npm ci; npm run check:node; npm run validate:workbook-source; npm run validate:static-export; npm run routes:inventory; npm run lint; npm run typecheck; npm run data:build; npm run data:validate; npm run guard:source-of-truth; npm run build:deploy; npm run verify:output; npm run audit:seo-reports; npm run indexability:report; node scripts/ci/audit-internal-redirect-links.mjs; npm run validate:route-seo; npm run audit:high" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Artifacts: seo-audit-reports (including indexability candidates); npm-audit-after" >> "$GITHUB_STEP_SUMMARY"
           echo "- Status: ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What this adds

- Runs the existing indexability summary after the production data build.
- Uploads `ops/indexability-review/indexability-summary.json` with the SEO audit artifact.
- Surfaces the highest-scoring `NOINDEX` and `NEEDS_REVIEW` profiles instead of guessing which pages should be promoted.

## Why

The crawl plumbing is now clean: no crawlable orphan pages and no internal links through redirects. The next indexing work has to be evidence-governed content promotion, not mass-removing `noindex`. This report gives the exact safe candidate queue.