### PR TITLE
Calibrate Ashwagandha anxiety claims and buying path

### DIFF
--- a/app/guides/anxiety/__tests__/ashwagandha-for-anxiety-claims.test.ts
+++ b/app/guides/anxiety/__tests__/ashwagandha-for-anxiety-claims.test.ts
@@ -1,0 +1,33 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const pagePath = path.join(
+  process.cwd(),
+  'app/guides/anxiety/ashwagandha-for-anxiety/page.tsx',
+)
+const source = fs.readFileSync(pagePath, 'utf8')
+
+describe('Ashwagandha for Anxiety claim and conversion discipline', () => {
+  it('does not promise acute L-theanine efficacy or reassure about combination safety', () => {
+    expect(source).not.toMatch(/works? within\s+30/i)
+    expect(source).not.toMatch(/no well-documented major interactions/i)
+    expect(source).not.toMatch(/cleaner first choice/i)
+    expect(source).not.toMatch(/fastest useful choice/i)
+    expect(source).toMatch(/does not establish that ashwagandha and magnesium are safe or beneficial to combine/i)
+  })
+
+  it('keeps one curated, tracked buying path instead of generic Amazon search exits', () => {
+    expect(source).not.toMatch(/AFFILIATE_TAGS/)
+    expect(source).not.toMatch(/amazon\.com\/s\?k=/i)
+    expect(source).toContain('Curated ashwagandha product examples')
+    expect(source).toContain('trackingProductSlug="ashwagandha"')
+    expect(source).toContain('trackingLocation="guide-ashwagandha-anxiety"')
+  })
+
+  it('records the editorial refresh separately from the original publish date', () => {
+    expect(source).toContain("PUBLISHED_DATE = '2026-06-10'")
+    expect(source).toContain("UPDATED_DATE = '2026-08-11'")
+    expect(source).toContain('<LastUpdatedBadge date={UPDATED_DATE} />')
+  })
+})

--- a/app/guides/anxiety/ashwagandha-for-anxiety/page.tsx
+++ b/app/guides/anxiety/ashwagandha-for-anxiety/page.tsx
@@ -9,15 +9,13 @@ import { getRevenueProductSet } from '@/config/revenue-products'
 import RecommendationSection from '@/components/RecommendationSection'
 import NewsletterCtaBlock from '@/components/NewsletterCtaBlock'
 import LastUpdatedBadge from '../../../../src/components/editorial/LastUpdatedBadge'
-import { AFFILIATE_TAGS } from '@/config/affiliate'
-
-// ─── Article metadata ─────────────────────────────────────────────────────────
 
 const SLUG = 'ashwagandha-for-anxiety'
 const TITLE = 'Ashwagandha for Anxiety: Benefits, Dosage, Safety, and Research Review'
 const DESCRIPTION =
   'An evidence-based review of ashwagandha for anxiety, including mechanisms, clinical research, dosage, safety, side effects, and how it compares with other natural anxiety supplements.'
-const DATE = '2026-06-10'
+const PUBLISHED_DATE = '2026-06-10'
+const UPDATED_DATE = '2026-08-11'
 
 export const metadata = buildPageMetadata({
   title: compactMetaTitle(TITLE),
@@ -26,42 +24,46 @@ export const metadata = buildPageMetadata({
   openGraphType: 'article',
 })
 
-// ─── FAQ data (also used for JSON-LD) ────────────────────────────────────────
-
 const FAQS = [
   {
     question: 'Does ashwagandha help anxiety?',
     answer:
-      'Ashwagandha has been studied for its potential to support stress-related anxiety. Some research suggests it may help with symptoms associated with chronic stress, though results vary and it is not a substitute for professional mental health care.',
+      'Ashwagandha has been studied for stress and anxiety-related outcomes. Some trials and meta-analyses report improvements, but studies use different extracts and populations and certainty is not uniform. It is not a substitute for professional mental health care.',
   },
   {
     question: 'How long does it take for ashwagandha to work for anxiety?',
     answer:
-      'Most studies evaluate ashwagandha over periods of 4–8 weeks or longer. It is generally not considered a fast-acting option and is typically used for ongoing support rather than immediate relief.',
+      'Most human trials evaluate ashwagandha over several weeks rather than as an immediate intervention. Those study durations do not establish a precise onset time for an individual, so avoid treating a fixed week-by-week timeline as guaranteed.',
   },
   {
     question: 'Is ashwagandha better than CBD for anxiety?',
     answer:
-      'There is limited direct comparative research. Ashwagandha has a longer history of traditional use and some clinical trial data for stress, while CBD has different regulatory status and emerging but still developing evidence. Individual responses vary significantly.',
+      'There is limited direct comparative research. Ashwagandha and CBD have different evidence bases, safety considerations, and regulatory contexts, so the available data do not establish a universal winner.',
   },
   {
     question: 'Can I take ashwagandha with magnesium?',
     answer:
-      'Many people combine ashwagandha with magnesium as part of a broader stress or sleep support routine. There are no well-documented major interactions, but it is best to introduce one supplement at a time and consult a clinician, especially if taking medications.',
+      'This article does not establish that ashwagandha and magnesium are safe or beneficial to combine. Supplement interaction data can be incomplete. Introduce one product at a time and review the full combination with a pharmacist or other qualified health professional if you take medications or have a medical condition.',
   },
   {
     question: 'Can I take ashwagandha every day?',
     answer:
-      'Daily use is common in research and traditional practice. Most studies use consistent daily dosing for several weeks. Long-term safety data is still limited, so periodic breaks or professional guidance is often recommended.',
+      'Many clinical studies use consistent daily dosing for several weeks, but that does not establish indefinite-use safety. Follow the specific product or study context and reassess ongoing use, especially if you take medications or have thyroid, autoimmune, liver, or other medical concerns.',
   },
   {
     question: 'Is ashwagandha safe for long-term use?',
     answer:
-      'Short- to medium-term use (up to several months) appears generally well-tolerated in studies. Long-term safety, particularly regarding liver, thyroid, and hormonal effects, requires more research. Regular monitoring and professional advice are advisable for extended use.',
+      'Short-term studies generally report tolerability in many participants, but long-term safety is not well established. Thyroid effects, pregnancy concerns, medication interactions, and rare liver-injury reports are reasons to review extended use with a qualified health professional.',
   },
 ]
 
-// ─── Page ─────────────────────────────────────────────────────────────────────
+const BUYING_CHECKLIST = [
+  'Match the extract and serving size to the evidence you are actually using; do not treat all ashwagandha products as interchangeable.',
+  'Prefer a label that clearly identifies the plant part, extract, serving size, and withanolide standardization.',
+  'Look for credible third-party quality testing or a readily available certificate of analysis when possible.',
+  'Avoid proprietary blends that hide the amount of ashwagandha or make it impossible to compare the serving with studied preparations.',
+  'Review pregnancy, thyroid, autoimmune, liver, sedation, and medication cautions before shopping for a product.',
+]
 
 export default function AshwagandhaForAnxietyPage() {
   const pageBreadcrumb = breadcrumbJsonLd([
@@ -71,37 +73,30 @@ export default function AshwagandhaForAnxietyPage() {
   ])
 
   const articleLd = blogJsonLd(
-    { title: TITLE, slug: SLUG, date: DATE, description: DESCRIPTION },
+    { title: TITLE, slug: SLUG, date: PUBLISHED_DATE, description: DESCRIPTION },
     `/guides/anxiety/${SLUG}/`,
   )
 
   const faqLd = faqPageJsonLd({ pagePath: `/guides/anxiety/${SLUG}/`, questions: FAQS })
+  const products = getRevenueProductSet('ashwagandha')?.products ?? []
 
   return (
     <>
-      {/* JSON-LD Structured Data */}
       <JsonLd schema={articleLd} />
       <JsonLd schema={pageBreadcrumb} />
-      {faqLd && (
-        <JsonLd schema={faqLd} />
-      )}
+      {faqLd ? <JsonLd schema={faqLd} /> : null}
 
       <div className="max-w-4xl mx-auto px-4 py-8">
-        {/* Hero / Header */}
         <div className="mb-8">
-          <LastUpdatedBadge date={DATE} />
-          <h1 className="text-4xl font-bold tracking-tight mt-4 mb-4">
-            {TITLE}
-          </h1>
-          <p className="text-xl text-muted-foreground">
-            {DESCRIPTION}
-          </p>
+          <LastUpdatedBadge date={UPDATED_DATE} />
+          <h1 className="text-4xl font-bold tracking-tight mt-4 mb-4">{TITLE}</h1>
+          <p className="text-xl text-muted-foreground">{DESCRIPTION}</p>
 
           <figure className="mt-6">
             <div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white">
               <Image
                 src="/images/guides/ashwagandha-for-anxiety.jpg"
-                alt="Dried ashwagandha roots, leaves, and golden powder — an adaptogen used to reduce stress and anxiety"
+                alt="Dried ashwagandha roots, leaves, and golden powder used in ashwagandha supplements"
                 width={1536}
                 height={1024}
                 priority
@@ -109,105 +104,83 @@ export default function AshwagandhaForAnxietyPage() {
               />
             </div>
             <figcaption className="mt-3 text-center text-sm text-muted-foreground">
-              Ashwagandha (Withania somnifera) — an adaptogen with clinical evidence for lowering stress and anxiety.
+              Ashwagandha (<em>Withania somnifera</em>) has been studied for stress and anxiety-related outcomes, with important extract and study differences.
             </figcaption>
           </figure>
         </div>
 
-        {/* Affiliate Disclosure */}
         <div className="prose prose-sm mb-8 p-4 bg-muted/50 rounded-lg">
           <p className="text-sm">
-            <strong>Affiliate Disclosure:</strong> This article contains affiliate links.
-            If you make a purchase through these links, we may earn a small commission at no extra cost to you.
-            This helps support our research and content. We only recommend products we believe offer genuine value.
+            <strong>Affiliate Disclosure:</strong> This article contains affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you. Product examples appear only after the evidence and safety sections below.
           </p>
         </div>
 
-        {/* Fastest useful choice */}
         <div className="mb-10 p-6 border border-brand-700/30 rounded-xl bg-brand-50/60">
-          <h2 className="text-2xl font-semibold mb-4">Fastest useful choice</h2>
+          <h2 className="text-2xl font-semibold mb-4">Timing and fit at a glance</h2>
           <p className="text-muted-foreground">
-            <strong>Ashwagandha is not the fastest useful choice for anxiety.</strong>{' '}
-            Onset is slow &mdash; meaningful effects typically require 6&ndash;8 weeks of consistent
-            use at 300&ndash;600&nbsp;mg/day of a standardized extract (KSM-66 or Sensoril). If you
-            need faster relief for racing thoughts or situational anxiety,{' '}
+            <strong>Ashwagandha should not be treated as an acute anxiety treatment.</strong>{' '}
+            Most human trials evaluate a specific extract over multiple weeks, so those trial durations are better read as study context than as a promised onset timeline. The evidence also does not establish that{' '}
             <Link href="/guides/herbs/l-theanine/" className="text-primary underline font-semibold">L-theanine</Link>{' '}
-            (100&ndash;200&nbsp;mg) works within 30&ndash;60 minutes and is a cleaner first choice for
-            acute anxiety. Ashwagandha is best reserved for chronic, stress-driven anxiety where you can
-            commit to a multi-week course. See the{' '}
-            <Link href="/guides/herbs/ashwagandha/" className="text-primary underline font-semibold">ashwagandha article</Link>{' '}
-            for the full evidence review and the{' '}
-            <Link href="/guides/anxiety/natural-anxiety-relief/" className="text-primary underline font-semibold">natural anxiety relief hub</Link>{' '}
-            for how it fits alongside other options.
+            is a universally faster or better choice for situational anxiety. If symptoms are severe, sudden, or impairing, prioritize clinical evaluation rather than trying to optimize supplement timing. For a broader decision path, review the{' '}
+            <Link href="/guides/herbs/ashwagandha/" className="text-primary underline font-semibold">ashwagandha evidence review</Link>{' '}
+            and the{' '}
+            <Link href="/guides/anxiety/natural-anxiety-relief/" className="text-primary underline font-semibold">natural anxiety relief hub</Link>.
           </p>
         </div>
 
-        {/* Quick Verdict */}
         <div className="mb-10 p-6 border rounded-xl bg-card">
           <h2 className="text-2xl font-semibold mb-4">Quick Verdict</h2>
           <ul className="space-y-2 text-muted-foreground">
-            <li>• Ashwagandha is one of the most researched herbs for stress-related anxiety.</li>
-            <li>• May be most useful when anxiety is strongly linked to chronic stress.</li>
-            <li>• Usually evaluated over weeks, not days.</li>
-            <li>• Not a replacement for emergency mental health care or prescribed treatment.</li>
-            <li>• Conservative use and professional guidance are recommended, especially with medications or health conditions.</li>
+            <li>• Multiple human trials have studied ashwagandha for stress and anxiety-related outcomes, but preparations and study quality vary.</li>
+            <li>• The evidence is more relevant to ongoing stress-related symptoms than to acute panic or crisis care.</li>
+            <li>• Trials generally evaluate use over weeks; they do not establish a guaranteed personal onset time.</li>
+            <li>• It is not a replacement for emergency mental health care, therapy, or prescribed treatment.</li>
+            <li>• Medication, pregnancy, thyroid, autoimmune, and liver context matter before use.</li>
           </ul>
-          <p className="mt-4 text-sm text-muted-foreground">
-            Evidence quality and effect sizes vary across studies. Individual results differ significantly.
-          </p>
         </div>
 
-        {/* Decision framework */}
         <section className="mb-12">
           <h2 className="text-3xl font-semibold mb-6">Is Ashwagandha the Right Tool for Your Anxiety Pattern?</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div className="border rounded-xl p-5 bg-card">
-              <h3 className="font-semibold text-lg mb-2">More plausible fit</h3>
+              <h3 className="font-semibold text-lg mb-2">More relevant evidence context</h3>
               <ul className="list-disc pl-5 space-y-2 text-muted-foreground">
-                <li>Stress has been elevated for weeks, not just during isolated events.</li>
+                <li>Stress has been elevated for weeks rather than only during isolated events.</li>
                 <li>Poor sleep and feeling persistently “on” are part of the same pattern.</li>
-                <li>You can evaluate one standardized extract consistently for 6–8 weeks.</li>
-                <li>You are not pregnant and have no thyroid, autoimmune, or liver concern.</li>
+                <li>You can evaluate one clearly labeled extract consistently and track tolerance over time.</li>
+                <li>You have reviewed pregnancy, thyroid, autoimmune, liver, and medication cautions first.</li>
               </ul>
             </div>
             <div className="border rounded-xl p-5 bg-muted/40">
               <h3 className="font-semibold text-lg mb-2">Choose a different first step</h3>
               <ul className="list-disc pl-5 space-y-2 text-muted-foreground">
                 <li><strong>Panic, crisis, or severe impairment:</strong> seek clinical support rather than self-treating.</li>
-                <li><strong>One-off performance anxiety:</strong> a slow-onset adaptogen is a poor match.</li>
+                <li><strong>One-off performance anxiety:</strong> the available ashwagandha literature does not establish acute relief.</li>
                 <li><strong>Medication or complex health history:</strong> ask a pharmacist or prescriber to screen interactions.</li>
                 <li><strong>Unclear cause:</strong> address caffeine, sleep loss, alcohol, and medical contributors first.</li>
               </ul>
             </div>
           </div>
           <p className="mt-4 text-sm text-muted-foreground">
-            This framework is a fit check, not a diagnosis. The clinical literature mostly studies
-            adults with elevated stress or anxiety over several weeks; it does not establish
-            ashwagandha as an acute treatment or a replacement for anxiety care.
+            This framework is a fit check, not a diagnosis. The clinical literature mostly studies adults with elevated stress or anxiety over several weeks; it does not establish ashwagandha as an acute treatment or a replacement for anxiety care.
           </p>
         </section>
 
-        {/* What Is Ashwagandha? */}
         <section className="mb-12">
           <h2 className="text-3xl font-semibold mb-6">What Is Ashwagandha?</h2>
           <div className="prose prose-lg max-w-none">
             <p>
-              Ashwagandha (<em>Withania somnifera</em>) is a shrub native to India and parts of Africa and the Middle East.
-              It has been used for centuries in Ayurvedic medicine as a <strong>rasayana</strong> (rejuvenative) and adaptogen.
+              Ashwagandha (<em>Withania somnifera</em>) is a shrub native to India and parts of Africa and the Middle East. It has been used for centuries in Ayurvedic medicine as a <strong>rasayana</strong> (rejuvenative) and adaptogen.
             </p>
             <p>
-              The root is the primary part used in supplements. Modern extracts are typically standardized to withanolides,
-              a group of steroidal lactones believed to contribute to its biological activity.
+              The root is the primary part used in many supplements. Modern extracts may be standardized to withanolides, a group of steroidal lactones studied as possible contributors to its biological activity.
             </p>
             <p>
-              In contemporary use, ashwagandha is most commonly positioned as an adaptogen — an herb that may help the body
-              adapt to physical and emotional stressors. This has led to significant interest in its potential role for
-              stress-related anxiety and sleep support.
+              In contemporary use, ashwagandha is commonly positioned as an adaptogen. That traditional and commercial framing is separate from the clinical question of whether a specific preparation improves a specific stress or anxiety outcome.
             </p>
           </div>
         </section>
 
-        {/* How Ashwagandha May Affect Anxiety */}
         <section className="mb-12">
           <h2 className="text-3xl font-semibold mb-6">How Ashwagandha May Affect Anxiety</h2>
           <div className="prose prose-lg max-w-none">
@@ -215,93 +188,70 @@ export default function AshwagandhaForAnxietyPage() {
               Research on ashwagandha and anxiety has largely focused on its relationship with the stress response system.
             </p>
             <p>
-              Some studies have examined its potential effects on the HPA axis (hypothalamic-pituitary-adrenal axis)
-              and cortisol levels in people experiencing chronic stress. Lowering perceived stress may indirectly
-              influence anxiety symptoms for certain individuals.
+              Some studies have examined HPA-axis and cortisol-related outcomes in people experiencing chronic stress. Those mechanistic and biomarker findings can support plausibility, but they do not by themselves prove an anxiety benefit.
             </p>
             <p>
-              There is also interest in how improved sleep quality (when present) might support emotional resilience
-              and daytime anxiety levels, creating a potential bidirectional relationship between sleep and anxiety support.
+              Sleep outcomes are also studied in some populations. When sleep improves, that may overlap with daytime wellbeing, but the sleep mechanism should not be treated as proof of an anxiety effect.
             </p>
             <p>
-              Current evidence suggests ashwagandha is more likely to be helpful for anxiety that has a strong
-              stress-related component rather than acute panic or severe clinical anxiety disorders.
-              More research is needed to clarify mechanisms and identify who is most likely to benefit.
-            </p>
-            <p className="text-sm text-muted-foreground">
-              Language note: All statements use conservative phrasing (&ldquo;may&rdquo;, &ldquo;appears to&rdquo;,
-              &ldquo;has been studied for&rdquo;) because definitive causal claims are not supported across the full body of evidence.
+              Most of the available human evidence is more relevant to stress-related populations than to acute panic or severe clinical anxiety disorders. More research is needed to clarify preparation-specific effects and who is most likely to benefit.
             </p>
           </div>
         </section>
 
-        {/* Evidence Summary */}
         <section className="mb-12">
           <h2 className="text-3xl font-semibold mb-6">Evidence Summary</h2>
-
           <EvidenceSummaryCard
             title="Ashwagandha for Anxiety &amp; Stress"
             evidenceLevel="Moderate"
-            humanEvidence="Randomized trials in adults with elevated stress or anxiety report improvements on standardized anxiety scales (e.g., PSS, GAD-7, HAM-A), with some cortisol-related signals. Most trials use KSM-66 or Sensoril extracts at 300–600 mg/day over 8–12 weeks. Evidence is stronger for perceived stress than for diagnosed anxiety disorders."
-            mechanisticEvidence="Proposed HPA-axis modulation and cortisol reduction; possible GABA-A receptor interaction via withanolides. Most mechanistic data are from animal studies, with limited direct human neurochemistry work. Withanolide standardization varies across extracts."
-            safetyProfile="Key cautions include potential thyroid modulation (monitor if thyroid conditions exist), autoimmune activation risk, contraindication in pregnancy and breastfeeding, and rare case reports of liver injury. Most trials show good tolerability at standard doses over short durations."
+            humanEvidence="Randomized trials and meta-analyses report possible improvements in stress and anxiety-related scales, but studies use varied populations, extracts, doses, and durations and show meaningful heterogeneity. The evidence is stronger for stress-related outcomes than for treating a diagnosed anxiety disorder."
+            mechanisticEvidence="Proposed HPA-axis and cortisol-related effects, plus possible GABA-related mechanisms, are biologically interesting but do not establish clinical benefit or effect size on their own."
+            safetyProfile="Important cautions include pregnancy, possible thyroid effects, autoimmune context, medication interactions, sedation, and rare reports of liver injury. Long-term safety is not well established."
           />
         </section>
 
-        {/* Dosage and Timing */}
         <section className="mb-12">
           <h2 className="text-3xl font-semibold mb-6">Dosage and Timing</h2>
           <div className="prose prose-lg max-w-none">
             <p>
-              Most human studies on ashwagandha for stress and anxiety have used daily doses in the range of
-              <strong> 300–600 mg</strong> of a standardized root extract, often taken once or twice daily.
+              Human studies use preparation-specific regimens, commonly involving standardized extracts taken daily for several weeks. A dose used in one trial should not automatically be generalized to a different extract or product.
             </p>
             <p>
-              Timing: Some people prefer morning dosing for daytime stress support, while others take it in the
-              evening if sleep support is also a goal. Consistency appears more important than exact timing in available research.
+              Some products are taken once daily and others are divided across the day. Available research does not establish one universal morning-or-evening timing rule for anxiety outcomes.
             </p>
             <p>
-              Extracts are typically standardized to withanolide content (e.g., 5% withanolides). Different
-              branded extracts (KSM-66, Sensoril, etc.) have been used in trials with varying results.
+              Check the exact extract, withanolide standardization, serving size, and study context before comparing doses. Use the product label and clinician/pharmacist guidance when medication or health conditions complicate the decision.
             </p>
           </div>
-
         </section>
 
-        {/* Ashwagandha vs L-Theanine */}
         <section className="mb-12">
           <h2 className="text-3xl font-semibold mb-6">Ashwagandha vs L-Theanine</h2>
           <div className="prose prose-lg max-w-none">
             <p>
-              <strong>Ashwagandha</strong> is generally positioned for longer-term stress adaptation and may take
-              weeks to show noticeable effects. It is often chosen when chronic stress is a primary driver of anxiety.
+              Ashwagandha studies often use multi-week protocols focused on stress-related outcomes. That does not establish a fixed personal onset time.
             </p>
             <p>
-              <strong>L-Theanine</strong> tends to act more acutely (within hours) and is frequently used for
-              promoting calm focus or easing racing thoughts without sedation. It is popular for daytime use.
+              L-theanine has a different evidence base, including some acute stress and attention paradigms, but those studies do not establish that it is a universally faster or superior anxiety treatment.
             </p>
             <p>
-              Many people use them together or at different times of day. See our comparison in the{' '}
-              <Link href="/guides/sleep/l-theanine-for-sleep/" className="text-primary underline">L-Theanine for Sleep</Link>, the umbrella{' '}
-              <Link href="/guides/herbs/l-theanine/" className="text-primary underline">L-Theanine article</Link>, and the{' '}
+              Do not infer that the two are automatically compatible because their mechanisms differ. Review each profile and the full combination safety context before stacking. See the{' '}
+              <Link href="/guides/herbs/l-theanine/" className="text-primary underline">L-Theanine article</Link>, the{' '}
               <Link href="/guides/anxiety/natural-anxiety-relief/" className="text-primary underline">Natural Anxiety Relief</Link>{' '}
-              hub. For the full{' '}
-              <Link href="/guides/herbs/ashwagandha/" className="text-primary underline">ashwagandha evidence review</Link>, see the umbrella article.
+              hub, and the{' '}
+              <Link href="/guides/herbs/ashwagandha/" className="text-primary underline">ashwagandha evidence review</Link>.
             </p>
           </div>
         </section>
 
-        {/* Ashwagandha vs Magnesium */}
         <section className="mb-12">
           <h2 className="text-3xl font-semibold mb-6">Ashwagandha vs Magnesium</h2>
           <div className="prose prose-lg max-w-none">
             <p>
-              Magnesium is often used for muscle tension, sleep support, and general nervous system calming.
-              It has a faster onset for some physical symptoms compared to ashwagandha.
+              Magnesium is essential for neuromuscular function and is commonly marketed for relaxation and sleep. That physiology does not establish a faster anxiety effect than ashwagandha, and supplemental benefit can depend on baseline status and the outcome being measured.
             </p>
             <p>
-              Ashwagandha&apos;s research focus is more on the stress response and perceived stress over time.
-              The two are frequently stacked because they may address overlapping but distinct aspects of stress and sleep.
+              Ashwagandha research is more directly centered on stress-related outcomes, but there is not enough head-to-head evidence here to rank the two as anxiety treatments. Combining them also requires its own safety review rather than assuming separate mechanisms prove compatibility.
             </p>
             <p>
               See related content:{' '}
@@ -311,96 +261,63 @@ export default function AshwagandhaForAnxietyPage() {
           </div>
         </section>
 
-        {/* Ashwagandha vs CBD */}
         <section className="mb-12">
           <h2 className="text-3xl font-semibold mb-6">Ashwagandha vs CBD</h2>
           <div className="prose prose-lg max-w-none">
             <p>
-              <strong>Regulatory status</strong>: Ashwagandha is sold as a dietary supplement in most jurisdictions.
-              CBD has more complex and varying legal status depending on source (hemp vs cannabis) and location.
+              <strong>Regulatory status:</strong> Ashwagandha is sold as a dietary supplement in the United States. CBD has a different and more complex federal/state regulatory context.
             </p>
             <p>
-              <strong>Evidence base</strong>: Ashwagandha has a larger number of published human trials for stress,
-              though many are small or industry-funded. CBD research for anxiety is growing but still relatively limited
-              and heterogeneous.
+              <strong>Evidence base:</strong> Ashwagandha has multiple human trials for stress-related outcomes, though many are small and preparations vary. CBD research for anxiety uses different formulations and populations and remains heterogeneous.
             </p>
             <p>
-              <strong>Practical considerations</strong>: Onset, duration, cost, drug testing concerns (CBD),
-              and personal preference all play roles. There is currently insufficient high-quality head-to-head data
-              to declare one clearly superior.
-            </p>
-            <p className="text-sm text-muted-foreground">
-              This section uses deliberately conservative language due to limited comparative evidence.
+              <strong>Practical considerations:</strong> Product quality, medication interactions, cost, regulatory context, and the exact outcome matter. There is insufficient high-quality head-to-head evidence to declare one universally superior.
             </p>
           </div>
         </section>
 
-        {/* Safety and Side Effects */}
         <section className="mb-12">
           <h2 className="text-3xl font-semibold mb-6">Safety and Side Effects</h2>
-
           <SafetyNotice title="Important Safety Considerations for Ashwagandha">
             <ul className="ml-5 space-y-1.5 list-disc">
-              <li>
-                <strong>Pregnancy and breastfeeding:</strong> Generally advised to avoid due to insufficient safety data.
-              </li>
-              <li>
-                <strong>Autoimmune conditions:</strong> May stimulate immune activity; caution is recommended.
-              </li>
-              <li>
-                <strong>Thyroid disorders:</strong> Some evidence suggests possible effects on thyroid hormones — monitoring advised.
-              </li>
-              <li>
-                <strong>Sedative medications or substances:</strong> Potential additive effects on drowsiness.
-              </li>
-              <li>
-                <strong>Psychiatric medications (SSRIs, SNRIs, MAOIs, benzodiazepines, lithium):</strong> Limited interaction data; ashwagandha may have additive sedative or serotonergic effects &mdash; consult a clinician before combining.
-              </li>
-              <li>
-                <strong>Liver safety:</strong> Rare case reports of hepatotoxicity have been noted with some ashwagandha products. Discontinue and seek medical attention if symptoms appear (jaundice, dark urine, severe fatigue, right-sided abdominal pain).
-              </li>
-              <li>
-                Always speak with a qualified healthcare provider before starting, especially if you have medical conditions or take medications.
-              </li>
+              <li><strong>Pregnancy and breastfeeding:</strong> Avoid use unless a qualified clinician specifically advises otherwise.</li>
+              <li><strong>Autoimmune conditions:</strong> Review use with a clinician because immune-related effects are a concern.</li>
+              <li><strong>Thyroid disorders:</strong> Some evidence suggests effects on thyroid hormones; monitoring may be appropriate.</li>
+              <li><strong>Sedative medications or substances:</strong> Additive drowsiness is a practical concern.</li>
+              <li><strong>Psychiatric and other medications:</strong> Interaction data are incomplete; ask a pharmacist or prescriber to review the full regimen rather than assuming compatibility.</li>
+              <li><strong>Liver safety:</strong> Rare liver-injury reports have been published. Stop use and seek medical care for jaundice, dark urine, severe fatigue, or significant abdominal symptoms.</li>
             </ul>
           </SafetyNotice>
-
-          <p className="mt-4 text-sm text-muted-foreground">
-            This is not medical advice. Individual risk profiles vary.
-          </p>
+          <p className="mt-4 text-sm text-muted-foreground">This is educational information, not individualized medical advice.</p>
         </section>
 
-        {/* Who Might Consider Ashwagandha? */}
         <section className="mb-12">
           <h2 className="text-3xl font-semibold mb-6">Who Might Consider Ashwagandha?</h2>
           <div className="prose prose-lg max-w-none">
-            <p>Ashwagandha may be worth considering for people who:</p>
+            <p>The available evidence may be more relevant when:</p>
             <ul>
-              <li>Experience anxiety that feels closely tied to chronic stress</li>
-              <li>Have stress-related sleep difficulties</li>
-              <li>Are looking for a non-stimulant, daily support option</li>
-              <li>Prefer herbal approaches with a relatively long history of traditional use</li>
+              <li>Stress-related symptoms have persisted rather than appearing only during one isolated event.</li>
+              <li>Stress and sleep difficulties overlap.</li>
+              <li>You can test one clearly labeled preparation at a time and track benefit and side effects.</li>
+              <li>You have already reviewed medication and health-condition cautions.</li>
             </ul>
             <p>
-              It is generally not positioned as a first-line solution for severe anxiety, panic disorders,
-              or acute mental health crises.
+              It should not be positioned as a first-line solution for severe anxiety, panic disorders, or acute mental health crises.
             </p>
           </div>
         </section>
 
-        {/* What Not To Do */}
         <section className="mb-12">
           <h2 className="text-3xl font-semibold mb-6">What Not To Do</h2>
           <ul className="space-y-3 text-muted-foreground">
-            <li>• Do not expect overnight or dramatic results — most research shows effects building over weeks.</li>
-            <li>• Do not start multiple new calming supplements at once (hard to know what is helping or causing issues).</li>
+            <li>• Do not turn multi-week trial durations into a guaranteed onset timeline.</li>
+            <li>• Do not start multiple new calming supplements at once; it becomes harder to identify benefit or side effects.</li>
             <li>• Do not stop prescribed psychiatric medications without medical supervision.</li>
-            <li>• Do not ignore severe or worsening anxiety symptoms — seek professional mental health support.</li>
-            <li>• Do not use any supplement as a replacement for emergency mental health care or therapy when needed.</li>
+            <li>• Do not ignore severe or worsening anxiety symptoms; seek professional mental health support.</li>
+            <li>• Do not assume two supplements are safe together because each looks low-risk alone.</li>
           </ul>
         </section>
 
-        {/* FAQ */}
         <section className="mb-12">
           <h2 className="text-3xl font-semibold mb-6">Frequently Asked Questions</h2>
           <div className="space-y-6">
@@ -413,134 +330,72 @@ export default function AshwagandhaForAnxietyPage() {
           </div>
         </section>
 
-        {/* Related Articles */}
         <section className="mb-12">
           <h2 className="text-3xl font-semibold mb-6">Related Articles</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <Link href="/guides/anxiety/natural-anxiety-relief/" className="block p-4 border rounded-lg hover:bg-muted transition-colors">
-              Natural Anxiety Relief: Evidence-Based Approaches
-            </Link>
-            <Link href="/guides/anxiety/l-theanine-for-anxiety/" className="block p-4 border rounded-lg hover:bg-muted transition-colors">
-              L-Theanine for Anxiety
-            </Link>
-            <Link href="/guides/anxiety/cbd-vs-ashwagandha-for-anxiety/" className="block p-4 border rounded-lg hover:bg-muted transition-colors">
-              CBD vs Ashwagandha for Anxiety
-            </Link>
-            <Link href="/guides/anxiety/anxiety-stack-guide/" className="block p-4 border rounded-lg hover:bg-muted transition-colors">
-              Anxiety Stack Guide
-            </Link>
-            <Link href="/guides/sleep/ashwagandha-for-sleep/" className="block p-4 border rounded-lg hover:bg-muted transition-colors">
-              Ashwagandha for Sleep
-            </Link>
-            <Link href="/guides/herbs/l-theanine/" className="block p-4 border rounded-lg hover:bg-muted transition-colors">
-              L-Theanine: Full Guide
-            </Link>
-            <Link href="/guides/anxiety/" className="block p-4 border rounded-lg hover:bg-muted transition-colors">
-              Anxiety Goal Hub
-            </Link>
+            <Link href="/guides/anxiety/natural-anxiety-relief/" className="block p-4 border rounded-lg hover:bg-muted transition-colors">Natural Anxiety Relief: Evidence-Based Approaches</Link>
+            <Link href="/guides/anxiety/l-theanine-for-anxiety/" className="block p-4 border rounded-lg hover:bg-muted transition-colors">L-Theanine for Anxiety</Link>
+            <Link href="/guides/anxiety/cbd-vs-ashwagandha-for-anxiety/" className="block p-4 border rounded-lg hover:bg-muted transition-colors">CBD vs Ashwagandha for Anxiety</Link>
+            <Link href="/guides/anxiety/anxiety-stack-guide/" className="block p-4 border rounded-lg hover:bg-muted transition-colors">Anxiety Stack Guide</Link>
+            <Link href="/guides/sleep/ashwagandha-for-sleep/" className="block p-4 border rounded-lg hover:bg-muted transition-colors">Ashwagandha for Sleep</Link>
+            <Link href="/guides/herbs/l-theanine/" className="block p-4 border rounded-lg hover:bg-muted transition-colors">L-Theanine: Full Guide</Link>
+            <Link href="/guides/anxiety/" className="block p-4 border rounded-lg hover:bg-muted transition-colors">Anxiety Goal Hub</Link>
           </div>
         </section>
 
-        {/* Buyer Guide */}
-        <section className="mb-12">
-          <h2 className="text-3xl font-semibold mb-6">Buyer Guide: Choosing an Ashwagandha Supplement</h2>
-
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            {/* KSM-66 */}
-            <div className="border rounded-xl p-5">
-              <h3 className="font-semibold mb-2">KSM-66 Ashwagandha</h3>
-              <p className="text-sm text-muted-foreground mb-4">
-                Full-spectrum root extract used in many clinical studies. Often standardized to 5% withanolides.
-              </p>
-              <a
-                href={`https://www.amazon.com/s?k=KSM-66+ashwagandha&tag=${AFFILIATE_TAGS.amazon}`}
-                target="_blank"
-                rel="noopener noreferrer sponsored"
-                className="text-primary underline text-sm"
-              >
-                Search on Amazon →
-              </a>
-            </div>
-
-            {/* Sensoril */}
-            <div className="border rounded-xl p-5">
-              <h3 className="font-semibold mb-2">Sensoril Ashwagandha</h3>
-              <p className="text-sm text-muted-foreground mb-4">
-                Another well-studied extract (often leaf + root). May have slightly different withanolide profile.
-              </p>
-              <a
-                href={`https://www.amazon.com/s?k=Sensoril+ashwagandha&tag=${AFFILIATE_TAGS.amazon}`}
-                target="_blank"
-                rel="noopener noreferrer sponsored"
-                className="text-primary underline text-sm"
-              >
-                Search on Amazon →
-              </a>
-            </div>
-
-            {/* Standardized Extract */}
-            <div className="border rounded-xl p-5">
-              <h3 className="font-semibold mb-2">Standardized Ashwagandha Extract</h3>
-              <p className="text-sm text-muted-foreground mb-4">
-                Look for third-party testing, clear withanolide percentage, and reputable brands. Avoid products with unnecessary fillers.
-              </p>
-              <a
-                href={`https://www.amazon.com/s?k=standardized+ashwagandha+extract+third+party+tested&tag=${AFFILIATE_TAGS.amazon}`}
-                target="_blank"
-                rel="noopener noreferrer sponsored"
-                className="text-primary underline text-sm"
-              >
-                Search on Amazon →
-              </a>
-            </div>
-          </div>
+        <section className="mb-12 rounded-2xl border border-brand-900/10 bg-white/90 p-6 shadow-sm">
+          <p className="eyebrow-label">Buyer checklist</p>
+          <h2 className="mt-1 text-3xl font-semibold text-ink">What to check before buying ashwagandha</h2>
+          <p className="mt-3 text-sm leading-7 text-muted-foreground">
+            Product selection comes after fit and safety. Use these checks before comparing the curated examples below.
+          </p>
+          <ul className="mt-5 space-y-3 text-sm leading-7 text-muted-foreground">
+            {BUYING_CHECKLIST.map((item) => (
+              <li key={item} className="flex gap-3">
+                <span aria-hidden="true" className="font-bold text-brand-700">✓</span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
         </section>
 
-        {/* Sources */}
-        <section className="mb-12">
+        {products.length > 0 ? (
+          <RecommendationSection
+            title="Curated ashwagandha product examples"
+            products={products}
+            trackingProductSlug="ashwagandha"
+            trackingLocation="guide-ashwagandha-anxiety"
+          />
+        ) : null}
+
+        <section className="my-12">
           <h2 className="text-3xl font-semibold mb-6">Sources &amp; References</h2>
           <div className="p-6 bg-muted/50 rounded-xl text-sm">
-            <p className="mb-4 font-medium">
-              Key human evidence and safety sources used for this review:
-            </p>
+            <p className="mb-4 font-medium">Key human evidence and safety sources used for this review:</p>
             <ul className="list-disc pl-5 space-y-1 text-muted-foreground">
               <li>
-                <a href="https://pubmed.ncbi.nlm.nih.gov/39348746/" target="_blank" rel="noopener noreferrer" className="text-primary underline">
-                  Arumugam et al. (2024), systematic review and meta-analysis
-                </a>{' '}
-                — nine randomized trials; supports a possible stress/anxiety signal but does not
-                establish which extract works best.
+                <a href="https://pubmed.ncbi.nlm.nih.gov/39348746/" target="_blank" rel="noopener noreferrer" className="text-primary underline">Arumugam et al. (2024), systematic review and meta-analysis</a>{' '}
+                — nine randomized trials; supports a possible stress/anxiety signal but does not establish which extract works best.
               </li>
               <li>
-                <a href="https://pubmed.ncbi.nlm.nih.gov/36017529/" target="_blank" rel="noopener noreferrer" className="text-primary underline">
-                  Akhgarjand et al. (2022), systematic review and dose-response meta-analysis
-                </a>{' '}
+                <a href="https://pubmed.ncbi.nlm.nih.gov/36017529/" target="_blank" rel="noopener noreferrer" className="text-primary underline">Akhgarjand et al. (2022), systematic review and dose-response meta-analysis</a>{' '}
                 — found high between-study heterogeneity and rated certainty low for both outcomes.
               </li>
               <li>
-                <a href="https://pubmed.ncbi.nlm.nih.gov/34559859/" target="_blank" rel="noopener noreferrer" className="text-primary underline">
-                  Cheah et al. (2021), sleep systematic review and meta-analysis
-                </a>{' '}
+                <a href="https://pubmed.ncbi.nlm.nih.gov/34559859/" target="_blank" rel="noopener noreferrer" className="text-primary underline">Cheah et al. (2021), sleep systematic review and meta-analysis</a>{' '}
                 — informs the sleep-overlap discussion, not acute anxiety relief.
               </li>
               <li>
-                <a href="https://doi.org/10.1097/HC9.0000000000000270" target="_blank" rel="noopener noreferrer" className="text-primary underline">
-                  Philips et al. (2023), ashwagandha-associated liver injury case series
-                </a>{' '}
+                <a href="https://doi.org/10.1097/HC9.0000000000000270" target="_blank" rel="noopener noreferrer" className="text-primary underline">Philips et al. (2023), ashwagandha-associated liver injury case series</a>{' '}
                 — a safety signal from case reports, not an estimate of how often injury occurs.
               </li>
             </ul>
           </div>
         </section>
 
-        <RecommendationSection products={getRevenueProductSet('ashwagandha')?.products ?? []} />
-
-        {/* Email Capture / Newsletter */}
         <div className="my-12">
           <NewsletterCtaBlock />
-          <div className="mt-6">
-            <EmailCapture />
-          </div>
+          <div className="mt-6"><EmailCapture /></div>
         </div>
       </div>
     </>


### PR DESCRIPTION
## What changed
- replace acute-onset/ranking language with evidence-calibrated timing and fit guidance
- stop converting multi-week trial duration into a guaranteed personal onset timeline
- remove unsupported L-theanine speed/superiority claims and magnesium onset comparisons
- replace ashwagandha + magnesium interaction reassurance with explicit combination-uncertainty guidance
- tighten long-term safety and medication language
- separate mechanistic plausibility from clinical benefit
- replace three generic Amazon search exits with a neutral buyer checklist plus one curated, tracked recommendation section
- record the August 11 editorial refresh separately from the original publish date
- add focused regression coverage for claims, affiliate-path consolidation, and freshness metadata

## Why
This is the first explicit CRO/claim-discipline route in the August priority checklist. The old version mixed strong evidence framing with unsupported timing and combination language, then fragmented commercial intent across generic Amazon searches and the curated product system.

## Validation
Full CI/build suite plus focused source regression.