### PR TITLE
Secondary upgrade: fix compounds core-route verifier

### DIFF
--- a/scripts/verify-core-routes.mjs
+++ b/scripts/verify-core-routes.mjs
@@ -71,7 +71,7 @@ const routeContentExpectations = [
   },
   {
     route: '/compounds',
-    required: ['Compound Library', 'Compound profiles index', 'Compound research library'],
+    required: ['Compound Library', 'Published compound profiles index', 'Compound research library'],
     forbidden: ['Herb Profiles &amp; Research Library', 'Find the right supplement path for your goals.'],
   },
   {


### PR DESCRIPTION
## What changed
- Updates the `/compounds` core-route expectation from the obsolete `Compound profiles index` label to the current accessible label `Published compound profiles index`.

## Why
The page is healthy and exports correctly, but the stale verifier causes Site Health Check to report a false failure on every unrelated PR.

## Scope
One assertion string in `scripts/verify-core-routes.mjs`. No page code, content, styles, dependencies, or generated data changes.