### PR TITLE
Add session-level atlas performance reporting

### DIFF
--- a/src/dev/AnalyticsViewer.tsx
+++ b/src/dev/AnalyticsViewer.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
+import { buildAtlasSourcePerformance } from '@/lib/atlasAnalyticsReport'
 import { readAnalyticsEvents, type StoredAnalyticsEvent } from '@/utils/analytics/eventStorage'
 
 type GroupRow = {
@@ -67,6 +68,8 @@ export default function AnalyticsViewer() {
     [events]
   )
 
+  const atlasReport = useMemo(() => buildAtlasSourcePerformance(events), [events])
+
   const byHerb = useMemo(
     () => groupCounts(clickEvents, event => event.slug || 'unknown'),
     [clickEvents]
@@ -88,10 +91,46 @@ export default function AnalyticsViewer() {
   )
 
   return (
-    <aside className='fixed bottom-3 right-3 z-[100] max-h-[80vh] w-[min(26rem,92vw)] overflow-auto rounded-lg border border-white/15 bg-black/85 p-3 text-white shadow-lg backdrop-blur'>
+    <aside className='fixed bottom-3 right-3 z-[100] max-h-[80vh] w-[min(38rem,94vw)] overflow-auto rounded-lg border border-white/15 bg-black/85 p-3 text-white shadow-lg backdrop-blur'>
       <h2 className='text-sm font-semibold text-white'>Dev Analytics Viewer</h2>
-      <p className='mt-1 text-xs text-white/75'>Total affiliate clicks: {clickEvents.length}</p>
 
+      <section className='mt-3 rounded-md border border-white/10 bg-white/5 p-2'>
+        <h3 className='text-xs font-semibold uppercase tracking-wide text-white/80'>Atlas source performance</h3>
+        <p className='mt-1 text-xs text-white/65'>
+          {atlasReport.attributedSessions} attributed sessions
+          {atlasReport.unattributedEvents ? ` · ${atlasReport.unattributedEvents} legacy events excluded` : ''}
+        </p>
+        {atlasReport.rows.length === 0 ? (
+          <p className='mt-2 text-xs text-white/60'>No session-level atlas data yet.</p>
+        ) : (
+          <div className='mt-2 overflow-x-auto'>
+            <table className='min-w-full text-xs'>
+              <thead>
+                <tr className='text-left text-white/65'>
+                  <th className='pr-3 font-medium'>Source</th>
+                  <th className='pr-3 font-medium'>Sessions</th>
+                  <th className='pr-3 font-medium'>Profile rate</th>
+                  <th className='pr-3 font-medium'>Avg depth</th>
+                  <th className='font-medium'>Top first filter</th>
+                </tr>
+              </thead>
+              <tbody>
+                {atlasReport.rows.map(row => (
+                  <tr key={row.source} className='border-t border-white/10'>
+                    <td className='py-1.5 pr-3 font-medium text-white/95'>{row.source}</td>
+                    <td className='py-1.5 pr-3 text-white/80'>{row.sessions}</td>
+                    <td className='py-1.5 pr-3 text-white/80'>{Math.round(row.profileOpenRate * 100)}%</td>
+                    <td className='py-1.5 pr-3 text-white/80'>{row.averageFilterDepth.toFixed(1)}</td>
+                    <td className='py-1.5 text-white/80'>{row.topFirstFilter}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      <p className='mt-3 text-xs text-white/75'>Total affiliate clicks: {clickEvents.length}</p>
       <div className='mt-3 space-y-3'>
         <Table title='Clicks by herb' rows={byHerb} />
         <Table title='Clicks by product' rows={byProduct} />

--- a/src/lib/__tests__/atlasAnalyticsReport.test.ts
+++ b/src/lib/__tests__/atlasAnalyticsReport.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { buildAtlasSourcePerformance, parseAtlasContext } from '../atlasAnalyticsReport'
+
+describe('atlas analytics report', () => {
+  it('parses colon-delimited context values without losing later fields', () => {
+    const values = parseAtlasContext('effect:12;session:abc;source:sleep_hub;distinct_filters:2')
+    expect(values.get('session')).toBe('abc')
+    expect(values.get('source')).toBe('sleep_hub')
+    expect(values.get('distinct_filters')).toBe('2')
+  })
+
+  it('deduplicates events into sessions and calculates profile-open rate', () => {
+    const report = buildAtlasSourcePerformance([
+      { type: 'botanical_atlas_filter', context: 'effect:10;session:a;first_filter:effect;distinct_filters:1;profile_opened:no;source:sleep_hub' },
+      { type: 'botanical_atlas_filter', context: 'safety:4;session:a;first_filter:effect;distinct_filters:2;profile_opened:no;source:sleep_hub' },
+      { type: 'botanical_atlas_profile_click', context: 'position:1;session:a;first_filter:effect;distinct_filters:2;profile_opened:yes;source:sleep_hub' },
+      { type: 'botanical_atlas_filter', context: 'effect:8;session:b;first_filter:effect;distinct_filters:1;profile_opened:no;source:sleep_hub' },
+    ])
+
+    expect(report.attributedSessions).toBe(2)
+    expect(report.rows[0]).toMatchObject({
+      source: 'sleep_hub',
+      sessions: 2,
+      profileOpens: 1,
+      profileOpenRate: 0.5,
+      averageFilterDepth: 1.5,
+      topFirstFilter: 'effect',
+    })
+  })
+
+  it('ranks stronger conversion before raw session volume', () => {
+    const report = buildAtlasSourcePerformance([
+      { type: 'botanical_atlas_filter', context: 'effect:3;session:a;first_filter:effect;distinct_filters:1;profile_opened:no;source:focus_hub' },
+      { type: 'botanical_atlas_filter', context: 'effect:3;session:b;first_filter:effect;distinct_filters:1;profile_opened:no;source:focus_hub' },
+      { type: 'botanical_atlas_profile_click', context: 'position:1;session:c;first_filter:safety;distinct_filters:2;profile_opened:yes;source:anxiety_hub' },
+    ])
+
+    expect(report.rows.map((row) => row.source)).toEqual(['anxiety_hub', 'focus_hub'])
+  })
+
+  it('excludes pre-session legacy events from conversion denominators', () => {
+    const report = buildAtlasSourcePerformance([
+      { type: 'botanical_atlas_filter', context: 'effect:10;source:sleep_hub' },
+      { type: 'affiliate_link_click', context: 'unrelated' },
+    ])
+
+    expect(report.attributedSessions).toBe(0)
+    expect(report.unattributedEvents).toBe(1)
+    expect(report.rows).toEqual([])
+  })
+})

--- a/src/lib/atlasAnalyticsReport.ts
+++ b/src/lib/atlasAnalyticsReport.ts
@@ -1,0 +1,96 @@
+export type AtlasAnalyticsEvent = {
+  type?: string
+  context?: string
+}
+
+export type AtlasSourcePerformanceRow = {
+  source: string
+  sessions: number
+  profileOpens: number
+  profileOpenRate: number
+  averageFilterDepth: number
+  topFirstFilter: string
+}
+
+type SessionSummary = {
+  source: string
+  firstFilter: string
+  distinctFilters: number
+  profileOpened: boolean
+}
+
+export function parseAtlasContext(context = '') {
+  const values = new Map<string, string>()
+  context.split(';').forEach((segment) => {
+    const separator = segment.indexOf(':')
+    if (separator < 1) return
+    values.set(segment.slice(0, separator), segment.slice(separator + 1))
+  })
+  return values
+}
+
+export function buildAtlasSourcePerformance(events: AtlasAnalyticsEvent[]) {
+  const atlasEvents = events.filter((event) => event.type?.startsWith('botanical_atlas_'))
+  const sessions = new Map<string, SessionSummary>()
+  let unattributedEvents = 0
+
+  atlasEvents.forEach((event) => {
+    const values = parseAtlasContext(event.context)
+    const sessionId = values.get('session')
+    if (!sessionId) {
+      unattributedEvents += 1
+      return
+    }
+
+    const current = sessions.get(sessionId) ?? {
+      source: values.get('source') ?? 'direct_or_external',
+      firstFilter: values.get('first_filter') ?? 'none',
+      distinctFilters: 0,
+      profileOpened: false,
+    }
+
+    current.source = values.get('source') ?? current.source
+    if (current.firstFilter === 'none') current.firstFilter = values.get('first_filter') ?? 'none'
+    current.distinctFilters = Math.max(current.distinctFilters, Number(values.get('distinct_filters') ?? 0) || 0)
+    current.profileOpened = current.profileOpened
+      || values.get('profile_opened') === 'yes'
+      || event.type === 'botanical_atlas_profile_click'
+    sessions.set(sessionId, current)
+  })
+
+  const grouped = new Map<string, SessionSummary[]>()
+  sessions.forEach((session) => {
+    const rows = grouped.get(session.source) ?? []
+    rows.push(session)
+    grouped.set(session.source, rows)
+  })
+
+  const rows: AtlasSourcePerformanceRow[] = Array.from(grouped.entries()).map(([source, sourceSessions]) => {
+    const firstFilters = new Map<string, number>()
+    sourceSessions.forEach((session) => {
+      firstFilters.set(session.firstFilter, (firstFilters.get(session.firstFilter) ?? 0) + 1)
+    })
+    const topFirstFilter = Array.from(firstFilters.entries())
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))[0]?.[0] ?? 'none'
+    const profileOpens = sourceSessions.filter((session) => session.profileOpened).length
+    const averageFilterDepth = sourceSessions.reduce((sum, session) => sum + session.distinctFilters, 0) / sourceSessions.length
+
+    return {
+      source,
+      sessions: sourceSessions.length,
+      profileOpens,
+      profileOpenRate: profileOpens / sourceSessions.length,
+      averageFilterDepth,
+      topFirstFilter,
+    }
+  }).sort((a, b) => b.profileOpenRate - a.profileOpenRate
+    || b.averageFilterDepth - a.averageFilterDepth
+    || b.sessions - a.sessions
+    || a.source.localeCompare(b.source))
+
+  return {
+    rows,
+    attributedSessions: sessions.size,
+    unattributedEvents,
+  }
+}

--- a/src/lib/botanicalAtlasTracking.ts
+++ b/src/lib/botanicalAtlasTracking.ts
@@ -14,15 +14,24 @@ export type AtlasLandingSource =
   | 'direct_or_external'
 
 export type AtlasEngagementState = {
+  sessionId: string
   firstFilter: AtlasFilterName | null
   distinctFilters: AtlasFilterName[]
   profileOpened: boolean
 }
 
-const EMPTY_ENGAGEMENT: AtlasEngagementState = {
-  firstFilter: null,
-  distinctFilters: [],
-  profileOpened: false,
+function createSessionId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') return crypto.randomUUID()
+  return `atlas-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+}
+
+function emptyEngagement(): AtlasEngagementState {
+  return {
+    sessionId: createSessionId(),
+    firstFilter: null,
+    distinctFilters: [],
+    profileOpened: false,
+  }
 }
 
 export function getAtlasLandingSource(referrer = typeof document !== 'undefined' ? document.referrer : ''): AtlasLandingSource {
@@ -45,17 +54,26 @@ export function getAtlasLandingSource(referrer = typeof document !== 'undefined'
 }
 
 export function getAtlasEngagementState(): AtlasEngagementState {
-  if (typeof window === 'undefined') return EMPTY_ENGAGEMENT
+  if (typeof window === 'undefined') return emptyEngagement()
   try {
     const parsed = JSON.parse(window.sessionStorage.getItem(ENGAGEMENT_KEY) || 'null')
-    if (!parsed || !Array.isArray(parsed.distinctFilters)) return EMPTY_ENGAGEMENT
-    return {
+    if (!parsed || !Array.isArray(parsed.distinctFilters)) {
+      const next = emptyEngagement()
+      saveAtlasEngagementState(next)
+      return next
+    }
+    const next = {
+      sessionId: typeof parsed.sessionId === 'string' && parsed.sessionId ? parsed.sessionId : createSessionId(),
       firstFilter: parsed.firstFilter ?? null,
       distinctFilters: parsed.distinctFilters,
       profileOpened: Boolean(parsed.profileOpened),
     }
+    if (!parsed.sessionId) saveAtlasEngagementState(next)
+    return next
   } catch {
-    return EMPTY_ENGAGEMENT
+    const next = emptyEngagement()
+    saveAtlasEngagementState(next)
+    return next
   }
 }
 
@@ -87,7 +105,7 @@ function withLandingSource(context: string) {
 }
 
 function withEngagementDepth(context: string, state = getAtlasEngagementState()) {
-  return `${context};first_filter:${state.firstFilter ?? 'none'};distinct_filters:${state.distinctFilters.length};profile_opened:${state.profileOpened ? 'yes' : 'no'}`
+  return `${context};session:${state.sessionId};first_filter:${state.firstFilter ?? 'none'};distinct_filters:${state.distinctFilters.length};profile_opened:${state.profileOpened ? 'yes' : 'no'}`
 }
 
 export function trackAtlasFilter(params: {


### PR DESCRIPTION
## Summary
- add stable browser-session identifiers to atlas analytics events
- aggregate atlas behavior into true sessions instead of raw event counts
- rank entry sources by profile-open rate, average distinct-filter depth, and top first filter
- surface the report in the existing developer analytics viewer
- exclude older events without session IDs from conversion denominators
- add regression coverage for deduplication, ranking, parsing, and legacy-event handling

## Why this is high ROI
The atlas funnel is now actionable rather than merely instrumented. This report shows which traffic sources produce real research behavior and profile exploration, without presenting misleading event-level conversion rates.