### PR TITLE
Add observed behavior to comparison prioritization

### DIFF
--- a/scripts/rank-related-comparisons.ts
+++ b/scripts/rank-related-comparisons.ts
@@ -1,23 +1,41 @@
-import { mkdir, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
+import { buildRelatedBotanicalPerformance, type AtlasAnalyticsEvent } from '../src/lib/atlasAnalyticsReport'
 import { getBotanicalAtlasRecords } from '../src/lib/botanical-atlas-data'
 import { buildComparisonShortlist } from '../src/lib/comparison-shortlist'
 
 const outputDir = path.resolve(process.cwd(), 'reports/related-botanicals')
 const limit = Math.max(1, Number(process.env.COMPARISON_SHORTLIST_LIMIT ?? 30) || 30)
-const records = await getBotanicalAtlasRecords()
-const rows = buildComparisonShortlist(records, limit)
+const analyticsEventsPath = process.env.ANALYTICS_EVENTS_PATH
+
+async function loadBehaviorRows() {
+  if (!analyticsEventsPath) return []
+  const absolutePath = path.resolve(process.cwd(), analyticsEventsPath)
+  const payload = JSON.parse(await readFile(absolutePath, 'utf8')) as AtlasAnalyticsEvent[] | { events?: AtlasAnalyticsEvent[] }
+  const events = Array.isArray(payload) ? payload : payload.events ?? []
+  return buildRelatedBotanicalPerformance(events).cardRows
+}
+
+const [records, behaviorRows] = await Promise.all([
+  getBotanicalAtlasRecords(),
+  loadBehaviorRows(),
+])
+const rows = buildComparisonShortlist(records, limit, behaviorRows)
 
 const markdown = [
   '# Curated Botanical Comparison Shortlist',
   '',
   `Generated: ${new Date().toISOString()}`,
   '',
-  'Ranks unbuilt botanical comparison opportunities using separate scientific-priority and editorial-intent-proxy scores. The intent score is a deterministic editorial proxy based on shared user goals, recognizable shared compounds, and a chemistry-only penalty; it is not search-volume data. This remains a human-reviewed shortlist, not an auto-publishing queue.',
+  analyticsEventsPath
+    ? `Observed behavior source: \`${analyticsEventsPath}\` (${behaviorRows.length} pair-position rows)`
+    : 'Observed behavior source: none supplied. Set `ANALYTICS_EVENTS_PATH` to a JSON analytics export to add pair-level demand and research-depth signals.',
   '',
-  '| Rank | Pair | Combined | Scientific | Intent proxy | Relationship | Chemistry | Evidence | Shared specific effects |',
-  '| ---: | --- | ---: | ---: | ---: | ---: | :---: | --- | --- |',
-  ...rows.map((row, index) => `| ${index + 1} | **${row.a.name} vs ${row.b.name}** | ${row.priorityScore.toFixed(2)} | ${row.scientificPriorityScore.toFixed(2)} | ${row.editorialIntentScore.toFixed(2)} | ${row.relationshipScore.toFixed(2)} | ${row.chemistrySupported ? 'yes' : 'no'} | ${row.evidenceLabel} | ${row.sharedSpecificEffects.slice(0, 4).join(', ') || '—'} |`),
+  'Ranks unbuilt botanical comparison opportunities using scientific priority, deterministic editorial-intent proxies, and optional observed Related Botanicals behavior. Observed behavior is confidence-weighted so tiny samples cannot dominate the queue. This remains a human-reviewed shortlist, not an auto-publishing queue.',
+  '',
+  '| Rank | Pair | Combined | Scientific | Intent proxy | Observed behavior | Relationship | Chemistry | Evidence | Shared specific effects |',
+  '| ---: | --- | ---: | ---: | ---: | ---: | ---: | :---: | --- | --- |',
+  ...rows.map((row, index) => `| ${index + 1} | **${row.a.name} vs ${row.b.name}** | ${row.priorityScore.toFixed(2)} | ${row.scientificPriorityScore.toFixed(2)} | ${row.editorialIntentScore.toFixed(2)} | ${row.observedBehaviorScore.toFixed(2)} | ${row.relationshipScore.toFixed(2)} | ${row.chemistrySupported ? 'yes' : 'no'} | ${row.evidenceLabel} | ${row.sharedSpecificEffects.slice(0, 4).join(', ') || '—'} |`),
   '',
   '## Why these rank',
   '',
@@ -27,10 +45,12 @@ const markdown = [
     `- Combined priority: ${row.priorityScore.toFixed(2)}`,
     `- Scientific priority: ${row.scientificPriorityScore.toFixed(2)}`,
     `- Editorial intent proxy: ${row.editorialIntentScore.toFixed(2)}`,
+    `- Observed behavior: ${row.observedBehaviorScore.toFixed(2)} (${row.observedBehavior.clicks}/${row.observedBehavior.impressions} clicks; ${Math.round(row.observedBehavior.ctr * 100)}% CTR; ${Math.round(row.observedBehavior.deepExplorationRate * 100)}% depth 3+)`,
     `- Relationship score: ${row.relationshipScore.toFixed(2)}`,
     `- Chemistry-supported: ${row.chemistrySupported ? 'yes' : 'no'}`,
     `- Pair evidence tier: ${row.evidenceLabel}`,
     ...row.intentSignals.map((signal) => `- Intent signal (${signal.score >= 0 ? '+' : ''}${signal.score}): ${signal.label}`),
+    ...row.behaviorSignals.map((signal) => `- Behavior signal (+${signal.score}): ${signal.label}`),
     ...row.reasons.slice(0, 4).map((reason) => `- ${reason.label}: ${reason.values.join(', ')}`),
     '',
   ]),
@@ -38,16 +58,18 @@ const markdown = [
 
 await mkdir(outputDir, { recursive: true })
 await Promise.all([
-  writeFile(path.join(outputDir, 'comparison-shortlist.json'), JSON.stringify({ generatedAt: new Date().toISOString(), rows }, null, 2) + '\n'),
+  writeFile(path.join(outputDir, 'comparison-shortlist.json'), JSON.stringify({ generatedAt: new Date().toISOString(), analyticsEventsPath: analyticsEventsPath ?? null, rows }, null, 2) + '\n'),
   writeFile(path.join(outputDir, 'comparison-shortlist.md'), markdown + '\n'),
 ])
 
 console.log(JSON.stringify({
   candidates: rows.length,
+  behaviorRows: behaviorRows.length,
   top: rows.slice(0, 5).map((row) => ({
     pair: `${row.a.name} vs ${row.b.name}`,
     combined: row.priorityScore,
     scientific: row.scientificPriorityScore,
     intentProxy: row.editorialIntentScore,
+    observedBehavior: row.observedBehaviorScore,
   })),
 }, null, 2))

--- a/src/lib/__tests__/comparison-shortlist.test.ts
+++ b/src/lib/__tests__/comparison-shortlist.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { buildComparisonShortlist, evidenceTier, isAliasPair, scoreComparisonIntent } from '@/lib/comparison-shortlist'
+import {
+  buildComparisonShortlist,
+  evidenceTier,
+  isAliasPair,
+  scoreComparisonIntent,
+  scoreObservedComparisonBehavior,
+} from '@/lib/comparison-shortlist'
 import type { RelatedBotanicalRecord } from '@/lib/related-botanicals'
 
 const herb = (slug: string, overrides: Partial<RelatedBotanicalRecord> = {}): RelatedBotanicalRecord => ({
@@ -118,5 +124,38 @@ describe('comparison shortlist', () => {
 
     expect(intent.score).toBeGreaterThan(0)
     expect(intent.signals.some((signal) => signal.label.includes('Recognizable shared compound'))).toBe(true)
+  })
+
+  it('turns related-card demand into a confidence-weighted observed behavior score', () => {
+    const sparse = scoreObservedComparisonBehavior('alpha', 'beta', [
+      { sourceSlug: 'alpha', targetSlug: 'beta', position: 1, impressions: 1, clicks: 1, ctr: 1, averageClickDepth: 3, deepExplorationRate: 1 },
+    ])
+    const established = scoreObservedComparisonBehavior('alpha', 'beta', [
+      { sourceSlug: 'alpha', targetSlug: 'beta', position: 1, impressions: 20, clicks: 8, ctr: 0.4, averageClickDepth: 3.2, deepExplorationRate: 0.75 },
+    ])
+
+    expect(sparse.score).toBeGreaterThan(0)
+    expect(established.score).toBeGreaterThan(sparse.score)
+    expect(established.signals.some((signal) => signal.label.startsWith('Observed related-card demand'))).toBe(true)
+  })
+
+  it('uses observed behavior to break otherwise similar shortlist candidates', () => {
+    const source = herb('behavior-source', { explicitEffects: ['calming', 'sleep'] })
+    const demanded = herb('behavior-demanded', { explicitEffects: ['calming', 'sleep'] })
+    const quiet = herb('behavior-quiet', { explicitEffects: ['calming', 'sleep'] })
+
+    const rows = buildComparisonShortlist([source, demanded, quiet], 20, [
+      { sourceSlug: 'behavior-source', targetSlug: 'behavior-demanded', position: 1, impressions: 24, clicks: 9, ctr: 0.375, averageClickDepth: 3.1, deepExplorationRate: 0.78 },
+      { sourceSlug: 'behavior-demanded', targetSlug: 'behavior-source', position: 2, impressions: 12, clicks: 4, ctr: 0.333, averageClickDepth: 2.8, deepExplorationRate: 0.5 },
+      { sourceSlug: 'behavior-source', targetSlug: 'behavior-quiet', position: 1, impressions: 24, clicks: 1, ctr: 0.042, averageClickDepth: 2, deepExplorationRate: 0 },
+    ])
+
+    const demandedPair = rows.find((row) => [row.a.slug, row.b.slug].includes('behavior-source') && [row.a.slug, row.b.slug].includes('behavior-demanded'))
+    const quietPair = rows.find((row) => [row.a.slug, row.b.slug].includes('behavior-source') && [row.a.slug, row.b.slug].includes('behavior-quiet'))
+
+    expect(demandedPair).toBeTruthy()
+    expect(quietPair).toBeTruthy()
+    expect(demandedPair!.observedBehaviorScore).toBeGreaterThan(quietPair!.observedBehaviorScore)
+    expect(demandedPair!.priorityScore).toBeGreaterThan(quietPair!.priorityScore)
   })
 })

--- a/src/lib/comparison-shortlist.ts
+++ b/src/lib/comparison-shortlist.ts
@@ -1,8 +1,14 @@
 import { getValidComparisonSlug } from '@/lib/comparison-utils'
 import { isSameComparisonIdentity } from '@/lib/comparison-identity-groups'
+import type { RelatedBotanicalCardPerformanceRow } from '@/lib/atlasAnalyticsReport'
 import { scoreRelatedBotanical, type RelatedBotanicalRecord, type RelatedBotanicalReason } from '@/lib/related-botanicals'
 
 export type ComparisonIntentSignal = {
+  label: string
+  score: number
+}
+
+export type ComparisonBehaviorSignal = {
   label: string
   score: number
 }
@@ -13,12 +19,20 @@ export type ComparisonShortlistRow = {
   relationshipScore: number
   scientificPriorityScore: number
   editorialIntentScore: number
+  observedBehaviorScore: number
   priorityScore: number
   chemistrySupported: boolean
   sharedSpecificEffects: string[]
   evidenceTier: number
   evidenceLabel: string
   intentSignals: ComparisonIntentSignal[]
+  behaviorSignals: ComparisonBehaviorSignal[]
+  observedBehavior: {
+    impressions: number
+    clicks: number
+    ctr: number
+    deepExplorationRate: number
+  }
   reasons: RelatedBotanicalReason[]
 }
 
@@ -143,7 +157,67 @@ export function scoreComparisonIntent(
   return { score, signals }
 }
 
-export function buildComparisonShortlist(records: RelatedBotanicalRecord[], limit = 30) {
+export function scoreObservedComparisonBehavior(
+  aSlug: string,
+  bSlug: string,
+  rows: RelatedBotanicalCardPerformanceRow[] = [],
+): {
+  score: number
+  signals: ComparisonBehaviorSignal[]
+  impressions: number
+  clicks: number
+  ctr: number
+  deepExplorationRate: number
+} {
+  const pairRows = rows.filter((row) =>
+    (row.sourceSlug === aSlug && row.targetSlug === bSlug)
+    || (row.sourceSlug === bSlug && row.targetSlug === aSlug),
+  )
+  if (!pairRows.length) {
+    return { score: 0, signals: [], impressions: 0, clicks: 0, ctr: 0, deepExplorationRate: 0 }
+  }
+
+  const impressions = pairRows.reduce((sum, row) => sum + row.impressions, 0)
+  const clicks = pairRows.reduce((sum, row) => sum + row.clicks, 0)
+  const ctr = impressions ? clicks / impressions : 0
+  const deepClicks = pairRows.reduce((sum, row) => sum + row.deepExplorationRate * row.clicks, 0)
+  const deepExplorationRate = clicks ? deepClicks / clicks : 0
+
+  // Shrink low-sample CTR toward zero so one lucky click cannot dominate the queue.
+  const confidence = impressions / (impressions + 8)
+  const demandScore = confidence * ctr * 8
+  const depthScore = confidence * deepExplorationRate * 3
+  const clickScore = Math.min(clicks, 4) * 0.75
+  const exposureScore = Math.min(Math.log2(impressions + 1), 3) * 0.25
+  const score = demandScore + depthScore + clickScore + exposureScore
+
+  const signals: ComparisonBehaviorSignal[] = []
+  signals.push({
+    label: `Observed related-card demand (${clicks}/${impressions} clicks, ${Math.round(ctr * 100)}% CTR)`,
+    score: Number((demandScore + clickScore + exposureScore).toFixed(4)),
+  })
+  if (clicks > 0) {
+    signals.push({
+      label: `Post-click research depth (${Math.round(deepExplorationRate * 100)}% reached depth 3+)`,
+      score: Number(depthScore.toFixed(4)),
+    })
+  }
+
+  return {
+    score: Number(score.toFixed(4)),
+    signals,
+    impressions,
+    clicks,
+    ctr,
+    deepExplorationRate,
+  }
+}
+
+export function buildComparisonShortlist(
+  records: RelatedBotanicalRecord[],
+  limit = 30,
+  behaviorRows: RelatedBotanicalCardPerformanceRow[] = [],
+) {
   const seen = new Set<string>()
   const rows: ComparisonShortlistRow[] = []
 
@@ -168,7 +242,8 @@ export function buildComparisonShortlist(records: RelatedBotanicalRecord[], limi
         + tier * 2
         + Math.min(sharedSpecificEffects.length, 3)
       const intent = scoreComparisonIntent(a, b, chemistrySupported, sharedSpecificEffects)
-      const priorityScore = scientificPriorityScore + intent.score
+      const behavior = scoreObservedComparisonBehavior(a.slug, b.slug, behaviorRows)
+      const priorityScore = scientificPriorityScore + intent.score + behavior.score
 
       rows.push({
         a,
@@ -176,12 +251,20 @@ export function buildComparisonShortlist(records: RelatedBotanicalRecord[], limi
         relationshipScore: match.score,
         scientificPriorityScore: Number(scientificPriorityScore.toFixed(4)),
         editorialIntentScore: Number(intent.score.toFixed(4)),
+        observedBehaviorScore: behavior.score,
         priorityScore: Number(priorityScore.toFixed(4)),
         chemistrySupported,
         sharedSpecificEffects,
         evidenceTier: tier,
         evidenceLabel: tier === 3 ? 'strong' : tier === 2 ? 'moderate' : tier === 1 ? 'limited' : 'unclassified',
         intentSignals: intent.signals,
+        behaviorSignals: behavior.signals,
+        observedBehavior: {
+          impressions: behavior.impressions,
+          clicks: behavior.clicks,
+          ctr: behavior.ctr,
+          deepExplorationRate: behavior.deepExplorationRate,
+        },
         reasons: match.reasons,
       })
     }
@@ -189,6 +272,7 @@ export function buildComparisonShortlist(records: RelatedBotanicalRecord[], limi
 
   return rows
     .sort((x, y) => y.priorityScore - x.priorityScore
+      || y.observedBehaviorScore - x.observedBehaviorScore
       || y.editorialIntentScore - x.editorialIntentScore
       || y.scientificPriorityScore - x.scientificPriorityScore
       || y.relationshipScore - x.relationshipScore


### PR DESCRIPTION
## Summary
- add confidence-weighted observed behavior scoring to unbuilt botanical comparison candidates
- aggregate Related Botanicals pair impressions/clicks across both directions
- incorporate CTR, deep-exploration rate, click volume, and exposure volume without letting tiny samples dominate
- expose observed behavior score/signals on shortlist rows
- allow `scripts/rank-related-comparisons.ts` to ingest an analytics JSON export through `ANALYTICS_EVENTS_PATH`
- add tests proving established demand outranks sparse/lower-demand pairs

## Why
The shortlist previously relied on scientific relationship quality plus deterministic editorial-intent proxies. Related Botanicals now generates real pair-level user behavior before a comparison page exists, which gives us a stronger signal for what users actually want to compare. The weighting deliberately shrinks low-sample CTR so one lucky click cannot hijack the editorial queue.