### PR TITLE
Add editorial intent proxy to comparison shortlist

### DIFF
--- a/scripts/rank-related-comparisons.ts
+++ b/scripts/rank-related-comparisons.ts
@@ -13,21 +13,24 @@ const markdown = [
   '',
   `Generated: ${new Date().toISOString()}`,
   '',
-  'Ranks unbuilt botanical comparison opportunities. Relationship strength stays primary; chemistry support, evidence strength, and multiple specific shared effects add priority. This is an editorial shortlist, not an auto-publishing queue.',
+  'Ranks unbuilt botanical comparison opportunities using separate scientific-priority and editorial-intent-proxy scores. The intent score is a deterministic editorial proxy based on shared user goals, recognizable shared compounds, and a chemistry-only penalty; it is not search-volume data. This remains a human-reviewed shortlist, not an auto-publishing queue.',
   '',
-  '| Rank | Pair | Priority | Relationship | Chemistry | Evidence | Shared specific effects |',
-  '| ---: | --- | ---: | ---: | :---: | --- | --- |',
-  ...rows.map((row, index) => `| ${index + 1} | **${row.a.name} vs ${row.b.name}** | ${row.priorityScore.toFixed(2)} | ${row.relationshipScore.toFixed(2)} | ${row.chemistrySupported ? 'yes' : 'no'} | ${row.evidenceLabel} | ${row.sharedSpecificEffects.slice(0, 4).join(', ') || '—'} |`),
+  '| Rank | Pair | Combined | Scientific | Intent proxy | Relationship | Chemistry | Evidence | Shared specific effects |',
+  '| ---: | --- | ---: | ---: | ---: | ---: | :---: | --- | --- |',
+  ...rows.map((row, index) => `| ${index + 1} | **${row.a.name} vs ${row.b.name}** | ${row.priorityScore.toFixed(2)} | ${row.scientificPriorityScore.toFixed(2)} | ${row.editorialIntentScore.toFixed(2)} | ${row.relationshipScore.toFixed(2)} | ${row.chemistrySupported ? 'yes' : 'no'} | ${row.evidenceLabel} | ${row.sharedSpecificEffects.slice(0, 4).join(', ') || '—'} |`),
   '',
   '## Why these rank',
   '',
   ...rows.slice(0, 15).flatMap((row, index) => [
     `### ${index + 1}. ${row.a.name} vs ${row.b.name}`,
     '',
-    `- Priority score: ${row.priorityScore.toFixed(2)}`,
+    `- Combined priority: ${row.priorityScore.toFixed(2)}`,
+    `- Scientific priority: ${row.scientificPriorityScore.toFixed(2)}`,
+    `- Editorial intent proxy: ${row.editorialIntentScore.toFixed(2)}`,
     `- Relationship score: ${row.relationshipScore.toFixed(2)}`,
     `- Chemistry-supported: ${row.chemistrySupported ? 'yes' : 'no'}`,
     `- Pair evidence tier: ${row.evidenceLabel}`,
+    ...row.intentSignals.map((signal) => `- Intent signal (${signal.score >= 0 ? '+' : ''}${signal.score}): ${signal.label}`),
     ...row.reasons.slice(0, 4).map((reason) => `- ${reason.label}: ${reason.values.join(', ')}`),
     '',
   ]),
@@ -39,4 +42,12 @@ await Promise.all([
   writeFile(path.join(outputDir, 'comparison-shortlist.md'), markdown + '\n'),
 ])
 
-console.log(JSON.stringify({ candidates: rows.length, top: rows.slice(0, 5).map((row) => `${row.a.name} vs ${row.b.name}`) }, null, 2))
+console.log(JSON.stringify({
+  candidates: rows.length,
+  top: rows.slice(0, 5).map((row) => ({
+    pair: `${row.a.name} vs ${row.b.name}`,
+    combined: row.priorityScore,
+    scientific: row.scientificPriorityScore,
+    intentProxy: row.editorialIntentScore,
+  })),
+}, null, 2))

--- a/src/lib/__tests__/comparison-shortlist.test.ts
+++ b/src/lib/__tests__/comparison-shortlist.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildComparisonShortlist, evidenceTier, isAliasPair } from '@/lib/comparison-shortlist'
+import { buildComparisonShortlist, evidenceTier, isAliasPair, scoreComparisonIntent } from '@/lib/comparison-shortlist'
 import type { RelatedBotanicalRecord } from '@/lib/related-botanicals'
 
 const herb = (slug: string, overrides: Partial<RelatedBotanicalRecord> = {}): RelatedBotanicalRecord => ({
@@ -85,5 +85,30 @@ describe('comparison shortlist', () => {
     expect(effectPair).toBeTruthy()
     expect(chemistryPair!.chemistrySupported).toBe(true)
     expect(chemistryPair!.priorityScore).toBeGreaterThan(effectPair!.priorityScore)
+  })
+
+  it('boosts shared user goals and penalizes chemistry-only editorial candidates', () => {
+    const goalA = herb('goal-a', { explicitEffects: ['energy', 'focus'] })
+    const goalB = herb('goal-b', { explicitEffects: ['energy', 'focus'] })
+    const chemistryA = herb('chem-a', { explicitEffects: ['digestion'], compoundClasses: ['alkaloid'] })
+    const chemistryB = herb('chem-b', { explicitEffects: ['circulation'], compoundClasses: ['alkaloid'] })
+
+    const goalIntent = scoreComparisonIntent(goalA, goalB, false, ['energy', 'focus'])
+    const chemistryIntent = scoreComparisonIntent(chemistryA, chemistryB, true, [])
+
+    expect(goalIntent.score).toBeGreaterThan(0)
+    expect(chemistryIntent.score).toBeLessThan(0)
+    expect(goalIntent.signals.some((signal) => signal.label.startsWith('Shared user goal'))).toBe(true)
+    expect(chemistryIntent.signals.some((signal) => signal.label === 'Chemistry-only editorial penalty')).toBe(true)
+  })
+
+  it('recognizes familiar shared compounds as useful comparison anchors', () => {
+    const guarana = herb('guarana', { compounds: ['Caffeine', 'theobromine'], explicitEffects: ['energy'] })
+    const guayusa = herb('guayusa', { compounds: ['caffeine'], explicitEffects: ['energy'] })
+
+    const intent = scoreComparisonIntent(guarana, guayusa, true, ['energy'])
+
+    expect(intent.score).toBeGreaterThan(0)
+    expect(intent.signals.some((signal) => signal.label.includes('Recognizable shared compound'))).toBe(true)
   })
 })

--- a/src/lib/comparison-shortlist.ts
+++ b/src/lib/comparison-shortlist.ts
@@ -1,19 +1,38 @@
 import { getValidComparisonSlug } from '@/lib/comparison-utils'
 import { scoreRelatedBotanical, type RelatedBotanicalRecord, type RelatedBotanicalReason } from '@/lib/related-botanicals'
 
+export type ComparisonIntentSignal = {
+  label: string
+  score: number
+}
+
 export type ComparisonShortlistRow = {
   a: RelatedBotanicalRecord
   b: RelatedBotanicalRecord
   relationshipScore: number
+  scientificPriorityScore: number
+  editorialIntentScore: number
   priorityScore: number
   chemistrySupported: boolean
   sharedSpecificEffects: string[]
   evidenceTier: number
   evidenceLabel: string
+  intentSignals: ComparisonIntentSignal[]
   reasons: RelatedBotanicalReason[]
 }
 
 const GENERIC_EFFECTS = new Set(['antioxidant', 'tonic'])
+const RECOGNIZABLE_DECISION_COMPOUNDS = new Set([
+  'berberine',
+  'caffeine',
+  'carvacrol',
+  'curcumin',
+  'ginsenoside rb1',
+  'ginsenoside rg1',
+  'melatonin',
+  'theobromine',
+  'thymol',
+])
 
 function normalize(value = '') {
   return value
@@ -70,16 +89,55 @@ export function isAliasPair(a: RelatedBotanicalRecord, b: RelatedBotanicalRecord
   if (aScientific && aScientific === bName) return true
   if (bScientific && bScientific === aName) return true
 
-  // Runtime data sometimes drops scientificName on one duplicate record. Catch the
-  // common genus-only/common-name record paired with its explicit Latin species row.
   if (isGenusVsSpeciesName(aName, bName)) return true
-
-  // Parenthetical/binomial display names such as "Turmeric (Curcuma longa)" should
-  // collapse against a row explicitly named "Curcuma longa" when present.
   if (containsIdentityName(a.name, bScientific || b.name) && tokens(bScientific || b.name).length >= 2) return true
   if (containsIdentityName(b.name, aScientific || a.name) && tokens(aScientific || a.name).length >= 2) return true
 
   return false
+}
+
+function sharedNormalized(left: string[] = [], right: string[] = []) {
+  const rightSet = new Set(right.map(normalize).filter(Boolean))
+  return left.map((value) => ({ normalized: normalize(value), display: value }))
+    .filter(({ normalized }) => normalized && rightSet.has(normalized))
+}
+
+export function scoreComparisonIntent(
+  a: RelatedBotanicalRecord,
+  b: RelatedBotanicalRecord,
+  chemistrySupported: boolean,
+  sharedSpecificEffects: string[],
+): { score: number; signals: ComparisonIntentSignal[] } {
+  const signals: ComparisonIntentSignal[] = []
+
+  if (sharedSpecificEffects.length) {
+    signals.push({
+      label: `Shared user goal (${sharedSpecificEffects.slice(0, 3).join(', ')})`,
+      score: Math.min(sharedSpecificEffects.length, 3) * 2,
+    })
+  }
+
+  const recognizableCompounds = sharedNormalized(a.compounds, b.compounds)
+    .filter(({ normalized }) => RECOGNIZABLE_DECISION_COMPOUNDS.has(normalized))
+  if (recognizableCompounds.length) {
+    signals.push({
+      label: `Recognizable shared compound (${recognizableCompounds.slice(0, 2).map(({ display }) => display).join(', ')})`,
+      score: Math.min(recognizableCompounds.length, 2) * 2,
+    })
+  }
+
+  const bothHaveSpecificEffects = (a.explicitEffects ?? a.effects).some((value) => !GENERIC_EFFECTS.has(normalize(value)))
+    && (b.explicitEffects ?? b.effects).some((value) => !GENERIC_EFFECTS.has(normalize(value)))
+  if (bothHaveSpecificEffects && sharedSpecificEffects.length) {
+    signals.push({ label: 'Both records have user-facing effect context', score: 1 })
+  }
+
+  if (chemistrySupported && sharedSpecificEffects.length === 0) {
+    signals.push({ label: 'Chemistry-only editorial penalty', score: -4 })
+  }
+
+  const score = signals.reduce((sum, signal) => sum + signal.score, 0)
+  return { score, signals }
 }
 
 export function buildComparisonShortlist(records: RelatedBotanicalRecord[], limit = 30) {
@@ -102,20 +160,25 @@ export function buildComparisonShortlist(records: RelatedBotanicalRecord[], limi
         .find((reason) => reason.type === 'explicit-effect')?.values
         .filter((value) => !GENERIC_EFFECTS.has(normalize(value))) ?? []
       const tier = Math.min(evidenceTier(a.evidence), evidenceTier(b.evidence))
-      const priorityScore = match.score
+      const scientificPriorityScore = match.score
         + (chemistrySupported ? 4 : 0)
         + tier * 2
         + Math.min(sharedSpecificEffects.length, 3)
+      const intent = scoreComparisonIntent(a, b, chemistrySupported, sharedSpecificEffects)
+      const priorityScore = scientificPriorityScore + intent.score
 
       rows.push({
         a,
         b,
         relationshipScore: match.score,
+        scientificPriorityScore: Number(scientificPriorityScore.toFixed(4)),
+        editorialIntentScore: Number(intent.score.toFixed(4)),
         priorityScore: Number(priorityScore.toFixed(4)),
         chemistrySupported,
         sharedSpecificEffects,
         evidenceTier: tier,
         evidenceLabel: tier === 3 ? 'strong' : tier === 2 ? 'moderate' : tier === 1 ? 'limited' : 'unclassified',
+        intentSignals: intent.signals,
         reasons: match.reasons,
       })
     }
@@ -123,6 +186,8 @@ export function buildComparisonShortlist(records: RelatedBotanicalRecord[], limi
 
   return rows
     .sort((x, y) => y.priorityScore - x.priorityScore
+      || y.editorialIntentScore - x.editorialIntentScore
+      || y.scientificPriorityScore - x.scientificPriorityScore
       || y.relationshipScore - x.relationshipScore
       || x.a.name.localeCompare(y.a.name)
       || x.b.name.localeCompare(y.b.name))


### PR DESCRIPTION
## Summary
- separate scientific priority from editorial/search-intent proxy scoring
- boost shared user goals and recognizable comparison anchors
- penalize chemistry-only pairs that lack shared user-facing effects
- expose combined, scientific, and intent-proxy scores in Markdown/JSON reports
- add regression tests for goal overlap, chemistry-only demotion, and caffeine-style decision anchors

## Guardrail
The intent score is explicitly a deterministic editorial proxy, not keyword volume or search-demand data. Actual search validation remains a human/editorial step.