### PR TITLE
Track Related Botanicals profile exploration

### DIFF
--- a/components/RelatedBotanicalsTracked.tsx
+++ b/components/RelatedBotanicalsTracked.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useMemo } from 'react'
+import {
+  trackRelatedBotanicalClick,
+  trackRelatedBotanicalsShown,
+  type RelatedBotanicalTrackingItem,
+} from '@/lib/relatedBotanicalTracking'
+
+type DisplayReason = {
+  type: string
+  label: string
+  values: string[]
+}
+
+type RelatedBotanicalCard = {
+  slug: string
+  name: string
+  scientificName?: string
+  score: number
+  reasons: DisplayReason[]
+}
+
+type Props = {
+  sourceSlug: string
+  matches: RelatedBotanicalCard[]
+}
+
+export default function RelatedBotanicalsTracked({ sourceSlug, matches }: Props) {
+  const trackingItems = useMemo<RelatedBotanicalTrackingItem[]>(() =>
+    matches.map((match, index) => ({
+      slug: match.slug,
+      position: index + 1,
+      score: match.score,
+      reasonTypes: match.reasons.map((reason) => reason.type),
+    })), [matches])
+
+  useEffect(() => {
+    trackRelatedBotanicalsShown(sourceSlug, trackingItems)
+  }, [sourceSlug, trackingItems])
+
+  if (!matches.length) return null
+
+  return (
+    <section
+      className="space-y-4 rounded-2xl border border-brand-900/10 bg-white/80 p-4 sm:p-5"
+      aria-labelledby="related-botanicals-heading"
+    >
+      <div className="space-y-1">
+        <p id="related-botanicals-heading" className="text-xs font-bold uppercase tracking-wider text-brand-700">
+          Related botanicals
+        </p>
+        <p className="text-sm leading-6 text-muted">
+          Ranked from shared effects and chemistry. These are research-navigation links, not treatment recommendations.
+        </p>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-3">
+        {matches.map((match, index) => (
+          <Link
+            key={match.slug}
+            href={`/herbs/${match.slug}/`}
+            onClick={() => trackRelatedBotanicalClick(sourceSlug, trackingItems[index])}
+            className="group rounded-2xl border border-brand-900/10 bg-[var(--surface-card)] p-4 transition hover:border-brand-600/30 hover:bg-brand-50/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2"
+          >
+            <div className="space-y-1">
+              <h3 className="font-bold text-ink group-hover:text-brand-800">{match.name}</h3>
+              {match.scientificName ? <p className="text-xs italic text-muted">{match.scientificName}</p> : null}
+            </div>
+
+            {match.reasons.length > 0 ? (
+              <div className="mt-3 space-y-2">
+                <p className="text-[10px] font-bold uppercase tracking-wider text-muted">Why related</p>
+                {match.reasons.map((reason) => (
+                  <div key={`${match.slug}:${reason.type}`} className="text-xs leading-5 text-muted">
+                    <span className="font-semibold text-ink">{reason.label}:</span>{' '}
+                    {reason.values.slice(0, 3).join(', ')}
+                  </div>
+                ))}
+              </div>
+            ) : null}
+
+            <p className="mt-3 text-xs font-bold text-brand-800">Explore profile →</p>
+          </Link>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/components/SeeAlsoCluster.tsx
+++ b/components/SeeAlsoCluster.tsx
@@ -4,14 +4,13 @@
  * Herb profiles get an evidence-aware Related Botanicals block powered by the
  * deterministic relationship engine, followed by the existing semantic-cluster
  * navigation. Compound profiles keep the cluster navigation only.
- *
- * Server component — no client state, no side effects.
  */
 
 import Link from 'next/link'
 import { getClusterSeeAlso, getEntityClusters } from '@/lib/cluster-linking'
 import { getBotanicalAtlasRecords } from '@/lib/botanical-atlas-data'
 import { getRelatedBotanicals, type RelatedBotanicalMatch } from '@/lib/related-botanicals'
+import RelatedBotanicalsTracked from '@/components/RelatedBotanicalsTracked'
 import type { EntityKind } from '@/lib/schema'
 
 type SeeAlsoClusterProps = {
@@ -37,58 +36,18 @@ function meaningfulReasons(match: RelatedBotanicalMatch) {
   return (preferred.length ? preferred : fallback).slice(0, 2)
 }
 
-function RelatedBotanicals({ matches }: { matches: RelatedBotanicalMatch[] }) {
-  if (!matches.length) return null
-
-  return (
-    <section
-      className="space-y-4 rounded-2xl border border-brand-900/10 bg-white/80 p-4 sm:p-5"
-      aria-labelledby="related-botanicals-heading"
-    >
-      <div className="space-y-1">
-        <p id="related-botanicals-heading" className="text-xs font-bold uppercase tracking-wider text-brand-700">
-          Related botanicals
-        </p>
-        <p className="text-sm leading-6 text-muted">
-          Ranked from shared effects and chemistry. These are research-navigation links, not treatment recommendations.
-        </p>
-      </div>
-
-      <div className="grid gap-3 md:grid-cols-3">
-        {matches.map((match) => {
-          const reasons = meaningfulReasons(match)
-          return (
-            <Link
-              key={match.record.slug}
-              href={`/herbs/${match.record.slug}/`}
-              className="group rounded-2xl border border-brand-900/10 bg-[var(--surface-card)] p-4 transition hover:border-brand-600/30 hover:bg-brand-50/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2"
-            >
-              <div className="space-y-1">
-                <h3 className="font-bold text-ink group-hover:text-brand-800">{match.record.name}</h3>
-                {match.record.scientificName ? (
-                  <p className="text-xs italic text-muted">{match.record.scientificName}</p>
-                ) : null}
-              </div>
-
-              {reasons.length > 0 ? (
-                <div className="mt-3 space-y-2">
-                  <p className="text-[10px] font-bold uppercase tracking-wider text-muted">Why related</p>
-                  {reasons.map((reason) => (
-                    <div key={`${match.record.slug}:${reason.type}`} className="text-xs leading-5 text-muted">
-                      <span className="font-semibold text-ink">{reason.label}:</span>{' '}
-                      {reason.values.slice(0, 3).join(', ')}
-                    </div>
-                  ))}
-                </div>
-              ) : null}
-
-              <p className="mt-3 text-xs font-bold text-brand-800">Explore profile →</p>
-            </Link>
-          )
-        })}
-      </div>
-    </section>
-  )
+function toTrackedMatches(matches: RelatedBotanicalMatch[]) {
+  return matches.map((match) => ({
+    slug: match.record.slug,
+    name: match.record.name,
+    scientificName: match.record.scientificName,
+    score: match.score,
+    reasons: meaningfulReasons(match).map((reason) => ({
+      type: reason.type,
+      label: reason.label,
+      values: reason.values,
+    })),
+  }))
 }
 
 export default async function SeeAlsoCluster({
@@ -101,10 +60,11 @@ export default async function SeeAlsoCluster({
   const clusters = getEntityClusters(slug, kind)
 
   let relatedMatches: RelatedBotanicalMatch[] = []
+  let relatedSourceSlug = slug
   if (kind === 'herb') {
     const atlasRecords = await getBotanicalAtlasRecords()
-    const sourceSlug = HERB_SOURCE_ALIASES[slug] ?? slug
-    const source = atlasRecords.find((record) => record.slug === sourceSlug)
+    relatedSourceSlug = HERB_SOURCE_ALIASES[slug] ?? slug
+    const source = atlasRecords.find((record) => record.slug === relatedSourceSlug)
     if (source) relatedMatches = getRelatedBotanicals(source, atlasRecords, 3)
   }
 
@@ -131,7 +91,9 @@ export default async function SeeAlsoCluster({
 
   return (
     <div className={`space-y-4 ${className ?? ''}`}>
-      <RelatedBotanicals matches={relatedMatches} />
+      {relatedMatches.length > 0 ? (
+        <RelatedBotanicalsTracked sourceSlug={relatedSourceSlug} matches={toTrackedMatches(relatedMatches)} />
+      ) : null}
 
       {grouped.length > 0 ? (
         <section

--- a/src/lib/__tests__/related-botanical-tracking.test.ts
+++ b/src/lib/__tests__/related-botanical-tracking.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { trackRelatedBotanicalClick, trackRelatedBotanicalsShown } from '@/lib/relatedBotanicalTracking'
+
+const appendAnalyticsEvent = vi.fn()
+
+vi.mock('@/lib/analyticsEventStorage', () => ({ appendAnalyticsEvent }))
+
+describe('related botanical tracking', () => {
+  beforeEach(() => {
+    appendAnalyticsEvent.mockClear()
+    sessionStorage.clear()
+  })
+
+  it('records impressions with reason types and first-profile depth', () => {
+    trackRelatedBotanicalsShown('ashwagandha', [
+      { slug: 'rhodiola', position: 1, score: 10.5, reasonTypes: ['explicit-effect', 'compound-class'] },
+    ])
+
+    expect(appendAnalyticsEvent).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'related_botanicals_shown',
+      slug: 'ashwagandha',
+      item: 'rhodiola:1:10.5',
+      context: expect.stringContaining('depth:1'),
+    }))
+  })
+
+  it('increments profile depth when a related botanical is opened', () => {
+    trackRelatedBotanicalsShown('ashwagandha', [
+      { slug: 'rhodiola', position: 1, score: 10.5, reasonTypes: ['explicit-effect'] },
+    ])
+    trackRelatedBotanicalClick('ashwagandha', {
+      slug: 'rhodiola', position: 1, score: 10.5, reasonTypes: ['explicit-effect'],
+    })
+
+    expect(appendAnalyticsEvent).toHaveBeenLastCalledWith(expect.objectContaining({
+      type: 'related_botanical_click',
+      slug: 'ashwagandha',
+      item: 'rhodiola',
+      context: expect.stringContaining('profile_depth:2'),
+    }))
+  })
+
+  it('does not inflate depth when revisiting the same profile', () => {
+    const item = { slug: 'rhodiola', position: 1, score: 10.5, reasonTypes: ['explicit-effect'] }
+    trackRelatedBotanicalClick('ashwagandha', item)
+    trackRelatedBotanicalClick('ashwagandha', item)
+
+    expect(appendAnalyticsEvent).toHaveBeenLastCalledWith(expect.objectContaining({
+      context: expect.stringContaining('profile_depth:2'),
+    }))
+  })
+})

--- a/src/lib/relatedBotanicalTracking.ts
+++ b/src/lib/relatedBotanicalTracking.ts
@@ -1,0 +1,83 @@
+'use client'
+
+import { appendAnalyticsEvent } from '@/lib/analyticsEventStorage'
+
+const SESSION_KEY = 'hs_related_botanical_session'
+
+type RelatedBotanicalSession = {
+  sessionId: string
+  visitedProfiles: string[]
+}
+
+function createSessionId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') return crypto.randomUUID()
+  return `related-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+}
+
+function readSession(): RelatedBotanicalSession {
+  if (typeof window === 'undefined') return { sessionId: createSessionId(), visitedProfiles: [] }
+  try {
+    const parsed = JSON.parse(window.sessionStorage.getItem(SESSION_KEY) || 'null')
+    if (parsed && typeof parsed.sessionId === 'string' && Array.isArray(parsed.visitedProfiles)) {
+      return {
+        sessionId: parsed.sessionId,
+        visitedProfiles: parsed.visitedProfiles.filter((item: unknown): item is string => typeof item === 'string'),
+      }
+    }
+  } catch { /* analytics must never block UX */ }
+  return { sessionId: createSessionId(), visitedProfiles: [] }
+}
+
+function saveSession(session: RelatedBotanicalSession) {
+  if (typeof window === 'undefined') return
+  try { window.sessionStorage.setItem(SESSION_KEY, JSON.stringify(session)) } catch { /* ignore */ }
+}
+
+function ensureSourceVisited(sourceSlug: string) {
+  const session = readSession()
+  const visitedProfiles = session.visitedProfiles.includes(sourceSlug)
+    ? session.visitedProfiles
+    : [...session.visitedProfiles, sourceSlug]
+  const next = { ...session, visitedProfiles }
+  saveSession(next)
+  return next
+}
+
+export type RelatedBotanicalTrackingItem = {
+  slug: string
+  position: number
+  score: number
+  reasonTypes: string[]
+}
+
+export function trackRelatedBotanicalsShown(sourceSlug: string, items: RelatedBotanicalTrackingItem[]) {
+  if (typeof window === 'undefined' || !items.length) return
+  const session = ensureSourceVisited(sourceSlug)
+  appendAnalyticsEvent({
+    type: 'related_botanicals_shown',
+    slug: sourceSlug,
+    item: items.map((item) => `${item.slug}:${item.position}:${item.score}`).join(','),
+    context: `session:${session.sessionId};depth:${session.visitedProfiles.length};reason_types:${Array.from(new Set(items.flatMap((item) => item.reasonTypes))).sort().join('|')}`,
+    sourceType: 'herb',
+    targetType: 'herb',
+  })
+}
+
+export function trackRelatedBotanicalClick(sourceSlug: string, item: RelatedBotanicalTrackingItem) {
+  if (typeof window === 'undefined') return
+  const session = ensureSourceVisited(sourceSlug)
+  const visitedProfiles = session.visitedProfiles.includes(item.slug)
+    ? session.visitedProfiles
+    : [...session.visitedProfiles, item.slug]
+  const next = { ...session, visitedProfiles }
+  saveSession(next)
+
+  appendAnalyticsEvent({
+    type: 'related_botanical_click',
+    slug: sourceSlug,
+    item: item.slug,
+    context: `session:${next.sessionId};position:${item.position};score:${item.score};reason_types:${item.reasonTypes.join('|')};profile_depth:${next.visitedProfiles.length}`,
+    sourceType: 'herb',
+    targetType: 'herb',
+  })
+}


### PR DESCRIPTION
## Summary
- track Related Botanicals impressions and clicks using the existing anonymous analytics event store
- persist a session-scoped profile exploration chain to measure second/third profile depth
- include card position, recommendation score, and displayed reason types
- keep relationship scoring server-side and send only the three rendered cards to the client
- add regression tests for impression tracking, depth increments, and revisit deduplication

## Privacy / UX
Tracking stores only anonymous session IDs, herb slugs, scores, positions, and reason types in existing local/session storage. Analytics failures are non-blocking.