### PR TITLE
Secondary upgrade: register Stress route metadata

### DIFF
--- a/lib/navigation-config.ts
+++ b/lib/navigation-config.ts
@@ -88,9 +88,14 @@ export const routeLabels: Record<string, RouteMetadata> = {
     description: 'Sleep aids, alternatives, and sleep-hygiene evidence',
     parent: '/guides',
   },
+  '/guides/stress': {
+    label: 'Stress',
+    description: 'Acute tension, chronic overload, burnout, cortisol concerns, and stress-support evidence',
+    parent: '/guides',
+  },
   '/guides/anxiety': {
-    label: 'Anxiety & Stress',
-    description: 'Calming supports, adaptogens, and stress-management evidence',
+    label: 'Anxiety',
+    description: 'Anxiety patterns, calming supports, and evidence-aware safety guidance',
     parent: '/guides',
   },
   '/guides/focus': {

--- a/tests/stress-route-metadata.test.ts
+++ b/tests/stress-route-metadata.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import {
+  generateDynamicBreadcrumbs,
+  getRouteMetadata,
+  validateRoute,
+} from '../lib/navigation-config'
+
+describe('stress route metadata', () => {
+  it('treats Stress as a first-class guide hub', () => {
+    expect(validateRoute('/guides/stress')).toBe(true)
+    expect(getRouteMetadata('/guides/stress')).toMatchObject({
+      label: 'Stress',
+      parent: '/guides',
+    })
+
+    expect(generateDynamicBreadcrumbs('/guides/stress')).toEqual([
+      { label: 'Home', href: '/', current: false },
+      { label: 'Topics & Guides', href: '/guides', current: false },
+      { label: 'Stress', href: '/guides/stress', current: true },
+    ])
+  })
+
+  it('keeps Anxiety metadata distinct from Stress', () => {
+    expect(getRouteMetadata('/guides/anxiety')).toMatchObject({
+      label: 'Anxiety',
+      parent: '/guides',
+    })
+  })
+})


### PR DESCRIPTION
## What changed
- Registers `/guides/stress` in the shared route metadata registry.
- Gives Stress and Anxiety distinct labels and descriptions.
- Adds behavior-level coverage for route validation, metadata lookup, and breadcrumb generation.

## Why
The dedicated Stress hub was live and linked in navigation, but the central route registry still treated it as a generic dynamic guide. This makes the route a first-class hub across shared navigation helpers and keeps Anxiety metadata separate.

## Scope
One shared metadata file plus one focused test. No page content, styling, dependencies, generated data, or deployment-model changes.