### PR TITLE
Keep route SEO warnings production-only

### DIFF
--- a/scripts/ci/validate-route-seo.mjs
+++ b/scripts/ci/validate-route-seo.mjs
@@ -7,6 +7,8 @@ const read = (p) => fs.readFileSync(path.join(root, p), 'utf8')
 const exists = (p) => fs.existsSync(path.join(root, p))
 
 const pageFilePattern = /^page\.(tsx|ts|jsx|js)$/
+const testFilePattern = /\.(test|spec)\.(tsx|ts|jsx|js)$/
+const testOnlyDirectories = new Set(['__tests__', '__mocks__', '__fixtures__'])
 
 function collectFiles(dir, matcher = null) {
   const absDir = path.join(root, dir)
@@ -21,12 +23,13 @@ function collectFiles(dir, matcher = null) {
       const fullPath = path.join(currentDir, entry.name)
 
       if (entry.isDirectory()) {
+        if (testOnlyDirectories.has(entry.name)) continue
         walk(fullPath)
         continue
       }
 
       if (!entry.isFile()) continue
-
+      if (testFilePattern.test(entry.name)) continue
       if (matcher && !matcher(entry.name)) continue
 
       files.push(path.relative(root, fullPath).split(path.sep).join('/'))

--- a/scripts/ci/validate-route-seo.test.mjs
+++ b/scripts/ci/validate-route-seo.test.mjs
@@ -1,0 +1,58 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { afterEach, describe, expect, it } from 'vitest'
+
+let tmpDir
+
+afterEach(() => {
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true })
+  tmpDir = undefined
+})
+
+function write(relativePath, content) {
+  const fullPath = path.join(tmpDir, relativePath)
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true })
+  fs.writeFileSync(fullPath, content)
+}
+
+describe('validate-route-seo production source scan', () => {
+  it('ignores test fixtures while preserving warnings from production source', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'route-seo-audit-'))
+
+    write('app/page.tsx', 'export default function Page() { return null }')
+    write(
+      'app/lead-magnets/adhd-supplement-starter-checklist/page.tsx',
+      'export default function RequiredRoute() { return null }',
+    )
+    write(
+      'app/real/page.tsx',
+      'export default function RealPage() { return <a href="/missing-production/">Missing</a> }',
+    )
+    write(
+      'app/__tests__/route-fixture.test.tsx',
+      'export const fixture = <a href="/missing-test-fixture/">Fixture</a>',
+    )
+    write(
+      'components/seo/__tests__/schema-fixture.test.tsx',
+      'export const schemaFixture = { href: "/missing-schema-fixture/" }',
+    )
+    write(
+      'lib/helper.spec.ts',
+      'export const helperFixture = { href: "/missing-spec-fixture/" }',
+    )
+
+    const validator = path.resolve(process.cwd(), 'scripts/ci/validate-route-seo.mjs')
+    const result = spawnSync(process.execPath, [validator], {
+      cwd: tmpDir,
+      encoding: 'utf8',
+    })
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('Broken internal href /missing-production/ in app/real/page.tsx')
+    expect(result.stdout).not.toContain('/missing-test-fixture/')
+    expect(result.stdout).not.toContain('/missing-schema-fixture/')
+    expect(result.stdout).not.toContain('/missing-spec-fixture/')
+  })
+})


### PR DESCRIPTION
## Summary
- exclude `__tests__`, `__mocks__`, and `__fixtures__` directories from the route SEO source scan
- exclude `*.test.*` and `*.spec.*` files even when they live outside those directories
- keep the production page/route scan unchanged
- add an integration-style regression test that runs the real validator against a temporary mini-repo and proves production broken links are still reported while fixture-only links are ignored

## Why this is high ROI
The current Site Health report treats test fixture href strings as if they were production navigation, creating false broken-link warnings. That noise makes the audit less trustworthy and encourages agents to ignore warnings. This removes fixture noise without suppressing real production-link findings.

## Scope
Audit quality only. No production routes, page content, or SEO metadata change.