### PR TITLE
Remove evidence-tier winner badges

### DIFF
--- a/components/compare/CompareEvidenceMatrix.tsx
+++ b/components/compare/CompareEvidenceMatrix.tsx
@@ -6,16 +6,6 @@ interface CompareEvidenceMatrixProps {
   item2: CompareItem
 }
 
-// Numeric rank for determining which item has stronger evidence.
-const EVIDENCE_RANK: Record<EvidenceLevel, number> = {
-  strong: 5,
-  moderate: 4,
-  preliminary: 2,
-  anecdotal: 1,
-  unknown: 0,
-}
-
-// Tailwind color classes per evidence level for the label text.
 const EVIDENCE_TEXT_CLASS: Record<EvidenceLevel, string> = {
   strong: 'text-evidence-strong',
   moderate: 'text-evidence-moderate',
@@ -24,7 +14,6 @@ const EVIDENCE_TEXT_CLASS: Record<EvidenceLevel, string> = {
   unknown: 'text-evidence-theoretical',
 }
 
-// Bar fill width per filled-dot count (max 5).
 const BAR_WIDTH_CLASS: Record<number, string> = {
   0: 'w-0',
   1: 'w-1/5',
@@ -34,32 +23,15 @@ const BAR_WIDTH_CLASS: Record<number, string> = {
   5: 'w-full',
 }
 
-interface EvidencePanelProps {
-  item: CompareItem
-  isWinner: boolean
-}
-
-function EvidencePanel({ item, isWinner }: EvidencePanelProps) {
+function EvidencePanel({ item }: { item: CompareItem }) {
   const { filled, empty } = evidenceDots(item.evidenceLevel)
   const labelText = evidenceLabelText(item.evidenceLevel)
   const textClass = EVIDENCE_TEXT_CLASS[item.evidenceLevel]
   const barWidth = BAR_WIDTH_CLASS[filled] ?? 'w-0'
 
   return (
-    <div
-      className={`relative card-premium p-5 space-y-4 sm:p-6 ${
-        isWinner ? 'ring-2 ring-brand-700/30' : ''
-      }`}
-    >
-      {/* Winner badge */}
-      {isWinner && (
-        <span className="absolute right-4 top-4 inline-flex items-center rounded-full bg-brand-700 px-2.5 py-0.5 text-[0.65rem] font-bold uppercase tracking-[0.13em] text-white">
-          Stronger evidence
-        </span>
-      )}
-
-      {/* Item identity */}
-      <div className="pr-28">
+    <div className="card-premium p-5 space-y-4 sm:p-6">
+      <div>
         <p className="text-[0.65rem] font-bold uppercase tracking-[0.14em] text-brand-700">
           {item.type === 'herb' ? 'Herb' : 'Compound'}
         </p>
@@ -68,7 +40,6 @@ function EvidencePanel({ item, isWinner }: EvidencePanelProps) {
         </h3>
       </div>
 
-      {/* Dot indicator */}
       <div
         aria-label={`Evidence: ${labelText} (${filled} of 5)`}
         className="flex items-center gap-1"
@@ -93,7 +64,6 @@ function EvidencePanel({ item, isWinner }: EvidencePanelProps) {
         ))}
       </div>
 
-      {/* Evidence bar */}
       <div className="h-2 w-full overflow-hidden rounded-full bg-brand-100">
         <div
           className={`h-full rounded-full bg-brand-500 transition-all duration-300 ${barWidth}`}
@@ -101,10 +71,11 @@ function EvidencePanel({ item, isWinner }: EvidencePanelProps) {
         />
       </div>
 
-      {/* Evidence label */}
       <p className={`text-sm font-semibold ${textClass}`}>{labelText}</p>
+      <p className="text-xs leading-5 text-muted">
+        Overall profile signal only. Evidence strength can differ substantially by outcome, dose, formulation, and study design.
+      </p>
 
-      {/* Evidence grade */}
       {item.evidenceGrade && (
         <div className="flex items-center gap-2">
           <span className="text-[0.65rem] font-bold uppercase tracking-[0.12em] text-brand-700">
@@ -116,7 +87,6 @@ function EvidencePanel({ item, isWinner }: EvidencePanelProps) {
         </div>
       )}
 
-      {/* Evidence tier */}
       {item.evidenceTier && (
         <div className="flex items-center gap-2">
           <span className="text-[0.65rem] font-bold uppercase tracking-[0.12em] text-brand-700">
@@ -132,33 +102,24 @@ function EvidencePanel({ item, isWinner }: EvidencePanelProps) {
 }
 
 export default function CompareEvidenceMatrix({ item1, item2 }: CompareEvidenceMatrixProps) {
-  const rank1 = EVIDENCE_RANK[item1.evidenceLevel]
-  const rank2 = EVIDENCE_RANK[item2.evidenceLevel]
-  const tied = rank1 === rank2
-  const item1Wins = !tied && rank1 > rank2
-  const item2Wins = !tied && rank2 > rank1
-
   return (
     <section aria-labelledby="evidence-matrix-heading">
-      <div className="mb-5">
+      <div className="mb-5 max-w-3xl">
         <p className="text-[0.65rem] font-bold uppercase tracking-[0.18em] text-brand-700">
           Evidence quality
         </p>
         <h2 id="evidence-matrix-heading" className="mt-1 text-2xl font-semibold tracking-tight text-ink">
-          Evidence Comparison
+          Evidence Signals Side by Side
         </h2>
+        <p className="mt-2 text-sm leading-6 text-muted">
+          Compare the profile-level evidence labels without treating them as a head-to-head efficacy ranking. The relevant evidence depends on the exact outcome you care about.
+        </p>
       </div>
 
       <div className="grid gap-5 md:grid-cols-2">
-        <EvidencePanel item={item1} isWinner={item1Wins} />
-        <EvidencePanel item={item2} isWinner={item2Wins} />
+        <EvidencePanel item={item1} />
+        <EvidencePanel item={item2} />
       </div>
-
-      {tied && (
-        <p className="mt-4 text-center text-sm text-muted">
-          Similar evidence base — both items share the same evidence tier.
-        </p>
-      )}
     </section>
   )
 }

--- a/components/compare/__tests__/CompareEvidenceMatrix.test.tsx
+++ b/components/compare/__tests__/CompareEvidenceMatrix.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import CompareEvidenceMatrix from '../CompareEvidenceMatrix'
+import type { CompareItem } from '@/lib/compare'
+
+function item(overrides: Partial<CompareItem>): CompareItem {
+  return {
+    slug: 'example',
+    name: 'Example',
+    type: 'compound',
+    description: '',
+    primaryBenefits: [],
+    mechanisms: [],
+    canonicalMechanisms: [],
+    mechanismCategories: [],
+    evidenceLevel: 'unknown',
+    doNotMonetize: false,
+    isHarmReduction: false,
+    pageUrl: '/compounds/example',
+    ...overrides,
+  }
+}
+
+describe('CompareEvidenceMatrix', () => {
+  it('shows profile evidence signals without declaring a head-to-head winner', () => {
+    render(
+      <CompareEvidenceMatrix
+        item1={item({ name: 'Magnesium', evidenceLevel: 'moderate' })}
+        item2={item({ name: 'Melatonin', evidenceLevel: 'strong' })}
+      />,
+    )
+
+    expect(screen.getByRole('heading', { name: 'Evidence Signals Side by Side' })).toBeInTheDocument()
+    expect(screen.getByText(/without treating them as a head-to-head efficacy ranking/i)).toBeInTheDocument()
+    expect(screen.queryByText(/Stronger evidence/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Similar evidence base/i)).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## What changed
- remove “Stronger evidence” winner badges and winner rings from the evidence matrix
- remove the “Similar evidence base” tie claim
- keep each ingredient’s profile-level evidence label, grade, and tier
- explicitly note that evidence strength can differ by outcome, dose, formulation, and study design
- add focused regression coverage

## Why
An overall profile evidence tier is useful context, but it is not a head-to-head efficacy result. Presenting the higher tier as the winner can overstate what the underlying data establish.

## Validation
CI + focused CompareEvidenceMatrix regression.