### PR TITLE
Emit agent-ready comparison work packets

### DIFF
--- a/docs/agents/comparison-editorial-queue.md
+++ b/docs/agents/comparison-editorial-queue.md
@@ -1,0 +1,57 @@
+# Comparison Editorial Agent Contract
+
+This document defines how development/editorial agents should consume the behavioral comparison-priority system.
+
+## Source artifacts
+
+Running `scripts/rank-related-comparisons.ts` can produce these files under `reports/related-botanicals/`:
+
+- `comparison-shortlist.json` — full scientific + editorial ranking context.
+- `comparison-shortlist.md` — human-readable ranking and top assignments.
+- `observed-demand-editorial-queue.json` — compact behavior/evidence action queue.
+- `comparison-agent-work-queue.json` — executable work packets with explicit next tasks, blockers, and completion criteria.
+
+Observed behavior is optional. Set `ANALYTICS_EVENTS_PATH` to a JSON analytics export when generating the report. Without behavioral data, the scientific shortlist still works but no observed-demand work packets should be treated as production priorities.
+
+## Action contract
+
+### `build-next`
+
+The pair has high-confidence observed demand and at least moderate pair evidence. An agent may prepare a production-ready comparison artifact, but must still preserve normal evidence, safety, SEO, and editorial review gates.
+
+### `research-first`
+
+Demand is meaningful but the evidence gate is not strong enough for production. Research and document the evidence gap. Do **not** draft or publish the final comparison merely because demand is high.
+
+### `validate-and-outline`
+
+Demand is promising and evidence is adequate enough to justify a structured outline. Validate the actual decision question, identify evidence requirements section by section, and keep unresolved gaps visible.
+
+### `keep-observing`
+
+Demand is emerging but under-sampled. Do not spend production effort yet. Continue gathering Related Botanicals exposure/click behavior until the tier changes.
+
+### `no-action`
+
+No active agent assignment.
+
+## Non-negotiable guardrails
+
+1. Observed demand can raise urgency; it cannot lower the scientific evidence requirement.
+2. A high CTR from a tiny sample is not a production signal. Use the demand tier, not raw CTR alone.
+3. Never invent chemistry, mechanism, safety, or efficacy distinctions to make a comparison more interesting.
+4. Use the canonical evidence/data system for factual claims and preserve uncertainty in wording.
+5. Work packets are assignments, not publishing authorization. Existing review, CI, safety, and content-quality gates still apply.
+6. If a packet's evidence state has changed since generation, regenerate the queue before acting on it.
+
+## Packet execution
+
+Prefer `comparison-agent-work-queue.json` as the machine-facing entry point. For each packet:
+
+1. Read `recommendedAction`, `actionReason`, and `nextTask` first.
+2. Resolve every applicable item in `researchGaps` or explicitly document why it remains unresolved.
+3. Use `completionCriteria` as the definition of done for that assignment.
+4. Preserve `packetId` in notes/PR descriptions when practical so work remains traceable to the generated queue.
+5. Regenerate the queue after meaningful evidence, behavior, or comparison-page changes so completed/obsolete packets do not remain authoritative.
+
+The goal is a controlled progression from **observe → validate → research → build**, not autonomous page proliferation.

--- a/scripts/rank-related-comparisons.ts
+++ b/scripts/rank-related-comparisons.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import { buildRelatedBotanicalPerformance, type AtlasAnalyticsEvent } from '../src/lib/atlasAnalyticsReport'
 import { getBotanicalAtlasRecords } from '../src/lib/botanical-atlas-data'
+import { buildComparisonAgentWorkPacket } from '../src/lib/comparison-agent-work-queue'
 import { classifyObservedDemand, observedDemandRank, recommendEditorialAction } from '../src/lib/comparison-demand-tier'
 import { buildComparisonShortlist } from '../src/lib/comparison-shortlist'
 
@@ -41,6 +42,10 @@ const observedDemandQueue = rows
     || b.row.observedBehaviorScore - a.row.observedBehaviorScore
     || b.row.priorityScore - a.row.priorityScore)
 
+const agentWorkPackets = observedDemandQueue
+  .map(({ row, demandTier, recommendedAction }) => buildComparisonAgentWorkPacket(row, demandTier, recommendedAction))
+  .filter((packet) => packet.recommendedAction !== 'no-action')
+
 const markdown = [
   '# Curated Botanical Comparison Shortlist',
   '',
@@ -66,6 +71,23 @@ const markdown = [
       ]
     : ['No candidates currently clear the observed-demand sample thresholds.']),
   '',
+  '## Agent execution queue',
+  '',
+  agentWorkPackets.length
+    ? 'Each packet below is also emitted to `comparison-agent-work-queue.json` with explicit research gaps and completion criteria. Agents should execute the recommended task, not infer a more aggressive action from demand alone.'
+    : 'No active agent packets are available yet.',
+  '',
+  ...agentWorkPackets.slice(0, 15).flatMap((packet, index) => [
+    `### ${index + 1}. ${packet.title}`,
+    '',
+    `- Action: **${packet.recommendedAction}**`,
+    `- Proposed slug: \`${packet.proposedSlug}\``,
+    `- Why: ${packet.actionReason}`,
+    `- Next task: ${packet.nextTask}`,
+    `- Research gaps: ${packet.researchGaps.length ? packet.researchGaps.join(' | ') : 'none identified'}`,
+    `- Done when: ${packet.completionCriteria.join(' | ')}`,
+    '',
+  ]),
   '## Full scientific + editorial shortlist',
   '',
   '| Rank | Pair | Combined | Scientific | Intent proxy | Observed behavior | Relationship | Chemistry | Evidence | Shared specific effects |',
@@ -111,15 +133,17 @@ const editorialQueue = observedDemandQueue.map(({ row, demandTier, recommendedAc
 
 await mkdir(outputDir, { recursive: true })
 await Promise.all([
-  writeFile(path.join(outputDir, 'comparison-shortlist.json'), JSON.stringify({ generatedAt: new Date().toISOString(), analyticsEventsPath: analyticsEventsPath ?? null, editorialQueue, rows }, null, 2) + '\n'),
+  writeFile(path.join(outputDir, 'comparison-shortlist.json'), JSON.stringify({ generatedAt: new Date().toISOString(), analyticsEventsPath: analyticsEventsPath ?? null, editorialQueue, agentWorkPackets, rows }, null, 2) + '\n'),
   writeFile(path.join(outputDir, 'comparison-shortlist.md'), markdown + '\n'),
   writeFile(path.join(outputDir, 'observed-demand-editorial-queue.json'), JSON.stringify({ generatedAt: new Date().toISOString(), analyticsEventsPath: analyticsEventsPath ?? null, candidates: editorialQueue }, null, 2) + '\n'),
+  writeFile(path.join(outputDir, 'comparison-agent-work-queue.json'), JSON.stringify({ generatedAt: new Date().toISOString(), analyticsEventsPath: analyticsEventsPath ?? null, packets: agentWorkPackets }, null, 2) + '\n'),
 ])
 
 console.log(JSON.stringify({
   candidates: rows.length,
   behaviorRows: behaviorRows.length,
   observedDemandCandidates: editorialQueue.length,
+  agentWorkPackets: agentWorkPackets.length,
   buildNextCandidates: editorialQueue.filter((candidate) => candidate.recommendedAction === 'build-next').length,
   researchFirstCandidates: editorialQueue.filter((candidate) => candidate.recommendedAction === 'research-first').length,
   top: rows.slice(0, 5).map((row) => ({

--- a/src/lib/__tests__/comparison-agent-work-queue.test.ts
+++ b/src/lib/__tests__/comparison-agent-work-queue.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { buildComparisonAgentWorkPacket } from '@/lib/comparison-agent-work-queue'
+import type { ComparisonShortlistRow } from '@/lib/comparison-shortlist'
+
+function row(overrides: Partial<ComparisonShortlistRow> = {}): ComparisonShortlistRow {
+  return {
+    a: { slug: 'lemon-balm', name: 'Lemon Balm', effects: ['calming'], explicitEffects: ['calming'], compounds: [], compoundClasses: [], evidence: 'Moderate', intensity: 'Mild', safety: [] },
+    b: { slug: 'passionflower', name: 'Passionflower', effects: ['calming'], explicitEffects: ['calming'], compounds: [], compoundClasses: [], evidence: 'Moderate', intensity: 'Mild', safety: [] },
+    relationshipScore: 10,
+    scientificPriorityScore: 16,
+    editorialIntentScore: 5,
+    observedBehaviorScore: 6,
+    priorityScore: 27,
+    chemistrySupported: true,
+    sharedSpecificEffects: ['calming'],
+    evidenceTier: 2,
+    evidenceLabel: 'moderate',
+    intentSignals: [],
+    behaviorSignals: [],
+    observedBehavior: { impressions: 28, clicks: 8, ctr: 8 / 28, deepExplorationRate: 0.625 },
+    reasons: [],
+    ...overrides,
+  }
+}
+
+describe('comparison agent work queue', () => {
+  it('turns a build-next candidate into a deterministic production packet', () => {
+    const packet = buildComparisonAgentWorkPacket(row(), 'high-confidence', 'build-next')
+
+    expect(packet.packetId).toBe('comparison:lemon-balm:passionflower')
+    expect(packet.proposedSlug).toBe('lemon-balm-vs-passionflower')
+    expect(packet.recommendedAction).toBe('build-next')
+    expect(packet.nextTask).toContain('Draft the production comparison')
+    expect(packet.completionCriteria.some((item) => item.includes('concrete user decision question'))).toBe(true)
+  })
+
+  it('routes weak-evidence demand into research work instead of page drafting', () => {
+    const packet = buildComparisonAgentWorkPacket(row({ evidenceTier: 1, evidenceLabel: 'limited' }), 'high-confidence', 'research-first')
+
+    expect(packet.recommendedAction).toBe('research-first')
+    expect(packet.actionReason).toContain('evidence is only limited')
+    expect(packet.researchGaps.some((gap) => gap.includes('at least moderate'))).toBe(true)
+    expect(packet.nextTask).toContain('do not draft the production page')
+  })
+
+  it('turns emerging demand into a measurable observation task', () => {
+    const packet = buildComparisonAgentWorkPacket(row({
+      observedBehaviorScore: 1.2,
+      observedBehavior: { impressions: 8, clicks: 1, ctr: 0.125, deepExplorationRate: 0 },
+    }), 'emerging', 'keep-observing')
+
+    expect(packet.researchGaps).toEqual(expect.arrayContaining([
+      expect.stringContaining('12 more related-card impressions'),
+      expect.stringContaining('4 more related-card clicks'),
+    ]))
+    expect(packet.completionCriteria.some((item) => item.includes('Do not create a production page'))).toBe(true)
+  })
+
+  it('flags missing chemistry and decision-axis context as explicit research gaps', () => {
+    const packet = buildComparisonAgentWorkPacket(row({ chemistrySupported: false, sharedSpecificEffects: [] }), 'promising', 'validate-and-outline')
+
+    expect(packet.researchGaps.some((gap) => gap.includes('chemistry or mechanism distinction'))).toBe(true)
+    expect(packet.researchGaps.some((gap) => gap.includes('concrete user-facing decision axis'))).toBe(true)
+  })
+})

--- a/src/lib/comparison-agent-work-queue.ts
+++ b/src/lib/comparison-agent-work-queue.ts
@@ -1,0 +1,136 @@
+import type { EditorialQueueAction, ObservedDemandTier } from '@/lib/comparison-demand-tier'
+import type { ComparisonShortlistRow } from '@/lib/comparison-shortlist'
+
+export type ComparisonAgentWorkPacket = {
+  packetId: string
+  proposedSlug: string
+  title: string
+  recommendedAction: EditorialQueueAction
+  demandTier: ObservedDemandTier
+  actionReason: string
+  nextTask: string
+  researchGaps: string[]
+  completionCriteria: string[]
+  aSlug: string
+  bSlug: string
+  evidenceTier: number
+  evidenceLabel: string
+  chemistrySupported: boolean
+  sharedSpecificEffects: string[]
+  priorityScore: number
+  scientificPriorityScore: number
+  editorialIntentScore: number
+  observedBehaviorScore: number
+  observedBehavior: ComparisonShortlistRow['observedBehavior']
+}
+
+function stablePair(aSlug: string, bSlug: string) {
+  return [aSlug, bSlug].sort((a, b) => a.localeCompare(b))
+}
+
+function actionReason(action: EditorialQueueAction, row: ComparisonShortlistRow, demandTier: ObservedDemandTier) {
+  if (action === 'build-next') {
+    return `High-confidence observed demand is backed by ${row.evidenceLabel} pair evidence, so this comparison is ready for editorial production.`
+  }
+  if (action === 'research-first') {
+    return `${demandTier} observed demand is meaningful, but the pair evidence is only ${row.evidenceLabel}; strengthen the evidence base before drafting a production comparison.`
+  }
+  if (action === 'validate-and-outline') {
+    return `Promising observed demand and ${row.evidenceLabel} evidence justify validating the decision axis and preparing an outline before committing to a full page.`
+  }
+  if (action === 'keep-observing') {
+    return 'The pair has an emerging behavioral signal, but the sample is still too small to justify production work.'
+  }
+  return 'The pair does not currently have enough observed demand to justify agent work.'
+}
+
+function buildResearchGaps(row: ComparisonShortlistRow, demandTier: ObservedDemandTier) {
+  const gaps: string[] = []
+  if (row.evidenceTier < 2) gaps.push('Raise the pair evidence basis to at least moderate before recommending production.')
+  if (!row.chemistrySupported) gaps.push('Verify whether a defensible chemistry or mechanism distinction can help users choose between the botanicals.')
+  if (row.sharedSpecificEffects.length === 0) gaps.push('Identify a concrete user-facing decision axis beyond generic botanical similarity.')
+
+  if (demandTier !== 'high-confidence') {
+    const impressionsNeeded = Math.max(0, 20 - row.observedBehavior.impressions)
+    const clicksNeeded = Math.max(0, 5 - row.observedBehavior.clicks)
+    if (impressionsNeeded > 0) gaps.push(`Collect at least ${impressionsNeeded} more related-card impressions before treating demand as high-confidence.`)
+    if (clicksNeeded > 0) gaps.push(`Collect at least ${clicksNeeded} more related-card clicks before treating demand as high-confidence.`)
+  }
+  return gaps
+}
+
+function nextTask(action: EditorialQueueAction, row: ComparisonShortlistRow) {
+  const pair = `${row.a.name} vs ${row.b.name}`
+  if (action === 'build-next') return `Draft the production comparison for ${pair}, centered on the strongest shared user goal and the clearest evidence-backed differences.`
+  if (action === 'research-first') return `Research the evidence gaps for ${pair}; do not draft the production page until the evidence gate reaches moderate or stronger.`
+  if (action === 'validate-and-outline') return `Validate the primary decision question for ${pair} and create a concise comparison outline with evidence requirements for each section.`
+  if (action === 'keep-observing') return `Keep collecting Related Botanicals behavior for ${pair}; reassess when the pair reaches the promising or high-confidence thresholds.`
+  return `No active task for ${pair}; leave it in the scientific shortlist until demand changes.`
+}
+
+function completionCriteria(action: EditorialQueueAction, row: ComparisonShortlistRow) {
+  const common = [
+    'Use only claims supportable by the canonical evidence/data system.',
+    'Preserve safety caveats and avoid implying unsupported superiority.',
+  ]
+  if (action === 'build-next') {
+    return [
+      'Create a comparison page or production-ready content artifact for the proposed slug.',
+      'Answer a concrete user decision question rather than merely listing similarities.',
+      'Include evidence-backed differences, shared goals, safety context, and useful next-step links.',
+      ...common,
+    ]
+  }
+  if (action === 'research-first') {
+    return [
+      'Document the missing or weak evidence that blocks production.',
+      'Resolve enough evidence gaps for the pair evidence tier to reach at least moderate, or explicitly document why it cannot.',
+      ...common,
+    ]
+  }
+  if (action === 'validate-and-outline') {
+    return [
+      'Define the primary comparison question in one sentence.',
+      'Produce an outline whose sections each have a clear evidence requirement.',
+      'Record any unresolved evidence or chemistry gaps before promoting to build-next.',
+      ...common,
+    ]
+  }
+  if (action === 'keep-observing') {
+    return [
+      `Reassess after at least ${Math.max(20, row.observedBehavior.impressions)} total impressions or a higher demand tier is reached.`,
+      'Do not create a production page from the emerging signal alone.',
+    ]
+  }
+  return ['No action required until new behavioral or evidence signals change the recommendation.']
+}
+
+export function buildComparisonAgentWorkPacket(
+  row: ComparisonShortlistRow,
+  demandTier: ObservedDemandTier,
+  recommendedAction: EditorialQueueAction,
+): ComparisonAgentWorkPacket {
+  const [firstSlug, secondSlug] = stablePair(row.a.slug, row.b.slug)
+  return {
+    packetId: `comparison:${firstSlug}:${secondSlug}`,
+    proposedSlug: `${firstSlug}-vs-${secondSlug}`,
+    title: `${row.a.name} vs ${row.b.name}`,
+    recommendedAction,
+    demandTier,
+    actionReason: actionReason(recommendedAction, row, demandTier),
+    nextTask: nextTask(recommendedAction, row),
+    researchGaps: buildResearchGaps(row, demandTier),
+    completionCriteria: completionCriteria(recommendedAction, row),
+    aSlug: row.a.slug,
+    bSlug: row.b.slug,
+    evidenceTier: row.evidenceTier,
+    evidenceLabel: row.evidenceLabel,
+    chemistrySupported: row.chemistrySupported,
+    sharedSpecificEffects: row.sharedSpecificEffects,
+    priorityScore: row.priorityScore,
+    scientificPriorityScore: row.scientificPriorityScore,
+    editorialIntentScore: row.editorialIntentScore,
+    observedBehaviorScore: row.observedBehaviorScore,
+    observedBehavior: row.observedBehavior,
+  }
+}


### PR DESCRIPTION
> Superseded by #2541, which transplanted this architecture onto current `main`, passed the full validation suite, and merged.

## Summary
- add a deterministic comparison agent work-packet builder
- translate editorial actions into explicit task instructions rather than leaving agents to infer intent
- include proposed slugs, action rationale, research gaps, next tasks, completion criteria, scientific/editorial scores, and observed behavior
- add tests covering build-next, research-first, keep-observing, and missing decision-axis/chemistry gaps
- emit `reports/related-botanicals/comparison-agent-work-queue.json`
- surface the top agent assignments in the Markdown shortlist report

## Guardrails
Work packets preserve the existing evidence gate. `build-next` remains limited to high-confidence demand with at least moderate pair evidence; weak-evidence demand becomes research work rather than production drafting. The queue is an agent task source, not an auto-publishing mechanism.