### PR TITLE
Add second curated botanical comparison batch

### DIFF
--- a/app/guides/compare/coffee-vs-guarana/page.tsx
+++ b/app/guides/compare/coffee-vs-guarana/page.tsx
@@ -1,0 +1,92 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+import { buildPageMetadata } from '../../../../src/lib/seo'
+import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
+import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
+import CitationReadySummary from '@/components/seo/CitationReadySummary'
+import FAQSchema from '@/components/seo/FAQSchema'
+import References from '@/components/References'
+import AffiliateDisclosure from '../../../../components/AffiliateDisclosure'
+import Disclaimer from '../../../../src/components/Disclaimer'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Coffee vs Guarana: Caffeine Sources Compared',
+  description: 'Evidence-aware comparison of coffee and guarana for caffeine exposure, energy, timing, product variability, and stimulant safety.',
+  path: '/guides/compare/coffee-vs-guarana/',
+})
+
+const REFS = [
+  { n: 1, text: 'Socała K, et al. (2020). Neuroprotective effects of coffee bioactive compounds: a review.', url: 'https://pubmed.ncbi.nlm.nih.gov/33374338/' },
+  { n: 2, text: 'Safe S, et al. (2023). Health benefits of coffee consumption and mechanisms of action.', url: 'https://pubmed.ncbi.nlm.nih.gov/36769029/' },
+  { n: 3, text: 'Torres EAFS, et al. (2022). Effects of the consumption of guarana on human health: a narrative review.', url: 'https://pubmed.ncbi.nlm.nih.gov/34755935/' },
+  { n: 4, text: 'Jagim AR, et al. (2023). ISSN position stand: energy drinks and energy shots.', url: 'https://pubmed.ncbi.nlm.nih.gov/36862943/' },
+]
+
+const ROWS = [
+  { dimension: 'Main stimulant', coffee: 'Caffeine, alongside chlorogenic acids and many other coffee compounds.', guarana: 'Caffeine is the dominant stimulant; commercial extracts can be highly concentrated.' },
+  { dimension: 'Dose transparency', coffee: 'Cup-to-cup caffeine varies by bean, roast, brew method, and serving size.', guarana: 'Product variability can be even harder to judge unless the label explicitly states caffeine content.' },
+  { dimension: 'Typical context', coffee: 'Beverage consumed for alertness, taste, and routine.', guarana: 'Often appears in supplements, energy blends, powders, or beverages.' },
+  { dimension: 'Main safety edge', coffee: 'Excess caffeine can worsen anxiety, insomnia, palpitations, or blood-pressure response.', guarana: 'Same caffeine risks, plus a greater chance of accidental stimulant stacking in multi-ingredient products.' },
+]
+
+export default function CoffeeVsGuaranaPage() {
+  return (
+    <div className="container-page space-y-10 py-10">
+      <AuthorityJsonLd title="Coffee vs Guarana" description="Evidence-aware comparison of two common caffeine sources." url="https://thehippiescientist.net/guides/compare/coffee-vs-guarana/" type="Article" />
+      <AuthorityBreadcrumbs items={[{ label: 'Home', href: '/' }, { label: 'Compare', href: '/guides/compare/' }, { label: 'Coffee vs Guarana' }]} />
+
+      <section className="max-w-4xl space-y-5">
+        <p className="eyebrow-label">Educational Comparison · Stimulant Cluster</p>
+        <h1 className="text-4xl font-bold tracking-tight text-ink sm:text-5xl">Coffee vs Guarana: Same Core Stimulant, Different Delivery</h1>
+        <p className="text-lg leading-8 text-muted">Both ultimately deliver caffeine. The practical difference is usually the matrix and the label: coffee is a familiar beverage with variable caffeine per cup, while guarana often appears as a concentrated ingredient inside supplements and energy products.</p>
+      </section>
+
+      <CitationReadySummary
+        answer="Coffee and guarana are both meaningful caffeine sources. Neither has a special exemption from caffeine's stimulant effects: dose, timing, individual sensitivity, and total daily intake matter more than whether the caffeine came from coffee beans or guarana seed."
+        bestFor={[
+          'Comparing ordinary coffee with guarana-containing supplements or energy products.',
+          'Understanding why total caffeine matters more than a “natural energy” label.',
+          'Avoiding accidental stimulant stacking from multiple caffeine sources.',
+        ]}
+        evidenceLevel="Coffee has a broad observational and mechanistic literature. Guarana has a smaller human evidence base, with many practical effects likely driven substantially by caffeine exposure."
+        safetyNote="Both can contribute to insomnia, anxiety, tremor, palpitations, and blood-pressure elevation. Guarana products should disclose caffeine content clearly before they are combined with coffee, energy drinks, stimulant medicines, or other caffeine sources."
+        notClaiming="This page is not claiming coffee or guarana treats fatigue, ADHD, cognitive impairment, or any diagnosed condition."
+        referencesHref="#references"
+      />
+
+      <section className="card-premium p-6 sm:p-8">
+        <h2 className="text-2xl font-semibold text-ink">Side by side</h2>
+        <div className="mt-6 overflow-x-auto">
+          <table className="min-w-full border-collapse text-left text-sm">
+            <thead><tr className="border-b border-brand-900/10"><th className="py-3 pr-4">Dimension</th><th className="py-3 pr-4">Coffee</th><th className="py-3">Guarana</th></tr></thead>
+            <tbody>{ROWS.map((row) => <tr key={row.dimension} className="border-b border-brand-900/5 align-top last:border-0"><td className="py-3 pr-4 font-semibold text-ink">{row.dimension}</td><td className="py-3 pr-4 text-muted">{row.coffee}</td><td className="py-3 text-muted">{row.guarana}</td></tr>)}</tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="card-premium space-y-4 p-6 sm:p-8">
+        <h2 className="text-2xl font-semibold text-ink">The important variable is total caffeine</h2>
+        <div className="space-y-4 text-sm leading-7 text-muted">
+          <p><strong className="text-ink">Coffee</strong> contains caffeine within a complex beverage matrix that also includes chlorogenic acids and many other bioactive compounds.<sup>[1][2]</sup> That makes coffee more than purified caffeine, but caffeine still explains much of the acute alerting effect.</p>
+          <p><strong className="text-ink">Guarana</strong> is a caffeine-rich seed commonly used in energy products and supplements. Human-health reviews emphasize both its stimulant potential and the importance of understanding actual caffeine exposure.<sup>[3]</sup></p>
+          <p>The biggest practical hazard is stacking: coffee in the morning, a guarana-containing pre-workout later, then an energy drink can become a much larger caffeine load than any one label suggests. Energy-product guidance therefore focuses heavily on disclosed caffeine dose and total intake.<sup>[4]</sup></p>
+        </div>
+      </section>
+
+      <section className="grid gap-4 sm:grid-cols-2">
+        <Link href="/herbs/coffea-arabica/" className="card-premium p-5 font-semibold text-brand-800">Explore Coffee →</Link>
+        <Link href="/herbs/guarana/" className="card-premium p-5 font-semibold text-brand-800">Explore Guarana →</Link>
+      </section>
+
+      <FAQSchema pagePath="/guides/compare/coffee-vs-guarana/" questions={[
+        { question: 'Is guarana stronger than coffee?', answer: 'Not inherently. The relevant comparison is caffeine dose. A concentrated guarana extract can deliver more caffeine than a cup of coffee, but products vary widely.' },
+        { question: 'Does guarana contain caffeine?', answer: 'Yes. Guarana seed is naturally caffeine-rich, and many guarana products are used specifically for their stimulant caffeine content.' },
+        { question: 'Can you use coffee and guarana together?', answer: 'They can add together as caffeine sources. Combining them increases total stimulant exposure and can raise the chance of insomnia, anxiety, tremor, palpitations, or blood-pressure effects.' },
+      ]} />
+
+      <div className="space-y-3"><AffiliateDisclosure /><Disclaimer /></div>
+      <References refs={REFS} />
+    </div>
+  )
+}

--- a/app/guides/compare/coptis-vs-goldenseal/page.tsx
+++ b/app/guides/compare/coptis-vs-goldenseal/page.tsx
@@ -1,0 +1,92 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+import { buildPageMetadata } from '../../../../src/lib/seo'
+import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
+import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
+import CitationReadySummary from '@/components/seo/CitationReadySummary'
+import FAQSchema from '@/components/seo/FAQSchema'
+import References from '@/components/References'
+import AffiliateDisclosure from '../../../../components/AffiliateDisclosure'
+import Disclaimer from '../../../../src/components/Disclaimer'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Coptis vs Goldenseal: Berberine-Rich Herbs Compared',
+  description: 'Evidence-aware comparison of Coptis and Goldenseal, including shared berberine chemistry, safety, interactions, and practical differences.',
+  path: '/guides/compare/coptis-vs-goldenseal/',
+})
+
+const REFS = [
+  { n: 1, text: 'Song D, et al. (2020). Biological properties and clinical applications of berberine.', url: 'https://pubmed.ncbi.nlm.nih.gov/32335802/' },
+  { n: 2, text: 'Cheng W, et al. (2023). Herb-drug interactions and their impact on pharmacokinetics: an update.', url: 'https://pubmed.ncbi.nlm.nih.gov/36650621/' },
+  { n: 3, text: 'Asher GN, et al. (2017). Common herbal dietary supplement-drug interactions.', url: 'https://pubmed.ncbi.nlm.nih.gov/28762712/' },
+  { n: 4, text: 'Cicero AFG, et al. (2016). Berberine and its role in chronic disease.', url: 'https://pubmed.ncbi.nlm.nih.gov/27671811/' },
+]
+
+const ROWS = [
+  { dimension: 'Shared chemistry', coptis: 'Berberine and palmatine are prominent shared alkaloids; Coptis also commonly carries coptisine.', goldenseal: 'Berberine and palmatine overlap with Coptis; hydrastine is a distinguishing Goldenseal constituent.' },
+  { dimension: 'Site evidence emphasis', coptis: 'Inflammatory and metabolic signaling, with berberine-centered mechanistic evidence.', goldenseal: 'Inflammatory signaling plus a particularly important herb-drug interaction burden.' },
+  { dimension: 'Medication caution', coptis: 'High. Caution with antidiabetic medicines, CYP/P-gp substrates, anticoagulants, and immunosuppressants.', goldenseal: 'High. Goldenseal is especially notable for clinically relevant interaction concerns involving CYP/P-gp pathways.' },
+  { dimension: 'Pregnancy / infants', coptis: 'Avoid medicinal use in pregnancy/breastfeeding and infants without specialist oversight.', goldenseal: 'Avoid in pregnancy/breastfeeding and infants; berberine-containing products raise bilirubin-risk concerns.' },
+]
+
+export default function CoptisVsGoldensealPage() {
+  return (
+    <div className="container-page space-y-10 py-10">
+      <AuthorityJsonLd title="Coptis vs Goldenseal" description="Evidence-aware comparison of two berberine-rich botanicals." url="https://thehippiescientist.net/guides/compare/coptis-vs-goldenseal/" type="Article" />
+      <AuthorityBreadcrumbs items={[{ label: 'Home', href: '/' }, { label: 'Compare', href: '/guides/compare/' }, { label: 'Coptis vs Goldenseal' }]} />
+
+      <section className="max-w-4xl space-y-5">
+        <p className="eyebrow-label">Educational Comparison · Alkaloid Cluster</p>
+        <h1 className="text-4xl font-bold tracking-tight text-ink sm:text-5xl">Coptis vs Goldenseal: Similar Berberine Chemistry, Different Botanical Profiles</h1>
+        <p className="text-lg leading-8 text-muted">These herbs overlap strongly in berberine-family alkaloids, which is exactly why they should not be treated as interchangeable or casually stacked. The useful comparison is chemistry, interaction burden, and preparation—not which one is “stronger.”</p>
+      </section>
+
+      <CitationReadySummary
+        answer="Coptis and Goldenseal are chemically related because both contain berberine-family alkaloids, including berberine and palmatine. Coptis also commonly includes coptisine, while Goldenseal is distinguished by hydrastine. Both deserve substantial medication-interaction caution."
+        bestFor={[
+          'Understanding how two berberine-rich herbs overlap chemically.',
+          'Comparing interaction burden before choosing a botanical product.',
+          'Avoiding the assumption that two herbs sharing berberine are equivalent preparations.',
+        ]}
+        evidenceLevel="The strongest shared evidence is constituent- and mechanism-centered rather than proof that either whole herb treats a specific disease."
+        safetyNote="Both can carry meaningful drug-interaction concerns. Avoid medicinal use in pregnancy/breastfeeding and infants, and review use with a clinician or pharmacist when taking prescription medicines."
+        notClaiming="This page is not claiming either herb treats infection, diabetes, inflammatory disease, or any other diagnosed condition."
+        referencesHref="#references"
+      />
+
+      <section className="card-premium p-6 sm:p-8">
+        <h2 className="text-2xl font-semibold text-ink">Side by side</h2>
+        <div className="mt-6 overflow-x-auto">
+          <table className="min-w-full border-collapse text-left text-sm">
+            <thead><tr className="border-b border-brand-900/10"><th className="py-3 pr-4">Dimension</th><th className="py-3 pr-4">Coptis</th><th className="py-3">Goldenseal</th></tr></thead>
+            <tbody>{ROWS.map((row) => <tr key={row.dimension} className="border-b border-brand-900/5 align-top last:border-0"><td className="py-3 pr-4 font-semibold text-ink">{row.dimension}</td><td className="py-3 pr-4 text-muted">{row.coptis}</td><td className="py-3 text-muted">{row.goldenseal}</td></tr>)}</tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="card-premium space-y-4 p-6 sm:p-8">
+        <h2 className="text-2xl font-semibold text-ink">The practical distinction</h2>
+        <div className="space-y-4 text-sm leading-7 text-muted">
+          <p><strong className="text-ink">Coptis</strong> is useful to think of as a berberine-rich rhizome with additional alkaloids such as coptisine. Its evidence base on this site is concentrated around berberine biology, inflammatory signaling, and metabolic pathways.<sup>[1][2]</sup></p>
+          <p><strong className="text-ink">Goldenseal</strong> also contains berberine, but its constituent profile includes hydrastine and its interaction story is especially important. Reviews of herbal supplement-drug interactions repeatedly flag Goldenseal as a botanical that can materially alter drug metabolism.<sup>[3][4]</sup></p>
+          <p>Because both share potentially active alkaloids, combining them can increase exposure without creating a clearly proven benefit. That makes “which preparation is appropriate?” a better question than “can I stack both?”</p>
+        </div>
+      </section>
+
+      <section className="grid gap-4 sm:grid-cols-2">
+        <Link href="/herbs/coptis/" className="card-premium p-5 font-semibold text-brand-800">Explore Coptis →</Link>
+        <Link href="/herbs/goldenseal/" className="card-premium p-5 font-semibold text-brand-800">Explore Goldenseal →</Link>
+      </section>
+
+      <FAQSchema pagePath="/guides/compare/coptis-vs-goldenseal/" questions={[
+        { question: 'Do Coptis and Goldenseal both contain berberine?', answer: 'Yes. Both are berberine-rich botanicals and also overlap in palmatine. Their complete constituent profiles differ, so they should not be treated as identical products.' },
+        { question: 'Can Coptis and Goldenseal be taken together?', answer: 'There is not a strong evidence base showing that combining the two improves outcomes, while overlapping alkaloids may increase interaction or tolerability concerns. Medication review is especially important.' },
+        { question: 'Which has more drug-interaction concern?', answer: 'Both deserve caution. Goldenseal is particularly well known for herb-drug interaction concerns involving drug-metabolizing pathways, while Coptis also carries cautions with antidiabetic medicines and CYP/P-gp substrates.' },
+      ]} />
+
+      <div className="space-y-3"><AffiliateDisclosure /><Disclaimer /></div>
+      <References refs={REFS} />
+    </div>
+  )
+}

--- a/app/guides/compare/oregano-vs-thyme/page.tsx
+++ b/app/guides/compare/oregano-vs-thyme/page.tsx
@@ -1,0 +1,91 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+import { buildPageMetadata } from '../../../../src/lib/seo'
+import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
+import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
+import CitationReadySummary from '@/components/seo/CitationReadySummary'
+import FAQSchema from '@/components/seo/FAQSchema'
+import References from '@/components/References'
+import AffiliateDisclosure from '../../../../components/AffiliateDisclosure'
+import Disclaimer from '../../../../src/components/Disclaimer'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Oregano vs Thyme: Essential-Oil Chemistry Compared',
+  description: 'Evidence-aware comparison of oregano and thyme, including thymol/carvacrol chemistry, culinary vs concentrated preparations, and safety differences.',
+  path: '/guides/compare/oregano-vs-thyme/',
+})
+
+const REFS = [
+  { n: 1, text: 'Sakkas H, et al. (2017). Antimicrobial activity of basil, oregano, and thyme essential oils.', url: 'https://pubmed.ncbi.nlm.nih.gov/27994215/' },
+  { n: 2, text: 'Salehi B, et al. (2018). Thymol, thyme, and other plant sources: health and potential uses.', url: 'https://pubmed.ncbi.nlm.nih.gov/29785774/' },
+  { n: 3, text: 'Kowalczyk A, et al. (2020). Thymol and thyme essential oil—new insights into selected therapeutic applications.', url: 'https://pubmed.ncbi.nlm.nih.gov/32917001/' },
+]
+
+const ROWS = [
+  { dimension: 'Shared chemistry', oregano: 'Often rich in carvacrol and may contain substantial thymol depending on chemotype.', thyme: 'Often thymol-forward, though composition varies by species and chemotype.' },
+  { dimension: 'Everyday use', oregano: 'Common culinary herb; concentrated oregano oil is a very different exposure from food use.', thyme: 'Common culinary herb and tea ingredient; essential oil is far more concentrated than food use.' },
+  { dimension: 'Evidence emphasis', oregano: 'Much of the literature focuses on essential-oil chemistry and antimicrobial activity.', thyme: 'Essential-oil and thymol literature is comparatively well characterized, but human outcome evidence remains preparation-specific.' },
+  { dimension: 'Main safety edge', oregano: 'Concentrated oil can irritate GI mucosa and skin.', thyme: 'Concentrated oil can irritate mucosa; high-dose extracts deserve anticoagulant caution.' },
+]
+
+export default function OreganoVsThymePage() {
+  return (
+    <div className="container-page space-y-10 py-10">
+      <AuthorityJsonLd title="Oregano vs Thyme" description="Evidence-aware comparison of oregano and thyme chemistry and preparation safety." url="https://thehippiescientist.net/guides/compare/oregano-vs-thyme/" type="Article" />
+      <AuthorityBreadcrumbs items={[{ label: 'Home', href: '/' }, { label: 'Compare', href: '/guides/compare/' }, { label: 'Oregano vs Thyme' }]} />
+
+      <section className="max-w-4xl space-y-5">
+        <p className="eyebrow-label">Educational Comparison · Aromatic Herbs</p>
+        <h1 className="text-4xl font-bold tracking-tight text-ink sm:text-5xl">Oregano vs Thyme: Similar Aromatic Chemistry, Different Emphasis</h1>
+        <p className="text-lg leading-8 text-muted">Oregano and thyme overlap heavily in aromatic phenols such as thymol and carvacrol. The biggest practical distinction is often not the herb name—it is whether you are talking about food, tea, an extract, or a concentrated essential oil.</p>
+      </section>
+
+      <CitationReadySummary
+        answer="Oregano and thyme share overlapping essential-oil chemistry, especially thymol and carvacrol, but their proportions vary by species, cultivar, and chemotype. Culinary use is generally much lower exposure than concentrated oils or extracts."
+        bestFor={[
+          'Comparing two closely related culinary/aromatic herbs.',
+          'Understanding why essential-oil claims do not automatically apply to food or tea.',
+          'Separating chemistry overlap from evidence for specific human outcomes.',
+        ]}
+        evidenceLevel="Laboratory and compositional evidence is much stronger than evidence that either herb, by itself, treats a specific disease in humans."
+        safetyNote="Culinary use is generally low-risk. Concentrated essential oils can irritate skin and mucosa and should not be treated like ordinary food exposure."
+        notClaiming="This page is not claiming oregano or thyme treats infection, insomnia, inflammation, or any diagnosed condition."
+        referencesHref="#references"
+      />
+
+      <section className="card-premium p-6 sm:p-8">
+        <h2 className="text-2xl font-semibold text-ink">Side by side</h2>
+        <div className="mt-6 overflow-x-auto">
+          <table className="min-w-full border-collapse text-left text-sm">
+            <thead><tr className="border-b border-brand-900/10"><th className="py-3 pr-4">Dimension</th><th className="py-3 pr-4">Oregano</th><th className="py-3">Thyme</th></tr></thead>
+            <tbody>{ROWS.map((row) => <tr key={row.dimension} className="border-b border-brand-900/5 align-top last:border-0"><td className="py-3 pr-4 font-semibold text-ink">{row.dimension}</td><td className="py-3 pr-4 text-muted">{row.oregano}</td><td className="py-3 text-muted">{row.thyme}</td></tr>)}</tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="card-premium space-y-4 p-6 sm:p-8">
+        <h2 className="text-2xl font-semibold text-ink">Why they look so similar in the atlas</h2>
+        <div className="space-y-4 text-sm leading-7 text-muted">
+          <p>Both herbs sit in the mint family and can produce essential oils rich in phenolic monoterpenes. Comparative laboratory work frequently studies oregano and thyme together because their oils overlap in antimicrobial chemistry.<sup>[1]</sup></p>
+          <p><strong className="text-ink">Thyme</strong> is especially associated with thymol, which has a substantial chemistry and pharmacology literature.<sup>[2][3]</sup> <strong className="text-ink">Oregano</strong> is often more carvacrol-forward, although composition can shift dramatically by chemotype.</p>
+          <p>That variation is why a bottle labeled “oregano oil” or “thyme oil” cannot be interpreted from the plant name alone. Concentration and constituent profile matter more than a simple herb-vs-herb ranking.</p>
+        </div>
+      </section>
+
+      <section className="grid gap-4 sm:grid-cols-2">
+        <Link href="/herbs/oregano/" className="card-premium p-5 font-semibold text-brand-800">Explore Oregano →</Link>
+        <Link href="/herbs/thyme/" className="card-premium p-5 font-semibold text-brand-800">Explore Thyme →</Link>
+      </section>
+
+      <FAQSchema pagePath="/guides/compare/oregano-vs-thyme/" questions={[
+        { question: 'Is oregano oil stronger than thyme oil?', answer: 'There is no universal answer. Essential-oil composition varies by chemotype and product, so constituent concentrations matter more than the common name on the bottle.' },
+        { question: 'Do oregano and thyme contain the same compounds?', answer: 'They overlap substantially, especially in thymol and carvacrol chemistry, but the proportions and full constituent profiles differ.' },
+        { question: 'Is using oregano or thyme in food the same as taking essential oil?', answer: 'No. Essential oils are concentrated preparations with very different exposure and safety considerations from culinary use.' },
+      ]} />
+
+      <div className="space-y-3"><AffiliateDisclosure /><Disclaimer /></div>
+      <References refs={REFS} />
+    </div>
+  )
+}

--- a/lib/comparison-utils.ts
+++ b/lib/comparison-utils.ts
@@ -22,12 +22,15 @@ export const BUILT_COMPARE_SLUGS = [
   'berberine-vs-metformin',
   'caffeine-vs-l-theanine',
   'caffeine-vs-l-theanine-vs-bacopa-for-focus',
+  'coffee-vs-guarana',
+  'coptis-vs-goldenseal',
   'curcumin-vs-boswellia-vs-omega-3',
   'guarana-vs-yerba-mate',
   'kanna-vs-ssris',
   'kava-vs-alcohol',
   'melatonin-vs-magnesium',
   'melatonin-vs-valerian-vs-magnesium-for-sleep',
+  'oregano-vs-thyme',
   'rhodiola-vs-ashwagandha',
   'sleep-herbs-vs-melatonin',
 ] as const
@@ -37,6 +40,7 @@ const validSlugs = new Set<string>(BUILT_COMPARE_SLUGS)
 const COMPARISON_ENTITY_ALIASES: Record<string, string> = {
   'panax-quinquefolius': 'american-ginseng',
   'panax-ginseng': 'asian-ginseng',
+  'coffea-arabica': 'coffee',
 }
 
 function comparisonEntitySlug(slug: string) {

--- a/src/lib/__tests__/related-botanical-compare-routing.test.ts
+++ b/src/lib/__tests__/related-botanical-compare-routing.test.ts
@@ -5,11 +5,15 @@ describe('related botanical comparison routing', () => {
   it('emits a comparison only when a static route is actually built', () => {
     expect(getValidComparisonSlug('ashwagandha', 'rhodiola')).toBe('rhodiola-vs-ashwagandha')
     expect(getValidComparisonSlug('guarana', 'yerba-mate')).toBe('guarana-vs-yerba-mate')
+    expect(getValidComparisonSlug('coptis', 'goldenseal')).toBe('coptis-vs-goldenseal')
+    expect(getValidComparisonSlug('oregano', 'thyme')).toBe('oregano-vs-thyme')
     expect(getValidComparisonSlug('ashwagandha', 'lemon-balm')).toBeUndefined()
   })
 
   it('maps canonical profile slugs to readable comparison routes', () => {
     expect(getValidComparisonSlug('panax-quinquefolius', 'panax-ginseng'))
       .toBe('american-ginseng-vs-asian-ginseng')
+    expect(getValidComparisonSlug('coffea-arabica', 'guarana'))
+      .toBe('coffee-vs-guarana')
   })
 })


### PR DESCRIPTION
## Summary
- add Coptis vs Goldenseal from the strongest distinct chemistry/evidence shortlist candidates
- add Oregano vs Thyme for high everyday comparison intent
- add Coffee vs Guarana for clear caffeine/stimulant intent
- register only these built routes in the static comparison allowlist
- map `coffea-arabica` to the readable `coffee` comparison entity slug
- extend route regression coverage

## Editorial guardrail
All three pages use conservative, evidence-aware language tied to the site's existing sourced profiles. No mass generation and no treatment claims.