### PR TITLE
Add explainable Related Botanicals to herb profiles

### DIFF
--- a/components/SeeAlsoCluster.tsx
+++ b/components/SeeAlsoCluster.tsx
@@ -1,32 +1,97 @@
 /**
- * SeeAlsoCluster — "See also in cluster" module.
+ * SeeAlsoCluster — profile discovery module.
  *
- * Renders chip-style links to related herbs/compounds in the same semantic
- * cluster(s) as the current profile. Groups by cluster and links to the
- * relevant goal page for the full cluster context.
+ * Herb profiles get an evidence-aware Related Botanicals block powered by the
+ * deterministic relationship engine, followed by the existing semantic-cluster
+ * navigation. Compound profiles keep the cluster navigation only.
  *
  * Server component — no client state, no side effects.
- *
- * Usage (herb page):
- *   <SeeAlsoCluster slug={normalizedSlug} kind="herb" />
- *
- * Usage (compound page):
- *   <SeeAlsoCluster slug={slug} kind="compound" limit={8} />
  */
 
 import Link from 'next/link'
 import { getClusterSeeAlso, getEntityClusters } from '@/lib/cluster-linking'
+import { getBotanicalAtlasRecords } from '@/lib/botanical-atlas-data'
+import { getRelatedBotanicals, type RelatedBotanicalMatch } from '@/lib/related-botanicals'
 import type { EntityKind } from '@/lib/schema'
 
 type SeeAlsoClusterProps = {
   slug: string
   kind: EntityKind
-  /** Max number of "see also" entries to render (default 6). */
+  /** Max number of semantic-cluster entries to render (default 6). */
   limit?: number
   className?: string
 }
 
-export default function SeeAlsoCluster({
+const HERB_SOURCE_ALIASES: Record<string, string> = {
+  'lions-mane': 'hericium-erinaceus',
+  passionflower: 'passiflora-incarnata',
+  kava: 'piper-methysticum',
+  'ashwagandha-withania-somnifera': 'ashwagandha',
+}
+
+function meaningfulReasons(match: RelatedBotanicalMatch) {
+  const preferred = match.reasons.filter((reason) =>
+    reason.type === 'compound' || reason.type === 'compound-class' || reason.type === 'explicit-effect',
+  )
+  const fallback = match.reasons.filter((reason) => reason.type !== 'safety')
+  return (preferred.length ? preferred : fallback).slice(0, 2)
+}
+
+function RelatedBotanicals({ matches }: { matches: RelatedBotanicalMatch[] }) {
+  if (!matches.length) return null
+
+  return (
+    <section
+      className="space-y-4 rounded-2xl border border-brand-900/10 bg-white/80 p-4 sm:p-5"
+      aria-labelledby="related-botanicals-heading"
+    >
+      <div className="space-y-1">
+        <p id="related-botanicals-heading" className="text-xs font-bold uppercase tracking-wider text-brand-700">
+          Related botanicals
+        </p>
+        <p className="text-sm leading-6 text-muted">
+          Ranked from shared effects and chemistry. These are research-navigation links, not treatment recommendations.
+        </p>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-3">
+        {matches.map((match) => {
+          const reasons = meaningfulReasons(match)
+          return (
+            <Link
+              key={match.record.slug}
+              href={`/herbs/${match.record.slug}/`}
+              className="group rounded-2xl border border-brand-900/10 bg-[var(--surface-card)] p-4 transition hover:border-brand-600/30 hover:bg-brand-50/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2"
+            >
+              <div className="space-y-1">
+                <h3 className="font-bold text-ink group-hover:text-brand-800">{match.record.name}</h3>
+                {match.record.scientificName ? (
+                  <p className="text-xs italic text-muted">{match.record.scientificName}</p>
+                ) : null}
+              </div>
+
+              {reasons.length > 0 ? (
+                <div className="mt-3 space-y-2">
+                  <p className="text-[10px] font-bold uppercase tracking-wider text-muted">Why related</p>
+                  {reasons.map((reason) => (
+                    <div key={`${match.record.slug}:${reason.type}`} className="text-xs leading-5 text-muted">
+                      <span className="font-semibold text-ink">{reason.label}:</span>{' '}
+                      {reason.values.slice(0, 3).join(', ')}
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+
+              <p className="mt-3 text-xs font-bold text-brand-800">Explore profile →</p>
+            </Link>
+          )
+        })}
+      </div>
+    </section>
+  )
+}
+
+export default async function SeeAlsoCluster({
   slug,
   kind,
   limit = 6,
@@ -35,7 +100,13 @@ export default function SeeAlsoCluster({
   const seeAlso = getClusterSeeAlso(slug, kind, limit)
   const clusters = getEntityClusters(slug, kind)
 
-  if (!seeAlso.length || !clusters.length) return null
+  let relatedMatches: RelatedBotanicalMatch[] = []
+  if (kind === 'herb') {
+    const atlasRecords = await getBotanicalAtlasRecords()
+    const sourceSlug = HERB_SOURCE_ALIASES[slug] ?? slug
+    const source = atlasRecords.find((record) => record.slug === sourceSlug)
+    if (source) relatedMatches = getRelatedBotanicals(source, atlasRecords, 3)
+  }
 
   type GroupedEntry = {
     clusterId: string
@@ -53,56 +124,62 @@ export default function SeeAlsoCluster({
     }))
     .filter((group) => group.entries.length > 0)
 
-  if (!grouped.length) return null
+  if (!relatedMatches.length && !grouped.length) return null
 
   const guideLinkClass =
     'inline-flex min-h-11 items-center rounded-lg px-2.5 text-xs font-semibold text-brand-700 transition hover:bg-brand-50 hover:text-brand-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2'
 
   return (
-    <section
-      className={`space-y-4 rounded-2xl border border-brand-900/10 bg-white/80 p-4 sm:p-5 ${className ?? ''}`}
-      aria-labelledby="see-also-cluster-heading"
-    >
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <p
-          id="see-also-cluster-heading"
-          className="text-xs font-bold uppercase tracking-wider text-brand-700"
-        >
-          Also in this cluster
-        </p>
-        {grouped.length === 1 ? (
-          <Link href={grouped[0].clusterGoalHref} className={guideLinkClass}>
-            {grouped[0].clusterLabel} guide →
-          </Link>
-        ) : null}
-      </div>
+    <div className={`space-y-4 ${className ?? ''}`}>
+      <RelatedBotanicals matches={relatedMatches} />
 
-      {grouped.map((group) => (
-        <div key={group.clusterId} className="space-y-2">
-          {grouped.length > 1 ? (
-            <div className="flex items-center justify-between gap-2">
-              <p className="text-xs font-semibold uppercase tracking-wider text-muted">
-                {group.clusterLabel}
-              </p>
-              <Link href={group.clusterGoalHref} className={guideLinkClass}>
-                Full guide →
+      {grouped.length > 0 ? (
+        <section
+          className="space-y-4 rounded-2xl border border-brand-900/10 bg-white/80 p-4 sm:p-5"
+          aria-labelledby="see-also-cluster-heading"
+        >
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <p
+              id="see-also-cluster-heading"
+              className="text-xs font-bold uppercase tracking-wider text-brand-700"
+            >
+              Also in this cluster
+            </p>
+            {grouped.length === 1 ? (
+              <Link href={grouped[0].clusterGoalHref} className={guideLinkClass}>
+                {grouped[0].clusterLabel} guide →
               </Link>
-            </div>
-          ) : null}
-          <div className="flex gap-2 overflow-x-auto pb-1.5 [-webkit-overflow-scrolling:touch] [scrollbar-width:thin]">
-            {group.entries.map((entry) => (
-              <Link
-                key={`${entry.kind}:${entry.slug}`}
-                href={entry.href}
-                title={entry.reason}
-                className="inline-flex min-h-11 shrink-0 items-center whitespace-nowrap rounded-full border border-brand-900/10 bg-brand-50/50 px-3.5 text-sm font-semibold capitalize text-brand-800 transition hover:bg-brand-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2"
-              >
-                {entry.label} →
-              </Link>
-            ))}
+            ) : null}
           </div>
-        </div>
-      ))}
-    </section>
+
+          {grouped.map((group) => (
+            <div key={group.clusterId} className="space-y-2">
+              {grouped.length > 1 ? (
+                <div className="flex items-center justify-between gap-2">
+                  <p className="text-xs font-semibold uppercase tracking-wider text-muted">
+                    {group.clusterLabel}
+                  </p>
+                  <Link href={group.clusterGoalHref} className={guideLinkClass}>
+                    Full guide →
+                  </Link>
+                </div>
+              ) : null}
+              <div className="flex gap-2 overflow-x-auto pb-1.5 [-webkit-overflow-scrolling:touch] [scrollbar-width:thin]">
+                {group.entries.map((entry) => (
+                  <Link
+                    key={`${entry.kind}:${entry.slug}`}
+                    href={entry.href}
+                    title={entry.reason}
+                    className="inline-flex min-h-11 shrink-0 items-center whitespace-nowrap rounded-full border border-brand-900/10 bg-brand-50/50 px-3.5 text-sm font-semibold capitalize text-brand-800 transition hover:bg-brand-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2"
+                  >
+                    {entry.label} →
+                  </Link>
+                ))}
+              </div>
+            </div>
+          ))}
+        </section>
+      ) : null}
+    </div>
   )
 }

--- a/src/lib/botanical-atlas-data.ts
+++ b/src/lib/botanical-atlas-data.ts
@@ -1,4 +1,5 @@
 import { getHerbCompoundMap, getHerbs } from '@/lib/runtime-data'
+import { cache } from '@/lib/react-cache'
 import { getRuntimeVisibility } from '../../lib/runtime-visibility'
 import {
   inferAtlasEffectsFromMechanisms,
@@ -144,7 +145,7 @@ export function enrichAtlasRecordWithMappedCompounds(
   return { ...record, compounds, compoundClasses }
 }
 
-export async function getBotanicalAtlasRecords(): Promise<BotanicalAtlasRecord[]> {
+export const getBotanicalAtlasRecords = cache(async (): Promise<BotanicalAtlasRecord[]> => {
   const [rawHerbs, herbCompoundMap] = await Promise.all([
     getHerbs(),
     getHerbCompoundMap(),
@@ -163,4 +164,4 @@ export async function getBotanicalAtlasRecords(): Promise<BotanicalAtlasRecord[]
     .map((record) => enrichAtlasRecordWithMappedCompounds(record, mappedCompoundsByHerb.get(record.slug)))
     .filter((herb) => herb.effects.length || herb.compounds.length || herb.safety.length)
     .sort((a, b) => a.name.localeCompare(b.name))
-}
+})


### PR DESCRIPTION
## Summary
- add the first public Related Botanicals block to herb profile discovery
- rank three deterministic matches from the audited relationship engine
- show concise "Why related" explanations emphasizing chemistry and explicit effects
- keep safety signals out of benefit-style explanations
- label the feature as research navigation rather than treatment advice
- reuse the existing SeeAlsoCluster integration point to avoid risky edits to the large herb page template
- cache atlas record assembly for repeated static profile renders

## Validation context
The latest real-data audit after canonical herb-compound map enrichment reported 286 chemistry-supported matches, 6 botanicals without qualifying matches, 0 low-confidence matches, 0 safety-dominated matches, and an average top score of 9.65.