### PR TITLE
Secondary upgrade: improve herb compound tap targets

### DIFF
--- a/app/__tests__/herb-compound-tap-targets.test.ts
+++ b/app/__tests__/herb-compound-tap-targets.test.ts
@@ -1,0 +1,20 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const source = fs.readFileSync(
+  path.join(process.cwd(), 'components/seo/HerbCompoundLinks.tsx'),
+  'utf8',
+)
+
+describe('HerbCompoundLinks accessibility', () => {
+  it('keeps compound profile links large enough to tap and visibly focusable', () => {
+    expect(source).toContain('min-h-11')
+    expect(source).toContain('focus-visible:ring-2')
+    expect(source).toContain('focus-visible:ring-brand-700')
+  })
+
+  it('keeps a clear directional action cue', () => {
+    expect(source).toContain('<span aria-hidden="true">→</span>')
+  })
+})

--- a/components/seo/HerbCompoundLinks.tsx
+++ b/components/seo/HerbCompoundLinks.tsx
@@ -16,7 +16,7 @@ export default async function HerbCompoundLinks({ herbSlug, herbName }: HerbComp
   if (links.length === 0) return null
 
   return (
-    <section className="card-premium p-4 sm:p-5 space-y-3" aria-labelledby="active-compounds-heading">
+    <section className="card-premium space-y-3 p-4 sm:p-5" aria-labelledby="active-compounds-heading">
       <div className="space-y-1">
         <h2 id="active-compounds-heading" className="text-lg font-bold text-ink">
           Active Compounds
@@ -30,9 +30,10 @@ export default async function HerbCompoundLinks({ herbSlug, herbName }: HerbComp
           <li key={link.slug} className="shrink-0">
             <Link
               href={link.href}
-              className="inline-block whitespace-nowrap rounded-full border border-brand-900/10 bg-brand-50/50 px-3 py-1.5 text-xs font-semibold text-brand-800 hover:bg-brand-50"
+              className="inline-flex min-h-11 items-center gap-1.5 whitespace-nowrap rounded-full border border-brand-900/10 bg-brand-50/50 px-4 py-2 text-sm font-semibold text-brand-800 transition hover:border-brand-700/30 hover:bg-brand-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-700 focus-visible:ring-offset-2"
             >
               {link.anchor}
+              <span aria-hidden="true">→</span>
             </Link>
           </li>
         ))}


### PR DESCRIPTION
## What changed
- Raises active-compound pills to a minimum 44px tap target while preserving the compact horizontal-scroll layout.
- Increases label size, adds a clear action arrow, and adds visible keyboard focus-ring styling.
- Adds regression coverage for target size, focus treatment, and the directional cue.

## Why
The reverse relationship module on herb profiles still used small `text-xs` pills with cramped vertical padding. This brings both directions of the herb–compound relationship system to the same mobile and keyboard-accessibility standard.

## Scope
One shared herb-profile component plus one focused test. No relationship data, destinations, profile copy, dependencies, or page layouts changed.