### PR TITLE
Turn comparison work packets into stable agent assignments

### DIFF
--- a/agent/orchestrator/prepare-comparison-assignments.js
+++ b/agent/orchestrator/prepare-comparison-assignments.js
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = process.cwd()
+const DEFAULT_QUEUE = path.join(repoRoot, 'reports', 'related-botanicals', 'comparison-agent-work-queue.json')
+const EXECUTABLE_ACTIONS = new Set(['build-next', 'research-first', 'validate-and-outline'])
+
+export function parseComparisonAssignmentArgs(argv = process.argv.slice(2), root = repoRoot) {
+  const value = (name) => argv.find((arg) => arg.startsWith(`--${name}=`))?.split('=').slice(1).join('=')
+  const action = value('action') || 'all'
+  const packetId = value('packet') || null
+  const queueArg = value('queue')
+  const queuePath = queueArg ? path.resolve(root, queueArg) : path.join(root, 'reports', 'related-botanicals', 'comparison-agent-work-queue.json')
+  const requestedLimit = Number(value('limit'))
+  const limit = Number.isFinite(requestedLimit) ? Math.min(50, Math.max(1, requestedLimit)) : 10
+
+  if (action !== 'all' && !EXECUTABLE_ACTIONS.has(action)) {
+    throw new Error(`Unsupported executable action: ${action}. Allowed: all, ${[...EXECUTABLE_ACTIONS].join(', ')}`)
+  }
+
+  return { action, packetId, queuePath, limit }
+}
+
+export function readComparisonWorkQueue(queuePath = DEFAULT_QUEUE) {
+  if (!fs.existsSync(queuePath)) {
+    throw new Error(`Comparison work queue not found: ${queuePath}. Generate it with scripts/rank-related-comparisons.ts first.`)
+  }
+
+  const parsed = JSON.parse(fs.readFileSync(queuePath, 'utf8'))
+  const packets = Array.isArray(parsed) ? parsed : parsed.packets ?? parsed.assignments ?? []
+  if (!Array.isArray(packets)) throw new Error('Comparison work queue must contain a packets array.')
+  return packets
+}
+
+function priorityRank(action) {
+  if (action === 'build-next') return 3
+  if (action === 'research-first') return 2
+  if (action === 'validate-and-outline') return 1
+  return 0
+}
+
+function stableAssignmentId(packetId) {
+  const suffix = String(packetId || 'missing-packet').replace(/^comparison:/, '')
+  return `comparison-assignment:${suffix}`
+}
+
+export function selectComparisonAssignments(packets, { action = 'all', packetId = null, limit = 10 } = {}) {
+  return packets
+    .filter((packet) => EXECUTABLE_ACTIONS.has(packet?.recommendedAction))
+    .filter((packet) => action === 'all' || packet.recommendedAction === action)
+    .filter((packet) => !packetId || packet.packetId === packetId)
+    .sort((a, b) =>
+      priorityRank(b.recommendedAction) - priorityRank(a.recommendedAction)
+      || Number(b.priorityScore || 0) - Number(a.priorityScore || 0)
+      || String(a.packetId || '').localeCompare(String(b.packetId || '')))
+    .slice(0, limit)
+    .map((packet) => ({
+      assignmentId: stableAssignmentId(packet.packetId),
+      sourcePacketId: packet.packetId,
+      action: packet.recommendedAction,
+      status: 'ready-for-agent',
+      title: packet.title,
+      proposedSlug: packet.proposedSlug,
+      instruction: packet.nextTask,
+      rationale: packet.actionReason,
+      researchGaps: packet.researchGaps ?? [],
+      completionCriteria: packet.completionCriteria ?? [],
+      guardrails: [
+        'Do not publish automatically.',
+        'Do not promote an assignment beyond its evidence-gated action without regenerating the queue.',
+        'Use canonical repository evidence/data sources for factual claims.',
+        'Return reviewable repository changes or research artifacts for human/CI review.',
+      ],
+      evidence: {
+        tier: packet.evidenceTier,
+        label: packet.evidenceLabel,
+        chemistrySupported: Boolean(packet.chemistrySupported),
+      },
+      demand: {
+        tier: packet.demandTier,
+        observedBehaviorScore: Number(packet.observedBehaviorScore || 0),
+        observedBehavior: packet.observedBehavior ?? {},
+      },
+      scores: {
+        priority: Number(packet.priorityScore || 0),
+        scientific: Number(packet.scientificPriorityScore || 0),
+        editorialIntent: Number(packet.editorialIntentScore || 0),
+      },
+      entities: {
+        aSlug: packet.aSlug,
+        bSlug: packet.bSlug,
+      },
+    }))
+}
+
+export function prepareComparisonAssignments(options = parseComparisonAssignmentArgs()) {
+  const packets = readComparisonWorkQueue(options.queuePath)
+  const assignments = selectComparisonAssignments(packets, options)
+
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    sourceQueue: path.relative(repoRoot, options.queuePath),
+    filters: {
+      action: options.action,
+      packetId: options.packetId,
+      limit: options.limit,
+    },
+    assignmentCount: assignments.length,
+    assignments,
+  }
+}
+
+function main() {
+  process.stdout.write(`${JSON.stringify(prepareComparisonAssignments(), null, 2)}\n`)
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : null
+const modulePath = fileURLToPath(import.meta.url)
+if (invokedPath === modulePath) {
+  try {
+    main()
+  } catch (error) {
+    console.error(`[comparison-assignments] ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
+}

--- a/agent/orchestrator/prepare-comparison-assignments.test.js
+++ b/agent/orchestrator/prepare-comparison-assignments.test.js
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  parseComparisonAssignmentArgs,
+  selectComparisonAssignments,
+} from './prepare-comparison-assignments.js'
+
+function packet(overrides = {}) {
+  return {
+    packetId: 'comparison:ashwagandha:rhodiola',
+    proposedSlug: 'ashwagandha-vs-rhodiola',
+    title: 'Ashwagandha vs Rhodiola',
+    recommendedAction: 'build-next',
+    demandTier: 'high-confidence',
+    actionReason: 'Demand and evidence support production.',
+    nextTask: 'Draft the comparison.',
+    researchGaps: [],
+    completionCriteria: ['Answer the decision question.'],
+    aSlug: 'ashwagandha',
+    bSlug: 'rhodiola',
+    evidenceTier: 3,
+    evidenceLabel: 'strong',
+    chemistrySupported: true,
+    priorityScore: 9,
+    scientificPriorityScore: 8,
+    editorialIntentScore: 7,
+    observedBehaviorScore: 6,
+    observedBehavior: { impressions: 30, clicks: 8 },
+    ...overrides,
+  }
+}
+
+describe('selectComparisonAssignments', () => {
+  it('selects only executable actions and preserves review guardrails', () => {
+    const assignments = selectComparisonAssignments([
+      packet(),
+      packet({ packetId: 'comparison:a:b', recommendedAction: 'keep-observing' }),
+      packet({ packetId: 'comparison:c:d', recommendedAction: 'no-action' }),
+    ])
+
+    expect(assignments).toHaveLength(1)
+    expect(assignments[0].action).toBe('build-next')
+    expect(assignments[0].guardrails).toContain('Do not publish automatically.')
+  })
+
+  it('prioritizes build work before research and outline work', () => {
+    const assignments = selectComparisonAssignments([
+      packet({ packetId: 'comparison:outline:item', recommendedAction: 'validate-and-outline', priorityScore: 100 }),
+      packet({ packetId: 'comparison:research:item', recommendedAction: 'research-first', priorityScore: 50 }),
+      packet({ packetId: 'comparison:build:item', recommendedAction: 'build-next', priorityScore: 1 }),
+    ])
+
+    expect(assignments.map((assignment) => assignment.action)).toEqual([
+      'build-next',
+      'research-first',
+      'validate-and-outline',
+    ])
+  })
+
+  it('supports action, packet, and limit filters without promoting work', () => {
+    const assignments = selectComparisonAssignments([
+      packet({ packetId: 'comparison:first:item', recommendedAction: 'research-first', priorityScore: 2 }),
+      packet({ packetId: 'comparison:second:item', recommendedAction: 'research-first', priorityScore: 5 }),
+      packet({ packetId: 'comparison:third:item', recommendedAction: 'build-next', priorityScore: 10 }),
+    ], {
+      action: 'research-first',
+      packetId: 'comparison:second:item',
+      limit: 1,
+    })
+
+    expect(assignments).toHaveLength(1)
+    expect(assignments[0].sourcePacketId).toBe('comparison:second:item')
+    expect(assignments[0].action).toBe('research-first')
+  })
+
+  it('keeps assignment IDs stable when filters or queue ordering change', () => {
+    const target = packet({ packetId: 'comparison:lemon-balm:passionflower', priorityScore: 5 })
+    const first = selectComparisonAssignments([
+      packet({ packetId: 'comparison:higher:item', priorityScore: 50 }),
+      target,
+    ])
+    const filtered = selectComparisonAssignments([target], {
+      packetId: 'comparison:lemon-balm:passionflower',
+      limit: 1,
+    })
+
+    expect(first.find((assignment) => assignment.sourcePacketId === target.packetId)?.assignmentId)
+      .toBe('comparison-assignment:lemon-balm:passionflower')
+    expect(filtered[0].assignmentId).toBe('comparison-assignment:lemon-balm:passionflower')
+  })
+})
+
+describe('parseComparisonAssignmentArgs', () => {
+  it('clamps limits and resolves queue paths', () => {
+    const parsed = parseComparisonAssignmentArgs([
+      '--action=research-first',
+      '--packet=comparison:a:b',
+      '--limit=500',
+      '--queue=tmp/queue.json',
+    ], '/repo')
+
+    expect(parsed).toEqual({
+      action: 'research-first',
+      packetId: 'comparison:a:b',
+      limit: 50,
+      queuePath: '/repo/tmp/queue.json',
+    })
+  })
+
+  it('rejects non-executable action filters', () => {
+    expect(() => parseComparisonAssignmentArgs(['--action=keep-observing'], '/repo'))
+      .toThrow('Unsupported executable action')
+  })
+})

--- a/docs/agents/comparison-editorial-queue.md
+++ b/docs/agents/comparison-editorial-queue.md
@@ -54,4 +54,26 @@ Prefer `comparison-agent-work-queue.json` as the machine-facing entry point. For
 4. Preserve `packetId` in notes or PR descriptions when practical so work remains traceable to the generated queue.
 5. Regenerate the queue after meaningful evidence, behavior, or comparison-page changes so completed or obsolete packets do not remain authoritative.
 
+## Preparing agent assignments
+
+Use the orchestrator adapter when an agent needs a smaller, ordered set of executable assignments instead of the full work-packet queue:
+
+```bash
+node agent/orchestrator/prepare-comparison-assignments.js
+```
+
+The adapter intentionally converts only `build-next`, `research-first`, and `validate-and-outline` packets. `keep-observing` and `no-action` are not promoted into executable work.
+
+Useful filters:
+
+```bash
+node agent/orchestrator/prepare-comparison-assignments.js --action=research-first --limit=5
+node agent/orchestrator/prepare-comparison-assignments.js --packet=comparison:lemon-balm:passionflower --limit=1
+node agent/orchestrator/prepare-comparison-assignments.js --queue=reports/related-botanicals/comparison-agent-work-queue.json
+```
+
+Assignments are ordered by evidence-gated action priority, then the existing comparison priority score. Their `assignmentId` is derived from the stable source `packetId`, so filtering or changing the queue limit does not rename the same underlying task.
+
+The adapter does not execute, publish, or promote work. It only packages already-authorized packet actions into reviewable assignments with the packet's rationale, evidence state, demand state, research gaps, completion criteria, and explicit no-auto-publish guardrails.
+
 The goal is a controlled progression from **observe → validate → research → build**, not autonomous page proliferation.


### PR DESCRIPTION
## Summary
- transplant the useful orchestrator adapter from stale stacked PR #2518 onto current `main`
- select only evidence-gated executable actions: `build-next`, `research-first`, and `validate-and-outline`
- preserve packet rationale, research gaps, completion criteria, evidence/demand state, entity IDs, and explicit no-auto-publish guardrails
- support action, packet-ID, queue-path, and bounded limit filters
- order assignments by action priority, then existing comparison priority score
- improve the stale design by deriving stable assignment IDs from source packet IDs instead of output position
- document the adapter workflow and add focused regression coverage

## Why this is high ROI
#2541 now produces deterministic evidence-gated work packets. This closes the next mile by turning that full queue into a small, ordered set of reviewable agent assignments without granting any new publishing authority or allowing demand to override evidence.

## Supersedes
This is a clean current-main replacement for #2518, which was stacked on the now-superseded #2516 branch.