### PR TITLE
Attribute downstream atlas actions to landing source

### DIFF
--- a/src/lib/__tests__/botanical-atlas-landing-attribution.test.ts
+++ b/src/lib/__tests__/botanical-atlas-landing-attribution.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { getAtlasLandingSource } from '../botanicalAtlasTracking'
+
+describe('botanical atlas landing attribution', () => {
+  it('separates the three goal hubs', () => {
+    expect(getAtlasLandingSource('https://thehippiescientist.net/guides/anxiety/')).toBe('anxiety_hub')
+    expect(getAtlasLandingSource('https://thehippiescientist.net/guides/sleep/best-supplements-for-sleep/')).toBe('sleep_hub')
+    expect(getAtlasLandingSource('https://thehippiescientist.net/guides/focus/')).toBe('focus_hub')
+  })
+
+  it('recognizes profile and editorial entry points', () => {
+    expect(getAtlasLandingSource('https://thehippiescientist.net/herbs/ashwagandha/')).toBe('herb_profile')
+    expect(getAtlasLandingSource('https://thehippiescientist.net/compounds/caffeine/')).toBe('compound_profile')
+    expect(getAtlasLandingSource('https://thehippiescientist.net/articles/example/')).toBe('editorial')
+  })
+
+  it('falls back safely for direct, external, and malformed referrers', () => {
+    expect(getAtlasLandingSource('')).toBe('direct_or_external')
+    expect(getAtlasLandingSource('https://example.com/story')).toBe('direct_or_external')
+    expect(getAtlasLandingSource('not a url')).toBe('direct_or_external')
+  })
+})

--- a/src/lib/botanicalAtlasTracking.ts
+++ b/src/lib/botanicalAtlasTracking.ts
@@ -2,6 +2,39 @@ import { appendAnalyticsEvent } from '@/utils/analytics/eventStorage'
 
 type AtlasFilterName = 'search' | 'effect' | 'chemistry' | 'evidence' | 'noticeability' | 'safety'
 
+export type AtlasLandingSource =
+  | 'anxiety_hub'
+  | 'sleep_hub'
+  | 'focus_hub'
+  | 'evidence_library'
+  | 'herb_profile'
+  | 'compound_profile'
+  | 'editorial'
+  | 'direct_or_external'
+
+export function getAtlasLandingSource(referrer = typeof document !== 'undefined' ? document.referrer : ''): AtlasLandingSource {
+  if (!referrer) return 'direct_or_external'
+
+  try {
+    const pathname = new URL(referrer, 'https://thehippiescientist.net').pathname
+    if (pathname === '/guides/anxiety/' || pathname.startsWith('/guides/anxiety/')) return 'anxiety_hub'
+    if (pathname === '/guides/sleep/' || pathname.startsWith('/guides/sleep/')) return 'sleep_hub'
+    if (pathname === '/guides/focus/' || pathname.startsWith('/guides/focus/')) return 'focus_hub'
+    if (pathname === '/guides/' || pathname.startsWith('/guides')) return 'evidence_library'
+    if (pathname.startsWith('/herbs/')) return 'herb_profile'
+    if (pathname.startsWith('/compounds/')) return 'compound_profile'
+    if (pathname.startsWith('/articles/') || pathname.startsWith('/learn/')) return 'editorial'
+  } catch {
+    return 'direct_or_external'
+  }
+
+  return 'direct_or_external'
+}
+
+function withLandingSource(context: string) {
+  return `${context};source:${getAtlasLandingSource()}`
+}
+
 export function trackAtlasFilter(params: {
   filter: AtlasFilterName
   value: string
@@ -13,7 +46,7 @@ export function trackAtlasFilter(params: {
     type: 'botanical_atlas_filter',
     slug: 'botanical-activity-atlas',
     item: params.value || 'cleared',
-    context: `${params.filter}:${params.resultCount}`,
+    context: withLandingSource(`${params.filter}:${params.resultCount}`),
     sourceType: 'collection',
     targetType: 'collection',
   })
@@ -26,7 +59,7 @@ export function trackAtlasReset(activeFilterCount: number) {
     type: 'botanical_atlas_reset',
     slug: 'botanical-activity-atlas',
     item: String(activeFilterCount),
-    context: 'reset-filters',
+    context: withLandingSource('reset-filters'),
     sourceType: 'collection',
     targetType: 'collection',
   })
@@ -43,7 +76,7 @@ export function trackAtlasProfileClick(params: {
     type: 'botanical_atlas_profile_click',
     slug: 'botanical-activity-atlas',
     item: params.slug,
-    context: `position:${params.position};filters:${params.activeFilterCount}`,
+    context: withLandingSource(`position:${params.position};filters:${params.activeFilterCount}`),
     sourceType: 'collection',
     targetType: 'herb',
   })


### PR DESCRIPTION
## Summary
- derive atlas landing context from the internal referrer without adding tracking parameters to shareable URLs
- attach that source to filter, reset, and profile-click analytics
- distinguish Anxiety, Sleep, Focus, Evidence Library, herb profiles, compound profiles, editorial pages, and direct/external traffic
- add regression coverage for internal sources and safe fallbacks

## Why this is high ROI
Hub click events now connect to downstream atlas behavior. This makes it possible to see which entry path drives real exploration rather than only measuring the initial click.