### PR TITLE
Calibrate melatonin dosing guide to current evidence

### DIFF
--- a/app/__tests__/melatonin-dosing-evidence-calibration.test.ts
+++ b/app/__tests__/melatonin-dosing-evidence-calibration.test.ts
@@ -1,0 +1,41 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const PAGE = 'app/guides/other/melatonin-dosage-guide/page.tsx'
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+}
+
+describe('melatonin dosing evidence calibration', () => {
+  it('does not restore a universal low-dose protocol or overdose framing', () => {
+    const source = read(PAGE)
+
+    expect(source).not.toContain('Take 0.3-1 mg of melatonin')
+    expect(source).not.toContain('Most melatonin is overdosed')
+    expect(source).not.toContain('0.3-1 mg is as effective as higher doses')
+    expect(source).not.toContain('receptor desensitization')
+    expect(source).toContain('There is no single evidence-based melatonin dose for every sleep problem')
+    expect(source).toContain('study context, not a universal protocol')
+  })
+
+  it('keeps chronic insomnia, children, and product variability boundaries visible', () => {
+    const source = read(PAGE)
+
+    expect(source).toContain('CBT-I is the strongest recommended treatment for chronic insomnia')
+    expect(source).toContain('parents should discuss melatonin with a pediatric health professional')
+    expect(source).toContain('74% to 347% of the labeled amount')
+  })
+
+  it('anchors current evidence and avoids product-selling inside the dose guide', () => {
+    const source = read(PAGE)
+
+    expect(source).toContain('38888087')
+    expect(source).toContain('nccih.nih.gov/health/melatonin-what-you-need-to-know')
+    expect(source).toContain('aasm.org/advocacy/position-statements/melatonin-use-in-children-and-adolescents-health-advisory')
+    expect(source).not.toContain('RecommendationSection')
+    expect(source).not.toContain('getRevenueProductSet')
+    expect(source).toContain('<References refs={MELATONIN_REFS} />')
+  })
+})

--- a/app/guides/other/melatonin-dosage-guide/page.tsx
+++ b/app/guides/other/melatonin-dosage-guide/page.tsx
@@ -1,8 +1,6 @@
 import type { Metadata } from 'next'
-import RecommendationSection from '@/components/RecommendationSection'
-import { getRevenueProductSet } from '@/config/revenue-products'
-import Link from 'next/link'
 import Image from 'next/image'
+import Link from 'next/link'
 import { buildPageMetadata } from '../../../../src/lib/seo'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
@@ -11,53 +9,243 @@ import References from '@/components/References'
 import EmailCapture from '../../../../components/EmailCapture'
 
 export const metadata: Metadata = buildPageMetadata({
-  title: 'Melatonin Dosing: Why Less Is More (2026 Guide)',
-  description: 'Most melatonin is overdosed at 3-10 mg. Evidence shows 0.3-1 mg is equally effective with fewer side effects. The complete dosing guide.',
+  title: 'Melatonin Dosing: Timing, Evidence & Safety (2026)',
+  description:
+    'Evidence-first melatonin dosing guide: why there is no universal dose, how timing and indication change the answer, chronic-insomnia limits, pediatric safety, and product-label variability.',
   path: '/guides/other/melatonin-dosage-guide/',
   openGraphType: 'article',
 })
 
 const FAQS = [
-  { question: 'Why is most melatonin overdosed?', answer: 'The original 1995 MIT patent for melatonin used 0.3-0.5 mg — the physiological dose. But because melatonin is not patentable as a natural hormone, manufacturers produced higher doses (3-10 mg) to differentiate their products. The clinical evidence consistently shows that 0.3-1 mg is as effective as higher doses for sleep onset, with far fewer side effects (morning grogginess, vivid dreams, next-day impairment). The melatonin industry is built on a dosing mistake.' },
-  { question: 'What dose of melatonin should I take for sleep?', answer: '0.3-1 mg, taken 1-2 hours before bed. This produces physiological blood levels (50-200 pg/mL) matching your body\'s natural nighttime melatonin. Higher doses (3-10 mg) produce supraphysiological levels (10-50x normal) that desensitize melatonin receptors over time and cause morning grogginess. Start at 0.3 mg — you can always take more, but you cannot un-take an overdose.' },
-  { question: 'Does melatonin work for jet lag?', answer: 'Yes — this is the best-supported use. Take 0.5-5 mg at the target bedtime in your new time zone for 3-5 days after arrival. Eastward travel (phase advance) is harder to adjust to than westward travel. Melatonin is more effective for jet lag than for chronic insomnia because jet lag is a circadian misalignment problem, which is exactly what melatonin evolved to regulate.' },
-  { question: 'Is melatonin safe for children?', answer: 'Short-term use appears safe at low doses (0.5-3 mg) for children with sleep disorders, particularly ADHD and autism-related sleep issues. Long-term safety data in children is limited. Melatonin is a hormone — pediatric use should be supervised by a physician. Do not use melatonin as a "sleep gummy" for healthy children with occasional sleep issues — behavioral interventions (consistent bedtime, no screens) should be first-line.' },
-  { question: 'Can you build tolerance to melatonin?', answer: 'No — melatonin does not produce tolerance or dependence. Unlike benzodiazepines or z-drugs, melatonin is not a sedative. It is a chronobiotic — it regulates your circadian clock rather than forcing sleep. However, chronic high-dose use (10+ mg) can desensitize melatonin receptors, making your endogenous melatonin less effective. This is reversible by stopping or reducing the dose.' },
+  {
+    question: 'What is the best dose of melatonin for sleep?',
+    answer:
+      'There is no single evidence-based melatonin dose for every sleep problem. Dose, timing, age, formulation, and the reason for use all matter. A 2024 dose-response meta-analysis of randomized trials did not support the simple claim that 0.3–1 mg is always as effective as higher doses; the pooled sleep-promoting response peaked around 4 mg, with earlier administration also influencing outcomes. That is study context, not a universal protocol.',
+  },
+  {
+    question: 'Is lower-dose melatonin always better?',
+    answer:
+      'No. Lower doses can be appropriate in some circadian or sleep-onset contexts, but the evidence does not justify calling all 3–10 mg products overdosed or claiming one narrow dose range is universally optimal. The useful question is what problem is being treated, when melatonin is taken relative to the desired sleep window, and whether melatonin is the right tool at all.',
+  },
+  {
+    question: 'Does melatonin work for chronic insomnia?',
+    answer:
+      'Melatonin may modestly improve sleep-onset latency in some studies, but major sleep guidelines have recommended against using it as routine treatment for chronic insomnia because the overall evidence is limited. CBT-I is the strongest recommended treatment for chronic insomnia. Persistent insomnia deserves evaluation for behavioral, circadian, medication, breathing, movement, and mental-health contributors.',
+  },
+  {
+    question: 'Does melatonin help jet lag?',
+    answer:
+      'Research summarized by NCCIH suggests melatonin may help jet-lag symptoms, particularly after travel across multiple time zones. Timing matters because melatonin is a circadian signal, not simply a sedative. The ideal schedule depends on travel direction, destination bedtime, light exposure, and individual sensitivity rather than one fixed dose table.',
+  },
+  {
+    question: 'Is melatonin safe for children?',
+    answer:
+      'Short-term use may help certain pediatric sleep problems, but long-term safety and optimal dosing remain uncertain. The American Academy of Sleep Medicine advises that parents should discuss melatonin with a pediatric health professional before use. Product-label variability and accidental ingestion are additional concerns, especially with gummies.',
+  },
 ]
 
 const MELATONIN_REFS = [
-  { n: 1, text: 'Zhdanova IV, et al. (2001). Melatonin doses for sleep. J Clin Endocrinol Metab, 86(1): 129-134.', url: 'https://pubmed.ncbi.nlm.nih.gov/11231984/' },
-  { n: 2, text: 'Ferracioli-Oda E, et al. (2013). Melatonin for primary sleep disorders. PLoS ONE, 8(5): e63773.', url: 'https://pubmed.ncbi.nlm.nih.gov/23691095/' },
-  { n: 3, text: 'Herxheimer A, Petrie KJ. (2002). Melatonin for jet lag. Cochrane Database Syst Rev, (2): CD001520.', url: 'https://pubmed.ncbi.nlm.nih.gov/12076414/' },
+  {
+    n: 1,
+    text: 'National Center for Complementary and Integrative Health. Melatonin: What You Need To Know.',
+    url: 'https://www.nccih.nih.gov/health/melatonin-what-you-need-to-know',
+  },
+  {
+    n: 2,
+    text: 'National Center for Complementary and Integrative Health. Sleep Disorders and Complementary Health Approaches: Usefulness and Safety.',
+    url: 'https://www.nccih.nih.gov/health/sleep-disorders-and-complementary-health-approaches',
+  },
+  {
+    n: 3,
+    text: 'Cruz-Sanabria F, et al. (2024). Optimizing the Time and Dose of Melatonin as a Sleep-Promoting Drug: A Systematic Review and Dose-Response Meta-Analysis. J Pineal Res. PMID: 38888087.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/38888087/',
+  },
+  {
+    n: 4,
+    text: 'American Academy of Sleep Medicine. Health Advisory: Melatonin Use in Children and Adolescents.',
+    url: 'https://aasm.org/advocacy/position-statements/melatonin-use-in-children-and-adolescents-health-advisory/',
+  },
+]
+
+const evidenceCards = [
+  {
+    title: 'Chronic insomnia',
+    evidence:
+      'Melatonin can change sleep timing and may modestly shorten sleep-onset latency, but evidence for chronic insomnia is inconsistent and guideline support is weak.',
+    boundary:
+      'Do not turn a supplement dose into the main treatment plan. CBT-I is the strongest recommended treatment for chronic insomnia, and persistent symptoms deserve evaluation.',
+  },
+  {
+    title: 'Jet lag and circadian timing',
+    evidence:
+      'Melatonin is better supported when the problem is circadian misalignment, such as jet lag or delayed sleep timing, than when the problem is generic chronic insomnia.',
+    boundary:
+      'Timing relative to the destination sleep window and light exposure can matter as much as dose. A fixed “take X mg at bedtime” rule is too crude for a clock-shifting intervention.',
+  },
+  {
+    title: 'Dose-response evidence',
+    evidence:
+      'A 2024 meta-analysis of 26 randomized trials found a dose-response relationship for sleep onset and total sleep time, with the pooled response peaking around 4 mg and earlier administration associated with better outcomes [3].',
+    boundary:
+      'That pooled result does not make 4 mg the correct personal dose. The studies were heterogeneous, and indication, formulation, timing, age, and baseline sleep problem all varied.',
+  },
+]
+
+const decisionRows = [
+  {
+    situation: 'Occasional difficulty falling asleep',
+    nextStep:
+      'Check caffeine, alcohol, light exposure, schedule drift, stress, and sleep opportunity before assuming the dose is the main problem.',
+  },
+  {
+    situation: 'Chronic insomnia lasting weeks or months',
+    nextStep:
+      'Prioritize CBT-I and evaluation for sleep apnea, restless legs, medication effects, mood/anxiety, pain, and circadian problems rather than escalating melatonin.',
+  },
+  {
+    situation: 'Jet lag or a shifted body clock',
+    nextStep:
+      'Treat melatonin as a timing signal. Travel direction, destination bedtime, and light exposure change the schedule; individualized timing matters more than copying a universal dose.',
+  },
+  {
+    situation: 'Child or teenager',
+    nextStep:
+      'Discuss the decision with a pediatric health professional. Many pediatric sleep problems respond to schedule and behavior changes, and long-term melatonin safety remains uncertain.',
+  },
 ]
 
 export default function MelatoninDosingPage() {
   return (
     <div className="container-page py-10 space-y-10">
-      <AuthorityJsonLd title="Melatonin Dosing Guide" description="Why 0.3 mg works better than 10 mg." url="https://thehippiescientist.net/guides/other/melatonin-dosage-guide" type="Article" />
-      <AuthorityBreadcrumbs items={[{ label: 'Home', href: '/' }, { label: 'Guides', href: '/guides/' }, { label: 'Melatonin Dosing' }]} />
+      <AuthorityJsonLd
+        title="Melatonin Dosing: Timing, Evidence and Safety"
+        description="Evidence-first review of melatonin dose, timing, insomnia, jet lag, pediatric safety, and product-label variability."
+        url="https://thehippiescientist.net/guides/other/melatonin-dosage-guide"
+        type="Article"
+        citationUrls={MELATONIN_REFS.map((ref) => ref.url)}
+      />
+      <AuthorityBreadcrumbs
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Guides', href: '/guides/' },
+          { label: 'Melatonin Dosing' },
+        ]}
+      />
       <FAQSchema pagePath="/guides/other/melatonin-dosage-guide/" questions={FAQS} />
 
-      <section className="space-y-5 max-w-4xl"><p className="eyebrow-label">Evidence Review · 3 References</p><h1 className="text-5xl font-bold tracking-tight text-ink">Melatonin: Why You Are Probably Taking Too Much</h1><p className="text-lg leading-8 text-muted">The melatonin in your medicine cabinet is almost certainly overdosed. The original MIT research used 0.3 mg. Drugstore melatonin is 3-10 mg — up to 30 times the studied effective dose. Here is why less is more, and how to dose melatonin correctly.</p>
-        <figure className="mt-6"><div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white"><Image src="/images/guides/melatonin-dosage-guide.jpg" alt="Low-dose melatonin tablet beside sleep mask and lavender" width={1536} height={1024} priority className="w-full h-auto" /></div><figcaption className="mt-3 text-center text-sm text-muted">Melatonin — less is more.</figcaption></figure></section>
+      <section className="space-y-5 max-w-4xl">
+        <p className="eyebrow-label">Evidence Review · Dose and timing recalibrated</p>
+        <h1 className="text-5xl font-bold tracking-tight text-ink">Melatonin Dosing: Why There Is No Universal “Best Dose”</h1>
+        <p className="text-lg leading-8 text-muted">
+          Melatonin is a circadian signal, so the useful question is not simply “how many milligrams?” The reason for use, timing relative to the desired sleep window, age, formulation, and light exposure can all change the answer. Older advice often treats 0.3–1 mg as universally optimal and higher doses as inherently excessive. Current evidence is not that simple.
+        </p>
+        <figure className="mt-6">
+          <div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white">
+            <Image
+              src="/images/guides/melatonin-dosage-guide.jpg"
+              alt="Melatonin supplement beside a sleep mask and clock for a timing-focused evidence review"
+              width={1536}
+              height={1024}
+              priority
+              className="w-full h-auto"
+            />
+          </div>
+          <figcaption className="mt-3 text-center text-sm text-muted">
+            With melatonin, indication and timing can matter as much as the number on the label.
+          </figcaption>
+        </figure>
+      </section>
 
-      <section className="card-premium p-6 space-y-4"><h2 className="text-2xl font-semibold">Quick answer</h2><p className="text-sm leading-7 text-muted"><strong>Take 0.3-1 mg of melatonin, not 3-10 mg.</strong> Low-dose melatonin produces physiological blood levels that naturally trigger sleep onset [1]. High-dose melatonin (3-10 mg) produces supraphysiological levels (10-50x normal) — it still works, but causes morning grogginess, vivid dreams, and receptor desensitization with chronic use. The meta-analyses consistently show that melatonin works for sleep onset latency (falling asleep faster) but the dose-response curve is flat — more is not better [2]. For jet lag: 0.5-5 mg at target bedtime for 3-5 days [3]. Cost: $5-10/month for properly dosed melatonin.</p></section>
+      <section className="card-premium p-6 space-y-4 border-l-4 border-brand-700 bg-brand-50/30">
+        <p className="text-xs font-bold uppercase tracking-wider text-brand-700">Quick answer</p>
+        <h2 className="text-2xl font-semibold text-ink">There is no single evidence-based melatonin dose for every sleep problem</h2>
+        <p className="text-sm leading-7 text-muted">
+          Low-dose melatonin can be useful in some settings, but current randomized-trial evidence does not support the blanket claim that 0.3–1 mg is always as effective as higher doses. A 2024 dose-response meta-analysis found that sleep-promoting effects in the pooled studies increased with dose and peaked around 4 mg, while earlier administration also influenced outcomes [3]. That result is study context, not a universal protocol: the included populations, formulations, doses, and sleep problems varied.
+        </p>
+        <p className="text-sm leading-7 text-muted">
+          For chronic insomnia, dose optimization may be the wrong question altogether. NCCIH notes that CBT-I is the strongest recommended treatment for insomnia and that clinical guidelines have recommended against melatonin as routine treatment for chronic insomnia [2].
+        </p>
+      </section>
 
-      <section className="card-premium p-6 space-y-4 max-w-4xl border-l-4 border-brand-700 bg-brand-50/30"><p className="text-xs font-bold uppercase tracking-wider text-brand-700">At a Glance · Melatonin Dosing by Use</p><div className="overflow-x-auto"><table className="min-w-full text-sm"><thead><tr className="border-b"><th className="text-left py-2 pr-4 font-semibold text-ink">Use Case</th><th className="text-left py-2 pr-4 font-semibold text-ink">Optimal Dose</th><th className="text-left py-2 pr-4 font-semibold text-ink">Timing</th><th className="text-left py-2 font-semibold text-ink">Duration</th></tr></thead><tbody className="text-muted">
-          <tr className="border-b"><td className="py-2 pr-4 font-medium text-ink">Sleep onset (can not fall asleep)</td><td className="py-2 pr-4">0.3-1 mg</td><td className="py-2 pr-4">1-2 hrs before bed</td><td className="py-2">Ongoing as needed</td></tr>
-          <tr className="border-b"><td className="py-2 pr-4 font-medium text-ink">Jet lag (eastward)</td><td className="py-2 pr-4">3-5 mg</td><td className="py-2 pr-4">At target bedtime</td><td className="py-2">3-5 days after arrival</td></tr>
-          <tr className="border-b"><td className="py-2 pr-4 font-medium text-ink">Jet lag (westward)</td><td className="py-2 pr-4">0.5-3 mg</td><td className="py-2 pr-4">At target bedtime</td><td className="py-2">2-4 days after arrival</td></tr>
-          <tr className="border-b"><td className="py-2 pr-4 font-medium text-ink">Shift work</td><td className="py-2 pr-4">1-3 mg</td><td className="py-2 pr-4">Before daytime sleep</td><td className="py-2">During night shifts</td></tr>
-          <tr><td className="py-2 pr-4 font-medium text-ink">Children (physician supervised)</td><td className="py-2 pr-4">0.5-3 mg</td><td className="py-2 pr-4">30-60 min before bed</td><td className="py-2">As directed by physician</td></tr>
-        </tbody></table></div></section>
+      <section className="grid gap-5 lg:grid-cols-3">
+        {evidenceCards.map((card) => (
+          <article key={card.title} className="card-premium p-6 space-y-4">
+            <h2 className="text-xl font-semibold text-ink">{card.title}</h2>
+            <div>
+              <p className="text-xs font-bold uppercase tracking-wider text-emerald-800">What the evidence suggests</p>
+              <p className="mt-2 text-sm leading-6 text-muted">{card.evidence}</p>
+            </div>
+            <div>
+              <p className="text-xs font-bold uppercase tracking-wider text-amber-800">Decision boundary</p>
+              <p className="mt-2 text-sm leading-6 text-muted">{card.boundary}</p>
+            </div>
+          </article>
+        ))}
+      </section>
 
-      <section className="card-premium p-6 space-y-4"><h2 className="text-2xl font-semibold">Bottom line</h2><p className="text-sm leading-7 text-muted">Most melatonin is overdosed at 3-10 mg. The evidence supports 0.3-1 mg for sleep onset [1,2]. Higher doses do not work better — they just cause more side effects. If your melatonin gives you morning grogginess, reduce the dose, not increase it. The best value: buy 1 mg tablets and break them in half. Or buy liquid melatonin and measure 0.3-0.5 mg. This will cost $5-10/month and work as well as the 10 mg capsules that cost 3x more with 3x the side effects.</p></section>
+      <section className="space-y-4 max-w-5xl">
+        <h2 className="text-3xl font-semibold tracking-tight text-ink">Choose the sleep problem before choosing a dose</h2>
+        <div className="overflow-x-auto rounded-2xl border border-brand-900/10 bg-white/90 dark:border-white/10 dark:bg-white/5">
+          <table className="min-w-[760px] w-full text-left text-sm">
+            <thead>
+              <tr className="border-b border-brand-900/10 text-ink">
+                <th className="p-4">Situation</th>
+                <th className="p-4">Better next question</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-brand-900/10 text-muted">
+              {decisionRows.map((row) => (
+                <tr key={row.situation}>
+                  <td className="p-4 font-semibold text-ink">{row.situation}</td>
+                  <td className="p-4 leading-6">{row.nextStep}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="card-premium p-6 space-y-4 max-w-4xl">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Product quality changes the dosing conversation</h2>
+        <p className="text-sm leading-7 text-muted">
+          In the United States, melatonin is sold as a dietary supplement rather than an approved insomnia drug. NCCIH summarizes a 2023 analysis of 25 melatonin gummy products in which measured melatonin ranged from 74% to 347% of the labeled amount [1]. That means a label dose is not always the dose a person actually receives.
+        </p>
+        <p className="text-sm leading-7 text-muted">
+          This variability is one reason a dosing guide should not double as a product-selling page. A precise-looking milligram recommendation can create false confidence when formulation quality, timing, and the actual sleep diagnosis are still uncertain.
+        </p>
+      </section>
+
+      <section className="rounded-2xl border border-amber-900/15 bg-amber-50/70 p-6 text-amber-950 dark:border-amber-200/20 dark:bg-amber-950/20 dark:text-amber-50">
+        <p className="text-xs font-bold uppercase tracking-[0.16em]">Safety boundary</p>
+        <h2 className="mt-2 text-2xl font-semibold">Children and long-term use need extra caution</h2>
+        <p className="mt-3 text-sm leading-7">
+          Melatonin appears relatively safe for short-term use, but long-term safety is less certain [1,2]. The American Academy of Sleep Medicine advises that parents should discuss melatonin with a pediatric health professional before giving it to a child or adolescent [4]. Product variability, flavored gummies, and accidental ingestion also make safe storage important. NCCIH notes additional caution for people with epilepsy or those taking blood thinners, and persistent sleep problems should be evaluated rather than managed indefinitely by escalating a supplement dose [1].
+        </p>
+        <div className="mt-5 flex flex-wrap gap-3">
+          <Link href="/safety-checker/" className="rounded-full bg-amber-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-950 dark:bg-amber-100 dark:text-amber-950">
+            Check supplement interactions
+          </Link>
+          <Link href="/guides/sleep/" className="rounded-full border border-amber-900/20 px-4 py-2 text-sm font-semibold text-amber-950 transition hover:bg-white/60 dark:border-amber-100/30 dark:text-amber-50">
+            Browse sleep guides
+          </Link>
+        </div>
+      </section>
+
       <References refs={MELATONIN_REFS} />
-      <div className="max-w-4xl">
-        <RecommendationSection products={getRevenueProductSet('melatonin')?.products ?? []} />
+      <EmailCapture
+        headline="Get evidence reviews like this"
+        description="Sleep evidence, timing, and safety — without one-size-fits-all protocols."
+        ctaLabel="Get the evidence"
+        location="guide-melatonin-dosing"
+      />
+      <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between">
+        <Link href="/guides/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">
+          ← Back to guides
+        </Link>
+        <Link href="/guides/sleep/best-supplements-for-sleep/" className="text-sm font-bold text-brand-800 hover:underline">
+          Best sleep supplements →
+        </Link>
       </div>
-      <EmailCapture headline="Get evidence reviews like this" description="Melatonin dosing — less is more." ctaLabel="Get the evidence" location="guide-melatonin-dosing" />
-      <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between"><Link href="/guides/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">← Back to guides</Link><Link href="/herbs/" className="text-sm font-bold text-brand-800 hover:underline">Herb library →</Link></div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- remove the universal 0.3–1 mg dosing protocol and “most melatonin is overdosed” framing
- replace fixed adult/jet-lag/shift-work/child dose tables with indication-first decision context
- distinguish chronic insomnia from circadian uses such as jet lag
- add CBT-I and pediatric safety boundaries
- surface supplement-label variability (74%–347% of labeled melatonin in a cited gummy analysis)
- replace older dose claims with current NCCIH, AASM, and 2024 dose-response evidence
- remove the melatonin product module from a dosing/safety guide
- add route-specific regression coverage

## Why this is high ROI
This is a high-intent YMYL dosing page. The old copy presented one low-dose range as universally optimal, called common retail doses overdoses, and gave fixed dosing protocols across adults, children, jet lag, and shift work. Current evidence is more indication- and timing-dependent. Correcting it materially improves safety, trust, and search resilience.

## Evidence anchors
- NCCIH: Melatonin — What You Need To Know
- NCCIH: Sleep Disorders and Complementary Health Approaches
- Cruz-Sanabria et al. 2024 dose-response meta-analysis, PMID 38888087
- American Academy of Sleep Medicine pediatric melatonin advisory

## Validation intent
- route/canonical preserved
- FAQ/schema preserved
- references and email capture preserved
- no product recommendation module remains
