### PR TITLE
Restore canonical auditing for the /learn namespace

### DIFF
--- a/scripts/audit/check-education-canonicals.mjs
+++ b/scripts/audit/check-education-canonicals.mjs
@@ -1,107 +1,12 @@
 #!/usr/bin/env node
 /**
- * Source-level audit: every App Router page under app/education/**\/page.tsx
- * must export `metadata` with `alternates.canonical` pointing at its own route.
+ * Backward-compatible entrypoint.
  *
- * Pages that don't override metadata inherit the root layout's canonical (/)
- * and Google treats them as duplicates of the homepage. This script catches
- * the regression before build.
- *
- * Usage: node scripts/audit/check-education-canonicals.mjs
+ * The education namespace was renamed to /learn. Keep this file so existing
+ * npm/automation callers do not break, but delegate all behavior to the
+ * current learn canonical audit.
  */
-import fs from 'node:fs';
-import path from 'node:path';
+import { auditLearnCanonicals } from './check-learn-canonicals.mjs'
 
-const ROOT = process.cwd();
-const TARGET_DIR = path.join(ROOT, 'app', 'education');
-
-function walk(dir) {
-  const out = [];
-  if (!fs.existsSync(dir)) return out;
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      if (/^\[.+\]$/.test(entry.name)) continue; // dynamic routes use generateMetadata, skip
-      out.push(...walk(full));
-    } else if (entry.isFile() && entry.name === 'page.tsx') {
-      out.push(full);
-    }
-  }
-  return out;
-}
-
-function extractCanonical(src) {
-  // Look for an explicit metadata export
-  // Case 1: `alternates: { canonical: '...' }` inside an object literal
-  const alternatesMatch = src.match(/alternates\s*:\s*\{[^}]*canonical\s*:\s*['"]([^'"]+)['"]/);
-  if (alternatesMatch) return alternatesMatch[1];
-
-  // Case 2: buildPageMetadata({ ..., path: '/...' }) — check the path arg
-  const buildMetaMatch = src.match(/buildPageMetadata\s*\(\s*\{[\s\S]*?path\s*:\s*['"]([^'"]+)['"]/);
-  if (buildMetaMatch) return `via buildPageMetadata path=${buildMetaMatch[1]}`;
-
-  // Case 3: generatePathwayMetadata('x') — indirect call to buildPageMetadata
-  const pathwayMatch = src.match(/generatePathwayMetadata\s*\(\s*['"]([^'"]+)['"]/);
-  if (pathwayMatch) {
-    return `via generatePathwayMetadata path=/education/${pathwayMatch[1]}/`;
-  }
-
-  return null;
-}
-
-function isExplicitlyNoindex(src) {
-  // Pages that opt out of indexing (utility routes, explorers, etc.) don't
-  // need their own canonical — they explicitly tell crawlers not to index.
-  return /index\s*:\s*false/.test(src) || /noindex\s*:/.test(src);
-}
-
-function expectedRouteFromPath(filePath) {
-  const rel = path.relative(TARGET_DIR, filePath).replace(/\\/g, '/');
-  const parts = rel.split('/').filter((p) => p && p !== 'page.tsx');
-  return '/' + ['education', ...parts].join('/');
-}
-
-const files = walk(TARGET_DIR);
-let problems = 0;
-
-for (const f of files) {
-  const src = fs.readFileSync(f, 'utf8');
-  const expectedRoute = expectedRouteFromPath(f);
-  const expectedCanonical = `${expectedRoute}/`;
-  const actual = extractCanonical(src);
-  const noindex = isExplicitlyNoindex(src);
-
-  let status = 'OK';
-  let detail = actual ?? '(none)';
-
-  if (!actual && noindex) {
-    // Intentional noindex — no canonical needed (inherits parent is fine
-    // because we're telling crawlers not to index the page anyway).
-    detail = 'noindex page, no canonical required';
-  } else if (!actual) {
-    status = 'FAIL';
-    detail = 'no canonical declared';
-    problems++;
-  } else if (actual.startsWith('via buildPageMetadata') || actual.startsWith('via generatePathwayMetadata')) {
-    const m = actual.match(/path=(\/[^ ]+)/);
-    const declaredPath = m ? m[1] : '';
-    if (declaredPath !== expectedCanonical) {
-      status = 'FAIL';
-      detail = `path mismatch: declared=${declaredPath}, expected=${expectedCanonical}`;
-      problems++;
-    } else {
-      detail = actual;
-    }
-  } else if (actual !== expectedCanonical) {
-    status = 'FAIL';
-    detail = `canonical mismatch: actual=${actual}, expected=${expectedCanonical}`;
-    problems++;
-  }
-
-  const rel = path.relative(ROOT, f);
-  const tag = status === 'OK' ? '✅' : '❌';
-  console.log(`${tag} ${rel} → ${detail}`);
-}
-
-console.log(`\n[check-education-canonicals] ${files.length} files, ${problems} problems`);
-process.exit(problems > 0 ? 1 : 0);
+const { failures } = auditLearnCanonicals()
+process.exit(failures.length > 0 ? 1 : 0)

--- a/scripts/audit/check-learn-canonicals.mjs
+++ b/scripts/audit/check-learn-canonicals.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+/**
+ * Source-level audit: every static App Router page under app/learn/**/page.tsx
+ * must declare a canonical that resolves to its own /learn route.
+ *
+ * Dynamic routes are skipped because they typically use generateMetadata.
+ * Explicit noindex pages may omit a canonical.
+ *
+ * Usage: node scripts/audit/check-learn-canonicals.mjs
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = process.cwd()
+const TARGET_DIR = path.join(ROOT, 'app', 'learn')
+const ROUTE_ROOT = '/learn'
+
+export function walkStaticPages(dir) {
+  const out = []
+  if (!fs.existsSync(dir)) return out
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      if (/^\[.+\]$/.test(entry.name)) continue
+      if (entry.name.startsWith('_')) continue
+      out.push(...walkStaticPages(full))
+    } else if (entry.isFile() && entry.name === 'page.tsx') {
+      out.push(full)
+    }
+  }
+
+  return out
+}
+
+export function normalizeCanonical(value) {
+  if (!value) return null
+  let normalized = value.trim()
+  normalized = normalized.replace(/^https?:\/\/(?:www\.)?thehippiescientist\.net/i, '')
+  if (!normalized.startsWith('/')) return normalized
+  normalized = normalized.replace(/\/+$/, '')
+  return normalized === '' ? '/' : `${normalized}/`
+}
+
+function resolveCanonicalIdentifier(src, identifier, expectedCanonical) {
+  const escaped = identifier.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+  const literal = src.match(new RegExp(`(?:const|let)\\s+${escaped}\\s*=\\s*['\"]([^'\"]+)['\"]`))
+  if (literal) return normalizeCanonical(literal[1])
+
+  const siteUrlTemplate = src.match(
+    new RegExp(`(?:const|let)\\s+${escaped}\\s*=\\s*\`\\$\\{SITE_URL\\}([^\`$]+)\``),
+  )
+  if (siteUrlTemplate) return normalizeCanonical(siteUrlTemplate[1])
+
+  const collectionUrl = src.match(
+    new RegExp(`(?:const|let)\\s+${escaped}\\s*=\\s*\`\\$\\{SITE_URL\\}\\$\\{([A-Za-z_$][\\w$]*)\\.url\\}/?\``),
+  )
+  if (collectionUrl) {
+    const pageVar = collectionUrl[1]
+    const escapedPageVar = pageVar.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const slugMatch = src.match(
+      new RegExp(
+        `(?:const|let)\\s+${escapedPageVar}\\s*=[\\s\\S]*?\\.find\\([\\s\\S]*?slug\\s*===\\s*['\"]([^'\"]+)['\"]`,
+      ),
+    )
+    if (slugMatch) {
+      const inferred = normalizeCanonical(`${ROUTE_ROOT}/${slugMatch[1]}/`)
+      if (inferred === expectedCanonical) return inferred
+    }
+  }
+
+  return null
+}
+
+export function extractCanonical(src, expectedCanonical = null) {
+  const literalMatch = src.match(
+    /alternates\s*:\s*\{[^}]*canonical\s*:\s*['"]([^'"]+)['"]/,
+  )
+  if (literalMatch) return normalizeCanonical(literalMatch[1])
+
+  const templateMatch = src.match(
+    /alternates\s*:\s*\{[^}]*canonical\s*:\s*`\$\{SITE_URL\}([^`$]+)`/,
+  )
+  if (templateMatch) return normalizeCanonical(templateMatch[1])
+
+  const buildMetaMatch = src.match(
+    /buildPageMetadata\s*\(\s*\{[\s\S]*?path\s*:\s*['"]([^'"]+)['"]/,
+  )
+  if (buildMetaMatch) return normalizeCanonical(buildMetaMatch[1])
+
+  const pathwayMatch = src.match(/generatePathwayMetadata\s*\(\s*['"]([^'"]+)['"]\s*\)/)
+  if (pathwayMatch) return normalizeCanonical(`${ROUTE_ROOT}/${pathwayMatch[1]}/`)
+
+  const identifierMatch = src.match(
+    /alternates\s*:\s*\{[^}]*canonical\s*:\s*([A-Za-z_$][\w$]*)/,
+  )
+  if (identifierMatch && expectedCanonical) {
+    return resolveCanonicalIdentifier(src, identifierMatch[1], expectedCanonical)
+  }
+
+  return null
+}
+
+export function isExplicitlyNoindex(src) {
+  return /index\s*:\s*false/.test(src) || /noindex\s*:/.test(src)
+}
+
+export function expectedRouteFromPath(filePath, targetDir = TARGET_DIR) {
+  const rel = path.relative(targetDir, filePath).replace(/\\/g, '/')
+  const parts = rel
+    .split('/')
+    .filter((part) => part && part !== 'page.tsx' && !/^\(.+\)$/.test(part))
+  return normalizeCanonical('/' + [ROUTE_ROOT.slice(1), ...parts].join('/'))
+}
+
+export function auditLearnCanonicals({ root = ROOT, targetDir = TARGET_DIR, logger = console.log } = {}) {
+  const files = walkStaticPages(targetDir)
+  const failures = []
+
+  for (const file of files) {
+    const src = fs.readFileSync(file, 'utf8')
+    const expectedCanonical = expectedRouteFromPath(file, targetDir)
+    const actual = extractCanonical(src, expectedCanonical)
+    const noindex = isExplicitlyNoindex(src)
+
+    let status = 'OK'
+    let detail = actual ?? '(none)'
+
+    if (!actual && noindex) {
+      detail = 'noindex page, no canonical required'
+    } else if (!actual) {
+      status = 'FAIL'
+      detail = 'no canonical declared or statically resolvable'
+      failures.push({ file, expectedCanonical, actual: null, detail })
+    } else if (actual !== expectedCanonical) {
+      status = 'FAIL'
+      detail = `canonical mismatch: actual=${actual}, expected=${expectedCanonical}`
+      failures.push({ file, expectedCanonical, actual, detail })
+    }
+
+    const rel = path.relative(root, file)
+    logger(`${status === 'OK' ? '✅' : '❌'} ${rel} → ${detail}`)
+  }
+
+  logger(`\n[check-learn-canonicals] ${files.length} files, ${failures.length} problems`)
+  return { files, failures }
+}
+
+export function isMainModule(argv1 = process.argv[1]) {
+  if (!argv1) return false
+  return path.resolve(argv1) === fileURLToPath(import.meta.url)
+}
+
+if (isMainModule()) {
+  const { failures } = auditLearnCanonicals()
+  process.exit(failures.length > 0 ? 1 : 0)
+}

--- a/scripts/audit/check-learn-canonicals.mjs
+++ b/scripts/audit/check-learn-canonicals.mjs
@@ -46,7 +46,7 @@ export function normalizeCanonical(value) {
 function resolveCanonicalIdentifier(src, identifier, expectedCanonical) {
   const escaped = identifier.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
-  const literal = src.match(new RegExp(`(?:const|let)\\s+${escaped}\\s*=\\s*['\"]([^'\"]+)['\"]`))
+  const literal = src.match(new RegExp(`(?:const|let)\\s+${escaped}\\s*=\\s*['"]([^'"]+)['"]`))
   if (literal) return normalizeCanonical(literal[1])
 
   const siteUrlTemplate = src.match(
@@ -62,7 +62,7 @@ function resolveCanonicalIdentifier(src, identifier, expectedCanonical) {
     const escapedPageVar = pageVar.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
     const slugMatch = src.match(
       new RegExp(
-        `(?:const|let)\\s+${escapedPageVar}\\s*=[\\s\\S]*?\\.find\\([\\s\\S]*?slug\\s*===\\s*['\"]([^'\"]+)['\"]`,
+        `(?:const|let)\\s+${escapedPageVar}\\s*=[\\s\\S]*?\\.find\\([\\s\\S]*?slug\\s*===\\s*['"]([^'"]+)['"]`,
       ),
     )
     if (slugMatch) {

--- a/scripts/audit/check-learn-canonicals.mjs
+++ b/scripts/audit/check-learn-canonicals.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Source-level audit: every static App Router page under app/learn/**/page.tsx
+ * Source-level audit: every static App Router page under app/learn/<segments>/page.tsx
  * must declare a canonical that resolves to its own /learn route.
  *
  * Dynamic routes are skipped because they typically use generateMetadata.

--- a/scripts/audit/check-learn-canonicals.test.mjs
+++ b/scripts/audit/check-learn-canonicals.test.mjs
@@ -1,0 +1,98 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  auditLearnCanonicals,
+  expectedRouteFromPath,
+  extractCanonical,
+  normalizeCanonical,
+  walkStaticPages,
+} from './check-learn-canonicals.mjs'
+
+let tmpDir
+
+afterEach(() => {
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true })
+  tmpDir = undefined
+})
+
+describe('learn canonical audit helpers', () => {
+  it('normalizes site URLs and trailing slashes', () => {
+    expect(normalizeCanonical('/learn/calming')).toBe('/learn/calming/')
+    expect(normalizeCanonical('https://thehippiescientist.net/learn/calming/')).toBe('/learn/calming/')
+  })
+
+  it('derives /learn routes and ignores route-group directory names', () => {
+    const target = path.join('/tmp', 'repo', 'app', 'learn')
+    expect(expectedRouteFromPath(path.join(target, 'page.tsx'), target)).toBe('/learn/')
+    expect(expectedRouteFromPath(path.join(target, '(foundations)', 'evidence', 'page.tsx'), target)).toBe('/learn/evidence/')
+  })
+
+  it('extracts the metadata styles currently used by static learn pages', () => {
+    expect(extractCanonical("alternates: { canonical: '/learn/' }", '/learn/')).toBe('/learn/')
+    expect(
+      extractCanonical(
+        "alternates: { canonical: `${SITE_URL}/learn/serotonin-syndrome-supplements/` }",
+        '/learn/serotonin-syndrome-supplements/',
+      ),
+    ).toBe('/learn/serotonin-syndrome-supplements/')
+    expect(
+      extractCanonical("buildPageMetadata({ title: 'Calm', path: '/learn/calming' })", '/learn/calming/'),
+    ).toBe('/learn/calming/')
+    expect(
+      extractCanonical("generatePathwayMetadata('inflammation')", '/learn/inflammation/'),
+    ).toBe('/learn/inflammation/')
+  })
+
+  it('resolves content-collection canonicalUrl variables when the bound slug matches the route', () => {
+    const source = `
+      const page = allConceptPages.find((item) => item.slug === 'rhabdomyolysis')!
+      const canonicalUrl = \`${'${SITE_URL}'}${'${page.url}'}/\`
+      export const metadata = { alternates: { canonical: canonicalUrl } }
+    `
+    expect(extractCanonical(source, '/learn/rhabdomyolysis/')).toBe('/learn/rhabdomyolysis/')
+  })
+})
+
+describe('learn canonical audit integration', () => {
+  it('walks static pages, skips dynamic routes, and reports canonical mismatches', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'learn-canonical-audit-'))
+    const target = path.join(tmpDir, 'app', 'learn')
+    const goodDir = path.join(target, 'good')
+    const badDir = path.join(target, 'bad')
+    const dynamicDir = path.join(target, '[slug]')
+    fs.mkdirSync(goodDir, { recursive: true })
+    fs.mkdirSync(badDir, { recursive: true })
+    fs.mkdirSync(dynamicDir, { recursive: true })
+
+    fs.writeFileSync(path.join(target, 'page.tsx'), "export const metadata = { alternates: { canonical: '/learn/' } }")
+    fs.writeFileSync(path.join(goodDir, 'page.tsx'), "export const metadata = buildPageMetadata({ path: '/learn/good/' })")
+    fs.writeFileSync(path.join(badDir, 'page.tsx'), "export const metadata = { alternates: { canonical: '/learn/wrong/' } }")
+    fs.writeFileSync(path.join(dynamicDir, 'page.tsx'), 'export default function DynamicPage() { return null }')
+
+    expect(walkStaticPages(target)).toHaveLength(3)
+
+    const output = []
+    const result = auditLearnCanonicals({ root: tmpDir, targetDir: target, logger: (line) => output.push(line) })
+    expect(result.files).toHaveLength(3)
+    expect(result.failures).toHaveLength(1)
+    expect(result.failures[0].expectedCanonical).toBe('/learn/bad/')
+    expect(output.at(-1)).toContain('3 files, 1 problems')
+  })
+
+  it('allows an explicit noindex page without a canonical', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'learn-canonical-noindex-'))
+    const target = path.join(tmpDir, 'app', 'learn')
+    const utilityDir = path.join(target, 'utility')
+    fs.mkdirSync(utilityDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(utilityDir, 'page.tsx'),
+      'export const metadata = { robots: { index: false, follow: false } }',
+    )
+
+    const result = auditLearnCanonicals({ root: tmpDir, targetDir: target, logger: () => {} })
+    expect(result.failures).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Summary
- replace the dead `app/education` canonical scan with a real static-page audit of `app/learn`
- keep the old `check-education-canonicals.mjs` entrypoint as a compatibility shim for existing npm/automation callers
- support the metadata patterns currently used by Learn pages: literal canonicals, `${SITE_URL}` templates, `buildPageMetadata`, `generatePathwayMetadata`, and content-collection `canonicalUrl` bindings
- normalize trailing slashes and canonical host variants before comparison
- skip dynamic route folders and explicitly noindex pages
- add focused Vitest coverage for route derivation, metadata extraction, content-collection resolution, dynamic-route skipping, mismatch detection, and noindex behavior

## Why this is high ROI
The repo's own loop notes documented that this audit still targeted a removed `app/education` tree and therefore reported a misleading `0 files, 0 problems`. Fixing the checker restores a preventative SEO gate across the current Learn namespace and gives future autonomous cycles a trustworthy signal instead of a false all-clear.

## Scope
Audit/tooling only. No production route, page copy, data pipeline, or canonical value is changed by this PR.