### PR TITLE
Add Related Botanicals performance analytics

### DIFF
--- a/src/dev/AnalyticsViewer.tsx
+++ b/src/dev/AnalyticsViewer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { buildAtlasRecoveryPerformance, buildAtlasSourcePerformance } from '@/lib/atlasAnalyticsReport'
+import { buildAtlasRecoveryPerformance, buildAtlasSourcePerformance, buildRelatedBotanicalPerformance } from '@/lib/atlasAnalyticsReport'
 import { readAnalyticsEvents, type StoredAnalyticsEvent } from '@/utils/analytics/eventStorage'
 
 type GroupRow = { label: string; count: number }
@@ -35,12 +35,13 @@ export default function AnalyticsViewer() {
   const clickEvents = useMemo(() => events.filter(event => event.type === 'affiliate_link_click'), [events])
   const atlasReport = useMemo(() => buildAtlasSourcePerformance(events), [events])
   const recoveryReport = useMemo(() => buildAtlasRecoveryPerformance(events), [events])
+  const relatedReport = useMemo(() => buildRelatedBotanicalPerformance(events), [events])
   const byHerb = useMemo(() => groupCounts(clickEvents, event => event.slug || 'unknown'), [clickEvents])
   const byProduct = useMemo(() => groupCounts(clickEvents, event => event.item || 'unknown'), [clickEvents])
   const byPosition = useMemo(() => groupCounts(clickEvents, event => event.productPosition || 'unknown'), [clickEvents])
   const byUseCaseAnchor = useMemo(() => groupCounts(clickEvents, event => event.useCaseAnchor || 'none'), [clickEvents])
 
-  return <aside className='fixed bottom-3 right-3 z-[100] max-h-[80vh] w-[min(44rem,96vw)] overflow-auto rounded-lg border border-white/15 bg-black/85 p-3 text-white shadow-lg backdrop-blur'>
+  return <aside className='fixed bottom-3 right-3 z-[100] max-h-[80vh] w-[min(52rem,96vw)] overflow-auto rounded-lg border border-white/15 bg-black/85 p-3 text-white shadow-lg backdrop-blur'>
     <h2 className='text-sm font-semibold text-white'>Dev Analytics Viewer</h2>
 
     <section className='mt-3 rounded-md border border-white/10 bg-white/5 p-2'>
@@ -53,6 +54,15 @@ export default function AnalyticsViewer() {
       <h3 className='text-xs font-semibold uppercase tracking-wide text-white/80'>Atlas recovery performance</h3>
       <p className='mt-1 text-xs text-white/65'>{recoveryReport.recoverySessions} recovery sessions{recoveryReport.unattributedEvents ? ` · ${recoveryReport.unattributedEvents} legacy events excluded` : ''}</p>
       {recoveryReport.rows.length === 0 ? <p className='mt-2 text-xs text-white/60'>No recovery-funnel data yet.</p> : <div className='mt-2 overflow-x-auto'><table className='min-w-full text-xs'><thead><tr className='text-left text-white/65'><th className='pr-3 font-medium'>Action</th><th className='pr-3 font-medium'>Shown</th><th className='pr-3 font-medium'>Accepted</th><th className='pr-3 font-medium'>Accept rate</th><th className='pr-3 font-medium'>Profile rate</th><th className='font-medium'>Avg restored</th></tr></thead><tbody>{recoveryReport.rows.map(row => <tr key={row.action} className='border-t border-white/10'><td className='py-1.5 pr-3 font-medium text-white/95'>{row.action}</td><td className='py-1.5 pr-3 text-white/80'>{row.impressions}</td><td className='py-1.5 pr-3 text-white/80'>{row.acceptances}</td><td className='py-1.5 pr-3 text-white/80'>{Math.round(row.acceptanceRate * 100)}%</td><td className='py-1.5 pr-3 text-white/80'>{Math.round(row.postRecoveryProfileRate * 100)}%</td><td className='py-1.5 text-white/80'>{row.averageRestoredResults.toFixed(1)}</td></tr>)}</tbody></table></div>}
+    </section>
+
+    <section className='mt-3 rounded-md border border-white/10 bg-white/5 p-2'>
+      <h3 className='text-xs font-semibold uppercase tracking-wide text-white/80'>Related Botanicals performance</h3>
+      <p className='mt-1 text-xs text-white/65'>{relatedReport.attributedImpressions} unique card impressions · {relatedReport.attributedClicks} unique clicks{relatedReport.unattributedEvents ? ` · ${relatedReport.unattributedEvents} unattributed events excluded` : ''}</p>
+      {relatedReport.cardRows.length === 0 ? <p className='mt-2 text-xs text-white/60'>No Related Botanicals data yet.</p> : <div className='mt-2 overflow-x-auto'><table className='min-w-full text-xs'><thead><tr className='text-left text-white/65'><th className='pr-3 font-medium'>Card</th><th className='pr-3 font-medium'>Pos</th><th className='pr-3 font-medium'>Shown</th><th className='pr-3 font-medium'>Clicks</th><th className='pr-3 font-medium'>CTR</th><th className='pr-3 font-medium'>Avg depth</th><th className='font-medium'>Depth 3+</th></tr></thead><tbody>{relatedReport.cardRows.slice(0, 20).map(row => <tr key={`${row.sourceSlug}:${row.targetSlug}:${row.position}`} className='border-t border-white/10'><td className='py-1.5 pr-3 font-medium text-white/95'>{row.sourceSlug} → {row.targetSlug}</td><td className='py-1.5 pr-3 text-white/80'>{row.position}</td><td className='py-1.5 pr-3 text-white/80'>{row.impressions}</td><td className='py-1.5 pr-3 text-white/80'>{row.clicks}</td><td className='py-1.5 pr-3 text-white/80'>{Math.round(row.ctr * 100)}%</td><td className='py-1.5 pr-3 text-white/80'>{row.averageClickDepth.toFixed(1)}</td><td className='py-1.5 text-white/80'>{Math.round(row.deepExplorationRate * 100)}%</td></tr>)}</tbody></table></div>}
+
+      <h4 className='mt-3 text-xs font-semibold uppercase tracking-wide text-white/80'>Reason signal performance</h4>
+      {relatedReport.reasonRows.length === 0 ? <p className='mt-1 text-xs text-white/60'>No reason-signal data yet.</p> : <div className='mt-1 overflow-x-auto'><table className='min-w-full text-xs'><thead><tr className='text-left text-white/65'><th className='pr-3 font-medium'>Reason</th><th className='pr-3 font-medium'>Shown</th><th className='pr-3 font-medium'>Clicks</th><th className='pr-3 font-medium'>CTR</th><th className='pr-3 font-medium'>Avg depth</th><th className='font-medium'>Depth 3+</th></tr></thead><tbody>{relatedReport.reasonRows.map(row => <tr key={row.reasonType} className='border-t border-white/10'><td className='py-1.5 pr-3 font-medium text-white/95'>{row.reasonType}</td><td className='py-1.5 pr-3 text-white/80'>{row.impressions}</td><td className='py-1.5 pr-3 text-white/80'>{row.clicks}</td><td className='py-1.5 pr-3 text-white/80'>{Math.round(row.ctr * 100)}%</td><td className='py-1.5 pr-3 text-white/80'>{row.averageClickDepth.toFixed(1)}</td><td className='py-1.5 text-white/80'>{Math.round(row.deepExplorationRate * 100)}%</td></tr>)}</tbody></table></div>}
     </section>
 
     <p className='mt-3 text-xs text-white/75'>Total affiliate clicks: {clickEvents.length}</p>

--- a/src/lib/__tests__/related-botanical-performance-report.test.ts
+++ b/src/lib/__tests__/related-botanical-performance-report.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import { buildRelatedBotanicalPerformance } from '@/lib/atlasAnalyticsReport'
+
+describe('Related Botanicals analytics report', () => {
+  it('deduplicates repeated impressions and computes CTR/depth by card', () => {
+    const events = [
+      {
+        type: 'related_botanicals_shown',
+        slug: 'ashwagandha',
+        item: 'rhodiola~1~10~explicit-effect|compound-class,kava~2~8~explicit-effect',
+        context: 'session:s1;depth:1;reason_types:compound-class|explicit-effect',
+      },
+      {
+        type: 'related_botanicals_shown',
+        slug: 'ashwagandha',
+        item: 'rhodiola~1~10~explicit-effect|compound-class,kava~2~8~explicit-effect',
+        context: 'session:s1;depth:1;reason_types:compound-class|explicit-effect',
+      },
+      {
+        type: 'related_botanical_click',
+        slug: 'ashwagandha',
+        item: 'rhodiola',
+        context: 'session:s1;position:1;score:10;reason_types:explicit-effect|compound-class;profile_depth:2',
+      },
+      {
+        type: 'related_botanicals_shown',
+        slug: 'ashwagandha',
+        item: 'rhodiola~1~10~explicit-effect|compound-class,kava~2~8~explicit-effect',
+        context: 'session:s2;depth:1;reason_types:compound-class|explicit-effect',
+      },
+    ]
+
+    const report = buildRelatedBotanicalPerformance(events)
+    const rhodiola = report.cardRows.find((row) => row.targetSlug === 'rhodiola')
+    expect(rhodiola).toMatchObject({ impressions: 2, clicks: 1, position: 1 })
+    expect(rhodiola?.ctr).toBe(0.5)
+    expect(rhodiola?.averageClickDepth).toBe(2)
+    expect(rhodiola?.deepExplorationRate).toBe(0)
+    expect(report.attributedImpressions).toBe(4)
+    expect(report.attributedClicks).toBe(1)
+  })
+
+  it('attributes reason types per card and ranks deeper exploration first', () => {
+    const events = [
+      {
+        type: 'related_botanicals_shown', slug: 'a',
+        item: 'b~1~9~compound|explicit-effect,c~2~7~explicit-effect',
+        context: 'session:s1;depth:1;reason_types:compound|explicit-effect',
+      },
+      {
+        type: 'related_botanical_click', slug: 'a', item: 'b',
+        context: 'session:s1;position:1;score:9;reason_types:compound|explicit-effect;profile_depth:3',
+      },
+      {
+        type: 'related_botanicals_shown', slug: 'a',
+        item: 'b~1~9~compound|explicit-effect,c~2~7~explicit-effect',
+        context: 'session:s2;depth:1;reason_types:compound|explicit-effect',
+      },
+      {
+        type: 'related_botanical_click', slug: 'a', item: 'c',
+        context: 'session:s2;position:2;score:7;reason_types:explicit-effect;profile_depth:2',
+      },
+    ]
+
+    const report = buildRelatedBotanicalPerformance(events)
+    const compound = report.reasonRows.find((row) => row.reasonType === 'compound')
+    const effect = report.reasonRows.find((row) => row.reasonType === 'explicit-effect')
+
+    expect(compound).toMatchObject({ impressions: 2, clicks: 1, deepExplorationRate: 1 })
+    expect(effect).toMatchObject({ impressions: 4, clicks: 2, deepExplorationRate: 0.5 })
+    expect(report.reasonRows[0]?.reasonType).toBe('compound')
+  })
+
+  it('excludes events without a session id', () => {
+    const report = buildRelatedBotanicalPerformance([
+      { type: 'related_botanicals_shown', slug: 'a', item: 'b~1~9~compound', context: 'depth:1' },
+      { type: 'related_botanical_click', slug: 'a', item: 'b', context: 'position:1;profile_depth:2' },
+    ])
+
+    expect(report.attributedImpressions).toBe(0)
+    expect(report.attributedClicks).toBe(0)
+    expect(report.unattributedEvents).toBe(2)
+  })
+})

--- a/src/lib/atlasAnalyticsReport.ts
+++ b/src/lib/atlasAnalyticsReport.ts
@@ -2,6 +2,7 @@ export type AtlasAnalyticsEvent = {
   type?: string
   context?: string
   item?: string
+  slug?: string
 }
 
 export type AtlasSourcePerformanceRow = {
@@ -23,6 +24,26 @@ export type AtlasRecoveryPerformanceRow = {
   averageRestoredResults: number
 }
 
+export type RelatedBotanicalCardPerformanceRow = {
+  sourceSlug: string
+  targetSlug: string
+  position: number
+  impressions: number
+  clicks: number
+  ctr: number
+  averageClickDepth: number
+  deepExplorationRate: number
+}
+
+export type RelatedBotanicalReasonPerformanceRow = {
+  reasonType: string
+  impressions: number
+  clicks: number
+  ctr: number
+  averageClickDepth: number
+  deepExplorationRate: number
+}
+
 type SessionSummary = {
   source: string
   firstFilter: string
@@ -35,6 +56,18 @@ type RecoverySessionSummary = {
   accepted: string | null
   restoredResults: number
   profileOpened: boolean
+}
+
+type RelatedExposure = {
+  sessionId: string
+  sourceSlug: string
+  targetSlug: string
+  position: number
+  reasonTypes: string[]
+}
+
+type RelatedClick = RelatedExposure & {
+  profileDepth: number
 }
 
 export function parseAtlasContext(context = '') {
@@ -177,6 +210,141 @@ export function buildAtlasRecoveryPerformance(events: AtlasAnalyticsEvent[]) {
   return {
     rows,
     recoverySessions: Array.from(sessions.values()).filter((session) => session.shown.size || session.accepted).length,
+    unattributedEvents,
+  }
+}
+
+function parseReasonTypes(value = '') {
+  return value.split('|').map((item) => item.trim()).filter(Boolean)
+}
+
+function parseRelatedShownItems(item = '', fallbackReasonTypes: string[] = []) {
+  return item.split(',').map((entry) => {
+    const [targetSlug = '', positionRaw = '0', , reasonsRaw = ''] = entry.split('~')
+    return {
+      targetSlug,
+      position: Number(positionRaw) || 0,
+      reasonTypes: parseReasonTypes(reasonsRaw).length ? parseReasonTypes(reasonsRaw) : fallbackReasonTypes,
+    }
+  }).filter((entry) => entry.targetSlug)
+}
+
+export function buildRelatedBotanicalPerformance(events: AtlasAnalyticsEvent[]) {
+  const exposures = new Map<string, RelatedExposure>()
+  const clicks = new Map<string, RelatedClick>()
+  let unattributedEvents = 0
+
+  events.forEach((event) => {
+    if (event.type !== 'related_botanicals_shown' && event.type !== 'related_botanical_click') return
+    const values = parseAtlasContext(event.context)
+    const sessionId = values.get('session')
+    const sourceSlug = event.slug || 'unknown'
+    if (!sessionId) {
+      unattributedEvents += 1
+      return
+    }
+
+    if (event.type === 'related_botanicals_shown') {
+      const fallbackReasonTypes = parseReasonTypes(values.get('reason_types'))
+      parseRelatedShownItems(event.item, fallbackReasonTypes).forEach((item) => {
+        const key = `${sessionId}|${sourceSlug}|${item.targetSlug}`
+        if (!exposures.has(key)) exposures.set(key, { sessionId, sourceSlug, ...item })
+      })
+      return
+    }
+
+    const targetSlug = event.item || 'unknown'
+    const key = `${sessionId}|${sourceSlug}|${targetSlug}`
+    const click: RelatedClick = {
+      sessionId,
+      sourceSlug,
+      targetSlug,
+      position: Number(values.get('position') ?? 0) || 0,
+      reasonTypes: parseReasonTypes(values.get('reason_types')),
+      profileDepth: Number(values.get('profile_depth') ?? 0) || 0,
+    }
+    const prior = clicks.get(key)
+    if (!prior || click.profileDepth > prior.profileDepth) clicks.set(key, click)
+  })
+
+  const cardStats = new Map<string, {
+    sourceSlug: string
+    targetSlug: string
+    position: number
+    impressions: number
+    clicks: number
+    clickDepthTotal: number
+    deepClicks: number
+  }>()
+
+  exposures.forEach((exposure, key) => {
+    const groupKey = `${exposure.sourceSlug}|${exposure.targetSlug}|${exposure.position}`
+    const current = cardStats.get(groupKey) ?? {
+      sourceSlug: exposure.sourceSlug,
+      targetSlug: exposure.targetSlug,
+      position: exposure.position,
+      impressions: 0,
+      clicks: 0,
+      clickDepthTotal: 0,
+      deepClicks: 0,
+    }
+    current.impressions += 1
+    const click = clicks.get(key)
+    if (click) {
+      current.clicks += 1
+      current.clickDepthTotal += click.profileDepth
+      if (click.profileDepth >= 3) current.deepClicks += 1
+    }
+    cardStats.set(groupKey, current)
+  })
+
+  const cardRows: RelatedBotanicalCardPerformanceRow[] = Array.from(cardStats.values()).map((values) => ({
+    sourceSlug: values.sourceSlug,
+    targetSlug: values.targetSlug,
+    position: values.position,
+    impressions: values.impressions,
+    clicks: values.clicks,
+    ctr: values.impressions ? values.clicks / values.impressions : 0,
+    averageClickDepth: values.clicks ? values.clickDepthTotal / values.clicks : 0,
+    deepExplorationRate: values.clicks ? values.deepClicks / values.clicks : 0,
+  })).sort((a, b) => b.deepExplorationRate - a.deepExplorationRate
+    || b.ctr - a.ctr
+    || b.impressions - a.impressions
+    || a.sourceSlug.localeCompare(b.sourceSlug)
+    || a.targetSlug.localeCompare(b.targetSlug))
+
+  const reasonStats = new Map<string, { impressions: number; clicks: number; clickDepthTotal: number; deepClicks: number }>()
+  exposures.forEach((exposure, key) => {
+    const click = clicks.get(key)
+    Array.from(new Set(exposure.reasonTypes)).forEach((reasonType) => {
+      const current = reasonStats.get(reasonType) ?? { impressions: 0, clicks: 0, clickDepthTotal: 0, deepClicks: 0 }
+      current.impressions += 1
+      if (click) {
+        current.clicks += 1
+        current.clickDepthTotal += click.profileDepth
+        if (click.profileDepth >= 3) current.deepClicks += 1
+      }
+      reasonStats.set(reasonType, current)
+    })
+  })
+
+  const reasonRows: RelatedBotanicalReasonPerformanceRow[] = Array.from(reasonStats.entries()).map(([reasonType, values]) => ({
+    reasonType,
+    impressions: values.impressions,
+    clicks: values.clicks,
+    ctr: values.impressions ? values.clicks / values.impressions : 0,
+    averageClickDepth: values.clicks ? values.clickDepthTotal / values.clicks : 0,
+    deepExplorationRate: values.clicks ? values.deepClicks / values.clicks : 0,
+  })).sort((a, b) => b.deepExplorationRate - a.deepExplorationRate
+    || b.ctr - a.ctr
+    || b.impressions - a.impressions
+    || a.reasonType.localeCompare(b.reasonType))
+
+  return {
+    cardRows,
+    reasonRows,
+    attributedImpressions: exposures.size,
+    attributedClicks: clicks.size,
     unattributedEvents,
   }
 }

--- a/src/lib/relatedBotanicalTracking.ts
+++ b/src/lib/relatedBotanicalTracking.ts
@@ -56,7 +56,7 @@ export function trackRelatedBotanicalsShown(sourceSlug: string, items: RelatedBo
   appendAnalyticsEvent({
     type: 'related_botanicals_shown',
     slug: sourceSlug,
-    item: items.map((item) => `${item.slug}:${item.position}:${item.score}`).join(','),
+    item: items.map((item) => `${item.slug}~${item.position}~${item.score}~${item.reasonTypes.join('|')}`).join(','),
     context: `session:${session.sessionId};depth:${session.visitedProfiles.length};reason_types:${Array.from(new Set(items.flatMap((item) => item.reasonTypes))).sort().join('|')}`,
     sourceType: 'herb',
     targetType: 'herb',


### PR DESCRIPTION
## Summary
- add card-level Related Botanicals analytics to the existing developer viewer
- report unique impressions, clicks, CTR, average exploration depth, and depth-3+ rate
- report the same metrics by displayed relationship reason type
- preserve per-card reason types in impression events for exact attribution
- deduplicate repeated renders within the same session/source/target
- add regression tests for card CTR, reason attribution, deep exploration, and unattributed events

## Notes
Recommendation scoring remains server-side. Reporting uses the existing anonymous local/session analytics storage.