### PR TITLE
Secondary upgrade: normalize decision-router cards

### DIFF
--- a/components/guides/DecisionRouter.tsx
+++ b/components/guides/DecisionRouter.tsx
@@ -31,14 +31,14 @@ export function DecisionRouter({ items }: { items: IntentRoute[] }) {
         <Link
           key={item.href + item.problem}
           href={item.href}
-          className="group flex flex-col rounded-xl border-2 border-brand-900/12 bg-white p-5 shadow-[0_1px_2px_rgba(13,23,18,0.06)] transition-all hover:-translate-y-0.5 hover:border-brand-700/30 hover:shadow-md dark:border-white/10 dark:bg-[var(--surface-card)]"
+          className="group flex h-full flex-col rounded-2xl border border-brand-900/10 bg-white p-5 shadow-[0_1px_2px_rgba(13,23,18,0.06)] transition-all hover:-translate-y-0.5 hover:border-brand-700/30 hover:shadow-md dark:border-white/10 dark:bg-[var(--surface-card)]"
         >
           <span className="text-[0.7rem] font-bold uppercase tracking-wider text-brand-700">
             If your problem is
           </span>
           <span className="mt-1 text-base font-bold leading-snug text-ink">{item.problem}</span>
           {item.why ? <span className="mt-2 text-sm leading-6 text-muted">{item.why}</span> : null}
-          <span className="mt-3 inline-flex items-center gap-1 text-sm font-bold text-brand-800 transition group-hover:gap-1.5 dark:text-[var(--text-primary)]">
+          <span className="mt-auto inline-flex items-center gap-1 pt-4 text-sm font-bold text-brand-800 transition group-hover:gap-1.5 dark:text-[var(--text-primary)]">
             Start with {item.cta}
             <span aria-hidden="true">→</span>
           </span>

--- a/tests/decision-router-card-rhythm.test.ts
+++ b/tests/decision-router-card-rhythm.test.ts
@@ -1,0 +1,17 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+}
+
+describe('DecisionRouter card rhythm', () => {
+  it('uses the shared discovery-card shell and aligned CTA spacing', () => {
+    const component = read('components/guides/DecisionRouter.tsx')
+
+    expect(component).toContain('flex h-full flex-col rounded-2xl border border-brand-900/10')
+    expect(component).toContain('mt-auto inline-flex items-center gap-1 pt-4')
+    expect(component).not.toContain('rounded-xl border-2')
+  })
+})


### PR DESCRIPTION
## What changed
- Aligns shared decision-router cards with the site’s discovery-card shell: `rounded-2xl`, single subtle border, white surface.
- Makes cards equal-height and anchors each CTA to the bottom for cleaner grid rhythm.
- Adds regression coverage for the shared shell and CTA alignment.

## Why
The UX consistency audit flagged mixed radii, border weights, and uneven card rhythm across discovery pages. This shared component powers multiple decision-first hubs, so one small change improves several high-intent routes at once.

## Scope
One shared presentation component plus one focused test. No destinations, copy, data, dependencies, or page-specific layouts changed.