### PR TITLE
Surface anxiety in the Best Supplement Guides hub

### DIFF
--- a/app/__tests__/best-guides-hub-coverage.test.ts
+++ b/app/__tests__/best-guides-hub-coverage.test.ts
@@ -1,0 +1,27 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const PAGE = 'app/guides/best/page.tsx'
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+}
+
+describe('best supplement guides hub coverage', () => {
+  it('surfaces the core sleep, anxiety, stress, and focus decision guides', () => {
+    const source = read(PAGE)
+
+    expect(source).toContain('/guides/sleep/best-supplements-for-sleep/')
+    expect(source).toContain('/guides/anxiety/best-herbs-for-anxiety/')
+    expect(source).toContain('/guides/best/supplements-for-stress/')
+    expect(source).toContain('/guides/focus/best-nootropics-for-focus/')
+  })
+
+  it('keeps anxiety represented in hub metadata and schema copy', () => {
+    const source = read(PAGE)
+
+    expect(source.match(/sleep, anxiety, focus, ADHD, stress/g)?.length).toBeGreaterThanOrEqual(2)
+    expect(source).toContain("title: 'Best Herbs for Anxiety'")
+  })
+})

--- a/app/guides/best/page.tsx
+++ b/app/guides/best/page.tsx
@@ -7,7 +7,7 @@ import { buildGuideHubSchemaGraph } from '../../../src/lib/schema-graph'
 export const metadata: Metadata = buildPageMetadata({
   title: 'Best Supplement Guides by Goal',
   description:
-    'Browse evidence-informed best supplement guides for sleep, focus, ADHD, stress, blood pressure, fat loss, gut health, and joint support, with safety-first decision context.',
+    'Browse evidence-informed best supplement guides for sleep, anxiety, focus, ADHD, stress, blood pressure, fat loss, gut health, and joint support, with safety-first decision context.',
   path: '/guides/best/',
 })
 
@@ -41,6 +41,16 @@ const bestGuides = [
       'Readers who want to separate same-day alertness from longer-term memory support and avoid treating every cognitive supplement as an interchangeable focus booster.',
     caution:
       'Caffeine can worsen sleep, anxiety, palpitations, and blood pressure, while persistent concentration problems may need assessment rather than a larger supplement stack.',
+  },
+  {
+    title: 'Best Herbs for Anxiety',
+    href: '/guides/anxiety/best-herbs-for-anxiety/',
+    description:
+      'Compare calming herbs by the anxiety, stress, tension, or sleep-adjacent outcomes actually studied instead of treating every calming ingredient as interchangeable.',
+    bestFor:
+      'Readers comparing herbal options for anxiety-related goals who want evidence boundaries and safety context before choosing a product or stack.',
+    caution:
+      'Sedatives, antidepressants, pregnancy, liver disease, alcohol use, and persistent or severe anxiety can materially change the safety and next-step decision.',
   },
   {
     title: 'Best Supplements for Stress',
@@ -106,7 +116,7 @@ export default function BestSupplementGuidesHub() {
     path: '/guides/best/',
     title: 'Best Supplement Guides by Goal',
     description:
-      'Browse evidence-informed best supplement guides for sleep, focus, ADHD, stress, blood pressure, fat loss, gut health, and joint support, with safety-first decision context.',
+      'Browse evidence-informed best supplement guides for sleep, anxiety, focus, ADHD, stress, blood pressure, fat loss, gut health, and joint support, with safety-first decision context.',
     breadcrumbs: [
       { name: 'Home', url: `${SITE_URL}/` },
       { name: 'Guides', url: `${SITE_URL}/guides/` },


### PR DESCRIPTION
## Summary
- add the existing Best Herbs for Anxiety decision guide to `/guides/best/`
- update hub metadata/schema copy so anxiety is represented alongside sleep, focus, ADHD, and stress
- add regression coverage for the core high-intent guide set

## Why this is high ROI
The curated best-of hub already routes users into Sleep, Focus, ADHD, and Stress but omitted the mature Anxiety decision page. This is a small discovery/internal-link improvement that strengthens a core commercial-intent cluster without adding new medical claims or runtime complexity.

## Validation intent
- current `/guides/*` taxonomy only
- no route changes
- no affiliate or safety logic changes
- focused regression test added
