### PR TITLE
Normalize machine-readable herb entity schema

### DIFF
--- a/scripts/ci/audit-ai-entity-completeness.mjs
+++ b/scripts/ci/audit-ai-entity-completeness.mjs
@@ -2,7 +2,7 @@
 
 import fs from 'node:fs/promises'
 import path from 'node:path'
-import { buildAiEntityArtifacts } from '../data/ai-entity-enrichment-lib.mjs'
+import { buildAiEntityArtifacts } from '../data/ai-entity-artifacts.mjs'
 
 const ROOT = process.cwd()
 const DATA_DIR_ARG = process.argv.find((arg) => arg.startsWith('--data-dir='))

--- a/scripts/data/ai-entity-artifacts.mjs
+++ b/scripts/data/ai-entity-artifacts.mjs
@@ -1,0 +1,58 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { buildAiEntityArtifacts as buildBaseAiEntityArtifacts } from './ai-entity-enrichment-lib.mjs'
+
+function normalizeSchemaTypes(value) {
+  if (Array.isArray(value)) return value.map(normalizeSchemaTypes)
+  if (!value || typeof value !== 'object') return value
+
+  const normalized = {}
+  for (const [key, entry] of Object.entries(value)) {
+    if (key === '@type') {
+      if (entry === 'MedicalSubstance') {
+        normalized[key] = 'Substance'
+        continue
+      }
+      if (Array.isArray(entry)) {
+        normalized[key] = entry.map((type) => type === 'MedicalSubstance' ? 'Substance' : type)
+        continue
+      }
+    }
+    normalized[key] = normalizeSchemaTypes(entry)
+  }
+  return normalized
+}
+
+async function normalizeArtifactDirectory(directory) {
+  let names = []
+  try {
+    names = await fs.readdir(directory)
+  } catch {
+    return
+  }
+
+  await Promise.all(names
+    .filter((name) => name.endsWith('.json'))
+    .map(async (name) => {
+      const filePath = path.join(directory, name)
+      const raw = await fs.readFile(filePath, 'utf8')
+      if (!raw.includes('MedicalSubstance')) return
+      const parsed = JSON.parse(raw)
+      const normalized = normalizeSchemaTypes(parsed)
+      await fs.writeFile(filePath, `${JSON.stringify(normalized)}\n`, 'utf8')
+    }))
+}
+
+export async function normalizeAiEntitySchemaTypes(dataDir = 'public/data') {
+  const root = path.resolve(process.cwd(), dataDir, 'ai-entities')
+  await Promise.all([
+    normalizeArtifactDirectory(path.join(root, 'herb')),
+    normalizeArtifactDirectory(path.join(root, 'compound')),
+  ])
+}
+
+export async function buildAiEntityArtifacts(args = {}) {
+  const report = await buildBaseAiEntityArtifacts(args)
+  await normalizeAiEntitySchemaTypes(args.dataDir || 'public/data')
+  return report
+}

--- a/scripts/data/ai-entity-enrichment-smoke.mjs
+++ b/scripts/data/ai-entity-enrichment-smoke.mjs
@@ -4,7 +4,7 @@ import assert from 'node:assert/strict'
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
-import { buildAiEntityArtifacts } from './ai-entity-enrichment-lib.mjs'
+import { buildAiEntityArtifacts } from './ai-entity-artifacts.mjs'
 
 const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'ths-ai-entity-'))
 const previousCwd = process.cwd()
@@ -77,21 +77,38 @@ try {
         },
       },
     ],
-    compounds: [],
+    compounds: [
+      {
+        slug: 'test-compound',
+        name: 'Test Compound',
+        relatedEntities: [
+          {
+            entityType: 'herb',
+            slug: 'test-herb',
+            relationshipType: 'found-in',
+          },
+        ],
+      },
+    ],
   })
 
-  assert.equal(report.summary.entities, 1)
+  assert.equal(report.summary.entities, 2)
   assert.ok(report.summary.averageScore > 0)
 
-  const artifactPath = path.join(dataDir, 'ai-entities', 'herb', 'test-herb.json')
+  const herbArtifactPath = path.join(dataDir, 'ai-entities', 'herb', 'test-herb.json')
+  const compoundArtifactPath = path.join(dataDir, 'ai-entities', 'compound', 'test-compound.json')
   const manifestPath = path.join(dataDir, 'ai-entities', 'manifest.json')
-  const artifact = JSON.parse(await fs.readFile(artifactPath, 'utf8'))
+  const herbArtifact = JSON.parse(await fs.readFile(herbArtifactPath, 'utf8'))
+  const compoundArtifact = JSON.parse(await fs.readFile(compoundArtifactPath, 'utf8'))
   const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'))
 
-  assert.equal(artifact['@context'], 'https://schema.org')
-  assert.ok(artifact['@graph'].some((node) => node['@type'] === 'Claim'))
-  assert.ok(artifact['@graph'].some((node) => node['@type'] === 'ScholarlyArticle'))
-  assert.equal(manifest.entities[0].dataUrl, '/data/ai-entities/herb/test-herb.json')
+  assert.equal(herbArtifact['@context'], 'https://schema.org')
+  assert.ok(herbArtifact['@graph'].some((node) => node['@type'] === 'Claim'))
+  assert.ok(herbArtifact['@graph'].some((node) => node['@type'] === 'ScholarlyArticle'))
+  assert.ok(herbArtifact['@graph'].some((node) => Array.isArray(node['@type']) && node['@type'].includes('Substance')))
+  assert.ok(!JSON.stringify(herbArtifact).includes('MedicalSubstance'))
+  assert.ok(!JSON.stringify(compoundArtifact).includes('MedicalSubstance'))
+  assert.equal(manifest.entities.find((entry) => entry.slug === 'test-herb')?.dataUrl, '/data/ai-entities/herb/test-herb.json')
 
   console.log('AI entity enrichment smoke test passed.')
 } finally {

--- a/scripts/data/build-runtime-summary-indexes.mjs
+++ b/scripts/data/build-runtime-summary-indexes.mjs
@@ -7,7 +7,7 @@ import {
   printBuildTimingReport,
 } from '../ci/report-build-stage-timings.mjs'
 import { exportCanonicalCitationsToRuntime } from './canonical/citation-export.mjs'
-import { buildAiEntityArtifacts } from './ai-entity-enrichment-lib.mjs'
+import { buildAiEntityArtifacts } from './ai-entity-artifacts.mjs'
 
 const DATA_DIR_ARG = process.argv.find((arg) => arg.startsWith('--data-dir='))
 const DATA_DIR = DATA_DIR_ARG


### PR DESCRIPTION
## What changed
- add a shared AI-entity artifact wrapper that normalizes non-canonical `MedicalSubstance` types to Schema.org `Substance`
- normalize both herb entity nodes and herb relationship mentions, including herb mentions inside compound artifacts
- route runtime summary generation and the AI-entity completeness audit through the normalized builder
- expand the smoke test to assert no generated herb/compound artifact contains `MedicalSubstance`

## Why
The rendered herb profile graph is now normalized, but the linked machine-readable `/data/ai-entities/...` JSON-LD corpus was still emitting `MedicalSubstance` for herbs. Those artifacts are explicitly exposed for machine/AI entity resolution, so the HTML graph and downloadable entity graph should agree on one canonical botanical entity type.

## Validation
AI entity smoke test + full CI/data build.