### PR TITLE
Secondary upgrade: canonicalize Stress goal links

### DIFF
--- a/src/lib/goal-hub-links.ts
+++ b/src/lib/goal-hub-links.ts
@@ -25,13 +25,13 @@ const GOAL_COMPARE_SLUGS: Record<string, string[]> = {
     'melatonin-vs-valerian-vs-magnesium-for-sleep',
   ],
   stress: [
-    'ashwagandha-vs-rhodiola',
+    'rhodiola-vs-ashwagandha',
     'ashwagandha-vs-rhodiola-for-stress',
     'ashwagandha-vs-magnesium',
     'ashwagandha-vs-l-theanine-vs-magnesium',
   ],
   anxiety: [
-    'ashwagandha-vs-rhodiola',
+    'rhodiola-vs-ashwagandha',
     'melatonin-vs-l-theanine',
     'ashwagandha-vs-l-theanine-vs-magnesium',
   ],
@@ -45,7 +45,7 @@ const GOAL_COMPARE_SLUGS: Record<string, string[]> = {
     'caffeine-vs-theanine',
     'caffeine-vs-l-theanine-vs-bacopa-for-focus',
   ],
-  energy: ['caffeine-vs-theanine', 'ashwagandha-vs-rhodiola'],
+  energy: ['caffeine-vs-theanine', 'rhodiola-vs-ashwagandha'],
 }
 
 const GOAL_SEO_ENTRIES: Record<string, GoalHubLink> = {
@@ -68,7 +68,7 @@ const GOAL_SEO_ENTRIES: Record<string, GoalHubLink> = {
 
 const GOAL_GUIDE_ROUTES: Record<string, string> = {
   sleep: '/guides/sleep/',
-  stress: '/guides/anxiety/',
+  stress: '/guides/stress/',
   anxiety: '/guides/anxiety/',
   focus: '/guides/focus/',
   cognition: '/guides/focus/',

--- a/tests/goal-hub-canonical-links.test.ts
+++ b/tests/goal-hub-canonical-links.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { getGoalCompareLinks, getGoalsForEntity } from '@/src/lib/goal-hub-links'
+
+describe('goal hub canonical links', () => {
+  it('routes stress entities to the dedicated stress hub', () => {
+    const links = getGoalsForEntity('ashwagandha')
+
+    expect(links).toContainEqual({ label: 'stress', href: '/guides/stress/' })
+    expect(links).toContainEqual({ label: 'anxiety', href: '/guides/anxiety/' })
+  })
+
+  it('uses the canonical rhodiola versus ashwagandha comparison route', () => {
+    const stressLinks = getGoalCompareLinks('stress')
+    const anxietyLinks = getGoalCompareLinks('anxiety')
+    const energyLinks = getGoalCompareLinks('energy')
+
+    for (const links of [stressLinks, anxietyLinks, energyLinks]) {
+      expect(links.some((link) => link.href === '/guides/compare/rhodiola-vs-ashwagandha/')).toBe(true)
+      expect(links.some((link) => link.href === '/guides/compare/ashwagandha-vs-rhodiola/')).toBe(false)
+    }
+  })
+})


### PR DESCRIPTION
## What changed
- Routes shared Stress entity links to `/guides/stress/` instead of `/guides/anxiety/`.
- Replaces the redirected `ashwagandha-vs-rhodiola` comparison slug with the canonical `rhodiola-vs-ashwagandha` slug across Stress, Anxiety, and Energy goal links.
- Adds behavior tests for both route distinctions and canonical comparison links.

## Why
The public navigation surfaces now treat Stress and Anxiety as distinct intents, but shared entity/goal helpers still collapsed Stress into Anxiety. They also generated internal links through a redirect alias. Fixing the shared source improves multiple herb, compound, and goal pages at once.

## Scope
One shared link helper plus one focused test. No content records, styling, dependencies, templates, or generated data changed.