### PR TITLE
Add explainable related botanicals scoring engine

### DIFF
--- a/src/lib/__tests__/related-botanicals.test.ts
+++ b/src/lib/__tests__/related-botanicals.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { getRelatedBotanicals, scoreRelatedBotanical, type RelatedBotanicalRecord } from '../related-botanicals'
+
+const herb = (overrides: Partial<RelatedBotanicalRecord>): RelatedBotanicalRecord => ({
+  slug: 'source',
+  name: 'Source',
+  explicitEffects: [],
+  effects: [],
+  compounds: [],
+  compoundClasses: [],
+  evidence: 'Moderate',
+  intensity: 'Subtle',
+  safety: [],
+  ...overrides,
+})
+
+describe('related botanicals engine', () => {
+  it('prioritizes shared explicit effects and chemistry over metadata-only matches', () => {
+    const source = herb({ explicitEffects: ['Calming'], effects: ['Calming'], compoundClasses: ['Flavonoids'] })
+    const strong = herb({ slug: 'strong', name: 'Strong', explicitEffects: ['Calming'], effects: ['Calming'], compoundClasses: ['Flavonoids'], evidence: 'Preliminary', intensity: 'Pronounced' })
+    const weak = herb({ slug: 'weak', name: 'Weak', evidence: 'Moderate', intensity: 'Subtle' })
+
+    expect(getRelatedBotanicals(source, [weak, strong]).map((match) => match.record.slug)).toEqual(['strong'])
+  })
+
+  it('explains every scored relationship with stable reason types and values', () => {
+    const source = herb({ explicitEffects: ['Calming'], effects: ['Calming'], compounds: ['Apigenin'], compoundClasses: ['Flavonoids'], safety: ['Sedating'] })
+    const candidate = herb({ slug: 'candidate', name: 'Candidate', explicitEffects: ['Calming'], effects: ['Calming'], compounds: ['apigenin'], compoundClasses: ['Flavonoids'], safety: ['Sedating'] })
+    const match = scoreRelatedBotanical(source, candidate)
+
+    expect(match?.reasons.map((reason) => reason.type)).toEqual([
+      'explicit-effect',
+      'compound-class',
+      'compound',
+      'safety',
+      'evidence',
+      'noticeability',
+    ])
+    expect(match?.reasons.find((reason) => reason.type === 'compound')?.values).toEqual(['Apigenin'])
+  })
+
+  it('does not recommend the source record or safety-only similarities', () => {
+    const source = herb({ safety: ['Serotonergic'] })
+    const safetyOnly = herb({ slug: 'risk', name: 'Risk', safety: ['Serotonergic'] })
+
+    expect(scoreRelatedBotanical(source, source)).toBeNull()
+    expect(scoreRelatedBotanical(source, safetyOnly)).toBeNull()
+  })
+
+  it('falls back to combined effects when explicit effect provenance is unavailable', () => {
+    const source = herb({ explicitEffects: undefined, effects: ['Cognition / focus'] })
+    const candidate = herb({ slug: 'legacy', name: 'Legacy', explicitEffects: undefined, effects: ['Cognition / focus'] })
+
+    expect(scoreRelatedBotanical(source, candidate)?.reasons[0]).toMatchObject({
+      type: 'explicit-effect',
+      values: ['Cognition / focus'],
+    })
+  })
+
+  it('uses deterministic alphabetical tie breaking and respects limits', () => {
+    const source = herb({ explicitEffects: ['Calming'], effects: ['Calming'] })
+    const beta = herb({ slug: 'beta', name: 'Beta', explicitEffects: ['Calming'], effects: ['Calming'] })
+    const alpha = herb({ slug: 'alpha', name: 'Alpha', explicitEffects: ['Calming'], effects: ['Calming'] })
+
+    expect(getRelatedBotanicals(source, [beta, alpha], 1).map((match) => match.record.name)).toEqual(['Alpha'])
+    expect(getRelatedBotanicals(source, [beta, alpha], 0)).toEqual([])
+  })
+})

--- a/src/lib/related-botanicals.ts
+++ b/src/lib/related-botanicals.ts
@@ -1,0 +1,119 @@
+export type RelatedBotanicalRecord = {
+  slug: string
+  name: string
+  explicitEffects?: string[]
+  effects: string[]
+  compounds: string[]
+  compoundClasses: string[]
+  evidence: string
+  intensity: string
+  safety: string[]
+}
+
+export type RelatedBotanicalReasonType =
+  | 'explicit-effect'
+  | 'compound-class'
+  | 'compound'
+  | 'safety'
+  | 'evidence'
+  | 'noticeability'
+
+export type RelatedBotanicalReason = {
+  type: RelatedBotanicalReasonType
+  label: string
+  values: string[]
+  score: number
+}
+
+export type RelatedBotanicalMatch = {
+  record: RelatedBotanicalRecord
+  score: number
+  reasons: RelatedBotanicalReason[]
+}
+
+const WEIGHTS = {
+  explicitEffect: 8,
+  compoundClass: 6,
+  compound: 4,
+  safety: 1.5,
+  evidence: 1,
+  noticeability: 0.75,
+} as const
+
+const normalized = (values: string[] = []) =>
+  new Map(values.filter(Boolean).map((value) => [value.trim().toLowerCase(), value.trim()]))
+
+function sharedValues(left: string[] = [], right: string[] = []) {
+  const a = normalized(left)
+  const b = normalized(right)
+  return Array.from(a.entries())
+    .filter(([key]) => b.has(key))
+    .map(([, display]) => display)
+    .sort((x, y) => x.localeCompare(y))
+}
+
+function boundedOverlap(shared: number, left: number, right: number) {
+  if (!shared || !left || !right) return 0
+  return shared / Math.sqrt(left * right)
+}
+
+function overlapReason(
+  type: RelatedBotanicalReasonType,
+  label: string,
+  left: string[] | undefined,
+  right: string[] | undefined,
+  weight: number,
+): RelatedBotanicalReason | null {
+  const values = sharedValues(left, right)
+  if (!values.length) return null
+  const score = weight * boundedOverlap(values.length, left?.length ?? 0, right?.length ?? 0)
+  return { type, label, values, score }
+}
+
+export function scoreRelatedBotanical(
+  source: RelatedBotanicalRecord,
+  candidate: RelatedBotanicalRecord,
+): RelatedBotanicalMatch | null {
+  if (source.slug === candidate.slug) return null
+
+  const sourceExplicit = source.explicitEffects?.length ? source.explicitEffects : source.effects
+  const candidateExplicit = candidate.explicitEffects?.length ? candidate.explicitEffects : candidate.effects
+  const reasons = [
+    overlapReason('explicit-effect', 'Shared explicit effects', sourceExplicit, candidateExplicit, WEIGHTS.explicitEffect),
+    overlapReason('compound-class', 'Shared chemistry families', source.compoundClasses, candidate.compoundClasses, WEIGHTS.compoundClass),
+    overlapReason('compound', 'Shared active compounds', source.compounds, candidate.compounds, WEIGHTS.compound),
+    overlapReason('safety', 'Shared safety signals', source.safety, candidate.safety, WEIGHTS.safety),
+  ].filter((reason): reason is RelatedBotanicalReason => Boolean(reason))
+
+  if (source.evidence && source.evidence === candidate.evidence && source.evidence !== 'Unclassified') {
+    reasons.push({ type: 'evidence', label: 'Similar evidence level', values: [source.evidence], score: WEIGHTS.evidence })
+  }
+  if (source.intensity && source.intensity === candidate.intensity && source.intensity !== 'Unknown') {
+    reasons.push({ type: 'noticeability', label: 'Similar noticeability', values: [source.intensity], score: WEIGHTS.noticeability })
+  }
+
+  const score = reasons.reduce((sum, reason) => sum + reason.score, 0)
+  const hasSubstantiveRelationship = reasons.some((reason) =>
+    reason.type === 'explicit-effect' || reason.type === 'compound-class' || reason.type === 'compound',
+  )
+  if (!hasSubstantiveRelationship || score <= 0) return null
+
+  return {
+    record: candidate,
+    score: Number(score.toFixed(4)),
+    reasons: reasons.sort((a, b) => b.score - a.score || a.label.localeCompare(b.label)),
+  }
+}
+
+export function getRelatedBotanicals(
+  source: RelatedBotanicalRecord,
+  records: RelatedBotanicalRecord[],
+  limit = 6,
+): RelatedBotanicalMatch[] {
+  if (limit <= 0) return []
+  return records
+    .map((candidate) => scoreRelatedBotanical(source, candidate))
+    .filter((match): match is RelatedBotanicalMatch => Boolean(match))
+    .sort((a, b) => b.score - a.score || a.record.name.localeCompare(b.record.name) || a.record.slug.localeCompare(b.record.slug))
+    .slice(0, limit)
+}


### PR DESCRIPTION
## Summary
- add a deterministic related-botanicals scoring engine
- prioritize shared explicit effects, chemistry families, and exact active compounds
- treat shared safety signals as explanatory context with deliberately low weight
- use evidence and noticeability only as secondary tie-strengthening signals
- reject self-matches and weak metadata-only relationships
- return stable, explainable reasons suitable for future profile UI
- add regression coverage for weighting, reasons, legacy effect fallback, safety-only rejection, tie-breaking, and limits

## Why this is high ROI
This creates the reusable intelligence layer for related-profile links, automated comparisons, and future graph exploration without prematurely exposing unvalidated recommendations in the interface.