### PR TITLE
Security: remove raw HTML rendering from the contact page

### DIFF
--- a/app/__tests__/contact-page-safe-render.test.ts
+++ b/app/__tests__/contact-page-safe-render.test.ts
@@ -1,0 +1,27 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const PAGE = path.join(process.cwd(), 'app/info/contact/page.tsx')
+
+function source() {
+  return fs.readFileSync(PAGE, 'utf8')
+}
+
+describe('contact page safe rendering', () => {
+  it('does not inject raw HTML to render the contact address', () => {
+    const page = source()
+
+    expect(page).not.toContain('dangerouslySetInnerHTML')
+    expect(page).not.toContain('<!--email_off-->')
+    expect(page).toContain("href='mailto:randolphwillie77@gmail.com'")
+    expect(page).toContain('randolphwillie77@gmail.com')
+  })
+
+  it('keeps structured data on approved SEO components', () => {
+    const page = source()
+
+    expect(page).toContain('<AuthorityJsonLd')
+    expect(page).toContain('<FaqJsonLd')
+  })
+})

--- a/app/info/contact/page.tsx
+++ b/app/info/contact/page.tsx
@@ -111,11 +111,15 @@ export default function ContactPage() {
           <p className='eyebrow-label'>Primary contact</p>
           <h2 className='mt-3 text-3xl font-semibold tracking-tight text-ink'>Reach The Hippie Scientist</h2>
           <div className='mt-5 space-y-4 text-sm leading-7 text-muted sm:text-base'>
-            <p
-              dangerouslySetInnerHTML={{
-                __html: 'Email: <!--email_off-->randolphwillie77@gmail.com<!--/email_off-->',
-              }}
-            />
+            <p>
+              Email:{' '}
+              <a
+                href='mailto:randolphwillie77@gmail.com'
+                className='font-medium text-brand-700 underline-offset-4 hover:underline'
+              >
+                randolphwillie77@gmail.com
+              </a>
+            </p>
             <p>
               The project focuses on evidence-informed summaries of herbs, compounds, pathways, mechanisms,
               product-quality checks, and related wellness research topics.


### PR DESCRIPTION
Fixes the current-main output-safety failure on `app/info/contact/page.tsx`.

- replaces the raw `dangerouslySetInnerHTML` email markup with a normal `mailto:` link
- preserves the existing approved `AuthorityJsonLd` and `FaqJsonLd` structured-data components
- removes the obsolete inline email-obfuscation comment markers
- adds focused regression coverage preventing raw HTML injection from returning on the contact page

This fixes the source defect rather than weakening `validate-dangerously-set-inner-html.mjs`.