### PR TITLE
Secondary upgrade: improve evidence grade disclosure

### DIFF
--- a/components/ui/EvidenceGradeExplainer.tsx
+++ b/components/ui/EvidenceGradeExplainer.tsx
@@ -36,8 +36,8 @@ const GRADES = [
 export default function EvidenceGradeExplainer() {
   return (
     <details className="group">
-      <summary className="flex cursor-pointer items-center gap-2 text-xs font-semibold uppercase tracking-wider text-muted select-none hover:text-ink transition-colors">
-        <span aria-hidden="true" className="text-brand-500 group-open:rotate-90 transition-transform inline-block">▶</span>
+      <summary className="flex min-h-11 cursor-pointer items-center gap-2 rounded-xl px-3 py-2 text-xs font-semibold uppercase tracking-wider text-muted select-none transition-colors hover:bg-brand-50/60 hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2">
+        <span aria-hidden="true" className="inline-block text-brand-500 transition-transform group-open:rotate-90">▶</span>
         How evidence grades work
       </summary>
       <div className="mt-3 rounded-xl border border-brand-900/10 bg-white/70 p-3 space-y-2">

--- a/components/ui/__tests__/EvidenceGradeExplainer.test.tsx
+++ b/components/ui/__tests__/EvidenceGradeExplainer.test.tsx
@@ -3,11 +3,17 @@ import { render, screen } from '@testing-library/react'
 import EvidenceGradeExplainer from '../EvidenceGradeExplainer'
 
 describe('EvidenceGradeExplainer', () => {
-  it('renders all four evidence grades with their labels inside a collapsed disclosure', () => {
+  it('renders all four evidence grades inside an accessible collapsed disclosure', () => {
     const { container } = render(<EvidenceGradeExplainer />)
 
     expect(container.querySelector('details')).not.toBeNull()
     expect(container.querySelector('details')?.hasAttribute('open')).toBe(false)
+
+    const summary = screen.getByText('How evidence grades work').closest('summary')
+    expect(summary).not.toBeNull()
+    expect(summary?.className).toContain('min-h-11')
+    expect(summary?.className).toContain('focus-visible:ring-2')
+    expect(summary?.className).toContain('focus-visible:ring-brand-500')
 
     for (const [grade, label] of [
       ['A', 'Strong'],


### PR DESCRIPTION
## What changed
- Raises the “How evidence grades work” disclosure summary to a minimum 44px target.
- Adds a visible hover surface and keyboard focus ring.
- Preserves the native collapsed disclosure behavior and all evidence-grade definitions.
- Extends the existing focused test to protect target size and focus treatment.

## Why
This shared explainer appears on herb and compound profiles, but its summary remained a small text-only control. The change brings it in line with the accessibility standard used across the rest of the secondary-upgrade pass.

## Scope
One shared component plus its existing focused test. No evidence logic, grade definitions, profile data, dependencies, or page layouts changed.