### PR TITLE
Fix comparison entity schema semantics

### DIFF
--- a/components/compare/CompareSchema.tsx
+++ b/components/compare/CompareSchema.tsx
@@ -17,12 +17,16 @@ interface CompareSchemaProps {
   citationUrls?: string[]
 }
 
-export default function CompareSchema({ item1, item2, slug, faqs, dateModified, citationUrls = [] }: CompareSchemaProps) {
+function entitySchemaType(item: Pick<CompareItem, 'type'>): 'Substance' | 'ChemicalSubstance' {
+  return item.type === 'herb' ? 'Substance' : 'ChemicalSubstance'
+}
+
+export function buildCompareSchema({ item1, item2, slug, faqs, dateModified, citationUrls = [] }: CompareSchemaProps) {
   const pageUrl = `${SITE_URL}/guides/compare/${slug}/`
   const headline = `${item1.name} vs ${item2.name}: Complete Comparison`
-  const description = `Compare ${item1.name} and ${item2.name} by evidence, mechanisms, dosing, safety, and best-fit use cases.`
+  const description = `Compare ${item1.name} and ${item2.name} by evidence, mechanisms, source-reported dosing context, and safety considerations.`
 
-  const schema = {
+  return {
     '@context': 'https://schema.org',
     '@graph': [
       {
@@ -48,12 +52,12 @@ export default function CompareSchema({ item1, item2, slug, faqs, dateModified, 
         },
         about: [
           {
-            '@type': item1.type === 'herb' ? 'MedicalTherapy' : 'ChemicalSubstance',
+            '@type': entitySchemaType(item1),
             name: item1.name,
             url: `${SITE_URL}/${item1.type === 'herb' ? 'herbs' : 'compounds'}/${item1.slug}/`,
           },
           {
-            '@type': item2.type === 'herb' ? 'MedicalTherapy' : 'ChemicalSubstance',
+            '@type': entitySchemaType(item2),
             name: item2.name,
             url: `${SITE_URL}/${item2.type === 'herb' ? 'herbs' : 'compounds'}/${item2.slug}/`,
           },
@@ -84,6 +88,8 @@ export default function CompareSchema({ item1, item2, slug, faqs, dateModified, 
         : []),
     ],
   }
+}
 
-  return <JsonLd schema={schema} />
+export default function CompareSchema(props: CompareSchemaProps) {
+  return <JsonLd schema={buildCompareSchema(props)} />
 }

--- a/components/compare/__tests__/CompareSchema.test.ts
+++ b/components/compare/__tests__/CompareSchema.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { buildCompareSchema } from '../CompareSchema'
+import type { CompareItem } from '@/lib/compare'
+
+function item(overrides: Partial<CompareItem>): CompareItem {
+  return {
+    slug: 'example',
+    name: 'Example',
+    type: 'compound',
+    description: '',
+    primaryBenefits: [],
+    mechanisms: [],
+    canonicalMechanisms: [],
+    mechanismCategories: [],
+    evidenceLevel: 'unknown',
+    doNotMonetize: false,
+    isHarmReduction: false,
+    pageUrl: '/compounds/example',
+    ...overrides,
+  }
+}
+
+describe('buildCompareSchema', () => {
+  it('describes herbs as substances rather than medical therapies', () => {
+    const schema = buildCompareSchema({
+      item1: item({ slug: 'ashwagandha', name: 'Ashwagandha', type: 'herb', pageUrl: '/herbs/ashwagandha' }),
+      item2: item({ slug: 'l-theanine', name: 'L-theanine' }),
+      slug: 'ashwagandha-vs-l-theanine',
+      faqs: [],
+    })
+
+    const article = schema['@graph'][0] as { description: string; about: Array<{ '@type': string }> }
+    expect(article.about[0]['@type']).toBe('Substance')
+    expect(article.about[1]['@type']).toBe('ChemicalSubstance')
+    expect(article.description).toMatch(/source-reported dosing context/i)
+    expect(JSON.stringify(schema)).not.toContain('MedicalTherapy')
+    expect(JSON.stringify(schema)).not.toContain('best-fit use cases')
+  })
+})


### PR DESCRIPTION
## What changed
- stop marking herb profile subjects as `MedicalTherapy`
- use Schema.org `Substance` for botanical/herb subjects and keep `ChemicalSubstance` for compounds
- remove “best-fit use cases” from comparison schema description in favor of source-reported dosing context and safety considerations
- extract a schema builder for focused regression coverage

## Why
Schema.org defines `MedicalTherapy` as a medical intervention designed to prevent, treat, or cure conditions, while `Substance` covers matter of biological, mineral, or chemical origin. Ingredient comparison pages describe substances; they should not encode a botanical profile as a therapeutic intervention.

## Validation
CI + focused schema regression.