### PR TITLE
Add evidence-sorted atlas comparisons to legacy guides

### DIFF
--- a/app/guides/[slug]/__tests__/atlas-comparison-links.test.ts
+++ b/app/guides/[slug]/__tests__/atlas-comparison-links.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const source = fs.readFileSync(path.join(process.cwd(), 'app/guides/[slug]/page.tsx'), 'utf8')
+
+describe('legacy guide atlas comparisons', () => {
+  it('links ashwagandha to evidence-sorted calming botanicals', () => {
+    expect(source).toContain('/tools/botanical-activity-atlas/calming-botanicals/?effect=Calming&sort=evidence')
+  })
+
+  it('links Lion\'s Mane to evidence-sorted cognition botanicals', () => {
+    expect(source).toContain('/tools/botanical-activity-atlas/?effect=Cognition+%2F+focus&sort=evidence')
+  })
+
+  it('keeps the complete atlas in guide support navigation', () => {
+    expect(source).toContain('href="/tools/botanical-activity-atlas/"')
+  })
+})

--- a/app/guides/[slug]/page.tsx
+++ b/app/guides/[slug]/page.tsx
@@ -12,58 +12,32 @@ interface Props {
   params: Promise<{ slug: string }>;
 }
 
-// NOTE: kava, elderberry, passionflower, and the rhodiola hub (complete-guide,
-// extract-vs-powder, energy, sleep-stack) were migrated to dedicated rich component
-// pages under app/guides/<slug>/page.tsx (Phase 2). They are removed here to avoid
-// static-export route collisions. ashwagandha and lions-mane remain on this legacy
-// renderer until they are upgraded to the dedicated pattern.
-const GUIDE_SLUGS = [
-  "ashwagandha",
-  "lions-mane",
-];
+const GUIDE_SLUGS = ["ashwagandha", "lions-mane"];
 
-// Related guides cross-links for the 4 main guide slugs
 const RELATED_GUIDE_MAP: Record<string, RelatedArticle[]> = {
   ashwagandha: [
-    {
-      href: "/guides/turmeric-curcumin/",
-      title: "Turmeric & Curcumin Guide",
-      description: "Anti-inflammatory evidence, bioavailability forms, and dosage comparison.",
-      category: "stress",
-    },
-    {
-      href: "/guides/lions-mane/",
-      title: "Lion's Mane Guide",
-      description: "Cognitive support, NGF synthesis, and neuroregeneration evidence.",
-      category: "focus",
-    },
-    {
-      href: "/guides/sleep/magnesium-for-sleep/",
-      title: "Magnesium for Sleep Guide",
-      description: "Magnesium forms, dosage, and evidence for sleep and anxiety support.",
-      category: "sleep",
-    },
+    { href: "/guides/turmeric-curcumin/", title: "Turmeric & Curcumin Guide", description: "Anti-inflammatory evidence, bioavailability forms, and dosage comparison.", category: "stress" },
+    { href: "/guides/lions-mane/", title: "Lion's Mane Guide", description: "Cognitive support, NGF synthesis, and neuroregeneration evidence.", category: "focus" },
+    { href: "/guides/sleep/magnesium-for-sleep/", title: "Magnesium for Sleep Guide", description: "Magnesium forms, dosage, and evidence for sleep and anxiety support.", category: "sleep" },
   ],
   "lions-mane": [
-    {
-      href: "/guides/ashwagandha/",
-      title: "Ashwagandha Guide",
-      description: "Cortisol modulation, stress adaptation, and sleep quality evidence.",
-      category: "stress",
-    },
-    {
-      href: "/guides/turmeric-curcumin/",
-      title: "Turmeric & Curcumin Guide",
-      description: "Anti-inflammatory and neuroprotective evidence with bioavailability context.",
-      category: "stress",
-    },
-    {
-      href: "/guides/sleep/magnesium-for-sleep/",
-      title: "Magnesium for Sleep Guide",
-      description: "Magnesium forms, dosage, and evidence for sleep and anxiety support.",
-      category: "sleep",
-    },
+    { href: "/guides/ashwagandha/", title: "Ashwagandha Guide", description: "Cortisol modulation, stress adaptation, and sleep quality evidence.", category: "stress" },
+    { href: "/guides/turmeric-curcumin/", title: "Turmeric & Curcumin Guide", description: "Anti-inflammatory and neuroprotective evidence with bioavailability context.", category: "stress" },
+    { href: "/guides/sleep/magnesium-for-sleep/", title: "Magnesium for Sleep Guide", description: "Magnesium forms, dosage, and evidence for sleep and anxiety support.", category: "sleep" },
   ],
+};
+
+const ATLAS_GUIDE_MAP: Record<string, { href: string; title: string; description: string }> = {
+  ashwagandha: {
+    href: "/tools/botanical-activity-atlas/calming-botanicals/?effect=Calming&sort=evidence",
+    title: "Compare calming botanicals",
+    description: "See ashwagandha beside other calming herbs, filtered by effect and sorted by strongest evidence.",
+  },
+  "lions-mane": {
+    href: "/tools/botanical-activity-atlas/?effect=Cognition+%2F+focus&sort=evidence",
+    title: "Compare cognition-focused botanicals",
+    description: "Compare Lion's Mane with other cognition and focus botanicals using the atlas evidence view.",
+  },
 };
 
 export async function generateStaticParams() {
@@ -74,11 +48,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params;
   const guide = await getGuideBySlug(slug);
   if (!guide) return { title: 'Page Not Found', robots: { index: false, follow: true } };
-  return buildPageMetadata({
-    title: compactMetaTitle(guide.title),
-    description: guide.description,
-    path: `/guides/${slug}/`,
-  });
+  return buildPageMetadata({ title: compactMetaTitle(guide.title), description: guide.description, path: `/guides/${slug}/` });
 }
 
 export default async function GuidePage({ params }: Props) {
@@ -89,12 +59,9 @@ export default async function GuidePage({ params }: Props) {
   const ga4Id = process.env.NEXT_PUBLIC_GA4_ID?.trim() || "";
   const pageUrl = `${SITE_URL}/guides/${slug}/`;
   const publishDate = guide.publishDate || "2024-01-01";
-  const contentBlocks = guide.content
-    .split(/\n{2,}/)
-    .map((block) => block.trim())
-    .filter(Boolean);
-
+  const contentBlocks = guide.content.split(/\n{2,}/).map((block) => block.trim()).filter(Boolean);
   const relatedGuides = RELATED_GUIDE_MAP[slug] ?? [];
+  const atlasGuide = ATLAS_GUIDE_MAP[slug];
 
   return (
     <ArticleLayout zone="supplement">
@@ -114,16 +81,7 @@ export default async function GuidePage({ params }: Props) {
           id={`guide-page-view-${slug}`}
           strategy="afterInteractive"
           dangerouslySetInnerHTML={{
-            __html: `
-              window.dataLayer = window.dataLayer || [];
-              function gtag(){dataLayer.push(arguments);}
-              gtag('event', 'page_view', {
-                page_path: '/guides/${slug}/',
-                page_title: '${guide.title.replace(/'/g, "\\'")}',
-                guide_slug: '${slug}',
-                guide_type: 'guide'
-              });
-            `,
+            __html: `window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('event','page_view',{page_path:'/guides/${slug}/',page_title:'${guide.title.replace(/'/g, "\\'")}',guide_slug:'${slug}',guide_type:'guide'});`,
           }}
         />
       )}
@@ -132,17 +90,25 @@ export default async function GuidePage({ params }: Props) {
           <h1>{guide.title}</h1>
           <p className="mt-2 text-muted">{guide.description}</p>
           <div className="mt-6 space-y-4">
-            {contentBlocks.map((block) => (
-              <p key={block} className="text-muted">{block}</p>
-            ))}
+            {contentBlocks.map((block) => <p key={block} className="text-muted">{block}</p>)}
           </div>
         </div>
-        {relatedGuides.length > 0 && (
-          <RelatedArticles articles={relatedGuides} />
+
+        {atlasGuide && (
+          <aside className="rounded-2xl border border-emerald-900/10 bg-emerald-50/60 p-5">
+            <p className="text-xs font-bold uppercase tracking-wider text-emerald-800">Botanical Activity Atlas</p>
+            <h2 className="mt-2 text-xl font-bold text-ink">{atlasGuide.title}</h2>
+            <p className="mt-2 text-sm leading-6 text-muted">{atlasGuide.description}</p>
+            <Link href={atlasGuide.href} className="mt-4 inline-flex min-h-[44px] items-center rounded-full bg-emerald-800 px-5 text-sm font-semibold text-white hover:bg-emerald-900">
+              Open evidence-sorted comparison →
+            </Link>
+          </aside>
         )}
+
+        {relatedGuides.length > 0 && <RelatedArticles articles={relatedGuides} />}
         <nav className="flex flex-wrap gap-4 text-sm font-semibold text-brand-700" aria-label="Guide support links">
           <Link href="/guides/" className="hover:text-brand-800">All guides</Link>
-          <Link href="/guides/" className="hover:text-brand-800">Guides</Link>
+          <Link href="/tools/botanical-activity-atlas/" className="hover:text-brand-800">Botanical Activity Atlas</Link>
           <Link href="/safety-checker/" className="hover:text-brand-800">Safety checker</Link>
         </nav>
       </div>


### PR DESCRIPTION
## Summary
- add a calming-botanicals comparison to the Ashwagandha guide
- add a cognition/focus comparison to the Lion's Mane guide
- keep both links prefiltered and sorted by strongest evidence
- add the complete atlas to guide support navigation
- add regression coverage for both deep links

## Why this is high ROI
These evergreen guides already attract users comparing outcomes. The atlas callouts turn passive reading into structured comparison without changing the underlying editorial claims.