### PR TITLE
Sanitize generic comparison FAQ claims

### DIFF
--- a/components/compare/ComparePageScaffold.tsx
+++ b/components/compare/ComparePageScaffold.tsx
@@ -29,11 +29,13 @@ type DiscoveryGroup = {
   links: Array<{ href: string; label: string }>
 }
 
+type ComparisonFaq = { question: string; answer: string }
+
 type ComparePageScaffoldProps = {
   item1: CompareItem
   item2: CompareItem
   slug: string
-  faqs: { question: string; answer: string }[]
+  faqs: ComparisonFaq[]
   schemaGraph: Record<string, unknown>
   title: string
   isHarmReduction: boolean
@@ -44,6 +46,61 @@ type ComparePageScaffoldProps = {
   relatedDiscoveryGroups: DiscoveryGroup[]
   citationUrls?: string[]
   children: ReactNode
+}
+
+export function sanitizeComparisonFaqs(
+  item1: Pick<CompareItem, 'name' | 'onsetTime'>,
+  item2: Pick<CompareItem, 'name' | 'onsetTime'>,
+  faqs: ComparisonFaq[],
+): ComparisonFaq[] {
+  return faqs.map((faq) => {
+    const question = faq.question.trim()
+    const normalized = question.toLowerCase()
+
+    if (normalized.startsWith('which is better,')) {
+      return {
+        question,
+        answer: `There is no universal winner between ${item1.name} and ${item2.name}. The better fit depends on the exact outcome, the quality of evidence for that outcome, dose and form, side effects, interactions, and your medical context. Use the comparison table to match those tradeoffs rather than treating one ingredient as the default winner.`,
+      }
+    }
+
+    if (normalized.startsWith('can i take') && normalized.includes('together')) {
+      return {
+        question,
+        answer: `This comparison does not establish that ${item1.name} and ${item2.name} are safe or beneficial to combine. Interaction data for supplements can be incomplete, and mechanism differences do not prove compatibility. Review each ingredient's interaction and contraindication information and check the full combination with a pharmacist or other qualified health professional if you use medications or have a medical condition.`,
+      }
+    }
+
+    if (normalized.startsWith('which works faster')) {
+      const timingParts = [
+        item1.onsetTime ? `${item1.name}: ${item1.onsetTime}` : null,
+        item2.onsetTime ? `${item2.name}: ${item2.onsetTime}` : null,
+      ].filter((value): value is string => Boolean(value))
+
+      return {
+        question,
+        answer: timingParts.length > 0
+          ? `The source data report these ingredient-specific onset notes: ${timingParts.join('; ')}. They are not a head-to-head timing result, and onset can vary by outcome, dose, form, and individual response.`
+          : `There is no reliable head-to-head onset estimate surfaced here for ${item1.name} versus ${item2.name}. Onset can vary by the outcome being measured, dose, form, and individual response, so avoid assuming that either requires a generic days-or-weeks timeline.`,
+      }
+    }
+
+    if (normalized.startsWith('which is safer')) {
+      return {
+        question,
+        answer: `Safety is not a single ranking between ${item1.name} and ${item2.name}. It depends on dose, product quality, health conditions, pregnancy or breastfeeding status, and other medicines or supplements. Compare the contraindications and interaction sections for both ingredients before making a decision.`,
+      }
+    }
+
+    if (normalized.startsWith('what is the key difference')) {
+      return {
+        question,
+        answer: `${item1.name} and ${item2.name} differ in their evidence base, proposed mechanisms, dosing context, and safety profile. Those differences can help narrow a choice, but a different mechanism does not by itself prove that one is more effective, faster, safer, or better to combine.`,
+      }
+    }
+
+    return faq
+  })
 }
 
 export default function ComparePageScaffold({
@@ -62,7 +119,8 @@ export default function ComparePageScaffold({
   citationUrls = [],
   children,
 }: ComparePageScaffoldProps) {
-  const schemaFaqs = isHarmReduction ? [] : faqs
+  const safeFaqs = sanitizeComparisonFaqs(item1, item2, faqs)
+  const schemaFaqs = isHarmReduction ? [] : safeFaqs
 
   return (
     <div className="mx-auto max-w-5xl px-4 py-8 space-y-12">
@@ -87,16 +145,16 @@ export default function ComparePageScaffold({
       {children}
 
       <CompareRelated comparisons={relatedComparisons} currentSlug={slug} />
-      <CompareFAQ faqs={faqs} />
+      <CompareFAQ faqs={safeFaqs} />
       <CompareCitations item1={item1} item2={item2} />
 
       <section className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {relatedStack && (
           <article className="card-premium p-5 space-y-2">
             <h3 className="font-bold text-ink">Use in a routine</h3>
-            <p className="text-sm text-muted">These options can be stacked for goal-based synergy.</p>
+            <p className="text-sm text-muted">A related routine is available. Review combined safety and avoid assuming that a stack is more effective than testing ingredients individually.</p>
             <Link href={`/stacks/${relatedStack.slug}`} className="inline-block text-sm font-bold text-brand-700 hover:text-brand-900">
-              View stack →
+              Review routine →
             </Link>
           </article>
         )}

--- a/components/compare/__tests__/ComparePageScaffold.test.ts
+++ b/components/compare/__tests__/ComparePageScaffold.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { sanitizeComparisonFaqs } from '../ComparePageScaffold'
+
+describe('sanitizeComparisonFaqs', () => {
+  it('removes generic compatibility, winner, safety, and onset claims before UI and schema use', () => {
+    const faqs = sanitizeComparisonFaqs(
+      { name: 'Magnesium', onsetTime: undefined },
+      { name: 'Melatonin', onsetTime: '30–60 minutes' },
+      [
+        { question: 'Which is better, Magnesium or Melatonin?', answer: 'Melatonin may be the better default.' },
+        { question: 'Can I take Magnesium and Melatonin together?', answer: 'They are commonly used together because they work through different mechanisms.' },
+        { question: 'Which works faster, Magnesium or Melatonin?', answer: 'Both may take days to weeks.' },
+        { question: 'Which is safer, Magnesium or Melatonin?', answer: 'Both are generally well-tolerated.' },
+        { question: 'What is the key difference between Magnesium and Melatonin?', answer: 'Different mechanisms make one better suited.' },
+      ],
+    )
+
+    const joined = faqs.map((faq) => faq.answer).join(' ')
+    expect(joined).not.toMatch(/commonly used together/i)
+    expect(joined).not.toMatch(/better default/i)
+    expect(joined).not.toMatch(/both may take days to weeks/i)
+    expect(joined).not.toMatch(/both are generally well-tolerated/i)
+    expect(joined).toMatch(/does not establish that Magnesium and Melatonin are safe or beneficial to combine/i)
+    expect(joined).toMatch(/Melatonin: 30–60 minutes/i)
+  })
+})


### PR DESCRIPTION
## What changed
- sanitize generated comparison FAQs before both visible rendering and FAQ schema
- replace generic winner, compatibility, onset, safety, and mechanism-superiority language with evidence-limited answers
- preserve ingredient-specific onset only when source data actually provide it
- replace “stacked for goal-based synergy” with a safety-first routine handoff
- add regression coverage using the live Magnesium vs Melatonin failure mode

## Why
The generic FAQ generator can turn broad evidence tiers and mechanism differences into medical-sounding claims such as “better default,” “commonly used together,” and generic days-to-weeks onset. Sanitizing at the scaffold ensures the corrected answers feed both the page and structured data without duplicating logic across comparison routes.

## Validation
CI + focused Vitest regression.