### PR TITLE
Add real-data quality audit for related botanicals

### DIFF
--- a/.github/workflows/related-botanicals-audit.yml
+++ b/.github/workflows/related-botanicals-audit.yml
@@ -1,0 +1,39 @@
+name: Related Botanicals Quality Audit
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'src/lib/related-botanicals.ts'
+      - 'src/lib/botanical-atlas-data.ts'
+      - 'scripts/audit-related-botanicals.ts'
+      - '.github/workflows/related-botanicals-audit.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'src/lib/related-botanicals.ts'
+      - 'src/lib/botanical-atlas-data.ts'
+      - 'scripts/audit-related-botanicals.ts'
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Build runtime data
+        run: npm run data:build:core
+      - name: Generate recommendation audit
+        run: npx tsx scripts/audit-related-botanicals.ts
+      - name: Add summary
+        run: cat reports/related-botanicals/related-botanicals-audit.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload audit artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: related-botanicals-audit-${{ github.sha }}
+          path: reports/related-botanicals/
+          retention-days: 30

--- a/scripts/audit-related-botanicals.ts
+++ b/scripts/audit-related-botanicals.ts
@@ -1,0 +1,76 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { getBotanicalAtlasRecords } from '../src/lib/botanical-atlas-data'
+import { getRelatedBotanicals } from '../src/lib/related-botanicals'
+
+const outputDir = path.resolve(process.cwd(), 'reports/related-botanicals')
+const topN = Math.max(1, Number(process.env.RELATED_BOTANICALS_TOP_N ?? 5) || 5)
+
+const records = await getBotanicalAtlasRecords()
+const rows = records.map((source) => ({
+  source: { slug: source.slug, name: source.name },
+  matches: getRelatedBotanicals(source, records, topN).map((match) => ({
+    slug: match.record.slug,
+    name: match.record.name,
+    score: match.score,
+    reasons: match.reasons.map((reason) => ({
+      type: reason.type,
+      label: reason.label,
+      values: reason.values,
+      score: Number(reason.score.toFixed(4)),
+    })),
+  })),
+}))
+
+const noMatches = rows.filter((row) => row.matches.length === 0)
+const lowConfidence = rows.flatMap((row) => row.matches
+  .filter((match) => match.score < 4)
+  .map((match) => ({ source: row.source, match })))
+const safetyDominated = rows.flatMap((row) => row.matches
+  .filter((match) => match.reasons[0]?.type === 'safety')
+  .map((match) => ({ source: row.source, match })))
+
+const summary = {
+  generatedAt: new Date().toISOString(),
+  botanicals: records.length,
+  topN,
+  botanicalsWithoutMatches: noMatches.length,
+  lowConfidenceMatches: lowConfidence.length,
+  safetyDominatedMatches: safetyDominated.length,
+}
+
+const markdown = [
+  '# Related Botanicals Quality Audit',
+  '',
+  `Generated: ${summary.generatedAt}`,
+  '',
+  '## Summary',
+  '',
+  `- Botanicals evaluated: ${summary.botanicals}`,
+  `- Recommendations per botanical: up to ${summary.topN}`,
+  `- Botanicals without qualifying matches: ${summary.botanicalsWithoutMatches}`,
+  `- Low-confidence matches (score < 4): ${summary.lowConfidenceMatches}`,
+  `- Safety-dominated top reasons: ${summary.safetyDominatedMatches}`,
+  '',
+  '## Recommendations',
+  '',
+  ...rows.flatMap((row) => [
+    `### ${row.source.name} (${row.source.slug})`,
+    '',
+    ...(row.matches.length
+      ? row.matches.flatMap((match, index) => [
+          `${index + 1}. **${match.name}** — score ${match.score}`,
+          ...match.reasons.map((reason) => `   - ${reason.label}: ${reason.values.join(', ')} (+${reason.score})`),
+        ])
+      : ['_No qualifying related botanicals._']),
+    '',
+  ]),
+].join('\n')
+
+await mkdir(outputDir, { recursive: true })
+await Promise.all([
+  writeFile(path.join(outputDir, 'related-botanicals-audit.json'), JSON.stringify({ summary, rows }, null, 2) + '\n'),
+  writeFile(path.join(outputDir, 'related-botanicals-audit.md'), markdown + '\n'),
+])
+
+console.log(JSON.stringify(summary, null, 2))

--- a/src/lib/__tests__/related-botanicals-audit.test.ts
+++ b/src/lib/__tests__/related-botanicals-audit.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const script = readFileSync('scripts/audit-related-botanicals.ts', 'utf8')
+const workflow = readFileSync('.github/workflows/related-botanicals-audit.yml', 'utf8')
+
+describe('related botanicals quality audit', () => {
+  it('runs the real atlas records through the recommendation engine', () => {
+    expect(script).toContain('getBotanicalAtlasRecords()')
+    expect(script).toContain('getRelatedBotanicals(source, records, topN)')
+  })
+
+  it('reports explainability and suspicious recommendation signals', () => {
+    expect(script).toContain('botanicalsWithoutMatches')
+    expect(script).toContain('lowConfidenceMatches')
+    expect(script).toContain('safetyDominatedMatches')
+    expect(script).toContain('reason.values')
+  })
+
+  it('publishes both human-readable and machine-readable artifacts', () => {
+    expect(script).toContain('related-botanicals-audit.md')
+    expect(script).toContain('related-botanicals-audit.json')
+    expect(workflow).toContain('actions/upload-artifact@v4')
+    expect(workflow).toContain('GITHUB_STEP_SUMMARY')
+  })
+})


### PR DESCRIPTION
## Summary
- run the Related Botanicals engine against the real Botanical Activity Atlas dataset
- generate human-readable Markdown and machine-readable JSON audit artifacts
- show each botanical's top matches, scores, and explainable reasons
- flag botanicals with no matches, low-confidence recommendations, and safety-dominated reasoning
- run the audit in GitHub Actions when the engine or atlas adapter changes
- publish the full report to the Actions summary and retain artifacts for 30 days
- add regression guards for real-data execution and artifact generation

## Why this is high ROI
This creates a quality gate before recommendations appear on profile pages. We can inspect real pairings and tune the engine without exposing questionable relationships to visitors.