### PR TITLE
Enrich goal affiliate tracking context

### DIFF
--- a/components/monetization/GoalTopAffiliatePicks.tsx
+++ b/components/monetization/GoalTopAffiliatePicks.tsx
@@ -55,6 +55,7 @@ export default function GoalTopAffiliatePicks({
         href,
         rationale: product.rationale || `Starting point for ${pick.need.toLowerCase()} — verify dose and safety on the full profile.`,
         slotLabel: SLOT_LABELS[product.slot] || 'Editor pick',
+        productSlot: product.slot,
       },
     ]
   })
@@ -78,6 +79,9 @@ export default function GoalTopAffiliatePicks({
               href={pick.href}
               rationale={pick.rationale}
               slotLabel={pick.slotLabel}
+              productSlug={pick.key}
+              productSlot={pick.productSlot}
+              trackingLocation='goal-top-picks'
             />
           </div>
         ))}

--- a/components/monetization/ProductTrustAffiliate.tsx
+++ b/components/monetization/ProductTrustAffiliate.tsx
@@ -8,6 +8,9 @@ type ProductTrustAffiliateProps = {
   slotLabel?: string
   compact?: boolean
   suppressMonetization?: boolean
+  productSlug?: string
+  productSlot?: string
+  trackingLocation?: string
 }
 
 export default function ProductTrustAffiliate({
@@ -18,6 +21,9 @@ export default function ProductTrustAffiliate({
   slotLabel,
   compact = false,
   suppressMonetization = false,
+  productSlug,
+  productSlot,
+  trackingLocation,
 }: ProductTrustAffiliateProps) {
   if (suppressMonetization) return null
 
@@ -37,6 +43,9 @@ export default function ProductTrustAffiliate({
           href={href}
           target='_blank'
           rel='nofollow sponsored noopener noreferrer'
+          data-ingredient={productSlug || undefined}
+          data-product-slot={productSlot || undefined}
+          data-tracking-location={trackingLocation || undefined}
           className='inline-flex min-h-10 w-full items-center justify-center rounded-full bg-brand-950 px-3.5 py-2 text-xs font-bold text-white transition hover:bg-brand-900 dark:bg-brand-200 dark:text-brand-950 dark:hover:bg-brand-100'
         >
           Review on Amazon →
@@ -63,6 +72,9 @@ export default function ProductTrustAffiliate({
         href={href}
         target='_blank'
         rel='nofollow sponsored noopener noreferrer'
+        data-ingredient={productSlug || undefined}
+        data-product-slot={productSlot || undefined}
+        data-tracking-location={trackingLocation || undefined}
         className='mt-4 inline-flex min-h-11 w-full items-center justify-center rounded-full bg-brand-950 px-4 py-2.5 text-sm font-bold text-white transition hover:bg-brand-900 dark:bg-brand-200 dark:text-brand-950 dark:hover:bg-brand-100'
       >
         Check {productName} sourcing on Amazon →

--- a/components/monetization/__tests__/GoalTopAffiliateTracking.test.tsx
+++ b/components/monetization/__tests__/GoalTopAffiliateTracking.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import GoalTopAffiliatePicks from '../GoalTopAffiliatePicks'
+
+describe('goal affiliate tracking context', () => {
+  it('labels product links with ingredient, slot, and module context for ClickTracker', () => {
+    render(<GoalTopAffiliatePicks goalSlug='stress' limit={3} />)
+
+    const links = screen.getAllByRole('link', { name: /sourcing on amazon/i })
+    expect(links).toHaveLength(3)
+
+    expect(links[0]).toHaveAttribute('data-ingredient', 'ashwagandha')
+    expect(links[1]).toHaveAttribute('data-ingredient', 'rhodiola')
+    expect(links[2]).toHaveAttribute('data-ingredient', 'l-theanine')
+
+    links.forEach((link) => {
+      expect(link).toHaveAttribute('data-product-slot', 'overall')
+      expect(link).toHaveAttribute('data-tracking-location', 'goal-top-picks')
+    })
+  })
+})


### PR DESCRIPTION
## What changed
- add optional product slug, product slot, and module-location metadata to `ProductTrustAffiliate` links
- pass that metadata from `GoalTopAffiliatePicks`
- let the existing document-level ClickTracker record goal-page affiliate clicks with real product context instead of generic document-capture data
- add focused regression coverage

## Why
Goal routes do not encode the clicked ingredient in their URL, so plain affiliate anchors lose the product context that revenue analysis needs. This reuses the tracker’s existing `data-*` contract instead of adding a second analytics path.

## Validation
CI + focused Vitest regression.