### PR TITLE
Show only published profiles in compound library

### DIFF
--- a/app/__tests__/compound-library-canonical-listing.test.ts
+++ b/app/__tests__/compound-library-canonical-listing.test.ts
@@ -40,14 +40,24 @@ describe('compound library canonical listings', () => {
     expect(isRedirectedCompoundDuplicate('gingerol', presentSlugs)).toBe(true)
   })
 
-  it('applies the canonical filter to both the first and paginated library routes', () => {
+  it('lists only indexable canonical profiles on both library routes', () => {
     const firstPage = read('app/compounds/page.tsx')
     const paginatedPage = read('app/compounds/page/[page]/page.tsx')
 
     for (const source of [firstPage, paginatedPage]) {
+      expect(source).toContain('getRuntimeVisibility(compound).canIndex')
+      expect(source).not.toContain('getRuntimeVisibility(compound).canRender')
       expect(source).toContain('isRedirectedCompoundDuplicate')
       expect(source).toContain('presentSlugs')
       expect(source).toContain('!isRedirectedCompoundDuplicate')
     }
+  })
+
+  it('does not advertise an inflated fixed profile count in metadata', () => {
+    const firstPage = read('app/compounds/page.tsx')
+
+    expect(firstPage).not.toContain('Browse 600+ compound profiles')
+    expect(firstPage).toContain('Browse published compound profiles')
+    expect(firstPage).toContain('published compounds')
   })
 })

--- a/app/compounds/page.tsx
+++ b/app/compounds/page.tsx
@@ -16,7 +16,7 @@ import Pagination from '@/components/Pagination'
 export const metadata: Metadata = buildPageMetadata({
   title: 'Compound Library',
   description:
-    'Browse 600+ compound profiles with mechanisms, evidence levels, safety status, and practical context. Evidence-first, no hype.',
+    'Browse published compound profiles with mechanisms, evidence levels, safety status, and practical context. Evidence-first, no hype.',
   path: '/compounds',
 })
 
@@ -39,7 +39,7 @@ function loadBrowseCompounds(records: RuntimeRecord[]) {
     .filter(
       (compound) =>
         compound?.slug &&
-        getRuntimeVisibility(compound).canRender &&
+        getRuntimeVisibility(compound).canIndex &&
         !isRedirectedCompoundDuplicate(String(compound.slug), presentSlugs),
     )
     .sort((a, b) => getCompoundName(a).localeCompare(getCompoundName(b)))
@@ -64,13 +64,13 @@ export default async function CompoundsPage() {
         <p className="mt-2 max-w-2xl text-sm leading-6 text-muted">
           Mechanism, evidence strength, and safety context for bioactive molecules and supplement constituents.
         </p>
-        <p className="mt-2 text-sm font-semibold text-muted">Browsing {allCompounds.length} compounds</p>
+        <p className="mt-2 text-sm font-semibold text-muted">Browsing {allCompounds.length} published compounds</p>
       </section>
 
       <Pagination basePath="/compounds" currentPage={1} totalPages={pageData.totalPages} itemLabel="Compound profiles" />
 
       {/* SEO-crawlable index (hidden from visual users, served to Googlebot) */}
-      <nav aria-label="Compound profiles index" className="sr-only">
+      <nav aria-label="Published compound profiles index" className="sr-only">
         <ul>
           {allCompounds.map((c) => (
             <li key={c.slug}>

--- a/app/compounds/page/[page]/page.tsx
+++ b/app/compounds/page/[page]/page.tsx
@@ -33,7 +33,7 @@ async function loadBrowseCompounds(): Promise<RuntimeRecord[]> {
     .filter(
       (compound) =>
         compound?.slug &&
-        getRuntimeVisibility(compound).canRender &&
+        getRuntimeVisibility(compound).canIndex &&
         !isRedirectedCompoundDuplicate(String(compound.slug), presentSlugs),
     )
     .sort((a, b) => getCompoundName(a).localeCompare(getCompoundName(b)))
@@ -53,7 +53,7 @@ export async function generateMetadata({ params }: P): Promise<Metadata> {
 
   return {
     title: `Compound Profiles & Research Library — Page ${n}`,
-    description: `Browse page ${n} of The Hippie Scientist compound research library, with evidence, mechanism, safety, and practical context for supplement constituents.`,
+    description: `Browse page ${n} of The Hippie Scientist published compound library, with evidence, mechanism, safety, and practical context for supplement constituents.`,
     alternates: {
       canonical: `/compounds/page/${n}/`,
     },
@@ -81,7 +81,7 @@ export default async function CompoundsPageN({ params }: P) {
 
       <Pagination basePath="/compounds" currentPage={p.currentPage} totalPages={p.totalPages} itemLabel="Compound profiles" />
 
-      <nav aria-label="Compound profiles on this page" className="sr-only">
+      <nav aria-label="Published compound profiles on this page" className="sr-only">
         <ul>
           {p.pageItems.map((compound) => (
             <li key={compound.slug}>


### PR DESCRIPTION
## High-ROI finding

The public compound directory was using `canRender`, so it mixed published/indexable profiles with hundreds of noindex, hidden-until-grounded, needs-review, and research-only records.

The current runtime contains roughly 177 indexable compounds versus about 388 non-indexable records. Presenting all 565 as one published library inflated the profile count, exposed uneven/thin entries in the primary browse experience, and gave crawlers a large internal-link path into URLs the site explicitly does not want indexed.

## Changes

- Filter the first compound-library page by `getRuntimeVisibility(...).canIndex`.
- Apply the same published-only filter to every paginated library page and `generateStaticParams`.
- Keep canonical redirect-alias filtering from PR #2417.
- Limit the crawler-visible index and client-side search/filter payload to published canonical profiles.
- Replace the fixed “600+ profiles” metadata claim with truthful published-library language.
- Update visible count copy to say “published compounds.”
- Add regression coverage for both routes and the metadata claim.

## Expected ROI

- A much tighter, higher-trust compound library.
- Less crawl budget spent on noindex/research-only pages.
- Internal link equity concentrated on pages eligible to rank.
- Published profile count, pagination, search, and crawler index all agree.
- Thin or unfinished research records remain renderable by direct URL where governance allows, but are no longer promoted as finished library entries.

## Scope / risk

- Three files only.
- No profile content, workbook data, robots directives, redirects, or runtime governance decisions changed.
- This changes discovery/promotion only; it does not delete any profile URL.