### PR TITLE
Add compare actions to Related Botanicals

### DIFF
--- a/components/RelatedBotanicalsTracked.tsx
+++ b/components/RelatedBotanicalsTracked.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { useEffect, useMemo } from 'react'
 import {
   trackRelatedBotanicalClick,
+  trackRelatedBotanicalCompare,
   trackRelatedBotanicalsShown,
   type RelatedBotanicalTrackingItem,
 } from '@/lib/relatedBotanicalTracking'
@@ -19,6 +20,7 @@ type RelatedBotanicalCard = {
   name: string
   scientificName?: string
   score: number
+  compareHref?: string
   reasons: DisplayReason[]
 }
 
@@ -58,14 +60,12 @@ export default function RelatedBotanicalsTracked({ sourceSlug, matches }: Props)
 
       <div className="grid gap-3 md:grid-cols-3">
         {matches.map((match, index) => (
-          <Link
+          <article
             key={match.slug}
-            href={`/herbs/${match.slug}/`}
-            onClick={() => trackRelatedBotanicalClick(sourceSlug, trackingItems[index])}
-            className="group rounded-2xl border border-brand-900/10 bg-[var(--surface-card)] p-4 transition hover:border-brand-600/30 hover:bg-brand-50/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2"
+            className="rounded-2xl border border-brand-900/10 bg-[var(--surface-card)] p-4 transition hover:border-brand-600/30 hover:bg-brand-50/40"
           >
             <div className="space-y-1">
-              <h3 className="font-bold text-ink group-hover:text-brand-800">{match.name}</h3>
+              <h3 className="font-bold text-ink">{match.name}</h3>
               {match.scientificName ? <p className="text-xs italic text-muted">{match.scientificName}</p> : null}
             </div>
 
@@ -81,8 +81,25 @@ export default function RelatedBotanicalsTracked({ sourceSlug, matches }: Props)
               </div>
             ) : null}
 
-            <p className="mt-3 text-xs font-bold text-brand-800">Explore profile →</p>
-          </Link>
+            <div className="mt-4 flex flex-wrap gap-2">
+              <Link
+                href={`/herbs/${match.slug}/`}
+                onClick={() => trackRelatedBotanicalClick(sourceSlug, trackingItems[index])}
+                className="inline-flex min-h-10 items-center rounded-full bg-brand-800 px-3.5 text-xs font-bold text-white transition hover:bg-brand-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2"
+              >
+                Explore profile →
+              </Link>
+              {match.compareHref ? (
+                <Link
+                  href={match.compareHref}
+                  onClick={() => trackRelatedBotanicalCompare(sourceSlug, trackingItems[index], match.compareHref!)}
+                  className="inline-flex min-h-10 items-center rounded-full border border-brand-900/15 px-3.5 text-xs font-bold text-brand-800 transition hover:bg-brand-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2"
+                >
+                  Compare ↔
+                </Link>
+              ) : null}
+            </div>
+          </article>
         ))}
       </div>
     </section>

--- a/components/SeeAlsoCluster.tsx
+++ b/components/SeeAlsoCluster.tsx
@@ -10,6 +10,7 @@ import Link from 'next/link'
 import { getClusterSeeAlso, getEntityClusters } from '@/lib/cluster-linking'
 import { getBotanicalAtlasRecords } from '@/lib/botanical-atlas-data'
 import { getRelatedBotanicals, type RelatedBotanicalMatch } from '@/lib/related-botanicals'
+import { getValidComparisonSlug } from '@/lib/comparison-utils'
 import RelatedBotanicalsTracked from '@/components/RelatedBotanicalsTracked'
 import type { EntityKind } from '@/lib/schema'
 
@@ -36,18 +37,22 @@ function meaningfulReasons(match: RelatedBotanicalMatch) {
   return (preferred.length ? preferred : fallback).slice(0, 2)
 }
 
-function toTrackedMatches(matches: RelatedBotanicalMatch[]) {
-  return matches.map((match) => ({
-    slug: match.record.slug,
-    name: match.record.name,
-    scientificName: match.record.scientificName,
-    score: match.score,
-    reasons: meaningfulReasons(match).map((reason) => ({
-      type: reason.type,
-      label: reason.label,
-      values: reason.values,
-    })),
-  }))
+function toTrackedMatches(sourceSlug: string, matches: RelatedBotanicalMatch[]) {
+  return matches.map((match) => {
+    const comparisonSlug = getValidComparisonSlug(sourceSlug, match.record.slug)
+    return {
+      slug: match.record.slug,
+      name: match.record.name,
+      scientificName: match.record.scientificName,
+      score: match.score,
+      compareHref: comparisonSlug ? `/guides/compare/${comparisonSlug}/` : undefined,
+      reasons: meaningfulReasons(match).map((reason) => ({
+        type: reason.type,
+        label: reason.label,
+        values: reason.values,
+      })),
+    }
+  })
 }
 
 export default async function SeeAlsoCluster({
@@ -92,7 +97,7 @@ export default async function SeeAlsoCluster({
   return (
     <div className={`space-y-4 ${className ?? ''}`}>
       {relatedMatches.length > 0 ? (
-        <RelatedBotanicalsTracked sourceSlug={relatedSourceSlug} matches={toTrackedMatches(relatedMatches)} />
+        <RelatedBotanicalsTracked sourceSlug={relatedSourceSlug} matches={toTrackedMatches(relatedSourceSlug, relatedMatches)} />
       ) : null}
 
       {grouped.length > 0 ? (

--- a/src/lib/__tests__/related-botanical-compare-routing.test.ts
+++ b/src/lib/__tests__/related-botanical-compare-routing.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+import { getValidComparisonSlug } from '@/lib/comparison-utils'
+
+describe('related botanical comparison routing', () => {
+  it('emits a comparison only when a static route is actually built', () => {
+    expect(getValidComparisonSlug('ashwagandha', 'rhodiola')).toBe('rhodiola-vs-ashwagandha')
+    expect(getValidComparisonSlug('ashwagandha', 'lemon-balm')).toBeUndefined()
+  })
+})

--- a/src/lib/__tests__/related-botanical-tracking.test.ts
+++ b/src/lib/__tests__/related-botanical-tracking.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { trackRelatedBotanicalClick, trackRelatedBotanicalsShown } from '@/lib/relatedBotanicalTracking'
+import {
+  trackRelatedBotanicalClick,
+  trackRelatedBotanicalCompare,
+  trackRelatedBotanicalsShown,
+} from '@/lib/relatedBotanicalTracking'
 
 const appendAnalyticsEvent = vi.fn()
 
@@ -19,7 +23,7 @@ describe('related botanical tracking', () => {
     expect(appendAnalyticsEvent).toHaveBeenCalledWith(expect.objectContaining({
       type: 'related_botanicals_shown',
       slug: 'ashwagandha',
-      item: 'rhodiola:1:10.5',
+      item: 'rhodiola~1~10.5~explicit-effect|compound-class',
       context: expect.stringContaining('depth:1'),
     }))
   })
@@ -47,6 +51,20 @@ describe('related botanical tracking', () => {
 
     expect(appendAnalyticsEvent).toHaveBeenLastCalledWith(expect.objectContaining({
       context: expect.stringContaining('profile_depth:2'),
+    }))
+  })
+
+  it('tracks comparison clicks without inflating profile exploration depth', () => {
+    const item = { slug: 'rhodiola', position: 1, score: 10.5, reasonTypes: ['explicit-effect'] }
+    trackRelatedBotanicalsShown('ashwagandha', [item])
+    trackRelatedBotanicalCompare('ashwagandha', item, '/guides/compare/rhodiola-vs-ashwagandha/')
+
+    expect(appendAnalyticsEvent).toHaveBeenLastCalledWith(expect.objectContaining({
+      type: 'related_botanical_compare_click',
+      slug: 'ashwagandha',
+      item: 'rhodiola',
+      targetType: 'comparison',
+      context: expect.stringContaining('profile_depth:1'),
     }))
   })
 })

--- a/src/lib/relatedBotanicalTracking.ts
+++ b/src/lib/relatedBotanicalTracking.ts
@@ -81,3 +81,16 @@ export function trackRelatedBotanicalClick(sourceSlug: string, item: RelatedBota
     targetType: 'herb',
   })
 }
+
+export function trackRelatedBotanicalCompare(sourceSlug: string, item: RelatedBotanicalTrackingItem, compareHref: string) {
+  if (typeof window === 'undefined') return
+  const session = ensureSourceVisited(sourceSlug)
+  appendAnalyticsEvent({
+    type: 'related_botanical_compare_click',
+    slug: sourceSlug,
+    item: item.slug,
+    context: `session:${session.sessionId};position:${item.position};score:${item.score};reason_types:${item.reasonTypes.join('|')};compare_href:${compareHref};profile_depth:${session.visitedProfiles.length}`,
+    sourceType: 'herb',
+    targetType: 'comparison',
+  })
+}


### PR DESCRIPTION
## Summary
- add one-click Compare actions to Related Botanicals cards when a real static comparison route exists
- guard all generated compare links with getValidComparisonSlug so no phantom /guides/compare/* URLs are emitted
- restructure cards to avoid nested links
- track compare clicks separately from profile exploration clicks
- add regression coverage for compare routing and compare analytics
- fix the stale related-botanical impression test expectation to the current per-card reason encoding

## SEO safety
No comparison link is rendered unless the route is present in BUILT_COMPARE_SLUGS.