### PR TITLE
Rebuild anxiety stack guide around ingredient-level evidence

### DIFF
--- a/app/__tests__/anxiety-stack-current-evidence.test.ts
+++ b/app/__tests__/anxiety-stack-current-evidence.test.ts
@@ -1,0 +1,91 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const PAGE = path.join(process.cwd(), 'app/guides/anxiety/anxiety-stack-guide/page.tsx')
+
+function source() {
+  return fs.readFileSync(PAGE, 'utf8').replace(/\s+/g, ' ')
+}
+
+describe('anxiety stack evidence calibration', () => {
+  it('anchors ingredient claims to current systematic reviews and direct trial context', () => {
+    const text = source()
+
+    expect(text).toContain('42410082')
+    expect(text).toContain('39348746')
+    expect(text).toContain('41815853')
+    expect(text).toContain('38817505')
+    expect(text).toContain('31 RCTs and 1,168 participants')
+    expect(text).toContain('Nine placebo-controlled RCTs / 558 participants')
+    expect(text).toContain('141 healthy adults ages 18–65 with moderate stress/anxiety for 8 weeks')
+    expect(text).toContain('300 mg proprietary root extract twice daily')
+    expect(text).toContain('15 interventional studies in the 2024 review; seven measured anxiety-related outcomes')
+    expect(text).toContain("const DATE = '2026-08-11'")
+  })
+
+  it('does not restore named stack recipes or rapid-anxiety promises', () => {
+    const text = source()
+
+    expect(text).not.toMatch(/Fastest useful choice/i)
+    expect(text).not.toMatch(/Beginner Stack:/i)
+    expect(text).not.toMatch(/Stress Stack:/i)
+    expect(text).not.toMatch(/Racing Thoughts Stack:/i)
+    expect(text).not.toMatch(/Anxiety \+ Sleep Stack:/i)
+    expect(text).not.toMatch(/Full Stack:/i)
+    expect(text).not.toMatch(/works within 30[–-]60 minutes/i)
+    expect(text).not.toMatch(/most reliable beginner stack/i)
+    expect(text).not.toMatch(/synergy — using lower doses of multiple compounds/i)
+  })
+
+  it('states the central combination-evidence boundary', () => {
+    const text = source()
+
+    expect(text).toMatch(/Ingredient evidence does not validate a named anxiety stack/i)
+    expect(text).toMatch(/A positive trial for one ingredient does not tell us whether adding a second or third ingredient improves the outcome/i)
+    expect(text).toMatch(/Combining ingredients creates a new evidence and interaction question/i)
+    expect(text).toMatch(/changing one variable at a time is easier to interpret/i)
+  })
+
+  it('keeps the three ingredient evidence limits distinct', () => {
+    const text = source()
+
+    expect(text).toMatch(/Acute stress effect was modest and bias-sensitive; anxiety findings were inconsistent overall/i)
+    expect(text).toMatch(/Repeated-dose, formulation-specific evidence in stressed adults; long-term safety remains less certain/i)
+    expect(text).toMatch(/Populations, salts, doses, durations, baseline status, and co-ingredients varied substantially/i)
+  })
+
+  it('uses the canonical guide route in metadata and structured data', () => {
+    const text = source()
+
+    expect(text).toContain('path: `/guides/anxiety/${SLUG}`')
+    expect(text).toContain('`/guides/anxiety/${SLUG}/`')
+    expect(text).not.toContain('`/articles/${slug}`')
+  })
+
+  it('includes clear medication, complexity, and crisis stop rules', () => {
+    const text = source()
+
+    expect(text).toMatch(/Review medications and health conditions first/i)
+    expect(text).toMatch(/Multiple sedating substances/i)
+    expect(text).toMatch(/suicidal thoughts/i)
+    expect(text).toMatch(/thoughts of self-harm/i)
+    expect(text).toMatch(/inability to stay safe/i)
+    expect(text).toMatch(/immediate emergency or crisis care/i)
+  })
+
+  it('preserves evidence discovery and symmetric neutral monetization plumbing', () => {
+    const text = source()
+
+    expect(text).toContain('/guides/anxiety/l-theanine-for-anxiety/')
+    expect(text).toContain('/guides/anxiety/ashwagandha-for-anxiety/')
+    expect(text).toContain('/guides/other/magnesium-types-guide/')
+    expect(text).toContain("getRevenueProductSet('ashwagandha')")
+    expect(text).toContain("getRevenueProductSet('l-theanine')")
+    expect(text).toContain("getRevenueProductSet('magnesium')")
+    expect(text).toContain('<RecommendationSection products={comparisonProducts} />')
+    expect(text).toMatch(/cover the three ingredients compared on this page—ashwagandha, L-theanine, and magnesium/i)
+    expect(text).toContain('<NewsletterCtaBlock />')
+    expect(text).toContain('<EmailCapture />')
+  })
+})

--- a/app/guides/anxiety/anxiety-stack-guide/page.tsx
+++ b/app/guides/anxiety/anxiety-stack-guide/page.tsx
@@ -1,483 +1,315 @@
-import Link from 'next/link';
-import Image from 'next/image';
+import Link from 'next/link'
+import Image from 'next/image'
 import JsonLd from '@/components/seo/JsonLd'
 import {
   buildPageMetadata,
   blogJsonLd,
   breadcrumbJsonLd,
   faqPageJsonLd,
-  compactMetaTitle
-} from '../../../../src/lib/seo';
-import LastUpdatedBadge from '../../../../src/components/editorial/LastUpdatedBadge';
-import ResponsiveTable from '@/components/ui/ResponsiveTable';
-import SafetyNotice from '@/components/evidence/SafetyNotice';
-import EmailCapture from '@/components/EmailCapture';
-import { getRevenueProductSet } from '@/config/revenue-products';
-import RecommendationSection from '@/components/RecommendationSection';
-import NewsletterCtaBlock from '@/components/NewsletterCtaBlock';
-import { AFFILIATE_TAGS } from '@/config/affiliate';
+  compactMetaTitle,
+} from '../../../../src/lib/seo'
+import LastUpdatedBadge from '../../../../src/components/editorial/LastUpdatedBadge'
+import ResponsiveTable from '@/components/ui/ResponsiveTable'
+import SafetyNotice from '@/components/evidence/SafetyNotice'
+import EmailCapture from '@/components/EmailCapture'
+import { getRevenueProductSet } from '@/config/revenue-products'
+import RecommendationSection from '@/components/RecommendationSection'
+import NewsletterCtaBlock from '@/components/NewsletterCtaBlock'
 
-const articleTitle = "Anxiety Stack Guide: Ashwagandha, L-Theanine, Magnesium, and Practical Combinations";
-const articleDescription = "An evidence-based guide to anxiety supplement stacks, including ashwagandha, L-theanine, magnesium, safety considerations, timing, and who should consider each approach.";
-const lastUpdated = "2026-06-10";
-const slug = "anxiety-stack-guide";
+const SLUG = 'anxiety-stack-guide'
+const TITLE = 'Anxiety Supplement Stacks: Evidence, Interactions, and Safer Combination Rules'
+const DESCRIPTION =
+  'An evidence-first anxiety stack guide: what current research actually supports for L-theanine, ashwagandha, and magnesium, why ingredient evidence does not validate a named stack, and how to reduce avoidable combination risk.'
+const DATE = '2026-08-11'
 
 export const metadata = buildPageMetadata({
-  title: compactMetaTitle(articleTitle),
-  description: articleDescription,
-  path: `/guides/anxiety/${slug}`,
+  title: compactMetaTitle(TITLE),
+  description: DESCRIPTION,
+  path: `/guides/anxiety/${SLUG}`,
   openGraphType: 'article',
-});
+})
 
-const breadcrumbs = [
-  { name: 'Home', url: '/' },
-  { name: 'Anxiety', url: '/guides/anxiety/natural-anxiety-relief/' },
-  { name: 'Anxiety Stack Guide', url: `/articles/${slug}` },
-];
+const FAQS = [
+  {
+    question: 'What is the best anxiety supplement stack?',
+    answer:
+      'Current evidence does not establish a universal best stack. L-theanine, ashwagandha, and magnesium have been studied mostly as individual interventions or in heterogeneous formulations. Evidence for one ingredient cannot be assumed to prove that a named multi-supplement combination is more effective or safer.',
+  },
+  {
+    question: 'Can I combine ashwagandha and L-theanine?',
+    answer:
+      'The combination is commercially common, but ingredient-level evidence does not validate the pair as a treatment. Ashwagandha evidence is primarily repeated-dose and formulation-specific, while a 2026 L-theanine meta-analysis found inconsistent anxiety effects. Adding both together also makes benefit, side effects, and interactions harder to attribute.',
+  },
+  {
+    question: 'Can I combine magnesium with anxiety supplements?',
+    answer:
+      'Magnesium is often included in combination products, but the 2024 systematic review found heterogeneous populations, formulations, doses, durations, and some multi-ingredient trials. That makes it difficult to infer what magnesium contributes to a specific stack. Kidney disease and medication timing can also materially change magnesium safety.',
+  },
+  {
+    question: 'How fast should an anxiety stack work?',
+    answer:
+      'There is no evidence-based onset time for an anxiety stack. L-theanine is often studied 30–60 minutes before cognitive testing, but its robust acute signal was attention rather than reliable anxiety relief. Ashwagandha evidence is generally repeated-dose over weeks, while magnesium studies vary widely in duration and population.',
+  },
+  {
+    question: 'Is starting several supplements at once a good way to test a stack?',
+    answer:
+      'Starting several new ingredients together makes it harder to identify what helped or caused a side effect and increases interaction complexity. If a clinician or pharmacist agrees that supplementation is reasonable, changing one variable at a time is easier to interpret than beginning a multi-ingredient regimen all at once.',
+  },
+  {
+    question: 'When is a supplement stack the wrong tool for anxiety?',
+    answer:
+      'Persistent, worsening, panic-level, or functionally impairing anxiety deserves established mental-health care rather than supplement escalation. Suicidal thoughts, thoughts of self-harm, inability to stay safe, or imminent danger require immediate emergency or crisis care.',
+  },
+]
+
+const SOURCES = [
+  {
+    label: 'L-theanine systematic review and meta-analysis of 31 randomized trials (2026)',
+    href: 'https://pubmed.ncbi.nlm.nih.gov/42410082/',
+    note: '31 RCTs and 1,168 participants; robust short-term attention signal, modest bias-sensitive acute-stress effect, and inconsistent anxiety findings.',
+  },
+  {
+    label: 'Ashwagandha stress and anxiety systematic review and meta-analysis (2024)',
+    href: 'https://pubmed.ncbi.nlm.nih.gov/39348746/',
+    note: 'Nine randomized trials and 558 participants; pooled stress/anxiety signals versus placebo using specific formulations, with long-term safety still less certain.',
+  },
+  {
+    label: 'Ashwagandha root-extract randomized trial in adults with moderate stress and anxiety (2026)',
+    href: 'https://pubmed.ncbi.nlm.nih.gov/41815853/',
+    note: '141 healthy adults ages 18–65; 8-week three-arm trial comparing 300 mg proprietary root extract twice daily, another root extract, and placebo.',
+  },
+  {
+    label: 'Magnesium anxiety and sleep systematic review (2024)',
+    href: 'https://pubmed.ncbi.nlm.nih.gov/38817505/',
+    note: '15 interventional studies, seven with anxiety outcomes; heterogeneity in populations, formulations, doses, durations, and co-ingredients limits firm conclusions.',
+  },
+  {
+    label: 'NIH Office of Dietary Supplements: Magnesium fact sheet for health professionals',
+    href: 'https://ods.od.nih.gov/factsheets/Magnesium-HealthProfessional/',
+    note: 'Safety, tolerable upper-intake context for supplemental magnesium, kidney-risk considerations, and medication interactions.',
+  },
+]
 
 export default function AnxietyStackGuidePage() {
-  const faqItems = [
-    {
-      question: "What is the best anxiety stack?",
-      answer: "There is no single 'best' stack. The most appropriate combination depends on whether anxiety is primarily driven by chronic stress, racing thoughts, or sleep issues. Starting simple (e.g., magnesium only) and adding one supplement at a time is generally safer than combining many at once."
-    },
-    {
-      question: "Can I combine ashwagandha and L-theanine?",
-      answer: "Many people use them together for complementary effects (longer-term stress adaptation + more acute calm focus). Limited published research exists on the specific combination. Introduce one at a time and monitor how you feel."
-    },
-    {
-      question: "Can I combine magnesium and ashwagandha?",
-      answer: "This is a common and generally well-tolerated pairing. Magnesium often supports physical relaxation while ashwagandha targets stress response. As with any stack, start low and consult a clinician if you take medications."
-    },
-    {
-      question: "How long do anxiety supplements take to work?",
-      answer: "L-theanine often produces noticeable effects within 30–60 minutes. Ashwagandha typically requires consistent daily use over 2–8 weeks. Magnesium effects can vary from hours (for relaxation) to days/weeks depending on the form and individual status."
-    },
-    {
-      question: "Are anxiety stacks safe?",
-      answer: "When used thoughtfully and one at a time, many people tolerate these supplements well. However, combining multiple supplements increases the chance of interactions or side effects. People on psychiatric medications, sedatives, or with certain medical conditions should consult a healthcare provider first."
-    },
-    {
-      question: "Can anxiety stacks help with sleep?",
-      answer: "Yes, particularly when anxiety interferes with sleep. Ashwagandha and L-theanine have both been studied in the context of stress-related sleep issues. See the Sleep Stack Guide for more targeted combinations."
-    }
-  ];
-
-  const post = {
-    title: articleTitle,
-    description: articleDescription,
-    slug: slug,
-    date: lastUpdated,
-  };
-
+  const breadcrumbs = breadcrumbJsonLd([
+    { name: 'Guides', url: 'https://thehippiescientist.net/guides/' },
+    { name: 'Anxiety', url: 'https://thehippiescientist.net/guides/anxiety/' },
+    { name: TITLE, url: `https://thehippiescientist.net/guides/anxiety/${SLUG}/` },
+  ])
+  const articleLd = blogJsonLd(
+    { title: TITLE, slug: SLUG, date: DATE, description: DESCRIPTION },
+    `/guides/anxiety/${SLUG}/`,
+  )
+  const faqLd = faqPageJsonLd({ pagePath: `/guides/anxiety/${SLUG}/`, questions: FAQS })
+  const comparisonProducts = [
+    ...(getRevenueProductSet('ashwagandha')?.products ?? []),
+    ...(getRevenueProductSet('l-theanine')?.products ?? []),
+    ...(getRevenueProductSet('magnesium')?.products ?? []),
+  ]
 
   return (
-    <>
-      <JsonLd schema={blogJsonLd(post, `/articles/${slug}`)} />
-      <JsonLd schema={breadcrumbJsonLd(breadcrumbs)} />
-      <JsonLd schema={faqPageJsonLd({
-            pagePath: `/articles/${slug}`,
-            questions: faqItems,
-          })} />
+    <article className="mx-auto max-w-5xl space-y-0 px-4 pb-20 pt-6 sm:px-6 lg:px-8">
+      <JsonLd schema={articleLd} />
+      <JsonLd schema={breadcrumbs} />
+      {faqLd ? <JsonLd schema={faqLd} /> : null}
 
-      <div className="max-w-4xl mx-auto px-4 py-8">
-        <div className="mb-8">
-          <LastUpdatedBadge date={lastUpdated} />
-          <h1 className="text-4xl font-bold tracking-tight mt-4 mb-4">
-            {articleTitle}
-          </h1>
-          <p className="text-xl text-muted-foreground">
-            {articleDescription}
-          </p>
+      <nav className="mb-6 flex items-center gap-2 text-sm text-muted" aria-label="Breadcrumb">
+        <Link href="/guides/" className="hover:text-ink">Guides</Link>
+        <span>/</span>
+        <Link href="/guides/anxiety/" className="hover:text-ink">Anxiety</Link>
+        <span>/</span>
+        <span className="text-ink">Stack Guide</span>
+      </nav>
 
-          <figure className="mt-6">
-            <div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white">
-              <Image
-                src="/images/guides/anxiety-stack-guide.jpg"
-                alt="An anxiety supplement stack with ashwagandha, magnesium, and L-theanine"
-                width={1536}
-                height={1024}
-                priority
-                className="w-full h-auto"
-              />
+      <section className="rounded-[1.5rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8 lg:p-10">
+        <div className="flex flex-wrap items-center gap-2 text-xs">
+          <span className="rounded-full border border-brand-900/10 bg-brand-50 px-2.5 py-0.5 font-bold uppercase tracking-wider text-brand-800">
+            Combination evidence guide
+          </span>
+          <span className="text-muted">Evidence review · August 11, 2026</span>
+        </div>
+        <h1 className="mt-4 font-display text-3xl font-bold leading-tight tracking-tight text-ink sm:text-4xl lg:text-5xl">
+          {TITLE}
+        </h1>
+        <div className="mt-3"><LastUpdatedBadge date={DATE} label="Last evidence review" /></div>
+        <p className="mt-4 max-w-3xl text-base leading-7 text-muted">{DESCRIPTION}</p>
+
+        <figure className="mt-6">
+          <div className="overflow-hidden rounded-2xl border border-brand-900/10 bg-white shadow-sm">
+            <Image
+              src="/images/guides/anxiety-stack-guide.jpg"
+              alt="Several supplement containers and capsules arranged for comparison rather than as a prescribed anxiety stack"
+              width={1536}
+              height={1024}
+              priority
+              className="h-auto w-full"
+            />
+          </div>
+          <figcaption className="mt-3 text-center text-sm text-muted">
+            Combining ingredients creates a new evidence and interaction question; it is not automatically supported by each ingredient&apos;s individual studies.
+          </figcaption>
+        </figure>
+      </section>
+
+      <div className="mt-4 rounded-[1rem] border border-brand-900/10 bg-brand-50/60 px-5 py-3 text-xs leading-6 text-muted">
+        <strong className="text-ink">Affiliate disclosure:</strong> This guide contains affiliate links. The optional sourcing examples cover the three ingredients compared on this page—ashwagandha, L-theanine, and magnesium—and are not evidence that a product or combination treats anxiety. We may earn a commission at no added cost to you.
+      </div>
+
+      <div className="mt-6 space-y-6">
+        <section className="rounded-[1rem] border border-brand-700/20 bg-brand-50/60 p-6 shadow-sm sm:p-8">
+          <p className="eyebrow-label">Evidence bottom line</p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
+            Ingredient evidence does not validate a named anxiety stack
+          </h2>
+          <div className="mt-3 space-y-3 text-[1.01rem] leading-[1.85] text-muted">
+            <p>
+              The old page presented several recipe-style combinations as if they were validated protocols. A positive trial for one ingredient does not tell us whether adding a second or third ingredient improves the outcome, adds nothing, or mainly adds side effects and interaction complexity.
+            </p>
+            <p>
+              A more defensible approach is to separate <strong>what was studied directly</strong> from what is only a combination hypothesis. If someone still chooses to combine supplements, changing one variable at a time is easier to interpret than starting a multi-ingredient regimen all at once.
+            </p>
+          </div>
+        </section>
+
+        <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+          <p className="eyebrow-label">What current evidence actually covers</p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">Three popular ingredients, three different evidence boundaries</h2>
+          <div className="mt-5 overflow-x-auto">
+            <ResponsiveTable label="Evidence boundaries for common anxiety stack ingredients">
+              <table className="min-w-[760px] w-full text-sm">
+                <thead>
+                  <tr className="border-b border-brand-900/10">
+                    <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">Ingredient</th>
+                    <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">Studied directly</th>
+                    <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">Key limit</th>
+                    <th className="pb-2 text-left text-xs font-bold uppercase tracking-wider text-muted">What it does not prove</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-brand-900/5">
+                  <tr className="align-top">
+                    <td className="py-3 pr-4 font-semibold text-ink">L-theanine</td>
+                    <td className="py-3 pr-4 text-muted">31 placebo-controlled RCTs across healthy and clinical populations; robust short-term choice-reaction-time signal.</td>
+                    <td className="py-3 pr-4 text-muted">Acute stress effect was modest and bias-sensitive; anxiety findings were inconsistent overall.</td>
+                    <td className="py-3 text-muted">No reliable acute-anxiety onset and no proof that adding magnesium or ashwagandha creates a better anxiety treatment.</td>
+                  </tr>
+                  <tr className="align-top">
+                    <td className="py-3 pr-4 font-semibold text-ink">Ashwagandha</td>
+                    <td className="py-3 pr-4 text-muted">Nine placebo-controlled RCTs / 558 participants in the 2024 meta-analysis. A representative 2026 trial enrolled 141 healthy adults ages 18–65 with moderate stress/anxiety for 8 weeks and compared 300 mg proprietary root extract twice daily, another root extract, and placebo.</td>
+                    <td className="py-3 pr-4 text-muted">Repeated-dose, formulation-specific evidence in stressed adults; long-term safety remains less certain.</td>
+                    <td className="py-3 text-muted">No immediate calming promise, no class effect for every ashwagandha product, and no validation of an ashwagandha-plus-magnesium combination.</td>
+                  </tr>
+                  <tr className="align-top">
+                    <td className="py-3 pr-4 font-semibold text-ink">Magnesium</td>
+                    <td className="py-3 pr-4 text-muted">15 interventional studies in the 2024 review; seven measured anxiety-related outcomes.</td>
+                    <td className="py-3 pr-4 text-muted">Populations, salts, doses, durations, baseline status, and co-ingredients varied substantially.</td>
+                    <td className="py-3 text-muted">No universal anxiety dose/form and no way to assign a combination benefit to magnesium when several actives change together.</td>
+                  </tr>
+                </tbody>
+              </table>
+            </ResponsiveTable>
+          </div>
+        </section>
+
+        <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+          <p className="eyebrow-label">Why stacking changes the question</p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">More ingredients mean more uncertainty, not automatically more benefit</h2>
+          <div className="mt-5 grid gap-4 sm:grid-cols-2">
+            <div className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+              <h3 className="font-semibold text-ink">Attribution gets harder</h3>
+              <p className="mt-2 text-sm leading-6 text-muted">If symptoms change after three new supplements start together, you cannot tell which ingredient helped, which did nothing, or which caused an adverse effect.</p>
             </div>
-            <figcaption className="mt-3 text-center text-sm text-muted-foreground">
-              Building an anxiety stack — start with one supplement and add deliberately.
-            </figcaption>
-          </figure>
-        </div>
-
-        <div className="prose prose-sm mb-8 p-4 bg-muted/50 rounded-lg">
-          <p className="text-sm">
-            <strong>Affiliate Disclosure:</strong> This article contains affiliate links.
-            Purchases through these links may earn us a small commission at no extra cost to you.
-          </p>
-        </div>
-
-        <div className="mb-10 p-6 border rounded-xl bg-card">
-          <h2 className="text-2xl font-semibold mb-4">Quick Verdict</h2>
-          <ul className="space-y-2 text-muted-foreground">
-            <li>• <strong>Beginner stack</strong>: Start with magnesium only.</li>
-            <li>• <strong>Stress-focused stack</strong>: Ashwagandha + Magnesium.</li>
-            <li>• <strong>Racing thoughts stack</strong>: L-Theanine + Magnesium.</li>
-            <li>• <strong>Anxiety + Sleep stack</strong>: Ashwagandha + Magnesium + L-Theanine.</li>
-            <li>• <strong>Important</strong>: Do not start multiple new supplements at once. Introduce one at a time and monitor effects.</li>
-          </ul>
-        </div>
-
-        {/* Fastest useful choice */}
-        <section className="mb-12 rounded-[1rem] border border-brand-700/20 bg-brand-50/60 p-6 shadow-sm">
-          <p className="eyebrow-label">Fastest useful choice</p>
-          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">If you only try one thing: L-theanine alone</h2>
-          <p className="mt-3 text-base leading-7 text-muted">
-            <strong>L-theanine (100–200&nbsp;mg) alone is the fastest useful choice for anxiety stacks.</strong>{' '}
-            It works within 30–60 minutes, does not require stacking to be effective, and has a clean
-            safety profile. Adding magnesium (200–400&nbsp;mg/day, glycinate form) creates the most
-            reliable beginner stack. Reserve ashwagandha for when you have a clear chronic-stress
-            pattern and can commit to 6–8 weeks of daily use. See the{' '}
-            <Link href="/guides/herbs/l-theanine/" className="font-semibold text-brand-700 hover:underline">
-              full L-theanine guide
-            </Link>{' '}
-            and the{' '}
-            <Link href="/guides/herbs/ashwagandha/" className="font-semibold text-brand-700 hover:underline">
-              ashwagandha guide
-            </Link>
-            .
-          </p>
-        </section>
-
-        <section className="mb-12">
-          <h2 className="text-3xl font-semibold mb-6">What Is an Anxiety Stack?</h2>
-          <div className="prose prose-lg max-w-none">
-            <p>
-              An anxiety stack refers to the intentional combination of supplements that target complementary aspects of stress and anxiety (e.g., stress hormone regulation, mental relaxation, physical tension, and sleep support).
-            </p>
-            <p>
-              The goal of a well-designed stack is synergy — using lower doses of multiple compounds that work through different mechanisms rather than high doses of a single supplement. However, stacking also increases complexity and the potential for interactions or side effects.
-            </p>
-            <p>
-              Randomly combining many supplements ("supplement piling") is generally discouraged. A thoughtful, goal-oriented approach with gradual introduction is safer and more effective for most people.
-            </p>
+            <div className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+              <h3 className="font-semibold text-ink">Interactions compound</h3>
+              <p className="mt-2 text-sm leading-6 text-muted">Sedation, blood-pressure effects, GI effects, medication absorption, thyroid effects, liver concerns, and kidney function can matter differently for each ingredient.</p>
+            </div>
+            <div className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+              <h3 className="font-semibold text-ink">Dose logic does not transfer automatically</h3>
+              <p className="mt-2 text-sm leading-6 text-muted">A dose studied alone is not automatically the right dose when combined with other active ingredients, and a product label is not a validated anxiety protocol.</p>
+            </div>
+            <div className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+              <h3 className="font-semibold text-ink">The underlying problem may be misclassified</h3>
+              <p className="mt-2 text-sm leading-6 text-muted">Panic, persistent anxiety, medication effects, sleep disorders, substance effects, thyroid disease, and other conditions are not solved by escalating supplement complexity.</p>
+            </div>
           </div>
         </section>
 
-        <section className="mb-12">
-          <h2 className="text-3xl font-semibold mb-6">Core Anxiety Supplements</h2>
-          <div className="prose prose-lg max-w-none">
-            <p>
-              The three supplements most commonly discussed for anxiety support in this cluster are:
-            </p>
-            <ul>
-              <li><strong>Ashwagandha</strong> — Adaptogen with research on chronic stress and stress-related anxiety. See <Link href="/guides/herbs/ashwagandha/" className="text-primary underline">Ashwagandha for Anxiety</Link> or the umbrella <Link href="/guides/herbs/ashwagandha/" className="text-primary underline">Ashwagandha article</Link>.</li>
-              <li><strong>L-Theanine</strong> — Amino acid from tea that may promote calm focus and relaxation without heavy sedation. See <Link href="/guides/herbs/l-theanine/" className="text-primary underline">L-Theanine for Anxiety</Link> or the umbrella <Link href="/guides/herbs/l-theanine/" className="text-primary underline">L-Theanine article</Link>.</li>
-              <li><strong>Magnesium</strong> — Mineral involved in nervous system function and often used for physical tension and sleep support. See <Link href="/guides/sleep/magnesium-for-sleep/" className="text-primary underline">Magnesium for Sleep</Link>.</li>
-            </ul>
-          </div>
+        <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+          <p className="eyebrow-label">If supplementation is still being considered</p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">A lower-complexity decision sequence</h2>
+          <ol className="mt-5 space-y-4 text-sm leading-7 text-muted">
+            <li><strong className="text-ink">1. Define the outcome.</strong> “Anxiety” can mean laboratory stress, racing thoughts, panic, chronic generalized anxiety, sleep disruption, or physical tension. The evidence is not interchangeable across those outcomes.</li>
+            <li><strong className="text-ink">2. Check whether the ingredient evidence matches that outcome.</strong> Use the dedicated evidence reviews rather than a stack label: <Link href="/guides/anxiety/l-theanine-for-anxiety/" className="font-semibold text-brand-700 hover:underline">L-theanine</Link>, <Link href="/guides/anxiety/ashwagandha-for-anxiety/" className="font-semibold text-brand-700 hover:underline">ashwagandha</Link>, and <Link href="/guides/other/magnesium-types-guide/" className="font-semibold text-brand-700 hover:underline">magnesium forms</Link>.</li>
+            <li><strong className="text-ink">3. Review medications and health conditions first.</strong> A pharmacist or clinician can catch interaction, kidney, liver, thyroid, pregnancy, sedation, or absorption issues that a generic stack chart cannot.</li>
+            <li><strong className="text-ink">4. Avoid changing several variables together.</strong> If supplementation is appropriate, one change at a time makes response and side effects easier to interpret.</li>
+            <li><strong className="text-ink">5. Reassess rather than automatically adding another ingredient.</strong> If the first approach does not address the problem, the answer may be a different diagnosis or treatment—not a larger stack.</li>
+          </ol>
         </section>
 
-        <section className="mb-12">
-          <h2 className="text-3xl font-semibold mb-6">Stack Comparison</h2>
-
-          <ResponsiveTable label="Anxiety stack comparison by use case and complexity">
-            <table className="min-w-[680px] w-full text-sm">
-              <thead>
-                <tr className="border-b border-brand-900/10">
-                  <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">Stack</th>
-                  <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">Ingredients</th>
-                  <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">Best For</th>
-                  <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">Complexity</th>
-                  <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">Cost</th>
-                  <th className="pb-2 text-left text-xs font-bold uppercase tracking-wider text-muted">Main Caution</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-brand-900/5">
-                <tr className="align-top">
-                  <td className="py-3 pr-4 font-medium text-ink">Beginner Stack</td>
-                  <td className="py-3 pr-4 text-muted">Magnesium</td>
-                  <td className="py-3 pr-4 text-muted">General stress support, low complexity</td>
-                  <td className="py-3 pr-4 text-muted">Low</td>
-                  <td className="py-3 pr-4 text-muted">Low</td>
-                  <td className="py-3 text-muted">Mild GI upset in some forms</td>
-                </tr>
-                <tr className="align-top">
-                  <td className="py-3 pr-4 font-medium text-ink">Stress Stack</td>
-                  <td className="py-3 pr-4 text-muted">Ashwagandha + Magnesium</td>
-                  <td className="py-3 pr-4 text-muted">Chronic stress, daily foundational support</td>
-                  <td className="py-3 pr-4 text-muted">Medium</td>
-                  <td className="py-3 pr-4 text-muted">Medium</td>
-                  <td className="py-3 text-muted">Ashwagandha cautions (thyroid, autoimmune)</td>
-                </tr>
-                <tr className="align-top">
-                  <td className="py-3 pr-4 font-medium text-ink">Racing Thoughts Stack</td>
-                  <td className="py-3 pr-4 text-muted">L-Theanine + Magnesium</td>
-                  <td className="py-3 pr-4 text-muted">Mental tension, calm focus</td>
-                  <td className="py-3 pr-4 text-muted">Low–Medium</td>
-                  <td className="py-3 pr-4 text-muted">Low–Medium</td>
-                  <td className="py-3 text-muted">Generally well tolerated</td>
-                </tr>
-                <tr className="align-top">
-                  <td className="py-3 pr-4 font-medium text-ink">Anxiety + Sleep Stack</td>
-                  <td className="py-3 pr-4 text-muted">Ashwagandha + Magnesium + L-Theanine</td>
-                  <td className="py-3 pr-4 text-muted">Stress + sleep overlap</td>
-                  <td className="py-3 pr-4 text-muted">Medium–High</td>
-                  <td className="py-3 pr-4 text-muted">Medium</td>
-                  <td className="py-3 text-muted">More variables to monitor</td>
-                </tr>
-                <tr className="align-top">
-                  <td className="py-3 pr-4 font-medium text-ink">Full Stack</td>
-                  <td className="py-3 pr-4 text-muted">All three + others</td>
-                  <td className="py-3 pr-4 text-muted">Comprehensive (not for beginners)</td>
-                  <td className="py-3 pr-4 text-muted">High</td>
-                  <td className="py-3 pr-4 text-muted">Higher</td>
-                  <td className="py-3 text-muted">Highest risk of over-supplementation</td>
-                </tr>
-              </tbody>
-            </table>
-          </ResponsiveTable>
-        </section>
-
-        <section className="mb-12">
-          <h2 className="text-3xl font-semibold mb-6">Beginner Stack: Magnesium Only</h2>
-          <div className="prose prose-lg max-w-none">
-            <p>
-              For most people new to supplement stacks for anxiety, starting with a single well-tolerated mineral like magnesium is the lowest-risk approach.
-            </p>
-            <p>
-              Magnesium glycinate or bisglycinate is frequently recommended for its good tolerability and potential benefits for both physical relaxation and sleep quality.
-            </p>
-          </div>
-        </section>
-
-        <section className="mb-12">
-          <h2 className="text-3xl font-semibold mb-6">Stress Stack: Ashwagandha + Magnesium</h2>
-          <div className="prose prose-lg max-w-none">
-            <p>
-              This combination targets both the physiological stress response (ashwagandha) and physical/muscular tension plus sleep support (magnesium). It is a popular foundational stack for people experiencing chronic stress that manifests as anxiety.
-            </p>
-          </div>
-        </section>
-
-        <section className="mb-12">
-          <h2 className="text-3xl font-semibold mb-6">Racing Thoughts Stack: L-Theanine + Magnesium</h2>
-          <div className="prose prose-lg max-w-none">
-            <p>
-              This pairing focuses more on mental relaxation and calm focus during the day. L-theanine may help with racing thoughts while magnesium supports overall nervous system calm. Many people find this combination less "heavy" than stacks containing ashwagandha.
-            </p>
-          </div>
-        </section>
-
-        <section className="mb-12">
-          <h2 className="text-3xl font-semibold mb-6">Anxiety + Sleep Stack: Ashwagandha + Magnesium + L-Theanine</h2>
-          <div className="prose prose-lg max-w-none">
-            <p>
-              This is a more comprehensive stack that addresses chronic stress (ashwagandha), mental tension (L-theanine), and physical relaxation/sleep (magnesium). It is best suited for people whose anxiety significantly impacts sleep.
-            </p>
-            <p>
-              See also: <Link href="/guides/sleep/sleep-stack-guide/" className="text-primary underline">Sleep Stack Guide</Link> and <Link href="/guides/sleep/best-herbs-for-sleep/" className="text-primary underline">Best Herbs for Sleep</Link>.
-            </p>
-          </div>
-        </section>
-
-        <section className="mb-12">
-          <h2 className="text-3xl font-semibold mb-6">Timing Guide</h2>
-
-          <ResponsiveTable label="Anxiety supplement timing guide">
-            <table className="min-w-[500px] w-full text-sm">
-              <thead>
-                <tr className="border-b border-brand-900/10">
-                  <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">Time of Day</th>
-                  <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">Recommended Supplements</th>
-                  <th className="pb-2 text-left text-xs font-bold uppercase tracking-wider text-muted">Notes</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-brand-900/5">
-                <tr className="align-top">
-                  <td className="py-3 pr-4 font-medium text-ink">Morning</td>
-                  <td className="py-3 pr-4 text-muted">Ashwagandha (some prefer), L-Theanine (with or without caffeine)</td>
-                  <td className="py-3 text-muted">Timing is flexible; most evidence does not specify strict time-of-day requirements. Some prefer ashwagandha with meals to reduce GI upset.</td>
-                </tr>
-                <tr className="align-top">
-                  <td className="py-3 pr-4 font-medium text-ink">Afternoon</td>
-                  <td className="py-3 pr-4 text-muted">L-Theanine (for calm focus)</td>
-                  <td className="py-3 text-muted">Useful during high-stress periods</td>
-                </tr>
-                <tr className="align-top">
-                  <td className="py-3 pr-4 font-medium text-ink">Evening</td>
-                  <td className="py-3 pr-4 text-muted">Magnesium, Ashwagandha (some prefer), L-Theanine</td>
-                  <td className="py-3 text-muted">Support relaxation and sleep quality</td>
-                </tr>
-              </tbody>
-            </table>
-          </ResponsiveTable>
-        </section>
-
-        <section className="mb-12">
-          <h2 className="text-3xl font-semibold mb-6">Dosing Guide</h2>
-
-          <ResponsiveTable label="Anxiety supplement dosing guide">
-            <table className="min-w-[500px] w-full text-sm">
-              <thead>
-                <tr className="border-b border-brand-900/10">
-                  <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">Supplement</th>
-                  <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">Common Research Range</th>
-                  <th className="pb-2 text-left text-xs font-bold uppercase tracking-wider text-muted">Notes</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-brand-900/5">
-                <tr className="align-top">
-                  <td className="py-3 pr-4 font-medium text-ink">Ashwagandha (standardized extract)</td>
-                  <td className="py-3 pr-4 text-muted">300–600 mg/day (standardized extract)</td>
-                  <td className="py-3 text-muted">Often taken once or twice daily</td>
-                </tr>
-                <tr className="align-top">
-                  <td className="py-3 pr-4 font-medium text-ink">L-Theanine</td>
-                  <td className="py-3 pr-4 text-muted">100–200 mg per dose, 100–400 mg/day</td>
-                  <td className="py-3 text-muted">Often 100–200 mg per dose</td>
-                </tr>
-                <tr className="align-top">
-                  <td className="py-3 pr-4 font-medium text-ink">Magnesium (glycinate/bisglycinate)</td>
-                  <td className="py-3 pr-4 text-muted">200–400 mg elemental magnesium/day</td>
-                  <td className="py-3 text-muted">Split doses may improve tolerability</td>
-                </tr>
-              </tbody>
-            </table>
-          </ResponsiveTable>
-        </section>
-
-        <section className="mb-12">
-          <h2 className="text-3xl font-semibold mb-6">Safety and Interactions</h2>
-
-          <SafetyNotice>
-            <ul className="space-y-2">
-              <li>Combining multiple supplements increases the potential for additive effects, drug interactions, or side effects &mdash; introduce one supplement at a time.</li>
-              <li><strong>Ashwagandha:</strong> avoid in pregnancy and breastfeeding; rare hepatotoxicity reported; may affect thyroid hormone levels; caution with autoimmune disease and immunosuppressants.</li>
-              <li><strong>Magnesium:</strong> caution with kidney disease (kidneys regulate excretion); high doses cause loose stools &mdash; lower the dose rather than stopping.</li>
-              <li><strong>L-theanine:</strong> generally well-tolerated; some evidence of mild blood pressure reduction &mdash; caution with antihypertensives; do not combine with sedatives without medical supervision.</li>
-              <li>Caution with sedatives, psychiatric medications, SSRIs/SNRIs/MAOIs, blood pressure medications, and thyroid medications.</li>
-              <li>Severe anxiety, panic attacks, suicidal thoughts, or significant functional impairment require professional mental health support, not self-managed supplement stacks.</li>
+        <section className="space-y-4">
+          <h2 className="text-2xl font-semibold tracking-tight text-ink">Safety and stop rules</h2>
+          <SafetyNotice title="Combination safety matters more as complexity rises">
+            <ul className="ml-5 list-disc space-y-2">
+              <li><strong>Ashwagandha:</strong> pregnancy, thyroid, autoimmune, medication, and rare liver-injury concerns require ingredient-specific review.</li>
+              <li><strong>Magnesium:</strong> kidney disease can increase risk, and magnesium can interfere with absorption of some medications when taken too close together.</li>
+              <li><strong>L-theanine:</strong> short trials are generally reassuring, but they do not establish unlimited long-term safety or compatibility with every medication and condition.</li>
+              <li><strong>Multiple sedating substances:</strong> alcohol, sleep medications, benzodiazepines, opioids, antihistamines, and sedating supplements can compound impairment.</li>
+              <li><strong>Do not use stack escalation as a substitute for care:</strong> persistent, worsening, panic-level, or functionally impairing anxiety deserves professional evaluation.</li>
+              <li><strong>Immediate stop rule:</strong> suicidal thoughts, thoughts of self-harm, inability to stay safe, or imminent danger require immediate emergency or crisis care.</li>
             </ul>
           </SafetyNotice>
         </section>
 
-        <section className="mb-12">
-          <h2 className="text-3xl font-semibold mb-6">Who Should Consider Which Stack?</h2>
-          <div className="prose prose-lg max-w-none">
-            <p><strong>Beginner / Low complexity</strong>: Start with magnesium only.</p>
-            <p><strong>Chronic stress dominant</strong>: Consider Ashwagandha + Magnesium.</p>
-            <p><strong>Racing thoughts / daytime tension</strong>: Consider L-Theanine + Magnesium.</p>
-            <p><strong>Significant sleep disruption</strong>: Consider the three-supplement Anxiety + Sleep stack (after trying simpler options).</p>
-            <p>
-              People with complex medical histories, on multiple medications, or with severe anxiety should work with a clinician rather than self-experimenting with stacks.
-            </p>
-          </div>
-        </section>
-
-        <section className="mb-12">
-          <h2 className="text-3xl font-semibold mb-6">What Not To Do</h2>
-          <ul className="space-y-3 text-muted-foreground">
-            <li>• Do not start multiple new supplements at the same time.</li>
-            <li>• Do not replace prescribed psychiatric care or therapy with supplements.</li>
-            <li>• Do not ignore panic attacks, severe anxiety, or suicidal thoughts — seek professional help immediately.</li>
-            <li>• Do not megadose supplements in an attempt to get faster results.</li>
-            <li>• Do not assume "natural" means risk-free when combining multiple compounds.</li>
-          </ul>
-        </section>
-
-        <section className="mb-12">
-          <h2 className="text-3xl font-semibold mb-6">Frequently Asked Questions</h2>
-          <div className="space-y-6">
-            {faqItems.map((faq, index) => (
-              <div key={index} className="border-l-4 border-primary pl-4">
-                <h3 className="font-semibold text-lg mb-2">{faq.question}</h3>
-                <p className="text-muted-foreground">{faq.answer}</p>
+        <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+          <h2 className="text-2xl font-semibold tracking-tight text-ink">Frequently asked questions</h2>
+          <div className="mt-5 space-y-4">
+            {FAQS.map((faq) => (
+              <div key={faq.question} className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+                <h3 className="font-semibold text-ink">{faq.question}</h3>
+                <p className="mt-2 text-sm leading-7 text-muted">{faq.answer}</p>
               </div>
             ))}
           </div>
         </section>
 
-        <section className="mb-12">
-          <h2 className="text-3xl font-semibold mb-6">Related Articles</h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <Link href="/guides/anxiety/natural-anxiety-relief/" className="block p-4 border rounded-lg hover:bg-muted transition-colors">
-              Natural Anxiety Relief: Evidence-Based Approaches
-            </Link>
-            <Link href="/guides/herbs/ashwagandha/" className="block p-4 border rounded-lg hover:bg-muted transition-colors">
-              Ashwagandha: Full Guide
-            </Link>
-            <Link href="/guides/herbs/l-theanine/" className="block p-4 border rounded-lg hover:bg-muted transition-colors">
-              L-Theanine: Full Guide
-            </Link>
-            <Link href="/guides/anxiety/cbd-vs-ashwagandha-for-anxiety/" className="block p-4 border rounded-lg hover:bg-muted transition-colors">
-              CBD vs Ashwagandha for Anxiety
-            </Link>
-            <Link href="/guides/sleep/sleep-stack-guide/" className="block p-4 border rounded-lg hover:bg-muted transition-colors">
-              Sleep Stack Guide
-            </Link>
-            <Link href="/guides/anxiety/" className="block p-4 border rounded-lg hover:bg-muted transition-colors">
-              Anxiety Goal Hub
-            </Link>
+        <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+          <h2 className="text-2xl font-semibold tracking-tight text-ink">Sources and directness notes</h2>
+          <ol className="mt-5 space-y-4">
+            {SOURCES.map((source, index) => (
+              <li key={source.href} className="text-sm leading-7 text-muted">
+                <span className="font-semibold text-ink">{index + 1}. </span>
+                <a href={source.href} target="_blank" rel="noopener noreferrer" className="font-semibold text-brand-700 hover:underline">{source.label}</a>
+                <span> — {source.note}</span>
+              </li>
+            ))}
+          </ol>
+        </section>
+
+        <section className="rounded-[1rem] border border-brand-900/10 bg-brand-50/40 p-6">
+          <h2 className="text-xl font-semibold text-ink">Related evidence guides</h2>
+          <div className="mt-4 grid gap-3 sm:grid-cols-2">
+            <Link href="/guides/anxiety/natural-anxiety-relief/" className="font-semibold text-brand-700 hover:underline">Natural Anxiety Relief →</Link>
+            <Link href="/guides/anxiety/best-herbs-for-anxiety/" className="font-semibold text-brand-700 hover:underline">Best Herbs for Anxiety →</Link>
+            <Link href="/guides/herbs/l-theanine/" className="font-semibold text-brand-700 hover:underline">L-Theanine Umbrella Guide →</Link>
+            <Link href="/guides/herbs/ashwagandha/" className="font-semibold text-brand-700 hover:underline">Ashwagandha Umbrella Guide →</Link>
           </div>
-          <p className="mt-4 text-sm text-muted-foreground">
-            Future articles: Magnesium for Anxiety • Passionflower for Anxiety • Saffron for Anxiety
+        </section>
+
+        <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+          <p className="eyebrow-label">Optional sourcing examples</p>
+          <h2 className="mt-2 text-xl font-semibold text-ink">Neutral product coverage for all three compared ingredients</h2>
+          <p className="mt-2 text-sm leading-6 text-muted">
+            The sourcing module below includes ashwagandha, L-theanine, and magnesium examples from the same shared product registry. Inclusion is for label/form comparison and affiliate convenience; it does not rank one ingredient above another or validate a combination.
           </p>
-        </section>
-
-        <section className="mb-12">
-          <h2 className="text-3xl font-semibold mb-6">Buyer Guide</h2>
-          <div className="prose prose-lg max-w-none">
-            <p>Look for third-party tested products from reputable brands when possible.</p>
-          </div>
-
-          <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div className="border rounded-xl p-5">
-              <h3 className="font-semibold mb-2">Ashwagandha</h3>
-              <a href={`https://www.amazon.com/s?k=KSM-66+ashwagandha+third+party+tested&tag=${AFFILIATE_TAGS.amazon}`} target="_blank" rel="noopener noreferrer sponsored" className="text-primary underline text-sm">
-                Search KSM-66 Ashwagandha →
-              </a>
-            </div>
-            <div className="border rounded-xl p-5">
-              <h3 className="font-semibold mb-2">Magnesium Glycinate</h3>
-              <a href={`https://www.amazon.com/s?k=magnesium+glycinate+third+party+tested&tag=${AFFILIATE_TAGS.amazon}`} target="_blank" rel="noopener noreferrer sponsored" className="text-primary underline text-sm">
-                Search Magnesium Glycinate →
-              </a>
-            </div>
-            <div className="border rounded-xl p-5">
-              <h3 className="font-semibold mb-2">L-Theanine</h3>
-              <a href={`https://www.amazon.com/s?k=l-theanine+third+party+tested&tag=${AFFILIATE_TAGS.amazon}`} target="_blank" rel="noopener noreferrer sponsored" className="text-primary underline text-sm">
-                Search L-Theanine →
-              </a>
-            </div>
-            <div className="border rounded-xl p-5">
-              <h3 className="font-semibold mb-2">Stress Support Supplements</h3>
-              <a href={`https://www.amazon.com/s?k=stress+support+supplements&tag=${AFFILIATE_TAGS.amazon}`} target="_blank" rel="noopener noreferrer sponsored" className="text-primary underline text-sm">
-                Browse options →
-              </a>
-            </div>
+          <div className="mt-5">
+            <RecommendationSection products={comparisonProducts} />
           </div>
         </section>
-
-        <section className="mb-12">
-          <h2 className="text-3xl font-semibold mb-6">Sources &amp; References</h2>
-          <div className="p-6 bg-muted/50 rounded-xl text-sm">
-            <p className="mb-4 font-medium">Key sources include:</p>
-            <ul className="list-disc pl-5 space-y-1 text-muted-foreground">
-              <li>Anxiety and stress evidence for Ashwagandha, L-Theanine, and Magnesium</li>
-              <li>Stack safety and interaction data</li>
-              <li>Systematic reviews</li>
-              <li>Timing and dosing verification from clinical studies</li>
-            </ul>
-          </div>
-        </section>
-
-        <RecommendationSection products={getRevenueProductSet('ashwagandha')?.products ?? []} />
 
         <div className="my-12">
           <NewsletterCtaBlock />
-          <div className="mt-6">
-            <EmailCapture />
-          </div>
+          <div className="mt-6"><EmailCapture /></div>
         </div>
       </div>
-    </>
-  );
+    </article>
+  )
 }


### PR DESCRIPTION
High-ROI evidence/trust rebuild of the anxiety supplement stack guide.

- removes named “beginner,” “stress,” “racing thoughts,” “anxiety + sleep,” and “full” stack recipes
- removes the 30–60-minute L-theanine anxiety promise, timing table, and fixed anxiety-stack dosing table
- makes the central evidence boundary explicit: ingredient-level trials do not validate a named multi-supplement combination
- updates L-theanine to the July 2026 meta-analysis (31 RCTs / 1,168 participants; robust attention signal, inconsistent anxiety results)
- updates ashwagandha to the 2024 stress/anxiety meta-analysis (9 RCTs / 558 participants; repeated-dose, formulation-specific evidence)
- updates magnesium to the 2024 systematic review (15 interventional studies, 7 anxiety-related; heterogeneous forms/doses/durations and some co-ingredients)
- replaces recipe selection with a lower-complexity decision sequence: define the outcome, check ingredient directness, review medications/conditions, change one variable at a time, and reassess instead of automatically adding ingredients
- retains explicit medication, sedation, kidney/liver/thyroid, and immediate-crisis stop rules
- fixes structured-data/canonical paths to the actual `/guides/anxiety/anxiety-stack-guide/` route
- preserves image, internal evidence discovery, neutral affiliate sourcing, newsletter, and email capture

Focused regression coverage locks the evidence PMIDs/directness, bans the old stack recipes and rapid-anxiety claims, protects canonical routing, and preserves safety/monetization plumbing.