### PR TITLE
Secondary upgrade: improve profile TOC controls

### DIFF
--- a/app/__tests__/profile-toc-accessibility.test.ts
+++ b/app/__tests__/profile-toc-accessibility.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync(join(process.cwd(), 'components/ui/ProfileTOC.tsx'), 'utf8')
+
+describe('ProfileTOC accessibility contract', () => {
+  it('keeps mobile controls and jump links at least 44px tall', () => {
+    expect(source.match(/min-h-11/g)?.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('provides visible keyboard focus treatment', () => {
+    expect(source.match(/focus-visible:ring-2/g)?.length).toBeGreaterThanOrEqual(2)
+    expect(source).toContain('focus-visible:ring-brand-600')
+  })
+
+  it('preserves desktop sticky navigation', () => {
+    expect(source).toContain('lg:sticky lg:top-24')
+  })
+})

--- a/components/ui/ProfileTOC.tsx
+++ b/components/ui/ProfileTOC.tsx
@@ -38,7 +38,7 @@ export default function ProfileTOC({ items, variant = 'all' }: { items: TocItem[
               href={`#${id}`}
               onClick={() => setMobileOpen(false)}
               aria-current={isActive ? 'location' : undefined}
-              className={`block rounded-xl px-3 py-2 text-sm transition-colors ${
+              className={`flex min-h-11 items-center rounded-xl px-3 py-2 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2 ${
                 isActive
                   ? 'bg-brand-50 font-semibold text-brand-900 shadow-sm dark:bg-white/10 dark:text-brand-50'
                   : 'text-muted hover:bg-brand-50/60 hover:text-ink dark:hover:bg-white/10 dark:hover:text-brand-50'
@@ -63,7 +63,7 @@ export default function ProfileTOC({ items, variant = 'all' }: { items: TocItem[
             type='button'
             aria-expanded={mobileOpen}
             onClick={() => setMobileOpen((open) => !open)}
-            className='flex w-full items-center justify-between rounded-xl px-2 py-1 text-left text-sm font-semibold text-ink'
+            className='flex min-h-11 w-full items-center justify-between rounded-xl px-3 py-2 text-left text-sm font-semibold text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2'
           >
             On this page
             <span aria-hidden='true' className={`text-muted transition-transform ${mobileOpen ? 'rotate-180' : ''}`}>


### PR DESCRIPTION
## What changed
- Raises the mobile “On this page” toggle and all jump links to a minimum 44px target.
- Adds visible keyboard focus rings to the toggle and section links.
- Preserves the existing collapsible mobile behavior and sticky desktop navigation.
- Adds focused regression coverage.

## Why
The shared profile table of contents had undersized mobile controls and relied on default focus styling. This brings herb and compound profile navigation in line with the accessibility standard used across the rest of the secondary-upgrade pass.

## Scope
One shared component plus one focused test. No section IDs, active-section logic, sticky positioning, page content, dependencies, or route behavior changed.