### PR TITLE
Calibrate public affiliate product claims

### DIFF
--- a/components/AffiliateProductCard.tsx
+++ b/components/AffiliateProductCard.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image'
 import { isOptimizableRemoteImage } from '../src/lib/image-hosts'
+import { getPublicProductRationale } from '../src/lib/commercial-copy'
 import { getOutboundLinkRel, resolveRegionalUrl, type RegionalUrlMap } from '../src/lib/platforms'
 import { trackRevenueEvent } from '../src/lib/revenue-tracking'
 
@@ -35,7 +36,7 @@ type AffiliateProductCardProps = {
 export default function AffiliateProductCard({ product, compact = false }: AffiliateProductCardProps) {
   const title = product.title || product.name || 'Supplement option'
   const imageUrl = product.imageUrl || product.image
-  const rationale = product.rationale || product.notes || 'Review the label, dose, third-party testing, and safety context before buying.'
+  const rationale = getPublicProductRationale(product)
   const rawUrl = product.affiliateUrl || product.url || product.link
   const resolvedUrl = rawUrl
     ? resolveRegionalUrl({

--- a/components/monetization/ProductTrustAffiliate.tsx
+++ b/components/monetization/ProductTrustAffiliate.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { getPublicProductRationale } from '@/src/lib/commercial-copy'
 
 type ProductTrustAffiliateProps = {
   productName: string
@@ -28,6 +29,11 @@ export default function ProductTrustAffiliate({
   if (suppressMonetization) return null
 
   const displayTitle = brand ? `${brand} — ${productName}` : productName
+  const publicRationale = getPublicProductRationale({
+    title: productName,
+    brand,
+    rationale,
+  })
 
   if (compact) {
     return (
@@ -35,7 +41,7 @@ export default function ProductTrustAffiliate({
         <p className='text-[10px] font-bold uppercase tracking-wider text-emerald-800 dark:text-brand-200'>
           Why we link this {slotLabel ? `(${slotLabel})` : ''}
         </p>
-        <p className='text-xs leading-relaxed text-muted'>{rationale}</p>
+        <p className='text-xs leading-relaxed text-muted'>{publicRationale}</p>
         <p className='text-[10px] leading-relaxed text-muted'>
           Third-party testing, labeled standardization, and clear serving size weighed more than lowest price.
         </p>
@@ -61,7 +67,7 @@ export default function ProductTrustAffiliate({
       ) : null}
       <h3 className='mt-1 text-base font-semibold text-ink'>{displayTitle}</h3>
       <p className='mt-2 text-sm leading-6 text-muted'>
-        <strong className='font-semibold text-ink'>Why we recommend it:</strong> {rationale}
+        <strong className='font-semibold text-ink'>Why we recommend it:</strong> {publicRationale}
       </p>
       <ul className='mt-3 space-y-1.5 text-xs leading-relaxed text-muted'>
         <li>• Prefer third-party tested brands (USP, NSF, ConsumerLab, or published COA)</li>

--- a/src/lib/__tests__/commercial-copy.test.ts
+++ b/src/lib/__tests__/commercial-copy.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { getPublicProductRationale } from '../commercial-copy'
+
+describe('getPublicProductRationale', () => {
+  it('removes the product-specific first-pass and review claim from Natrol melatonin copy', () => {
+    const result = getPublicProductRationale({
+      brand: 'Natrol',
+      title: 'Natrol Melatonin 5 mg Fast Dissolve',
+      rationale: 'Best overall for a fast-dissolve tablet that avoids first-pass metabolism; well-reviewed.',
+    })
+
+    expect(result).toMatch(/fast-dissolve format/i)
+    expect(result).not.toMatch(/first-pass|well-reviewed/i)
+  })
+
+  it('removes the sweeping researcher-preference claim from NOW melatonin copy', () => {
+    const result = getPublicProductRationale({
+      brand: 'NOW Foods',
+      title: 'NOW Melatonin 3 mg',
+      rationale: 'Budget pick for a common 3 mg melatonin capsule — lower dose preferred by most sleep researchers.',
+    })
+
+    expect(result).toMatch(/simple 3 mg melatonin capsule/i)
+    expect(result).not.toMatch(/most sleep researchers/i)
+  })
+
+  it('falls back when generic catalog copy makes a pharmacokinetic superiority claim', () => {
+    const result = getPublicProductRationale({
+      brand: 'Example',
+      title: 'Example Extract',
+      rationale: 'Premium liquid extract for faster absorption and flexible dosing.',
+    })
+
+    expect(result).toMatch(/product-format example/i)
+    expect(result).not.toMatch(/faster absorption/i)
+  })
+
+  it('preserves objective low-risk rationale copy', () => {
+    const rationale = 'Budget pick for a simple single-ingredient capsule with clear serving-size labeling.'
+    expect(getPublicProductRationale({ rationale })).toBe(rationale)
+  })
+})

--- a/src/lib/commercial-copy.ts
+++ b/src/lib/commercial-copy.ts
@@ -1,0 +1,41 @@
+export type PublicProductCopyInput = {
+  title?: string
+  name?: string
+  brand?: string
+  rationale?: string
+  notes?: string
+}
+
+const FALLBACK_RATIONALE =
+  'Use this as a product-format example. Verify serving size, formulation, third-party testing, and safety context before buying.'
+
+const UNSUPPORTED_OR_DYNAMIC_COPY =
+  /\b(avoids? first-pass metabolism|preferred by most sleep researchers|well-reviewed|faster absorption|superior bioavailability)\b/i
+
+function normalizedIdentity(input: PublicProductCopyInput): string {
+  const title = input.title || input.name || ''
+  return `${input.brand || ''}|${title}`.trim().toLowerCase()
+}
+
+const PRODUCT_RATIONALE_OVERRIDES: Record<string, string> = {
+  'now foods|now melatonin 3 mg':
+    'Budget option for a simple 3 mg melatonin capsule. Check whether 3 mg matches the dose you intend to use.',
+  'natrol|natrol melatonin 5 mg fast dissolve':
+    'Fast-dissolve format for readers who prefer a tablet that dissolves in the mouth. Check whether 5 mg matches the dose you intend to use.',
+  'thorne|thorne melaton-3':
+    'Premium-format option for readers who prefer a simple 3 mg melatonin capsule from a practitioner-oriented brand.',
+}
+
+export function getPublicProductRationale(input: PublicProductCopyInput): string {
+  const override = PRODUCT_RATIONALE_OVERRIDES[normalizedIdentity(input)]
+  if (override) return override
+
+  const raw = (input.rationale || input.notes || '').trim()
+  if (!raw) return FALLBACK_RATIONALE
+
+  if (UNSUPPORTED_OR_DYNAMIC_COPY.test(raw)) {
+    return FALLBACK_RATIONALE
+  }
+
+  return raw
+}


### PR DESCRIPTION
Superseded by #2571. Main gained a narrower first-pass affiliate-copy sanitizer after this branch was created, so #2571 extends that existing authority instead of introducing a parallel commercial-copy layer.