### PR TITLE
Extend affiliate claim guard

### DIFF
--- a/src/lib/__tests__/affiliate-copy.test.ts
+++ b/src/lib/__tests__/affiliate-copy.test.ts
@@ -15,6 +15,41 @@ describe('affiliateRationaleForDisplay', () => {
     expect(result).not.toMatch(/well-reviewed/i)
   })
 
+  it('removes sweeping researcher-preference claims from unsourced retail rationale', () => {
+    const result = affiliateRationaleForDisplay(
+      'NOW Melatonin 3 mg',
+      'Budget pick for a common 3 mg melatonin capsule — lower dose preferred by most sleep researchers.',
+    )
+
+    expect(result).toContain('3 mg serving')
+    expect(result).not.toMatch(/preferred by most sleep researchers/i)
+  })
+
+  it('removes unsourced absorption or bioavailability superiority from retail rationale', () => {
+    const faster = affiliateRationaleForDisplay(
+      'Example Liquid Extract',
+      'Premium liquid extract for faster absorption and flexible dosing.',
+    )
+    const superior = affiliateRationaleForDisplay(
+      'Example Phytosome',
+      'Premium form with superior bioavailability over the standard extract.',
+    )
+
+    expect(faster).not.toMatch(/faster absorption/i)
+    expect(superior).not.toMatch(/superior bioavailability/i)
+    expect(faster).toMatch(/product-format example/i)
+    expect(superior).toMatch(/product-format example/i)
+  })
+
+  it('removes dynamic popularity claims when no live source is attached to the card', () => {
+    const result = affiliateRationaleForDisplay(
+      'Example Product',
+      'Simple format and well-reviewed by shoppers.',
+    )
+
+    expect(result).not.toMatch(/well-reviewed/i)
+  })
+
   it('preserves ordinary sourcing rationale', () => {
     expect(
       affiliateRationaleForDisplay(

--- a/src/lib/affiliate-copy.ts
+++ b/src/lib/affiliate-copy.ts
@@ -1,7 +1,19 @@
+const DEFAULT_FALLBACK =
+  'Review the label, dose, third-party testing, and safety context before buying.'
+
+const DYNAMIC_OR_UNSOURCED_SUPERIORITY =
+  /\b(well[- ]reviewed|preferred by most sleep researchers|faster absorption|superior bioavailability)\b/i
+
+function formatFirstPassFallback(productName: string): string {
+  const doseMatch = productName.match(/\b\d+(?:\.\d+)?\s*(?:mg|mcg|µg)\b/i)?.[0]
+  const doseContext = doseMatch ? ` with a clearly labeled ${doseMatch} dose` : ''
+  return `${productName} uses a fast-dissolve format${doseContext}. Treat the dosage form as a convenience feature, not evidence of superior absorption or better clinical outcomes.`
+}
+
 export function affiliateRationaleForDisplay(
   productName: string,
   rationale?: string,
-  fallback = 'Review the label, dose, third-party testing, and safety context before buying.',
+  fallback = DEFAULT_FALLBACK,
 ): string {
   const text = rationale?.trim() || fallback
 
@@ -10,9 +22,17 @@ export function affiliateRationaleForDisplay(
   // different administration system. In particular, "fast dissolve" tablets are
   // not automatically equivalent to validated oral-transmucosal delivery systems.
   if (/\b(?:avoid|avoids|bypass|bypasses|skip|skips)(?:ing)?\s+(?:hepatic\s+)?first[- ]pass\s+metabolism\b/i.test(text)) {
+    return formatFirstPassFallback(productName)
+  }
+
+  // Retail rationale is rendered on decision/commercial surfaces without a source
+  // attached to the product card. Dynamic popularity claims and pharmacokinetic
+  // superiority therefore should not survive into public copy unless they are moved
+  // into a source-backed editorial section instead.
+  if (DYNAMIC_OR_UNSOURCED_SUPERIORITY.test(text)) {
     const doseMatch = productName.match(/\b\d+(?:\.\d+)?\s*(?:mg|mcg|µg)\b/i)?.[0]
-    const doseContext = doseMatch ? ` with a clearly labeled ${doseMatch} dose` : ''
-    return `${productName} uses a fast-dissolve format${doseContext}. Treat the dosage form as a convenience feature, not evidence of superior absorption or better clinical outcomes.`
+    const doseContext = doseMatch ? ` The product label identifies a ${doseMatch} serving.` : ''
+    return `Use ${productName} as a product-format example.${doseContext} Verify formulation, serving size, third-party testing, and safety context before buying.`
   }
 
   return text


### PR DESCRIPTION
## What changed
- extend the existing shared affiliate-copy sanitizer rather than adding a parallel commercial-copy layer
- retain the existing fast-dissolve / first-pass protection
- remove unsourced dynamic popularity claims such as “well-reviewed”
- remove sweeping researcher-preference claims from retail rationale
- remove unsourced “faster absorption” and “superior bioavailability” superiority claims from product cards
- preserve ordinary objective sourcing/form rationale
- add focused regression coverage

## Why
Affiliate product cards do not attach claim-level evidence. They should describe observable product attributes and sourcing factors, while pharmacokinetic superiority or popularity claims belong in source-backed editorial content.

## Supersedes
This is the conflict-free, smaller successor to #2566 after main gained the initial first-pass sanitizer.

## Validation
CI + affiliate-copy regressions.