### PR TITLE
Secondary upgrade: sync Herbs metadata count

### DIFF
--- a/app/herbs/page.tsx
+++ b/app/herbs/page.tsx
@@ -10,12 +10,13 @@ import { buildPageMetadata } from '../../src/lib/seo'
 import { formatDisplayLabel } from '@/lib/display-utils'
 import { isRedirectedDuplicate } from '@/lib/deprecated-herb-canonicals'
 import { toLeanProfileIndexRecords } from '@/lib/profile-index-records'
+import buildReport from '@/public/data/build-report.json'
 import HerbsIndexClient from './HerbsIndexClient'
 import Pagination from '@/components/Pagination'
 
 export const metadata: Metadata = buildPageMetadata({
   title: 'Herb Profiles & Research Library',
-  description: 'Browse profiles for 100+ herbs — mechanisms, safety notes, active compounds, and research context in plain language.',
+  description: `Browse ${buildReport.counts.herbs} herb profiles — mechanisms, safety notes, active compounds, and research context in plain language.`,
   path: '/herbs',
 })
 

--- a/tests/herbs-metadata-count.test.ts
+++ b/tests/herbs-metadata-count.test.ts
@@ -1,0 +1,17 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+}
+
+describe('herbs metadata inventory count', () => {
+  it('uses the canonical build report instead of a hardcoded public total', () => {
+    const page = read('app/herbs/page.tsx')
+
+    expect(page).toContain("import buildReport from '@/public/data/build-report.json'")
+    expect(page).toContain('buildReport.counts.herbs')
+    expect(page).not.toContain('100+ herbs')
+  })
+})


### PR DESCRIPTION
## What changed
- Replaces the stale `100+ herbs` SEO description on `/herbs/` with the canonical herb count from `public/data/build-report.json`.
- Adds a regression test preventing hardcoded herb inventory totals from returning.

## Why
The visible Herbs page already derives its count from runtime data, but search and social metadata still advertised an old threshold. Using the generated build report keeps the public claim accurate across surfaces.

## Scope
One metadata data-source change plus one focused test. No herb records, styles, dependencies, routing, or generated data changed.