### PR TITLE
Remove personal-pick FAQ handoff language

### DIFF
--- a/components/compare/CompareFAQ.tsx
+++ b/components/compare/CompareFAQ.tsx
@@ -51,10 +51,10 @@ export default function CompareFAQ({ faqs }: CompareFAQProps) {
       <div className="rounded-2xl border border-brand-900/10 bg-brand-50/80 p-4 sm:flex sm:items-center sm:justify-between sm:gap-4">
         <div className="space-y-1">
           <p className="text-xs font-bold uppercase tracking-wider text-brand-700">
-            Need a faster decision?
+            Need a clearer next step?
           </p>
           <p className="text-sm leading-6 text-muted">
-            Use the preference quiz above, or browse the full compare hub for nearby tradeoffs.
+            Review the decision guide above, or browse the full compare hub for nearby tradeoffs.
           </p>
         </div>
         <div className="mt-3 flex flex-col gap-2 sm:mt-0 sm:flex-row">
@@ -62,7 +62,7 @@ export default function CompareFAQ({ faqs }: CompareFAQProps) {
             href="#compare-decision"
             className="rounded-full bg-brand-700 px-4 py-2 text-center text-xs font-bold text-white transition-colors hover:bg-brand-600"
           >
-            Get a personal pick ↑
+            Review decision guide ↑
           </a>
           <Link
             href="/guides/compare/"

--- a/components/compare/__tests__/CompareFAQ.test.tsx
+++ b/components/compare/__tests__/CompareFAQ.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import CompareFAQ from '../CompareFAQ'
+
+describe('CompareFAQ', () => {
+  it('routes readers back to a neutral decision guide instead of promising a personal pick', () => {
+    render(
+      <CompareFAQ
+        faqs={[{ question: 'Which is better?', answer: 'It depends on the evidence and safety tradeoffs.' }]}
+      />,
+    )
+
+    expect(screen.getByText('Need a clearer next step?')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /review decision guide/i })).toHaveAttribute('href', '#compare-decision')
+    expect(screen.queryByText(/personal pick/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/preference quiz/i)).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## What changed
- replace “Get a personal pick” with “Review decision guide”
- replace “preference quiz” wording with neutral decision-guide language
- keep the compare-hub path intact
- add focused regression coverage

## Why
The comparison FAQ footer still promised an individualized recommendation even after the comparison content was being moved toward evidence navigation. This keeps the CTA aligned with the safer decision flow.

## Validation
CI + focused CompareFAQ regression.