### PR TITLE
Secondary upgrade: separate Anxiety and Stress on Guides hub

### DIFF
--- a/app/guides/page.tsx
+++ b/app/guides/page.tsx
@@ -39,11 +39,11 @@ const SECTIONS = [
     articles: ['Best supplements for sleep', 'Magnesium for sleep', 'Magnesium vs melatonin', 'Sleep stack guide', 'Herbs for sleep'],
   },
   {
-    title: 'Anxiety & Stress',
+    title: 'Anxiety',
     href: '/guides/anxiety/',
-    desc: 'Adaptogens, anxiolytics, and stress management — 14 evidence-graded guides with safety warnings.',
+    desc: 'Evidence-graded guides for anxious thoughts, physical tension, and calm — with safety warnings kept visible.',
     color: 'border-l-amber-500',
-    articles: ['Best herbs for anxiety', 'Best adaptogens for stress', 'How to lower cortisol', 'Ashwagandha for anxiety', 'L-theanine for calm'],
+    articles: ['Best herbs for anxiety', 'Natural anxiety support', 'Ashwagandha for anxiety', 'L-theanine for calm', 'Magnesium for anxiety'],
   },
   {
     title: 'Focus & Cognition',

--- a/tests/guides-anxiety-stress-routes.test.ts
+++ b/tests/guides-anxiety-stress-routes.test.ts
@@ -1,0 +1,19 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+}
+
+describe('Guides hub anxiety and stress routes', () => {
+  it('keeps anxiety and stress as distinct visitor paths', () => {
+    const guides = read('app/guides/page.tsx')
+
+    expect(guides).toContain("title: 'Anxiety'")
+    expect(guides).toContain("href: '/guides/anxiety/'")
+    expect(guides).toContain("title: 'Stress Decision Hub'")
+    expect(guides).toContain("href: '/guides/stress/'")
+    expect(guides).not.toContain("title: 'Anxiety & Stress'")
+  })
+})


### PR DESCRIPTION
## What changed
- Renames the combined `Anxiety & Stress` Guides card to `Anxiety` and keeps it routed to `/guides/anxiety/`.
- Keeps the existing `Stress Decision Hub` as the separate Stress route at `/guides/stress/`.
- Updates the Anxiety card copy and examples so it no longer implies Stress content lives behind the Anxiety route.
- Adds a regression test requiring distinct Anxiety and Stress entries.

## Why
The homepage, global navigation, and route metadata now treat Anxiety and Stress as separate visitor intents. The main Guides hub was the remaining public navigation surface that still combined them while linking only to Anxiety.

## Scope
One Guides hub content/navigation correction plus one focused test. No dependencies, data records, templates, or routing-system changes.