### PR TITLE
Use canonical herb-compound map for atlas chemistry

### DIFF
--- a/src/lib/__tests__/botanical-atlas-data.test.ts
+++ b/src/lib/__tests__/botanical-atlas-data.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { toAtlasRecord } from '@/lib/botanical-atlas-data'
+import {
+  buildMappedCompoundsByHerb,
+  enrichAtlasRecordWithMappedCompounds,
+  toAtlasRecord,
+} from '@/lib/botanical-atlas-data'
 import type { RuntimeRecord } from '@/types/content'
 
 const record = (overrides: Record<string, unknown>): RuntimeRecord => ({
@@ -74,5 +78,23 @@ describe('Botanical Activity Atlas runtime fallbacks', () => {
     const result = toAtlasRecord(record({ mechanisms: ['Unmapped experimental pathway XYZ'] }))
     expect(result.effects).toEqual([])
     expect(result.inferredEffects).toEqual([])
+  })
+
+  it('indexes only contains relationships from the canonical herb-compound map', () => {
+    const mapped = buildMappedCompoundsByHerb([
+      record({ herb_slug: 'ashwagandha', compound: 'Withanolides', relationship: 'contains_compound' }),
+      record({ herb_slug: 'ashwagandha', compound: 'Withaferin A', relationship: 'contains_compound' }),
+      record({ herb_slug: 'ashwagandha', compound: 'Noise', relationship: 'compared_with' }),
+    ])
+
+    expect(mapped.get('ashwagandha')).toEqual(['Withanolides', 'Withaferin A'])
+  })
+
+  it('merges canonical mapped compounds without duplicates and infers chemistry classes', () => {
+    const atlasRecord = toAtlasRecord(record({ slug: 'ashwagandha', effects: ['calming'], active_constituents: ['Withaferin A'] }))
+    const enriched = enrichAtlasRecordWithMappedCompounds(atlasRecord, ['withaferin a', 'Withanolides'])
+
+    expect(enriched.compounds).toEqual(['withaferin a', 'Withanolides'])
+    expect(enriched.compoundClasses).toContain('Withanolides')
   })
 })

--- a/src/lib/botanical-atlas-data.ts
+++ b/src/lib/botanical-atlas-data.ts
@@ -1,4 +1,4 @@
-import { getHerbs } from '@/lib/runtime-data'
+import { getHerbCompoundMap, getHerbs } from '@/lib/runtime-data'
 import { getRuntimeVisibility } from '../../lib/runtime-visibility'
 import {
   inferAtlasEffectsFromMechanisms,
@@ -113,8 +113,44 @@ export const toAtlasRecord = (herb: RuntimeRecord): BotanicalAtlasRecord => {
   }
 }
 
+export function buildMappedCompoundsByHerb(rows: RuntimeRecord[]): Map<string, string[]> {
+  const compoundsByHerb = new Map<string, string[]>()
+
+  for (const row of rows) {
+    const herbSlug = text(row.herb_slug, row.herbSlug)
+    const compound = text(row.compound, row.compound_name, row.compoundName, row.compound_slug, row.compoundSlug)
+    const relationship = text(row.relationship, row.relationship_type, row.relationshipType).toLowerCase()
+    if (!herbSlug || !compound) continue
+    if (relationship && !relationship.includes('contains')) continue
+
+    const existing = compoundsByHerb.get(herbSlug) ?? []
+    compoundsByHerb.set(herbSlug, collect(existing, compound))
+  }
+
+  return compoundsByHerb
+}
+
+export function enrichAtlasRecordWithMappedCompounds(
+  record: BotanicalAtlasRecord,
+  mappedCompounds: string[] = [],
+): BotanicalAtlasRecord {
+  const compounds = Array.from(new Map(
+    collect(record.compounds, mappedCompounds).map((compound) => [compound.toLowerCase(), compound]),
+  ).values())
+  const compoundClasses = record.compoundClasses.length
+    ? record.compoundClasses
+    : inferCompoundClasses(compounds)
+
+  return { ...record, compounds, compoundClasses }
+}
+
 export async function getBotanicalAtlasRecords(): Promise<BotanicalAtlasRecord[]> {
-  const rawHerbs: RuntimeRecord[] = await getHerbs()
+  const [rawHerbs, herbCompoundMap] = await Promise.all([
+    getHerbs(),
+    getHerbCompoundMap(),
+  ])
+  const mappedCompoundsByHerb = buildMappedCompoundsByHerb(herbCompoundMap)
+
   return rawHerbs
     .filter((herb) => {
       try {
@@ -124,6 +160,7 @@ export async function getBotanicalAtlasRecords(): Promise<BotanicalAtlasRecord[]
       }
     })
     .map(toAtlasRecord)
+    .map((record) => enrichAtlasRecordWithMappedCompounds(record, mappedCompoundsByHerb.get(record.slug)))
     .filter((herb) => herb.effects.length || herb.compounds.length || herb.safety.length)
     .sort((a, b) => a.name.localeCompare(b.name))
 }


### PR DESCRIPTION
## Summary
- enrich Botanical Activity Atlas records from the canonical `herb-compound-map.json`
- only ingest herb-compound relationships that represent containment
- merge mapped chemistry with profile chemistry without duplicates
- infer known compound classes from the enriched compound set
- add regression coverage for relationship filtering, deduplication, and chemistry-class inference

## Why
The latest real-data Related Botanicals audit still reported 0 chemistry-supported recommendations despite the runtime field fixes. The repository already generates a canonical herb-compound relationship map with explicit `contains_compound` edges, so the atlas should use that source directly rather than relying on duplicated profile-row chemistry.