### PR TITLE
Remove one-sided commerce from broad adaptogen comparison

### DIFF
--- a/app/__tests__/adaptogens-compared-commercial-neutrality.test.ts
+++ b/app/__tests__/adaptogens-compared-commercial-neutrality.test.ts
@@ -1,0 +1,26 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const PAGE = 'app/guides/other/adaptogens-compared/page.tsx'
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+}
+
+describe('adaptogens compared commercial neutrality', () => {
+  it('keeps the broad comparison independent from a one-ingredient product module', () => {
+    const source = read(PAGE)
+
+    expect(source).not.toContain('RecommendationSection')
+    expect(source).not.toContain('getRevenueProductSet')
+    expect(source).not.toContain('Ashwagandha product picks')
+  })
+
+  it('preserves evidence references and owned-audience capture', () => {
+    const source = read(PAGE)
+
+    expect(source).toContain('<References refs={ADAPTOGENS_REFS} />')
+    expect(source).toContain('location="guide-adaptogens"')
+  })
+})

--- a/app/guides/other/adaptogens-compared/page.tsx
+++ b/app/guides/other/adaptogens-compared/page.tsx
@@ -7,8 +7,6 @@ import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
 import FAQSchema from '@/components/seo/FAQSchema'
 import References from '@/components/References'
 import EmailCapture from '../../../../components/EmailCapture'
-import RecommendationSection from '@/components/RecommendationSection'
-import { getRevenueProductSet } from '@/config/revenue-products'
 
 export const metadata: Metadata = buildPageMetadata({
   title: 'Adaptogens Compared: Ashwagandha, Rhodiola, Holy Basil & More (2026)',
@@ -70,14 +68,6 @@ export default function AdaptogensComparedPage() {
       </section>
 
       <section className="card-premium p-6 space-y-4 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">Bottom line</h2><p className="text-sm leading-7 text-muted">Adaptogens are not interchangeable. Match the herb to your stress pattern: <strong>ashwagandha for the anxious-overactivated</strong> [2,5], <strong>rhodiola for the fatigued-depleted</strong> [4,6], and <strong>holy basil for general maintenance</strong>. Start one at a time for 2-4 weeks before assessing. Most people benefit from ashwagandha first — it has the strongest evidence base and addresses the most common stress pattern. The adaptogen category is real, clinically relevant, and underutilized.</p></section>
-
-      <div className="max-w-4xl">
-        <RecommendationSection
-          title="Ashwagandha product picks"
-          description="Ashwagandha has the strongest evidence of the adaptogens compared here and fits the most common stress pattern. These are sourcing starting points — confirm dose, standardization, and fit for your situation, and review the safety notes above before buying."
-          products={getRevenueProductSet('ashwagandha')?.products ?? []}
-        />
-      </div>
 
       <References refs={ADAPTOGENS_REFS} />
       <EmailCapture headline="Get evidence reviews like this" description="Adaptogens, stacking safety, evidence — not marketing." ctaLabel="Get the evidence" location="guide-adaptogens" />


### PR DESCRIPTION
## Summary
- remove the Ashwagandha-only product module from a five-adaptogen comparison
- keep the evidence references and email capture unchanged
- add regression coverage preventing single-ingredient commercialization from returning to this broad comparison

## Why this is high ROI
The page compares Ashwagandha, Rhodiola, Holy Basil, Eleuthero, and Schisandra, but monetized only Ashwagandha. That conflicts with the repo's commercial-neutrality rule for broad decision pages and risks making the evidence ordering look revenue-driven. Removing the asymmetric module improves trust without changing any efficacy claims or route behavior.

## Validation intent
- route/canonical unchanged
- no evidence or safety claims changed
- citations preserved
- owned-audience capture preserved
