### PR TITLE
Neutralize caffeine-vs-theanine comparison commerce

### DIFF
--- a/app/__tests__/caffeine-theanine-commercial-neutrality.test.ts
+++ b/app/__tests__/caffeine-theanine-commercial-neutrality.test.ts
@@ -1,0 +1,26 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const PAGE = 'app/guides/compare/caffeine-vs-l-theanine/page.tsx'
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+}
+
+describe('caffeine vs l-theanine commercial neutrality', () => {
+  it('does not monetize only one side of a two-way comparison', () => {
+    const source = read(PAGE)
+
+    expect(source).not.toContain('RecommendationSection')
+    expect(source).not.toContain('getRevenueProductSet')
+  })
+
+  it('routes readers to the evidence-first focus guide and preserves references', () => {
+    const source = read(PAGE)
+
+    expect(source).toContain('/guides/focus/best-nootropics-for-focus/')
+    expect(source).not.toContain('/guides/focus/best-supplements-for-focus/')
+    expect(source).toContain('<References refs={CAFFEINE_VS_L_THEANINE_REFS} />')
+  })
+})

--- a/app/guides/compare/caffeine-vs-l-theanine/page.tsx
+++ b/app/guides/compare/caffeine-vs-l-theanine/page.tsx
@@ -1,6 +1,4 @@
 import type { Metadata } from 'next'
-import RecommendationSection from '@/components/RecommendationSection'
-import { getRevenueProductSet } from '@/config/revenue-products'
 import Link from 'next/link'
 import { buildPageMetadata } from '../../../../src/lib/seo'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
@@ -200,15 +198,12 @@ export default function CaffeineVsLTheaninePage() {
           <Link href="/learn/why-calm-focus-differs-from-stimulation/" className="inline-flex min-h-[44px] items-center rounded-full border border-brand-900/10 px-5 text-sm font-semibold text-ink transition hover:bg-white/70 dark:border-white/10 dark:hover:bg-white/10">
             Calm focus vs stimulation
           </Link>
-          <Link href="/guides/focus/best-supplements-for-focus/" className="inline-flex min-h-[44px] items-center rounded-full border border-brand-900/10 px-5 text-sm font-semibold text-ink transition hover:bg-white/70 dark:border-white/10 dark:hover:bg-white/10">
-            Best focus supplements
+          <Link href="/guides/focus/best-nootropics-for-focus/" className="inline-flex min-h-[44px] items-center rounded-full border border-brand-900/10 px-5 text-sm font-semibold text-ink transition hover:bg-white/70 dark:border-white/10 dark:hover:bg-white/10">
+            Best focus nootropics
           </Link>
         </div>
       </section>
 
-      <div className="max-w-4xl">
-        <RecommendationSection products={getRevenueProductSet('l-theanine')?.products ?? []} />
-      </div>
       <References refs={CAFFEINE_VS_L_THEANINE_REFS} />
     </div>
   )


### PR DESCRIPTION
## Summary
- remove the L-Theanine-only product module from the two-way Caffeine vs L-Theanine comparison
- point the next-step focus CTA directly at the evidence-first Best Nootropics for Focus guide
- add regression coverage for commercial neutrality and canonical routing

## Why this is high ROI
A two-way comparison should not monetize only one side when the page is meant to help readers choose symmetrically. The page also linked to the older Focus quick-reference URL now being consolidated. This removes a trust bias and a redirect hop without changing efficacy or safety claims.

## Validation intent
- route/canonical unchanged
- references preserved
- no evidence claims changed
- no affiliate module remains on the comparison
