### PR TITLE
Improve stress decision hub

### DIFF
--- a/app/__tests__/stress-hub-quality.test.ts
+++ b/app/__tests__/stress-hub-quality.test.ts
@@ -1,0 +1,23 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const source = fs.readFileSync(path.join(process.cwd(), 'app/guides/stress/page.tsx'), 'utf8')
+
+describe('stress guide hub quality', () => {
+  it('uses the shared decision-first hub components without nesting a main landmark', () => {
+    expect(source).toContain('<DecisionRouter items={START_HERE} />')
+    expect(source).toContain('<GuideCardGrid cards={BEST_FIRST} />')
+    expect(source).toContain('<GuideCardGrid cards={COMPARISONS} />')
+    expect(source).not.toMatch(/<main\b/)
+  })
+
+  it('connects the discovery hub to depth, evidence, safety, and comparison pages', () => {
+    expect(source).toContain('/herbs/ashwagandha/')
+    expect(source).toContain('/compounds/l-theanine/')
+    expect(source).toContain('/guides/compare/rhodiola-vs-ashwagandha/')
+    expect(source).toContain('/learn/evidence-literacy/')
+    expect(source).toContain('/info/supplement-safety-checklist/')
+    expect(source).toContain('/info/disclaimer/')
+  })
+})

--- a/app/guides/stress/page.tsx
+++ b/app/guides/stress/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { SITE_URL } from '@/src/lib/seo'
+import { DecisionRouter, type IntentRoute } from '@/components/guides/DecisionRouter'
+import { GuideCardGrid, type GuideCard } from '@/components/guides/GuideCardGrid'
+import { HubSectionHeading } from '@/components/guides/HubSectionHeading'
 import SchemaGraphScript from '@/components/seo/SchemaGraphScript'
 import { buildGuideHubSchemaGraph } from '@/src/lib/schema-graph'
 
@@ -22,61 +25,104 @@ export const metadata: Metadata = {
   },
 }
 
-const routes = [
+const START_HERE: IntentRoute[] = [
   {
     problem: 'I feel wired, tense, or overstimulated right now',
-    detail: 'Start with faster, generally non-sedating options used for acute stress rather than long-term adaptogens.',
+    why: 'Start with timing, evidence limits, and safety for an amino acid studied in stress contexts.',
     href: '/guides/anxiety/l-theanine-for-anxiety/',
-    cta: 'See L-theanine for acute stress',
+    cta: 'L-Theanine for Anxiety',
   },
   {
     problem: 'My stress has been elevated for weeks or months',
-    detail: 'Compare adaptogens studied for perceived stress and cortisol-related symptoms over time.',
+    why: 'Compare longer-term options without treating every adaptogen as interchangeable.',
     href: '/guides/anxiety/best-adaptogens-for-stress/',
-    cta: 'Compare stress adaptogens',
+    cta: 'Best Adaptogens for Stress',
   },
   {
     problem: 'Stress is keeping me awake',
-    detail: 'Focus on nighttime options, timing, next-day sedation, and anxiety-driven insomnia.',
+    why: 'Focus on nighttime fit, interaction risk, and possible next-day sedation.',
     href: '/guides/anxiety/best-herbs-for-stress-and-anxiety-at-night/',
-    cta: 'See nighttime stress options',
+    cta: 'Herbs for Nighttime Stress',
   },
   {
     problem: 'I feel depleted, foggy, or burned out',
-    detail: 'Separate calming support from stimulating adaptogens and consider whether fatigue needs medical evaluation.',
+    why: 'Separate calming support from more activating options and consider whether persistent fatigue needs evaluation.',
     href: '/guides/anxiety/best-supplements-for-stress/',
-    cta: 'Review supplements for chronic stress',
+    cta: 'Best Supplements for Stress',
   },
   {
     problem: 'I am mainly worried about high cortisol',
-    detail: 'Use a broader plan that includes sleep, caffeine, exercise load, and evidence-based supplement context.',
+    why: 'Use a broader decision guide that puts sleep, habits, testing limits, and supplement evidence in context.',
     href: '/guides/anxiety/how-to-lower-cortisol-naturally/',
-    cta: 'Read the cortisol guide',
+    cta: 'How to Lower Cortisol',
   },
   {
     problem: 'I want to combine multiple options',
-    detail: 'Check overlap, sedation, medication interactions, and whether a stack is actually necessary.',
+    why: 'Check overlapping effects, medication interactions, and whether a stack is necessary before combining products.',
     href: '/safety-checker/',
-    cta: 'Check a combination first',
+    cta: 'Supplement Safety Checker',
   },
 ]
 
-const comparisons = [
+const BEST_FIRST: GuideCard[] = [
+  {
+    href: '/guides/anxiety/best-supplements-for-stress/',
+    title: 'Best Supplements for Stress',
+    desc: 'A decision-oriented overview of common options, evidence strength, safety, and who should be cautious.',
+  },
+  {
+    href: '/guides/anxiety/best-adaptogens-for-stress/',
+    title: 'Best Adaptogens for Stress',
+    desc: 'Compare slower, longer-term options by evidence and fit instead of assuming one adaptogen works for everyone.',
+  },
+  {
+    href: '/guides/anxiety/natural-anxiety-relief/',
+    title: 'Natural Anxiety Relief',
+    desc: 'Start here when stress and anxiety overlap or the pattern is not yet clear.',
+  },
+  {
+    href: '/guides/anxiety/how-to-lower-cortisol-naturally/',
+    title: 'How to Lower Cortisol Naturally',
+    desc: 'Put cortisol concerns in context before treating a symptom, wearable reading, or single test as a diagnosis.',
+  },
+]
+
+const COMPARISONS: GuideCard[] = [
   {
     href: '/guides/compare/rhodiola-vs-ashwagandha/',
     title: 'Rhodiola vs Ashwagandha',
-    text: 'A more activating adaptogen versus a more calming one.',
+    desc: 'Compare a generally more activating profile with a generally more calming one, including evidence and safety tradeoffs.',
   },
   {
     href: '/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium/',
     title: 'Ashwagandha vs L-Theanine vs Magnesium',
-    text: 'Long-term stress support, acute calm, and mineral support compared.',
+    desc: 'Longer-term stress support, shorter-term calming context, and mineral support compared symmetrically.',
   },
   {
     href: '/guides/anxiety/cbd-vs-ashwagandha-for-anxiety/',
     title: 'CBD vs Ashwagandha',
-    text: 'Different evidence bases, timelines, and safety considerations.',
+    desc: 'Different evidence bases, timelines, product-quality concerns, and interaction profiles.',
   },
+]
+
+const DEPTH_LINKS = [
+  { href: '/herbs/ashwagandha/', title: 'Ashwagandha', kind: 'Herb profile' },
+  { href: '/herbs/rhodiola/', title: 'Rhodiola Rosea', kind: 'Herb profile' },
+  { href: '/compounds/l-theanine/', title: 'L-Theanine', kind: 'Compound profile' },
+  { href: '/compounds/magnesium-glycinate/', title: 'Magnesium Glycinate', kind: 'Compound profile' },
+  { href: '/herbs/schisandra/', title: 'Schisandra', kind: 'Herb profile' },
+  { href: '/herbs/holy-basil/', title: 'Holy Basil (Tulsi)', kind: 'Herb profile' },
+]
+
+const ALL_GUIDES = [
+  { href: '/guides/anxiety/best-supplements-for-stress/', title: 'Best Supplements for Stress' },
+  { href: '/guides/anxiety/best-adaptogens-for-stress/', title: 'Best Adaptogens for Stress' },
+  { href: '/guides/anxiety/how-to-lower-cortisol-naturally/', title: 'How to Lower Cortisol Naturally' },
+  { href: '/guides/anxiety/l-theanine-for-anxiety/', title: 'L-Theanine for Anxiety' },
+  { href: '/guides/anxiety/ashwagandha-for-anxiety/', title: 'Ashwagandha for Anxiety' },
+  { href: '/guides/anxiety/best-herbs-for-stress-and-anxiety-at-night/', title: 'Herbs for Stress at Night' },
+  { href: '/guides/anxiety/anxiety-stack-guide/', title: 'Anxiety & Stress Stack Guide' },
+  { href: '/guides/anxiety/natural-anxiety-relief/', title: 'Natural Anxiety Relief' },
 ]
 
 export default function StressGuidePage() {
@@ -90,14 +136,14 @@ export default function StressGuidePage() {
       { name: 'Stress', url: `${SITE_URL}${PATH}` },
     ],
     itemListName: 'Stress supplement decision paths',
-    items: [...routes, ...comparisons].map(item => ({
-      name: 'problem' in item ? item.problem : item.title,
+    items: [...BEST_FIRST, ...COMPARISONS].map(item => ({
+      name: item.title,
       url: `${SITE_URL}${item.href}`,
     })),
   })
 
   return (
-    <main className="mx-auto max-w-5xl px-4 pb-24 pt-8 sm:px-6">
+    <div className="mx-auto max-w-5xl px-4 pb-24 pt-8 sm:px-6">
       <SchemaGraphScript graph={schemaGraph} />
       <nav className="mb-5 text-xs text-muted" aria-label="Breadcrumb">
         <Link href="/guides/" className="hover:text-ink">
@@ -120,50 +166,103 @@ export default function StressGuidePage() {
         </p>
       </header>
 
-      <section className="mt-10" aria-labelledby="stress-router-heading">
-        <h2 id="stress-router-heading" className="text-2xl font-bold text-ink sm:text-3xl">
-          What does your stress feel like?
-        </h2>
-        <div className="mt-6 grid gap-4 md:grid-cols-2">
-          {routes.map((route) => (
+      <section className="mt-10">
+        <HubSectionHeading
+          eyebrow="Start here"
+          title="What does your stress feel like?"
+          sub="Choose the closest pattern. Each path leads to the page that explains the evidence, limitations, and safety context in full."
+        />
+        <DecisionRouter items={START_HERE} />
+      </section>
+
+      <section className="mt-14">
+        <HubSectionHeading
+          eyebrow="Best first reads"
+          title="Build context before choosing"
+          sub="These guides help separate the type of problem from the supplement category being marketed for it."
+        />
+        <GuideCardGrid cards={BEST_FIRST} />
+      </section>
+
+      <section className="mt-14">
+        <HubSectionHeading
+          eyebrow="Compare & choose"
+          title="Weigh common options side by side"
+          sub="Use a comparison when you already have a shortlist and need a clearer tradeoff."
+        />
+        <GuideCardGrid cards={COMPARISONS} />
+      </section>
+
+      <section className="mt-14 rounded-2xl border border-brand-900/10 bg-brand-50/60 p-6 dark:border-white/10 dark:bg-[var(--surface-subtle)]">
+        <HubSectionHeading eyebrow="Decision check" title="Three questions before you choose" />
+        <ol className="grid gap-5 text-sm leading-7 text-muted sm:grid-cols-3">
+          <li>
+            <strong className="block text-ink">1. Is the pattern acute or persistent?</strong>
+            A short-lived stressful event and weeks of poor sleep or fatigue call for different next steps.
+          </li>
+          <li>
+            <strong className="block text-ink">2. What kind of evidence applies?</strong>
+            Human stress outcomes, mechanistic plausibility, and traditional use should not be treated as equal support.
+          </li>
+          <li>
+            <strong className="block text-ink">3. What could make it a poor fit?</strong>
+            Review medications, sedation, pregnancy, underlying conditions, and duplicated ingredients before adding a product.
+          </li>
+        </ol>
+        <div className="mt-5 flex flex-wrap gap-4 text-sm font-semibold">
+          <Link href="/learn/evidence-literacy/" className="text-brand-800 hover:underline">
+            Learn how evidence grades work →
+          </Link>
+          <Link href="/info/supplement-safety-checklist/" className="text-brand-800 hover:underline">
+            Review the safety checklist →
+          </Link>
+        </div>
+      </section>
+
+      <section className="mt-14">
+        <HubSectionHeading
+          eyebrow="Research deeper"
+          title="Stress-relevant ingredient profiles"
+          sub="Use the monographs to inspect evidence summaries, mechanisms, cautions, and related compounds after selecting a guide."
+        />
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {DEPTH_LINKS.map((item) => (
             <Link
-              key={route.problem}
-              href={route.href}
-              className="group rounded-2xl border border-brand-900/10 bg-white p-5 transition hover:-translate-y-0.5 hover:border-brand-700/30 hover:shadow-sm dark:border-white/10 dark:bg-[var(--surface-card)]"
+              key={item.href}
+              href={item.href}
+              className="rounded-xl border border-brand-900/12 bg-white p-4 transition hover:border-brand-700/30 hover:bg-brand-50 dark:border-white/10 dark:bg-[var(--surface-card)] dark:hover:bg-white/10"
             >
-              <h3 className="text-base font-bold text-ink dark:text-[var(--text-primary)]">{route.problem}</h3>
-              <p className="mt-2 text-sm leading-6 text-muted dark:text-[var(--text-secondary)]">{route.detail}</p>
-              <span className="mt-4 inline-flex text-sm font-semibold text-brand-800 group-hover:underline dark:text-[var(--text-primary)]">
-                {route.cta} →
+              <span className="block text-[11px] font-bold uppercase tracking-widest text-muted">{item.kind}</span>
+              <span className="mt-1 block text-sm font-semibold text-brand-800 dark:text-[var(--text-primary)]">
+                {item.title} →
               </span>
             </Link>
           ))}
         </div>
       </section>
 
-      <section className="mt-14" aria-labelledby="stress-comparisons-heading">
-        <h2 id="stress-comparisons-heading" className="text-2xl font-bold text-ink sm:text-3xl">
-          Compare the most common options
-        </h2>
-        <div className="mt-6 grid gap-4 md:grid-cols-3">
-          {comparisons.map((item) => (
-            <Link
-              key={item.href}
-              href={item.href}
-              className="rounded-2xl border border-brand-900/10 bg-brand-50/60 p-5 transition hover:border-brand-700/30 dark:border-white/10 dark:bg-[var(--surface-subtle)]"
-            >
-              <h3 className="font-bold text-ink dark:text-[var(--text-primary)]">{item.title}</h3>
-              <p className="mt-2 text-sm leading-6 text-muted dark:text-[var(--text-secondary)]">{item.text}</p>
-            </Link>
+      <section className="mt-14">
+        <HubSectionHeading eyebrow="Full library" title="All stress decision guides" />
+        <ul className="grid gap-x-6 gap-y-2 sm:grid-cols-2">
+          {ALL_GUIDES.map((item) => (
+            <li key={item.href}>
+              <Link href={item.href} className="text-sm font-medium text-brand-800 hover:underline dark:text-[var(--text-primary)]">
+                {item.title}
+              </Link>
+            </li>
           ))}
-        </div>
+        </ul>
       </section>
 
       <aside className="mt-14 rounded-2xl border-l-4 border-brand-700/50 bg-brand-50/70 p-5 dark:bg-[var(--surface-subtle)]">
         <p className="text-sm leading-7 text-ink dark:text-[var(--text-secondary)]">
-          <strong>Safety note:</strong> Persistent stress, severe anxiety, chest pain, major sleep disruption, or worsening mood deserves professional evaluation. Supplements can interact with prescriptions and are not a substitute for treatment.
+          <strong>Safety note:</strong> Persistent stress, severe anxiety, chest pain, major sleep disruption, or worsening mood deserves professional evaluation. Supplements can interact with prescriptions and are not a substitute for treatment. Read the full{' '}
+          <Link href="/info/disclaimer/" className="font-semibold text-brand-800 underline">
+            medical disclaimer
+          </Link>
+          .
         </p>
       </aside>
-    </main>
+    </div>
   )
 }


### PR DESCRIPTION
## What changed

- upgraded `/guides/stress/` to the shared decision-first hub pattern
- added best-first reads, comparison paths, ingredient monographs, evidence literacy, safety guidance, and a complete stress guide index
- connected the hub to the Botanical Activity Atlas through the shared router
- removed the nested page-level `main` landmark
- added a regression test for the hub structure and trust/discovery links

## Why

The repository content audit identified `/guides/stress/` as one of only two thin audited pages. It also lagged the sleep and anxiety hubs in depth-page discovery and used a nested `main` landmark. This change strengthens a high-intent discovery route without changing URLs or introducing unsupported health claims.

## Impact

Readers can now route by stress pattern, compare realistic options, inspect ingredient-level evidence and safety, and reach the full stress guide library from one page. Shared components keep the hub visually and accessibly consistent with other goal hubs.

## Validation

- `npm run audit:content` — pass; `/guides/stress` no longer flagged as thin
- `npx vitest run app/__tests__/stress-hub-quality.test.ts app/__tests__/a11y.test.tsx` — 7 tests passed
- `npm run validate:route-seo` — pass
- `npm run check:fast` — pass
- `npm run build` — pass; 21 production steps completed
- `npm run verify:output` — pass, including sitemap, route, schema, Pagefind, internal-link, and performance audits
- Playwright spot checks at 390px and 1440px in light and dark mode — pass
