### PR TITLE
Unify comparison evidence scale

### DIFF
--- a/components/compare/CompareHero.tsx
+++ b/components/compare/CompareHero.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import type { CompareItem, EvidenceLevel } from '@/lib/compare'
+import { evidenceDots, evidenceLabelText } from '@/lib/compare'
 
 interface CompareHeroProps {
   item1: CompareItem
@@ -7,26 +8,6 @@ interface CompareHeroProps {
 }
 
 const EVIDENCE_DOTS = 5
-
-function evidenceLevelToScore(level: EvidenceLevel): number {
-  switch (level) {
-    case 'strong':      return 5
-    case 'moderate':    return 4
-    case 'preliminary': return 3
-    case 'anecdotal':   return 2
-    case 'unknown':     return 1
-  }
-}
-
-function evidenceLevelLabel(level: EvidenceLevel): string {
-  switch (level) {
-    case 'strong':      return 'Strong Evidence'
-    case 'moderate':    return 'Moderate Evidence'
-    case 'preliminary': return 'Preliminary Evidence'
-    case 'anecdotal':   return 'Anecdotal / Traditional'
-    case 'unknown':     return 'Evidence Unknown'
-  }
-}
 
 function evidenceDotColorClass(level: EvidenceLevel): string {
   switch (level) {
@@ -39,21 +20,21 @@ function evidenceDotColorClass(level: EvidenceLevel): string {
 }
 
 function EvidenceDots({ level }: { level: EvidenceLevel }) {
-  const score = evidenceLevelToScore(level)
+  const { filled } = evidenceDots(level)
   const colorClass = evidenceDotColorClass(level)
-  const label = evidenceLevelLabel(level)
+  const label = evidenceLabelText(level)
 
   return (
     <span
       className={`inline-flex items-center gap-0.5 ${colorClass}`}
-      aria-label={label}
+      aria-label={`${label} (${filled} of ${EVIDENCE_DOTS})`}
       title={label}
     >
       {Array.from({ length: EVIDENCE_DOTS }, (_, i) => (
         <span
           key={i}
           aria-hidden="true"
-          className={i < score ? 'opacity-100' : 'opacity-20'}
+          className={i < filled ? 'opacity-100' : 'opacity-20'}
         >
           ●
         </span>

--- a/components/compare/__tests__/CompareHero.test.tsx
+++ b/components/compare/__tests__/CompareHero.test.tsx
@@ -36,4 +36,16 @@ describe('CompareHero', () => {
     expect(screen.queryByText(/typically chosen/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/tends to be favored/i)).not.toBeInTheDocument()
   })
+
+  it('uses the central evidence scale instead of a hero-specific inflated score', () => {
+    render(
+      <CompareHero
+        item1={item({ name: 'Unknown Example', evidenceLevel: 'unknown' })}
+        item2={item({ name: 'Preliminary Example', evidenceLevel: 'preliminary' })}
+      />,
+    )
+
+    expect(screen.getByLabelText('Evidence unknown (0 of 5)')).toBeInTheDocument()
+    expect(screen.getByLabelText('Preliminary evidence (2 of 5)')).toBeInTheDocument()
+  })
 })

--- a/components/compare/__tests__/CompareHero.test.tsx
+++ b/components/compare/__tests__/CompareHero.test.tsx
@@ -45,7 +45,7 @@ describe('CompareHero', () => {
       />,
     )
 
-    expect(screen.getByLabelText('Evidence unknown (0 of 5)')).toBeInTheDocument()
-    expect(screen.getByLabelText('Preliminary evidence (2 of 5)')).toBeInTheDocument()
+    expect(screen.getByLabelText('Evidence Unknown (0 of 5)')).toBeInTheDocument()
+    expect(screen.getByLabelText('Preliminary Evidence (2 of 5)')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## What changed
- remove the hero-specific evidence scoring scale
- use the central `evidenceDots` and `evidenceLabelText` helpers so the hero matches the evidence matrix and other profile UI
- expose the filled-dot count in the evidence accessibility label
- add regression coverage for `unknown` = 0/5 and `preliminary` = 2/5

## Why
The comparison hero was visually inflating weaker evidence tiers relative to the rest of the page, including showing unknown evidence as 1/5. A single evidence tier should have one visual meaning everywhere.

## Validation
CI + expanded CompareHero regression.