### PR TITLE
Secondary upgrade: tighten Learn hub hero

### DIFF
--- a/app/learn/page.tsx
+++ b/app/learn/page.tsx
@@ -297,8 +297,8 @@ export default function EducationHubPage() {
         <div className='space-y-4'>
           <p className='eyebrow-label'>Educational Authority Hub</p>
 
-          <h1 className='text-6xl font-bold tracking-tight text-ink leading-tight'>
-            Neuroscience, Neuropharmacology, and Systems-Biology Education
+          <h1 className='max-w-4xl text-4xl font-bold leading-[1.08] tracking-tight text-ink sm:text-5xl lg:text-6xl'>
+            Neuroscience and Neuropharmacology, Explained Clearly
           </h1>
         </div>
 
@@ -313,21 +313,9 @@ export default function EducationHubPage() {
           />
         </div>
 
-        <div className='space-y-5 text-lg leading-9 text-muted max-w-4xl'>
-          <p>
-            The Hippie Scientist educational ecosystem explores neurochemistry,
-            cognition systems, stress neurobiology, psychoactive education,
-            recovery-oriented neuroscience, and evidence-informed
-            neuropharmacology through a systems-oriented framework.
-          </p>
-
-          <p>
-            Educational content is designed to emphasize scientific nuance,
-            biological complexity, evidence interpretation, uncertainty
-            awareness, and anti-oversimplification neuroscience literacy rather
-            than sensationalized optimization narratives.
-          </p>
-        </div>
+        <p className='max-w-4xl text-base leading-8 text-muted sm:text-lg sm:leading-9'>
+          Explore how stress, sleep, cognition, neurotransmitters, psychoactive substances, and research evidence fit together—without reducing complex biology to simplistic claims.
+        </p>
 
         <div className='flex flex-wrap gap-3'>
           <Link

--- a/tests/learn-hero-readability.test.ts
+++ b/tests/learn-hero-readability.test.ts
@@ -1,0 +1,20 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+}
+
+describe('Learn hub hero readability', () => {
+  it('uses responsive heading scale and one concise introduction', () => {
+    const page = read('app/learn/page.tsx')
+
+    expect(page).toContain("text-4xl")
+    expect(page).toContain("sm:text-5xl")
+    expect(page).toContain("lg:text-6xl")
+    expect(page).toContain('Neuroscience and Neuropharmacology, Explained Clearly')
+    expect(page).toContain('without reducing complex biology to simplistic claims')
+    expect(page).not.toContain("<div className='space-y-5 text-lg leading-9 text-muted max-w-4xl'>")
+  })
+})


### PR DESCRIPTION
## What changed
- Replaces the long Learn hub H1 with a shorter plain-language heading.
- Uses responsive `text-4xl → text-6xl` sizing instead of forcing `text-6xl` on mobile.
- Condenses two dense introduction paragraphs into one focused sentence.
- Adds regression coverage for the responsive scale and concise intro.

## Why
The previous hero consumed too much vertical space and required substantial reading before visitors reached the first topic choices. This improves mobile scanning and first-click speed without redesigning the educational hub.

## Scope
One hero content/layout block plus one focused test. All educational clusters, links, metadata, images, dependencies, and data remain unchanged.