### PR TITLE
Restore production security flow for ADHD article signups

### DIFF
--- a/components/articles/EmailCapture.tsx
+++ b/components/articles/EmailCapture.tsx
@@ -3,6 +3,7 @@
 import { FormEvent, useId, useState } from 'react'
 import Link from 'next/link'
 import { trackEmailSignup } from '@/lib/analytics'
+import TurnstileWidget, { turnstileEnabled } from '@/components/security/TurnstileWidget'
 
 type EmailCaptureProps = {
   title: string
@@ -22,11 +23,20 @@ export default function EmailCapture({ title, description, ctaLabel, magnet }: E
   const [email, setEmail] = useState('')
   const [firstName, setFirstName] = useState('')
   const [confirmEmail, setConfirmEmail] = useState('')
+  const [turnstileToken, setTurnstileToken] = useState('')
+  const [turnstileResetKey, setTurnstileResetKey] = useState(0)
   const [state, setState] = useState<SubmitState>('idle')
   const [message, setMessage] = useState('')
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
+
+    if (turnstileEnabled && !turnstileToken) {
+      setState('error')
+      setMessage('Complete the security check before subscribing.')
+      return
+    }
+
     setState('loading')
     setMessage('')
 
@@ -34,7 +44,13 @@ export default function EmailCapture({ title, description, ctaLabel, magnet }: E
       const response = await fetch('/api/subscribe', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, firstName, magnet, confirmEmail }),
+        body: JSON.stringify({
+          email,
+          firstName,
+          magnet,
+          confirmEmail,
+          turnstileToken: turnstileEnabled ? turnstileToken : undefined,
+        }),
       })
       const payload = (await response.json().catch(() => null)) as { ok?: boolean; error?: string } | null
 
@@ -44,10 +60,12 @@ export default function EmailCapture({ title, description, ctaLabel, magnet }: E
 
       setState('success')
       setMessage('You are subscribed. Open the checklist below.')
+      setTurnstileResetKey((value) => value + 1)
       trackEmailSignup({ source: `article-${magnet}` })
     } catch (error) {
       setState('error')
       setMessage(error instanceof Error ? error.message : 'Could not subscribe this email right now.')
+      setTurnstileResetKey((value) => value + 1)
     }
   }
 
@@ -123,9 +141,11 @@ export default function EmailCapture({ title, description, ctaLabel, magnet }: E
             />
           </div>
 
+          <TurnstileWidget onTokenChange={setTurnstileToken} resetKey={turnstileResetKey} />
+
           <button
             type="submit"
-            disabled={isLoading}
+            disabled={isLoading || (turnstileEnabled && !turnstileToken)}
             className="inline-flex w-full items-center justify-center rounded-full bg-brand-700 px-5 py-3 text-sm font-bold text-white transition hover:bg-brand-800 disabled:cursor-not-allowed disabled:opacity-70 sm:w-fit"
           >
             {isLoading ? 'Sending…' : ctaLabel}

--- a/components/articles/__tests__/EmailCapture.test.tsx
+++ b/components/articles/__tests__/EmailCapture.test.tsx
@@ -1,3 +1,5 @@
+import fs from 'node:fs'
+import path from 'node:path'
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 
@@ -19,5 +21,16 @@ describe('article EmailCapture', () => {
       '/lead-magnets/adhd-supplement-starter-checklist',
     )
     expect(screen.getByRole('button', { name: /send me the checklist/i })).toBeEnabled()
+  })
+
+  it('passes production security verification through the subscribe request', () => {
+    const source = fs.readFileSync(
+      path.join(process.cwd(), 'components/articles/EmailCapture.tsx'),
+      'utf8',
+    )
+
+    expect(source).toContain('<TurnstileWidget')
+    expect(source).toContain('turnstileToken: turnstileEnabled ? turnstileToken : undefined')
+    expect(source).toContain('disabled={isLoading || (turnstileEnabled && !turnstileToken)}')
   })
 })

--- a/components/security/TurnstileWidget.tsx
+++ b/components/security/TurnstileWidget.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+type TurnstileApi = {
+  render: (
+    element: HTMLElement,
+    options: {
+      sitekey: string
+      callback: (token: string) => void
+      'expired-callback': () => void
+      'error-callback': () => void
+    },
+  ) => string
+  reset: (widgetId?: string) => void
+}
+
+type TurnstileWindow = Window & { turnstile?: TurnstileApi }
+
+type TurnstileWidgetProps = {
+  onTokenChange: (token: string) => void
+  resetKey?: number
+  className?: string
+}
+
+export const turnstileSiteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY?.trim() || ''
+export const turnstileEnabled = Boolean(turnstileSiteKey)
+
+const SCRIPT_SRC = 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit'
+
+function getTurnstile(): TurnstileApi | undefined {
+  if (typeof window === 'undefined') return undefined
+  return (window as TurnstileWindow).turnstile
+}
+
+function loadScript() {
+  if (typeof document === 'undefined') return
+  if (document.querySelector(`script[src="${SCRIPT_SRC}"]`)) return
+
+  const script = document.createElement('script')
+  script.src = SCRIPT_SRC
+  script.async = true
+  script.defer = true
+  document.head.appendChild(script)
+}
+
+export default function TurnstileWidget({
+  onTokenChange,
+  resetKey = 0,
+  className = 'min-h-[65px]',
+}: TurnstileWidgetProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const widgetIdRef = useRef<string | undefined>(undefined)
+  const lastResetKeyRef = useRef(resetKey)
+  const onTokenChangeRef = useRef(onTokenChange)
+
+  useEffect(() => {
+    onTokenChangeRef.current = onTokenChange
+  }, [onTokenChange])
+
+  useEffect(() => {
+    if (!turnstileEnabled || !containerRef.current || widgetIdRef.current) return
+
+    let cancelled = false
+    let retryTimer: number | undefined
+    loadScript()
+
+    const renderWhenReady = () => {
+      if (cancelled || !containerRef.current || widgetIdRef.current) return
+      const turnstile = getTurnstile()
+
+      if (turnstile) {
+        widgetIdRef.current = turnstile.render(containerRef.current, {
+          sitekey: turnstileSiteKey,
+          callback: (token) => onTokenChangeRef.current(token),
+          'expired-callback': () => onTokenChangeRef.current(''),
+          'error-callback': () => onTokenChangeRef.current(''),
+        })
+        return
+      }
+
+      retryTimer = window.setTimeout(renderWhenReady, 150)
+    }
+
+    renderWhenReady()
+
+    return () => {
+      cancelled = true
+      if (retryTimer !== undefined) window.clearTimeout(retryTimer)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!turnstileEnabled || resetKey === lastResetKeyRef.current) return
+    lastResetKeyRef.current = resetKey
+    onTokenChangeRef.current('')
+    getTurnstile()?.reset(widgetIdRef.current)
+  }, [resetKey])
+
+  if (!turnstileEnabled) return null
+  return <div ref={containerRef} className={className} />
+}


### PR DESCRIPTION
## What changed
- add a reusable Turnstile widget for client-side subscription forms
- render it in the live ADHD article email capture when a site key is configured
- send the resulting `turnstileToken` to `/api/subscribe`
- disable submission until the production security challenge is complete
- reset the widget after success or failure
- add focused regression coverage for the token flow

## Why
The hardened `/api/subscribe` endpoint verifies Turnstile whenever the production secret is configured. The live article signup posted to that endpoint without ever rendering or sending a Turnstile token, so correctly secured production deployments could reject otherwise valid ADHD checklist signups.

## Validation
Full CI/build/site-health/Lighthouse/UI suite plus focused signup regression.