### PR TITLE
Make comparison citation provenance explicit

### DIFF
--- a/components/compare/CompareCitations.tsx
+++ b/components/compare/CompareCitations.tsx
@@ -102,9 +102,11 @@ export default function CompareCitations({ item1, item2 }: CompareCitationsProps
               <ItemSources item={item2} />
             </>
           ) : (
-            <p className="text-sm text-muted">
-              Sources forthcoming. Data derived from herb and compound profiles.
-            </p>
+            <div className="rounded-xl border border-brand-900/10 bg-[var(--surface-subtle)] p-4">
+              <p className="text-sm leading-6 text-muted">
+                No source-level citations are surfaced in this comparison record. The comparison is assembled from the structured herb and compound profile data; open the full profiles below to inspect any source context available there.
+              </p>
+            </div>
           )}
 
           <div className="rounded-2xl border border-brand-900/10 bg-brand-50/70 p-4">
@@ -129,10 +131,6 @@ export default function CompareCitations({ item1, item2 }: CompareCitationsProps
               </Link>
             </div>
           </div>
-
-          <p className="border-t border-brand-900/10 pt-4 text-xs text-muted">
-            Last reviewed: 2026
-          </p>
         </div>
       </details>
     </section>

--- a/components/compare/__tests__/CompareCitations.test.tsx
+++ b/components/compare/__tests__/CompareCitations.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import CompareCitations from '../CompareCitations'
+import type { CompareItem } from '@/lib/compare'
+
+function item(overrides: Partial<CompareItem>): CompareItem {
+  return {
+    slug: 'example',
+    name: 'Example',
+    type: 'compound',
+    description: '',
+    primaryBenefits: [],
+    mechanisms: [],
+    canonicalMechanisms: [],
+    mechanismCategories: [],
+    evidenceLevel: 'unknown',
+    sources: [],
+    doNotMonetize: false,
+    isHarmReduction: false,
+    pageUrl: '/compounds/example',
+    ...overrides,
+  }
+}
+
+describe('CompareCitations', () => {
+  it('states missing comparison citations explicitly without inventing a review date', () => {
+    render(
+      <CompareCitations
+        item1={item({ slug: 'magnesium', name: 'Magnesium' })}
+        item2={item({ slug: 'melatonin', name: 'Melatonin' })}
+      />,
+    )
+
+    expect(screen.getByText(/No source-level citations are surfaced in this comparison record/i)).toBeInTheDocument()
+    expect(screen.queryByText(/Sources forthcoming/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Last reviewed:/i)).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Read Magnesium profile/i })).toHaveAttribute('href', '/compounds/example')
+  })
+})


### PR DESCRIPTION
## What changed
- replace “Sources forthcoming” with an explicit statement that no source-level citations are surfaced in the comparison record
- point readers to the full profiles for any source context available there
- remove the hard-coded “Last reviewed: 2026” freshness stamp because the component has no review-date authority
- add focused regression coverage

## Why
A citations section should distinguish absent provenance from planned provenance, and a review date should only appear when backed by actual review metadata. This makes the comparison library more transparent without inventing citations or freshness.

## Validation
CI + focused CompareCitations regression.