### PR TITLE
Track atlas comparison clicks by guide hub

### DIFF
--- a/app/__tests__/atlas-hub-click-analytics.test.ts
+++ b/app/__tests__/atlas-hub-click-analytics.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const readSource = (path: string) => readFileSync(join(process.cwd(), path), 'utf8')
+
+describe('atlas hub click analytics', () => {
+  const calloutSource = readSource('components/guides/AtlasComparisonCallout.tsx')
+  const routerSource = readSource('components/guides/DecisionRouter.tsx')
+
+  it('records a dedicated atlas callout event with source, target, and destination', () => {
+    expect(calloutSource).toContain("event: 'atlas_callout_click'")
+    expect(calloutSource).toContain('atlas_source: source')
+    expect(calloutSource).toContain('atlas_target: target')
+    expect(calloutSource).toContain('atlas_destination: destination')
+    expect(calloutSource).toContain("gtag?.('event', 'atlas_callout_click'")
+  })
+
+  it('tracks primary and secondary actions separately', () => {
+    expect(calloutSource).toContain("target: 'primary'")
+    expect(calloutSource).toContain("target: 'secondary'")
+    expect(calloutSource).toContain('data-atlas-target="primary"')
+    expect(calloutSource).toContain('data-atlas-target="secondary"')
+  })
+
+  it('labels the three major guide hubs independently', () => {
+    expect(routerSource).toContain("trackingSource: 'anxiety_hub'")
+    expect(routerSource).toContain("trackingSource: 'sleep_hub'")
+    expect(routerSource).toContain("trackingSource: 'focus_hub'")
+  })
+})

--- a/components/guides/AtlasComparisonCallout.tsx
+++ b/components/guides/AtlasComparisonCallout.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import Link from 'next/link'
 
 type AtlasComparisonCalloutProps = {
@@ -8,6 +10,41 @@ type AtlasComparisonCalloutProps = {
   cta: string
   secondaryHref?: string
   secondaryCta?: string
+  trackingSource?: string
+}
+
+type AtlasClickTarget = 'primary' | 'secondary'
+
+function trackAtlasCalloutClick({
+  source,
+  target,
+  destination,
+}: {
+  source: string
+  target: AtlasClickTarget
+  destination: string
+}) {
+  if (typeof window === 'undefined') return
+
+  const event = {
+    event: 'atlas_callout_click',
+    atlas_source: source,
+    atlas_target: target,
+    atlas_destination: destination,
+  }
+
+  const analyticsWindow = window as typeof window & {
+    dataLayer?: Array<Record<string, unknown>>
+    gtag?: (...args: unknown[]) => void
+  }
+
+  analyticsWindow.dataLayer = analyticsWindow.dataLayer || []
+  analyticsWindow.dataLayer.push(event)
+  analyticsWindow.gtag?.('event', 'atlas_callout_click', {
+    source,
+    target,
+    destination,
+  })
 }
 
 export function AtlasComparisonCallout({
@@ -18,6 +55,7 @@ export function AtlasComparisonCallout({
   cta,
   secondaryHref = '/tools/botanical-activity-atlas/',
   secondaryCta = 'Open the full atlas',
+  trackingSource = 'editorial_callout',
 }: AtlasComparisonCalloutProps) {
   return (
     <section className="mb-12 rounded-2xl border border-brand-700/20 bg-brand-50/60 p-6 shadow-sm dark:border-white/10 dark:bg-white/5">
@@ -29,12 +67,30 @@ export function AtlasComparisonCallout({
       <div className="mt-5 flex flex-wrap gap-3">
         <Link
           href={href}
+          onClick={() =>
+            trackAtlasCalloutClick({
+              source: trackingSource,
+              target: 'primary',
+              destination: href,
+            })
+          }
+          data-atlas-source={trackingSource}
+          data-atlas-target="primary"
           className="inline-flex min-h-[44px] items-center rounded-full bg-brand-700 px-5 text-sm font-semibold text-white transition hover:bg-brand-800"
         >
           {cta} →
         </Link>
         <Link
           href={secondaryHref}
+          onClick={() =>
+            trackAtlasCalloutClick({
+              source: trackingSource,
+              target: 'secondary',
+              destination: secondaryHref,
+            })
+          }
+          data-atlas-source={trackingSource}
+          data-atlas-target="secondary"
           className="inline-flex min-h-[44px] items-center rounded-full border border-brand-900/10 bg-white/70 px-5 text-sm font-semibold text-ink transition hover:bg-white dark:border-white/10 dark:bg-white/5 dark:hover:bg-white/10"
         >
           {secondaryCta}

--- a/components/guides/DecisionRouter.tsx
+++ b/components/guides/DecisionRouter.tsx
@@ -19,6 +19,7 @@ type AtlasCalloutConfig = {
   cta: string
   secondaryHref: string
   secondaryCta: string
+  trackingSource: string
 }
 
 function getAtlasCallout(items: IntentRoute[]): AtlasCalloutConfig | null {
@@ -32,6 +33,7 @@ function getAtlasCallout(items: IntentRoute[]): AtlasCalloutConfig | null {
       cta: 'Compare calming botanicals',
       secondaryHref: '/tools/botanical-activity-atlas/',
       secondaryCta: 'Open the full atlas',
+      trackingSource: 'anxiety_hub',
     }
   }
 
@@ -45,6 +47,7 @@ function getAtlasCallout(items: IntentRoute[]): AtlasCalloutConfig | null {
       cta: 'Compare sleep botanicals',
       secondaryHref: '/tools/botanical-activity-atlas/',
       secondaryCta: 'Open the full atlas',
+      trackingSource: 'sleep_hub',
     }
   }
 
@@ -58,6 +61,7 @@ function getAtlasCallout(items: IntentRoute[]): AtlasCalloutConfig | null {
       cta: 'Compare focus botanicals',
       secondaryHref: '/tools/botanical-activity-atlas/',
       secondaryCta: 'Open the full atlas',
+      trackingSource: 'focus_hub',
     }
   }
 


### PR DESCRIPTION
## Summary
- instrument the reusable atlas comparison callout with a dedicated analytics event
- capture source, primary vs secondary target, and destination URL
- label Anxiety, Sleep, and Focus hub clicks separately
- send events through both the existing dataLayer and gtag when available
- add regression coverage for event shape and hub labels

## Why this is high ROI
This turns the new internal-link network into a measurable funnel. We can now see which guide hub actually drives atlas usage and whether visitors prefer the goal-specific comparison or the full-atlas fallback.