### PR TITLE
Calibrate iron supplement guide to current guidance

### DIFF
--- a/app/__tests__/iron-supplement-evidence-calibration.test.ts
+++ b/app/__tests__/iron-supplement-evidence-calibration.test.ts
@@ -1,0 +1,42 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const PAGE = 'app/guides/other/iron-supplement-guide/page.tsx'
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+}
+
+describe('iron supplement evidence calibration', () => {
+  it('does not restore a universal diagnosis or self-treatment protocol', () => {
+    const source = read(PAGE)
+
+    expect(source).not.toContain('If ferritin is below 30 ng/mL')
+    expect(source).not.toContain('25-50 mg/day + vitamin C 200 mg')
+    expect(source).not.toContain('bisglycinate 25-50 mg every other day')
+    expect(source).not.toContain('Iron Bisglycinate')
+    expect(source).toContain('There is no single ferritin cutoff that diagnoses iron deficiency in every clinical context')
+    expect(source).toContain('treatment dose should follow the diagnosis, cause, severity, and response')
+  })
+
+  it('keeps formulation, excess-iron, and medication boundaries explicit', () => {
+    const source = read(PAGE)
+
+    expect(source).toContain('No single oral iron formulation has a proven overall advantage')
+    expect(source).toContain('45 mg per day is the adult tolerable upper intake level, not a treatment ceiling')
+    expect(source).toContain('levothyroxine')
+    expect(source).toContain('levodopa')
+  })
+
+  it('uses current guidance and avoids product-selling inside a deficiency guide', () => {
+    const source = read(PAGE)
+
+    expect(source).toContain('ods.od.nih.gov/factsheets/Iron-HealthProfessional/')
+    expect(source).toContain('gastro.org/clinical-guidance/management-of-iron-deficiency-anemia/')
+    expect(source).toContain('gastro.org/clinical-guidance/gastrointestinal-evaluation-of-iron-deficiency-anemia/')
+    expect(source).not.toContain('RecommendationSection')
+    expect(source).not.toContain('getRevenueProductSet')
+    expect(source).toContain('<References refs={IRON_REFS} />')
+  })
+})

--- a/app/guides/other/iron-supplement-guide/page.tsx
+++ b/app/guides/other/iron-supplement-guide/page.tsx
@@ -1,8 +1,6 @@
 import type { Metadata } from 'next'
-import RecommendationSection from '@/components/RecommendationSection'
-import { getRevenueProductSet } from '@/config/revenue-products'
-import Link from 'next/link'
 import Image from 'next/image'
+import Link from 'next/link'
 import { buildPageMetadata } from '../../../../src/lib/seo'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
@@ -11,51 +9,243 @@ import References from '@/components/References'
 import EmailCapture from '../../../../components/EmailCapture'
 
 export const metadata: Metadata = buildPageMetadata({
-  title: 'Iron Supplements: Types, Dosing & Deficiency Guide (2026)',
-  description: 'Iron bisglycinate, sulfate, and heme compared. Evidence-based dosing for deficiency, anemia, and who should not supplement without blood work.',
+  title: 'Iron Supplements: Testing, Forms & Safety (2026)',
+  description:
+    'Evidence-first iron supplement guide: why diagnosis matters, how ferritin is interpreted in context, oral iron formulation tradeoffs, dosing boundaries, interactions, and iron-overload risk.',
   path: '/guides/other/iron-supplement-guide/',
   openGraphType: 'article',
 })
 
 const FAQS = [
-  { question: 'Which form of iron is best?', answer: 'Iron bisglycinate (ferrous bisglycinate) is best-absorbed with the fewest GI side effects. Ferrous sulfate is the most studied and cheapest but causes constipation and nausea in 20-30% of users. Heme iron (from animal sources) has the highest absorption but costs significantly more. For most people: bisglycinate 25-50 mg/day with vitamin C is the best balance of absorption, tolerability, and cost.' },
-  { question: 'How do I know if I need iron?', answer: 'Get blood work — do not supplement based on symptoms alone. Ferritin below 30 ng/mL indicates iron deficiency. Hemoglobin below 12 g/dL (women) or 13 g/dL (men) indicates anemia. Symptoms of deficiency — fatigue, pallor, shortness of breath, restless legs — are nonspecific and common to many conditions. Iron overload (hemochromatosis) is dangerous and underdiagnosed. Testing before supplementing is essential.' },
-  { question: 'Why does iron cause constipation?', answer: 'Unabsorbed iron is pro-oxidative in the gut, irritating the intestinal lining and slowing motility. Bisglycinate is better tolerated because the glycine chelation improves absorption, leaving less unabsorbed iron in the gut. Taking iron with vitamin C (200 mg) increases absorption. Taking iron every other day (rather than daily) may improve absorption and reduce side effects through the hepcidin mechanism.' },
-  { question: 'Can men take iron supplements?', answer: 'Rarely. Men do not menstruate and are at much higher risk of iron overload (hemochromatosis affects 1 in 200 people of Northern European descent). Do not supplement iron without a confirmed deficiency on blood work. Excess iron is pro-oxidative and associated with increased cardiovascular and cancer risk. The exception: male endurance athletes (foot strike hemolysis) and vegetarians may have higher needs.' },
-  { question: 'What blocks iron absorption?', answer: 'Calcium (dairy, supplements), tannins (tea, coffee), phytates (whole grains, legumes), and PPIs (reduce stomach acid needed for absorption). Take iron 2 hours apart from these. Conversely, vitamin C (200 mg) and heme iron (meat) enhance absorption. The best time: morning on an empty stomach with vitamin C, but if this causes nausea, take with a small non-dairy meal.' },
+  {
+    question: 'Which form of oral iron is best?',
+    answer:
+      'No single oral iron formulation has a proven overall advantage. The American Gastroenterological Association advises that ferrous sulfate is generally preferred because it is the least expensive, not because it is universally more effective. Tolerability, elemental iron content, cost, adherence, and the clinical reason for treatment all matter.',
+  },
+  {
+    question: 'What ferritin level means iron deficiency?',
+    answer:
+      'There is no single ferritin cutoff that diagnoses iron deficiency in every clinical context. In people who already have anemia, the AGA recommends a ferritin cutoff of 45 ng/mL rather than 15 ng/mL for diagnosing iron deficiency. Inflammation, chronic kidney disease, heart failure, pregnancy, and other conditions can change how ferritin is interpreted. A low ferritin can support iron deficiency, but the result belongs with the complete blood count, transferrin saturation, symptoms, and clinical context.',
+  },
+  {
+    question: 'Should I take iron for fatigue without blood work?',
+    answer:
+      'Fatigue alone is not enough to establish iron deficiency. Iron can be harmful when taken unnecessarily, and iron-deficiency anemia can signal blood loss, malabsorption, gastrointestinal disease, pregnancy-related needs, or another underlying cause that deserves evaluation. Testing and cause-finding are more important than guessing from symptoms.',
+  },
+  {
+    question: 'Is every-other-day iron better than daily iron?',
+    answer:
+      'AGA guidance says oral iron should be given once daily at most and that every-other-day dosing may be better tolerated for some people with similar or equal absorption. That is treatment context, not a universal self-dosing rule. The schedule should follow the diagnosis, formulation, severity, side effects, and response.',
+  },
+  {
+    question: 'What medicines can interact with iron?',
+    answer:
+      'Iron can reduce absorption of levothyroxine and levodopa, and proton pump inhibitors can reduce non-heme iron absorption. Calcium can also interfere with iron absorption in some circumstances. People taking regular medications should review timing and compatibility with a pharmacist or clinician rather than assuming a supplement can be added freely.',
+  },
 ]
 
 const IRON_REFS = [
-  { n: 1, text: 'Stoffel NU, et al. (2017). Iron bisglycinate vs ferrous sulfate. Lancet Haematol, 4(11): e524-e533.', url: 'https://pubmed.ncbi.nlm.nih.gov/29032957/' },
-  { n: 2, text: 'Moretti D, et al. (2015). Iron bioavailability from supplements. Blood, 126(17): 1981-1989.', url: 'https://pubmed.ncbi.nlm.nih.gov/26276669/' },
-  { n: 3, text: 'Camaschella C. (2015). Iron-deficiency anemia. N Engl J Med, 372(19): 1832-1843.', url: 'https://pubmed.ncbi.nlm.nih.gov/25946282/' },
+  {
+    n: 1,
+    text: 'NIH Office of Dietary Supplements. Iron — Health Professional Fact Sheet.',
+    url: 'https://ods.od.nih.gov/factsheets/Iron-HealthProfessional/',
+  },
+  {
+    n: 2,
+    text: 'American Gastroenterological Association. Management of Iron Deficiency Anemia. Clinical Practice Update, 2024.',
+    url: 'https://gastro.org/clinical-guidance/management-of-iron-deficiency-anemia/',
+  },
+  {
+    n: 3,
+    text: 'American Gastroenterological Association. Gastrointestinal Evaluation of Iron Deficiency Anemia. Clinical Guideline.',
+    url: 'https://gastro.org/clinical-guidance/gastrointestinal-evaluation-of-iron-deficiency-anemia/',
+  },
+  {
+    n: 4,
+    text: 'World Health Organization. Guideline on use of ferritin concentrations to assess iron status in individuals and populations.',
+    url: 'https://www.who.int/publications/i/item/9789240000124',
+  },
+]
+
+const decisionRows = [
+  {
+    situation: 'Fatigue, brain fog, shortness of breath, or restless legs without recent iron studies',
+    nextStep:
+      'Confirm whether iron deficiency is actually present. These symptoms are nonspecific and can come from many other conditions.',
+  },
+  {
+    situation: 'Anemia plus a low or borderline ferritin',
+    nextStep:
+      'Interpret ferritin with the CBC and clinical context. AGA uses a 45 ng/mL cutoff in patients with anemia, while inflammation and chronic disease can shift ferritin interpretation.',
+  },
+  {
+    situation: 'Confirmed iron-deficiency anemia',
+    nextStep:
+      'Treat the deficiency and investigate the cause. Men, postmenopausal women, and some premenopausal patients may need evaluation for gastrointestinal blood loss rather than iron replacement alone.',
+  },
+  {
+    situation: 'Oral iron causes constipation, nausea, or abdominal pain',
+    nextStep:
+      'Do not assume a premium formulation is automatically superior. Dose frequency, food timing, formulation, and whether intravenous iron is appropriate can be discussed with the treating clinician.',
+  },
+]
+
+const evidenceBoundaries = [
+  {
+    title: 'Ferritin is useful, but context changes the cutoff',
+    shows:
+      'Ferritin reflects iron stores and is central to diagnosing iron deficiency. AGA recommends a 45 ng/mL cutoff in patients with anemia, and WHO emphasizes adjustment when inflammation is present.',
+    doesNotShow:
+      'That one number such as 30 ng/mL diagnoses iron deficiency in every adult regardless of anemia, inflammation, pregnancy, kidney disease, or other clinical context.',
+  },
+  {
+    title: 'Formulation is mainly a tolerability and practicality decision',
+    shows:
+      'Common oral forms contain different amounts of elemental iron and can differ in gastrointestinal tolerability. Ferrous sulfate is inexpensive and well established.',
+    doesNotShow:
+      'That iron bisglycinate is universally the best-absorbed or best choice. AGA states that no single oral formulation has a proven overall advantage.',
+  },
+  {
+    title: 'Treatment dosing is not a wellness protocol',
+    shows:
+      'People with confirmed iron deficiency may need doses above normal dietary requirements under clinical supervision, with monitoring of blood counts and iron parameters.',
+    doesNotShow:
+      'That anyone with fatigue should start a fixed milligram dose. The treatment dose should follow the diagnosis, cause, severity, and response.',
+  },
 ]
 
 export default function IronSupplementPage() {
   return (
     <div className="container-page py-10 space-y-10">
-      <AuthorityJsonLd title="Iron Supplement Guide" description="Types, dosing, and deficiency evidence." url="https://thehippiescientist.net/guides/other/iron-supplement-guide" type="Article" />
-      <AuthorityBreadcrumbs items={[{ label: 'Home', href: '/' }, { label: 'Guides', href: '/guides/' }, { label: 'Iron Supplements' }]} />
+      <AuthorityJsonLd
+        title="Iron Supplements: Testing, Forms and Safety"
+        description="Evidence-first review of iron testing, ferritin interpretation, oral formulations, treatment boundaries, interactions, and overload risk."
+        url="https://thehippiescientist.net/guides/other/iron-supplement-guide"
+        type="Article"
+        citationUrls={IRON_REFS.map((ref) => ref.url)}
+      />
+      <AuthorityBreadcrumbs
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Guides', href: '/guides/' },
+          { label: 'Iron Supplements' },
+        ]}
+      />
       <FAQSchema pagePath="/guides/other/iron-supplement-guide/" questions={FAQS} />
 
-      <section className="space-y-5 max-w-4xl"><p className="eyebrow-label">Evidence Review · 3 References</p><h1 className="text-5xl font-bold tracking-tight text-ink">Iron: The Supplement You Should Not Take Without a Blood Test</h1><p className="text-lg leading-8 text-muted">Iron deficiency is the most common nutritional deficiency worldwide — affecting 25% of the global population. But iron overload is also dangerous, and supplementing without testing can cause harm. Here is how to supplement safely, which form to choose, and when iron is actually necessary.</p>
-        <figure className="mt-6"><div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white"><Image src="/images/guides/iron-supplement-guide.jpg" alt="Iron capsules beside spinach and red meat" width={1536} height={1024} priority className="w-full h-auto" /></div><figcaption className="mt-3 text-center text-sm text-muted">Iron — do not supplement without a blood test.</figcaption></figure></section>
+      <section className="space-y-5 max-w-4xl">
+        <p className="eyebrow-label">Evidence Review · Diagnosis before dosing</p>
+        <h1 className="text-5xl font-bold tracking-tight text-ink">Iron Supplements: Test the Problem Before Treating the Number</h1>
+        <p className="text-lg leading-8 text-muted">
+          Iron is essential, but it is not a general energy supplement. Fatigue, low exercise tolerance, pallor, restless legs, and brain fog can occur with iron deficiency, but they are not specific enough to diagnose it. The safer sequence is to confirm the deficiency, understand why it happened, and then choose a treatment plan that matches the laboratory and clinical picture.
+        </p>
+        <figure className="mt-6">
+          <div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white">
+            <Image
+              src="/images/guides/iron-supplement-guide.jpg"
+              alt="Iron supplement beside iron-rich foods and laboratory paperwork"
+              width={1536}
+              height={1024}
+              priority
+              className="w-full h-auto"
+            />
+          </div>
+          <figcaption className="mt-3 text-center text-sm text-muted">
+            Iron decisions are strongest when they start with laboratory context and the cause of deficiency.
+          </figcaption>
+        </figure>
+      </section>
 
-      <section className="card-premium p-6 space-y-4"><h2 className="text-2xl font-semibold">Quick answer</h2><p className="text-sm leading-7 text-muted"><strong>Test ferritin before supplementing.</strong> If ferritin is below 30 ng/mL: iron bisglycinate 25-50 mg/day + vitamin C 200 mg. Take on an empty stomach if tolerated, every other day to reduce GI effects. Re-test in 3 months. Do not supplement without a confirmed deficiency — iron overload (hemochromatosis) is underdiagnosed and dangerous. Women with heavy periods, vegetarians, and endurance athletes are at highest risk for deficiency [1,3]. Ferrous sulfate is the cheapest but causes constipation in 20-30% — bisglycinate is worth the small premium [2].</p></section>
+      <section className="card-premium p-6 space-y-4 border-l-4 border-brand-700 bg-brand-50/30">
+        <p className="text-xs font-bold uppercase tracking-wider text-brand-700">Quick answer</p>
+        <h2 className="text-2xl font-semibold text-ink">Do not turn fatigue or one ferritin number into a self-treatment protocol</h2>
+        <p className="text-sm leading-7 text-muted">
+          There is no single ferritin cutoff that diagnoses iron deficiency in every clinical context. In patients with anemia, AGA recommends using 45 ng/mL rather than 15 ng/mL as the ferritin cutoff for iron deficiency [3]. WHO guidance emphasizes that infection and inflammation can raise ferritin and change how results should be interpreted [4]. Once iron deficiency is confirmed, the treatment dose should follow the diagnosis, cause, severity, and response rather than a universal internet dose.
+        </p>
+        <p className="text-sm leading-7 text-muted">
+          The same caution applies to formulation. AGA states that no single oral iron formulation has a proven overall advantage and prefers ferrous sulfate mainly because it is inexpensive [2]. Every-other-day dosing may be better tolerated for some people, but that is treatment context—not a one-size-fits-all regimen [2].
+        </p>
+      </section>
 
-      <section className="card-premium p-6 space-y-4 max-w-4xl border-l-4 border-brand-700 bg-brand-50/30"><p className="text-xs font-bold uppercase tracking-wider text-brand-700">At a Glance · Iron Form Comparison</p><div className="overflow-x-auto"><table className="min-w-full text-sm"><thead><tr className="border-b"><th className="text-left py-2 pr-4 font-semibold text-ink">Form</th><th className="text-left py-2 pr-4 font-semibold text-ink">Absorption</th><th className="text-left py-2 pr-4 font-semibold text-ink">GI Tolerance</th><th className="text-left py-2 pr-4 font-semibold text-ink">Cost/mo</th><th className="text-left py-2 font-semibold text-ink">Best For</th></tr></thead><tbody className="text-muted">
-          <tr className="border-b"><td className="py-2 pr-4 font-medium text-ink">Iron Bisglycinate</td><td className="py-2 pr-4 text-emerald-700 font-semibold">Excellent</td><td className="py-2 pr-4 text-emerald-700">Good</td><td className="py-2 pr-4">$8-15</td><td className="py-2">Best all-purpose choice</td></tr>
-          <tr className="border-b"><td className="py-2 pr-4 font-medium text-ink">Ferrous Sulfate</td><td className="py-2 pr-4 text-amber-700 font-semibold">Good</td><td className="py-2 pr-4 text-red-600">Poor (constipation)</td><td className="py-2 pr-4">$3-5</td><td className="py-2">Budget, short-term correction</td></tr>
-          <tr><td className="py-2 pr-4 font-medium text-ink">Heme Iron</td><td className="py-2 pr-4 text-emerald-700 font-semibold">Best</td><td className="py-2 pr-4 text-emerald-700">Excellent</td><td className="py-2 pr-4">$20-30</td><td className="py-2">Severe deficiency, poor responders</td></tr>
-        </tbody></table></div></section>
+      <section className="grid gap-5 lg:grid-cols-3">
+        {evidenceBoundaries.map((card) => (
+          <article key={card.title} className="card-premium p-6 space-y-4">
+            <h2 className="text-xl font-semibold text-ink">{card.title}</h2>
+            <div>
+              <p className="text-xs font-bold uppercase tracking-wider text-emerald-800">What it supports</p>
+              <p className="mt-2 text-sm leading-6 text-muted">{card.shows}</p>
+            </div>
+            <div>
+              <p className="text-xs font-bold uppercase tracking-wider text-amber-800">What it does not support</p>
+              <p className="mt-2 text-sm leading-6 text-muted">{card.doesNotShow}</p>
+            </div>
+          </article>
+        ))}
+      </section>
 
-      <section className="card-premium p-6 space-y-4"><h2 className="text-2xl font-semibold">Bottom line</h2><p className="text-sm leading-7 text-muted">Iron is not a general wellness supplement — it is a deficiency correction tool. Test before supplementing. Bisglycinate at 25-50 mg every other day + vitamin C is the best-tolerated, best-absorbed approach for most people [1,2]. Men and postmenopausal women should rarely supplement iron without confirmed deficiency. The risks of iron overload (oxidative damage, organ dysfunction) outweigh the benefits in iron-replete individuals [3].</p></section>
+      <section className="space-y-4 max-w-5xl">
+        <h2 className="text-3xl font-semibold tracking-tight text-ink">Choose the clinical question before choosing iron</h2>
+        <div className="overflow-x-auto rounded-2xl border border-brand-900/10 bg-white/90 dark:border-white/10 dark:bg-white/5">
+          <table className="min-w-[820px] w-full text-left text-sm">
+            <thead>
+              <tr className="border-b border-brand-900/10 text-ink">
+                <th className="p-4">Situation</th>
+                <th className="p-4">Better next step</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-brand-900/10 text-muted">
+              {decisionRows.map((row) => (
+                <tr key={row.situation}>
+                  <td className="p-4 font-semibold text-ink">{row.situation}</td>
+                  <td className="p-4 leading-6">{row.nextStep}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="card-premium p-6 space-y-4 max-w-4xl">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Dose and safety boundaries</h2>
+        <ul className="list-disc space-y-3 pl-5 text-sm leading-7 text-muted">
+          <li><strong className="text-ink">Upper-limit context:</strong> NIH lists 45 mg per day as the adult tolerable upper intake level for iron from food and supplements [1]. 45 mg per day is the adult tolerable upper intake level, not a treatment ceiling; clinicians sometimes prescribe more for confirmed iron-deficiency anemia.</li>
+          <li><strong className="text-ink">Side effects:</strong> supplemental iron can cause nausea, constipation, abdominal pain, vomiting, and diarrhea, especially at higher doses [1].</li>
+          <li><strong className="text-ink">Iron overload:</strong> hereditary hemochromatosis can cause toxic iron accumulation and organ damage. People with known hemochromatosis should avoid iron supplements unless specifically directed [1].</li>
+          <li><strong className="text-ink">Children:</strong> accidental iron poisoning can be severe or fatal. Iron products need secure storage away from children [1].</li>
+        </ul>
+      </section>
+
+      <section className="rounded-2xl border border-amber-900/15 bg-amber-50/70 p-6 text-amber-950 dark:border-amber-200/20 dark:bg-amber-950/20 dark:text-amber-50">
+        <p className="text-xs font-bold uppercase tracking-[0.16em]">Medication and cause-finding boundary</p>
+        <h2 className="mt-2 text-2xl font-semibold">Iron deficiency can be a clue, not just a nutrient gap</h2>
+        <p className="mt-3 text-sm leading-7">
+          Iron can interfere with levothyroxine and levodopa, while proton pump inhibitors can reduce non-heme iron absorption [1]. More importantly, confirmed iron-deficiency anemia can reflect menstrual blood loss, gastrointestinal bleeding, malabsorption, pregnancy-related needs, dietary insufficiency, inflammatory disease, or other causes. AGA guidance recommends gastrointestinal evaluation in several adult groups rather than simply replacing iron indefinitely [3].
+        </p>
+        <div className="mt-5 flex flex-wrap gap-3">
+          <Link href="/safety-checker/" className="rounded-full bg-amber-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-950 dark:bg-amber-100 dark:text-amber-950">
+            Check supplement interactions
+          </Link>
+          <Link href="/info/supplement-safety-checklist/" className="rounded-full border border-amber-900/20 px-4 py-2 text-sm font-semibold text-amber-950 transition hover:bg-white/60 dark:border-amber-100/30 dark:text-amber-50">
+            Supplement safety checklist
+          </Link>
+        </div>
+      </section>
+
       <References refs={IRON_REFS} />
-      <div className="max-w-4xl">
-        <RecommendationSection products={getRevenueProductSet('iron')?.products ?? []} />
+      <EmailCapture
+        headline="Get evidence reviews like this"
+        description="Testing, deficiency, and supplement safety — without self-treatment shortcuts."
+        ctaLabel="Get the evidence"
+        location="guide-iron"
+      />
+      <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between">
+        <Link href="/guides/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">
+          ← Back to guides
+        </Link>
+        <Link href="/info/supplement-safety-checklist/" className="text-sm font-bold text-brand-800 hover:underline">
+          Safety checklist →
+        </Link>
       </div>
-      <EmailCapture headline="Get evidence reviews like this" description="Iron, deficiency, forms — evidence over guesswork." ctaLabel="Get the evidence" location="guide-iron" />
-      <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between"><Link href="/guides/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">← Back to guides</Link><Link href="/herbs/" className="text-sm font-bold text-brand-800 hover:underline">Herb library →</Link></div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- remove the universal ferritin <30 ng/mL diagnosis and fixed 25–50 mg self-treatment protocol
- replace “bisglycinate is best” language with current AGA formulation guidance
- distinguish ferritin interpretation in anemia and inflammatory/clinical contexts
- add excess-iron, hemochromatosis, pediatric poisoning, levothyroxine, and levodopa safety boundaries
- emphasize cause-finding for confirmed iron-deficiency anemia
- replace selective older citations with NIH ODS, AGA, and WHO guidance
- remove the iron product module from a deficiency/dosing page
- add route-specific regression coverage

## Why this is high ROI
This high-intent YMYL page previously turned a single ferritin threshold into a diagnosis and a fixed supplement dose into a self-treatment plan. Current guidance is more context-dependent, and unnecessary iron can cause harm. The update improves safety, trust, and long-term search resilience without changing the route.

## Evidence anchors
- NIH ODS Iron Health Professional Fact Sheet
- AGA 2024 Clinical Practice Update: Management of Iron Deficiency Anemia
- AGA guideline: Gastrointestinal Evaluation of Iron Deficiency Anemia
- WHO ferritin guideline

## Validation intent
- route/canonical preserved
- FAQ/schema preserved
- references and email capture preserved
- no product recommendation module remains
