### PR TITLE
Finish final test gate cleanup

### DIFF
--- a/components/__tests__/SeeAlsoCluster.test.tsx
+++ b/components/__tests__/SeeAlsoCluster.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import type { AnchorHTMLAttributes, ReactNode } from 'react'
 import SeeAlsoCluster from '../SeeAlsoCluster'
 
@@ -39,9 +39,12 @@ describe('SeeAlsoCluster', () => {
     expect(screen.queryByRole('link', { name: /^Bacopa$/ })).toBeNull()
   })
 
-  it('respects the limit prop on the number of peer entries shown', async () => {
+  it('respects the limit prop on the number of semantic-cluster peer entries shown', async () => {
     await renderCluster({ slug: 'bacopa', kind: 'herb', limit: 1 })
-    const peerLinks = screen.getAllByRole('link').filter((link) => !/Full guide|guide →/.test(link.textContent || ''))
+    const clusterRegion = screen.getByRole('region', { name: 'Also in this cluster' })
+    const peerLinks = within(clusterRegion)
+      .getAllByRole('link')
+      .filter((link) => !/Full guide|guide →/.test(link.textContent || ''))
     expect(peerLinks.length).toBeLessThanOrEqual(1)
   })
 })

--- a/src/lib/__tests__/botanical-atlas-engagement.test.ts
+++ b/src/lib/__tests__/botanical-atlas-engagement.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { appendAnalyticsEvent } = vi.hoisted(() => ({ appendAnalyticsEvent: vi.fn() }))
-vi.mock('@/utils/analytics/eventStorage', () => ({ appendAnalyticsEvent }))
+vi.mock('@/lib/analyticsEventStorage', () => ({ appendAnalyticsEvent }))
 
 import {
   getAtlasEngagementState,


### PR DESCRIPTION
## Summary
- point Botanical Atlas engagement tests at the analytics module actually used by production code
- scope the SeeAlsoCluster limit assertion to the semantic-cluster region so Related Botanicals links are not miscounted

## Context
The previous CI run reached 902/905 passing tests. These two test-harness fixes address the final three known failures without changing production behavior.