### PR TITLE
Secondary upgrade: improve related discovery links

### DIFF
--- a/components/ui/RelatedDiscoveryGroups.tsx
+++ b/components/ui/RelatedDiscoveryGroups.tsx
@@ -40,8 +40,13 @@ export default function RelatedDiscoveryGroups({
             {group.description ? <p className="mt-1 text-xs leading-5 text-muted">{group.description}</p> : null}
             <div className="mt-2 space-y-1.5">
               {group.links.slice(0, 4).map((item) => (
-                <Link key={item.href} href={item.href} className="block text-sm text-muted underline-offset-4 hover:underline">
-                  {item.label}
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className="flex min-h-11 items-center justify-between gap-3 rounded-lg px-2 py-2 text-sm font-medium text-brand-800 transition hover:bg-brand-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2"
+                >
+                  <span>{item.label}</span>
+                  <span aria-hidden="true">→</span>
                 </Link>
               ))}
             </div>

--- a/components/ui/__tests__/related-discovery-groups-accessibility.test.ts
+++ b/components/ui/__tests__/related-discovery-groups-accessibility.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync('components/ui/RelatedDiscoveryGroups.tsx', 'utf8')
+
+describe('RelatedDiscoveryGroups accessibility contract', () => {
+  it('keeps discovery links large, focusable, and directional', () => {
+    expect(source).toContain('min-h-11')
+    expect(source).toContain('focus-visible:ring-2')
+    expect(source).toContain('focus-visible:ring-brand-600')
+    expect(source).toContain('aria-hidden="true">→</span>')
+  })
+})


### PR DESCRIPTION
## What changed
- Turns related-discovery text links into full-row minimum-44px tap targets.
- Adds visible keyboard focus rings and directional arrows.
- Preserves the existing horizontal-card layout and group structure.
- Adds focused regression coverage.

## Why
`RelatedDiscoveryGroups` is a shared profile-discovery surface, but its links were still small text-only targets. This brings it in line with the other relationship and cluster modules upgraded in this pass.

## Scope
One shared component plus one focused source-contract test. No destinations, discovery data, grouping logic, dependencies, or page layouts changed.