### PR TITLE
Prefer curated profile sourcing over generic search

### DIFF
--- a/src/components/sourcing/SourcingCta.tsx
+++ b/src/components/sourcing/SourcingCta.tsx
@@ -1,4 +1,5 @@
 import { AFFILIATE_TAGS } from '@/config/affiliate'
+import { getRevenueProductSet } from '@/config/revenue-products'
 import { canRenderAffiliateLinks, extractUrlString, ensureAmazonAffiliateTag } from '../../lib/affiliate'
 import { text } from '@/lib/display-utils'
 import { isRestrictedIngredient } from '../../lib/restricted-ingredients'
@@ -11,6 +12,13 @@ type SourcingCtaProps = {
 export function SourcingCta({ record, displayName }: SourcingCtaProps) {
   // Compliance gate: never render affiliate CTAs for records flagged doNotMonetize/doNotPromote in source data.
   if (!canRenderAffiliateLinks(record) || isRestrictedIngredient(displayName)) return null
+
+  // Profiles with a governed product set render RecommendationSection immediately
+  // below this component. Prefer that curated endpoint instead of showing a generic
+  // Amazon search first and making the two CTAs compete with each other.
+  const profileSlug = text(record?.slug)
+  const curatedSet = getRevenueProductSet(profileSlug || displayName)
+  if (curatedSet?.products.some((product) => Boolean(product.affiliateUrl))) return null
 
   // 1. Affiliate-ready detection
   const rawUrl = extractUrlString(record?.amazon_affiliate_url || record?.affiliate_url)

--- a/src/components/sourcing/__tests__/SourcingCta.test.tsx
+++ b/src/components/sourcing/__tests__/SourcingCta.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { SourcingCta } from '../SourcingCta'
+
+describe('SourcingCta', () => {
+  it('does not compete with a curated profile product set', () => {
+    render(
+      <SourcingCta
+        record={{ slug: 'ashwagandha', affiliate_query: 'ashwagandha' }}
+        displayName='Ashwagandha'
+      />,
+    )
+
+    expect(screen.queryByRole('link', { name: /check sourcing options/i })).not.toBeInTheDocument()
+    expect(screen.queryByText(/review available sources/i)).not.toBeInTheDocument()
+  })
+
+  it('keeps the generic fallback for profiles without a curated product set', () => {
+    render(
+      <SourcingCta
+        record={{ slug: 'unlisted-test-botanical', affiliate_query: 'unlisted test botanical' }}
+        displayName='Unlisted Test Botanical'
+      />,
+    )
+
+    const link = screen.getByRole('link', { name: /check sourcing options/i })
+    expect(link).toHaveAttribute('rel', 'nofollow sponsored noopener noreferrer')
+    expect(link.getAttribute('href')).toContain('amazon.com')
+  })
+})


### PR DESCRIPTION
## What changed
- suppress the generic profile sourcing CTA when the profile already has a governed curated product set
- keep the generic Amazon-search fallback for profiles without curated products
- add regression coverage for both paths

## Why
Current curated profiles such as Ashwagandha can show a generic Amazon search immediately before curated budget/overall/premium product picks. That creates competing commercial exits and weakens the evidence → safety → curated choice funnel. This change keeps one stronger endpoint without reducing monetization coverage on uncatalogued profiles.

## Validation
CI + focused Vitest regression.