### PR TITLE
Add contextual Botanical Activity Atlas links to herb profiles

### DIFF
--- a/components/seo/HerbCompoundLinks.tsx
+++ b/components/seo/HerbCompoundLinks.tsx
@@ -1,5 +1,8 @@
 import Link from 'next/link'
 import { getHerbCompoundLinks } from '@/lib/herb-compound-links'
+import { getHerbBySlug } from '@/lib/runtime-data'
+import { getAtlasProfileLinks } from '@/lib/atlas-profile-links'
+import type { RuntimeRecord } from '@/types/content'
 
 type HerbCompoundLinksProps = {
   herbSlug: string
@@ -7,37 +10,70 @@ type HerbCompoundLinksProps = {
 }
 
 /**
- * Renders the active compounds found in a herb as keyword-rich internal links,
- * sourced from the curated herb-compound relationship map. Renders nothing when
- * the herb has no mapped (renderable) compounds.
+ * Renders active-compound links plus data-driven Botanical Activity Atlas paths.
+ * The atlas links are derived from the herb's normalized chemistry, effect, and
+ * safety labels, so profiles stay connected without hand-maintained mappings.
  */
 export default async function HerbCompoundLinks({ herbSlug, herbName }: HerbCompoundLinksProps) {
-  const links = await getHerbCompoundLinks(herbSlug, herbName)
-  if (links.length === 0) return null
+  const [links, herb] = await Promise.all([
+    getHerbCompoundLinks(herbSlug, herbName),
+    getHerbBySlug(herbSlug),
+  ])
+  const atlasLinks = herb ? getAtlasProfileLinks(herb as RuntimeRecord) : []
+
+  if (links.length === 0 && atlasLinks.length === 0) return null
 
   return (
-    <section className="card-premium space-y-3 p-4 sm:p-5" aria-labelledby="active-compounds-heading">
-      <div className="space-y-1">
-        <h2 id="active-compounds-heading" className="text-lg font-bold text-ink">
-          Active Compounds
-        </h2>
-        <p className="text-sm text-muted">
-          Key constituents studied in {herbName || 'this herb'}, with full pharmacology and safety profiles.
-        </p>
-      </div>
-      <ul className="flex gap-2 overflow-x-auto pb-1.5 [-webkit-overflow-scrolling:touch] [scrollbar-width:thin]">
-        {links.map((link) => (
-          <li key={link.slug} className="shrink-0">
-            <Link
-              href={link.href}
-              className="inline-flex min-h-11 items-center gap-1.5 whitespace-nowrap rounded-full border border-brand-900/10 bg-brand-50/50 px-4 py-2 text-sm font-semibold text-brand-800 transition hover:border-brand-700/30 hover:bg-brand-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-700 focus-visible:ring-offset-2"
-            >
-              {link.anchor}
-              <span aria-hidden="true">→</span>
-            </Link>
-          </li>
-        ))}
-      </ul>
+    <section className="card-premium space-y-4 p-4 sm:p-5" aria-labelledby="active-compounds-heading">
+      {links.length > 0 ? (
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <h2 id="active-compounds-heading" className="text-lg font-bold text-ink">
+              Active Compounds
+            </h2>
+            <p className="text-sm text-muted">
+              Key constituents studied in {herbName || 'this herb'}, with full pharmacology and safety profiles.
+            </p>
+          </div>
+          <ul className="flex gap-2 overflow-x-auto pb-1.5 [-webkit-overflow-scrolling:touch] [scrollbar-width:thin]">
+            {links.map((link) => (
+              <li key={link.slug} className="shrink-0">
+                <Link
+                  href={link.href}
+                  className="inline-flex min-h-11 items-center gap-1.5 whitespace-nowrap rounded-full border border-brand-900/10 bg-brand-50/50 px-4 py-2 text-sm font-semibold text-brand-800 transition hover:border-brand-700/30 hover:bg-brand-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-700 focus-visible:ring-offset-2"
+                >
+                  {link.anchor}
+                  <span aria-hidden="true">→</span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {atlasLinks.length > 0 ? (
+        <div className={links.length > 0 ? 'border-t border-brand-900/10 pt-4' : ''}>
+          <div className="space-y-1">
+            <h2 className="text-base font-bold text-ink">Compare related active botanicals</h2>
+            <p className="text-sm text-muted">
+              Explore botanicals with similar chemistry, effects, or safety considerations in the Botanical Activity Atlas.
+            </p>
+          </div>
+          <ul className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            {atlasLinks.map((link) => (
+              <li key={link.href}>
+                <Link
+                  href={link.href}
+                  className="group block h-full rounded-xl border border-emerald-900/10 bg-emerald-50/45 px-3.5 py-3 transition hover:border-emerald-700/30 hover:bg-emerald-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-700 focus-visible:ring-offset-2"
+                >
+                  <span className="block text-sm font-bold text-emerald-950 group-hover:underline">{link.label} →</span>
+                  <span className="mt-1 block text-xs leading-5 text-muted">{link.reason}</span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
     </section>
   )
 }

--- a/src/lib/__tests__/atlas-profile-links.test.ts
+++ b/src/lib/__tests__/atlas-profile-links.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { getAtlasProfileLinks } from '@/lib/atlas-profile-links'
+import type { RuntimeRecord } from '@/types/content'
+
+const record = (overrides: Partial<RuntimeRecord>): RuntimeRecord => ({
+  slug: 'example-herb',
+  name: 'Example Herb',
+  ...overrides,
+} as RuntimeRecord)
+
+describe('getAtlasProfileLinks', () => {
+  it('routes alkaloid chemistry to the alkaloid guide', () => {
+    const links = getAtlasProfileLinks(record({ compoundClasses: ['Isoquinoline alkaloids'] }))
+    expect(links.map((link) => link.href)).toContain('/tools/botanical-activity-atlas/alkaloid-botanicals/')
+  })
+
+  it('routes stimulant effects to the natural stimulant guide', () => {
+    const links = getAtlasProfileLinks(record({ primary_effects: ['Alertness and energy'] }))
+    expect(links.map((link) => link.href)).toContain('/tools/botanical-activity-atlas/natural-stimulants/')
+  })
+
+  it('routes calming and sleep effects to the calming guide', () => {
+    const links = getAtlasProfileLinks(record({ effects: ['Anxiolytic', 'Sleep support'] }))
+    expect(links.map((link) => link.href)).toContain('/tools/botanical-activity-atlas/calming-botanicals/')
+  })
+
+  it('routes perception effects to the dream guide', () => {
+    const links = getAtlasProfileLinks(record({ primaryActions: ['Dream enhancement'] }))
+    expect(links.map((link) => link.href)).toContain('/tools/botanical-activity-atlas/dream-and-perception-herbs/')
+  })
+
+  it('routes serotonergic safety signals to the interaction-risk guide', () => {
+    const links = getAtlasProfileLinks(record({ safety_flags: ['Potential SSRI interaction'] }))
+    expect(links.map((link) => link.href)).toContain('/tools/botanical-activity-atlas/serotonergic-interaction-risk/')
+  })
+
+  it('always provides the full atlas and limits profile links to three', () => {
+    const links = getAtlasProfileLinks(record({
+      primary_effects: ['Energy', 'Calming', 'Dream enhancement'],
+      compoundClasses: ['Alkaloids'],
+      safety_flags: ['Serotonergic interaction'],
+    }))
+    expect(links).toHaveLength(3)
+    expect(links.some((link) => link.href === '/tools/botanical-activity-atlas/')).toBe(true)
+  })
+})

--- a/src/lib/atlas-profile-links.ts
+++ b/src/lib/atlas-profile-links.ts
@@ -1,0 +1,84 @@
+import type { RuntimeRecord } from '@/types/content'
+import {
+  normalizeCompoundClass,
+  normalizeEffect,
+  normalizeSafetySignal,
+  uniqueNormalized,
+} from '@/lib/botanical-atlas-taxonomy'
+
+export type AtlasProfileLink = {
+  href: string
+  label: string
+  reason: string
+}
+
+const list = (value: unknown): string[] => {
+  if (Array.isArray(value)) return value.flatMap(list)
+  if (typeof value !== 'string') return []
+  return value.split(/[;,|]/).map((item) => item.trim()).filter(Boolean)
+}
+
+export function getAtlasProfileLinks(record: RuntimeRecord): AtlasProfileLink[] {
+  const effects = uniqueNormalized(
+    list(record.primary_effects ?? record.effects ?? record.primaryActions),
+    normalizeEffect,
+  )
+  const compoundClasses = uniqueNormalized(
+    list(record.compoundClasses ?? record.pharmCategories ?? record.compoundClass),
+    normalizeCompoundClass,
+  )
+  const safety = uniqueNormalized(
+    list(record.safety_flags ?? record.interactionTags ?? record.contraindications ?? record.interactions),
+    normalizeSafetySignal,
+  )
+
+  const links: AtlasProfileLink[] = []
+
+  if (compoundClasses.includes('Alkaloids') || compoundClasses.includes('Methylxanthines')) {
+    links.push({
+      href: '/tools/botanical-activity-atlas/alkaloid-botanicals/',
+      label: 'Compare alkaloid botanicals',
+      reason: 'Related active-chemistry family',
+    })
+  }
+
+  if (effects.includes('Stimulating / energy')) {
+    links.push({
+      href: '/tools/botanical-activity-atlas/natural-stimulants/',
+      label: 'Compare natural stimulants',
+      reason: 'Related effect profile',
+    })
+  }
+
+  if (effects.includes('Calming') || effects.includes('Sedating / sleep')) {
+    links.push({
+      href: '/tools/botanical-activity-atlas/calming-botanicals/',
+      label: 'Compare calming botanicals',
+      reason: 'Related effect profile',
+    })
+  }
+
+  if (effects.includes('Dream / perception')) {
+    links.push({
+      href: '/tools/botanical-activity-atlas/dream-and-perception-herbs/',
+      label: 'Explore dream & perception herbs',
+      reason: 'Related effect profile',
+    })
+  }
+
+  if (safety.includes('Serotonergic')) {
+    links.push({
+      href: '/tools/botanical-activity-atlas/serotonergic-interaction-risk/',
+      label: 'Review serotonergic risks',
+      reason: 'Related safety signal',
+    })
+  }
+
+  links.push({
+    href: '/tools/botanical-activity-atlas/',
+    label: 'Open the full activity atlas',
+    reason: 'Compare effects, evidence, and safety',
+  })
+
+  return links.slice(0, 3)
+}

--- a/src/lib/atlas-profile-links.ts
+++ b/src/lib/atlas-profile-links.ts
@@ -18,6 +18,12 @@ const list = (value: unknown): string[] => {
   return value.split(/[;,|]/).map((item) => item.trim()).filter(Boolean)
 }
 
+const FULL_ATLAS_LINK: AtlasProfileLink = {
+  href: '/tools/botanical-activity-atlas/',
+  label: 'Open the full activity atlas',
+  reason: 'Compare effects, evidence, and safety',
+}
+
 export function getAtlasProfileLinks(record: RuntimeRecord): AtlasProfileLink[] {
   const effects = uniqueNormalized(
     list(record.primary_effects ?? record.effects ?? record.primaryActions),
@@ -32,10 +38,10 @@ export function getAtlasProfileLinks(record: RuntimeRecord): AtlasProfileLink[] 
     normalizeSafetySignal,
   )
 
-  const links: AtlasProfileLink[] = []
+  const specificLinks: AtlasProfileLink[] = []
 
   if (compoundClasses.includes('Alkaloids') || compoundClasses.includes('Methylxanthines')) {
-    links.push({
+    specificLinks.push({
       href: '/tools/botanical-activity-atlas/alkaloid-botanicals/',
       label: 'Compare alkaloid botanicals',
       reason: 'Related active-chemistry family',
@@ -43,7 +49,7 @@ export function getAtlasProfileLinks(record: RuntimeRecord): AtlasProfileLink[] 
   }
 
   if (effects.includes('Stimulating / energy')) {
-    links.push({
+    specificLinks.push({
       href: '/tools/botanical-activity-atlas/natural-stimulants/',
       label: 'Compare natural stimulants',
       reason: 'Related effect profile',
@@ -51,7 +57,7 @@ export function getAtlasProfileLinks(record: RuntimeRecord): AtlasProfileLink[] 
   }
 
   if (effects.includes('Calming') || effects.includes('Sedating / sleep')) {
-    links.push({
+    specificLinks.push({
       href: '/tools/botanical-activity-atlas/calming-botanicals/',
       label: 'Compare calming botanicals',
       reason: 'Related effect profile',
@@ -59,7 +65,7 @@ export function getAtlasProfileLinks(record: RuntimeRecord): AtlasProfileLink[] 
   }
 
   if (effects.includes('Dream / perception')) {
-    links.push({
+    specificLinks.push({
       href: '/tools/botanical-activity-atlas/dream-and-perception-herbs/',
       label: 'Explore dream & perception herbs',
       reason: 'Related effect profile',
@@ -67,18 +73,12 @@ export function getAtlasProfileLinks(record: RuntimeRecord): AtlasProfileLink[] 
   }
 
   if (safety.includes('Serotonergic')) {
-    links.push({
+    specificLinks.push({
       href: '/tools/botanical-activity-atlas/serotonergic-interaction-risk/',
       label: 'Review serotonergic risks',
       reason: 'Related safety signal',
     })
   }
 
-  links.push({
-    href: '/tools/botanical-activity-atlas/',
-    label: 'Open the full activity atlas',
-    reason: 'Compare effects, evidence, and safety',
-  })
-
-  return links.slice(0, 3)
+  return [...specificLinks.slice(0, 2), FULL_ATLAS_LINK]
 }


### PR DESCRIPTION
## Summary
- derive relevant atlas guides from each herb's normalized chemistry, effects, and safety signals
- extend the existing Active Compounds profile module instead of editing the large herb template
- show up to two specific category guides plus the complete atlas
- preserve compound links and render atlas links even when a herb has no mapped compound profile
- add regression coverage for alkaloid, stimulant, calming, dream/perception, and serotonergic routing

## Why this is high ROI
Every herb profile now contributes contextual internal links into the atlas ecosystem. The logic is data-driven, so new and updated herb records inherit the correct pathways without manual link maintenance.

## Scope
Three files. No workbook, generated runtime data, dosing content, or profile canonical behavior changed.