### PR TITLE
Secondary upgrade: sync Guides library counts

### DIFF
--- a/app/guides/page.tsx
+++ b/app/guides/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { SITE_URL } from '@/lib/navigation-config'
+import buildReport from '@/public/data/build-report.json'
 
 export const metadata: Metadata = {
   title: 'Evidence Library — Supplements, Science & Mental Health',
@@ -101,6 +102,8 @@ const FEATURED_DECISION_ROUTES = [
   },
 ]
 
+const counts = buildReport.counts
+
 export default function LibraryHub() {
   return (
     <div className="mx-auto max-w-5xl px-4 pb-24 pt-8">
@@ -151,7 +154,9 @@ export default function LibraryHub() {
 
       <div className="mt-16 rounded-2xl border border-brand-900/10 bg-brand-50/50 p-8 text-center">
         <h2 className="text-xl font-bold text-ink">Browse the reference databases</h2>
-        <p className="mt-2 text-muted">Prefer structured profiles? Explore 290 herbs and 557 active compounds.</p>
+        <p className="mt-2 text-muted">
+          Prefer structured profiles? Explore {counts.herbs} herbs and {counts.compounds} active compounds.
+        </p>
         <div className="mt-4 flex justify-center gap-3">
           <Link href="/herbs/" className="rounded-full bg-brand-700 px-6 py-2.5 text-sm font-semibold text-white transition hover:bg-brand-800">Browse Herbs →</Link>
           <Link href="/compounds/" className="rounded-full border border-brand-700 px-6 py-2.5 text-sm font-semibold text-brand-700 transition hover:bg-brand-50">Browse Compounds →</Link>

--- a/tests/guides-library-counts.test.ts
+++ b/tests/guides-library-counts.test.ts
@@ -1,0 +1,17 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+}
+
+describe('guides library counts', () => {
+  it('uses generated build counts instead of hardcoded totals', () => {
+    const guidesPage = read('app/guides/page.tsx')
+
+    expect(guidesPage).toContain("import buildReport from '@/public/data/build-report.json'")
+    expect(guidesPage).toContain('Explore {counts.herbs} herbs and {counts.compounds} active compounds.')
+    expect(guidesPage).not.toMatch(/Explore \d+ herbs and \d+ active compounds\./)
+  })
+})


### PR DESCRIPTION
## What changed
- Replaces hardcoded herb and compound totals on `/guides/` with counts from `public/data/build-report.json`.
- Adds a regression test preventing hardcoded library totals from returning.

## Why
The Guides hub displayed stale trust numbers even though the homepage already uses generated counts. Pulling from the canonical build report keeps public inventory claims accurate automatically.

## Scope
One small page-data change plus one focused test. No content records, styles, dependencies, routing, or generated data changed.