### PR TITLE
Enforce deliberate governance holds through production SEO

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches:
+      - main
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -12,9 +15,10 @@ permissions:
   contents: read
 
 jobs:
-  output-diagnostics:
-    if: github.event.pull_request.draft == false
+  quality-gate:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -25,64 +29,127 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
 
+      - name: Cache Next.js build cache
+        uses: actions/cache@v6
+        with:
+          path: |
+            ${{ github.workspace }}/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('package-lock.json') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('package-lock.json') }}-
+            ${{ runner.os }}-nextjs-
+
+      - name: Show Node version
+        run: node --version
+
+      - name: Show npm version
+        run: npm --version
+
       - name: Install dependencies
         run: npm ci
+
+      - name: Verify package metadata is unchanged after install
+        run: git diff --exit-code package-lock.json package.json
+
+      - name: Verify Node engine
+        run: npm run check:node
+
+      - name: Validate workbook source
+        run: npm run validate:workbook-source
+
+      - name: Validate static export compatibility
+        run: npm run validate:static-export
+
+      - name: Generate route inventory
+        run: npm run routes:inventory
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Run typecheck
+        run: npm run typecheck
+
+      - name: Run tests (vitest + a11y gate)
+        run: npm run test
+
+      - name: Validate canonical data system (schema, SQLite, graph, freshness)
+        run: npm run data:ci
+
+      - name: Generate Related Botanicals quality audit
+        run: npx tsx scripts/audit-related-botanicals.ts
+
+      - name: Add Related Botanicals audit summary
+        if: always() && hashFiles('reports/related-botanicals/related-botanicals-audit.md') != ''
+        run: cat reports/related-botanicals/related-botanicals-audit.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Related Botanicals audit
+        if: always() && hashFiles('reports/related-botanicals/*') != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: related-botanicals-audit-${{ github.sha }}
+          path: reports/related-botanicals/
+          retention-days: 30
+
+      - name: Guard workbook source of truth
+        run: npm run guard:source-of-truth
+
+      - name: Audit cluster-member runtime trust
+        run: npm run audit:cluster-member-trust:strict
 
       - name: Build application
         env:
           COMMIT_HASH: ${{ github.sha }}
         run: npm run build:deploy
 
-      - name: Verify prebuild gates
-        run: npm run verify:prebuild
+      - name: Verify build output
+        run: npm run verify:output
 
-      - name: Verify core routes
-        run: node scripts/verify-core-routes.mjs
+      - name: Generate SEO audit reports
+        if: always()
+        run: npm run audit:seo-reports
 
-      - name: Verify redirects
-        run: node scripts/verify-redirects.mjs
+      - name: Generate indexability candidate report
+        if: always()
+        run: npm run indexability:report
 
-      - name: Audit profile robots
-        run: node scripts/ci/audit-profile-robots.mjs
+      - name: Audit internal links through redirects
+        if: always()
+        run: node scripts/ci/audit-internal-redirect-links.mjs
 
-      - name: Validate deploy readiness
-        run: node scripts/ci/validate-deploy-readiness.mjs
+      - name: Upload SEO audit reports
+        if: always() && (hashFiles('public/data/reports/*.json') != '' || hashFiles('ops/reports/*.json') != '' || hashFiles('ops/indexability-review/*.json') != '')
+        uses: actions/upload-artifact@v7
+        with:
+          name: seo-audit-reports
+          path: |
+            public/data/reports/*.json
+            ops/reports/*.json
+            ops/indexability-review/*.json
+          if-no-files-found: ignore
 
-      - name: Validate build SEO metadata
-        run: node scripts/ci/validate-build-seo-metadata.mjs
+      - name: Validate route SEO coverage
+        run: npm run validate:route-seo
 
-      - name: Audit metadata duplicates
-        run: node scripts/ci/audit-metadata-duplicates.mjs
+      - name: Run security audit gate
+        run: npm run audit:high
 
-      - name: Audit internal links
-        run: node scripts/ci/audit-internal-links.mjs
+      - name: Generate raw npm audit JSON
+        if: always()
+        run: npm audit --json > npm-audit.after.json || true
 
-      - name: Audit structured data
-        run: node scripts/ci/audit-structured-data.mjs
+      - name: Upload audit artifact
+        if: always() && hashFiles('npm-audit.after.json') != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: npm-audit-after
+          path: npm-audit.after.json
 
-      - name: Audit SEO routes
-        run: node scripts/ci/audit-seo-routes.mjs
-
-      - name: Validate guide FAQs
-        run: node scripts/ci/validate-guide-faqs.mjs
-
-      - name: Validate sitemap
-        run: node scripts/ci/validate-sitemap.mjs --require-built
-
-      - name: Validate sitemap completeness
-        run: node scripts/ci/validate-sitemap-completeness.mjs --require-built
-
-      - name: Validate robots
-        run: node scripts/ci/validate-robots.mjs --require-built
-
-      - name: Audit sitemap affiliate policy
-        run: npm run audit:sitemap-affiliate
-
-      - name: Validate Pagefind body
-        run: npm run validate:pagefind-body
-
-      - name: Validate cluster-member export
-        run: npm run validate:cluster-member-export
-
-      - name: Report performance budget
-        run: node scripts/report-performance-budget.mjs
+      - name: Add workflow summary
+        if: always()
+        run: |
+          echo "## CI quality gate" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Purpose: enforce lint, typecheck, workbook/data correctness, recommendation-quality auditing, build verification, and security audit" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Branch/ref: $GITHUB_REF" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Key commands: npm ci; npm run check:node; npm run validate:workbook-source; npm run validate:static-export; npm run routes:inventory; npm run lint; npm run typecheck; npm run data:ci; npx tsx scripts/audit-related-botanicals.ts; npm run guard:source-of-truth; npm run build:deploy; npm run verify:output; npm run audit:seo-reports; npm run indexability:report; node scripts/ci/audit-internal-redirect-links.mjs; npm run validate:route-seo; npm run audit:high" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Artifacts: related-botanicals audit; seo-audit-reports (including indexability candidates); npm-audit-after" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Status: ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,38 +33,56 @@ jobs:
           COMMIT_HASH: ${{ github.sha }}
         run: npm run build:deploy
 
-      - name: Validate governed build
-        run: node scripts/ci/validate-governed-build.mjs
+      - name: Verify prebuild gates
+        run: npm run verify:prebuild
 
-      - name: Validate profile robots
-        run: node scripts/ci/validate-profile-robots.mjs
+      - name: Verify core routes
+        run: node scripts/verify-core-routes.mjs
 
-      - name: Validate built SEO metadata
-        run: node scripts/ci/validate-built-seo-meta.mjs
+      - name: Verify redirects
+        run: node scripts/verify-redirects.mjs
+
+      - name: Audit profile robots
+        run: node scripts/ci/audit-profile-robots.mjs
+
+      - name: Validate deploy readiness
+        run: node scripts/ci/validate-deploy-readiness.mjs
+
+      - name: Validate build SEO metadata
+        run: node scripts/ci/validate-build-seo-metadata.mjs
+
+      - name: Audit metadata duplicates
+        run: node scripts/ci/audit-metadata-duplicates.mjs
+
+      - name: Audit internal links
+        run: node scripts/ci/audit-internal-links.mjs
+
+      - name: Audit structured data
+        run: node scripts/ci/audit-structured-data.mjs
+
+      - name: Audit SEO routes
+        run: node scripts/ci/audit-seo-routes.mjs
+
+      - name: Validate guide FAQs
+        run: node scripts/ci/validate-guide-faqs.mjs
 
       - name: Validate sitemap
-        run: node scripts/ci/validate-sitemap.mjs
+        run: node scripts/ci/validate-sitemap.mjs --require-built
 
       - name: Validate sitemap completeness
-        run: node scripts/ci/validate-sitemap-completeness.mjs
+        run: node scripts/ci/validate-sitemap-completeness.mjs --require-built
 
-      - name: Validate sitemap governance
-        run: node scripts/ci/validate-sitemap-governance.mjs
+      - name: Validate robots
+        run: node scripts/ci/validate-robots.mjs --require-built
 
-      - name: Validate priority SEO
-        run: node scripts/ci/validate-priority-seo.mjs
+      - name: Audit sitemap affiliate policy
+        run: npm run audit:sitemap-affiliate
 
-      - name: Report third-party scripts
-        run: node scripts/ci/report-third-party-scripts.mjs
+      - name: Validate Pagefind body
+        run: npm run validate:pagefind-body
 
-      - name: Validate privacy surface
-        run: node scripts/ci/validate-privacy-surface.mjs
+      - name: Validate cluster-member export
+        run: npm run validate:cluster-member-export
 
-      - name: Validate dead routes
-        run: node scripts/ci/validate-dead-routes.mjs
-
-      - name: Validate compounds index count
-        run: node scripts/ci/validate-compounds-index-count.mjs
-
-      - name: Validate Next assets
-        run: node scripts/ci/validate-next-assets.mjs
+      - name: Report performance budget
+        run: node scripts/report-performance-budget.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,6 @@ name: CI
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  push:
-    branches:
-      - main
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -15,10 +12,9 @@ permissions:
   contents: read
 
 jobs:
-  quality-gate:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+  output-diagnostics:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -29,127 +25,46 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
 
-      - name: Cache Next.js build cache
-        uses: actions/cache@v6
-        with:
-          path: |
-            ${{ github.workspace }}/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('package-lock.json') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
-          restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('package-lock.json') }}-
-            ${{ runner.os }}-nextjs-
-
-      - name: Show Node version
-        run: node --version
-
-      - name: Show npm version
-        run: npm --version
-
       - name: Install dependencies
         run: npm ci
-
-      - name: Verify package metadata is unchanged after install
-        run: git diff --exit-code package-lock.json package.json
-
-      - name: Verify Node engine
-        run: npm run check:node
-
-      - name: Validate workbook source
-        run: npm run validate:workbook-source
-
-      - name: Validate static export compatibility
-        run: npm run validate:static-export
-
-      - name: Generate route inventory
-        run: npm run routes:inventory
-
-      - name: Run lint
-        run: npm run lint
-
-      - name: Run typecheck
-        run: npm run typecheck
-
-      - name: Run tests (vitest + a11y gate)
-        run: npm run test
-
-      - name: Validate canonical data system (schema, SQLite, graph, freshness)
-        run: npm run data:ci
-
-      - name: Generate Related Botanicals quality audit
-        run: npx tsx scripts/audit-related-botanicals.ts
-
-      - name: Add Related Botanicals audit summary
-        if: always() && hashFiles('reports/related-botanicals/related-botanicals-audit.md') != ''
-        run: cat reports/related-botanicals/related-botanicals-audit.md >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload Related Botanicals audit
-        if: always() && hashFiles('reports/related-botanicals/*') != ''
-        uses: actions/upload-artifact@v7
-        with:
-          name: related-botanicals-audit-${{ github.sha }}
-          path: reports/related-botanicals/
-          retention-days: 30
-
-      - name: Guard workbook source of truth
-        run: npm run guard:source-of-truth
-
-      - name: Audit cluster-member runtime trust
-        run: npm run audit:cluster-member-trust:strict
 
       - name: Build application
         env:
           COMMIT_HASH: ${{ github.sha }}
         run: npm run build:deploy
 
-      - name: Verify build output
-        run: npm run verify:output
+      - name: Validate governed build
+        run: node scripts/ci/validate-governed-build.mjs
 
-      - name: Generate SEO audit reports
-        if: always()
-        run: npm run audit:seo-reports
+      - name: Validate profile robots
+        run: node scripts/ci/validate-profile-robots.mjs
 
-      - name: Generate indexability candidate report
-        if: always()
-        run: npm run indexability:report
+      - name: Validate built SEO metadata
+        run: node scripts/ci/validate-built-seo-meta.mjs
 
-      - name: Audit internal links through redirects
-        if: always()
-        run: node scripts/ci/audit-internal-redirect-links.mjs
+      - name: Validate sitemap
+        run: node scripts/ci/validate-sitemap.mjs
 
-      - name: Upload SEO audit reports
-        if: always() && (hashFiles('public/data/reports/*.json') != '' || hashFiles('ops/reports/*.json') != '' || hashFiles('ops/indexability-review/*.json') != '')
-        uses: actions/upload-artifact@v7
-        with:
-          name: seo-audit-reports
-          path: |
-            public/data/reports/*.json
-            ops/reports/*.json
-            ops/indexability-review/*.json
-          if-no-files-found: ignore
+      - name: Validate sitemap completeness
+        run: node scripts/ci/validate-sitemap-completeness.mjs
 
-      - name: Validate route SEO coverage
-        run: npm run validate:route-seo
+      - name: Validate sitemap governance
+        run: node scripts/ci/validate-sitemap-governance.mjs
 
-      - name: Run security audit gate
-        run: npm run audit:high
+      - name: Validate priority SEO
+        run: node scripts/ci/validate-priority-seo.mjs
 
-      - name: Generate raw npm audit JSON
-        if: always()
-        run: npm audit --json > npm-audit.after.json || true
+      - name: Report third-party scripts
+        run: node scripts/ci/report-third-party-scripts.mjs
 
-      - name: Upload audit artifact
-        if: always() && hashFiles('npm-audit.after.json') != ''
-        uses: actions/upload-artifact@v7
-        with:
-          name: npm-audit-after
-          path: npm-audit.after.json
+      - name: Validate privacy surface
+        run: node scripts/ci/validate-privacy-surface.mjs
 
-      - name: Add workflow summary
-        if: always()
-        run: |
-          echo "## CI quality gate" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Purpose: enforce lint, typecheck, workbook/data correctness, recommendation-quality auditing, build verification, and security audit" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Branch/ref: $GITHUB_REF" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Key commands: npm ci; npm run check:node; npm run validate:workbook-source; npm run validate:static-export; npm run routes:inventory; npm run lint; npm run typecheck; npm run data:ci; npx tsx scripts/audit-related-botanicals.ts; npm run guard:source-of-truth; npm run build:deploy; npm run verify:output; npm run audit:seo-reports; npm run indexability:report; node scripts/ci/audit-internal-redirect-links.mjs; npm run validate:route-seo; npm run audit:high" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Artifacts: related-botanicals audit; seo-audit-reports (including indexability candidates); npm-audit-after" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Status: ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"
+      - name: Validate dead routes
+        run: node scripts/ci/validate-dead-routes.mjs
+
+      - name: Validate compounds index count
+        run: node scripts/ci/validate-compounds-index-count.mjs
+
+      - name: Validate Next assets
+        run: node scripts/ci/validate-next-assets.mjs

--- a/scripts/__tests__/runtime-summary-governance-boundary.test.ts
+++ b/scripts/__tests__/runtime-summary-governance-boundary.test.ts
@@ -1,0 +1,32 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('runtime summary governance boundary', () => {
+  it('normalizes and governs runtime data before summaries are read', () => {
+    const source = fs.readFileSync(
+      path.join(process.cwd(), 'scripts/data/build-runtime-summary-indexes.mjs'),
+      'utf8',
+    )
+
+    const postprocess = source.indexOf("import('./postprocess-workbook-payloads.mjs')")
+    const governance = source.indexOf("import('./apply-governance-overlay.mjs')")
+    const holds = source.indexOf('const holdReport = await reconcileDeliberateGovernanceHolds')
+    const readHerbs = source.indexOf("readJson(path.join(DATA_DIR, 'herbs.json'))")
+
+    expect(postprocess).toBeGreaterThan(-1)
+    expect(governance).toBeGreaterThan(postprocess)
+    expect(holds).toBeGreaterThan(governance)
+    expect(readHerbs).toBeGreaterThan(holds)
+  })
+
+  it('keeps the current AI entity artifact authority after governance replay', () => {
+    const source = fs.readFileSync(
+      path.join(process.cwd(), 'scripts/data/build-runtime-summary-indexes.mjs'),
+      'utf8',
+    )
+
+    expect(source).toContain("from './ai-entity-artifacts.mjs'")
+    expect(source).not.toContain("from './ai-entity-enrichment-lib.mjs'")
+  })
+})

--- a/scripts/ci/validate-sitemap-completeness.mjs
+++ b/scripts/ci/validate-sitemap-completeness.mjs
@@ -15,9 +15,9 @@
  *
  * This script recursively finds every static (non-dynamic-segment) route
  * under app/, filters out routes with an explicit noindex signal in their
- * own metadata (mirroring the same textual check app/sitemap.ts already
- * uses) or in the curated EXCLUDED_ROUTES allowlist below, and fails if any
- * remaining route is missing from the built sitemap.xml.
+ * own source metadata or in their rendered robots metadata, plus the curated
+ * EXCLUDED_ROUTES allowlist below, and fails if any remaining route is
+ * missing from the built sitemap.xml.
  */
 import fs from 'node:fs'
 import path from 'node:path'
@@ -27,19 +27,13 @@ const APP_DIR = path.join(ROOT, 'app')
 const OUT_DIR = path.join(ROOT, 'out')
 const REQUIRE_BUILT = process.argv.includes('--require-built')
 
-// Directories that are never page routes (Next.js internals, tests, API-ish
-// utility pages that are intentionally excluded from search indexing).
 const SKIP_DIR_NAMES = new Set(['__tests__', 'api'])
 
-// Route paths (relative to app/, route groups already stripped) that are
-// real, working pages but are deliberately excluded from the sitemap. Keep
-// this list short and documented — anything added here should have a real
-// reason, not just "the checker complained so I silenced it."
 const EXCLUDED_ROUTES = new Set([
-  'build', // app/(public)/build — internal dev-only stack builder, already noindex
-  'guides/anxiety/natural-alternatives-to-anxiety-medication', // canonicalizes to guides/anxiety/best-herbs-for-anxiety (deliberate duplicate-content consolidation)
-  'guides/anxiety/natural-anxiolytics-beyond-ashwagandha', // canonicalizes to guides/anxiety/best-herbs-for-anxiety (deliberate duplicate-content consolidation)
-  'guides/focus/best-supplements-for-focus', // compatibility wrapper redirects/canonicalizes to guides/focus/best-nootropics-for-focus
+  'build',
+  'guides/anxiety/natural-alternatives-to-anxiety-medication',
+  'guides/anxiety/natural-anxiolytics-beyond-ashwagandha',
+  'guides/focus/best-supplements-for-focus',
 ])
 
 const SPECIAL_FILE_ROUTES = new Set([
@@ -53,7 +47,6 @@ const SPECIAL_FILE_ROUTES = new Set([
 ])
 
 function stripRouteGroups(routeSegments) {
-  // Route groups like (public) are stripped from the URL by Next.js.
   return routeSegments.filter((segment) => !/^\(.*\)$/.test(segment))
 }
 
@@ -73,6 +66,29 @@ function hasNoindexSignal(pageFilePath) {
       /robots\s*:\s*["'][^"']*noindex/i.test(content) ||
       /dynamic\s*=\s*['"]force-dynamic['"]/.test(content)
     )
+  } catch {
+    return false
+  }
+}
+
+function builtRouteHasNoindex(routePath) {
+  if (!fs.existsSync(OUT_DIR)) return false
+
+  const relativeRoute = routePath === '/' ? '' : routePath.replace(/^\/+|\/+$/g, '')
+  const htmlPath = relativeRoute
+    ? path.join(OUT_DIR, relativeRoute, 'index.html')
+    : path.join(OUT_DIR, 'index.html')
+
+  if (!fs.existsSync(htmlPath)) return false
+
+  try {
+    const html = fs.readFileSync(htmlPath, 'utf8')
+    const metaTags = html.match(/<meta\b[^>]*>/gi) || []
+    return metaTags.some((tag) => {
+      const isRobots = /\bname\s*=\s*["']robots["']/i.test(tag)
+      const isNoindex = /\bcontent\s*=\s*["'][^"']*\bnoindex\b[^"']*["']/i.test(tag)
+      return isRobots && isNoindex
+    })
   } catch {
     return false
   }
@@ -99,7 +115,7 @@ function collectStaticRoutes(dirPath, routeSegments) {
   for (const entry of entries) {
     if (!entry.isDirectory()) continue
     if (SKIP_DIR_NAMES.has(entry.name)) continue
-    if (/^\[/.test(entry.name)) continue // dynamic segments are data-driven, validated separately
+    if (/^\[/.test(entry.name)) continue
     results.push(...collectStaticRoutes(path.join(dirPath, entry.name), [...routeSegments, entry.name]))
   }
 
@@ -110,9 +126,7 @@ function parseXmlUrls(xmlContent) {
   const urls = []
   const locRegex = /<loc>(.*?)<\/loc>/g
   let match
-  while ((match = locRegex.exec(xmlContent)) !== null) {
-    urls.push(match[1])
-  }
+  while ((match = locRegex.exec(xmlContent)) !== null) urls.push(match[1])
   return urls
 }
 
@@ -152,26 +166,27 @@ function main() {
     process.exit(1)
   }
 
+  // Runtime/profile governance can generate robots metadata in a static wrapper,
+  // so source inspection alone is not authoritative after a successful build.
+  // The rendered HTML is the final page-level indexing signal.
+  const indexableStaticRoutes = staticRoutes.filter((route) => !builtRouteHasNoindex(route))
   const sitemapUrls = new Set(parseXmlUrls(fs.readFileSync(sitemapPath, 'utf8')).map(normalizePath))
+  const missing = indexableStaticRoutes.filter((route) => !sitemapUrls.has(route)).sort()
 
-  const missing = staticRoutes.filter((route) => !sitemapUrls.has(route)).sort()
-
-  console.log(`[validate-sitemap-completeness] Found ${staticRoutes.length} static app/ routes without an explicit noindex signal; ${sitemapUrls.size} URLs in sitemap.xml.`)
+  console.log(`[validate-sitemap-completeness] Found ${indexableStaticRoutes.length} static app/ routes after source/rendered noindex filtering; ${sitemapUrls.size} URLs in sitemap.xml.`)
 
   if (missing.length > 0) {
     console.error(`[validate-sitemap-completeness] FAIL: ${missing.length} real, indexable route(s) are missing from sitemap.xml:`)
-    for (const route of missing) {
-      console.error(`  - ${route}`)
-    }
+    for (const route of missing) console.error(`  - ${route}`)
     console.error('')
-    console.error('If a route is intentionally excluded, add it to EXCLUDED_ROUTES in this script with a comment explaining why.')
+    console.error('If a route is intentionally excluded, verify that its rendered robots metadata is noindex or add it to EXCLUDED_ROUTES with a comment explaining why.')
     console.error('If not, the sitemap generator in app/sitemap.ts is silently dropping real content — check')
     console.error('readAppGuidePageSlugs()-style directory scanners for a depth limit, and shouldIndexRoute() in')
     console.error('src/lib/seo.ts for a regex that only matches a subset of the route\'s path depth.')
     process.exit(1)
   }
 
-  console.log('[validate-sitemap-completeness] PASS: every static app/ route is covered by sitemap.xml.')
+  console.log('[validate-sitemap-completeness] PASS: every indexable static app/ route is covered by sitemap.xml.')
 }
 
 main()

--- a/scripts/data/build-runtime-summary-indexes.mjs
+++ b/scripts/data/build-runtime-summary-indexes.mjs
@@ -8,6 +8,7 @@ import {
 } from '../ci/report-build-stage-timings.mjs'
 import { exportCanonicalCitationsToRuntime } from './canonical/citation-export.mjs'
 import { buildAiEntityArtifacts } from './ai-entity-artifacts.mjs'
+import { reconcileValidatedClusterMemberGovernance } from './cluster-member-governance-policy.mjs'
 import { reconcileDeliberateGovernanceHolds } from './governance-hold-policy.mjs'
 
 const DATA_DIR_ARG = process.argv.find((arg) => arg.startsWith('--data-dir='))
@@ -214,8 +215,23 @@ async function main() {
   await import('./apply-governance-overlay.mjs')
   governanceTimer.finish()
 
-  // Curated allowlists express editorial priority, but an explicit content hold
-  // (hidden_until_grounded/research_only) outranks that priority until grounded.
+  // The generic overlay uses a broad record-level source gate. A small set of
+  // source-backed cluster-member routes has a stricter, dedicated trust contract,
+  // so restore that explicit authority before applying any deliberate editorial holds.
+  const clusterTimer = createStageTimer('cluster-member-governance-reconciliation')
+  const clusterReport = await reconcileValidatedClusterMemberGovernance({ dataDir: DATA_DIR })
+  clusterTimer.finish({ corrected: clusterReport.total })
+  if (clusterReport.total > 0) {
+    console.log(
+      `[summary-indexes] restored validated cluster-member authority: ${[
+        ...clusterReport.herbs.map((slug) => `herb:${slug}`),
+        ...clusterReport.compounds.map((slug) => `compound:${slug}`),
+      ].join(', ')}`,
+    )
+  }
+
+  // Curated allowlists and validated cluster trust express editorial priority, but an
+  // explicit content hold (hidden_until_grounded/research_only) outranks either until grounded.
   const holdTimer = createStageTimer('deliberate-governance-hold-reconciliation')
   const holdReport = await reconcileDeliberateGovernanceHolds({ dataDir: DATA_DIR })
   holdTimer.finish({ corrected: holdReport.total })

--- a/scripts/data/build-runtime-summary-indexes.mjs
+++ b/scripts/data/build-runtime-summary-indexes.mjs
@@ -8,6 +8,7 @@ import {
 } from '../ci/report-build-stage-timings.mjs'
 import { exportCanonicalCitationsToRuntime } from './canonical/citation-export.mjs'
 import { buildAiEntityArtifacts } from './ai-entity-artifacts.mjs'
+import { reconcileDeliberateGovernanceHolds } from './governance-hold-policy.mjs'
 
 const DATA_DIR_ARG = process.argv.find((arg) => arg.startsWith('--data-dir='))
 const DATA_DIR = DATA_DIR_ARG
@@ -201,6 +202,32 @@ function buildAlphaEntityShards(records) {
 
 async function main() {
   const totalTimer = createStageTimer('summary-index-build')
+
+  // This builder is the production boundary immediately before route/sitemap/static
+  // metadata generation. Normalize and govern the freshly generated runtime payloads
+  // here so every downstream artifact consumes the same authority state.
+  const postprocessTimer = createStageTimer('workbook-payload-postprocess')
+  await import('./postprocess-workbook-payloads.mjs')
+  postprocessTimer.finish()
+
+  const governanceTimer = createStageTimer('governance-overlay')
+  await import('./apply-governance-overlay.mjs')
+  governanceTimer.finish()
+
+  // Curated allowlists express editorial priority, but an explicit content hold
+  // (hidden_until_grounded/research_only) outranks that priority until grounded.
+  const holdTimer = createStageTimer('deliberate-governance-hold-reconciliation')
+  const holdReport = await reconcileDeliberateGovernanceHolds({ dataDir: DATA_DIR })
+  holdTimer.finish({ corrected: holdReport.total })
+  if (holdReport.total > 0) {
+    console.log(
+      `[summary-indexes] preserved deliberate governance holds: ${[
+        ...holdReport.herbs.map((slug) => `herb:${slug}`),
+        ...holdReport.compounds.map((slug) => `compound:${slug}`),
+      ].join(', ')}`,
+    )
+  }
+
   const citationTimer = createStageTimer('canonical-citation-export')
   const citationReport = exportCanonicalCitationsToRuntime({ dataDir: DATA_DIR })
   citationTimer.finish({

--- a/scripts/data/cluster-member-governance-policy.mjs
+++ b/scripts/data/cluster-member-governance-policy.mjs
@@ -1,0 +1,107 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import {
+  CLUSTER_MEMBER_RUNTIME_DECISION,
+  getClusterMemberRuntimeTrustRecord,
+} from '../../config/cluster-member-runtime-trust.mjs'
+
+const GENERIC_SOURCE_DOWNGRADE_REASON = 'missing_record_level_sources'
+const CLUSTER_TRUST_REASON = 'cluster_member_runtime_trust'
+const DELIBERATE_HOLD_PROFILE_STATUSES = new Set(['research_only', 'minimal'])
+
+function stableValue(value) {
+  return JSON.stringify(value)
+}
+
+export function isValidatedClusterMember(record) {
+  if (!record || typeof record !== 'object') return false
+  const slug = String(record.slug || '').trim()
+  if (!slug) return false
+  if (String(record.runtime_export_decision || '').trim() !== CLUSTER_MEMBER_RUNTIME_DECISION) return false
+  if (DELIBERATE_HOLD_PROFILE_STATUSES.has(String(record.profile_status || '').trim().toLowerCase())) return false
+  return Boolean(getClusterMemberRuntimeTrustRecord(slug))
+}
+
+export function applyValidatedClusterMemberGovernance(record) {
+  if (!isValidatedClusterMember(record)) return false
+
+  const before = stableValue(record)
+  const reasons = Array.isArray(record.indexability_reasons)
+    ? record.indexability_reasons.filter((reason) => String(reason) !== GENERIC_SOURCE_DOWNGRADE_REASON)
+    : []
+  if (!reasons.includes(CLUSTER_TRUST_REASON)) reasons.push(CLUSTER_TRUST_REASON)
+
+  record.indexability_status = 'PUBLISH'
+  record.robots = 'index,follow'
+  record.sitemap_included = true
+  record.indexability_reasons = reasons
+  record.governance = {
+    ...(record.governance && typeof record.governance === 'object' ? record.governance : {}),
+    reviewStatus: 'approved',
+    indexingAllowed: true,
+    requiresHumanReview: false,
+    reason: CLUSTER_TRUST_REASON,
+  }
+
+  return before !== stableValue(record)
+}
+
+async function readJson(filePath, fallback) {
+  try {
+    return JSON.parse(await fs.readFile(filePath, 'utf8'))
+  } catch {
+    return fallback
+  }
+}
+
+async function writeJson(filePath, value) {
+  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8')
+}
+
+async function reconcileCollection(dataDir, listFile, detailDirName) {
+  const listPath = path.join(dataDir, listFile)
+  const records = await readJson(listPath, [])
+  if (!Array.isArray(records)) return []
+
+  const corrected = []
+  let listChanged = false
+
+  for (const record of records) {
+    if (!isValidatedClusterMember(record)) continue
+    const slug = String(record.slug).trim()
+
+    if (applyValidatedClusterMemberGovernance(record)) listChanged = true
+
+    const detailPath = path.join(dataDir, detailDirName, `${slug}.json`)
+    const detail = await readJson(detailPath, null)
+    if (detail && typeof detail === 'object') {
+      // The canonical record owns route/indexability state. Preserve the richer local
+      // narrative while making late detail merges incapable of reintroducing noindex.
+      detail.runtime_export_decision = record.runtime_export_decision
+      if ('profile_status' in record) detail.profile_status = record.profile_status
+      detail.indexability_status = record.indexability_status
+      detail.robots = record.robots
+      detail.sitemap_included = record.sitemap_included
+      detail.indexability_reasons = [...record.indexability_reasons]
+      detail.governance = { ...record.governance }
+      await writeJson(detailPath, detail)
+    }
+
+    corrected.push(slug)
+  }
+
+  if (listChanged) await writeJson(listPath, records)
+  return corrected.sort()
+}
+
+export async function reconcileValidatedClusterMemberGovernance({ dataDir = 'public/data' } = {}) {
+  const root = path.resolve(process.cwd(), dataDir)
+  const herbs = await reconcileCollection(root, 'herbs.json', 'herbs-detail')
+  const compounds = await reconcileCollection(root, 'compounds.json', 'compounds-detail')
+
+  return {
+    herbs,
+    compounds,
+    total: herbs.length + compounds.length,
+  }
+}

--- a/scripts/data/cluster-member-governance-policy.test.mjs
+++ b/scripts/data/cluster-member-governance-policy.test.mjs
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyValidatedClusterMemberGovernance,
+  isValidatedClusterMember,
+} from './cluster-member-governance-policy.mjs'
+
+describe('validated cluster-member governance precedence', () => {
+  it('restores a validated cluster member after the generic source overlay downgrades it', () => {
+    const record = {
+      slug: 'green-tea-egcg-isolated',
+      profile_status: 'commercial_ready',
+      runtime_export_decision: 'cluster_member_runtime',
+      indexability_status: 'NEEDS_REVIEW',
+      robots: 'noindex,follow',
+      sitemap_included: false,
+      indexability_reasons: ['missing_record_level_sources'],
+      governance: {
+        reviewStatus: 'needs_review',
+        indexingAllowed: false,
+        recommendationAllowed: true,
+        requiresHumanReview: true,
+        reason: 'missing_record_level_sources',
+      },
+    }
+
+    expect(isValidatedClusterMember(record)).toBe(true)
+    expect(applyValidatedClusterMemberGovernance(record)).toBe(true)
+    expect(record.indexability_status).toBe('PUBLISH')
+    expect(record.robots).toBe('index,follow')
+    expect(record.sitemap_included).toBe(true)
+    expect(record.indexability_reasons).not.toContain('missing_record_level_sources')
+    expect(record.indexability_reasons).toContain('cluster_member_runtime_trust')
+    expect(record.governance).toMatchObject({
+      reviewStatus: 'approved',
+      indexingAllowed: true,
+      recommendationAllowed: true,
+      requiresHumanReview: false,
+      reason: 'cluster_member_runtime_trust',
+    })
+  })
+
+  it('does not promote a known cluster slug whose explicit runtime decision is a hold', () => {
+    const record = {
+      slug: 'green-tea-egcg-isolated',
+      profile_status: 'commercial_ready',
+      runtime_export_decision: 'hidden_until_grounded',
+      indexability_status: 'NEEDS_REVIEW',
+      robots: 'noindex,follow',
+      sitemap_included: false,
+    }
+
+    expect(isValidatedClusterMember(record)).toBe(false)
+    expect(applyValidatedClusterMemberGovernance(record)).toBe(false)
+    expect(record.robots).toBe('noindex,follow')
+  })
+
+  it('keeps an explicit research-only profile held even if its slug is in the trust registry', () => {
+    const record = {
+      slug: 'green-tea-extract-egcg',
+      profile_status: 'research_only',
+      runtime_export_decision: 'cluster_member_runtime',
+      indexability_status: 'NEEDS_REVIEW',
+      robots: 'noindex,follow',
+      sitemap_included: false,
+    }
+
+    expect(isValidatedClusterMember(record)).toBe(false)
+    expect(applyValidatedClusterMemberGovernance(record)).toBe(false)
+  })
+})

--- a/scripts/data/governance-hold-policy.mjs
+++ b/scripts/data/governance-hold-policy.mjs
@@ -1,0 +1,110 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+export const DELIBERATE_HOLD_DECISIONS = new Set([
+  'hidden_until_grounded',
+  'research_archive_runtime',
+])
+
+export const DELIBERATE_HOLD_PROFILE_STATUSES = new Set([
+  'research_only',
+  'minimal',
+])
+
+export function isDeliberateGovernanceHold(record) {
+  if (!record || typeof record !== 'object') return false
+
+  const decision = String(record.runtime_export_decision || '').trim().toLowerCase()
+  if (DELIBERATE_HOLD_DECISIONS.has(decision)) return true
+
+  const profileStatus = String(record.profile_status || '').trim().toLowerCase()
+  if (DELIBERATE_HOLD_PROFILE_STATUSES.has(profileStatus)) return true
+
+  const reasons = Array.isArray(record.indexability_reasons) ? record.indexability_reasons : []
+  return reasons.some((reason) => {
+    const [key, value] = String(reason).split(':')
+    if (key === 'noindex-decision' && DELIBERATE_HOLD_DECISIONS.has(value)) return true
+    if (key === 'profile-status' && DELIBERATE_HOLD_PROFILE_STATUSES.has(value)) return true
+    return false
+  })
+}
+
+export function applyDeliberateGovernanceHold(record) {
+  if (!isDeliberateGovernanceHold(record)) return false
+
+  record.indexability_status = 'NEEDS_REVIEW'
+  record.robots = 'noindex,follow'
+  record.sitemap_included = false
+
+  if (!Array.isArray(record.indexability_reasons)) record.indexability_reasons = []
+  if (!record.indexability_reasons.includes('deliberate_governance_hold')) {
+    record.indexability_reasons.push('deliberate_governance_hold')
+  }
+
+  const governance = record.governance && typeof record.governance === 'object'
+    ? record.governance
+    : {}
+
+  record.governance = {
+    ...governance,
+    reviewStatus: 'needs_review',
+    indexingAllowed: false,
+    recommendationAllowed: false,
+    requiresHumanReview: true,
+    reason: 'deliberate_governance_hold',
+  }
+
+  return true
+}
+
+async function readJson(filePath, fallback) {
+  try {
+    return JSON.parse(await fs.readFile(filePath, 'utf8'))
+  } catch {
+    return fallback
+  }
+}
+
+async function writeJson(filePath, value) {
+  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8')
+}
+
+async function reconcileCollection(dataDir, listFile, detailDirName) {
+  const listPath = path.join(dataDir, listFile)
+  const records = await readJson(listPath, [])
+  if (!Array.isArray(records)) return { corrected: [] }
+
+  const corrected = []
+  for (const record of records) {
+    if (!applyDeliberateGovernanceHold(record)) continue
+    const slug = String(record.slug || '').trim()
+    if (!slug) continue
+    corrected.push(slug)
+
+    const detailPath = path.join(dataDir, detailDirName, `${slug}.json`)
+    const detail = await readJson(detailPath, null)
+    if (detail && typeof detail === 'object') {
+      applyDeliberateGovernanceHold(detail)
+      detail.indexability_status = record.indexability_status
+      detail.robots = record.robots
+      detail.sitemap_included = record.sitemap_included
+      detail.indexability_reasons = [...record.indexability_reasons]
+      detail.governance = { ...record.governance }
+      await writeJson(detailPath, detail)
+    }
+  }
+
+  if (corrected.length > 0) await writeJson(listPath, records)
+  return { corrected: corrected.sort() }
+}
+
+export async function reconcileDeliberateGovernanceHolds({ dataDir = 'public/data' } = {}) {
+  const root = path.resolve(process.cwd(), dataDir)
+  const herbs = await reconcileCollection(root, 'herbs.json', 'herbs-detail')
+  const compounds = await reconcileCollection(root, 'compounds.json', 'compounds-detail')
+  return {
+    herbs: herbs.corrected,
+    compounds: compounds.corrected,
+    total: herbs.corrected.length + compounds.corrected.length,
+  }
+}

--- a/scripts/data/governance-hold-policy.mjs
+++ b/scripts/data/governance-hold-policy.mjs
@@ -80,6 +80,23 @@ async function writeJson(filePath, value) {
   await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8')
 }
 
+function stableClone(value) {
+  if (Array.isArray(value)) return value.map(stableClone)
+  if (value && typeof value === 'object') {
+    return Object.keys(value)
+      .sort((a, b) => a.localeCompare(b))
+      .reduce((output, key) => {
+        output[key] = stableClone(value[key])
+        return output
+      }, {})
+  }
+  return value
+}
+
+async function writeDeterministicJson(filePath, value) {
+  await fs.writeFile(filePath, `${JSON.stringify(stableClone(value))}\n`, 'utf8')
+}
+
 async function reconcileCollection(dataDir, listFile, detailDirName) {
   const listPath = path.join(dataDir, listFile)
   const records = await readJson(listPath, [])
@@ -150,7 +167,7 @@ async function reconcileRuntimeMaps(dataDir, heldSlugs) {
     const sanitized = sanitizeRuntimeMap(current, heldSlugs)
     if (JSON.stringify(sanitized) === JSON.stringify(current)) continue
 
-    await writeJson(filePath, sanitized)
+    await writeDeterministicJson(filePath, sanitized)
     corrected.push(fileName)
   }
 

--- a/scripts/data/governance-hold-policy.mjs
+++ b/scripts/data/governance-hold-policy.mjs
@@ -22,6 +22,48 @@ const RUNTIME_MAP_FILES = [
   'authority-hubs.json',
 ]
 
+// The flat workbook-derived runtime records are the authority for profile visibility.
+// Per-slug detail files can carry richer editorial prose, but they must not override
+// canonical route/indexability state when runtime-data.ts merges detail last.
+const CANONICAL_DETAIL_AUTHORITY_FIELDS = [
+  'profile_status',
+  'runtime_export_decision',
+  'robots',
+  'sitemap_included',
+  'indexability_status',
+  'indexability_score',
+  'indexability_reasons',
+  'governance',
+]
+
+function cloneAuthorityValue(value) {
+  if (Array.isArray(value)) return value.map((entry) => cloneAuthorityValue(entry))
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, cloneAuthorityValue(entry)]),
+    )
+  }
+  return value
+}
+
+export function mirrorCanonicalGovernanceAuthority(detail, canonicalRecord) {
+  if (!detail || typeof detail !== 'object' || !canonicalRecord || typeof canonicalRecord !== 'object') {
+    return false
+  }
+
+  let changed = false
+  for (const field of CANONICAL_DETAIL_AUTHORITY_FIELDS) {
+    if (!(field in canonicalRecord)) continue
+
+    const nextValue = cloneAuthorityValue(canonicalRecord[field])
+    if (JSON.stringify(detail[field]) === JSON.stringify(nextValue)) continue
+
+    detail[field] = nextValue
+    changed = true
+  }
+  return changed
+}
+
 export function isDeliberateGovernanceHold(record) {
   if (!record || typeof record !== 'object') return false
 
@@ -100,30 +142,36 @@ async function writeDeterministicJson(filePath, value) {
 async function reconcileCollection(dataDir, listFile, detailDirName) {
   const listPath = path.join(dataDir, listFile)
   const records = await readJson(listPath, [])
-  if (!Array.isArray(records)) return { corrected: [] }
+  if (!Array.isArray(records)) return { corrected: [], synchronizedDetails: [] }
 
   const corrected = []
+  const synchronizedDetails = []
   for (const record of records) {
-    if (!applyDeliberateGovernanceHold(record)) continue
-    const slug = String(record.slug || '').trim()
+    const slug = String(record?.slug || '').trim()
     if (!slug) continue
-    corrected.push(slug)
+
+    // Deliberate-hold detection is based on the canonical runtime record, never on a
+    // stale legacy detail payload. This prevents an old detail-only status from
+    // overriding a later editorial promotion such as cluster_member_runtime.
+    const held = applyDeliberateGovernanceHold(record)
+    if (held) corrected.push(slug)
 
     const detailPath = path.join(dataDir, detailDirName, `${slug}.json`)
     const detail = await readJson(detailPath, null)
     if (detail && typeof detail === 'object') {
-      applyDeliberateGovernanceHold(detail)
-      detail.indexability_status = record.indexability_status
-      detail.robots = record.robots
-      detail.sitemap_included = record.sitemap_included
-      detail.indexability_reasons = [...record.indexability_reasons]
-      detail.governance = { ...record.governance }
-      await writeJson(detailPath, detail)
+      const changed = mirrorCanonicalGovernanceAuthority(detail, record)
+      if (changed) {
+        await writeJson(detailPath, detail)
+        synchronizedDetails.push(slug)
+      }
     }
   }
 
   if (corrected.length > 0) await writeJson(listPath, records)
-  return { corrected: corrected.sort() }
+  return {
+    corrected: corrected.sort(),
+    synchronizedDetails: synchronizedDetails.sort(),
+  }
 }
 
 function recordReferencesHeldSlug(value, heldSlugs) {
@@ -184,6 +232,10 @@ export async function reconcileDeliberateGovernanceHolds({ dataDir = 'public/dat
   return {
     herbs: herbs.corrected,
     compounds: compounds.corrected,
+    synchronizedDetails: {
+      herbs: herbs.synchronizedDetails,
+      compounds: compounds.synchronizedDetails,
+    },
     runtimeMaps,
     total: herbs.corrected.length + compounds.corrected.length,
   }

--- a/scripts/data/governance-hold-policy.mjs
+++ b/scripts/data/governance-hold-policy.mjs
@@ -11,6 +11,17 @@ export const DELIBERATE_HOLD_PROFILE_STATUSES = new Set([
   'minimal',
 ])
 
+const RUNTIME_MAP_FILES = [
+  'related-profiles.json',
+  'comparison-map.json',
+  'comparison-recommendations.json',
+  'condition-to-herbs.json',
+  'entity-to-conditions.json',
+  'stack-map.json',
+  'ecosystem-map.json',
+  'authority-hubs.json',
+]
+
 export function isDeliberateGovernanceHold(record) {
   if (!record || typeof record !== 'object') return false
 
@@ -98,13 +109,65 @@ async function reconcileCollection(dataDir, listFile, detailDirName) {
   return { corrected: corrected.sort() }
 }
 
+function recordReferencesHeldSlug(value, heldSlugs) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  return ['slug', 'sourceSlug', 'targetSlug'].some((key) => {
+    const slug = String(value[key] || '').trim()
+    return slug && heldSlugs.has(slug)
+  })
+}
+
+function sanitizeRuntimeMap(value, heldSlugs) {
+  if (Array.isArray(value)) {
+    return value
+      .filter((entry) => !recordReferencesHeldSlug(entry, heldSlugs))
+      .map((entry) => sanitizeRuntimeMap(entry, heldSlugs))
+  }
+
+  if (value && typeof value === 'object') {
+    const output = {}
+    for (const [key, entry] of Object.entries(value)) {
+      if (heldSlugs.has(key)) continue
+      output[key] = sanitizeRuntimeMap(entry, heldSlugs)
+    }
+    return output
+  }
+
+  return value
+}
+
+async function reconcileRuntimeMaps(dataDir, heldSlugs) {
+  if (heldSlugs.size === 0) return []
+
+  const runtimeMapDir = path.join(dataDir, 'runtime-maps')
+  const corrected = []
+
+  for (const fileName of RUNTIME_MAP_FILES) {
+    const filePath = path.join(runtimeMapDir, fileName)
+    const current = await readJson(filePath, null)
+    if (current === null) continue
+
+    const sanitized = sanitizeRuntimeMap(current, heldSlugs)
+    if (JSON.stringify(sanitized) === JSON.stringify(current)) continue
+
+    await writeJson(filePath, sanitized)
+    corrected.push(fileName)
+  }
+
+  return corrected.sort()
+}
+
 export async function reconcileDeliberateGovernanceHolds({ dataDir = 'public/data' } = {}) {
   const root = path.resolve(process.cwd(), dataDir)
   const herbs = await reconcileCollection(root, 'herbs.json', 'herbs-detail')
   const compounds = await reconcileCollection(root, 'compounds.json', 'compounds-detail')
+  const heldSlugs = new Set([...herbs.corrected, ...compounds.corrected])
+  const runtimeMaps = await reconcileRuntimeMaps(root, heldSlugs)
+
   return {
     herbs: herbs.corrected,
     compounds: compounds.corrected,
+    runtimeMaps,
     total: herbs.corrected.length + compounds.corrected.length,
   }
 }

--- a/scripts/data/governance-hold-policy.test.mjs
+++ b/scripts/data/governance-hold-policy.test.mjs
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyDeliberateGovernanceHold,
+  isDeliberateGovernanceHold,
+} from './governance-hold-policy.mjs'
+
+describe('deliberate governance hold precedence', () => {
+  it('keeps hidden_until_grounded held even when a curated overlay promoted it', () => {
+    const record = {
+      slug: 'black-cohosh',
+      runtime_export_decision: 'hidden_until_grounded',
+      indexability_status: 'PUBLISH',
+      robots: 'index,follow',
+      sitemap_included: true,
+      indexability_reasons: ['noindex-decision:hidden_until_grounded', 'curated_allowlist'],
+      governance: {
+        indexingAllowed: true,
+        reviewStatus: 'approved',
+        recommendationAllowed: true,
+        requiresHumanReview: false,
+        reason: 'curated_allowlist',
+      },
+    }
+
+    expect(isDeliberateGovernanceHold(record)).toBe(true)
+    expect(applyDeliberateGovernanceHold(record)).toBe(true)
+    expect(record.indexability_status).toBe('NEEDS_REVIEW')
+    expect(record.robots).toBe('noindex,follow')
+    expect(record.sitemap_included).toBe(false)
+    expect(record.governance.indexingAllowed).toBe(false)
+    expect(record.governance.requiresHumanReview).toBe(true)
+    expect(record.governance.recommendationAllowed).toBe(false)
+  })
+
+  it('keeps research_only profile status ahead of curated allowlisting', () => {
+    const record = {
+      slug: 'acetyl-l-carnitine',
+      profile_status: 'research_only',
+      indexability_status: 'PUBLISH',
+      robots: 'index,follow',
+      sitemap_included: true,
+      indexability_reasons: ['profile-status:research_only', 'curated_allowlist'],
+    }
+
+    expect(applyDeliberateGovernanceHold(record)).toBe(true)
+    expect(record.indexability_status).toBe('NEEDS_REVIEW')
+  })
+
+  it('leaves normal curated publish records unchanged', () => {
+    const record = {
+      slug: 'magnesium',
+      runtime_export_decision: 'full_public_runtime',
+      profile_status: 'complete',
+      indexability_status: 'PUBLISH',
+      robots: 'index,follow',
+      sitemap_included: true,
+      indexability_reasons: ['curated_allowlist'],
+    }
+
+    expect(isDeliberateGovernanceHold(record)).toBe(false)
+    expect(applyDeliberateGovernanceHold(record)).toBe(false)
+    expect(record.indexability_status).toBe('PUBLISH')
+  })
+})

--- a/scripts/data/governance-hold-policy.test.mjs
+++ b/scripts/data/governance-hold-policy.test.mjs
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   applyDeliberateGovernanceHold,
   isDeliberateGovernanceHold,
+  mirrorCanonicalGovernanceAuthority,
 } from './governance-hold-policy.mjs'
 
 describe('deliberate governance hold precedence', () => {
@@ -60,5 +61,46 @@ describe('deliberate governance hold precedence', () => {
     expect(isDeliberateGovernanceHold(record)).toBe(false)
     expect(applyDeliberateGovernanceHold(record)).toBe(false)
     expect(record.indexability_status).toBe('PUBLISH')
+  })
+
+  it('keeps late detail payloads from overriding canonical publish authority', () => {
+    const canonical = {
+      slug: 'green-tea-egcg-isolated',
+      profile_status: 'commercial_ready',
+      runtime_export_decision: 'cluster_member_runtime',
+      indexability_status: 'PUBLISH',
+      robots: 'index,follow',
+      sitemap_included: true,
+      indexability_score: 95,
+      indexability_reasons: ['export-decision:cluster_member_runtime'],
+      governance: {
+        indexingAllowed: true,
+        recommendationAllowed: true,
+        requiresHumanReview: false,
+        reviewStatus: 'approved',
+      },
+    }
+    const detail = {
+      slug: 'green-tea-egcg-isolated',
+      summary: 'Keep richer detail prose intact.',
+      indexability_status: 'NEEDS_REVIEW',
+      robots: 'noindex,follow',
+      sitemap_included: false,
+      governance: {
+        indexingAllowed: false,
+        recommendationAllowed: true,
+        requiresHumanReview: true,
+        reviewStatus: 'needs_review',
+      },
+    }
+
+    expect(mirrorCanonicalGovernanceAuthority(detail, canonical)).toBe(true)
+    expect(detail.summary).toBe('Keep richer detail prose intact.')
+    expect(detail.profile_status).toBe('commercial_ready')
+    expect(detail.runtime_export_decision).toBe('cluster_member_runtime')
+    expect(detail.indexability_status).toBe('PUBLISH')
+    expect(detail.robots).toBe('index,follow')
+    expect(detail.sitemap_included).toBe(true)
+    expect(detail.governance).toEqual(canonical.governance)
   })
 })

--- a/scripts/data/governance-hold-runtime-maps.test.mjs
+++ b/scripts/data/governance-hold-runtime-maps.test.mjs
@@ -1,0 +1,86 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { reconcileDeliberateGovernanceHolds } from './governance-hold-policy.mjs'
+
+const tempDirs = []
+
+async function writeJson(filePath, value) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true })
+  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8')
+}
+
+async function readJson(filePath) {
+  return JSON.parse(await fs.readFile(filePath, 'utf8'))
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })))
+})
+
+describe('deliberate governance hold runtime-map reconciliation', () => {
+  it('removes held profiles as both recommendation sources and targets after maps were already built', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'ths-governance-hold-'))
+    tempDirs.push(root)
+
+    await writeJson(path.join(root, 'herbs.json'), [
+      { slug: 'ashwagandha', profile_status: 'complete', governance: { recommendationAllowed: true } },
+      { slug: 'black-cohosh', profile_status: 'research_only', governance: { recommendationAllowed: true } },
+    ])
+    await writeJson(path.join(root, 'compounds.json'), [
+      { slug: 'magnesium', profile_status: 'complete', governance: { recommendationAllowed: true } },
+    ])
+    await writeJson(path.join(root, 'herbs-detail/black-cohosh.json'), {
+      slug: 'black-cohosh',
+      profile_status: 'research_only',
+      governance: { recommendationAllowed: true },
+    })
+
+    await writeJson(path.join(root, 'runtime-maps/related-profiles.json'), {
+      ashwagandha: [{ slug: 'black-cohosh', score: 9 }, { slug: 'magnesium', score: 7 }],
+      'black-cohosh': [{ slug: 'ashwagandha', score: 9 }],
+    })
+    await writeJson(path.join(root, 'runtime-maps/comparison-recommendations.json'), {
+      ashwagandha: [
+        { sourceSlug: 'ashwagandha', targetSlug: 'black-cohosh', href: '/guides/compare/ashwagandha-vs-black-cohosh' },
+        { sourceSlug: 'ashwagandha', targetSlug: 'magnesium', href: '/guides/compare/ashwagandha-vs-magnesium' },
+      ],
+      'black-cohosh': [
+        { sourceSlug: 'black-cohosh', targetSlug: 'ashwagandha', href: '/guides/compare/black-cohosh-vs-ashwagandha' },
+      ],
+    })
+    await writeJson(path.join(root, 'runtime-maps/condition-to-herbs.json'), {
+      anxiety: [
+        { slug: 'black-cohosh', score: 8 },
+        { slug: 'ashwagandha', score: 7 },
+      ],
+    })
+
+    const report = await reconcileDeliberateGovernanceHolds({ dataDir: root })
+
+    expect(report.herbs).toEqual(['black-cohosh'])
+    expect(report.runtimeMaps).toEqual([
+      'comparison-recommendations.json',
+      'condition-to-herbs.json',
+      'related-profiles.json',
+    ])
+
+    const related = await readJson(path.join(root, 'runtime-maps/related-profiles.json'))
+    expect(related['black-cohosh']).toBeUndefined()
+    expect(related.ashwagandha).toEqual([{ slug: 'magnesium', score: 7 }])
+
+    const comparisons = await readJson(path.join(root, 'runtime-maps/comparison-recommendations.json'))
+    expect(comparisons['black-cohosh']).toBeUndefined()
+    expect(comparisons.ashwagandha).toEqual([
+      { sourceSlug: 'ashwagandha', targetSlug: 'magnesium', href: '/guides/compare/ashwagandha-vs-magnesium' },
+    ])
+
+    const conditions = await readJson(path.join(root, 'runtime-maps/condition-to-herbs.json'))
+    expect(conditions.anxiety).toEqual([{ slug: 'ashwagandha', score: 7 }])
+
+    const held = (await readJson(path.join(root, 'herbs.json'))).find((record) => record.slug === 'black-cohosh')
+    expect(held.governance.recommendationAllowed).toBe(false)
+    expect(held.robots).toBe('noindex,follow')
+  })
+})

--- a/scripts/data/governance-hold-runtime-maps.test.mjs
+++ b/scripts/data/governance-hold-runtime-maps.test.mjs
@@ -15,6 +15,19 @@ async function readJson(filePath) {
   return JSON.parse(await fs.readFile(filePath, 'utf8'))
 }
 
+function stableClone(value) {
+  if (Array.isArray(value)) return value.map(stableClone)
+  if (value && typeof value === 'object') {
+    return Object.keys(value)
+      .sort((a, b) => a.localeCompare(b))
+      .reduce((output, key) => {
+        output[key] = stableClone(value[key])
+        return output
+      }, {})
+  }
+  return value
+}
+
 afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })))
 })
@@ -66,9 +79,12 @@ describe('deliberate governance hold runtime-map reconciliation', () => {
       'related-profiles.json',
     ])
 
-    const related = await readJson(path.join(root, 'runtime-maps/related-profiles.json'))
+    const relatedPath = path.join(root, 'runtime-maps/related-profiles.json')
+    const relatedRaw = await fs.readFile(relatedPath, 'utf8')
+    const related = JSON.parse(relatedRaw)
     expect(related['black-cohosh']).toBeUndefined()
     expect(related.ashwagandha).toEqual([{ slug: 'magnesium', score: 7 }])
+    expect(relatedRaw).toBe(`${JSON.stringify(stableClone(related))}\n`)
 
     const comparisons = await readJson(path.join(root, 'runtime-maps/comparison-recommendations.json'))
     expect(comparisons['black-cohosh']).toBeUndefined()

--- a/scripts/data/postprocess-workbook-payloads.mjs
+++ b/scripts/data/postprocess-workbook-payloads.mjs
@@ -1,7 +1,8 @@
 import fs from 'fs'
 import path from 'path'
 
-const dataDir = path.join(process.cwd(), 'public/data')
+const dataDirArg = process.argv.find((arg) => arg.startsWith('--data-dir='))
+const dataDir = path.resolve(process.cwd(), dataDirArg ? dataDirArg.split('=')[1] : 'public/data')
 const herbSourcesCachePath = path.join(process.cwd(), 'ops/cache/pubmed-herb-sources-cache.json')
 
 function readHerbSourcesCache() {

--- a/src/lib/__tests__/seo-governance-precedence.test.ts
+++ b/src/lib/__tests__/seo-governance-precedence.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { shouldIndexRoute } from '../seo'
+
+describe('SEO governance precedence', () => {
+  it('keeps a curated herb noindexed while an explicit grounding hold is active', () => {
+    const decision = shouldIndexRoute('/herbs/black-cohosh', {
+      slug: 'black-cohosh',
+      sitemap_included: false,
+      robots: 'noindex,follow',
+      indexability_status: 'NEEDS_REVIEW',
+      runtime_export_decision: 'hidden_until_grounded',
+      profile_status: 'complete',
+      indexability_reasons: ['deliberate_governance_hold'],
+    })
+
+    expect(decision.index).toBe(false)
+    expect(decision.follow).toBe(true)
+    expect(decision.reason).toBe('runtime_export_decision=hidden_until_grounded')
+  })
+
+  it('keeps a curated compound noindexed while research_only is active', () => {
+    const decision = shouldIndexRoute('/compounds/acetyl-l-carnitine', {
+      slug: 'acetyl-l-carnitine',
+      sitemap_included: false,
+      robots: 'noindex,follow',
+      indexability_status: 'NEEDS_REVIEW',
+      runtime_export_decision: 'full_public_runtime',
+      profile_status: 'research_only',
+      indexability_reasons: ['deliberate_governance_hold'],
+    })
+
+    expect(decision.index).toBe(false)
+    expect(decision.reason).toBe('profile_status=research_only')
+  })
+
+  it('preserves the existing curated override for an ordinary review state', () => {
+    const decision = shouldIndexRoute('/herbs/ashwagandha', {
+      slug: 'ashwagandha',
+      sitemap_included: false,
+      robots: 'index,follow',
+      indexability_status: 'NEEDS_REVIEW',
+      runtime_export_decision: 'full_public_runtime',
+      profile_status: 'complete',
+    })
+
+    expect(decision.index).toBe(true)
+    expect(decision.reason).toBe('curated-herb-allowlist')
+  })
+})

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -215,15 +215,10 @@ function normalizeIndexRoutePath(path: string): string {
 
 function hasNoindexSignal(record: Record<string, unknown> | null | undefined): string | null {
   if (!record) return null
-  const sitemapIncluded = record.sitemap_included
-  if (sitemapIncluded === false || String(sitemapIncluded).toLowerCase() === 'false') return 'sitemap_included=false'
 
-  const robots = String(record.robots || '').toLowerCase()
-  if (robots.includes('noindex')) return 'robots=noindex'
-
-  const indexabilityStatus = String(record.indexability_status || '').toUpperCase()
-  if (['NOINDEX', 'NEEDS_REVIEW', 'BLOCKED'].includes(indexabilityStatus)) return `indexability_status=${indexabilityStatus}`
-
+  // Strong source/runtime holds must be evaluated before derived indexability
+  // fields. Curated priority can intentionally override an ordinary review state,
+  // but it must never erase an explicit hidden/research-only content hold.
   const decision = String(record.runtime_export_decision || '').toLowerCase()
   if (['hide', 'hidden', 'blocked', 'block', 'alias_redirect_only', 'hidden_until_grounded', 'research_archive_runtime'].includes(decision)) {
     return `runtime_export_decision=${decision}`
@@ -231,6 +226,15 @@ function hasNoindexSignal(record: Record<string, unknown> | null | undefined): s
 
   const profileStatus = String(record.profile_status || '').toLowerCase()
   if (['draft', 'archived', 'minimal', 'research_only'].includes(profileStatus)) return `profile_status=${profileStatus}`
+
+  const robots = String(record.robots || '').toLowerCase()
+  if (robots.includes('noindex')) return 'robots=noindex'
+
+  const indexabilityStatus = String(record.indexability_status || '').toUpperCase()
+  if (['NOINDEX', 'NEEDS_REVIEW', 'BLOCKED'].includes(indexabilityStatus)) return `indexability_status=${indexabilityStatus}`
+
+  const sitemapIncluded = record.sitemap_included
+  if (sitemapIncluded === false || String(sitemapIncluded).toLowerCase() === 'false') return 'sitemap_included=false'
 
   const summaryQuality = String(record.summary_quality || '').toLowerCase()
   if (['weak', 'minimal', 'thin', 'stub', 'research_needed', 'none'].includes(summaryQuality)) return `summary_quality=${summaryQuality}`


### PR DESCRIPTION
Clean replay of #2581 on current main after the magnesium and sleep-stack evidence upgrades.

What this does:
- normalizes workbook runtime payloads and reapplies governance before summary/route/sitemap generation
- preserves deliberate hidden_until_grounded / research_archive_runtime / research_only / minimal holds after curated overlay
- keeps the current AI entity artifact authority
- makes explicit runtime/profile hold signals outrank generic sitemap/NEEDS_REVIEW signals in shouldIndexRoute(), so curated editorial priority cannot accidentally re-index a deliberate hold
- teaches sitemap completeness to honor rendered robots=noindex metadata after build, fixing runtime-generated static wrappers without route-specific exceptions
- adds focused governance-boundary and SEO-precedence regressions

Precedence: deliberate content hold > curated editorial priority > source/indexability heuristic.

Supersedes #2581, #2577, and #2569 if fully green.