### PR TITLE
Remove stale Sleep supplements redirect hop

### DIFF
--- a/app/__tests__/sleep-best-supplements-route-consolidation.test.ts
+++ b/app/__tests__/sleep-best-supplements-route-consolidation.test.ts
@@ -4,9 +4,12 @@ import { describe, expect, it } from 'vitest'
 
 const RETIRED_PAGE = 'app/guides/sleep/sleep-best-supplements/page.tsx'
 const HUB = 'app/guides/sleep/page.tsx'
+const APIGENIN_GUIDE = 'app/guides/sleep/apigenin-for-sleep/page.tsx'
 const GOAL_LINKS = 'lib/goal-start-here-links.ts'
 const GOAL_CLUSTERS = 'lib/goal-clusters.ts'
 const OVERRIDE = 'public/redirect-overrides/003-sleep-best-supplements-consolidation.txt'
+const RETIRED_ROUTE = '/guides/sleep/sleep-best-supplements/'
+const CANONICAL_ROUTE = '/guides/sleep/best-supplements-for-sleep/'
 
 function read(relativePath: string) {
   return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
@@ -17,14 +20,20 @@ describe('sleep best supplements route consolidation', () => {
     expect(fs.existsSync(path.join(process.cwd(), RETIRED_PAGE))).toBe(false)
 
     const redirects = read(OVERRIDE)
-    expect(redirects).toContain('/guides/sleep/sleep-best-supplements/')
-    expect(redirects).toContain('/guides/sleep/best-supplements-for-sleep/ 301')
+    expect(redirects).toContain(RETIRED_ROUTE)
+    expect(redirects).toContain(`${CANONICAL_ROUTE} 301`)
   })
 
   it('removes the retired route from discovery and shared goal navigation', () => {
     expect(read(HUB)).not.toContain('sleep-best-supplements')
-    expect(read(GOAL_LINKS)).not.toContain('/guides/sleep/sleep-best-supplements/')
-    expect(read(GOAL_LINKS)).toContain('/guides/sleep/best-supplements-for-sleep/')
+    expect(read(GOAL_LINKS)).not.toContain(RETIRED_ROUTE)
+    expect(read(GOAL_LINKS)).toContain(CANONICAL_ROUTE)
     expect(read(GOAL_CLUSTERS)).not.toContain("'sleep-best-supplements'")
+  })
+
+  it('links sleep guides directly to the canonical decision route instead of through the redirect', () => {
+    const apigenin = read(APIGENIN_GUIDE)
+    expect(apigenin).not.toContain(RETIRED_ROUTE)
+    expect(apigenin).toContain(CANONICAL_ROUTE)
   })
 })

--- a/app/guides/sleep/apigenin-for-sleep/page.tsx
+++ b/app/guides/sleep/apigenin-for-sleep/page.tsx
@@ -176,7 +176,7 @@ export default function Page() {
             For most readers, apigenin should come after the cleaner decision pages. Start with the actual sleep problem, then decide whether a low-confidence trend supplement is even needed.
           </p>
           <div className="mt-4 flex flex-wrap gap-3 text-sm font-semibold">
-            <Link href="/guides/sleep/sleep-best-supplements/" className="text-brand-800 hover:underline dark:text-[var(--text-primary)]">Best sleep supplements →</Link>
+            <Link href="/guides/sleep/best-supplements-for-sleep/" className="text-brand-800 hover:underline dark:text-[var(--text-primary)]">Best sleep supplements →</Link>
             <Link href="/guides/sleep/l-theanine-for-sleep/" className="text-brand-800 hover:underline dark:text-[var(--text-primary)]">L-theanine for sleep →</Link>
             <Link href="/guides/sleep/magnesium-for-sleep/" className="text-brand-800 hover:underline dark:text-[var(--text-primary)]">Magnesium for sleep →</Link>
           </div>


### PR DESCRIPTION
## Summary
- repoint the Apigenin for Sleep “Best sleep supplements” link directly to `/guides/sleep/best-supplements-for-sleep/`
- extend the existing Sleep route-consolidation regression test so future sleep guides cannot reintroduce the retired route through this page

## Why this is high ROI
The old `/guides/sleep/sleep-best-supplements/` route was intentionally retired and 301s to the current decision guide, but this live page still sent readers and crawlers through that redirect. This removes the avoidable hop and makes the earlier consolidation complete at this discovery point.

## Scope
Two-line behavioral change plus focused regression coverage. No health claims, route behavior, or data pipeline changes.