### PR TITLE
Connect Botanical Activity Atlas to safety and indexation

### DIFF
--- a/app/safety-checker/page.tsx
+++ b/app/safety-checker/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import dynamic from 'next/dynamic'
+import Link from 'next/link'
 import { Suspense } from 'react'
 import { getHerbs, getCompounds } from '../../src/lib/runtime-data'
 import { getRuntimeVisibility } from '../../lib/runtime-visibility'
@@ -128,6 +129,22 @@ export default async function SafetyCheckerPage() {
           compounds={compounds.map((compound) => toSafetyToolRecord(compound, 'compound'))}
         />
       </Suspense>
+
+      <section className='rounded-2xl border border-emerald-900/10 bg-emerald-50/45 p-5 shadow-sm'>
+        <p className='eyebrow-label'>Continue researching</p>
+        <h2 className='mt-2 text-xl font-bold tracking-tight text-ink'>Compare active botanicals by chemistry and risk</h2>
+        <p className='mt-2 max-w-3xl text-sm leading-6 text-muted'>
+          The Botanical Activity Atlas groups herbs by active-compound class, effect profile, evidence, noticeability, and structured safety signals. Use the focused serotonergic guide when antidepressants, MAO inhibition, or serotonin-related stacking is part of the question.
+        </p>
+        <div className='mt-4 flex flex-wrap gap-3'>
+          <Link href='/tools/botanical-activity-atlas/serotonergic-interaction-risk/' className='rounded-full bg-emerald-900 px-4 py-2 text-sm font-bold text-white transition hover:bg-emerald-800'>
+            View serotonergic-risk botanicals
+          </Link>
+          <Link href='/tools/botanical-activity-atlas/' className='rounded-full border border-emerald-900/20 bg-white px-4 py-2 text-sm font-bold text-emerald-900 transition hover:border-emerald-900/35'>
+            Open the complete atlas
+          </Link>
+        </div>
+      </section>
 
       <section className='rounded-2xl border border-rose-900/15 bg-rose-50/50 p-5 text-xs leading-relaxed text-rose-950'>
         <p className='font-bold flex items-center gap-1.5'>

--- a/src/lib/__tests__/botanical-atlas-indexability.test.ts
+++ b/src/lib/__tests__/botanical-atlas-indexability.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { CORE_INDEXABLE_ROUTES } from '../index-allowlist'
+
+const ATLAS_ROUTES = [
+  '/tools/botanical-activity-atlas',
+  '/tools/botanical-activity-atlas/alkaloid-botanicals',
+  '/tools/botanical-activity-atlas/natural-stimulants',
+  '/tools/botanical-activity-atlas/calming-botanicals',
+  '/tools/botanical-activity-atlas/dream-and-perception-herbs',
+  '/tools/botanical-activity-atlas/serotonergic-interaction-risk',
+] as const
+
+describe('Botanical Activity Atlas indexability', () => {
+  it('keeps the atlas and all editorial category guides in the core index allowlist', () => {
+    for (const route of ATLAS_ROUTES) {
+      expect(CORE_INDEXABLE_ROUTES).toContain(route)
+    }
+  })
+
+  it('does not contain duplicate atlas routes', () => {
+    const routes = CORE_INDEXABLE_ROUTES.filter((route) => route.startsWith('/tools/botanical-activity-atlas'))
+    expect(new Set(routes).size).toBe(routes.length)
+  })
+})

--- a/src/lib/index-allowlist.ts
+++ b/src/lib/index-allowlist.ts
@@ -18,6 +18,12 @@ export const CORE_INDEXABLE_ROUTES = [
   '/info/supplement-safety-checklist',
   '/stacks',
   '/tools',
+  '/tools/botanical-activity-atlas',
+  '/tools/botanical-activity-atlas/alkaloid-botanicals',
+  '/tools/botanical-activity-atlas/natural-stimulants',
+  '/tools/botanical-activity-atlas/calming-botanicals',
+  '/tools/botanical-activity-atlas/dream-and-perception-herbs',
+  '/tools/botanical-activity-atlas/serotonergic-interaction-risk',
 ] as const
 
 export const MONEY_ENTRY_ROUTES = [


### PR DESCRIPTION
## Summary
- explicitly allowlist the main Botanical Activity Atlas and all five category guides for indexing
- add contextual links from the Safety Interaction Checker to the serotonergic-risk guide and complete atlas
- add regression coverage for route presence and duplicate prevention

## Why this is high ROI
The new category pages now have a strong contextual crawl path from a closely related high-value safety tool, while the index allowlist guarantees they are not accidentally suppressed by route governance.

## Scope
Three files only. No workbook, generated runtime data, taxonomy, or dosing guidance changed.