### PR TITLE
Normalize herb entity schema semantics

### DIFF
--- a/components/seo/SchemaGraphScript.tsx
+++ b/components/seo/SchemaGraphScript.tsx
@@ -45,6 +45,52 @@ export function getEntityArtifact(graph: Record<string, unknown>): EntityArtifac
   return null
 }
 
+export function normalizeProfileEntitySemantics(
+  graph: Record<string, unknown>,
+  artifact: EntityArtifact | null,
+): Record<string, unknown> {
+  if (!artifact || !artifact.href.includes('/herb/') || !Array.isArray(graph['@graph'])) return graph
+
+  const nodes = graph['@graph'].map((node) => {
+    if (!node || typeof node !== 'object') return node
+    const record = node as Record<string, unknown>
+
+    if (record['@id'] === artifact.entityId) {
+      return {
+        ...record,
+        // Schema.org `Substance` covers matter of biological origin. Avoid the
+        // non-canonical `MedicalSubstance` label previously emitted for herbs.
+        '@type': 'Substance',
+      }
+    }
+
+    const mainEntity = record.mainEntity
+    const mainEntityId =
+      mainEntity && typeof mainEntity === 'object'
+        ? (mainEntity as Record<string, unknown>)['@id']
+        : null
+    const about = record.about
+    const aboutType =
+      about && typeof about === 'object'
+        ? (about as Record<string, unknown>)['@type']
+        : null
+
+    if (mainEntityId === artifact.entityId && aboutType === 'MedicalTherapy') {
+      return {
+        ...record,
+        // The profile page is about the canonical herb entity, not a treatment
+        // intervention. Point `about` to the same Substance node used by
+        // `mainEntity` so the graph has one consistent identity.
+        about: { '@id': artifact.entityId },
+      }
+    }
+
+    return node
+  })
+
+  return { ...graph, '@graph': nodes }
+}
+
 export function attachEntityDataset(
   graph: Record<string, unknown>,
   artifact: EntityArtifact | null,
@@ -87,7 +133,8 @@ export function attachEntityDataset(
 
 export default function SchemaGraphScript({ graph }: SchemaGraphScriptProps) {
   const artifact = getEntityArtifact(graph)
-  const enrichedGraph = attachEntityDataset(graph, artifact)
+  const normalizedGraph = normalizeProfileEntitySemantics(graph, artifact)
+  const enrichedGraph = attachEntityDataset(normalizedGraph, artifact)
 
   return (
     <>

--- a/components/seo/__tests__/SchemaGraphScript.test.ts
+++ b/components/seo/__tests__/SchemaGraphScript.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { attachEntityDataset, getEntityArtifact } from '../SchemaGraphScript'
+import {
+  attachEntityDataset,
+  getEntityArtifact,
+  normalizeProfileEntitySemantics,
+} from '../SchemaGraphScript'
 
 describe('SchemaGraphScript AI entity data discovery', () => {
   const graph = {
@@ -40,6 +44,43 @@ describe('SchemaGraphScript AI entity data discovery', () => {
     })
     expect(dataset?.url).toBe('https://thehippiescientist.net/data/ai-entities/compound/magnesium.json')
     expect(dataset?.encodingFormat).toBe('application/ld+json')
+  })
+
+  it('normalizes herb entities to Substance and removes duplicate MedicalTherapy about nodes', () => {
+    const herbGraph = {
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': ['MedicalWebPage', 'WebPage'],
+          '@id': 'https://thehippiescientist.net/herbs/ashwagandha/#webpage',
+          url: 'https://thehippiescientist.net/herbs/ashwagandha/',
+          mainEntity: { '@id': 'https://thehippiescientist.net/herbs/ashwagandha/#entity' },
+          about: { '@type': 'MedicalTherapy', name: 'Ashwagandha' },
+        },
+        {
+          '@type': ['MedicalSubstance', 'Thing'],
+          '@id': 'https://thehippiescientist.net/herbs/ashwagandha/#entity',
+          name: 'Ashwagandha',
+          url: 'https://thehippiescientist.net/herbs/ashwagandha/',
+        },
+      ],
+    }
+
+    const artifact = getEntityArtifact(herbGraph)
+    const normalized = normalizeProfileEntitySemantics(herbGraph, artifact)
+    const nodes = normalized['@graph'] as Record<string, unknown>[]
+    const webpage = nodes.find((node) => node['@id'] === 'https://thehippiescientist.net/herbs/ashwagandha/#webpage')
+    const entity = nodes.find((node) => node['@id'] === artifact?.entityId)
+
+    expect(entity?.['@type']).toBe('Substance')
+    expect(webpage?.about).toEqual({ '@id': artifact?.entityId })
+    expect(JSON.stringify(normalized)).not.toContain('MedicalSubstance')
+    expect(JSON.stringify(normalized)).not.toContain('MedicalTherapy')
+  })
+
+  it('does not rewrite compound entity semantics', () => {
+    const artifact = getEntityArtifact(graph)
+    expect(normalizeProfileEntitySemantics(graph, artifact)).toEqual(graph)
   })
 
   it('ignores non-profile schema graphs', () => {


### PR DESCRIPTION
## What changed
- normalize canonical herb profile entities to Schema.org `Substance` at the shared graph-rendering boundary
- replace the duplicate herb `MedicalTherapy` `about` object with a reference to the canonical herb entity
- leave compound graphs unchanged
- keep the existing machine-readable Dataset linkage intact
- add focused regression coverage for both herb and compound behavior

## Why
Schema.org defines `MedicalTherapy` as a treatment intervention, while `Substance` covers matter of biological origin. The profile graph also emitted the non-canonical `MedicalSubstance` label for herbs. A herb profile should identify one canonical botanical substance entity rather than simultaneously describing the plant as an invalid medical substance and a therapy.

## Validation
CI + focused SchemaGraphScript regression.