### PR TITLE
Block stale pipeline prose from live detail pages

### DIFF
--- a/lib/__tests__/runtime-detail-leak-guard.test.mjs
+++ b/lib/__tests__/runtime-detail-leak-guard.test.mjs
@@ -1,0 +1,92 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import {
+  isLeakedPresentationText,
+  resolveRuntimeRecordLayers,
+} from '../runtime-record-resolver.mjs'
+
+const root = process.cwd()
+const dataDir = path.join(root, 'public', 'data')
+const PRESENTATION_FIELDS = [
+  'name',
+  'displayName',
+  'summary',
+  'description',
+  'hero',
+  'coreInsight',
+  'short_earthy_summary',
+  'shortEarthySummary',
+  'dosage',
+  'typical_dosage',
+]
+
+function readJson(relativePath) {
+  return JSON.parse(fs.readFileSync(path.join(dataDir, relativePath), 'utf8'))
+}
+
+function buildSlugMap(records) {
+  return new Map(
+    records
+      .filter((record) => record && typeof record.slug === 'string' && record.slug)
+      .map((record) => [record.slug, record]),
+  )
+}
+
+function detailFiles(directory) {
+  const absoluteDir = path.join(dataDir, directory)
+  if (!fs.existsSync(absoluteDir)) return []
+
+  return fs
+    .readdirSync(absoluteDir)
+    .filter((fileName) => fileName.endsWith('.json'))
+    .sort()
+    .map((fileName) => ({
+      fileName,
+      detail: JSON.parse(fs.readFileSync(path.join(absoluteDir, fileName), 'utf8')),
+    }))
+}
+
+function auditResolvedDetails(kind, baseRecords, directory) {
+  const baseBySlug = buildSlugMap(baseRecords)
+  const leaks = []
+  const resolverErrors = []
+  let checked = 0
+
+  for (const { fileName, detail } of detailFiles(directory)) {
+    const slug = String(detail?.slug || detail?.id || fileName.replace(/\.json$/, ''))
+    const base = baseBySlug.get(slug)
+    if (!base) continue
+
+    let resolved
+    try {
+      resolved = resolveRuntimeRecordLayers(base, [detail])
+    } catch (error) {
+      resolverErrors.push(`${kind}/${fileName}: ${error instanceof Error ? error.message : String(error)}`)
+      continue
+    }
+
+    checked += 1
+    for (const field of PRESENTATION_FIELDS) {
+      const value = resolved?.[field]
+      if (typeof value !== 'string' || !isLeakedPresentationText(value, field)) continue
+      leaks.push(`${kind}/${fileName} ${field}: ${value}`)
+    }
+  }
+
+  return { checked, leaks, resolverErrors }
+}
+
+describe('runtime detail presentation leak guard', () => {
+  it('prevents committed detail artifacts from leaking pipeline prose after runtime resolution', () => {
+    const herbs = readJson('herbs.json')
+    const compounds = readJson('compounds.json')
+    const herbResult = auditResolvedDetails('herbs-detail', herbs, 'herbs-detail')
+    const compoundResult = auditResolvedDetails('compounds-detail', compounds, 'compounds-detail')
+
+    expect(herbResult.checked + compoundResult.checked).toBeGreaterThan(0)
+    expect([...herbResult.resolverErrors, ...compoundResult.resolverErrors]).toEqual([])
+    expect([...herbResult.leaks, ...compoundResult.leaks]).toEqual([])
+  })
+})

--- a/lib/__tests__/runtime-detail-leak-guard.test.mjs
+++ b/lib/__tests__/runtime-detail-leak-guard.test.mjs
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import process from 'node:process'
 import { describe, expect, it } from 'vitest'
 
 import {

--- a/lib/__tests__/runtime-record-resolver.test.mjs
+++ b/lib/__tests__/runtime-record-resolver.test.mjs
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  isLeakedPresentationText,
   normalizeRuntimeList,
   resolveRuntimeRecordLayers,
   resolveTrustValue,
@@ -29,6 +30,7 @@ const standardRecord = {
   robots: 'index,follow',
   sitemap_included: true,
   summary: 'Canonical summary.',
+  description: 'Canonical description.',
 }
 
 describe('cluster-member runtime record resolver', () => {
@@ -104,6 +106,25 @@ describe('standard runtime record resolver', () => {
 
     expect(result.summary).toBe('Expanded detail summary.')
     expect(result.dosage).toBe('200 mg with food')
+  })
+
+  it('rejects stale pipeline prose while preserving the canonical presentation text', () => {
+    const result = resolveRuntimeRecordLayers(standardRecord, [{
+      slug: standardRecord.slug,
+      summary: 'Decision-ready summary: this item is best framed for a merged decision layer.',
+      description: 'Supports cognition with high confidence in this merged decision layer.',
+    }])
+
+    expect(result.summary).toBe(standardRecord.summary)
+    expect(result.description).toBe(standardRecord.description)
+    expect(isLeakedPresentationText(result.summary, 'summary')).toBe(false)
+    expect(isLeakedPresentationText(result.description, 'description')).toBe(false)
+  })
+
+  it('does not classify ordinary evidence-aware copy as pipeline leakage', () => {
+    expect(isLeakedPresentationText('Human evidence is preliminary and condition-specific.', 'summary')).toBe(false)
+    expect(isLeakedPresentationText('Decision-ready summary: internal text', 'summary')).toBe(true)
+    expect(isLeakedPresentationText('Decision-ready summary: internal text', 'audit_notes')).toBe(false)
   })
 
   it('allows a deliberate trust-field override only when explicitly approved', () => {

--- a/lib/runtime-record-resolver.mjs
+++ b/lib/runtime-record-resolver.mjs
@@ -10,6 +10,39 @@ const LIST_FIELDS = new Set([
   'caution_signals',
   'indexability_reasons',
 ])
+const PRESENTATION_TEXT_FIELDS = new Set([
+  'name',
+  'displayName',
+  'summary',
+  'description',
+  'hero',
+  'coreInsight',
+  'short_earthy_summary',
+  'shortEarthySummary',
+  'dosage',
+  'typical_dosage',
+])
+const LEAKED_PRESENTATION_PATTERNS = [
+  /lean bulk ingestion row/i,
+  /lean bulk/i,
+  /^ingestion row/i,
+  /\bTODO\b/i,
+  /\bFIXME\b/i,
+  /\bPLACEHOLDER\b/i,
+  /\btest entry\b/i,
+  /\bdummy\b/i,
+  /is linked here to/i,
+  /lean herb row|lean monograph row/i,
+  /high.speed phytochemical/i,
+  /internal cross-linking supports/i,
+  /\bis tracked for\b/i,
+  /it is best framed (as|around|for)/i,
+  /decision[-\s]?ready summary/i,
+  /merged decision layer/i,
+  /evidence level:/i,
+  /scispace evidence pass|evidence pass/i,
+  /enriched in bulk|bulk mode/i,
+]
 const CORE_OWNED_FIELDS = new Set([
   'id',
   'slug',
@@ -39,12 +72,19 @@ function canonicalField(field) {
   return SAFETY_ALIASES.has(field) ? 'safety' : field
 }
 
+export function isLeakedPresentationText(value, field = '') {
+  if (!PRESENTATION_TEXT_FIELDS.has(field)) return false
+  const normalized = text(value)
+  return Boolean(normalized && LEAKED_PRESENTATION_PATTERNS.some((pattern) => pattern.test(normalized)))
+}
+
 export function isMeaningfulRuntimeValue(value, field = '') {
   const canonical = canonicalField(field)
   if (typeof value === 'string') {
     if (LIST_FIELDS.has(canonical)) return false
     const normalized = text(value)
     if (PLACEHOLDERS.has(normalized.toLowerCase())) return false
+    if (isLeakedPresentationText(normalized, field)) return false
     if (canonical === 'safety' && GENERIC_SAFETY.test(normalized)) return false
     return true
   }


### PR DESCRIPTION
## High-ROI finding

The flat workbook runtime can be clean while committed `herbs-detail` and `compounds-detail` records remain stale. Detail generation is not part of the deploy-time workbook build, yet those records are merged over canonical flat data when profile pages render.

That allowed internal enrichment language such as “Decision-ready summary” and “merged decision layer” to replace clean public summaries on live pages, including Acetyl-L-Carnitine. The existing leaked-text audit missed the problem because it scans only the flat herb and compound files.

## Changes

- Add presentation-only pipeline-leak detection to the shared runtime record resolver.
- Reject known internal/template phrases when they appear in public presentation fields such as summary, description, hero copy, and dosage.
- Fall back to the canonical workbook-derived value instead of exposing stale detail prose.
- Preserve normal curated detail enrichment and all existing trust-field protections.
- Add focused unit coverage proving ordinary evidence-aware copy remains valid.
- Add a repository-wide regression test that resolves the current committed herb and compound detail artifacts against their canonical base records and fails if any pipeline prose survives.

## Expected ROI

- Removes internal editorial/pipeline language from potentially many live profile pages at once.
- Improves user trust, perceived editorial quality, and search-snippet cleanliness.
- Prevents stale detail artifacts from silently undoing clean workbook updates.
- Closes a blind spot that flat-data audits could not detect.

## Scope / risk

- Three files only.
- No workbook, generated data, dependencies, routes, robots directives, or scientific claims changed.
- Detection is limited to known leak patterns and public presentation fields; internal metadata remains untouched.