### PR TITLE
Make Botanical Activity Atlas states shareable

### DIFF
--- a/src/components/atlas/BotanicalActivityAtlasClient.tsx
+++ b/src/components/atlas/BotanicalActivityAtlasClient.tsx
@@ -1,8 +1,15 @@
 'use client'
 
 import Link from 'next/link'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { trackAtlasFilter, trackAtlasProfileClick, trackAtlasReset } from '@/lib/botanicalAtlasTracking'
+import {
+  DEFAULT_ATLAS_URL_STATE,
+  parseAtlasUrlState,
+  serializeAtlasUrlState,
+  type AtlasEffectSource,
+  type AtlasSortOption,
+} from '@/lib/botanical-atlas-url-state'
 
 export interface BotanicalAtlasRecord {
   slug: string
@@ -21,13 +28,10 @@ export interface BotanicalAtlasRecord {
 }
 
 interface Props { records: BotanicalAtlasRecord[] }
-type SortOption = 'name' | 'evidence' | 'noticeability'
-type EffectSource = 'all' | 'explicit'
-
 type AtlasFilters = {
   query: string
   effect: string
-  effectSource: EffectSource
+  effectSource: AtlasEffectSource
   evidence: string
   intensity: string
   compoundClass: string
@@ -39,7 +43,7 @@ const sortedUnique = (values: string[]) => Array.from(new Set(values.filter(Bool
 const evidenceRank: Record<string, number> = { Strong: 5, Moderate: 4, Preliminary: 3, 'Traditional / preclinical': 2, Unclassified: 1 }
 const intensityRank: Record<string, number> = { Pronounced: 5, Moderate: 4, Subtle: 3, Variable: 2, Unknown: 1 }
 
-export function effectsForSource(record: BotanicalAtlasRecord, source: EffectSource): string[] {
+export function effectsForSource(record: BotanicalAtlasRecord, source: AtlasEffectSource): string[] {
   return source === 'explicit' ? (record.explicitEffects ?? record.effects) : record.effects
 }
 
@@ -55,39 +59,46 @@ export function matchesFilters(record: BotanicalAtlasRecord, filters: AtlasFilte
     && (filters.safety === 'all' || record.safety.includes(filters.safety))
 }
 
-function EffectTags({ record, limit = 5, source = 'all' }: { record: BotanicalAtlasRecord; limit?: number; source?: EffectSource }) {
+function EffectTags({ record, limit = 5, source = 'all' }: { record: BotanicalAtlasRecord; limit?: number; source?: AtlasEffectSource }) {
   const visibleEffects = effectsForSource(record, source)
   const inferred = new Set(record.inferredEffects ?? [])
   if (!visibleEffects.length) return <span className='text-muted'>Unclassified</span>
-  return (
-    <span className='flex flex-wrap gap-1.5'>
-      {visibleEffects.slice(0, limit).map((effect) => {
-        const pathwayDerived = source === 'all' && inferred.has(effect)
-        return (
-          <span
-            key={effect}
-            title={pathwayDerived ? 'Pathway-derived category; not a clinical outcome claim' : 'Reported or explicitly assigned effect category'}
-            className={pathwayDerived
-              ? 'rounded-full border border-dashed border-sky-700/30 bg-sky-50 px-2 py-0.5 text-xs font-medium text-sky-950'
-              : 'rounded-full border border-emerald-900/10 bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-950'}
-          >
-            {effect}{pathwayDerived ? ' · pathway' : ''}
-          </span>
-        )
-      })}
-    </span>
-  )
+  return <span className='flex flex-wrap gap-1.5'>{visibleEffects.slice(0, limit).map((effect) => {
+    const pathwayDerived = source === 'all' && inferred.has(effect)
+    return <span key={effect} title={pathwayDerived ? 'Pathway-derived category; not a clinical outcome claim' : 'Reported or explicitly assigned effect category'} className={pathwayDerived ? 'rounded-full border border-dashed border-sky-700/30 bg-sky-50 px-2 py-0.5 text-xs font-medium text-sky-950' : 'rounded-full border border-emerald-900/10 bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-950'}>{effect}{pathwayDerived ? ' · pathway' : ''}</span>
+  })}</span>
 }
 
 export default function BotanicalActivityAtlasClient({ records }: Props) {
   const [query, setQuery] = useState('')
   const [effect, setEffect] = useState('all')
-  const [effectSource, setEffectSource] = useState<EffectSource>('all')
+  const [effectSource, setEffectSource] = useState<AtlasEffectSource>('all')
   const [evidence, setEvidence] = useState('all')
   const [intensity, setIntensity] = useState('all')
   const [compoundClass, setCompoundClass] = useState('all')
   const [safety, setSafety] = useState('all')
-  const [sort, setSort] = useState<SortOption>('name')
+  const [sort, setSort] = useState<AtlasSortOption>('name')
+  const [urlReady, setUrlReady] = useState(false)
+  const [copyStatus, setCopyStatus] = useState<'idle' | 'copied' | 'failed'>('idle')
+
+  useEffect(() => {
+    const initial = parseAtlasUrlState(window.location.search)
+    setQuery(initial.query)
+    setEffect(initial.effect)
+    setEffectSource(initial.effectSource)
+    setEvidence(initial.evidence)
+    setIntensity(initial.intensity)
+    setCompoundClass(initial.compoundClass)
+    setSafety(initial.safety)
+    setSort(initial.sort)
+    setUrlReady(true)
+  }, [])
+
+  useEffect(() => {
+    if (!urlReady) return
+    const search = serializeAtlasUrlState({ query, effect, effectSource, evidence, intensity, compoundClass, safety, sort })
+    window.history.replaceState(null, '', `${window.location.pathname}${search}${window.location.hash}`)
+  }, [urlReady, query, effect, effectSource, evidence, intensity, compoundClass, safety, sort])
 
   const effects = useMemo(() => sortedUnique(records.flatMap((record) => effectsForSource(record, effectSource))), [records, effectSource])
   const evidenceLevels = useMemo(() => sortedUnique(records.map((record) => record.evidence)), [records])
@@ -96,98 +107,81 @@ export default function BotanicalActivityAtlasClient({ records }: Props) {
   const safetySignals = useMemo(() => sortedUnique(records.flatMap((record) => record.safety)), [records])
   const filters = useMemo(() => ({ query, effect, effectSource, evidence, intensity, compoundClass, safety }), [query, effect, effectSource, evidence, intensity, compoundClass, safety])
 
-  const filtered = useMemo(() => {
-    const matches = records.filter((record) => matchesFilters(record, filters))
-    return matches.sort((a, b) => {
-      if (sort === 'evidence') return (evidenceRank[b.evidence] ?? 0) - (evidenceRank[a.evidence] ?? 0) || a.name.localeCompare(b.name)
-      if (sort === 'noticeability') return (intensityRank[b.intensity] ?? 0) - (intensityRank[a.intensity] ?? 0) || a.name.localeCompare(b.name)
-      return a.name.localeCompare(b.name)
-    })
-  }, [records, filters, sort])
+  const filtered = useMemo(() => records.filter((record) => matchesFilters(record, filters)).sort((a, b) => {
+    if (sort === 'evidence') return (evidenceRank[b.evidence] ?? 0) - (evidenceRank[a.evidence] ?? 0) || a.name.localeCompare(b.name)
+    if (sort === 'noticeability') return (intensityRank[b.intensity] ?? 0) - (intensityRank[a.intensity] ?? 0) || a.name.localeCompare(b.name)
+    return a.name.localeCompare(b.name)
+  }), [records, filters, sort])
 
-  const activeFilters = [
-    query && `Search: ${query}`,
-    effect !== 'all' && `Effect: ${effect}`,
-    effectSource === 'explicit' && 'Effect source: explicit only',
-    evidence !== 'all' && `Evidence: ${evidence}`,
-    intensity !== 'all' && `Noticeability: ${intensity}`,
-    compoundClass !== 'all' && `Chemistry: ${compoundClass}`,
-    safety !== 'all' && `Safety: ${safety}`,
-  ].filter(Boolean) as string[]
+  const activeFilters = [query && `Search: ${query}`, effect !== 'all' && `Effect: ${effect}`, effectSource === 'explicit' && 'Effect source: explicit only', evidence !== 'all' && `Evidence: ${evidence}`, intensity !== 'all' && `Noticeability: ${intensity}`, compoundClass !== 'all' && `Chemistry: ${compoundClass}`, safety !== 'all' && `Safety: ${safety}`].filter(Boolean) as string[]
 
   const setTrackedFilter = (filter: 'effect' | 'chemistry' | 'evidence' | 'noticeability' | 'safety', value: string, setter: (value: string) => void) => {
-    const nextFilters = {
-      ...filters,
-      effect: filter === 'effect' ? value : effect,
-      compoundClass: filter === 'chemistry' ? value : compoundClass,
-      evidence: filter === 'evidence' ? value : evidence,
-      intensity: filter === 'noticeability' ? value : intensity,
-      safety: filter === 'safety' ? value : safety,
-    }
+    const nextFilters = { ...filters, effect: filter === 'effect' ? value : effect, compoundClass: filter === 'chemistry' ? value : compoundClass, evidence: filter === 'evidence' ? value : evidence, intensity: filter === 'noticeability' ? value : intensity, safety: filter === 'safety' ? value : safety }
     setter(value)
     trackAtlasFilter({ filter, value, resultCount: records.filter((record) => matchesFilters(record, nextFilters)).length })
   }
 
-  const changeEffectSource = (value: EffectSource) => {
+  const changeEffectSource = (value: AtlasEffectSource) => {
     const available = sortedUnique(records.flatMap((record) => effectsForSource(record, value)))
     const nextEffect = effect === 'all' || available.includes(effect) ? effect : 'all'
-    const nextFilters = { ...filters, effectSource: value, effect: nextEffect }
     setEffectSource(value)
     setEffect(nextEffect)
-    trackAtlasFilter({ filter: 'effect', value: value === 'explicit' ? 'explicit-only' : 'include-pathways', resultCount: records.filter((record) => matchesFilters(record, nextFilters)).length })
+    trackAtlasFilter({ filter: 'effect', value: value === 'explicit' ? 'explicit-only' : 'include-pathways', resultCount: records.filter((record) => matchesFilters(record, { ...filters, effectSource: value, effect: nextEffect })).length })
   }
 
   const reset = () => {
     trackAtlasReset(activeFilters.length)
-    setQuery(''); setEffect('all'); setEffectSource('all'); setEvidence('all'); setIntensity('all'); setCompoundClass('all'); setSafety('all'); setSort('name')
+    setQuery(DEFAULT_ATLAS_URL_STATE.query); setEffect(DEFAULT_ATLAS_URL_STATE.effect); setEffectSource(DEFAULT_ATLAS_URL_STATE.effectSource); setEvidence(DEFAULT_ATLAS_URL_STATE.evidence); setIntensity(DEFAULT_ATLAS_URL_STATE.intensity); setCompoundClass(DEFAULT_ATLAS_URL_STATE.compoundClass); setSafety(DEFAULT_ATLAS_URL_STATE.safety); setSort(DEFAULT_ATLAS_URL_STATE.sort)
   }
 
-  const trackProfile = (record: BotanicalAtlasRecord, index: number) =>
-    trackAtlasProfileClick({ slug: record.slug, position: index + 1, activeFilterCount: activeFilters.length })
+  const copyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href)
+      setCopyStatus('copied')
+    } catch {
+      setCopyStatus('failed')
+    }
+    window.setTimeout(() => setCopyStatus('idle'), 1800)
+  }
 
+  const trackProfile = (record: BotanicalAtlasRecord, index: number) => trackAtlasProfileClick({ slug: record.slug, position: index + 1, activeFilterCount: activeFilters.length })
   const selectClass = 'w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2 text-sm text-ink'
   const labelClass = 'mb-1 block text-xs font-bold uppercase tracking-wide text-muted'
 
-  return (
-    <section className='space-y-5'>
-      <div className='grid gap-3 rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm md:grid-cols-2 xl:grid-cols-4'>
-        <label><span className={labelClass}>Search</span><input value={query} onChange={(event) => setQuery(event.target.value)} onBlur={() => query.trim() && trackAtlasFilter({ filter: 'search', value: query.trim(), resultCount: filtered.length })} placeholder='Herb, compound, effect…' className={selectClass} /></label>
-        <label><span className={labelClass}>Effect source</span><select value={effectSource} onChange={(event) => changeEffectSource(event.target.value as EffectSource)} className={selectClass}><option value='all'>Include pathway-derived</option><option value='explicit'>Explicit effects only</option></select></label>
-        <label><span className={labelClass}>Effect</span><select value={effect} onChange={(event) => setTrackedFilter('effect', event.target.value, setEffect)} className={selectClass}><option value='all'>All effects</option>{effects.map((item) => <option key={item}>{item}</option>)}</select></label>
-        <label><span className={labelClass}>Chemistry</span><select value={compoundClass} onChange={(event) => setTrackedFilter('chemistry', event.target.value, setCompoundClass)} className={selectClass}><option value='all'>All classes</option>{compoundClasses.map((item) => <option key={item}>{item}</option>)}</select></label>
-        <label><span className={labelClass}>Evidence</span><select value={evidence} onChange={(event) => setTrackedFilter('evidence', event.target.value, setEvidence)} className={selectClass}><option value='all'>All evidence</option>{evidenceLevels.map((item) => <option key={item}>{item}</option>)}</select></label>
-        <label><span className={labelClass}>Noticeability</span><select value={intensity} onChange={(event) => setTrackedFilter('noticeability', event.target.value, setIntensity)} className={selectClass}><option value='all'>All levels</option>{intensityLevels.map((item) => <option key={item}>{item}</option>)}</select></label>
-        <label><span className={labelClass}>Safety concern</span><select value={safety} onChange={(event) => setTrackedFilter('safety', event.target.value, setSafety)} className={selectClass}><option value='all'>All signals</option>{safetySignals.map((item) => <option key={item}>{item}</option>)}</select></label>
+  return <section className='space-y-5'>
+    <div className='grid gap-3 rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm md:grid-cols-2 xl:grid-cols-4'>
+      <label><span className={labelClass}>Search</span><input value={query} onChange={(event) => setQuery(event.target.value)} onBlur={() => query.trim() && trackAtlasFilter({ filter: 'search', value: query.trim(), resultCount: filtered.length })} placeholder='Herb, compound, effect…' className={selectClass} /></label>
+      <label><span className={labelClass}>Effect source</span><select value={effectSource} onChange={(event) => changeEffectSource(event.target.value as AtlasEffectSource)} className={selectClass}><option value='all'>Include pathway-derived</option><option value='explicit'>Explicit effects only</option></select></label>
+      <label><span className={labelClass}>Effect</span><select value={effect} onChange={(event) => setTrackedFilter('effect', event.target.value, setEffect)} className={selectClass}><option value='all'>All effects</option>{effects.map((item) => <option key={item}>{item}</option>)}</select></label>
+      <label><span className={labelClass}>Chemistry</span><select value={compoundClass} onChange={(event) => setTrackedFilter('chemistry', event.target.value, setCompoundClass)} className={selectClass}><option value='all'>All classes</option>{compoundClasses.map((item) => <option key={item}>{item}</option>)}</select></label>
+      <label><span className={labelClass}>Evidence</span><select value={evidence} onChange={(event) => setTrackedFilter('evidence', event.target.value, setEvidence)} className={selectClass}><option value='all'>All evidence</option>{evidenceLevels.map((item) => <option key={item}>{item}</option>)}</select></label>
+      <label><span className={labelClass}>Noticeability</span><select value={intensity} onChange={(event) => setTrackedFilter('noticeability', event.target.value, setIntensity)} className={selectClass}><option value='all'>All levels</option>{intensityLevels.map((item) => <option key={item}>{item}</option>)}</select></label>
+      <label><span className={labelClass}>Safety concern</span><select value={safety} onChange={(event) => setTrackedFilter('safety', event.target.value, setSafety)} className={selectClass}><option value='all'>All signals</option>{safetySignals.map((item) => <option key={item}>{item}</option>)}</select></label>
+    </div>
+
+    <div className='rounded-xl border border-sky-900/10 bg-sky-50/70 px-4 py-3 text-sm text-sky-950'><strong>Effect provenance:</strong> solid green labels come from explicit effect data. Dashed blue “pathway” labels are inferred from structured mechanisms and should not be read as demonstrated clinical outcomes.</div>
+
+    <div className='flex flex-wrap items-end justify-between gap-3 text-sm text-muted'>
+      <p><strong className='text-ink'>{filtered.length}</strong> of {records.length} botanicals shown</p>
+      <div className='flex flex-wrap items-end gap-3'>
+        <label><span className={labelClass}>Sort</span><select value={sort} onChange={(event) => setSort(event.target.value as AtlasSortOption)} className={selectClass}><option value='name'>Name A–Z</option><option value='evidence'>Strongest evidence</option><option value='noticeability'>Most noticeable</option></select></label>
+        <button type='button' onClick={copyLink} className='mb-2 font-semibold text-emerald-800 hover:underline' aria-live='polite'>{copyStatus === 'copied' ? 'Link copied ✓' : copyStatus === 'failed' ? 'Copy failed' : 'Copy link'}</button>
+        <button type='button' onClick={reset} disabled={!activeFilters.length && sort === 'name'} className='mb-2 font-semibold text-emerald-800 hover:underline disabled:opacity-40'>Reset</button>
       </div>
+    </div>
 
-      <div className='rounded-xl border border-sky-900/10 bg-sky-50/70 px-4 py-3 text-sm text-sky-950'>
-        <strong>Effect provenance:</strong> solid green labels come from explicit effect data. Dashed blue “pathway” labels are inferred from structured mechanisms and should not be read as demonstrated clinical outcomes.
-      </div>
+    {activeFilters.length ? <div className='flex flex-wrap gap-2' aria-label='Active filters'>{activeFilters.map((item) => <span key={item} className='rounded-full border border-emerald-900/10 bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-950'>{item}</span>)}</div> : null}
 
-      <div className='flex flex-wrap items-end justify-between gap-3 text-sm text-muted'>
-        <p><strong className='text-ink'>{filtered.length}</strong> of {records.length} botanicals shown</p>
-        <div className='flex items-end gap-3'><label><span className={labelClass}>Sort</span><select value={sort} onChange={(event) => setSort(event.target.value as SortOption)} className={selectClass}><option value='name'>Name A–Z</option><option value='evidence'>Strongest evidence</option><option value='noticeability'>Most noticeable</option></select></label><button type='button' onClick={reset} disabled={!activeFilters.length && sort === 'name'} className='mb-2 font-semibold text-emerald-800 hover:underline disabled:opacity-40'>Reset</button></div>
-      </div>
+    <div className='grid gap-4 md:hidden'>{filtered.map((record, index) => <article key={record.slug} className='rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm'>
+      <div className='flex items-start justify-between gap-3'><div><Link href={`/herbs/${record.slug}/`} onClick={() => trackProfile(record, index)} className='text-lg font-bold text-emerald-900 hover:underline'>{record.name}</Link>{record.scientificName ? <p className='mt-1 text-xs italic text-muted'>{record.scientificName}</p> : null}</div><span className='rounded-full bg-brand-50 px-2.5 py-1 text-xs font-bold text-ink'>{record.evidence}</span></div>
+      <div className='mt-4 grid grid-cols-2 gap-3 text-sm'><div><p className={labelClass}>Noticeability</p><p className='font-semibold text-ink'>{record.intensity}</p></div><div><p className={labelClass}>Chemistry</p><p className='text-ink'>{record.compoundClasses.slice(0, 2).join(', ') || 'Not mapped'}</p></div></div>
+      <div className='mt-4'><p className={labelClass}>Effects</p><EffectTags record={record} limit={4} source={effectSource} /></div>
+      {record.safety.length ? <div className='mt-4 rounded-xl bg-amber-50 p-3'><p className='text-xs font-bold uppercase tracking-wide text-amber-950'>Safety signals</p><p className='mt-1 text-sm text-amber-950'>{record.safety.slice(0, 3).join(' · ')}</p></div> : null}
+      <Link href={`/herbs/${record.slug}/`} onClick={() => trackProfile(record, index)} className='mt-4 inline-flex font-semibold text-emerald-800 hover:underline'>Open full profile →</Link>
+    </article>)}</div>
 
-      {activeFilters.length ? <div className='flex flex-wrap gap-2' aria-label='Active filters'>{activeFilters.map((item) => <span key={item} className='rounded-full border border-emerald-900/10 bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-950'>{item}</span>)}</div> : null}
+    <div className='hidden overflow-x-auto rounded-2xl border border-brand-900/10 bg-white/90 shadow-sm md:block'><table className='min-w-[1100px] w-full border-collapse text-left text-sm'><thead className='bg-brand-50/80 text-xs uppercase tracking-wide text-muted'><tr><th className='p-4'>Botanical</th><th className='p-4'>Active chemistry</th><th className='p-4'>Effect profile</th><th className='p-4'>Noticeability</th><th className='p-4'>Evidence</th><th className='p-4'>Safety signals</th><th className='p-4'>Timing</th></tr></thead><tbody>{filtered.map((record, index) => <tr key={record.slug} className='border-t border-brand-900/10 align-top'><td className='p-4'><Link href={`/herbs/${record.slug}/`} onClick={() => trackProfile(record, index)} className='font-bold text-emerald-900 hover:underline'>{record.name}</Link>{record.scientificName ? <p className='mt-1 text-xs italic text-muted'>{record.scientificName}</p> : null}</td><td className='p-4'><p className='font-medium text-ink'>{record.compounds.slice(0, 4).join(', ') || 'Not yet mapped'}</p>{record.compoundClasses.length ? <p className='mt-1 text-xs text-muted'>{record.compoundClasses.join(', ')}</p> : null}</td><td className='p-4'><EffectTags record={record} source={effectSource} /></td><td className='p-4 font-semibold text-ink'>{record.intensity}</td><td className='p-4'>{record.evidence}</td><td className='p-4 text-muted'>{record.safety.slice(0, 4).join(' · ') || 'No structured flags'}</td><td className='p-4 text-muted'>{[record.onset && `Onset: ${record.onset}`, record.duration && `Duration: ${record.duration}`].filter(Boolean).join(' · ') || 'Not established'}</td></tr>)}</tbody></table></div>
 
-      <div className='grid gap-4 md:hidden'>
-        {filtered.map((record, index) => <article key={record.slug} className='rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm'>
-          <div className='flex items-start justify-between gap-3'><div><Link href={`/herbs/${record.slug}/`} onClick={() => trackProfile(record, index)} className='text-lg font-bold text-emerald-900 hover:underline'>{record.name}</Link>{record.scientificName ? <p className='mt-1 text-xs italic text-muted'>{record.scientificName}</p> : null}</div><span className='rounded-full bg-brand-50 px-2.5 py-1 text-xs font-bold text-ink'>{record.evidence}</span></div>
-          <div className='mt-4 grid grid-cols-2 gap-3 text-sm'><div><p className={labelClass}>Noticeability</p><p className='font-semibold text-ink'>{record.intensity}</p></div><div><p className={labelClass}>Chemistry</p><p className='text-ink'>{record.compoundClasses.slice(0, 2).join(', ') || 'Not mapped'}</p></div></div>
-          <div className='mt-4'><p className={labelClass}>Effects</p><EffectTags record={record} limit={4} source={effectSource} /></div>
-          {record.safety.length ? <div className='mt-4 rounded-xl bg-amber-50 p-3'><p className='text-xs font-bold uppercase tracking-wide text-amber-950'>Safety signals</p><p className='mt-1 text-sm text-amber-950'>{record.safety.slice(0, 3).join(' · ')}</p></div> : null}
-          <Link href={`/herbs/${record.slug}/`} onClick={() => trackProfile(record, index)} className='mt-4 inline-flex font-semibold text-emerald-800 hover:underline'>Open full profile →</Link>
-        </article>)}
-      </div>
-
-      <div className='hidden overflow-x-auto rounded-2xl border border-brand-900/10 bg-white/90 shadow-sm md:block'>
-        <table className='min-w-[1100px] w-full border-collapse text-left text-sm'><thead className='bg-brand-50/80 text-xs uppercase tracking-wide text-muted'><tr><th className='p-4'>Botanical</th><th className='p-4'>Active chemistry</th><th className='p-4'>Effect profile</th><th className='p-4'>Noticeability</th><th className='p-4'>Evidence</th><th className='p-4'>Safety signals</th><th className='p-4'>Timing</th></tr></thead>
-          <tbody>{filtered.map((record, index) => <tr key={record.slug} className='border-t border-brand-900/10 align-top'><td className='p-4'><Link href={`/herbs/${record.slug}/`} onClick={() => trackProfile(record, index)} className='font-bold text-emerald-900 hover:underline'>{record.name}</Link>{record.scientificName ? <p className='mt-1 text-xs italic text-muted'>{record.scientificName}</p> : null}</td><td className='p-4'><p className='font-medium text-ink'>{record.compounds.slice(0, 4).join(', ') || 'Not yet mapped'}</p>{record.compoundClasses.length ? <p className='mt-1 text-xs text-muted'>{record.compoundClasses.join(', ')}</p> : null}</td><td className='p-4'><EffectTags record={record} source={effectSource} /></td><td className='p-4 font-semibold text-ink'>{record.intensity}</td><td className='p-4'>{record.evidence}</td><td className='p-4 text-muted'>{record.safety.slice(0, 4).join(' · ') || 'No structured flags'}</td><td className='p-4 text-muted'>{[record.onset && `Onset: ${record.onset}`, record.duration && `Duration: ${record.duration}`].filter(Boolean).join(' · ') || 'Not established'}</td></tr>)}</tbody>
-        </table>
-      </div>
-
-      {!filtered.length ? <div className='rounded-2xl border border-dashed border-brand-900/20 bg-white/70 p-8 text-center text-muted'>No botanicals match those filters. Try removing one filter or using a broader search term.</div> : null}
-    </section>
-  )
+    {!filtered.length ? <div className='rounded-2xl border border-dashed border-brand-900/20 bg-white/70 p-8 text-center text-muted'>No botanicals match those filters. Try removing one filter or using a broader search term.</div> : null}
+  </section>
 }

--- a/src/lib/__tests__/botanical-atlas-url-state.test.ts
+++ b/src/lib/__tests__/botanical-atlas-url-state.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_ATLAS_URL_STATE,
+  parseAtlasUrlState,
+  serializeAtlasUrlState,
+} from '../botanical-atlas-url-state'
+
+describe('Botanical Activity Atlas URL state', () => {
+  it('returns defaults for an empty query string', () => {
+    expect(parseAtlasUrlState('')).toEqual(DEFAULT_ATLAS_URL_STATE)
+    expect(serializeAtlasUrlState(DEFAULT_ATLAS_URL_STATE)).toBe('')
+  })
+
+  it('round-trips a complete shareable state', () => {
+    const state = {
+      query: 'green tea',
+      effect: 'Stimulating / energy',
+      effectSource: 'explicit' as const,
+      evidence: 'Moderate',
+      intensity: 'Pronounced',
+      compoundClass: 'Methylxanthines',
+      safety: 'Cardiovascular',
+      sort: 'evidence' as const,
+    }
+
+    expect(parseAtlasUrlState(serializeAtlasUrlState(state))).toEqual(state)
+  })
+
+  it('encodes spaces and punctuation safely', () => {
+    const search = serializeAtlasUrlState({
+      ...DEFAULT_ATLAS_URL_STATE,
+      query: 'kava & kanna',
+      effect: 'Sedating / sleep',
+    })
+
+    expect(search).toContain('q=kava+%26+kanna')
+    expect(parseAtlasUrlState(search).query).toBe('kava & kanna')
+  })
+
+  it('falls back for unsupported enum values', () => {
+    const parsed = parseAtlasUrlState('?source=mechanistic&sort=popular')
+    expect(parsed.effectSource).toBe('all')
+    expect(parsed.sort).toBe('name')
+  })
+
+  it('omits defaults while preserving active filters', () => {
+    const search = serializeAtlasUrlState({
+      ...DEFAULT_ATLAS_URL_STATE,
+      safety: 'Serotonergic',
+    })
+
+    expect(search).toBe('?safety=Serotonergic')
+  })
+})

--- a/src/lib/botanical-atlas-url-state.ts
+++ b/src/lib/botanical-atlas-url-state.ts
@@ -1,0 +1,56 @@
+export type AtlasEffectSource = 'all' | 'explicit'
+export type AtlasSortOption = 'name' | 'evidence' | 'noticeability'
+
+export type AtlasUrlState = {
+  query: string
+  effect: string
+  effectSource: AtlasEffectSource
+  evidence: string
+  intensity: string
+  compoundClass: string
+  safety: string
+  sort: AtlasSortOption
+}
+
+export const DEFAULT_ATLAS_URL_STATE: AtlasUrlState = {
+  query: '',
+  effect: 'all',
+  effectSource: 'all',
+  evidence: 'all',
+  intensity: 'all',
+  compoundClass: 'all',
+  safety: 'all',
+  sort: 'name',
+}
+
+const validEffectSource = (value: string | null): AtlasEffectSource => value === 'explicit' ? 'explicit' : 'all'
+const validSort = (value: string | null): AtlasSortOption =>
+  value === 'evidence' || value === 'noticeability' ? value : 'name'
+
+export function parseAtlasUrlState(search: string): AtlasUrlState {
+  const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search)
+  return {
+    query: params.get('q')?.trim() ?? '',
+    effect: params.get('effect')?.trim() || 'all',
+    effectSource: validEffectSource(params.get('source')),
+    evidence: params.get('evidence')?.trim() || 'all',
+    intensity: params.get('noticeability')?.trim() || 'all',
+    compoundClass: params.get('chemistry')?.trim() || 'all',
+    safety: params.get('safety')?.trim() || 'all',
+    sort: validSort(params.get('sort')),
+  }
+}
+
+export function serializeAtlasUrlState(state: AtlasUrlState): string {
+  const params = new URLSearchParams()
+  if (state.query.trim()) params.set('q', state.query.trim())
+  if (state.effectSource === 'explicit') params.set('source', 'explicit')
+  if (state.effect !== 'all') params.set('effect', state.effect)
+  if (state.compoundClass !== 'all') params.set('chemistry', state.compoundClass)
+  if (state.evidence !== 'all') params.set('evidence', state.evidence)
+  if (state.intensity !== 'all') params.set('noticeability', state.intensity)
+  if (state.safety !== 'all') params.set('safety', state.safety)
+  if (state.sort !== 'name') params.set('sort', state.sort)
+  const value = params.toString()
+  return value ? `?${value}` : ''
+}


### PR DESCRIPTION
## Summary
- parse atlas filters and sorting from URL parameters on load
- keep the address bar synchronized with search, effect source, effect, chemistry, evidence, noticeability, safety, and sort state
- omit default values to keep shared URLs clean
- add a one-click Copy link control with visible success/failure feedback
- preserve static-export compatibility by using client-side history replacement instead of navigation reloads
- add unit tests for defaults, round trips, encoding, invalid enum fallbacks, and default omission

## Why this is high ROI
Articles, herb profiles, compound profiles, safety pages, and social posts can now deep-link into a specific comparison instead of sending users to an unfiltered tool.