### PR TITLE
Add Botanical Activity Atlas coverage audit

### DIFF
--- a/.github/workflows/botanical-atlas-coverage.yml
+++ b/.github/workflows/botanical-atlas-coverage.yml
@@ -1,0 +1,38 @@
+name: Botanical Activity Atlas Coverage
+
+on:
+  pull_request:
+    paths:
+      - 'public/data/herbs.json'
+      - 'public/data/compounds.json'
+      - 'src/lib/index-allowlist.ts'
+      - 'src/lib/botanical-atlas-taxonomy.ts'
+      - 'scripts/audit/botanical-atlas-coverage.mjs'
+      - '.github/workflows/botanical-atlas-coverage.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  coverage-report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Generate atlas coverage report
+        run: node scripts/audit/botanical-atlas-coverage.mjs
+
+      - name: Add coverage summary
+        run: cat reports/botanical-atlas/coverage.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: botanical-atlas-coverage
+          path: reports/botanical-atlas/
+          retention-days: 30

--- a/scripts/audit/__tests__/botanical-atlas-coverage.test.ts
+++ b/scripts/audit/__tests__/botanical-atlas-coverage.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const script = readFileSync('scripts/audit/botanical-atlas-coverage.mjs', 'utf8')
+const workflow = readFileSync('.github/workflows/botanical-atlas-coverage.yml', 'utf8')
+
+describe('Botanical Activity Atlas coverage audit', () => {
+  it('audits the fields used by the atlas experience', () => {
+    for (const field of ['effects', 'chemistry', 'evidence', 'noticeability', 'safety', 'timing']) {
+      expect(script).toContain(`${field}:`)
+    }
+  })
+
+  it('prioritizes curated indexable profiles and emits reviewable formats', () => {
+    expect(script).toContain('CURATED_INDEXABLE_HERB_SLUGS')
+    expect(script).toContain('CURATED_INDEXABLE_COMPOUND_SLUGS')
+    expect(script).toContain("'coverage.json'")
+    expect(script).toContain("'coverage.csv'")
+    expect(script).toContain("'coverage.md'")
+  })
+
+  it('runs automatically when atlas source data changes', () => {
+    expect(workflow).toContain("public/data/herbs.json")
+    expect(workflow).toContain("public/data/compounds.json")
+    expect(workflow).toContain('actions/upload-artifact@v4')
+    expect(workflow).toContain('GITHUB_STEP_SUMMARY')
+  })
+})

--- a/scripts/audit/botanical-atlas-coverage.mjs
+++ b/scripts/audit/botanical-atlas-coverage.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const outDir = path.join(root, 'reports', 'botanical-atlas')
+const herbPath = path.join(root, 'public', 'data', 'herbs.json')
+const compoundPath = path.join(root, 'public', 'data', 'compounds.json')
+const allowlistPath = path.join(root, 'src', 'lib', 'index-allowlist.ts')
+
+const readJsonArray = (filePath) => {
+  if (!existsSync(filePath)) return []
+  const parsed = JSON.parse(readFileSync(filePath, 'utf8'))
+  return Array.isArray(parsed) ? parsed : []
+}
+
+const list = (value) => {
+  if (Array.isArray(value)) return value.flatMap(list)
+  if (typeof value !== 'string') return []
+  return value.split(/[;,|]/).map((item) => item.trim()).filter(Boolean)
+}
+
+const text = (...values) => {
+  const match = values.find((value) => typeof value === 'string' && value.trim())
+  return typeof match === 'string' ? match.trim() : ''
+}
+
+const extractAllowlist = (source, exportName) => {
+  const match = source.match(new RegExp(`export const ${exportName} = \\[([\\s\\S]*?)\\] as const`))
+  if (!match) return new Set()
+  return new Set(Array.from(match[1].matchAll(/['"]([^'"]+)['"]/g), (entry) => entry[1]))
+}
+
+const allowlistSource = existsSync(allowlistPath) ? readFileSync(allowlistPath, 'utf8') : ''
+const herbAllowlist = extractAllowlist(allowlistSource, 'CURATED_INDEXABLE_HERB_SLUGS')
+const compoundAllowlist = extractAllowlist(allowlistSource, 'CURATED_INDEXABLE_COMPOUND_SLUGS')
+
+const fieldGroups = {
+  effects: ['primary_effects', 'effects', 'primaryActions'],
+  chemistry: ['compoundClasses', 'pharmCategories', 'compoundClass', 'activeCompounds', 'active_compounds', 'compounds', 'activeconstituents'],
+  evidence: ['evidence_tier', 'evidenceTier', 'evidence_grade', 'evidenceLevel'],
+  noticeability: ['intensityLabel', 'intensityClean', 'intensityLevel', 'intensity'],
+  safety: ['safety_flags', 'interactionTags', 'contraindications', 'interactions', 'safetyNotes', 'safety_notes'],
+  timing: ['time_to_effect', 'onset', 'duration'],
+}
+
+const hasGroup = (record, keys) => keys.some((key) => list(record[key]).length > 0 || text(record[key]))
+
+const coverageRow = (record, type, indexable) => {
+  const coverage = Object.fromEntries(
+    Object.entries(fieldGroups).map(([group, keys]) => [group, hasGroup(record, keys)]),
+  )
+  const missing = Object.entries(coverage).filter(([, present]) => !present).map(([group]) => group)
+  const criticalMissing = missing.filter((group) => ['effects', 'chemistry', 'noticeability', 'safety'].includes(group))
+  const score = Math.round((Object.values(coverage).filter(Boolean).length / Object.keys(coverage).length) * 100)
+  const priority = (indexable ? 100 : 0) + criticalMissing.length * 20 + missing.length * 5
+
+  return {
+    type,
+    slug: String(record.slug || ''),
+    name: text(record.displayName, record.name, record.commonName, record.title, record.slug),
+    indexable,
+    score,
+    priority,
+    missing,
+    ...coverage,
+  }
+}
+
+const herbs = readJsonArray(herbPath)
+const compounds = readJsonArray(compoundPath)
+const rows = [
+  ...herbs.map((record) => coverageRow(record, 'herb', herbAllowlist.has(String(record.slug || '')))),
+  ...compounds.map((record) => coverageRow(record, 'compound', compoundAllowlist.has(String(record.slug || '')))),
+].filter((row) => row.slug)
+
+rows.sort((a, b) => b.priority - a.priority || a.score - b.score || a.slug.localeCompare(b.slug))
+
+const indexableRows = rows.filter((row) => row.indexable)
+const summary = {
+  generatedAt: new Date().toISOString(),
+  totals: {
+    profiles: rows.length,
+    herbs: rows.filter((row) => row.type === 'herb').length,
+    compounds: rows.filter((row) => row.type === 'compound').length,
+    curatedIndexable: indexableRows.length,
+  },
+  indexableCoverage: Object.fromEntries(
+    Object.keys(fieldGroups).map((group) => [
+      group,
+      indexableRows.length
+        ? Math.round((indexableRows.filter((row) => row[group]).length / indexableRows.length) * 100)
+        : 0,
+    ]),
+  ),
+  topPriorityGaps: rows.filter((row) => row.missing.length).slice(0, 50),
+}
+
+mkdirSync(outDir, { recursive: true })
+writeFileSync(path.join(outDir, 'coverage.json'), `${JSON.stringify({ summary, rows }, null, 2)}\n`)
+
+const csvEscape = (value) => `"${String(value ?? '').replaceAll('"', '""')}"`
+const csvHeaders = ['type', 'slug', 'name', 'indexable', 'score', 'priority', ...Object.keys(fieldGroups), 'missing']
+const csv = [
+  csvHeaders.join(','),
+  ...rows.map((row) => csvHeaders.map((key) => csvEscape(key === 'missing' ? row.missing.join('|') : row[key])).join(',')),
+].join('\n')
+writeFileSync(path.join(outDir, 'coverage.csv'), `${csv}\n`)
+
+const percentLines = Object.entries(summary.indexableCoverage)
+  .map(([field, percent]) => `| ${field} | ${percent}% |`)
+  .join('\n')
+const priorityLines = summary.topPriorityGaps.slice(0, 25)
+  .map((row, index) => `${index + 1}. **${row.name || row.slug}** (${row.type}${row.indexable ? ', indexable' : ''}) — missing ${row.missing.join(', ')}`)
+  .join('\n') || 'No coverage gaps found.'
+
+const markdown = `# Botanical Activity Atlas Coverage Report\n\nGenerated: ${summary.generatedAt}\n\n## Dataset\n\n- Profiles: ${summary.totals.profiles}\n- Herbs: ${summary.totals.herbs}\n- Compounds: ${summary.totals.compounds}\n- Curated indexable profiles: ${summary.totals.curatedIndexable}\n\n## Curated indexable coverage\n\n| Field group | Coverage |\n|---|---:|\n${percentLines}\n\n## Highest-priority gaps\n\n${priorityLines}\n\n## Outputs\n\n- \`reports/botanical-atlas/coverage.json\`\n- \`reports/botanical-atlas/coverage.csv\`\n- \`reports/botanical-atlas/coverage.md\`\n`
+writeFileSync(path.join(outDir, 'coverage.md'), markdown)
+
+console.log(markdown)
+
+if (process.argv.includes('--strict')) {
+  const incompleteIndexable = indexableRows.filter((row) => !row.effects || !row.chemistry || !row.safety)
+  if (incompleteIndexable.length > 0) {
+    console.error(`Atlas coverage audit failed: ${incompleteIndexable.length} curated indexable profiles lack effects, chemistry, or safety data.`)
+    process.exitCode = 1
+  }
+}


### PR DESCRIPTION
## Summary
- add a deterministic audit for atlas effects, chemistry, evidence, noticeability, safety, and timing coverage
- prioritize curated indexable herbs and compounds
- export Markdown, CSV, and JSON reports
- add optional strict mode for missing critical fields
- run the report automatically on relevant pull requests and upload it as a workflow artifact
- add regression coverage for audited fields, outputs, and workflow triggers

## Why this is high ROI
The atlas now spans tools, category guides, herb profiles, and compound profiles. This audit makes missing structured data visible and ranks the gaps that affect indexable pages first, preventing quiet degradation as the dataset changes.

## Scope
Audit tooling only. No workbook records, runtime data, taxonomy rules, profile content, or indexability decisions changed.