### PR TITLE
Filter aliases from comparison shortlist

### DIFF
--- a/docs/.comparison-shortlist-alias-fix
+++ b/docs/.comparison-shortlist-alias-fix
@@ -1,0 +1,1 @@
+Alias filtering for curated comparison shortlist.

--- a/docs/.comparison-shortlist-alias-fix
+++ b/docs/.comparison-shortlist-alias-fix
@@ -1,1 +1,0 @@
-Alias filtering for curated comparison shortlist.

--- a/src/lib/__tests__/comparison-shortlist.test.ts
+++ b/src/lib/__tests__/comparison-shortlist.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildComparisonShortlist, evidenceTier } from '@/lib/comparison-shortlist'
+import { buildComparisonShortlist, evidenceTier, isAliasPair } from '@/lib/comparison-shortlist'
 import type { RelatedBotanicalRecord } from '@/lib/related-botanicals'
 
 const herb = (slug: string, overrides: Partial<RelatedBotanicalRecord> = {}): RelatedBotanicalRecord => ({
@@ -34,6 +34,20 @@ describe('comparison shortlist', () => {
     const lemonPairs = rows.filter((row) => row.a.slug === 'lemon-balm' || row.b.slug === 'lemon-balm')
     const keys = lemonPairs.map((row) => [row.a.slug, row.b.slug].sort().join('::'))
     expect(new Set(keys).size).toBe(keys.length)
+  })
+
+  it('filters scientific-name aliases and common-name to Latin-name duplicates', () => {
+    const astragalus = herb('astragalus', { name: 'Astragalus', scientificName: 'Astragalus membranaceus' })
+    const astragalusLatin = herb('astragalus-membranaceus', { name: 'Astragalus Membranaceus' })
+    const phellodendron = herb('phellodendron', { name: 'Phellodendron', scientificName: 'Phellodendron amurense' })
+    const phellodendronLatin = herb('phellodendron-amurense', { name: 'Phellodendron Amurense' })
+
+    expect(isAliasPair(astragalus, astragalusLatin)).toBe(true)
+    expect(isAliasPair(phellodendron, phellodendronLatin)).toBe(true)
+
+    const rows = buildComparisonShortlist([astragalus, astragalusLatin, phellodendron, phellodendronLatin], 20)
+    expect(rows.some((row) => new Set([row.a.slug, row.b.slug]).has('astragalus') && new Set([row.a.slug, row.b.slug]).has('astragalus-membranaceus'))).toBe(false)
+    expect(rows.some((row) => new Set([row.a.slug, row.b.slug]).has('phellodendron') && new Set([row.a.slug, row.b.slug]).has('phellodendron-amurense'))).toBe(false)
   })
 
   it('prioritizes chemistry-supported, better-evidenced candidates', () => {

--- a/src/lib/comparison-shortlist.ts
+++ b/src/lib/comparison-shortlist.ts
@@ -16,7 +16,7 @@ export type ComparisonShortlistRow = {
 const GENERIC_EFFECTS = new Set(['antioxidant', 'tonic'])
 
 function normalize(value = '') {
-  return value.trim().toLowerCase()
+  return value.trim().toLowerCase().replace(/\s+/g, ' ')
 }
 
 export function evidenceTier(value = '') {
@@ -32,13 +32,27 @@ function pairKey(a: string, b: string) {
   return [a, b].sort().join('::')
 }
 
+export function isAliasPair(a: RelatedBotanicalRecord, b: RelatedBotanicalRecord) {
+  const aName = normalize(a.name)
+  const bName = normalize(b.name)
+  const aScientific = normalize(a.scientificName)
+  const bScientific = normalize(b.scientificName)
+
+  if (aName && aName === bName) return true
+  if (aScientific && bScientific && aScientific === bScientific) return true
+  if (aScientific && aScientific === bName) return true
+  if (bScientific && bScientific === aName) return true
+
+  return false
+}
+
 export function buildComparisonShortlist(records: RelatedBotanicalRecord[], limit = 30) {
   const seen = new Set<string>()
   const rows: ComparisonShortlistRow[] = []
 
   for (const a of records) {
     for (const b of records) {
-      if (a.slug === b.slug) continue
+      if (a.slug === b.slug || isAliasPair(a, b)) continue
       const key = pairKey(a.slug, b.slug)
       if (seen.has(key)) continue
       seen.add(key)


### PR DESCRIPTION
## Summary
- filter same-botanical aliases from the curated comparison shortlist
- detect shared scientific-name identity and common-name ↔ Latin-name duplicates
- add regression coverage for Astragalus/Astragalus membranaceus and Phellodendron/Phellodendron amurense-style duplicates

## Why
The first real shortlist was polluted by duplicate identity records, which pushed alias pairs above genuinely useful editorial comparisons. This keeps the queue focused on distinct botanicals.