### PR TITLE
Use reader-facing wording for pending safety badges

### DIFF
--- a/app/__tests__/a11y.test.tsx
+++ b/app/__tests__/a11y.test.tsx
@@ -14,13 +14,14 @@ async function checkA11y(container: HTMLElement) {
 }
 
 describe('a11y (axe-core)', () => {
-  it('SafetyBadge for pending status has accessible label and no serious violations', async () => {
+  it('SafetyBadge for pending status has accessible public wording and no serious violations', async () => {
     const { container } = render(<SafetyBadge level="Safety review pending" />)
-    // Visible text
-    expect(screen.getByText(/Safety review pending/i)).toBeInTheDocument()
-    // Has explanatory aria for ambiguous state
-    const badge = screen.getByText(/Safety review pending/i).closest('span')
-    expect(badge).toHaveAttribute('aria-label', expect.stringContaining('pending review'))
+    // Public text communicates the evidence state rather than the editorial workflow state.
+    expect(screen.getByText(/Safety data limited/i)).toBeInTheDocument()
+    expect(screen.queryByText(/Safety review pending/i)).not.toBeInTheDocument()
+    // The ambiguous/limited state still has an actionable accessible explanation.
+    const badge = screen.getByText(/Safety data limited/i).closest('span')
+    expect(badge).toHaveAttribute('aria-label', expect.stringMatching(/data.*limited.*caution.*full profile/i))
     await checkA11y(container)
   })
 

--- a/components/ui/SafetyBadge.tsx
+++ b/components/ui/SafetyBadge.tsx
@@ -6,18 +6,19 @@ import {
 } from '@/lib/decision-primitives'
 
 export default function SafetyBadge({ level = 'Safety review pending' }: { level?: string }) {
-  const label = normalizeDecisionSafety(level)
-  const tone = getDecisionSafetyTone(label)
-  const isPending = label === 'Safety review pending'
+  const normalizedLabel = normalizeDecisionSafety(level)
+  const isPending = normalizedLabel === 'Safety review pending'
+  const label = isPending ? 'Safety data limited' : normalizedLabel
+  const tone = getDecisionSafetyTone(normalizedLabel)
   const aria = isPending
-    ? 'Safety data pending review; use caution and review the full profile before choosing.'
+    ? 'Safety data are limited; use caution and review the full profile before choosing.'
     : undefined
 
   return (
     <span
       className={`${decisionStatusBadgeClass} ${safetyToneClasses(tone)}`}
       aria-label={aria}
-      title={isPending ? 'Safety data is still under review' : undefined}
+      title={isPending ? 'Safety data are limited; review the full profile' : undefined}
     >
       {label}
     </span>

--- a/components/ui/__tests__/SafetyBadge.test.tsx
+++ b/components/ui/__tests__/SafetyBadge.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import SafetyBadge from '../SafetyBadge'
+
+describe('SafetyBadge', () => {
+  it('keeps pending-review workflow state out of reader-facing copy', () => {
+    render(<SafetyBadge />)
+
+    expect(screen.getByText('Safety data limited')).toBeInTheDocument()
+    expect(screen.queryByText('Safety review pending')).not.toBeInTheDocument()
+    expect(screen.getByText('Safety data limited')).toHaveAttribute(
+      'aria-label',
+      'Safety data are limited; use caution and review the full profile before choosing.',
+    )
+  })
+
+  it('preserves substantive safety labels', () => {
+    render(<SafetyBadge level='Interaction risk' />)
+    expect(screen.getByText('Interaction risk')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## What changed
- keep the internal `Safety review pending` normalization state unchanged
- render that state to readers as `Safety data limited` only in the shared public `SafetyBadge`
- add an accessible explanation that limited data require caution and full-profile review
- preserve substantive states such as `Interaction risk`
- add focused component regression coverage

## Why
Editorial workflow state is useful internally, but reader-facing decision cards should communicate the evidence state rather than the implementation queue. This keeps the internal safety model intact while removing prototype-looking copy from public goal/decision cards.

## Validation
Full CI from fresh main + focused SafetyBadge regression.