### PR TITLE
Run atlas coverage audit on main

### DIFF
--- a/.github/workflows/botanical-atlas-coverage.yml
+++ b/.github/workflows/botanical-atlas-coverage.yml
@@ -9,6 +9,16 @@ on:
       - 'src/lib/botanical-atlas-taxonomy.ts'
       - 'scripts/audit/botanical-atlas-coverage.mjs'
       - '.github/workflows/botanical-atlas-coverage.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'public/data/herbs.json'
+      - 'public/data/compounds.json'
+      - 'src/lib/index-allowlist.ts'
+      - 'src/lib/botanical-atlas-taxonomy.ts'
+      - 'scripts/audit/botanical-atlas-coverage.mjs'
+      - '.github/workflows/botanical-atlas-coverage.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- add a `push` trigger for `main` to the Botanical Activity Atlas coverage workflow
- preserve the existing path filters and manual dispatch

## Why
The audit was merged before GitHub had a matching PR run, so no baseline artifact was produced. This ensures every relevant change merged to `main` creates an authoritative coverage report.