### PR TITLE
Add ranked comparison opportunity shortlist

### DIFF
--- a/.github/workflows/related-botanicals-audit.yml
+++ b/.github/workflows/related-botanicals-audit.yml
@@ -6,14 +6,20 @@ on:
     paths:
       - 'src/lib/related-botanicals.ts'
       - 'src/lib/botanical-atlas-data.ts'
+      - 'src/lib/comparison-shortlist.ts'
+      - 'lib/comparison-utils.ts'
       - 'scripts/audit-related-botanicals.ts'
+      - 'scripts/rank-related-comparisons.ts'
       - '.github/workflows/related-botanicals-audit.yml'
   push:
     branches: [main]
     paths:
       - 'src/lib/related-botanicals.ts'
       - 'src/lib/botanical-atlas-data.ts'
+      - 'src/lib/comparison-shortlist.ts'
+      - 'lib/comparison-utils.ts'
       - 'scripts/audit-related-botanicals.ts'
+      - 'scripts/rank-related-comparisons.ts'
 
 jobs:
   audit:
@@ -29,8 +35,13 @@ jobs:
         run: npm run data:build:core
       - name: Generate recommendation audit
         run: npx tsx scripts/audit-related-botanicals.ts
+      - name: Generate comparison shortlist
+        run: npx tsx scripts/rank-related-comparisons.ts
       - name: Add summary
-        run: cat reports/related-botanicals/related-botanicals-audit.md >> "$GITHUB_STEP_SUMMARY"
+        run: |
+          cat reports/related-botanicals/related-botanicals-audit.md >> "$GITHUB_STEP_SUMMARY"
+          printf '\n\n' >> "$GITHUB_STEP_SUMMARY"
+          cat reports/related-botanicals/comparison-shortlist.md >> "$GITHUB_STEP_SUMMARY"
       - name: Upload audit artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/scripts/rank-related-comparisons.ts
+++ b/scripts/rank-related-comparisons.ts
@@ -1,0 +1,42 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { getBotanicalAtlasRecords } from '../src/lib/botanical-atlas-data'
+import { buildComparisonShortlist } from '../src/lib/comparison-shortlist'
+
+const outputDir = path.resolve(process.cwd(), 'reports/related-botanicals')
+const limit = Math.max(1, Number(process.env.COMPARISON_SHORTLIST_LIMIT ?? 30) || 30)
+const records = await getBotanicalAtlasRecords()
+const rows = buildComparisonShortlist(records, limit)
+
+const markdown = [
+  '# Curated Botanical Comparison Shortlist',
+  '',
+  `Generated: ${new Date().toISOString()}`,
+  '',
+  'Ranks unbuilt botanical comparison opportunities. Relationship strength stays primary; chemistry support, evidence strength, and multiple specific shared effects add priority. This is an editorial shortlist, not an auto-publishing queue.',
+  '',
+  '| Rank | Pair | Priority | Relationship | Chemistry | Evidence | Shared specific effects |',
+  '| ---: | --- | ---: | ---: | :---: | --- | --- |',
+  ...rows.map((row, index) => `| ${index + 1} | **${row.a.name} vs ${row.b.name}** | ${row.priorityScore.toFixed(2)} | ${row.relationshipScore.toFixed(2)} | ${row.chemistrySupported ? 'yes' : 'no'} | ${row.evidenceLabel} | ${row.sharedSpecificEffects.slice(0, 4).join(', ') || '—'} |`),
+  '',
+  '## Why these rank',
+  '',
+  ...rows.slice(0, 15).flatMap((row, index) => [
+    `### ${index + 1}. ${row.a.name} vs ${row.b.name}`,
+    '',
+    `- Priority score: ${row.priorityScore.toFixed(2)}`,
+    `- Relationship score: ${row.relationshipScore.toFixed(2)}`,
+    `- Chemistry-supported: ${row.chemistrySupported ? 'yes' : 'no'}`,
+    `- Pair evidence tier: ${row.evidenceLabel}`,
+    ...row.reasons.slice(0, 4).map((reason) => `- ${reason.label}: ${reason.values.join(', ')}`),
+    '',
+  ]),
+].join('\n')
+
+await mkdir(outputDir, { recursive: true })
+await Promise.all([
+  writeFile(path.join(outputDir, 'comparison-shortlist.json'), JSON.stringify({ generatedAt: new Date().toISOString(), rows }, null, 2) + '\n'),
+  writeFile(path.join(outputDir, 'comparison-shortlist.md'), markdown + '\n'),
+])
+
+console.log(JSON.stringify({ candidates: rows.length, top: rows.slice(0, 5).map((row) => `${row.a.name} vs ${row.b.name}`) }, null, 2))

--- a/src/lib/__tests__/comparison-shortlist.test.ts
+++ b/src/lib/__tests__/comparison-shortlist.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { buildComparisonShortlist, evidenceTier } from '@/lib/comparison-shortlist'
+import type { RelatedBotanicalRecord } from '@/lib/related-botanicals'
+
+const herb = (slug: string, overrides: Partial<RelatedBotanicalRecord> = {}): RelatedBotanicalRecord => ({
+  slug,
+  name: slug,
+  effects: ['calming'],
+  explicitEffects: ['calming'],
+  compounds: [],
+  compoundClasses: [],
+  evidence: 'Moderate',
+  intensity: 'Mild',
+  safety: [],
+  ...overrides,
+})
+
+describe('comparison shortlist', () => {
+  it('normalizes evidence tiers', () => {
+    expect(evidenceTier('Strong')).toBe(3)
+    expect(evidenceTier('Moderate')).toBe(2)
+    expect(evidenceTier('Limited')).toBe(1)
+    expect(evidenceTier('Unclassified')).toBe(0)
+  })
+
+  it('excludes already-built comparisons and deduplicates reversed pairs', () => {
+    const rows = buildComparisonShortlist([
+      herb('ashwagandha'),
+      herb('rhodiola'),
+      herb('lemon-balm'),
+    ], 20)
+
+    expect(rows.some((row) => new Set([row.a.slug, row.b.slug]).has('ashwagandha') && new Set([row.a.slug, row.b.slug]).has('rhodiola'))).toBe(false)
+    const lemonPairs = rows.filter((row) => row.a.slug === 'lemon-balm' || row.b.slug === 'lemon-balm')
+    const keys = lemonPairs.map((row) => [row.a.slug, row.b.slug].sort().join('::'))
+    expect(new Set(keys).size).toBe(keys.length)
+  })
+
+  it('prioritizes chemistry-supported, better-evidenced candidates', () => {
+    const source = herb('source', { evidence: 'Strong', compoundClasses: ['alkaloid'] })
+    const chemistry = herb('chemistry', { evidence: 'Strong', compoundClasses: ['alkaloid'] })
+    const effectOnly = herb('effect-only', { evidence: 'Limited' })
+
+    const rows = buildComparisonShortlist([source, chemistry, effectOnly], 20)
+    const chemistryPair = rows.find((row) => [row.a.slug, row.b.slug].includes('source') && [row.a.slug, row.b.slug].includes('chemistry'))
+    const effectPair = rows.find((row) => [row.a.slug, row.b.slug].includes('source') && [row.a.slug, row.b.slug].includes('effect-only'))
+
+    expect(chemistryPair).toBeTruthy()
+    expect(effectPair).toBeTruthy()
+    expect(chemistryPair!.chemistrySupported).toBe(true)
+    expect(chemistryPair!.priorityScore).toBeGreaterThan(effectPair!.priorityScore)
+  })
+})

--- a/src/lib/comparison-shortlist.ts
+++ b/src/lib/comparison-shortlist.ts
@@ -1,0 +1,80 @@
+import { getValidComparisonSlug } from '@/lib/comparison-utils'
+import { scoreRelatedBotanical, type RelatedBotanicalRecord, type RelatedBotanicalReason } from '@/lib/related-botanicals'
+
+export type ComparisonShortlistRow = {
+  a: RelatedBotanicalRecord
+  b: RelatedBotanicalRecord
+  relationshipScore: number
+  priorityScore: number
+  chemistrySupported: boolean
+  sharedSpecificEffects: string[]
+  evidenceTier: number
+  evidenceLabel: string
+  reasons: RelatedBotanicalReason[]
+}
+
+const GENERIC_EFFECTS = new Set(['antioxidant', 'tonic'])
+
+function normalize(value = '') {
+  return value.trim().toLowerCase()
+}
+
+export function evidenceTier(value = '') {
+  const text = normalize(value)
+  if (!text || text === 'unclassified' || text === 'unknown') return 0
+  if (/strong|high|robust|well[- ]?supported/.test(text)) return 3
+  if (/moderate|medium|mixed/.test(text)) return 2
+  if (/limited|low|preliminary|emerging|traditional/.test(text)) return 1
+  return 1
+}
+
+function pairKey(a: string, b: string) {
+  return [a, b].sort().join('::')
+}
+
+export function buildComparisonShortlist(records: RelatedBotanicalRecord[], limit = 30) {
+  const seen = new Set<string>()
+  const rows: ComparisonShortlistRow[] = []
+
+  for (const a of records) {
+    for (const b of records) {
+      if (a.slug === b.slug) continue
+      const key = pairKey(a.slug, b.slug)
+      if (seen.has(key)) continue
+      seen.add(key)
+
+      if (getValidComparisonSlug(a.slug, b.slug)) continue
+      const match = scoreRelatedBotanical(a, b)
+      if (!match) continue
+
+      const chemistrySupported = match.reasons.some((reason) => reason.type === 'compound' || reason.type === 'compound-class')
+      const sharedSpecificEffects = match.reasons
+        .find((reason) => reason.type === 'explicit-effect')?.values
+        .filter((value) => !GENERIC_EFFECTS.has(normalize(value))) ?? []
+      const tier = Math.min(evidenceTier(a.evidence), evidenceTier(b.evidence))
+      const priorityScore = match.score
+        + (chemistrySupported ? 4 : 0)
+        + tier * 2
+        + Math.min(sharedSpecificEffects.length, 3)
+
+      rows.push({
+        a,
+        b,
+        relationshipScore: match.score,
+        priorityScore: Number(priorityScore.toFixed(4)),
+        chemistrySupported,
+        sharedSpecificEffects,
+        evidenceTier: tier,
+        evidenceLabel: tier === 3 ? 'strong' : tier === 2 ? 'moderate' : tier === 1 ? 'limited' : 'unclassified',
+        reasons: match.reasons,
+      })
+    }
+  }
+
+  return rows
+    .sort((x, y) => y.priorityScore - x.priorityScore
+      || y.relationshipScore - x.relationshipScore
+      || x.a.name.localeCompare(y.a.name)
+      || x.b.name.localeCompare(y.b.name))
+    .slice(0, Math.max(0, limit))
+}


### PR DESCRIPTION
## Summary
- rank unbuilt Related Botanicals pairs for editorial comparison-page expansion
- keep relationship strength primary, with bonuses for chemistry support, evidence tier, and multiple specific shared effects
- exclude already-built static comparison routes and deduplicate reversed pairs
- generate Markdown and JSON shortlist artifacts
- include the shortlist in the existing Related Botanicals audit workflow and job summary
- add regression tests for evidence tiers, built-route exclusion, pair deduplication, and priority scoring

## Editorial guardrail
This produces a developer shortlist only. It does not auto-create or auto-publish comparison pages.