### PR TITLE
Guard affiliate pharmacokinetic claims

### DIFF
--- a/components/AffiliateProductCard.tsx
+++ b/components/AffiliateProductCard.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image'
 import { isOptimizableRemoteImage } from '../src/lib/image-hosts'
 import { getOutboundLinkRel, resolveRegionalUrl, type RegionalUrlMap } from '../src/lib/platforms'
 import { trackRevenueEvent } from '../src/lib/revenue-tracking'
+import { affiliateRationaleForDisplay } from '../src/lib/affiliate-copy'
 
 export type AffiliateProduct = {
   asin?: string
@@ -35,7 +36,7 @@ type AffiliateProductCardProps = {
 export default function AffiliateProductCard({ product, compact = false }: AffiliateProductCardProps) {
   const title = product.title || product.name || 'Supplement option'
   const imageUrl = product.imageUrl || product.image
-  const rationale = product.rationale || product.notes || 'Review the label, dose, third-party testing, and safety context before buying.'
+  const rationale = affiliateRationaleForDisplay(title, product.rationale || product.notes)
   const rawUrl = product.affiliateUrl || product.url || product.link
   const resolvedUrl = rawUrl
     ? resolveRegionalUrl({

--- a/components/monetization/ProductTrustAffiliate.tsx
+++ b/components/monetization/ProductTrustAffiliate.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { affiliateRationaleForDisplay } from '@/src/lib/affiliate-copy'
 
 type ProductTrustAffiliateProps = {
   productName: string
@@ -28,6 +29,7 @@ export default function ProductTrustAffiliate({
   if (suppressMonetization) return null
 
   const displayTitle = brand ? `${brand} — ${productName}` : productName
+  const displayRationale = affiliateRationaleForDisplay(productName, rationale)
 
   if (compact) {
     return (
@@ -35,7 +37,7 @@ export default function ProductTrustAffiliate({
         <p className='text-[10px] font-bold uppercase tracking-wider text-emerald-800 dark:text-brand-200'>
           Why we link this {slotLabel ? `(${slotLabel})` : ''}
         </p>
-        <p className='text-xs leading-relaxed text-muted'>{rationale}</p>
+        <p className='text-xs leading-relaxed text-muted'>{displayRationale}</p>
         <p className='text-[10px] leading-relaxed text-muted'>
           Third-party testing, labeled standardization, and clear serving size weighed more than lowest price.
         </p>
@@ -61,7 +63,7 @@ export default function ProductTrustAffiliate({
       ) : null}
       <h3 className='mt-1 text-base font-semibold text-ink'>{displayTitle}</h3>
       <p className='mt-2 text-sm leading-6 text-muted'>
-        <strong className='font-semibold text-ink'>Why we recommend it:</strong> {rationale}
+        <strong className='font-semibold text-ink'>Why we recommend it:</strong> {displayRationale}
       </p>
       <ul className='mt-3 space-y-1.5 text-xs leading-relaxed text-muted'>
         <li>• Prefer third-party tested brands (USP, NSF, ConsumerLab, or published COA)</li>

--- a/src/lib/__tests__/affiliate-copy.test.ts
+++ b/src/lib/__tests__/affiliate-copy.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { affiliateRationaleForDisplay } from '../affiliate-copy'
+
+describe('affiliateRationaleForDisplay', () => {
+  it('removes product-specific first-pass metabolism claims from fast-dissolve affiliate copy', () => {
+    const result = affiliateRationaleForDisplay(
+      'Natrol Melatonin 5 mg Fast Dissolve',
+      'Best overall for a fast-dissolve tablet that avoids first-pass metabolism; well-reviewed.',
+    )
+
+    expect(result).toContain('fast-dissolve format')
+    expect(result).toContain('5 mg dose')
+    expect(result).toContain('not evidence of superior absorption or better clinical outcomes')
+    expect(result).not.toMatch(/first[- ]pass metabolism/i)
+    expect(result).not.toMatch(/well-reviewed/i)
+  })
+
+  it('preserves ordinary sourcing rationale', () => {
+    expect(
+      affiliateRationaleForDisplay(
+        'Jarrow Theanine 200 mg',
+        'Best overall pick for a simple 200 mg L-theanine capsule format.',
+      ),
+    ).toBe('Best overall pick for a simple 200 mg L-theanine capsule format.')
+  })
+})

--- a/src/lib/affiliate-copy.ts
+++ b/src/lib/affiliate-copy.ts
@@ -1,0 +1,19 @@
+export function affiliateRationaleForDisplay(
+  productName: string,
+  rationale?: string,
+  fallback = 'Review the label, dose, third-party testing, and safety context before buying.',
+): string {
+  const text = rationale?.trim() || fallback
+
+  // Product registries should describe observable product attributes, not promote a
+  // retail dosage form with a pharmacokinetic claim that was established for a
+  // different administration system. In particular, "fast dissolve" tablets are
+  // not automatically equivalent to validated oral-transmucosal delivery systems.
+  if (/\b(?:avoid|avoids|bypass|bypasses|skip|skips)(?:ing)?\s+(?:hepatic\s+)?first[- ]pass\s+metabolism\b/i.test(text)) {
+    const doseMatch = productName.match(/\b\d+(?:\.\d+)?\s*(?:mg|mcg|µg)\b/i)?.[0]
+    const doseContext = doseMatch ? ` with a clearly labeled ${doseMatch} dose` : ''
+    return `${productName} uses a fast-dissolve format${doseContext}. Treat the dosage form as a convenience feature, not evidence of superior absorption or better clinical outcomes.`
+  }
+
+  return text
+}


### PR DESCRIPTION
## What changed
- add a shared affiliate-copy guard for product rationales that claim a retail dosage form avoids/bypasses first-pass metabolism
- apply the guard to both generic recommendation cards and goal/trust affiliate cards
- replace the Natrol 5 mg Fast Dissolve rationale with form/dose context that explicitly avoids claiming superior absorption or clinical outcomes
- remove unsupported “well-reviewed” language from the guarded rationale
- add regression coverage for the exact melatonin failure mode

## Why
Research on validated oral-transmucosal melatonin systems suggests they may reduce first-pass metabolism, but a retail “fast dissolve” tablet is not automatically equivalent to those studied delivery systems. Product cards should describe observable formulation features rather than extrapolate pharmacokinetic superiority.

## Validation
CI + focused Vitest regression.