### PR TITLE
Tighten Related Botanicals recommendation quality

### DIFF
--- a/src/lib/__tests__/related-botanicals.test.ts
+++ b/src/lib/__tests__/related-botanicals.test.ts
@@ -47,6 +47,37 @@ describe('related botanicals engine', () => {
     expect(scoreRelatedBotanical(source, safetyOnly)).toBeNull()
   })
 
+  it('does not recommend duplicate aliases for the same scientific species', () => {
+    const source = herb({ scientificName: 'Morus alba', explicitEffects: ['Metabolic'], effects: ['Metabolic'] })
+    const alias = herb({ slug: 'mulberry-leaf', name: 'Mulberry Leaf', scientificName: ' morus   alba ', explicitEffects: ['Metabolic'], effects: ['Metabolic'] })
+
+    expect(scoreRelatedBotanical(source, alias)).toBeNull()
+  })
+
+  it('does not qualify broad antioxidant or tonic labels by themselves', () => {
+    const antioxidantSource = herb({ explicitEffects: ['antioxidant'], effects: ['antioxidant'] })
+    const antioxidantCandidate = herb({ slug: 'antioxidant', name: 'Antioxidant', explicitEffects: ['antioxidant'], effects: ['antioxidant'] })
+    const tonicSource = herb({ explicitEffects: ['tonic'], effects: ['tonic'] })
+    const tonicCandidate = herb({ slug: 'tonic', name: 'Tonic', explicitEffects: ['tonic'], effects: ['tonic'] })
+
+    expect(scoreRelatedBotanical(antioxidantSource, antioxidantCandidate)).toBeNull()
+    expect(scoreRelatedBotanical(tonicSource, tonicCandidate)).toBeNull()
+  })
+
+  it('allows broad labels when chemistry independently supports the relationship', () => {
+    const source = herb({ explicitEffects: ['antioxidant'], effects: ['antioxidant'], compoundClasses: ['Flavonoids'] })
+    const candidate = herb({ slug: 'chemistry', name: 'Chemistry', explicitEffects: ['antioxidant'], effects: ['antioxidant'], compoundClasses: ['Flavonoids'] })
+
+    expect(scoreRelatedBotanical(source, candidate)?.reasons.some((reason) => reason.type === 'compound-class')).toBe(true)
+  })
+
+  it('rejects otherwise-substantive matches below the minimum confidence score', () => {
+    const source = herb({ explicitEffects: ['Cognition / focus', 'Calming', 'Mood'] })
+    const candidate = herb({ slug: 'thin', name: 'Thin', explicitEffects: ['Cognition / focus', 'Metabolic', 'Immune'] })
+
+    expect(scoreRelatedBotanical(source, candidate)).toBeNull()
+  })
+
   it('falls back to combined effects when explicit effect provenance is unavailable', () => {
     const source = herb({ explicitEffects: undefined, effects: ['Cognition / focus'] })
     const candidate = herb({ slug: 'legacy', name: 'Legacy', explicitEffects: undefined, effects: ['Cognition / focus'] })

--- a/src/lib/related-botanicals.ts
+++ b/src/lib/related-botanicals.ts
@@ -1,6 +1,7 @@
 export type RelatedBotanicalRecord = {
   slug: string
   name: string
+  scientificName?: string
   explicitEffects?: string[]
   effects: string[]
   compounds: string[]
@@ -40,8 +41,16 @@ const WEIGHTS = {
   noticeability: 0.75,
 } as const
 
+// Broad umbrella labels can be useful supporting context, but should not by
+// themselves create a recommendation. Otherwise common tags such as
+// "antioxidant" produce many technically-correct but low-value pairings.
+const GENERIC_EFFECTS = new Set(['antioxidant', 'tonic'])
+const MINIMUM_RECOMMENDATION_SCORE = 4
+
+const normalizedText = (value = '') => value.trim().toLowerCase().replace(/\s+/g, ' ')
+
 const normalized = (values: string[] = []) =>
-  new Map(values.filter(Boolean).map((value) => [value.trim().toLowerCase(), value.trim()]))
+  new Map(values.filter(Boolean).map((value) => [normalizedText(value), value.trim()]))
 
 function sharedValues(left: string[] = [], right: string[] = []) {
   const a = normalized(left)
@@ -70,11 +79,18 @@ function overlapReason(
   return { type, label, values, score }
 }
 
+function isSameBotanical(source: RelatedBotanicalRecord, candidate: RelatedBotanicalRecord) {
+  if (source.slug === candidate.slug) return true
+  const sourceScientific = normalizedText(source.scientificName)
+  const candidateScientific = normalizedText(candidate.scientificName)
+  return Boolean(sourceScientific && candidateScientific && sourceScientific === candidateScientific)
+}
+
 export function scoreRelatedBotanical(
   source: RelatedBotanicalRecord,
   candidate: RelatedBotanicalRecord,
 ): RelatedBotanicalMatch | null {
-  if (source.slug === candidate.slug) return null
+  if (isSameBotanical(source, candidate)) return null
 
   const sourceExplicit = source.explicitEffects?.length ? source.explicitEffects : source.effects
   const candidateExplicit = candidate.explicitEffects?.length ? candidate.explicitEffects : candidate.effects
@@ -93,10 +109,13 @@ export function scoreRelatedBotanical(
   }
 
   const score = reasons.reduce((sum, reason) => sum + reason.score, 0)
-  const hasSubstantiveRelationship = reasons.some((reason) =>
-    reason.type === 'explicit-effect' || reason.type === 'compound-class' || reason.type === 'compound',
+  const effectReason = reasons.find((reason) => reason.type === 'explicit-effect')
+  const hasSpecificEffect = Boolean(effectReason?.values.some((value) => !GENERIC_EFFECTS.has(normalizedText(value))))
+  const hasChemistryRelationship = reasons.some((reason) =>
+    reason.type === 'compound-class' || reason.type === 'compound',
   )
-  if (!hasSubstantiveRelationship || score <= 0) return null
+  const hasSubstantiveRelationship = hasSpecificEffect || hasChemistryRelationship
+  if (!hasSubstantiveRelationship || score < MINIMUM_RECOMMENDATION_SCORE) return null
 
   return {
     record: candidate,


### PR DESCRIPTION
## Summary
- suppress same-species alias recommendations using normalized scientific names
- prevent broad umbrella effects like `antioxidant` and `tonic` from qualifying a recommendation on their own
- require a minimum recommendation score of 4
- keep broad labels usable when chemistry independently supports the relationship
- add regression coverage for alias suppression, broad-effect filtering, chemistry exceptions, and minimum confidence

## Why
The first real audit was strong overall, but surfaced duplicate/synonym pairings and many technically-valid yet low-value broad-effect matches. These guardrails improve usefulness before any profile UI is enabled.