### PR TITLE
Repair runtime botanical identity and chemistry handoff

### DIFF
--- a/config/runtime-herb-fields.mjs
+++ b/config/runtime-herb-fields.mjs
@@ -9,6 +9,7 @@ export const HERB_RUNTIME_FIELDS = [
   'id',
   'slug',
   'name',
+  'scientific_name',
   'latin_name',
   'common_names',
   'aliases',

--- a/src/lib/__tests__/botanical-atlas-data.test.ts
+++ b/src/lib/__tests__/botanical-atlas-data.test.ts
@@ -20,6 +20,19 @@ describe('Botanical Activity Atlas runtime fallbacks', () => {
     expect(result.compoundClasses).toEqual(['Methylxanthines'])
   })
 
+  it('reads snake_case runtime identity and chemistry fields', () => {
+    const result = toAtlasRecord(record({
+      scientific_name: 'Morus alba',
+      active_constituents: ['caffeine'],
+      compound_profile: ['theobromine'],
+      related_compounds: ['theophylline'],
+    }))
+
+    expect(result.scientificName).toBe('Morus alba')
+    expect(result.compounds).toEqual(['caffeine', 'theobromine', 'theophylline'])
+    expect(result.compoundClasses).toEqual(['Methylxanthines'])
+  })
+
   it('does not turn unknown compound names into fake chemical classes', () => {
     const result = toAtlasRecord(record({ activeCompounds: ['mystery constituent'] }))
     expect(result.compoundClasses).toEqual([])

--- a/src/lib/botanical-atlas-data.ts
+++ b/src/lib/botanical-atlas-data.ts
@@ -55,7 +55,15 @@ export const toAtlasRecord = (herb: RuntimeRecord): BotanicalAtlasRecord => {
   const inferredEffects = inferAtlasEffectsFromMechanisms(mechanisms)
     .filter((effect) => !explicitEffects.includes(effect))
   const effects = [...explicitEffects, ...inferredEffects]
-  const compounds = collect(herb.activeCompounds, herb.active_compounds, herb.compounds, herb.activeconstituents)
+  const compounds = collect(
+    herb.activeCompounds,
+    herb.active_compounds,
+    herb.active_constituents,
+    herb.activeconstituents,
+    herb.compounds,
+    herb.compound_profile,
+    herb.related_compounds,
+  )
   const explicitClasses = uniqueNormalized(
     collect(herb.compoundClasses, herb.pharmCategories, herb.compoundClass),
     normalizeCompoundClass,
@@ -74,7 +82,13 @@ export const toAtlasRecord = (herb: RuntimeRecord): BotanicalAtlasRecord => {
   return {
     slug: herb.slug,
     name: text(herb.displayName, herb.name, herb.commonName, herb.common, herb.slug.replaceAll('-', ' ')),
-    scientificName: text(herb.scientificName, herb.scientificname, herb.latinName) || undefined,
+    scientificName: text(
+      herb.scientificName,
+      herb.scientificname,
+      herb.scientific_name,
+      herb.latinName,
+      herb.latin_name,
+    ) || undefined,
     effects,
     explicitEffects,
     inferredEffects,


### PR DESCRIPTION
## Summary
- expose `scientific_name` through the herb runtime contract
- teach the atlas adapter to read snake_case scientific-name fields
- ingest runtime chemistry fields including `active_constituents`, `compound_profile`, and `related_compounds`
- add regression coverage for snake_case identity and chemistry data

## Why
The third real-data Related Botanicals audit still showed duplicate aliases and zero chemistry-supported recommendations. The root cause is a broken runtime-data handoff: scientific names were built but dropped by the allowlist, while the atlas adapter missed several snake_case chemistry fields. This repairs that contract before any profile recommendation UI ships.