### PR TITLE
Expand Botanical Activity Atlas named compound taxonomy

### DIFF
--- a/src/lib/__tests__/botanical-atlas-taxonomy.test.ts
+++ b/src/lib/__tests__/botanical-atlas-taxonomy.test.ts
@@ -35,6 +35,26 @@ describe('botanical atlas taxonomy', () => {
     expect(normalizeSafetySignal('Potential hepatotoxicity')).toBe('Liver')
   })
 
+  it('recognizes established named compounds across major botanical families', () => {
+    expect(normalizeCompoundClass('withaferin A')).toBe('Withanolides')
+    expect(normalizeCompoundClass('CBD and CBG')).toBe('Cannabinoids')
+    expect(normalizeCompoundClass('kavain and methysticin')).toBe('Lactones')
+    expect(normalizeCompoundClass('EGCG and epicatechin')).toBe('Flavonoids')
+    expect(normalizeCompoundClass('linalool and beta-caryophyllene')).toBe('Terpenes / terpenoids')
+    expect(normalizeCompoundClass('ginsenosides')).toBe('Glycosides')
+    expect(normalizeCompoundClass('rosmarinic acid')).toBe('Phenolics')
+    expect(normalizeCompoundClass('berberine and palmatine')).toBe('Alkaloids')
+  })
+
+  it('keeps specific classes ahead of broad alkaloid matching', () => {
+    expect(normalizeCompoundClass('caffeine alkaloid')).toBe('Methylxanthines')
+    expect(normalizeCompoundClass('withanolide lactone')).toBe('Withanolides')
+  })
+
+  it('does not invent a class for an unknown compound name', () => {
+    expect(normalizeCompoundClass('mystery constituent ZX-41')).toBe('mystery constituent ZX-41')
+  })
+
   it('deduplicates normalized variants', () => {
     expect(uniqueNormalized(['calming', 'anxiolytic', 'relaxing'], normalizeEffect)).toEqual(['Calming'])
   })

--- a/src/lib/botanical-atlas-taxonomy.ts
+++ b/src/lib/botanical-atlas-taxonomy.ts
@@ -16,16 +16,19 @@ const EFFECT_RULES: Array<[string, RegExp]> = [
   ['Hormonal / reproductive', /hormon|libido|sexual|fertil|testoster|estrogen|thyroid/],
 ]
 
+// Specific families come before broad classes so named compounds land in the
+// most useful atlas bucket. Patterns are intentionally conservative: an
+// unrecognized compound remains unclassified rather than being guessed.
 const CLASS_RULES: Array<[string, RegExp]> = [
-  ['Methylxanthines', /methylxanthine|caffeine|theobromine|theophylline/],
-  ['Alkaloids', /alkaloid|amine|indole|isoquinoline|aporphine|tropane|xanthine/],
-  ['Flavonoids', /flavonoid|flavone|flavan|catechin/],
-  ['Terpenes / terpenoids', /terpene|terpenoid|sesquiterp|diterp|triterp/],
-  ['Glycosides', /glycoside|saponin/],
-  ['Phenolics', /phenol|polyphenol|phenolic acid/],
-  ['Lactones', /lactone|kavalactone/],
-  ['Cannabinoids', /cannabinoid/],
-  ['Withanolides', /withanolide/],
+  ['Methylxanthines', /\b(?:methylxanthines?|caffeine|theobromine|theophylline|paraxanthine)\b/],
+  ['Withanolides', /\b(?:withanolides?|withaferin(?: a)?|withanosides?)\b/],
+  ['Cannabinoids', /\b(?:cannabinoids?|cannabidiol|cannabigerol|cannabinol|tetrahydrocannabinol|thc|cbd|cbg|cbn)\b/],
+  ['Lactones', /\b(?:lactones?|kavalactones?|kavain|dihydrokavain|methysticin|dihydromethysticin|yangonin|lactucin|lactucopicrin)\b/],
+  ['Flavonoids', /\b(?:flavonoids?|flavones?|flavanones?|flavanols?|catechins?|epicatechin|egcg|apigenin|quercetin|kaempferol|luteolin|rutin|hesperidin|naringenin)\b/],
+  ['Terpenes / terpenoids', /\b(?:terpenes?|terpenoids?|sesquiterpenes?|diterpenes?|triterpenes?|linalool|limonene|myrcene|pinene|caryophyllene|humulene|borneol|menthol|camphor|thymol|carvacrol)\b/],
+  ['Glycosides', /\b(?:glycosides?|saponins?|ginsenosides?|salicin|glycyrrhizin|glycyrrhizic acid|bacosides?|asiaticoside)\b/],
+  ['Phenolics', /\b(?:phenols?|polyphenols?|phenolic acids?|rosmarinic acid|caffeic acid|ferulic acid|gallic acid|ellagic acid|curcumin|eugenol)\b/],
+  ['Alkaloids', /\b(?:alkaloids?|isoquinolines?|aporphines?|tropanes?|indole alkaloids?|berberine|palmatine|mitragynine|mesembrine|yohimbine|harmine|harmaline|hordenine|synephrine|nicotine|lobeline|huperzine a|tetrahydropalmatine)\b/],
 ]
 
 const SAFETY_RULES: Array<[string, RegExp]> = [


### PR DESCRIPTION
## Summary
- recognize established named compounds across methylxanthines, withanolides, cannabinoids, lactones, flavonoids, terpenes, glycosides, phenolics, and alkaloids
- keep specific chemical families ahead of broad alkaloid matching
- preserve unknown compounds as unclassified rather than guessing
- add regression coverage for representative compounds and precedence rules

## Why this is high ROI
Many runtime records already list named active compounds but omit explicit compound-class fields. This improves atlas filtering, category membership, and contextual links across the existing dataset without editing generated content or adding unsupported claims.