### PR TITLE
CI/SEO: restore the production quality baseline

### DIFF
--- a/app/__tests__/contact-page-safe-render.test.ts
+++ b/app/__tests__/contact-page-safe-render.test.ts
@@ -1,0 +1,27 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const PAGE = path.join(process.cwd(), 'app/info/contact/page.tsx')
+
+function source() {
+  return fs.readFileSync(PAGE, 'utf8')
+}
+
+describe('contact page safe rendering', () => {
+  it('does not inject raw HTML to render the contact address', () => {
+    const page = source()
+
+    expect(page).not.toContain('dangerouslySetInnerHTML')
+    expect(page).not.toContain('<!--email_off-->')
+    expect(page).toContain("href='mailto:randolphwillie77@gmail.com'")
+    expect(page).toContain('randolphwillie77@gmail.com')
+  })
+
+  it('keeps structured data on approved SEO components', () => {
+    const page = source()
+
+    expect(page).toContain('<AuthorityJsonLd')
+    expect(page).toContain('<FaqJsonLd')
+  })
+})

--- a/app/info/contact/page.tsx
+++ b/app/info/contact/page.tsx
@@ -111,11 +111,15 @@ export default function ContactPage() {
           <p className='eyebrow-label'>Primary contact</p>
           <h2 className='mt-3 text-3xl font-semibold tracking-tight text-ink'>Reach The Hippie Scientist</h2>
           <div className='mt-5 space-y-4 text-sm leading-7 text-muted sm:text-base'>
-            <p
-              dangerouslySetInnerHTML={{
-                __html: 'Email: <!--email_off-->randolphwillie77@gmail.com<!--/email_off-->',
-              }}
-            />
+            <p>
+              Email:{' '}
+              <a
+                href='mailto:randolphwillie77@gmail.com'
+                className='font-medium text-brand-700 underline-offset-4 hover:underline'
+              >
+                randolphwillie77@gmail.com
+              </a>
+            </p>
             <p>
               The project focuses on evidence-informed summaries of herbs, compounds, pathways, mechanisms,
               product-quality checks, and related wellness research topics.

--- a/functions/_shared/legacy-compare.ts
+++ b/functions/_shared/legacy-compare.ts
@@ -39,9 +39,13 @@ export function handleLegacyCompareRequest(request: Request, legacyPrefix: strin
     return Response.redirect(url.toString(), 301)
   }
 
-  // Old comparison URLs are still present in historical/internal content. Sending
-  // them to the live comparison hub avoids dead-end 410 responses while keeping
-  // retired thin pages out of the index.
-  url.pathname = '/guides/compare/'
-  return Response.redirect(url.toString(), 301)
+  // Redirect only legacy URLs with a verified destination. Unknown comparison
+  // slugs should not inherit a generic 301 to the hub because that hides retired
+  // or phantom URLs behind an unrelated canonical destination.
+  return new Response(null, {
+    status: 410,
+    headers: {
+      'X-Robots-Tag': 'noindex, nofollow',
+    },
+  })
 }

--- a/scripts/audit-cluster-member-trust.test.mjs
+++ b/scripts/audit-cluster-member-trust.test.mjs
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { beforeAll, describe, expect, it } from 'vitest'
 import {
   auditClusterMemberTrust,
   evaluateClusterMemberProfile,
@@ -40,9 +40,16 @@ function validFixture(slug = 'fixture') {
   }
 }
 
+const AUDIT_TIMEOUT_MS = 60_000
+let baselineReport
+
 describe('cluster member runtime trust audit', () => {
-  it('resolves all four historical false positives as valid inheritance', async () => {
-    const report = await auditClusterMemberTrust()
+  beforeAll(async () => {
+    baselineReport = await auditClusterMemberTrust()
+  }, AUDIT_TIMEOUT_MS)
+
+  it('resolves all four historical false positives as valid inheritance', () => {
+    const report = baselineReport
 
     expect(report.counts.profiles).toBe(4)
     expect(report.profiles.map(profile => profile.slug)).toEqual([
@@ -61,8 +68,8 @@ describe('cluster member runtime trust audit', () => {
     ])
   })
 
-  it('reports zero remaining structured, runtime, and rendering defects', async () => {
-    const report = await auditClusterMemberTrust()
+  it('reports zero remaining structured, runtime, and rendering defects', () => {
+    const report = baselineReport
 
     expect(report.counts.evidenceLabelledSummaries).toBe(4)
     expect(report.counts.structuredSafetyGaps).toBe(0)
@@ -73,13 +80,12 @@ describe('cluster member runtime trust audit', () => {
   })
 
   it('keeps every classification deterministic and in the mission taxonomy', async () => {
-    const first = await auditClusterMemberTrust()
     const second = await auditClusterMemberTrust()
 
-    expect(second).toEqual(first)
-    expect(first.findings.every(item => ISSUE_CATEGORIES.includes(item.category))).toBe(true)
-    expect(Object.keys(first.countsByCategory)).toEqual(ISSUE_CATEGORIES)
-  })
+    expect(second).toEqual(baselineReport)
+    expect(baselineReport.findings.every(item => ISSUE_CATEGORIES.includes(item.category))).toBe(true)
+    expect(Object.keys(baselineReport.countsByCategory)).toEqual(ISSUE_CATEGORIES)
+  }, AUDIT_TIMEOUT_MS)
 
   it('still fails a synthetic true runtime gap in strict mode', () => {
     const fixture = validFixture()

--- a/scripts/ci/validate-sitemap-completeness.mjs
+++ b/scripts/ci/validate-sitemap-completeness.mjs
@@ -15,7 +15,8 @@
  *
  * This script recursively finds every static (non-dynamic-segment) route
  * under app/, filters out routes with an explicit noindex signal in their
- * own source metadata or in their rendered robots metadata, plus the curated
+ * own source metadata or in their rendered robots metadata, routes whose
+ * rendered canonical points at a different URL, plus the curated
  * EXCLUDED_ROUTES allowlist below, and fails if any remaining route is
  * missing from the built sitemap.xml.
  */
@@ -71,14 +72,17 @@ function hasNoindexSignal(pageFilePath) {
   }
 }
 
+function builtRouteHtmlPath(routePath) {
+  const relativeRoute = routePath === '/' ? '' : routePath.replace(/^\/+|\/+$/g, '')
+  return relativeRoute
+    ? path.join(OUT_DIR, relativeRoute, 'index.html')
+    : path.join(OUT_DIR, 'index.html')
+}
+
 function builtRouteHasNoindex(routePath) {
   if (!fs.existsSync(OUT_DIR)) return false
 
-  const relativeRoute = routePath === '/' ? '' : routePath.replace(/^\/+|\/+$/g, '')
-  const htmlPath = relativeRoute
-    ? path.join(OUT_DIR, relativeRoute, 'index.html')
-    : path.join(OUT_DIR, 'index.html')
-
+  const htmlPath = builtRouteHtmlPath(routePath)
   if (!fs.existsSync(htmlPath)) return false
 
   try {
@@ -89,6 +93,27 @@ function builtRouteHasNoindex(routePath) {
       const isNoindex = /\bcontent\s*=\s*["'][^"']*\bnoindex\b[^"']*["']/i.test(tag)
       return isRobots && isNoindex
     })
+  } catch {
+    return false
+  }
+}
+
+function builtRouteCanonicalizesElsewhere(routePath) {
+  if (!fs.existsSync(OUT_DIR)) return false
+
+  const htmlPath = builtRouteHtmlPath(routePath)
+  if (!fs.existsSync(htmlPath)) return false
+
+  try {
+    const html = fs.readFileSync(htmlPath, 'utf8')
+    const linkTags = html.match(/<link\b[^>]*>/gi) || []
+    const canonicalTag = linkTags.find((tag) => /\brel\s*=\s*["']canonical["']/i.test(tag))
+    if (!canonicalTag) return false
+
+    const hrefMatch = canonicalTag.match(/\bhref\s*=\s*["']([^"']+)["']/i)
+    if (!hrefMatch?.[1]) return false
+
+    return normalizePath(hrefMatch[1]) !== normalizePath(routePath)
   } catch {
     return false
   }
@@ -136,7 +161,9 @@ function normalizePath(url) {
     const p = u.pathname.replace(/\/+$/, '')
     return p === '' ? '/' : p
   } catch {
-    return url
+    const p = String(url || '').split(/[?#]/)[0].replace(/\/+$/, '')
+    if (!p || p === '') return '/'
+    return p.startsWith('/') ? p : `/${p}`
   }
 }
 
@@ -166,27 +193,31 @@ function main() {
     process.exit(1)
   }
 
-  // Runtime/profile governance can generate robots metadata in a static wrapper,
-  // so source inspection alone is not authoritative after a successful build.
-  // The rendered HTML is the final page-level indexing signal.
-  const indexableStaticRoutes = staticRoutes.filter((route) => !builtRouteHasNoindex(route))
+  // Runtime/profile governance can generate robots and canonical metadata in a
+  // static wrapper, so source inspection alone is not authoritative after a
+  // successful build. The rendered HTML is the final page-level indexing and
+  // canonicalization signal. A static compatibility alias whose canonical
+  // points elsewhere must not be required in the sitemap.
+  const indexableStaticRoutes = staticRoutes.filter(
+    (route) => !builtRouteHasNoindex(route) && !builtRouteCanonicalizesElsewhere(route),
+  )
   const sitemapUrls = new Set(parseXmlUrls(fs.readFileSync(sitemapPath, 'utf8')).map(normalizePath))
   const missing = indexableStaticRoutes.filter((route) => !sitemapUrls.has(route)).sort()
 
-  console.log(`[validate-sitemap-completeness] Found ${indexableStaticRoutes.length} static app/ routes after source/rendered noindex filtering; ${sitemapUrls.size} URLs in sitemap.xml.`)
+  console.log(`[validate-sitemap-completeness] Found ${indexableStaticRoutes.length} canonical, indexable static app/ routes after rendered metadata filtering; ${sitemapUrls.size} URLs in sitemap.xml.`)
 
   if (missing.length > 0) {
-    console.error(`[validate-sitemap-completeness] FAIL: ${missing.length} real, indexable route(s) are missing from sitemap.xml:`)
+    console.error(`[validate-sitemap-completeness] FAIL: ${missing.length} real, canonical, indexable route(s) are missing from sitemap.xml:`)
     for (const route of missing) console.error(`  - ${route}`)
     console.error('')
-    console.error('If a route is intentionally excluded, verify that its rendered robots metadata is noindex or add it to EXCLUDED_ROUTES with a comment explaining why.')
+    console.error('If a route is intentionally excluded, verify that its rendered robots metadata is noindex, its rendered canonical points elsewhere, or add it to EXCLUDED_ROUTES with a comment explaining why.')
     console.error('If not, the sitemap generator in app/sitemap.ts is silently dropping real content — check')
     console.error('readAppGuidePageSlugs()-style directory scanners for a depth limit, and shouldIndexRoute() in')
     console.error('src/lib/seo.ts for a regex that only matches a subset of the route\'s path depth.')
     process.exit(1)
   }
 
-  console.log('[validate-sitemap-completeness] PASS: every indexable static app/ route is covered by sitemap.xml.')
+  console.log('[validate-sitemap-completeness] PASS: every canonical, indexable static app/ route is covered by sitemap.xml.')
 }
 
 main()

--- a/scripts/data/build-route-manifest-tools.test.mjs
+++ b/scripts/data/build-route-manifest-tools.test.mjs
@@ -1,0 +1,25 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const root = path.resolve(import.meta.dirname, '..', '..')
+const manifestBuilder = fs.readFileSync(path.join(root, 'scripts', 'data', 'build-route-manifest.mjs'), 'utf8')
+const toolsPage = fs.readFileSync(path.join(root, 'app', 'tools', 'page.tsx'), 'utf8')
+
+describe('route manifest tools hub coverage', () => {
+  it('keeps the indexable tools hub in static route metadata', () => {
+    expect(manifestBuilder).toContain("'/tools': {")
+    expect(manifestBuilder).toContain("title: 'Research Tools | The Hippie Scientist'")
+    expect(manifestBuilder).toContain(
+      "description: 'Interactive research tools for comparing botanicals, evidence, activity, compounds, and safety context.'",
+    )
+  })
+
+  it('keeps manifest metadata aligned with the public tools page', () => {
+    expect(toolsPage).toContain("title: 'Research Tools | The Hippie Scientist'")
+    expect(toolsPage).toContain(
+      "description: 'Interactive research tools for comparing botanicals, evidence, activity, compounds, and safety context.'",
+    )
+    expect(toolsPage).toContain("path: '/tools/'")
+  })
+})

--- a/scripts/data/build-route-manifest.mjs
+++ b/scripts/data/build-route-manifest.mjs
@@ -37,6 +37,10 @@ const STATIC_ROUTE_METADATA = {
     title: 'Supplement Stacks & Combination Guides',
     description: 'Review supplement combinations with evidence limits, interaction cautions, timing context, and safer decision paths kept visible.',
   },
+  '/tools': {
+    title: 'Evidence & Supplement Tools',
+    description: 'Explore evidence-first tools for comparing supplements, checking safety context, and navigating botanical and compound research.',
+  },
   '/tools/botanical-activity-atlas': {
     title: 'Botanical Activity Atlas',
     description: 'Explore botanical activity and mechanism relationships across herbs and compounds with conservative evidence and safety context.',

--- a/scripts/data/build-route-manifest.mjs
+++ b/scripts/data/build-route-manifest.mjs
@@ -38,8 +38,8 @@ const STATIC_ROUTE_METADATA = {
     description: 'Review supplement combinations with evidence limits, interaction cautions, timing context, and safer decision paths kept visible.',
   },
   '/tools': {
-    title: 'Evidence & Supplement Tools',
-    description: 'Explore evidence-first tools for comparing supplements, checking safety context, and navigating botanical and compound research.',
+    title: 'Research Tools | The Hippie Scientist',
+    description: 'Interactive research tools for comparing botanicals, evidence, activity, compounds, and safety context.',
   },
   '/tools/botanical-activity-atlas': {
     title: 'Botanical Activity Atlas',


### PR DESCRIPTION
Restores a genuinely green production quality baseline by fixing the independent current-main defects that otherwise cause unrelated PRs to fail.

1. **Tools sitemap authority**
   - adds the real, indexable `/tools` hub to the authoritative static route manifest
   - aligns manifest metadata with `app/tools/page.tsx`
   - adds focused manifest regression coverage

2. **Legacy comparison routing**
   - keeps 301 redirects for verified built comparison pages and explicit aliases
   - returns `410` + `X-Robots-Tag: noindex, nofollow` for unknown/phantom legacy comparison slugs
   - satisfies the existing phantom-comparison regression instead of redirecting retired URLs to an unrelated hub

3. **Contact page output safety**
   - removes the remaining raw `dangerouslySetInnerHTML` email markup
   - renders the contact address as a normal accessible `mailto:` link
   - preserves approved `AuthorityJsonLd` / `FaqJsonLd` structured-data components
   - adds focused regression coverage preventing raw HTML injection from returning

4. **Sitemap completeness canonical-awareness**
   - fixes the post-build completeness validator so a static compatibility alias whose rendered canonical points elsewhere is not incorrectly required in the sitemap
   - keeps canonical-only sitemap behavior for `/articles/best-supplements-for-sleep`, which re-exports the canonical sleep guide
   - uses rendered canonical metadata at the same authority boundary where the validator already uses rendered robots metadata

5. **Cluster trust audit test stability**
   - removes redundant full-workbook parsing from repeated read-only assertions
   - shares one baseline audit result while retaining an independent second full audit for determinism coverage
   - gives the genuinely heavy workbook reads a realistic per-hook/test timeout without weakening any trust assertions

These fixes are consolidated because the individual branches inherited one another’s baseline failures. No quality gate is weakened or allowlisted; source and validation-boundary defects are fixed so Site Health, unit tests, and post-build output verification can evaluate a coherent current baseline.