### PR TITLE
Attach atlas coverage to Site Health Check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,3 +42,19 @@ jobs:
 
       - name: Run full check
         run: npm run check:full
+
+      - name: Generate Botanical Activity Atlas coverage report
+        if: always()
+        run: node scripts/audit/botanical-atlas-coverage.mjs
+
+      - name: Add atlas coverage summary
+        if: always()
+        run: cat reports/botanical-atlas/coverage.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload atlas coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: botanical-atlas-coverage-${{ github.run_id }}
+          path: reports/botanical-atlas/
+          retention-days: 30


### PR DESCRIPTION
## Summary
- run the Botanical Activity Atlas coverage audit inside the existing Site Health Check workflow
- append the coverage summary even when an earlier validation step fails
- upload Markdown, CSV, and JSON coverage artifacts with a run-specific name

## Why
The standalone atlas workflow is registered but has not scheduled any runs. Site Health Check is already an established workflow on every `main` push and PR, so this gives the audit a reliable execution path without weakening existing validation.