### PR TITLE
Frame affiliate products as neutral sourcing examples

### DIFF
--- a/components/AffiliateBlock.tsx
+++ b/components/AffiliateBlock.tsx
@@ -50,14 +50,14 @@ export default function AffiliateBlock({ compound, intentLabel, compact = false 
   }
 
   const products = [entry.products?.[0], entry.products?.[1]].filter(Boolean)
-  const labels = ['Best overall', 'Best budget']
+  const labels = ['Featured example', 'Budget example']
 
   return (
     <div className={`grid gap-3 ${compact ? '' : 'mt-2'}`}>
       {intentLabel ? <p className='text-xs font-black uppercase tracking-[0.16em] text-emerald-100'>{intentLabel}</p> : null}
       {products.map((p: Record<string, unknown>, i: number) => (
         <div key={i} className='rounded-2xl border border-white/10 bg-white/[0.03] p-2'>
-          <p className='mb-2 px-1 text-[0.7rem] font-black uppercase tracking-[0.16em] text-white/45'>{labels[i] ?? 'Top pick'}</p>
+          <p className='mb-2 px-1 text-[0.7rem] font-black uppercase tracking-[0.16em] text-white/45'>{labels[i] ?? 'Product example'}</p>
           <AffiliateProductCard product={p} />
         </div>
       ))}

--- a/components/AffiliateProductBox.tsx
+++ b/components/AffiliateProductBox.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import RevenueImpressionTracker from './RevenueImpressionTracker'
+import { affiliateRationaleForDisplay } from '../src/lib/affiliate-copy'
 import { trackRevenueEvent } from '../src/lib/revenue-tracking'
 
 export interface AffiliateEntry {
@@ -20,12 +21,12 @@ interface Props {
 }
 
 const SLOT_LABELS: Record<string, string> = {
-  budget: 'Best Value',
-  overall: 'Best Overall',
-  premium: 'Premium Pick',
+  budget: 'Budget example',
+  overall: 'Featured example',
+  premium: 'Premium example',
 }
 
-export default function AffiliateProductBox({ slug, products, heading = 'Recommended Products' }: Props) {
+export default function AffiliateProductBox({ slug, products, heading = 'Product sourcing examples' }: Props) {
   const visible = products.filter((p) => p.affiliateUrl && p.affiliateUrl.startsWith('http'))
   if (visible.length === 0) return null
 
@@ -35,6 +36,7 @@ export default function AffiliateProductBox({ slug, products, heading = 'Recomme
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {visible.map((product) => {
           const displayTitle = product.title || product.name || 'Supplement option'
+          const displayRationale = affiliateRationaleForDisplay(displayTitle, product.rationale)
           const url = product.affiliateUrl!
           return (
             <RevenueImpressionTracker
@@ -54,9 +56,7 @@ export default function AffiliateProductBox({ slug, products, heading = 'Recomme
                   <p className="mt-0.5 text-xs font-semibold text-muted">{product.brand}</p>
                 )}
                 <h3 className="mt-2 text-sm font-semibold text-ink leading-5">{displayTitle}</h3>
-                {product.rationale && (
-                  <p className="mt-2 text-xs leading-5 text-muted flex-1">{product.rationale}</p>
-                )}
+                <p className="mt-2 text-xs leading-5 text-muted flex-1">{displayRationale}</p>
                 <a
                   href={url}
                   target="_blank"

--- a/components/RecommendationSection.tsx
+++ b/components/RecommendationSection.tsx
@@ -21,13 +21,13 @@ type RecommendationSectionProps = {
 }
 
 const slotLabels: Record<RecommendationSlot, string> = {
-  budget: 'Budget pick',
-  overall: 'Best overall',
-  premium: 'Premium pick',
+  budget: 'Budget example',
+  overall: 'Featured example',
+  premium: 'Premium example',
 }
 
 export default function RecommendationSection({
-  title = 'Product recommendations',
+  title = 'Product sourcing examples',
   description = 'Use these as sourcing starting points, not medical recommendations. Product quality, dose, and fit still need review.',
   products,
   preferredRegion = null,

--- a/components/monetization/GoalTopAffiliatePicks.tsx
+++ b/components/monetization/GoalTopAffiliatePicks.tsx
@@ -6,9 +6,9 @@ import { isRestrictedRecord } from '@/src/lib/restricted-ingredients'
 import { resolveRegionalUrl } from '@/src/lib/platforms'
 
 const SLOT_LABELS: Record<string, string> = {
-  budget: 'Budget pick',
-  overall: 'Best overall',
-  premium: 'Premium pick',
+  budget: 'Budget example',
+  overall: 'Featured example',
+  premium: 'Premium example',
 }
 
 type GoalTopAffiliatePicksProps = {
@@ -54,7 +54,7 @@ export default function GoalTopAffiliatePicks({
         brand: product.brand,
         href,
         rationale: product.rationale || `Starting point for ${pick.need.toLowerCase()} — verify dose and safety on the full profile.`,
-        slotLabel: SLOT_LABELS[product.slot] || 'Editor pick',
+        slotLabel: SLOT_LABELS[product.slot] || 'Product example',
         productSlot: product.slot,
       },
     ]
@@ -65,7 +65,7 @@ export default function GoalTopAffiliatePicks({
   return (
     <section className='card-premium p-5 sm:p-8'>
       <p className='eyebrow-label'>Optional sourcing notes</p>
-      <h2 className='mt-2 text-xl font-semibold text-ink'>Sourcing picks for this goal</h2>
+      <h2 className='mt-2 text-xl font-semibold text-ink'>Sourcing examples for this goal</h2>
       <p className='mt-2 text-sm leading-6 text-muted'>
         These are product examples to research carefully — not prescriptions and not a substitute for the safety notes above.
       </p>

--- a/components/monetization/ProductTrustAffiliate.tsx
+++ b/components/monetization/ProductTrustAffiliate.tsx
@@ -35,7 +35,7 @@ export default function ProductTrustAffiliate({
     return (
       <div className='mt-4 space-y-3 border-t border-brand-900/10 pt-4 dark:border-white/10'>
         <p className='text-[10px] font-bold uppercase tracking-wider text-emerald-800 dark:text-brand-200'>
-          Why we link this {slotLabel ? `(${slotLabel})` : ''}
+          Sourcing note {slotLabel ? `(${slotLabel})` : ''}
         </p>
         <p className='text-xs leading-relaxed text-muted'>{displayRationale}</p>
         <p className='text-[10px] leading-relaxed text-muted'>
@@ -63,7 +63,7 @@ export default function ProductTrustAffiliate({
       ) : null}
       <h3 className='mt-1 text-base font-semibold text-ink'>{displayTitle}</h3>
       <p className='mt-2 text-sm leading-6 text-muted'>
-        <strong className='font-semibold text-ink'>Why we recommend it:</strong> {displayRationale}
+        <strong className='font-semibold text-ink'>Sourcing note:</strong> {displayRationale}
       </p>
       <ul className='mt-3 space-y-1.5 text-xs leading-relaxed text-muted'>
         <li>• Prefer third-party tested brands (USP, NSF, ConsumerLab, or published COA)</li>

--- a/components/monetization/__tests__/GoalTopAffiliatePicks.test.tsx
+++ b/components/monetization/__tests__/GoalTopAffiliatePicks.test.tsx
@@ -6,8 +6,9 @@ describe('GoalTopAffiliatePicks', () => {
   it('turns a goal shortlist into a small, safety-framed sourcing endpoint', () => {
     render(<GoalTopAffiliatePicks goalSlug='stress' limit={3} />)
 
-    expect(screen.getByRole('heading', { name: 'Sourcing picks for this goal' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Sourcing examples for this goal' })).toBeInTheDocument()
     expect(screen.getByText(/not prescriptions/i)).toBeInTheDocument()
+    expect(screen.queryByText(/best overall/i)).not.toBeInTheDocument()
 
     const productLinks = screen.getAllByRole('link', { name: /sourcing on amazon/i })
     expect(productLinks).toHaveLength(3)

--- a/src/lib/__tests__/affiliate-copy.test.ts
+++ b/src/lib/__tests__/affiliate-copy.test.ts
@@ -50,7 +50,7 @@ describe('affiliateRationaleForDisplay', () => {
     expect(result).not.toMatch(/well-reviewed/i)
   })
 
-  it('turns unsourced commercial ranking prefixes into neutral product examples', () => {
+  it('turns live unsourced commercial ranking prefixes into neutral product examples', () => {
     expect(
       affiliateRationaleForDisplay(
         'Jarrow Theanine 200 mg',
@@ -59,8 +59,26 @@ describe('affiliateRationaleForDisplay', () => {
     ).toBe('Product example for a simple 200 mg L-theanine capsule format.')
 
     expect(
+      affiliateRationaleForDisplay(
+        'Gaia Herbs Kava Kava',
+        'Best overall for phyto-caps with standardized kavalactone content and sourcing transparency.',
+      ),
+    ).toBe('Product example for phyto-caps with standardized kavalactone content and sourcing transparency.')
+
+    expect(
+      affiliateRationaleForDisplay(
+        'Example Fast Dissolve',
+        'Best overall fast-dissolve tablet format.',
+      ),
+    ).toBe('Product example: fast-dissolve tablet format.')
+
+    expect(
       affiliateRationaleForDisplay('Example Budget', 'Budget pick for a basic capsule format.'),
     ).toBe('Budget product example for a basic capsule format.')
+
+    expect(
+      affiliateRationaleForDisplay('Example Capsule', 'Budget capsule pick for a basic entry point.'),
+    ).toBe('Budget capsule example for a basic entry point.')
 
     expect(
       affiliateRationaleForDisplay('Example Premium', 'Premium pick for a liquid extract format.'),

--- a/src/lib/__tests__/affiliate-copy.test.ts
+++ b/src/lib/__tests__/affiliate-copy.test.ts
@@ -50,12 +50,29 @@ describe('affiliateRationaleForDisplay', () => {
     expect(result).not.toMatch(/well-reviewed/i)
   })
 
-  it('preserves ordinary sourcing rationale', () => {
+  it('turns unsourced commercial ranking prefixes into neutral product examples', () => {
     expect(
       affiliateRationaleForDisplay(
         'Jarrow Theanine 200 mg',
         'Best overall pick for a simple 200 mg L-theanine capsule format.',
       ),
-    ).toBe('Best overall pick for a simple 200 mg L-theanine capsule format.')
+    ).toBe('Product example for a simple 200 mg L-theanine capsule format.')
+
+    expect(
+      affiliateRationaleForDisplay('Example Budget', 'Budget pick for a basic capsule format.'),
+    ).toBe('Budget product example for a basic capsule format.')
+
+    expect(
+      affiliateRationaleForDisplay('Example Premium', 'Premium pick for a liquid extract format.'),
+    ).toBe('Premium product example for a liquid extract format.')
+  })
+
+  it('preserves ordinary non-ranking sourcing rationale', () => {
+    expect(
+      affiliateRationaleForDisplay(
+        'Example Product',
+        'Capsule format with a clearly labeled serving size.',
+      ),
+    ).toBe('Capsule format with a clearly labeled serving size.')
   })
 })

--- a/src/lib/__tests__/affiliate-surface-copy.test.ts
+++ b/src/lib/__tests__/affiliate-surface-copy.test.ts
@@ -1,0 +1,33 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const SHARED_AFFILIATE_SURFACES = [
+  'components/AffiliateProductBox.tsx',
+  'components/AffiliateBlock.tsx',
+  'components/RecommendationSection.tsx',
+  'components/monetization/GoalTopAffiliatePicks.tsx',
+  'components/monetization/ProductTrustAffiliate.tsx',
+]
+
+function source(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+}
+
+describe('shared affiliate surface copy', () => {
+  it.each(SHARED_AFFILIATE_SURFACES)('%s avoids unsourced comparative ranking labels', (relativePath) => {
+    const file = source(relativePath)
+
+    expect(file).not.toMatch(/\bbest overall\b/i)
+    expect(file).not.toMatch(/\bbest value\b/i)
+    expect(file).not.toMatch(/why we recommend it/i)
+  })
+
+  it('routes AffiliateProductBox rationale through the shared display sanitizer', () => {
+    const file = source('components/AffiliateProductBox.tsx')
+
+    expect(file).toContain("import { affiliateRationaleForDisplay } from '../src/lib/affiliate-copy'")
+    expect(file).toContain('affiliateRationaleForDisplay(displayTitle, product.rationale)')
+    expect(file).not.toContain('{product.rationale}')
+  })
+})

--- a/src/lib/affiliate-copy.ts
+++ b/src/lib/affiliate-copy.ts
@@ -5,8 +5,11 @@ const DYNAMIC_OR_UNSOURCED_SUPERIORITY =
   /\b(well[- ]reviewed|preferred by most sleep researchers|faster absorption|superior bioavailability)\b/i
 
 const RANKING_PREFIXES: Array<[RegExp, string]> = [
-  [/^best\s+overall\s+(?:pick|choice|option)\s+for\s+/i, 'Product example for '],
-  [/^best\s+value\s+(?:pick|choice|option)\s+for\s+/i, 'Value-oriented product example for '],
+  // Registry copy uses both “Best overall for …” and “Best overall pick for …”.
+  [/^best\s+overall(?:\s+(?:pick|choice|option))?\s+for\s+/i, 'Product example for '],
+  [/^best\s+overall(?:\s+(?:pick|choice|option))?\s+/i, 'Product example: '],
+  [/^best\s+value(?:\s+(?:pick|choice|option))?\s+for\s+/i, 'Value-oriented product example for '],
+  [/^best\s+value(?:\s+(?:pick|choice|option))?\s+/i, 'Value-oriented product example: '],
   [/^budget\s+(?:pick|choice|option)\s+for\s+/i, 'Budget product example for '],
   [/^premium\s+(?:pick|choice|option)\s+for\s+/i, 'Premium product example for '],
 ]
@@ -15,6 +18,15 @@ function neutralizeUnsourcedRanking(text: string): string {
   for (const [pattern, replacement] of RANKING_PREFIXES) {
     if (pattern.test(text)) return text.replace(pattern, replacement)
   }
+
+  // Some registry rows insert a format word before “pick” (for example,
+  // “Budget capsule pick for …”). Keep the useful format descriptor while removing
+  // the editorial-selection word.
+  const budgetFormatPick = text.match(/^budget\s+([\w-]+)\s+pick\s+for\s+/i)
+  if (budgetFormatPick) {
+    return text.replace(budgetFormatPick[0], `Budget ${budgetFormatPick[1]} example for `)
+  }
+
   return text
 }
 

--- a/src/lib/affiliate-copy.ts
+++ b/src/lib/affiliate-copy.ts
@@ -4,6 +4,20 @@ const DEFAULT_FALLBACK =
 const DYNAMIC_OR_UNSOURCED_SUPERIORITY =
   /\b(well[- ]reviewed|preferred by most sleep researchers|faster absorption|superior bioavailability)\b/i
 
+const RANKING_PREFIXES: Array<[RegExp, string]> = [
+  [/^best\s+overall\s+(?:pick|choice|option)\s+for\s+/i, 'Product example for '],
+  [/^best\s+value\s+(?:pick|choice|option)\s+for\s+/i, 'Value-oriented product example for '],
+  [/^budget\s+(?:pick|choice|option)\s+for\s+/i, 'Budget product example for '],
+  [/^premium\s+(?:pick|choice|option)\s+for\s+/i, 'Premium product example for '],
+]
+
+function neutralizeUnsourcedRanking(text: string): string {
+  for (const [pattern, replacement] of RANKING_PREFIXES) {
+    if (pattern.test(text)) return text.replace(pattern, replacement)
+  }
+  return text
+}
+
 function formatFirstPassFallback(productName: string): string {
   const doseMatch = productName.match(/\b\d+(?:\.\d+)?\s*(?:mg|mcg|µg)\b/i)?.[0]
   const doseContext = doseMatch ? ` with a clearly labeled ${doseMatch} dose` : ''
@@ -35,5 +49,8 @@ export function affiliateRationaleForDisplay(
     return `Use ${productName} as a product-format example.${doseContext} Verify formulation, serving size, third-party testing, and safety context before buying.`
   }
 
-  return text
+  // Unsourced commercial cards can organize examples by registry slot, but labels
+  // such as "best overall" read like evidence-backed comparative judgments. Keep the
+  // useful product-format rationale while removing that unsupported ranking signal.
+  return neutralizeUnsourcedRanking(text)
 }


### PR DESCRIPTION
High-ROI trust/monetization cleanup across shared affiliate surfaces.

What changes:
- replaces unsourced comparative labels such as “Best overall” / “Best value” with neutral sourcing-example labels
- changes “Why we recommend it” framing to explicit sourcing notes
- routes AffiliateProductBox rationale through the shared affiliate-copy sanitizer instead of rendering registry rationale raw
- neutralizes leading ranking language in affiliate rationale while preserving concrete product-format information
- keeps affiliate links, tracking, disclosures, product inventory, and CTAs intact
- adds focused regressions for ranking-prefix sanitization and shared-surface copy

Intent: preserve the revenue path while making the commercial/editorial boundary clearer and more defensible.