### PR TITLE
Honor item monetization flags in comparisons

### DIFF
--- a/components/compare/CompareAffiliate.tsx
+++ b/components/compare/CompareAffiliate.tsx
@@ -12,8 +12,8 @@ interface CompareAffiliateProps {
 export default function CompareAffiliate({ item1, item2, isHR }: CompareAffiliateProps) {
   if (isHR) return null
 
-  const set1 = revenueProductSets[item1.slug]
-  const set2 = revenueProductSets[item2.slug]
+  const set1 = item1.doNotMonetize ? undefined : revenueProductSets[item1.slug]
+  const set2 = item2.doNotMonetize ? undefined : revenueProductSets[item2.slug]
 
   if (!set1 && !set2) return null
 
@@ -28,7 +28,7 @@ export default function CompareAffiliate({ item1, item2, isHR }: CompareAffiliat
             Only shop after the fit makes sense
           </h2>
           <p className="text-sm leading-6 text-muted">
-            Use the comparison, dosing notes, safety flags, and full profiles first. These product sections are optional next steps for readers who already know which side fits their goal.
+            Use the comparison, dosing notes, safety flags, and full profiles first. These product sections are optional next steps for readers who already know which side deserves further consideration.
           </p>
           <Link
             href="/info/affiliate-disclosure/"
@@ -41,7 +41,7 @@ export default function CompareAffiliate({ item1, item2, isHR }: CompareAffiliat
 
       {set1 && (
         <RecommendationSection
-          title={`If you choose ${item1.name}`}
+          title={`Product examples for ${item1.name}`}
           products={set1.products}
           trackingProductSlug={item1.slug}
           trackingLocation="compare-recommendation"
@@ -49,7 +49,7 @@ export default function CompareAffiliate({ item1, item2, isHR }: CompareAffiliat
       )}
       {set2 && (
         <RecommendationSection
-          title={`If you choose ${item2.name}`}
+          title={`Product examples for ${item2.name}`}
           products={set2.products}
           trackingProductSlug={item2.slug}
           trackingLocation="compare-recommendation"

--- a/components/compare/__tests__/CompareAffiliate.test.tsx
+++ b/components/compare/__tests__/CompareAffiliate.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import CompareAffiliate from '../CompareAffiliate'
+import type { CompareItem } from '@/lib/compare'
+
+function item(overrides: Partial<CompareItem>): CompareItem {
+  return {
+    slug: 'example',
+    name: 'Example',
+    type: 'compound',
+    description: '',
+    primaryBenefits: [],
+    mechanisms: [],
+    canonicalMechanisms: [],
+    mechanismCategories: [],
+    evidenceLevel: 'unknown',
+    doNotMonetize: false,
+    isHarmReduction: false,
+    pageUrl: '/compounds/example',
+    ...overrides,
+  }
+}
+
+describe('CompareAffiliate', () => {
+  it('does not render a product set for an item flagged doNotMonetize', () => {
+    render(
+      <CompareAffiliate
+        item1={item({ slug: 'ashwagandha', name: 'Ashwagandha', type: 'herb', doNotMonetize: true })}
+        item2={item({ slug: 'unlisted-test-compound', name: 'Unlisted Test Compound' })}
+        isHR={false}
+      />,
+    )
+
+    expect(screen.queryByRole('heading', { name: /product options/i })).not.toBeInTheDocument()
+    expect(screen.queryByText(/Ashwagandha/i)).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## What changed
- suppress each compared item’s curated product set when that item is flagged `doNotMonetize`
- retain the page-level harm-reduction monetization gate
- change product-section titles from “If you choose X” to neutral “Product examples for X” language
- add focused regression coverage

## Why
Comparison monetization should obey both page-level and ingredient-level safety/compliance authority. A non-harm-reduction comparison can still contain an individual record that must not be monetized.

## Validation
CI + focused CompareAffiliate regression.