### PR TITLE
Add indexable Botanical Activity Atlas category guides

### DIFF
--- a/app/tools/botanical-activity-atlas/[category]/page.tsx
+++ b/app/tools/botanical-activity-atlas/[category]/page.tsx
@@ -1,0 +1,118 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import SchemaGraphScript from '@/components/seo/SchemaGraphScript'
+import BotanicalActivityAtlasClient from '@/components/atlas/BotanicalActivityAtlasClient'
+import { getBotanicalAtlasRecords } from '@/lib/botanical-atlas-data'
+import {
+  BOTANICAL_ATLAS_CATEGORIES,
+  getBotanicalAtlasCategory,
+} from '@/lib/botanical-atlas-categories'
+import { buildToolPageSchemaGraph } from '@/lib/schema-graph'
+import { buildPageMetadata, SITE_URL } from '@/lib/seo'
+
+interface PageProps {
+  params: Promise<{ category: string }>
+}
+
+export const dynamicParams = false
+
+export function generateStaticParams() {
+  return BOTANICAL_ATLAS_CATEGORIES.map(({ slug }) => ({ category: slug }))
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { category: slug } = await params
+  const category = getBotanicalAtlasCategory(slug)
+  if (!category) return {}
+
+  return buildPageMetadata({
+    title: category.title,
+    description: category.description,
+    path: `/tools/botanical-activity-atlas/${category.slug}`,
+  })
+}
+
+export default async function BotanicalAtlasCategoryPage({ params }: PageProps) {
+  const { category: slug } = await params
+  const category = getBotanicalAtlasCategory(slug)
+  if (!category) notFound()
+
+  const allRecords = await getBotanicalAtlasRecords()
+  const records = allRecords.filter(category.matches)
+  const related = BOTANICAL_ATLAS_CATEGORIES.filter((item) => item.slug !== category.slug)
+
+  const path = `/tools/botanical-activity-atlas/${category.slug}`
+  const schemaGraph = buildToolPageSchemaGraph({
+    path,
+    title: category.title,
+    description: category.description,
+    breadcrumbs: [
+      { name: 'Home', url: `${SITE_URL}/` },
+      { name: 'Tools', url: `${SITE_URL}/tools/` },
+      { name: 'Botanical Activity Atlas', url: `${SITE_URL}/tools/botanical-activity-atlas/` },
+      { name: category.shortTitle, url: `${SITE_URL}${path}/` },
+    ],
+    faqQuestions: [
+      {
+        question: `How were botanicals selected for this ${category.shortTitle.toLowerCase()} comparison?`,
+        answer: 'The page filters structured herb records using normalized effect, chemistry, or safety categories. Inclusion does not prove effectiveness, product quality, or personal suitability.',
+      },
+      {
+        question: 'Does stronger noticeability mean stronger evidence?',
+        answer: 'No. Noticeability and evidence are separate dimensions. A botanical may produce obvious sensations while having weak clinical evidence, or have useful evidence without feeling immediately noticeable.',
+      },
+      {
+        question: 'Can this comparison replace an interaction check?',
+        answer: 'No. It is an educational screening and discovery tool. Medication, health-condition, dose, product, and combination risks require individualized review.',
+      },
+    ],
+  })
+
+  return (
+    <main className='mx-auto max-w-7xl space-y-8 px-4 py-8 sm:py-10'>
+      <SchemaGraphScript graph={schemaGraph} />
+
+      <nav aria-label='Breadcrumb' className='text-sm text-muted'>
+        <Link href='/tools/botanical-activity-atlas/' className='font-semibold text-emerald-800 hover:underline'>Botanical Activity Atlas</Link>
+        <span aria-hidden='true' className='mx-2'>/</span>
+        <span>{category.shortTitle}</span>
+      </nav>
+
+      <section className='rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8'>
+        <p className='eyebrow-label'>{category.eyebrow}</p>
+        <h1 className='mt-2 text-3xl font-bold tracking-tight text-ink sm:text-5xl'>{category.title}</h1>
+        <p className='mt-4 max-w-4xl text-base leading-7 text-muted sm:text-lg'>{category.intro}</p>
+        <div className='mt-5 flex flex-wrap items-center gap-3 text-sm'>
+          <span className='rounded-full bg-emerald-50 px-3 py-1 font-semibold text-emerald-950'>{records.length} matching botanicals</span>
+          <Link href='/tools/botanical-activity-atlas/' className='font-semibold text-emerald-800 hover:underline'>Browse the complete atlas →</Link>
+        </div>
+      </section>
+
+      <section className='rounded-2xl border border-amber-900/15 bg-amber-50/60 p-5 text-sm leading-6 text-amber-950'>
+        <h2 className='font-bold'>Important context</h2>
+        <p className='mt-1.5'>{category.safetyNote}</p>
+      </section>
+
+      <BotanicalActivityAtlasClient records={records} />
+
+      <section className='space-y-4'>
+        <h2 className='text-2xl font-bold text-ink'>Explore related atlas guides</h2>
+        <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-4'>
+          {related.map((item) => (
+            <Link key={item.slug} href={`/tools/botanical-activity-atlas/${item.slug}/`} className='rounded-2xl border border-brand-900/10 bg-white/85 p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-emerald-800/30'>
+              <p className='text-xs font-bold uppercase tracking-wide text-emerald-800'>{item.eyebrow}</p>
+              <h3 className='mt-2 font-bold text-ink'>{item.shortTitle}</h3>
+              <p className='mt-2 text-sm leading-6 text-muted'>{item.description}</p>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      <section className='rounded-2xl border border-brand-900/10 bg-white/80 p-5 text-xs leading-relaxed text-muted'>
+        <p className='font-bold text-ink'>Educational use only</p>
+        <p className='mt-1.5'>These comparisons summarize normalized reference data. They do not verify a commercial product, establish a dose, diagnose a condition, or determine whether a botanical is safe for an individual.</p>
+      </section>
+    </main>
+  )
+}

--- a/app/tools/botanical-activity-atlas/page.tsx
+++ b/app/tools/botanical-activity-atlas/page.tsx
@@ -1,19 +1,11 @@
 import type { Metadata } from 'next'
+import Link from 'next/link'
 import SchemaGraphScript from '@/components/seo/SchemaGraphScript'
-import BotanicalActivityAtlasClient, { type BotanicalAtlasRecord } from '@/components/atlas/BotanicalActivityAtlasClient'
-import { getHerbs } from '@/lib/runtime-data'
-import { getRuntimeVisibility } from '../../../lib/runtime-visibility'
+import BotanicalActivityAtlasClient from '@/components/atlas/BotanicalActivityAtlasClient'
+import { getBotanicalAtlasRecords } from '@/lib/botanical-atlas-data'
+import { BOTANICAL_ATLAS_CATEGORIES } from '@/lib/botanical-atlas-categories'
 import { buildToolPageSchemaGraph } from '@/lib/schema-graph'
 import { buildPageMetadata, SITE_URL } from '@/lib/seo'
-import {
-  normalizeCompoundClass,
-  normalizeEffect,
-  normalizeEvidence,
-  normalizeIntensity,
-  normalizeSafetySignal,
-  uniqueNormalized,
-} from '@/lib/botanical-atlas-taxonomy'
-import type { RuntimeRecord } from '@/types/content'
 
 export const metadata: Metadata = buildPageMetadata({
   title: 'Botanical Activity Atlas – Effects, Compounds & Safety',
@@ -22,50 +14,8 @@ export const metadata: Metadata = buildPageMetadata({
   path: '/tools/botanical-activity-atlas',
 })
 
-const list = (value: unknown): string[] => {
-  if (Array.isArray(value)) return value.map(String).map((item) => item.trim()).filter(Boolean)
-  if (typeof value === 'string') return value.split(/[;,|]/).map((item) => item.trim()).filter(Boolean)
-  return []
-}
-
-const text = (...values: unknown[]): string => {
-  const value = values.find((item) => typeof item === 'string' && item.trim())
-  return typeof value === 'string' ? value.trim() : ''
-}
-
-const toAtlasRecord = (herb: RuntimeRecord): BotanicalAtlasRecord => {
-  const rawEffects = list(herb.primary_effects ?? herb.effects ?? herb.primaryActions)
-  const rawClasses = list(herb.compoundClasses ?? herb.pharmCategories ?? herb.compoundClass)
-  const rawSafety = list(herb.safety_flags ?? herb.interactionTags ?? herb.contraindications ?? herb.interactions)
-
-  return {
-    slug: herb.slug,
-    name: text(herb.displayName, herb.name, herb.commonName, herb.common, herb.slug.replaceAll('-', ' ')),
-    scientificName: text(herb.scientificName, herb.scientificname, herb.latinName) || undefined,
-    effects: uniqueNormalized(rawEffects, normalizeEffect),
-    compounds: list(herb.activeCompounds ?? herb.active_compounds ?? herb.compounds ?? herb.activeconstituents),
-    compoundClasses: uniqueNormalized(rawClasses, normalizeCompoundClass),
-    evidence: normalizeEvidence(text(herb.evidence_tier, herb.evidenceTier, herb.evidence_grade, herb.evidenceLevel)),
-    intensity: normalizeIntensity(text(herb.intensityLabel, herb.intensityClean, herb.intensityLevel, herb.intensity)),
-    safety: uniqueNormalized(rawSafety, normalizeSafetySignal),
-    onset: text(herb.time_to_effect, herb.onset) || undefined,
-    duration: text(herb.duration) || undefined,
-  }
-}
-
 export default async function BotanicalActivityAtlasPage() {
-  const rawHerbs = await getHerbs()
-  const herbs = rawHerbs
-    .filter((herb: RuntimeRecord) => {
-      try {
-        return getRuntimeVisibility(herb).canRender
-      } catch {
-        return true
-      }
-    })
-    .map(toAtlasRecord)
-    .filter((herb: BotanicalAtlasRecord) => herb.effects.length || herb.compounds.length || herb.safety.length)
-    .sort((a: BotanicalAtlasRecord, b: BotanicalAtlasRecord) => a.name.localeCompare(b.name))
+  const herbs = await getBotanicalAtlasRecords()
 
   const schemaGraph = buildToolPageSchemaGraph({
     path: '/tools/botanical-activity-atlas',
@@ -121,6 +71,24 @@ export default async function BotanicalActivityAtlasPage() {
           <h2 className='font-bold text-ink'>Labels are normalized</h2>
           <p className='mt-2 text-sm leading-6 text-muted'>Related source terms are grouped into consistent effect, evidence, chemistry, noticeability, and safety categories.</p>
         </article>
+      </section>
+
+      <section className='space-y-4'>
+        <div>
+          <p className='eyebrow-label'>Focused Comparisons</p>
+          <h2 className='mt-1 text-2xl font-bold text-ink'>Start with a high-interest category</h2>
+          <p className='mt-2 max-w-3xl text-sm leading-6 text-muted'>These curated entry pages use the same atlas data while adding category-specific context and safety framing.</p>
+        </div>
+        <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-3'>
+          {BOTANICAL_ATLAS_CATEGORIES.map((category) => (
+            <Link key={category.slug} href={`/tools/botanical-activity-atlas/${category.slug}/`} className='rounded-2xl border border-brand-900/10 bg-white/85 p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-emerald-800/30'>
+              <p className='text-xs font-bold uppercase tracking-wide text-emerald-800'>{category.eyebrow}</p>
+              <h3 className='mt-2 font-bold text-ink'>{category.shortTitle}</h3>
+              <p className='mt-2 text-sm leading-6 text-muted'>{category.description}</p>
+              <span className='mt-3 inline-block text-sm font-semibold text-emerald-800'>Open comparison →</span>
+            </Link>
+          ))}
+        </div>
       </section>
 
       <BotanicalActivityAtlasClient records={herbs} />

--- a/src/lib/__tests__/botanical-atlas-categories.test.ts
+++ b/src/lib/__tests__/botanical-atlas-categories.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { BOTANICAL_ATLAS_CATEGORIES, getBotanicalAtlasCategory } from '@/lib/botanical-atlas-categories'
+import type { BotanicalAtlasRecord } from '@/components/atlas/BotanicalActivityAtlasClient'
+
+const baseRecord: BotanicalAtlasRecord = {
+  slug: 'example',
+  name: 'Example',
+  effects: [],
+  compounds: [],
+  compoundClasses: [],
+  evidence: 'Preliminary',
+  intensity: 'Moderate',
+  safety: [],
+}
+
+describe('Botanical Activity Atlas category presets', () => {
+  it('uses unique stable slugs', () => {
+    const slugs = BOTANICAL_ATLAS_CATEGORIES.map((category) => category.slug)
+    expect(new Set(slugs).size).toBe(slugs.length)
+    expect(slugs).toEqual(expect.arrayContaining([
+      'alkaloid-botanicals',
+      'natural-stimulants',
+      'calming-botanicals',
+      'dream-and-perception-herbs',
+      'serotonergic-interaction-risk',
+    ]))
+  })
+
+  it('matches each normalized taxonomy dimension', () => {
+    expect(getBotanicalAtlasCategory('alkaloid-botanicals')?.matches({ ...baseRecord, compoundClasses: ['Alkaloids'] })).toBe(true)
+    expect(getBotanicalAtlasCategory('natural-stimulants')?.matches({ ...baseRecord, effects: ['Stimulating / energy'] })).toBe(true)
+    expect(getBotanicalAtlasCategory('calming-botanicals')?.matches({ ...baseRecord, effects: ['Calming'] })).toBe(true)
+    expect(getBotanicalAtlasCategory('dream-and-perception-herbs')?.matches({ ...baseRecord, effects: ['Dream / perception'] })).toBe(true)
+    expect(getBotanicalAtlasCategory('serotonergic-interaction-risk')?.matches({ ...baseRecord, safety: ['Serotonergic'] })).toBe(true)
+  })
+})

--- a/src/lib/botanical-atlas-categories.ts
+++ b/src/lib/botanical-atlas-categories.ts
@@ -1,0 +1,68 @@
+import type { BotanicalAtlasRecord } from '@/components/atlas/BotanicalActivityAtlasClient'
+
+export interface BotanicalAtlasCategory {
+  slug: string
+  title: string
+  shortTitle: string
+  description: string
+  eyebrow: string
+  intro: string
+  safetyNote: string
+  matches: (record: BotanicalAtlasRecord) => boolean
+}
+
+export const BOTANICAL_ATLAS_CATEGORIES: BotanicalAtlasCategory[] = [
+  {
+    slug: 'alkaloid-botanicals',
+    title: 'Alkaloid-Containing Botanicals Compared',
+    shortTitle: 'Alkaloid botanicals',
+    description: 'Compare botanicals containing alkaloid-class constituents by effects, evidence, noticeability, timing, and safety signals.',
+    eyebrow: 'Active Chemistry Guide',
+    intro: 'Alkaloids are a broad chemical family that includes mild stimulants, medicinal constituents, and compounds with substantial interaction or dependence risks. This page groups botanicals whose structured profiles map to the alkaloid class; it does not imply that every product is intoxicating or equally potent.',
+    safetyNote: 'Alkaloid content can vary sharply by species, plant part, extraction method, and product concentration. Stronger sensation does not establish purity, effectiveness, or safety.',
+    matches: (record) => record.compoundClasses.includes('Alkaloids'),
+  },
+  {
+    slug: 'natural-stimulants',
+    title: 'Natural Stimulant Botanicals Compared',
+    shortTitle: 'Natural stimulants',
+    description: 'Compare stimulating and energy-associated botanicals by active chemistry, evidence, noticeability, timing, and cardiovascular safety signals.',
+    eyebrow: 'Effect-Based Guide',
+    intro: 'Botanicals described as stimulating may increase alertness, perceived energy, wakefulness, or physical drive through very different mechanisms. This comparison separates effect labels from evidence strength and highlights safety signals that matter when stimulants are combined.',
+    safetyNote: 'Combining multiple stimulants can amplify insomnia, anxiety, blood-pressure changes, or heart-rate effects even when each ingredient is sold as natural.',
+    matches: (record) => record.effects.includes('Stimulating / energy'),
+  },
+  {
+    slug: 'calming-botanicals',
+    title: 'Calming Botanicals Compared',
+    shortTitle: 'Calming botanicals',
+    description: 'Compare calming and relaxation-associated botanicals by evidence, noticeability, active chemistry, timing, and sedation risks.',
+    eyebrow: 'Effect-Based Guide',
+    intro: 'Calming botanicals range from subtle stress-support herbs to more noticeably sedating plants. This page distinguishes calming effect labels from sleep-promoting intensity and surfaces the evidence and safety context behind each profile.',
+    safetyNote: 'Calming products may compound alcohol, sleep medications, antihistamines, or other sedatives. A mild label does not rule out impairment or interaction risk.',
+    matches: (record) => record.effects.includes('Calming'),
+  },
+  {
+    slug: 'dream-and-perception-herbs',
+    title: 'Dream and Perception Botanicals Compared',
+    shortTitle: 'Dream and perception herbs',
+    description: 'Compare botanicals associated with dreams, lucid dreaming, perception changes, or psychoactive effects by evidence and safety.',
+    eyebrow: 'Perception & Dream Guide',
+    intro: 'Traditional dream herbs and perception-altering botanicals are often discussed together despite major differences in chemistry, evidence, and risk. This page collects profiles mapped to dream or perception effects while keeping weak evidence and toxicity concerns visible.',
+    safetyNote: 'Perception-related effects can include confusion, impaired coordination, panic, or poisoning—not just vivid dreams. Avoid treating this category as a recreational recommendation list.',
+    matches: (record) => record.effects.includes('Dream / perception'),
+  },
+  {
+    slug: 'serotonergic-interaction-risk',
+    title: 'Botanicals With Serotonergic Interaction Signals',
+    shortTitle: 'Serotonergic interaction risks',
+    description: 'Compare botanicals flagged for serotonergic or MAOI-related interaction concerns, including evidence, effects, and additional safety signals.',
+    eyebrow: 'Medication Safety Guide',
+    intro: 'This page gathers botanicals whose structured safety data contains serotonergic, SSRI, SNRI, MAOI, or monoamine-oxidase interaction language. It is designed as a screening aid, not a personalized interaction checker.',
+    safetyNote: 'Do not start, stop, or combine a serotonergic botanical with antidepressants, stimulants, migraine medicines, or other psychoactive drugs based only on this page. A pharmacist or prescriber should review the full combination.',
+    matches: (record) => record.safety.includes('Serotonergic'),
+  },
+]
+
+export const getBotanicalAtlasCategory = (slug: string) =>
+  BOTANICAL_ATLAS_CATEGORIES.find((category) => category.slug === slug)

--- a/src/lib/botanical-atlas-data.ts
+++ b/src/lib/botanical-atlas-data.ts
@@ -1,0 +1,58 @@
+import { getHerbs } from '@/lib/runtime-data'
+import { getRuntimeVisibility } from '../../lib/runtime-visibility'
+import {
+  normalizeCompoundClass,
+  normalizeEffect,
+  normalizeEvidence,
+  normalizeIntensity,
+  normalizeSafetySignal,
+  uniqueNormalized,
+} from '@/lib/botanical-atlas-taxonomy'
+import type { BotanicalAtlasRecord } from '@/components/atlas/BotanicalActivityAtlasClient'
+import type { RuntimeRecord } from '@/types/content'
+
+const list = (value: unknown): string[] => {
+  if (Array.isArray(value)) return value.map(String).map((item) => item.trim()).filter(Boolean)
+  if (typeof value === 'string') return value.split(/[;,|]/).map((item) => item.trim()).filter(Boolean)
+  return []
+}
+
+const text = (...values: unknown[]): string => {
+  const value = values.find((item) => typeof item === 'string' && item.trim())
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+export const toAtlasRecord = (herb: RuntimeRecord): BotanicalAtlasRecord => {
+  const rawEffects = list(herb.primary_effects ?? herb.effects ?? herb.primaryActions)
+  const rawClasses = list(herb.compoundClasses ?? herb.pharmCategories ?? herb.compoundClass)
+  const rawSafety = list(herb.safety_flags ?? herb.interactionTags ?? herb.contraindications ?? herb.interactions)
+
+  return {
+    slug: herb.slug,
+    name: text(herb.displayName, herb.name, herb.commonName, herb.common, herb.slug.replaceAll('-', ' ')),
+    scientificName: text(herb.scientificName, herb.scientificname, herb.latinName) || undefined,
+    effects: uniqueNormalized(rawEffects, normalizeEffect),
+    compounds: list(herb.activeCompounds ?? herb.active_compounds ?? herb.compounds ?? herb.activeconstituents),
+    compoundClasses: uniqueNormalized(rawClasses, normalizeCompoundClass),
+    evidence: normalizeEvidence(text(herb.evidence_tier, herb.evidenceTier, herb.evidence_grade, herb.evidenceLevel)),
+    intensity: normalizeIntensity(text(herb.intensityLabel, herb.intensityClean, herb.intensityLevel, herb.intensity)),
+    safety: uniqueNormalized(rawSafety, normalizeSafetySignal),
+    onset: text(herb.time_to_effect, herb.onset) || undefined,
+    duration: text(herb.duration) || undefined,
+  }
+}
+
+export async function getBotanicalAtlasRecords(): Promise<BotanicalAtlasRecord[]> {
+  const rawHerbs = await getHerbs()
+  return rawHerbs
+    .filter((herb: RuntimeRecord) => {
+      try {
+        return getRuntimeVisibility(herb).canRender
+      } catch {
+        return true
+      }
+    })
+    .map(toAtlasRecord)
+    .filter((herb) => herb.effects.length || herb.compounds.length || herb.safety.length)
+    .sort((a, b) => a.name.localeCompare(b.name))
+}


### PR DESCRIPTION
## Summary
- extract one shared server-side atlas record builder
- add five static, indexable atlas category routes
- add unique metadata, FAQ schema, breadcrumbs, editorial context, and safety framing per category
- cross-link category pages and surface them from the main atlas
- add regression tests for preset slugs and taxonomy matching

## New routes
- `/tools/botanical-activity-atlas/alkaloid-botanicals/`
- `/tools/botanical-activity-atlas/natural-stimulants/`
- `/tools/botanical-activity-atlas/calming-botanicals/`
- `/tools/botanical-activity-atlas/dream-and-perception-herbs/`
- `/tools/botanical-activity-atlas/serotonergic-interaction-risk/`

## Why this is high ROI
One structured dataset now supports five focused organic-search entry points without duplicating profile data or creating manually maintained comparison tables.

## Safety
No workbook changes, generated runtime changes, product recommendations, or dosing guidance.