### PR TITLE
Show effect provenance in Botanical Activity Atlas

### DIFF
--- a/src/components/atlas/BotanicalActivityAtlasClient.tsx
+++ b/src/components/atlas/BotanicalActivityAtlasClient.tsx
@@ -2,17 +2,15 @@
 
 import Link from 'next/link'
 import { useMemo, useState } from 'react'
-import {
-  trackAtlasFilter,
-  trackAtlasProfileClick,
-  trackAtlasReset,
-} from '@/lib/botanicalAtlasTracking'
+import { trackAtlasFilter, trackAtlasProfileClick, trackAtlasReset } from '@/lib/botanicalAtlasTracking'
 
 export interface BotanicalAtlasRecord {
   slug: string
   name: string
   scientificName?: string
   effects: string[]
+  explicitEffects?: string[]
+  inferredEffects?: string[]
   compounds: string[]
   compoundClasses: string[]
   evidence: string
@@ -22,10 +20,7 @@ export interface BotanicalAtlasRecord {
   duration?: string
 }
 
-interface Props {
-  records: BotanicalAtlasRecord[]
-}
-
+interface Props { records: BotanicalAtlasRecord[] }
 type SortOption = 'name' | 'evidence' | 'noticeability'
 
 const normalize = (value: string) => value.trim().toLowerCase()
@@ -33,31 +28,37 @@ const sortedUnique = (values: string[]) => Array.from(new Set(values.filter(Bool
 const evidenceRank: Record<string, number> = { Strong: 5, Moderate: 4, Preliminary: 3, 'Traditional / preclinical': 2, Unclassified: 1 }
 const intensityRank: Record<string, number> = { Pronounced: 5, Moderate: 4, Subtle: 3, Variable: 2, Unknown: 1 }
 
-function matchesFilters(record: BotanicalAtlasRecord, filters: {
-  query: string
-  effect: string
-  evidence: string
-  intensity: string
-  compoundClass: string
-  safety: string
-}) {
+function matchesFilters(record: BotanicalAtlasRecord, filters: { query: string; effect: string; evidence: string; intensity: string; compoundClass: string; safety: string }) {
+  const searchable = [record.name, record.scientificName ?? '', ...record.effects, ...record.compounds, ...record.compoundClasses, ...record.safety].join(' ').toLowerCase()
   const needle = normalize(filters.query)
-  const searchable = [
-    record.name,
-    record.scientificName ?? '',
-    ...record.effects,
-    ...record.compounds,
-    ...record.compoundClasses,
-    ...record.safety,
-  ].join(' ').toLowerCase()
+  return (!needle || searchable.includes(needle))
+    && (filters.effect === 'all' || record.effects.includes(filters.effect))
+    && (filters.evidence === 'all' || record.evidence === filters.evidence)
+    && (filters.intensity === 'all' || record.intensity === filters.intensity)
+    && (filters.compoundClass === 'all' || record.compoundClasses.includes(filters.compoundClass))
+    && (filters.safety === 'all' || record.safety.includes(filters.safety))
+}
 
+function EffectTags({ record, limit = 5 }: { record: BotanicalAtlasRecord; limit?: number }) {
+  const inferred = new Set(record.inferredEffects ?? [])
+  if (!record.effects.length) return <span className='text-muted'>Unclassified</span>
   return (
-    (!needle || searchable.includes(needle)) &&
-    (filters.effect === 'all' || record.effects.includes(filters.effect)) &&
-    (filters.evidence === 'all' || record.evidence === filters.evidence) &&
-    (filters.intensity === 'all' || record.intensity === filters.intensity) &&
-    (filters.compoundClass === 'all' || record.compoundClasses.includes(filters.compoundClass)) &&
-    (filters.safety === 'all' || record.safety.includes(filters.safety))
+    <span className='flex flex-wrap gap-1.5'>
+      {record.effects.slice(0, limit).map((effect) => {
+        const pathwayDerived = inferred.has(effect)
+        return (
+          <span
+            key={effect}
+            title={pathwayDerived ? 'Pathway-derived category; not a clinical outcome claim' : 'Reported or explicitly assigned effect category'}
+            className={pathwayDerived
+              ? 'rounded-full border border-dashed border-sky-700/30 bg-sky-50 px-2 py-0.5 text-xs font-medium text-sky-950'
+              : 'rounded-full border border-emerald-900/10 bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-950'}
+          >
+            {effect}{pathwayDerived ? ' · pathway' : ''}
+          </span>
+        )
+      })}
+    </span>
   )
 }
 
@@ -75,7 +76,6 @@ export default function BotanicalActivityAtlasClient({ records }: Props) {
   const intensityLevels = useMemo(() => sortedUnique(records.map((record) => record.intensity)), [records])
   const compoundClasses = useMemo(() => sortedUnique(records.flatMap((record) => record.compoundClasses)), [records])
   const safetySignals = useMemo(() => sortedUnique(records.flatMap((record) => record.safety)), [records])
-
   const filters = useMemo(() => ({ query, effect, evidence, intensity, compoundClass, safety }), [query, effect, evidence, intensity, compoundClass, safety])
 
   const filtered = useMemo(() => {
@@ -96,11 +96,7 @@ export default function BotanicalActivityAtlasClient({ records }: Props) {
     safety !== 'all' && `Safety: ${safety}`,
   ].filter(Boolean) as string[]
 
-  const setTrackedFilter = (
-    filter: 'effect' | 'chemistry' | 'evidence' | 'noticeability' | 'safety',
-    value: string,
-    setter: (value: string) => void,
-  ) => {
+  const setTrackedFilter = (filter: 'effect' | 'chemistry' | 'evidence' | 'noticeability' | 'safety', value: string, setter: (value: string) => void) => {
     const nextFilters = {
       ...filters,
       effect: filter === 'effect' ? value : effect,
@@ -115,90 +111,50 @@ export default function BotanicalActivityAtlasClient({ records }: Props) {
 
   const reset = () => {
     trackAtlasReset(activeFilters.length)
-    setQuery('')
-    setEffect('all')
-    setEvidence('all')
-    setIntensity('all')
-    setCompoundClass('all')
-    setSafety('all')
-    setSort('name')
+    setQuery(''); setEffect('all'); setEvidence('all'); setIntensity('all'); setCompoundClass('all'); setSafety('all'); setSort('name')
   }
 
-  const trackProfile = (record: BotanicalAtlasRecord, index: number) => {
+  const trackProfile = (record: BotanicalAtlasRecord, index: number) =>
     trackAtlasProfileClick({ slug: record.slug, position: index + 1, activeFilterCount: activeFilters.length })
-  }
+
+  const selectClass = 'w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2 text-sm text-ink'
+  const labelClass = 'mb-1 block text-xs font-bold uppercase tracking-wide text-muted'
 
   return (
     <section className='space-y-5'>
       <div className='grid gap-3 rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm md:grid-cols-2 xl:grid-cols-6'>
-        <label>
-          <span className='mb-1 block text-xs font-bold uppercase tracking-wide text-muted'>Search</span>
-          <input value={query} onChange={(event) => setQuery(event.target.value)} onBlur={() => query.trim() && trackAtlasFilter({ filter: 'search', value: query.trim(), resultCount: filtered.length })} placeholder='Herb, compound, effect…' className='w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2 text-sm text-ink outline-none focus:border-emerald-600' />
-        </label>
-        <label>
-          <span className='mb-1 block text-xs font-bold uppercase tracking-wide text-muted'>Effect</span>
-          <select value={effect} onChange={(event) => setTrackedFilter('effect', event.target.value, setEffect)} className='w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2 text-sm text-ink'><option value='all'>All effects</option>{effects.map((item) => <option key={item} value={item}>{item}</option>)}</select>
-        </label>
-        <label>
-          <span className='mb-1 block text-xs font-bold uppercase tracking-wide text-muted'>Chemistry</span>
-          <select value={compoundClass} onChange={(event) => setTrackedFilter('chemistry', event.target.value, setCompoundClass)} className='w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2 text-sm text-ink'><option value='all'>All classes</option>{compoundClasses.map((item) => <option key={item} value={item}>{item}</option>)}</select>
-        </label>
-        <label>
-          <span className='mb-1 block text-xs font-bold uppercase tracking-wide text-muted'>Evidence</span>
-          <select value={evidence} onChange={(event) => setTrackedFilter('evidence', event.target.value, setEvidence)} className='w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2 text-sm text-ink'><option value='all'>All evidence</option>{evidenceLevels.map((item) => <option key={item} value={item}>{item}</option>)}</select>
-        </label>
-        <label>
-          <span className='mb-1 block text-xs font-bold uppercase tracking-wide text-muted'>Noticeability</span>
-          <select value={intensity} onChange={(event) => setTrackedFilter('noticeability', event.target.value, setIntensity)} className='w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2 text-sm text-ink'><option value='all'>All levels</option>{intensityLevels.map((item) => <option key={item} value={item}>{item}</option>)}</select>
-        </label>
-        <label>
-          <span className='mb-1 block text-xs font-bold uppercase tracking-wide text-muted'>Safety concern</span>
-          <select value={safety} onChange={(event) => setTrackedFilter('safety', event.target.value, setSafety)} className='w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2 text-sm text-ink'><option value='all'>All signals</option>{safetySignals.map((item) => <option key={item} value={item}>{item}</option>)}</select>
-        </label>
+        <label><span className={labelClass}>Search</span><input value={query} onChange={(event) => setQuery(event.target.value)} onBlur={() => query.trim() && trackAtlasFilter({ filter: 'search', value: query.trim(), resultCount: filtered.length })} placeholder='Herb, compound, effect…' className={selectClass} /></label>
+        <label><span className={labelClass}>Effect</span><select value={effect} onChange={(event) => setTrackedFilter('effect', event.target.value, setEffect)} className={selectClass}><option value='all'>All effects</option>{effects.map((item) => <option key={item}>{item}</option>)}</select></label>
+        <label><span className={labelClass}>Chemistry</span><select value={compoundClass} onChange={(event) => setTrackedFilter('chemistry', event.target.value, setCompoundClass)} className={selectClass}><option value='all'>All classes</option>{compoundClasses.map((item) => <option key={item}>{item}</option>)}</select></label>
+        <label><span className={labelClass}>Evidence</span><select value={evidence} onChange={(event) => setTrackedFilter('evidence', event.target.value, setEvidence)} className={selectClass}><option value='all'>All evidence</option>{evidenceLevels.map((item) => <option key={item}>{item}</option>)}</select></label>
+        <label><span className={labelClass}>Noticeability</span><select value={intensity} onChange={(event) => setTrackedFilter('noticeability', event.target.value, setIntensity)} className={selectClass}><option value='all'>All levels</option>{intensityLevels.map((item) => <option key={item}>{item}</option>)}</select></label>
+        <label><span className={labelClass}>Safety concern</span><select value={safety} onChange={(event) => setTrackedFilter('safety', event.target.value, setSafety)} className={selectClass}><option value='all'>All signals</option>{safetySignals.map((item) => <option key={item}>{item}</option>)}</select></label>
+      </div>
+
+      <div className='rounded-xl border border-sky-900/10 bg-sky-50/70 px-4 py-3 text-sm text-sky-950'>
+        <strong>Effect provenance:</strong> solid green labels come from explicit effect data. Dashed blue “pathway” labels are inferred from structured mechanisms and should not be read as demonstrated clinical outcomes.
       </div>
 
       <div className='flex flex-wrap items-end justify-between gap-3 text-sm text-muted'>
         <p><strong className='text-ink'>{filtered.length}</strong> of {records.length} botanicals shown</p>
-        <div className='flex items-end gap-3'>
-          <label>
-            <span className='mb-1 block text-xs font-bold uppercase tracking-wide text-muted'>Sort</span>
-            <select value={sort} onChange={(event) => setSort(event.target.value as SortOption)} className='rounded-xl border border-brand-900/15 bg-white px-3 py-2 text-sm text-ink'>
-              <option value='name'>Name A–Z</option>
-              <option value='evidence'>Strongest evidence</option>
-              <option value='noticeability'>Most noticeable</option>
-            </select>
-          </label>
-          <button type='button' onClick={reset} disabled={!activeFilters.length && sort === 'name'} className='mb-2 font-semibold text-emerald-800 hover:underline disabled:cursor-not-allowed disabled:opacity-40'>Reset</button>
-        </div>
+        <div className='flex items-end gap-3'><label><span className={labelClass}>Sort</span><select value={sort} onChange={(event) => setSort(event.target.value as SortOption)} className={selectClass}><option value='name'>Name A–Z</option><option value='evidence'>Strongest evidence</option><option value='noticeability'>Most noticeable</option></select></label><button type='button' onClick={reset} disabled={!activeFilters.length && sort === 'name'} className='mb-2 font-semibold text-emerald-800 hover:underline disabled:opacity-40'>Reset</button></div>
       </div>
 
       {activeFilters.length ? <div className='flex flex-wrap gap-2' aria-label='Active filters'>{activeFilters.map((item) => <span key={item} className='rounded-full border border-emerald-900/10 bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-950'>{item}</span>)}</div> : null}
 
       <div className='grid gap-4 md:hidden'>
-        {filtered.map((record, index) => (
-          <article key={record.slug} className='rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm'>
-            <div className='flex items-start justify-between gap-3'>
-              <div>
-                <Link href={`/herbs/${record.slug}/`} onClick={() => trackProfile(record, index)} className='text-lg font-bold text-emerald-900 hover:underline'>{record.name}</Link>
-                {record.scientificName ? <p className='mt-1 text-xs italic text-muted'>{record.scientificName}</p> : null}
-              </div>
-              <span className='rounded-full bg-brand-50 px-2.5 py-1 text-xs font-bold text-ink'>{record.evidence}</span>
-            </div>
-            <div className='mt-4 grid grid-cols-2 gap-3 text-sm'>
-              <div><p className='text-xs font-bold uppercase tracking-wide text-muted'>Noticeability</p><p className='mt-1 font-semibold text-ink'>{record.intensity}</p></div>
-              <div><p className='text-xs font-bold uppercase tracking-wide text-muted'>Chemistry</p><p className='mt-1 text-ink'>{record.compoundClasses.slice(0, 2).join(', ') || 'Not mapped'}</p></div>
-            </div>
-            <div className='mt-4'><p className='text-xs font-bold uppercase tracking-wide text-muted'>Effects</p><p className='mt-1 text-sm text-muted'>{record.effects.slice(0, 4).join(' · ') || 'Unclassified'}</p></div>
-            {record.safety.length ? <div className='mt-4 rounded-xl bg-amber-50 p-3'><p className='text-xs font-bold uppercase tracking-wide text-amber-950'>Safety signals</p><p className='mt-1 text-sm text-amber-950'>{record.safety.slice(0, 3).join(' · ')}</p></div> : null}
-            <Link href={`/herbs/${record.slug}/`} onClick={() => trackProfile(record, index)} className='mt-4 inline-flex font-semibold text-emerald-800 hover:underline'>Open full profile →</Link>
-          </article>
-        ))}
+        {filtered.map((record, index) => <article key={record.slug} className='rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm'>
+          <div className='flex items-start justify-between gap-3'><div><Link href={`/herbs/${record.slug}/`} onClick={() => trackProfile(record, index)} className='text-lg font-bold text-emerald-900 hover:underline'>{record.name}</Link>{record.scientificName ? <p className='mt-1 text-xs italic text-muted'>{record.scientificName}</p> : null}</div><span className='rounded-full bg-brand-50 px-2.5 py-1 text-xs font-bold text-ink'>{record.evidence}</span></div>
+          <div className='mt-4 grid grid-cols-2 gap-3 text-sm'><div><p className={labelClass}>Noticeability</p><p className='font-semibold text-ink'>{record.intensity}</p></div><div><p className={labelClass}>Chemistry</p><p className='text-ink'>{record.compoundClasses.slice(0, 2).join(', ') || 'Not mapped'}</p></div></div>
+          <div className='mt-4'><p className={labelClass}>Effects</p><EffectTags record={record} limit={4} /></div>
+          {record.safety.length ? <div className='mt-4 rounded-xl bg-amber-50 p-3'><p className='text-xs font-bold uppercase tracking-wide text-amber-950'>Safety signals</p><p className='mt-1 text-sm text-amber-950'>{record.safety.slice(0, 3).join(' · ')}</p></div> : null}
+          <Link href={`/herbs/${record.slug}/`} onClick={() => trackProfile(record, index)} className='mt-4 inline-flex font-semibold text-emerald-800 hover:underline'>Open full profile →</Link>
+        </article>)}
       </div>
 
       <div className='hidden overflow-x-auto rounded-2xl border border-brand-900/10 bg-white/90 shadow-sm md:block'>
-        <table className='min-w-[1100px] w-full border-collapse text-left text-sm'>
-          <thead className='bg-brand-50/80 text-xs uppercase tracking-wide text-muted'><tr><th className='p-4'>Botanical</th><th className='p-4'>Active chemistry</th><th className='p-4'>Effect profile</th><th className='p-4'>Noticeability</th><th className='p-4'>Evidence</th><th className='p-4'>Safety signals</th><th className='p-4'>Timing</th></tr></thead>
-          <tbody>{filtered.map((record, index) => <tr key={record.slug} className='border-t border-brand-900/10 align-top'><td className='p-4'><Link href={`/herbs/${record.slug}/`} onClick={() => trackProfile(record, index)} className='font-bold text-emerald-900 hover:underline'>{record.name}</Link>{record.scientificName ? <p className='mt-1 text-xs italic text-muted'>{record.scientificName}</p> : null}</td><td className='p-4'><p className='font-medium text-ink'>{record.compounds.slice(0, 4).join(', ') || 'Not yet mapped'}</p>{record.compoundClasses.length ? <p className='mt-1 text-xs text-muted'>{record.compoundClasses.join(', ')}</p> : null}</td><td className='p-4 text-muted'>{record.effects.slice(0, 5).join(' · ') || 'Unclassified'}</td><td className='p-4 font-semibold text-ink'>{record.intensity}</td><td className='p-4'>{record.evidence}</td><td className='p-4 text-muted'>{record.safety.slice(0, 4).join(' · ') || 'No structured flags'}</td><td className='p-4 text-muted'>{[record.onset && `Onset: ${record.onset}`, record.duration && `Duration: ${record.duration}`].filter(Boolean).join(' · ') || 'Not established'}</td></tr>)}</tbody>
+        <table className='min-w-[1100px] w-full border-collapse text-left text-sm'><thead className='bg-brand-50/80 text-xs uppercase tracking-wide text-muted'><tr><th className='p-4'>Botanical</th><th className='p-4'>Active chemistry</th><th className='p-4'>Effect profile</th><th className='p-4'>Noticeability</th><th className='p-4'>Evidence</th><th className='p-4'>Safety signals</th><th className='p-4'>Timing</th></tr></thead>
+          <tbody>{filtered.map((record, index) => <tr key={record.slug} className='border-t border-brand-900/10 align-top'><td className='p-4'><Link href={`/herbs/${record.slug}/`} onClick={() => trackProfile(record, index)} className='font-bold text-emerald-900 hover:underline'>{record.name}</Link>{record.scientificName ? <p className='mt-1 text-xs italic text-muted'>{record.scientificName}</p> : null}</td><td className='p-4'><p className='font-medium text-ink'>{record.compounds.slice(0, 4).join(', ') || 'Not yet mapped'}</p>{record.compoundClasses.length ? <p className='mt-1 text-xs text-muted'>{record.compoundClasses.join(', ')}</p> : null}</td><td className='p-4'><EffectTags record={record} /></td><td className='p-4 font-semibold text-ink'>{record.intensity}</td><td className='p-4'>{record.evidence}</td><td className='p-4 text-muted'>{record.safety.slice(0, 4).join(' · ') || 'No structured flags'}</td><td className='p-4 text-muted'>{[record.onset && `Onset: ${record.onset}`, record.duration && `Duration: ${record.duration}`].filter(Boolean).join(' · ') || 'Not established'}</td></tr>)}</tbody>
         </table>
       </div>
 

--- a/src/lib/__tests__/botanical-atlas-data.test.ts
+++ b/src/lib/__tests__/botanical-atlas-data.test.ts
@@ -10,80 +10,56 @@ const record = (overrides: Partial<RuntimeRecord>): RuntimeRecord => ({
 
 describe('Botanical Activity Atlas runtime fallbacks', () => {
   it('combines safety fields instead of stopping at an empty array', () => {
-    const result = toAtlasRecord(record({
-      safety_flags: [],
-      safety: 'May cause sedation and interact with anticoagulants.',
-    }))
-
+    const result = toAtlasRecord(record({ safety_flags: [], safety: 'May cause sedation and interact with anticoagulants.' }))
     expect(result.safety).toContain('Sedation')
     expect(result.safety).toContain('Bleeding')
   })
 
   it('infers known chemical families from named active compounds', () => {
-    const result = toAtlasRecord(record({
-      activeCompounds: ['caffeine', 'theobromine'],
-    }))
-
+    const result = toAtlasRecord(record({ activeCompounds: ['caffeine', 'theobromine'] }))
     expect(result.compoundClasses).toEqual(['Methylxanthines'])
   })
 
   it('does not turn unknown compound names into fake chemical classes', () => {
-    const result = toAtlasRecord(record({
-      activeCompounds: ['mystery constituent'],
-    }))
-
+    const result = toAtlasRecord(record({ activeCompounds: ['mystery constituent'] }))
     expect(result.compoundClasses).toEqual([])
   })
 
   it('recognizes additional noticeability and timing aliases', () => {
-    const result = toAtlasRecord(record({
-      noticeability: 'noticeable',
-      onsetTime: '30 minutes',
-      effectDuration: '4 hours',
-    }))
-
+    const result = toAtlasRecord(record({ noticeability: 'noticeable', onsetTime: '30 minutes', effectDuration: '4 hours' }))
     expect(result.intensity).toBe('Moderate')
     expect(result.onset).toBe('30 minutes')
     expect(result.duration).toBe('4 hours')
   })
 
   it('combines effects from multiple populated fields', () => {
-    const result = toAtlasRecord(record({
-      primary_effects: [],
-      effects: ['calming'],
-      benefits: ['sleep support'],
-    }))
-
-    expect(result.effects).toContain('Calming')
-    expect(result.effects).toContain('Sedating / sleep')
+    const result = toAtlasRecord(record({ primary_effects: [], effects: ['calming'], benefits: ['sleep support'] }))
+    expect(result.explicitEffects).toEqual(['Calming', 'Sedating / sleep'])
+    expect(result.inferredEffects).toEqual([])
+    expect(result.effects).toEqual(['Calming', 'Sedating / sleep'])
   })
 
-  it('enriches discovery effects from structured mechanisms', () => {
+  it('tracks mechanism-enriched categories as inferred', () => {
     const result = toAtlasRecord(record({
       effects: [],
       mechanisms: ['GABA-A positive allosteric modulation', 'acetylcholinesterase inhibition'],
       canonical_mechanisms: ['Serotonergic signaling'],
     }))
-
-    expect(result.effects).toContain('Calming')
-    expect(result.effects).toContain('Cognition / focus')
-    expect(result.effects).toContain('Mood')
+    expect(result.explicitEffects).toEqual([])
+    expect(result.inferredEffects).toEqual(['Calming', 'Cognition / focus', 'Mood'])
+    expect(result.effects).toEqual(result.inferredEffects)
   })
 
-  it('keeps explicit effects and deduplicates inferred matches', () => {
-    const result = toAtlasRecord(record({
-      effects: ['calming'],
-      mechanisms: ['GABA-A modulation', 'HPA axis modulation'],
-    }))
-
-    expect(result.effects.filter((effect) => effect === 'Calming')).toHaveLength(1)
+  it('keeps explicit effects authoritative and removes inferred overlap', () => {
+    const result = toAtlasRecord(record({ effects: ['calming'], mechanisms: ['GABA-A modulation', 'HPA axis modulation'] }))
+    expect(result.explicitEffects).toEqual(['Calming'])
+    expect(result.inferredEffects).toEqual([])
+    expect(result.effects).toEqual(['Calming'])
   })
 
   it('does not expose unknown mechanism text as an effect label', () => {
-    const result = toAtlasRecord(record({
-      mechanisms: ['Unmapped experimental pathway XYZ'],
-    }))
-
+    const result = toAtlasRecord(record({ mechanisms: ['Unmapped experimental pathway XYZ'] }))
     expect(result.effects).toEqual([])
+    expect(result.inferredEffects).toEqual([])
   })
 })

--- a/src/lib/botanical-atlas-data.ts
+++ b/src/lib/botanical-atlas-data.ts
@@ -53,7 +53,8 @@ export const toAtlasRecord = (herb: RuntimeRecord): BotanicalAtlasRecord => {
     herb.mechanism_classes,
   )
   const inferredEffects = inferAtlasEffectsFromMechanisms(mechanisms)
-  const effects = Array.from(new Set([...explicitEffects, ...inferredEffects]))
+    .filter((effect) => !explicitEffects.includes(effect))
+  const effects = [...explicitEffects, ...inferredEffects]
   const compounds = collect(herb.activeCompounds, herb.active_compounds, herb.compounds, herb.activeconstituents)
   const explicitClasses = uniqueNormalized(
     collect(herb.compoundClasses, herb.pharmCategories, herb.compoundClass),
@@ -75,6 +76,8 @@ export const toAtlasRecord = (herb: RuntimeRecord): BotanicalAtlasRecord => {
     name: text(herb.displayName, herb.name, herb.commonName, herb.common, herb.slug.replaceAll('-', ' ')),
     scientificName: text(herb.scientificName, herb.scientificname, herb.latinName) || undefined,
     effects,
+    explicitEffects,
+    inferredEffects,
     compounds,
     compoundClasses,
     evidence: normalizeEvidence(text(herb.evidence_tier, herb.evidenceTier, herb.evidence_grade, herb.evidenceLevel)),


### PR DESCRIPTION
## Summary
- preserve explicit and mechanism-inferred effects as separate fields while keeping the combined effect list for search and filtering
- label explicit effects with solid green chips and pathway-derived categories with dashed blue chips
- add a clear legend explaining that pathway-derived categories are not demonstrated clinical outcomes
- remove inferred duplicates when an effect is already explicitly assigned
- add regression coverage for explicit, inferred, overlap, and unknown-pathway behavior

## Why this is high ROI
The atlas now enriches effects from mechanisms. Showing provenance protects trust and lets readers distinguish reported effect data from pathway-level discovery without weakening search or category coverage.