### PR TITLE
Restore goal-page sourcing endpoint

### DIFF
--- a/app/goals/[slug]/page.tsx
+++ b/app/goals/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { goals, type Goal } from '@/data/goals'
 import { getGoalContentExtension } from '@/data/goal-content'
 import { getGoalStartHereLinks } from '@/lib/goal-start-here-links'
 import GoalStartHereLinks from '@/components/goals/GoalStartHereLinks'
+import GoalTopAffiliatePicks from '@/components/monetization/GoalTopAffiliatePicks'
 import GoalContentDepth from '@/src/components/goals/GoalContentDepth'
 import GoalHubSections from '@/src/components/goals/GoalHubSections'
 import { getGoalHubLinks } from '@/src/lib/goal-hub-links'
@@ -204,6 +205,8 @@ export default async function GoalPage({ params }: PageProps) {
         compares={compares}
         seoEntry={seoEntry}
       />
+
+      <GoalTopAffiliatePicks goalSlug={goal.slug} limit={3} />
 
       {relatedGoals.length > 0 ? (
         <section className="card-premium p-5 sm:p-8">

--- a/components/monetization/__tests__/GoalTopAffiliatePicks.test.tsx
+++ b/components/monetization/__tests__/GoalTopAffiliatePicks.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import GoalTopAffiliatePicks from '../GoalTopAffiliatePicks'
+
+describe('GoalTopAffiliatePicks', () => {
+  it('turns a goal shortlist into a small, safety-framed sourcing endpoint', () => {
+    render(<GoalTopAffiliatePicks goalSlug='stress' limit={3} />)
+
+    expect(screen.getByRole('heading', { name: 'Sourcing picks for this goal' })).toBeInTheDocument()
+    expect(screen.getByText(/not prescriptions/i)).toBeInTheDocument()
+
+    const productLinks = screen.getAllByRole('link', { name: /sourcing on amazon/i })
+    expect(productLinks).toHaveLength(3)
+    productLinks.forEach((link) => {
+      expect(link).toHaveAttribute('target', '_blank')
+      expect(link).toHaveAttribute('rel', 'nofollow sponsored noopener noreferrer')
+    })
+  })
+})


### PR DESCRIPTION
## What changed
- wire the existing `GoalTopAffiliatePicks` module back into the canonical `/goals/[slug]` template
- show up to three goal-specific sourcing picks only after the evidence/safety and comparison journey
- keep existing restricted-ingredient filtering, affiliate disclosure, and sponsored-link attributes
- add focused regression coverage for the stress goal

## Why
The current goal template helps users compare fit, onset, evidence, form, and safety but then stops before a product-selection endpoint. The repo already has a safety-framed product module and curated revenue registry, so this restores a dormant conversion path rather than adding new commercial infrastructure.

## Validation
CI + focused Vitest regression.