### PR TITLE
Micro upgrade: keep one homepage email CTA

### DIFF
--- a/components/HomepageEmailCapture.tsx
+++ b/components/HomepageEmailCapture.tsx
@@ -2,20 +2,23 @@ import NewsletterSignup from '@/components/NewsletterSignup'
 
 export default function HomepageEmailCapture() {
   return (
-    <section
-      aria-label='Free supplement safety checklist'
-      className='border-t border-brand-900/10 bg-[#f5f1e8] py-12 dark:border-white/10 dark:bg-[#0d1713] sm:py-16'
-    >
-      <div className='mx-auto max-w-6xl px-5 sm:px-8 lg:px-10'>
-        <NewsletterSignup
-          title='Get the free 5-point supplement safety checklist'
-          description='Use it to screen dose clarity, interactions, product testing, and marketing red flags before you buy—plus get occasional evidence notes when important guides publish.'
-          ctaLabel='Send me the checklist'
-          location='homepage-safety-checklist'
-          variant='editorial'
-          className='mb-0'
-        />
-      </div>
-    </section>
+    <>
+      <style>{`[data-signup-location='global-footer'] { display: none; }`}</style>
+      <section
+        aria-label='Free supplement safety checklist'
+        className='border-t border-brand-900/10 bg-[#f5f1e8] py-12 dark:border-white/10 dark:bg-[#0d1713] sm:py-16'
+      >
+        <div className='mx-auto max-w-6xl px-5 sm:px-8 lg:px-10'>
+          <NewsletterSignup
+            title='Get the free 5-point supplement safety checklist'
+            description='Use it to screen dose clarity, interactions, product testing, and marketing red flags before you buy—plus get occasional evidence notes when important guides publish.'
+            ctaLabel='Send me the checklist'
+            location='homepage-safety-checklist'
+            variant='editorial'
+            className='mb-0'
+          />
+        </div>
+      </section>
+    </>
   )
 }

--- a/tests/homepage-safety-checklist.test.ts
+++ b/tests/homepage-safety-checklist.test.ts
@@ -7,7 +7,7 @@ function read(relativePath: string) {
 }
 
 describe('homepage safety checklist capture', () => {
-  it('keeps the owned-audience conversion surface on the homepage', () => {
+  it('keeps one owned-audience conversion surface on the homepage', () => {
     const page = read('app/page.tsx')
     const capture = read('components/HomepageEmailCapture.tsx')
 
@@ -17,5 +17,6 @@ describe('homepage safety checklist capture', () => {
     expect(capture).toContain("variant='editorial'")
     expect(capture).toContain('Get the free 5-point supplement safety checklist')
     expect(capture).toContain('Send me the checklist')
+    expect(capture).toContain("[data-signup-location='global-footer'] { display: none; }")
   })
 })


### PR DESCRIPTION
## What changed
- Keeps the homepage-specific safety checklist signup and its dedicated analytics source.
- Hides the generic global-footer signup while the homepage capture is mounted.
- Adds a regression assertion so the duplicate CTA does not quietly return.

## Why
The live homepage currently shows two nearly identical email signup blocks near the bottom. One focused CTA is cleaner, shorter, and less likely to create conversion fatigue.

## Scope
Two small files. No content, routing, database, or newsletter backend changes.