### PR TITLE
Secondary upgrade: register Goals route metadata

### DIFF
--- a/lib/navigation-config.ts
+++ b/lib/navigation-config.ts
@@ -68,6 +68,17 @@ export const routeLabels: Record<string, RouteMetadata> = {
     description: 'Search the complete site',
     parent: '/library',
   },
+  '/goals': {
+    label: 'Supplement Goals',
+    description: 'Compare supplement options by the outcome you want to improve',
+    parent: '/library',
+  },
+  '/goals/[slug]': {
+    label: 'Goal Guide',
+    description: 'Goal-based supplement comparison by fit, onset, evidence, and risk',
+    parent: '/goals',
+    isDynamic: true,
+  },
   '/guides': {
     label: 'Topics & Guides',
     description: 'Goal-based and practical evidence guides',

--- a/tests/goals-route-metadata.test.ts
+++ b/tests/goals-route-metadata.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  generateDynamicBreadcrumbs,
+  getRouteMetadata,
+  validateRoute,
+} from '@/lib/navigation-config'
+
+describe('goals route metadata', () => {
+  it('recognizes the goals hub and dynamic goal pages', () => {
+    expect(validateRoute('/goals')).toBe(true)
+    expect(validateRoute('/goals/sleep')).toBe(true)
+
+    expect(getRouteMetadata('/goals')).toMatchObject({
+      label: 'Supplement Goals',
+      parent: '/library',
+    })
+    expect(getRouteMetadata('/goals/sleep')).toMatchObject({
+      label: 'Goal Guide',
+      parent: '/goals',
+      isDynamic: true,
+    })
+  })
+
+  it('builds a clear breadcrumb trail for a goal page', () => {
+    expect(generateDynamicBreadcrumbs('/goals/sleep')).toEqual([
+      { label: 'Home', href: '/', current: false },
+      { label: 'Supplement Goals', href: '/goals', current: false },
+      { label: 'Sleep', href: '/goals/sleep', current: true },
+    ])
+  })
+})


### PR DESCRIPTION
## What changed
- Registers `/goals` as the Supplement Goals hub in shared route metadata.
- Registers `/goals/[slug]` as the dynamic goal-guide family.
- Adds behavior coverage for validation, metadata lookup, and breadcrumbs using `/goals/sleep`.

## Why
The Goals pages are live, indexed, and internally linked, but shared navigation helpers treated them as unregistered generic paths. This makes the route family first-class and gives breadcrumbs a clear `Home → Supplement Goals → Goal` hierarchy.

## Scope
One shared metadata file plus one focused test. No page content, goal data, styling, dependencies, or generated output changes.