### PR TITLE
Adapt comparison work packets into agent assignments

### DIFF
--- a/agent/orchestrator/prepare-comparison-assignments.js
+++ b/agent/orchestrator/prepare-comparison-assignments.js
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+const repoRoot = process.cwd()
+const DEFAULT_QUEUE = path.join(repoRoot, 'reports', 'related-botanicals', 'comparison-agent-work-queue.json')
+const EXECUTABLE_ACTIONS = new Set(['build-next', 'research-first', 'validate-and-outline'])
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const value = (name) => argv.find((arg) => arg.startsWith(`--${name}=`))?.split('=').slice(1).join('=')
+  const action = value('action') || 'all'
+  const packetId = value('packet') || null
+  const queuePath = value('queue') ? path.resolve(repoRoot, value('queue')) : DEFAULT_QUEUE
+  const requestedLimit = Number(value('limit'))
+  const limit = Number.isFinite(requestedLimit) ? Math.min(50, Math.max(1, requestedLimit)) : 10
+
+  if (action !== 'all' && !EXECUTABLE_ACTIONS.has(action)) {
+    throw new Error(`Unsupported executable action: ${action}. Allowed: all, ${[...EXECUTABLE_ACTIONS].join(', ')}`)
+  }
+
+  return { action, packetId, queuePath, limit }
+}
+
+function readQueue(queuePath) {
+  if (!fs.existsSync(queuePath)) {
+    throw new Error(`Comparison work queue not found: ${queuePath}. Generate it with scripts/rank-related-comparisons.ts first.`)
+  }
+
+  const parsed = JSON.parse(fs.readFileSync(queuePath, 'utf8'))
+  const packets = Array.isArray(parsed) ? parsed : parsed.packets ?? parsed.assignments ?? []
+  if (!Array.isArray(packets)) throw new Error('Comparison work queue must contain a packets array.')
+  return packets
+}
+
+function priorityRank(action) {
+  if (action === 'build-next') return 3
+  if (action === 'research-first') return 2
+  if (action === 'validate-and-outline') return 1
+  return 0
+}
+
+export function selectComparisonAssignments(packets, { action = 'all', packetId = null, limit = 10 } = {}) {
+  return packets
+    .filter((packet) => EXECUTABLE_ACTIONS.has(packet?.recommendedAction))
+    .filter((packet) => action === 'all' || packet.recommendedAction === action)
+    .filter((packet) => !packetId || packet.packetId === packetId)
+    .sort((a, b) =>
+      priorityRank(b.recommendedAction) - priorityRank(a.recommendedAction)
+      || Number(b.priorityScore || 0) - Number(a.priorityScore || 0)
+      || String(a.packetId || '').localeCompare(String(b.packetId || '')))
+    .slice(0, limit)
+    .map((packet, index) => ({
+      assignmentId: `comparison-assignment:${index + 1}:${packet.packetId}`,
+      sourcePacketId: packet.packetId,
+      action: packet.recommendedAction,
+      status: 'ready-for-agent',
+      title: packet.title,
+      proposedSlug: packet.proposedSlug,
+      instruction: packet.nextTask,
+      rationale: packet.actionReason,
+      researchGaps: packet.researchGaps ?? [],
+      completionCriteria: packet.completionCriteria ?? [],
+      guardrails: [
+        'Do not publish automatically.',
+        'Do not promote an assignment beyond its evidence-gated action without regenerating the queue.',
+        'Use canonical repository evidence/data sources for factual claims.',
+        'Return reviewable repository changes or research artifacts for human/CI review.',
+      ],
+      evidence: {
+        tier: packet.evidenceTier,
+        label: packet.evidenceLabel,
+        chemistrySupported: Boolean(packet.chemistrySupported),
+      },
+      demand: {
+        tier: packet.demandTier,
+        observedBehaviorScore: Number(packet.observedBehaviorScore || 0),
+        observedBehavior: packet.observedBehavior ?? {},
+      },
+      scores: {
+        priority: Number(packet.priorityScore || 0),
+        scientific: Number(packet.scientificPriorityScore || 0),
+        editorialIntent: Number(packet.editorialIntentScore || 0),
+      },
+      entities: {
+        aSlug: packet.aSlug,
+        bSlug: packet.bSlug,
+      },
+    }))
+}
+
+function main() {
+  const options = parseArgs()
+  const packets = readQueue(options.queuePath)
+  const assignments = selectComparisonAssignments(packets, options)
+
+  const output = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    sourceQueue: path.relative(repoRoot, options.queuePath),
+    filters: {
+      action: options.action,
+      packetId: options.packetId,
+      limit: options.limit,
+    },
+    assignmentCount: assignments.length,
+    assignments,
+  }
+
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(new URL(import.meta.url).pathname)) {
+  try {
+    main()
+  } catch (error) {
+    console.error(`[comparison-assignments] ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
+}

--- a/agent/orchestrator/prepare-comparison-assignments.test.js
+++ b/agent/orchestrator/prepare-comparison-assignments.test.js
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+
+import { selectComparisonAssignments } from './prepare-comparison-assignments.js'
+
+function packet(overrides = {}) {
+  return {
+    packetId: 'comparison:ashwagandha:rhodiola',
+    proposedSlug: 'ashwagandha-vs-rhodiola',
+    title: 'Ashwagandha vs Rhodiola',
+    recommendedAction: 'build-next',
+    demandTier: 'high-confidence',
+    actionReason: 'Demand and evidence support production.',
+    nextTask: 'Draft the comparison.',
+    researchGaps: [],
+    completionCriteria: ['Answer the decision question.'],
+    aSlug: 'ashwagandha',
+    bSlug: 'rhodiola',
+    evidenceTier: 3,
+    evidenceLabel: 'strong',
+    chemistrySupported: true,
+    priorityScore: 9,
+    scientificPriorityScore: 8,
+    editorialIntentScore: 7,
+    observedBehaviorScore: 6,
+    observedBehavior: { impressions: 30, clicks: 8 },
+    ...overrides,
+  }
+}
+
+describe('selectComparisonAssignments', () => {
+  it('selects only executable actions and preserves review guardrails', () => {
+    const assignments = selectComparisonAssignments([
+      packet(),
+      packet({ packetId: 'comparison:a:b', recommendedAction: 'keep-observing' }),
+      packet({ packetId: 'comparison:c:d', recommendedAction: 'no-action' }),
+    ])
+
+    expect(assignments).toHaveLength(1)
+    expect(assignments[0].action).toBe('build-next')
+    expect(assignments[0].guardrails).toContain('Do not publish automatically.')
+  })
+
+  it('prioritizes build work before research and outline work', () => {
+    const assignments = selectComparisonAssignments([
+      packet({ packetId: 'comparison:outline:item', recommendedAction: 'validate-and-outline', priorityScore: 100 }),
+      packet({ packetId: 'comparison:research:item', recommendedAction: 'research-first', priorityScore: 50 }),
+      packet({ packetId: 'comparison:build:item', recommendedAction: 'build-next', priorityScore: 1 }),
+    ])
+
+    expect(assignments.map((assignment) => assignment.action)).toEqual([
+      'build-next',
+      'research-first',
+      'validate-and-outline',
+    ])
+  })
+
+  it('supports action, packet, and limit filters without promoting work', () => {
+    const assignments = selectComparisonAssignments([
+      packet({ packetId: 'comparison:first:item', recommendedAction: 'research-first', priorityScore: 2 }),
+      packet({ packetId: 'comparison:second:item', recommendedAction: 'research-first', priorityScore: 5 }),
+      packet({ packetId: 'comparison:third:item', recommendedAction: 'build-next', priorityScore: 10 }),
+    ], {
+      action: 'research-first',
+      packetId: 'comparison:second:item',
+      limit: 1,
+    })
+
+    expect(assignments).toHaveLength(1)
+    expect(assignments[0].sourcePacketId).toBe('comparison:second:item')
+    expect(assignments[0].action).toBe('research-first')
+  })
+})


### PR DESCRIPTION
> Superseded by #2544, which rebuilt this adapter on current `main`, added stable assignment IDs, passed all applicable validation workflows, and merged.

## Summary
- add a deterministic orchestrator adapter for `comparison-agent-work-queue.json`
- convert only `build-next`, `research-first`, and `validate-and-outline` packets into executable agent assignments
- support action, packet-id, and limit filters
- order work by gated action priority and existing comparison priority score
- preserve evidence, demand, entity, rationale, gaps, and completion criteria in each assignment
- attach explicit no-auto-publish and canonical-data review guardrails
- add Vitest coverage for filtering, ordering, targeting, and guardrail preservation

## Stacked PR
This was intentionally based on #2516 (`feat/comparison-agent-work-packets`). The current-main replacement is now #2544.