### PR TITLE
Scope temporary August npm audit exceptions

### DIFF
--- a/scripts/ci/audit-high-with-allowlist.mjs
+++ b/scripts/ci/audit-high-with-allowlist.mjs
@@ -6,9 +6,23 @@ import { fileURLToPath } from 'node:url'
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
 const allowlistPath = path.join(repoRoot, 'security', 'audit-allowlist.json')
+const allowlistFragmentsDir = path.join(repoRoot, 'security', 'audit-allowlist.d')
 
-const allowlist = JSON.parse(fs.readFileSync(allowlistPath, 'utf8'))
-const rules = Array.isArray(allowlist.rules) ? allowlist.rules : []
+function readRules(filePath) {
+  const payload = JSON.parse(fs.readFileSync(filePath, 'utf8'))
+  return Array.isArray(payload.rules) ? payload.rules : []
+}
+
+const fragmentPaths = fs.existsSync(allowlistFragmentsDir)
+  ? fs.readdirSync(allowlistFragmentsDir)
+      .filter((name) => name.endsWith('.json'))
+      .sort()
+      .map((name) => path.join(allowlistFragmentsDir, name))
+  : []
+const rules = [
+  ...readRules(allowlistPath),
+  ...fragmentPaths.flatMap((filePath) => readRules(filePath)),
+]
 
 function getNpmInvocation() {
   const npmExecPath = process.env.npm_execpath

--- a/security/audit-allowlist.d/2026-08-upstream-build-tooling.json
+++ b/security/audit-allowlist.d/2026-08-upstream-build-tooling.json
@@ -1,0 +1,28 @@
+{
+  "version": 1,
+  "generatedAt": "2026-08-07",
+  "rules": [
+    {
+      "id": "js-yaml-gray-matter-build-tooling-2026-08",
+      "package": "js-yaml",
+      "severity": "high",
+      "expiresOn": "2026-08-22",
+      "advisoryUrls": [
+        "https://github.com/advisories/GHSA-5p4m-2wfm-xmqj"
+      ],
+      "followUpIssueUrl": "https://github.com/Razzleberrytt/hippie-scientist-site/issues/new?title=Remove%20js-yaml%20audit%20exception%20after%20gray-matter%20upstream%20update",
+      "rationale": "The affected js-yaml 3.15.0 copy is nested under gray-matter 4.0.3 and is used only while parsing repository-controlled front matter during trusted local/CI content builds. The advisory is a CPU denial-of-service in !!omap resolution. The advisory lists 3.15.1 as patched, but npm currently publishes 3.15.0 as the v3 legacy release; forcing js-yaml 4/5 into gray-matter is incompatible with gray-matter's v3 API usage. The static export ships no YAML parser or user-controlled YAML endpoint. Short-lived exception pending an upstream-compatible patched gray-matter/js-yaml path."
+    },
+    {
+      "id": "nanoid-postcss-build-tooling-2026-08",
+      "package": "nanoid",
+      "severity": "high",
+      "expiresOn": "2026-08-22",
+      "advisoryUrls": [
+        "https://github.com/advisories/GHSA-2v37-7h3g-55p8"
+      ],
+      "followUpIssueUrl": "https://github.com/Razzleberrytt/hippie-scientist-site/issues/new?title=Remove%20nanoid%20audit%20exception%20after%20PostCSS%20upstream%20update",
+      "rationale": "The affected nanoid 3.3.16 copy is transitive build tooling through PostCSS and is used only in trusted CSS compilation. The advisory concerns custom generators looping indefinitely when called with size zero; the site does not call nanoid directly and no user-controlled size reaches the build pipeline. The advisory lists 3.3.17 as patched, but npm currently publishes 3.3.16 as the v3 legacy release; forcing nanoid 5/6 across PostCSS's dependency boundary risks ESM/API incompatibility. The static export ships no server-side nanoid endpoint. Short-lived exception pending a compatible PostCSS/nanoid release."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add support for small JSON audit-allowlist fragments under `security/audit-allowlist.d/`
- add short-lived, advisory-specific exceptions for the newly reported `js-yaml` and `nanoid` high-severity findings
- expire both exceptions on 2026-08-22
- document why forced major overrides are currently riskier than the affected trusted build-time paths

## Context
The full production quality gate is green through lint, typecheck, tests, canonical data, build, SEO, redirects, and route coverage. `npm audit` now reports two new transitive highs: `js-yaml@3.15.0` under `gray-matter` and `nanoid@3.3.16` under PostCSS. The advisories name legacy patch versions (`3.15.1` and `3.3.17`) that are not currently published on npm, while forcing newer majors crosses compatibility boundaries. These exceptions are narrowly scoped, temporary, and automatically fail after August 22 if not removed or renewed.