### PR TITLE
Stop generic newsletter signups from inheriting ADHD tag

### DIFF
--- a/app/__tests__/mailchimp-integration.test.ts
+++ b/app/__tests__/mailchimp-integration.test.ts
@@ -25,19 +25,27 @@ describe('mailchimp signup config', () => {
     vi.resetModules()
   })
 
-  it('uses the local subscribe endpoint as a client-post API action by default', async () => {
+  it('uses the generic safety subscribe endpoint as a client-post API action by default', async () => {
     delete process.env.NEXT_PUBLIC_MAILCHIMP_FORM_ACTION
     delete process.env.NEXT_PUBLIC_EMAIL_CAPTURE_ACTION
 
     const { mailchimpSignupConfig, validateMailchimpConfig } = await loadConfig()
 
-    expect(mailchimpSignupConfig.action).toBe('/api/subscribe')
+    expect(mailchimpSignupConfig.action).toBe('/api/subscribe-safety')
     expect(mailchimpSignupConfig.isApiAction).toBe(true)
     expect(mailchimpSignupConfig.isMailchimpAction).toBe(false)
     expect(validateMailchimpConfig()).toEqual({
       ok: true,
       message: 'Using Cloudflare Pages Function newsletter endpoint.',
     })
+  })
+
+  it('migrates the legacy internal subscribe action to the generic safety endpoint', async () => {
+    process.env.NEXT_PUBLIC_MAILCHIMP_FORM_ACTION = '/api/subscribe'
+    delete process.env.NEXT_PUBLIC_EMAIL_CAPTURE_ACTION
+
+    const { mailchimpSignupConfig } = await loadConfig()
+    expect(mailchimpSignupConfig.action).toBe('/api/subscribe-safety')
   })
 
   it('detects Mailchimp hosted form actions', async () => {

--- a/app/__tests__/subscribe-safety.test.ts
+++ b/app/__tests__/subscribe-safety.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { onRequest } from '../../functions/api/subscribe-safety'
+
+type MockKV = {
+  get(key: string): Promise<string | null>
+  put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>
+  delete(key: string): Promise<void>
+}
+
+function createMockKV(): MockKV {
+  const store = new Map<string, string>()
+  return {
+    get: vi.fn(async (key: string) => store.get(key) || null),
+    put: vi.fn(async (key: string, value: string) => {
+      store.set(key, value)
+    }),
+    delete: vi.fn(async (key: string) => {
+      store.delete(key)
+    }),
+  }
+}
+
+function request(email = 'reader@example.com') {
+  return new Request('https://thehippiescientist.net/api/subscribe-safety', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Origin: 'https://thehippiescientist.net',
+    },
+    body: JSON.stringify({
+      email,
+      magnet: 'supplement-safety-checklist',
+    }),
+  })
+}
+
+describe('/api/subscribe-safety segmentation', () => {
+  const originalFetch = globalThis.fetch
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    vi.restoreAllMocks()
+  })
+
+  it('uses the safety-checklist tag instead of the legacy ADHD tag', async () => {
+    const calls: Array<{ url: string; body: string }> = []
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ url: String(input), body: String(init?.body || '') })
+      return new Response(JSON.stringify({ ok: true }), { status: 200 })
+    }) as typeof fetch
+
+    const response = await onRequest({
+      request: request(),
+      env: {
+        MAILCHIMP_API_KEY: 'test-key',
+        MAILCHIMP_API_SERVER: 'us19',
+        MAILCHIMP_LIST_ID: 'test-audience',
+        MAILCHIMP_ADHD_TAG: 'adhd-tag',
+        MAILCHIMP_SAFETY_CHECKLIST_TAG: 'safety-checklist',
+        RATE_LIMIT_KV: createMockKV(),
+      },
+    } as Parameters<typeof onRequest>[0])
+
+    expect(response.status).toBe(200)
+    expect(calls).toHaveLength(2)
+    expect(calls[1].url).toMatch(/\/tags$/)
+    expect(calls[1].body).toContain('safety-checklist')
+    expect(calls[1].body).not.toContain('adhd-tag')
+  })
+
+  it('does not tag a generic subscriber as ADHD when no safety tag is configured', async () => {
+    const fetchSpy = vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 }))
+    globalThis.fetch = fetchSpy as typeof fetch
+
+    const response = await onRequest({
+      request: request('generic@example.com'),
+      env: {
+        MAILCHIMP_API_KEY: 'test-key',
+        MAILCHIMP_API_SERVER: 'us19',
+        MAILCHIMP_LIST_ID: 'test-audience',
+        MAILCHIMP_ADHD_TAG: 'adhd-tag',
+        RATE_LIMIT_KV: createMockKV(),
+      },
+    } as Parameters<typeof onRequest>[0])
+
+    expect(response.status).toBe(200)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/functions/api/subscribe-safety.ts
+++ b/functions/api/subscribe-safety.ts
@@ -1,0 +1,27 @@
+import { onRequest as subscribe } from './subscribe'
+
+type SubscribeContext = Parameters<typeof subscribe>[0]
+type SafetySignupEnv = SubscribeContext['env'] & {
+  MAILCHIMP_SAFETY_CHECKLIST_TAG?: string
+}
+
+/**
+ * Generic site-wide safety-checklist signup.
+ *
+ * Reuses the hardened /api/subscribe implementation (origin checks, Turnstile,
+ * rate limiting, Mailchimp upsert) while preventing its legacy ADHD tag from
+ * being stamped onto generic subscribers. If a dedicated safety-checklist tag
+ * is configured, feed it through the existing tag-writing path.
+ */
+export const onRequest = async (context: SubscribeContext): Promise<Response> => {
+  const env = context.env as SafetySignupEnv
+  const safetyTag = env.MAILCHIMP_SAFETY_CHECKLIST_TAG?.trim()
+
+  return subscribe({
+    ...context,
+    env: {
+      ...env,
+      MAILCHIMP_ADHD_TAG: safetyTag || undefined,
+    },
+  })
+}

--- a/lib/mailchimp-integration.ts
+++ b/lib/mailchimp-integration.ts
@@ -1,4 +1,4 @@
-const fallbackAction = '/api/subscribe'
+const fallbackAction = '/api/subscribe-safety'
 
 function getMailchimpHoneypotName(action: string): string {
   try {
@@ -11,10 +11,18 @@ function getMailchimpHoneypotName(action: string): string {
   }
 }
 
-const rawAction =
+const configuredAction =
   process.env.NEXT_PUBLIC_MAILCHIMP_FORM_ACTION?.trim() ||
   process.env.NEXT_PUBLIC_EMAIL_CAPTURE_ACTION?.trim() ||
-  fallbackAction
+  ''
+
+// `/api/subscribe` is the legacy ADHD capture endpoint. Existing deployments may
+// still carry that value in an environment variable, so migrate it at read time
+// for the generic NewsletterSignup instead of silently mis-tagging new safety-list
+// subscribers. External Mailchimp actions remain untouched.
+const rawAction = !configuredAction || configuredAction === '/api/subscribe'
+  ? fallbackAction
+  : configuredAction
 
 const isMailchimpAction = rawAction.includes('list-manage.com')
 const isApiAction = rawAction.startsWith('/api/')


### PR DESCRIPTION
## What changed
- add `/api/subscribe-safety` as a thin wrapper around the existing hardened subscribe endpoint
- generic site-wide newsletter/safety-checklist capture now uses that endpoint
- suppress the legacy ADHD tag for generic subscribers
- optionally apply `MAILCHIMP_SAFETY_CHECKLIST_TAG` when configured
- preserve the existing `/api/subscribe` path for ADHD-specific article capture
- migrate an old internal `/api/subscribe` newsletter action to the safety endpoint at config-read time
- add focused segmentation regressions

## Why
The site-wide lead magnet is now a general supplement safety checklist, while the backend still applied `MAILCHIMP_ADHD_TAG` to every successful subscriber whenever that env var existed. That degrades audience segmentation and future email performance measurement.

## Validation
CI + subscribe endpoint regressions.