### PR TITLE
Micro upgrade: fix homepage stress destination

### DIFF
--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -28,7 +28,7 @@ const heroGoals = [
     slug: 'stress',
     tone: 'stress',
     title: 'Stress',
-    href: '/guides/anxiety/',
+    href: '/guides/stress/',
     icon: Leaf,
     prompt: 'Sort calming supports and adaptogens by symptom pattern.',
   },

--- a/tests/homepage-goal-routes.test.ts
+++ b/tests/homepage-goal-routes.test.ts
@@ -1,0 +1,16 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+}
+
+describe('homepage goal routes', () => {
+  it('sends stress and anxiety visitors to their distinct decision hubs', () => {
+    const homepage = read('components/homepage-v2.tsx')
+
+    expect(homepage).toMatch(/slug: 'stress',[\s\S]*?href: '\/guides\/stress\/'/)
+    expect(homepage).toMatch(/slug: 'anxiety',[\s\S]*?href: '\/guides\/anxiety\/'/)
+  })
+})


### PR DESCRIPTION
## What changed
- Sends the homepage Stress card to `/guides/stress/` instead of the Anxiety hub.
- Adds a regression test requiring Stress and Anxiety to retain distinct destinations.

## Why
The site already has a purpose-built stress decision hub, but the homepage bypassed it. Visitors choosing Stress should land on the route tailored to acute tension, chronic overload, sleep disruption, burnout, cortisol concerns, and stacking risk.

## Scope
One link correction plus one focused test. No content, styling, data, dependency, or routing-system changes.