### PR TITLE
Govern production runtime at summary boundary

### DIFF
--- a/scripts/__tests__/runtime-summary-governance-boundary.test.ts
+++ b/scripts/__tests__/runtime-summary-governance-boundary.test.ts
@@ -1,0 +1,32 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('runtime summary governance boundary', () => {
+  it('normalizes and governs runtime data before summaries are read', () => {
+    const source = fs.readFileSync(
+      path.join(process.cwd(), 'scripts/data/build-runtime-summary-indexes.mjs'),
+      'utf8',
+    )
+
+    const postprocess = source.indexOf("import('./postprocess-workbook-payloads.mjs')")
+    const governance = source.indexOf("import('./apply-governance-overlay.mjs')")
+    const holds = source.indexOf('reconcileDeliberateGovernanceHolds')
+    const readHerbs = source.indexOf("readJson(path.join(DATA_DIR, 'herbs.json'))")
+
+    expect(postprocess).toBeGreaterThan(-1)
+    expect(governance).toBeGreaterThan(postprocess)
+    expect(holds).toBeGreaterThan(governance)
+    expect(readHerbs).toBeGreaterThan(holds)
+  })
+
+  it('keeps the current AI entity artifact authority after governance replay', () => {
+    const source = fs.readFileSync(
+      path.join(process.cwd(), 'scripts/data/build-runtime-summary-indexes.mjs'),
+      'utf8',
+    )
+
+    expect(source).toContain("from './ai-entity-artifacts.mjs'")
+    expect(source).not.toContain("from './ai-entity-enrichment-lib.mjs'")
+  })
+})

--- a/scripts/__tests__/runtime-summary-governance-boundary.test.ts
+++ b/scripts/__tests__/runtime-summary-governance-boundary.test.ts
@@ -11,7 +11,7 @@ describe('runtime summary governance boundary', () => {
 
     const postprocess = source.indexOf("import('./postprocess-workbook-payloads.mjs')")
     const governance = source.indexOf("import('./apply-governance-overlay.mjs')")
-    const holds = source.indexOf('reconcileDeliberateGovernanceHolds')
+    const holds = source.indexOf('const holdReport = await reconcileDeliberateGovernanceHolds')
     const readHerbs = source.indexOf("readJson(path.join(DATA_DIR, 'herbs.json'))")
 
     expect(postprocess).toBeGreaterThan(-1)

--- a/scripts/data/build-runtime-summary-indexes.mjs
+++ b/scripts/data/build-runtime-summary-indexes.mjs
@@ -8,6 +8,7 @@ import {
 } from '../ci/report-build-stage-timings.mjs'
 import { exportCanonicalCitationsToRuntime } from './canonical/citation-export.mjs'
 import { buildAiEntityArtifacts } from './ai-entity-artifacts.mjs'
+import { reconcileDeliberateGovernanceHolds } from './governance-hold-policy.mjs'
 
 const DATA_DIR_ARG = process.argv.find((arg) => arg.startsWith('--data-dir='))
 const DATA_DIR = DATA_DIR_ARG
@@ -201,6 +202,32 @@ function buildAlphaEntityShards(records) {
 
 async function main() {
   const totalTimer = createStageTimer('summary-index-build')
+
+  // This builder is the production boundary immediately before route/sitemap/static
+  // metadata generation. Normalize and govern the freshly generated runtime payloads
+  // here so every downstream artifact consumes the same authority state.
+  const postprocessTimer = createStageTimer('workbook-payload-postprocess')
+  await import('./postprocess-workbook-payloads.mjs')
+  postprocessTimer.finish()
+
+  const governanceTimer = createStageTimer('governance-overlay')
+  await import('./apply-governance-overlay.mjs')
+  governanceTimer.finish()
+
+  // Curated allowlists express editorial priority, but an explicit content hold
+  // (hidden_until_grounded/research_only) outranks that priority until grounded.
+  const holdTimer = createStageTimer('deliberate-governance-hold-reconciliation')
+  const holdReport = await reconcileDeliberateGovernanceHolds({ dataDir: DATA_DIR })
+  holdTimer.finish({ corrected: holdReport.total })
+  if (holdReport.total > 0) {
+    console.log(
+      `[summary-indexes] preserved deliberate governance holds: ${[
+        ...holdReport.herbs.map((slug) => `herb:${slug}`),
+        ...holdReport.compounds.map((slug) => `compound:${slug}`),
+      ].join(', ')}`,
+    )
+  }
+
   const citationTimer = createStageTimer('canonical-citation-export')
   const citationReport = exportCanonicalCitationsToRuntime({ dataDir: DATA_DIR })
   citationTimer.finish({

--- a/scripts/data/governance-hold-policy.mjs
+++ b/scripts/data/governance-hold-policy.mjs
@@ -1,0 +1,110 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+export const DELIBERATE_HOLD_DECISIONS = new Set([
+  'hidden_until_grounded',
+  'research_archive_runtime',
+])
+
+export const DELIBERATE_HOLD_PROFILE_STATUSES = new Set([
+  'research_only',
+  'minimal',
+])
+
+export function isDeliberateGovernanceHold(record) {
+  if (!record || typeof record !== 'object') return false
+
+  const decision = String(record.runtime_export_decision || '').trim().toLowerCase()
+  if (DELIBERATE_HOLD_DECISIONS.has(decision)) return true
+
+  const profileStatus = String(record.profile_status || '').trim().toLowerCase()
+  if (DELIBERATE_HOLD_PROFILE_STATUSES.has(profileStatus)) return true
+
+  const reasons = Array.isArray(record.indexability_reasons) ? record.indexability_reasons : []
+  return reasons.some((reason) => {
+    const [key, value] = String(reason).split(':')
+    if (key === 'noindex-decision' && DELIBERATE_HOLD_DECISIONS.has(value)) return true
+    if (key === 'profile-status' && DELIBERATE_HOLD_PROFILE_STATUSES.has(value)) return true
+    return false
+  })
+}
+
+export function applyDeliberateGovernanceHold(record) {
+  if (!isDeliberateGovernanceHold(record)) return false
+
+  record.indexability_status = 'NEEDS_REVIEW'
+  record.robots = 'noindex,follow'
+  record.sitemap_included = false
+
+  if (!Array.isArray(record.indexability_reasons)) record.indexability_reasons = []
+  if (!record.indexability_reasons.includes('deliberate_governance_hold')) {
+    record.indexability_reasons.push('deliberate_governance_hold')
+  }
+
+  const governance = record.governance && typeof record.governance === 'object'
+    ? record.governance
+    : {}
+
+  record.governance = {
+    ...governance,
+    reviewStatus: 'needs_review',
+    indexingAllowed: false,
+    recommendationAllowed: false,
+    requiresHumanReview: true,
+    reason: 'deliberate_governance_hold',
+  }
+
+  return true
+}
+
+async function readJson(filePath, fallback) {
+  try {
+    return JSON.parse(await fs.readFile(filePath, 'utf8'))
+  } catch {
+    return fallback
+  }
+}
+
+async function writeJson(filePath, value) {
+  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8')
+}
+
+async function reconcileCollection(dataDir, listFile, detailDirName) {
+  const listPath = path.join(dataDir, listFile)
+  const records = await readJson(listPath, [])
+  if (!Array.isArray(records)) return { corrected: [] }
+
+  const corrected = []
+  for (const record of records) {
+    if (!applyDeliberateGovernanceHold(record)) continue
+    const slug = String(record.slug || '').trim()
+    if (!slug) continue
+    corrected.push(slug)
+
+    const detailPath = path.join(dataDir, detailDirName, `${slug}.json`)
+    const detail = await readJson(detailPath, null)
+    if (detail && typeof detail === 'object') {
+      applyDeliberateGovernanceHold(detail)
+      detail.indexability_status = record.indexability_status
+      detail.robots = record.robots
+      detail.sitemap_included = record.sitemap_included
+      detail.indexability_reasons = [...record.indexability_reasons]
+      detail.governance = { ...record.governance }
+      await writeJson(detailPath, detail)
+    }
+  }
+
+  if (corrected.length > 0) await writeJson(listPath, records)
+  return { corrected: corrected.sort() }
+}
+
+export async function reconcileDeliberateGovernanceHolds({ dataDir = 'public/data' } = {}) {
+  const root = path.resolve(process.cwd(), dataDir)
+  const herbs = await reconcileCollection(root, 'herbs.json', 'herbs-detail')
+  const compounds = await reconcileCollection(root, 'compounds.json', 'compounds-detail')
+  return {
+    herbs: herbs.corrected,
+    compounds: compounds.corrected,
+    total: herbs.corrected.length + compounds.corrected.length,
+  }
+}

--- a/scripts/data/governance-hold-policy.test.mjs
+++ b/scripts/data/governance-hold-policy.test.mjs
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyDeliberateGovernanceHold,
+  isDeliberateGovernanceHold,
+} from './governance-hold-policy.mjs'
+
+describe('deliberate governance hold precedence', () => {
+  it('keeps hidden_until_grounded held even when a curated overlay promoted it', () => {
+    const record = {
+      slug: 'black-cohosh',
+      runtime_export_decision: 'hidden_until_grounded',
+      indexability_status: 'PUBLISH',
+      robots: 'index,follow',
+      sitemap_included: true,
+      indexability_reasons: ['noindex-decision:hidden_until_grounded', 'curated_allowlist'],
+      governance: {
+        indexingAllowed: true,
+        reviewStatus: 'approved',
+        recommendationAllowed: true,
+        requiresHumanReview: false,
+        reason: 'curated_allowlist',
+      },
+    }
+
+    expect(isDeliberateGovernanceHold(record)).toBe(true)
+    expect(applyDeliberateGovernanceHold(record)).toBe(true)
+    expect(record.indexability_status).toBe('NEEDS_REVIEW')
+    expect(record.robots).toBe('noindex,follow')
+    expect(record.sitemap_included).toBe(false)
+    expect(record.governance.indexingAllowed).toBe(false)
+    expect(record.governance.requiresHumanReview).toBe(true)
+    expect(record.governance.recommendationAllowed).toBe(false)
+  })
+
+  it('keeps research_only profile status ahead of curated allowlisting', () => {
+    const record = {
+      slug: 'acetyl-l-carnitine',
+      profile_status: 'research_only',
+      indexability_status: 'PUBLISH',
+      robots: 'index,follow',
+      sitemap_included: true,
+      indexability_reasons: ['profile-status:research_only', 'curated_allowlist'],
+    }
+
+    expect(applyDeliberateGovernanceHold(record)).toBe(true)
+    expect(record.indexability_status).toBe('NEEDS_REVIEW')
+  })
+
+  it('leaves normal curated publish records unchanged', () => {
+    const record = {
+      slug: 'magnesium',
+      runtime_export_decision: 'full_public_runtime',
+      profile_status: 'complete',
+      indexability_status: 'PUBLISH',
+      robots: 'index,follow',
+      sitemap_included: true,
+      indexability_reasons: ['curated_allowlist'],
+    }
+
+    expect(isDeliberateGovernanceHold(record)).toBe(false)
+    expect(applyDeliberateGovernanceHold(record)).toBe(false)
+    expect(record.indexability_status).toBe('PUBLISH')
+  })
+})

--- a/scripts/data/postprocess-workbook-payloads.mjs
+++ b/scripts/data/postprocess-workbook-payloads.mjs
@@ -1,7 +1,8 @@
 import fs from 'fs'
 import path from 'path'
 
-const dataDir = path.join(process.cwd(), 'public/data')
+const dataDirArg = process.argv.find((arg) => arg.startsWith('--data-dir='))
+const dataDir = path.resolve(process.cwd(), dataDirArg ? dataDirArg.split('=')[1] : 'public/data')
 const herbSourcesCachePath = path.join(process.cwd(), 'ops/cache/pubmed-herb-sources-cache.json')
 
 function readHerbSourcesCache() {


### PR DESCRIPTION
## What changed
- run workbook payload postprocessing and the canonical governance overlay inside the runtime-summary build boundary, before summaries/routes/sitemap/static metadata consume regenerated runtime data
- make workbook postprocessing honor the same `--data-dir` used by the summary builder
- preserve deliberate `hidden_until_grounded`, `research_archive_runtime`, `research_only`, and `minimal` holds even when curated allowlists express future editorial priority
- preserve the newly merged `ai-entity-artifacts.mjs` authority from #2573
- add focused precedence and build-boundary regressions

## Why
The production deploy path regenerates runtime JSON, then builds summary indexes that feed routes, sitemap, and static metadata. Previously the canonical postprocess/governance authority was not guaranteed at that boundary, allowing split-brain states such as `governance.indexingAllowed=false` beside `PUBLISH/index,follow`. The older #2569 attempted to patch the large deploy pipeline directly and became stale after #2573. This replay puts the invariant at the smaller mandatory downstream boundary instead.

## Precedence
Deliberate content hold > curated editorial priority > source/indexability heuristic.

## Validation
Full CI/build/site-health/Lighthouse/UI suite plus focused governance-boundary tests.