### PR TITLE
Track comparison page research outcomes

### DIFF
--- a/components/compare/CompareHubAnalytics.tsx
+++ b/components/compare/CompareHubAnalytics.tsx
@@ -2,13 +2,60 @@
 
 import { useEffect } from 'react'
 import { usePathname } from 'next/navigation'
-import { trackCompareHubCategoryShown, trackCompareHubClick, type CompareHubClickSource } from '@/lib/compareHubTracking'
+import {
+  trackCompareHubCategoryShown,
+  trackCompareHubClick,
+  trackComparisonOutcome,
+  trackComparisonPageViewed,
+  type CompareHubClickSource,
+  type ComparisonOutcomeType,
+} from '@/lib/compareHubTracking'
+
+function comparisonPageSlug(pathname: string) {
+  const match = pathname.match(/^\/guides\/compare\/([^/]+)\/?$/)
+  if (!match || match[1] === 'dynamic') return undefined
+  return match[1]
+}
+
+function classifyOutcome(anchor: HTMLAnchorElement): ComparisonOutcomeType | undefined {
+  const href = anchor.getAttribute('href') || ''
+  if (href === '/guides/compare/' || href === '/guides/compare') return 'compare_hub'
+  if (href.startsWith('/herbs/')) return 'herb_profile'
+  if (href.startsWith('/compounds/')) return 'compound_profile'
+  if (href.startsWith('/safety-checker')) return 'safety_checker'
+  if (href.startsWith('/guides/compare/')) return 'another_comparison'
+  if (href.startsWith('#references') || anchor.closest('#references')) return 'reference'
+  if (/pubmed\.ncbi\.nlm\.nih\.gov|doi\.org/i.test(href)) return 'reference'
+  return undefined
+}
 
 export default function CompareHubAnalytics() {
   const pathname = usePathname()
 
   useEffect(() => {
-    if (pathname !== '/guides/compare' && pathname !== '/guides/compare/') return
+    const isHub = pathname === '/guides/compare' || pathname === '/guides/compare/'
+    const pageSlug = comparisonPageSlug(pathname)
+
+    if (!isHub && pageSlug) {
+      trackComparisonPageViewed(pageSlug)
+      const onOutcomeClick = (event: MouseEvent) => {
+        const target = event.target instanceof Element ? event.target : null
+        const anchor = target?.closest<HTMLAnchorElement>('a[href]')
+        if (!anchor) return
+        const outcome = classifyOutcome(anchor)
+        if (!outcome) return
+        trackComparisonOutcome({
+          pageSlug,
+          outcome,
+          href: anchor.getAttribute('href') || '',
+          label: anchor.textContent?.replace(/\s+/g, ' ').trim(),
+        })
+      }
+      document.addEventListener('click', onOutcomeClick, true)
+      return () => document.removeEventListener('click', onOutcomeClick, true)
+    }
+
+    if (!isHub) return
 
     const featured = document.querySelector('#featured-comparisons')
     const categoryNodes = featured

--- a/src/dev/AnalyticsViewer.tsx
+++ b/src/dev/AnalyticsViewer.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { buildAtlasRecoveryPerformance, buildAtlasSourcePerformance, buildRelatedBotanicalPerformance } from '@/lib/atlasAnalyticsReport'
 import { buildCompareHubPerformance } from '@/lib/compareHubAnalyticsReport'
+import ComparisonOutcomeAnalyticsPanel from '@/dev/ComparisonOutcomeAnalyticsPanel'
 import { readAnalyticsEvents, type StoredAnalyticsEvent } from '@/utils/analytics/eventStorage'
 
 type GroupRow = { label: string; count: number }
@@ -78,6 +79,8 @@ export default function AnalyticsViewer() {
       <h4 className='mt-3 text-xs font-semibold uppercase tracking-wide text-white/80'>Top comparison destinations</h4>
       {compareHubReport.routeRows.length === 0 ? <p className='mt-1 text-xs text-white/60'>No comparison clicks yet.</p> : <div className='mt-1 overflow-x-auto'><table className='min-w-full text-xs'><thead><tr className='text-left text-white/65'><th className='pr-3 font-medium'>Destination</th><th className='font-medium'>Clicks</th></tr></thead><tbody>{compareHubReport.routeRows.slice(0, 12).map(row => <tr key={row.href} className='border-t border-white/10'><td className='py-1.5 pr-3 text-white/90'>{row.label}</td><td className='py-1.5 text-white/80'>{row.clicks}</td></tr>)}</tbody></table></div>}
     </section>
+
+    <ComparisonOutcomeAnalyticsPanel events={events} />
 
     <p className='mt-3 text-xs text-white/75'>Total affiliate clicks: {clickEvents.length}</p>
     <div className='mt-3 space-y-3'><Table title='Clicks by herb' rows={byHerb} /><Table title='Clicks by product' rows={byProduct} /><Table title='Clicks by position' rows={byPosition} /><Table title='Clicks by use-case anchor' rows={byUseCaseAnchor} /></div>

--- a/src/dev/ComparisonOutcomeAnalyticsPanel.tsx
+++ b/src/dev/ComparisonOutcomeAnalyticsPanel.tsx
@@ -1,0 +1,57 @@
+import { buildComparisonOutcomePerformance, type ComparisonOutcomeAnalyticsEvent } from '@/lib/comparisonOutcomeAnalyticsReport'
+
+const LABELS: Record<string, string> = {
+  herb_profile: 'Herb profile',
+  compound_profile: 'Compound profile',
+  safety_checker: 'Safety checker',
+  reference: 'Reference / source',
+  another_comparison: 'Another comparison',
+  compare_hub: 'Comparison hub',
+}
+
+export default function ComparisonOutcomeAnalyticsPanel({ events }: { events: ComparisonOutcomeAnalyticsEvent[] }) {
+  const report = buildComparisonOutcomePerformance(events)
+
+  return (
+    <section className='mt-3 rounded-md border border-white/10 bg-white/5 p-2'>
+      <h3 className='text-xs font-semibold uppercase tracking-wide text-white/80'>Comparison research outcomes</h3>
+      <p className='mt-1 text-xs text-white/65'>
+        {report.attributedViews} unique comparison views · {report.attributedOutcomes} unique continuation actions
+        {report.unattributedEvents ? ` · ${report.unattributedEvents} unattributed events excluded` : ''}
+      </p>
+
+      {report.pageRows.length === 0 ? (
+        <p className='mt-2 text-xs text-white/60'>No comparison outcome data yet.</p>
+      ) : (
+        <div className='mt-2 overflow-x-auto'>
+          <table className='min-w-full text-xs'>
+            <thead><tr className='text-left text-white/65'><th className='pr-3 font-medium'>Page</th><th className='pr-3 font-medium'>Views</th><th className='pr-3 font-medium'>Continued</th><th className='pr-3 font-medium'>Rate</th><th className='font-medium'>Actions</th></tr></thead>
+            <tbody>{report.pageRows.slice(0, 20).map(row => (
+              <tr key={row.pageSlug} className='border-t border-white/10'>
+                <td className='py-1.5 pr-3 font-medium text-white/95'>{row.pageSlug}</td>
+                <td className='py-1.5 pr-3 text-white/80'>{row.views}</td>
+                <td className='py-1.5 pr-3 text-white/80'>{row.engagedSessions}</td>
+                <td className='py-1.5 pr-3 text-white/80'>{Math.round(row.continuationRate * 100)}%</td>
+                <td className='py-1.5 text-white/80'>{row.outcomes}</td>
+              </tr>
+            ))}</tbody>
+          </table>
+        </div>
+      )}
+
+      <h4 className='mt-3 text-xs font-semibold uppercase tracking-wide text-white/80'>Continuation mix</h4>
+      {report.outcomeRows.length === 0 ? (
+        <p className='mt-1 text-xs text-white/60'>No continuation actions yet.</p>
+      ) : (
+        <div className='mt-1 grid gap-1 text-xs sm:grid-cols-2'>
+          {report.outcomeRows.map(row => (
+            <div key={row.outcome} className='flex justify-between gap-3 border-t border-white/10 py-1.5'>
+              <span className='text-white/90'>{LABELS[row.outcome] ?? row.outcome}</span>
+              <span className='text-white/70'>{row.clicks}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/lib/__tests__/compare-hub-tracking.test.ts
+++ b/src/lib/__tests__/compare-hub-tracking.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { trackCompareHubCategoryShown, trackCompareHubClick } from '@/lib/compareHubTracking'
+import {
+  trackCompareHubCategoryShown,
+  trackCompareHubClick,
+  trackComparisonOutcome,
+  trackComparisonPageViewed,
+} from '@/lib/compareHubTracking'
 
 const appendAnalyticsEvent = vi.fn()
 vi.mock('@/lib/analyticsEventStorage', () => ({ appendAnalyticsEvent }))
@@ -35,6 +40,34 @@ describe('comparison hub tracking', () => {
       slug: '/guides/compare/coffee-vs-green-tea/',
       item: 'Coffee vs Green Tea',
       context: expect.stringContaining('source:featured_category;category:Energy & focus'),
+    }))
+  })
+
+  it('records one comparison view per page per session', () => {
+    trackComparisonPageViewed('coffee-vs-green-tea')
+    trackComparisonPageViewed('coffee-vs-green-tea')
+    trackComparisonPageViewed('st-johns-wort-vs-saffron')
+
+    expect(appendAnalyticsEvent).toHaveBeenCalledTimes(2)
+    expect(appendAnalyticsEvent).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'comparison_page_viewed',
+      slug: 'coffee-vs-green-tea',
+    }))
+  })
+
+  it('records research continuation type and destination', () => {
+    trackComparisonOutcome({
+      pageSlug: 'coffee-vs-green-tea',
+      outcome: 'herb_profile',
+      href: '/herbs/coffea-arabica/',
+      label: 'Coffee',
+    })
+
+    expect(appendAnalyticsEvent).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'comparison_outcome_click',
+      slug: 'coffee-vs-green-tea',
+      item: '/herbs/coffea-arabica/',
+      context: expect.stringContaining('outcome:herb_profile'),
     }))
   })
 })

--- a/src/lib/__tests__/comparison-outcome-analytics-report.test.ts
+++ b/src/lib/__tests__/comparison-outcome-analytics-report.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { buildComparisonOutcomePerformance } from '@/lib/comparisonOutcomeAnalyticsReport'
+
+describe('comparison outcome analytics report', () => {
+  it('computes continuation rate from unique page views and engaged sessions', () => {
+    const report = buildComparisonOutcomePerformance([
+      { type: 'comparison_page_viewed', slug: 'coffee-vs-green-tea', context: 'session:s1' },
+      { type: 'comparison_page_viewed', slug: 'coffee-vs-green-tea', context: 'session:s2' },
+      { type: 'comparison_outcome_click', slug: 'coffee-vs-green-tea', item: '/herbs/coffea-arabica/', context: 'session:s1;outcome:herb_profile' },
+      { type: 'comparison_outcome_click', slug: 'coffee-vs-green-tea', item: '/herbs/camellia-sinensis/', context: 'session:s1;outcome:herb_profile' },
+    ])
+
+    expect(report.pageRows[0]).toMatchObject({
+      pageSlug: 'coffee-vs-green-tea',
+      views: 2,
+      engagedSessions: 1,
+      continuationRate: 0.5,
+      outcomes: 2,
+    })
+    expect(report.outcomeRows[0]).toEqual({ outcome: 'herb_profile', clicks: 2 })
+  })
+
+  it('deduplicates repeated destination clicks in the same session', () => {
+    const events = [
+      { type: 'comparison_page_viewed', slug: 'a-vs-b', context: 'session:s1' },
+      { type: 'comparison_outcome_click', slug: 'a-vs-b', item: '/safety-checker/', context: 'session:s1;outcome:safety_checker' },
+      { type: 'comparison_outcome_click', slug: 'a-vs-b', item: '/safety-checker/', context: 'session:s1;outcome:safety_checker' },
+    ]
+    const report = buildComparisonOutcomePerformance(events)
+    expect(report.attributedOutcomes).toBe(1)
+    expect(report.pageRows[0]?.outcomes).toBe(1)
+  })
+
+  it('reports different research continuation types independently', () => {
+    const report = buildComparisonOutcomePerformance([
+      { type: 'comparison_page_viewed', slug: 'a-vs-b', context: 'session:s1' },
+      { type: 'comparison_outcome_click', slug: 'a-vs-b', item: '#references', context: 'session:s1;outcome:reference' },
+      { type: 'comparison_outcome_click', slug: 'a-vs-b', item: '/guides/compare/c-vs-d/', context: 'session:s1;outcome:another_comparison' },
+    ])
+    expect(report.outcomeRows).toEqual(expect.arrayContaining([
+      { outcome: 'reference', clicks: 1 },
+      { outcome: 'another_comparison', clicks: 1 },
+    ]))
+  })
+
+  it('excludes events without a session id', () => {
+    const report = buildComparisonOutcomePerformance([
+      { type: 'comparison_page_viewed', slug: 'a-vs-b', context: '' },
+      { type: 'comparison_outcome_click', slug: 'a-vs-b', item: '/herbs/a/', context: 'outcome:herb_profile' },
+    ])
+    expect(report.attributedViews).toBe(0)
+    expect(report.attributedOutcomes).toBe(0)
+    expect(report.unattributedEvents).toBe(2)
+  })
+})

--- a/src/lib/compareHubTracking.ts
+++ b/src/lib/compareHubTracking.ts
@@ -4,6 +4,7 @@ import { appendAnalyticsEvent } from '@/lib/analyticsEventStorage'
 
 const SESSION_KEY = 'hs_compare_hub_session'
 const SEEN_CATEGORY_KEY = 'hs_compare_hub_seen_categories'
+const SEEN_COMPARISON_KEY = 'hs_compare_seen_pages'
 
 type HubSession = { sessionId: string }
 
@@ -23,22 +24,27 @@ function getSession(): HubSession {
   return session
 }
 
-function seenCategories() {
+function readStringSet(key: string) {
   if (typeof window === 'undefined') return new Set<string>()
   try {
-    const parsed = JSON.parse(window.sessionStorage.getItem(SEEN_CATEGORY_KEY) || '[]')
+    const parsed = JSON.parse(window.sessionStorage.getItem(key) || '[]')
     return new Set(Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : [])
   } catch {
     return new Set<string>()
   }
 }
 
+function persistStringSet(key: string, values: Set<string>) {
+  if (typeof window === 'undefined') return
+  try { window.sessionStorage.setItem(key, JSON.stringify(Array.from(values))) } catch { /* ignore */ }
+}
+
 export function trackCompareHubCategoryShown(category: string) {
   if (typeof window === 'undefined' || !category) return
-  const seen = seenCategories()
+  const seen = readStringSet(SEEN_CATEGORY_KEY)
   if (seen.has(category)) return
   seen.add(category)
-  try { window.sessionStorage.setItem(SEEN_CATEGORY_KEY, JSON.stringify(Array.from(seen))) } catch { /* ignore */ }
+  persistStringSet(SEEN_CATEGORY_KEY, seen)
   const session = getSession()
   appendAnalyticsEvent({
     type: 'compare_hub_category_shown',
@@ -71,5 +77,47 @@ export function trackCompareHubClick({
     context: `session:${session.sessionId};source:${source};category:${category || 'none'}`,
     sourceType: 'compare_hub',
     targetType: href.includes('/dynamic/') ? 'dynamic_matrix' : 'comparison',
+  })
+}
+
+export type ComparisonOutcomeType = 'herb_profile' | 'compound_profile' | 'safety_checker' | 'reference' | 'another_comparison' | 'compare_hub'
+
+export function trackComparisonPageViewed(pageSlug: string) {
+  if (typeof window === 'undefined' || !pageSlug) return
+  const session = getSession()
+  const seen = readStringSet(SEEN_COMPARISON_KEY)
+  const key = `${session.sessionId}|${pageSlug}`
+  if (seen.has(key)) return
+  seen.add(key)
+  persistStringSet(SEEN_COMPARISON_KEY, seen)
+  appendAnalyticsEvent({
+    type: 'comparison_page_viewed',
+    slug: pageSlug,
+    context: `session:${session.sessionId}`,
+    sourceType: 'comparison',
+    targetType: 'comparison',
+  })
+}
+
+export function trackComparisonOutcome({
+  pageSlug,
+  outcome,
+  href,
+  label,
+}: {
+  pageSlug: string
+  outcome: ComparisonOutcomeType
+  href: string
+  label?: string
+}) {
+  if (typeof window === 'undefined' || !pageSlug || !href) return
+  const session = getSession()
+  appendAnalyticsEvent({
+    type: 'comparison_outcome_click',
+    slug: pageSlug,
+    item: href,
+    context: `session:${session.sessionId};outcome:${outcome};label:${(label || href).replace(/[;:]/g, ' ')}`,
+    sourceType: 'comparison',
+    targetType: outcome,
   })
 }

--- a/src/lib/comparisonOutcomeAnalyticsReport.ts
+++ b/src/lib/comparisonOutcomeAnalyticsReport.ts
@@ -1,0 +1,84 @@
+export type ComparisonOutcomeAnalyticsEvent = {
+  type?: string
+  context?: string
+  item?: string
+  slug?: string
+}
+
+function parseContext(context = '') {
+  const values = new Map<string, string>()
+  context.split(';').forEach((segment) => {
+    const separator = segment.indexOf(':')
+    if (separator < 1) return
+    values.set(segment.slice(0, separator), segment.slice(separator + 1))
+  })
+  return values
+}
+
+export function buildComparisonOutcomePerformance(events: ComparisonOutcomeAnalyticsEvent[]) {
+  const views = new Set<string>()
+  const outcomes = new Map<string, { session: string; pageSlug: string; outcome: string; href: string }>()
+  let unattributedEvents = 0
+
+  events.forEach((event) => {
+    if (event.type !== 'comparison_page_viewed' && event.type !== 'comparison_outcome_click') return
+    const values = parseContext(event.context)
+    const session = values.get('session')
+    if (!session) {
+      unattributedEvents += 1
+      return
+    }
+
+    const pageSlug = event.slug || 'unknown'
+    if (event.type === 'comparison_page_viewed') {
+      views.add(`${session}|${pageSlug}`)
+      return
+    }
+
+    const outcome = values.get('outcome') || 'unknown'
+    const href = event.item || 'unknown'
+    const key = `${session}|${pageSlug}|${outcome}|${href}`
+    if (!outcomes.has(key)) outcomes.set(key, { session, pageSlug, outcome, href })
+  })
+
+  const pageStats = new Map<string, { views: number; engagedSessions: Set<string>; outcomes: number }>()
+  views.forEach((key) => {
+    const separator = key.indexOf('|')
+    const pageSlug = key.slice(separator + 1)
+    const current = pageStats.get(pageSlug) ?? { views: 0, engagedSessions: new Set<string>(), outcomes: 0 }
+    current.views += 1
+    pageStats.set(pageSlug, current)
+  })
+
+  const outcomeCounts = new Map<string, number>()
+  outcomes.forEach((outcome) => {
+    const current = pageStats.get(outcome.pageSlug) ?? { views: 0, engagedSessions: new Set<string>(), outcomes: 0 }
+    current.engagedSessions.add(outcome.session)
+    current.outcomes += 1
+    pageStats.set(outcome.pageSlug, current)
+    outcomeCounts.set(outcome.outcome, (outcomeCounts.get(outcome.outcome) ?? 0) + 1)
+  })
+
+  const pageRows = Array.from(pageStats.entries()).map(([pageSlug, stats]) => ({
+    pageSlug,
+    views: stats.views,
+    engagedSessions: stats.engagedSessions.size,
+    continuationRate: stats.views ? stats.engagedSessions.size / stats.views : 0,
+    outcomes: stats.outcomes,
+  })).sort((a, b) => b.continuationRate - a.continuationRate
+    || b.engagedSessions - a.engagedSessions
+    || b.views - a.views
+    || a.pageSlug.localeCompare(b.pageSlug))
+
+  const outcomeRows = Array.from(outcomeCounts.entries())
+    .map(([outcome, clicks]) => ({ outcome, clicks }))
+    .sort((a, b) => b.clicks - a.clicks || a.outcome.localeCompare(b.outcome))
+
+  return {
+    pageRows,
+    outcomeRows,
+    attributedViews: views.size,
+    attributedOutcomes: outcomes.size,
+    unattributedEvents,
+  }
+}


### PR DESCRIPTION
## Summary
- track one unique comparison-page view per anonymous session/page
- classify meaningful continuation clicks into herb profile, compound profile, safety checker, reference/source, another comparison, or comparison hub
- keep tracking inside the existing lightweight compare-route observer
- report continuation rate per comparison page and aggregate continuation mix
- expose the new outcome funnel in the developer analytics viewer
- add regression coverage for page-view deduplication, continuation attribution, outcome deduplication, and report calculations

## Privacy / architecture
Uses the existing anonymous session/local analytics store. No personal data is added. Comparison pages remain server-rendered.