### PR TITLE
Refresh evidence graph identity foundation

### DIFF
--- a/.github/workflows/evidence-graph-identity-check.yml
+++ b/.github/workflows/evidence-graph-identity-check.yml
@@ -1,0 +1,111 @@
+name: Evidence Graph Identity Check
+
+on:
+  push:
+    paths:
+      - '.github/workflows/evidence-graph-identity-check.yml'
+      - 'config/evidence-graph/**'
+      - 'data/graph/identity/**'
+      - 'docs/evidence-graph/**'
+      - 'scripts/evidence-graph/**'
+      - 'scripts/data/workbook-parser.mjs'
+      - 'scripts/workbook-source.mjs'
+      - 'data-sources/herb_monograph_master.xlsx'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - '.github/workflows/evidence-graph-identity-check.yml'
+      - 'config/evidence-graph/**'
+      - 'data/graph/identity/**'
+      - 'docs/evidence-graph/**'
+      - 'scripts/evidence-graph/**'
+      - 'scripts/data/workbook-parser.mjs'
+      - 'scripts/workbook-source.mjs'
+      - 'data-sources/herb_monograph_master.xlsx'
+  workflow_dispatch:
+
+concurrency:
+  group: evidence-graph-identity-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  identity-registry:
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node from .nvmrc
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run identity unit tests
+        run: node --test scripts/evidence-graph/__tests__/*.test.mjs
+
+      - name: Build registry from workbook
+        run: |
+          node scripts/evidence-graph/build-identity-registry.mjs
+          node scripts/evidence-graph/build-identity-collision-review.mjs
+          node scripts/evidence-graph/apply-identity-resolutions.mjs
+
+      - name: Verify generated outputs
+        run: |
+          node --input-type=module <<'NODE'
+          import fs from 'node:fs'
+          import assert from 'node:assert/strict'
+
+          const registry = JSON.parse(fs.readFileSync('data/graph/identity/substance-registry.json', 'utf8'))
+          const report = JSON.parse(fs.readFileSync('data/graph/identity/identity-validation-report.json', 'utf8'))
+          const resolutionReport = JSON.parse(fs.readFileSync('data/graph/identity/identity-resolution-report.json', 'utf8'))
+          const collisionCsv = fs.readFileSync('data/graph/identity/identity-collision-review.csv', 'utf8').trimEnd()
+          const collisionCsvRows = collisionCsv ? collisionCsv.split('\n').length - 1 : 0
+          const deprecated = registry.filter((record) => record.status === 'deprecated')
+          const forms = registry.filter((record) => record.reviewFlags?.includes('form-of-parent-identity'))
+          const berberine = registry.find((record) => record.id === 'compound:berberine')
+          const berberineHcl = registry.find((record) => record.id === 'compound:berberine-hcl')
+
+          assert.ok(Array.isArray(registry), 'Registry must be a JSON array')
+          assert.ok(registry.length > 0, 'Registry must contain imported identities')
+          assert.equal(report.summary.missingIdRecords, 0, 'Workbook identities must all have stable IDs')
+          assert.equal(report.summary.registryRecords, registry.length, 'Registry count must match valid report count')
+          assert.equal(collisionCsvRows, report.summary.collisionCount, 'Collision CSV must contain one row per collision group')
+          assert.equal(resolutionReport.summary.appliedResolutions, 4, 'All approved identity resolutions must apply')
+          assert.equal(resolutionReport.summary.skippedResolutions, 0, 'Approved resolutions must not be skipped')
+          assert.equal(resolutionReport.summary.deprecatedRecords, deprecated.length, 'Deprecated count must match registry')
+          assert.equal(resolutionReport.summary.formRecords, forms.length, 'Form count must match registry')
+          assert.equal(berberineHcl.parentEntityId, berberine.id, 'Berberine HCl must link to parent berberine')
+          assert.equal(berberineHcl.canonicalName, 'Berberine hydrochloride')
+          assert.equal(berberineHcl.status, 'active', 'Distinct forms must remain active identities')
+          assert.ok(berberineHcl.aliases.includes('Berberine HCl'))
+          assert.ok(!berberineHcl.reviewFlags.includes('identity-collision'))
+
+          console.log(JSON.stringify({
+            baseline: report.summary,
+            collisionSummary: report.collisionSummary,
+            resolutions: resolutionReport.summary,
+          }, null, 2))
+          NODE
+
+      - name: Upload identity outputs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: evidence-graph-identity-output
+          path: |
+            data/graph/identity/substance-registry.json
+            data/graph/identity/identity-validation-report.json
+            data/graph/identity/identity-collision-review.csv
+            data/graph/identity/identity-resolutions.json
+            data/graph/identity/identity-resolution-report.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/config/evidence-graph/identity-rules.mjs
+++ b/config/evidence-graph/identity-rules.mjs
@@ -1,0 +1,79 @@
+export const ENTITY_PREFIXES = Object.freeze({
+  herb: 'herb',
+  compound: 'compound',
+  substanceForm: 'form',
+});
+
+export const IDENTITY_STATUSES = Object.freeze([
+  'active',
+  'needs-review',
+  'duplicate-candidate',
+  'deprecated',
+  'archived',
+]);
+
+const NON_ALPHANUMERIC = /[^a-z0-9]+/g;
+const EDGE_DASHES = /^-+|-+$/g;
+
+export function normalizeIdentityText(value) {
+  return String(value ?? '')
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .trim()
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(NON_ALPHANUMERIC, '-')
+    .replace(EDGE_DASHES, '');
+}
+
+export function buildStableEntityId(entityType, canonicalSlug) {
+  const prefix = ENTITY_PREFIXES[entityType];
+  if (!prefix) {
+    throw new Error(`Unsupported evidence-graph entity type: ${entityType}`);
+  }
+
+  const normalizedSlug = normalizeIdentityText(canonicalSlug);
+  if (!normalizedSlug) {
+    throw new Error(`Cannot build ${entityType} identity without a canonical slug`);
+  }
+
+  return `${prefix}:${normalizedSlug}`;
+}
+
+export function normalizeAliases(values) {
+  const source = Array.isArray(values) ? values : [values];
+  const seen = new Set();
+
+  return source
+    .flatMap((value) => String(value ?? '').split(/[|;\n]/g))
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .filter((value) => {
+      const key = normalizeIdentityText(value);
+      if (!key || seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+}
+
+export const IDENTITY_MATCH_PRIORITY = Object.freeze([
+  'stable-id',
+  'canonical-slug',
+  'canonical-name',
+  'scientific-name',
+  'approved-alias',
+  'normalized-name',
+  'manual-review',
+]);
+
+export const FORM_SENSITIVE_PATTERNS = Object.freeze([
+  /\b(glycinate|citrate|oxide|malate|threonate|chloride|sulfate|carbonate)\b/i,
+  /\b(root|leaf|bark|seed|fruit|flower|aerial parts?)\b/i,
+  /\b(extract|standardized|standardised|isolate|ferment|strain)\b/i,
+  /\b(l-|d-|dl-|r-|s-)\w+/i,
+]);
+
+export function requiresFormReview(value) {
+  const text = String(value ?? '');
+  return FORM_SENSITIVE_PATTERNS.some((pattern) => pattern.test(text));
+}

--- a/data/graph/identity/README.md
+++ b/data/graph/identity/README.md
@@ -1,0 +1,3 @@
+# Generated identity artifacts
+
+Files in this directory are produced by the evidence-graph identity workflow. Commit durable policy and resolution inputs; regenerate reports and registry outputs from the canonical workbook.

--- a/data/graph/identity/identity-resolutions.json
+++ b/data/graph/identity/identity-resolutions.json
@@ -1,0 +1,51 @@
+{
+  "schemaVersion": "0.2.0",
+  "resolutions": [
+    {
+      "collisionKey": "coenzyme-q10",
+      "collisionType": "canonical-name-collision",
+      "action": "merge-alias",
+      "canonicalRecordId": "compound:coenzyme-q10",
+      "retiredRecordIds": ["compound:coq10"],
+      "status": "approved",
+      "reason": "CoQ10 is an alternate common name for coenzyme Q10; preserve the established canonical identity and route alias.",
+      "reviewedAt": "2026-08-05"
+    },
+    {
+      "collisionKey": "lion-s-mane",
+      "collisionType": "canonical-name-collision",
+      "action": "merge-alias",
+      "canonicalRecordId": "herb:lions-mane",
+      "retiredRecordIds": ["herb:hericium-erinaceus"],
+      "status": "approved",
+      "reason": "The common-name route remains canonical while the scientific-name slug is retained as an alias.",
+      "reviewedAt": "2026-08-05"
+    },
+    {
+      "collisionKey": "nicotinamide-riboside",
+      "collisionType": "canonical-name-collision",
+      "action": "merge-alias",
+      "canonicalRecordId": "compound:nicotinamide-riboside",
+      "retiredRecordIds": ["compound:nr"],
+      "status": "approved",
+      "reason": "NR is an abbreviation for nicotinamide riboside and should remain an alias rather than a separate compound identity.",
+      "reviewedAt": "2026-08-05"
+    },
+    {
+      "collisionKey": "berberine",
+      "collisionType": "canonical-name-collision",
+      "action": "establish-form",
+      "canonicalRecordId": "compound:berberine",
+      "formRecordIds": ["compound:berberine-hcl"],
+      "formCanonicalNames": {
+        "compound:berberine-hcl": "Berberine hydrochloride"
+      },
+      "formAliases": {
+        "compound:berberine-hcl": ["Berberine HCl"]
+      },
+      "status": "approved",
+      "reason": "Berberine hydrochloride is a distinct salt form used in products and research. It must remain queryable as a child identity rather than being flattened into the parent compound.",
+      "reviewedAt": "2026-08-05"
+    }
+  ]
+}

--- a/data/graph/identity/substance-registry.schema.json
+++ b/data/graph/identity/substance-registry.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://thehippiescientist.net/schemas/substance-registry.schema.json",
+  "title": "Evidence Graph Substance Registry",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+      "id",
+      "entityType",
+      "canonicalSlug",
+      "canonicalName",
+      "aliases",
+      "status",
+      "provenance"
+    ],
+    "properties": {
+      "id": {
+        "type": "string",
+        "pattern": "^(herb|compound|form):[a-z0-9]+(?:-[a-z0-9]+)*$"
+      },
+      "entityType": {
+        "enum": ["herb", "compound", "substanceForm"]
+      },
+      "canonicalSlug": {
+        "type": "string",
+        "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+      },
+      "canonicalName": {
+        "type": "string",
+        "minLength": 1
+      },
+      "scientificName": {
+        "type": ["string", "null"]
+      },
+      "parentEntityId": {
+        "type": ["string", "null"],
+        "pattern": "^(herb|compound):[a-z0-9]+(?:-[a-z0-9]+)*$"
+      },
+      "aliases": {
+        "type": "array",
+        "items": { "type": "string", "minLength": 1 },
+        "uniqueItems": true
+      },
+      "status": {
+        "enum": [
+          "active",
+          "needs-review",
+          "duplicate-candidate",
+          "deprecated",
+          "archived"
+        ]
+      },
+      "reviewFlags": {
+        "type": "array",
+        "items": { "type": "string", "minLength": 1 },
+        "uniqueItems": true
+      },
+      "provenance": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["workbook", "sheet", "sourceSlug"],
+        "properties": {
+          "workbook": { "type": "string", "minLength": 1 },
+          "sheet": { "type": "string", "minLength": 1 },
+          "sourceRow": { "type": ["integer", "null"], "minimum": 2 },
+          "sourceSlug": { "type": "string", "minLength": 1 },
+          "canonicalSlugField": { "type": ["string", "null"] },
+          "duplicateGroup": { "type": ["string", "null"] },
+          "importerVersion": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  }
+}

--- a/docs/evidence-graph/identity-registry.md
+++ b/docs/evidence-graph/identity-registry.md
@@ -1,0 +1,40 @@
+# Evidence Graph Identity Registry
+
+This subsystem creates stable herb and compound identities from the canonical workbook without changing the live site importer or writing back to the workbook.
+
+## Outputs
+
+Running the pipeline generates:
+
+- `data/graph/identity/substance-registry.json`
+- `data/graph/identity/identity-validation-report.json`
+- `data/graph/identity/identity-collision-review.csv`
+- `data/graph/identity/identity-resolution-report.json`
+
+Generated outputs are validation artifacts. The durable source files are the identity rules, registry schema, scripts, and the human-reviewed resolution ledger.
+
+## Commands
+
+```bash
+node scripts/evidence-graph/build-identity-registry.mjs
+node scripts/evidence-graph/build-identity-collision-review.mjs
+node scripts/evidence-graph/apply-identity-resolutions.mjs
+node --test scripts/evidence-graph/__tests__/*.test.mjs
+```
+
+## Identity policy
+
+1. Stable IDs use `herb:<canonical-slug>` and `compound:<canonical-slug>`.
+2. Canonical slugs take precedence over names and aliases.
+3. Duplicate names and slugs enter a review queue; they are never merged automatically.
+4. Approved alias merges remain visible as deprecated child records pointing to the canonical identity.
+5. Distinct chemical or product forms remain active child identities with `parentEntityId`.
+6. The workbook remains the source of imported identity candidates; `identity-resolutions.json` is the source of human decisions.
+
+## Current approved resolutions
+
+The initial ledger resolves CoQ10, lion's mane, and nicotinamide riboside abbreviations as aliases, while retaining berberine hydrochloride as an active form of berberine.
+
+## Next work
+
+Review remaining same-type canonical-name collisions and cross-type name conflicts before claims, sources, and relationship edges rely on these identities.

--- a/scripts/evidence-graph/README.md
+++ b/scripts/evidence-graph/README.md
@@ -1,0 +1,3 @@
+# Evidence graph scripts
+
+The identity foundation is intentionally isolated from the live runtime. Run the registry builder, collision exporter, and resolution applicator in that order. See `docs/evidence-graph/identity-registry.md` for policy and workflow details.

--- a/scripts/evidence-graph/__tests__/identity-foundation.test.mjs
+++ b/scripts/evidence-graph/__tests__/identity-foundation.test.mjs
@@ -1,0 +1,47 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { buildStableEntityId, normalizeAliases, normalizeIdentityText, requiresFormReview } from '../../../config/evidence-graph/identity-rules.mjs'
+import { applyIdentityResolutions } from '../apply-identity-resolutions.mjs'
+
+test('identity normalization produces stable graph IDs', () => {
+  assert.equal(normalizeIdentityText('Lion’s Mane & Extract'), 'lion-s-mane-and-extract')
+  assert.equal(buildStableEntityId('compound', 'Berberine HCl'), 'compound:berberine-hcl')
+  assert.deepEqual(normalizeAliases(['CoQ10|Coenzyme Q10', 'coq10']), ['CoQ10', 'Coenzyme Q10'])
+  assert.equal(requiresFormReview('magnesium glycinate extract'), true)
+})
+
+test('approved resolutions merge aliases and preserve child forms', () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'identity-foundation-'))
+  const dir = path.join(repoRoot, 'data/graph/identity')
+  fs.mkdirSync(dir, { recursive: true })
+  const registry = [
+    { id: 'compound:coenzyme-q10', canonicalSlug: 'coenzyme-q10', canonicalName: 'Coenzyme Q10', aliases: [], status: 'duplicate-candidate', parentEntityId: null, reviewFlags: ['identity-collision'] },
+    { id: 'compound:coq10', canonicalSlug: 'coq10', canonicalName: 'CoQ10', aliases: [], status: 'duplicate-candidate', parentEntityId: null, reviewFlags: ['identity-collision'] },
+    { id: 'compound:berberine', canonicalSlug: 'berberine', canonicalName: 'Berberine', aliases: [], status: 'duplicate-candidate', parentEntityId: null, reviewFlags: ['identity-collision'] },
+    { id: 'compound:berberine-hcl', canonicalSlug: 'berberine-hcl', canonicalName: 'Berberine', aliases: [], status: 'duplicate-candidate', parentEntityId: null, reviewFlags: ['identity-collision'] },
+  ]
+  const resolutions = {
+    schemaVersion: '0.2.0',
+    resolutions: [
+      { action: 'merge-alias', canonicalRecordId: 'compound:coenzyme-q10', retiredRecordIds: ['compound:coq10'], status: 'approved' },
+      { action: 'establish-form', canonicalRecordId: 'compound:berberine', formRecordIds: ['compound:berberine-hcl'], formCanonicalNames: { 'compound:berberine-hcl': 'Berberine hydrochloride' }, formAliases: { 'compound:berberine-hcl': ['Berberine HCl'] }, status: 'approved' },
+    ],
+  }
+  fs.writeFileSync(path.join(dir, 'substance-registry.json'), JSON.stringify(registry))
+  fs.writeFileSync(path.join(dir, 'identity-resolutions.json'), JSON.stringify(resolutions))
+
+  const { registry: resolved, report } = applyIdentityResolutions({ repoRoot })
+  const coq10 = resolved.find((record) => record.id === 'compound:coq10')
+  const canonical = resolved.find((record) => record.id === 'compound:coenzyme-q10')
+  const form = resolved.find((record) => record.id === 'compound:berberine-hcl')
+
+  assert.equal(report.summary.appliedResolutions, 2)
+  assert.equal(coq10.status, 'deprecated')
+  assert.ok(canonical.aliases.includes('CoQ10'))
+  assert.equal(form.parentEntityId, 'compound:berberine')
+  assert.equal(form.canonicalName, 'Berberine hydrochloride')
+  assert.ok(form.aliases.includes('Berberine HCl'))
+})

--- a/scripts/evidence-graph/apply-identity-resolutions.mjs
+++ b/scripts/evidence-graph/apply-identity-resolutions.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { normalizeAliases } from '../../config/evidence-graph/identity-rules.mjs'
+import { getRepoRoot } from '../workbook-source.mjs'
+
+function writeJson(target, value) {
+  fs.mkdirSync(path.dirname(target), { recursive: true })
+  fs.writeFileSync(target, `${JSON.stringify(value, null, 2)}\n`)
+}
+
+export function applyIdentityResolutions(options = {}) {
+  const repoRoot = options.repoRoot || getRepoRoot()
+  const registryPath = path.resolve(repoRoot, options.registryPath || 'data/graph/identity/substance-registry.json')
+  const resolutionsPath = path.resolve(repoRoot, options.resolutionsPath || 'data/graph/identity/identity-resolutions.json')
+  const reportPath = path.resolve(repoRoot, options.reportPath || 'data/graph/identity/identity-resolution-report.json')
+  const registry = JSON.parse(fs.readFileSync(registryPath, 'utf8'))
+  const ledger = JSON.parse(fs.readFileSync(resolutionsPath, 'utf8'))
+  const byId = new Map(registry.map((record) => [record.id, record]))
+  let applied = 0
+  let skipped = 0
+
+  for (const resolution of ledger.resolutions.filter((item) => item.status === 'approved')) {
+    const canonical = byId.get(resolution.canonicalRecordId)
+    if (!canonical) { skipped += 1; continue }
+
+    if (resolution.action === 'merge-alias') {
+      const retired = (resolution.retiredRecordIds || []).map((id) => byId.get(id)).filter(Boolean)
+      if (!retired.length) { skipped += 1; continue }
+      canonical.aliases = normalizeAliases([...canonical.aliases, ...retired.flatMap((record) => [record.canonicalName, record.canonicalSlug, ...record.aliases])])
+      for (const record of retired) {
+        record.status = 'deprecated'
+        record.parentEntityId = canonical.id
+        record.reviewFlags = [...new Set([...record.reviewFlags.filter((flag) => flag !== 'identity-collision'), 'merged-as-alias'])]
+      }
+      canonical.status = 'active'
+      canonical.reviewFlags = canonical.reviewFlags.filter((flag) => flag !== 'identity-collision')
+      applied += 1
+      continue
+    }
+
+    if (resolution.action === 'establish-form') {
+      const forms = (resolution.formRecordIds || []).map((id) => byId.get(id)).filter(Boolean)
+      if (!forms.length) { skipped += 1; continue }
+      for (const form of forms) {
+        form.parentEntityId = canonical.id
+        form.canonicalName = resolution.formCanonicalNames?.[form.id] || form.canonicalName
+        form.aliases = normalizeAliases([...form.aliases, ...(resolution.formAliases?.[form.id] || [])])
+        form.status = 'active'
+        form.reviewFlags = [...new Set([...form.reviewFlags.filter((flag) => flag !== 'identity-collision'), 'form-of-parent-identity'])]
+      }
+      canonical.status = 'active'
+      canonical.reviewFlags = canonical.reviewFlags.filter((flag) => flag !== 'identity-collision')
+      applied += 1
+      continue
+    }
+
+    skipped += 1
+  }
+
+  writeJson(registryPath, registry)
+  const report = {
+    schemaVersion: ledger.schemaVersion,
+    generatedAt: new Date().toISOString(),
+    summary: {
+      approvedResolutions: ledger.resolutions.filter((item) => item.status === 'approved').length,
+      appliedResolutions: applied,
+      skippedResolutions: skipped,
+      deprecatedRecords: registry.filter((record) => record.status === 'deprecated').length,
+      formRecords: registry.filter((record) => record.reviewFlags?.includes('form-of-parent-identity')).length,
+    },
+  }
+  writeJson(reportPath, report)
+  return { registry, report }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  try {
+    const { report } = applyIdentityResolutions()
+    console.log(`[evidence-graph] Applied ${report.summary.appliedResolutions} identity resolutions`)
+  } catch (error) {
+    console.error(error)
+    process.exitCode = 1
+  }
+}

--- a/scripts/evidence-graph/build-identity-collision-review.mjs
+++ b/scripts/evidence-graph/build-identity-collision-review.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { getRepoRoot } from '../workbook-source.mjs'
+
+const quote = (value) => `"${String(value ?? '').replaceAll('"', '""')}"`
+
+export function buildCollisionReview(options = {}) {
+  const repoRoot = options.repoRoot || getRepoRoot()
+  const reportPath = path.resolve(repoRoot, options.reportPath || 'data/graph/identity/identity-validation-report.json')
+  const outputPath = path.resolve(repoRoot, options.outputPath || 'data/graph/identity/identity-collision-review.csv')
+  const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'))
+  const headers = ['collision_key', 'collision_type', 'classification', 'severity', 'record_ids', 'resolution_action', 'canonical_record_id', 'notes']
+  const rows = report.collisions.map((collision) => [
+    collision.key,
+    collision.type,
+    collision.classification,
+    collision.severity,
+    collision.recordIds.join('|'),
+    '',
+    '',
+    '',
+  ])
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true })
+  fs.writeFileSync(outputPath, `${[headers, ...rows].map((row) => row.map(quote).join(',')).join('\n')}\n`)
+  return { outputPath, rows: rows.length }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  try {
+    const result = buildCollisionReview()
+    console.log(`[evidence-graph] Collision review rows: ${result.rows}`)
+  } catch (error) {
+    console.error(error)
+    process.exitCode = 1
+  }
+}

--- a/scripts/evidence-graph/build-identity-registry.mjs
+++ b/scripts/evidence-graph/build-identity-registry.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { buildStableEntityId, normalizeAliases, normalizeIdentityText, requiresFormReview } from '../../config/evidence-graph/identity-rules.mjs'
+import { getSheet, getSheetNames, readWorkbook, sheetToRows } from '../data/workbook-parser.mjs'
+import { assertWorkbookExists, getRepoRoot, resolveWorkbookPath } from '../workbook-source.mjs'
+
+const OUTPUT = 'data/graph/identity/substance-registry.json'
+const REPORT = 'data/graph/identity/identity-validation-report.json'
+const SHEETS = ['Entity_Master', 'Sheet7', 'Herb Master V3', 'Herb Monographs', 'Site Export Herbs', 'Compound Master V3', 'Site Export Compounds']
+const clean = (value) => String(value ?? '').replace(/\s+/g, ' ').trim()
+const normalizeType = (value) => ['herb', 'compound'].includes(clean(value).toLowerCase()) ? clean(value).toLowerCase() : null
+
+function writeJson(target, value) {
+  fs.mkdirSync(path.dirname(target), { recursive: true })
+  fs.writeFileSync(target, `${JSON.stringify(value, null, 2)}\n`)
+}
+
+function recordFromRow(row, index, sheet, entityType, workbookPath) {
+  const canonicalSlug = clean(row.canonical_slug_v2 || row.slug)
+  const canonicalName = clean(row.name || row.canonical_name)
+  const scientificName = clean(row.latin_name || row.scientific_name || row.scientificName) || null
+  const aliases = normalizeAliases([row.aliases, row.common_names, row.commonNames, row.alternate_names, row.synonyms, scientificName])
+    .filter((alias) => normalizeIdentityText(alias) !== normalizeIdentityText(canonicalName))
+  const reviewFlags = []
+  if (!canonicalSlug) reviewFlags.push('missing-canonical-slug')
+  if (!canonicalName) reviewFlags.push('missing-canonical-name')
+  if (requiresFormReview([canonicalName, scientificName, row.formulations, row.oral_form, row.extract_type, row.standardization_target, row.preparation].filter(Boolean).join(' '))) reviewFlags.push('form-sensitive-identity')
+
+  return {
+    id: canonicalSlug ? buildStableEntityId(entityType, canonicalSlug) : null,
+    entityType,
+    canonicalSlug: canonicalSlug || null,
+    canonicalName: canonicalName || null,
+    scientificName,
+    parentEntityId: null,
+    aliases,
+    status: reviewFlags.length ? 'needs-review' : 'active',
+    reviewFlags,
+    provenance: {
+      workbook: path.basename(workbookPath),
+      sheet,
+      sourceRow: index + 2,
+      sourceSlug: clean(row.slug) || canonicalSlug || `row-${index + 2}`,
+      canonicalSlugField: clean(row.canonical_slug_v2) ? 'canonical_slug_v2' : 'slug',
+      duplicateGroup: clean(row.duplicate_group_v2) || null,
+      importerVersion: '0.4.0',
+    },
+  }
+}
+
+function collisionGroups(records) {
+  const groups = []
+  const indexes = [
+    ['stable-id-collision', (r) => r.id],
+    ['canonical-slug-collision', (r) => normalizeIdentityText(r.canonicalSlug)],
+    ['canonical-name-collision', (r) => normalizeIdentityText(r.canonicalName)],
+  ]
+  for (const [type, keyOf] of indexes) {
+    const index = new Map()
+    for (const record of records) {
+      const key = keyOf(record)
+      if (!key) continue
+      index.set(key, [...(index.get(key) || []), record])
+    }
+    for (const [key, matches] of index) {
+      if (matches.length < 2) continue
+      const crossType = new Set(matches.map((r) => r.entityType)).size > 1
+      groups.push({
+        type,
+        key,
+        recordIds: matches.map((r) => r.id),
+        classification: type.includes('name') ? (crossType ? 'cross-type-name-conflict' : 'same-type-name-duplicate') : 'identity-critical',
+        severity: type.includes('name') ? 'high' : 'blocking',
+      })
+    }
+  }
+  return groups
+}
+
+export async function buildIdentityRegistry(options = {}) {
+  const repoRoot = options.repoRoot || getRepoRoot()
+  const workbookPath = options.workbookPath || resolveWorkbookPath(repoRoot)
+  assertWorkbookExists(workbookPath)
+  const workbook = await readWorkbook(workbookPath, { sheets: SHEETS })
+  const names = getSheetNames(workbook)
+  const master = names.find((name) => ['Entity_Master', 'Sheet7'].includes(name))
+  const records = []
+
+  if (master) {
+    sheetToRows(getSheet(workbook, master)).forEach((row, index) => {
+      const entityType = normalizeType(row.entity_type)
+      if (entityType) records.push(recordFromRow(row, index, master, entityType, workbookPath))
+    })
+  } else {
+    for (const [entityType, candidates] of [['herb', ['Herb Master V3', 'Herb Monographs', 'Site Export Herbs']], ['compound', ['Compound Master V3', 'Site Export Compounds']]]) {
+      const sheet = candidates.find((name) => names.includes(name))
+      if (!sheet) continue
+      sheetToRows(getSheet(workbook, sheet)).forEach((row, index) => records.push(recordFromRow(row, index, sheet, entityType, workbookPath)))
+    }
+  }
+
+  const valid = records.filter((r) => r.id && r.canonicalSlug && r.canonicalName)
+  const collisions = collisionGroups(valid)
+  const collided = new Set(collisions.flatMap((group) => group.recordIds))
+  for (const record of valid) {
+    if (!collided.has(record.id)) continue
+    record.status = 'duplicate-candidate'
+    record.reviewFlags = [...new Set([...record.reviewFlags, 'identity-collision'])]
+  }
+  valid.sort((a, b) => a.entityType.localeCompare(b.entityType) || a.canonicalSlug.localeCompare(b.canonicalSlug))
+
+  const report = {
+    importerVersion: '0.4.0',
+    generatedAt: new Date().toISOString(),
+    summary: {
+      totalCandidates: records.length,
+      registryRecords: valid.length,
+      herbRecords: valid.filter((r) => r.entityType === 'herb').length,
+      compoundRecords: valid.filter((r) => r.entityType === 'compound').length,
+      invalidRecords: records.length - valid.length,
+      missingIdRecords: records.filter((r) => !r.id).length,
+      collisionCount: collisions.length,
+      reviewQueueRecords: valid.filter((r) => r.status !== 'active').length,
+      duplicateCandidateRecords: valid.filter((r) => r.status === 'duplicate-candidate').length,
+    },
+    collisions,
+    collisionSummary: {
+      byType: Object.fromEntries([...new Set(collisions.map((c) => c.type))].map((type) => [type, collisions.filter((c) => c.type === type).length])),
+      byClassification: Object.fromEntries([...new Set(collisions.map((c) => c.classification))].map((type) => [type, collisions.filter((c) => c.classification === type).length])),
+    },
+  }
+
+  const outputPath = path.resolve(repoRoot, options.outputPath || OUTPUT)
+  const reportPath = path.resolve(repoRoot, options.reportPath || REPORT)
+  writeJson(outputPath, valid)
+  writeJson(reportPath, report)
+  return { registry: valid, report, outputPath, reportPath }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  buildIdentityRegistry().then(({ report }) => console.log(`[evidence-graph] ${report.summary.registryRecords} identities; ${report.summary.collisionCount} collisions`)).catch((error) => { console.error(error); process.exitCode = 1 })
+}


### PR DESCRIPTION
## Summary
- rebuild the conflicted Evidence Graph identity foundation from current `main`
- keep stable ID normalization, schema, workbook import, collision review, and explicit human-approved resolutions
- preserve alias merges for CoQ10, lion's mane, and nicotinamide riboside
- preserve berberine hydrochloride as an active child form of berberine
- add focused regression coverage and an isolated GitHub Actions workflow
- regenerate registry/report artifacts from the current workbook instead of copying the stale generated snapshot

## Conflict resolution
This replaces conflicted PR #2443. The replacement branch starts from current `main` and contains only durable source, policy, test, workflow, and documentation files.

## Safety
- no live routes changed
- no workbook writes
- no generated public runtime data changed
- no automatic identity merges outside the approved resolution ledger
