### PR TITLE
Secondary upgrade: improve source-herb tap targets

### DIFF
--- a/components/seo/CompoundSourceHerbs.tsx
+++ b/components/seo/CompoundSourceHerbs.tsx
@@ -31,8 +31,12 @@ export default async function CompoundSourceHerbs({
       <ul className="space-y-2">
         {links.map((link) => (
           <li key={link.slug}>
-            <Link href={link.href} className="text-sm font-semibold text-brand-800 hover:underline">
-              {link.anchor}
+            <Link
+              href={link.href}
+              className="flex min-h-11 items-center justify-between rounded-xl border border-brand-900/10 bg-white px-3 py-2 text-sm font-semibold text-brand-800 transition hover:border-brand-700/30 hover:bg-brand-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600/40"
+            >
+              <span>{link.anchor}</span>
+              <span aria-hidden="true">→</span>
             </Link>
           </li>
         ))}

--- a/tests/ui/compound-source-herbs-tap-targets.test.ts
+++ b/tests/ui/compound-source-herbs-tap-targets.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync('components/seo/CompoundSourceHerbs.tsx', 'utf8')
+
+describe('compound source herb links', () => {
+  it('uses full-width accessible tap targets with visible focus treatment', () => {
+    expect(source).toContain('flex min-h-11 items-center justify-between')
+    expect(source).toContain('focus-visible:ring-2')
+    expect(source).toContain('<span aria-hidden="true">→</span>')
+  })
+})


### PR DESCRIPTION
## What changed
- Turns each source-herb text link into a full-width, minimum-44px tap target.
- Adds subtle card treatment, a visible action arrow, and keyboard focus-ring styling.
- Adds regression coverage for mobile target size and focus treatment.

## Why
Compound profiles can list source herbs, but the existing inline text rows were cramped on mobile. This shared component improves every compound profile that renders reverse herb relationships.

## Scope
One shared profile component plus one focused test. No relationship data, destinations, profile copy, dependencies, or page layouts changed.