### PR TITLE
Secondary upgrade: make sleep-guide tables accessible

### DIFF
--- a/app/guides/sleep/apigenin-for-sleep/page.tsx
+++ b/app/guides/sleep/apigenin-for-sleep/page.tsx
@@ -135,19 +135,25 @@ export default function Page() {
 
         <section className="card-premium p-6 sm:p-8">
           <h2 className="text-xl font-semibold text-ink dark:text-[var(--text-primary)]">Verdict table</h2>
-          <div className="mt-5 overflow-x-auto">
+          <div
+            className="accessible-table-region mt-5 overflow-x-auto"
+            role="region"
+            aria-label="Apigenin sleep evidence verdict table"
+            tabIndex={0}
+          >
             <table className="min-w-full border-collapse text-left text-sm">
+              <caption className="sr-only">Verdicts and context for common apigenin sleep questions</caption>
               <thead>
                 <tr className="border-b border-brand-900/10 dark:border-white/10">
-                  <th className="py-3 pr-4 text-xs font-bold uppercase tracking-wider text-ink dark:text-[var(--text-primary)]">Question</th>
-                  <th className="py-3 pr-4 text-xs font-bold uppercase tracking-wider text-ink dark:text-[var(--text-primary)]">Answer</th>
-                  <th className="py-3 text-xs font-bold uppercase tracking-wider text-ink dark:text-[var(--text-primary)]">Context</th>
+                  <th scope="col" className="py-3 pr-4 text-xs font-bold uppercase tracking-wider text-ink dark:text-[var(--text-primary)]">Question</th>
+                  <th scope="col" className="py-3 pr-4 text-xs font-bold uppercase tracking-wider text-ink dark:text-[var(--text-primary)]">Answer</th>
+                  <th scope="col" className="py-3 text-xs font-bold uppercase tracking-wider text-ink dark:text-[var(--text-primary)]">Context</th>
                 </tr>
               </thead>
               <tbody>
                 {verdictRows.map((row) => (
                   <tr key={row.question} className="border-b border-brand-900/5 align-top last:border-0 dark:border-white/10">
-                    <td className="py-3 pr-4 font-semibold text-ink dark:text-[var(--text-primary)]">{row.question}</td>
+                    <th scope="row" className="py-3 pr-4 text-left font-semibold text-ink dark:text-[var(--text-primary)]">{row.question}</th>
                     <td className="py-3 pr-4 text-muted dark:text-[var(--text-secondary)]">{row.answer}</td>
                     <td className="py-3 text-muted dark:text-[var(--text-secondary)]">{row.note}</td>
                   </tr>
@@ -185,7 +191,13 @@ export default function Page() {
           <ul className="mt-4 space-y-2 text-sm leading-7 text-muted dark:text-[var(--text-secondary)]">
             {references.map((reference) => (
               <li key={reference.href}>
-                <a href={reference.href} className="font-semibold text-brand-800 hover:underline dark:text-[var(--text-primary)]" rel="noreferrer" target="_blank">
+                <a
+                  href={reference.href}
+                  className="font-semibold text-brand-800 hover:underline dark:text-[var(--text-primary)]"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  aria-label={`${reference.label} (opens in a new tab)`}
+                >
                   {reference.label}
                 </a>
               </li>

--- a/app/guides/sleep/apigenin-for-sleep/page.tsx
+++ b/app/guides/sleep/apigenin-for-sleep/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
+import ResponsiveTable from '@/components/ui/ResponsiveTable'
 import { SITE_URL } from '@/src/lib/seo'
 
 const path = '/guides/sleep/apigenin-for-sleep/'
@@ -135,12 +136,7 @@ export default function Page() {
 
         <section className="card-premium p-6 sm:p-8">
           <h2 className="text-xl font-semibold text-ink dark:text-[var(--text-primary)]">Verdict table</h2>
-          <div
-            className="accessible-table-region mt-5 overflow-x-auto"
-            role="region"
-            aria-label="Apigenin sleep evidence verdict table"
-            tabIndex={0}
-          >
+          <ResponsiveTable label="Apigenin sleep evidence verdict table" className="mt-5">
             <table className="min-w-full border-collapse text-left text-sm">
               <caption className="sr-only">Verdicts and context for common apigenin sleep questions</caption>
               <thead>
@@ -160,7 +156,7 @@ export default function Page() {
                 ))}
               </tbody>
             </table>
-          </div>
+          </ResponsiveTable>
         </section>
 
         {sections.map((section) => (

--- a/app/guides/sleep/glycine-for-sleep/page.tsx
+++ b/app/guides/sleep/glycine-for-sleep/page.tsx
@@ -137,19 +137,25 @@ export default function Page() {
 
         <section className="card-premium p-6 sm:p-8">
           <h2 className="text-xl font-semibold text-ink dark:text-[var(--text-primary)]">Best-fit decision table</h2>
-          <div className="mt-5 overflow-x-auto">
+          <div
+            className="accessible-table-region mt-5 overflow-x-auto"
+            role="region"
+            aria-label="Glycine best-fit decision table"
+            tabIndex={0}
+          >
             <table className="min-w-full border-collapse text-left text-sm">
+              <caption className="sr-only">Situations where glycine may or may not fit a sleep goal</caption>
               <thead>
                 <tr className="border-b border-brand-900/10 dark:border-white/10">
-                  <th className="py-3 pr-4 text-xs font-bold uppercase tracking-wider text-ink dark:text-[var(--text-primary)]">Situation</th>
-                  <th className="py-3 pr-4 text-xs font-bold uppercase tracking-wider text-ink dark:text-[var(--text-primary)]">Fit</th>
-                  <th className="py-3 text-xs font-bold uppercase tracking-wider text-ink dark:text-[var(--text-primary)]">Why</th>
+                  <th scope="col" className="py-3 pr-4 text-xs font-bold uppercase tracking-wider text-ink dark:text-[var(--text-primary)]">Situation</th>
+                  <th scope="col" className="py-3 pr-4 text-xs font-bold uppercase tracking-wider text-ink dark:text-[var(--text-primary)]">Fit</th>
+                  <th scope="col" className="py-3 text-xs font-bold uppercase tracking-wider text-ink dark:text-[var(--text-primary)]">Why</th>
                 </tr>
               </thead>
               <tbody>
                 {fitRows.map((row) => (
                   <tr key={row.situation} className="border-b border-brand-900/5 align-top last:border-0 dark:border-white/10">
-                    <td className="py-3 pr-4 font-semibold text-ink dark:text-[var(--text-primary)]">{row.situation}</td>
+                    <th scope="row" className="py-3 pr-4 text-left font-semibold text-ink dark:text-[var(--text-primary)]">{row.situation}</th>
                     <td className="py-3 pr-4 text-muted dark:text-[var(--text-secondary)]">{row.fit}</td>
                     <td className="py-3 text-muted dark:text-[var(--text-secondary)]">{row.why}</td>
                   </tr>
@@ -188,7 +194,13 @@ export default function Page() {
           <ul className="mt-4 space-y-2 text-sm leading-7 text-muted dark:text-[var(--text-secondary)]">
             {references.map((reference) => (
               <li key={reference.href}>
-                <a href={reference.href} className="font-semibold text-brand-800 hover:underline dark:text-[var(--text-primary)]" rel="noreferrer" target="_blank">
+                <a
+                  href={reference.href}
+                  className="font-semibold text-brand-800 hover:underline dark:text-[var(--text-primary)]"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  aria-label={`${reference.label} (opens in a new tab)`}
+                >
                   {reference.label}
                 </a>
               </li>

--- a/app/guides/sleep/glycine-for-sleep/page.tsx
+++ b/app/guides/sleep/glycine-for-sleep/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
+import ResponsiveTable from '@/components/ui/ResponsiveTable'
 import { SITE_URL } from '@/src/lib/seo'
 import RecommendationSection from '@/components/RecommendationSection'
 import { getRevenueProductSet } from '@/config/revenue-products'
@@ -137,12 +138,7 @@ export default function Page() {
 
         <section className="card-premium p-6 sm:p-8">
           <h2 className="text-xl font-semibold text-ink dark:text-[var(--text-primary)]">Best-fit decision table</h2>
-          <div
-            className="accessible-table-region mt-5 overflow-x-auto"
-            role="region"
-            aria-label="Glycine best-fit decision table"
-            tabIndex={0}
-          >
+          <ResponsiveTable label="Glycine best-fit decision table" className="mt-5">
             <table className="min-w-full border-collapse text-left text-sm">
               <caption className="sr-only">Situations where glycine may or may not fit a sleep goal</caption>
               <thead>
@@ -162,7 +158,7 @@ export default function Page() {
                 ))}
               </tbody>
             </table>
-          </div>
+          </ResponsiveTable>
         </section>
 
         {sections.map((section) => (

--- a/app/guides/sleep/magnesium-glycinate-vs-l-threonate-for-sleep/page.tsx
+++ b/app/guides/sleep/magnesium-glycinate-vs-l-threonate-for-sleep/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
+import ResponsiveTable from '@/components/ui/ResponsiveTable'
 import { SITE_URL } from '@/src/lib/seo'
 import RecommendationSection from '@/components/RecommendationSection'
 import { getRevenueProductSet } from '@/config/revenue-products'
@@ -147,12 +148,7 @@ export default function Page() {
 
         <section className="card-premium p-6 sm:p-8">
           <h2 className="text-xl font-semibold text-ink dark:text-[var(--text-primary)]">Decision table</h2>
-          <div
-            className="accessible-table-region mt-5 overflow-x-auto"
-            role="region"
-            aria-label="Magnesium glycinate and L-threonate sleep comparison table"
-            tabIndex={0}
-          >
+          <ResponsiveTable label="Magnesium glycinate and L-threonate sleep comparison table" className="mt-5">
             <table className="min-w-full border-collapse text-left text-sm">
               <caption className="sr-only">Sleep-focused comparison of magnesium glycinate and magnesium L-threonate</caption>
               <thead>
@@ -174,7 +170,7 @@ export default function Page() {
                 ))}
               </tbody>
             </table>
-          </div>
+          </ResponsiveTable>
         </section>
 
         {sections.map((section) => (

--- a/app/guides/sleep/magnesium-glycinate-vs-l-threonate-for-sleep/page.tsx
+++ b/app/guides/sleep/magnesium-glycinate-vs-l-threonate-for-sleep/page.tsx
@@ -147,20 +147,26 @@ export default function Page() {
 
         <section className="card-premium p-6 sm:p-8">
           <h2 className="text-xl font-semibold text-ink dark:text-[var(--text-primary)]">Decision table</h2>
-          <div className="mt-5 overflow-x-auto">
+          <div
+            className="accessible-table-region mt-5 overflow-x-auto"
+            role="region"
+            aria-label="Magnesium glycinate and L-threonate sleep comparison table"
+            tabIndex={0}
+          >
             <table className="min-w-full border-collapse text-left text-sm">
+              <caption className="sr-only">Sleep-focused comparison of magnesium glycinate and magnesium L-threonate</caption>
               <thead>
                 <tr className="border-b border-brand-900/10 dark:border-white/10">
-                  <th className="py-3 pr-4 text-xs font-bold uppercase tracking-wider text-ink dark:text-[var(--text-primary)]">Factor</th>
-                  <th className="py-3 pr-4 text-xs font-bold uppercase tracking-wider text-ink dark:text-[var(--text-primary)]">Glycinate</th>
-                  <th className="py-3 pr-4 text-xs font-bold uppercase tracking-wider text-ink dark:text-[var(--text-primary)]">L-threonate</th>
-                  <th className="py-3 text-xs font-bold uppercase tracking-wider text-ink dark:text-[var(--text-primary)]">Call</th>
+                  <th scope="col" className="py-3 pr-4 text-xs font-bold uppercase tracking-wider text-ink dark:text-[var(--text-primary)]">Factor</th>
+                  <th scope="col" className="py-3 pr-4 text-xs font-bold uppercase tracking-wider text-ink dark:text-[var(--text-primary)]">Glycinate</th>
+                  <th scope="col" className="py-3 pr-4 text-xs font-bold uppercase tracking-wider text-ink dark:text-[var(--text-primary)]">L-threonate</th>
+                  <th scope="col" className="py-3 text-xs font-bold uppercase tracking-wider text-ink dark:text-[var(--text-primary)]">Call</th>
                 </tr>
               </thead>
               <tbody>
                 {comparisonRows.map((row) => (
                   <tr key={row.factor} className="border-b border-brand-900/5 align-top last:border-0 dark:border-white/10">
-                    <td className="py-3 pr-4 font-semibold text-ink dark:text-[var(--text-primary)]">{row.factor}</td>
+                    <th scope="row" className="py-3 pr-4 text-left font-semibold text-ink dark:text-[var(--text-primary)]">{row.factor}</th>
                     <td className="py-3 pr-4 text-muted dark:text-[var(--text-secondary)]">{row.glycinate}</td>
                     <td className="py-3 pr-4 text-muted dark:text-[var(--text-secondary)]">{row.threonate}</td>
                     <td className="py-3 text-muted dark:text-[var(--text-secondary)]">{row.call}</td>
@@ -200,7 +206,13 @@ export default function Page() {
           <ul className="mt-4 space-y-2 text-sm leading-7 text-muted dark:text-[var(--text-secondary)]">
             {references.map((reference) => (
               <li key={reference.href}>
-                <a href={reference.href} className="font-semibold text-brand-800 hover:underline dark:text-[var(--text-primary)]" rel="noreferrer" target="_blank">
+                <a
+                  href={reference.href}
+                  className="font-semibold text-brand-800 hover:underline dark:text-[var(--text-primary)]"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  aria-label={`${reference.label} (opens in a new tab)`}
+                >
                   {reference.label}
                 </a>
               </li>


### PR DESCRIPTION
## What changed
- Reuses the existing `ResponsiveTable` component on three newer sleep guides
- Makes horizontally scrollable tables keyboard reachable with the site's established WCAG pattern and hidden usage hint
- Adds accessible table captions plus explicit column and row header scopes
- Hardens reference links with `noopener noreferrer`
- Announces that reference links open in a new tab

## Why
These newer sleep guides were added after the shared responsive-table pattern and did not fully use it. This closes that consistency gap without changing article claims or visual design.

## Validation
- Only the three intended guide files are changed
- 46 additions / 22 deletions total
- No route, metadata, product, or content-data changes
- First CI attempt correctly caught direct `tabIndex` usage; the pages were refactored to the repository's existing `ResponsiveTable` abstraction instead