### PR TITLE
Rebuild nighttime stress and anxiety guide around current evidence

### DIFF
--- a/app/__tests__/nighttime-anxiety-current-evidence.test.ts
+++ b/app/__tests__/nighttime-anxiety-current-evidence.test.ts
@@ -8,7 +8,7 @@ const PAGE = path.join(
 )
 
 function source() {
-  return fs.readFileSync(PAGE, 'utf8')
+  return fs.readFileSync(PAGE, 'utf8').replace(/\s+/g, ' ')
 }
 
 describe('nighttime stress and anxiety evidence calibration', () => {
@@ -17,10 +17,11 @@ describe('nighttime stress and anxiety evidence calibration', () => {
 
     expect(text).toContain('42410082')
     expect(text).toContain('39348746')
+    expect(text).toContain('41815853')
     expect(text).toContain('www.nccih.nih.gov/health/passionflower')
     expect(text).toContain('new-guideline-supports-behavioral-psychological-treatments-for-insomnia')
     expect(text).toContain('31 randomized trials and 1,168 participants')
-    expect(text).toContain('nine randomized trials and 558 participants')
+    expect(text).toContain('nine randomized placebo-controlled trials and 558 participants')
     expect(text).toContain("const DATE = '2026-08-11'")
   })
 
@@ -56,12 +57,31 @@ describe('nighttime stress and anxiety evidence calibration', () => {
     expect(text).toMatch(/interact with anesthesia/i)
   })
 
+  it('states the direct trial context behind the ashwagandha signal', () => {
+    const text = source()
+
+    expect(text).toMatch(/141 healthy men and women ages 18[–-]65 with moderate stress and anxiety/i)
+    expect(text).toMatch(/8 weeks to 300 mg of a proprietary ashwagandha root extract twice daily/i)
+    expect(text).toMatch(/another root extract, or placebo/i)
+    expect(text).toMatch(/formulation-specific evidence in stressed adults/i)
+  })
+
   it('places chronic insomnia in the CBT-I evidence context', () => {
     const text = source()
 
     expect(text).toMatch(/CBT-I has a strong guideline recommendation/i)
     expect(text).toMatch(/ranked herb list is not an evidence-equivalent replacement/i)
     expect(text).toMatch(/move beyond sleep-hygiene tips and consider CBT-I/i)
+  })
+
+  it('restores an explicit immediate-crisis stop rule', () => {
+    const text = source()
+
+    expect(text).toMatch(/Immediate stop rule/i)
+    expect(text).toMatch(/suicidal thoughts/i)
+    expect(text).toMatch(/thoughts of self-harm/i)
+    expect(text).toMatch(/inability to stay safe/i)
+    expect(text).toMatch(/seek immediate emergency or crisis care/i)
   })
 
   it('preserves monetization and internal evidence discovery without turning products into treatment picks', () => {

--- a/app/__tests__/nighttime-anxiety-current-evidence.test.ts
+++ b/app/__tests__/nighttime-anxiety-current-evidence.test.ts
@@ -1,0 +1,76 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const PAGE = path.join(
+  process.cwd(),
+  'app/guides/anxiety/best-herbs-for-stress-and-anxiety-at-night/page.tsx',
+)
+
+function source() {
+  return fs.readFileSync(PAGE, 'utf8')
+}
+
+describe('nighttime stress and anxiety evidence calibration', () => {
+  it('anchors the page to current direct evidence and insomnia guidance', () => {
+    const text = source()
+
+    expect(text).toContain('42410082')
+    expect(text).toContain('39348746')
+    expect(text).toContain('www.nccih.nih.gov/health/passionflower')
+    expect(text).toContain('new-guideline-supports-behavioral-psychological-treatments-for-insomnia')
+    expect(text).toContain('31 randomized trials and 1,168 participants')
+    expect(text).toContain('nine randomized trials and 558 participants')
+    expect(text).toContain("const DATE = '2026-08-11'")
+  })
+
+  it('does not restore the old rapid-onset or treatment-like supplement claims', () => {
+    const text = source()
+
+    expect(text).not.toMatch(/Fastest useful choice/i)
+    expect(text).not.toMatch(/fastest-acting option/i)
+    expect(text).not.toMatch(/most reliable fast-acting/i)
+    expect(text).not.toMatch(/effects within 30[–-]60 minutes/i)
+    expect(text).not.toMatch(/stacks cleanly/i)
+    expect(text).not.toMatch(/work the same night/i)
+    expect(text).not.toMatch(/addresses the cause rather than just the symptom/i)
+    expect(text).not.toMatch(/most reliable calming bedtime options/i)
+    expect(text).not.toMatch(/quiet[s]? stress-driven arousal within an hour/i)
+  })
+
+  it('keeps L-theanine study timing separate from anxiety relief', () => {
+    const text = source()
+
+    expect(text).toMatch(/study timing should not be converted into a guaranteed anxiety-relief onset/i)
+    expect(text).toMatch(/attention outcome, not demonstrated acute anxiety relief/i)
+    expect(text).toMatch(/does not support calling L-theanine a dependable same-night anxiolytic/i)
+  })
+
+  it('states passionflower uncertainty and concrete safety limits', () => {
+    const text = source()
+
+    expect(text).toMatch(/conclusions about anxiety are not definite/i)
+    expect(text).toMatch(/sleep-onset and sleep-maintenance findings are mixed/i)
+    expect(text).toMatch(/drowsiness, dizziness, and confusion/i)
+    expect(text).toMatch(/should not be used during pregnancy/i)
+    expect(text).toMatch(/interact with anesthesia/i)
+  })
+
+  it('places chronic insomnia in the CBT-I evidence context', () => {
+    const text = source()
+
+    expect(text).toMatch(/CBT-I has a strong guideline recommendation/i)
+    expect(text).toMatch(/ranked herb list is not an evidence-equivalent replacement/i)
+    expect(text).toMatch(/move beyond sleep-hygiene tips and consider CBT-I/i)
+  })
+
+  it('preserves monetization and internal evidence discovery without turning products into treatment picks', () => {
+    const text = source()
+
+    expect(text).toContain("getRevenueProductSet('ashwagandha')")
+    expect(text).toContain('<RecommendationSection products={ashwagandhaProducts.products} />')
+    expect(text).toContain('/guides/anxiety/natural-anxiety-relief/')
+    expect(text).toContain('/guides/anxiety/l-theanine-for-anxiety/')
+    expect(text).toContain('/guides/anxiety/ashwagandha-for-anxiety/')
+  })
+})

--- a/app/guides/anxiety/best-herbs-for-stress-and-anxiety-at-night/page.tsx
+++ b/app/guides/anxiety/best-herbs-for-stress-and-anxiety-at-night/page.tsx
@@ -9,19 +9,19 @@ import { getRevenueProductSet } from '@/config/revenue-products'
 import RecommendationSection from '@/components/RecommendationSection'
 import AffiliateDisclosure from '@/components/AffiliateDisclosure'
 import EmailCapture from '@/components/EmailCapture'
-import References from '@/components/References'
 
 const PAGE_URL = `${SITE_URL}/guides/anxiety/best-herbs-for-stress-and-anxiety-at-night`
+const DATE = '2026-08-11'
 
 export const metadata: Metadata = {
-  title: 'Best Herbs for Stress and Anxiety at Night — Calm-Down Guide',
+  title: 'Best Herbs for Stress and Anxiety at Night: Evidence & Safety',
   description:
-    'Evening stress and anxiety keeping you awake? An evidence-informed guide to calming herbs for nighttime — passionflower, lemon balm, ashwagandha, magnolia, valerian and L-theanine — with a wind-down routine, dosing and safety.',
+    'An evidence-first guide to nighttime stress and anxiety: what current research says about L-theanine, passionflower, ashwagandha, valerian, sleep routines, and when supplements are the wrong tool.',
   alternates: { canonical: '/guides/anxiety/best-herbs-for-stress-and-anxiety-at-night/' },
   openGraph: {
-    title: 'Best Herbs for Stress and Anxiety at Night — Calm-Down Guide',
+    title: 'Best Herbs for Stress and Anxiety at Night: Evidence & Safety',
     description:
-      'Calming herbs for evening stress and racing thoughts, matched to how nighttime anxiety actually shows up — with a practical wind-down routine, dosing and safety.',
+      'Separate same-night claims from repeated-dose evidence, compare safety limits, and learn when chronic insomnia or anxiety deserves a stronger approach than supplements.',
     url: '/guides/anxiety/best-herbs-for-stress-and-anxiety-at-night/',
     type: 'article',
     images: ['/og-default.jpg'],
@@ -30,287 +30,299 @@ export const metadata: Metadata = {
 
 const FAQS = [
   {
-    question: 'Which herb is best for nighttime anxiety?',
+    question: 'What herb works fastest for nighttime anxiety?',
     answer:
-      'For most people, passionflower and lemon balm are the gentlest reliable starting points for evening anxiety, because they raise calming GABA tone without strong sedation. If the anxiety is clearly stress-hormone driven — the "wired but tired" pattern — ashwagandha taken in the evening addresses the cause rather than just the symptom. L-theanine is the fastest-acting option for racing thoughts at bedtime.',
+      'Current evidence does not establish a reliably fast herbal treatment for nighttime anxiety. L-theanine is often studied 30–60 minutes before cognitive testing, but a 2026 meta-analysis found its strongest acute signal in attention while anxiety outcomes were inconsistent. Study timing should not be converted into a guaranteed anxiety-relief onset.',
   },
   {
-    question: 'Can I take calming herbs every night?',
+    question: 'Is passionflower a reliable bedtime anxiety remedy?',
     answer:
-      'Gentle options like lemon balm, passionflower and L-theanine are generally well tolerated for regular evening use. Ashwagandha is designed for daily use over weeks. Sedating herbs such as valerian are better used in shorter courses. If you feel you cannot fall asleep at all without a herbal aid for more than a few weeks, treat that as a prompt to look at the underlying stress, schedule or a possible anxiety disorder with a clinician.',
+      'Not based on current evidence. NCCIH describes only a small amount of human research, with conclusions about anxiety not definite and mixed findings for sleep onset and staying asleep. Passionflower can also cause drowsiness, dizziness, and confusion and should not be used during pregnancy.',
   },
   {
-    question: 'Are calming herbs safe with anxiety medication?',
+    question: 'Does ashwagandha have a proven immediate bedtime effect?',
     answer:
-      'Not automatically. Sedating and GABA-active herbs can add to the effects of benzodiazepines, sleep medications and alcohol, and some adaptogens may interact with other drugs. If you take any prescription medication for anxiety, sleep or mood, check with a pharmacist or clinician before adding herbs rather than assuming "natural" means compatible.',
+      'Ashwagandha should not be framed as a same-night remedy. The better human evidence comes from repeated-dose trials and meta-analyses in adults with stress or anxiety symptoms using specific extracts over weeks. That does not establish an immediate effect or a class effect for every ashwagandha product.',
   },
   {
-    question: 'How fast do nighttime calming herbs work?',
+    question: 'What if anxiety keeps me awake most nights?',
     answer:
-      'L-theanine and passionflower tea can take the edge off within 30–60 minutes. Lemon balm is similar. Ashwagandha works on the stress system over 2–6 weeks and is not a same-night fix. Valerian is variable and tends to perform better after a week or two of consistent use.',
+      'Frequent nighttime anxiety and chronic insomnia deserve more than supplement ranking. Cognitive behavioral therapy for insomnia (CBT-I) is strongly recommended for chronic insomnia, and persistent or impairing anxiety should be evaluated rather than managed only with herbs.',
+  },
+  {
+    question: 'Can calming herbs be combined with sleep or anxiety medication?',
+    answer:
+      'Do not assume they are compatible. Sedating supplements can add to alcohol, sleep medicines, benzodiazepines, opioids, anesthesia, and other central-nervous-system depressants. Medication interactions and medical conditions should be reviewed with a pharmacist or clinician before regular use.',
   },
 ]
 
 const HEADINGS: Heading[] = [
-  { id: 'quick-answer', text: 'Quick answer', level: 2 },
-  { id: 'takeaways', text: 'Key takeaways', level: 2 },
-  { id: 'choose', text: 'Choose by how anxiety shows up at night', level: 2 },
-  { id: 'herbs', text: 'The calming herbs worth knowing', level: 2 },
-  { id: 'routine', text: 'A simple evening wind-down', level: 2 },
-  { id: 'risks', text: 'Risks & safety', level: 2 },
+  { id: 'bottom-line', text: 'Bottom line', level: 2 },
+  { id: 'bigger-question', text: 'Nighttime anxiety or chronic insomnia?', level: 2 },
+  { id: 'evidence', text: 'Evidence by ingredient', level: 2 },
+  { id: 'routine', text: 'What to prioritize tonight', level: 2 },
+  { id: 'safety', text: 'Safety and interactions', level: 2 },
+  { id: 'sources', text: 'Sources', level: 2 },
   { id: 'faq', text: 'Frequently asked questions', level: 2 },
 ]
 
-const BEST_HERBS_FOR_STRESS_AND_ANXIETY_AT_NIGHT_REFS = [
-  { n: 1, text: 'Sarris J, et al. (2013). Kava for GAD. J Clin Psychopharmacol, 33(5): 643-648.', url: 'https://pubmed.ncbi.nlm.nih.gov/23942365/' },
-  { n: 2, text: 'Chandrasekhar K, et al. (2012). Ashwagandha for stress. Indian J Psychol Med, 34(3): 255-262.', url: 'https://pubmed.ncbi.nlm.nih.gov/23439798/' },
-  { n: 3, text: 'Ngan A, Conduit R. (2011). Passionflower for sleep. Phytother Res, 25(8): 1153-1159.', url: 'https://pubmed.ncbi.nlm.nih.gov/21294203/' },
+const SOURCES = [
+  {
+    label: 'L-theanine systematic review and meta-analysis of 31 randomized trials (2026)',
+    href: 'https://pubmed.ncbi.nlm.nih.gov/42410082/',
+    note: '31 RCTs and 1,168 participants; robust short-term attention signal, modest bias-sensitive acute-stress effect, and inconsistent anxiety findings.',
+  },
+  {
+    label: 'Ashwagandha stress and anxiety systematic review and meta-analysis (2024)',
+    href: 'https://pubmed.ncbi.nlm.nih.gov/39348746/',
+    note: 'Nine randomized trials and 558 participants; repeated-dose evidence using specific formulations, with heterogeneity and unresolved long-term safety.',
+  },
+  {
+    label: 'NCCIH: Passionflower usefulness and safety',
+    href: 'https://www.nccih.nih.gov/health/passionflower',
+    note: 'Small amount of research; anxiety conclusions are not definite, sleep findings are mixed, and pregnancy/anesthesia cautions matter.',
+  },
+  {
+    label: 'NCCIH: Anxiety and complementary health approaches',
+    href: 'https://www.nccih.nih.gov/health/anxiety-and-complementary-health-approaches',
+    note: 'Complementary approaches can carry side effects and medication interactions and should not substitute for established care for an anxiety disorder.',
+  },
+  {
+    label: 'American Academy of Sleep Medicine: behavioral and psychological treatments for chronic insomnia',
+    href: 'https://aasm.org/new-guideline-supports-behavioral-psychological-treatments-for-insomnia/',
+    note: 'Strong recommendation for cognitive behavioral therapy for insomnia (CBT-I) in adults with chronic insomnia disorder.',
+  },
 ]
 
 export default function Page() {
   const toc = <TableOfContents headings={HEADINGS} />
   const ashwagandhaProducts = getRevenueProductSet('ashwagandha')
+
   return (
     <ArticleLayout toc={toc} zone="supplement">
       <StructuredData
         pageUrl={PAGE_URL}
-        headline="Best Herbs for Stress and Anxiety at Night"
-        description="Evidence-informed guide to calming herbs for nighttime stress and anxiety — passionflower, lemon balm, ashwagandha, magnolia, valerian and L-theanine — with a wind-down routine, dosing and safety."
+        headline="Best Herbs for Stress and Anxiety at Night: Evidence & Safety"
+        description="Evidence-first guide to nighttime stress and anxiety, including L-theanine, passionflower, ashwagandha, valerian, sleep routines, and safety."
         datePublished="2026-06-18"
-        dateModified="2026-06-18"
+        dateModified={DATE}
         faqs={FAQS}
         breadcrumbs={[
           { label: 'Home', href: '/' },
           { label: 'Guides', href: '/guides' },
-          { label: 'Best Herbs for Stress and Anxiety at Night', href: '/guides/anxiety/best-herbs-for-stress-and-anxiety-at-night' },
+          { label: 'Anxiety', href: '/guides/anxiety/' },
+          { label: 'Nighttime stress and anxiety', href: '/guides/anxiety/best-herbs-for-stress-and-anxiety-at-night' },
         ]}
       />
 
-      <div className="space-y-12">
+      <div className="space-y-10">
         <AffiliateDisclosure variant="compact" className="mb-6" />
-        {/* Hero */}
+
         <section className="hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-10">
-          <p className="eyebrow-label">Night routine guide</p>
+          <p className="eyebrow-label">Nighttime evidence guide</p>
           <h1 className="mt-3 text-3xl font-semibold tracking-tight text-ink sm:text-4xl">
             Best Herbs for Stress and Anxiety at Night
           </h1>
           <p className="mt-2 text-xs text-muted">
             Written and edited by{' '}
-            <Link href="/info/author/" rel="author" className="font-medium text-brand-700 hover:underline">Willie B. Randolph III</Link>
-            {' '}· Last updated June 2026
+            <Link href="/info/author/" rel="author" className="font-medium text-brand-700 hover:underline">
+              Willie B. Randolph III
+            </Link>{' '}
+            · Last evidence review August 11, 2026
           </p>
-          <p className="detail-reading mt-4 text-muted">
-            Nighttime is when stress finally gets your attention. With the distractions of the day gone,
-            the same worries circle back as racing thoughts, a tight chest, or a body that feels tired
-            but refuses to switch off. Calming herbs can genuinely help here — but only when matched to
-            how your evening anxiety actually shows up, and only alongside a consistent wind-down routine.
-            This guide covers the best-supported options and how to use them safely.
+          <p className="mt-4 max-w-3xl text-base leading-7 text-muted">
+            Nighttime stress, racing thoughts, and insomnia overlap, but they are not the same outcome.
+            Human trials do not support a universal “best herb” or a reliably fast supplement for bedtime
+            anxiety. This guide separates same-night claims from repeated-dose evidence and puts chronic
+            insomnia and persistent anxiety in the right treatment context.
           </p>
 
-        <figure className="mt-6">
-          <div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white">
-            <Image
-              src="/images/guides/best-herbs-for-stress-and-anxiety-at-night.jpg"
-              alt="Calming nighttime herbs — lavender, chamomile, passionflower — with herbal tea"
-              width={1536}
-              height={1024}
-              priority
-              className="w-full h-auto"
-            />
+          <figure className="mt-6">
+            <div className="overflow-hidden rounded-2xl border border-brand-900/10 bg-white shadow-sm">
+              <Image
+                src="/images/guides/best-herbs-for-stress-and-anxiety-at-night.jpg"
+                alt="Calming nighttime herbs including lavender, chamomile, and passionflower beside herbal tea"
+                width={1536}
+                height={1024}
+                priority
+                className="h-auto w-full"
+              />
+            </div>
+            <figcaption className="mt-3 text-center text-sm text-muted">
+              Bedtime supplement evidence varies sharply by ingredient, outcome, preparation, and duration.
+            </figcaption>
+          </figure>
+        </section>
+
+        <section id="bottom-line" className="card-premium scroll-mt-20 space-y-3 border-brand-700/30 bg-brand-50/60 p-6">
+          <p className="eyebrow-label">Bottom line</p>
+          <h2 className="text-2xl font-semibold text-ink">
+            No herb is proven to be a reliably fast treatment for nighttime anxiety
+          </h2>
+          <div className="space-y-3 text-muted">
+            <p>
+              <strong>L-theanine</strong> has short-term cognitive and stress research, but the July 2026
+              meta-analysis found anxiety effects inconsistent overall. The often-cited 30–60-minute window
+              describes study timing; the strongest robust result in that window was an attention outcome,
+              not demonstrated acute anxiety relief.
+            </p>
+            <p>
+              <strong>Passionflower</strong> has only a small amount of human research, and NCCIH says the
+              conclusions about anxiety are not definite. <strong>Ashwagandha</strong> has a more substantial
+              repeated-dose stress/anxiety signal, but that evidence comes from specific extracts studied over
+              weeks rather than a same-night bedtime effect.
+            </p>
           </div>
-          <figcaption className="mt-3 text-center text-sm text-muted">
-            Calming herbs best suited to nighttime stress and anxiety.
-          </figcaption>
-        </figure>
         </section>
 
-        {/* Fastest useful choice */}
-        <section className="card-premium scroll-mt-20 space-y-3 border-brand-700/30 bg-brand-50/60 p-6">
-          <p className="eyebrow-label">Fastest useful choice</p>
-          <h2 className="text-xl font-semibold text-ink">If you only try one thing: passionflower tea or L-theanine</h2>
-          <p className="text-muted">
-            <strong>For racing thoughts at bedtime, L-theanine 100–200&nbsp;mg is the fastest useful choice</strong>{' '}
-            — effects within 30–60 minutes, no sedation, no dependency. For a gentler route,{' '}
-            <Link href="/herbs/passionflower/" className="font-semibold text-brand-700 hover:underline">
-              passionflower
-            </Link>{' '}
-            tea is one of the most reliable calming bedtime options with mild evidence. Pair either with
-            dim light, no screens, and a consistent bedtime &mdash; the routine is what makes the herb land.
-            See the{' '}
-            <Link href="/guides/herbs/l-theanine/" className="font-semibold text-brand-700 hover:underline">
-              full L-theanine guide
-            </Link>{' '}
-            and the{' '}
-            <Link href="/guides/herbs/ashwagandha/" className="font-semibold text-brand-700 hover:underline">
-              ashwagandha guide
-            </Link>{' '}
-            for the deeper evidence reviews.
+        <section id="bigger-question" className="card-premium scroll-mt-20 space-y-4 p-6">
+          <p className="eyebrow-label">Start with the bigger question</p>
+          <h2 className="text-2xl font-semibold text-ink">Is the main problem occasional arousal, chronic insomnia, or persistent anxiety?</h2>
+          <div className="grid gap-4 sm:grid-cols-3">
+            <div className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+              <h3 className="font-semibold text-ink">Occasional stressful evening</h3>
+              <p className="mt-2 text-sm leading-6 text-muted">
+                Avoid converting a single stressful night into a supplement stack. A predictable wind-down,
+                lower stimulation, and protecting the sleep window are lower-complexity first steps.
+              </p>
+            </div>
+            <div className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+              <h3 className="font-semibold text-ink">Chronic insomnia</h3>
+              <p className="mt-2 text-sm leading-6 text-muted">
+                CBT-I has a strong guideline recommendation for adults with chronic insomnia. Sleep hygiene can
+                support it, but a ranked herb list is not an evidence-equivalent replacement.
+              </p>
+            </div>
+            <div className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+              <h3 className="font-semibold text-ink">Persistent or impairing anxiety</h3>
+              <p className="mt-2 text-sm leading-6 text-muted">
+                If anxiety is frequent, escalating, causing panic, or impairing daily life, treat that as an
+                anxiety-care question rather than a search for the strongest nighttime supplement.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section id="evidence" className="scroll-mt-20 space-y-5">
+          <p className="eyebrow-label">Evidence by ingredient</p>
+          <h2 className="text-2xl font-semibold text-ink">What the better human evidence actually supports</h2>
+
+          <article className="card-premium p-6">
+            <div className="flex flex-wrap items-center gap-2">
+              <h3 className="text-xl font-semibold text-brand-800">
+                <Link href="/guides/anxiety/l-theanine-for-anxiety/" className="hover:underline">L-theanine</Link>
+              </h3>
+              <span className="rounded-full bg-brand-50 px-3 py-0.5 text-xs font-semibold text-brand-800">Anxiety evidence: inconsistent</span>
+            </div>
+            <p className="mt-3 text-sm leading-7 text-muted">
+              The 2026 meta-analysis included 31 randomized trials and 1,168 participants. A single 200 mg dose
+              studied 30–60 minutes before cognitive testing improved choice reaction time; acute-stress reduction
+              was modest and sensitive to study quality, while anxiety effects were inconsistent and generally
+              non-significant. That does not support calling L-theanine a dependable same-night anxiolytic.
+            </p>
+          </article>
+
+          <article className="card-premium p-6">
+            <div className="flex flex-wrap items-center gap-2">
+              <h3 className="text-xl font-semibold text-brand-800">
+                <Link href="/herbs/passionflower/" className="hover:underline">Passionflower</Link>
+              </h3>
+              <span className="rounded-full bg-brand-50 px-3 py-0.5 text-xs font-semibold text-brand-800">Evidence: sparse</span>
+            </div>
+            <p className="mt-3 text-sm leading-7 text-muted">
+              NCCIH says passionflower has not been studied extensively. A small amount of research suggests
+              possible anxiety or pre-procedure benefit, but conclusions are not definite. For sleep, total sleep
+              time may improve in some studies while sleep-onset and sleep-maintenance findings are mixed.
+            </p>
+            <p className="mt-3 text-sm leading-7 text-muted">
+              Safety matters: drowsiness, dizziness, and confusion are possible; passionflower can interact with
+              anesthesia and should not be used during pregnancy because of uterine-contraction concerns.
+            </p>
+          </article>
+
+          <article className="card-premium p-6">
+            <div className="flex flex-wrap items-center gap-2">
+              <h3 className="text-xl font-semibold text-brand-800">
+                <Link href="/herbs/ashwagandha/" className="hover:underline">Ashwagandha</Link>
+              </h3>
+              <span className="rounded-full bg-brand-50 px-3 py-0.5 text-xs font-semibold text-brand-800">Repeated-dose signal</span>
+            </div>
+            <p className="mt-3 text-sm leading-7 text-muted">
+              A 2024 meta-analysis pooled nine randomized trials and 558 participants and reported reductions in
+              stress/anxiety measures and cortisol. The studies used specific formulations and repeated dosing;
+              they do not establish that every root powder or extract works the same way, and they do not prove a
+              same-night bedtime effect. Long-term safety remains less certain than short-trial safety.
+            </p>
+          </article>
+
+          <article className="card-premium p-6">
+            <div className="flex flex-wrap items-center gap-2">
+              <h3 className="text-xl font-semibold text-brand-800">
+                <Link href="/herbs/valerian/" className="hover:underline">Valerian and other sedating herbs</Link>
+              </h3>
+              <span className="rounded-full bg-brand-50 px-3 py-0.5 text-xs font-semibold text-brand-800">Do not over-rank</span>
+            </div>
+            <p className="mt-3 text-sm leading-7 text-muted">
+              Valerian, lemon balm, magnolia, and other calming herbs are frequently marketed for bedtime use,
+              but direct anxiety evidence is not strong enough to build a reliable symptom-to-herb ranking.
+              Sedation also changes the safety calculation, especially with alcohol, sleep medication,
+              benzodiazepines, opioids, or other central-nervous-system depressants.
+            </p>
+          </article>
+        </section>
+
+        <section id="routine" className="scroll-mt-20 space-y-4 rounded-[1.65rem] border border-brand-900/10 bg-brand-50/40 p-6">
+          <p className="eyebrow-label">Lower-risk first layer</p>
+          <h2 className="text-xl font-semibold text-ink">What to prioritize tonight before adding another supplement</h2>
+          <ul className="space-y-2 text-sm leading-7 text-muted">
+            <li>• Protect a consistent sleep opportunity and reduce avoidable late stimulation rather than chasing a stronger sedative effect.</li>
+            <li>• If caffeine is contributing to evening arousal, changing caffeine timing is more direct than adding a supplement to counteract it.</li>
+            <li>• A short written “brain dump,” relaxation exercise, or low-stimulation wind-down can be useful components of a bedtime routine.</li>
+            <li>• If insomnia is chronic, move beyond sleep-hygiene tips and consider CBT-I, which has stronger guideline support than supplement ranking.</li>
+          </ul>
+          <p className="text-xs leading-6 text-muted">
+            A bedtime routine is not a substitute for evaluation when anxiety, depression, panic, trauma symptoms,
+            sleep apnea, restless legs, substance use, medication effects, or another condition may be driving the sleep problem.
           </p>
         </section>
 
-        {/* Quick Answer */}
-        <section id="quick-answer" className="card-premium scroll-mt-20 space-y-3 p-6">
-          <h2 className="text-2xl font-semibold text-ink">Quick answer</h2>
-          <p className="text-muted">
-            For racing thoughts at bedtime, start with{' '}
-            <strong className="text-ink">L-theanine</strong> (100–200&nbsp;mg) or a cup of{' '}
-            <strong className="text-ink">passionflower</strong> tea. For the &ldquo;wired but tired&rdquo;
-            pattern driven by stress hormones, take{' '}
-            <strong className="text-ink">ashwagandha</strong> in the evening and give it a few weeks. For
-            mild restlessness, <strong className="text-ink">lemon balm</strong> and{' '}
-            <strong className="text-ink">magnolia bark</strong> are gentle traditional options, with{' '}
-            <strong className="text-ink">valerian</strong> reserved for short courses. Pair any of these
-            with dim light, a screen curfew and a steady bedtime — the herb is the smaller lever.
-          </p>
-        </section>
-
-        {/* Key Takeaways */}
-        <section id="takeaways" className="scroll-mt-20 space-y-4">
-          <h2 className="text-2xl font-semibold text-ink">Key takeaways</h2>
-          <ul className="space-y-2 text-muted">
-            <li>• <strong className="text-ink">Identify the pattern first:</strong> racing mind, physical tension, or stress-hormone &ldquo;wired but tired.&rdquo; Each responds to a different herb.</li>
-            <li>• <strong className="text-ink">Fast vs foundational:</strong> L-theanine, passionflower and lemon balm work the same night; ashwagandha works on the cause over weeks.</li>
-            <li>• <strong className="text-ink">Gentle before strong:</strong> begin with the lowest-risk options before reaching for sedating herbs like valerian.</li>
-            <li>• <strong className="text-ink">Routine multiplies the effect:</strong> dim light, no late caffeine and a consistent bedtime make every herb work better.</li>
-            <li>• <strong className="text-ink">Persistent nighttime anxiety</strong> that disrupts daily life deserves a clinician&rsquo;s input, not just supplements.</li>
+        <section id="safety" className="scroll-mt-20 space-y-3 rounded-[1.65rem] border border-amber-200 bg-amber-50/70 p-6">
+          <h2 className="text-xl font-semibold text-amber-900">Safety and interactions</h2>
+          <ul className="space-y-2 text-sm leading-7 text-amber-900">
+            <li>• Do not assume “natural” means non-sedating or interaction-free. Alcohol and prescription sedatives can compound impairment.</li>
+            <li>• <strong>Passionflower:</strong> possible drowsiness, dizziness, and confusion; avoid during pregnancy and discuss use around surgery/anesthesia.</li>
+            <li>• <strong>Ashwagandha:</strong> pregnancy, thyroid, autoimmune, medication, and rare liver-injury concerns deserve specific review.</li>
+            <li>• <strong>L-theanine:</strong> short trials are generally reassuring, but that does not establish unlimited long-term safety or compatibility with every medication or condition.</li>
+            <li>• If nighttime anxiety is frequent, severe, or impairing, supplements should not delay established mental-health or sleep care.</li>
           </ul>
         </section>
 
-        {/* Match pattern */}
-        <section id="choose" className="scroll-mt-20 space-y-4">
-          <p className="eyebrow-label">Match to your pattern</p>
-          <h2 className="text-2xl font-semibold text-ink">Choose by how anxiety shows up at night</h2>
-          <div className="grid gap-4 sm:grid-cols-2">
-            {[
-              { pattern: 'Racing thoughts you cannot switch off', pick: 'L-theanine, then passionflower', href: '/compounds/l-theanine' },
-              { pattern: '"Wired but tired" — stress hormones high', pick: 'Ashwagandha in the evening', href: '/herbs/ashwagandha' },
-              { pattern: 'Restless, tense, mild worry', pick: 'Lemon balm or magnolia bark', href: '/herbs/melissa-officinalis' },
-              { pattern: 'Anxiety plus trouble staying asleep', pick: 'Passionflower + magnesium', href: '/herbs/passionflower/' },
-              { pattern: 'Occasional, situational restlessness', pick: 'Valerian (short course)', href: '/herbs/valerian' },
-              { pattern: 'Stress carried over from the whole day', pick: 'Magnesium glycinate base', href: '/compounds/magnesium-glycinate' },
-            ].map((row) => (
-              <Link key={row.pattern} href={row.href} className="card-premium block p-5 transition hover:border-brand-700/40">
-                <p className="text-xs font-semibold uppercase tracking-wider text-muted">If it shows up as</p>
-                <p className="mt-1 text-sm font-semibold text-ink">{row.pattern}</p>
-                <p className="mt-2 text-xs font-bold uppercase tracking-wider text-brand-700">Start with</p>
-                <p className="mt-1 text-sm font-medium text-brand-800">{row.pick} →</p>
-              </Link>
+        <section id="sources" className="card-premium scroll-mt-20 space-y-4 p-6">
+          <h2 className="text-2xl font-semibold text-ink">Sources and directness notes</h2>
+          <ol className="space-y-4">
+            {SOURCES.map((source, index) => (
+              <li key={source.href} className="text-sm leading-7 text-muted">
+                <span className="font-semibold text-ink">{index + 1}. </span>
+                <a href={source.href} target="_blank" rel="noopener noreferrer" className="font-semibold text-brand-700 hover:underline">
+                  {source.label}
+                </a>
+                <span> — {source.note}</span>
+              </li>
             ))}
-          </div>
-        </section>
-
-        {/* Evidence overview */}
-        <section id="herbs" className="scroll-mt-20 space-y-5">
-          <p className="eyebrow-label">Evidence overview</p>
-          <h2 className="text-2xl font-semibold text-ink">The calming herbs worth knowing</h2>
-
-          <article className="card-premium p-6">
-            <h3 className="text-xl font-semibold text-brand-800">
-              <Link href="/herbs/passionflower/" className="hover:underline">Passionflower</Link>
-            </h3>
-            <p className="mt-3 text-sm text-muted">
-              Passionflower raises GABA activity and has small but encouraging trials for anxiety and
-              restless sleep. It is one of the gentlest ways to take the edge off bedtime worry, used as a
-              tea or extract. A practical first choice when the issue is anxiety rather than deep
-              tiredness. See the dedicated{' '}
-              <Link href="/guides/passionflower/" className="font-medium text-brand-700 hover:underline">passionflower guide</Link>.
-            </p>
-          </article>
-
-          <article className="card-premium p-6">
-            <h3 className="text-xl font-semibold text-brand-800">
-              <Link href="/herbs/melissa-officinalis/" className="hover:underline">Lemon balm (Melissa)</Link>
-            </h3>
-            <p className="mt-3 text-sm text-muted">
-              A mild, pleasant calming herb with traditional and some clinical support for reducing
-              stress and improving calm, especially when combined with valerian. Good for low-grade
-              evening tension and easy to take as a tea before bed.
-            </p>
-          </article>
-
-          <article className="card-premium p-6">
-            <h3 className="text-xl font-semibold text-brand-800">
-              <Link href="/herbs/ashwagandha/" className="hover:underline">Ashwagandha</Link>{' '}
-              <span className="ml-2 rounded-full bg-brand-50 px-3 py-0.5 align-middle text-xs font-semibold text-brand-800">Best for &ldquo;wired but tired&rdquo;</span>
-            </h3>
-            <p className="mt-3 text-sm text-muted">
-              The most clinically studied adaptogen for stress. By moderating the HPA axis and lowering
-              cortisol, evening ashwagandha targets the root of stress-driven wakefulness rather than
-              just sedating you. Allow 2–6 weeks of consistent use. Learn how it compares in{' '}
-              <Link href="/guides/compare/rhodiola-vs-ashwagandha/" className="font-medium text-brand-700 hover:underline">rhodiola vs ashwagandha</Link>{' '}
-              and our{' '}
-              <Link href="/guides/anxiety/how-to-lower-cortisol-naturally/" className="font-medium text-brand-700 hover:underline">how to lower cortisol naturally</Link>{' '}
-              guide.
-            </p>
-          </article>
-
-          <article className="card-premium p-6">
-            <h3 className="text-xl font-semibold text-brand-800">
-              <Link href="/herbs/magnolia-officinalis/" className="hover:underline">Magnolia bark</Link> &amp;{' '}
-              <Link href="/herbs/valerian/" className="hover:underline">valerian</Link>
-            </h3>
-            <p className="mt-3 text-sm text-muted">
-              Magnolia&rsquo;s honokiol acts on GABA receptors and is used traditionally for evening
-              tension. Valerian is more sedating and better evidenced for sleep onset, but results vary by
-              extract and it is best in short courses. Keep either away from alcohol and other sedatives.
-            </p>
-          </article>
-
-          <article className="card-premium p-6">
-            <h3 className="text-xl font-semibold text-brand-800">
-              <Link href="/compounds/l-theanine/" className="hover:underline">L-theanine</Link>{' '}
-              <span className="ml-2 rounded-full bg-brand-50 px-3 py-0.5 align-middle text-xs font-semibold text-brand-800">Fastest for racing thoughts</span>
-            </h3>
-            <p className="mt-3 text-sm text-muted">
-              Not a herb but the most reliable fast-acting option for mental noise: 100–200&nbsp;mg quiets
-              stress-driven arousal within an hour without sedation, and it stacks cleanly with magnesium
-              or passionflower. See{' '}
-              <Link href="/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium/" className="font-medium text-brand-700 hover:underline">L-theanine vs magnesium</Link>.
-            </p>
-          </article>
-        </section>
-
-        {/* Wind-down routine */}
-        <section id="routine" className="scroll-mt-20 space-y-3 rounded-[1.65rem] border border-brand-900/10 bg-brand-50/40 p-6">
-          <h2 className="text-xl font-semibold text-ink">A simple evening wind-down</h2>
-          <ol className="list-decimal space-y-2 pl-5 text-sm text-muted">
-            <li>Set a caffeine curfew — nothing after early afternoon if evenings are when anxiety peaks.</li>
-            <li>Dim lights and reduce screens 60–90&nbsp;minutes before bed to let melatonin rise naturally.</li>
-            <li>Take your chosen calming herb or L-theanine 30–60&nbsp;minutes before bed.</li>
-            <li>Offload the racing mind: a two-minute &ldquo;brain dump&rdquo; on paper beats fighting it lying down.</li>
-            <li>Keep a consistent bedtime — a steady schedule is the most powerful anti-anxiety lever you have.</li>
           </ol>
         </section>
 
-        {/* Risks & safety */}
-        <section id="risks" className="scroll-mt-20 space-y-3 rounded-[1.65rem] border border-amber-200 bg-amber-50/70 p-6">
-          <h2 className="text-xl font-semibold text-amber-900">Risks &amp; safety</h2>
-          <ul className="space-y-2 text-sm text-amber-900">
-            <li>• Do not combine sedating herbs (valerian, passionflower, magnolia) with alcohol, benzodiazepines, sleep medication, or opioids &mdash; additive CNS depression is a real safety risk.</li>
-            <li>• <strong>Ashwagandha:</strong> avoid in pregnancy and breastfeeding; rare hepatotoxicity reported; caution with thyroid conditions, autoimmune disease, and immunosuppressants.</li>
-            <li>• <strong>Valerian:</strong> avoid in pregnancy; do not combine with sedatives; short courses only.</li>
-            <li>• <strong>Passionflower:</strong> avoid in pregnancy (uterotonic activity in animal models); do not combine with prescription sedatives.</li>
-            <li>• <strong>Lemon balm:</strong> caution with sedatives and thyroid medications.</li>
-            <li>• Herbs are educational support, not a treatment for diagnosed anxiety disorders, panic disorder, PTSD, or OCD.</li>
-            <li>• If nighttime anxiety is frequent, intense, or paired with low mood, panic, or suicidal thoughts, contact a clinician &mdash; this is a mental health concern that supplements cannot address.</li>
-          </ul>
-        </section>
+        {ashwagandhaProducts ? (
+          <RecommendationSection products={ashwagandhaProducts.products} />
+        ) : null}
 
-        {ashwagandhaProducts && (
-        <>
-          <References refs={BEST_HERBS_FOR_STRESS_AND_ANXIETY_AT_NIGHT_REFS} />
-            <RecommendationSection products={ashwagandhaProducts.products} />
-        </>
-        )}
-
-        {/* FAQs */}
         <section id="faq" className="scroll-mt-20 space-y-4">
           <h2 className="text-2xl font-semibold text-ink">Frequently asked questions</h2>
           <div className="space-y-3">
             {FAQS.map((faq) => (
               <details key={faq.question} className="card-premium p-5">
                 <summary className="cursor-pointer text-base font-semibold text-ink">{faq.question}</summary>
-                <p className="mt-2 text-sm text-muted">{faq.answer}</p>
+                <p className="mt-2 text-sm leading-7 text-muted">{faq.answer}</p>
               </details>
             ))}
           </div>
@@ -318,15 +330,14 @@ export default function Page() {
 
         <EmailCapture location="guides-best-herbs-for-stress-and-anxiety-at-night" className="mt-6" />
 
-        {/* Related */}
         <section className="space-y-4">
-          <h2 className="text-2xl font-semibold text-ink">Related guides &amp; comparisons</h2>
+          <h2 className="text-2xl font-semibold text-ink">Related evidence guides</h2>
           <div className="grid gap-3 sm:grid-cols-2">
-            <Link href="/guides/sleep/best-natural-sleep-aids-that-work/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Best Natural Sleep Aids That Work →</Link>
+            <Link href="/guides/sleep/best-natural-sleep-aids-that-work/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Natural Sleep Aids: Evidence & Safety →</Link>
+            <Link href="/guides/anxiety/natural-anxiety-relief/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Natural Anxiety Relief: Current Evidence →</Link>
+            <Link href="/guides/anxiety/l-theanine-for-anxiety/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">L-Theanine for Anxiety →</Link>
+            <Link href="/guides/anxiety/ashwagandha-for-anxiety/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Ashwagandha for Anxiety →</Link>
             <Link href="/guides/anxiety/best-herbs-for-anxiety/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Best Herbs for Anxiety →</Link>
-            <Link href="/guides/anxiety/how-to-lower-cortisol-naturally/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">How to Lower Cortisol Naturally →</Link>
-            <Link href="/guides/anxiety/natural-anxiolytics-beyond-ashwagandha/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Natural Anxiolytics Beyond Ashwagandha →</Link>
-            <Link href="/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">Ashwagandha vs L-theanine vs Magnesium →</Link>
             <Link href="/guides/anxiety/" className="card-premium block p-4 text-sm font-semibold text-brand-700 hover:border-brand-700/40">All Anxiety Guides →</Link>
           </div>
         </section>

--- a/app/guides/anxiety/best-herbs-for-stress-and-anxiety-at-night/page.tsx
+++ b/app/guides/anxiety/best-herbs-for-stress-and-anxiety-at-night/page.tsx
@@ -42,7 +42,7 @@ const FAQS = [
   {
     question: 'Does ashwagandha have a proven immediate bedtime effect?',
     answer:
-      'Ashwagandha should not be framed as a same-night remedy. The better human evidence comes from repeated-dose trials and meta-analyses in adults with stress or anxiety symptoms using specific extracts over weeks. That does not establish an immediate effect or a class effect for every ashwagandha product.',
+      'No immediate bedtime effect has been established. The better human evidence comes from repeated-dose trials and meta-analyses in adults with stress or anxiety symptoms using specific extracts over weeks. That does not establish an acute effect or a class effect for every ashwagandha product.',
   },
   {
     question: 'What if anxiety keeps me awake most nights?',
@@ -75,7 +75,12 @@ const SOURCES = [
   {
     label: 'Ashwagandha stress and anxiety systematic review and meta-analysis (2024)',
     href: 'https://pubmed.ncbi.nlm.nih.gov/39348746/',
-    note: 'Nine randomized trials and 558 participants; repeated-dose evidence using specific formulations, with heterogeneity and unresolved long-term safety.',
+    note: 'Nine randomized trials and 558 participants; pooled effects versus placebo using specific formulations, with heterogeneity and unresolved long-term safety.',
+  },
+  {
+    label: 'Ashwagandha root-extract randomized trial in adults with moderate stress and anxiety (2026)',
+    href: 'https://pubmed.ncbi.nlm.nih.gov/41815853/',
+    note: '141 healthy adults ages 18–65; 8-week three-arm trial comparing 300 mg proprietary root extract twice daily, another root extract, and placebo.',
   },
   {
     label: 'NCCIH: Passionflower usefulness and safety',
@@ -248,10 +253,12 @@ export default function Page() {
               <span className="rounded-full bg-brand-50 px-3 py-0.5 text-xs font-semibold text-brand-800">Repeated-dose signal</span>
             </div>
             <p className="mt-3 text-sm leading-7 text-muted">
-              A 2024 meta-analysis pooled nine randomized trials and 558 participants and reported reductions in
-              stress/anxiety measures and cortisol. The studies used specific formulations and repeated dosing;
-              they do not establish that every root powder or extract works the same way, and they do not prove a
-              same-night bedtime effect. Long-term safety remains less certain than short-trial safety.
+              A 2024 meta-analysis pooled nine randomized placebo-controlled trials and 558 participants and
+              reported reductions in stress/anxiety measures and cortisol. A representative 2026 trial enrolled
+              141 healthy men and women ages 18–65 with moderate stress and anxiety and randomized them for
+              8 weeks to 300 mg of a proprietary ashwagandha root extract twice daily, another root extract, or
+              placebo. That is repeated-dose, formulation-specific evidence in stressed adults—not evidence of an
+              immediate bedtime effect or a class effect for every powder, extract, or product shown below.
             </p>
           </article>
 
@@ -294,6 +301,7 @@ export default function Page() {
             <li>• <strong>Ashwagandha:</strong> pregnancy, thyroid, autoimmune, medication, and rare liver-injury concerns deserve specific review.</li>
             <li>• <strong>L-theanine:</strong> short trials are generally reassuring, but that does not establish unlimited long-term safety or compatibility with every medication or condition.</li>
             <li>• If nighttime anxiety is frequent, severe, or impairing, supplements should not delay established mental-health or sleep care.</li>
+            <li>• <strong>Immediate stop rule:</strong> if anxiety comes with suicidal thoughts, thoughts of self-harm, an inability to stay safe, or imminent danger, seek immediate emergency or crisis care rather than trying another supplement.</li>
           </ul>
         </section>
 


### PR DESCRIPTION
High-ROI evidence/trust rebuild of the nighttime stress/anxiety guide.

- removes the old “fastest useful choice,” 30–60-minute anxiety-onset promises, “stacks cleanly,” and symptom-to-supplement prescription grid
- updates L-theanine to the July 2026 meta-analysis: strong short-term attention signal, modest bias-sensitive acute-stress effect, inconsistent anxiety findings
- reframes ashwagandha around repeated-dose extract evidence rather than “targets the root cause” or same-night claims
- replaces passionflower reliability language with current NCCIH evidence limits plus drowsiness, pregnancy, and anesthesia cautions
- stops over-ranking valerian, lemon balm, magnolia, and other sedating herbs where direct anxiety evidence is insufficient
- puts chronic insomnia in the CBT-I guideline context rather than treating supplement escalation as an equivalent path
- preserves route/SEO metadata, image, structured-data FAQs, affiliate disclosure, ashwagandha sourcing, email capture, and internal discovery

Regression coverage locks the current evidence anchors, bans the stale rapid-treatment language, requires passionflower safety context, and preserves CBT-I framing plus monetization/discovery plumbing.