### PR TITLE
Calibrate high-intent goal evidence claims

### DIFF
--- a/app/goals/[slug]/page.tsx
+++ b/app/goals/[slug]/page.tsx
@@ -10,6 +10,7 @@ import GoalTopAffiliatePicks from '@/components/monetization/GoalTopAffiliatePic
 import GoalContentDepth from '@/src/components/goals/GoalContentDepth'
 import GoalHubSections from '@/src/components/goals/GoalHubSections'
 import { getGoalHubLinks } from '@/src/lib/goal-hub-links'
+import { getPublicGoalContentExtension } from '@/src/lib/goal-public-copy'
 import SchemaOrg from '@/components/SchemaOrg'
 import Disclaimer from '@/src/components/Disclaimer'
 import { breadcrumbJsonLd, faqPageJsonLd, SITE_URL } from '@/src/lib/seo'
@@ -55,7 +56,10 @@ export default async function GoalPage({ params }: PageProps) {
   if (!goal) notFound()
 
   const goalPath = `/goals/${goal.slug}/`
-  const extension = getGoalContentExtension(goal.slug)
+  const rawExtension = getGoalContentExtension(goal.slug)
+  const extension = rawExtension
+    ? getPublicGoalContentExtension(goal.slug, rawExtension)
+    : null
   const startHereLinks = getGoalStartHereLinks(goal.slug)
   const { stack, compares, seoEntry } = getGoalHubLinks(goal.slug)
 

--- a/src/lib/__tests__/goal-public-copy.test.ts
+++ b/src/lib/__tests__/goal-public-copy.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import type { GoalContentExtension } from '@/data/goal-content'
+import { getPublicGoalContentExtension } from '../goal-public-copy'
+
+const fixture: GoalContentExtension = {
+  faqItems: [
+    {
+      question: 'How do melatonin, valerian, and magnesium compare for sleep?',
+      answer: 'Valerian helps reduce sleep latency over weeks.',
+    },
+  ],
+  dosingNotes: [
+    {
+      compound: 'Valerian Root',
+      note: 'Typically 300–600 mg before bed.',
+    },
+  ],
+  evidenceRows: [
+    {
+      compound: 'Valerian Root',
+      evidence: 'Limited to moderate',
+      humanData: 'Subjective scales',
+      limitation: 'Requires 2–4 weeks for cumulative effect',
+    },
+  ],
+  safetyBullets: ['Review safety.'],
+}
+
+describe('getPublicGoalContentExtension', () => {
+  it('removes unsupported valerian efficacy and cumulative-effect claims from sleep public copy', () => {
+    const result = getPublicGoalContentExtension('sleep', fixture)
+
+    expect(result.faqItems[0].answer).toMatch(/evidence for valerian in insomnia is inconsistent/i)
+    expect(result.faqItems[0].answer).not.toMatch(/helps reduce sleep latency/i)
+    expect(result.evidenceRows[0].evidence).toBe('Inconsistent / insufficient')
+    expect(result.evidenceRows[0].limitation).not.toMatch(/requires 2–4 weeks/i)
+    expect(result.dosingNotes[0].note).toMatch(/evidence for insomnia remains inconsistent/i)
+  })
+
+  it('does not mutate the source extension', () => {
+    const original = fixture.faqItems[0].answer
+    getPublicGoalContentExtension('sleep', fixture)
+    expect(fixture.faqItems[0].answer).toBe(original)
+  })
+
+  it('leaves unrelated goal content unchanged', () => {
+    const result = getPublicGoalContentExtension('focus', fixture)
+    expect(result.faqItems[0].answer).toBe(fixture.faqItems[0].answer)
+    expect(result.evidenceRows[0]).toEqual(fixture.evidenceRows[0])
+  })
+})

--- a/src/lib/goal-public-copy.ts
+++ b/src/lib/goal-public-copy.ts
@@ -1,0 +1,78 @@
+import type {
+  GoalContentExtension,
+  GoalDosingNote,
+  GoalEvidenceRow,
+  GoalFaqItem,
+} from '@/data/goal-content'
+
+const FAQ_OVERRIDES: Record<string, Record<string, string>> = {
+  sleep: {
+    'What is the best evidence-based supplement for sleep onset?':
+      'Melatonin has evidence for circadian-timing problems and may modestly shorten sleep-onset latency in some people, but clinical guidelines do not recommend it as a general treatment for chronic insomnia. Evidence for magnesium, L-Theanine, and valerian is more limited or inconsistent. Match any trial to the specific sleep problem and review safety before combining products.',
+    'How do melatonin, valerian, and magnesium compare for sleep?':
+      'Melatonin is a circadian timing signal and has the clearest role when sleep timing is the problem, such as jet lag or a delayed sleep schedule. Evidence for valerian in insomnia is inconsistent. Magnesium is essential for nerve and muscle function, but supplemental magnesium is not established as a general insomnia treatment. Use the detailed comparison to review evidence and safety rather than assuming these options are interchangeable.',
+    'How long before bed should I take sleep supplements?':
+      'Timing varies by ingredient, formulation, dose, and the sleep problem being targeted. Melatonin timing is especially context-dependent because it affects circadian timing. Follow product- or study-specific instructions and avoid assuming one universal pre-bed timing rule for all sleep supplements.',
+    'Why do some sleep aids cause next-day grogginess?':
+      'Melatonin and other sedating products can contribute to next-day drowsiness in some people, and combining multiple sedating products makes the cause harder to identify. If morning impairment is persistent or significant, stop the new product and review the situation with a qualified health professional.',
+  },
+  stress: {
+    'Ashwagandha vs L-Theanine vs Magnesium — which fits my stress pattern?':
+      'Some ashwagandha preparations have supportive human evidence for stress symptoms, but studies are often small and use different preparations, and long-term safety is not well established. L-Theanine and magnesium have different evidence bases and should not be ranked from mechanism or onset claims alone. Compare the profile evidence, dose/form, cautions, and medication context for each option.',
+    'Ashwagandha vs rhodiola — which has better stress evidence?':
+      'Ashwagandha has supportive human evidence for stress with important study and preparation differences. Rhodiola has a separate, variable evidence base for stress-related fatigue and performance outcomes. There is not a single head-to-head evidence ranking that makes one the default choice; compare the exact outcome, preparation, safety profile, and study quality.',
+    'Why do some people feel emotionally flat on ashwagandha?':
+      'New mood or emotional changes after starting a supplement deserve attention, but emotional blunting is not established as a common ashwagandha adverse effect in major clinical evidence summaries. If a meaningful mood change begins after starting a product, stop the new product and discuss it with a qualified health professional.',
+  },
+}
+
+const EVIDENCE_OVERRIDES: Record<string, Record<string, Partial<GoalEvidenceRow>>> = {
+  sleep: {
+    'Valerian Root': {
+      evidence: 'Inconsistent / insufficient',
+      humanData: 'Small and mixed studies',
+      limitation: 'Not recommended for chronic insomnia by AASM; long-term safety is uncertain',
+    },
+  },
+  stress: {
+    Ashwagandha: {
+      evidence: 'Supportive human evidence for stress',
+      humanData: 'Small trials using varied preparations',
+      limitation: 'Preparation-specific results; long-term safety is uncertain',
+    },
+  },
+}
+
+const DOSING_OVERRIDES: Record<string, Record<string, string>> = {
+  sleep: {
+    'Valerian Root':
+      'Research has used varied valerian preparations and doses, but evidence for insomnia remains inconsistent. Do not treat a commonly used dose as proof of effectiveness; follow the product label and review sedative interactions.',
+  },
+}
+
+function publicFaq(slug: string, item: GoalFaqItem): GoalFaqItem {
+  const answer = FAQ_OVERRIDES[slug]?.[item.question]
+  return answer ? { ...item, answer } : item
+}
+
+function publicEvidenceRow(slug: string, row: GoalEvidenceRow): GoalEvidenceRow {
+  const override = EVIDENCE_OVERRIDES[slug]?.[row.compound]
+  return override ? { ...row, ...override } : row
+}
+
+function publicDosingNote(slug: string, note: GoalDosingNote): GoalDosingNote {
+  const override = DOSING_OVERRIDES[slug]?.[note.compound]
+  return override ? { ...note, note: override } : note
+}
+
+export function getPublicGoalContentExtension(
+  slug: string,
+  content: GoalContentExtension,
+): GoalContentExtension {
+  return {
+    ...content,
+    faqItems: content.faqItems.map((item) => publicFaq(slug, item)),
+    evidenceRows: content.evidenceRows.map((row) => publicEvidenceRow(slug, row)),
+    dosingNotes: content.dosingNotes.map((note) => publicDosingNote(slug, note)),
+  }
+}


### PR DESCRIPTION
## What changed
- add a public-copy authority layer for goal FAQ, evidence-row, and dosing text
- calibrate Sleep claims around melatonin, valerian, magnesium, timing, and next-day drowsiness
- replace the valerian cumulative-effect claim with explicit inconsistent/insufficient evidence language
- calibrate Stress claims around ashwagandha evidence, preparation variability, long-term safety, rhodiola comparisons, and anecdotal emotional-blunting reports
- apply the calibrated FAQ copy to both visible goal content and FAQ structured data
- add focused regression coverage

## Why
The high-intent goal hubs are decision pages and their FAQ answers also feed schema. Public copy should reflect the evidence boundary rather than upgrading traditional use, mechanisms, or anecdotal reports into established efficacy or adverse-effect claims.

## Evidence basis
NCCIH sleep/melatonin/valerian and ashwagandha evidence summaries were used to set the public evidence boundaries.

## Validation
CI + focused goal-public-copy regression.