### PR TITLE
Fix real-data Related Botanicals alias suppression

### DIFF
--- a/scripts/audit-related-botanicals.ts
+++ b/scripts/audit-related-botanicals.ts
@@ -8,10 +8,11 @@ const topN = Math.max(1, Number(process.env.RELATED_BOTANICALS_TOP_N ?? 5) || 5)
 
 const records = await getBotanicalAtlasRecords()
 const rows = records.map((source) => ({
-  source: { slug: source.slug, name: source.name },
+  source: { slug: source.slug, name: source.name, scientificName: source.scientificName },
   matches: getRelatedBotanicals(source, records, topN).map((match) => ({
     slug: match.record.slug,
     name: match.record.name,
+    scientificName: match.record.scientificName,
     score: match.score,
     reasons: match.reasons.map((reason) => ({
       type: reason.type,
@@ -30,6 +31,15 @@ const safetyDominated = rows.flatMap((row) => row.matches
   .filter((match) => match.reasons[0]?.type === 'safety')
   .map((match) => ({ source: row.source, match })))
 const allPairs = rows.flatMap((row) => row.matches.map((match) => ({ source: row.source, match })))
+const chemistrySupported = allPairs.filter(({ match }) => match.reasons.some((reason) =>
+  reason.type === 'compound-class' || reason.type === 'compound',
+))
+const effectOnly = allPairs.filter(({ match }) => {
+  const substantiveTypes = new Set(match.reasons
+    .filter((reason) => ['explicit-effect', 'compound-class', 'compound'].includes(reason.type))
+    .map((reason) => reason.type))
+  return substantiveTypes.size === 1 && substantiveTypes.has('explicit-effect')
+})
 const strongestPairs = [...allPairs]
   .sort((a, b) => b.match.score - a.match.score
     || a.source.name.localeCompare(b.source.name)
@@ -46,6 +56,8 @@ const summary = {
   botanicalsWithoutMatches: noMatches.length,
   lowConfidenceMatches: lowConfidence.length,
   safetyDominatedMatches: safetyDominated.length,
+  chemistrySupportedMatches: chemistrySupported.length,
+  effectOnlyMatches: effectOnly.length,
   averageTopScore: Number(averageTopScore.toFixed(2)),
 }
 
@@ -61,6 +73,8 @@ const markdown = [
   `- Botanicals without qualifying matches: ${summary.botanicalsWithoutMatches}`,
   `- Low-confidence matches (score < 4): ${summary.lowConfidenceMatches}`,
   `- Safety-dominated top reasons: ${summary.safetyDominatedMatches}`,
+  `- Chemistry-supported matches: ${summary.chemistrySupportedMatches}`,
+  `- Effect-only matches: ${summary.effectOnlyMatches}`,
   `- Average top recommendation score: ${summary.averageTopScore}`,
   '',
   '## Strongest pairings',

--- a/src/lib/__tests__/related-botanicals.test.ts
+++ b/src/lib/__tests__/related-botanicals.test.ts
@@ -54,6 +54,14 @@ describe('related botanicals engine', () => {
     expect(scoreRelatedBotanical(source, alias)).toBeNull()
   })
 
+  it('suppresses aliases when a scientific name matches the other record display name', () => {
+    const commonName = herb({ name: 'Thunder God Vine', scientificName: 'Tripterygium wilfordii', explicitEffects: ['Inflammation'], effects: ['Inflammation'] })
+    const latinName = herb({ slug: 'tripterygium-wilfordii', name: 'Tripterygium Wilfordii', explicitEffects: ['Inflammation'], effects: ['Inflammation'] })
+
+    expect(scoreRelatedBotanical(commonName, latinName)).toBeNull()
+    expect(scoreRelatedBotanical(latinName, commonName)).toBeNull()
+  })
+
   it('does not qualify broad antioxidant or tonic labels by themselves', () => {
     const antioxidantSource = herb({ explicitEffects: ['antioxidant'], effects: ['antioxidant'] })
     const antioxidantCandidate = herb({ slug: 'antioxidant', name: 'Antioxidant', explicitEffects: ['antioxidant'], effects: ['antioxidant'] })

--- a/src/lib/related-botanicals.ts
+++ b/src/lib/related-botanicals.ts
@@ -81,9 +81,17 @@ function overlapReason(
 
 function isSameBotanical(source: RelatedBotanicalRecord, candidate: RelatedBotanicalRecord) {
   if (source.slug === candidate.slug) return true
+
+  const sourceName = normalizedText(source.name)
+  const candidateName = normalizedText(candidate.name)
   const sourceScientific = normalizedText(source.scientificName)
   const candidateScientific = normalizedText(candidate.scientificName)
-  return Boolean(sourceScientific && candidateScientific && sourceScientific === candidateScientific)
+
+  if (sourceScientific && candidateScientific && sourceScientific === candidateScientific) return true
+  if (sourceScientific && sourceScientific === candidateName) return true
+  if (candidateScientific && candidateScientific === sourceName) return true
+
+  return false
 }
 
 export function scoreRelatedBotanical(


### PR DESCRIPTION
## Summary
- suppress duplicate botanical aliases when one record's scientific name matches the other record's display name
- add regression coverage for common-name ↔ Latin-name duplicates
- expose chemistry-supported and effect-only recommendation counts in the quality audit
- include scientific names in audit output for easier duplicate review

## Why
The second real-data audit showed the original scientific-name guardrail was not enough for records where only one alias carries a scientific-name field. It also revealed that the current top recommendations are overwhelmingly effect-driven, so the audit now measures chemistry coverage explicitly before profile UI is approved.