### PR TITLE
Remove fabricated comparison dosing defaults

### DIFF
--- a/components/compare/CompareDosing.tsx
+++ b/components/compare/CompareDosing.tsx
@@ -7,15 +7,15 @@ interface CompareDosingProps {
 
 function deriveFormNote(item: CompareItem): string {
   if (item.type === 'herb') {
-    return `Available as capsules, powder, tincture, or tea. Look for standardised root or aerial-part extracts with clearly labelled active constituents and third-party testing.`
+    return 'Product forms vary. Verify the plant part, extract ratio or standardization when relevant, amount per serving, and independent quality testing on the specific label.'
   }
-  return `Typically available as capsules or powder. Look for products with third-party purity verification and clearly labelled active constituent percentages.`
+  return 'Product forms vary. Verify the exact compound or mineral form, amount per serving, added ingredients, and independent quality testing on the specific label.'
 }
 
 function DosingCard({ item }: { item: CompareItem }) {
-  const dose = item.typicalDose || '—'
-  const timing = item.bestTiming || 'With or without food'
-  const onset = item.onsetTime || 'Varies — often 2–4 weeks for adaptogens'
+  const dose = item.typicalDose || 'Not reported in the comparison source data'
+  const timing = item.bestTiming || 'Not reported in the comparison source data'
+  const onset = item.onsetTime || 'Not reported in the comparison source data'
   const formNote = deriveFormNote(item)
 
   return (
@@ -26,28 +26,23 @@ function DosingCard({ item }: { item: CompareItem }) {
 
       <div className="space-y-3 text-sm">
         <div>
-          <p className="font-semibold text-ink">Effective Dose</p>
+          <p className="font-semibold text-ink">Dose / Form in Source Data</p>
           <p className="text-muted leading-relaxed mt-0.5">{dose}</p>
         </div>
 
         <div>
-          <p className="font-semibold text-ink">Form / Extract</p>
+          <p className="font-semibold text-ink">Product Form Check</p>
           <p className="text-muted leading-relaxed mt-0.5">{formNote}</p>
         </div>
 
         <div>
-          <p className="font-semibold text-ink">Best Timing</p>
+          <p className="font-semibold text-ink">Timing in Source Data</p>
           <p className="text-muted leading-relaxed mt-0.5">{timing}</p>
         </div>
 
         <div>
-          <p className="font-semibold text-ink">Time to Effects</p>
+          <p className="font-semibold text-ink">Onset in Source Data</p>
           <p className="text-muted leading-relaxed mt-0.5">{onset}</p>
-        </div>
-
-        <div>
-          <p className="font-semibold text-ink">Approximate Cost</p>
-          <p className="text-muted leading-relaxed mt-0.5">Check current pricing</p>
         </div>
       </div>
     </div>
@@ -58,10 +53,13 @@ export default function CompareDosing({ item1, item2 }: CompareDosingProps) {
   return (
     <section className="max-w-4xl space-y-6">
       <div>
-        <p className="text-xs font-bold uppercase tracking-[0.18em] text-brand-700">Dosing &amp; Timing</p>
+        <p className="text-xs font-bold uppercase tracking-[0.18em] text-brand-700">Dose, Form &amp; Timing</p>
         <h2 className="text-2xl font-semibold tracking-tight text-ink mt-1">
-          Dosage and Usage Guidelines
+          What the Source Data Actually Report
         </h2>
+        <p className="mt-2 max-w-3xl text-sm leading-6 text-muted">
+          These fields summarize the underlying profile data. They are not a personalized dosing protocol, and a product form listed in a source field should not be read as a proven effective dose.
+        </p>
       </div>
 
       <div className="grid gap-6 md:grid-cols-2">
@@ -71,7 +69,7 @@ export default function CompareDosing({ item1, item2 }: CompareDosingProps) {
 
       <div className="rounded-xl border border-brand-900/10 bg-brand-50/50 p-4">
         <p className="text-xs leading-relaxed text-muted">
-          Cost estimates vary by brand, form, and dose. Standardised extracts typically cost more than raw powder. Always verify dose and extract concentration on the product label before purchasing.
+          Missing values are shown as missing rather than filled with a generic timing or onset assumption. Verify serving size, formulation, contraindications, and medication interactions on the full ingredient profile and product label before use.
         </p>
       </div>
     </section>

--- a/components/compare/__tests__/CompareDosing.test.tsx
+++ b/components/compare/__tests__/CompareDosing.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import CompareDosing from '../CompareDosing'
+import type { CompareItem } from '@/lib/compare'
+
+function item(overrides: Partial<CompareItem>): CompareItem {
+  return {
+    slug: 'example',
+    name: 'Example',
+    type: 'compound',
+    description: '',
+    primaryBenefits: [],
+    mechanisms: [],
+    canonicalMechanisms: [],
+    mechanismCategories: [],
+    evidenceLevel: 'unknown',
+    doNotMonetize: false,
+    isHarmReduction: false,
+    pageUrl: '/compounds/example',
+    ...overrides,
+  }
+}
+
+describe('CompareDosing', () => {
+  it('shows missing source data as missing instead of manufacturing generic timing and onset guidance', () => {
+    render(
+      <CompareDosing
+        item1={item({ slug: 'magnesium', name: 'Magnesium', typicalDose: 'chelated mineral capsule or powder' })}
+        item2={item({ slug: 'melatonin', name: 'Melatonin', bestTiming: '30–60 minutes before bed' })}
+      />,
+    )
+
+    expect(screen.getAllByText('Dose / Form in Source Data')).toHaveLength(2)
+    expect(screen.getAllByText('Onset in Source Data')).toHaveLength(2)
+    expect(screen.getAllByText('Not reported in the comparison source data').length).toBeGreaterThan(0)
+    expect(screen.getByText('chelated mineral capsule or powder')).toBeInTheDocument()
+    expect(screen.getByText('30–60 minutes before bed')).toBeInTheDocument()
+    expect(screen.queryByText(/2–4 weeks for adaptogens/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/with or without food/i)).not.toBeInTheDocument()
+    expect(screen.queryByText('Effective Dose')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## What changed
- replace the generic “2–4 weeks for adaptogens” onset fallback with an explicit missing-data state
- replace the generic “with or without food” timing fallback with an explicit missing-data state
- rename “Effective Dose” to “Dose / Form in Source Data” so product forms are not presented as proven effective doses
- make product-form guidance ingredient-type appropriate instead of claiming active-constituent percentages for every compound
- remove the empty “Approximate Cost / Check current pricing” row
- add focused regression coverage using Magnesium + Melatonin

## Why
The live generic comparison output currently applies adaptogen timing assumptions to non-adaptogens and upgrades ambiguous source fields into dosing guidance. Missing data should remain visibly missing rather than being replaced with plausible-sounding defaults.

## Validation
CI + focused CompareDosing regression.