### PR TITLE
Add evidence-gated actions to comparison editorial queue

### DIFF
--- a/scripts/rank-related-comparisons.ts
+++ b/scripts/rank-related-comparisons.ts
@@ -2,7 +2,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import { buildRelatedBotanicalPerformance, type AtlasAnalyticsEvent } from '../src/lib/atlasAnalyticsReport'
 import { getBotanicalAtlasRecords } from '../src/lib/botanical-atlas-data'
-import { classifyObservedDemand, observedDemandRank } from '../src/lib/comparison-demand-tier'
+import { classifyObservedDemand, observedDemandRank, recommendEditorialAction } from '../src/lib/comparison-demand-tier'
 import { buildComparisonShortlist } from '../src/lib/comparison-shortlist'
 
 const outputDir = path.resolve(process.cwd(), 'reports/related-botanicals')
@@ -23,15 +23,19 @@ const [records, behaviorRows] = await Promise.all([
 ])
 const rows = buildComparisonShortlist(records, limit, behaviorRows)
 const observedDemandQueue = rows
-  .map((row) => ({
-    row,
-    demandTier: classifyObservedDemand({
+  .map((row) => {
+    const demandTier = classifyObservedDemand({
       impressions: row.observedBehavior.impressions,
       clicks: row.observedBehavior.clicks,
       ctr: row.observedBehavior.ctr,
       observedBehaviorScore: row.observedBehaviorScore,
-    }),
-  }))
+    })
+    return {
+      row,
+      demandTier,
+      recommendedAction: recommendEditorialAction(demandTier, row.evidenceTier),
+    }
+  })
   .filter(({ demandTier }) => demandTier !== 'insufficient')
   .sort((a, b) => observedDemandRank(b.demandTier) - observedDemandRank(a.demandTier)
     || b.row.observedBehaviorScore - a.row.observedBehaviorScore
@@ -46,19 +50,19 @@ const markdown = [
     ? `Observed behavior source: \`${analyticsEventsPath}\` (${behaviorRows.length} pair-position rows)`
     : 'Observed behavior source: none supplied. Set `ANALYTICS_EVENTS_PATH` to a JSON analytics export to add pair-level demand and research-depth signals.',
   '',
-  'Ranks unbuilt botanical comparison opportunities using scientific priority, deterministic editorial-intent proxies, and optional observed Related Botanicals behavior. Observed behavior is confidence-weighted so tiny samples cannot dominate the queue. This remains a human-reviewed shortlist, not an auto-publishing queue.',
+  'Ranks unbuilt botanical comparison opportunities using scientific priority, deterministic editorial-intent proxies, and optional observed Related Botanicals behavior. Observed behavior is confidence-weighted so tiny samples cannot dominate the queue. Demand tiers are then gated by evidence quality before a recommended editorial action is assigned. This remains a human-reviewed shortlist, not an auto-publishing queue.',
   '',
   '## Observed-demand editorial queue',
   '',
   analyticsEventsPath
-    ? 'Candidates below have enough real Related Botanicals behavior to earn an observed-demand tier. High-confidence requires at least 20 impressions, 5 clicks, 20% CTR, and a behavior score of 4.5; lower tiers retain stricter sample-size floors than raw CTR alone.'
+    ? 'Candidates below have enough real Related Botanicals behavior to earn an observed-demand tier. High-confidence requires at least 20 impressions, 5 clicks, 20% CTR, and a behavior score of 4.5. A high-demand pair only receives `build-next` when its pair evidence tier is at least moderate; otherwise it is routed to `research-first`.'
     : 'No analytics export supplied, so no observed-demand editorial queue can be generated yet.',
   '',
   ...(observedDemandQueue.length
     ? [
-        '| Tier | Pair | Behavior | Clicks / impressions | CTR | Depth 3+ | Combined priority |',
-        '| --- | --- | ---: | ---: | ---: | ---: | ---: |',
-        ...observedDemandQueue.map(({ row, demandTier }) => `| **${demandTier}** | ${row.a.name} vs ${row.b.name} | ${row.observedBehaviorScore.toFixed(2)} | ${row.observedBehavior.clicks} / ${row.observedBehavior.impressions} | ${Math.round(row.observedBehavior.ctr * 100)}% | ${Math.round(row.observedBehavior.deepExplorationRate * 100)}% | ${row.priorityScore.toFixed(2)} |`),
+        '| Action | Tier | Pair | Evidence | Behavior | Clicks / impressions | CTR | Depth 3+ | Combined priority |',
+        '| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: |',
+        ...observedDemandQueue.map(({ row, demandTier, recommendedAction }) => `| **${recommendedAction}** | ${demandTier} | ${row.a.name} vs ${row.b.name} | ${row.evidenceLabel} | ${row.observedBehaviorScore.toFixed(2)} | ${row.observedBehavior.clicks} / ${row.observedBehavior.impressions} | ${Math.round(row.observedBehavior.ctr * 100)}% | ${Math.round(row.observedBehavior.deepExplorationRate * 100)}% | ${row.priorityScore.toFixed(2)} |`),
       ]
     : ['No candidates currently clear the observed-demand sample thresholds.']),
   '',
@@ -70,29 +74,36 @@ const markdown = [
   '',
   '## Why these rank',
   '',
-  ...rows.slice(0, 15).flatMap((row, index) => [
-    `### ${index + 1}. ${row.a.name} vs ${row.b.name}`,
-    '',
-    `- Combined priority: ${row.priorityScore.toFixed(2)}`,
-    `- Scientific priority: ${row.scientificPriorityScore.toFixed(2)}`,
-    `- Editorial intent proxy: ${row.editorialIntentScore.toFixed(2)}`,
-    `- Observed behavior: ${row.observedBehaviorScore.toFixed(2)} (${row.observedBehavior.clicks}/${row.observedBehavior.impressions} clicks; ${Math.round(row.observedBehavior.ctr * 100)}% CTR; ${Math.round(row.observedBehavior.deepExplorationRate * 100)}% depth 3+)`,
-    `- Observed-demand tier: ${classifyObservedDemand({ impressions: row.observedBehavior.impressions, clicks: row.observedBehavior.clicks, ctr: row.observedBehavior.ctr, observedBehaviorScore: row.observedBehaviorScore })}`,
-    `- Relationship score: ${row.relationshipScore.toFixed(2)}`,
-    `- Chemistry-supported: ${row.chemistrySupported ? 'yes' : 'no'}`,
-    `- Pair evidence tier: ${row.evidenceLabel}`,
-    ...row.intentSignals.map((signal) => `- Intent signal (${signal.score >= 0 ? '+' : ''}${signal.score}): ${signal.label}`),
-    ...row.behaviorSignals.map((signal) => `- Behavior signal (+${signal.score}): ${signal.label}`),
-    ...row.reasons.slice(0, 4).map((reason) => `- ${reason.label}: ${reason.values.join(', ')}`),
-    '',
-  ]),
+  ...rows.slice(0, 15).flatMap((row, index) => {
+    const demandTier = classifyObservedDemand({ impressions: row.observedBehavior.impressions, clicks: row.observedBehavior.clicks, ctr: row.observedBehavior.ctr, observedBehaviorScore: row.observedBehaviorScore })
+    return [
+      `### ${index + 1}. ${row.a.name} vs ${row.b.name}`,
+      '',
+      `- Combined priority: ${row.priorityScore.toFixed(2)}`,
+      `- Scientific priority: ${row.scientificPriorityScore.toFixed(2)}`,
+      `- Editorial intent proxy: ${row.editorialIntentScore.toFixed(2)}`,
+      `- Observed behavior: ${row.observedBehaviorScore.toFixed(2)} (${row.observedBehavior.clicks}/${row.observedBehavior.impressions} clicks; ${Math.round(row.observedBehavior.ctr * 100)}% CTR; ${Math.round(row.observedBehavior.deepExplorationRate * 100)}% depth 3+)`,
+      `- Observed-demand tier: ${demandTier}`,
+      `- Recommended action: ${recommendEditorialAction(demandTier, row.evidenceTier)}`,
+      `- Relationship score: ${row.relationshipScore.toFixed(2)}`,
+      `- Chemistry-supported: ${row.chemistrySupported ? 'yes' : 'no'}`,
+      `- Pair evidence tier: ${row.evidenceLabel}`,
+      ...row.intentSignals.map((signal) => `- Intent signal (${signal.score >= 0 ? '+' : ''}${signal.score}): ${signal.label}`),
+      ...row.behaviorSignals.map((signal) => `- Behavior signal (+${signal.score}): ${signal.label}`),
+      ...row.reasons.slice(0, 4).map((reason) => `- ${reason.label}: ${reason.values.join(', ')}`),
+      '',
+    ]
+  }),
 ].join('\n')
 
-const editorialQueue = observedDemandQueue.map(({ row, demandTier }) => ({
+const editorialQueue = observedDemandQueue.map(({ row, demandTier, recommendedAction }) => ({
+  recommendedAction,
   demandTier,
   pair: `${row.a.name} vs ${row.b.name}`,
   aSlug: row.a.slug,
   bSlug: row.b.slug,
+  evidenceTier: row.evidenceTier,
+  evidenceLabel: row.evidenceLabel,
   priorityScore: row.priorityScore,
   observedBehaviorScore: row.observedBehaviorScore,
   ...row.observedBehavior,
@@ -109,7 +120,8 @@ console.log(JSON.stringify({
   candidates: rows.length,
   behaviorRows: behaviorRows.length,
   observedDemandCandidates: editorialQueue.length,
-  highConfidenceCandidates: editorialQueue.filter((candidate) => candidate.demandTier === 'high-confidence').length,
+  buildNextCandidates: editorialQueue.filter((candidate) => candidate.recommendedAction === 'build-next').length,
+  researchFirstCandidates: editorialQueue.filter((candidate) => candidate.recommendedAction === 'research-first').length,
   top: rows.slice(0, 5).map((row) => ({
     pair: `${row.a.name} vs ${row.b.name}`,
     combined: row.priorityScore,

--- a/src/lib/__tests__/comparison-demand-tier.test.ts
+++ b/src/lib/__tests__/comparison-demand-tier.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { classifyObservedDemand, observedDemandRank } from '@/lib/comparison-demand-tier'
+import { classifyObservedDemand, observedDemandRank, recommendEditorialAction } from '@/lib/comparison-demand-tier'
 
 describe('comparison observed demand tiers', () => {
   it('requires both sample size and meaningful demand for high confidence', () => {
@@ -17,5 +17,14 @@ describe('comparison observed demand tiers', () => {
     expect(observedDemandRank('high-confidence')).toBeGreaterThan(observedDemandRank('promising'))
     expect(observedDemandRank('promising')).toBeGreaterThan(observedDemandRank('emerging'))
     expect(observedDemandRank('emerging')).toBeGreaterThan(observedDemandRank('insufficient'))
+  })
+
+  it('does not recommend building a high-demand comparison until evidence is adequate', () => {
+    expect(recommendEditorialAction('high-confidence', 2)).toBe('build-next')
+    expect(recommendEditorialAction('high-confidence', 1)).toBe('research-first')
+    expect(recommendEditorialAction('promising', 2)).toBe('validate-and-outline')
+    expect(recommendEditorialAction('promising', 1)).toBe('research-first')
+    expect(recommendEditorialAction('emerging', 3)).toBe('keep-observing')
+    expect(recommendEditorialAction('insufficient', 3)).toBe('no-action')
   })
 })

--- a/src/lib/comparison-demand-tier.ts
+++ b/src/lib/comparison-demand-tier.ts
@@ -1,4 +1,5 @@
 export type ObservedDemandTier = 'high-confidence' | 'promising' | 'emerging' | 'insufficient'
+export type EditorialQueueAction = 'build-next' | 'research-first' | 'validate-and-outline' | 'keep-observing' | 'no-action'
 
 export type ObservedDemandInput = {
   impressions: number
@@ -24,4 +25,14 @@ export function observedDemandRank(tier: ObservedDemandTier) {
   if (tier === 'promising') return 2
   if (tier === 'emerging') return 1
   return 0
+}
+
+export function recommendEditorialAction(
+  demandTier: ObservedDemandTier,
+  evidenceTier: number,
+): EditorialQueueAction {
+  if (demandTier === 'high-confidence') return evidenceTier >= 2 ? 'build-next' : 'research-first'
+  if (demandTier === 'promising') return evidenceTier >= 2 ? 'validate-and-outline' : 'research-first'
+  if (demandTier === 'emerging') return 'keep-observing'
+  return 'no-action'
 }


### PR DESCRIPTION
## Summary
- add explicit editorial actions: build-next, research-first, validate-and-outline, keep-observing, no-action
- gate build-next on both high-confidence observed demand and at least moderate pair evidence
- route high-demand but weak-evidence comparisons to research-first instead of build
- add unit coverage for action decisions
- include recommended actions and evidence fields in the Markdown/JSON editorial queue
- expose build-next and research-first counts in ranking command output

## Why
Observed user demand should influence editorial priorities, but it should not override scientific quality. This makes the queue actionable for agents while preserving an evidence gate before recommending a comparison page for production.