### PR TITLE
Fix remaining atlas typecheck blockers

### DIFF
--- a/src/lib/__tests__/atlas-profile-links.test.ts
+++ b/src/lib/__tests__/atlas-profile-links.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { getAtlasProfileLinks } from '@/lib/atlas-profile-links'
 import type { RuntimeRecord } from '@/types/content'
 
-const record = (overrides: Partial<RuntimeRecord>): RuntimeRecord => ({
+const record = (overrides: Record<string, unknown>): RuntimeRecord => ({
   slug: 'example-herb',
   name: 'Example Herb',
   ...overrides,

--- a/src/lib/__tests__/botanical-atlas-data.test.ts
+++ b/src/lib/__tests__/botanical-atlas-data.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { toAtlasRecord } from '@/lib/botanical-atlas-data'
 import type { RuntimeRecord } from '@/types/content'
 
-const record = (overrides: Partial<RuntimeRecord>): RuntimeRecord => ({
+const record = (overrides: Record<string, unknown>): RuntimeRecord => ({
   slug: 'test-herb',
   name: 'Test Herb',
   ...overrides,

--- a/src/lib/botanical-atlas-data.ts
+++ b/src/lib/botanical-atlas-data.ts
@@ -100,9 +100,9 @@ export const toAtlasRecord = (herb: RuntimeRecord): BotanicalAtlasRecord => {
 }
 
 export async function getBotanicalAtlasRecords(): Promise<BotanicalAtlasRecord[]> {
-  const rawHerbs = await getHerbs()
+  const rawHerbs: RuntimeRecord[] = await getHerbs()
   return rawHerbs
-    .filter((herb: RuntimeRecord) => {
+    .filter((herb) => {
       try {
         return getRuntimeVisibility(herb).canRender
       } catch {

--- a/src/lib/botanicalAtlasTracking.ts
+++ b/src/lib/botanicalAtlasTracking.ts
@@ -1,4 +1,4 @@
-import { appendAnalyticsEvent } from '@/utils/analytics/eventStorage'
+import { appendAnalyticsEvent } from '@/lib/analyticsEventStorage'
 import type { AtlasRecoveryAction, AtlasRecoverySuggestion } from '@/lib/botanical-atlas-recovery'
 
 type AtlasFilterName = 'search' | 'effect' | 'chemistry' | 'evidence' | 'noticeability' | 'safety'


### PR DESCRIPTION
## Summary
- point atlas tracking at the active analytics event storage module
- type atlas runtime records before filtering and sorting
- loosen test fixture builders so legacy string-shaped safety data can be exercised without conflicting with the stricter RuntimeRecord type

## Why
CI was reaching typecheck but failing on six narrow atlas errors before the Related Botanicals audit step. This removes those blockers without changing runtime behavior.