### PR TITLE
Improve Botanical Activity Atlas runtime coverage

### DIFF
--- a/src/lib/__tests__/botanical-atlas-data.test.ts
+++ b/src/lib/__tests__/botanical-atlas-data.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { toAtlasRecord } from '@/lib/botanical-atlas-data'
+import type { RuntimeRecord } from '@/types/content'
+
+const record = (overrides: Partial<RuntimeRecord>): RuntimeRecord => ({
+  slug: 'test-herb',
+  name: 'Test Herb',
+  ...overrides,
+} as RuntimeRecord)
+
+describe('Botanical Activity Atlas runtime fallbacks', () => {
+  it('combines safety fields instead of stopping at an empty array', () => {
+    const result = toAtlasRecord(record({
+      safety_flags: [],
+      safety: 'May cause sedation and interact with anticoagulants.',
+    }))
+
+    expect(result.safety).toContain('Sedation')
+    expect(result.safety).toContain('Bleeding')
+  })
+
+  it('infers known chemical families from named active compounds', () => {
+    const result = toAtlasRecord(record({
+      activeCompounds: ['caffeine', 'theobromine'],
+    }))
+
+    expect(result.compoundClasses).toEqual(['Methylxanthines'])
+  })
+
+  it('does not turn unknown compound names into fake chemical classes', () => {
+    const result = toAtlasRecord(record({
+      activeCompounds: ['mystery constituent'],
+    }))
+
+    expect(result.compoundClasses).toEqual([])
+  })
+
+  it('recognizes additional noticeability and timing aliases', () => {
+    const result = toAtlasRecord(record({
+      noticeability: 'noticeable',
+      onsetTime: '30 minutes',
+      effectDuration: '4 hours',
+    }))
+
+    expect(result.intensity).toBe('Moderate')
+    expect(result.onset).toBe('30 minutes')
+    expect(result.duration).toBe('4 hours')
+  })
+
+  it('combines effects from multiple populated fields', () => {
+    const result = toAtlasRecord(record({
+      primary_effects: [],
+      effects: ['calming'],
+      benefits: ['sleep support'],
+    }))
+
+    expect(result.effects).toContain('Calming')
+    expect(result.effects).toContain('Sedating / sleep')
+  })
+})

--- a/src/lib/botanical-atlas-data.ts
+++ b/src/lib/botanical-atlas-data.ts
@@ -17,28 +17,69 @@ const list = (value: unknown): string[] => {
   return []
 }
 
+const collect = (...values: unknown[]): string[] => values.flatMap(list)
+
 const text = (...values: unknown[]): string => {
   const value = values.find((item) => typeof item === 'string' && item.trim())
   return typeof value === 'string' ? value.trim() : ''
 }
 
+const KNOWN_COMPOUND_CLASSES = new Set([
+  'Methylxanthines',
+  'Alkaloids',
+  'Flavonoids',
+  'Terpenes / terpenoids',
+  'Glycosides',
+  'Phenolics',
+  'Lactones',
+  'Cannabinoids',
+  'Withanolides',
+])
+
+const inferCompoundClasses = (compounds: string[]): string[] =>
+  uniqueNormalized(compounds, normalizeCompoundClass).filter((value) => KNOWN_COMPOUND_CLASSES.has(value))
+
 export const toAtlasRecord = (herb: RuntimeRecord): BotanicalAtlasRecord => {
-  const rawEffects = list(herb.primary_effects ?? herb.effects ?? herb.primaryActions)
-  const rawClasses = list(herb.compoundClasses ?? herb.pharmCategories ?? herb.compoundClass)
-  const rawSafety = list(herb.safety_flags ?? herb.interactionTags ?? herb.contraindications ?? herb.interactions)
+  const rawEffects = collect(herb.primary_effects, herb.effects, herb.primaryActions, herb.benefits)
+  const compounds = collect(herb.activeCompounds, herb.active_compounds, herb.compounds, herb.activeconstituents)
+  const explicitClasses = uniqueNormalized(
+    collect(herb.compoundClasses, herb.pharmCategories, herb.compoundClass),
+    normalizeCompoundClass,
+  )
+  const compoundClasses = explicitClasses.length ? explicitClasses : inferCompoundClasses(compounds)
+  const rawSafety = collect(
+    herb.safety_flags,
+    herb.interactionTags,
+    herb.contraindications,
+    herb.interactions,
+    herb.safety,
+    herb.warnings,
+    herb.side_effects,
+  )
 
   return {
     slug: herb.slug,
     name: text(herb.displayName, herb.name, herb.commonName, herb.common, herb.slug.replaceAll('-', ' ')),
     scientificName: text(herb.scientificName, herb.scientificname, herb.latinName) || undefined,
     effects: uniqueNormalized(rawEffects, normalizeEffect),
-    compounds: list(herb.activeCompounds ?? herb.active_compounds ?? herb.compounds ?? herb.activeconstituents),
-    compoundClasses: uniqueNormalized(rawClasses, normalizeCompoundClass),
+    compounds,
+    compoundClasses,
     evidence: normalizeEvidence(text(herb.evidence_tier, herb.evidenceTier, herb.evidence_grade, herb.evidenceLevel)),
-    intensity: normalizeIntensity(text(herb.intensityLabel, herb.intensityClean, herb.intensityLevel, herb.intensity)),
+    intensity: normalizeIntensity(
+      text(
+        herb.intensityLabel,
+        herb.intensityClean,
+        herb.intensityLevel,
+        herb.intensity,
+        herb.noticeability,
+        herb.effectIntensity,
+        herb.subjectiveIntensity,
+        herb.strength,
+      ),
+    ),
     safety: uniqueNormalized(rawSafety, normalizeSafetySignal),
-    onset: text(herb.time_to_effect, herb.onset) || undefined,
-    duration: text(herb.duration) || undefined,
+    onset: text(herb.time_to_effect, herb.onset, herb.onsetTime) || undefined,
+    duration: text(herb.duration, herb.effectDuration) || undefined,
   }
 }
 


### PR DESCRIPTION
## Summary
- combine populated effect and safety fields instead of stopping at the first empty array
- include the primary safety narrative, warnings, and side effects in normalized safety signals
- infer recognized chemical families from named active compounds when explicit class fields are absent
- support additional noticeability, onset, and duration aliases
- add focused regression tests

## Why this is high ROI
The generated records already contain useful information that the atlas adapter was discarding. This improves filtering, category membership, safety discovery, and contextual links across many profiles without changing the workbook or inventing new claims.

## Guardrails
Unknown active compounds are not converted into fake chemical classes, and explicit class data still takes precedence.