### PR TITLE
Secondary upgrade: normalize guide-card grid

### DIFF
--- a/components/guides/GuideCardGrid.tsx
+++ b/components/guides/GuideCardGrid.tsx
@@ -25,10 +25,13 @@ export function GuideCardGrid({ cards }: { cards: GuideCard[] }) {
         <Link
           key={card.href}
           href={card.href}
-          className="rounded-xl border-2 border-brand-900/12 bg-white p-5 shadow-[0_1px_2px_rgba(13,23,18,0.06)] transition hover:border-brand-700/30 hover:shadow-md dark:border-white/10 dark:bg-[var(--surface-card)]"
+          className="flex h-full flex-col rounded-2xl border border-brand-900/10 bg-white p-5 shadow-[0_1px_2px_rgba(13,23,18,0.06)] transition hover:-translate-y-0.5 hover:border-brand-700/30 hover:shadow-md dark:border-white/10 dark:bg-[var(--surface-card)]"
         >
           <h3 className="font-bold text-ink">{card.title}</h3>
           {card.desc ? <p className="mt-1.5 text-sm leading-relaxed text-muted">{card.desc}</p> : null}
+          <span className="mt-auto pt-4 text-sm font-bold text-brand-800 dark:text-[var(--text-primary)]">
+            Open guide <span aria-hidden="true">→</span>
+          </span>
         </Link>
       ))}
     </div>

--- a/tests/guide-card-grid-consistency.test.ts
+++ b/tests/guide-card-grid-consistency.test.ts
@@ -1,0 +1,18 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+}
+
+describe('shared guide card grid', () => {
+  it('uses the normalized discovery-card shell and explicit guide action', () => {
+    const grid = read('components/guides/GuideCardGrid.tsx')
+
+    expect(grid).toContain('flex h-full flex-col rounded-2xl border border-brand-900/10')
+    expect(grid).toContain('mt-auto pt-4')
+    expect(grid).toContain('Open guide')
+    expect(grid).not.toContain('rounded-xl border-2')
+  })
+})


### PR DESCRIPTION
## What changed
- Aligns `GuideCardGrid` with the normalized decision-card shell: `rounded-2xl`, single subtle border, white surface.
- Makes cards equal-height and adds a consistent bottom-aligned `Open guide` action.
- Adds regression coverage for the shared shell and action alignment.

## Why
The same hub currently switches from normalized decision cards to heavier guide cards farther down the page. This removes that visual jitter across every hub using the shared grid.

## Scope
One shared presentation component plus one focused test. No destinations, guide copy, data, dependencies, or page-specific layouts changed.