### PR TITLE
SEO: stop redirecting phantom legacy comparisons

### DIFF
--- a/functions/_shared/legacy-compare.ts
+++ b/functions/_shared/legacy-compare.ts
@@ -39,9 +39,13 @@ export function handleLegacyCompareRequest(request: Request, legacyPrefix: strin
     return Response.redirect(url.toString(), 301)
   }
 
-  // Old comparison URLs are still present in historical/internal content. Sending
-  // them to the live comparison hub avoids dead-end 410 responses while keeping
-  // retired thin pages out of the index.
-  url.pathname = '/guides/compare/'
-  return Response.redirect(url.toString(), 301)
+  // Redirect only legacy URLs with a verified destination. Unknown comparison
+  // slugs should not inherit a generic 301 to the hub because that hides retired
+  // or phantom URLs behind an unrelated canonical destination.
+  return new Response(null, {
+    status: 410,
+    headers: {
+      'X-Robots-Tag': 'noindex, nofollow',
+    },
+  })
 }


### PR DESCRIPTION
Fixes a current-main regression caught by the existing legacy comparison routing test.

- keeps the legacy comparison index redirect to the comparison hub
- keeps 301 redirects only for verified built comparison pages and explicit aliases
- returns 410 + `X-Robots-Tag: noindex, nofollow` for unknown/phantom comparison slugs instead of issuing a generic 301 to an unrelated hub
- restores the existing regression invariant and avoids masking retired or nonexistent comparison URLs behind a generic canonical destination