### PR TITLE
Enrich Botanical Activity Atlas effects from mechanisms

### DIFF
--- a/src/lib/__tests__/botanical-atlas-data.test.ts
+++ b/src/lib/__tests__/botanical-atlas-data.test.ts
@@ -57,4 +57,33 @@ describe('Botanical Activity Atlas runtime fallbacks', () => {
     expect(result.effects).toContain('Calming')
     expect(result.effects).toContain('Sedating / sleep')
   })
+
+  it('enriches discovery effects from structured mechanisms', () => {
+    const result = toAtlasRecord(record({
+      effects: [],
+      mechanisms: ['GABA-A positive allosteric modulation', 'acetylcholinesterase inhibition'],
+      canonical_mechanisms: ['Serotonergic signaling'],
+    }))
+
+    expect(result.effects).toContain('Calming')
+    expect(result.effects).toContain('Cognition / focus')
+    expect(result.effects).toContain('Mood')
+  })
+
+  it('keeps explicit effects and deduplicates inferred matches', () => {
+    const result = toAtlasRecord(record({
+      effects: ['calming'],
+      mechanisms: ['GABA-A modulation', 'HPA axis modulation'],
+    }))
+
+    expect(result.effects.filter((effect) => effect === 'Calming')).toHaveLength(1)
+  })
+
+  it('does not expose unknown mechanism text as an effect label', () => {
+    const result = toAtlasRecord(record({
+      mechanisms: ['Unmapped experimental pathway XYZ'],
+    }))
+
+    expect(result.effects).toEqual([])
+  })
 })

--- a/src/lib/botanical-atlas-data.ts
+++ b/src/lib/botanical-atlas-data.ts
@@ -1,6 +1,7 @@
 import { getHerbs } from '@/lib/runtime-data'
 import { getRuntimeVisibility } from '../../lib/runtime-visibility'
 import {
+  inferAtlasEffectsFromMechanisms,
   normalizeCompoundClass,
   normalizeEffect,
   normalizeEvidence,
@@ -40,7 +41,19 @@ const inferCompoundClasses = (compounds: string[]): string[] =>
   uniqueNormalized(compounds, normalizeCompoundClass).filter((value) => KNOWN_COMPOUND_CLASSES.has(value))
 
 export const toAtlasRecord = (herb: RuntimeRecord): BotanicalAtlasRecord => {
-  const rawEffects = collect(herb.primary_effects, herb.effects, herb.primaryActions, herb.benefits)
+  const explicitEffects = uniqueNormalized(
+    collect(herb.primary_effects, herb.effects, herb.primaryActions, herb.benefits),
+    normalizeEffect,
+  )
+  const mechanisms = collect(
+    herb.mechanisms,
+    herb.raw_mechanisms,
+    herb.canonical_mechanisms,
+    herb.mechanism_target_systems,
+    herb.mechanism_classes,
+  )
+  const inferredEffects = inferAtlasEffectsFromMechanisms(mechanisms)
+  const effects = Array.from(new Set([...explicitEffects, ...inferredEffects]))
   const compounds = collect(herb.activeCompounds, herb.active_compounds, herb.compounds, herb.activeconstituents)
   const explicitClasses = uniqueNormalized(
     collect(herb.compoundClasses, herb.pharmCategories, herb.compoundClass),
@@ -61,7 +74,7 @@ export const toAtlasRecord = (herb: RuntimeRecord): BotanicalAtlasRecord => {
     slug: herb.slug,
     name: text(herb.displayName, herb.name, herb.commonName, herb.common, herb.slug.replaceAll('-', ' ')),
     scientificName: text(herb.scientificName, herb.scientificname, herb.latinName) || undefined,
-    effects: uniqueNormalized(rawEffects, normalizeEffect),
+    effects,
     compounds,
     compoundClasses,
     evidence: normalizeEvidence(text(herb.evidence_tier, herb.evidenceTier, herb.evidence_grade, herb.evidenceLevel)),

--- a/src/lib/botanical-atlas-taxonomy.ts
+++ b/src/lib/botanical-atlas-taxonomy.ts
@@ -16,6 +16,22 @@ const EFFECT_RULES: Array<[string, RegExp]> = [
   ['Hormonal / reproductive', /hormon|libido|sexual|fertil|testoster|estrogen|thyroid/],
 ]
 
+// Mechanism labels can improve discovery when a record lacks plain-language
+// effects. These mappings describe pathway relevance, not proven outcomes.
+const MECHANISM_EFFECT_RULES: Array<[string, RegExp]> = [
+  ['Calming', /\b(?:gaba(?:-?a|-?b)?|benzodiazepine|hpa axis|cortisol|adaptogenic?)\b/],
+  ['Sedating / sleep', /\b(?:melatonin|orexin|hypnotic|sleep architecture|sleep latency)\b/],
+  ['Stimulating / energy', /\b(?:adenosine antagon|adrenergic|norepinephrine|noradrenaline|dopaminergic|catecholamine|ampk activation)\b/],
+  ['Mood', /\b(?:serotonin|serotonergic|5-ht|monoamine oxidase|maoi|sri|reuptake inhibition)\b/],
+  ['Cognition / focus', /\b(?:acetylcholine|cholinergic|acetylcholinesterase|ache inhibit|muscarinic|nicotinic receptor|bdnf|neuroplasticity)\b/],
+  ['Pain / discomfort', /\b(?:opioid|mu-opioid|kappa-opioid|nocicept|analges|cox inhibition)\b/],
+  ['Dream / perception', /\b(?:5-ht2a|kappa-opioid agon|cb1 agon|dissociative|oneirogenic)\b/],
+  ['Cardiovascular', /\b(?:vasodilat|vasoconstrict|ace inhibit|calcium channel|blood pressure|cardiac ion channel)\b/],
+  ['Metabolic', /\b(?:glucose metabolism|insulin sensit|ampk|lipid metabolism|thermogen)\b/],
+  ['Inflammation', /\b(?:cox-?1|cox-?2|nf-?kappa-?b|nf-?kb|inflammatory signaling|cytokine modulation)\b/],
+  ['Immune', /\b(?:immune signaling|immunomod|toll-like receptor|antiviral|antimicrobial)\b/],
+]
+
 // Specific families come before broad classes so named compounds land in the
 // most useful atlas bucket. Patterns are intentionally conservative: an
 // unrecognized compound remains unclassified rather than being guessed.
@@ -54,6 +70,16 @@ const firstMatch = (value: string, rules: Array<[string, RegExp]>) => {
 export const normalizeEffect = (value: string) => firstMatch(value, EFFECT_RULES) ?? value.trim()
 export const normalizeCompoundClass = (value: string) => firstMatch(value, CLASS_RULES) ?? value.trim()
 export const normalizeSafetySignal = (value: string) => firstMatch(value, SAFETY_RULES) ?? value.trim()
+
+export const inferAtlasEffectsFromMechanisms = (values: string[]): string[] => {
+  const effects = values.flatMap((value) => {
+    const normalized = clean(value)
+    return MECHANISM_EFFECT_RULES
+      .filter(([, pattern]) => pattern.test(normalized))
+      .map(([effect]) => effect)
+  })
+  return Array.from(new Set(effects))
+}
 
 export const normalizeEvidence = (value: string) => {
   const normalized = clean(value)


### PR DESCRIPTION
## Summary
- infer controlled atlas effect categories from structured mechanism fields
- cover GABAergic, melatonin/orexin, adrenergic, serotonergic, cholinergic, opioid-like, perception, cardiovascular, metabolic, inflammatory, and immune pathways
- merge inferred categories behind explicit effects and deduplicate them
- ignore unknown mechanism text rather than exposing raw labels
- add focused regression tests

## Guardrail
These mappings improve pathway-based discovery only. They do not convert mechanisms into clinical efficacy claims, and unknown pathways remain unclassified.