### PR TITLE
Enforce governance in production data build

### DIFF
--- a/scripts/__tests__/build-deploy-governance.test.ts
+++ b/scripts/__tests__/build-deploy-governance.test.ts
@@ -1,0 +1,33 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('production build governance ordering', () => {
+  it('postprocesses and governs runtime data before downstream manifests', () => {
+    const source = fs.readFileSync(path.join(process.cwd(), 'scripts/build-deploy.mjs'), 'utf8')
+
+    const runtime = source.indexOf("name: 'build-runtime-from-workbook'")
+    const postprocess = source.indexOf("name: 'postprocess-workbook-payloads'")
+    const governance = source.indexOf("name: 'apply-governance-overlay'")
+    const related = source.indexOf("name: 'build-related-runtime-maps'")
+    const routes = source.indexOf("name: 'build-route-manifest'")
+    const sitemap = source.indexOf("name: 'build-sitemap-manifest'")
+
+    expect(runtime).toBeGreaterThan(-1)
+    expect(postprocess).toBeGreaterThan(runtime)
+    expect(governance).toBeGreaterThan(postprocess)
+    expect(related).toBeGreaterThan(governance)
+    expect(routes).toBeGreaterThan(governance)
+    expect(sitemap).toBeGreaterThan(governance)
+  })
+
+  it('does not cache away the governance pass', () => {
+    const source = fs.readFileSync(path.join(process.cwd(), 'scripts/build-deploy.mjs'), 'utf8')
+    const governanceBlock = source.slice(
+      source.indexOf("name: 'apply-governance-overlay'"),
+      source.indexOf("name: 'build-related-runtime-maps'"),
+    )
+
+    expect(governanceBlock).toMatch(/cacheable:\s*false/)
+  })
+})

--- a/scripts/build-deploy.mjs
+++ b/scripts/build-deploy.mjs
@@ -15,27 +15,31 @@
  * 2. build-blog (blog post generation)
  * 3. build-articles (long-form article generation)
  * 4. build-runtime-from-workbook (data extraction)
- * 5. build-related-runtime-maps (relationship maps)
- * 6. build-runtime-summary-indexes (search indexes)
- * 7. build-route-manifest (route discovery)
- * 8. build-internal-link-engine (semantic internal links)
- * 9. build-sitemap-manifest (SEO sitemap source manifest)
- * 10. build-export-batches (batch optimization)
- * 11. build-semantic-snapshots (snapshot generation)
- * 12. build-production (next build)
- * 13. repair-broken-canonicals (replace deprecated canonical aliases in exported HTML)
- * 14. inject-content-depth-support (add route-aware supporting copy for low text/HTML pages)
- * 15. validate-structured-data-regressions (report known Semrush schema failures)
- * 16. apply-redirect-overrides (prepend exact audit-cleanup redirects)
- * 17. write-static-sitemap (physical out/sitemap.xml for Cloudflare Pages)
- * 18. validate-sitemap-static (prove /sitemap.xml is real XML, not HTML)
- * 19. repair-static-blog-h1s (legacy static blog heading repair)
- * 20. build-pagefind (static search index)
+ * 5. postprocess-workbook-payloads (normalize workbook-derived runtime fields)
+ * 6. apply-governance-overlay (enforce evidence/indexability/monetization authority)
+ * 7. build-related-runtime-maps (relationship maps)
+ * 8. build-runtime-summary-indexes (search indexes)
+ * 9. build-route-manifest (route discovery)
+ * 10. build-internal-link-engine (semantic internal links)
+ * 11. build-sitemap-manifest (SEO sitemap source manifest)
+ * 12. build-export-batches (batch optimization)
+ * 13. build-semantic-snapshots (snapshot generation)
+ * 14. build-production (next build)
+ * 15. repair-broken-canonicals (replace deprecated canonical aliases in exported HTML)
+ * 16. inject-content-depth-support (add route-aware supporting copy for low text/HTML pages)
+ * 17. validate-structured-data-regressions (report known Semrush schema failures)
+ * 18. apply-redirect-overrides (prepend exact audit-cleanup redirects)
+ * 19. write-static-sitemap (physical out/sitemap.xml for Cloudflare Pages)
+ * 20. validate-sitemap-static (prove /sitemap.xml is real XML, not HTML)
+ * 21. repair-static-blog-h1s (legacy static blog heading repair)
+ * 22. build-pagefind (static search index)
  *
  * Time estimate: cold builds are dominated by Next static export and Pagefind;
  * warm builds skip cacheable generation steps when inputs and outputs match.
  * Savings come from deferring non-critical checks to npm run build:qa and
- * reusing unchanged generated artifacts.
+ * reusing unchanged generated artifacts. Governance/postprocessing intentionally
+ * run every deploy because stale policy metadata is more expensive than the small
+ * deterministic normalization pass.
  */
 
 import { execSync } from 'child_process'
@@ -84,6 +88,45 @@ const steps = [
     cmd: 'node --trace-uncaught --enable-source-maps scripts/data/build-runtime-from-workbook.mjs --out public/data',
     inputs: ['data/**/*.xlsx', 'data/**/*.json', 'data-sources/**/*.xlsx', 'scripts/data/**/*.mjs'],
     outputs: ['public/data/**/*'],
+  },
+  {
+    name: 'postprocess-workbook-payloads',
+    cmd: 'node scripts/data/postprocess-workbook-payloads.mjs',
+    inputs: [
+      'public/data/herbs.json',
+      'public/data/compounds.json',
+      'public/data/herbs-detail/**/*.json',
+      'public/data/compounds-detail/**/*.json',
+      'scripts/data/postprocess-workbook-payloads.mjs',
+    ],
+    outputs: [
+      'public/data/herbs.json',
+      'public/data/compounds.json',
+      'public/data/herbs-detail/**/*',
+      'public/data/compounds-detail/**/*',
+    ],
+    cacheable: false,
+  },
+  {
+    name: 'apply-governance-overlay',
+    cmd: 'node scripts/data/apply-governance-overlay.mjs --data-dir=public/data',
+    inputs: [
+      'public/data/herbs.json',
+      'public/data/compounds.json',
+      'public/data/herbs-detail/**/*.json',
+      'public/data/compounds-detail/**/*.json',
+      'public/data/claims.json',
+      'src/lib/index-allowlist.ts',
+      'scripts/data/apply-governance-overlay.mjs',
+    ],
+    outputs: [
+      'public/data/herbs.json',
+      'public/data/compounds.json',
+      'public/data/herbs-detail/**/*',
+      'public/data/compounds-detail/**/*',
+      'ops/audit/governance-overlay-report.json',
+    ],
+    cacheable: false,
   },
   {
     name: 'build-related-runtime-maps',

--- a/scripts/data/build-runtime-summary-indexes.mjs
+++ b/scripts/data/build-runtime-summary-indexes.mjs
@@ -8,6 +8,7 @@ import {
 } from '../ci/report-build-stage-timings.mjs'
 import { exportCanonicalCitationsToRuntime } from './canonical/citation-export.mjs'
 import { buildAiEntityArtifacts } from './ai-entity-enrichment-lib.mjs'
+import { reconcileDeliberateGovernanceHolds } from './governance-hold-policy.mjs'
 
 const DATA_DIR_ARG = process.argv.find((arg) => arg.startsWith('--data-dir='))
 const DATA_DIR = DATA_DIR_ARG
@@ -201,6 +202,24 @@ function buildAlphaEntityShards(records) {
 
 async function main() {
   const totalTimer = createStageTimer('summary-index-build')
+
+  // Curated allowlists express editorial priority, but they must never outrank an
+  // explicit runtime/profile hold such as hidden_until_grounded or research_only.
+  // The governance overlay runs before this builder in production; reconcile that
+  // precedence here before summary records become the metadata source consumed by
+  // Next static generation, route manifests, and sitemap logic.
+  const holdTimer = createStageTimer('deliberate-governance-hold-reconciliation')
+  const holdReport = await reconcileDeliberateGovernanceHolds({ dataDir: DATA_DIR })
+  holdTimer.finish({ corrected: holdReport.total })
+  if (holdReport.total > 0) {
+    console.log(
+      `[summary-indexes] preserved deliberate governance holds: ${[
+        ...holdReport.herbs.map((slug) => `herb:${slug}`),
+        ...holdReport.compounds.map((slug) => `compound:${slug}`),
+      ].join(', ')}`,
+    )
+  }
+
   const citationTimer = createStageTimer('canonical-citation-export')
   const citationReport = exportCanonicalCitationsToRuntime({ dataDir: DATA_DIR })
   citationTimer.finish({

--- a/scripts/data/governance-hold-policy.mjs
+++ b/scripts/data/governance-hold-policy.mjs
@@ -1,0 +1,110 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+export const DELIBERATE_HOLD_DECISIONS = new Set([
+  'hidden_until_grounded',
+  'research_archive_runtime',
+])
+
+export const DELIBERATE_HOLD_PROFILE_STATUSES = new Set([
+  'research_only',
+  'minimal',
+])
+
+export function isDeliberateGovernanceHold(record) {
+  if (!record || typeof record !== 'object') return false
+
+  const decision = String(record.runtime_export_decision || '').trim().toLowerCase()
+  if (DELIBERATE_HOLD_DECISIONS.has(decision)) return true
+
+  const profileStatus = String(record.profile_status || '').trim().toLowerCase()
+  if (DELIBERATE_HOLD_PROFILE_STATUSES.has(profileStatus)) return true
+
+  const reasons = Array.isArray(record.indexability_reasons) ? record.indexability_reasons : []
+  return reasons.some((reason) => {
+    const [key, value] = String(reason).split(':')
+    if (key === 'noindex-decision' && DELIBERATE_HOLD_DECISIONS.has(value)) return true
+    if (key === 'profile-status' && DELIBERATE_HOLD_PROFILE_STATUSES.has(value)) return true
+    return false
+  })
+}
+
+export function applyDeliberateGovernanceHold(record) {
+  if (!isDeliberateGovernanceHold(record)) return false
+
+  record.indexability_status = 'NEEDS_REVIEW'
+  record.robots = 'noindex,follow'
+  record.sitemap_included = false
+
+  if (!Array.isArray(record.indexability_reasons)) record.indexability_reasons = []
+  if (!record.indexability_reasons.includes('deliberate_governance_hold')) {
+    record.indexability_reasons.push('deliberate_governance_hold')
+  }
+
+  const governance = record.governance && typeof record.governance === 'object'
+    ? record.governance
+    : {}
+
+  record.governance = {
+    ...governance,
+    reviewStatus: 'needs_review',
+    indexingAllowed: false,
+    recommendationAllowed: false,
+    requiresHumanReview: true,
+    reason: 'deliberate_governance_hold',
+  }
+
+  return true
+}
+
+async function readJson(filePath, fallback) {
+  try {
+    return JSON.parse(await fs.readFile(filePath, 'utf8'))
+  } catch {
+    return fallback
+  }
+}
+
+async function writeJson(filePath, value) {
+  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8')
+}
+
+async function reconcileCollection(dataDir, listFile, detailDirName) {
+  const listPath = path.join(dataDir, listFile)
+  const records = await readJson(listPath, [])
+  if (!Array.isArray(records)) return { corrected: [] }
+
+  const corrected = []
+  for (const record of records) {
+    if (!applyDeliberateGovernanceHold(record)) continue
+    const slug = String(record.slug || '').trim()
+    if (!slug) continue
+    corrected.push(slug)
+
+    const detailPath = path.join(dataDir, detailDirName, `${slug}.json`)
+    const detail = await readJson(detailPath, null)
+    if (detail && typeof detail === 'object') {
+      applyDeliberateGovernanceHold(detail)
+      detail.indexability_status = record.indexability_status
+      detail.robots = record.robots
+      detail.sitemap_included = record.sitemap_included
+      detail.indexability_reasons = [...record.indexability_reasons]
+      detail.governance = { ...record.governance }
+      await writeJson(detailPath, detail)
+    }
+  }
+
+  if (corrected.length > 0) await writeJson(listPath, records)
+  return { corrected: corrected.sort() }
+}
+
+export async function reconcileDeliberateGovernanceHolds({ dataDir = 'public/data' } = {}) {
+  const root = path.resolve(process.cwd(), dataDir)
+  const herbs = await reconcileCollection(root, 'herbs.json', 'herbs-detail')
+  const compounds = await reconcileCollection(root, 'compounds.json', 'compounds-detail')
+  return {
+    herbs: herbs.corrected,
+    compounds: compounds.corrected,
+    total: herbs.corrected.length + compounds.corrected.length,
+  }
+}

--- a/scripts/data/governance-hold-policy.test.mjs
+++ b/scripts/data/governance-hold-policy.test.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  applyDeliberateGovernanceHold,
+  isDeliberateGovernanceHold,
+} from './governance-hold-policy.mjs'
+
+test('hidden_until_grounded remains held even when a curated overlay promoted it', () => {
+  const record = {
+    slug: 'black-cohosh',
+    runtime_export_decision: 'hidden_until_grounded',
+    indexability_status: 'PUBLISH',
+    robots: 'index,follow',
+    sitemap_included: true,
+    indexability_reasons: ['noindex-decision:hidden_until_grounded', 'curated_allowlist'],
+    governance: {
+      indexingAllowed: true,
+      reviewStatus: 'approved',
+      recommendationAllowed: true,
+      requiresHumanReview: false,
+      reason: 'curated_allowlist',
+    },
+  }
+
+  assert.equal(isDeliberateGovernanceHold(record), true)
+  assert.equal(applyDeliberateGovernanceHold(record), true)
+  assert.equal(record.indexability_status, 'NEEDS_REVIEW')
+  assert.equal(record.robots, 'noindex,follow')
+  assert.equal(record.sitemap_included, false)
+  assert.equal(record.governance.indexingAllowed, false)
+  assert.equal(record.governance.requiresHumanReview, true)
+  assert.equal(record.governance.recommendationAllowed, false)
+})
+
+test('research_only profile status outranks curated allowlisting', () => {
+  const record = {
+    slug: 'acetyl-l-carnitine',
+    profile_status: 'research_only',
+    indexability_status: 'PUBLISH',
+    robots: 'index,follow',
+    sitemap_included: true,
+    indexability_reasons: ['profile-status:research_only', 'curated_allowlist'],
+  }
+
+  assert.equal(applyDeliberateGovernanceHold(record), true)
+  assert.equal(record.indexability_status, 'NEEDS_REVIEW')
+})
+
+test('normal curated publish records are unchanged', () => {
+  const record = {
+    slug: 'magnesium',
+    runtime_export_decision: 'full_public_runtime',
+    profile_status: 'complete',
+    indexability_status: 'PUBLISH',
+    robots: 'index,follow',
+    sitemap_included: true,
+    indexability_reasons: ['curated_allowlist'],
+  }
+
+  assert.equal(isDeliberateGovernanceHold(record), false)
+  assert.equal(applyDeliberateGovernanceHold(record), false)
+  assert.equal(record.indexability_status, 'PUBLISH')
+})

--- a/scripts/data/governance-hold-policy.test.mjs
+++ b/scripts/data/governance-hold-policy.test.mjs
@@ -1,63 +1,64 @@
-import assert from 'node:assert/strict'
-import test from 'node:test'
+import { describe, expect, it } from 'vitest'
 import {
   applyDeliberateGovernanceHold,
   isDeliberateGovernanceHold,
 } from './governance-hold-policy.mjs'
 
-test('hidden_until_grounded remains held even when a curated overlay promoted it', () => {
-  const record = {
-    slug: 'black-cohosh',
-    runtime_export_decision: 'hidden_until_grounded',
-    indexability_status: 'PUBLISH',
-    robots: 'index,follow',
-    sitemap_included: true,
-    indexability_reasons: ['noindex-decision:hidden_until_grounded', 'curated_allowlist'],
-    governance: {
-      indexingAllowed: true,
-      reviewStatus: 'approved',
-      recommendationAllowed: true,
-      requiresHumanReview: false,
-      reason: 'curated_allowlist',
-    },
-  }
+describe('deliberate governance hold precedence', () => {
+  it('keeps hidden_until_grounded held even when a curated overlay promoted it', () => {
+    const record = {
+      slug: 'black-cohosh',
+      runtime_export_decision: 'hidden_until_grounded',
+      indexability_status: 'PUBLISH',
+      robots: 'index,follow',
+      sitemap_included: true,
+      indexability_reasons: ['noindex-decision:hidden_until_grounded', 'curated_allowlist'],
+      governance: {
+        indexingAllowed: true,
+        reviewStatus: 'approved',
+        recommendationAllowed: true,
+        requiresHumanReview: false,
+        reason: 'curated_allowlist',
+      },
+    }
 
-  assert.equal(isDeliberateGovernanceHold(record), true)
-  assert.equal(applyDeliberateGovernanceHold(record), true)
-  assert.equal(record.indexability_status, 'NEEDS_REVIEW')
-  assert.equal(record.robots, 'noindex,follow')
-  assert.equal(record.sitemap_included, false)
-  assert.equal(record.governance.indexingAllowed, false)
-  assert.equal(record.governance.requiresHumanReview, true)
-  assert.equal(record.governance.recommendationAllowed, false)
-})
+    expect(isDeliberateGovernanceHold(record)).toBe(true)
+    expect(applyDeliberateGovernanceHold(record)).toBe(true)
+    expect(record.indexability_status).toBe('NEEDS_REVIEW')
+    expect(record.robots).toBe('noindex,follow')
+    expect(record.sitemap_included).toBe(false)
+    expect(record.governance.indexingAllowed).toBe(false)
+    expect(record.governance.requiresHumanReview).toBe(true)
+    expect(record.governance.recommendationAllowed).toBe(false)
+  })
 
-test('research_only profile status outranks curated allowlisting', () => {
-  const record = {
-    slug: 'acetyl-l-carnitine',
-    profile_status: 'research_only',
-    indexability_status: 'PUBLISH',
-    robots: 'index,follow',
-    sitemap_included: true,
-    indexability_reasons: ['profile-status:research_only', 'curated_allowlist'],
-  }
+  it('keeps research_only profile status ahead of curated allowlisting', () => {
+    const record = {
+      slug: 'acetyl-l-carnitine',
+      profile_status: 'research_only',
+      indexability_status: 'PUBLISH',
+      robots: 'index,follow',
+      sitemap_included: true,
+      indexability_reasons: ['profile-status:research_only', 'curated_allowlist'],
+    }
 
-  assert.equal(applyDeliberateGovernanceHold(record), true)
-  assert.equal(record.indexability_status, 'NEEDS_REVIEW')
-})
+    expect(applyDeliberateGovernanceHold(record)).toBe(true)
+    expect(record.indexability_status).toBe('NEEDS_REVIEW')
+  })
 
-test('normal curated publish records are unchanged', () => {
-  const record = {
-    slug: 'magnesium',
-    runtime_export_decision: 'full_public_runtime',
-    profile_status: 'complete',
-    indexability_status: 'PUBLISH',
-    robots: 'index,follow',
-    sitemap_included: true,
-    indexability_reasons: ['curated_allowlist'],
-  }
+  it('leaves normal curated publish records unchanged', () => {
+    const record = {
+      slug: 'magnesium',
+      runtime_export_decision: 'full_public_runtime',
+      profile_status: 'complete',
+      indexability_status: 'PUBLISH',
+      robots: 'index,follow',
+      sitemap_included: true,
+      indexability_reasons: ['curated_allowlist'],
+    }
 
-  assert.equal(isDeliberateGovernanceHold(record), false)
-  assert.equal(applyDeliberateGovernanceHold(record), false)
-  assert.equal(record.indexability_status, 'PUBLISH')
+    expect(isDeliberateGovernanceHold(record)).toBe(false)
+    expect(applyDeliberateGovernanceHold(record)).toBe(false)
+    expect(record.indexability_status).toBe('PUBLISH')
+  })
 })


### PR DESCRIPTION
## What changed
- add workbook postprocessing to the production deploy pipeline immediately after runtime generation
- add the canonical governance/evidence overlay before related maps, route manifests, sitemap manifests, semantic snapshots, and the Next build
- force the small postprocess/governance passes to run even when heavier generation steps are cached
- document the production-critical ordering
- add a regression test that fails if governance moves behind route/sitemap generation or becomes cache-skippable

## Why
The full data pipeline already applies postprocessing and governance, but the production deploy path regenerated runtime JSON without them. That can produce split-brain records such as governance.indexingAllowed=false alongside indexability_status=PUBLISH / robots=index,follow, and then bake the regenerated state into downstream manifests and HTML.

## Validation
Full CI/build pipeline plus focused ordering regression.