### PR TITLE
Secondary upgrade: canonicalize Compare hub link

### DIFF
--- a/app/guides/compare/page.tsx
+++ b/app/guides/compare/page.tsx
@@ -35,7 +35,7 @@ const FEATURED_CATEGORIES: CompareCategory[] = [
     label: 'Adaptogens',
     blurb: 'Stress-response herbs compared by onset speed, stimulation profile, and how long each takes to build an effect.',
     pairs: [
-      { slug: 'ashwagandha-vs-rhodiola', label: 'Ashwagandha vs Rhodiola' },
+      { slug: 'rhodiola-vs-ashwagandha', label: 'Rhodiola vs Ashwagandha' },
       { slug: 'ashwagandha-vs-eleuthero', label: 'Ashwagandha vs Eleuthero' },
       { slug: 'reishi-vs-ashwagandha', label: 'Reishi vs Ashwagandha' },
       { slug: 'bacopa-vs-rhodiola', label: 'Bacopa vs Rhodiola' },

--- a/tests/compare-hub-canonical-links.test.ts
+++ b/tests/compare-hub-canonical-links.test.ts
@@ -1,0 +1,17 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+}
+
+describe('Compare hub canonical links', () => {
+  it('links directly to the canonical Rhodiola vs Ashwagandha comparison', () => {
+    const page = read('app/guides/compare/page.tsx')
+
+    expect(page).toContain("slug: 'rhodiola-vs-ashwagandha'")
+    expect(page).not.toContain("slug: 'ashwagandha-vs-rhodiola'")
+    expect(page).toContain("href: '/guides/compare/rhodiola-vs-ashwagandha/'")
+  })
+})


### PR DESCRIPTION
## What changed
- Replaces the redirected `ashwagandha-vs-rhodiola` featured-card slug with the canonical `rhodiola-vs-ashwagandha` route.
- Aligns the card label with the canonical page title.
- Adds a regression test preventing the alias from returning to the Compare hub.

## Why
The old featured card still worked through a redirect, but internal navigation should link directly to canonical pages. This removes an unnecessary hop and keeps the hub consistent with its goal-starter and flagship links.

## Scope
One Compare hub link plus one focused test. No comparison content, redirects, styling, dependencies, or data changed.