### PR TITLE
Track atlas engagement depth across research sessions

### DIFF
--- a/src/lib/__tests__/botanical-atlas-engagement.test.ts
+++ b/src/lib/__tests__/botanical-atlas-engagement.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const appendAnalyticsEvent = vi.fn()
+vi.mock('@/utils/analytics/eventStorage', () => ({ appendAnalyticsEvent }))
+
+import {
+  getAtlasEngagementState,
+  trackAtlasFilter,
+  trackAtlasProfileClick,
+} from '../botanicalAtlasTracking'
+
+describe('botanical atlas engagement depth', () => {
+  beforeEach(() => {
+    appendAnalyticsEvent.mockClear()
+    window.sessionStorage.clear()
+  })
+
+  it('records the first filter and counts distinct filter categories', () => {
+    trackAtlasFilter({ filter: 'effect', value: 'Calming', resultCount: 12 })
+    trackAtlasFilter({ filter: 'effect', value: 'Sedating / sleep', resultCount: 5 })
+    trackAtlasFilter({ filter: 'evidence', value: 'Strong', resultCount: 2 })
+
+    expect(getAtlasEngagementState()).toEqual({
+      firstFilter: 'effect',
+      distinctFilters: ['effect', 'evidence'],
+      profileOpened: false,
+    })
+  })
+
+  it('adds engagement depth to a profile-open event', () => {
+    trackAtlasFilter({ filter: 'chemistry', value: 'Alkaloids', resultCount: 8 })
+    trackAtlasFilter({ filter: 'safety', value: 'Serotonergic', resultCount: 3 })
+    trackAtlasProfileClick({ slug: 'kanna', position: 1, activeFilterCount: 2 })
+
+    const profileEvent = appendAnalyticsEvent.mock.calls.at(-1)?.[0]
+    expect(profileEvent.context).toContain('first_filter:chemistry')
+    expect(profileEvent.context).toContain('distinct_filters:2')
+    expect(profileEvent.context).toContain('profile_opened:yes')
+    expect(getAtlasEngagementState().profileOpened).toBe(true)
+  })
+
+  it('fails safely when stored session data is malformed', () => {
+    window.sessionStorage.setItem('botanical-atlas-engagement', '{bad json')
+    expect(getAtlasEngagementState()).toEqual({
+      firstFilter: null,
+      distinctFilters: [],
+      profileOpened: false,
+    })
+  })
+})

--- a/src/lib/botanicalAtlasTracking.ts
+++ b/src/lib/botanicalAtlasTracking.ts
@@ -1,6 +1,7 @@
 import { appendAnalyticsEvent } from '@/utils/analytics/eventStorage'
 
 type AtlasFilterName = 'search' | 'effect' | 'chemistry' | 'evidence' | 'noticeability' | 'safety'
+const ENGAGEMENT_KEY = 'botanical-atlas-engagement'
 
 export type AtlasLandingSource =
   | 'anxiety_hub'
@@ -11,6 +12,18 @@ export type AtlasLandingSource =
   | 'compound_profile'
   | 'editorial'
   | 'direct_or_external'
+
+export type AtlasEngagementState = {
+  firstFilter: AtlasFilterName | null
+  distinctFilters: AtlasFilterName[]
+  profileOpened: boolean
+}
+
+const EMPTY_ENGAGEMENT: AtlasEngagementState = {
+  firstFilter: null,
+  distinctFilters: [],
+  profileOpened: false,
+}
 
 export function getAtlasLandingSource(referrer = typeof document !== 'undefined' ? document.referrer : ''): AtlasLandingSource {
   if (!referrer) return 'direct_or_external'
@@ -31,8 +44,50 @@ export function getAtlasLandingSource(referrer = typeof document !== 'undefined'
   return 'direct_or_external'
 }
 
+export function getAtlasEngagementState(): AtlasEngagementState {
+  if (typeof window === 'undefined') return EMPTY_ENGAGEMENT
+  try {
+    const parsed = JSON.parse(window.sessionStorage.getItem(ENGAGEMENT_KEY) || 'null')
+    if (!parsed || !Array.isArray(parsed.distinctFilters)) return EMPTY_ENGAGEMENT
+    return {
+      firstFilter: parsed.firstFilter ?? null,
+      distinctFilters: parsed.distinctFilters,
+      profileOpened: Boolean(parsed.profileOpened),
+    }
+  } catch {
+    return EMPTY_ENGAGEMENT
+  }
+}
+
+function saveAtlasEngagementState(state: AtlasEngagementState) {
+  if (typeof window === 'undefined') return
+  try {
+    window.sessionStorage.setItem(ENGAGEMENT_KEY, JSON.stringify(state))
+  } catch {
+    // Analytics must never block the atlas experience.
+  }
+}
+
+function recordFilterDepth(filter: AtlasFilterName) {
+  const current = getAtlasEngagementState()
+  const distinctFilters = current.distinctFilters.includes(filter)
+    ? current.distinctFilters
+    : [...current.distinctFilters, filter]
+  const next = {
+    ...current,
+    firstFilter: current.firstFilter ?? filter,
+    distinctFilters,
+  }
+  saveAtlasEngagementState(next)
+  return next
+}
+
 function withLandingSource(context: string) {
   return `${context};source:${getAtlasLandingSource()}`
+}
+
+function withEngagementDepth(context: string, state = getAtlasEngagementState()) {
+  return `${context};first_filter:${state.firstFilter ?? 'none'};distinct_filters:${state.distinctFilters.length};profile_opened:${state.profileOpened ? 'yes' : 'no'}`
 }
 
 export function trackAtlasFilter(params: {
@@ -41,12 +96,13 @@ export function trackAtlasFilter(params: {
   resultCount: number
 }) {
   if (typeof window === 'undefined') return
+  const engagement = recordFilterDepth(params.filter)
 
   appendAnalyticsEvent({
     type: 'botanical_atlas_filter',
     slug: 'botanical-activity-atlas',
     item: params.value || 'cleared',
-    context: withLandingSource(`${params.filter}:${params.resultCount}`),
+    context: withLandingSource(withEngagementDepth(`${params.filter}:${params.resultCount}`, engagement)),
     sourceType: 'collection',
     targetType: 'collection',
   })
@@ -59,7 +115,7 @@ export function trackAtlasReset(activeFilterCount: number) {
     type: 'botanical_atlas_reset',
     slug: 'botanical-activity-atlas',
     item: String(activeFilterCount),
-    context: withLandingSource('reset-filters'),
+    context: withLandingSource(withEngagementDepth('reset-filters')),
     sourceType: 'collection',
     targetType: 'collection',
   })
@@ -71,12 +127,14 @@ export function trackAtlasProfileClick(params: {
   activeFilterCount: number
 }) {
   if (typeof window === 'undefined') return
+  const engagement = { ...getAtlasEngagementState(), profileOpened: true }
+  saveAtlasEngagementState(engagement)
 
   appendAnalyticsEvent({
     type: 'botanical_atlas_profile_click',
     slug: 'botanical-activity-atlas',
     item: params.slug,
-    context: withLandingSource(`position:${params.position};filters:${params.activeFilterCount}`),
+    context: withLandingSource(withEngagementDepth(`position:${params.position};filters:${params.activeFilterCount}`, engagement)),
     sourceType: 'collection',
     targetType: 'herb',
   })


### PR DESCRIPTION
## Summary
- persist atlas engagement depth for the browser session
- record the first filter category used
- count distinct filter categories without inflating repeated changes
- mark whether the visitor ultimately opens a profile
- attach engagement depth to filter, reset, and profile-click analytics
- preserve landing-source attribution
- add regression coverage for depth tracking and malformed session data

## Why this is high ROI
This distinguishes shallow atlas visits from real research behavior. We can compare traffic sources by whether visitors explore multiple dimensions and proceed into a botanical profile, rather than optimizing around raw clicks alone.