### PR TITLE
Enforce deliberate governance holds through production SEO

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,59 @@ jobs:
           COMMIT_HASH: ${{ github.sha }}
         run: npm run build:deploy
 
-      - name: Verify build output
-        run: npm run verify:output
+      - name: Verify prebuild contracts
+        run: npm run verify:prebuild
+
+      - name: Verify core routes
+        run: node scripts/verify-core-routes.mjs
+
+      - name: Verify redirects
+        run: node scripts/verify-redirects.mjs
+
+      - name: Audit profile robots
+        run: node scripts/ci/audit-profile-robots.mjs
+
+      - name: Validate deploy readiness
+        run: node scripts/ci/validate-deploy-readiness.mjs
+
+      - name: Validate built SEO metadata
+        run: node scripts/ci/validate-build-seo-metadata.mjs
+
+      - name: Audit metadata duplicates
+        run: node scripts/ci/audit-metadata-duplicates.mjs
+
+      - name: Audit internal links
+        run: node scripts/ci/audit-internal-links.mjs
+
+      - name: Audit structured data
+        run: node scripts/ci/audit-structured-data.mjs
+
+      - name: Audit SEO routes
+        run: node scripts/ci/audit-seo-routes.mjs
+
+      - name: Validate guide FAQs
+        run: node scripts/ci/validate-guide-faqs.mjs
+
+      - name: Validate built sitemap
+        run: node scripts/ci/validate-sitemap.mjs --require-built
+
+      - name: Validate sitemap completeness
+        run: node scripts/ci/validate-sitemap-completeness.mjs --require-built
+
+      - name: Validate robots
+        run: node scripts/ci/validate-robots.mjs --require-built
+
+      - name: Audit sitemap affiliate links
+        run: npm run audit:sitemap-affiliate
+
+      - name: Validate Pagefind body
+        run: npm run validate:pagefind-body
+
+      - name: Validate cluster-member export
+        run: npm run validate:cluster-member-export
+
+      - name: Report performance budget
+        run: node scripts/report-performance-budget.mjs
 
       - name: Generate SEO audit reports
         if: always()
@@ -150,6 +201,6 @@ jobs:
           echo "## CI quality gate" >> "$GITHUB_STEP_SUMMARY"
           echo "- Purpose: enforce lint, typecheck, workbook/data correctness, recommendation-quality auditing, build verification, and security audit" >> "$GITHUB_STEP_SUMMARY"
           echo "- Branch/ref: $GITHUB_REF" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Key commands: npm ci; npm run check:node; npm run validate:workbook-source; npm run validate:static-export; npm run routes:inventory; npm run lint; npm run typecheck; npm run data:ci; npx tsx scripts/audit-related-botanicals.ts; npm run guard:source-of-truth; npm run build:deploy; npm run verify:output; npm run audit:seo-reports; npm run indexability:report; node scripts/ci/audit-internal-redirect-links.mjs; npm run validate:route-seo; npm run audit:high" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Key commands: npm ci; npm run check:node; npm run validate:workbook-source; npm run validate:static-export; npm run routes:inventory; npm run lint; npm run typecheck; npm run data:ci; npx tsx scripts/audit-related-botanicals.ts; npm run guard:source-of-truth; npm run build:deploy; granular verify:output diagnostics; npm run audit:seo-reports; npm run indexability:report; node scripts/ci/audit-internal-redirect-links.mjs; npm run validate:route-seo; npm run audit:high" >> "$GITHUB_STEP_SUMMARY"
           echo "- Artifacts: related-botanicals audit; seo-audit-reports (including indexability candidates); npm-audit-after" >> "$GITHUB_STEP_SUMMARY"
           echo "- Status: ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/__tests__/runtime-summary-governance-boundary.test.ts
+++ b/scripts/__tests__/runtime-summary-governance-boundary.test.ts
@@ -1,0 +1,32 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('runtime summary governance boundary', () => {
+  it('normalizes and governs runtime data before summaries are read', () => {
+    const source = fs.readFileSync(
+      path.join(process.cwd(), 'scripts/data/build-runtime-summary-indexes.mjs'),
+      'utf8',
+    )
+
+    const postprocess = source.indexOf("import('./postprocess-workbook-payloads.mjs')")
+    const governance = source.indexOf("import('./apply-governance-overlay.mjs')")
+    const holds = source.indexOf('const holdReport = await reconcileDeliberateGovernanceHolds')
+    const readHerbs = source.indexOf("readJson(path.join(DATA_DIR, 'herbs.json'))")
+
+    expect(postprocess).toBeGreaterThan(-1)
+    expect(governance).toBeGreaterThan(postprocess)
+    expect(holds).toBeGreaterThan(governance)
+    expect(readHerbs).toBeGreaterThan(holds)
+  })
+
+  it('keeps the current AI entity artifact authority after governance replay', () => {
+    const source = fs.readFileSync(
+      path.join(process.cwd(), 'scripts/data/build-runtime-summary-indexes.mjs'),
+      'utf8',
+    )
+
+    expect(source).toContain("from './ai-entity-artifacts.mjs'")
+    expect(source).not.toContain("from './ai-entity-enrichment-lib.mjs'")
+  })
+})

--- a/scripts/ci/validate-sitemap-completeness.mjs
+++ b/scripts/ci/validate-sitemap-completeness.mjs
@@ -27,19 +27,13 @@ const APP_DIR = path.join(ROOT, 'app')
 const OUT_DIR = path.join(ROOT, 'out')
 const REQUIRE_BUILT = process.argv.includes('--require-built')
 
-// Directories that are never page routes (Next.js internals, tests, API-ish
-// utility pages that are intentionally excluded from search indexing).
 const SKIP_DIR_NAMES = new Set(['__tests__', 'api'])
 
-// Route paths (relative to app/, route groups already stripped) that are
-// real, working pages but are deliberately excluded from the sitemap. Keep
-// this list short and documented — anything added here should have a real
-// reason, not just "the checker complained so I silenced it."
 const EXCLUDED_ROUTES = new Set([
-  'build', // app/(public)/build — internal dev-only stack builder, already noindex
-  'guides/anxiety/natural-alternatives-to-anxiety-medication', // canonicalizes to guides/anxiety/best-herbs-for-anxiety (deliberate duplicate-content consolidation)
-  'guides/anxiety/natural-anxiolytics-beyond-ashwagandha', // canonicalizes to guides/anxiety/best-herbs-for-anxiety (deliberate duplicate-content consolidation)
-  'guides/focus/best-supplements-for-focus', // compatibility wrapper redirects/canonicalizes to guides/focus/best-nootropics-for-focus
+  'build',
+  'guides/anxiety/natural-alternatives-to-anxiety-medication',
+  'guides/anxiety/natural-anxiolytics-beyond-ashwagandha',
+  'guides/focus/best-supplements-for-focus',
 ])
 
 const SPECIAL_FILE_ROUTES = new Set([
@@ -53,7 +47,6 @@ const SPECIAL_FILE_ROUTES = new Set([
 ])
 
 function stripRouteGroups(routeSegments) {
-  // Route groups like (public) are stripped from the URL by Next.js.
   return routeSegments.filter((segment) => !/^\(.*\)$/.test(segment))
 }
 
@@ -99,7 +92,7 @@ function collectStaticRoutes(dirPath, routeSegments) {
   for (const entry of entries) {
     if (!entry.isDirectory()) continue
     if (SKIP_DIR_NAMES.has(entry.name)) continue
-    if (/^\[/.test(entry.name)) continue // dynamic segments are data-driven, validated separately
+    if (/^\[/.test(entry.name)) continue
     results.push(...collectStaticRoutes(path.join(dirPath, entry.name), [...routeSegments, entry.name]))
   }
 
@@ -110,9 +103,7 @@ function parseXmlUrls(xmlContent) {
   const urls = []
   const locRegex = /<loc>(.*?)<\/loc>/g
   let match
-  while ((match = locRegex.exec(xmlContent)) !== null) {
-    urls.push(match[1])
-  }
+  while ((match = locRegex.exec(xmlContent)) !== null) urls.push(match[1])
   return urls
 }
 
@@ -124,6 +115,15 @@ function normalizePath(url) {
   } catch {
     return url
   }
+}
+
+function writeDiagnostic(staticRoutes, sitemapUrls, missing) {
+  const reportDir = path.join(ROOT, 'ops', 'reports')
+  fs.mkdirSync(reportDir, { recursive: true })
+  fs.writeFileSync(
+    path.join(reportDir, 'sitemap-completeness-diagnostic.json'),
+    JSON.stringify({ staticRouteCount: staticRoutes.length, sitemapUrlCount: sitemapUrls.size, missing }, null, 2) + '\n',
+  )
 }
 
 function main() {
@@ -153,16 +153,14 @@ function main() {
   }
 
   const sitemapUrls = new Set(parseXmlUrls(fs.readFileSync(sitemapPath, 'utf8')).map(normalizePath))
-
   const missing = staticRoutes.filter((route) => !sitemapUrls.has(route)).sort()
+  writeDiagnostic(staticRoutes, sitemapUrls, missing)
 
   console.log(`[validate-sitemap-completeness] Found ${staticRoutes.length} static app/ routes without an explicit noindex signal; ${sitemapUrls.size} URLs in sitemap.xml.`)
 
   if (missing.length > 0) {
     console.error(`[validate-sitemap-completeness] FAIL: ${missing.length} real, indexable route(s) are missing from sitemap.xml:`)
-    for (const route of missing) {
-      console.error(`  - ${route}`)
-    }
+    for (const route of missing) console.error(`  - ${route}`)
     console.error('')
     console.error('If a route is intentionally excluded, add it to EXCLUDED_ROUTES in this script with a comment explaining why.')
     console.error('If not, the sitemap generator in app/sitemap.ts is silently dropping real content — check')

--- a/scripts/data/build-runtime-summary-indexes.mjs
+++ b/scripts/data/build-runtime-summary-indexes.mjs
@@ -8,6 +8,7 @@ import {
 } from '../ci/report-build-stage-timings.mjs'
 import { exportCanonicalCitationsToRuntime } from './canonical/citation-export.mjs'
 import { buildAiEntityArtifacts } from './ai-entity-artifacts.mjs'
+import { reconcileDeliberateGovernanceHolds } from './governance-hold-policy.mjs'
 
 const DATA_DIR_ARG = process.argv.find((arg) => arg.startsWith('--data-dir='))
 const DATA_DIR = DATA_DIR_ARG
@@ -201,6 +202,32 @@ function buildAlphaEntityShards(records) {
 
 async function main() {
   const totalTimer = createStageTimer('summary-index-build')
+
+  // This builder is the production boundary immediately before route/sitemap/static
+  // metadata generation. Normalize and govern the freshly generated runtime payloads
+  // here so every downstream artifact consumes the same authority state.
+  const postprocessTimer = createStageTimer('workbook-payload-postprocess')
+  await import('./postprocess-workbook-payloads.mjs')
+  postprocessTimer.finish()
+
+  const governanceTimer = createStageTimer('governance-overlay')
+  await import('./apply-governance-overlay.mjs')
+  governanceTimer.finish()
+
+  // Curated allowlists express editorial priority, but an explicit content hold
+  // (hidden_until_grounded/research_only) outranks that priority until grounded.
+  const holdTimer = createStageTimer('deliberate-governance-hold-reconciliation')
+  const holdReport = await reconcileDeliberateGovernanceHolds({ dataDir: DATA_DIR })
+  holdTimer.finish({ corrected: holdReport.total })
+  if (holdReport.total > 0) {
+    console.log(
+      `[summary-indexes] preserved deliberate governance holds: ${[
+        ...holdReport.herbs.map((slug) => `herb:${slug}`),
+        ...holdReport.compounds.map((slug) => `compound:${slug}`),
+      ].join(', ')}`,
+    )
+  }
+
   const citationTimer = createStageTimer('canonical-citation-export')
   const citationReport = exportCanonicalCitationsToRuntime({ dataDir: DATA_DIR })
   citationTimer.finish({

--- a/scripts/data/governance-hold-policy.mjs
+++ b/scripts/data/governance-hold-policy.mjs
@@ -1,0 +1,110 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+export const DELIBERATE_HOLD_DECISIONS = new Set([
+  'hidden_until_grounded',
+  'research_archive_runtime',
+])
+
+export const DELIBERATE_HOLD_PROFILE_STATUSES = new Set([
+  'research_only',
+  'minimal',
+])
+
+export function isDeliberateGovernanceHold(record) {
+  if (!record || typeof record !== 'object') return false
+
+  const decision = String(record.runtime_export_decision || '').trim().toLowerCase()
+  if (DELIBERATE_HOLD_DECISIONS.has(decision)) return true
+
+  const profileStatus = String(record.profile_status || '').trim().toLowerCase()
+  if (DELIBERATE_HOLD_PROFILE_STATUSES.has(profileStatus)) return true
+
+  const reasons = Array.isArray(record.indexability_reasons) ? record.indexability_reasons : []
+  return reasons.some((reason) => {
+    const [key, value] = String(reason).split(':')
+    if (key === 'noindex-decision' && DELIBERATE_HOLD_DECISIONS.has(value)) return true
+    if (key === 'profile-status' && DELIBERATE_HOLD_PROFILE_STATUSES.has(value)) return true
+    return false
+  })
+}
+
+export function applyDeliberateGovernanceHold(record) {
+  if (!isDeliberateGovernanceHold(record)) return false
+
+  record.indexability_status = 'NEEDS_REVIEW'
+  record.robots = 'noindex,follow'
+  record.sitemap_included = false
+
+  if (!Array.isArray(record.indexability_reasons)) record.indexability_reasons = []
+  if (!record.indexability_reasons.includes('deliberate_governance_hold')) {
+    record.indexability_reasons.push('deliberate_governance_hold')
+  }
+
+  const governance = record.governance && typeof record.governance === 'object'
+    ? record.governance
+    : {}
+
+  record.governance = {
+    ...governance,
+    reviewStatus: 'needs_review',
+    indexingAllowed: false,
+    recommendationAllowed: false,
+    requiresHumanReview: true,
+    reason: 'deliberate_governance_hold',
+  }
+
+  return true
+}
+
+async function readJson(filePath, fallback) {
+  try {
+    return JSON.parse(await fs.readFile(filePath, 'utf8'))
+  } catch {
+    return fallback
+  }
+}
+
+async function writeJson(filePath, value) {
+  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8')
+}
+
+async function reconcileCollection(dataDir, listFile, detailDirName) {
+  const listPath = path.join(dataDir, listFile)
+  const records = await readJson(listPath, [])
+  if (!Array.isArray(records)) return { corrected: [] }
+
+  const corrected = []
+  for (const record of records) {
+    if (!applyDeliberateGovernanceHold(record)) continue
+    const slug = String(record.slug || '').trim()
+    if (!slug) continue
+    corrected.push(slug)
+
+    const detailPath = path.join(dataDir, detailDirName, `${slug}.json`)
+    const detail = await readJson(detailPath, null)
+    if (detail && typeof detail === 'object') {
+      applyDeliberateGovernanceHold(detail)
+      detail.indexability_status = record.indexability_status
+      detail.robots = record.robots
+      detail.sitemap_included = record.sitemap_included
+      detail.indexability_reasons = [...record.indexability_reasons]
+      detail.governance = { ...record.governance }
+      await writeJson(detailPath, detail)
+    }
+  }
+
+  if (corrected.length > 0) await writeJson(listPath, records)
+  return { corrected: corrected.sort() }
+}
+
+export async function reconcileDeliberateGovernanceHolds({ dataDir = 'public/data' } = {}) {
+  const root = path.resolve(process.cwd(), dataDir)
+  const herbs = await reconcileCollection(root, 'herbs.json', 'herbs-detail')
+  const compounds = await reconcileCollection(root, 'compounds.json', 'compounds-detail')
+  return {
+    herbs: herbs.corrected,
+    compounds: compounds.corrected,
+    total: herbs.corrected.length + compounds.corrected.length,
+  }
+}

--- a/scripts/data/governance-hold-policy.test.mjs
+++ b/scripts/data/governance-hold-policy.test.mjs
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyDeliberateGovernanceHold,
+  isDeliberateGovernanceHold,
+} from './governance-hold-policy.mjs'
+
+describe('deliberate governance hold precedence', () => {
+  it('keeps hidden_until_grounded held even when a curated overlay promoted it', () => {
+    const record = {
+      slug: 'black-cohosh',
+      runtime_export_decision: 'hidden_until_grounded',
+      indexability_status: 'PUBLISH',
+      robots: 'index,follow',
+      sitemap_included: true,
+      indexability_reasons: ['noindex-decision:hidden_until_grounded', 'curated_allowlist'],
+      governance: {
+        indexingAllowed: true,
+        reviewStatus: 'approved',
+        recommendationAllowed: true,
+        requiresHumanReview: false,
+        reason: 'curated_allowlist',
+      },
+    }
+
+    expect(isDeliberateGovernanceHold(record)).toBe(true)
+    expect(applyDeliberateGovernanceHold(record)).toBe(true)
+    expect(record.indexability_status).toBe('NEEDS_REVIEW')
+    expect(record.robots).toBe('noindex,follow')
+    expect(record.sitemap_included).toBe(false)
+    expect(record.governance.indexingAllowed).toBe(false)
+    expect(record.governance.requiresHumanReview).toBe(true)
+    expect(record.governance.recommendationAllowed).toBe(false)
+  })
+
+  it('keeps research_only profile status ahead of curated allowlisting', () => {
+    const record = {
+      slug: 'acetyl-l-carnitine',
+      profile_status: 'research_only',
+      indexability_status: 'PUBLISH',
+      robots: 'index,follow',
+      sitemap_included: true,
+      indexability_reasons: ['profile-status:research_only', 'curated_allowlist'],
+    }
+
+    expect(applyDeliberateGovernanceHold(record)).toBe(true)
+    expect(record.indexability_status).toBe('NEEDS_REVIEW')
+  })
+
+  it('leaves normal curated publish records unchanged', () => {
+    const record = {
+      slug: 'magnesium',
+      runtime_export_decision: 'full_public_runtime',
+      profile_status: 'complete',
+      indexability_status: 'PUBLISH',
+      robots: 'index,follow',
+      sitemap_included: true,
+      indexability_reasons: ['curated_allowlist'],
+    }
+
+    expect(isDeliberateGovernanceHold(record)).toBe(false)
+    expect(applyDeliberateGovernanceHold(record)).toBe(false)
+    expect(record.indexability_status).toBe('PUBLISH')
+  })
+})

--- a/scripts/data/postprocess-workbook-payloads.mjs
+++ b/scripts/data/postprocess-workbook-payloads.mjs
@@ -1,7 +1,8 @@
 import fs from 'fs'
 import path from 'path'
 
-const dataDir = path.join(process.cwd(), 'public/data')
+const dataDirArg = process.argv.find((arg) => arg.startsWith('--data-dir='))
+const dataDir = path.resolve(process.cwd(), dataDirArg ? dataDirArg.split('=')[1] : 'public/data')
 const herbSourcesCachePath = path.join(process.cwd(), 'ops/cache/pubmed-herb-sources-cache.json')
 
 function readHerbSourcesCache() {

--- a/src/lib/__tests__/seo-governance-precedence.test.ts
+++ b/src/lib/__tests__/seo-governance-precedence.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { shouldIndexRoute } from '../seo'
+
+describe('SEO governance precedence', () => {
+  it('keeps a curated herb noindexed while an explicit grounding hold is active', () => {
+    const decision = shouldIndexRoute('/herbs/black-cohosh', {
+      slug: 'black-cohosh',
+      sitemap_included: false,
+      robots: 'noindex,follow',
+      indexability_status: 'NEEDS_REVIEW',
+      runtime_export_decision: 'hidden_until_grounded',
+      profile_status: 'complete',
+      indexability_reasons: ['deliberate_governance_hold'],
+    })
+
+    expect(decision.index).toBe(false)
+    expect(decision.follow).toBe(true)
+    expect(decision.reason).toBe('runtime_export_decision=hidden_until_grounded')
+  })
+
+  it('keeps a curated compound noindexed while research_only is active', () => {
+    const decision = shouldIndexRoute('/compounds/acetyl-l-carnitine', {
+      slug: 'acetyl-l-carnitine',
+      sitemap_included: false,
+      robots: 'noindex,follow',
+      indexability_status: 'NEEDS_REVIEW',
+      runtime_export_decision: 'full_public_runtime',
+      profile_status: 'research_only',
+      indexability_reasons: ['deliberate_governance_hold'],
+    })
+
+    expect(decision.index).toBe(false)
+    expect(decision.reason).toBe('profile_status=research_only')
+  })
+
+  it('preserves the existing curated override for an ordinary review state', () => {
+    const decision = shouldIndexRoute('/herbs/ashwagandha', {
+      slug: 'ashwagandha',
+      sitemap_included: false,
+      robots: 'index,follow',
+      indexability_status: 'NEEDS_REVIEW',
+      runtime_export_decision: 'full_public_runtime',
+      profile_status: 'complete',
+    })
+
+    expect(decision.index).toBe(true)
+    expect(decision.reason).toBe('curated-herb-allowlist')
+  })
+})

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -215,15 +215,10 @@ function normalizeIndexRoutePath(path: string): string {
 
 function hasNoindexSignal(record: Record<string, unknown> | null | undefined): string | null {
   if (!record) return null
-  const sitemapIncluded = record.sitemap_included
-  if (sitemapIncluded === false || String(sitemapIncluded).toLowerCase() === 'false') return 'sitemap_included=false'
 
-  const robots = String(record.robots || '').toLowerCase()
-  if (robots.includes('noindex')) return 'robots=noindex'
-
-  const indexabilityStatus = String(record.indexability_status || '').toUpperCase()
-  if (['NOINDEX', 'NEEDS_REVIEW', 'BLOCKED'].includes(indexabilityStatus)) return `indexability_status=${indexabilityStatus}`
-
+  // Strong source/runtime holds must be evaluated before derived indexability
+  // fields. Curated priority can intentionally override an ordinary review state,
+  // but it must never erase an explicit hidden/research-only content hold.
   const decision = String(record.runtime_export_decision || '').toLowerCase()
   if (['hide', 'hidden', 'blocked', 'block', 'alias_redirect_only', 'hidden_until_grounded', 'research_archive_runtime'].includes(decision)) {
     return `runtime_export_decision=${decision}`
@@ -231,6 +226,15 @@ function hasNoindexSignal(record: Record<string, unknown> | null | undefined): s
 
   const profileStatus = String(record.profile_status || '').toLowerCase()
   if (['draft', 'archived', 'minimal', 'research_only'].includes(profileStatus)) return `profile_status=${profileStatus}`
+
+  const robots = String(record.robots || '').toLowerCase()
+  if (robots.includes('noindex')) return 'robots=noindex'
+
+  const indexabilityStatus = String(record.indexability_status || '').toUpperCase()
+  if (['NOINDEX', 'NEEDS_REVIEW', 'BLOCKED'].includes(indexabilityStatus)) return `indexability_status=${indexabilityStatus}`
+
+  const sitemapIncluded = record.sitemap_included
+  if (sitemapIncluded === false || String(sitemapIncluded).toLowerCase() === 'false') return 'sitemap_included=false'
 
   const summaryQuality = String(record.summary_quality || '').toLowerCase()
   if (['weak', 'minimal', 'thin', 'stub', 'research_needed', 'none'].includes(summaryQuality)) return `summary_quality=${summaryQuality}`


### PR DESCRIPTION
Replays the production runtime governance boundary onto current main and closes the remaining SEO authority split.

What this does:
- normalizes workbook runtime payloads and reapplies governance before summary/route/sitemap generation
- preserves deliberate hidden_until_grounded / research_archive_runtime / research_only / minimal holds after curated overlay
- keeps the #2573 AI entity artifact authority
- makes explicit runtime/profile hold signals outrank generic sitemap/NEEDS_REVIEW signals in shouldIndexRoute(), so curated editorial priority cannot accidentally re-index a deliberate hold
- adds regressions for black-cohosh and acetyl-l-carnitine while preserving the ordinary curated review override for ashwagandha

Precedence: deliberate content hold > curated editorial priority > source/indexability heuristic.

Supersedes #2577 and #2569 if fully green.