### PR TITLE
Secondary upgrade: fix Learn goal CTA destination

### DIFF
--- a/app/learn/page.tsx
+++ b/app/learn/page.tsx
@@ -331,7 +331,7 @@ export default function EducationHubPage() {
 
         <div className='flex flex-wrap gap-3'>
           <Link
-            href='/guides/'
+            href='/goals/'
             className='rounded-full border border-brand-900/15 px-4 py-2 text-sm font-medium text-ink transition hover:bg-ink hover:text-white'
           >
             Explore Goal Guides

--- a/tests/learn-goals-cta.test.ts
+++ b/tests/learn-goals-cta.test.ts
@@ -1,0 +1,16 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+}
+
+describe('Learn hub hero actions', () => {
+  it('sends goal exploration and guide browsing to distinct hubs', () => {
+    const page = read('app/learn/page.tsx')
+
+    expect(page).toMatch(/href='\/goals\/'[\s\S]*?Explore Goal Guides/)
+    expect(page).toMatch(/href='\/guides\/'[\s\S]*?Browse all guides/)
+  })
+})


### PR DESCRIPTION
## What changed
- Sends the Learn hub’s `Explore Goal Guides` action to `/goals/`.
- Keeps `Browse all guides` routed to `/guides/`.
- Adds regression coverage requiring the two hero actions to remain distinct.

## Why
Both buttons previously opened the same Guides hub despite promising different starting points. Routing the goal action to the dedicated Goals hub improves first-click clarity without redesigning the page.

## Scope
One CTA destination plus one focused test. No educational content, styling, dependencies, data, or templates changed.