### PR TITLE
Add prefiltered atlas comparison to stimulant editorial content

### DIFF
--- a/content/articles/lions-mane-vs-stimulants-adhd.md
+++ b/content/articles/lions-mane-vs-stimulants-adhd.md
@@ -3,7 +3,7 @@ slug: lions-mane-vs-stimulants-adhd
 title: "Lion's Mane vs Stimulants for ADHD: What the Evidence Shows"
 description: "Honest comparison of Lion's Mane and prescription stimulants (Adderall, Vyvanse, Ritalin) for ADHD. Covers the evidence gap, realistic expectations, and why Lion's Mane is not a substitute for ADHD medication."
 date: '2026-06-30'
-updatedAt: '2026-07-05'
+updatedAt: '2026-08-06'
 author: Will
 category: Cognitive health
 keywords:
@@ -56,7 +56,6 @@ references:
 | **Side effects** | Mild (GI upset, possible allergy) | Significant (appetite suppression, insomnia, anxiety, cardiovascular strain) |
 | **Regulation** | Supplement — no FDA oversight, no quality standards for ADHD claims | Schedule II controlled substance — rigorous manufacturing and prescribing standards |
 | **Cost** | $15–40/month | $30–300/month (varies widely by insurance) |
-
 
 ![Lions Mane Vs Stimulants Adhd](/images/guides/lions-mane.jpg)
 
@@ -115,8 +114,15 @@ Lion's Mane could be considered as a supplement to — **not a replacement for**
 
 ---
 
+## Compare active botanicals
+
+Use the [Natural Stimulants comparison](/tools/botanical-activity-atlas/natural-stimulants/?effect=Stimulating+%2F+energy&sort=evidence) to compare botanicals by evidence, noticeability, chemistry, and safety. The atlas separates explicit effect data from pathway-derived discovery categories and does not treat supplements as substitutes for prescribed ADHD care.
+
+---
+
 ## Related Articles
 
 - [Lion's Mane: Benefits, Dosage & Evidence](/articles/lions-mane-mushroom-benefits-mechanisms-dosage-evidence-guide/)
 - [L-Theanine: Calm Focus Guide](/articles/l-theanine/)
 - [Bacopa Monnieri: Memory Evidence Guide](/articles/bacopa-monnieri/)
+- [Compare natural stimulants in the Botanical Activity Atlas](/tools/botanical-activity-atlas/natural-stimulants/?effect=Stimulating+%2F+energy&sort=evidence)

--- a/src/lib/__tests__/editorial-atlas-deep-links.test.ts
+++ b/src/lib/__tests__/editorial-atlas-deep-links.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('editorial Botanical Activity Atlas links', () => {
+  it('keeps the ADHD stimulant comparison linked to a prefiltered atlas view', () => {
+    const article = readFileSync(
+      join(process.cwd(), 'content/articles/lions-mane-vs-stimulants-adhd.md'),
+      'utf8',
+    )
+
+    expect(article).toContain('/tools/botanical-activity-atlas/natural-stimulants/')
+    expect(article).toContain('effect=Stimulating+%2F+energy')
+    expect(article).toContain('sort=evidence')
+  })
+})


### PR DESCRIPTION
## Summary
- add a contextual Botanical Activity Atlas callout to the Lion's Mane vs ADHD stimulants article
- deep-link directly into the natural-stimulants view filtered to stimulating/energy botanicals and sorted by evidence
- add the atlas comparison to the related-articles section
- refresh the article update date
- add a regression test protecting the prefiltered editorial link

## Why this is high ROI
This article already captures stimulant-comparison intent. Sending readers directly into an evidence-sorted botanical comparison creates a useful next step without encouraging supplements as replacements for prescribed ADHD care.