### PR TITLE
Micro upgrade: render one homepage email CTA

### DIFF
--- a/components/HomepageEmailCapture.tsx
+++ b/components/HomepageEmailCapture.tsx
@@ -2,23 +2,20 @@ import NewsletterSignup from '@/components/NewsletterSignup'
 
 export default function HomepageEmailCapture() {
   return (
-    <>
-      <style>{`[data-signup-location='global-footer'] { display: none; }`}</style>
-      <section
-        aria-label='Free supplement safety checklist'
-        className='border-t border-brand-900/10 bg-[#f5f1e8] py-12 dark:border-white/10 dark:bg-[#0d1713] sm:py-16'
-      >
-        <div className='mx-auto max-w-6xl px-5 sm:px-8 lg:px-10'>
-          <NewsletterSignup
-            title='Get the free 5-point supplement safety checklist'
-            description='Use it to screen dose clarity, interactions, product testing, and marketing red flags before you buy—plus get occasional evidence notes when important guides publish.'
-            ctaLabel='Send me the checklist'
-            location='homepage-safety-checklist'
-            variant='editorial'
-            className='mb-0'
-          />
-        </div>
-      </section>
-    </>
+    <section
+      aria-label='Free supplement safety checklist'
+      className='border-t border-brand-900/10 bg-[#f5f1e8] py-12 dark:border-white/10 dark:bg-[#0d1713] sm:py-16'
+    >
+      <div className='mx-auto max-w-6xl px-5 sm:px-8 lg:px-10'>
+        <NewsletterSignup
+          title='Get the free 5-point supplement safety checklist'
+          description='Use it to screen dose clarity, interactions, product testing, and marketing red flags before you buy—plus get occasional evidence notes when important guides publish.'
+          ctaLabel='Send me the checklist'
+          location='homepage-safety-checklist'
+          variant='editorial'
+          className='mb-0'
+        />
+      </div>
+    </section>
   )
 }

--- a/components/NewsletterSignup.tsx
+++ b/components/NewsletterSignup.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Link from 'next/link'
+import { usePathname } from 'next/navigation'
 import { type FormEvent, useEffect, useId, useRef, useState } from 'react'
 import { safetyChecklistLeadMagnet } from '@/lib/lead-magnet'
 import { mailchimpSignupConfig } from '@/lib/mailchimp-integration'
@@ -57,6 +58,8 @@ export default function NewsletterSignup({
   variant = 'card',
   className = '',
 }: NewsletterSignupProps) {
+  const pathname = usePathname()
+  const suppressOnHomepage = location === 'global-footer' && pathname === '/'
   const isFooter = variant === 'footer'
   const textColor = isFooter ? 'text-white' : 'text-ink'
   const mutedColor = isFooter ? 'text-white/65' : 'text-muted'
@@ -80,7 +83,7 @@ export default function NewsletterSignup({
   const usesTurnstile = usesClientPost && Boolean(turnstileSiteKey)
 
   useEffect(() => {
-    if (!usesTurnstile || !turnstileContainerRef.current || turnstileWidgetIdRef.current) return
+    if (suppressOnHomepage || !usesTurnstile || !turnstileContainerRef.current || turnstileWidgetIdRef.current) return
 
     let cancelled = false
     loadTurnstileScript()
@@ -106,7 +109,7 @@ export default function NewsletterSignup({
     return () => {
       cancelled = true
     }
-  }, [usesTurnstile])
+  }, [suppressOnHomepage, usesTurnstile])
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     if (!usesClientPost) return
@@ -150,6 +153,8 @@ export default function NewsletterSignup({
       setMessage(error instanceof Error ? error.message : 'Could not subscribe this email right now.')
     }
   }
+
+  if (suppressOnHomepage) return null
 
   return (
     <section className={`${variantClasses[variant]} ${className}`} data-signup-location={location}>

--- a/tests/homepage-safety-checklist.test.ts
+++ b/tests/homepage-safety-checklist.test.ts
@@ -7,9 +7,10 @@ function read(relativePath: string) {
 }
 
 describe('homepage safety checklist capture', () => {
-  it('keeps one owned-audience conversion surface on the homepage', () => {
+  it('renders one owned-audience conversion surface on the homepage', () => {
     const page = read('app/page.tsx')
     const capture = read('components/HomepageEmailCapture.tsx')
+    const signup = read('components/NewsletterSignup.tsx')
 
     expect(page).toContain("import HomepageEmailCapture from '@/components/HomepageEmailCapture'")
     expect(page).toContain('<HomepageEmailCapture />')
@@ -17,6 +18,9 @@ describe('homepage safety checklist capture', () => {
     expect(capture).toContain("variant='editorial'")
     expect(capture).toContain('Get the free 5-point supplement safety checklist')
     expect(capture).toContain('Send me the checklist')
-    expect(capture).toContain("[data-signup-location='global-footer'] { display: none; }")
+    expect(capture).not.toContain("[data-signup-location='global-footer']")
+    expect(signup).toContain("import { usePathname } from 'next/navigation'")
+    expect(signup).toContain("location === 'global-footer' && pathname === '/'")
+    expect(signup).toContain('if (suppressOnHomepage) return null')
   })
 })


### PR DESCRIPTION
## What changed
- Suppresses the global-footer newsletter signup on the homepage at render time.
- Keeps the homepage-specific safety-checklist signup unchanged.
- Removes the temporary CSS hiding rule.
- Updates the regression test to require pathname-based suppression.

## Why
The previous patch visually hid the duplicate footer form, but its HTML still existed in the page source. This follow-up ensures visitors, assistive technology, and crawlers receive a single homepage signup form.

## Scope
Three focused files. No email API, dependency, routing, database, or content-data changes.