### PR TITLE
Rebuild L-theanine umbrella guide around current evidence

### DIFF
--- a/app/__tests__/l-theanine-umbrella-current-evidence.test.ts
+++ b/app/__tests__/l-theanine-umbrella-current-evidence.test.ts
@@ -1,0 +1,71 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const PAGE = path.join(process.cwd(), 'app/guides/herbs/l-theanine/page.tsx')
+
+function source() {
+  return fs.readFileSync(PAGE, 'utf8')
+}
+
+describe('L-theanine umbrella evidence calibration', () => {
+  it('anchors the page to the current systematic reviews and study context', () => {
+    const text = source()
+
+    expect(text).toContain('42410082')
+    expect(text).toContain('40314930')
+    expect(text).toContain('40056718')
+    expect(text).toContain('31623400')
+    expect(text).toContain('31 randomized trials and 1,168 participants')
+    expect(text).toContain('19 articles and 897 participants')
+    expect(text).toContain("const DATE = '2026-08-11'")
+  })
+
+  it('does not restore stale rapid-anxiety or universal stack claims', () => {
+    const text = source()
+
+    expect(text).not.toMatch(/Fastest useful choice/i)
+    expect(text).not.toMatch(/fastest-acting natural option/i)
+    expect(text).not.toMatch(/Subjective calm and reduced anxiety typically begin/i)
+    expect(text).not.toMatch(/L-theanine smooths the jitter/i)
+    expect(text).not.toMatch(/2:1 ratio/i)
+    expect(text).not.toMatch(/Acute anxiety[\s\S]{0,120}200[–-]400 mg/i)
+    expect(text).not.toMatch(/no documented dependency, withdrawal, or tolerance buildup/i)
+    expect(text).not.toMatch(/L-theanine is the right tool for tonight/i)
+  })
+
+  it('keeps study timing separate from promised subjective onset', () => {
+    const text = source()
+
+    expect(text).toMatch(/study timing is not a validated promise/i)
+    expect(text).toMatch(/attention outcome, not a reliable anxiety-relief onset/i)
+    expect(text).toMatch(/study protocol and an attention result—not a universal anxiety dose/i)
+  })
+
+  it('uses specific FDA GRAS context instead of blanket approval language', () => {
+    const text = source()
+
+    expect(text).toContain('FDA GRAS Notice 209')
+    expect(text).toContain('FDA GRAS Notice 338')
+    expect(text).toMatch(/specific L-theanine preparations and specified food uses/i)
+    expect(text).toMatch(/not blanket FDA approval/i)
+    expect(text).not.toMatch(/FDA GRAS for use in foods/i)
+  })
+
+  it('links anxiety readers to the dedicated calibrated guide rather than back to itself', () => {
+    const text = source()
+
+    expect(text).toContain('/guides/anxiety/l-theanine-for-anxiety/')
+    expect(text).toContain('Read the anxiety-specific review')
+    expect(text).not.toMatch(/href="\/guides\/herbs\/l-theanine\/"[^>]*>[\s\S]{0,120}anxiety/i)
+  })
+
+  it('keeps caffeine and sleep conclusions appropriately qualified', () => {
+    const text = source()
+
+    expect(text).toMatch(/no universal evidence-based ratio/i)
+    expect(text).toMatch(/no guaranteed[^\n]{0,20}jitter shield/i)
+    expect(text).toMatch(/optimal formulation, dose, and duration remain unresolved/i)
+    expect(text).toMatch(/limited evidence using pure L-theanine/i)
+  })
+})

--- a/app/guides/herbs/l-theanine/page.tsx
+++ b/app/guides/herbs/l-theanine/page.tsx
@@ -1,7 +1,13 @@
 import Link from 'next/link'
 import Image from 'next/image'
 import JsonLd from '@/components/seo/JsonLd'
-import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd } from '../../../../src/lib/seo'
+import {
+  buildPageMetadata,
+  blogJsonLd,
+  breadcrumbJsonLd,
+  faqPageJsonLd,
+  compactMetaTitle,
+} from '../../../../src/lib/seo'
 import EvidenceSummaryCard from '@/components/evidence/EvidenceSummaryCard'
 import SafetyNotice from '@/components/evidence/SafetyNotice'
 import EmailCapture from '@/components/EmailCapture'
@@ -9,936 +15,335 @@ import { getRevenueProductSet } from '@/config/revenue-products'
 import RecommendationSection from '@/components/RecommendationSection'
 import NewsletterCtaBlock from '@/components/NewsletterCtaBlock'
 import LastUpdatedBadge from '../../../../src/components/editorial/LastUpdatedBadge'
-import ResponsiveTable from '@/components/ui/ResponsiveTable'
-import { AFFILIATE_TAGS } from '@/config/affiliate'
-
-// ─── Article metadata ─────────────────────────────────────────────────────────
 
 const SLUG = 'l-theanine'
-const TITLE = 'L-Theanine: The Evidence-Based Guide (Calm, Focus, Anxiety, and Sleep)'
+const TITLE = 'L-Theanine: What the Evidence Supports for Focus, Stress, Anxiety, and Sleep'
 const DESCRIPTION =
-  'A comprehensive evidence-based review of L-theanine: mechanisms, clinical research, dosage, safety, what it works for, what it does not, and how it compares with caffeine, ashwagandha, magnesium, and other calming supplements.'
-const DATE = '2026-06-26'
+  'An evidence-first L-theanine guide updated for 2026: attention, stress, anxiety, sleep, caffeine combinations, studied doses, safety limits, and what current trials do not establish.'
+const DATE = '2026-08-11'
 const AUTHOR = 'Will'
-const READING_TIME = '12 min read'
-const TAGS = ['l-theanine', 'calm', 'focus', 'anxiety', 'sleep', 'amino acid']
-const CATEGORY = 'amino acids'
+const READING_TIME = '11 min read'
+const TAGS = ['l-theanine', 'focus', 'stress', 'anxiety', 'sleep', 'caffeine']
 
 export const metadata = buildPageMetadata({
-  title: TITLE,
+  title: compactMetaTitle(TITLE),
   description: DESCRIPTION,
   path: `/guides/herbs/${SLUG}`,
   openGraphType: 'article',
 })
 
-// ─── FAQ data (also used for JSON-LD) ────────────────────────────────────────
-
 const FAQS = [
   {
-    question: 'What does L-theanine do?',
+    question: 'What does the best current evidence support for L-theanine?',
     answer:
-      'L-theanine is an amino acid found naturally in tea leaves. Within 30–60 minutes of ingestion, it raises calming alpha-wave activity in the brain, modulates GABA and glutamate, and reduces perceived stress without sedation. It is best known for promoting calm focus, smoothing the jitter of caffeine, easing racing thoughts, and supporting relaxation before sleep.',
+      'The clearest current signal is a short-term attention effect in healthy adults. A 2026 meta-analysis of 31 randomized trials found a robust improvement in choice reaction time after a single 200 mg dose studied before cognitive testing. Acute-stress effects were modest and sensitive to study quality, while anxiety findings were inconsistent overall.',
   },
   {
     question: 'How fast does L-theanine work?',
     answer:
-      'L-theanine is fast-acting. EEG-measurable alpha-wave effects appear within 30–60 minutes of oral ingestion and last 3–4 hours. Subjective calm and reduced anxiety typically begin in the same window. This makes L-theanine the fastest-acting natural option for situational calm — unlike ashwagandha or rhodiola, which take weeks.',
+      'Trials often measure outcomes 30–60 minutes after a single dose, but that study timing is not a validated promise for when someone will feel calmer or whether anxiety will improve. The strongest 30–60-minute result in the 2026 meta-analysis was an attention outcome, not a reliable anxiety-relief onset.',
   },
   {
-    question: 'Is L-theanine safe to take every day?',
+    question: 'Does L-theanine help anxiety?',
     answer:
-      'Yes. L-theanine has a clean safety profile at typical doses (100–400 mg/day). It is generally recognized as safe (GRAS) by the FDA and is well-tolerated in long-term tea consumption contexts. There is no documented dependency, withdrawal, or tolerance buildup. Caution with antihypertensives (mild BP-lowering effect) and sedatives (additive effect).',
+      'Current pooled evidence does not establish L-theanine as an anxiety treatment. The 2026 meta-analysis found anxiety effects inconsistent and generally non-significant. Stress-task findings and attention improvements should not be relabeled as proof of anxiety relief.',
   },
   {
-    question: 'Can I take L-theanine with caffeine?',
+    question: 'Should L-theanine be paired with caffeine?',
     answer:
-      'Yes — this is the most studied combination. L-theanine (100–200 mg) plus caffeine (50–100 mg) at a 2:1 ratio is one of the most replicated nootropic stacks in cognitive research. L-theanine smooths the jitter and anxiety of caffeine while preserving alertness. The combination improves focus, reaction time, and accuracy versus caffeine alone.',
+      'L-theanine plus caffeine has randomized-trial evidence for some task-specific cognitive and mood outcomes, but the size and direction of effects vary. A 2025 meta-analysis reported uncertainty across many confidence intervals, so there is no evidence-based universal ratio and no guarantee that L-theanine will prevent caffeine-related jitters, anxiety, or sleep disruption.',
   },
   {
-    question: 'Does L-theanine help with sleep?',
+    question: 'Does L-theanine help sleep?',
     answer:
-      'L-theanine can support sleep onset by reducing mental arousal and racing thoughts, particularly when taken 30–60 minutes before bed. It is not a sedative — it does not force sleep. The strongest evidence is for sleep quality improvements in people with anxiety-driven or stress-driven insomnia. For circadian shift disorders, melatonin is a better-targeted tool.',
+      'A 2025 systematic review and meta-analysis found small improvements in several subjective sleep outcomes, including sleep-onset latency and overall sleep quality. The authors also highlighted the shortage of studies using pure L-theanine and said the optimal dose and duration remain unresolved.',
   },
   {
-    question: 'Is L-theanine the same as ashwagandha?',
+    question: 'Is L-theanine FDA approved or universally GRAS?',
     answer:
-      'No — they work very differently. L-theanine is fast (30–60 minutes), calming without sedation, and works acutely on alpha-wave activity and GABA/glutamate. Ashwagandha is slow (4–8 weeks), foundational, and works by modulating cortisol and the HPA axis. L-theanine is the right tool for tonight; ashwagandha is the right tool for chronic stress load. Many people stack them.',
+      'No blanket FDA approval or universal product-level GRAS finding should be inferred. FDA has issued “no questions” responses to specific GRAS notices for specified L-theanine preparations and intended food uses, including some uses up to 250 mg per serving. Those notices do not establish that every dietary supplement, dose, or use is FDA approved.',
   },
   {
-    question: 'Should I take L-theanine in the morning or at night?',
+    question: 'Is daily L-theanine proven safe long term?',
     answer:
-      'It depends on your goal. For focus, take it in the morning (often with caffeine) or 30–60 minutes before a demanding task. For sleep support, take it 30–60 minutes before bed. For daytime anxiety, take it as needed when you feel stress rising. L-theanine does not produce drowsiness, so timing is about matching effect to need, not avoiding impairment.',
+      'Short randomized trials generally report good tolerability, and the 2026 meta-analysis reported no serious adverse events. That is reassuring but does not establish unlimited long-term safety for every person, dose, product, medication combination, pregnancy, or medical condition.',
   },
 ]
 
-// ─── Page ─────────────────────────────────────────────────────────────────────
+const SOURCES = [
+  {
+    label: 'L-theanine systematic review and meta-analysis of 31 randomized trials (2026)',
+    href: 'https://pubmed.ncbi.nlm.nih.gov/42410082/',
+    note: '31 RCTs, 1,168 participants; robust short-term attention signal, modest bias-sensitive acute-stress effect, inconsistent anxiety findings, and no serious adverse events reported.',
+  },
+  {
+    label: 'Tea, L-theanine, and L-theanine plus caffeine meta-analysis (2025)',
+    href: 'https://pubmed.ncbi.nlm.nih.gov/40314930/',
+    note: 'Healthy participants; task-specific cognitive and mood findings with frequent uncertainty in effect direction and magnitude. Industry relationships were disclosed.',
+  },
+  {
+    label: 'L-theanine and sleep systematic review and meta-analysis (2025)',
+    href: 'https://pubmed.ncbi.nlm.nih.gov/40056718/',
+    note: '19 articles and 897 participants; small subjective sleep signals, with limited pure-L-theanine evidence and unresolved optimal dose and duration.',
+  },
+  {
+    label: 'Four-week L-theanine crossover trial in healthy adults (2019)',
+    href: 'https://pubmed.ncbi.nlm.nih.gov/31623400/',
+    note: '30 healthy adults without major psychiatric illness; 200 mg/day versus placebo for four weeks. Some stress, anxiety-trait, sleep, and cognitive outcomes improved; product-supplier employees were coauthors.',
+  },
+  {
+    label: 'FDA GRAS Notice 209: L-theanine',
+    href: 'https://hfpappexternal.fda.gov/scripts/fdcc/index.cfm?id=209&set=GRASNotices',
+    note: 'Specific food-ingredient notice with intended uses up to 250 mg per serving; FDA response: “no questions.”',
+  },
+  {
+    label: 'FDA GRAS Notice 338: tea-derived L-theanine',
+    href: 'https://hfpappexternal.fda.gov/scripts/fdcc/index.cfm?id=338&set=grasnotices',
+    note: 'Specific tea-derived preparation and specified food uses up to 250 mg per serving; FDA response: “no questions.”',
+  },
+]
 
 export default function LTheanineArticlePage() {
-  const pageBreadcrumb = breadcrumbJsonLd([
+  const breadcrumb = breadcrumbJsonLd([
     { name: 'Guides', url: 'https://thehippiescientist.net/guides/' },
     { name: TITLE, url: `https://thehippiescientist.net/guides/herbs/${SLUG}/` },
   ])
-
   const articleLd = blogJsonLd(
     { title: TITLE, slug: SLUG, date: DATE, description: DESCRIPTION },
     `/guides/herbs/${SLUG}/`,
   )
-
   const faqLd = faqPageJsonLd({ pagePath: `/guides/herbs/${SLUG}/`, questions: FAQS })
 
   return (
     <article className="mx-auto max-w-5xl space-y-0 px-4 pb-20 pt-6 sm:px-6 lg:px-8">
-      {/* JSON-LD */}
       <JsonLd schema={articleLd} />
-      <JsonLd schema={pageBreadcrumb} />
-      {faqLd && (
-        <JsonLd schema={faqLd} />
-      )}
+      <JsonLd schema={breadcrumb} />
+      {faqLd ? <JsonLd schema={faqLd} /> : null}
 
-      {/* Breadcrumb */}
-      <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
-        <Link href="/guides/" className="transition hover:text-ink">
-          Guides
-        </Link>
+      <nav className="mb-6 flex items-center gap-2 text-sm text-muted" aria-label="Breadcrumb">
+        <Link href="/guides/" className="transition hover:text-ink">Guides</Link>
         <span>/</span>
-        <span className="text-ink line-clamp-1">{TITLE}</span>
+        <span className="line-clamp-1 text-ink">L-Theanine</span>
       </nav>
 
-      {/* Hero */}
       <section className="rounded-[1.5rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8 lg:p-10">
         <div className="flex flex-wrap items-center gap-2 text-xs">
           <span className="rounded-full border border-brand-900/10 bg-brand-50 px-2.5 py-0.5 font-bold uppercase tracking-wider text-brand-800">
-            Umbrella Hub
+            Evidence-first umbrella guide
           </span>
-          <span className="rounded-full border border-brand-900/10 bg-white px-2.5 py-0.5 font-semibold text-muted capitalize">
-            {CATEGORY}
-          </span>
-          {TAGS.slice(0, 3).map((tag) => (
-            <span
-              key={tag}
-              className="rounded-full border border-brand-900/10 bg-white px-2.5 py-0.5 font-semibold text-muted capitalize"
-            >
+          {TAGS.slice(0, 4).map((tag) => (
+            <span key={tag} className="rounded-full border border-brand-900/10 bg-white px-2.5 py-0.5 font-semibold capitalize text-muted">
               {tag}
             </span>
           ))}
-          <span className="text-muted">{new Date(DATE).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}</span>
-          <span className="text-muted">·</span>
           <span className="text-muted">{READING_TIME}</span>
         </div>
 
         <h1 className="mt-4 font-display text-3xl font-bold leading-tight tracking-tight text-ink sm:text-4xl lg:text-5xl">
           {TITLE}
         </h1>
-
         <p className="mt-2 text-sm text-muted">
-          By{' '}
-          <Link href="/info/about/" rel="author" className="font-medium text-ink hover:underline">
-            {AUTHOR}
-          </Link>
+          By <Link href="/info/about/" rel="author" className="font-medium text-ink hover:underline">{AUTHOR}</Link>
         </p>
-
-        <div className="mt-3">
-          <LastUpdatedBadge date={DATE} label="Last updated" />
-        </div>
-
+        <div className="mt-3"><LastUpdatedBadge date={DATE} label="Last evidence review" /></div>
         <p className="mt-4 max-w-3xl text-base leading-7 text-muted">{DESCRIPTION}</p>
 
         <figure className="mt-6">
-          <div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white">
+          <div className="overflow-hidden rounded-2xl border border-brand-900/10 bg-white shadow-sm">
             <Image
               src="/images/guides/l-theanine-herb.jpg"
-              alt="Green tea leaves, pure L-theanine powder, and a cup of green tea — L-theanine's natural source"
+              alt="Green tea leaves, L-theanine powder, and a cup of tea"
               width={1536}
               height={1024}
               priority
-              className="w-full h-auto"
+              className="h-auto w-full"
             />
           </div>
           <figcaption className="mt-3 text-center text-sm text-muted">
-            L-theanine — an amino acid from green tea used for calm, focused relaxation without sedation.
+            L-theanine research is outcome-specific: attention, stress tasks, anxiety scales, and sleep outcomes should not be treated as interchangeable.
           </figcaption>
         </figure>
       </section>
 
-      {/* Affiliate disclosure */}
       <div className="mt-4 rounded-[1rem] border border-brand-900/10 bg-brand-50/60 px-5 py-3 text-xs leading-6 text-muted">
-        <strong className="text-ink">Affiliate disclosure:</strong> This article contains affiliate
-        links. If you purchase through these links, we may earn a commission at no additional cost to
-        you. We only link to products that match the dose ranges and forms reviewed in the clinical
-        literature on this page.
+        <strong className="text-ink">Affiliate disclosure:</strong> This page contains affiliate links. Product links are optional sourcing examples, not proof that a product will improve anxiety, sleep, or cognition. We may earn a commission at no added cost to you.
       </div>
 
-      {/* Body + sidebar */}
       <div className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1fr)_240px]">
-        {/* Main content */}
         <div className="space-y-6">
-
-          {/* Fastest useful choice */}
-          <section className="rounded-[1rem] border border-brand-700/20 bg-brand-50/60 p-6 shadow-sm sm:p-8">
-            <p className="eyebrow-label">Fastest useful choice</p>
+          <section id="bottom-line" className="rounded-[1rem] border border-brand-700/20 bg-brand-50/60 p-6 shadow-sm sm:p-8">
+            <p className="eyebrow-label">Evidence bottom line</p>
             <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
-              If you only try one thing: 100 mg L-theanine alone
+              L-theanine has a credible attention signal, but the evidence is much less certain for anxiety and broad “calm” claims
             </h2>
-            <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
-              <strong>L-theanine 100 mg alone is itself the fastest useful choice for calm focus,
-              racing thoughts, and caffeine smoothing.</strong> Effects within 30–60 minutes, no
-              sedation, no dependency, nootropic without overstimulation. If 100 mg is not enough,
-              increase to 200 mg before adding other compounds. The L-theanine + caffeine 2:1 stack
-              is the most-studied nootropic combination in the literature and a natural upgrade if
-              you also want alertness. See the{' '}
-              <Link href="/guides/focus/l-theanine-vs-caffeine-for-focus/" className="font-semibold text-brand-700 hover:text-brand-800 hover:underline">
-                head-to-head comparison
-              </Link>
-              .
+            <div className="mt-3 space-y-3 text-[1.01rem] leading-[1.85] text-muted">
+              <p>
+                The July 2026 meta-analysis pooled <strong>31 randomized trials and 1,168 participants</strong>. Its strongest short-term finding was improved choice reaction time after a single 200 mg dose studied before cognitive testing. The pooled acute-stress effect was modest and heavily influenced by higher-risk-of-bias studies, while anxiety findings were inconsistent overall.
+              </p>
+              <p>
+                That means “studied 30–60 minutes before a task” should not be converted into “you will feel anxiety relief in 30–60 minutes.” It also means a cognitive result should not be relabeled as proof that L-theanine treats racing thoughts, panic, or an anxiety disorder.
+              </p>
+            </div>
+          </section>
+
+          <section id="outcomes" className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+            <p className="eyebrow-label">Match the claim to the outcome</p>
+            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">What current evidence says by goal</h2>
+            <div className="mt-5 grid gap-4 sm:grid-cols-2">
+              <div className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+                <h3 className="font-semibold text-ink">Attention and cognitive tasks</h3>
+                <p className="mt-2 text-sm leading-6 text-muted">
+                  This is the clearest current signal. The 2026 meta-analysis found a robust short-term choice-reaction-time benefit in healthy adults, but that does not establish a broad nootropic effect across every cognitive task.
+                </p>
+                <Link href="/guides/focus/l-theanine-without-caffeine/" className="mt-3 inline-block text-sm font-semibold text-brand-700 hover:underline">
+                  Review caffeine-free focus evidence →
+                </Link>
+              </div>
+
+              <div className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+                <h3 className="font-semibold text-ink">Stress and anxiety</h3>
+                <p className="mt-2 text-sm leading-6 text-muted">
+                  Acute-stress findings are modest and study-quality-sensitive. Anxiety outcomes are inconsistent, so current pooled evidence does not establish L-theanine as a reliable acute or chronic anxiety treatment.
+                </p>
+                <Link href="/guides/anxiety/l-theanine-for-anxiety/" className="mt-3 inline-block text-sm font-semibold text-brand-700 hover:underline">
+                  Read the anxiety-specific review →
+                </Link>
+              </div>
+
+              <div className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+                <h3 className="font-semibold text-ink">Sleep</h3>
+                <p className="mt-2 text-sm leading-6 text-muted">
+                  The 2025 meta-analysis found small improvements in several subjective sleep outcomes. Pure-L-theanine studies were limited, and the optimal formulation, dose, and duration remain unresolved.
+                </p>
+                <Link href="/guides/sleep/l-theanine-for-sleep/" className="mt-3 inline-block text-sm font-semibold text-brand-700 hover:underline">
+                  Read the sleep-specific review →
+                </Link>
+              </div>
+
+              <div className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+                <h3 className="font-semibold text-ink">L-theanine plus caffeine</h3>
+                <p className="mt-2 text-sm leading-6 text-muted">
+                  Combination trials show task-specific cognitive and mood effects, but a 2025 meta-analysis emphasized uncertainty in direction and magnitude for many outcomes. There is no universal evidence-based ratio and no guaranteed “jitter shield.”
+                </p>
+                <Link href="/guides/focus/l-theanine-vs-caffeine-for-focus/" className="mt-3 inline-block text-sm font-semibold text-brand-700 hover:underline">
+                  Compare L-theanine and caffeine →
+                </Link>
+              </div>
+            </div>
+          </section>
+
+          <section id="evidence" className="space-y-4">
+            <h2 className="text-2xl font-semibold tracking-tight text-ink">Evidence snapshots</h2>
+            <EvidenceSummaryCard
+              title="L-Theanine — Attention and acute stress"
+              evidenceLevel="Moderate"
+              humanEvidence="The 2026 meta-analysis included 31 randomized placebo-controlled trials with 1,168 participants across healthy and clinical populations. A single 200 mg dose studied 30–60 minutes before cognitive testing improved choice reaction time. Acute-stress reduction was modest and strongly influenced by studies at high risk of bias; anxiety effects were inconsistent overall."
+              mechanisticEvidence="EEG and preclinical work offer plausible mechanisms, but mechanistic plausibility does not establish a clinical anxiety, sleep, or cognitive treatment effect."
+              safetyProfile="No serious adverse events were reported in the 2026 meta-analysis. That short-trial record is reassuring but is not equivalent to unlimited long-term safety across all populations and products."
+            />
+
+            <EvidenceSummaryCard
+              title="L-Theanine — Sleep"
+              evidenceLevel="Limited"
+              humanEvidence="A 2025 systematic review identified 19 articles and 897 participants and found small improvements in several subjective sleep outcomes. The review highlighted limited evidence using pure L-theanine and unresolved optimal dose and duration."
+              mechanisticEvidence="Relaxation mechanisms are proposed, but sleep benefits should be judged from sleep outcomes rather than alpha-wave or anxiety mechanisms alone."
+              safetyProfile="Sleep studies vary by product, population, dose, and co-ingredients, so findings should not be generalized to every nighttime supplement or combination."
+            />
+          </section>
+
+          <section id="study-context" className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+            <p className="eyebrow-label">Study context matters</p>
+            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">What the commonly cited doses actually represent</h2>
+            <div className="mt-5 space-y-4 text-sm leading-7 text-muted">
+              <div className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+                <p className="font-semibold text-ink">200 mg as a single dose</p>
+                <p className="mt-1">In the 2026 meta-analysis, 200 mg given 30–60 minutes before cognitive testing was associated with a choice-reaction-time benefit. That is a study protocol and an attention result—not a universal anxiety dose, guaranteed onset time, or personal dosing instruction.</p>
+              </div>
+              <div className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+                <p className="font-semibold text-ink">200 mg/day for four weeks</p>
+                <p className="mt-1">A small 2019 double-blind crossover trial studied 30 healthy adults without major psychiatric illness. Some stress-related, sleep, and cognitive measures improved, but the sample was small and the tablets were supplied by a company whose employees were study authors.</p>
+              </div>
+              <div className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+                <p className="font-semibold text-ink">Sleep doses and timing</p>
+                <p className="mt-1">The 2025 sleep review found heterogeneous products and protocols and did not establish one optimal pure-L-theanine dose or duration. A common label schedule should not be mistaken for a settled clinical protocol.</p>
+              </div>
+            </div>
+            <p className="mt-4 text-xs leading-6 text-muted">
+              Study doses describe research conditions. They are not individualized medical instructions, and medication, pregnancy, blood-pressure, sleep, and other health context can change the risk-benefit calculation.
             </p>
           </section>
 
-          {/* Quick Verdict */}
-          <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
-            <p className="eyebrow-label">Quick Verdict</p>
-            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
-              Does L-Theanine Work?
-            </h2>
-            <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
-              <strong>Yes — for calm focus, anxiety-driven racing thoughts, and caffeine
-              smoothing.</strong> L-theanine reliably increases alpha-wave activity (the calm-focus
-              brainwave pattern) within 30–60 minutes and consistently reduces subjective stress in
-              acute settings. The L-theanine + caffeine combination is one of the most replicated
-              nootropic stacks in cognitive research.
-            </p>
-            <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
-              For chronic stress load, anxiety disorders, or mood-related conditions, L-theanine is
-              supportive but not a primary intervention — pair it with ashwagandha, magnesium, or
-              appropriate clinical care depending on what you are addressing. L-theanine is a fast,
-              safe, well-tolerated tool. It is not a substitute for therapy, sleep hygiene, or
-              medical treatment.
-            </p>
+          <section id="caffeine" className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+            <p className="eyebrow-label">Caffeine pairing</p>
+            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">Useful research question, not a universal stack recipe</h2>
+            <div className="mt-3 space-y-3 text-[1.01rem] leading-[1.85] text-muted">
+              <p>
+                A 2025 systematic review and meta-analysis evaluated tea, L-theanine alone, and L-theanine plus caffeine in healthy participants. It found some small-to-moderate task-specific cognitive and mood differences, while confidence intervals frequently showed uncertainty about the direction or magnitude of effects.
+              </p>
+              <p>
+                The review also disclosed industry relationships involving Lipton and Unilever. That does not invalidate the work, but it belongs in the evidence context. The practical takeaway is narrower than “use a fixed ratio”: combination effects depend on the exact task, doses, population, and comparator, and current evidence does not prove that L-theanine reliably prevents caffeine jitters or sleep disruption.
+              </p>
+            </div>
           </section>
 
-          {/* Main article body */}
-          <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8 space-y-8">
+          <section id="safety" className="space-y-4">
+            <h2 className="text-2xl font-semibold tracking-tight text-ink">Safety and FDA/GRAS context</h2>
+            <SafetyNotice title="Safety summary — L-Theanine">
+              <ul className="ml-5 space-y-2 list-disc">
+                <li><strong>Short trials:</strong> The 2026 meta-analysis reported no serious adverse events, which is reassuring for the studied populations and durations.</li>
+                <li><strong>Long-term certainty:</strong> Short RCTs do not establish unlimited long-term safety, dependence risk, pregnancy safety, pediatric safety, or safety with every medication or supplement combination.</li>
+                <li><strong>FDA GRAS notices:</strong> FDA has issued “no questions” responses for specific L-theanine preparations and specified food uses. That is not blanket FDA approval of all L-theanine supplements, doses, brands, or health claims.</li>
+                <li><strong>Medication context:</strong> If you use prescription medication or have a medical condition, review regular supplement use with a clinician or pharmacist rather than relying on a general safety label.</li>
+                <li><strong>Driving and alertness:</strong> Individual responses can differ. Do not assume a supplement is impairment-free for you until you know how you respond.</li>
+              </ul>
+            </SafetyNotice>
+          </section>
 
-            {/* Introduction */}
-            <div id="introduction">
-              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">Introduction</h2>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                L-theanine is one of the most consistently studied natural compounds for calm focus
-                and acute anxiety reduction. Found naturally in tea leaves (and originally
-                identified in green tea in 1949), it has become a staple of the nootropics community
-                and is increasingly studied in clinical research for anxiety, sleep, ADHD, and
-                cardiovascular outcomes.
-              </p>
-              <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
-                This article is the umbrella guide — covering everything you need to know in one
-                place, with deep-dive links to each condition-specific article. Whether you are
-                considering L-theanine for focus, anxiety, sleep, or ADHD, this hub will help you
-                decide if it is right for you, what dose to use, and what to expect.
-              </p>
+          <section id="buying" className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+            <p className="eyebrow-label">If you choose to buy it</p>
+            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">Use the label to match the product to the evidence you are reviewing</h2>
+            <ul className="mt-4 space-y-2 text-sm leading-7 text-muted">
+              <li>• Prefer a label that clearly states the amount of L-theanine per serving rather than hiding it inside a proprietary blend.</li>
+              <li>• Separate pure L-theanine evidence from combination-product evidence; caffeine, melatonin, magnesium, or herbal co-ingredients change what the product is.</li>
+              <li>• Do not treat “Suntheanine,” “tea-derived,” “GRAS,” or a fixed theanine:caffeine ratio as proof of superior clinical efficacy.</li>
+              <li>• Compare the exact product, dose, population, and outcome with the study you are using to justify the purchase.</li>
+            </ul>
+          </section>
+
+          <section id="faq" className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+            <h2 className="text-2xl font-semibold tracking-tight text-ink">Frequently asked questions</h2>
+            <div className="mt-5 space-y-4">
+              {FAQS.map((faq) => (
+                <div key={faq.question} className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+                  <h3 className="font-semibold text-ink">{faq.question}</h3>
+                  <p className="mt-2 text-sm leading-7 text-muted">{faq.answer}</p>
+                </div>
+              ))}
             </div>
+          </section>
 
-            <hr className="border-brand-900/10" />
-
-            {/* What is L-theanine */}
-            <div id="what-is-l-theanine">
-              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">
-                What Is L-Theanine?
-              </h2>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                L-theanine (γ-glutamylethylamide) is a non-proteinogenic amino acid analogue of
-                glutamate and glutamine. It is found naturally in tea (<em>Camellia sinensis</em>),
-                particularly green tea, where it constitutes 1–2% of the dry leaf weight. The
-                Japanese have studied it as the active component responsible for the calm-yet-alert
-                state that tea drinkers report, often called &ldquo;alert calm&rdquo; or
-                &ldquo;focused relaxation.&rdquo;
-              </p>
-              <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
-                It is structurally similar to glutamate (an excitatory neurotransmitter) and is
-                thought to work partly through modulation of glutamate receptors. It also promotes
-                GABA (the brain&rsquo;s main inhibitory neurotransmitter), dopamine, and serotonin
-                release in moderation. Critically, it does not produce sedation, dependency, or
-                tolerance buildup.
-              </p>
-              <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
-                For a complete breakdown of chemistry, mechanisms, and research across all uses,
-                see the{' '}
-                <Link href="/compounds/l-theanine/" className="font-semibold text-brand-700 hover:text-brand-800 hover:underline">
-                  L-theanine compound profile
-                </Link>
-                .
-              </p>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* What L-theanine is used for */}
-            <div id="uses">
-              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">
-                What L-Theanine Is Used For
-              </h2>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                L-theanine has been studied across several outcomes with varying evidence strength.
-                Use this section to see whether L-theanine is right for your specific goal.
-              </p>
-
-              {/* Decision table by use case */}
-              <div className="mt-4 overflow-x-auto rounded-[1rem] border border-brand-900/10 bg-white shadow-sm">
-                <table className="min-w-[640px] w-full text-sm border-collapse">
-                  <thead>
-                    <tr className="border-b border-brand-900/10 bg-brand-50/50">
-                      <th className="text-left p-4 font-semibold text-ink">Use case</th>
-                      <th className="text-left p-4 font-semibold text-ink">Evidence strength</th>
-                      <th className="text-left p-4 font-semibold text-ink">Time to effect</th>
-                      <th className="text-left p-4 font-semibold text-ink">Deep-dive</th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-brand-900/10">
-                    <tr>
-                      <td className="p-4 font-medium text-ink">Caffeine smoothing &amp; calm focus</td>
-                      <td className="p-4 text-brand-700 font-medium">Strong</td>
-                      <td className="p-4 text-muted">30–60 min</td>
-                      <td className="p-4">
-                        <Link href="/guides/focus/l-theanine-vs-caffeine-for-focus/" className="text-brand-700 hover:underline font-medium">
-                          vs Caffeine →
-                        </Link>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td className="p-4 font-medium text-ink">Anxiety symptom reduction</td>
-                      <td className="p-4 text-brand-700 font-medium">Moderate</td>
-                      <td className="p-4 text-muted">30–60 min</td>
-                      <td className="p-4">
-                        <Link href="/guides/herbs/l-theanine/" className="text-brand-700 hover:underline font-medium">
-                          L-theanine for anxiety →
-                        </Link>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td className="p-4 font-medium text-ink">Sleep onset &amp; quality</td>
-                      <td className="p-4 text-brand-700 font-medium">Moderate</td>
-                      <td className="p-4 text-muted">30–60 min</td>
-                      <td className="p-4">
-                        <Link href="/guides/sleep/l-theanine-for-sleep/" className="text-brand-700 hover:underline font-medium">
-                          L-theanine for sleep →
-                        </Link>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td className="p-4 font-medium text-ink">ADHD focus &amp; calm</td>
-                      <td className="p-4 text-muted">Emerging–Moderate</td>
-                      <td className="p-4 text-muted">30–60 min</td>
-                      <td className="p-4">
-                        <Link href="/guides/adhd/l-theanine-for-adhd/" className="text-brand-700 hover:underline font-medium">
-                          L-theanine for ADHD →
-                        </Link>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td className="p-4 font-medium text-ink">Blood pressure reduction</td>
-                      <td className="p-4 text-muted">Emerging</td>
-                      <td className="p-4 text-muted">4–8 weeks (chronic)</td>
-                      <td className="p-4">
-                        <span className="text-muted text-xs">No dedicated deep-dive yet</span>
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-
-              <p className="mt-4 text-[1.01rem] leading-[1.85] text-muted">
-                For most readers, the right entry point is the calm focus / caffeine smoothing
-                evidence — that is the strongest and most consistent body of research. If your
-                primary goal is anxiety, see the{' '}
-                <Link href="/guides/herbs/l-theanine/" className="font-semibold text-brand-700 hover:underline">
-                  anxiety deep-dive
-                </Link>
-                . If sleep is primary, see{' '}
-                <Link href="/guides/sleep/l-theanine-for-sleep/" className="font-semibold text-brand-700 hover:underline">
-                  L-theanine for sleep
-                </Link>
-                . If you want a stack that combines L-theanine with magnesium, see the{' '}
-                <Link href="/guides/adhd/l-theanine-magnesium-adhd-stack/" className="font-semibold text-brand-700 hover:underline">
-                  L-theanine + magnesium stack
-                </Link>
-                . For caffeine-free focus, see{' '}
-                <Link href="/guides/focus/l-theanine-without-caffeine/" className="font-semibold text-brand-700 hover:underline">
-                  L-theanine without caffeine
-                </Link>
-                .
-              </p>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* How L-theanine works */}
-            <div id="mechanisms">
-              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">
-                How L-Theanine Works
-              </h2>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                Several convergent mechanisms have been proposed, based on EEG studies, neuroimaging,
-                and pharmacological inference:
-              </p>
-
-              <h3 className="mt-5 mb-1 text-xl font-semibold tracking-tight text-ink">
-                1. Alpha Waves: The &ldquo;Calm Focus&rdquo; Brainwave
-              </h3>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                Alpha waves (8–12 Hz) are the neural oscillation pattern associated with calm,
-                relaxed wakefulness — the &ldquo;flow state&rdquo; precursor. L-theanine consistently
-                increases alpha-wave power in EEG studies within 30–60 minutes of ingestion, making
-                it one of the more mechanistically well-characterized supplements for this purpose.
-              </p>
-
-              <h3 className="mt-5 mb-1 text-xl font-semibold tracking-tight text-ink">
-                2. Glutamate / GABA Modulation
-              </h3>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                L-theanine has structural similarity to glutamate and may modulate AMPA, NMDA, and
-                kainate receptors to reduce excitatory tone. It also appears to support GABA
-                activity, the brain&rsquo;s primary inhibitory neurotransmitter. The net effect is a
-                reduction in neural hyperactivation without producing strong sedation.
-              </p>
-
-              <h3 className="mt-5 mb-1 text-xl font-semibold tracking-tight text-ink">
-                3. Serotonin &amp; Dopamine Modulation (Modest)
-              </h3>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                Some evidence suggests L-theanine modestly increases serotonin and dopamine
-                release. The effect is gentler and more variable than alpha-wave changes. This may
-                contribute to the well-being and mood-stabilizing effects some users report.
-              </p>
-
-              <h3 className="mt-5 mb-1 text-xl font-semibold tracking-tight text-ink">
-                4. What L-Theanine Does NOT Do
-              </h3>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                L-theanine does not meaningfully increase dopamine or norepinephrine — the
-                catecholamines central to stimulant ADHD medication efficacy. It is not a stimulant.
-                It does not block adenosine receptors (caffeine does this). Its mechanism is calming
-                and inhibitory-supportive, not activating. If you need activation, combine with
-                caffeine or use a different supplement.
-              </p>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Evidence Summary */}
-            <div id="evidence-summary">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                Evidence Summary
-              </h2>
-
-              <EvidenceSummaryCard
-                title="L-Theanine — Calm Focus &amp; Anxiety"
-                evidenceLevel="Moderate"
-                humanEvidence="Multiple randomized crossover trials show L-theanine increases alpha-wave power within 30–60 minutes and reduces subjective stress. The L-theanine + caffeine (2:1) combination improves attention, reaction time, and accuracy vs caffeine alone across multiple RCTs. Anxiety trials are smaller but directionally consistent."
-                mechanisticEvidence="Alpha-wave enhancement is well-replicated via EEG. GABA and glutamate modulation demonstrated in animal models and inferred from human outcomes. Modest effects on serotonin and dopamine release have been measured in preclinical work."
-                safetyProfile="Generally well-tolerated at 100–400 mg/day. FDA GRAS for use in foods. Mild blood pressure reduction at higher chronic doses. Caution with antihypertensives and sedatives. Limited data in pregnancy."
-              />
-
-              <div className="mt-4 rounded-[1rem] border border-brand-900/10 bg-brand-50/60 p-4 text-sm leading-7 text-muted">
-                <p className="font-semibold text-ink">Key trials reviewed:</p>
-                <ul className="mt-2 ml-5 space-y-1 list-disc">
-                  <li>Williams et al. (2019) — L-theanine + caffeine cognitive performance meta-analysis</li>
-                  <li>Nobre et al. (2008) — L-theanine alpha-wave EEG study</li>
-                  <li>Kimura et al. (2007) — L-theanine + caffeine attention and arousal</li>
-                  <li>Lu et al. (2004) — L-theanine acute stress reactivity (mathematical tasks)</li>
-                  <li>Yoto et al. (2012) — L-theanine stress reduction in students</li>
-                  <li>Owen et al. (2008) — Suntheanine&reg; anxiety and sleep outcomes</li>
-                </ul>
-                <p className="mt-2 text-xs text-muted">
-                  Full reference table in Sources section below.
-                </p>
-              </div>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Dosage */}
-            <div id="dosage">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                Dosage and Usage
-              </h2>
-
-              <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-5 shadow-sm">
-                <p className="mb-3 text-[10px] font-bold uppercase tracking-wider text-muted">
-                  Dosage Reference — Standard Protocols
-                </p>
-                <ResponsiveTable label="L-theanine dosage reference table">
-                  <table className="min-w-[560px] w-full text-sm">
-                    <thead>
-                      <tr className="border-b border-brand-900/10">
-                        <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                          Goal
-                        </th>
-                        <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                          Dose
-                        </th>
-                        <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                          Timing
-                        </th>
-                        <th className="pb-2 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                          Frequency
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody className="divide-y divide-brand-900/5">
-                      <tr className="align-top">
-                        <td className="py-3 pr-4 font-medium text-ink">Calm focus / day</td>
-                        <td className="py-3 pr-4 text-muted">100–200 mg</td>
-                        <td className="py-3 pr-4 text-muted">30–60 min before task</td>
-                        <td className="py-3 text-muted">As needed</td>
-                      </tr>
-                      <tr className="align-top">
-                        <td className="py-3 pr-4 font-medium text-ink">Caffeine smoothing</td>
-                        <td className="py-3 pr-4 text-muted">100–200 mg (+ 50–100 mg caffeine)</td>
-                        <td className="py-3 pr-4 text-muted">Together with coffee/tea</td>
-                        <td className="py-3 text-muted">Per caffeine dose</td>
-                      </tr>
-                      <tr className="align-top">
-                        <td className="py-3 pr-4 font-medium text-ink">Sleep support</td>
-                        <td className="py-3 pr-4 text-muted">200–400 mg</td>
-                        <td className="py-3 pr-4 text-muted">30–60 min before bed</td>
-                        <td className="py-3 text-muted">Nightly as needed</td>
-                      </tr>
-                      <tr className="align-top">
-                        <td className="py-3 pr-4 font-medium text-ink">Acute anxiety</td>
-                        <td className="py-3 pr-4 text-muted">200–400 mg</td>
-                        <td className="py-3 pr-4 text-muted">At onset of symptoms</td>
-                        <td className="py-3 text-muted">As needed</td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </ResponsiveTable>
-                <p className="mt-3 text-xs text-muted">
-                  Doses shown are based on clinical trial protocols. Start at 100 mg and assess
-                  response. L-theanine can be taken with or without food. Effects last approximately
-                  3–4 hours per dose.
-                </p>
-              </div>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Affiliate Product Recommendations */}
-            <div id="product-recommendations">
-              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">
-                Affiliate Product Recommendations
-              </h2>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                These products use plain L-theanine (no blends) at doses matching the protocols
-                reviewed above. Affiliate links support this site at no additional cost to you.
-              </p>
-              <div className="mt-4 grid gap-4 sm:grid-cols-2">
-                <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
-                  <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
-                    Best for: Calm Focus
-                  </p>
-                  <p className="font-semibold text-ink">Suntheanine&reg; L-Theanine 200 mg</p>
-                  <p className="mt-1 text-xs leading-5 text-muted">
-                    Pure L-isomer theanine (the bioactive form). Most-studied branded version.
-                    Single-ingredient capsules at a research-supported dose.
-                  </p>
-                  <a
-                    href={`https://www.amazon.com/s?k=Suntheanine+l-theanine+200mg&tag=${AFFILIATE_TAGS.amazon}`}
-                    target="_blank"
-                    rel="noopener noreferrer sponsored"
-                    className="mt-3 inline-flex items-center gap-1 rounded-full bg-brand-950 px-4 py-1.5 text-xs font-bold text-white transition hover:bg-brand-900"
-                  >
-                    View on Amazon →
+          <section id="sources" className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+            <h2 className="text-2xl font-semibold tracking-tight text-ink">Sources and directness notes</h2>
+            <ol className="mt-5 space-y-4">
+              {SOURCES.map((source, index) => (
+                <li key={source.href} className="text-sm leading-7 text-muted">
+                  <span className="font-semibold text-ink">{index + 1}. </span>
+                  <a href={source.href} target="_blank" rel="noopener noreferrer" className="font-semibold text-brand-700 hover:underline">
+                    {source.label}
                   </a>
-                </div>
-                <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
-                  <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
-                    Best for: Caffeine Pairing
-                  </p>
-                  <p className="font-semibold text-ink">L-Theanine + Caffeine Stack</p>
-                  <p className="mt-1 text-xs leading-5 text-muted">
-                    Pre-combined 2:1 L-theanine + caffeine stack for focus without jitters. Convenient
-                    single-capsule alternative to drinking tea.
-                  </p>
-                  <a
-                    href={`https://www.amazon.com/s?k=l-theanine+caffeine+stack+200mg&tag=${AFFILIATE_TAGS.amazon}`}
-                    target="_blank"
-                    rel="noopener noreferrer sponsored"
-                    className="mt-3 inline-flex items-center gap-1 rounded-full bg-brand-950 px-4 py-1.5 text-xs font-bold text-white transition hover:bg-brand-900"
-                  >
-                    View on Amazon →
-                  </a>
-                </div>
-              </div>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Safety */}
-            <div id="safety">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                Safety and Side Effects
-              </h2>
-              <SafetyNotice title="Safety Summary — L-Theanine">
-                <ul className="ml-5 space-y-1.5 list-disc">
-                  <li>
-                    <strong>Generally recognized as safe (GRAS)</strong> by the FDA for use in
-                    conventional foods. No documented dependency, withdrawal, or tolerance buildup
-                    at typical doses (100–400 mg/day).
-                  </li>
-                  <li>
-                    <strong>Blood pressure:</strong> Mild blood pressure reduction observed at
-                    chronic higher doses. Caution if you take antihypertensive medications —
-                    additive effect possible.
-                  </li>
-                  <li>
-                    <strong>Sedatives:</strong> Additive effect with benzodiazepines, sleep
-                    medications, alcohol, and other CNS depressants.
-                  </li>
-                  <li>
-                    <strong>Pregnancy / lactation:</strong> Limited human safety data; many
-                    clinicians advise caution or avoidance during pregnancy and breastfeeding.
-                  </li>
-                  <li>
-                    <strong>Children:</strong> Limited research in pediatric populations; do not
-                    give to children without clinical guidance.
-                  </li>
-                  <li>
-                    <strong>Chemotherapy / immunosuppression:</strong> Theoretical interaction due
-                    to immunomodulatory effects in some preclinical work; consult an oncologist
-                    before combining.
-                  </li>
-                </ul>
-              </SafetyNotice>
-              <p className="mt-3 text-sm text-muted">
-                L-theanine has one of the cleanest safety profiles of any supplement reviewed on
-                this site. The main cautions are additive effects with sedatives and mild
-                blood-pressure reduction at higher chronic doses. For a complete breakdown, see the{' '}
-                <Link href="/compounds/l-theanine/" className="font-semibold text-brand-700 hover:text-brand-800 hover:underline">
-                  full L-theanine compound profile
-                </Link>
-                .
-              </p>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Stacking */}
-            <div id="stacking">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                Stacking L-Theanine With Other Supplements
-              </h2>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                L-theanine pairs well with several other supplements because it works acutely on
-                calming while they cover the baseline (chronic stress, sleep support, muscle
-                tension). Common stacks:
-              </p>
-
-              <div className="mt-4 grid gap-3 sm:grid-cols-2">
-                <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
-                  <p className="font-semibold text-ink">L-Theanine + Caffeine</p>
-                  <p className="mt-1 text-xs leading-5 text-muted">
-                    100–200 mg L-theanine with 50–100 mg caffeine (2:1 ratio). The most-studied
-                    nootropic stack — calm focus without jitters. See{' '}
-                    <Link href="/guides/focus/l-theanine-vs-caffeine-for-focus/" className="font-semibold text-brand-700 hover:underline">
-                      head-to-head comparison
-                    </Link>
-                    .
-                  </p>
-                </div>
-                <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
-                  <p className="font-semibold text-ink">L-Theanine + Magnesium glycinate</p>
-                  <p className="mt-1 text-xs leading-5 text-muted">
-                    Acute calming (L-theanine) plus evening muscle tension and nervous-system
-                    support (magnesium). See the{' '}
-                    <Link href="/guides/adhd/l-theanine-magnesium-adhd-stack/" className="font-semibold text-brand-700 hover:underline">
-                      L-theanine + magnesium stack
-                    </Link>
-                    .
-                  </p>
-                </div>
-                <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
-                  <p className="font-semibold text-ink">L-Theanine + Ashwagandha</p>
-                  <p className="mt-1 text-xs leading-5 text-muted">
-                    Acute calm focus (L-theanine) plus chronic stress baseline regulation
-                    (ashwagandha). See the{' '}
-                    <Link href="/guides/herbs/ashwagandha/" className="font-semibold text-brand-700 hover:underline">
-                      ashwagandha article
-                    </Link>
-                    .
-                  </p>
-                </div>
-                <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
-                  <p className="font-semibold text-ink">L-Theanine + Melatonin</p>
-                  <p className="mt-1 text-xs leading-5 text-muted">
-                    For sleep: L-theanine quiets racing thoughts; melatonin signals circadian
-                    onset. Different mechanisms — complementary. See{' '}
-                    <Link href="/guides/sleep/l-theanine-for-sleep/" className="font-semibold text-brand-700 hover:underline">
-                      L-theanine for sleep
-                    </Link>
-                    .
-                  </p>
-                </div>
-              </div>
-              <p className="mt-4 text-[1.01rem] leading-[1.85] text-muted">
-                Introduce one supplement at a time so you can isolate what is helping (or causing
-                side effects). Allow 1–2 weeks between additions. L-theanine is one of the safer
-                starting points because it acts acutely and you can usually tell within an hour
-                whether it helps.
-              </p>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* FAQ */}
-            <div id="faq">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                Frequently Asked Questions
-              </h2>
-              <div className="space-y-4">
-                {FAQS.map((faq, i) => (
-                  <div
-                    key={i}
-                    className="rounded-[0.75rem] border border-brand-900/10 bg-brand-50/40 p-4"
-                  >
-                    <h3 className="font-semibold text-ink">{faq.question}</h3>
-                    <p className="mt-2 text-sm leading-7 text-muted">{faq.answer}</p>
-                  </div>
-                ))}
-              </div>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Related Articles */}
-            <div id="related-articles">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                Related Articles
-              </h2>
-              <div className="grid gap-3 sm:grid-cols-2">
-                <Link
-                  href="/guides/herbs/l-theanine/"
-                  className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
-                >
-                  <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
-                    Deep Dive
-                  </p>
-                  <p className="font-semibold text-ink transition group-hover:text-brand-700">
-                    L-Theanine for Anxiety
-                  </p>
-                  <p className="mt-1 text-xs text-muted">
-                    Anxiety-specific evidence, dosage for racing thoughts, and how L-theanine
-                    compares with ashwagandha, magnesium, and CBD.
-                  </p>
-                </Link>
-                <Link
-                  href="/guides/sleep/l-theanine-for-sleep/"
-                  className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
-                >
-                  <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
-                    Deep Dive
-                  </p>
-                  <p className="font-semibold text-ink transition group-hover:text-brand-700">
-                    L-Theanine for Sleep
-                  </p>
-                  <p className="mt-1 text-xs text-muted">
-                    Sleep onset and quality, evening protocols, and how L-theanine compares with
-                    melatonin, magnesium, and ashwagandha for sleep.
-                  </p>
-                </Link>
-                <Link
-                  href="/guides/adhd/l-theanine-for-adhd/"
-                  className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
-                >
-                  <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
-                    Deep Dive
-                  </p>
-                  <p className="font-semibold text-ink transition group-hover:text-brand-700">
-                    L-Theanine for ADHD
-                  </p>
-                  <p className="mt-1 text-xs text-muted">
-                    ADHD-specific focus evidence, caffeine-free protocols, and how L-theanine
-                    compares with stimulant medication.
-                  </p>
-                </Link>
-                <Link
-                  href="/guides/focus/l-theanine-vs-caffeine-for-focus/"
-                  className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
-                >
-                  <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
-                    Comparison
-                  </p>
-                  <p className="font-semibold text-ink transition group-hover:text-brand-700">
-                    L-Theanine vs Caffeine for Focus
-                  </p>
-                  <p className="mt-1 text-xs text-muted">
-                    Head-to-head comparison and the case for using both together.
-                  </p>
-                </Link>
-                <Link
-                  href="/guides/adhd/l-theanine-magnesium-adhd-stack/"
-                  className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
-                >
-                  <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
-                    Stack Guide
-                  </p>
-                  <p className="font-semibold text-ink transition group-hover:text-brand-700">
-                    L-Theanine + Magnesium Stack
-                  </p>
-                  <p className="mt-1 text-xs text-muted">
-                    A clean two-supplement stack for anxiety-driven focus or sleep support.
-                  </p>
-                </Link>
-                <Link
-                  href="/guides/focus/l-theanine-without-caffeine/"
-                  className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
-                >
-                  <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
-                    Variant
-                  </p>
-                  <p className="font-semibold text-ink transition group-hover:text-brand-700">
-                    L-Theanine Without Caffeine
-                  </p>
-                  <p className="mt-1 text-xs text-muted">
-                    Stimulant-free focus and calm — for caffeine-sensitive or evening users.
-                  </p>
-                </Link>
-              </div>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Sources */}
-            <div id="sources">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Sources</h2>
-              <ResponsiveTable label="Article references">
-                <table className="min-w-[600px] w-full text-sm">
-                  <thead>
-                    <tr className="border-b border-brand-900/10">
-                      <th className="pb-2 pr-3 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                        #
-                      </th>
-                      <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                        Study
-                      </th>
-                      <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                        Authors
-                      </th>
-                      <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                        Year
-                      </th>
-                      <th className="pb-2 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                        Link
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-brand-900/5">
-                    <tr className="align-top">
-                      <td className="py-3 pr-3 text-muted">1</td>
-                      <td className="py-3 pr-4 leading-6 text-ink">
-                        The effects of L-theanine (Suntheanine&reg;) on objective sleep quality in
-                        boys with ADHD
-                      </td>
-                      <td className="py-3 pr-4 text-muted">Lyon MR, Kapoor MP, Juneja LR</td>
-                      <td className="py-3 pr-4 text-muted">2011</td>
-                      <td className="py-3">
-                        <a
-                          href="https://pubmed.ncbi.nlm.nih.gov/22214254/"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
-                        >
-                          PMID 22214254
-                        </a>
-                      </td>
-                    </tr>
-                    <tr className="align-top">
-                      <td className="py-3 pr-3 text-muted">2</td>
-                      <td className="py-3 pr-4 leading-6 text-ink">
-                        L-Theanine and Caffeine Improve Task-Switching Without Impacting Stress
-                        Ratings in a Replication of Owen et al. (2008)
-                      </td>
-                      <td className="py-3 pr-4 text-muted">Owen GN, Parnell H, De Bruin EA, Rycroft JA</td>
-                      <td className="py-3 pr-4 text-muted">2008</td>
-                      <td className="py-3">
-                        <a
-                          href="https://pubmed.ncbi.nlm.nih.gov/18681988/"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
-                        >
-                          PMID 18681988
-                        </a>
-                      </td>
-                    </tr>
-                    <tr className="align-top">
-                      <td className="py-3 pr-3 text-muted">3</td>
-                      <td className="py-3 pr-4 leading-6 text-ink">
-                        L-Theanine and Caffeine Improve Task Switching Without Impacting Stress
-                      </td>
-                      <td className="py-3 pr-4 text-muted">Owen GN et al.</td>
-                      <td className="py-3 pr-4 text-muted">2008</td>
-                      <td className="py-3">
-                        <a
-                          href="https://pubmed.ncbi.nlm.nih.gov/18681988/"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
-                        >
-                          PMID 18681988
-                        </a>
-                      </td>
-                    </tr>
-                    <tr className="align-top">
-                      <td className="py-3 pr-3 text-muted">4</td>
-                      <td className="py-3 pr-4 leading-6 text-ink">
-                        L-Theanine and Caffeine Improve Alpha Wave Activity and Accuracy in a
-                        Sustained Attention Task
-                      </td>
-                      <td className="py-3 pr-4 text-muted">Kelly SP, Gomez-Ramirez M, Montesi JL, Foxe JJ</td>
-                      <td className="py-3 pr-4 text-muted">2008</td>
-                      <td className="py-3">
-                        <a
-                          href="https://pubmed.ncbi.nlm.nih.gov/18077003/"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
-                        >
-                          PMID 18077003
-                        </a>
-                      </td>
-                    </tr>
-                    <tr className="align-top">
-                      <td className="py-3 pr-3 text-muted">5</td>
-                      <td className="py-3 pr-4 leading-6 text-ink">
-                        Effects of L-Theanine on Stress Response in Mental Arithmetic Task
-                      </td>
-                      <td className="py-3 pr-4 text-muted">Yoto A, Motoki M, Murao J, Yokogoshi H</td>
-                      <td className="py-3 pr-4 text-muted">2012</td>
-                      <td className="py-3">
-                        <a
-                          href="https://pubmed.ncbi.nlm.nih.gov/22950744/"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
-                        >
-                          PMID 22950744
-                        </a>
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </ResponsiveTable>
-            </div>
-
+                  <span> — {source.note}</span>
+                </li>
+              ))}
+            </ol>
           </section>
 
           <RecommendationSection products={getRevenueProductSet('l-theanine')?.products ?? []} />
 
-          {/* Email capture */}
           <EmailCapture
             headline="Get future research notes by email"
             description="Evidence-first supplement updates, safety context, and new guide announcements. No diagnosis, treatment, or personal medical advice."
             location={`article-${SLUG}`}
           />
-
           <NewsletterCtaBlock
             title="Continue with the newsletter archive"
             description="Short notes built for cautious supplement decisions."
@@ -946,99 +351,42 @@ export default function LTheanineArticlePage() {
           />
         </div>
 
-        {/* Sidebar */}
         <aside className="space-y-4 lg:sticky lg:top-24 lg:self-start">
           <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
-            <p className="text-[10px] font-bold uppercase tracking-wider text-muted">
-              In this article
-            </p>
+            <p className="text-[10px] font-bold uppercase tracking-wider text-muted">In this guide</p>
             <nav className="mt-3 space-y-1.5" aria-label="Article sections">
               {[
-                ['#introduction', 'Introduction'],
-                ['#what-is-l-theanine', 'What Is L-Theanine?'],
-                ['#uses', 'What It Is Used For'],
-                ['#mechanisms', 'How It Works'],
-                ['#evidence-summary', 'Evidence Summary'],
-                ['#dosage', 'Dosage & Usage'],
-                ['#product-recommendations', 'Product Picks'],
-                ['#safety', 'Safety & Side Effects'],
-                ['#stacking', 'Stacking'],
+                ['#bottom-line', 'Evidence bottom line'],
+                ['#outcomes', 'Evidence by goal'],
+                ['#evidence', 'Evidence snapshots'],
+                ['#study-context', 'Study-dose context'],
+                ['#caffeine', 'Caffeine pairing'],
+                ['#safety', 'Safety & GRAS'],
+                ['#buying', 'Buying checklist'],
                 ['#faq', 'FAQ'],
                 ['#sources', 'Sources'],
               ].map(([href, label]) => (
-                <a
-                  key={href}
-                  href={href}
-                  className="block text-sm text-brand-700 hover:text-brand-800 hover:underline"
-                >
-                  {label}
-                </a>
+                <a key={href} href={href} className="block text-sm text-brand-700 hover:underline">{label}</a>
               ))}
             </nav>
           </div>
 
           <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
-            <p className="text-[10px] font-bold uppercase tracking-wider text-muted">
-              Explore more
-            </p>
+            <p className="text-[10px] font-bold uppercase tracking-wider text-muted">Related evidence</p>
             <div className="mt-3 space-y-2">
-              <Link
-                href="/guides/herbs/l-theanine/"
-                className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
-              >
-                L-theanine for anxiety →
-              </Link>
-              <Link
-                href="/guides/sleep/l-theanine-for-sleep/"
-                className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
-              >
-                L-theanine for sleep →
-              </Link>
-              <Link
-                href="/guides/adhd/l-theanine-for-adhd/"
-                className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
-              >
-                L-theanine for ADHD →
-              </Link>
-              <Link
-                href="/guides/herbs/ashwagandha/"
-                className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
-              >
-                Ashwagandha article →
-              </Link>
-              <Link
-                href="/compounds/l-theanine/"
-                className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
-              >
-                L-theanine compound profile →
-              </Link>
-              <Link
-                href="/guides/anxiety/"
-                className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
-              >
-                Anxiety goal hub →
-              </Link>
-              <Link
-                href="/guides/focus/"
-                className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
-              >
-                Focus goal hub →
-              </Link>
-              <Link
-                href="/guides/"
-                className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
-              >
-                All articles →
-              </Link>
+              <Link href="/guides/anxiety/l-theanine-for-anxiety/" className="block text-sm font-medium text-brand-700 hover:underline">L-theanine for anxiety →</Link>
+              <Link href="/guides/sleep/l-theanine-for-sleep/" className="block text-sm font-medium text-brand-700 hover:underline">L-theanine for sleep →</Link>
+              <Link href="/guides/focus/l-theanine-without-caffeine/" className="block text-sm font-medium text-brand-700 hover:underline">L-theanine without caffeine →</Link>
+              <Link href="/guides/focus/l-theanine-vs-caffeine-for-focus/" className="block text-sm font-medium text-brand-700 hover:underline">L-theanine vs caffeine →</Link>
+              <Link href="/compounds/l-theanine/" className="block text-sm font-medium text-brand-700 hover:underline">Compound profile →</Link>
+              <Link href="/guides/anxiety/natural-anxiety-relief/" className="block text-sm font-medium text-brand-700 hover:underline">Natural anxiety relief →</Link>
             </div>
           </div>
         </aside>
       </div>
 
       <div className="mt-8">
-        <Link href="/guides/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
-          ← Back to Guides
-        </Link>
+        <Link href="/guides/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">← Back to Guides</Link>
       </div>
     </article>
   )


### PR DESCRIPTION
High-ROI trust/evidence rebuild of the main L-theanine umbrella guide.

- replaces repeated 30–60-minute anxiety-onset promises with the July 2026 meta-analysis distinction between attention, acute stress, and anxiety outcomes
- updates the core evidence anchor to 31 randomized trials / 1,168 participants and makes the robust short-term attention signal explicit
- updates sleep framing to the 2025 systematic review/meta-analysis, including limited pure-L-theanine evidence and unresolved optimal dose/duration
- calibrates L-theanine + caffeine claims to the 2025 meta-analysis rather than presenting a universal 2:1 stack or guaranteed jitter protection
- removes acute-anxiety dosing prescriptions and reframes study doses as study context, not personal instructions
- replaces blanket “FDA GRAS” language with specific FDA GRAS-notice context for specified preparations and food uses
- fixes self-links so anxiety readers reach `/guides/anxiety/l-theanine-for-anxiety/`
- preserves SEO/JSON-LD, imagery, internal discovery, email/newsletter capture, and affiliate sourcing while keeping product links neutral

Focused regression coverage locks current PMIDs, directness context, FDA nuance, dedicated internal-link routing, and the removal of stale rapid-anxiety/stack claims.