### PR TITLE
Surface evidence-sorted atlas comparison from Evidence Library

### DIFF
--- a/app/guides/page.tsx
+++ b/app/guides/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { SITE_URL } from '@/lib/navigation-config'
 import buildReport from '@/public/data/build-report.json'
+import { AtlasComparisonCallout } from '@/components/guides/AtlasComparisonCallout'
 
 export const metadata: Metadata = {
   title: 'Evidence Library — Supplements, Science & Mental Health',
@@ -113,6 +114,15 @@ export default function LibraryHub() {
           Guides, articles, mental health explainers, comparisons, and science foundations — organized as one connected library instead of separate content silos.
         </p>
       </header>
+
+      <AtlasComparisonCallout
+        title="Compare botanicals across anxiety, sleep, and focus goals"
+        description="Use the Botanical Activity Atlas to filter the same structured library by calming, sleep-related, stimulating, cognition, chemistry, evidence strength, noticeability, and safety signals. It is the fastest way to compare options before opening individual guides."
+        href="/tools/botanical-activity-atlas/?sort=evidence"
+        cta="Compare botanicals by evidence"
+        secondaryHref="/safety-checker/"
+        secondaryCta="Check interaction risk"
+      />
 
       <div className="grid gap-0 border-y border-brand-900/10 md:grid-cols-2 md:gap-6 md:border-0">
         {SECTIONS.map((section) => (

--- a/components/guides/AtlasComparisonCallout.tsx
+++ b/components/guides/AtlasComparisonCallout.tsx
@@ -1,0 +1,45 @@
+import Link from 'next/link'
+
+type AtlasComparisonCalloutProps = {
+  eyebrow?: string
+  title: string
+  description: string
+  href: string
+  cta: string
+  secondaryHref?: string
+  secondaryCta?: string
+}
+
+export function AtlasComparisonCallout({
+  eyebrow = 'Compare the evidence',
+  title,
+  description,
+  href,
+  cta,
+  secondaryHref = '/tools/botanical-activity-atlas/',
+  secondaryCta = 'Open the full atlas',
+}: AtlasComparisonCalloutProps) {
+  return (
+    <section className="mb-12 rounded-2xl border border-brand-700/20 bg-brand-50/60 p-6 shadow-sm dark:border-white/10 dark:bg-white/5">
+      <p className="text-xs font-bold uppercase tracking-[0.16em] text-brand-800 dark:text-brand-100">
+        {eyebrow}
+      </p>
+      <h2 className="mt-2 text-2xl font-bold tracking-tight text-ink">{title}</h2>
+      <p className="mt-3 max-w-3xl text-sm leading-7 text-muted">{description}</p>
+      <div className="mt-5 flex flex-wrap gap-3">
+        <Link
+          href={href}
+          className="inline-flex min-h-[44px] items-center rounded-full bg-brand-700 px-5 text-sm font-semibold text-white transition hover:bg-brand-800"
+        >
+          {cta} →
+        </Link>
+        <Link
+          href={secondaryHref}
+          className="inline-flex min-h-[44px] items-center rounded-full border border-brand-900/10 bg-white/70 px-5 text-sm font-semibold text-ink transition hover:bg-white dark:border-white/10 dark:bg-white/5 dark:hover:bg-white/10"
+        >
+          {secondaryCta}
+        </Link>
+      </div>
+    </section>
+  )
+}

--- a/tests/ui/evidence-library-atlas-callout.test.ts
+++ b/tests/ui/evidence-library-atlas-callout.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const libraryPage = fs.readFileSync(path.join(root, 'app/guides/page.tsx'), 'utf8')
+const callout = fs.readFileSync(path.join(root, 'components/guides/AtlasComparisonCallout.tsx'), 'utf8')
+
+describe('Evidence Library atlas comparison callout', () => {
+  it('links visitors to the evidence-sorted Botanical Activity Atlas', () => {
+    expect(libraryPage).toContain('/tools/botanical-activity-atlas/?sort=evidence')
+    expect(libraryPage).toContain('Compare botanicals across anxiety, sleep, and focus goals')
+  })
+
+  it('keeps interaction checking beside the comparison pathway', () => {
+    expect(libraryPage).toContain('secondaryHref="/safety-checker/"')
+    expect(libraryPage).toContain('secondaryCta="Check interaction risk"')
+  })
+
+  it('uses accessible tap targets in the reusable callout', () => {
+    expect(callout).toContain('min-h-[44px]')
+    expect(callout).toContain("secondaryHref = '/tools/botanical-activity-atlas/'")
+  })
+})


### PR DESCRIPTION
## Summary
- add a reusable AtlasComparisonCallout component for guide and editorial hubs
- surface the Botanical Activity Atlas prominently on the central Evidence Library page
- link directly to an evidence-sorted comparison state
- keep the Safety Checker beside the atlas as the safety-oriented companion action
- add regression coverage for the filtered URL, safety link, and accessible tap targets

## Why this is high ROI
The Evidence Library is the shared entry point for Anxiety, Sleep, Focus, ADHD, and supplement-guide visitors. This creates one strong discovery pathway into the atlas without duplicating markup across fragmented hub architectures.