### PR TITLE
Rebuild best-herbs anxiety guide around evidence directness

### DIFF
--- a/app/__tests__/best-herbs-anxiety-current-evidence.test.ts
+++ b/app/__tests__/best-herbs-anxiety-current-evidence.test.ts
@@ -24,12 +24,16 @@ describe('best herbs for anxiety evidence calibration', () => {
     expect(text).toContain("const DATE = '2026-08-11'")
   })
 
-  it('keeps Silexan evidence formulation-specific', () => {
+  it('keeps Silexan evidence formulation-specific and discloses manufacturer involvement', () => {
     const text = source()
 
     expect(text).toMatch(/proprietary oral lavender-oil preparation/i)
     expect(text).toMatch(/does not automatically apply to lavender tea, aromatherapy, raw essential oil/i)
     expect(text).toMatch(/supports the studied oral preparation—not every lavender product/i)
+    expect(text).toMatch(/all five included trials were completed by the manufacturer/i)
+    expect(text).toMatch(/financially supported by Dr\. Willmar Schwabe GmbH/i)
+    expect(text).toMatch(/One coauthor was a company employee/i)
+    expect(text).toMatch(/multiple authors disclosed Schwabe/i)
   })
 
   it('does not restore same-day herb rankings or overclaim tiny active-comparator data', () => {
@@ -53,6 +57,13 @@ describe('best herbs for anxiety evidence calibration', () => {
     expect(text).toMatch(/Kava did not significantly outperform placebo/i)
     expect(text).toMatch(/rare severe and sometimes fatal liver injury/i)
     expect(text).toMatch(/avoid combining kava with benzodiazepines or alcohol/i)
+  })
+
+  it('keeps the broad comparison limited to options with auditable directness', () => {
+    const text = source()
+
+    expect(text).not.toMatch(/Lemon balm \/ chamomile/i)
+    expect(text).not.toMatch(/small or preliminary anxiety studies and traditional-use context/i)
   })
 
   it('preserves an explicit crisis and medication stop rule', () => {

--- a/app/__tests__/best-herbs-anxiety-current-evidence.test.ts
+++ b/app/__tests__/best-herbs-anxiety-current-evidence.test.ts
@@ -1,0 +1,88 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const PAGE = path.join(process.cwd(), 'app/guides/anxiety/best-herbs-for-anxiety/page.tsx')
+
+function source() {
+  return fs.readFileSync(PAGE, 'utf8').replace(/\s+/g, ' ')
+}
+
+describe('best herbs for anxiety evidence calibration', () => {
+  it('anchors the comparison to direct current evidence', () => {
+    const text = source()
+
+    expect(text).toContain('36717399')
+    expect(text).toContain('24456909')
+    expect(text).toContain('39348746')
+    expect(text).toContain('11679026')
+    expect(text).toContain('31813230')
+    expect(text).toContain('1,213 adult outpatients')
+    expect(text).toContain('nine randomized placebo-controlled trials and 558 participants')
+    expect(text).toContain('36 outpatients for 4 weeks')
+    expect(text).toContain('171 non-medicated adults')
+    expect(text).toContain("const DATE = '2026-08-11'")
+  })
+
+  it('keeps Silexan evidence formulation-specific', () => {
+    const text = source()
+
+    expect(text).toMatch(/proprietary oral lavender-oil preparation/i)
+    expect(text).toMatch(/does not automatically apply to lavender tea, aromatherapy, raw essential oil/i)
+    expect(text).toMatch(/supports the studied oral preparation—not every lavender product/i)
+  })
+
+  it('does not restore same-day herb rankings or overclaim tiny active-comparator data', () => {
+    const text = source()
+
+    expect(text).not.toMatch(/Fastest useful choice/i)
+    expect(text).not.toMatch(/Best herb choice/i)
+    expect(text).not.toMatch(/Same-day calming:/i)
+    expect(text).not.toMatch(/Acute \/ situational anxiety/i)
+    expect(text).not.toMatch(/comparable to oxazepam/i)
+    expect(text).not.toMatch(/Kava \(aqueous extract, low dose\)/i)
+    expect(text).not.toMatch(/Addresses root HPA dysregulation/i)
+    expect(text).not.toMatch(/best for acute anxiety/i)
+  })
+
+  it('states passionflower and kava evidence limits concretely', () => {
+    const text = source()
+
+    expect(text).toMatch(/small pilot cannot establish equivalence/i)
+    expect(text).toMatch(/NCCIH still considers the broader anxiety evidence too limited for definite conclusions/i)
+    expect(text).toMatch(/Kava did not significantly outperform placebo/i)
+    expect(text).toMatch(/rare severe and sometimes fatal liver injury/i)
+    expect(text).toMatch(/avoid combining kava with benzodiazepines or alcohol/i)
+  })
+
+  it('preserves an explicit crisis and medication stop rule', () => {
+    const text = source()
+
+    expect(text).toMatch(/suicidal thoughts/i)
+    expect(text).toMatch(/thoughts of self-harm/i)
+    expect(text).toMatch(/inability to stay safe/i)
+    expect(text).toMatch(/immediate emergency or crisis care/i)
+    expect(text).toMatch(/Do not stop, reduce, or replace prescribed anxiety medication/i)
+  })
+
+  it('keeps monetization transparent instead of ranking one herb through affiliate placement', () => {
+    const text = source()
+
+    expect(text).not.toContain('RecommendationSection')
+    expect(text).not.toContain('getRevenueProductSet')
+    expect(text).toMatch(/broad comparison intentionally does not rank affiliate products/i)
+    expect(text).toMatch(/monetization does not silently decide which herb appears to be the winner/i)
+    expect(text).toContain('<NewsletterCtaBlock />')
+    expect(text).toContain('<EmailCapture />')
+  })
+
+  it('preserves evidence discovery across the anxiety cluster', () => {
+    const text = source()
+
+    expect(text).toContain('/guides/anxiety/natural-anxiety-relief/')
+    expect(text).toContain('/guides/anxiety/anxiety-stack-guide/')
+    expect(text).toContain('/guides/anxiety/l-theanine-for-anxiety/')
+    expect(text).toContain('/guides/anxiety/ashwagandha-for-anxiety/')
+    expect(text).toContain('/guides/kava/')
+  })
+})

--- a/app/guides/anxiety/best-herbs-for-anxiety/page.tsx
+++ b/app/guides/anxiety/best-herbs-for-anxiety/page.tsx
@@ -15,12 +15,12 @@ const DATE = '2026-08-11'
 export const metadata: Metadata = {
   title: 'Best Herbs for Anxiety: What the Evidence Supports in 2026',
   description:
-    'Evidence-first comparison of ashwagandha, oral Silexan lavender oil, passionflower, kava, lemon balm, and chamomile for anxiety, with directness and safety limits.',
+    'Evidence-first comparison of ashwagandha, oral Silexan lavender oil, passionflower, and kava for anxiety, with directness, funding, and safety limits.',
   alternates: { canonical: '/guides/anxiety/best-herbs-for-anxiety/' },
   openGraph: {
     title: 'Best Herbs for Anxiety: What the Evidence Supports in 2026',
     description:
-      'Compare anxiety herbs by direct human evidence, formulation, duration, and safety instead of same-day rankings or universal winners.',
+      'Compare anxiety herbs by direct human evidence, formulation, duration, funding context, and safety instead of same-day rankings or universal winners.',
     url: '/guides/anxiety/best-herbs-for-anxiety/',
     type: 'article',
     images: ['/og-default.jpg'],
@@ -31,7 +31,7 @@ const FAQS = [
   {
     question: 'Which herb has the strongest direct anxiety evidence?',
     answer:
-      'There is no universal best herb. Among the options on this page, the most direct anxiety-disorder trial program belongs to Silexan, a proprietary oral lavender-oil preparation studied at defined doses over 10 weeks. That evidence does not automatically apply to lavender tea, aromatherapy, raw essential oil, or every lavender supplement. Ashwagandha has a repeated-dose stress/anxiety signal, but its evidence is formulation-specific and often comes from adults with elevated stress rather than a single anxiety diagnosis.',
+      'There is no universal best herb. Among the options on this page, the most direct anxiety-disorder trial program belongs to Silexan, a proprietary oral lavender-oil preparation studied at defined doses over 10 weeks. That evidence does not automatically apply to lavender tea, aromatherapy, raw essential oil, or every lavender supplement. The 2023 meta-analysis also reports that its five included trials were completed by the Silexan manufacturer, and the research and publication were financially supported by that manufacturer, so funding and author ties are an important interpretation limit. Ashwagandha has a repeated-dose stress/anxiety signal, but its evidence is formulation-specific and often comes from adults with elevated stress rather than a single anxiety diagnosis.',
   },
   {
     question: 'Is passionflower proven to work as well as oxazepam?',
@@ -59,7 +59,7 @@ const SOURCES = [
   {
     label: 'Silexan meta-analysis of randomized placebo-controlled anxiety trials (2023)',
     href: 'https://pubmed.ncbi.nlm.nih.gov/36717399/',
-    note: 'Five double-blind placebo-controlled trials; 1,213 adult outpatients received the proprietary oral lavender-oil preparation Silexan 80 mg/day or placebo for 10 weeks.',
+    note: 'Five double-blind placebo-controlled trials; 1,213 adult outpatients received Silexan 80 mg/day or placebo for 10 weeks. The paper states the included trials were completed by the manufacturer and that the research/publication were financially supported by Dr. Willmar Schwabe GmbH & Co. KG; one author was a company employee and multiple authors disclosed Schwabe ties.',
   },
   {
     label: 'Silexan randomized trial in generalized anxiety disorder (2014)',
@@ -124,7 +124,7 @@ export default function BestHerbsForAnxietyPage() {
       <StructuredData
         pageUrl={PAGE_URL}
         headline="Best Herbs for Anxiety: What the Evidence Supports in 2026"
-        description="Evidence-first comparison of ashwagandha, Silexan lavender oil, passionflower, kava, lemon balm, and chamomile for anxiety."
+        description="Evidence-first comparison of ashwagandha, Silexan lavender oil, passionflower, and kava for anxiety."
         datePublished="2026-06-16"
         dateModified={DATE}
         breadcrumbs={[
@@ -139,15 +139,13 @@ export default function BestHerbsForAnxietyPage() {
       <div className="space-y-10">
         <section className="rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-10">
           <p className="eyebrow-label">Anxiety herb evidence guide</p>
-          <h1 className="mt-3 text-3xl font-bold tracking-tight text-ink sm:text-4xl">
-            Best Herbs for Anxiety
-          </h1>
+          <h1 className="mt-3 text-3xl font-bold tracking-tight text-ink sm:text-4xl">Best Herbs for Anxiety</h1>
           <p className="mt-2 text-xs text-muted">Last evidence review August 11, 2026</p>
           <p className="mt-4 max-w-3xl text-sm leading-7 text-muted sm:text-base">
             “Best” is the wrong first question for anxiety herbs. The useful comparison is what was studied
-            directly, in whom, with which preparation, for how long, and what safety limits come with it.
-            This guide keeps formulation-specific evidence separate from broad herb-category claims and does
-            not turn study timing into a same-day treatment promise.
+            directly, in whom, with which preparation, for how long, who funded the evidence, and what safety
+            limits come with it. This guide keeps formulation-specific evidence separate from broad herb-category
+            claims and does not turn study timing into a same-day treatment promise.
           </p>
 
           <div className="mt-5 rounded-xl border border-red-200 bg-red-50 p-4 text-sm leading-6 text-red-950">
@@ -160,7 +158,7 @@ export default function BestHerbsForAnxietyPage() {
             <div className="overflow-hidden rounded-2xl border border-brand-900/10 bg-white shadow-sm">
               <Image
                 src="/images/guides/best-herbs-for-anxiety.jpg"
-                alt="Passionflower, lavender, lemon balm, kava root, and ashwagandha arranged for an evidence comparison"
+                alt="Anxiety-related botanicals arranged for an evidence comparison"
                 width={1536}
                 height={1024}
                 priority
@@ -175,14 +173,14 @@ export default function BestHerbsForAnxietyPage() {
 
         <section id="bottom-line" className="scroll-mt-20 rounded-[1.65rem] border border-brand-700/25 bg-brand-50/60 p-6 shadow-sm">
           <p className="eyebrow-label">Bottom line</p>
-          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
-            The evidence hierarchy is not the same as a “best herb” ranking
-          </h2>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">The evidence hierarchy is not the same as a “best herb” ranking</h2>
           <div className="mt-4 space-y-3 text-sm leading-7 text-muted sm:text-base">
             <p>
-              <strong>Oral Silexan</strong> has the most direct anxiety-disorder trial program among the
-              options compared here, but the evidence belongs to a proprietary oral lavender-oil preparation
-              studied for 10 weeks. It should not be generalized to lavender tea, aromatherapy, or raw essential oil.
+              <strong>Oral Silexan</strong> has the most direct anxiety-disorder trial program among the options
+              compared here, but the evidence belongs to a proprietary oral lavender-oil preparation studied for
+              10 weeks. It should not be generalized to lavender tea, aromatherapy, or raw essential oil. The
+              evidence concentration also needs a funding caveat: the 2023 meta-analysis reports manufacturer-
+              completed trials, manufacturer financial support, a company-employed coauthor, and multiple Schwabe ties.
             </p>
             <p>
               <strong>Ashwagandha</strong> has a meaningful repeated-dose stress/anxiety signal across randomized
@@ -210,7 +208,7 @@ export default function BestHerbsForAnxietyPage() {
                 <tr className="align-top">
                   <td className="p-4 font-semibold text-ink">Silexan oral lavender oil</td>
                   <td className="p-4 text-muted">Five placebo-controlled anxiety trials in 1,213 adult outpatients at 80 mg/day for 10 weeks; additional GAD dose-ranging data exist.</td>
-                  <td className="p-4 text-muted">Evidence is for a proprietary oral preparation, not “lavender” as a class.</td>
+                  <td className="p-4 text-muted">Proprietary preparation; the meta-analysis reports manufacturer-completed trials and manufacturer funding/author ties.</td>
                   <td className="p-4 text-muted">Do not ingest raw essential oil as if it were the studied product.</td>
                 </tr>
                 <tr className="align-top">
@@ -231,12 +229,6 @@ export default function BestHerbsForAnxietyPage() {
                   <td className="p-4 text-muted">The trial did not significantly outperform placebo; the broader efficacy literature is mixed.</td>
                   <td className="p-4 text-muted">Rare severe or fatal liver injury has been linked to kava products; avoid combining kava with benzodiazepines or alcohol.</td>
                 </tr>
-                <tr className="align-top">
-                  <td className="p-4 font-semibold text-ink">Lemon balm / chamomile</td>
-                  <td className="p-4 text-muted">Small or preliminary anxiety studies and traditional-use context exist, but the evidence base is much thinner than the options above.</td>
-                  <td className="p-4 text-muted">Do not convert “calming” plausibility or a tea ritual into evidence for an anxiety disorder.</td>
-                  <td className="p-4 text-muted">Sedation, allergy, medication, and product-specific cautions still apply.</td>
-                </tr>
               </tbody>
             </table>
           </div>
@@ -254,9 +246,14 @@ export default function BestHerbsForAnxietyPage() {
               compared 80 mg and 160 mg Silexan with paroxetine and placebo. This is comparatively direct anxiety
               evidence, but it supports the studied oral preparation—not every lavender product.
             </p>
-            <Link href="/compounds/lavender/" className="mt-3 inline-block text-sm font-semibold text-brand-700 hover:underline">
-              Lavender evidence profile →
-            </Link>
+            <p className="mt-3 text-sm leading-7 text-muted">
+              <strong>Funding/conflict boundary:</strong> the meta-analysis states that all five included trials
+              were completed by the manufacturer of Silexan and that the research and publication were financially
+              supported by Dr. Willmar Schwabe GmbH &amp; Co. KG. One coauthor was a company employee, and several
+              authors disclosed Schwabe consulting, honoraria, or other ties. That does not nullify the trials, but
+              it is a material bias boundary when judging how confidently to elevate this program over alternatives.
+            </p>
+            <Link href="/compounds/lavender/" className="mt-3 inline-block text-sm font-semibold text-brand-700 hover:underline">Lavender evidence profile →</Link>
           </article>
 
           <article className="rounded-[1.65rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm">
@@ -267,9 +264,7 @@ export default function BestHerbsForAnxietyPage() {
               trials used defined formulations over repeated dosing, often in adults with stress or anxiety symptoms.
               That supports a multi-week extract signal, not a same-day calming promise or a guarantee for every product.
             </p>
-            <Link href="/guides/anxiety/ashwagandha-for-anxiety/" className="mt-3 inline-block text-sm font-semibold text-brand-700 hover:underline">
-              Ashwagandha for anxiety →
-            </Link>
+            <Link href="/guides/anxiety/ashwagandha-for-anxiety/" className="mt-3 inline-block text-sm font-semibold text-brand-700 hover:underline">Ashwagandha for anxiety →</Link>
           </article>
 
           <article className="rounded-[1.65rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm">
@@ -281,9 +276,7 @@ export default function BestHerbsForAnxietyPage() {
               evidence that passionflower is equivalent to oxazepam, and NCCIH still considers the broader anxiety
               evidence too limited for definite conclusions.
             </p>
-            <Link href="/herbs/passionflower/" className="mt-3 inline-block text-sm font-semibold text-brand-700 hover:underline">
-              Passionflower profile →
-            </Link>
+            <Link href="/herbs/passionflower/" className="mt-3 inline-block text-sm font-semibold text-brand-700 hover:underline">Passionflower profile →</Link>
           </article>
 
           <article className="rounded-[1.65rem] border border-red-200 bg-red-50/70 p-6 shadow-sm">
@@ -295,9 +288,7 @@ export default function BestHerbsForAnxietyPage() {
               products and advises against combining kava with benzodiazepines or alcohol. That combination of
               uncertain benefit and potentially serious harm makes a rapid-use kava ranking inappropriate.
             </p>
-            <Link href="/guides/kava/" className="mt-3 inline-block text-sm font-semibold text-red-900 hover:underline">
-              Kava safety guide →
-            </Link>
+            <Link href="/guides/kava/" className="mt-3 inline-block text-sm font-semibold text-red-900 hover:underline">Kava safety guide →</Link>
           </article>
         </section>
 
@@ -331,9 +322,7 @@ export default function BestHerbsForAnxietyPage() {
             {SOURCES.map((source, index) => (
               <li key={source.href} className="text-sm leading-7 text-muted">
                 <span className="font-semibold text-ink">{index + 1}. </span>
-                <a href={source.href} target="_blank" rel="noopener noreferrer" className="font-semibold text-brand-700 hover:underline">
-                  {source.label}
-                </a>
+                <a href={source.href} target="_blank" rel="noopener noreferrer" className="font-semibold text-brand-700 hover:underline">{source.label}</a>
                 <span> — {source.note}</span>
               </li>
             ))}

--- a/app/guides/anxiety/best-herbs-for-anxiety/page.tsx
+++ b/app/guides/anxiety/best-herbs-for-anxiety/page.tsx
@@ -6,146 +6,108 @@ import JsonLd from '@/components/seo/JsonLd'
 import { SITE_URL } from '@/lib/navigation-config'
 import { ArticleLayout, TableOfContents } from '@/components/articles'
 import type { Heading } from '@/components/articles'
-import { getRevenueProductSet } from '@/config/revenue-products'
-import RecommendationSection from '@/components/RecommendationSection'
+import EmailCapture from '@/components/EmailCapture'
+import NewsletterCtaBlock from '@/components/NewsletterCtaBlock'
 
 const PAGE_URL = `${SITE_URL}/guides/anxiety/best-herbs-for-anxiety`
+const DATE = '2026-08-11'
 
 export const metadata: Metadata = {
-  title: 'Best Herbs for Anxiety: Ashwagandha, Passionflower, Lavender & More',
+  title: 'Best Herbs for Anxiety: What the Evidence Supports in 2026',
   description:
-    'Evidence-graded review of the best herbs for anxiety: ashwagandha, kava, passionflower, lemon balm, valerian, and lavender. Mechanisms, dosing, safety, drug interactions, and decision framework.',
+    'Evidence-first comparison of ashwagandha, oral Silexan lavender oil, passionflower, kava, lemon balm, and chamomile for anxiety, with directness and safety limits.',
   alternates: { canonical: '/guides/anxiety/best-herbs-for-anxiety/' },
   openGraph: {
-    title: 'Best Herbs for Anxiety: Ashwagandha, Passionflower, Lavender & More',
+    title: 'Best Herbs for Anxiety: What the Evidence Supports in 2026',
     description:
-      'Which herbs actually help with anxiety? Ashwagandha, kava, passionflower, lemon balm — evidence-graded with dosing, safety, and interaction warnings.',
+      'Compare anxiety herbs by direct human evidence, formulation, duration, and safety instead of same-day rankings or universal winners.',
     url: '/guides/anxiety/best-herbs-for-anxiety/',
     type: 'article',
     images: ['/og-default.jpg'],
   },
 }
 
-const ANXIETY_HERBS = [
+const FAQS = [
   {
-    name: 'Ashwagandha (KSM-66)',
-    mechanism: 'HPA axis regulation; cortisol reduction via withanolides; GABAergic modulation; anti-inflammatory effects on stress pathways',
-    evidence: 'B — multiple RCTs show statistically significant reductions in perceived stress (PSS) and cortisol in stressed, non-clinical populations',
-    dose: '300–600 mg standardized extract (≥5% withanolides) once or twice daily; effects emerge over 4–8 weeks',
-    safety: 'Generally well-tolerated; rare liver injury has been reported; use caution with thyroid medications, immunosuppressants, pregnancy, or autoimmune conditions',
-    bestFor: 'Chronic stress-related anxiety, HPA dysregulation, generalized anxiety in healthy adults',
-    href: '/guides/herbs/ashwagandha/',
-    badge: 'Moderate–Strong',
-    interactions: 'Thyroid meds, sedatives, immunosuppressants, pregnancy/autoimmune caution',
+    question: 'Which herb has the strongest direct anxiety evidence?',
+    answer:
+      'There is no universal best herb. Among the options on this page, the most direct anxiety-disorder trial program belongs to Silexan, a proprietary oral lavender-oil preparation studied at defined doses over 10 weeks. That evidence does not automatically apply to lavender tea, aromatherapy, raw essential oil, or every lavender supplement. Ashwagandha has a repeated-dose stress/anxiety signal, but its evidence is formulation-specific and often comes from adults with elevated stress rather than a single anxiety diagnosis.',
   },
   {
-    name: 'Kava (Piper methysticum)',
-    mechanism: 'Kavalactones modulate GABA-A receptors; reduce limbic system excitability; non-sedating anxiolytic effect at moderate doses',
-    evidence: 'B — Cochrane review (2003) found significant benefit for GAD; aqueous extracts safer than ethanolic',
-    dose: '70–250 mg kavalactones per dose, 1–3× daily using aqueous (water-based) extract only',
-    safety: 'CAUTION — rare but serious hepatotoxicity risk with ethanolic/acetone extracts and daily high-dose use; avoid with alcohol, liver disease, sedatives, or CYP1A2/2D6/3A4 medications',
-    bestFor: 'Acute anxiety relief; social anxiety; short-term episodic use only',
-    href: '/guides/kava',
-    badge: 'Moderate (with significant safety caveats)',
-    interactions: 'Alcohol, benzodiazepines, antidepressants, hepatotoxic drugs, CYP-metabolized medications',
+    question: 'Is passionflower proven to work as well as oxazepam?',
+    answer:
+      'No. The often-cited trial enrolled only 36 outpatients with generalized anxiety disorder for 4 weeks and compared passionflower extract with oxazepam. The small study found no significant difference at the end of the trial, but it was a pilot and was not designed to establish equivalence. NCCIH still describes the overall passionflower evidence as limited and inconclusive.',
   },
   {
-    name: 'Passionflower',
-    mechanism: 'Increases brain GABA levels; mild MAOI activity; flavonoids (chrysin) have anxiolytic properties',
-    evidence: 'C–B — small RCTs comparable to oxazepam for GAD; limited large studies',
-    dose: '250–500 mg extract or 1–2 cups tea, taken 30–60 min before stressful events or at bedtime',
-    safety: 'Generally well-tolerated; mild sedation possible; use caution with sedatives and anticoagulants',
-    bestFor: 'Mild to moderate anxiety; anxiety + sleep overlap; episodic situational anxiety',
-    href: '/herbs/passionflower',
-    badge: 'Emerging–Moderate',
-    interactions: 'Sedatives, anticoagulants (theoretical)',
+    question: 'Is kava a good option for acute anxiety?',
+    answer:
+      'Current evidence does not support presenting kava as a reliable acute-anxiety choice. A 16-week placebo-controlled trial in 171 non-medicated adults with diagnosed generalized anxiety disorder did not find a significant anxiety benefit over placebo. Kava products have also been linked to rare severe and sometimes fatal liver injury, and kava should not be combined with alcohol or other sedatives.',
   },
   {
-    name: 'Lemon Balm (Melissa officinalis)',
-    mechanism: 'GABA-T inhibition (increases GABA); mild acetylcholinesterase inhibition; rosmarinic acid with anxiolytic effects',
-    evidence: 'C — small positive RCTs for anxiety and mood; generally used in combination with valerian',
-    dose: '300–600 mg standardized extract (≥5% rosmarinic acid); often combined with valerian',
-    safety: 'Generally low-risk at typical doses; mild sedation at high doses; use caution with thyroid conditions or thyroid medication',
-    bestFor: 'Mild anxiety; anxiety + cognitive fog overlap; combination with valerian for sleep-anxiety',
-    href: '/herbs/melissa-officinalis',
-    badge: 'Emerging',
-    interactions: 'Thyroid medications (theoretical at high doses), sedatives',
+    question: 'Can anxiety herbs replace medication or therapy?',
+    answer:
+      'No. Supplements should not replace prescribed medication, psychotherapy, or evaluation of persistent or impairing anxiety. Do not stop or reduce psychiatric medication based on this guide, and review herb–drug interactions with a clinician or pharmacist.',
   },
   {
-    name: 'Lavender (Silexan)',
-    mechanism: 'Calcium channel modulation by linalool and linalool acetate; reduces 5-HT1A serotonin reuptake; limbic system effects',
-    evidence: 'B — oral Silexan (80 mg lavender oil) has RCT evidence comparable to lorazepam 0.5 mg for GAD',
-    dose: 'Oral Silexan 80 mg/day (standardized lavender oil capsules); 6–10 week trials',
-    safety: 'Generally well-tolerated at studied oral Silexan doses; avoid ingesting raw lavender essential oil, which is a different preparation',
-    bestFor: 'Generalized anxiety; when pharmaceutical anxiolytics are not appropriate',
-    href: '/compounds/lavender',
-    badge: 'Moderate',
-    interactions: 'Sedatives (additive effect)',
-  },
-  {
-    name: 'Chamomile',
-    mechanism: 'Apigenin-containing flower preparation with mild GABAergic and calming plausibility',
-    evidence: 'C — small anxiety trials and traditional use; not as strong as Silexan or ashwagandha',
-    dose: 'Tea or standardized extract per label; clinical extract doses vary by preparation',
-    safety: 'Generally gentle; avoid with ragweed allergy and use caution with sedatives or anticoagulants',
-    bestFor: 'Mild situational anxiety, evening ritual, anxiety + sleep overlap',
-    href: '/compounds/apigenin',
-    badge: 'Preliminary',
-    interactions: 'Sedatives, anticoagulants, ragweed allergy',
+    question: 'What if anxiety is severe or I do not feel safe?',
+    answer:
+      'Severe panic, rapidly worsening symptoms, suicidal thoughts, thoughts of self-harm, inability to stay safe, or imminent danger require immediate emergency or crisis care rather than supplement experimentation.',
   },
 ]
 
-const HERB_CHOICE_FRAMEWORK = [
-  { scenario: 'Chronic daily anxiety / stress', recommendation: 'Ashwagandha (long-term, 8+ weeks)', note: 'Addresses root HPA dysregulation rather than just symptoms' },
-  { scenario: 'Acute / situational anxiety', recommendation: 'Passionflower or Lavender (Silexan)', note: 'Faster onset, better for episodic use' },
-  { scenario: 'Anxiety + sleep disruption', recommendation: 'Passionflower + Magnesium Glycinate', note: 'Addresses both arms without heavy sedation' },
-  { scenario: 'Social anxiety (short-term use only)', recommendation: 'Kava (aqueous extract, low dose)', note: 'Effective but significant safety caveats; not for daily long-term use' },
-  { scenario: 'Mild anxiety + brain fog', recommendation: 'Lemon Balm + Ashwagandha', note: 'Lemon balm offers mild cognitive support alongside anxiolysis' },
+const SOURCES = [
+  {
+    label: 'Silexan meta-analysis of randomized placebo-controlled anxiety trials (2023)',
+    href: 'https://pubmed.ncbi.nlm.nih.gov/36717399/',
+    note: 'Five double-blind placebo-controlled trials; 1,213 adult outpatients received the proprietary oral lavender-oil preparation Silexan 80 mg/day or placebo for 10 weeks.',
+  },
+  {
+    label: 'Silexan randomized trial in generalized anxiety disorder (2014)',
+    href: 'https://pubmed.ncbi.nlm.nih.gov/24456909/',
+    note: '539 adults with GAD were randomized to Silexan 160 mg, Silexan 80 mg, paroxetine 20 mg, or placebo for 10 weeks.',
+  },
+  {
+    label: 'Ashwagandha stress and anxiety systematic review and meta-analysis (2024)',
+    href: 'https://pubmed.ncbi.nlm.nih.gov/39348746/',
+    note: 'Nine randomized placebo-controlled trials and 558 participants; repeated-dose evidence using specific ashwagandha formulations.',
+  },
+  {
+    label: 'Passionflower versus oxazepam pilot trial in generalized anxiety disorder (2001)',
+    href: 'https://pubmed.ncbi.nlm.nih.gov/11679026/',
+    note: '36 outpatients with DSM-IV GAD; passionflower extract 45 drops/day versus oxazepam 30 mg/day for 4 weeks. A small pilot cannot establish equivalence.',
+  },
+  {
+    label: 'Kava randomized placebo-controlled trial in generalized anxiety disorder (2020)',
+    href: 'https://pubmed.ncbi.nlm.nih.gov/31813230/',
+    note: '171 non-medicated adults with diagnosed GAD; aqueous dried-root extract standardized to 120 mg kavalactones twice daily for 16 weeks did not significantly outperform placebo.',
+  },
+  {
+    label: 'NCCIH: Kava usefulness and safety',
+    href: 'https://www.nccih.nih.gov/health/kava',
+    note: 'Current safety summary includes rare severe or fatal liver injury reports and cautions against combining kava with benzodiazepines or alcohol.',
+  },
+  {
+    label: 'NCCIH: Passionflower usefulness and safety',
+    href: 'https://www.nccih.nih.gov/health/passionflower',
+    note: 'Overall human evidence is limited; anxiety conclusions are not definite. Drowsiness, dizziness, confusion, pregnancy, and anesthesia cautions matter.',
+  },
 ]
-
-const ANXIETY_FAQS = [
-  {
-    question: 'What is the fastest-acting herb for anxiety?',
-    answer: 'Passionflower, lavender/Silexan, or carefully selected kava may feel more acute than ashwagandha, but fast-acting does not mean risk-free. Kava has important liver, alcohol, and medication cautions.',
-  },
-  {
-    question: 'Can herbs replace anxiety medication?',
-    answer: 'No. Herbs should not replace prescribed anxiety medication or therapy. Discuss any supplement plan with a healthcare professional, especially before changing SSRIs, benzodiazepines, or other psychiatric medications.',
-  },
-  {
-    question: 'Can I take anxiety herbs with SSRIs?',
-    answer: 'Do not stack serotonergic, sedating, or liver-active herbs with SSRIs without clinician guidance. Interaction risk depends on the herb, dose, medication, liver function, and personal history.',
-  },
-  {
-    question: 'Which anxiety herb is best for daily use?',
-    answer: 'Ashwagandha or lavender/Silexan are more often studied over multi-week daily windows, while kava is better treated as short-term and safety-limited. Individual fit and contraindications matter more than a universal winner.',
-  },
-]
-
-const ANXIETY_REFERENCES = [
-  ['Silexan anxiety meta-analysis', 'https://pmc.ncbi.nlm.nih.gov/articles/PMC10465640/'],
-  ['Silexan anxiety meta-analysis on PubMed', 'https://pubmed.ncbi.nlm.nih.gov/36717399/'],
-  ['Ashwagandha stress RCT', 'https://pmc.ncbi.nlm.nih.gov/articles/PMC6750292/'],
-  ['Ashwagandha adaptogenic and anxiolytic trial', 'https://pmc.ncbi.nlm.nih.gov/articles/PMC6979308/'],
-] as const
 
 const HEADINGS: Heading[] = [
-  { id: 'match', text: 'Match herb to anxiety pattern', level: 2 },
-  { id: 'time-horizon', text: 'Choose by time horizon', level: 2 },
-  { id: 'risks', text: 'SSRI and sedative stacking risk', level: 2 },
-  { id: 'evidence', text: 'Herb-by-herb evidence review', level: 2 },
-  { id: 'limits', text: "What the evidence can't tell you", level: 2 },
-  { id: 'dosing', text: 'Dosing and timing snapshot', level: 2 },
+  { id: 'bottom-line', text: 'Bottom line', level: 2 },
+  { id: 'directness', text: 'Compare by evidence directness', level: 2 },
+  { id: 'evidence', text: 'Herb-by-herb evidence', level: 2 },
+  { id: 'safety', text: 'Safety can outrank efficacy', level: 2 },
+  { id: 'limits', text: 'What not to infer', level: 2 },
+  { id: 'sources', text: 'Sources', level: 2 },
   { id: 'faq', text: 'Frequently asked questions', level: 2 },
 ]
 
 export default function BestHerbsForAnxietyPage() {
-  const ashwagandhaProducts = getRevenueProductSet('ashwagandha')
-
   const faqSchema = {
     '@context': 'https://schema.org',
     '@type': 'FAQPage',
-    mainEntity: ANXIETY_FAQS.map((faq) => ({
+    mainEntity: FAQS.map((faq) => ({
       '@type': 'Question',
       name: faq.question,
       acceptedAnswer: {
@@ -161,243 +123,256 @@ export default function BestHerbsForAnxietyPage() {
     <ArticleLayout toc={toc} zone="supplement">
       <StructuredData
         pageUrl={PAGE_URL}
-        headline="Best Herbs for Anxiety: Ashwagandha, Passionflower, Lavender & More"
-        description="Evidence-graded guide to the best herbs for anxiety including ashwagandha, kava, passionflower, lemon balm, and lavender. Covers mechanisms, evidence quality, dosing, safety, and drug interactions."
+        headline="Best Herbs for Anxiety: What the Evidence Supports in 2026"
+        description="Evidence-first comparison of ashwagandha, Silexan lavender oil, passionflower, kava, lemon balm, and chamomile for anxiety."
         datePublished="2026-06-16"
-        dateModified="2026-06-26"
+        dateModified={DATE}
         breadcrumbs={[
           { label: 'Home', href: '/' },
           { label: 'Guides', href: '/guides' },
+          { label: 'Anxiety', href: '/guides/anxiety/' },
           { label: 'Best Herbs for Anxiety', href: '/guides/anxiety/best-herbs-for-anxiety' },
         ]}
       />
       <JsonLd schema={faqSchema} />
 
-      <div className="space-y-14">
-
-        {/* Hero */}
+      <div className="space-y-10">
         <section className="rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-10">
-          <p className="eyebrow-label">Anxiety herb guide</p>
+          <p className="eyebrow-label">Anxiety herb evidence guide</p>
           <h1 className="mt-3 text-3xl font-bold tracking-tight text-ink sm:text-4xl">
             Best Herbs for Anxiety
           </h1>
-          <p className="mt-2 text-xs text-muted">Last updated June 26, 2026</p>
-          <p className="mt-4 text-sm leading-7 text-muted sm:text-base">
-            The herbal anxiety market is enormous and mostly noise. A handful of plants have credible
-            clinical evidence — but they work via different mechanisms, at different timescales, and
-            with very different safety profiles. This guide covers the five best-supported options
-            honestly: what they do, what the evidence actually shows, who they are appropriate for,
-            and when they are not.
+          <p className="mt-2 text-xs text-muted">Last evidence review August 11, 2026</p>
+          <p className="mt-4 max-w-3xl text-sm leading-7 text-muted sm:text-base">
+            “Best” is the wrong first question for anxiety herbs. The useful comparison is what was studied
+            directly, in whom, with which preparation, for how long, and what safety limits come with it.
+            This guide keeps formulation-specific evidence separate from broad herb-category claims and does
+            not turn study timing into a same-day treatment promise.
           </p>
-          <div className="mt-5 rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-900">
-            <strong>Important:</strong> Herbs for anxiety are educational context, not a substitute for
-            evaluation of an anxiety disorder. If symptoms significantly impair your functioning, speak
-            with a healthcare provider. Drug interactions (especially kava) are real and serious.
-          </div>
-          <div className="mt-4 rounded-xl border border-brand-900/10 bg-brand-50 p-4 text-sm text-brand-950">
-            <strong>Fastest useful choice:</strong> for chronic stress-related anxiety, start with{' '}
-            <Link href="/guides/herbs/ashwagandha/" className="font-semibold text-brand-800 hover:underline">ashwagandha</Link>;
-            for same-day calming, compare{' '}
-            <Link href="/herbs/passionflower/" className="font-semibold text-brand-800 hover:underline">passionflower</Link>{' '}
-            or <Link href="/compounds/lavender/" className="font-semibold text-brand-800 hover:underline">lavender/Silexan</Link>;
-            for higher-risk short-term use only, read the{' '}
-            <Link href="/guides/kava/" className="font-semibold text-brand-800 hover:underline">kava safety guide</Link> first.
+
+          <div className="mt-5 rounded-xl border border-red-200 bg-red-50 p-4 text-sm leading-6 text-red-950">
+            <strong>Care boundary:</strong> Persistent or impairing anxiety deserves established mental-health
+            care rather than supplement escalation. Suicidal thoughts, thoughts of self-harm, inability to stay
+            safe, or imminent danger require immediate emergency or crisis care.
           </div>
 
           <figure className="mt-6">
-            <div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white">
+            <div className="overflow-hidden rounded-2xl border border-brand-900/10 bg-white shadow-sm">
               <Image
                 src="/images/guides/best-herbs-for-anxiety.jpg"
-                alt="Calming anxiety herbs including passionflower, lavender, lemon balm, kava root, and ashwagandha arranged on a slate surface"
+                alt="Passionflower, lavender, lemon balm, kava root, and ashwagandha arranged for an evidence comparison"
                 width={1536}
                 height={1024}
                 priority
-                className="w-full h-auto"
+                className="h-auto w-full"
               />
             </div>
             <figcaption className="mt-3 text-center text-sm text-muted">
-              The best-supported herbs for anxiety — ashwagandha, passionflower, lavender, lemon balm, and kava — each work differently.
+              Anxiety evidence is preparation-specific: a studied extract or oral oil cannot be generalized to every product made from the same plant.
             </figcaption>
           </figure>
         </section>
 
-        {/* Decision framework */}
-        <section id="match" className="scroll-mt-20 space-y-4">
-          <p className="eyebrow-label">Start here</p>
-          <h2 className="text-2xl font-semibold tracking-tight text-ink">
-            Match herb to anxiety pattern
+        <section id="bottom-line" className="scroll-mt-20 rounded-[1.65rem] border border-brand-700/25 bg-brand-50/60 p-6 shadow-sm">
+          <p className="eyebrow-label">Bottom line</p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
+            The evidence hierarchy is not the same as a “best herb” ranking
           </h2>
-          <div className="overflow-x-auto rounded-[1.65rem] border border-brand-900/10 bg-white shadow-sm">
-            <table className="min-w-[600px] w-full text-sm border-collapse">
-              <thead>
-                <tr className="border-b border-brand-900/10 bg-brand-50/50">
-                  <th className="text-left p-4 font-semibold text-ink">Your situation</th>
-                  <th className="text-left p-4 font-semibold text-ink">Best herb choice</th>
-                  <th className="text-left p-4 font-semibold text-ink">Note</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-brand-900/10">
-                {HERB_CHOICE_FRAMEWORK.map((row) => (
-                  <tr key={row.scenario}>
-                    <td className="p-4 font-medium text-ink">{row.scenario}</td>
-                    <td className="p-4 text-brand-700 font-medium">{row.recommendation}</td>
-                    <td className="p-4 text-muted">{row.note}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </section>
-
-        <section className="grid gap-4 md:grid-cols-2">
-          <div id="time-horizon" className="scroll-mt-20 rounded-[1.65rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm">
-            <p className="eyebrow-label">Fast acting vs daily</p>
-            <h2 className="mt-1 text-xl font-semibold text-ink">Choose by time horizon</h2>
-            <ul className="mt-3 space-y-2 text-sm leading-6 text-muted">
-              <li><strong>Same-day calming:</strong> passionflower, lavender/Silexan, or kava with strict safety limits.</li>
-              <li><strong>Multi-week stress pattern:</strong> ashwagandha is a better fit than expecting immediate sedation.</li>
-              <li><strong>Mild evening ritual:</strong> chamomile or lemon balm may fit better than stronger anxiolytic herbs.</li>
-            </ul>
-          </div>
-          <div id="risks" className="scroll-mt-20 rounded-[1.65rem] border border-red-200 bg-red-50 p-6 shadow-sm">
-            <p className="eyebrow-label text-red-900">Medication safety</p>
-            <h2 className="mt-1 text-xl font-semibold text-red-950">SSRI and sedative stacking risk</h2>
-            <p className="mt-3 text-sm leading-6 text-red-900/90">
-              Do not stop, reduce, or combine prescribed anxiety medication with herbs based on this guide.
-              SSRIs, benzodiazepines, sleep medications, alcohol, kava, sedating herbs, and liver-active
-              products can create additive or unpredictable risks. Use clinician guidance before combining.
+          <div className="mt-4 space-y-3 text-sm leading-7 text-muted sm:text-base">
+            <p>
+              <strong>Oral Silexan</strong> has the most direct anxiety-disorder trial program among the
+              options compared here, but the evidence belongs to a proprietary oral lavender-oil preparation
+              studied for 10 weeks. It should not be generalized to lavender tea, aromatherapy, or raw essential oil.
+            </p>
+            <p>
+              <strong>Ashwagandha</strong> has a meaningful repeated-dose stress/anxiety signal across randomized
+              trials, but studies use specific formulations and multi-week exposure. <strong>Passionflower</strong>
+              remains supported mainly by small studies, while <strong>kava</strong> combines mixed efficacy with a
+              safety ceiling serious enough that it should not be promoted as the fast or obvious choice.
             </p>
           </div>
         </section>
 
-        {/* Herb profiles */}
-        <section id="evidence" className="scroll-mt-20 space-y-6">
-          <div>
-            <p className="eyebrow-label">Evidence profiles</p>
-            <h2 className="mt-1 text-2xl font-semibold tracking-tight text-ink">
-              Herb-by-herb evidence review
-            </h2>
-          </div>
-          <div className="space-y-5">
-            {ANXIETY_HERBS.map((h) => (
-              <div key={h.name} className="rounded-[1.65rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm">
-                <div className="flex flex-wrap items-start justify-between gap-2">
-                  <Link href={h.href} className="text-xl font-semibold text-brand-800 hover:underline">
-                    {h.name}
-                  </Link>
-                  <span className="rounded-full bg-brand-50 px-3 py-0.5 text-xs font-semibold text-brand-800">
-                    {h.badge}
-                  </span>
-                </div>
-                <div className="mt-4 grid gap-3 sm:grid-cols-2 text-sm">
-                  <div>
-                    <p className="font-semibold text-ink">Mechanism</p>
-                    <p className="mt-0.5 text-muted">{h.mechanism}</p>
-                  </div>
-                  <div>
-                    <p className="font-semibold text-ink">Best for</p>
-                    <p className="mt-0.5 text-muted">{h.bestFor}</p>
-                  </div>
-                  <div>
-                    <p className="font-semibold text-ink">Evidence</p>
-                    <p className="mt-0.5 text-muted">{h.evidence}</p>
-                  </div>
-                  <div>
-                    <p className="font-semibold text-ink">Typical dose</p>
-                    <p className="mt-0.5 text-muted">{h.dose}</p>
-                  </div>
-                  <div>
-                    <p className="font-semibold text-ink">Safety</p>
-                    <p className="mt-0.5 text-muted">{h.safety}</p>
-                  </div>
-                  <div>
-                    <p className="font-semibold text-ink">Key interactions</p>
-                    <p className="mt-0.5 text-muted">{h.interactions}</p>
-                  </div>
-                </div>
-                <Link href={h.href} className="mt-4 inline-block text-xs font-semibold text-brand-700 hover:underline">
-                  Full profile →
-                </Link>
-              </div>
-            ))}
-          </div>
-        </section>
-
-        {/* What evidence can't tell you */}
-        <section id="limits" className="scroll-mt-20 rounded-[1.65rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm space-y-3">
-          <h2 className="text-xl font-semibold text-ink">What the evidence can't tell you</h2>
-          <ul className="space-y-2 text-sm text-muted list-none">
-            <li>• Most herb anxiety trials last 4–12 weeks on non-clinical (subclinical) populations. Effects in clinical anxiety disorders may differ significantly.</li>
-            <li>• Standardization varies wildly between products. A 300 mg ashwagandha capsule with 1% withanolides is not the same as KSM-66 with 5%.</li>
-            <li>• Kava's safety data is heavily preparation-dependent. The Cochrane review supporting its use was on aqueous extracts; most of the hepatotoxicity reports involve ethanolic or acetone extracts.</li>
-            <li>• Individual response varies substantially. Someone with HPA dysregulation may see dramatic benefit from ashwagandha; someone with pure GABA dysregulation may not.</li>
-          </ul>
-        </section>
-
-        <section id="dosing" className="scroll-mt-20 rounded-[1.65rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm">
-          <h2 className="text-xl font-semibold text-ink">Dosing and timing snapshot</h2>
-          <div className="mt-4 overflow-x-auto rounded-[1rem] border border-brand-900/10 bg-white">
-            <table className="min-w-[640px] w-full text-left text-sm">
-              <thead className="bg-brand-50/60 text-xs font-bold uppercase tracking-wider text-muted">
+        <section id="directness" className="scroll-mt-20 space-y-4">
+          <p className="eyebrow-label">Compare directness, not popularity</p>
+          <h2 className="text-2xl font-semibold tracking-tight text-ink">What was actually studied?</h2>
+          <div className="overflow-x-auto rounded-[1.65rem] border border-brand-900/10 bg-white shadow-sm">
+            <table className="min-w-[820px] w-full text-sm">
+              <thead className="border-b border-brand-900/10 bg-brand-50/50">
                 <tr>
-                  <th className="p-4">Herb</th>
-                  <th className="p-4">Time horizon</th>
-                  <th className="p-4">Typical range</th>
-                  <th className="p-4">Main caution</th>
+                  <th className="p-4 text-left font-semibold text-ink">Option</th>
+                  <th className="p-4 text-left font-semibold text-ink">Direct human evidence</th>
+                  <th className="p-4 text-left font-semibold text-ink">Main limit</th>
+                  <th className="p-4 text-left font-semibold text-ink">Safety ceiling</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-brand-900/10">
-                {ANXIETY_HERBS.map((h) => (
-                  <tr key={h.name}>
-                    <td className="p-4 font-semibold text-ink">{h.name}</td>
-                    <td className="p-4 text-muted">{/Ashwagandha|Lavender/.test(h.name) ? 'Daily / multi-week' : 'Situational or evening'}</td>
-                    <td className="p-4 text-muted">{h.dose}</td>
-                    <td className="p-4 text-muted">{h.interactions}</td>
-                  </tr>
-                ))}
+                <tr className="align-top">
+                  <td className="p-4 font-semibold text-ink">Silexan oral lavender oil</td>
+                  <td className="p-4 text-muted">Five placebo-controlled anxiety trials in 1,213 adult outpatients at 80 mg/day for 10 weeks; additional GAD dose-ranging data exist.</td>
+                  <td className="p-4 text-muted">Evidence is for a proprietary oral preparation, not “lavender” as a class.</td>
+                  <td className="p-4 text-muted">Do not ingest raw essential oil as if it were the studied product.</td>
+                </tr>
+                <tr className="align-top">
+                  <td className="p-4 font-semibold text-ink">Ashwagandha</td>
+                  <td className="p-4 text-muted">Nine randomized placebo-controlled trials / 558 participants in the 2024 meta-analysis using specific formulations over repeated dosing.</td>
+                  <td className="p-4 text-muted">Heterogeneous extracts, populations, and outcome measures; not a class effect for every powder or capsule.</td>
+                  <td className="p-4 text-muted">Pregnancy, thyroid, autoimmune, medication, and rare liver-injury concerns require individual review.</td>
+                </tr>
+                <tr className="align-top">
+                  <td className="p-4 font-semibold text-ink">Passionflower</td>
+                  <td className="p-4 text-muted">One often-cited pilot enrolled 36 GAD outpatients for 4 weeks: passionflower extract 45 drops/day versus oxazepam 30 mg/day.</td>
+                  <td className="p-4 text-muted">Tiny active-comparator pilot; no basis for declaring equivalence, and NCCIH still calls the overall evidence inconclusive.</td>
+                  <td className="p-4 text-muted">Drowsiness, dizziness, confusion, pregnancy, and anesthesia interactions matter.</td>
+                </tr>
+                <tr className="align-top">
+                  <td className="p-4 font-semibold text-ink">Kava</td>
+                  <td className="p-4 text-muted">A 16-week placebo-controlled GAD trial in 171 non-medicated adults used aqueous dried-root extract standardized to 120 mg kavalactones twice daily.</td>
+                  <td className="p-4 text-muted">The trial did not significantly outperform placebo; the broader efficacy literature is mixed.</td>
+                  <td className="p-4 text-muted">Rare severe or fatal liver injury has been linked to kava products; avoid combining kava with benzodiazepines or alcohol.</td>
+                </tr>
+                <tr className="align-top">
+                  <td className="p-4 font-semibold text-ink">Lemon balm / chamomile</td>
+                  <td className="p-4 text-muted">Small or preliminary anxiety studies and traditional-use context exist, but the evidence base is much thinner than the options above.</td>
+                  <td className="p-4 text-muted">Do not convert “calming” plausibility or a tea ritual into evidence for an anxiety disorder.</td>
+                  <td className="p-4 text-muted">Sedation, allergy, medication, and product-specific cautions still apply.</td>
+                </tr>
               </tbody>
             </table>
           </div>
         </section>
 
-        {ashwagandhaProducts && (
-          <RecommendationSection products={ashwagandhaProducts.products} />
-        )}
+        <section id="evidence" className="scroll-mt-20 space-y-5">
+          <p className="eyebrow-label">Herb-by-herb evidence</p>
+          <h2 className="text-2xl font-semibold tracking-tight text-ink">How to interpret each option without overclaiming it</h2>
+
+          <article className="rounded-[1.65rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm">
+            <h3 className="text-xl font-semibold text-ink">Silexan: direct anxiety evidence, narrow formulation claim</h3>
+            <p className="mt-3 text-sm leading-7 text-muted">
+              The 2023 meta-analysis pooled five double-blind randomized placebo-controlled trials in 1,213 adult
+              outpatients who received Silexan 80 mg/day or placebo for 10 weeks. A separate 539-person GAD trial
+              compared 80 mg and 160 mg Silexan with paroxetine and placebo. This is comparatively direct anxiety
+              evidence, but it supports the studied oral preparation—not every lavender product.
+            </p>
+            <Link href="/compounds/lavender/" className="mt-3 inline-block text-sm font-semibold text-brand-700 hover:underline">
+              Lavender evidence profile →
+            </Link>
+          </article>
+
+          <article className="rounded-[1.65rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm">
+            <h3 className="text-xl font-semibold text-ink">Ashwagandha: repeated-dose signal, not an acute anxiolytic</h3>
+            <p className="mt-3 text-sm leading-7 text-muted">
+              The 2024 meta-analysis included nine randomized placebo-controlled trials and 558 participants and
+              found pooled improvements in stress/anxiety measures and cortisol. The key directness limit is that
+              trials used defined formulations over repeated dosing, often in adults with stress or anxiety symptoms.
+              That supports a multi-week extract signal, not a same-day calming promise or a guarantee for every product.
+            </p>
+            <Link href="/guides/anxiety/ashwagandha-for-anxiety/" className="mt-3 inline-block text-sm font-semibold text-brand-700 hover:underline">
+              Ashwagandha for anxiety →
+            </Link>
+          </article>
+
+          <article className="rounded-[1.65rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm">
+            <h3 className="text-xl font-semibold text-ink">Passionflower: a small signal, not benzodiazepine equivalence</h3>
+            <p className="mt-3 text-sm leading-7 text-muted">
+              The trial most often cited for generalized anxiety enrolled only 36 outpatients for 4 weeks. Eighteen
+              received passionflower extract 45 drops/day and 18 received oxazepam 30 mg/day. No significant
+              difference appeared at the end of the small pilot, while oxazepam acted faster. That result is not
+              evidence that passionflower is equivalent to oxazepam, and NCCIH still considers the broader anxiety
+              evidence too limited for definite conclusions.
+            </p>
+            <Link href="/herbs/passionflower/" className="mt-3 inline-block text-sm font-semibold text-brand-700 hover:underline">
+              Passionflower profile →
+            </Link>
+          </article>
+
+          <article className="rounded-[1.65rem] border border-red-200 bg-red-50/70 p-6 shadow-sm">
+            <h3 className="text-xl font-semibold text-red-950">Kava: mixed efficacy plus a high-consequence safety caveat</h3>
+            <p className="mt-3 text-sm leading-7 text-red-900">
+              In the larger 2020 GAD trial, 171 non-medicated adults received an aqueous dried-root extract
+              standardized to 120 mg kavalactones twice daily or placebo for 16 weeks. Kava did not significantly
+              outperform placebo. NCCIH also notes rare severe and sometimes fatal liver injury linked to kava
+              products and advises against combining kava with benzodiazepines or alcohol. That combination of
+              uncertain benefit and potentially serious harm makes a rapid-use kava ranking inappropriate.
+            </p>
+            <Link href="/guides/kava/" className="mt-3 inline-block text-sm font-semibold text-red-900 hover:underline">
+              Kava safety guide →
+            </Link>
+          </article>
+        </section>
+
+        <section id="safety" className="scroll-mt-20 rounded-[1.65rem] border border-amber-200 bg-amber-50/70 p-6 shadow-sm">
+          <p className="eyebrow-label text-amber-900">Safety can outrank efficacy</p>
+          <h2 className="mt-2 text-xl font-semibold text-amber-950">A stronger signal is not automatically a better personal choice</h2>
+          <ul className="mt-4 space-y-2 text-sm leading-7 text-amber-950">
+            <li>• Do not stop, reduce, or replace prescribed anxiety medication based on supplement evidence.</li>
+            <li>• Sedating herbs can add to alcohol, benzodiazepines, sleep medicines, opioids, or anesthesia.</li>
+            <li>• Kava deserves a separate liver-risk discussion before use; “water extract” does not erase all reported liver concerns.</li>
+            <li>• Passionflower should be avoided during pregnancy and discussed around surgery/anesthesia.</li>
+            <li>• Ashwagandha requires extra caution with pregnancy, thyroid disease/medication, autoimmune conditions, and liver concerns.</li>
+            <li>• Persistent or impairing anxiety is a care question, not a reason to keep escalating supplement complexity.</li>
+          </ul>
+        </section>
+
+        <section id="limits" className="scroll-mt-20 rounded-[1.65rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm">
+          <h2 className="text-xl font-semibold text-ink">What not to infer from this evidence</h2>
+          <ul className="mt-4 space-y-2 text-sm leading-7 text-muted">
+            <li>• A studied proprietary extract or oral oil does not validate every product sold under the same plant name.</li>
+            <li>• Study dose and timing describe the trial; they are not automatically personal dosing instructions.</li>
+            <li>• A non-significant difference between two small groups does not prove two treatments are equivalent.</li>
+            <li>• Traditional use, mechanism plausibility, or online popularity does not establish treatment efficacy for an anxiety disorder.</li>
+            <li>• Evidence for a single ingredient does not prove a multi-herb “anxiety stack” works better.</li>
+          </ul>
+        </section>
+
+        <section id="sources" className="scroll-mt-20 rounded-[1.65rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm">
+          <h2 className="text-xl font-semibold text-ink">Sources and directness notes</h2>
+          <ol className="mt-4 space-y-4">
+            {SOURCES.map((source, index) => (
+              <li key={source.href} className="text-sm leading-7 text-muted">
+                <span className="font-semibold text-ink">{index + 1}. </span>
+                <a href={source.href} target="_blank" rel="noopener noreferrer" className="font-semibold text-brand-700 hover:underline">
+                  {source.label}
+                </a>
+                <span> — {source.note}</span>
+              </li>
+            ))}
+          </ol>
+        </section>
 
         <section id="faq" className="scroll-mt-20 rounded-[1.65rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm">
           <h2 className="text-xl font-semibold text-ink">Frequently asked questions</h2>
           <div className="mt-4 divide-y divide-brand-900/10">
-            {ANXIETY_FAQS.map((faq) => (
+            {FAQS.map((faq) => (
               <div key={faq.question} className="py-4 first:pt-0 last:pb-0">
                 <h3 className="font-semibold text-ink">{faq.question}</h3>
-                <p className="mt-2 text-sm leading-6 text-muted">{faq.answer}</p>
+                <p className="mt-2 text-sm leading-7 text-muted">{faq.answer}</p>
               </div>
             ))}
           </div>
         </section>
 
-        <section className="rounded-[1.65rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm">
-          <h2 className="text-xl font-semibold text-ink">References</h2>
-          <ul className="mt-4 space-y-2 text-sm leading-6">
-            {ANXIETY_REFERENCES.map(([label, href]) => (
-              <li key={href}>
-                <a href={href} target="_blank" rel="noopener noreferrer" className="font-semibold text-brand-700 hover:underline">
-                  {label}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </section>
+        <div className="rounded-[1.65rem] border border-brand-900/10 bg-brand-50/50 p-6">
+          <p className="text-sm leading-7 text-muted">
+            <strong className="text-ink">Product sourcing:</strong> this broad comparison intentionally does not
+            rank affiliate products. Follow the ingredient-specific evidence guides for formulation and sourcing
+            context so monetization does not silently decide which herb appears to be the winner.
+          </p>
+        </div>
 
-        {/* Related guides */}
+        <div className="space-y-6">
+          <NewsletterCtaBlock />
+          <EmailCapture />
+        </div>
+
         <nav className="flex flex-wrap gap-4 text-sm font-semibold text-brand-700">
           <Link href="/guides/anxiety/" className="hover:text-brand-800">Anxiety goal hub →</Link>
-          <Link href="/guides/herbs/ashwagandha/" className="hover:text-brand-800">Ashwagandha Evidence Guide →</Link>
-          <Link href="/guides/anxiety/natural-anxiolytics-beyond-ashwagandha/" className="hover:text-brand-800">Anxiolytics Beyond Ashwagandha →</Link>
-          <Link href="/guides/anxiety/natural-alternatives-to-anxiety-medication/" className="hover:text-brand-800">Natural Alternatives to Anxiety Meds →</Link>
-          <Link href="/guides/kava/" className="hover:text-brand-800">Kava Safety Guide →</Link>
-          <Link href="/guides/anxiety/best-supplements-for-overthinking/" className="hover:text-brand-800">Supplements for Overthinking →</Link>
-          <Link href="/guides/" className="hover:text-brand-800">All Guides →</Link>
+          <Link href="/guides/anxiety/natural-anxiety-relief/" className="hover:text-brand-800">Natural anxiety relief →</Link>
+          <Link href="/guides/anxiety/anxiety-stack-guide/" className="hover:text-brand-800">Anxiety stack evidence guide →</Link>
+          <Link href="/guides/anxiety/l-theanine-for-anxiety/" className="hover:text-brand-800">L-theanine for anxiety →</Link>
+          <Link href="/guides/anxiety/ashwagandha-for-anxiety/" className="hover:text-brand-800">Ashwagandha for anxiety →</Link>
+          <Link href="/guides/kava/" className="hover:text-brand-800">Kava safety guide →</Link>
+          <Link href="/guides/" className="hover:text-brand-800">All guides →</Link>
         </nav>
       </div>
     </ArticleLayout>


### PR DESCRIPTION
High-ROI trust/evidence rebuild of the broad anxiety-herb comparison.

- removes same-day “best herb” rankings, fastest-choice language, and symptom-to-herb recommendation rows
- separates proprietary oral Silexan evidence from generic lavender products
- updates Silexan to the 2023 placebo-controlled meta-analysis (5 trials / 1,213 adult outpatients) plus direct GAD trial context
- updates ashwagandha to the 2024 meta-analysis (9 placebo-controlled RCTs / 558 participants) and keeps the claim repeated-dose/formulation-specific
- reframes the famous passionflower-vs-oxazepam result as what it was: a 36-person, 4-week pilot that cannot establish equivalence; aligns with NCCIH’s inconclusive overall summary
- updates kava to the 2020 16-week GAD trial (171 non-medicated adults; no significant benefit over placebo) and elevates NCCIH’s rare severe/fatal liver-injury warning
- removes the old dosing/timing snapshot so study regimens are not presented as personal instructions
- preserves route SEO, structured data, hero image, internal evidence discovery, newsletter/email conversion surfaces, and an explicit immediate-crisis stop rule
- removes the one-sided broad-comparison affiliate product block and transparently routes sourcing context to ingredient-specific guides instead

Focused regression coverage locks directness, formulation boundaries, passionflower/kava safety limits, crisis guidance, and the removal of old ranking shortcuts.