### PR TITLE
Separate public safety labels from workflow state

### DIFF
--- a/components/ui/SafetyBadge.tsx
+++ b/components/ui/SafetyBadge.tsx
@@ -1,23 +1,23 @@
 import {
   decisionStatusBadgeClass,
   getDecisionSafetyTone,
-  normalizeDecisionSafety,
+  publicSafetyLabel,
   safetyToneClasses,
 } from '@/lib/decision-primitives'
 
 export default function SafetyBadge({ level = 'Safety review pending' }: { level?: string }) {
-  const label = normalizeDecisionSafety(level)
+  const label = publicSafetyLabel(level)
   const tone = getDecisionSafetyTone(label)
-  const isPending = label === 'Safety review pending'
-  const aria = isPending
-    ? 'Safety data pending review; use caution and review the full profile before choosing.'
+  const isLimited = label === 'Safety data limited' || label === 'Limited safety data'
+  const aria = isLimited
+    ? 'Safety data are limited; use caution and review the full profile before choosing.'
     : undefined
 
   return (
     <span
       className={`${decisionStatusBadgeClass} ${safetyToneClasses(tone)}`}
       aria-label={aria}
-      title={isPending ? 'Safety data is still under review' : undefined}
+      title={isLimited ? 'Safety data are limited; review the full profile' : undefined}
     >
       {label}
     </span>

--- a/lib/__tests__/decision-primitives-public-safety.test.ts
+++ b/lib/__tests__/decision-primitives-public-safety.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeDecisionSafety, publicSafetyLabel } from '../decision-primitives'
+
+describe('public safety labels', () => {
+  it('keeps pending-review workflow state internally while presenting limited data publicly', () => {
+    expect(normalizeDecisionSafety()).toBe('Safety review pending')
+    expect(publicSafetyLabel()).toBe('Safety data limited')
+    expect(publicSafetyLabel('Safety review pending')).toBe('Safety data limited')
+  })
+
+  it('preserves substantive public safety states', () => {
+    expect(publicSafetyLabel('Interaction risk')).toBe('Interaction risk')
+    expect(publicSafetyLabel('Generally well tolerated')).toBe('Generally well tolerated')
+    expect(publicSafetyLabel('Use caution')).toBe('Use caution')
+  })
+})

--- a/lib/decision-primitives.ts
+++ b/lib/decision-primitives.ts
@@ -157,9 +157,13 @@ export function getDecisionSafetyTone(
 }
 
 export function publicSafetyLabel(labelOrValue?: unknown): StandardSafetyLabel {
-  // Always return the label (including "Safety review pending") so that pending safety status is visible
-  // and not hidden. Callers / metrics decide display; never imply reviewed safety when data is pending.
-  return normalizeDecisionSafety(labelOrValue)
+  const normalized = normalizeDecisionSafety(labelOrValue)
+  // Keep workflow state visible to internal audit/editorial tools via
+  // normalizeDecisionSafety, but do not expose implementation queue language to
+  // readers. Public cards should communicate the epistemic state: safety data are
+  // limited and the full profile should be reviewed.
+  if (normalized === 'Safety review pending') return 'Safety data limited'
+  return normalized
 }
 
 export function evidenceToneClasses(tone: DecisionEvidenceTone) {


### PR DESCRIPTION
Superseded by #2570, which merged the public-facing safety-badge wording and accessibility regression cleanly. Keeping this older branch closed avoids duplicate/stale implementation.