### PR TITLE
Add recovery performance to atlas analytics

### DIFF
--- a/src/dev/AnalyticsViewer.tsx
+++ b/src/dev/AnalyticsViewer.tsx
@@ -1,51 +1,22 @@
 import { useEffect, useMemo, useState } from 'react'
-import { buildAtlasSourcePerformance } from '@/lib/atlasAnalyticsReport'
+import { buildAtlasRecoveryPerformance, buildAtlasSourcePerformance } from '@/lib/atlasAnalyticsReport'
 import { readAnalyticsEvents, type StoredAnalyticsEvent } from '@/utils/analytics/eventStorage'
 
-type GroupRow = {
-  label: string
-  count: number
-}
+type GroupRow = { label: string; count: number }
 
 function groupCounts(events: StoredAnalyticsEvent[], selectLabel: (event: StoredAnalyticsEvent) => string) {
   const counts = new Map<string, number>()
-
   events.forEach(event => {
     const label = selectLabel(event)
     counts.set(label, (counts.get(label) ?? 0) + 1)
   })
-
   return Array.from(counts.entries())
     .map(([label, count]) => ({ label, count }))
     .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label))
 }
 
 function Table({ title, rows }: { title: string; rows: GroupRow[] }) {
-  return (
-    <section>
-      <h3 className='text-xs font-semibold uppercase tracking-wide text-white/80'>{title}</h3>
-      {rows.length === 0 ? (
-        <p className='mt-1 text-xs text-white/60'>No data</p>
-      ) : (
-        <table className='mt-1 w-full text-xs'>
-          <thead>
-            <tr className='text-left text-white/65'>
-              <th className='pr-2 font-medium'>Value</th>
-              <th className='font-medium'>Clicks</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map(row => (
-              <tr key={`${title}-${row.label}`} className='border-t border-white/10'>
-                <td className='py-1 pr-2 text-white/90'>{row.label}</td>
-                <td className='py-1 text-white/80'>{row.count}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      )}
-    </section>
-  )
+  return <section><h3 className='text-xs font-semibold uppercase tracking-wide text-white/80'>{title}</h3>{rows.length === 0 ? <p className='mt-1 text-xs text-white/60'>No data</p> : <table className='mt-1 w-full text-xs'><thead><tr className='text-left text-white/65'><th className='pr-2 font-medium'>Value</th><th className='font-medium'>Clicks</th></tr></thead><tbody>{rows.map(row => <tr key={`${title}-${row.label}`} className='border-t border-white/10'><td className='py-1 pr-2 text-white/90'>{row.label}</td><td className='py-1 text-white/80'>{row.count}</td></tr>)}</tbody></table>}</section>
 }
 
 export default function AnalyticsViewer() {
@@ -53,90 +24,38 @@ export default function AnalyticsViewer() {
 
   useEffect(() => {
     const refresh = () => setEvents(readAnalyticsEvents())
-
     window.addEventListener('hs:analytics-events-updated', refresh)
     window.addEventListener('storage', refresh)
-
     return () => {
       window.removeEventListener('hs:analytics-events-updated', refresh)
       window.removeEventListener('storage', refresh)
     }
   }, [])
 
-  const clickEvents = useMemo(
-    () => events.filter(event => event.type === 'affiliate_link_click'),
-    [events]
-  )
-
+  const clickEvents = useMemo(() => events.filter(event => event.type === 'affiliate_link_click'), [events])
   const atlasReport = useMemo(() => buildAtlasSourcePerformance(events), [events])
+  const recoveryReport = useMemo(() => buildAtlasRecoveryPerformance(events), [events])
+  const byHerb = useMemo(() => groupCounts(clickEvents, event => event.slug || 'unknown'), [clickEvents])
+  const byProduct = useMemo(() => groupCounts(clickEvents, event => event.item || 'unknown'), [clickEvents])
+  const byPosition = useMemo(() => groupCounts(clickEvents, event => event.productPosition || 'unknown'), [clickEvents])
+  const byUseCaseAnchor = useMemo(() => groupCounts(clickEvents, event => event.useCaseAnchor || 'none'), [clickEvents])
 
-  const byHerb = useMemo(
-    () => groupCounts(clickEvents, event => event.slug || 'unknown'),
-    [clickEvents]
-  )
+  return <aside className='fixed bottom-3 right-3 z-[100] max-h-[80vh] w-[min(44rem,96vw)] overflow-auto rounded-lg border border-white/15 bg-black/85 p-3 text-white shadow-lg backdrop-blur'>
+    <h2 className='text-sm font-semibold text-white'>Dev Analytics Viewer</h2>
 
-  const byProduct = useMemo(
-    () => groupCounts(clickEvents, event => event.item || 'unknown'),
-    [clickEvents]
-  )
+    <section className='mt-3 rounded-md border border-white/10 bg-white/5 p-2'>
+      <h3 className='text-xs font-semibold uppercase tracking-wide text-white/80'>Atlas source performance</h3>
+      <p className='mt-1 text-xs text-white/65'>{atlasReport.attributedSessions} attributed sessions{atlasReport.unattributedEvents ? ` · ${atlasReport.unattributedEvents} legacy events excluded` : ''}</p>
+      {atlasReport.rows.length === 0 ? <p className='mt-2 text-xs text-white/60'>No session-level atlas data yet.</p> : <div className='mt-2 overflow-x-auto'><table className='min-w-full text-xs'><thead><tr className='text-left text-white/65'><th className='pr-3 font-medium'>Source</th><th className='pr-3 font-medium'>Sessions</th><th className='pr-3 font-medium'>Profile rate</th><th className='pr-3 font-medium'>Avg depth</th><th className='font-medium'>Top first filter</th></tr></thead><tbody>{atlasReport.rows.map(row => <tr key={row.source} className='border-t border-white/10'><td className='py-1.5 pr-3 font-medium text-white/95'>{row.source}</td><td className='py-1.5 pr-3 text-white/80'>{row.sessions}</td><td className='py-1.5 pr-3 text-white/80'>{Math.round(row.profileOpenRate * 100)}%</td><td className='py-1.5 pr-3 text-white/80'>{row.averageFilterDepth.toFixed(1)}</td><td className='py-1.5 text-white/80'>{row.topFirstFilter}</td></tr>)}</tbody></table></div>}
+    </section>
 
-  const byPosition = useMemo(
-    () => groupCounts(clickEvents, event => event.productPosition || 'unknown'),
-    [clickEvents]
-  )
+    <section className='mt-3 rounded-md border border-white/10 bg-white/5 p-2'>
+      <h3 className='text-xs font-semibold uppercase tracking-wide text-white/80'>Atlas recovery performance</h3>
+      <p className='mt-1 text-xs text-white/65'>{recoveryReport.recoverySessions} recovery sessions{recoveryReport.unattributedEvents ? ` · ${recoveryReport.unattributedEvents} legacy events excluded` : ''}</p>
+      {recoveryReport.rows.length === 0 ? <p className='mt-2 text-xs text-white/60'>No recovery-funnel data yet.</p> : <div className='mt-2 overflow-x-auto'><table className='min-w-full text-xs'><thead><tr className='text-left text-white/65'><th className='pr-3 font-medium'>Action</th><th className='pr-3 font-medium'>Shown</th><th className='pr-3 font-medium'>Accepted</th><th className='pr-3 font-medium'>Accept rate</th><th className='pr-3 font-medium'>Profile rate</th><th className='font-medium'>Avg restored</th></tr></thead><tbody>{recoveryReport.rows.map(row => <tr key={row.action} className='border-t border-white/10'><td className='py-1.5 pr-3 font-medium text-white/95'>{row.action}</td><td className='py-1.5 pr-3 text-white/80'>{row.impressions}</td><td className='py-1.5 pr-3 text-white/80'>{row.acceptances}</td><td className='py-1.5 pr-3 text-white/80'>{Math.round(row.acceptanceRate * 100)}%</td><td className='py-1.5 pr-3 text-white/80'>{Math.round(row.postRecoveryProfileRate * 100)}%</td><td className='py-1.5 text-white/80'>{row.averageRestoredResults.toFixed(1)}</td></tr>)}</tbody></table></div>}
+    </section>
 
-  const byUseCaseAnchor = useMemo(
-    () => groupCounts(clickEvents, event => event.useCaseAnchor || 'none'),
-    [clickEvents]
-  )
-
-  return (
-    <aside className='fixed bottom-3 right-3 z-[100] max-h-[80vh] w-[min(38rem,94vw)] overflow-auto rounded-lg border border-white/15 bg-black/85 p-3 text-white shadow-lg backdrop-blur'>
-      <h2 className='text-sm font-semibold text-white'>Dev Analytics Viewer</h2>
-
-      <section className='mt-3 rounded-md border border-white/10 bg-white/5 p-2'>
-        <h3 className='text-xs font-semibold uppercase tracking-wide text-white/80'>Atlas source performance</h3>
-        <p className='mt-1 text-xs text-white/65'>
-          {atlasReport.attributedSessions} attributed sessions
-          {atlasReport.unattributedEvents ? ` · ${atlasReport.unattributedEvents} legacy events excluded` : ''}
-        </p>
-        {atlasReport.rows.length === 0 ? (
-          <p className='mt-2 text-xs text-white/60'>No session-level atlas data yet.</p>
-        ) : (
-          <div className='mt-2 overflow-x-auto'>
-            <table className='min-w-full text-xs'>
-              <thead>
-                <tr className='text-left text-white/65'>
-                  <th className='pr-3 font-medium'>Source</th>
-                  <th className='pr-3 font-medium'>Sessions</th>
-                  <th className='pr-3 font-medium'>Profile rate</th>
-                  <th className='pr-3 font-medium'>Avg depth</th>
-                  <th className='font-medium'>Top first filter</th>
-                </tr>
-              </thead>
-              <tbody>
-                {atlasReport.rows.map(row => (
-                  <tr key={row.source} className='border-t border-white/10'>
-                    <td className='py-1.5 pr-3 font-medium text-white/95'>{row.source}</td>
-                    <td className='py-1.5 pr-3 text-white/80'>{row.sessions}</td>
-                    <td className='py-1.5 pr-3 text-white/80'>{Math.round(row.profileOpenRate * 100)}%</td>
-                    <td className='py-1.5 pr-3 text-white/80'>{row.averageFilterDepth.toFixed(1)}</td>
-                    <td className='py-1.5 text-white/80'>{row.topFirstFilter}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </section>
-
-      <p className='mt-3 text-xs text-white/75'>Total affiliate clicks: {clickEvents.length}</p>
-      <div className='mt-3 space-y-3'>
-        <Table title='Clicks by herb' rows={byHerb} />
-        <Table title='Clicks by product' rows={byProduct} />
-        <Table title='Clicks by position' rows={byPosition} />
-        <Table title='Clicks by use-case anchor' rows={byUseCaseAnchor} />
-      </div>
-    </aside>
-  )
+    <p className='mt-3 text-xs text-white/75'>Total affiliate clicks: {clickEvents.length}</p>
+    <div className='mt-3 space-y-3'><Table title='Clicks by herb' rows={byHerb} /><Table title='Clicks by product' rows={byProduct} /><Table title='Clicks by position' rows={byPosition} /><Table title='Clicks by use-case anchor' rows={byUseCaseAnchor} /></div>
+  </aside>
 }

--- a/src/lib/__tests__/atlas-recovery-performance-report.test.ts
+++ b/src/lib/__tests__/atlas-recovery-performance-report.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { buildAtlasRecoveryPerformance } from '../atlasAnalyticsReport'
+
+const shown = (session: string, item: string) => ({
+  type: 'botanical_atlas_recovery_shown',
+  item,
+  context: `suggestions:2;session:${session};source:sleep_hub;profile_opened:no`,
+})
+
+const accepted = (session: string, action: string, restored: number) => ({
+  type: 'botanical_atlas_recovery_accepted',
+  item: action,
+  context: `restored:${restored};session:${session};source:sleep_hub;profile_opened:no;recovery:${action}`,
+})
+
+const profile = (session: string, action: string) => ({
+  type: 'botanical_atlas_profile_click',
+  item: 'valerian',
+  context: `position:1;session:${session};source:sleep_hub;profile_opened:yes;recovery:${action}`,
+})
+
+describe('atlas recovery performance report', () => {
+  it('deduplicates repeated impressions by session and action', () => {
+    const report = buildAtlasRecoveryPerformance([
+      shown('s1', 'clear-effect:8,clear-safety:12'),
+      shown('s1', 'clear-effect:8,clear-safety:12'),
+    ])
+
+    expect(report.rows.find((row) => row.action === 'clear-effect')?.impressions).toBe(1)
+    expect(report.rows.find((row) => row.action === 'clear-safety')?.impressions).toBe(1)
+  })
+
+  it('calculates acceptance and post-recovery profile rates from sessions', () => {
+    const report = buildAtlasRecoveryPerformance([
+      shown('s1', 'include-pathways:9'),
+      accepted('s1', 'include-pathways', 9),
+      profile('s1', 'include-pathways'),
+      shown('s2', 'include-pathways:5'),
+      accepted('s2', 'include-pathways', 5),
+      shown('s3', 'include-pathways:7'),
+    ])
+
+    const row = report.rows[0]
+    expect(row.action).toBe('include-pathways')
+    expect(row.impressions).toBe(3)
+    expect(row.acceptances).toBe(2)
+    expect(row.acceptanceRate).toBeCloseTo(2 / 3)
+    expect(row.profileOpens).toBe(1)
+    expect(row.postRecoveryProfileRate).toBe(0.5)
+    expect(row.averageRestoredResults).toBe(7)
+  })
+
+  it('counts recovery events without session IDs as legacy exclusions', () => {
+    const report = buildAtlasRecoveryPerformance([
+      { type: 'botanical_atlas_recovery_shown', item: 'clear-query:4', context: 'suggestions:1' },
+      { type: 'botanical_atlas_filter', item: 'Calming', context: 'effect:2' },
+    ])
+
+    expect(report.unattributedEvents).toBe(1)
+    expect(report.rows).toEqual([])
+  })
+
+  it('ranks profile-converting actions before high-impression nonconverters', () => {
+    const report = buildAtlasRecoveryPerformance([
+      shown('s1', 'clear-query:4,clear-effect:8'),
+      accepted('s1', 'clear-query', 4),
+      profile('s1', 'clear-query'),
+      shown('s2', 'clear-effect:8'),
+      shown('s3', 'clear-effect:8'),
+      accepted('s2', 'clear-effect', 8),
+    ])
+
+    expect(report.rows.map((row) => row.action)).toEqual(['clear-query', 'clear-effect'])
+  })
+})

--- a/src/lib/atlasAnalyticsReport.ts
+++ b/src/lib/atlasAnalyticsReport.ts
@@ -1,6 +1,7 @@
 export type AtlasAnalyticsEvent = {
   type?: string
   context?: string
+  item?: string
 }
 
 export type AtlasSourcePerformanceRow = {
@@ -12,10 +13,27 @@ export type AtlasSourcePerformanceRow = {
   topFirstFilter: string
 }
 
+export type AtlasRecoveryPerformanceRow = {
+  action: string
+  impressions: number
+  acceptances: number
+  acceptanceRate: number
+  profileOpens: number
+  postRecoveryProfileRate: number
+  averageRestoredResults: number
+}
+
 type SessionSummary = {
   source: string
   firstFilter: string
   distinctFilters: number
+  profileOpened: boolean
+}
+
+type RecoverySessionSummary = {
+  shown: Set<string>
+  accepted: string | null
+  restoredResults: number
   profileOpened: boolean
 }
 
@@ -88,9 +106,77 @@ export function buildAtlasSourcePerformance(events: AtlasAnalyticsEvent[]) {
     || b.sessions - a.sessions
     || a.source.localeCompare(b.source))
 
+  return { rows, attributedSessions: sessions.size, unattributedEvents }
+}
+
+function parseShownSuggestions(item = '') {
+  return item.split(',').map((entry) => entry.split(':')[0]).filter(Boolean)
+}
+
+export function buildAtlasRecoveryPerformance(events: AtlasAnalyticsEvent[]) {
+  const sessions = new Map<string, RecoverySessionSummary>()
+  let unattributedEvents = 0
+
+  events.filter((event) => event.type?.startsWith('botanical_atlas_')).forEach((event) => {
+    const values = parseAtlasContext(event.context)
+    const sessionId = values.get('session')
+    if (!sessionId) {
+      if (event.type === 'botanical_atlas_recovery_shown' || event.type === 'botanical_atlas_recovery_accepted') unattributedEvents += 1
+      return
+    }
+
+    const current = sessions.get(sessionId) ?? {
+      shown: new Set<string>(),
+      accepted: null,
+      restoredResults: 0,
+      profileOpened: false,
+    }
+
+    if (event.type === 'botanical_atlas_recovery_shown') {
+      parseShownSuggestions(event.item).forEach((action) => current.shown.add(action))
+    }
+    if (event.type === 'botanical_atlas_recovery_accepted') {
+      current.accepted = event.item || values.get('recovery') || null
+      current.restoredResults = Number(values.get('restored') ?? 0) || 0
+    }
+    current.profileOpened = current.profileOpened
+      || event.type === 'botanical_atlas_profile_click'
+      || values.get('profile_opened') === 'yes'
+    sessions.set(sessionId, current)
+  })
+
+  const actions = new Map<string, { impressions: number; acceptances: number; profileOpens: number; restoredTotal: number }>()
+  sessions.forEach((session) => {
+    session.shown.forEach((action) => {
+      const current = actions.get(action) ?? { impressions: 0, acceptances: 0, profileOpens: 0, restoredTotal: 0 }
+      current.impressions += 1
+      actions.set(action, current)
+    })
+    if (session.accepted) {
+      const current = actions.get(session.accepted) ?? { impressions: 0, acceptances: 0, profileOpens: 0, restoredTotal: 0 }
+      current.acceptances += 1
+      current.restoredTotal += session.restoredResults
+      if (session.profileOpened) current.profileOpens += 1
+      actions.set(session.accepted, current)
+    }
+  })
+
+  const rows: AtlasRecoveryPerformanceRow[] = Array.from(actions.entries()).map(([action, values]) => ({
+    action,
+    impressions: values.impressions,
+    acceptances: values.acceptances,
+    acceptanceRate: values.impressions ? values.acceptances / values.impressions : 0,
+    profileOpens: values.profileOpens,
+    postRecoveryProfileRate: values.acceptances ? values.profileOpens / values.acceptances : 0,
+    averageRestoredResults: values.acceptances ? values.restoredTotal / values.acceptances : 0,
+  })).sort((a, b) => b.postRecoveryProfileRate - a.postRecoveryProfileRate
+    || b.acceptanceRate - a.acceptanceRate
+    || b.impressions - a.impressions
+    || a.action.localeCompare(b.action))
+
   return {
     rows,
-    attributedSessions: sessions.size,
+    recoverySessions: Array.from(sessions.values()).filter((session) => session.shown.size || session.accepted).length,
     unattributedEvents,
   }
 }


### PR DESCRIPTION
## Summary
- aggregate zero-result recovery impressions by unique session and action
- calculate acceptance rate, post-recovery profile-open rate, and average restored results
- exclude legacy recovery events without session IDs from denominators
- add a dedicated recovery-performance table to the developer analytics viewer
- add regression coverage for deduplication, conversion math, ranking, and legacy-event handling

## Why this is high ROI
The recovery system is now measurable as a funnel. This shows which suggested filter changes merely attract clicks and which ones actually move visitors into botanical profiles.