### PR TITLE
Track atlas recovery funnel through profile conversion

### DIFF
--- a/src/components/atlas/AtlasEmptyResultRecovery.tsx
+++ b/src/components/atlas/AtlasEmptyResultRecovery.tsx
@@ -1,6 +1,8 @@
 'use client'
 
+import { useEffect, useMemo } from 'react'
 import { getAtlasRecoverySuggestions, type AtlasRecoveryAction, type AtlasRecoveryFilters, type AtlasRecoveryRecord } from '@/lib/botanical-atlas-recovery'
+import { trackAtlasRecoveryAccepted, trackAtlasRecoveryShown } from '@/lib/botanicalAtlasTracking'
 
 type Props = {
   records: AtlasRecoveryRecord[]
@@ -10,7 +12,12 @@ type Props = {
 }
 
 export default function AtlasEmptyResultRecovery({ records, filters, onRecover, onReset }: Props) {
-  const suggestions = getAtlasRecoverySuggestions(records, filters)
+  const suggestions = useMemo(() => getAtlasRecoverySuggestions(records, filters), [records, filters])
+  const signature = suggestions.map((item) => `${item.action}:${item.recoveredCount}`).join('|')
+
+  useEffect(() => {
+    if (suggestions.length) trackAtlasRecoveryShown(suggestions)
+  }, [signature]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <section className='rounded-2xl border border-dashed border-amber-900/25 bg-amber-50/60 p-6 text-amber-950' aria-live='polite'>
@@ -24,7 +31,7 @@ export default function AtlasEmptyResultRecovery({ records, filters, onRecover, 
             <button
               key={suggestion.action}
               type='button'
-              onClick={() => onRecover(suggestion.action)}
+              onClick={() => { trackAtlasRecoveryAccepted(suggestion); onRecover(suggestion.action) }}
               className='min-h-11 rounded-xl border border-amber-900/15 bg-white px-4 py-3 text-left font-semibold text-amber-950 shadow-sm transition hover:-translate-y-0.5 hover:border-amber-900/30'
             >
               <span className='block'>{suggestion.label}</span>

--- a/src/lib/__tests__/botanical-atlas-engagement.test.ts
+++ b/src/lib/__tests__/botanical-atlas-engagement.test.ts
@@ -7,6 +7,8 @@ import {
   getAtlasEngagementState,
   trackAtlasFilter,
   trackAtlasProfileClick,
+  trackAtlasRecoveryAccepted,
+  trackAtlasRecoveryShown,
 } from '../botanicalAtlasTracking'
 
 describe('botanical atlas engagement depth', () => {
@@ -20,31 +22,49 @@ describe('botanical atlas engagement depth', () => {
     trackAtlasFilter({ filter: 'effect', value: 'Sedating / sleep', resultCount: 5 })
     trackAtlasFilter({ filter: 'evidence', value: 'Strong', resultCount: 2 })
 
-    expect(getAtlasEngagementState()).toEqual({
+    expect(getAtlasEngagementState()).toMatchObject({
       firstFilter: 'effect',
       distinctFilters: ['effect', 'evidence'],
       profileOpened: false,
+      recoveryAccepted: null,
     })
   })
 
-  it('adds engagement depth to a profile-open event', () => {
-    trackAtlasFilter({ filter: 'chemistry', value: 'Alkaloids', resultCount: 8 })
-    trackAtlasFilter({ filter: 'safety', value: 'Serotonergic', resultCount: 3 })
-    trackAtlasProfileClick({ slug: 'kanna', position: 1, activeFilterCount: 2 })
+  it('tracks shown and accepted recovery suggestions in the same session', () => {
+    const suggestions = [
+      { action: 'clear-evidence' as const, label: 'Show all evidence levels', recoveredCount: 18 },
+      { action: 'clear-safety' as const, label: 'Show all safety signals', recoveredCount: 9 },
+    ]
+
+    trackAtlasRecoveryShown(suggestions)
+    trackAtlasRecoveryAccepted(suggestions[0])
+
+    const shown = appendAnalyticsEvent.mock.calls[0][0]
+    const accepted = appendAnalyticsEvent.mock.calls[1][0]
+    expect(shown.type).toBe('botanical_atlas_recovery_shown')
+    expect(shown.item).toContain('clear-evidence:18')
+    expect(accepted.type).toBe('botanical_atlas_recovery_accepted')
+    expect(accepted.context).toContain('restored:18')
+    expect(getAtlasEngagementState().recoveryAccepted).toBe('clear-evidence')
+  })
+
+  it('carries accepted recovery into a later profile-open event', () => {
+    trackAtlasRecoveryAccepted({ action: 'include-pathways', label: 'Include pathway-derived effects', recoveredCount: 7 })
+    trackAtlasProfileClick({ slug: 'kanna', position: 1, activeFilterCount: 1 })
 
     const profileEvent = appendAnalyticsEvent.mock.calls.at(-1)?.[0]
-    expect(profileEvent.context).toContain('first_filter:chemistry')
-    expect(profileEvent.context).toContain('distinct_filters:2')
     expect(profileEvent.context).toContain('profile_opened:yes')
+    expect(profileEvent.context).toContain('recovery:include-pathways')
     expect(getAtlasEngagementState().profileOpened).toBe(true)
   })
 
   it('fails safely when stored session data is malformed', () => {
     window.sessionStorage.setItem('botanical-atlas-engagement', '{bad json')
-    expect(getAtlasEngagementState()).toEqual({
+    expect(getAtlasEngagementState()).toMatchObject({
       firstFilter: null,
       distinctFilters: [],
       profileOpened: false,
+      recoveryAccepted: null,
     })
   })
 })

--- a/src/lib/__tests__/botanical-atlas-recovery-tracking.test.ts
+++ b/src/lib/__tests__/botanical-atlas-recovery-tracking.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { getAtlasRecoverySuggestions } from '../botanical-atlas-recovery'
+
+describe('atlas recovery tracking inputs', () => {
+  it('returns stable action identifiers and restored counts for analytics', () => {
+    const records = [
+      { name: 'A', effects: ['Calming'], explicitEffects: ['Calming'], compounds: [], compoundClasses: [], evidence: 'Moderate', intensity: 'Subtle', safety: [] },
+      { name: 'B', effects: ['Calming'], explicitEffects: [], compounds: [], compoundClasses: [], evidence: 'Preliminary', intensity: 'Subtle', safety: [] },
+    ]
+    const suggestions = getAtlasRecoverySuggestions(records, {
+      query: '', effect: 'Calming', effectSource: 'explicit', evidence: 'Strong', intensity: 'all', compoundClass: 'all', safety: 'all',
+    })
+
+    expect(suggestions[0]).toMatchObject({ action: 'clear-evidence' })
+    expect(suggestions.every((item) => item.recoveredCount > 0)).toBe(true)
+  })
+})

--- a/src/lib/botanicalAtlasTracking.ts
+++ b/src/lib/botanicalAtlasTracking.ts
@@ -1,4 +1,5 @@
 import { appendAnalyticsEvent } from '@/utils/analytics/eventStorage'
+import type { AtlasRecoveryAction, AtlasRecoverySuggestion } from '@/lib/botanical-atlas-recovery'
 
 type AtlasFilterName = 'search' | 'effect' | 'chemistry' | 'evidence' | 'noticeability' | 'safety'
 const ENGAGEMENT_KEY = 'botanical-atlas-engagement'
@@ -18,6 +19,7 @@ export type AtlasEngagementState = {
   firstFilter: AtlasFilterName | null
   distinctFilters: AtlasFilterName[]
   profileOpened: boolean
+  recoveryAccepted: AtlasRecoveryAction | null
 }
 
 function createSessionId() {
@@ -26,17 +28,11 @@ function createSessionId() {
 }
 
 function emptyEngagement(): AtlasEngagementState {
-  return {
-    sessionId: createSessionId(),
-    firstFilter: null,
-    distinctFilters: [],
-    profileOpened: false,
-  }
+  return { sessionId: createSessionId(), firstFilter: null, distinctFilters: [], profileOpened: false, recoveryAccepted: null }
 }
 
 export function getAtlasLandingSource(referrer = typeof document !== 'undefined' ? document.referrer : ''): AtlasLandingSource {
   if (!referrer) return 'direct_or_external'
-
   try {
     const pathname = new URL(referrer, 'https://thehippiescientist.net').pathname
     if (pathname === '/guides/anxiety/' || pathname.startsWith('/guides/anxiety/')) return 'anxiety_hub'
@@ -46,10 +42,7 @@ export function getAtlasLandingSource(referrer = typeof document !== 'undefined'
     if (pathname.startsWith('/herbs/')) return 'herb_profile'
     if (pathname.startsWith('/compounds/')) return 'compound_profile'
     if (pathname.startsWith('/articles/') || pathname.startsWith('/learn/')) return 'editorial'
-  } catch {
-    return 'direct_or_external'
-  }
-
+  } catch { return 'direct_or_external' }
   return 'direct_or_external'
 }
 
@@ -58,102 +51,79 @@ export function getAtlasEngagementState(): AtlasEngagementState {
   try {
     const parsed = JSON.parse(window.sessionStorage.getItem(ENGAGEMENT_KEY) || 'null')
     if (!parsed || !Array.isArray(parsed.distinctFilters)) {
-      const next = emptyEngagement()
-      saveAtlasEngagementState(next)
-      return next
+      const next = emptyEngagement(); saveAtlasEngagementState(next); return next
     }
     const next = {
       sessionId: typeof parsed.sessionId === 'string' && parsed.sessionId ? parsed.sessionId : createSessionId(),
       firstFilter: parsed.firstFilter ?? null,
       distinctFilters: parsed.distinctFilters,
       profileOpened: Boolean(parsed.profileOpened),
+      recoveryAccepted: parsed.recoveryAccepted ?? null,
     }
     if (!parsed.sessionId) saveAtlasEngagementState(next)
     return next
   } catch {
-    const next = emptyEngagement()
-    saveAtlasEngagementState(next)
-    return next
+    const next = emptyEngagement(); saveAtlasEngagementState(next); return next
   }
 }
 
 function saveAtlasEngagementState(state: AtlasEngagementState) {
   if (typeof window === 'undefined') return
-  try {
-    window.sessionStorage.setItem(ENGAGEMENT_KEY, JSON.stringify(state))
-  } catch {
-    // Analytics must never block the atlas experience.
-  }
+  try { window.sessionStorage.setItem(ENGAGEMENT_KEY, JSON.stringify(state)) } catch { /* analytics must never block UX */ }
 }
 
 function recordFilterDepth(filter: AtlasFilterName) {
   const current = getAtlasEngagementState()
-  const distinctFilters = current.distinctFilters.includes(filter)
-    ? current.distinctFilters
-    : [...current.distinctFilters, filter]
-  const next = {
-    ...current,
-    firstFilter: current.firstFilter ?? filter,
-    distinctFilters,
-  }
+  const distinctFilters = current.distinctFilters.includes(filter) ? current.distinctFilters : [...current.distinctFilters, filter]
+  const next = { ...current, firstFilter: current.firstFilter ?? filter, distinctFilters }
   saveAtlasEngagementState(next)
   return next
 }
 
-function withLandingSource(context: string) {
-  return `${context};source:${getAtlasLandingSource()}`
-}
-
+function withLandingSource(context: string) { return `${context};source:${getAtlasLandingSource()}` }
 function withEngagementDepth(context: string, state = getAtlasEngagementState()) {
-  return `${context};session:${state.sessionId};first_filter:${state.firstFilter ?? 'none'};distinct_filters:${state.distinctFilters.length};profile_opened:${state.profileOpened ? 'yes' : 'no'}`
+  return `${context};session:${state.sessionId};first_filter:${state.firstFilter ?? 'none'};distinct_filters:${state.distinctFilters.length};profile_opened:${state.profileOpened ? 'yes' : 'no'};recovery:${state.recoveryAccepted ?? 'none'}`
 }
 
-export function trackAtlasFilter(params: {
-  filter: AtlasFilterName
-  value: string
-  resultCount: number
-}) {
+export function trackAtlasFilter(params: { filter: AtlasFilterName; value: string; resultCount: number }) {
   if (typeof window === 'undefined') return
   const engagement = recordFilterDepth(params.filter)
-
-  appendAnalyticsEvent({
-    type: 'botanical_atlas_filter',
-    slug: 'botanical-activity-atlas',
-    item: params.value || 'cleared',
-    context: withLandingSource(withEngagementDepth(`${params.filter}:${params.resultCount}`, engagement)),
-    sourceType: 'collection',
-    targetType: 'collection',
-  })
+  appendAnalyticsEvent({ type: 'botanical_atlas_filter', slug: 'botanical-activity-atlas', item: params.value || 'cleared', context: withLandingSource(withEngagementDepth(`${params.filter}:${params.resultCount}`, engagement)), sourceType: 'collection', targetType: 'collection' })
 }
 
 export function trackAtlasReset(activeFilterCount: number) {
   if (typeof window === 'undefined') return
+  appendAnalyticsEvent({ type: 'botanical_atlas_reset', slug: 'botanical-activity-atlas', item: String(activeFilterCount), context: withLandingSource(withEngagementDepth('reset-filters')), sourceType: 'collection', targetType: 'collection' })
+}
 
+export function trackAtlasRecoveryShown(suggestions: AtlasRecoverySuggestion[]) {
+  if (typeof window === 'undefined' || !suggestions.length) return
+  const state = getAtlasEngagementState()
   appendAnalyticsEvent({
-    type: 'botanical_atlas_reset',
+    type: 'botanical_atlas_recovery_shown',
     slug: 'botanical-activity-atlas',
-    item: String(activeFilterCount),
-    context: withLandingSource(withEngagementDepth('reset-filters')),
-    sourceType: 'collection',
-    targetType: 'collection',
+    item: suggestions.map((item) => `${item.action}:${item.recoveredCount}`).join(','),
+    context: withLandingSource(withEngagementDepth(`suggestions:${suggestions.length}`, state)),
+    sourceType: 'collection', targetType: 'collection',
   })
 }
 
-export function trackAtlasProfileClick(params: {
-  slug: string
-  position: number
-  activeFilterCount: number
-}) {
+export function trackAtlasRecoveryAccepted(suggestion: AtlasRecoverySuggestion) {
+  if (typeof window === 'undefined') return
+  const state = { ...getAtlasEngagementState(), recoveryAccepted: suggestion.action }
+  saveAtlasEngagementState(state)
+  appendAnalyticsEvent({
+    type: 'botanical_atlas_recovery_accepted',
+    slug: 'botanical-activity-atlas',
+    item: suggestion.action,
+    context: withLandingSource(withEngagementDepth(`restored:${suggestion.recoveredCount}`, state)),
+    sourceType: 'collection', targetType: 'collection',
+  })
+}
+
+export function trackAtlasProfileClick(params: { slug: string; position: number; activeFilterCount: number }) {
   if (typeof window === 'undefined') return
   const engagement = { ...getAtlasEngagementState(), profileOpened: true }
   saveAtlasEngagementState(engagement)
-
-  appendAnalyticsEvent({
-    type: 'botanical_atlas_profile_click',
-    slug: 'botanical-activity-atlas',
-    item: params.slug,
-    context: withLandingSource(withEngagementDepth(`position:${params.position};filters:${params.activeFilterCount}`, engagement)),
-    sourceType: 'collection',
-    targetType: 'herb',
-  })
+  appendAnalyticsEvent({ type: 'botanical_atlas_profile_click', slug: 'botanical-activity-atlas', item: params.slug, context: withLandingSource(withEngagementDepth(`position:${params.position};filters:${params.activeFilterCount}`, engagement)), sourceType: 'collection', targetType: 'herb' })
 }


### PR DESCRIPTION
## Summary
- track which zero-result recovery suggestions are shown
- record accepted recovery actions and restored result counts
- persist the accepted recovery in the atlas session state
- attach recovery attribution to later profile-open events
- add regression coverage for impressions, acceptance, session persistence, and downstream conversion

## Why this is high ROI
This closes the recovery measurement loop. We can now identify which dead-end fixes visitors choose and whether those recovered sessions continue into botanical profiles.