### PR TITLE
Secondary upgrade: clarify shared safety notice

### DIFF
--- a/components/evidence/SafetyNotice.tsx
+++ b/components/evidence/SafetyNotice.tsx
@@ -1,17 +1,19 @@
 interface SafetyNoticeProps {
   title?: string
+  eyebrow?: string
   children: React.ReactNode
 }
 
 export default function SafetyNotice({
   title = 'Safety considerations',
+  eyebrow = 'Check before using',
   children,
 }: SafetyNoticeProps) {
   return (
     <section className="space-y-4 rounded-3xl border border-amber-600/25 bg-amber-50/85 p-6 dark:border-amber-200/25 dark:bg-amber-300/10">
       <div className="space-y-2">
         <p className="eyebrow-label text-amber-800 dark:text-amber-100">
-          Educational Safety Notice
+          {eyebrow}
         </p>
 
         <h2 className="text-2xl font-semibold tracking-tight text-amber-950 dark:text-amber-50 sm:text-3xl">

--- a/tests/safety-notice-label.test.ts
+++ b/tests/safety-notice-label.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync('components/evidence/SafetyNotice.tsx', 'utf8')
+
+describe('SafetyNotice', () => {
+  it('uses a practical default eyebrow while allowing page-specific wording', () => {
+    expect(source).toContain("eyebrow?: string")
+    expect(source).toContain("eyebrow = 'Check before using'")
+    expect(source).toContain('{eyebrow}')
+    expect(source).not.toContain('Educational Safety Notice')
+  })
+})


### PR DESCRIPTION
## What changed
- Replaces the abstract default eyebrow `Educational Safety Notice` with the practical instruction `Check before using`.
- Adds an optional `eyebrow` prop so specialized pages can provide more specific safety framing.
- Adds regression coverage for the default and override contract.

## Why
The UX consistency audit recommends practical, action-oriented labels on high-intent pages. This shared component appears across many educational pages, so one small wording improvement makes safety framing easier to recognize site-wide.

## Scope
One shared safety component plus one focused test. No medical guidance, page content, routes, styling tokens, data, or dependencies changed.