### PR TITLE
Turn observed comparison demand into an editorial queue

### DIFF
--- a/scripts/rank-related-comparisons.ts
+++ b/scripts/rank-related-comparisons.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import { buildRelatedBotanicalPerformance, type AtlasAnalyticsEvent } from '../src/lib/atlasAnalyticsReport'
 import { getBotanicalAtlasRecords } from '../src/lib/botanical-atlas-data'
+import { classifyObservedDemand, observedDemandRank } from '../src/lib/comparison-demand-tier'
 import { buildComparisonShortlist } from '../src/lib/comparison-shortlist'
 
 const outputDir = path.resolve(process.cwd(), 'reports/related-botanicals')
@@ -21,6 +22,20 @@ const [records, behaviorRows] = await Promise.all([
   loadBehaviorRows(),
 ])
 const rows = buildComparisonShortlist(records, limit, behaviorRows)
+const observedDemandQueue = rows
+  .map((row) => ({
+    row,
+    demandTier: classifyObservedDemand({
+      impressions: row.observedBehavior.impressions,
+      clicks: row.observedBehavior.clicks,
+      ctr: row.observedBehavior.ctr,
+      observedBehaviorScore: row.observedBehaviorScore,
+    }),
+  }))
+  .filter(({ demandTier }) => demandTier !== 'insufficient')
+  .sort((a, b) => observedDemandRank(b.demandTier) - observedDemandRank(a.demandTier)
+    || b.row.observedBehaviorScore - a.row.observedBehaviorScore
+    || b.row.priorityScore - a.row.priorityScore)
 
 const markdown = [
   '# Curated Botanical Comparison Shortlist',
@@ -32,6 +47,22 @@ const markdown = [
     : 'Observed behavior source: none supplied. Set `ANALYTICS_EVENTS_PATH` to a JSON analytics export to add pair-level demand and research-depth signals.',
   '',
   'Ranks unbuilt botanical comparison opportunities using scientific priority, deterministic editorial-intent proxies, and optional observed Related Botanicals behavior. Observed behavior is confidence-weighted so tiny samples cannot dominate the queue. This remains a human-reviewed shortlist, not an auto-publishing queue.',
+  '',
+  '## Observed-demand editorial queue',
+  '',
+  analyticsEventsPath
+    ? 'Candidates below have enough real Related Botanicals behavior to earn an observed-demand tier. High-confidence requires at least 20 impressions, 5 clicks, 20% CTR, and a behavior score of 4.5; lower tiers retain stricter sample-size floors than raw CTR alone.'
+    : 'No analytics export supplied, so no observed-demand editorial queue can be generated yet.',
+  '',
+  ...(observedDemandQueue.length
+    ? [
+        '| Tier | Pair | Behavior | Clicks / impressions | CTR | Depth 3+ | Combined priority |',
+        '| --- | --- | ---: | ---: | ---: | ---: | ---: |',
+        ...observedDemandQueue.map(({ row, demandTier }) => `| **${demandTier}** | ${row.a.name} vs ${row.b.name} | ${row.observedBehaviorScore.toFixed(2)} | ${row.observedBehavior.clicks} / ${row.observedBehavior.impressions} | ${Math.round(row.observedBehavior.ctr * 100)}% | ${Math.round(row.observedBehavior.deepExplorationRate * 100)}% | ${row.priorityScore.toFixed(2)} |`),
+      ]
+    : ['No candidates currently clear the observed-demand sample thresholds.']),
+  '',
+  '## Full scientific + editorial shortlist',
   '',
   '| Rank | Pair | Combined | Scientific | Intent proxy | Observed behavior | Relationship | Chemistry | Evidence | Shared specific effects |',
   '| ---: | --- | ---: | ---: | ---: | ---: | ---: | :---: | --- | --- |',
@@ -46,6 +77,7 @@ const markdown = [
     `- Scientific priority: ${row.scientificPriorityScore.toFixed(2)}`,
     `- Editorial intent proxy: ${row.editorialIntentScore.toFixed(2)}`,
     `- Observed behavior: ${row.observedBehaviorScore.toFixed(2)} (${row.observedBehavior.clicks}/${row.observedBehavior.impressions} clicks; ${Math.round(row.observedBehavior.ctr * 100)}% CTR; ${Math.round(row.observedBehavior.deepExplorationRate * 100)}% depth 3+)`,
+    `- Observed-demand tier: ${classifyObservedDemand({ impressions: row.observedBehavior.impressions, clicks: row.observedBehavior.clicks, ctr: row.observedBehavior.ctr, observedBehaviorScore: row.observedBehaviorScore })}`,
     `- Relationship score: ${row.relationshipScore.toFixed(2)}`,
     `- Chemistry-supported: ${row.chemistrySupported ? 'yes' : 'no'}`,
     `- Pair evidence tier: ${row.evidenceLabel}`,
@@ -56,15 +88,28 @@ const markdown = [
   ]),
 ].join('\n')
 
+const editorialQueue = observedDemandQueue.map(({ row, demandTier }) => ({
+  demandTier,
+  pair: `${row.a.name} vs ${row.b.name}`,
+  aSlug: row.a.slug,
+  bSlug: row.b.slug,
+  priorityScore: row.priorityScore,
+  observedBehaviorScore: row.observedBehaviorScore,
+  ...row.observedBehavior,
+}))
+
 await mkdir(outputDir, { recursive: true })
 await Promise.all([
-  writeFile(path.join(outputDir, 'comparison-shortlist.json'), JSON.stringify({ generatedAt: new Date().toISOString(), analyticsEventsPath: analyticsEventsPath ?? null, rows }, null, 2) + '\n'),
+  writeFile(path.join(outputDir, 'comparison-shortlist.json'), JSON.stringify({ generatedAt: new Date().toISOString(), analyticsEventsPath: analyticsEventsPath ?? null, editorialQueue, rows }, null, 2) + '\n'),
   writeFile(path.join(outputDir, 'comparison-shortlist.md'), markdown + '\n'),
+  writeFile(path.join(outputDir, 'observed-demand-editorial-queue.json'), JSON.stringify({ generatedAt: new Date().toISOString(), analyticsEventsPath: analyticsEventsPath ?? null, candidates: editorialQueue }, null, 2) + '\n'),
 ])
 
 console.log(JSON.stringify({
   candidates: rows.length,
   behaviorRows: behaviorRows.length,
+  observedDemandCandidates: editorialQueue.length,
+  highConfidenceCandidates: editorialQueue.filter((candidate) => candidate.demandTier === 'high-confidence').length,
   top: rows.slice(0, 5).map((row) => ({
     pair: `${row.a.name} vs ${row.b.name}`,
     combined: row.priorityScore,

--- a/src/lib/__tests__/comparison-demand-tier.test.ts
+++ b/src/lib/__tests__/comparison-demand-tier.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { classifyObservedDemand, observedDemandRank } from '@/lib/comparison-demand-tier'
+
+describe('comparison observed demand tiers', () => {
+  it('requires both sample size and meaningful demand for high confidence', () => {
+    expect(classifyObservedDemand({ impressions: 24, clicks: 7, ctr: 7 / 24, observedBehaviorScore: 6.2 })).toBe('high-confidence')
+    expect(classifyObservedDemand({ impressions: 4, clicks: 4, ctr: 1, observedBehaviorScore: 6.2 })).not.toBe('high-confidence')
+  })
+
+  it('separates promising, emerging, and insufficient signals', () => {
+    expect(classifyObservedDemand({ impressions: 14, clicks: 3, ctr: 3 / 14, observedBehaviorScore: 3.4 })).toBe('promising')
+    expect(classifyObservedDemand({ impressions: 8, clicks: 1, ctr: 0.125, observedBehaviorScore: 1.4 })).toBe('emerging')
+    expect(classifyObservedDemand({ impressions: 3, clicks: 1, ctr: 1 / 3, observedBehaviorScore: 1.2 })).toBe('insufficient')
+  })
+
+  it('orders tiers for editorial queue sorting', () => {
+    expect(observedDemandRank('high-confidence')).toBeGreaterThan(observedDemandRank('promising'))
+    expect(observedDemandRank('promising')).toBeGreaterThan(observedDemandRank('emerging'))
+    expect(observedDemandRank('emerging')).toBeGreaterThan(observedDemandRank('insufficient'))
+  })
+})

--- a/src/lib/comparison-demand-tier.ts
+++ b/src/lib/comparison-demand-tier.ts
@@ -1,0 +1,27 @@
+export type ObservedDemandTier = 'high-confidence' | 'promising' | 'emerging' | 'insufficient'
+
+export type ObservedDemandInput = {
+  impressions: number
+  clicks: number
+  ctr: number
+  observedBehaviorScore: number
+}
+
+export function classifyObservedDemand({
+  impressions,
+  clicks,
+  ctr,
+  observedBehaviorScore,
+}: ObservedDemandInput): ObservedDemandTier {
+  if (impressions >= 20 && clicks >= 5 && ctr >= 0.2 && observedBehaviorScore >= 4.5) return 'high-confidence'
+  if (impressions >= 10 && clicks >= 2 && ctr >= 0.12 && observedBehaviorScore >= 2.5) return 'promising'
+  if (impressions >= 5 && clicks >= 1) return 'emerging'
+  return 'insufficient'
+}
+
+export function observedDemandRank(tier: ObservedDemandTier) {
+  if (tier === 'high-confidence') return 3
+  if (tier === 'promising') return 2
+  if (tier === 'emerging') return 1
+  return 0
+}


### PR DESCRIPTION
## Summary
- classify pair-level observed demand as high-confidence, promising, emerging, or insufficient
- require minimum sample sizes in addition to CTR/behavior score so small samples cannot look authoritative
- add unit coverage for confidence-tier boundaries and ordering
- generate a dedicated observed-demand editorial queue in the comparison shortlist Markdown
- emit `reports/related-botanicals/observed-demand-editorial-queue.json` for agents/editorial automation
- report high-confidence and total observed-demand candidate counts in the ranking command output

## Thresholds
High-confidence currently requires >=20 impressions, >=5 clicks, >=20% CTR, and observed behavior score >=4.5. Promising and emerging tiers use lower but still explicit sample floors. These tiers organize human editorial review; they do not auto-publish pages.