### PR TITLE
Reframe magnesium sleep guide around evidence, safety, and buyer fit

### DIFF
--- a/app/guides/sleep/magnesium-types-for-sleep/page.test.ts
+++ b/app/guides/sleep/magnesium-types-for-sleep/page.test.ts
@@ -1,0 +1,38 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const source = fs.readFileSync(
+  path.join(process.cwd(), 'app/guides/sleep/magnesium-types-for-sleep/page.tsx'),
+  'utf8',
+)
+
+describe('magnesium types for sleep evidence discipline', () => {
+  it('does not rank magnesium forms as proven sleep winners', () => {
+    expect(source).not.toContain('Best practical first trial')
+    expect(source).not.toContain('Best overall pick')
+    expect(source).not.toContain('★★★★★')
+    expect(source).not.toContain('Worst default sleep pick')
+    expect(source).toContain('No magnesium form has been shown in reliable head-to-head sleep trials to be best')
+  })
+
+  it('does not publish unsupported combination or fixed sleep protocol claims', () => {
+    expect(source).not.toContain('are not known to interact adversely')
+    expect(source).not.toContain('Most sleep-focused protocols use 200–400 mg')
+    expect(source).not.toContain('30–60 min before bed')
+    expect(source).not.toContain('usually resolves GI issues')
+    expect(source).toContain('350 mg/day')
+  })
+
+  it('uses one curated commercial handoff instead of generic Amazon searches', () => {
+    expect(source).not.toContain('AFFILIATE_TAGS')
+    expect(source).not.toContain('amazon.com/s?k=')
+    expect(source).toContain('<RecommendationSection')
+  })
+
+  it('preserves publication history while exposing a real review date', () => {
+    expect(source).toContain("const DATE = '2026-06-09'")
+    expect(source).toContain("const UPDATED_DATE = '2026-08-11'")
+    expect(source).toContain('updated: UPDATED_DATE')
+  })
+})

--- a/app/guides/sleep/magnesium-types-for-sleep/page.tsx
+++ b/app/guides/sleep/magnesium-types-for-sleep/page.tsx
@@ -10,17 +10,15 @@ import RecommendationSection from '@/components/RecommendationSection'
 import NewsletterCtaBlock from '@/components/NewsletterCtaBlock'
 import LastUpdatedBadge from '../../../../src/components/editorial/LastUpdatedBadge'
 import ResponsiveTable from '@/components/ui/ResponsiveTable'
-import { AFFILIATE_TAGS } from '@/config/affiliate'
-
-// ─── Article metadata ─────────────────────────────────────────────────────────
 
 const SLUG = 'magnesium-types-for-sleep'
 const TITLE = 'Magnesium Types for Sleep: Glycinate vs Threonate vs Citrate'
 const DESCRIPTION =
-  'A practical comparison of magnesium glycinate, threonate, citrate, oxide, malate, and taurate for sleep — covering absorption, GI tolerability, best uses, safety, and buyer guidance.'
+  'An evidence-first comparison of magnesium glycinate, threonate, citrate, oxide, malate, and taurate for sleep — separating absorption and tolerability from what sleep trials actually show.'
 const DATE = '2026-06-09'
+const UPDATED_DATE = '2026-08-11'
 const AUTHOR = 'Will'
-const READING_TIME = '13 min read'
+const READING_TIME = '11 min read'
 const TAGS = ['magnesium', 'sleep', 'glycinate', 'threonate', 'citrate']
 const CATEGORY = 'minerals'
 
@@ -31,42 +29,38 @@ export const metadata = buildPageMetadata({
   openGraphType: 'article',
 })
 
-// ─── FAQ data (also used for JSON-LD) ────────────────────────────────────────
-
 const FAQS = [
   {
     question: 'What is the best magnesium for sleep?',
     answer:
-      'Magnesium glycinate is the most widely recommended form for sleep. It has high bioavailability, excellent GI tolerability, and the glycine carrier molecule has independent calming and sleep-supporting properties. For those also prioritizing cognitive function, magnesium L-threonate is an alternative at a higher price point.',
+      'No magnesium form has been shown in reliable head-to-head sleep trials to be best. The overall evidence for magnesium supplements and insomnia is limited and conflicting. If you are considering a supplement, compare elemental magnesium, GI tolerability, price, other ingredients, and your reason for using magnesium rather than treating one form as a proven sleep winner.',
   },
   {
     question: 'Is magnesium glycinate better than citrate for sleep?',
     answer:
-      'For sleep specifically, glycinate is generally preferred over citrate. Both forms are better absorbed than oxide. Glycinate is gentler on the GI system at typical doses and the glycine component adds a calming effect. Citrate is better suited when constipation is also a concern, though higher doses of citrate can cause loose stools.',
+      'There is not good direct evidence showing that glycinate improves sleep more than citrate. Citrate has evidence of better absorption than oxide, but absorption studies do not establish better sleep outcomes. Citrate can have a laxative effect, while some people choose glycinate for tolerability; individual response varies.',
   },
   {
-    question: 'Is magnesium threonate worth it?',
+    question: 'Is magnesium threonate worth it for sleep?',
     answer:
-      'Magnesium L-threonate (often sold as Magtein™) is significantly more expensive than glycinate. The proposed advantage is better penetration into the central nervous system, supported by animal data and some early human trials showing cognitive benefits. If sleep is your only goal and budget matters, glycinate is likely adequate. If cognitive benefits alongside sleep are a priority, threonate may be worth the premium.',
+      'Higher price does not mean stronger sleep evidence. Magnesium L-threonate has form-specific research and is marketed heavily for brain-related effects, but current evidence does not establish that it produces better insomnia or sleep outcomes than less expensive forms. Treat the premium price as a product feature, not an evidence grade.',
   },
   {
-    question: 'Why does magnesium upset my stomach?',
+    question: 'Why can magnesium upset my stomach?',
     answer:
-      'GI upset from magnesium is most common with oxide and citrate forms, and at higher doses. Magnesium draws water into the gut osmotically, which can cause loose stools or cramping. Switching to magnesium glycinate, taking with food, and starting at lower doses (100–200 mg elemental) then titrating up usually resolves GI issues.',
+      'Unabsorbed magnesium can draw water into the intestine, so diarrhea, loose stools, nausea, and cramping become more likely as supplemental intake rises. The effect varies by dose, formulation, and person. Lowering the supplemental amount or changing formulations may help; persistent symptoms are a reason to stop and discuss the product with a clinician.',
   },
   {
     question: 'How much magnesium should I take for sleep?',
     answer:
-      'Most sleep-focused protocols use 200–400 mg of elemental magnesium per day, taken in the evening. Check the label for elemental magnesium content — this differs from total product weight. The tolerable upper intake level from supplements is 350 mg/day for most adults per standard regulatory guidance (NIH Office of Dietary Supplements).',
+      'There is no well-established universal magnesium dose for insomnia, and study doses have varied. Check the Supplement Facts panel for elemental magnesium rather than the total weight of the magnesium compound. For adults, the U.S. tolerable upper intake level for magnesium from supplements and medications is 350 mg/day unless a healthcare professional recommends otherwise; magnesium naturally present in food is not counted toward that supplemental limit.',
   },
   {
     question: 'Can I combine magnesium with ashwagandha?',
     answer:
-      'Yes. Magnesium and ashwagandha work through different primary mechanisms — magnesium via NMDA and GABA pathways, ashwagandha via HPA axis modulation — and are not known to interact adversely. They are commonly combined in sleep stacks. Start each supplement individually before combining to assess individual tolerability.',
+      'The absence of a well-known interaction is not enough to call a combination universally safe. Interaction data for supplement combinations can be incomplete, and safety depends on medications, health conditions, pregnancy status, dose, and the specific products used. A pharmacist or clinician can check your individual situation before you combine them.',
   },
 ]
-
-// ─── Page ─────────────────────────────────────────────────────────────────────
 
 export default function MagnesiumTypesForSleepPage() {
   const pageBreadcrumb = breadcrumbJsonLd([
@@ -75,7 +69,7 @@ export default function MagnesiumTypesForSleepPage() {
   ])
 
   const articleLd = blogJsonLd(
-    { title: TITLE, slug: SLUG, date: DATE, description: DESCRIPTION },
+    { title: TITLE, slug: SLUG, date: DATE, updated: UPDATED_DATE, description: DESCRIPTION },
     `/guides/sleep/${SLUG}/`,
   )
 
@@ -83,14 +77,10 @@ export default function MagnesiumTypesForSleepPage() {
 
   return (
     <article className="mx-auto max-w-5xl space-y-0 px-4 pb-20 pt-6 sm:px-6 lg:px-8">
-      {/* JSON-LD */}
       <JsonLd schema={articleLd} />
       <JsonLd schema={pageBreadcrumb} />
-      {faqLd && (
-        <JsonLd schema={faqLd} />
-      )}
+      {faqLd && <JsonLd schema={faqLd} />}
 
-      {/* Breadcrumb */}
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
         <Link href="/guides/" className="transition hover:text-ink">
           Guides
@@ -99,7 +89,6 @@ export default function MagnesiumTypesForSleepPage() {
         <span className="text-ink line-clamp-1">{TITLE}</span>
       </nav>
 
-      {/* Hero */}
       <section className="rounded-[1.5rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8 lg:p-10">
         <div className="flex flex-wrap items-center gap-2 text-xs">
           <span className="rounded-full border border-brand-900/10 bg-brand-50 px-2.5 py-0.5 font-bold uppercase tracking-wider text-brand-800">
@@ -133,186 +122,122 @@ export default function MagnesiumTypesForSleepPage() {
         </p>
 
         <div className="mt-3">
-          <LastUpdatedBadge date={DATE} label="Last updated" />
+          <LastUpdatedBadge date={UPDATED_DATE} label="Last updated" />
         </div>
 
         <p className="mt-4 max-w-3xl text-base leading-7 text-muted">{DESCRIPTION}</p>
 
         <figure className="mt-6">
-          <div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white">
+          <div className="overflow-hidden rounded-2xl border border-brand-900/10 bg-white shadow-sm">
             <Image
               src="/images/guides/magnesium-types-for-sleep.jpg"
               alt="Different types of magnesium supplements compared for sleep"
               width={1536}
               height={1024}
               priority
-              className="w-full h-auto"
+              className="h-auto w-full"
             />
           </div>
           <figcaption className="mt-3 text-center text-sm text-muted">
-            Not all magnesium is equal — the form matters for sleep.
+            Magnesium forms differ in formulation, absorption, price, and GI effects. Sleep superiority is not established.
           </figcaption>
         </figure>
       </section>
 
-      {/* Affiliate disclosure */}
       <div className="mt-4 rounded-[1rem] border border-brand-900/10 bg-brand-50/60 px-5 py-3 text-xs leading-6 text-muted">
-        <strong className="text-ink">Affiliate disclosure:</strong> This article contains affiliate
-        links. If you purchase through these links, we may earn a commission at no additional cost to
-        you. We only link to magnesium forms and dose ranges consistent with the clinical protocols
-        reviewed on this page.
+        <strong className="text-ink">Affiliate disclosure:</strong> This article may contain affiliate
+        links in the curated recommendation section. If you purchase through them, we may earn a
+        commission at no additional cost to you. Commercial links do not change the evidence rating
+        or safety discussion on this page.
       </div>
 
-      {/* Body + sidebar */}
       <div className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1fr)_240px]">
-        {/* Main content */}
         <div className="space-y-6">
-
-          {/* Quick Verdict */}
           <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
-            <p className="eyebrow-label">Quick Verdict</p>
+            <p className="eyebrow-label">Quick read</p>
             <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
-              Which Magnesium Type Is Best for Sleep?
+              What Can We Actually Say About Magnesium Forms and Sleep?
             </h2>
             <div className="mt-3 space-y-3 text-[1.01rem] leading-[1.85] text-muted">
               <p>
-                <strong>Best practical first trial: Magnesium glycinate.</strong> It is widely used
-                because it is usually easier on the gut than oxide and provides a clear elemental
-                magnesium dose. That is a buyer-fit judgment, not proof that glycinate improves
-                sleep more than every other form: direct head-to-head sleep trials are lacking.
+                <strong>No magnesium form has been shown in reliable head-to-head sleep trials to be best.</strong>{' '}
+                Research on magnesium supplements for insomnia is small and inconsistent overall,
+                and most form-comparison studies answer a different question: how well a form is
+                absorbed or tolerated.
               </p>
               <p>
-                <strong>Best premium/cognitive option: Magnesium threonate.</strong> Proposed CNS
-                targeting with early form-specific research, but little evidence that its higher
-                price produces better sleep outcomes than simpler forms.
-              </p>
-              <p>
-                <strong>Best if constipation is also an issue: Magnesium citrate.</strong> Better
-                absorbed than oxide; gentle laxative effect at moderate doses can be useful if
-                constipation overlaps with your sleep goals. Not ideal as a default sleep form.
-              </p>
-              <p>
-                <strong>Worst default sleep pick: Magnesium oxide.</strong> Cheapest and most
-                common in stores, but substantially lower absorption limits its usefulness for
-                sleep-specific applications. Best suited as a laxative.
-              </p>
-              <p>
-                <strong>Best for muscle pain/fatigue overlap: Magnesium malate.</strong> Malate
-                (malic acid) participates in energy metabolism, but that mechanism is not clinical
-                proof of a sleep benefit. Consider it for tolerance or preference, not as a
-                condition-specific treatment.
-              </p>
-              <p>
-                <strong>Possible calming option: Magnesium taurate.</strong> Taurine has calming
-                mechanisms of interest, but direct sleep evidence is sparse. Avoid choosing it on
-                cardiometabolic claims alone.
+                That distinction matters. A form can be better absorbed than another without being
+                proven to improve sleep more. For a buyer, the defensible comparison is therefore
+                <strong> elemental magnesium + tolerability + price + formulation</strong>, not a
+                five-star sleep ranking.
               </p>
               <p className="rounded-lg bg-muted/50 p-4 text-sm">
-                <strong>What the evidence can actually tell us:</strong> small trials suggest oral
-                magnesium may shorten sleep-onset time in some older adults, but a systematic review
-                rated that evidence low to very low quality. Form-comparison studies mostly measure
-                absorption, not sleep. Product choice should therefore prioritize elemental dose,
-                tolerability, cost, and the reason you may be low in magnesium.
+                <strong>Evidence boundary:</strong> a 2021 systematic review found only three
+                randomized trials in 151 older adults with insomnia. The authors rated the evidence
+                low to very low quality. NCCIH also describes the broader magnesium-and-sleep
+                literature as too limited and conflicting for confident conclusions.
               </p>
             </div>
           </section>
 
-          {/* Main article body */}
-          <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8 space-y-8">
-
-            {/* Comparison table */}
+          <section className="space-y-8 rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
             <div id="comparison-table">
               <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                Magnesium Forms Compared
+                Magnesium Forms Compared Without a Fake Sleep Ranking
               </h2>
               <p className="mb-4 text-[1.01rem] leading-[1.85] text-muted">
-                The table below summarises the six most commonly discussed magnesium forms for
-                sleep applications. Bioavailability rankings are relative — exact absorption
-                percentages vary by individual, dose, and food intake and are approximate estimates.
+                This table separates what is reasonably supported from what remains uncertain.
+                Absorption and GI behavior can differ by formulation; those differences should not
+                be converted into claims that one form is a superior insomnia treatment.
               </p>
 
               <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-5 shadow-sm">
-                <ResponsiveTable label="Magnesium forms comparison for sleep">
+                <ResponsiveTable label="Evidence-first comparison of magnesium forms for sleep">
                   <table className="min-w-[760px] w-full text-sm">
                     <thead>
                       <tr className="border-b border-brand-900/10">
-                        <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                          Form
-                        </th>
-                        <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                          Best For
-                        </th>
-                        <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                          Sleep Fit
-                        </th>
-                        <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                          GI Tolerance
-                        </th>
-                        <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                          Cost
-                        </th>
-                        <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                          Main Drawback
-                        </th>
-                        <th className="pb-2 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                          Buyer Verdict
-                        </th>
+                        <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">Form</th>
+                        <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">What is reasonably supported</th>
+                        <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">Practical consideration</th>
+                        <th className="pb-2 text-left text-xs font-bold uppercase tracking-wider text-muted">Sleep evidence gap</th>
                       </tr>
                     </thead>
                     <tbody className="divide-y divide-brand-900/5">
                       <tr className="align-top">
                         <td className="py-3 pr-4 font-medium text-ink">Glycinate</td>
-                        <td className="py-3 pr-4 text-muted">Sleep, relaxation, general</td>
-                        <td className="py-3 pr-4 text-muted">★★★★★</td>
-                        <td className="py-3 pr-4 text-muted">Excellent</td>
-                        <td className="py-3 pr-4 text-muted">Moderate</td>
-                        <td className="py-3 pr-4 text-muted">Higher cost than oxide</td>
-                        <td className="py-3 text-brand-700 font-semibold">Best overall pick</td>
+                        <td className="py-3 pr-4 text-muted">A magnesium chelate commonly sold for evening use.</td>
+                        <td className="py-3 pr-4 text-muted">Compare elemental magnesium, added ingredients, price, and personal GI tolerance.</td>
+                        <td className="py-3 text-muted">Direct evidence that glycinate improves sleep more than citrate, oxide, or other forms is insufficient.</td>
                       </tr>
                       <tr className="align-top">
-                        <td className="py-3 pr-4 font-medium text-ink">Threonate</td>
-                        <td className="py-3 pr-4 text-muted">Sleep + cognition</td>
-                        <td className="py-3 pr-4 text-muted">★★★★☆</td>
-                        <td className="py-3 pr-4 text-muted">Good</td>
-                        <td className="py-3 pr-4 text-muted">High</td>
-                        <td className="py-3 pr-4 text-muted">Expensive; limited trial data</td>
-                        <td className="py-3 text-muted">Premium option</td>
+                        <td className="py-3 pr-4 font-medium text-ink">L-threonate</td>
+                        <td className="py-3 pr-4 text-muted">A specialty formulation with form-specific research and premium pricing.</td>
+                        <td className="py-3 pr-4 text-muted">Usually provides less elemental magnesium per labeled serving than many other products; check the panel.</td>
+                        <td className="py-3 text-muted">Evidence does not establish superior insomnia outcomes versus less expensive forms.</td>
                       </tr>
                       <tr className="align-top">
                         <td className="py-3 pr-4 font-medium text-ink">Citrate</td>
-                        <td className="py-3 pr-4 text-muted">Constipation + sleep overlap</td>
-                        <td className="py-3 pr-4 text-muted">★★★☆☆</td>
-                        <td className="py-3 pr-4 text-muted">Moderate</td>
-                        <td className="py-3 pr-4 text-muted">Low–Moderate</td>
-                        <td className="py-3 pr-4 text-muted">Laxative effect at high doses</td>
-                        <td className="py-3 text-muted">If constipation overlaps</td>
+                        <td className="py-3 pr-4 text-muted">Small bioavailability studies support better absorption than magnesium oxide.</td>
+                        <td className="py-3 pr-4 text-muted">Can loosen stools because magnesium salts can have an osmotic effect.</td>
+                        <td className="py-3 text-muted">Better absorption than oxide does not prove better sleep outcomes.</td>
                       </tr>
                       <tr className="align-top">
                         <td className="py-3 pr-4 font-medium text-ink">Oxide</td>
-                        <td className="py-3 pr-4 text-muted">Laxative use; cheap repletion</td>
-                        <td className="py-3 pr-4 text-muted">★☆☆☆☆</td>
-                        <td className="py-3 pr-4 text-muted">Poor at higher doses</td>
-                        <td className="py-3 pr-4 text-muted">Very low</td>
-                        <td className="py-3 pr-4 text-muted">Low absorption; GI effects</td>
-                        <td className="py-3 text-muted">Not recommended for sleep</td>
+                        <td className="py-3 pr-4 text-muted">Inexpensive, high elemental-magnesium percentage by compound weight, and commonly used in laxative products.</td>
+                        <td className="py-3 pr-4 text-muted">Less completely absorbed than several more soluble forms in small studies and may cause GI effects.</td>
+                        <td className="py-3 text-muted">There is no basis to convert its lower absorption into a precise sleep-effect rating.</td>
                       </tr>
                       <tr className="align-top">
                         <td className="py-3 pr-4 font-medium text-ink">Malate</td>
-                        <td className="py-3 pr-4 text-muted">Muscle fatigue overlap</td>
-                        <td className="py-3 pr-4 text-muted">★★★☆☆</td>
-                        <td className="py-3 pr-4 text-muted">Good</td>
-                        <td className="py-3 pr-4 text-muted">Moderate</td>
-                        <td className="py-3 pr-4 text-muted">Limited direct sleep data</td>
-                        <td className="py-3 text-muted">If muscle fatigue overlaps</td>
+                        <td className="py-3 pr-4 text-muted">Magnesium bound to malate; sold mainly on formulation and non-sleep positioning.</td>
+                        <td className="py-3 pr-4 text-muted">Use label quality, elemental amount, cost, and tolerability as the practical filters.</td>
+                        <td className="py-3 text-muted">Direct sleep-specific human evidence is sparse.</td>
                       </tr>
                       <tr className="align-top">
                         <td className="py-3 pr-4 font-medium text-ink">Taurate</td>
-                        <td className="py-3 pr-4 text-muted">Calming, cardiometabolic</td>
-                        <td className="py-3 pr-4 text-muted">★★★☆☆</td>
-                        <td className="py-3 pr-4 text-muted">Good</td>
-                        <td className="py-3 pr-4 text-muted">Moderate–High</td>
-                        <td className="py-3 pr-4 text-muted">Very limited human sleep data</td>
-                        <td className="py-3 text-muted">Niche/overlap use</td>
+                        <td className="py-3 pr-4 text-muted">Magnesium bound to taurine; often marketed around taurine-related mechanisms.</td>
+                        <td className="py-3 pr-4 text-muted">Mechanistic marketing should not substitute for clinical outcome data.</td>
+                        <td className="py-3 text-muted">Direct human sleep evidence for the combined form is very limited.</td>
                       </tr>
                     </tbody>
                   </table>
@@ -322,442 +247,218 @@ export default function MagnesiumTypesForSleepPage() {
 
             <hr className="border-brand-900/10" />
 
-            {/* Why form matters */}
             <div id="why-form-matters">
-              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">
-                Why Magnesium Form Matters
-              </h2>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                Magnesium is a mineral — it cannot exist as a supplement on its own. It must be
-                bound to a carrier molecule (a salt or amino acid) to be stable and absorbable.
-                That carrier molecule determines four things that matter for sleep applications:
-              </p>
-
-              <h3 className="mt-5 mb-1 text-xl font-semibold tracking-tight text-ink">
-                1. Elemental Magnesium Content
-              </h3>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                A &quot;500 mg magnesium&quot; label almost never means 500 mg of actual magnesium.
-                It refers to the total weight of the magnesium salt compound. For example,
-                magnesium oxide has a high percentage of elemental magnesium by weight (~60%)
-                because oxide is a small molecule. Magnesium glycinate has a lower percentage
-                (~14%) because glycine is a heavier carrier. A label claiming 500 mg of magnesium
-                glycinate delivers far less elemental magnesium than the same weight of magnesium
-                oxide. Always look for &quot;elemental magnesium&quot; on the supplement facts panel
-                — that is the number that matters.
-              </p>
-
-              <h3 className="mt-5 mb-1 text-xl font-semibold tracking-tight text-ink">
-                2. Absorption Differences
-              </h3>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                Not all magnesium is absorbed equally. Organic salts (glycinate, malate, citrate,
-                threonate) are generally better absorbed than inorganic forms (oxide, carbonate).
-                The exact absorption percentages vary by form, dose, individual magnesium status,
-                and whether the supplement is taken with food.
-                Absorption rankings, from best to worst, are broadly: threonate ≈ glycinate &gt;
-                malate ≈ citrate &gt; oxide.
-              </p>
-
-              <h3 className="mt-5 mb-1 text-xl font-semibold tracking-tight text-ink">
-                3. GI Tolerance
-              </h3>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                Poorly absorbed magnesium stays in the gut and draws water osmotically — this is
-                how magnesium oxide works as a laxative. Magnesium citrate has a similar but
-                weaker effect at typical doses. Glycinate, malate, and threonate are absorbed more
-                efficiently before reaching the colon, producing far less GI disruption. If
-                previous magnesium experiences involved diarrhea or cramping, switching to
-                glycinate usually resolves this.
-              </p>
-
-              <h3 className="mt-5 mb-1 text-xl font-semibold tracking-tight text-ink">
-                4. Secondary Effects from the Carrier
-              </h3>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                The bound molecule is not inert — it exerts its own biological effects. Glycine
-                is an inhibitory amino acid and independent sleep-promoting agent. Taurine has
-                calming and cardiovascular properties. Malate (malic acid) is a Krebs cycle
-                intermediate involved in energy production. Threonate may help transport magnesium
-                across the blood-brain barrier. These secondary effects are part of why form
-                selection matters beyond simple bioavailability.
-              </p>
+              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">Why Form Still Matters</h2>
+              <div className="space-y-5 text-[1.01rem] leading-[1.85] text-muted">
+                <div>
+                  <h3 className="mb-1 text-xl font-semibold tracking-tight text-ink">1. The label reports elemental magnesium</h3>
+                  <p>
+                    The Supplement Facts panel reports the amount of elemental magnesium supplied by
+                    the product. That is the useful number for comparing products. Do not assume the
+                    large milligram number in a product name or front-label callout represents elemental magnesium.
+                  </p>
+                </div>
+                <div>
+                  <h3 className="mb-1 text-xl font-semibold tracking-tight text-ink">2. Absorption can differ by salt</h3>
+                  <p>
+                    NIH Office of Dietary Supplements notes that forms that dissolve well in liquid
+                    tend to be absorbed more completely. Small studies found aspartate, citrate,
+                    lactate, and chloride more bioavailable than oxide and sulfate. That is useful
+                    formulation evidence, but it is not a sleep-treatment ranking.
+                  </p>
+                </div>
+                <div>
+                  <h3 className="mb-1 text-xl font-semibold tracking-tight text-ink">3. GI tolerance can determine whether a product is usable</h3>
+                  <p>
+                    Supplemental magnesium can cause diarrhea, nausea, and abdominal cramping,
+                    especially as intake rises. Formulation matters, but so do dose, other ingredients,
+                    meals, and individual response. A tolerable product is more practical than one that
+                    repeatedly causes symptoms, regardless of its marketing category.
+                  </p>
+                </div>
+                <div>
+                  <h3 className="mb-1 text-xl font-semibold tracking-tight text-ink">4. Carrier mechanisms are not clinical outcomes</h3>
+                  <p>
+                    Glycine, taurine, malate, and threonate each have biological stories attached to
+                    them. Those stories can justify research questions; they do not by themselves show
+                    that the corresponding magnesium form improves insomnia. Keep mechanistic plausibility
+                    separate from demonstrated sleep benefit.
+                  </p>
+                </div>
+              </div>
             </div>
 
             <hr className="border-brand-900/10" />
 
-            {/* Glycinate deep dive */}
             <div id="glycinate">
-              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">
-                Deep Dive: Magnesium Glycinate
-              </h2>
-
+              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">Magnesium Glycinate</h2>
               <EvidenceSummaryCard
                 title="Magnesium Glycinate for Sleep"
                 evidenceLevel="Limited"
-                humanEvidence="Magnesium supplementation trials in older adults and deficient populations show improvements in sleep quality, sleep efficiency, and early morning awakening. Glycinate-specific sleep trials are limited — most evidence comes from magnesium supplementation studies that use various forms. Glycine independently has modest sleep trial support."
-                mechanisticEvidence="Magnesium NMDA antagonism and GABA-A potentiation; glycine is an inhibitory amino acid with independent calming and core body temperature-lowering effects shown in small human trials. Additive mechanism with complementary pathways."
-                safetyProfile="Excellent tolerability. Lowest GI side effect risk among magnesium forms at standard doses. Well-suited for daily use."
+                humanEvidence="Oral magnesium sleep studies are limited overall, and glycinate-specific head-to-head sleep trials are insufficient to establish superiority over other forms."
+                mechanisticEvidence="Magnesium has plausible neurophysiologic roles, and glycine has its own biology, but combining those mechanisms does not establish a larger clinical sleep effect."
+                safetyProfile="Supplemental magnesium can cause GI effects. Product dose, formulation, kidney function, medications, and individual tolerance matter more than marketing claims about a universally gentle form."
               />
-
               <div className="mt-5 space-y-3 text-[1.01rem] leading-[1.85] text-muted">
                 <p>
-                  Magnesium glycinate is magnesium bound to glycine — an amino acid that acts as
-                  an inhibitory neurotransmitter in the central nervous system. This gives
-                  glycinate a dual mechanism: magnesium contributes via NMDA receptor blockade and
-                  GABA-A support, while glycine independently promotes sleep by lowering core body
-                  temperature and modulating glycine receptors in the brainstem.
+                  Glycinate is popular in sleep products because it is a chelated formulation and
+                  because glycine is easy to build a calming mechanism story around. The evidence
+                  boundary is important: popularity and mechanistic plausibility are not direct proof
+                  that magnesium glycinate improves sleep more than other magnesium forms.
                 </p>
                 <p>
-                  The combination makes glycinate the most commonly recommended magnesium form for
-                  sleep in supplement-literate communities — and this recommendation is reasonable
-                  based on mechanistic logic, even though dedicated glycinate-specific sleep RCTs
-                  remain sparse.
+                  If you are comparing glycinate products, prioritize the declared elemental magnesium,
+                  ingredient list, serving size, independent quality testing where available, price per
+                  serving, and your own GI tolerance. Avoid choosing a product solely because the front
+                  label uses a larger compound-weight number.
                 </p>
-                <p>
-                  <strong>Tolerability</strong> is a key advantage. Glycinate is absorbed
-                  efficiently enough that minimal unabsorbed magnesium reaches the colon. People
-                  who experienced GI issues with citrate or oxide typically tolerate glycinate
-                  well, even at higher elemental doses.
-                </p>
-                <p>
-                  <strong>Buyer notes:</strong> Look for products that list elemental magnesium
-                  content explicitly on the supplement facts panel. Products providing 200–400 mg
-                  of elemental magnesium per serving are consistent with sleep-focused protocols.
-                  Avoid blends that combine magnesium glycinate with oxide as a filler to inflate
-                  the milligram count on the front label.
-                </p>
-                <div className="mt-2">
-                  <a
-                    href={`https://www.amazon.com/s?k=magnesium+glycinate+sleep&tag=${AFFILIATE_TAGS.amazon}`}
-                    target="_blank"
-                    rel="noopener noreferrer sponsored"
-                    className="inline-flex items-center gap-1 rounded-full bg-brand-950 px-4 py-1.5 text-xs font-bold text-white transition hover:bg-brand-900"
-                  >
-                    Search magnesium glycinate on Amazon →
-                  </a>
-                </div>
               </div>
             </div>
 
             <hr className="border-brand-900/10" />
 
-            {/* Threonate deep dive */}
             <div id="threonate">
-              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">
-                Deep Dive: Magnesium L-Threonate
-              </h2>
-
+              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">Magnesium L-Threonate</h2>
               <EvidenceSummaryCard
                 title="Magnesium L-Threonate for Sleep"
                 evidenceLevel="Limited"
-                humanEvidence="A small number of human trials (primarily Magtein™ brand) show improvements in sleep quality and cognitive performance in older adults. Sample sizes are modest and some trials were industry-funded. More robust independent replication is needed."
-                mechanisticEvidence="Threonate is proposed to transport magnesium across the blood-brain barrier more effectively than other carriers, raising brain magnesium levels. Animal studies show significant increases in synaptic density and cognitive function. Human CNS magnesium elevation has not been directly confirmed non-invasively."
-                safetyProfile="Generally well-tolerated. Good GI tolerability. Headaches and vivid dreams reported anecdotally in some users during initial use. Higher price point limits broad use."
+                humanEvidence="Form-specific human research exists, but current sleep evidence does not establish that L-threonate is superior to other magnesium forms for insomnia."
+                mechanisticEvidence="Preclinical work has motivated brain-magnesium hypotheses, but those hypotheses should not be translated into a claim of superior human sleep outcomes."
+                safetyProfile="Treat it as a magnesium supplement with product-specific dosing and standard magnesium safety considerations. Premium price is not a safety or efficacy signal."
               />
-
               <div className="mt-5 space-y-3 text-[1.01rem] leading-[1.85] text-muted">
                 <p>
-                  Magnesium L-threonate was developed by researchers at MIT and is commonly sold
-                  under the Magtein™ brand name. The key theoretical advantage is that the
-                  threonate carrier may facilitate magnesium transport across the blood-brain
-                  barrier, raising CNS magnesium levels more effectively than other forms.
+                  L-threonate is a premium formulation commonly marketed around cognitive and central
+                  nervous system claims. It may be a reasonable product to study, but a higher price and
+                  a more specialized carrier do not establish better sleep efficacy.
                 </p>
                 <p>
-                  This is a plausible hypothesis with animal model support. However, the claim
-                  that threonate raises brain magnesium levels in humans specifically has not been
-                  confirmed with direct CNS measurement in published human trials — the benefit is
-                  inferred from functional cognitive and sleep outcomes.
+                  Check the elemental magnesium on the label rather than comparing the total compound
+                  weight with glycinate or citrate products. If sleep is the purchasing reason, the key
+                  question is whether the added cost is justified by evidence you actually care about;
+                  current evidence does not show a clear sleep advantage.
                 </p>
-                <p>
-                  <strong>Cognitive positioning:</strong> Threonate is primarily marketed for
-                  cognitive function (memory, learning, cognitive resilience) with sleep as a
-                  secondary benefit. If cognitive improvements are also a goal alongside sleep,
-                  threonate is a reasonable premium option.
-                </p>
-                <p>
-                  <strong>Cost consideration:</strong> Threonate is typically 3–5× the cost of
-                  equivalent elemental magnesium from glycinate. For people whose sole goal is
-                  sleep improvement, the glycinate form at a fraction of the cost is the more
-                  practical choice.
-                </p>
-                <p>
-                  <strong>Dosing note:</strong> Magtein™ products typically deliver approximately
-                  ~144 mg elemental magnesium at the standard product dose. Follow the specific
-                  label — elemental magnesium per dose varies by product.
-                </p>
-                <div className="mt-2">
-                  <a
-                    href={`https://www.amazon.com/s?k=magnesium+l-threonate+magtein+sleep&tag=${AFFILIATE_TAGS.amazon}`}
-                    target="_blank"
-                    rel="noopener noreferrer sponsored"
-                    className="inline-flex items-center gap-1 rounded-full bg-brand-950 px-4 py-1.5 text-xs font-bold text-white transition hover:bg-brand-900"
-                  >
-                    Search magnesium threonate on Amazon →
-                  </a>
-                </div>
               </div>
             </div>
 
             <hr className="border-brand-900/10" />
 
-            {/* Citrate deep dive */}
-            <div id="citrate">
-              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">
-                Deep Dive: Magnesium Citrate
-              </h2>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                Magnesium citrate is one of the most widely available and affordable &quot;quality&quot;
-                magnesium forms — meaningfully better absorbed than oxide and considerably cheaper
-                than glycinate or threonate. It is a reasonable general-purpose magnesium
-                supplement.
-              </p>
-              <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
-                <strong>For sleep specifically:</strong> Citrate lacks the glycine co-mechanism
-                that makes glycinate particularly well-suited for sleep. The laxative effect at
-                moderate-to-high doses can be disruptive for sleep if GI symptoms occur overnight.
-              </p>
-              <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
-                <strong>When citrate is the better choice:</strong> If constipation overlaps with
-                your sleep goals — or if you simply want an affordable magnesium with reasonable
-                absorption for general repletion — citrate is practical. Start at 150–200 mg
-                elemental and increase gradually to avoid GI effects. Take with food and in the
-                evening if using for sleep.
-              </p>
-              <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
-                <strong>Not ideal as a default sleep form:</strong> For someone whose sole goal
-                is improved sleep quality, glycinate is the better first choice. The laxative
-                downside of citrate at doses needed for meaningful magnesium repletion is
-                a practical drawback at bedtime.
-              </p>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Oxide deep dive */}
-            <div id="oxide">
-              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">
-                Deep Dive: Magnesium Oxide
-              </h2>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                Magnesium oxide is the cheapest and most common magnesium form — it is the
-                default in budget multivitamins and the primary active ingredient in most OTC
-                laxative products. High elemental magnesium content by weight (~60%) makes it
-                attractive on paper.
-              </p>
-              <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
-                In practice, absorption of magnesium oxide is substantially lower than organic
-                forms. Most of the dose passes through the gastrointestinal tract largely
-                unabsorbed, drawing water into the colon — hence its effectiveness as a laxative.
-                A high on-label milligram count can be misleading if the form is poorly absorbed.
-              </p>
-              <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
-                <strong>For sleep:</strong> Not recommended as a primary sleep supplement. The
-                small amount of magnesium that is absorbed may provide minor general benefits, but
-                the GI side effects at doses needed for meaningful systemic magnesium delivery
-                make it a poor choice for nightly use aimed at sleep improvement.
-              </p>
-              <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
-                <strong>Where it is useful:</strong> Short-term constipation relief. Budget-only
-                situations where any magnesium form is better than none. Not for sleep-first
-                supplementation goals.
-              </p>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Malate and Taurate deep dive */}
-            <div id="malate-taurate">
-              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">
-                Deep Dive: Magnesium Malate and Taurate
-              </h2>
-
-              <h3 className="mt-4 mb-2 text-xl font-semibold tracking-tight text-ink">
-                Magnesium Malate
-              </h3>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                Magnesium malate combines magnesium with malic acid — a Krebs cycle intermediate
-                involved in ATP synthesis and energy metabolism. It is sometimes used in the
-                context of fibromyalgia, chronic fatigue, and muscle pain, where both magnesium
-                deficiency and malic acid may play overlapping roles.
-              </p>
-              <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
-                <strong>Sleep fit:</strong> If your sleep difficulty overlaps significantly with
-                muscle pain, fatigue, or fibromyalgia-like symptoms, malate may be a better fit
-                than glycinate due to the malic acid component addressing the metabolic overlap.
-                Direct sleep-specific RCT evidence for malate is limited compared to glycinate.
-              </p>
-              <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
-                <strong>Evidence caveat:</strong> Most malate trial data comes from fibromyalgia
-                and fatigue contexts, not sleep outcome studies. The sleep benefit is largely
-                inferred from magnesium&apos;s general sleep mechanisms plus reduced muscle pain
-                as a secondary sleep facilitator. No direct sleep-specific PMID for malate has been identified in the source registry.
-              </p>
-
-              <h3 className="mt-6 mb-2 text-xl font-semibold tracking-tight text-ink">
-                Magnesium Taurate
-              </h3>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                Magnesium taurate combines magnesium with taurine — a semi-essential amino acid
-                with calming, GABA-modulating, and cardiometabolic properties. Taurine has been
-                studied for anxiety reduction, blood pressure regulation, and cardiac function.
-              </p>
-              <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
-                <strong>Sleep fit:</strong> The taurine component&apos;s calming and GABA-supportive
-                properties are theoretically complementary to magnesium&apos;s sleep mechanisms.
-                Direct sleep RCT evidence for magnesium taurate is very limited. It is a
-                reasonable niche consideration for people with cardiovascular or anxiety overlap
-                alongside sleep goals.
-              </p>
-              <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
-                <strong>Evidence caveat:</strong> Do not confuse mechanistic plausibility with
-                clinical evidence. Taurate&apos;s theoretical advantages are not yet backed by
-                adequate sleep-specific human RCTs. No direct sleep-specific PMID for taurate has been identified in the source registry.
-              </p>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Dosage and label reading */}
-            <div id="dosage-label-reading">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                Dosage and Label Reading
-              </h2>
-
-              <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-5 shadow-sm">
-                <p className="mb-3 text-[10px] font-bold uppercase tracking-wider text-muted">
-                  Dosage Reference — Sleep Protocols by Form
+            <div id="citrate-oxide">
+              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">Citrate and Oxide</h2>
+              <div className="space-y-3 text-[1.01rem] leading-[1.85] text-muted">
+                <p>
+                  <strong>Citrate:</strong> small comparative studies support better absorption than
+                  oxide. It is also used for its osmotic GI effect, so loose stools can become a practical
+                  limitation. Neither point proves a superior sleep effect.
                 </p>
-                <ResponsiveTable label="Magnesium dosage reference for sleep by form">
-                  <table className="min-w-[580px] w-full text-sm">
+                <p>
+                  <strong>Oxide:</strong> it is inexpensive and contains a high proportion of elemental
+                  magnesium by compound weight, but NIH ODS summarizes evidence that several other forms
+                  are absorbed more completely. It is also common in laxative products. That makes it a
+                  different practical tradeoff, not a form that deserves a one-star sleep score.
+                </p>
+              </div>
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            <div id="malate-taurate">
+              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">Malate and Taurate</h2>
+              <div className="space-y-3 text-[1.01rem] leading-[1.85] text-muted">
+                <p>
+                  <strong>Malate:</strong> the carrier participates in normal energy metabolism, but
+                  that biochemical fact does not demonstrate a sleep benefit for magnesium malate.
+                  Direct sleep-specific human evidence is sparse.
+                </p>
+                <p>
+                  <strong>Taurate:</strong> taurine-related mechanisms are often used to market the
+                  combined form. Direct human sleep evidence for magnesium taurate remains very limited,
+                  so cardiometabolic or calming mechanism claims should not be used as a substitute for
+                  sleep outcomes.
+                </p>
+              </div>
+            </div>
+
+            <hr className="border-brand-900/10" />
+
+            <div id="dosage-label-reading">
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Dose, Timing, and Label Reading</h2>
+              <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-5 shadow-sm">
+                <ResponsiveTable label="Magnesium label and evidence notes by form">
+                  <table className="min-w-[680px] w-full text-sm">
                     <thead>
                       <tr className="border-b border-brand-900/10">
-                        <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                          Form
-                        </th>
-                        <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                          Elemental Dose
-                        </th>
-                        <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                          Timing
-                        </th>
-                        <th className="pb-2 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                          Notes
-                        </th>
+                        <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">Form</th>
+                        <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">Check on label</th>
+                        <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">Timing evidence</th>
+                        <th className="pb-2 text-left text-xs font-bold uppercase tracking-wider text-muted">Key caution</th>
                       </tr>
                     </thead>
                     <tbody className="divide-y divide-brand-900/5">
-                      <tr className="align-top">
-                        <td className="py-3 pr-4 font-medium text-ink">Glycinate</td>
-                        <td className="py-3 pr-4 text-muted">
-                          200–400 mg
-                        </td>
-                        <td className="py-3 pr-4 text-muted">30–60 min before bed</td>
-                        <td className="py-3 text-muted">Start low; most recommended form for sleep</td>
-                      </tr>
-                      <tr className="align-top">
-                        <td className="py-3 pr-4 font-medium text-ink">Threonate</td>
-                        <td className="py-3 pr-4 text-muted">
-                          ~144 mg (per typical Magtein™ label)
-                        </td>
-                        <td className="py-3 pr-4 text-muted">Evening; follow product label</td>
-                        <td className="py-3 text-muted">Product-specific dosing; check elemental Mg on label</td>
-                      </tr>
-                      <tr className="align-top">
-                        <td className="py-3 pr-4 font-medium text-ink">Citrate</td>
-                        <td className="py-3 pr-4 text-muted">200–350 mg</td>
-                        <td className="py-3 pr-4 text-muted">Evening, with food</td>
-                        <td className="py-3 text-muted">Higher doses may cause loose stools; split if needed</td>
-                      </tr>
-                      <tr className="align-top">
-                        <td className="py-3 pr-4 font-medium text-ink">Malate</td>
-                        <td className="py-3 pr-4 text-muted">
-                          200–400 mg
-                        </td>
-                        <td className="py-3 pr-4 text-muted">Evening; can split dose</td>
-                        <td className="py-3 text-muted">Often used twice daily in fatigue protocols</td>
-                      </tr>
+                      {[
+                        ['Glycinate', 'Elemental magnesium and serving size', 'No universally established bedtime timing', 'Do not infer sleep superiority from the carrier'],
+                        ['L-threonate', 'Elemental magnesium per product dose', 'Follow product/clinician instructions', 'Premium positioning is not stronger evidence'],
+                        ['Citrate', 'Elemental magnesium and total daily intake', 'No established sleep-specific timing advantage', 'May loosen stools'],
+                        ['Oxide', 'Elemental magnesium and intended use', 'No established sleep-specific timing advantage', 'Lower absorption than several other forms; GI effects'],
+                        ['Malate / Taurate', 'Elemental magnesium and added ingredients', 'No established sleep-specific timing advantage', 'Direct sleep evidence is sparse'],
+                      ].map(([form, label, timing, caution]) => (
+                        <tr key={form} className="align-top">
+                          <td className="py-3 pr-4 font-medium text-ink">{form}</td>
+                          <td className="py-3 pr-4 text-muted">{label}</td>
+                          <td className="py-3 pr-4 text-muted">{timing}</td>
+                          <td className="py-3 text-muted">{caution}</td>
+                        </tr>
+                      ))}
                     </tbody>
                   </table>
                 </ResponsiveTable>
-                <p className="mt-3 text-xs text-muted">
-                  Always check the supplement facts panel for <strong>elemental magnesium</strong>{' '}
-                  content — not total product weight. The tolerable upper intake level from
-                  supplements is 350 mg/day elemental magnesium for most adults per standard
-                  regulatory guidance.
-                </p>
               </div>
 
               <div className="mt-5 space-y-3 text-[1.01rem] leading-[1.85] text-muted">
                 <p>
-                  <strong>Start low, titrate up.</strong> Begin with 100–200 mg elemental and
-                  increase over 1–2 weeks. This identifies your personal GI tolerance threshold
-                  before committing to higher doses.
+                  There is no well-established universal supplemental magnesium dose or bedtime
+                  schedule for insomnia. Published studies have used different preparations,
+                  populations, and dosing regimens, which is one reason the evidence does not support
+                  a single protocol for everyone.
                 </p>
                 <p>
-                  <strong>Timing for sleep.</strong> Evening dosing 30–60 minutes before bed is
-                  the most common protocol in sleep-focused trials. Taking with a small snack
-                  reduces GI discomfort risk.
-                </p>
-                <p>
-                  <strong>Split dosing.</strong> If you experience GI symptoms at your target
-                  dose, divide it — half in the morning and half in the evening. This is
-                  particularly relevant for citrate at higher doses.
-                </p>
-                <p>
-                  <strong>Reading labels.</strong> A product labelled &quot;Magnesium Glycinate
-                  400 mg&quot; contains 400 mg of magnesium glycinate compound — not 400 mg of
-                  elemental magnesium. The supplement facts panel will show the actual elemental
-                  magnesium, which is typically 50–80 mg per 400 mg of magnesium glycinate
-                  compound depending on the specific chelate form used.
+                  For adults, the U.S. tolerable upper intake level for magnesium from
+                  <strong> supplements and medications is 350 mg/day</strong> unless a healthcare
+                  professional recommends a higher amount. That limit does not include magnesium
+                  naturally present in food. Check all supplements and magnesium-containing medicines
+                  when estimating the supplemental total.
                 </p>
               </div>
             </div>
 
             <hr className="border-brand-900/10" />
 
-            {/* Safety */}
             <div id="safety">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                Safety and Side Effects
-              </h2>
-              <SafetyNotice title="Safety Summary — Magnesium Types for Sleep">
-                <ul className="ml-5 space-y-1.5 list-disc">
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Safety and Interactions</h2>
+              <SafetyNotice title="Safety Summary — Magnesium Supplements">
+                <ul className="ml-5 list-disc space-y-1.5">
                   <li>
-                    <strong>Generally well-tolerated</strong> at supplemental doses of 200–400 mg
-                    elemental per day in healthy adults with normal kidney function. Glycinate and
-                    threonate have the best tolerability profiles; oxide and citrate at higher doses
-                    commonly cause GI effects.
+                    <strong>GI effects:</strong> supplemental magnesium can cause diarrhea, nausea,
+                    and abdominal cramping. Risk generally rises with supplemental intake.
                   </li>
                   <li>
-                    <strong>Kidney disease:</strong> The kidneys are the primary route of magnesium
-                    excretion. Supplementation in people with reduced kidney function (CKD stage 3+)
-                    can cause hypermagnesemia. Consult a physician before supplementing with any
-                    magnesium form if you have kidney disease.
+                    <strong>Kidney impairment:</strong> reduced kidney function increases the risk
+                    of magnesium accumulation and toxicity. Discuss supplementation with a clinician
+                    if you have kidney disease.
                   </li>
                   <li>
-                    <strong>GI effects:</strong> Diarrhea, loose stools, and cramping are the most
-                    common dose-dependent side effects. Most common with oxide and citrate at
-                    higher doses. Reduce dose or switch to glycinate if GI effects occur.
+                    <strong>Medication absorption:</strong> magnesium can interfere with absorption
+                    of some antibiotics and bisphosphonates. Medication-specific spacing instructions
+                    differ, so use the prescription label or ask a pharmacist rather than applying one
+                    universal spacing rule.
                   </li>
                   <li>
-                    <strong>Drug interactions — medication spacing:</strong> Magnesium can reduce
-                    the absorption of several medications. Separate magnesium supplements from
-                    fluoroquinolone antibiotics (ciprofloxacin, levofloxacin), tetracycline
-                    antibiotics, bisphosphonates (alendronate, risedronate), and thyroid
-                    medications (levothyroxine) by at least 2 hours.
+                    <strong>Total supplemental intake:</strong> the adult UL is 350 mg/day from
+                    supplements and medications unless a healthcare professional recommends otherwise.
                   </li>
                   <li>
-                    <strong>Do not exceed upper limit without clinical guidance:</strong> The
-                    tolerable upper intake level from supplemental magnesium is 350 mg/day elemental
-                    for most adults. Higher doses require medical supervision, particularly with
-                    any degree of kidney impairment.
-                  </li>
-                  <li>
-                    <strong>Pregnancy and lactation:</strong> Dietary magnesium is important during
-                    pregnancy. High supplemental doses should be discussed with a healthcare
-                    provider. IV magnesium is used medically in obstetric contexts under clinical
-                    supervision — this is not relevant to standard oral supplementation.
+                    <strong>Pregnancy, lactation, or complex medical care:</strong> discuss supplemental
+                    dosing and product combinations with a qualified healthcare professional.
                   </li>
                 </ul>
               </SafetyNotice>
@@ -765,117 +466,24 @@ export default function MagnesiumTypesForSleepPage() {
 
             <hr className="border-brand-900/10" />
 
-            {/* Decision tree */}
             <div id="which-type">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                Which Type Should You Buy?
-              </h2>
-              <p className="mb-4 text-[1.01rem] leading-[1.85] text-muted">
-                Use this decision framework to match your situation to the most appropriate form:
-              </p>
-              <div className="space-y-3 rounded-[1rem] border border-brand-900/10 bg-brand-50/40 p-5">
-                <div className="flex gap-3">
-                  <span className="mt-0.5 flex-shrink-0 text-brand-700">→</span>
-                  <p className="text-[1.01rem] leading-[1.85] text-muted">
-                    <strong>If you just want sleep support:</strong>{' '}
-                    <a
-                      href={`https://www.amazon.com/s?k=magnesium+glycinate+sleep&tag=${AFFILIATE_TAGS.amazon}`}
-                      target="_blank"
-                      rel="noopener noreferrer sponsored"
-                      className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
-                    >
-                      Magnesium glycinate
-                    </a>
-                    . Best overall combination of efficacy, tolerability, and cost for sleep.
-                  </p>
-                </div>
-                <div className="flex gap-3">
-                  <span className="mt-0.5 flex-shrink-0 text-brand-700">→</span>
-                  <p className="text-[1.01rem] leading-[1.85] text-muted">
-                    <strong>If budget is no issue and cognition also matters:</strong>{' '}
-                    <a
-                      href={`https://www.amazon.com/s?k=magnesium+l-threonate+magtein&tag=${AFFILIATE_TAGS.amazon}`}
-                      target="_blank"
-                      rel="noopener noreferrer sponsored"
-                      className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
-                    >
-                      Magnesium threonate
-                    </a>
-                    . Premium option with cognitive overlap; not materially better than glycinate
-                    for sleep alone.
-                  </p>
-                </div>
-                <div className="flex gap-3">
-                  <span className="mt-0.5 flex-shrink-0 text-brand-700">→</span>
-                  <p className="text-[1.01rem] leading-[1.85] text-muted">
-                    <strong>If constipation also matters:</strong>{' '}
-                    <a
-                      href={`https://www.amazon.com/s?k=magnesium+citrate+supplement&tag=${AFFILIATE_TAGS.amazon}`}
-                      target="_blank"
-                      rel="noopener noreferrer sponsored"
-                      className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
-                    >
-                      Magnesium citrate
-                    </a>
-                    . The gentle laxative effect becomes an advantage if GI motility is also a goal.
-                  </p>
-                </div>
-                <div className="flex gap-3">
-                  <span className="mt-0.5 flex-shrink-0 text-brand-700">→</span>
-                  <p className="text-[1.01rem] leading-[1.85] text-muted">
-                    <strong>If cheapest option only:</strong>{' '}
-                    Magnesium oxide is widely available and inexpensive. It delivers some systemic
-                    magnesium even with low absorption, but is not ideal for sleep-specific use —
-                    GI effects at effective doses are a consistent practical problem.
-                  </p>
-                </div>
-                <div className="flex gap-3">
-                  <span className="mt-0.5 flex-shrink-0 text-brand-700">→</span>
-                  <p className="text-[1.01rem] leading-[1.85] text-muted">
-                    <strong>If muscle fatigue overlaps:</strong>{' '}
-                    <a
-                      href={`https://www.amazon.com/s?k=magnesium+malate+supplement&tag=${AFFILIATE_TAGS.amazon}`}
-                      target="_blank"
-                      rel="noopener noreferrer sponsored"
-                      className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
-                    >
-                      Magnesium malate
-                    </a>
-                    . Suited for fibromyalgia/fatigue overlap with sleep difficulty.
-                  </p>
-                </div>
-                <div className="flex gap-3">
-                  <span className="mt-0.5 flex-shrink-0 text-brand-700">→</span>
-                  <p className="text-[1.01rem] leading-[1.85] text-muted">
-                    <strong>If calming/cardiometabolic overlap matters:</strong>{' '}
-                    <a
-                      href={`https://www.amazon.com/s?k=magnesium+taurate+supplement&tag=${AFFILIATE_TAGS.amazon}`}
-                      target="_blank"
-                      rel="noopener noreferrer sponsored"
-                      className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
-                    >
-                      Magnesium taurate
-                    </a>
-                    . Niche option; limited direct sleep evidence but taurine&apos;s calming and
-                    cardiovascular properties may complement magnesium for specific profiles.
-                  </p>
-                </div>
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">How to Choose Without Overreading the Evidence</h2>
+              <div className="space-y-3 rounded-[1rem] border border-brand-900/10 bg-brand-50/40 p-5 text-[1.01rem] leading-[1.85] text-muted">
+                <p><strong>If GI tolerance is your main concern:</strong> compare smaller servings and formulations you personally tolerate rather than assuming one carrier is universally gentler.</p>
+                <p><strong>If price matters:</strong> compare cost per declared elemental-magnesium amount, not just bottle price or front-label milligrams.</p>
+                <p><strong>If constipation is also a goal:</strong> citrate and some other magnesium salts can have laxative effects; that can be useful or unwanted depending on the person.</p>
+                <p><strong>If a premium brain-focused product interests you:</strong> L-threonate is a distinct formulation, but do not treat the premium price as proof of better sleep.</p>
+                <p><strong>If the goal is chronic insomnia:</strong> magnesium should not displace evaluation of causes and evidence-based insomnia care. CBT-I remains the strongest-supported non-drug treatment approach for chronic insomnia.</p>
               </div>
             </div>
 
             <hr className="border-brand-900/10" />
 
-            {/* FAQ */}
             <div id="faq">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                Frequently Asked Questions
-              </h2>
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Frequently Asked Questions</h2>
               <div className="space-y-4">
-                {FAQS.map((faq, i) => (
-                  <div
-                    key={i}
-                    className="rounded-[0.75rem] border border-brand-900/10 bg-brand-50/40 p-4"
-                  >
+                {FAQS.map((faq) => (
+                  <div key={faq.question} className="rounded-[0.75rem] border border-brand-900/10 bg-brand-50/40 p-4">
                     <h3 className="font-semibold text-ink">{faq.question}</h3>
                     <p className="mt-2 text-sm leading-7 text-muted">{faq.answer}</p>
                   </div>
@@ -885,225 +493,65 @@ export default function MagnesiumTypesForSleepPage() {
 
             <hr className="border-brand-900/10" />
 
-            {/* Related Articles */}
-            <div id="related-articles">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                Related Articles
-              </h2>
-              <div className="grid gap-3 sm:grid-cols-2">
-                <Link
-                  href="/guides/sleep/magnesium-for-sleep/"
-                  className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
-                >
-                  <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
-                    Sleep Cluster
-                  </p>
-                  <p className="font-semibold text-ink transition group-hover:text-brand-700">
-                    Magnesium for Sleep
-                  </p>
-                  <p className="mt-1 text-xs text-muted">
-                    Evidence, mechanisms, and dosage for magnesium as a sleep supplement — the
-                    broader clinical picture behind the forms reviewed here.
-                  </p>
-                </Link>
-                <Link
-                  href="/guides/sleep/best-herbs-for-sleep/"
-                  className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
-                >
-                  <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
-                    Sleep Cluster Hub
-                  </p>
-                  <p className="font-semibold text-ink transition group-hover:text-brand-700">
-                    Best Herbs for Sleep
-                  </p>
-                  <p className="mt-1 text-xs text-muted">
-                    Evidence-ranked guide to magnesium, ashwagandha, L-theanine, valerian,
-                    passionflower, and more — with decision framework and combination guidance.
-                  </p>
-                </Link>
-                <Link
-                  href="/guides/sleep/ashwagandha-for-sleep/"
-                  className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
-                >
-                  <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
-                    Sleep Cluster
-                  </p>
-                  <p className="font-semibold text-ink transition group-hover:text-brand-700">
-                    Ashwagandha for Sleep
-                  </p>
-                  <p className="mt-1 text-xs text-muted">
-                    Evidence, dosage, and mechanisms for ashwagandha as a sleep supplement — and
-                    how it stacks with magnesium.
-                  </p>
-                </Link>
-                <Link
-                  href="/guides/sleep/ashwagandha-vs-magnesium-for-sleep/"
-                  className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
-                >
-                  <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
-                    Sleep Cluster
-                  </p>
-                  <p className="font-semibold text-ink transition group-hover:text-brand-700">
-                    Ashwagandha vs Magnesium for Sleep
-                  </p>
-                  <p className="mt-1 text-xs text-muted">
-                    Direct comparison of mechanisms, evidence, cost, and use cases for the two
-                    most popular sleep supplements.
-                  </p>
-                </Link>
-                <Link
-                  href="/guides/sleep/sleep-stack-guide/"
-                  className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
-                >
-                  <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
-                    Sleep Cluster
-                  </p>
-                  <p className="font-semibold text-ink transition group-hover:text-brand-700">
-                    Sleep Stack Guide
-                  </p>
-                  <p className="mt-1 text-xs text-muted">
-                    How to combine magnesium, ashwagandha, and L-theanine in a practical
-                    sleep supplement stack.
-                  </p>
-                </Link>
-                <Link
-                  href="/guides/sleep/l-theanine-for-sleep/"
-                  className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
-                >
-                  <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
-                    Sleep Cluster
-                  </p>
-                  <p className="font-semibold text-ink transition group-hover:text-brand-700">
-                    L-Theanine for Sleep
-                  </p>
-                  <p className="mt-1 text-xs text-muted">
-                    How L-theanine promotes relaxation without sedation and when to use it
-                    alongside magnesium.
-                  </p>
-                </Link>
-                <Link
-                  href="/guides/adhd/magnesium-for-adhd/"
-                  className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
-                >
-                  <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
-                    Focus / ADHD Cluster
-                  </p>
-                  <p className="font-semibold text-ink transition group-hover:text-brand-700">
-                    Magnesium for ADHD
-                  </p>
-                  <p className="mt-1 text-xs text-muted">
-                    Evidence, deficiency symptoms, forms (glycinate vs threonate), and safety specific to ADHD.
-                  </p>
-                </Link>
-                <Link
-                  href="/guides/adhd/sleep-and-adhd/"
-                  className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
-                >
-                  <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
-                    Focus / ADHD Cluster
-                  </p>
-                  <p className="font-semibold text-ink transition group-hover:text-brand-700">
-                    Sleep and ADHD
-                  </p>
-                  <p className="mt-1 text-xs text-muted">
-                    Explores the bidirectional cycle where sleep disturbances exacerbate ADHD symptoms.
-                  </p>
-                </Link>
-              </div>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Sources */}
             <div id="sources">
               <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Sources</h2>
               <p className="mb-4 text-sm text-muted">
-                These sources separate three questions that are often blurred together: whether
-                magnesium affects sleep, whether one form is better absorbed, and what dose is safe.
-                Better absorption does not automatically mean a better sleep outcome.
+                These sources answer different questions: overall sleep evidence, form absorption,
+                and safety. Better absorption should not be silently converted into a claim of better sleep.
               </p>
               <ResponsiveTable label="Article references">
-                <table className="min-w-[600px] w-full text-sm">
+                <table className="min-w-[640px] w-full text-sm">
                   <thead>
                     <tr className="border-b border-brand-900/10">
-                      <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                        Topic
-                      </th>
-                      <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                        Evidence area
-                      </th>
-                      <th className="pb-2 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                        What it supports
-                      </th>
+                      <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">Topic</th>
+                      <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">Source</th>
+                      <th className="pb-2 text-left text-xs font-bold uppercase tracking-wider text-muted">What it supports</th>
                     </tr>
                   </thead>
                   <tbody className="divide-y divide-brand-900/5">
                     <tr className="align-top">
-                      <td className="py-3 pr-4 font-medium text-ink">Sleep outcomes</td>
+                      <td className="py-3 pr-4 font-medium text-ink">Overall sleep evidence</td>
                       <td className="py-3 pr-4 text-muted">
-                        <a href="https://pubmed.ncbi.nlm.nih.gov/33865376/" target="_blank" rel="noopener noreferrer" className="text-brand-700 underline">
-                          Mah &amp; Pitre (2021), systematic review and meta-analysis
-                        </a>
+                        <a href="https://www.nccih.nih.gov/health/sleep-disorders-and-complementary-health-approaches" target="_blank" rel="noopener noreferrer" className="text-brand-700 underline">NCCIH: Sleep Disorders and Complementary Health Approaches</a>
                       </td>
-                      <td className="py-3 text-muted text-xs">
-                        Three small trials in older adults; possible shorter sleep-onset latency,
-                        with low-to-very-low certainty.
-                      </td>
+                      <td className="py-3 text-xs text-muted">Very little magnesium-insomnia research; reviews are low quality or conflicting.</td>
                     </tr>
                     <tr className="align-top">
-                      <td className="py-3 pr-4 font-medium text-ink">Representative sleep trial</td>
+                      <td className="py-3 pr-4 font-medium text-ink">Sleep trials</td>
                       <td className="py-3 pr-4 text-muted">
-                        <a href="https://pubmed.ncbi.nlm.nih.gov/23853635/" target="_blank" rel="noopener noreferrer" className="text-brand-700 underline">
-                          Abbasi et al. (2012), double-blind placebo-controlled trial
-                        </a>
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33865376/" target="_blank" rel="noopener noreferrer" className="text-brand-700 underline">Mah &amp; Pitre (2021), systematic review and meta-analysis</a>
                       </td>
-                      <td className="py-3 text-muted text-xs">
-                        Older adults with primary insomnia; not a comparison of glycinate versus other forms.
+                      <td className="py-3 text-xs text-muted">Three randomized trials in 151 older adults; low-to-very-low certainty.</td>
+                    </tr>
+                    <tr className="align-top">
+                      <td className="py-3 pr-4 font-medium text-ink">Representative trial</td>
+                      <td className="py-3 pr-4 text-muted">
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23853635/" target="_blank" rel="noopener noreferrer" className="text-brand-700 underline">Abbasi et al., double-blind placebo-controlled trial</a>
                       </td>
+                      <td className="py-3 text-xs text-muted">Older adults with primary insomnia; not a head-to-head comparison of commercial magnesium forms.</td>
                     </tr>
                     <tr className="align-top">
                       <td className="py-3 pr-4 font-medium text-ink">Form bioavailability</td>
                       <td className="py-3 pr-4 text-muted">
-                        <a href="https://pubmed.ncbi.nlm.nih.gov/14596323/" target="_blank" rel="noopener noreferrer" className="text-brand-700 underline">
-                          Walker et al. (2003), randomized double-blind comparison
-                        </a>
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14596323/" target="_blank" rel="noopener noreferrer" className="text-brand-700 underline">Walker et al. (2003), randomized double-blind comparison</a>
                       </td>
-                      <td className="py-3 text-muted text-xs">
-                        Citrate and an amino-acid chelate were better absorbed than oxide; sleep was not tested.
-                      </td>
+                      <td className="py-3 text-xs text-muted">Compared absorption of magnesium preparations; sleep was not an endpoint.</td>
                     </tr>
                     <tr className="align-top">
-                      <td className="py-3 pr-4 font-medium text-ink">Citrate versus oxide</td>
+                      <td className="py-3 pr-4 font-medium text-ink">Safety and absorption</td>
                       <td className="py-3 pr-4 text-muted">
-                        <a href="https://pubmed.ncbi.nlm.nih.gov/32162607/" target="_blank" rel="noopener noreferrer" className="text-brand-700 underline">
-                          Werner et al. (2019), randomized bioavailability trial
-                        </a>
+                        <a href="https://ods.od.nih.gov/factsheets/Magnesium-HealthProfessional/" target="_blank" rel="noopener noreferrer" className="text-brand-700 underline">NIH Office of Dietary Supplements: Magnesium fact sheet</a>
                       </td>
-                      <td className="py-3 text-muted text-xs">
-                        Citrate produced higher plasma and urinary magnesium measures; no sleep endpoint.
-                      </td>
-                    </tr>
-                    <tr className="align-top">
-                      <td className="py-3 pr-4 font-medium text-ink">Safety and interactions</td>
-                      <td className="py-3 pr-4 text-muted">
-                        <a href="https://ods.od.nih.gov/factsheets/Magnesium-HealthProfessional/" target="_blank" rel="noopener noreferrer" className="text-brand-700 underline">
-                          NIH Office of Dietary Supplements: Magnesium fact sheet
-                        </a>
-                      </td>
-                      <td className="py-3 text-muted text-xs">
-                        Adult supplement/medication UL, adverse effects, kidney-risk context, and drug interactions.
-                      </td>
+                      <td className="py-3 text-xs text-muted">Elemental-magnesium labeling, form absorption, adult supplemental UL, adverse effects, kidney risk, and medication interactions.</td>
                     </tr>
                   </tbody>
                 </table>
               </ResponsiveTable>
             </div>
-
           </section>
 
           <RecommendationSection products={getRevenueProductSet('magnesium')?.products ?? []} />
 
-          {/* Email capture */}
           <EmailCapture
             headline="Get future research notes by email"
             description="Evidence-first supplement updates, safety context, and new guide announcements. No diagnosis, treatment, or personal medical advice."
@@ -1117,120 +565,48 @@ export default function MagnesiumTypesForSleepPage() {
           />
         </div>
 
-        {/* Sidebar */}
         <aside className="space-y-4 lg:sticky lg:top-24 lg:self-start">
-          {/* Table of contents */}
           <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
-            <p className="text-[10px] font-bold uppercase tracking-wider text-muted">
-              In this article
-            </p>
+            <p className="text-[10px] font-bold uppercase tracking-wider text-muted">In this article</p>
             <nav className="mt-3 space-y-1.5" aria-label="Article sections">
               {[
                 ['#comparison-table', 'Forms Compared'],
                 ['#why-form-matters', 'Why Form Matters'],
                 ['#glycinate', 'Glycinate'],
-                ['#threonate', 'Threonate'],
-                ['#citrate', 'Citrate'],
-                ['#oxide', 'Oxide'],
+                ['#threonate', 'L-Threonate'],
+                ['#citrate-oxide', 'Citrate & Oxide'],
                 ['#malate-taurate', 'Malate & Taurate'],
-                ['#dosage-label-reading', 'Dosage & Labels'],
+                ['#dosage-label-reading', 'Dose & Labels'],
                 ['#safety', 'Safety'],
-                ['#which-type', 'Which to Buy'],
+                ['#which-type', 'How to Choose'],
                 ['#faq', 'FAQ'],
                 ['#sources', 'Sources'],
               ].map(([href, label]) => (
-                <a
-                  key={href}
-                  href={href}
-                  className="block text-sm text-brand-700 hover:text-brand-800 hover:underline">{label}</a>
+                <a key={href} href={href} className="block text-sm text-brand-700 hover:text-brand-800 hover:underline">
+                  {label}
+                </a>
               ))}
             </nav>
           </div>
 
-          {/* Sleep cluster links */}
           <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
-            <p className="text-[10px] font-bold uppercase tracking-wider text-muted">
-              Sleep cluster
-            </p>
+            <p className="text-[10px] font-bold uppercase tracking-wider text-muted">Sleep cluster</p>
             <div className="mt-3 space-y-2">
-              <Link
-                href="/guides/sleep/magnesium-for-sleep/"
-                className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
-              >
-                Magnesium for sleep →
-              </Link>
-              <Link
-                href="/guides/sleep/best-herbs-for-sleep/"
-                className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
-              >
-                Best herbs for sleep →
-              </Link>
-              <Link
-                href="/guides/sleep/ashwagandha-for-sleep/"
-                className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
-              >
-                Ashwagandha for sleep →
-              </Link>
-              <Link
-                href="/guides/sleep/sleep-herbs-vs-melatonin/"
-                className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
-              >
-                Sleep herbs vs melatonin →
-              </Link>
-              <Link
-                href="/herbs/"
-                className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
-              >
-                All herb profiles →
-              </Link>
-              <Link
-                href="/guides/"
-                className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
-              >
-                All articles →
-              </Link>
+              <Link href="/guides/sleep/magnesium-for-sleep/" className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline">Magnesium for sleep →</Link>
+              <Link href="/guides/sleep/best-herbs-for-sleep/" className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline">Best herbs for sleep →</Link>
+              <Link href="/guides/sleep/ashwagandha-for-sleep/" className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline">Ashwagandha for sleep →</Link>
+              <Link href="/guides/sleep/sleep-stack-guide/" className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline">Sleep stack guide →</Link>
+              <Link href="/guides/sleep/l-theanine-for-sleep/" className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline">L-theanine for sleep →</Link>
+              <Link href="/guides/" className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline">All guides →</Link>
             </div>
           </div>
 
-          {/* Affiliate quick links */}
-          <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
-            <p className="text-[10px] font-bold uppercase tracking-wider text-muted">
-              Shop — top picks
+          <div className="rounded-[1rem] border border-brand-900/10 bg-brand-50/50 p-4 shadow-sm">
+            <p className="text-[10px] font-bold uppercase tracking-wider text-muted">Buyer checkpoint</p>
+            <p className="mt-2 text-sm leading-6 text-muted">
+              Compare elemental magnesium, serving size, other ingredients, quality testing, price,
+              and your own tolerance. Do not use a sleep-star rating as a substitute for clinical evidence.
             </p>
-            <div className="mt-3 space-y-2">
-              <a
-                href={`https://www.amazon.com/s?k=magnesium+glycinate+sleep&tag=${AFFILIATE_TAGS.amazon}`}
-                target="_blank"
-                rel="noopener noreferrer sponsored"
-                className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
-              >
-                Magnesium glycinate →
-              </a>
-              <a
-                href={`https://www.amazon.com/s?k=magnesium+l-threonate+magtein&tag=${AFFILIATE_TAGS.amazon}`}
-                target="_blank"
-                rel="noopener noreferrer sponsored"
-                className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
-              >
-                Magnesium threonate →
-              </a>
-              <a
-                href={`https://www.amazon.com/s?k=magnesium+citrate+supplement&tag=${AFFILIATE_TAGS.amazon}`}
-                target="_blank"
-                rel="noopener noreferrer sponsored"
-                className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
-              >
-                Magnesium citrate →
-              </a>
-              <a
-                href={`https://www.amazon.com/s?k=magnesium+malate+supplement&tag=${AFFILIATE_TAGS.amazon}`}
-                target="_blank"
-                rel="noopener noreferrer sponsored"
-                className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
-              >
-                Magnesium malate →
-              </a>
-            </div>
           </div>
         </aside>
       </div>


### PR DESCRIPTION
Priority CRO/trust pass for `/guides/sleep/magnesium-types-for-sleep`.

Changes:
- replaces form-level sleep winner/star rankings with an evidence-first comparison
- separates absorption/tolerability evidence from sleep efficacy
- rewrites FAQ + FAQ schema to reflect limited/conflicting magnesium-insomnia evidence
- removes unsupported magnesium+ashwagandha safety reassurance
- removes fixed 200–400 mg bedtime protocol framing and clarifies the adult 350 mg/day supplemental/medication UL
- removes generic Amazon search exits and keeps the curated RecommendationSection as the commercial handoff
- preserves original publication date and adds a real 2026-08-11 review date
- adds focused regressions so the risky claims/rankings/generic affiliate exits do not return

Evidence calibration follows NCCIH magnesium/sleep guidance, NIH ODS magnesium safety/absorption guidance, and the 2021 systematic review of oral magnesium for insomnia in older adults.