### PR TITLE
Add ranked recovery for empty atlas results

### DIFF
--- a/src/components/atlas/AtlasEmptyResultRecovery.tsx
+++ b/src/components/atlas/AtlasEmptyResultRecovery.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { getAtlasRecoverySuggestions, type AtlasRecoveryAction, type AtlasRecoveryFilters, type AtlasRecoveryRecord } from '@/lib/botanical-atlas-recovery'
+
+type Props = {
+  records: AtlasRecoveryRecord[]
+  filters: AtlasRecoveryFilters
+  onRecover: (action: AtlasRecoveryAction) => void
+  onReset: () => void
+}
+
+export default function AtlasEmptyResultRecovery({ records, filters, onRecover, onReset }: Props) {
+  const suggestions = getAtlasRecoverySuggestions(records, filters)
+
+  return (
+    <section className='rounded-2xl border border-dashed border-amber-900/25 bg-amber-50/60 p-6 text-amber-950' aria-live='polite'>
+      <p className='text-xs font-bold uppercase tracking-wide'>No matching botanicals</p>
+      <h2 className='mt-2 text-xl font-bold'>These filters are too narrow together</h2>
+      <p className='mt-2 max-w-2xl text-sm leading-6'>Try the change that restores the most useful comparison results. Your other filters will stay in place.</p>
+
+      {suggestions.length ? (
+        <div className='mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3'>
+          {suggestions.map((suggestion) => (
+            <button
+              key={suggestion.action}
+              type='button'
+              onClick={() => onRecover(suggestion.action)}
+              className='min-h-11 rounded-xl border border-amber-900/15 bg-white px-4 py-3 text-left font-semibold text-amber-950 shadow-sm transition hover:-translate-y-0.5 hover:border-amber-900/30'
+            >
+              <span className='block'>{suggestion.label}</span>
+              <span className='mt-1 block text-xs font-medium text-amber-800'>Restore {suggestion.recoveredCount} result{suggestion.recoveredCount === 1 ? '' : 's'}</span>
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      <button type='button' onClick={onReset} className='mt-4 min-h-11 font-semibold text-amber-900 underline-offset-4 hover:underline'>Reset all filters</button>
+    </section>
+  )
+}

--- a/src/components/atlas/BotanicalActivityAtlasClient.tsx
+++ b/src/components/atlas/BotanicalActivityAtlasClient.tsx
@@ -2,6 +2,8 @@
 
 import Link from 'next/link'
 import { useEffect, useMemo, useState } from 'react'
+import AtlasEmptyResultRecovery from '@/components/atlas/AtlasEmptyResultRecovery'
+import type { AtlasRecoveryAction } from '@/lib/botanical-atlas-recovery'
 import { trackAtlasFilter, trackAtlasProfileClick, trackAtlasReset } from '@/lib/botanicalAtlasTracking'
 import {
   DEFAULT_ATLAS_URL_STATE,
@@ -134,6 +136,16 @@ export default function BotanicalActivityAtlasClient({ records }: Props) {
     setQuery(DEFAULT_ATLAS_URL_STATE.query); setEffect(DEFAULT_ATLAS_URL_STATE.effect); setEffectSource(DEFAULT_ATLAS_URL_STATE.effectSource); setEvidence(DEFAULT_ATLAS_URL_STATE.evidence); setIntensity(DEFAULT_ATLAS_URL_STATE.intensity); setCompoundClass(DEFAULT_ATLAS_URL_STATE.compoundClass); setSafety(DEFAULT_ATLAS_URL_STATE.safety); setSort(DEFAULT_ATLAS_URL_STATE.sort)
   }
 
+  const recover = (action: AtlasRecoveryAction) => {
+    if (action === 'clear-query') setQuery('')
+    if (action === 'include-pathways') changeEffectSource('all')
+    if (action === 'clear-effect') setTrackedFilter('effect', 'all', setEffect)
+    if (action === 'clear-evidence') setTrackedFilter('evidence', 'all', setEvidence)
+    if (action === 'clear-intensity') setTrackedFilter('noticeability', 'all', setIntensity)
+    if (action === 'clear-chemistry') setTrackedFilter('chemistry', 'all', setCompoundClass)
+    if (action === 'clear-safety') setTrackedFilter('safety', 'all', setSafety)
+  }
+
   const copyLink = async () => {
     try {
       await navigator.clipboard.writeText(window.location.href)
@@ -172,6 +184,8 @@ export default function BotanicalActivityAtlasClient({ records }: Props) {
 
     {activeFilters.length ? <div className='flex flex-wrap gap-2' aria-label='Active filters'>{activeFilters.map((item) => <span key={item} className='rounded-full border border-emerald-900/10 bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-950'>{item}</span>)}</div> : null}
 
+    {!filtered.length ? <AtlasEmptyResultRecovery records={records} filters={filters} onRecover={recover} onReset={reset} /> : null}
+
     <div className='grid gap-4 md:hidden'>{filtered.map((record, index) => <article key={record.slug} className='rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm'>
       <div className='flex items-start justify-between gap-3'><div><Link href={`/herbs/${record.slug}/`} onClick={() => trackProfile(record, index)} className='text-lg font-bold text-emerald-900 hover:underline'>{record.name}</Link>{record.scientificName ? <p className='mt-1 text-xs italic text-muted'>{record.scientificName}</p> : null}</div><span className='rounded-full bg-brand-50 px-2.5 py-1 text-xs font-bold text-ink'>{record.evidence}</span></div>
       <div className='mt-4 grid grid-cols-2 gap-3 text-sm'><div><p className={labelClass}>Noticeability</p><p className='font-semibold text-ink'>{record.intensity}</p></div><div><p className={labelClass}>Chemistry</p><p className='text-ink'>{record.compoundClasses.slice(0, 2).join(', ') || 'Not mapped'}</p></div></div>
@@ -181,7 +195,5 @@ export default function BotanicalActivityAtlasClient({ records }: Props) {
     </article>)}</div>
 
     <div className='hidden overflow-x-auto rounded-2xl border border-brand-900/10 bg-white/90 shadow-sm md:block'><table className='min-w-[1100px] w-full border-collapse text-left text-sm'><thead className='bg-brand-50/80 text-xs uppercase tracking-wide text-muted'><tr><th className='p-4'>Botanical</th><th className='p-4'>Active chemistry</th><th className='p-4'>Effect profile</th><th className='p-4'>Noticeability</th><th className='p-4'>Evidence</th><th className='p-4'>Safety signals</th><th className='p-4'>Timing</th></tr></thead><tbody>{filtered.map((record, index) => <tr key={record.slug} className='border-t border-brand-900/10 align-top'><td className='p-4'><Link href={`/herbs/${record.slug}/`} onClick={() => trackProfile(record, index)} className='font-bold text-emerald-900 hover:underline'>{record.name}</Link>{record.scientificName ? <p className='mt-1 text-xs italic text-muted'>{record.scientificName}</p> : null}</td><td className='p-4'><p className='font-medium text-ink'>{record.compounds.slice(0, 4).join(', ') || 'Not yet mapped'}</p>{record.compoundClasses.length ? <p className='mt-1 text-xs text-muted'>{record.compoundClasses.join(', ')}</p> : null}</td><td className='p-4'><EffectTags record={record} source={effectSource} /></td><td className='p-4 font-semibold text-ink'>{record.intensity}</td><td className='p-4'>{record.evidence}</td><td className='p-4 text-muted'>{record.safety.slice(0, 4).join(' · ') || 'No structured flags'}</td><td className='p-4 text-muted'>{[record.onset && `Onset: ${record.onset}`, record.duration && `Duration: ${record.duration}`].filter(Boolean).join(' · ') || 'Not established'}</td></tr>)}</tbody></table></div>
-
-    {!filtered.length ? <div className='rounded-2xl border border-dashed border-brand-900/20 bg-white/70 p-8 text-center text-muted'>No botanicals match those filters. Try removing one filter or using a broader search term.</div> : null}
   </section>
 }

--- a/src/lib/__tests__/botanical-atlas-recovery.test.ts
+++ b/src/lib/__tests__/botanical-atlas-recovery.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import { getAtlasRecoverySuggestions } from '@/lib/botanical-atlas-recovery'
+
+const records = [
+  { name: 'Calm Herb', effects: ['Calming'], explicitEffects: ['Calming'], compounds: [], compoundClasses: ['Flavonoids'], evidence: 'Moderate', intensity: 'Subtle', safety: [] },
+  { name: 'Focus Herb', effects: ['Cognition / focus'], explicitEffects: [], compounds: [], compoundClasses: ['Alkaloids'], evidence: 'Preliminary', intensity: 'Moderate', safety: ['Serotonergic'] },
+  { name: 'Sleep Herb', effects: ['Sedating / sleep'], explicitEffects: ['Sedating / sleep'], compounds: [], compoundClasses: ['Terpenes'], evidence: 'Moderate', intensity: 'Pronounced', safety: ['Sedation'] },
+]
+
+const base = {
+  query: '',
+  effect: 'all',
+  effectSource: 'all' as const,
+  evidence: 'all',
+  intensity: 'all',
+  compoundClass: 'all',
+  safety: 'all',
+}
+
+describe('botanical atlas recovery', () => {
+  it('ranks the change restoring the most records first', () => {
+    const suggestions = getAtlasRecoverySuggestions(records, {
+      ...base,
+      effect: 'Calming',
+      compoundClass: 'Alkaloids',
+    })
+
+    expect(suggestions[0]).toMatchObject({ action: 'clear-effect', recoveredCount: 1 })
+    expect(suggestions[1]).toMatchObject({ action: 'clear-chemistry', recoveredCount: 1 })
+  })
+
+  it('offers pathway inclusion when explicit-only mode hides inferred effects', () => {
+    const suggestions = getAtlasRecoverySuggestions(records, {
+      ...base,
+      effect: 'Cognition / focus',
+      effectSource: 'explicit',
+    })
+
+    expect(suggestions).toContainEqual({
+      action: 'include-pathways',
+      label: 'Include pathway-derived effects',
+      recoveredCount: 1,
+    })
+  })
+
+  it('omits changes that would still produce zero results', () => {
+    const suggestions = getAtlasRecoverySuggestions(records, {
+      ...base,
+      query: 'does-not-exist',
+      safety: 'Serotonergic',
+    })
+
+    expect(suggestions).toEqual([
+      { action: 'clear-query', label: 'Clear search term', recoveredCount: 1 },
+    ])
+  })
+
+  it('limits the recovery queue', () => {
+    const suggestions = getAtlasRecoverySuggestions(records, {
+      query: 'missing',
+      effect: 'Calming',
+      effectSource: 'explicit',
+      evidence: 'Strong',
+      intensity: 'Unknown',
+      compoundClass: 'Alkaloids',
+      safety: 'Serotonergic',
+    }, 2)
+
+    expect(suggestions).toHaveLength(2)
+  })
+})

--- a/src/lib/botanical-atlas-recovery.ts
+++ b/src/lib/botanical-atlas-recovery.ts
@@ -1,0 +1,83 @@
+import type { AtlasEffectSource } from '@/lib/botanical-atlas-url-state'
+
+export type AtlasRecoveryRecord = {
+  name: string
+  scientificName?: string
+  effects: string[]
+  explicitEffects?: string[]
+  compounds: string[]
+  compoundClasses: string[]
+  evidence: string
+  intensity: string
+  safety: string[]
+}
+
+export type AtlasRecoveryFilters = {
+  query: string
+  effect: string
+  effectSource: AtlasEffectSource
+  evidence: string
+  intensity: string
+  compoundClass: string
+  safety: string
+}
+
+export type AtlasRecoveryAction =
+  | 'clear-query'
+  | 'include-pathways'
+  | 'clear-effect'
+  | 'clear-evidence'
+  | 'clear-intensity'
+  | 'clear-chemistry'
+  | 'clear-safety'
+
+export type AtlasRecoverySuggestion = {
+  action: AtlasRecoveryAction
+  label: string
+  recoveredCount: number
+}
+
+const normalize = (value: string) => value.trim().toLowerCase()
+
+function effectsForSource(record: AtlasRecoveryRecord, source: AtlasEffectSource) {
+  return source === 'explicit' ? (record.explicitEffects ?? record.effects) : record.effects
+}
+
+function matches(record: AtlasRecoveryRecord, filters: AtlasRecoveryFilters) {
+  const effects = effectsForSource(record, filters.effectSource)
+  const searchable = [record.name, record.scientificName ?? '', ...effects, ...record.compounds, ...record.compoundClasses, ...record.safety].join(' ').toLowerCase()
+  const needle = normalize(filters.query)
+
+  return (!needle || searchable.includes(needle))
+    && (filters.effect === 'all' || effects.includes(filters.effect))
+    && (filters.evidence === 'all' || record.evidence === filters.evidence)
+    && (filters.intensity === 'all' || record.intensity === filters.intensity)
+    && (filters.compoundClass === 'all' || record.compoundClasses.includes(filters.compoundClass))
+    && (filters.safety === 'all' || record.safety.includes(filters.safety))
+}
+
+export function getAtlasRecoverySuggestions(
+  records: AtlasRecoveryRecord[],
+  filters: AtlasRecoveryFilters,
+  limit = 3,
+): AtlasRecoverySuggestion[] {
+  const candidates: Array<{ action: AtlasRecoveryAction; label: string; filters: AtlasRecoveryFilters }> = []
+
+  if (filters.query.trim()) candidates.push({ action: 'clear-query', label: 'Clear search term', filters: { ...filters, query: '' } })
+  if (filters.effectSource === 'explicit') candidates.push({ action: 'include-pathways', label: 'Include pathway-derived effects', filters: { ...filters, effectSource: 'all' } })
+  if (filters.effect !== 'all') candidates.push({ action: 'clear-effect', label: 'Show all effects', filters: { ...filters, effect: 'all' } })
+  if (filters.evidence !== 'all') candidates.push({ action: 'clear-evidence', label: 'Show all evidence levels', filters: { ...filters, evidence: 'all' } })
+  if (filters.intensity !== 'all') candidates.push({ action: 'clear-intensity', label: 'Show all noticeability levels', filters: { ...filters, intensity: 'all' } })
+  if (filters.compoundClass !== 'all') candidates.push({ action: 'clear-chemistry', label: 'Show all chemistry classes', filters: { ...filters, compoundClass: 'all' } })
+  if (filters.safety !== 'all') candidates.push({ action: 'clear-safety', label: 'Show all safety signals', filters: { ...filters, safety: 'all' } })
+
+  return candidates
+    .map(({ action, label, filters: next }) => ({
+      action,
+      label,
+      recoveredCount: records.filter((record) => matches(record, next)).length,
+    }))
+    .filter((suggestion) => suggestion.recoveredCount > 0)
+    .sort((a, b) => b.recoveredCount - a.recoveredCount || a.label.localeCompare(b.label))
+    .slice(0, limit)
+}


### PR DESCRIPTION
## Summary
- replace the atlas zero-results dead end with ranked one-click recovery suggestions
- calculate how many botanicals each single filter change would restore
- preserve unaffected filters when applying a recovery
- support search, effect provenance, effect, evidence, noticeability, chemistry, and safety recovery paths
- retain a full reset option
- add focused tests for ranking, pathway recovery, zero-value omission, and suggestion limits

## Why this is high ROI
Shared and deeply filtered atlas links can now recover gracefully instead of presenting an empty comparison. Visitors are shown the smallest change that restores the most useful results.