### PR TITLE
Include Botanical Activity Atlas in sitemap manifest

### DIFF
--- a/scripts/data/build-route-manifest.mjs
+++ b/scripts/data/build-route-manifest.mjs
@@ -173,6 +173,7 @@ async function main() {
     routeEntry('/compare', 'static'),
     routeEntry('/goals', 'static'),
     routeEntry('/stacks', 'static'),
+    routeEntry('/tools/botanical-activity-atlas', 'static'),
   ].map(entry => ({
     ...entry,
     meta_title: entry.route === '/' ? 'The Hippie Scientist' : '',


### PR DESCRIPTION
## Summary
- add `/tools/botanical-activity-atlas` to the canonical deterministic route manifest
- allow the existing sitemap manifest consumer to include the built, indexable Atlas landing page
- fix the Site Health sitemap-completeness failure without hardcoding a second sitemap-only route source

## Context
The Site Health workflow confirmed the Atlas route is built and indexable but missing from `sitemap.xml`. The sitemap already consumes `public/data/runtime-manifests/route-manifest.json`; the missing piece was that the route-manifest generator's static route set did not include the Atlas tool.