### PR TITLE
Stop inferring mechanism-to-benefit pathways

### DIFF
--- a/components/compare/CompareMechanisms.tsx
+++ b/components/compare/CompareMechanisms.tsx
@@ -8,18 +8,9 @@ interface CompareMechanismsProps {
 const MAX_MECHANISMS = 4
 const MAX_CANONICAL = 3
 
-function buildPathwayLine(item: CompareItem): string | null {
-  const mechanism = item.mechanisms[0]
-  const benefit = item.primaryBenefits[0]
-  if (!mechanism && !benefit) return null
-  if (mechanism && benefit) return `${mechanism} → ${benefit}`
-  return mechanism ?? benefit ?? null
-}
-
 function ItemMechanismCard({ item }: { item: CompareItem }) {
   const mechanisms = item.mechanisms.slice(0, MAX_MECHANISMS)
   const canonical = item.canonicalMechanisms.slice(0, MAX_CANONICAL)
-  const pathwayLine = buildPathwayLine(item)
   const typeLabel = item.type === 'herb' ? 'Herb' : 'Compound'
 
   return (
@@ -30,13 +21,13 @@ function ItemMechanismCard({ item }: { item: CompareItem }) {
           {item.scientificName ? ` · ${item.scientificName}` : ''}
         </p>
         <h3 className="mt-1 text-lg font-semibold leading-snug text-ink sm:text-xl">
-          How {item.name} Works
+          Mechanism signals for {item.name}
         </h3>
       </div>
 
       <div>
         <p className="mb-2 text-[0.7rem] font-bold uppercase tracking-[0.12em] text-brand-700">
-          Primary mechanisms
+          Reported / proposed mechanisms
         </p>
         {mechanisms.length > 0 ? (
           <ul className="space-y-1.5">
@@ -48,14 +39,14 @@ function ItemMechanismCard({ item }: { item: CompareItem }) {
             ))}
           </ul>
         ) : (
-          <p className="text-sm text-muted">Mechanisms not yet catalogued.</p>
+          <p className="text-sm leading-6 text-muted">No mechanism field is surfaced in this comparison record.</p>
         )}
       </div>
 
       {canonical.length > 0 && (
         <div>
           <p className="mb-2 text-[0.7rem] font-bold uppercase tracking-[0.12em] text-brand-700">
-            Canonical mechanisms
+            Normalized mechanism labels
           </p>
           <div className="flex flex-wrap gap-1.5">
             {canonical.map((mech) => (
@@ -67,16 +58,9 @@ function ItemMechanismCard({ item }: { item: CompareItem }) {
         </div>
       )}
 
-      {pathwayLine && (
-        <div className="rounded-lg border border-brand-900/10 bg-paper-50 px-3 py-2">
-          <p className="text-[0.7rem] font-bold uppercase tracking-[0.11em] text-brand-700 mb-1">
-            Pathway
-          </p>
-          <p className="text-xs leading-relaxed text-muted font-mono">
-            → {pathwayLine}
-          </p>
-        </div>
-      )}
+      <p className="rounded-lg border border-brand-900/10 bg-paper-50 px-3 py-2 text-xs leading-relaxed text-muted">
+        Mechanism fields can help explain biological plausibility, but they do not by themselves prove a clinical benefit, effect size, safety, or superiority over the other option.
+      </p>
     </div>
   )
 }
@@ -84,13 +68,16 @@ function ItemMechanismCard({ item }: { item: CompareItem }) {
 export default function CompareMechanisms({ item1, item2 }: CompareMechanismsProps) {
   return (
     <section aria-labelledby="mechanisms-heading">
-      <div className="mb-5">
+      <div className="mb-5 max-w-3xl">
         <p className="text-[0.65rem] font-bold uppercase tracking-[0.18em] text-brand-700">
-          Mechanism of action
+          Mechanism context
         </p>
         <h2 id="mechanisms-heading" className="mt-1 text-2xl font-semibold tracking-tight text-ink">
-          How They Work
+          Proposed Mechanisms Side by Side
         </h2>
+        <p className="mt-2 text-sm leading-6 text-muted">
+          These labels summarize mechanistic information in the profile data. They are context for interpreting evidence, not a causal map from pathway to outcome.
+        </p>
       </div>
 
       <div className="grid gap-5 md:grid-cols-2">

--- a/components/compare/__tests__/CompareMechanisms.test.tsx
+++ b/components/compare/__tests__/CompareMechanisms.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import CompareMechanisms from '../CompareMechanisms'
+import type { CompareItem } from '@/lib/compare'
+
+function item(overrides: Partial<CompareItem>): CompareItem {
+  return {
+    slug: 'example',
+    name: 'Example',
+    type: 'compound',
+    description: '',
+    primaryBenefits: [],
+    mechanisms: [],
+    canonicalMechanisms: [],
+    mechanismCategories: [],
+    evidenceLevel: 'unknown',
+    doNotMonetize: false,
+    isHarmReduction: false,
+    pageUrl: '/compounds/example',
+    ...overrides,
+  }
+}
+
+describe('CompareMechanisms', () => {
+  it('shows mechanism context without manufacturing a pathway to a benefit', () => {
+    render(
+      <CompareMechanisms
+        item1={item({ name: 'Magnesium', mechanisms: ['NMDA modulation'], primaryBenefits: ['Sleep quality'] })}
+        item2={item({ name: 'Melatonin', mechanisms: ['MT1/MT2 signaling'], primaryBenefits: ['Sleep onset'] })}
+      />,
+    )
+
+    expect(screen.getByRole('heading', { name: 'Proposed Mechanisms Side by Side' })).toBeInTheDocument()
+    expect(screen.getAllByText(/do not by themselves prove a clinical benefit/i)).toHaveLength(2)
+    expect(screen.queryByText(/NMDA modulation.*Sleep quality/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/^Pathway$/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/How Magnesium Works/i)).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## What changed
- remove generated `mechanism → benefit` pathway lines built from unrelated profile fields
- rename “How X Works” to mechanism-signal language
- label mechanism entries as reported/proposed rather than proven causal explanations
- clarify that mechanisms do not establish clinical benefit, effect size, safety, or superiority
- add focused regression coverage

## Why
The comparison component was visually turning the first mechanism field and first benefit field into a causal pathway even though the source data did not encode that relationship. Mechanistic plausibility is useful context, but the UI should not manufacture a pathway-to-outcome claim.

## Validation
CI + focused CompareMechanisms regression.