### PR TITLE
Add Botanical Activity Atlas MVP

### DIFF
--- a/app/tools/botanical-activity-atlas/page.tsx
+++ b/app/tools/botanical-activity-atlas/page.tsx
@@ -1,0 +1,120 @@
+import type { Metadata } from 'next'
+import SchemaGraphScript from '@/components/seo/SchemaGraphScript'
+import BotanicalActivityAtlasClient, { type BotanicalAtlasRecord } from '@/components/atlas/BotanicalActivityAtlasClient'
+import { getHerbs } from '@/lib/runtime-data'
+import { getRuntimeVisibility } from '../../../lib/runtime-visibility'
+import { buildToolPageSchemaGraph } from '@/lib/schema-graph'
+import { buildPageMetadata, SITE_URL } from '@/lib/seo'
+import type { RuntimeRecord } from '@/types/content'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Botanical Activity Atlas – Effects, Compounds & Safety',
+  description:
+    'Compare pharmacologically active botanicals by effects, active compounds, noticeability, evidence strength, timing, and safety signals.',
+  path: '/tools/botanical-activity-atlas',
+})
+
+const list = (value: unknown): string[] => {
+  if (Array.isArray(value)) return value.map(String).map((item) => item.trim()).filter(Boolean)
+  if (typeof value === 'string') return value.split(/[;,|]/).map((item) => item.trim()).filter(Boolean)
+  return []
+}
+
+const text = (...values: unknown[]): string => {
+  const value = values.find((item) => typeof item === 'string' && item.trim())
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+const toAtlasRecord = (herb: RuntimeRecord): BotanicalAtlasRecord => ({
+  slug: herb.slug,
+  name: text(herb.displayName, herb.name, herb.commonName, herb.common, herb.slug.replaceAll('-', ' ')),
+  scientificName: text(herb.scientificName, herb.scientificname, herb.latinName) || undefined,
+  effects: list(herb.primary_effects ?? herb.effects ?? herb.primaryActions),
+  compounds: list(herb.activeCompounds ?? herb.active_compounds ?? herb.compounds ?? herb.activeconstituents),
+  compoundClasses: list(herb.compoundClasses ?? herb.pharmCategories ?? herb.compoundClass),
+  evidence: text(herb.evidence_tier, herb.evidenceTier, herb.evidence_grade, herb.evidenceLevel, 'Unclassified'),
+  intensity: text(herb.intensityLabel, herb.intensityClean, herb.intensityLevel, herb.intensity, 'Unknown'),
+  safety: list(herb.safety_flags ?? herb.interactionTags ?? herb.contraindications ?? herb.interactions),
+  onset: text(herb.time_to_effect, herb.onset) || undefined,
+  duration: text(herb.duration) || undefined,
+})
+
+export default async function BotanicalActivityAtlasPage() {
+  const rawHerbs = await getHerbs()
+  const herbs = rawHerbs
+    .filter((herb: RuntimeRecord) => {
+      try {
+        return getRuntimeVisibility(herb).canRender
+      } catch {
+        return true
+      }
+    })
+    .map(toAtlasRecord)
+    .filter((herb: BotanicalAtlasRecord) => herb.effects.length || herb.compounds.length || herb.safety.length)
+    .sort((a: BotanicalAtlasRecord, b: BotanicalAtlasRecord) => a.name.localeCompare(b.name))
+
+  const schemaGraph = buildToolPageSchemaGraph({
+    path: '/tools/botanical-activity-atlas',
+    title: 'Botanical Activity Atlas',
+    description:
+      'An interactive comparison of active botanicals by constituent chemistry, effect profile, evidence, noticeability, timing, and safety signals.',
+    breadcrumbs: [
+      { name: 'Home', url: `${SITE_URL}/` },
+      { name: 'Tools', url: `${SITE_URL}/tools/` },
+      { name: 'Botanical Activity Atlas', url: `${SITE_URL}/tools/botanical-activity-atlas/` },
+    ],
+    faqQuestions: [
+      {
+        question: 'What counts as an active botanical?',
+        answer:
+          'The atlas includes botanicals with constituents that may produce measurable physiological or psychological effects. Active does not necessarily mean intoxicating, strongly noticeable, effective, or safe.',
+      },
+      {
+        question: 'Does a high noticeability rating mean a botanical works better?',
+        answer:
+          'No. Noticeability describes how apparent an effect may be, while evidence strength describes how confidently an effect is supported. A noticeable product can still have weak evidence or an unfavorable safety profile.',
+      },
+      {
+        question: 'Can the atlas determine whether a botanical is safe for me?',
+        answer:
+          'No. It is an educational comparison tool. Medication use, health conditions, pregnancy, product quality, dose, and combinations can substantially change risk.',
+      },
+    ],
+  })
+
+  return (
+    <main className='mx-auto max-w-7xl space-y-8 px-4 py-8 sm:py-10'>
+      <SchemaGraphScript graph={schemaGraph} />
+
+      <section className='rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8'>
+        <p className='eyebrow-label'>Interactive Research Tool</p>
+        <h1 className='mt-2 text-3xl font-bold tracking-tight text-ink sm:text-5xl'>Botanical Activity Atlas</h1>
+        <p className='mt-4 max-w-3xl text-base leading-7 text-muted sm:text-lg'>
+          Explore which botanicals contain pharmacologically active compounds, what effects they are associated with, how noticeable those effects may be, how strong the evidence is, and which safety signals deserve attention.
+        </p>
+      </section>
+
+      <section className='grid gap-4 md:grid-cols-3'>
+        <article className='rounded-2xl border border-brand-900/10 bg-white/85 p-5 shadow-sm'>
+          <h2 className='font-bold text-ink'>Activity is not efficacy</h2>
+          <p className='mt-2 text-sm leading-6 text-muted'>A compound can affect a receptor, enzyme, or pathway without producing a useful real-world outcome.</p>
+        </article>
+        <article className='rounded-2xl border border-brand-900/10 bg-white/85 p-5 shadow-sm'>
+          <h2 className='font-bold text-ink'>Noticeability is not quality</h2>
+          <p className='mt-2 text-sm leading-6 text-muted'>Strong sensations may reflect stimulation, sedation, toxicity, side effects, or dose—not superior benefits.</p>
+        </article>
+        <article className='rounded-2xl border border-brand-900/10 bg-white/85 p-5 shadow-sm'>
+          <h2 className='font-bold text-ink'>Labels are not interchangeable</h2>
+          <p className='mt-2 text-sm leading-6 text-muted'>Species, plant part, extraction, adulteration, and batch variation can radically change a botanical product.</p>
+        </article>
+      </section>
+
+      <BotanicalActivityAtlasClient records={herbs} />
+
+      <section className='rounded-2xl border border-amber-900/15 bg-amber-50/60 p-5 text-xs leading-relaxed text-amber-950'>
+        <p className='font-bold'>Educational use only</p>
+        <p className='mt-1.5'>This atlas summarizes structured reference data and cannot establish product identity, dose, purity, personal suitability, or clinical safety. Review medication and health-condition interactions with a qualified clinician or pharmacist.</p>
+      </section>
+    </main>
+  )
+}

--- a/app/tools/botanical-activity-atlas/page.tsx
+++ b/app/tools/botanical-activity-atlas/page.tsx
@@ -5,6 +5,14 @@ import { getHerbs } from '@/lib/runtime-data'
 import { getRuntimeVisibility } from '../../../lib/runtime-visibility'
 import { buildToolPageSchemaGraph } from '@/lib/schema-graph'
 import { buildPageMetadata, SITE_URL } from '@/lib/seo'
+import {
+  normalizeCompoundClass,
+  normalizeEffect,
+  normalizeEvidence,
+  normalizeIntensity,
+  normalizeSafetySignal,
+  uniqueNormalized,
+} from '@/lib/botanical-atlas-taxonomy'
 import type { RuntimeRecord } from '@/types/content'
 
 export const metadata: Metadata = buildPageMetadata({
@@ -25,19 +33,25 @@ const text = (...values: unknown[]): string => {
   return typeof value === 'string' ? value.trim() : ''
 }
 
-const toAtlasRecord = (herb: RuntimeRecord): BotanicalAtlasRecord => ({
-  slug: herb.slug,
-  name: text(herb.displayName, herb.name, herb.commonName, herb.common, herb.slug.replaceAll('-', ' ')),
-  scientificName: text(herb.scientificName, herb.scientificname, herb.latinName) || undefined,
-  effects: list(herb.primary_effects ?? herb.effects ?? herb.primaryActions),
-  compounds: list(herb.activeCompounds ?? herb.active_compounds ?? herb.compounds ?? herb.activeconstituents),
-  compoundClasses: list(herb.compoundClasses ?? herb.pharmCategories ?? herb.compoundClass),
-  evidence: text(herb.evidence_tier, herb.evidenceTier, herb.evidence_grade, herb.evidenceLevel, 'Unclassified'),
-  intensity: text(herb.intensityLabel, herb.intensityClean, herb.intensityLevel, herb.intensity, 'Unknown'),
-  safety: list(herb.safety_flags ?? herb.interactionTags ?? herb.contraindications ?? herb.interactions),
-  onset: text(herb.time_to_effect, herb.onset) || undefined,
-  duration: text(herb.duration) || undefined,
-})
+const toAtlasRecord = (herb: RuntimeRecord): BotanicalAtlasRecord => {
+  const rawEffects = list(herb.primary_effects ?? herb.effects ?? herb.primaryActions)
+  const rawClasses = list(herb.compoundClasses ?? herb.pharmCategories ?? herb.compoundClass)
+  const rawSafety = list(herb.safety_flags ?? herb.interactionTags ?? herb.contraindications ?? herb.interactions)
+
+  return {
+    slug: herb.slug,
+    name: text(herb.displayName, herb.name, herb.commonName, herb.common, herb.slug.replaceAll('-', ' ')),
+    scientificName: text(herb.scientificName, herb.scientificname, herb.latinName) || undefined,
+    effects: uniqueNormalized(rawEffects, normalizeEffect),
+    compounds: list(herb.activeCompounds ?? herb.active_compounds ?? herb.compounds ?? herb.activeconstituents),
+    compoundClasses: uniqueNormalized(rawClasses, normalizeCompoundClass),
+    evidence: normalizeEvidence(text(herb.evidence_tier, herb.evidenceTier, herb.evidence_grade, herb.evidenceLevel)),
+    intensity: normalizeIntensity(text(herb.intensityLabel, herb.intensityClean, herb.intensityLevel, herb.intensity)),
+    safety: uniqueNormalized(rawSafety, normalizeSafetySignal),
+    onset: text(herb.time_to_effect, herb.onset) || undefined,
+    duration: text(herb.duration) || undefined,
+  }
+}
 
 export default async function BotanicalActivityAtlasPage() {
   const rawHerbs = await getHerbs()
@@ -104,8 +118,8 @@ export default async function BotanicalActivityAtlasPage() {
           <p className='mt-2 text-sm leading-6 text-muted'>Strong sensations may reflect stimulation, sedation, toxicity, side effects, or dose—not superior benefits.</p>
         </article>
         <article className='rounded-2xl border border-brand-900/10 bg-white/85 p-5 shadow-sm'>
-          <h2 className='font-bold text-ink'>Labels are not interchangeable</h2>
-          <p className='mt-2 text-sm leading-6 text-muted'>Species, plant part, extraction, adulteration, and batch variation can radically change a botanical product.</p>
+          <h2 className='font-bold text-ink'>Labels are normalized</h2>
+          <p className='mt-2 text-sm leading-6 text-muted'>Related source terms are grouped into consistent effect, evidence, chemistry, noticeability, and safety categories.</p>
         </article>
       </section>
 

--- a/lib/__tests__/primary-navigation.test.ts
+++ b/lib/__tests__/primary-navigation.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { primaryNavigation } from '../primary-navigation'
+
+describe('primary navigation', () => {
+  it('exposes the Botanical Activity Atlas through the Tools menu', () => {
+    const tools = primaryNavigation.find((item) => item.label === 'Tools')
+    const atlas = tools?.children?.find((item) => item.href === '/tools/botanical-activity-atlas')
+
+    expect(tools?.activePrefixes).toContain('/tools')
+    expect(atlas).toMatchObject({
+      label: 'Botanical Activity Atlas',
+      href: '/tools/botanical-activity-atlas',
+    })
+  })
+})

--- a/lib/primary-navigation.ts
+++ b/lib/primary-navigation.ts
@@ -71,10 +71,11 @@ export const primaryNavigation: PrimaryNavigationItem[] = [
   {
     label: 'Tools',
     href: '/safety-checker',
-    description: 'Safety checks, evidence lookup, dosing, and shareable resources',
-    activePrefixes: ['/safety-checker', '/evidence/evidence-checker', '/info/dosing', '/info/supplement-safety-checklist', '/info/infographics'],
+    description: 'Safety checks, evidence lookup, botanical comparisons, dosing, and shareable resources',
+    activePrefixes: ['/safety-checker', '/tools', '/evidence/evidence-checker', '/info/dosing', '/info/supplement-safety-checklist', '/info/infographics'],
     children: [
       { label: 'Safety checker', href: '/safety-checker', description: 'Herb-drug interaction and contraindication lookup' },
+      { label: 'Botanical Activity Atlas', href: '/tools/botanical-activity-atlas', description: 'Compare active botanicals by effects, chemistry, evidence, noticeability, and safety' },
       { label: 'Evidence lookup', href: '/evidence/evidence-checker', description: 'Search compounds by clinical evidence grade' },
       { label: 'Dosing guide', href: '/info/dosing', description: 'Bioavailability, timing, and stacking guidelines' },
       { label: 'Supplement checklist', href: '/info/supplement-safety-checklist', description: 'What to verify before buying a supplement' },

--- a/src/components/atlas/BotanicalActivityAtlasClient.tsx
+++ b/src/components/atlas/BotanicalActivityAtlasClient.tsx
@@ -22,27 +22,21 @@ interface Props {
 }
 
 const normalize = (value: string) => value.trim().toLowerCase()
+const sortedUnique = (values: string[]) => Array.from(new Set(values.filter(Boolean))).sort()
 
 export default function BotanicalActivityAtlasClient({ records }: Props) {
   const [query, setQuery] = useState('')
   const [effect, setEffect] = useState('all')
   const [evidence, setEvidence] = useState('all')
   const [intensity, setIntensity] = useState('all')
+  const [compoundClass, setCompoundClass] = useState('all')
+  const [safety, setSafety] = useState('all')
 
-  const effects = useMemo(
-    () => Array.from(new Set(records.flatMap((record) => record.effects))).sort(),
-    [records],
-  )
-
-  const evidenceLevels = useMemo(
-    () => Array.from(new Set(records.map((record) => record.evidence).filter(Boolean))).sort(),
-    [records],
-  )
-
-  const intensityLevels = useMemo(
-    () => Array.from(new Set(records.map((record) => record.intensity).filter(Boolean))).sort(),
-    [records],
-  )
+  const effects = useMemo(() => sortedUnique(records.flatMap((record) => record.effects)), [records])
+  const evidenceLevels = useMemo(() => sortedUnique(records.map((record) => record.evidence)), [records])
+  const intensityLevels = useMemo(() => sortedUnique(records.map((record) => record.intensity)), [records])
+  const compoundClasses = useMemo(() => sortedUnique(records.flatMap((record) => record.compoundClasses)), [records])
+  const safetySignals = useMemo(() => sortedUnique(records.flatMap((record) => record.safety)), [records])
 
   const filtered = useMemo(() => {
     const needle = normalize(query)
@@ -62,28 +56,50 @@ export default function BotanicalActivityAtlasClient({ records }: Props) {
         (!needle || searchable.includes(needle)) &&
         (effect === 'all' || record.effects.includes(effect)) &&
         (evidence === 'all' || record.evidence === evidence) &&
-        (intensity === 'all' || record.intensity === intensity)
+        (intensity === 'all' || record.intensity === intensity) &&
+        (compoundClass === 'all' || record.compoundClasses.includes(compoundClass)) &&
+        (safety === 'all' || record.safety.includes(safety))
       )
     })
-  }, [records, query, effect, evidence, intensity])
+  }, [records, query, effect, evidence, intensity, compoundClass, safety])
+
+  const activeFilters = [
+    query && `Search: ${query}`,
+    effect !== 'all' && `Effect: ${effect}`,
+    evidence !== 'all' && `Evidence: ${evidence}`,
+    intensity !== 'all' && `Noticeability: ${intensity}`,
+    compoundClass !== 'all' && `Chemistry: ${compoundClass}`,
+    safety !== 'all' && `Safety: ${safety}`,
+  ].filter(Boolean) as string[]
+
+  const reset = () => {
+    setQuery('')
+    setEffect('all')
+    setEvidence('all')
+    setIntensity('all')
+    setCompoundClass('all')
+    setSafety('all')
+  }
 
   return (
     <section className='space-y-5'>
-      <div className='grid gap-3 rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm md:grid-cols-4'>
-        <label className='md:col-span-1'>
+      <div className='grid gap-3 rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm md:grid-cols-2 xl:grid-cols-6'>
+        <label>
           <span className='mb-1 block text-xs font-bold uppercase tracking-wide text-muted'>Search</span>
-          <input
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            placeholder='Herb, compound, effect…'
-            className='w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2 text-sm text-ink outline-none focus:border-emerald-600'
-          />
+          <input value={query} onChange={(event) => setQuery(event.target.value)} placeholder='Herb, compound, effect…' className='w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2 text-sm text-ink outline-none focus:border-emerald-600' />
         </label>
         <label>
           <span className='mb-1 block text-xs font-bold uppercase tracking-wide text-muted'>Effect</span>
           <select value={effect} onChange={(event) => setEffect(event.target.value)} className='w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2 text-sm text-ink'>
             <option value='all'>All effects</option>
             {effects.map((item) => <option key={item} value={item}>{item}</option>)}
+          </select>
+        </label>
+        <label>
+          <span className='mb-1 block text-xs font-bold uppercase tracking-wide text-muted'>Chemistry</span>
+          <select value={compoundClass} onChange={(event) => setCompoundClass(event.target.value)} className='w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2 text-sm text-ink'>
+            <option value='all'>All classes</option>
+            {compoundClasses.map((item) => <option key={item} value={item}>{item}</option>)}
           </select>
         </label>
         <label>
@@ -100,12 +116,25 @@ export default function BotanicalActivityAtlasClient({ records }: Props) {
             {intensityLevels.map((item) => <option key={item} value={item}>{item}</option>)}
           </select>
         </label>
+        <label>
+          <span className='mb-1 block text-xs font-bold uppercase tracking-wide text-muted'>Safety concern</span>
+          <select value={safety} onChange={(event) => setSafety(event.target.value)} className='w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2 text-sm text-ink'>
+            <option value='all'>All signals</option>
+            {safetySignals.map((item) => <option key={item} value={item}>{item}</option>)}
+          </select>
+        </label>
       </div>
 
-      <div className='flex items-center justify-between gap-3 text-sm text-muted'>
-        <p><strong className='text-ink'>{filtered.length}</strong> botanicals shown</p>
-        <button type='button' onClick={() => { setQuery(''); setEffect('all'); setEvidence('all'); setIntensity('all') }} className='font-semibold text-emerald-800 hover:underline'>Reset filters</button>
+      <div className='flex flex-wrap items-center justify-between gap-3 text-sm text-muted'>
+        <p><strong className='text-ink'>{filtered.length}</strong> of {records.length} botanicals shown</p>
+        <button type='button' onClick={reset} disabled={!activeFilters.length} className='font-semibold text-emerald-800 hover:underline disabled:cursor-not-allowed disabled:opacity-40'>Reset filters</button>
       </div>
+
+      {activeFilters.length ? (
+        <div className='flex flex-wrap gap-2' aria-label='Active filters'>
+          {activeFilters.map((item) => <span key={item} className='rounded-full border border-emerald-900/10 bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-950'>{item}</span>)}
+        </div>
+      ) : null}
 
       <div className='overflow-x-auto rounded-2xl border border-brand-900/10 bg-white/90 shadow-sm'>
         <table className='min-w-[1100px] w-full border-collapse text-left text-sm'>
@@ -142,7 +171,7 @@ export default function BotanicalActivityAtlasClient({ records }: Props) {
         </table>
       </div>
 
-      {!filtered.length ? <div className='rounded-2xl border border-dashed border-brand-900/20 bg-white/70 p-8 text-center text-muted'>No botanicals match those filters.</div> : null}
+      {!filtered.length ? <div className='rounded-2xl border border-dashed border-brand-900/20 bg-white/70 p-8 text-center text-muted'>No botanicals match those filters. Try removing one filter or using a broader search term.</div> : null}
     </section>
   )
 }

--- a/src/components/atlas/BotanicalActivityAtlasClient.tsx
+++ b/src/components/atlas/BotanicalActivityAtlasClient.tsx
@@ -1,0 +1,148 @@
+'use client'
+
+import Link from 'next/link'
+import { useMemo, useState } from 'react'
+
+export interface BotanicalAtlasRecord {
+  slug: string
+  name: string
+  scientificName?: string
+  effects: string[]
+  compounds: string[]
+  compoundClasses: string[]
+  evidence: string
+  intensity: string
+  safety: string[]
+  onset?: string
+  duration?: string
+}
+
+interface Props {
+  records: BotanicalAtlasRecord[]
+}
+
+const normalize = (value: string) => value.trim().toLowerCase()
+
+export default function BotanicalActivityAtlasClient({ records }: Props) {
+  const [query, setQuery] = useState('')
+  const [effect, setEffect] = useState('all')
+  const [evidence, setEvidence] = useState('all')
+  const [intensity, setIntensity] = useState('all')
+
+  const effects = useMemo(
+    () => Array.from(new Set(records.flatMap((record) => record.effects))).sort(),
+    [records],
+  )
+
+  const evidenceLevels = useMemo(
+    () => Array.from(new Set(records.map((record) => record.evidence).filter(Boolean))).sort(),
+    [records],
+  )
+
+  const intensityLevels = useMemo(
+    () => Array.from(new Set(records.map((record) => record.intensity).filter(Boolean))).sort(),
+    [records],
+  )
+
+  const filtered = useMemo(() => {
+    const needle = normalize(query)
+    return records.filter((record) => {
+      const searchable = [
+        record.name,
+        record.scientificName ?? '',
+        ...record.effects,
+        ...record.compounds,
+        ...record.compoundClasses,
+        ...record.safety,
+      ]
+        .join(' ')
+        .toLowerCase()
+
+      return (
+        (!needle || searchable.includes(needle)) &&
+        (effect === 'all' || record.effects.includes(effect)) &&
+        (evidence === 'all' || record.evidence === evidence) &&
+        (intensity === 'all' || record.intensity === intensity)
+      )
+    })
+  }, [records, query, effect, evidence, intensity])
+
+  return (
+    <section className='space-y-5'>
+      <div className='grid gap-3 rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm md:grid-cols-4'>
+        <label className='md:col-span-1'>
+          <span className='mb-1 block text-xs font-bold uppercase tracking-wide text-muted'>Search</span>
+          <input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder='Herb, compound, effect…'
+            className='w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2 text-sm text-ink outline-none focus:border-emerald-600'
+          />
+        </label>
+        <label>
+          <span className='mb-1 block text-xs font-bold uppercase tracking-wide text-muted'>Effect</span>
+          <select value={effect} onChange={(event) => setEffect(event.target.value)} className='w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2 text-sm text-ink'>
+            <option value='all'>All effects</option>
+            {effects.map((item) => <option key={item} value={item}>{item}</option>)}
+          </select>
+        </label>
+        <label>
+          <span className='mb-1 block text-xs font-bold uppercase tracking-wide text-muted'>Evidence</span>
+          <select value={evidence} onChange={(event) => setEvidence(event.target.value)} className='w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2 text-sm text-ink'>
+            <option value='all'>All evidence</option>
+            {evidenceLevels.map((item) => <option key={item} value={item}>{item}</option>)}
+          </select>
+        </label>
+        <label>
+          <span className='mb-1 block text-xs font-bold uppercase tracking-wide text-muted'>Noticeability</span>
+          <select value={intensity} onChange={(event) => setIntensity(event.target.value)} className='w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2 text-sm text-ink'>
+            <option value='all'>All levels</option>
+            {intensityLevels.map((item) => <option key={item} value={item}>{item}</option>)}
+          </select>
+        </label>
+      </div>
+
+      <div className='flex items-center justify-between gap-3 text-sm text-muted'>
+        <p><strong className='text-ink'>{filtered.length}</strong> botanicals shown</p>
+        <button type='button' onClick={() => { setQuery(''); setEffect('all'); setEvidence('all'); setIntensity('all') }} className='font-semibold text-emerald-800 hover:underline'>Reset filters</button>
+      </div>
+
+      <div className='overflow-x-auto rounded-2xl border border-brand-900/10 bg-white/90 shadow-sm'>
+        <table className='min-w-[1100px] w-full border-collapse text-left text-sm'>
+          <thead className='bg-brand-50/80 text-xs uppercase tracking-wide text-muted'>
+            <tr>
+              <th className='p-4'>Botanical</th>
+              <th className='p-4'>Active chemistry</th>
+              <th className='p-4'>Effect profile</th>
+              <th className='p-4'>Noticeability</th>
+              <th className='p-4'>Evidence</th>
+              <th className='p-4'>Safety signals</th>
+              <th className='p-4'>Timing</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((record) => (
+              <tr key={record.slug} className='border-t border-brand-900/10 align-top'>
+                <td className='p-4'>
+                  <Link href={`/herbs/${record.slug}/`} className='font-bold text-emerald-900 hover:underline'>{record.name}</Link>
+                  {record.scientificName ? <p className='mt-1 text-xs italic text-muted'>{record.scientificName}</p> : null}
+                </td>
+                <td className='p-4'>
+                  <p className='font-medium text-ink'>{record.compounds.slice(0, 4).join(', ') || 'Not yet mapped'}</p>
+                  {record.compoundClasses.length ? <p className='mt-1 text-xs text-muted'>{record.compoundClasses.join(', ')}</p> : null}
+                </td>
+                <td className='p-4 text-muted'>{record.effects.slice(0, 5).join(' · ') || 'Unclassified'}</td>
+                <td className='p-4 font-semibold text-ink'>{record.intensity}</td>
+                <td className='p-4'>{record.evidence}</td>
+                <td className='p-4 text-muted'>{record.safety.slice(0, 4).join(' · ') || 'No structured flags'}</td>
+                <td className='p-4 text-muted'>{[record.onset && `Onset: ${record.onset}`, record.duration && `Duration: ${record.duration}`].filter(Boolean).join(' · ') || 'Not established'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {!filtered.length ? <div className='rounded-2xl border border-dashed border-brand-900/20 bg-white/70 p-8 text-center text-muted'>No botanicals match those filters.</div> : null}
+    </section>
+  )
+}

--- a/src/lib/__tests__/botanical-atlas-taxonomy.test.ts
+++ b/src/lib/__tests__/botanical-atlas-taxonomy.test.ts
@@ -30,6 +30,7 @@ describe('botanical atlas taxonomy', () => {
   it('groups active chemistry and safety concerns', () => {
     expect(normalizeCompoundClass('isoquinoline alkaloids')).toBe('Alkaloids')
     expect(normalizeCompoundClass('kavalactones')).toBe('Lactones')
+    expect(normalizeCompoundClass('caffeine and theobromine')).toBe('Methylxanthines')
     expect(normalizeSafetySignal('May interact with SSRIs')).toBe('Serotonergic')
     expect(normalizeSafetySignal('Potential hepatotoxicity')).toBe('Liver')
   })

--- a/src/lib/__tests__/botanical-atlas-taxonomy.test.ts
+++ b/src/lib/__tests__/botanical-atlas-taxonomy.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import {
+  normalizeCompoundClass,
+  normalizeEffect,
+  normalizeEvidence,
+  normalizeIntensity,
+  normalizeSafetySignal,
+  uniqueNormalized,
+} from '../botanical-atlas-taxonomy'
+
+describe('botanical atlas taxonomy', () => {
+  it('collapses effect synonyms into stable families', () => {
+    expect(normalizeEffect('Anxiolytic and stress reducing')).toBe('Calming')
+    expect(normalizeEffect('Wakefulness and alertness')).toBe('Stimulating / energy')
+    expect(normalizeEffect('Analgesic activity')).toBe('Pain / discomfort')
+  })
+
+  it('maps evidence labels to a small controlled scale', () => {
+    expect(normalizeEvidence('Strong human evidence')).toBe('Strong')
+    expect(normalizeEvidence('Limited pilot trial')).toBe('Preliminary')
+    expect(normalizeEvidence('Traditional use and animal evidence')).toBe('Traditional / preclinical')
+  })
+
+  it('normalizes noticeability labels', () => {
+    expect(normalizeIntensity('high intensity')).toBe('Pronounced')
+    expect(normalizeIntensity('mild')).toBe('Subtle')
+    expect(normalizeIntensity('dose-dependent')).toBe('Variable')
+  })
+
+  it('groups active chemistry and safety concerns', () => {
+    expect(normalizeCompoundClass('isoquinoline alkaloids')).toBe('Alkaloids')
+    expect(normalizeCompoundClass('kavalactones')).toBe('Lactones')
+    expect(normalizeSafetySignal('May interact with SSRIs')).toBe('Serotonergic')
+    expect(normalizeSafetySignal('Potential hepatotoxicity')).toBe('Liver')
+  })
+
+  it('deduplicates normalized variants', () => {
+    expect(uniqueNormalized(['calming', 'anxiolytic', 'relaxing'], normalizeEffect)).toEqual(['Calming'])
+  })
+})

--- a/src/lib/botanical-atlas-taxonomy.ts
+++ b/src/lib/botanical-atlas-taxonomy.ts
@@ -1,0 +1,74 @@
+const clean = (value: string) => value.trim().toLowerCase().replace(/[–—]/g, '-').replace(/\s+/g, ' ')
+
+const EFFECT_RULES: Array<[string, RegExp]> = [
+  ['Calming', /calm|relax|anxiol|stress|tranquil/],
+  ['Sedating / sleep', /sedat|sleep|hypnotic|somnol|insomnia/],
+  ['Stimulating / energy', /stimul|energy|alert|wake|fatigue|ergogenic/],
+  ['Mood', /mood|antidepress|euphor|well-being|seroton/],
+  ['Cognition / focus', /cognit|focus|attention|memory|nootropic|cholin/],
+  ['Pain / discomfort', /analges|pain|antinocicept|discomfort/],
+  ['Inflammation', /inflamm/],
+  ['Dream / perception', /dream|lucid|hallucin|percept|psychoactive|dissoci/],
+  ['Digestive', /digest|gastro|nausea|appetite|bowel|constipat/],
+  ['Cardiovascular', /cardio|blood pressure|vaso|heart|circulat/],
+  ['Metabolic', /metabol|glucose|insulin|lipid|cholesterol|weight/],
+  ['Immune', /immune|immunomod|antiviral|antimicrobial/],
+  ['Hormonal / reproductive', /hormon|libido|sexual|fertil|testoster|estrogen|thyroid/],
+]
+
+const CLASS_RULES: Array<[string, RegExp]> = [
+  ['Alkaloids', /alkaloid|amine|indole|isoquinoline|aporphine|tropane|xanthine/],
+  ['Flavonoids', /flavonoid|flavone|flavan|catechin/],
+  ['Terpenes / terpenoids', /terpene|terpenoid|sesquiterp|diterp|triterp/],
+  ['Glycosides', /glycoside|saponin/],
+  ['Phenolics', /phenol|polyphenol|phenolic acid/],
+  ['Lactones', /lactone|kavalactone/],
+  ['Cannabinoids', /cannabinoid/],
+  ['Withanolides', /withanolide/],
+  ['Methylxanthines', /methylxanthine|caffeine|theobromine|theophylline/],
+]
+
+const SAFETY_RULES: Array<[string, RegExp]> = [
+  ['Sedation', /sedat|drows|cns depress|sleepiness/],
+  ['Stimulation', /stimul|insomnia|agitat|jitter|anxiety/],
+  ['Serotonergic', /seroton|ssri|snri|maoi|monoamine oxidase/],
+  ['Cardiovascular', /blood pressure|hypertension|hypotension|heart|arrhythm|qt|tachy|brady/],
+  ['Bleeding', /bleed|anticoagul|antiplatelet/],
+  ['Liver', /liver|hepato/],
+  ['Kidney', /kidney|renal/],
+  ['Seizure', /seizure|convuls/],
+  ['Dependence / withdrawal', /depend|withdraw|addict|habit-forming|abuse/],
+  ['Pregnancy / breastfeeding', /pregnan|breastfeed|lactation/],
+  ['Drug metabolism', /cyp|drug metabolism|enzyme inhibit|enzyme induc/],
+  ['Toxicity concern', /toxic|poison|narrow therapeutic|fatal/],
+]
+
+const firstMatch = (value: string, rules: Array<[string, RegExp]>) => {
+  const normalized = clean(value)
+  return rules.find(([, pattern]) => pattern.test(normalized))?.[0]
+}
+
+export const normalizeEffect = (value: string) => firstMatch(value, EFFECT_RULES) ?? value.trim()
+export const normalizeCompoundClass = (value: string) => firstMatch(value, CLASS_RULES) ?? value.trim()
+export const normalizeSafetySignal = (value: string) => firstMatch(value, SAFETY_RULES) ?? value.trim()
+
+export const normalizeEvidence = (value: string) => {
+  const normalized = clean(value)
+  if (/^a\b|high|strong|robust|well established|multiple.*trial/.test(normalized)) return 'Strong'
+  if (/^b\b|moderate|promising|some human|clinical evidence/.test(normalized)) return 'Moderate'
+  if (/^c\b|preliminary|limited|early|pilot|small trial/.test(normalized)) return 'Preliminary'
+  if (/^d\b|traditional|preclinical|animal|in vitro|mechanistic/.test(normalized)) return 'Traditional / preclinical'
+  return 'Unclassified'
+}
+
+export const normalizeIntensity = (value: string) => {
+  const normalized = clean(value)
+  if (/strong|high|pronounced|intense|potent/.test(normalized)) return 'Pronounced'
+  if (/moderate|medium|noticeable/.test(normalized)) return 'Moderate'
+  if (/mild|low|subtle|gentle/.test(normalized)) return 'Subtle'
+  if (/variable|dose-dependent|biphasic/.test(normalized)) return 'Variable'
+  return 'Unknown'
+}
+
+export const uniqueNormalized = (values: string[], normalizer: (value: string) => string) =>
+  Array.from(new Set(values.map(normalizer).filter(Boolean)))

--- a/src/lib/botanical-atlas-taxonomy.ts
+++ b/src/lib/botanical-atlas-taxonomy.ts
@@ -17,6 +17,7 @@ const EFFECT_RULES: Array<[string, RegExp]> = [
 ]
 
 const CLASS_RULES: Array<[string, RegExp]> = [
+  ['Methylxanthines', /methylxanthine|caffeine|theobromine|theophylline/],
   ['Alkaloids', /alkaloid|amine|indole|isoquinoline|aporphine|tropane|xanthine/],
   ['Flavonoids', /flavonoid|flavone|flavan|catechin/],
   ['Terpenes / terpenoids', /terpene|terpenoid|sesquiterp|diterp|triterp/],
@@ -25,7 +26,6 @@ const CLASS_RULES: Array<[string, RegExp]> = [
   ['Lactones', /lactone|kavalactone/],
   ['Cannabinoids', /cannabinoid/],
   ['Withanolides', /withanolide/],
-  ['Methylxanthines', /methylxanthine|caffeine|theobromine|theophylline/],
 ]
 
 const SAFETY_RULES: Array<[string, RegExp]> = [


### PR DESCRIPTION
## Summary
- add `/tools/botanical-activity-atlas/`
- derive atlas rows from existing runtime herb records
- normalize inconsistent source labels into controlled effect, evidence, noticeability, chemistry, and safety categories
- add search plus effect, compound-class, evidence, noticeability, and safety filters
- show active-filter chips and result counts
- compare active chemistry, effects, evidence, safety signals, onset, and duration
- link each row to its herb profile
- add tool metadata, schema graph, FAQ markup, and safety framing

## Taxonomy added
- effect families such as calming, sleep, stimulation, mood, cognition, pain, dream/perception, cardiovascular, and metabolic
- evidence levels: Strong, Moderate, Preliminary, Traditional / preclinical, Unclassified
- noticeability: Pronounced, Moderate, Subtle, Variable, Unknown
- chemistry families including alkaloids, flavonoids, terpenes, glycosides, phenolics, lactones, cannabinoids, withanolides, and methylxanthines
- safety families including serotonergic, cardiovascular, bleeding, liver, seizure, dependence, pregnancy, metabolism, and toxicity concerns

## Why
This turns the existing herb/compound dataset into a distinctive browse-and-compare research tool rather than another static list article.

## Follow-up work
- validate production field coverage and inspect unmapped labels
- add navigation/internal links
- add tests and analytics events
- create curated SEO landing pages from high-value filter combinations

## Validation
No GitHub Actions workflow has appeared for the latest commit yet; PR remains draft pending automated or local validation.