### PR TITLE
Cap profile interaction link fan-out

### DIFF
--- a/src/components/InteractionWarnings.tsx
+++ b/src/components/InteractionWarnings.tsx
@@ -12,6 +12,7 @@ const MECHANISM_LABELS: Record<string, string> = {
 }
 
 const SEVERITY_ORDER: InteractionSeverity[] = ['severe', 'moderate', 'caution']
+const MAX_VISIBLE_PARTNERS_PER_MECHANISM = 12
 
 const SEVERITY_CONFIG: Record<InteractionSeverity, { label: string; accent: string; badge: string }> = {
   severe: {
@@ -84,51 +85,65 @@ export function InteractionWarnings({ edges, slugTypeMap }: InteractionWarningsP
 
               <div className='border-t border-[#123c2f]/10 px-4 pb-5 pt-4 sm:px-5'>
                 <p className='mb-4 text-xs font-semibold text-[#647168] dark:text-[var(--text-muted)]'>
-                  Browse the grouped cautions below. The list scrolls inside this card when long.
+                  Representative pairings are shown below. Large mechanism groups are intentionally summarized to keep profiles focused and crawl-efficient.
                 </p>
                 <div className='interaction-chip-scroll space-y-5 pr-1'>
-                  {byMechanism.map(({ mechanism, edges: mechanismEdges }) => (
-                    <div key={mechanism} className='space-y-3'>
-                      <span className={`inline-flex rounded-full border px-3 py-1 text-[0.68rem] font-extrabold uppercase tracking-[0.12em] ${config.badge}`}>
-                        {MECHANISM_LABELS[mechanism] ?? mechanism}
-                      </span>
-                      <ul className='flex flex-wrap gap-2'>
-                        {mechanismEdges.map((edge) => {
-                          const partnerType = slugTypeMap[edge.partner_slug]
-                          // interaction_edges.json carries raw workbook slugs, so a
-                          // partner can be a slug that only exists to be 301'd. Resolve
-                          // to the canonical URL rather than linking into a redirect.
-                          const partnerHref = partnerType
-                            ? canonicalProfileHref(
-                                partnerType === 'compound' ? 'compounds' : 'herbs',
-                                edge.partner_slug,
-                              )
-                            : null
+                  {byMechanism.map(({ mechanism, edges: mechanismEdges }) => {
+                    const visibleEdges = mechanismEdges.slice(0, MAX_VISIBLE_PARTNERS_PER_MECHANISM)
+                    const hiddenCount = mechanismEdges.length - visibleEdges.length
 
-                          const content = (
-                            <>
-                              <Leaf className='h-3.5 w-3.5 shrink-0 text-[#315f50]' aria-hidden='true' strokeWidth={1.8} />
-                              <span>{edge.partner_name}</span>
-                            </>
-                          )
+                    return (
+                      <div key={mechanism} className='space-y-3'>
+                        <span className={`inline-flex rounded-full border px-3 py-1 text-[0.68rem] font-extrabold uppercase tracking-[0.12em] ${config.badge}`}>
+                          {MECHANISM_LABELS[mechanism] ?? mechanism}
+                        </span>
+                        <ul className='flex flex-wrap gap-2'>
+                          {visibleEdges.map((edge) => {
+                            const partnerType = slugTypeMap[edge.partner_slug]
+                            // interaction_edges.json carries raw workbook slugs, so a
+                            // partner can be a slug that only exists to be 301'd. Resolve
+                            // to the canonical URL rather than linking into a redirect.
+                            const partnerHref = partnerType
+                              ? canonicalProfileHref(
+                                  partnerType === 'compound' ? 'compounds' : 'herbs',
+                                  edge.partner_slug,
+                                )
+                              : null
 
-                          return (
-                            <li key={`${edge.partner_slug}-${edge.risk_mechanism}`} title={edge.claim_language}>
-                              {partnerHref ? (
-                                <Link href={partnerHref} className='interaction-chip inline-flex items-center gap-1.5 rounded-full px-3 py-2 text-xs font-bold transition'>
-                                  {content}
-                                </Link>
-                              ) : (
-                                <span className='interaction-chip inline-flex items-center gap-1.5 rounded-full px-3 py-2 text-xs font-bold'>
-                                  {content}
-                                </span>
-                              )}
-                            </li>
-                          )
-                        })}
-                      </ul>
-                    </div>
-                  ))}
+                            const content = (
+                              <>
+                                <Leaf className='h-3.5 w-3.5 shrink-0 text-[#315f50]' aria-hidden='true' strokeWidth={1.8} />
+                                <span>{edge.partner_name}</span>
+                              </>
+                            )
+
+                            return (
+                              <li key={`${edge.partner_slug}-${edge.risk_mechanism}`} title={edge.claim_language}>
+                                {partnerHref ? (
+                                  <Link href={partnerHref} className='interaction-chip inline-flex items-center gap-1.5 rounded-full px-3 py-2 text-xs font-bold transition'>
+                                    {content}
+                                  </Link>
+                                ) : (
+                                  <span className='interaction-chip inline-flex items-center gap-1.5 rounded-full px-3 py-2 text-xs font-bold'>
+                                    {content}
+                                  </span>
+                                )}
+                              </li>
+                            )
+                          })}
+                        </ul>
+                        {hiddenCount > 0 && (
+                          <p className='text-xs leading-5 text-[#647168] dark:text-[var(--text-muted)]'>
+                            +{hiddenCount} more pairing{hiddenCount === 1 ? '' : 's'} share this mechanism.{' '}
+                            <Link href='/safety-checker' className='font-bold text-[#315f50] underline decoration-[#315f50]/30 underline-offset-2 hover:decoration-[#315f50]'>
+                              Use the Safety Checker
+                            </Link>{' '}
+                            to review a specific combination.
+                          </p>
+                        )}
+                      </div>
+                    )
+                  })}
                 </div>
               </div>
             </details>

--- a/src/components/__tests__/InteractionWarnings.test.tsx
+++ b/src/components/__tests__/InteractionWarnings.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { InteractionWarnings } from '../InteractionWarnings'
+import type { InteractionEdge, SlugEntityTypeMap } from '@/src/types/interactions'
+
+const makeEdges = (count: number): InteractionEdge[] =>
+  Array.from({ length: count }, (_, index) => ({
+    partner_slug: `partner-${index + 1}`,
+    partner_name: `Partner ${index + 1}`,
+    risk_mechanism: 'blood_glucose',
+    severity: 'moderate',
+    weight: 60,
+    claim_language: `Partner ${index + 1} shares a blood-glucose caution.`,
+    notes: '',
+  }))
+
+const makeSlugTypeMap = (count: number): SlugEntityTypeMap =>
+  Object.fromEntries(
+    Array.from({ length: count }, (_, index) => [`partner-${index + 1}`, 'herb']),
+  )
+
+describe('InteractionWarnings', () => {
+  it('summarizes large mechanism groups instead of rendering every partner link', () => {
+    render(
+      <InteractionWarnings
+        edges={makeEdges(15)}
+        slugTypeMap={makeSlugTypeMap(15)}
+      />,
+    )
+
+    expect(screen.getByText('15 flagged pairings')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Partner 12' })).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Partner 13' })).not.toBeInTheDocument()
+    expect(screen.getByText(/\+3 more pairings share this mechanism/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Use the Safety Checker' })).toHaveAttribute(
+      'href',
+      '/safety-checker',
+    )
+  })
+})


### PR DESCRIPTION
## What changed
- cap server-rendered interaction partner links at 12 per mechanism
- preserve full pairing counts and safety context
- route users with larger groups to the Safety Checker for specific combinations
- add regression coverage for large interaction groups

## Why
Some long-tail profiles expose 100+ partner links for a single mechanistic flag. Summarizing these keeps the safety signal visible while reducing page/crawl bloat and excessive internal-link fan-out.

## Validation
CI + focused Vitest regression.