### PR TITLE
Content: calibrate public goal evidence across sleep stress anxiety and focus

### DIFF
--- a/app/goals/[slug]/page.tsx
+++ b/app/goals/[slug]/page.tsx
@@ -10,7 +10,7 @@ import GoalTopAffiliatePicks from '@/components/monetization/GoalTopAffiliatePic
 import GoalContentDepth from '@/src/components/goals/GoalContentDepth'
 import GoalHubSections from '@/src/components/goals/GoalHubSections'
 import { getGoalHubLinks } from '@/src/lib/goal-hub-links'
-import { getPublicGoalContentExtension } from '@/src/lib/goal-public-copy'
+import { getPublicGoal, getPublicGoalContentExtension } from '@/src/lib/goal-public-copy'
 import SchemaOrg from '@/components/SchemaOrg'
 import Disclaimer from '@/src/components/Disclaimer'
 import { breadcrumbJsonLd, faqPageJsonLd, SITE_URL } from '@/src/lib/seo'
@@ -52,8 +52,9 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function GoalPage({ params }: PageProps) {
   const { slug } = await params
-  const goal = getGoal(slug)
-  if (!goal) notFound()
+  const rawGoal = getGoal(slug)
+  if (!rawGoal) notFound()
+  const goal = getPublicGoal(rawGoal)
 
   const goalPath = `/goals/${goal.slug}/`
   const rawExtension = getGoalContentExtension(goal.slug)

--- a/src/lib/__tests__/goal-public-copy.test.ts
+++ b/src/lib/__tests__/goal-public-copy.test.ts
@@ -1,6 +1,9 @@
+import fs from 'node:fs'
+import path from 'node:path'
 import { describe, expect, it } from 'vitest'
-import type { GoalContentExtension } from '@/data/goal-content'
-import { getPublicGoalContentExtension } from '../goal-public-copy'
+import { goals } from '@/data/goals'
+import { goalContentBySlug, type GoalContentExtension } from '@/data/goal-content'
+import { getPublicGoal, getPublicGoalContentExtension } from '../goal-public-copy'
 
 const fixture: GoalContentExtension = {
   faqItems: [
@@ -26,7 +29,17 @@ const fixture: GoalContentExtension = {
   safetyBullets: ['Review safety.'],
 }
 
-describe('getPublicGoalContentExtension', () => {
+function publicGoalContent(slug: keyof typeof goalContentBySlug) {
+  return getPublicGoalContentExtension(slug, goalContentBySlug[slug])
+}
+
+function publicPrimaryGoal(slug: string) {
+  const goal = goals.find((entry) => entry.slug === slug)
+  if (!goal) throw new Error(`Missing goal fixture: ${slug}`)
+  return getPublicGoal(goal)
+}
+
+describe('public goal evidence calibration', () => {
   it('removes unsupported valerian efficacy and cumulative-effect claims from sleep public copy', () => {
     const result = getPublicGoalContentExtension('sleep', fixture)
 
@@ -37,15 +50,134 @@ describe('getPublicGoalContentExtension', () => {
     expect(result.dosingNotes[0].note).toMatch(/evidence for insomnia remains inconsistent/i)
   })
 
-  it('does not mutate the source extension', () => {
-    const original = fixture.faqItems[0].answer
-    getPublicGoalContentExtension('sleep', fixture)
-    expect(fixture.faqItems[0].answer).toBe(original)
+  it('calibrates sleep evidence grades and removes universal theanine timing/dose claims', () => {
+    const result = publicGoalContent('sleep')
+    const magnesium = result.evidenceRows.find((row) => row.compound === 'Magnesium')
+    const theanine = result.evidenceRows.find((row) => row.compound === 'L-Theanine')
+    const theanineDose = result.dosingNotes.find((row) => row.compound === 'L-Theanine')
+
+    expect(magnesium?.evidence).toBe('Limited / heterogeneous')
+    expect(theanine?.evidence).toBe('Limited / mixed for sleep')
+    expect(theanine?.limitation).toMatch(/optimal dose and duration remain uncertain/i)
+    expect(theanineDose?.note).toMatch(/do not establish one optimal dose/i)
+    expect(theanineDose?.note).not.toMatch(/100[–-]200 mg before bed/i)
   })
 
-  it('leaves unrelated goal content unchanged', () => {
-    const result = getPublicGoalContentExtension('focus', fixture)
-    expect(result.faqItems[0].answer).toBe(fixture.faqItems[0].answer)
-    expect(result.evidenceRows[0]).toEqual(fixture.evidenceRows[0])
+  it('removes rapid-onset stress claims and calibrates rhodiola and theanine', () => {
+    const result = publicGoalContent('stress')
+    const faq = result.faqItems.find((item) => item.question.startsWith('Ashwagandha vs L-Theanine'))
+    const rhodiola = result.evidenceRows.find((row) => row.compound === 'Rhodiola')
+    const theanine = result.evidenceRows.find((row) => row.compound === 'L-Theanine')
+
+    expect(faq?.answer).not.toMatch(/30[–-]90 minutes|rapid, acute stress buffering/i)
+    expect(rhodiola?.evidence).toBe('Variable / outcome-specific')
+    expect(theanine?.evidence).toBe('Limited / mixed for stress')
+    expect(theanine?.limitation).toMatch(/bias-sensitive/i)
+  })
+
+  it('does not present kava or L-Theanine as established anxiety treatments', () => {
+    const result = publicGoalContent('anxiety')
+    const kavaFaq = result.faqItems.find((item) => item.question === 'Is kava effective for social anxiety?')
+    const theanineFaq = result.faqItems.find((item) => item.question.startsWith('Can L-Theanine'))
+    const kava = result.evidenceRows.find((row) => row.compound === 'Kava')
+    const theanine = result.evidenceRows.find((row) => row.compound === 'L-Theanine')
+    const kavaDose = result.dosingNotes.find((row) => row.compound === 'Kava')
+
+    expect(kavaFaq?.answer).toMatch(/does not establish it as a reliable treatment for social anxiety/i)
+    expect(kavaFaq?.answer).toMatch(/liver injury/i)
+    expect(theanineFaq?.answer).toMatch(/anxiety findings were inconsistent/i)
+    expect(kava?.evidence).toBe('Mixed / safety-limited')
+    expect(theanine?.evidence).toBe('Inconsistent for anxiety')
+    expect(kavaDose?.note).not.toMatch(/only reputable CO2 or aqueous extracts/i)
+  })
+
+  it('keeps caffeine evidence strong without promising theanine will smooth stimulation', () => {
+    const result = publicGoalContent('focus')
+    const comparison = result.faqItems.find((item) => item.question.startsWith('Caffeine vs L-Theanine'))
+    const caffeine = result.evidenceRows.find((row) => row.compound === 'Caffeine')
+    const theanine = result.evidenceRows.find((row) => row.compound === 'L-Theanine')
+    const bacopa = result.evidenceRows.find((row) => row.compound === 'Bacopa Monnieri')
+    const theanineDose = result.dosingNotes.find((row) => row.compound === 'L-Theanine')
+
+    expect(comparison?.answer).not.toMatch(/smooths out caffeine jitters/i)
+    expect(comparison?.answer).toMatch(/should not be assumed to reliably eliminate caffeine jitters/i)
+    expect(caffeine?.evidence).toBe('Strong acute attention evidence')
+    expect(theanine?.evidence).toBe('Task-specific / mixed')
+    expect(bacopa?.evidence).toBe('Repeated-dose memory evidence')
+    expect(theanineDose?.note).not.toMatch(/2:1 theanine:caffeine ratio/i)
+  })
+
+  it('calibrates anxiety quick picks and the first comparison table before deeper evidence sections', () => {
+    const result = publicPrimaryGoal('anxiety')
+    const kava = result.options.find((option) => option.slug === 'kava')
+    const theanine = result.options.find((option) => option.slug === 'l-theanine')
+    const kavaPick = result.quickPicks.find((pick) => pick.slug === 'kava')
+
+    expect(kava?.bestFor).not.toMatch(/rapid relief|social relaxation/i)
+    expect(kava?.speed).toMatch(/no reliable treatment onset/i)
+    expect(kava?.evidence).toBe('Mixed / safety-limited')
+    expect(kava?.risk).toBe('Moderate to high')
+    expect(kava?.avoidIf).toMatch(/liver disease|alcohol|sedatives/i)
+    expect(kavaPick?.need).toMatch(/higher-risk herbal evidence/i)
+    expect(theanine?.speed).not.toMatch(/30 to 90 minutes/i)
+    expect(theanine?.evidence).toBe('Inconsistent for anxiety')
+  })
+
+  it('calibrates primary sleep, stress, and focus comparison rows too', () => {
+    const sleep = publicPrimaryGoal('sleep')
+    const stress = publicPrimaryGoal('stress')
+    const focus = publicPrimaryGoal('focus')
+
+    const sleepTheanine = sleep.options.find((option) => option.slug === 'l-theanine')
+    const sleepMagnesium = sleep.options.find((option) => option.slug === 'magnesium')
+    const stressTheanine = stress.options.find((option) => option.slug === 'l-theanine')
+    const focusTheanine = focus.options.find((option) => option.slug === 'l-theanine')
+    const focusCaffeine = focus.options.find((option) => option.slug === 'caffeine')
+
+    expect(sleepTheanine?.speed).not.toMatch(/30 to 90 minutes/i)
+    expect(sleepTheanine?.evidence).toBe('Limited / mixed for sleep')
+    expect(sleepMagnesium?.evidence).toBe('Limited / heterogeneous for sleep')
+    expect(stressTheanine?.speed).not.toMatch(/30 to 90 minutes/i)
+    expect(stressTheanine?.evidence).toBe('Limited / mixed for stress')
+    expect(focusTheanine?.evidence).toBe('Task-specific / mixed')
+    expect(focusTheanine?.bestFor).not.toMatch(/calmer attention/i)
+    expect(focusCaffeine?.evidence).toBe('Strong acute attention evidence')
+  })
+
+  it('wires the calibrated primary goal into the rendered goal route', () => {
+    const goalPage = fs.readFileSync(
+      path.join(process.cwd(), 'app/goals/[slug]/page.tsx'),
+      'utf8',
+    )
+
+    expect(goalPage).toContain('getPublicGoal, getPublicGoalContentExtension')
+    expect(goalPage).toContain('const rawGoal = getGoal(slug)')
+    expect(goalPage).toContain('const goal = getPublicGoal(rawGoal)')
+    expect(goalPage).toContain('goal.quickPicks.map')
+    expect(goalPage).toContain('goal.options.map')
+  })
+
+  it('does not mutate the source extension or primary goal records', () => {
+    const originalFaq = fixture.faqItems[0].answer
+    const sourceAnxiety = goals.find((entry) => entry.slug === 'anxiety')
+    const originalKavaEvidence = sourceAnxiety?.options.find((option) => option.slug === 'kava')?.evidence
+
+    getPublicGoalContentExtension('sleep', fixture)
+    if (sourceAnxiety) getPublicGoal(sourceAnxiety)
+
+    expect(fixture.faqItems[0].answer).toBe(originalFaq)
+    expect(sourceAnxiety?.options.find((option) => option.slug === 'kava')?.evidence).toBe(originalKavaEvidence)
+  })
+
+  it('leaves unrelated goal content and primary goal records unchanged', () => {
+    const contentResult = getPublicGoalContentExtension('other', fixture)
+    const pain = goals.find((entry) => entry.slug === 'pain')
+    if (!pain) throw new Error('Missing pain goal fixture')
+    const primaryResult = getPublicGoal(pain)
+
+    expect(contentResult.faqItems[0].answer).toBe(fixture.faqItems[0].answer)
+    expect(contentResult.evidenceRows[0]).toEqual(fixture.evidenceRows[0])
+    expect(primaryResult).toEqual(pain)
+    expect(primaryResult).not.toBe(pain)
   })
 })

--- a/src/lib/goal-public-copy.ts
+++ b/src/lib/goal-public-copy.ts
@@ -1,3 +1,4 @@
+import type { Goal, GoalOption } from '@/data/goals'
 import type {
   GoalContentExtension,
   GoalDosingNote,
@@ -24,10 +25,34 @@ const FAQ_OVERRIDES: Record<string, Record<string, string>> = {
     'Why do some people feel emotionally flat on ashwagandha?':
       'New mood or emotional changes after starting a supplement deserve attention, but emotional blunting is not established as a common ashwagandha adverse effect in major clinical evidence summaries. If a meaningful mood change begins after starting a product, stop the new product and discuss it with a qualified health professional.',
   },
+  anxiety: {
+    'Is kava effective for social anxiety?':
+      'Kava has been studied for anxiety, but current evidence does not establish it as a reliable treatment for social anxiety, and findings in generalized anxiety disorder have been mixed. Rare but potentially severe liver injury and additive sedation are important parts of the decision.',
+    'Can L-Theanine help racing thoughts at night?':
+      'Direct evidence for L-Theanine specifically treating racing thoughts at night is lacking. A 2026 meta-analysis found a short-term attention signal and a modest acute-stress effect, while anxiety findings were inconsistent overall. Those results do not establish reliable anxiety relief or a predictable calming onset.',
+  },
+  focus: {
+    'Caffeine vs L-Theanine vs Bacopa — how do they differ for focus?':
+      'Caffeine has strong evidence for an acute attention effect in healthy adults. L-Theanine alone and with caffeine has task-specific cognitive and mood findings, but the size and direction of effects vary and it should not be assumed to reliably eliminate caffeine jitters. Bacopa has repeated-dose evidence centered more on memory than immediate focus, so these options are not interchangeable.',
+    'What is the best non-stimulant focus supplement?':
+      'There is no evidence-based universal best non-stimulant focus supplement. L-Theanine has task-specific attention findings, rhodiola has a separate evidence base centered on fatigue and performance under stress, and Bacopa is studied mainly with repeated dosing for memory outcomes. Match the option to the exact outcome rather than ranking them as one category.',
+    'Will caffeine help focus without side effects?':
+      'A 2025 meta-analysis of placebo-controlled trials found that caffeine acutely improved attention in healthy adults, but response and adverse effects vary with dose and individual sensitivity. L-Theanine plus caffeine may alter selected attention or mood outcomes, but it is not established as a guaranteed way to prevent caffeine-related jitters or sleep disruption.',
+  },
 }
 
 const EVIDENCE_OVERRIDES: Record<string, Record<string, Partial<GoalEvidenceRow>>> = {
   sleep: {
+    Magnesium: {
+      evidence: 'Limited / heterogeneous',
+      humanData: 'Small interventional studies',
+      limitation: 'Larger randomized trials are needed; benefit may depend on baseline magnesium status',
+    },
+    'L-Theanine': {
+      evidence: 'Limited / mixed for sleep',
+      humanData: 'Small RCTs; mostly subjective outcomes',
+      limitation: 'Pure L-Theanine data and optimal dose and duration remain uncertain',
+    },
     'Valerian Root': {
       evidence: 'Inconsistent / insufficient',
       humanData: 'Small and mixed studies',
@@ -40,13 +65,185 @@ const EVIDENCE_OVERRIDES: Record<string, Record<string, Partial<GoalEvidenceRow>
       humanData: 'Small trials using varied preparations',
       limitation: 'Preparation-specific results; long-term safety is uncertain',
     },
+    Rhodiola: {
+      evidence: 'Variable / outcome-specific',
+      humanData: 'Stress-fatigue and performance trials',
+      limitation: 'Product-specific studies do not establish a general stress treatment',
+    },
+    'L-Theanine': {
+      evidence: 'Limited / mixed for stress',
+      humanData: 'Acute stress and attention paradigms',
+      limitation: 'Acute-stress effect is modest and bias-sensitive; anxiety findings are inconsistent',
+    },
+  },
+  anxiety: {
+    Ashwagandha: {
+      evidence: 'Supportive but heterogeneous',
+      humanData: 'Repeated-dose stress and anxiety trials',
+      limitation: 'Extract and population differences limit generalization; not an acute panic treatment',
+    },
+    Kava: {
+      evidence: 'Mixed / safety-limited',
+      humanData: 'Anxiety trials with inconsistent GAD findings',
+      limitation: 'Rare serious liver injury and sedative interactions materially affect risk',
+    },
+    'L-Theanine': {
+      evidence: 'Inconsistent for anxiety',
+      humanData: '31-trial 2026 meta-analysis',
+      limitation: 'Attention and acute-stress signals do not establish an anxiety treatment',
+    },
+  },
+  focus: {
+    Caffeine: {
+      evidence: 'Strong acute attention evidence',
+      humanData: '31 placebo-controlled trials in healthy adults',
+      limitation: 'Dose-response and sleep or anxiety tradeoffs vary by person',
+    },
+    'L-Theanine': {
+      evidence: 'Task-specific / mixed',
+      humanData: 'Randomized attention and mood studies',
+      limitation: 'Not established as a stand-alone focus treatment or guaranteed caffeine smoother',
+    },
+    Rhodiola: {
+      evidence: 'Variable / outcome-specific',
+      humanData: 'Fatigue and performance studies',
+      limitation: 'Not established as a general attention treatment',
+    },
+    'Bacopa Monnieri': {
+      evidence: 'Repeated-dose memory evidence',
+      humanData: 'Longer-term randomized trials',
+      limitation: 'Not an acute focus aid; results are extract- and outcome-specific',
+    },
   },
 }
 
 const DOSING_OVERRIDES: Record<string, Record<string, string>> = {
   sleep: {
+    'L-Theanine':
+      'Sleep trials have used varied L-Theanine doses, formulations, and durations. Current reviews do not establish one optimal dose or a universal pre-bed timing rule.',
     'Valerian Root':
       'Research has used varied valerian preparations and doses, but evidence for insomnia remains inconsistent. Do not treat a commonly used dose as proof of effectiveness; follow the product label and review sedative interactions.',
+  },
+  stress: {
+    'L-Theanine':
+      'Trial doses and outcomes vary. Do not infer a predictable stress-relief onset from the dose alone; review the specific evidence and product label.',
+  },
+  anxiety: {
+    'L-Theanine':
+      'Trials have used varied doses and populations, and current pooled evidence does not establish a standard anxiety-treatment dose or predictable onset.',
+    Ashwagandha:
+      'Ashwagandha trial doses are extract-specific and should not be generalized across products; review the exact preparation, label, and safety context.',
+    Kava:
+      'Do not select a kava dose or extract type from efficacy claims alone. Rare serious liver injury and additive sedation make medication, alcohol, liver-health, and product-quality context important.',
+  },
+  focus: {
+    'L-Theanine':
+      'Studies use varied L-Theanine and caffeine doses. A fixed theanine-to-caffeine ratio is not established as a universal focus strategy.',
+  },
+}
+
+const QUICK_PICK_OVERRIDES: Record<string, Goal['quickPicks']> = {
+  sleep: [
+    { need: 'Circadian timing questions', option: 'Melatonin', slug: 'melatonin' },
+    { need: 'Review L-Theanine sleep evidence', option: 'L-Theanine', slug: 'l-theanine' },
+    { need: 'Review magnesium sleep evidence', option: 'Magnesium', slug: 'magnesium' },
+  ],
+  stress: [
+    { need: 'Repeated-dose stress evidence', option: 'Ashwagandha', slug: 'ashwagandha' },
+    { need: 'Fatigue and performance evidence', option: 'Rhodiola', slug: 'rhodiola' },
+    { need: 'Acute-stress research', option: 'L-Theanine', slug: 'l-theanine' },
+  ],
+  anxiety: [
+    { need: 'Review short-term L-Theanine evidence', option: 'L-Theanine', slug: 'l-theanine' },
+    { need: 'Review repeated-dose evidence', option: 'Ashwagandha', slug: 'ashwagandha' },
+    { need: 'Review higher-risk herbal evidence', option: 'Kava', slug: 'kava' },
+  ],
+  focus: [
+    { need: 'Task-specific attention evidence', option: 'L-Theanine', slug: 'l-theanine' },
+    { need: 'Fatigue and stress-performance evidence', option: 'Rhodiola', slug: 'rhodiola' },
+    { need: 'Established acute alertness', option: 'Caffeine', slug: 'caffeine' },
+  ],
+}
+
+const OPTION_OVERRIDES: Record<string, Record<string, Partial<GoalOption>>> = {
+  sleep: {
+    magnesium: {
+      bestFor: 'Reviewing magnesium status, intake, and sleep evidence',
+      speed: 'No established universal sleep onset',
+      evidence: 'Limited / heterogeneous for sleep',
+    },
+    'l-theanine': {
+      bestFor: 'Reviewing short-term sleep and relaxation research',
+      speed: 'No established universal calming onset',
+      evidence: 'Limited / mixed for sleep',
+    },
+    melatonin: {
+      bestFor: 'Circadian timing and sleep-schedule questions',
+      speed: 'Timing is circadian-context dependent',
+      evidence: 'Strongest for circadian timing; limited for chronic insomnia treatment',
+    },
+    'lemon-balm': {
+      bestFor: 'Reviewing preliminary anxiety- and sleep-related evidence',
+      speed: 'No established universal onset',
+      evidence: 'Limited; often studied in small or combination trials',
+    },
+  },
+  stress: {
+    ashwagandha: {
+      bestFor: 'Reviewing repeated-dose stress research',
+      speed: 'Repeated-dose studies; not an acute stress aid',
+      evidence: 'Supportive but heterogeneous for stress',
+    },
+    rhodiola: {
+      bestFor: 'Reviewing fatigue and performance-under-stress research',
+      speed: 'Study-dependent; not a universal acute effect',
+      evidence: 'Variable / outcome-specific',
+    },
+    'l-theanine': {
+      bestFor: 'Reviewing acute-stress and attention paradigms',
+      speed: 'No established predictable stress-relief onset',
+      evidence: 'Limited / mixed for stress',
+    },
+  },
+  anxiety: {
+    'l-theanine': {
+      bestFor: 'Reviewing short-term stress and attention evidence',
+      speed: 'No established predictable anxiety-relief onset',
+      evidence: 'Inconsistent for anxiety',
+      avoidIf: 'Review medication, blood-pressure, and sedative context before combining products',
+    },
+    ashwagandha: {
+      bestFor: 'Reviewing repeated-dose stress and anxiety studies',
+      speed: 'Repeated-dose studies; not an acute panic treatment',
+      evidence: 'Supportive but heterogeneous',
+    },
+    kava: {
+      bestFor: 'Reviewing mixed anxiety evidence with higher safety burden',
+      speed: 'No reliable treatment onset established',
+      evidence: 'Mixed / safety-limited',
+      risk: 'Moderate to high',
+      avoidIf: 'Liver disease, alcohol, sedatives, pregnancy, or activities requiring unimpaired alertness',
+      form: 'Product quality and preparation matter; do not infer safety from extract type alone',
+    },
+  },
+  focus: {
+    'l-theanine': {
+      bestFor: 'Task-specific attention research, including caffeine combinations',
+      speed: 'Single-dose studies assess effects within hours; personal onset is not established',
+      evidence: 'Task-specific / mixed',
+    },
+    rhodiola: {
+      bestFor: 'Fatigue and performance under stress',
+      speed: 'Study-dependent; not an established acute focus aid',
+      evidence: 'Variable / outcome-specific',
+    },
+    caffeine: {
+      evidence: 'Strong acute attention evidence',
+    },
+    bacopa: {
+      bestFor: 'Repeated-dose memory and learning research',
+      evidence: 'Repeated-dose memory evidence; not an acute focus aid',
+    },
   },
 }
 
@@ -63,6 +260,21 @@ function publicEvidenceRow(slug: string, row: GoalEvidenceRow): GoalEvidenceRow 
 function publicDosingNote(slug: string, note: GoalDosingNote): GoalDosingNote {
   const override = DOSING_OVERRIDES[slug]?.[note.compound]
   return override ? { ...note, note: override } : note
+}
+
+export function getPublicGoal(goal: Goal): Goal {
+  const optionOverrides = OPTION_OVERRIDES[goal.slug] ?? {}
+  const quickPicks = QUICK_PICK_OVERRIDES[goal.slug]
+
+  return {
+    ...goal,
+    quickPicks: (quickPicks ?? goal.quickPicks).map((pick) => ({ ...pick })),
+    options: goal.options.map((option) => ({
+      ...option,
+      ...(optionOverrides[option.slug] ?? {}),
+    })),
+    relatedGoals: [...goal.relatedGoals],
+  }
 }
 
 export function getPublicGoalContentExtension(


### PR DESCRIPTION
High-ROI central trust pass on the public goal render boundary.

- keeps the underlying goal data structure intact while correcting stale public-facing evidence labels and FAQ language
- sleep: downgrades magnesium/L-theanine certainty, removes universal theanine timing/dose assumptions, preserves valerian correction
- stress: removes rapid-onset theanine framing and calibrates rhodiola/theanine to outcome-specific evidence
- anxiety: removes treatment-like kava/social-anxiety and L-theanine/racing-thought certainty; strengthens liver/sedation context
- focus: preserves strong acute caffeine evidence while removing the claim that L-theanine reliably smooths caffeine; reframes Bacopa as repeated-dose memory evidence rather than acute focus
- neutralizes prescriptive dosing shortcuts for L-theanine/kava where the evidence does not establish a standard treatment dose
- adds regression coverage against the actual goal-content registry so stale source copy cannot leak through the public boundary