### PR TITLE
Add goal-specific atlas comparisons to guide hubs

### DIFF
--- a/components/guides/DecisionRouter.tsx
+++ b/components/guides/DecisionRouter.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { AtlasComparisonCallout } from '@/components/guides/AtlasComparisonCallout'
 
 export type IntentRoute = {
   /** The user's situation, phrased as they'd recognize it ("Racing thoughts at bedtime"). */
@@ -9,6 +10,58 @@ export type IntentRoute = {
   cta: string
   /** Destination href. Must be a real, existing route. */
   href: string
+}
+
+type AtlasCalloutConfig = {
+  title: string
+  description: string
+  href: string
+  cta: string
+  secondaryHref: string
+  secondaryCta: string
+}
+
+function getAtlasCallout(items: IntentRoute[]): AtlasCalloutConfig | null {
+  const isAnxietyHub = items.some((item) => item.href.startsWith('/guides/anxiety/'))
+  if (isAnxietyHub) {
+    return {
+      title: 'Compare calming botanicals side by side',
+      description:
+        'Move beyond a flat recommendation list. Compare calming botanicals by evidence strength, noticeability, active chemistry, and safety context.',
+      href: '/tools/botanical-activity-atlas/calming-botanicals/?effect=Calming&sort=evidence',
+      cta: 'Compare calming botanicals',
+      secondaryHref: '/tools/botanical-activity-atlas/',
+      secondaryCta: 'Open the full atlas',
+    }
+  }
+
+  const isSleepHub = items.some((item) => item.href.startsWith('/guides/sleep/'))
+  if (isSleepHub) {
+    return {
+      title: 'Compare sleep-oriented botanicals by evidence',
+      description:
+        'See which botanicals carry explicit sedating or sleep-related effects, how noticeable they may be, and which safety signals deserve attention before stacking.',
+      href: '/tools/botanical-activity-atlas/calming-botanicals/?effect=Sedating%20%2F%20sleep&sort=evidence',
+      cta: 'Compare sleep botanicals',
+      secondaryHref: '/tools/botanical-activity-atlas/',
+      secondaryCta: 'Open the full atlas',
+    }
+  }
+
+  const isFocusHub = items.some((item) => item.href.startsWith('/guides/focus/'))
+  if (isFocusHub) {
+    return {
+      title: 'Compare cognition and focus botanicals',
+      description:
+        'Compare focus-oriented botanicals by evidence strength, active chemistry, noticeability, and pathway-derived versus explicit effects.',
+      href: '/tools/botanical-activity-atlas/?effect=Cognition%20%2F%20focus&sort=evidence',
+      cta: 'Compare focus botanicals',
+      secondaryHref: '/tools/botanical-activity-atlas/',
+      secondaryCta: 'Open the full atlas',
+    }
+  }
+
+  return null
 }
 
 /**
@@ -25,26 +78,36 @@ export type IntentRoute = {
  * promise that the destination answers that specific problem.
  */
 export function DecisionRouter({ items }: { items: IntentRoute[] }) {
+  const atlasCallout = getAtlasCallout(items)
+
   return (
-    <div className="grid gap-3 sm:grid-cols-2">
-      {items.map((item) => (
-        <Link
-          key={item.href + item.problem}
-          href={item.href}
-          className="group flex h-full flex-col rounded-2xl border border-brand-900/10 bg-white p-5 shadow-[0_1px_2px_rgba(13,23,18,0.06)] transition-all hover:-translate-y-0.5 hover:border-brand-700/30 hover:shadow-md dark:border-white/10 dark:bg-[var(--surface-card)]"
-        >
-          <span className="text-[0.7rem] font-bold uppercase tracking-wider text-brand-700">
-            If your problem is
-          </span>
-          <span className="mt-1 text-base font-bold leading-snug text-ink">{item.problem}</span>
-          {item.why ? <span className="mt-2 text-sm leading-6 text-muted">{item.why}</span> : null}
-          <span className="mt-auto inline-flex items-center gap-1 pt-4 text-sm font-bold text-brand-800 transition group-hover:gap-1.5 dark:text-[var(--text-primary)]">
-            Start with {item.cta}
-            <span aria-hidden="true">→</span>
-          </span>
-        </Link>
-      ))}
-    </div>
+    <>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {items.map((item) => (
+          <Link
+            key={item.href + item.problem}
+            href={item.href}
+            className="group flex h-full flex-col rounded-2xl border border-brand-900/10 bg-white p-5 shadow-[0_1px_2px_rgba(13,23,18,0.06)] transition-all hover:-translate-y-0.5 hover:border-brand-700/30 hover:shadow-md dark:border-white/10 dark:bg-[var(--surface-card)]"
+          >
+            <span className="text-[0.7rem] font-bold uppercase tracking-wider text-brand-700">
+              If your problem is
+            </span>
+            <span className="mt-1 text-base font-bold leading-snug text-ink">{item.problem}</span>
+            {item.why ? <span className="mt-2 text-sm leading-6 text-muted">{item.why}</span> : null}
+            <span className="mt-auto inline-flex items-center gap-1 pt-4 text-sm font-bold text-brand-800 transition group-hover:gap-1.5 dark:text-[var(--text-primary)]">
+              Start with {item.cta}
+              <span aria-hidden="true">→</span>
+            </span>
+          </Link>
+        ))}
+      </div>
+
+      {atlasCallout ? (
+        <div className="mt-6">
+          <AtlasComparisonCallout {...atlasCallout} />
+        </div>
+      ) : null}
+    </>
   )
 }
 

--- a/components/guides/__tests__/decision-router-atlas-callouts.test.ts
+++ b/components/guides/__tests__/decision-router-atlas-callouts.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const source = readFileSync(resolve(process.cwd(), 'components/guides/DecisionRouter.tsx'), 'utf8')
+
+describe('DecisionRouter atlas callouts', () => {
+  it('provides evidence-sorted calming, sleep, and focus comparison states', () => {
+    expect(source).toContain('/tools/botanical-activity-atlas/calming-botanicals/?effect=Calming&sort=evidence')
+    expect(source).toContain('/tools/botanical-activity-atlas/calming-botanicals/?effect=Sedating%20%2F%20sleep&sort=evidence')
+    expect(source).toContain('/tools/botanical-activity-atlas/?effect=Cognition%20%2F%20focus&sort=evidence')
+  })
+
+  it('infers hub context from guide routes and keeps full-atlas access', () => {
+    expect(source).toContain("item.href.startsWith('/guides/anxiety/')")
+    expect(source).toContain("item.href.startsWith('/guides/sleep/')")
+    expect(source).toContain("item.href.startsWith('/guides/focus/')")
+    expect(source).toContain("secondaryHref: '/tools/botanical-activity-atlas/'")
+  })
+
+  it('reuses the accessible shared callout component', () => {
+    expect(source).toContain("import { AtlasComparisonCallout }")
+    expect(source).toContain('<AtlasComparisonCallout {...atlasCallout} />')
+  })
+})


### PR DESCRIPTION
## Summary
- reuse the shared AtlasComparisonCallout directly beneath the Anxiety, Sleep, and Focus decision routers
- infer the active hub from its existing guide routes, avoiding edits to three large page templates
- deep-link Anxiety to calming botanicals, Sleep to sedating/sleep botanicals, and Focus to cognition/focus botanicals
- sort every comparison by strongest evidence
- preserve a full-atlas secondary action
- add regression coverage for hub inference and exact filtered URLs

## Why this is high ROI
These three hubs are major decision points. Visitors now move from editorial routing into structured comparison without requiring duplicate callout markup or brittle page-by-page maintenance.