### PR TITLE
Deep-link profile atlas recommendations into filtered comparisons

### DIFF
--- a/src/lib/__tests__/atlas-profile-links.test.ts
+++ b/src/lib/__tests__/atlas-profile-links.test.ts
@@ -8,33 +8,50 @@ const record = (overrides: Partial<RuntimeRecord>): RuntimeRecord => ({
   ...overrides,
 } as RuntimeRecord)
 
+const findLink = (links: ReturnType<typeof getAtlasProfileLinks>, path: string) =>
+  links.find((link) => link.href.startsWith(path))
+
 describe('getAtlasProfileLinks', () => {
-  it('routes alkaloid chemistry to the alkaloid guide', () => {
+  it('routes alkaloid chemistry to a prefiltered alkaloid comparison', () => {
     const links = getAtlasProfileLinks(record({ compoundClasses: ['Isoquinoline alkaloids'] }))
-    expect(links.map((link) => link.href)).toContain('/tools/botanical-activity-atlas/alkaloid-botanicals/')
+    const link = findLink(links, '/tools/botanical-activity-atlas/alkaloid-botanicals/')
+    expect(link?.href).toContain('chemistry=Alkaloids')
   })
 
-  it('routes stimulant effects to the natural stimulant guide', () => {
+  it('keeps methylxanthines in their more specific chemistry bucket', () => {
+    const links = getAtlasProfileLinks(record({ compoundClasses: ['Methylxanthines', 'Alkaloids'] }))
+    const link = findLink(links, '/tools/botanical-activity-atlas/alkaloid-botanicals/')
+    expect(link?.href).toContain('chemistry=Methylxanthines')
+    expect(link?.label).toContain('methylxanthine')
+  })
+
+  it('routes stimulant effects to a prefiltered stimulant comparison', () => {
     const links = getAtlasProfileLinks(record({ primary_effects: ['Alertness and energy'] }))
-    expect(links.map((link) => link.href)).toContain('/tools/botanical-activity-atlas/natural-stimulants/')
+    const link = findLink(links, '/tools/botanical-activity-atlas/natural-stimulants/')
+    expect(link?.href).toContain('effect=Stimulating+%2F+energy')
   })
 
-  it('routes calming and sleep effects to the calming guide', () => {
-    const links = getAtlasProfileLinks(record({ effects: ['Anxiolytic', 'Sleep support'] }))
-    expect(links.map((link) => link.href)).toContain('/tools/botanical-activity-atlas/calming-botanicals/')
+  it('routes calming and sleep effects to the matching prefiltered guide', () => {
+    const calming = getAtlasProfileLinks(record({ effects: ['Anxiolytic'] }))
+    expect(findLink(calming, '/tools/botanical-activity-atlas/calming-botanicals/')?.href).toContain('effect=Calming')
+
+    const sleep = getAtlasProfileLinks(record({ effects: ['Sleep support'] }))
+    expect(findLink(sleep, '/tools/botanical-activity-atlas/calming-botanicals/')?.href).toContain('effect=Sedating+%2F+sleep')
   })
 
-  it('routes perception effects to the dream guide', () => {
+  it('routes perception effects to a prefiltered dream guide', () => {
     const links = getAtlasProfileLinks(record({ primaryActions: ['Dream enhancement'] }))
-    expect(links.map((link) => link.href)).toContain('/tools/botanical-activity-atlas/dream-and-perception-herbs/')
+    const link = findLink(links, '/tools/botanical-activity-atlas/dream-and-perception-herbs/')
+    expect(link?.href).toContain('effect=Dream+%2F+perception')
   })
 
-  it('routes serotonergic safety signals to the interaction-risk guide', () => {
-    const links = getAtlasProfileLinks(record({ safety_flags: ['Potential SSRI interaction'] }))
-    expect(links.map((link) => link.href)).toContain('/tools/botanical-activity-atlas/serotonergic-interaction-risk/')
+  it('reads narrative safety fields and prefilters serotonergic risk', () => {
+    const links = getAtlasProfileLinks(record({ safety: 'Potential interaction with SSRIs' }))
+    const link = findLink(links, '/tools/botanical-activity-atlas/serotonergic-interaction-risk/')
+    expect(link?.href).toContain('safety=Serotonergic')
   })
 
-  it('always provides the full atlas and limits profile links to three', () => {
+  it('always provides the unfiltered full atlas and limits profile links to three', () => {
     const links = getAtlasProfileLinks(record({
       primary_effects: ['Energy', 'Calming', 'Dream enhancement'],
       compoundClasses: ['Alkaloids'],

--- a/src/lib/atlas-profile-links.ts
+++ b/src/lib/atlas-profile-links.ts
@@ -5,6 +5,11 @@ import {
   normalizeSafetySignal,
   uniqueNormalized,
 } from '@/lib/botanical-atlas-taxonomy'
+import {
+  DEFAULT_ATLAS_URL_STATE,
+  serializeAtlasUrlState,
+  type AtlasUrlState,
+} from '@/lib/botanical-atlas-url-state'
 
 export type AtlasProfileLink = {
   href: string
@@ -18,65 +23,90 @@ const list = (value: unknown): string[] => {
   return value.split(/[;,|]/).map((item) => item.trim()).filter(Boolean)
 }
 
+const collect = (...values: unknown[]): string[] => values.flatMap(list)
+const ATLAS_ROOT = '/tools/botanical-activity-atlas/'
+
+const atlasHref = (path: string, overrides: Partial<AtlasUrlState>) =>
+  `${path}${serializeAtlasUrlState({ ...DEFAULT_ATLAS_URL_STATE, ...overrides })}`
+
 const FULL_ATLAS_LINK: AtlasProfileLink = {
-  href: '/tools/botanical-activity-atlas/',
+  href: ATLAS_ROOT,
   label: 'Open the full activity atlas',
   reason: 'Compare effects, evidence, and safety',
 }
 
 export function getAtlasProfileLinks(record: RuntimeRecord): AtlasProfileLink[] {
   const effects = uniqueNormalized(
-    list(record.primary_effects ?? record.effects ?? record.primaryActions),
+    collect(record.primary_effects, record.effects, record.primaryActions, record.benefits),
     normalizeEffect,
   )
   const compoundClasses = uniqueNormalized(
-    list(record.compoundClasses ?? record.pharmCategories ?? record.compoundClass),
+    collect(record.compoundClasses, record.pharmCategories, record.compoundClass),
     normalizeCompoundClass,
   )
   const safety = uniqueNormalized(
-    list(record.safety_flags ?? record.interactionTags ?? record.contraindications ?? record.interactions),
+    collect(
+      record.safety_flags,
+      record.interactionTags,
+      record.contraindications,
+      record.interactions,
+      record.safety,
+      record.warnings,
+      record.side_effects,
+    ),
     normalizeSafetySignal,
   )
 
   const specificLinks: AtlasProfileLink[] = []
+  const chemistry = compoundClasses.includes('Methylxanthines')
+    ? 'Methylxanthines'
+    : compoundClasses.includes('Alkaloids')
+      ? 'Alkaloids'
+      : null
 
-  if (compoundClasses.includes('Alkaloids') || compoundClasses.includes('Methylxanthines')) {
+  if (chemistry) {
     specificLinks.push({
-      href: '/tools/botanical-activity-atlas/alkaloid-botanicals/',
-      label: 'Compare alkaloid botanicals',
-      reason: 'Related active-chemistry family',
+      href: atlasHref(`${ATLAS_ROOT}alkaloid-botanicals/`, { compoundClass: chemistry }),
+      label: chemistry === 'Methylxanthines' ? 'Compare methylxanthine botanicals' : 'Compare alkaloid botanicals',
+      reason: `Filtered to the ${chemistry.toLowerCase()} chemistry family`,
     })
   }
 
   if (effects.includes('Stimulating / energy')) {
     specificLinks.push({
-      href: '/tools/botanical-activity-atlas/natural-stimulants/',
+      href: atlasHref(`${ATLAS_ROOT}natural-stimulants/`, { effect: 'Stimulating / energy' }),
       label: 'Compare natural stimulants',
-      reason: 'Related effect profile',
+      reason: 'Filtered to a related effect profile',
     })
   }
 
-  if (effects.includes('Calming') || effects.includes('Sedating / sleep')) {
+  const calmingEffect = effects.includes('Calming')
+    ? 'Calming'
+    : effects.includes('Sedating / sleep')
+      ? 'Sedating / sleep'
+      : null
+
+  if (calmingEffect) {
     specificLinks.push({
-      href: '/tools/botanical-activity-atlas/calming-botanicals/',
-      label: 'Compare calming botanicals',
-      reason: 'Related effect profile',
+      href: atlasHref(`${ATLAS_ROOT}calming-botanicals/`, { effect: calmingEffect }),
+      label: calmingEffect === 'Calming' ? 'Compare calming botanicals' : 'Compare sleep-supporting botanicals',
+      reason: 'Filtered to a related effect profile',
     })
   }
 
   if (effects.includes('Dream / perception')) {
     specificLinks.push({
-      href: '/tools/botanical-activity-atlas/dream-and-perception-herbs/',
+      href: atlasHref(`${ATLAS_ROOT}dream-and-perception-herbs/`, { effect: 'Dream / perception' }),
       label: 'Explore dream & perception herbs',
-      reason: 'Related effect profile',
+      reason: 'Filtered to a related effect profile',
     })
   }
 
   if (safety.includes('Serotonergic')) {
     specificLinks.push({
-      href: '/tools/botanical-activity-atlas/serotonergic-interaction-risk/',
+      href: atlasHref(`${ATLAS_ROOT}serotonergic-interaction-risk/`, { safety: 'Serotonergic' }),
       label: 'Review serotonergic risks',
-      reason: 'Related safety signal',
+      reason: 'Filtered to the relevant safety signal',
     })
   }
 


### PR DESCRIPTION
## Summary
- convert herb and compound profile atlas recommendations into prefiltered shareable URLs
- preserve category landing pages while applying exact chemistry, effect, or safety parameters
- prefer Methylxanthines over the broader Alkaloids class when both are present
- distinguish calming and sleep-focused comparison labels
- consume additional structured effect and safety fields already present in runtime records
- keep the unfiltered full atlas as an escape link
- expand regression coverage for URL encoding, precedence, narrative safety fields, and the three-link limit

## Why this is high ROI
Profile visitors now land directly in a relevant comparison instead of repeating filter setup, improving atlas engagement and the usefulness of internal links across the herb and compound databases.