### PR TITLE
Suppress known duplicate identities in comparison shortlist

### DIFF
--- a/src/lib/__tests__/comparison-shortlist.test.ts
+++ b/src/lib/__tests__/comparison-shortlist.test.ts
@@ -46,6 +46,14 @@ describe('comparison shortlist', () => {
     expect(isAliasPair(phellodendron, phellodendronLatin)).toBe(true)
   })
 
+  it('filters known same-entity records through canonical identity groups', () => {
+    expect(isAliasPair(herb('coptis'), herb('coptis-chinensis'))).toBe(true)
+    expect(isAliasPair(herb('phellodendron'), herb('phellodendron-amurense'))).toBe(true)
+    expect(isAliasPair(herb('hypericum-perforatum'), herb('st-johns-wort'))).toBe(true)
+    expect(isAliasPair(herb('citrus-sinensis'), herb('orange-peel'))).toBe(true)
+    expect(isAliasPair(herb('holy-basil'), herb('holy-basil-purple'))).toBe(true)
+  })
+
   it('filters genus-only rows against species rows even when scientific metadata is missing', () => {
     expect(isAliasPair(
       herb('berberis', { name: 'Berberis' }),

--- a/src/lib/comparison-identity-groups.ts
+++ b/src/lib/comparison-identity-groups.ts
@@ -1,0 +1,21 @@
+const CANONICAL_IDENTITY_GROUPS: string[][] = [
+  ['coptis', 'coptis-chinensis'],
+  ['phellodendron', 'phellodendron-amurense'],
+  ['hypericum-perforatum', 'st-johns-wort'],
+  ['citrus-sinensis', 'orange-peel'],
+  ['holy-basil', 'holy-basil-purple'],
+]
+
+const identityBySlug = new Map<string, string>()
+for (const group of CANONICAL_IDENTITY_GROUPS) {
+  const canonical = group[0]
+  for (const slug of group) identityBySlug.set(slug, canonical)
+}
+
+export function canonicalComparisonIdentity(slug: string) {
+  return identityBySlug.get(slug) ?? slug
+}
+
+export function isSameComparisonIdentity(aSlug: string, bSlug: string) {
+  return canonicalComparisonIdentity(aSlug) === canonicalComparisonIdentity(bSlug)
+}

--- a/src/lib/comparison-shortlist.ts
+++ b/src/lib/comparison-shortlist.ts
@@ -1,4 +1,5 @@
 import { getValidComparisonSlug } from '@/lib/comparison-utils'
+import { isSameComparisonIdentity } from '@/lib/comparison-identity-groups'
 import { scoreRelatedBotanical, type RelatedBotanicalRecord, type RelatedBotanicalReason } from '@/lib/related-botanicals'
 
 export type ComparisonIntentSignal = {
@@ -79,6 +80,8 @@ function isGenusVsSpeciesName(aName: string, bName: string) {
 }
 
 export function isAliasPair(a: RelatedBotanicalRecord, b: RelatedBotanicalRecord) {
+  if (isSameComparisonIdentity(a.slug, b.slug)) return true
+
   const aName = normalize(a.name)
   const bName = normalize(b.name)
   const aScientific = normalize(a.scientificName)


### PR DESCRIPTION
## Summary
- add a small canonical identity-group layer for known same-entity botanical records
- suppress Coptis/Coptis chinensis, Phellodendron/P. amurense, Hypericum/St. John's wort, Citrus sinensis/orange peel, and Holy Basil variants from editorial comparison ranking
- preserve distinct species such as different barberries
- add regression coverage for every canonical group

## Why
The first intent-aware shortlist was still dominated by same-plant or same-entity records. This removes known identity noise without widening fuzzy heuristics.