### PR TITLE
Add contextual Botanical Activity Atlas links to compound profiles

### DIFF
--- a/components/seo/CompoundSourceHerbs.tsx
+++ b/components/seo/CompoundSourceHerbs.tsx
@@ -1,5 +1,8 @@
 import Link from 'next/link'
 import { getCompoundSourceHerbs } from '@/lib/herb-compound-links'
+import { getCompoundBySlug } from '@/lib/runtime-data'
+import { getAtlasProfileLinks } from '@/lib/atlas-profile-links'
+import type { RuntimeRecord } from '@/types/content'
 
 type CompoundSourceHerbsProps = {
   compoundSlug: string
@@ -7,40 +10,79 @@ type CompoundSourceHerbsProps = {
 }
 
 /**
- * Renders the source herbs that contain a compound as keyword-rich internal
- * links (reverse lookup of the curated relationship map). Renders nothing when
- * the compound has no mapped (renderable) source herbs.
+ * Renders botanicals that contain a compound plus data-driven pathways into
+ * the Botanical Activity Atlas. Compounds without botanical relevance do not
+ * receive a generic atlas link merely because this shared module rendered.
  */
 export default async function CompoundSourceHerbs({
   compoundSlug,
   compoundName,
 }: CompoundSourceHerbsProps) {
-  const links = await getCompoundSourceHerbs(compoundSlug, compoundName)
-  if (links.length === 0) return null
+  const [sourceHerbs, compound] = await Promise.all([
+    getCompoundSourceHerbs(compoundSlug, compoundName),
+    getCompoundBySlug(compoundSlug),
+  ])
+
+  const candidateAtlasLinks = compound
+    ? getAtlasProfileLinks(compound as RuntimeRecord)
+    : []
+  const hasSpecificAtlasPath = candidateAtlasLinks.some(
+    (link) => link.href !== '/tools/botanical-activity-atlas/',
+  )
+  const atlasLinks = hasSpecificAtlasPath || sourceHerbs.length > 0
+    ? candidateAtlasLinks
+    : []
+
+  if (sourceHerbs.length === 0 && atlasLinks.length === 0) return null
 
   return (
-    <section className="card-premium p-4 sm:p-5 space-y-3" aria-labelledby="source-herbs-heading">
+    <section className="card-premium space-y-4 p-4 sm:p-5" aria-labelledby="compound-discovery-heading">
       <div className="space-y-1">
-        <h2 id="source-herbs-heading" className="text-lg font-bold text-ink">
-          Found In
+        <h2 id="compound-discovery-heading" className="text-lg font-bold text-ink">
+          Botanical Context
         </h2>
         <p className="text-sm text-muted">
-          Botanicals that contain {compoundName || 'this compound'}, with full herb profiles.
+          Source botanicals and comparison guides related to {compoundName || 'this compound'}.
         </p>
       </div>
-      <ul className="space-y-2">
-        {links.map((link) => (
-          <li key={link.slug}>
-            <Link
-              href={link.href}
-              className="flex min-h-11 items-center justify-between rounded-xl border border-brand-900/10 bg-white px-3 py-2 text-sm font-semibold text-brand-800 transition hover:border-brand-700/30 hover:bg-brand-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600/40"
-            >
-              <span>{link.anchor}</span>
-              <span aria-hidden="true">→</span>
-            </Link>
-          </li>
-        ))}
-      </ul>
+
+      {sourceHerbs.length > 0 ? (
+        <div className="space-y-2">
+          <h3 className="text-xs font-bold uppercase tracking-wide text-muted">Found in</h3>
+          <ul className="space-y-2">
+            {sourceHerbs.map((link) => (
+              <li key={link.slug}>
+                <Link
+                  href={link.href}
+                  className="flex min-h-11 items-center justify-between rounded-xl border border-brand-900/10 bg-white px-3 py-2 text-sm font-semibold text-brand-800 transition hover:border-brand-700/30 hover:bg-brand-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600/40"
+                >
+                  <span>{link.anchor}</span>
+                  <span aria-hidden="true">→</span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {atlasLinks.length > 0 ? (
+        <div className="space-y-2 border-t border-brand-900/10 pt-4">
+          <h3 className="text-xs font-bold uppercase tracking-wide text-muted">Compare active botanicals</h3>
+          <ul className="grid gap-2 sm:grid-cols-3">
+            {atlasLinks.map((link) => (
+              <li key={link.href}>
+                <Link
+                  href={link.href}
+                  className="flex h-full min-h-11 flex-col justify-center rounded-xl border border-emerald-900/10 bg-emerald-50/60 px-3 py-2 text-sm font-semibold text-emerald-950 transition hover:border-emerald-700/30 hover:bg-emerald-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-700/40"
+                >
+                  <span>{link.label}</span>
+                  <span className="mt-0.5 text-xs font-normal text-emerald-900/70">{link.reason}</span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
     </section>
   )
 }

--- a/tests/ui/compound-source-herbs-tap-targets.test.ts
+++ b/tests/ui/compound-source-herbs-tap-targets.test.ts
@@ -3,10 +3,26 @@ import { describe, expect, it } from 'vitest'
 
 const source = readFileSync('components/seo/CompoundSourceHerbs.tsx', 'utf8')
 
-describe('compound source herb links', () => {
-  it('uses full-width accessible tap targets with visible focus treatment', () => {
-    expect(source).toContain('flex min-h-11 items-center justify-between')
+describe('compound botanical context links', () => {
+  it('uses accessible tap targets with visible focus treatment', () => {
+    expect(source).toContain('min-h-11')
     expect(source).toContain('focus-visible:ring-2')
     expect(source).toContain('<span aria-hidden="true">→</span>')
+  })
+
+  it('derives atlas links from the compound record', () => {
+    expect(source).toContain('getCompoundBySlug(compoundSlug)')
+    expect(source).toContain('getAtlasProfileLinks(compound as RuntimeRecord)')
+  })
+
+  it('does not show a generic atlas link for compounds without botanical relevance', () => {
+    expect(source).toContain("link.href !== '/tools/botanical-activity-atlas/'")
+    expect(source).toContain('hasSpecificAtlasPath || sourceHerbs.length > 0')
+    expect(source).toContain('sourceHerbs.length === 0 && atlasLinks.length === 0')
+  })
+
+  it('preserves both source-herb and atlas discovery sections', () => {
+    expect(source).toContain('Found in')
+    expect(source).toContain('Compare active botanicals')
   })
 })


### PR DESCRIPTION
## Summary
- extend the shared compound source-herb module with data-driven atlas discovery links
- derive category relevance from the compound runtime record using the same normalized chemistry, effect, and safety taxonomy as herb profiles
- preserve existing source-herb reverse links
- suppress generic atlas links for compounds with no botanical relevance
- render up to two specific guides plus the complete atlas when relevant
- add regression guards for compound lookup, relevance gating, tap targets, and both discovery sections

## Why this is high ROI
Compound profiles now feed users and crawlers into the atlas ecosystem without editing the large compound template or manually mapping hundreds of compounds.

## Scope
Two files only. No workbook, generated data, canonical rules, dosing guidance, restricted-record behavior, or affiliate logic changed.