### PR TITLE
Attribute comparison outcomes to discovery source

### DIFF
--- a/src/dev/ComparisonOutcomeAnalyticsPanel.tsx
+++ b/src/dev/ComparisonOutcomeAnalyticsPanel.tsx
@@ -9,6 +9,14 @@ const LABELS: Record<string, string> = {
   compare_hub: 'Comparison hub',
 }
 
+const SOURCE_LABELS: Record<string, string> = {
+  goal_starter: 'Goal starter',
+  featured_category: 'Featured category',
+  featured_entry: 'Featured entry',
+  dynamic_matrix: 'Dynamic matrix',
+  direct_or_external: 'Direct / external',
+}
+
 export default function ComparisonOutcomeAnalyticsPanel({ events }: { events: ComparisonOutcomeAnalyticsEvent[] }) {
   const report = buildComparisonOutcomePerformance(events)
 
@@ -33,6 +41,30 @@ export default function ComparisonOutcomeAnalyticsPanel({ events }: { events: Co
                 <td className='py-1.5 pr-3 text-white/80'>{row.engagedSessions}</td>
                 <td className='py-1.5 pr-3 text-white/80'>{Math.round(row.continuationRate * 100)}%</td>
                 <td className='py-1.5 text-white/80'>{row.outcomes}</td>
+              </tr>
+            ))}</tbody>
+          </table>
+        </div>
+      )}
+
+      <h4 className='mt-3 text-xs font-semibold uppercase tracking-wide text-white/80'>Source → page → outcome</h4>
+      {report.journeyRows.length === 0 ? (
+        <p className='mt-1 text-xs text-white/60'>No source-attributed comparison journeys yet.</p>
+      ) : (
+        <div className='mt-1 overflow-x-auto'>
+          <table className='min-w-full text-xs'>
+            <thead><tr className='text-left text-white/65'><th className='pr-3 font-medium'>Entry</th><th className='pr-3 font-medium'>Page</th><th className='pr-3 font-medium'>Views</th><th className='pr-3 font-medium'>Continued</th><th className='pr-3 font-medium'>Rate</th><th className='font-medium'>Top next action</th></tr></thead>
+            <tbody>{report.journeyRows.slice(0, 24).map(row => (
+              <tr key={`${row.pageSlug}:${row.entrySource}:${row.entryCategory}`} className='border-t border-white/10'>
+                <td className='py-1.5 pr-3 text-white/90'>
+                  <span className='font-medium'>{SOURCE_LABELS[row.entrySource] ?? row.entrySource}</span>
+                  {row.entryCategory !== 'none' ? <span className='block text-white/55'>{row.entryCategory}</span> : null}
+                </td>
+                <td className='py-1.5 pr-3 font-medium text-white/95'>{row.pageSlug}</td>
+                <td className='py-1.5 pr-3 text-white/80'>{row.views}</td>
+                <td className='py-1.5 pr-3 text-white/80'>{row.engagedSessions}</td>
+                <td className='py-1.5 pr-3 text-white/80'>{Math.round(row.continuationRate * 100)}%</td>
+                <td className='py-1.5 text-white/80'>{LABELS[row.topOutcome] ?? row.topOutcome}</td>
               </tr>
             ))}</tbody>
           </table>

--- a/src/lib/__tests__/compare-hub-tracking.test.ts
+++ b/src/lib/__tests__/compare-hub-tracking.test.ts
@@ -43,6 +43,40 @@ describe('comparison hub tracking', () => {
     }))
   })
 
+  it('hands hub source attribution to the destination comparison view', () => {
+    trackCompareHubClick({
+      source: 'featured_category',
+      href: '/guides/compare/coffee-vs-green-tea/',
+      label: 'Coffee vs Green Tea',
+      category: 'Energy & focus',
+    })
+    appendAnalyticsEvent.mockClear()
+
+    trackComparisonPageViewed('coffee-vs-green-tea')
+
+    expect(appendAnalyticsEvent).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'comparison_page_viewed',
+      slug: 'coffee-vs-green-tea',
+      context: expect.stringContaining('entry_source:featured_category;entry_category:Energy & focus;entry_label:Coffee vs Green Tea'),
+    }))
+  })
+
+  it('does not attach a pending hub entry to a different comparison page', () => {
+    trackCompareHubClick({
+      source: 'goal_starter',
+      href: '/guides/compare/coffee-vs-green-tea/',
+      label: 'Compare Coffee & Green Tea',
+    })
+    appendAnalyticsEvent.mockClear()
+
+    trackComparisonPageViewed('st-johns-wort-vs-saffron')
+
+    expect(appendAnalyticsEvent).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'comparison_page_viewed',
+      context: expect.stringContaining('entry_source:direct_or_external;entry_category:none'),
+    }))
+  })
+
   it('records one comparison view per page per session', () => {
     trackComparisonPageViewed('coffee-vs-green-tea')
     trackComparisonPageViewed('coffee-vs-green-tea')

--- a/src/lib/__tests__/comparison-outcome-analytics-report.test.ts
+++ b/src/lib/__tests__/comparison-outcome-analytics-report.test.ts
@@ -43,6 +43,36 @@ describe('comparison outcome analytics report', () => {
     ]))
   })
 
+  it('attributes continuation behavior to the hub source and category that opened the comparison', () => {
+    const report = buildComparisonOutcomePerformance([
+      { type: 'comparison_page_viewed', slug: 'coffee-vs-green-tea', context: 'session:s1;entry_source:featured_category;entry_category:Energy & focus;entry_label:Coffee vs Green Tea' },
+      { type: 'comparison_page_viewed', slug: 'coffee-vs-green-tea', context: 'session:s2;entry_source:goal_starter;entry_category:none;entry_label:Compare Coffee & Green Tea' },
+      { type: 'comparison_outcome_click', slug: 'coffee-vs-green-tea', item: '/herbs/coffea-arabica/', context: 'session:s1;outcome:herb_profile' },
+      { type: 'comparison_outcome_click', slug: 'coffee-vs-green-tea', item: '#references', context: 'session:s2;outcome:reference' },
+    ])
+
+    expect(report.journeyRows).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        pageSlug: 'coffee-vs-green-tea',
+        entrySource: 'featured_category',
+        entryCategory: 'Energy & focus',
+        views: 1,
+        engagedSessions: 1,
+        continuationRate: 1,
+        topOutcome: 'herb_profile',
+      }),
+      expect.objectContaining({
+        pageSlug: 'coffee-vs-green-tea',
+        entrySource: 'goal_starter',
+        entryCategory: 'none',
+        views: 1,
+        engagedSessions: 1,
+        continuationRate: 1,
+        topOutcome: 'reference',
+      }),
+    ]))
+  })
+
   it('excludes events without a session id', () => {
     const report = buildComparisonOutcomePerformance([
       { type: 'comparison_page_viewed', slug: 'a-vs-b', context: '' },

--- a/src/lib/compareHubTracking.ts
+++ b/src/lib/compareHubTracking.ts
@@ -5,8 +5,15 @@ import { appendAnalyticsEvent } from '@/lib/analyticsEventStorage'
 const SESSION_KEY = 'hs_compare_hub_session'
 const SEEN_CATEGORY_KEY = 'hs_compare_hub_seen_categories'
 const SEEN_COMPARISON_KEY = 'hs_compare_seen_pages'
+const PENDING_ENTRY_KEY = 'hs_compare_pending_entry'
 
 type HubSession = { sessionId: string }
+type PendingEntry = {
+  pageSlug: string
+  source: CompareHubClickSource
+  category: string
+  label: string
+}
 
 function createSessionId() {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') return crypto.randomUUID()
@@ -37,6 +44,36 @@ function readStringSet(key: string) {
 function persistStringSet(key: string, values: Set<string>) {
   if (typeof window === 'undefined') return
   try { window.sessionStorage.setItem(key, JSON.stringify(Array.from(values))) } catch { /* ignore */ }
+}
+
+function comparisonSlugFromHref(href: string) {
+  const match = href.match(/^\/guides\/compare\/([^/?#]+)\/?(?:[?#].*)?$/)
+  if (!match || match[1] === 'dynamic') return undefined
+  return match[1]
+}
+
+function writePendingEntry(entry: PendingEntry) {
+  if (typeof window === 'undefined') return
+  try { window.sessionStorage.setItem(PENDING_ENTRY_KEY, JSON.stringify(entry)) } catch { /* ignore */ }
+}
+
+function consumePendingEntry(pageSlug: string): PendingEntry | undefined {
+  if (typeof window === 'undefined') return undefined
+  try {
+    const raw = window.sessionStorage.getItem(PENDING_ENTRY_KEY)
+    if (!raw) return undefined
+    const parsed = JSON.parse(raw) as Partial<PendingEntry>
+    if (parsed.pageSlug !== pageSlug || typeof parsed.source !== 'string') return undefined
+    window.sessionStorage.removeItem(PENDING_ENTRY_KEY)
+    return {
+      pageSlug,
+      source: parsed.source as CompareHubClickSource,
+      category: typeof parsed.category === 'string' ? parsed.category : 'none',
+      label: typeof parsed.label === 'string' ? parsed.label : pageSlug,
+    }
+  } catch {
+    return undefined
+  }
 }
 
 export function trackCompareHubCategoryShown(category: string) {
@@ -70,6 +107,15 @@ export function trackCompareHubClick({
 }) {
   if (typeof window === 'undefined') return
   const session = getSession()
+  const pageSlug = comparisonSlugFromHref(href)
+  if (pageSlug) {
+    writePendingEntry({
+      pageSlug,
+      source,
+      category: category || 'none',
+      label,
+    })
+  }
   appendAnalyticsEvent({
     type: 'compare_hub_click',
     slug: href,
@@ -90,10 +136,11 @@ export function trackComparisonPageViewed(pageSlug: string) {
   if (seen.has(key)) return
   seen.add(key)
   persistStringSet(SEEN_COMPARISON_KEY, seen)
+  const entry = consumePendingEntry(pageSlug)
   appendAnalyticsEvent({
     type: 'comparison_page_viewed',
     slug: pageSlug,
-    context: `session:${session.sessionId}`,
+    context: `session:${session.sessionId};entry_source:${entry?.source || 'direct_or_external'};entry_category:${entry?.category || 'none'};entry_label:${(entry?.label || pageSlug).replace(/[;:]/g, ' ')}`,
     sourceType: 'comparison',
     targetType: 'comparison',
   })

--- a/src/lib/comparisonOutcomeAnalyticsReport.ts
+++ b/src/lib/comparisonOutcomeAnalyticsReport.ts
@@ -5,6 +5,14 @@ export type ComparisonOutcomeAnalyticsEvent = {
   slug?: string
 }
 
+type ViewAttribution = {
+  session: string
+  pageSlug: string
+  entrySource: string
+  entryCategory: string
+  entryLabel: string
+}
+
 function parseContext(context = '') {
   const values = new Map<string, string>()
   context.split(';').forEach((segment) => {
@@ -16,7 +24,7 @@ function parseContext(context = '') {
 }
 
 export function buildComparisonOutcomePerformance(events: ComparisonOutcomeAnalyticsEvent[]) {
-  const views = new Set<string>()
+  const views = new Map<string, ViewAttribution>()
   const outcomes = new Map<string, { session: string; pageSlug: string; outcome: string; href: string }>()
   let unattributedEvents = 0
 
@@ -31,7 +39,16 @@ export function buildComparisonOutcomePerformance(events: ComparisonOutcomeAnaly
 
     const pageSlug = event.slug || 'unknown'
     if (event.type === 'comparison_page_viewed') {
-      views.add(`${session}|${pageSlug}`)
+      const key = `${session}|${pageSlug}`
+      if (!views.has(key)) {
+        views.set(key, {
+          session,
+          pageSlug,
+          entrySource: values.get('entry_source') || 'direct_or_external',
+          entryCategory: values.get('entry_category') || 'none',
+          entryLabel: values.get('entry_label') || pageSlug,
+        })
+      }
       return
     }
 
@@ -42,12 +59,10 @@ export function buildComparisonOutcomePerformance(events: ComparisonOutcomeAnaly
   })
 
   const pageStats = new Map<string, { views: number; engagedSessions: Set<string>; outcomes: number }>()
-  views.forEach((key) => {
-    const separator = key.indexOf('|')
-    const pageSlug = key.slice(separator + 1)
-    const current = pageStats.get(pageSlug) ?? { views: 0, engagedSessions: new Set<string>(), outcomes: 0 }
+  views.forEach((view) => {
+    const current = pageStats.get(view.pageSlug) ?? { views: 0, engagedSessions: new Set<string>(), outcomes: 0 }
     current.views += 1
-    pageStats.set(pageSlug, current)
+    pageStats.set(view.pageSlug, current)
   })
 
   const outcomeCounts = new Map<string, number>()
@@ -74,9 +89,61 @@ export function buildComparisonOutcomePerformance(events: ComparisonOutcomeAnaly
     .map(([outcome, clicks]) => ({ outcome, clicks }))
     .sort((a, b) => b.clicks - a.clicks || a.outcome.localeCompare(b.outcome))
 
+  const journeyStats = new Map<string, {
+    pageSlug: string
+    entrySource: string
+    entryCategory: string
+    views: number
+    engagedSessions: Set<string>
+    outcomeCounts: Map<string, number>
+  }>()
+
+  views.forEach((view) => {
+    const key = `${view.pageSlug}|${view.entrySource}|${view.entryCategory}`
+    const current = journeyStats.get(key) ?? {
+      pageSlug: view.pageSlug,
+      entrySource: view.entrySource,
+      entryCategory: view.entryCategory,
+      views: 0,
+      engagedSessions: new Set<string>(),
+      outcomeCounts: new Map<string, number>(),
+    }
+    current.views += 1
+    journeyStats.set(key, current)
+  })
+
+  outcomes.forEach((outcome) => {
+    const view = views.get(`${outcome.session}|${outcome.pageSlug}`)
+    if (!view) return
+    const key = `${view.pageSlug}|${view.entrySource}|${view.entryCategory}`
+    const current = journeyStats.get(key)
+    if (!current) return
+    current.engagedSessions.add(outcome.session)
+    current.outcomeCounts.set(outcome.outcome, (current.outcomeCounts.get(outcome.outcome) ?? 0) + 1)
+  })
+
+  const journeyRows = Array.from(journeyStats.values()).map((stats) => {
+    const topOutcome = Array.from(stats.outcomeCounts.entries())
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))[0]?.[0] ?? 'none'
+    return {
+      pageSlug: stats.pageSlug,
+      entrySource: stats.entrySource,
+      entryCategory: stats.entryCategory,
+      views: stats.views,
+      engagedSessions: stats.engagedSessions.size,
+      continuationRate: stats.views ? stats.engagedSessions.size / stats.views : 0,
+      topOutcome,
+    }
+  }).sort((a, b) => b.continuationRate - a.continuationRate
+    || b.engagedSessions - a.engagedSessions
+    || b.views - a.views
+    || a.pageSlug.localeCompare(b.pageSlug)
+    || a.entrySource.localeCompare(b.entrySource))
+
   return {
     pageRows,
     outcomeRows,
+    journeyRows,
     attributedViews: views.size,
     attributedOutcomes: outcomes.size,
     unattributedEvents,


### PR DESCRIPTION
## Summary
- carry comparison-hub entry source/category into the destination comparison view through session-scoped pending attribution
- preserve one unique comparison-page view per session/page and avoid query-parameter or URL changes
- report source → page → outcome journeys with continuation rate and top next action
- show the new journey table in the developer analytics panel
- add regression coverage for correct attribution, false-attribution prevention, and source-specific downstream behavior

## Privacy / architecture
Uses the existing anonymous session/local analytics store only. No personal data is added and comparison pages remain server-rendered.