### PR TITLE
Remove redirect-only aliases from compound library

### DIFF
--- a/app/__tests__/compound-library-canonical-listing.test.ts
+++ b/app/__tests__/compound-library-canonical-listing.test.ts
@@ -1,0 +1,53 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import { isRedirectedCompoundDuplicate } from '../../lib/deprecated-compound-canonicals'
+
+const root = process.cwd()
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(root, relativePath), 'utf8')
+}
+
+describe('compound library canonical listings', () => {
+  it('hides same-taxonomy aliases when their canonical compound is present', () => {
+    const presentSlugs = new Set([
+      'berberine',
+      'berberine-hcl',
+      'l-theanine',
+      'theanine',
+      'glycine',
+      'glycine-sleep',
+    ])
+
+    expect(isRedirectedCompoundDuplicate('berberine-hcl', presentSlugs)).toBe(true)
+    expect(isRedirectedCompoundDuplicate('theanine', presentSlugs)).toBe(true)
+    expect(isRedirectedCompoundDuplicate('glycine-sleep', presentSlugs)).toBe(true)
+    expect(isRedirectedCompoundDuplicate('berberine', presentSlugs)).toBe(false)
+  })
+
+  it('keeps an alias discoverable when it is the only same-taxonomy runtime record', () => {
+    const presentSlugs = new Set(['berberine-hcl'])
+
+    expect(isRedirectedCompoundDuplicate('berberine-hcl', presentSlugs)).toBe(false)
+  })
+
+  it('always hides cross-taxonomy compound aliases from the compound directory', () => {
+    const presentSlugs = new Set(['garlic', 'ginger'])
+
+    expect(isRedirectedCompoundDuplicate('garlic-extract', presentSlugs)).toBe(true)
+    expect(isRedirectedCompoundDuplicate('gingerol', presentSlugs)).toBe(true)
+  })
+
+  it('applies the canonical filter to both the first and paginated library routes', () => {
+    const firstPage = read('app/compounds/page.tsx')
+    const paginatedPage = read('app/compounds/page/[page]/page.tsx')
+
+    for (const source of [firstPage, paginatedPage]) {
+      expect(source).toContain('isRedirectedCompoundDuplicate')
+      expect(source).toContain('presentSlugs')
+      expect(source).toContain('!isRedirectedCompoundDuplicate')
+    }
+  })
+})

--- a/app/compounds/page.tsx
+++ b/app/compounds/page.tsx
@@ -8,6 +8,7 @@ import { buildPageMetadata } from '../../src/lib/seo'
 import { COMPOUNDS_PAGE_SIZE, paginateItems } from '@/lib/pagination'
 import { toLeanProfileIndexRecords } from '@/lib/profile-index-records'
 import { formatDisplayLabel } from '@/lib/display-utils'
+import { isRedirectedCompoundDuplicate } from '@/lib/deprecated-compound-canonicals'
 import CompoundsIndexClient from './CompoundsIndexClient'
 import type { RuntimeRecord } from '../../src/types/content'
 import Pagination from '@/components/Pagination'
@@ -32,8 +33,15 @@ function getCompoundName(compound: RuntimeRecord) {
 }
 
 function loadBrowseCompounds(records: RuntimeRecord[]) {
+  const presentSlugs = new Set(records.map((compound) => String(compound.slug || '')))
+
   return records
-    .filter((compound) => compound?.slug && getRuntimeVisibility(compound).canRender)
+    .filter(
+      (compound) =>
+        compound?.slug &&
+        getRuntimeVisibility(compound).canRender &&
+        !isRedirectedCompoundDuplicate(String(compound.slug), presentSlugs),
+    )
     .sort((a, b) => getCompoundName(a).localeCompare(getCompoundName(b)))
 }
 

--- a/app/compounds/page/[page]/page.tsx
+++ b/app/compounds/page/[page]/page.tsx
@@ -5,6 +5,7 @@ import { getRuntimeVisibility } from '../../../../lib/runtime-visibility'
 import { COMPOUNDS_PAGE_SIZE, clampPositiveInt, paginateItems } from '@/lib/pagination'
 import { toLeanProfileIndexRecords } from '@/lib/profile-index-records'
 import { formatDisplayLabel } from '@/lib/display-utils'
+import { isRedirectedCompoundDuplicate } from '@/lib/deprecated-compound-canonicals'
 import Link from 'next/link'
 import CompoundsIndexClient from '../../CompoundsIndexClient'
 import type { RuntimeRecord } from '../../../../src/types/content'
@@ -25,8 +26,16 @@ function getCompoundName(compound: RuntimeRecord) {
 }
 
 async function loadBrowseCompounds(): Promise<RuntimeRecord[]> {
-  return ((await getAllCompounds()) as unknown as RuntimeRecord[])
-    .filter((compound) => compound?.slug && getRuntimeVisibility(compound).canRender)
+  const compounds = (await getAllCompounds()) as unknown as RuntimeRecord[]
+  const presentSlugs = new Set(compounds.map((compound) => String(compound.slug || '')))
+
+  return compounds
+    .filter(
+      (compound) =>
+        compound?.slug &&
+        getRuntimeVisibility(compound).canRender &&
+        !isRedirectedCompoundDuplicate(String(compound.slug), presentSlugs),
+    )
     .sort((a, b) => getCompoundName(a).localeCompare(getCompoundName(b)))
 }
 

--- a/lib/deprecated-compound-canonicals.ts
+++ b/lib/deprecated-compound-canonicals.ts
@@ -50,3 +50,21 @@ export const DEPRECATED_COMPOUND_CANONICALS: Record<string, string> = {
   resveratrol: '/herbs/resveratrol',
   'trans-resveratrol': '/herbs/resveratrol',
 }
+
+// True when `slug` redirects to another browseable record. Same-taxonomy
+// aliases are hidden only when the canonical compound record is present, so an
+// alias can remain discoverable if it is the only runtime record available.
+// Cross-taxonomy aliases are always hidden because their canonical profile
+// belongs in the herb library rather than the compound directory.
+export function isRedirectedCompoundDuplicate(
+  slug: string | undefined | null,
+  presentSlugs: Set<string>,
+): boolean {
+  if (!slug) return false
+
+  const target = DEPRECATED_COMPOUND_CANONICALS[slug]
+  if (!target) return false
+  if (target.startsWith('/')) return true
+
+  return presentSlugs.has(target)
+}


### PR DESCRIPTION
## High-ROI finding

The compound directory was still presenting deprecated redirect sources as separate profiles. Search crawlers and users could see duplicate Berberine, CoQ10, L-theanine, glycine, inositol, probiotic, and herb-derived compound entries even though those URLs consolidate to canonical pages.

This wastes crawl attention, splits directory link equity across duplicate labels, inflates the advertised profile count, and makes the library look less curated.

## Changes

- Add `isRedirectedCompoundDuplicate()` beside the canonical compound alias map.
- Hide same-taxonomy aliases when the canonical compound record is present.
- Always hide cross-taxonomy aliases whose real home is the herb library.
- Apply the same filtering to the first compound-library page, all paginated pages, the crawler-visible index, and client-side search data.
- Preserve an alias when it is the only available same-taxonomy runtime record, preventing accidental disappearance.
- Add regression coverage for canonical-present, canonical-missing, cross-taxonomy, and both route implementations.

## Expected ROI

- Cleaner high-authority compound directory with one listing per canonical topic.
- Stronger internal-link concentration on ranking and conversion pages.
- Fewer duplicate labels and redirect-backed cards in search-engine rendering.
- More accurate library and pagination counts.

## Scope / risk

- Four files only.
- No workbook, generated runtime data, profile content, redirect behavior, or dependencies changed.
- Browse/index filtering only; canonical pages remain available exactly as before.