### PR TITLE
Rebuild ashwagandha vs magnesium sleep comparison

### DIFF
--- a/app/__tests__/ashwagandha-vs-magnesium-sleep-current-evidence.test.ts
+++ b/app/__tests__/ashwagandha-vs-magnesium-sleep-current-evidence.test.ts
@@ -1,0 +1,112 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const PAGE = path.join(process.cwd(), 'app/guides/sleep/ashwagandha-vs-magnesium-for-sleep/page.tsx')
+
+function source() {
+  return fs.readFileSync(PAGE, 'utf8').replace(/\s+/g, ' ')
+}
+
+describe('ashwagandha vs magnesium sleep evidence calibration', () => {
+  it('preserves publication history and anchors both sides to direct evidence', () => {
+    const text = source()
+
+    expect(text).toContain("const DATE = '2026-06-09'")
+    expect(text).toContain("const UPDATED_DATE = '2026-08-12'")
+    expect(text).toMatch(/date: DATE, updated: UPDATED_DATE/)
+    expect(text).toContain('34559859')
+    expect(text).toContain('33865376')
+    expect(text).toContain('40918053')
+    expect(text).toMatch(/five randomized trials \/ 400 adults/i)
+    expect(text).toMatch(/three randomized trials \/ 151 older adults/i)
+    expect(text).toMatch(/155 adults/i)
+    expect(text).toMatch(/250 mg elemental magnesium/i)
+    expect(text).toMatch(/four weeks/i)
+    expect(text).toMatch(/Cohen d=0\.2/i)
+    expect(text).toMatch(/separate sleep-quality measure was not significantly different/i)
+    expect(text).toMatch(/objective sleep was not measured/i)
+  })
+
+  it('keeps both sleep evidence ratings conservative and discloses trial context', () => {
+    const text = source()
+
+    expect(text).toMatch(/title="Ashwagandha for sleep" evidenceLevel="Limited"/i)
+    expect(text).toMatch(/title="Magnesium for sleep" evidenceLevel="Limited"/i)
+    expect(text).toMatch(/small significant overall sleep effect and moderate heterogeneity/i)
+    expect(text).toMatch(/low-to-very-low certainty/i)
+    expect(text).toMatch(/funded by the Institute of Food and One Health at Leibniz University Hannover/i)
+    expect(text).toMatch(/one coauthor disclosed nutraceutical-industry research funding and presentation honoraria/i)
+  })
+
+  it('does not restore same-night winner, symptom-matching, or fixed bedtime protocols', () => {
+    const text = source()
+
+    expect(text).not.toMatch(/Fastest useful choice/i)
+    expect(text).not.toMatch(/If you only try one tonight: magnesium glycinate/i)
+    expect(text).not.toMatch(/magnesium glycinate is the faster, lower-friction starting point/i)
+    expect(text).not.toMatch(/100[–-]300\s*(?:mg|&nbsp;mg).*30[–-]60 minutes before bed/i)
+    expect(text).not.toMatch(/add.*ashwagandha.*if stress-driven wakefulness persists/i)
+    expect(text).not.toMatch(/Choose magnesium if:/i)
+    expect(text).not.toMatch(/Choose ashwagandha if:/i)
+    expect(text).not.toMatch(/Consider both if:/i)
+    expect(text).not.toMatch(/start one first.*1[–-]2 weeks.*add the second/i)
+    expect(text).not.toMatch(/Evening or nighttime dosing is standard for both/i)
+    expect(text).not.toMatch(/start with ashwagandha \(KSM-66 or Sensoril\)/i)
+    expect(text).not.toMatch(/start with magnesium glycinate/i)
+    expect(text).not.toMatch(/combination is generally reasonable/i)
+    expect(text).toMatch(/four-week daily intervention/i)
+    expect(text).toMatch(/not a trial of one bedtime dose/i)
+    expect(text).toMatch(/same-night rescue effect/i)
+    expect(text).toMatch(/universal “magnesium first” sequence/i)
+  })
+
+  it('does not turn one bisglycinate trial or branded extracts into universal winners', () => {
+    const text = source()
+
+    expect(text).toMatch(/Bisglycinate now has one direct RCT/i)
+    expect(text).toMatch(/does not prove superiority over glycinate\/citrate\/other forms/i)
+    expect(text).toMatch(/No universal winner across KSM-66, Sensoril, Shoden, raw powder, or other preparations/i)
+    expect(text).not.toMatch(/KSM-66 or Sensoril.*better/i)
+  })
+
+  it('does not turn separate ingredient trials into a validated combination', () => {
+    const text = source()
+
+    expect(text).toMatch(/No direct evidence establishes the combination as better/i)
+    expect(text).toMatch(/Separate ashwagandha and magnesium trials do not prove that combining them improves sleep more, works faster, or is safer/i)
+    expect(text).toMatch(/does not recommend starting one and automatically adding the other after a fixed number of days or weeks/i)
+  })
+
+  it('preserves chronic-insomnia and ingredient-specific safety boundaries', () => {
+    const text = source()
+
+    expect(text).toMatch(/CBT-I.*first-line, evidence-based treatment for chronic insomnia/i)
+    expect(text).toContain('aasm.org/coding-quarterly-cognitive-behavioral-therapy-for-insomnia')
+    expect(text).toContain('www.nccih.nih.gov/health/ashwagandha')
+    expect(text).toContain('ods.od.nih.gov/factsheets/Magnesium-HealthProfessional')
+    expect(text).toMatch(/Ashwagandha:.*rare liver injury/i)
+    expect(text).toMatch(/pregnancy\/breastfeeding avoidance/i)
+    expect(text).toMatch(/thyroid and autoimmune cautions/i)
+    expect(text).toMatch(/Magnesium:.*toxicity risk rises with impaired kidney function/i)
+    expect(text).toMatch(/oral bisphosphonates and tetracycline\/quinolone antibiotics/i)
+    expect(text).toMatch(/medication timing should be reviewed with a pharmacist or prescriber rather than guessed/i)
+    expect(text).toMatch(/loud snoring\/gasping, dangerous daytime sleepiness/i)
+  })
+
+  it('keeps broad comparison monetization neutral and FAQ content visible', () => {
+    const text = source()
+
+    expect(text).not.toContain('RecommendationSection')
+    expect(text).not.toContain('getRevenueProductSet')
+    expect(text).not.toContain('AFFILIATE_TAGS')
+    expect(text).not.toMatch(/amazon\.com/i)
+    expect(text).toMatch(/broad comparison intentionally does not rank affiliate products/i)
+    expect(text).toMatch(/one magnesium-bisglycinate or ashwagandha-extract trial does not establish a retail winner/i)
+    expect(text).toContain('{FAQS.map((faq) => (')
+    expect(text).toMatch(/Should I try magnesium glycinate first tonight\?/i)
+    expect(text).toMatch(/faqPageJsonLd\(\{ pagePath: `\/guides\/sleep\/\$\{SLUG\}\/`, questions: FAQS \}\)/)
+    expect(text).toContain('<EmailCapture')
+    expect(text).toContain('<NewsletterCtaBlock')
+  })
+})

--- a/app/guides/sleep/ashwagandha-vs-magnesium-for-sleep/page.tsx
+++ b/app/guides/sleep/ashwagandha-vs-magnesium-for-sleep/page.tsx
@@ -1,90 +1,110 @@
 import Link from 'next/link'
 import Image from 'next/image'
 import JsonLd from '@/components/seo/JsonLd'
-import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd } from '../../../../src/lib/seo'
+import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd, compactMetaTitle } from '../../../../src/lib/seo'
 import EvidenceSummaryCard from '@/components/evidence/EvidenceSummaryCard'
 import SafetyNotice from '@/components/evidence/SafetyNotice'
 import EmailCapture from '@/components/EmailCapture'
-import { getRevenueProductSet } from '@/config/revenue-products'
-import RecommendationSection from '@/components/RecommendationSection'
 import NewsletterCtaBlock from '@/components/NewsletterCtaBlock'
 import LastUpdatedBadge from '../../../../src/components/editorial/LastUpdatedBadge'
 import ResponsiveTable from '@/components/ui/ResponsiveTable'
-import { AFFILIATE_TAGS } from '@/config/affiliate'
-import References from '@/components/References'
-
-// ─── Article metadata ─────────────────────────────────────────────────────────
 
 const SLUG = 'ashwagandha-vs-magnesium-for-sleep'
-const TITLE = 'Ashwagandha vs Magnesium for Sleep: Which Should You Take?'
+const TITLE = 'Ashwagandha vs Magnesium for Sleep: What the Evidence Supports in 2026'
 const DESCRIPTION =
-  'A practical comparison of ashwagandha and magnesium for sleep, including mechanisms, timing, evidence strength, safety, cost, and whether they can be combined.'
+  'Evidence-first comparison of ashwagandha and magnesium for sleep, including direct randomized evidence, preparation limits, medication and kidney cautions, chronic-insomnia care, and why there is no universal same-night winner.'
 const DATE = '2026-06-09'
+const UPDATED_DATE = '2026-08-12'
 const AUTHOR = 'Will'
-const READING_TIME = '12 min read'
-const TAGS = ['comparison', 'sleep', 'ashwagandha', 'magnesium']
-const CATEGORY = 'comparison'
+const READING_TIME = '10 min read'
 
 export const metadata = buildPageMetadata({
-  title: TITLE,
+  title: compactMetaTitle(TITLE),
   description: DESCRIPTION,
   path: `/guides/sleep/${SLUG}`,
   openGraphType: 'article',
 })
 
-// ─── FAQ data (also used for JSON-LD) ────────────────────────────────────────
-
-const FAQS = [
+const SOURCES = [
   {
-    question: 'Is ashwagandha better than magnesium for sleep?',
-    answer:
-      'Neither is universally better — they suit different situations. Ashwagandha is more consistently studied for sleep quality improvements in adults with elevated stress. Magnesium may be more helpful when muscle tension, restlessness, or low mineral status is the primary issue. Your sleep problem type matters more than which supplement is "stronger."',
+    label: 'Ashwagandha sleep systematic review and meta-analysis (2021)',
+    href: 'https://pubmed.ncbi.nlm.nih.gov/34559859/',
+    note: 'Five randomized controlled trials / 400 adults. The pooled sleep effect was small and statistically significant, with moderate heterogeneity; the authors called for more long-term safety data.',
   },
   {
-    question: 'Can I take ashwagandha and magnesium together?',
-    answer:
-      'Generally yes, for many healthy adults. They work through different mechanisms and no significant adverse interaction between them is established. However, direct combination trials are limited, so the evidence base for the combo is thinner than for either supplement alone. Start one first, assess it for 1–2 weeks, then add the second if needed.',
+    label: 'Magnesium for insomnia systematic review and meta-analysis (2021)',
+    href: 'https://pubmed.ncbi.nlm.nih.gov/33865376/',
+    note: 'Three randomized trials / 151 older adults. Sleep-onset latency improved in the pooled analysis, but all trials had moderate-to-high risk of bias and the certainty of evidence was low to very low.',
   },
   {
-    question: 'Which should I try first?',
-    answer:
-      'If your main issue is stress, racing thoughts, or anxiety that keeps you awake, start with ashwagandha (KSM-66 or Sensoril). If your main issue is physical tension, restlessness, or general sleep quality without a strong stress component, start with magnesium glycinate. If budget is tight, magnesium glycinate is typically less expensive and a reasonable first step for most people.',
+    label: 'Magnesium bisglycinate randomized placebo-controlled trial (2025)',
+    href: 'https://pubmed.ncbi.nlm.nih.gov/40918053/',
+    note: 'One hundred fifty-five adults with self-reported poor sleep received 250 mg elemental magnesium as bisglycinate or placebo for four weeks. The insomnia-severity difference was statistically significant but small (Cohen d=0.2); a separate sleep-quality measure was not significantly different and no objective sleep measure was used. The study was funded by the Institute of Food and One Health at Leibniz University Hannover; one coauthor disclosed nutraceutical-industry research funding and presentation honoraria.',
   },
   {
-    question: 'Should I take them at night?',
-    answer:
-      'Evening or nighttime dosing is standard for both when targeting sleep. For magnesium, 30–60 minutes before bed is commonly studied. For ashwagandha, 1–2 hours before bed is a common protocol, though some trials use split morning/evening dosing. Taking with a light meal or snack may reduce GI sensitivity.',
+    label: 'NCCIH: Ashwagandha usefulness and safety',
+    href: 'https://www.nccih.nih.gov/health/ashwagandha',
+    note: 'Some preparations may help insomnia and stress; long-term safety is not established. NCCIH lists pregnancy/breastfeeding, thyroid, autoimmune, surgery, liver, and medication-interaction cautions.',
   },
   {
-    question: 'Is magnesium safer than ashwagandha?',
-    answer:
-      'Magnesium has a broader safety dataset as an essential mineral and is generally well-tolerated in healthy adults at typical supplemental doses. The main caution is kidney disease. Ashwagandha has a shorter modern track record, rare liver injury reports, and more contraindications (pregnancy, thyroid disease, autoimmune conditions). For most healthy adults without those conditions, both have acceptable safety profiles at normal doses.',
+    label: 'NIH ODS: Magnesium health professional fact sheet',
+    href: 'https://ods.od.nih.gov/factsheets/Magnesium-HealthProfessional/',
+    note: 'High supplemental magnesium can cause gastrointestinal effects; toxicity risk rises with impaired kidney function. Magnesium can reduce absorption of oral bisphosphonates and tetracycline/quinolone antibiotics.',
   },
   {
-    question: 'Can either replace melatonin?',
-    answer:
-      'Neither is a melatonin substitute. Melatonin directly signals the circadian system and is the intervention of choice for sleep timing problems (jet lag, shift work, circadian disruption). Ashwagandha and magnesium work on stress/relaxation pathways, not circadian timing. They can be used alongside melatonin but serve a different function.',
+    label: 'NCCIH: Sleep disorders and complementary health approaches',
+    href: 'https://www.nccih.nih.gov/health/sleep-disorders-and-complementary-health-approaches',
+    note: 'NCCIH describes magnesium insomnia evidence as limited and identifies CBT-I as the most strongly recommended treatment for insomnia.',
+  },
+  {
+    label: 'AASM: cognitive behavioral therapy for insomnia',
+    href: 'https://aasm.org/coding-quarterly-cognitive-behavioral-therapy-for-insomnia/',
+    note: 'The American Academy of Sleep Medicine describes CBT-I as the first-line, evidence-based treatment for chronic insomnia.',
   },
 ]
 
-// ─── Page ─────────────────────────────────────────────────────────────────────
-
-const ASHWAGANDHA_VS_MAGNESIUM_FOR_SLEEP_REFS = [
-  { n: 1, text: 'Chandrasekhar K, et al. (2012). Ashwagandha root extract in reducing stress and anxiety. Indian J Psychol Med, 34(3): 255-262.', url: 'https://pubmed.ncbi.nlm.nih.gov/23439798/' },
-  { n: 2, text: 'Abbasi B, et al. (2012). Magnesium supplementation and primary insomnia. J Res Med Sci, 17(12): 1161-1169.', url: 'https://pubmed.ncbi.nlm.nih.gov/23853635/' },
-  { n: 3, text: 'Lopresti AL, et al. (2019). Ashwagandha for stress and anxiety. Medicine, 98(37): e17186.', url: 'https://pubmed.ncbi.nlm.nih.gov/31517876/' },
-  { n: 4, text: 'Rondanelli M, et al. (2011). Melatonin, magnesium, and zinc in primary insomnia. J Am Geriatr Soc, 59(1): 82-90.', url: 'https://pubmed.ncbi.nlm.nih.gov/21226679/' },
-  { n: 5, text: 'Salve J, et al. (2019). Ashwagandha root extract in healthy adults. Cureus, 11(12): e6466.', url: 'https://pubmed.ncbi.nlm.nih.gov/32021735/' },
+const FAQS = [
+  {
+    question: 'Is ashwagandha or magnesium better for sleep?',
+    answer:
+      'There is no universal winner. Ashwagandha has a more direct sleep-specific randomized/meta-analytic evidence base, but the pooled effect is small and preparation-specific. Magnesium evidence is thinner; a 2025 bisglycinate trial found a small insomnia-severity benefit, while older pooled evidence was low to very low certainty.',
+  },
+  {
+    question: 'Should I try magnesium glycinate first tonight?',
+    answer:
+      'The evidence does not support a universal same-night magnesium-first rule. The 2025 bisglycinate trial studied daily use for four weeks, not an as-needed bedtime rescue effect, and it did not establish magnesium glycinate as the best sleep form for everyone.',
+  },
+  {
+    question: 'How quickly does ashwagandha work for sleep?',
+    answer:
+      'Relevant trials generally studied repeated use over several weeks. Study duration is not a guaranteed personal onset, and the evidence does not establish that everyone needs a fixed course or a particular bedtime timing schedule.',
+  },
+  {
+    question: 'Can ashwagandha and magnesium be taken together?',
+    answer:
+      'Direct sleep trials of the combination are lacking, so separate ingredient studies do not establish that the combination is more effective or safer. Medication use, kidney function, thyroid or autoimmune conditions, pregnancy status, and sedating products can materially change the risk picture.',
+  },
+  {
+    question: 'Is magnesium glycinate the best magnesium form for sleep?',
+    answer:
+      'No form has been established as a universal sleep winner. A 2025 trial provides direct evidence for magnesium bisglycinate, but the effect was small and the trial does not prove superiority over other forms or establish an acute bedtime effect.',
+  },
+  {
+    question: 'What is first-line treatment for chronic insomnia?',
+    answer:
+      'CBT-I is the first-line evidence-based treatment for chronic insomnia. Persistent insomnia also warrants evaluation for sleep apnea, restless legs, circadian problems, medication effects, mood disorders, substance use, pain, or other causes.',
+  },
 ]
 
 export default function AshwagandhaVsMagnesiumForSleepPage() {
   const pageBreadcrumb = breadcrumbJsonLd([
     { name: 'Guides', url: 'https://thehippiescientist.net/guides/' },
+    { name: 'Sleep', url: 'https://thehippiescientist.net/guides/sleep/' },
     { name: TITLE, url: `https://thehippiescientist.net/guides/sleep/${SLUG}/` },
   ])
 
   const articleLd = blogJsonLd(
-    { title: TITLE, slug: SLUG, date: DATE, description: DESCRIPTION },
+    { title: TITLE, slug: SLUG, date: DATE, updated: UPDATED_DATE, description: DESCRIPTION },
     `/guides/sleep/${SLUG}/`,
   )
 
@@ -92,1102 +112,200 @@ export default function AshwagandhaVsMagnesiumForSleepPage() {
 
   return (
     <article className="mx-auto max-w-5xl space-y-0 px-4 pb-20 pt-6 sm:px-6 lg:px-8">
-      {/* JSON-LD */}
       <JsonLd schema={articleLd} />
       <JsonLd schema={pageBreadcrumb} />
-      {faqLd && (
-        <>
-          <References refs={ASHWAGANDHA_VS_MAGNESIUM_FOR_SLEEP_REFS} />
-          <JsonLd schema={faqLd} />
-        </>
-      )}
+      {faqLd ? <JsonLd schema={faqLd} /> : null}
 
-      {/* Breadcrumb */}
-      <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
-        <Link href="/guides/" className="transition hover:text-ink">
-          Guides
-        </Link>
+      <nav className="mb-6 flex items-center gap-2 text-sm text-muted" aria-label="Breadcrumb">
+        <Link href="/guides/" className="transition hover:text-ink">Guides</Link>
         <span>/</span>
-        <span className="text-ink line-clamp-1">{TITLE}</span>
+        <Link href="/guides/sleep/" className="transition hover:text-ink">Sleep</Link>
+        <span>/</span>
+        <span className="line-clamp-1 text-ink">Ashwagandha vs magnesium</span>
       </nav>
 
-      {/* Hero */}
       <section className="rounded-[1.5rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8 lg:p-10">
         <div className="flex flex-wrap items-center gap-2 text-xs">
-          <span className="rounded-full border border-brand-900/10 bg-brand-50 px-2.5 py-0.5 font-bold uppercase tracking-wider text-brand-800">
-            Comparison
-          </span>
-          <span className="rounded-full border border-brand-900/10 bg-white px-2.5 py-0.5 font-semibold text-muted capitalize">
-            {CATEGORY}
-          </span>
-          {TAGS.slice(0, 2).map((tag) => (
-            <span
-              key={tag}
-              className="rounded-full border border-brand-900/10 bg-white px-2.5 py-0.5 font-semibold text-muted capitalize"
-            >
-              {tag}
-            </span>
-          ))}
-          <span className="text-muted">June 9, 2026</span>
-          <span className="text-muted">·</span>
+          <span className="rounded-full border border-brand-900/10 bg-brand-50 px-2.5 py-0.5 font-bold uppercase tracking-wider text-brand-800">Sleep comparison</span>
           <span className="text-muted">{READING_TIME}</span>
         </div>
-
-        <h1 className="mt-4 font-display text-3xl font-bold leading-tight tracking-tight text-ink sm:text-4xl lg:text-5xl">
-          {TITLE}
-        </h1>
-
-        <p className="mt-2 text-sm text-muted">
-          By{' '}
-          <Link href="/info/about/" rel="author" className="font-medium text-ink hover:underline">
-            {AUTHOR}
-          </Link>
-        </p>
-
-        <div className="mt-3">
-          <LastUpdatedBadge date={DATE} label="Last updated" />
-        </div>
-
+        <h1 className="mt-4 font-display text-3xl font-bold leading-tight tracking-tight text-ink sm:text-4xl lg:text-5xl">{TITLE}</h1>
+        <p className="mt-2 text-sm text-muted">By <Link href="/info/about/" rel="author" className="font-medium text-ink hover:underline">{AUTHOR}</Link></p>
+        <div className="mt-3"><LastUpdatedBadge date={UPDATED_DATE} label="Last evidence review" /></div>
         <p className="mt-4 max-w-3xl text-base leading-7 text-muted">{DESCRIPTION}</p>
 
         <figure className="mt-6">
-          <div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white">
+          <div className="overflow-hidden rounded-2xl border border-brand-900/10 bg-white shadow-sm">
             <Image
               src="/images/guides/ashwagandha-vs-magnesium-for-sleep.jpg"
-              alt="Ashwagandha root and magnesium capsules compared for sleep"
+              alt="Ashwagandha root and magnesium capsules compared for sleep evidence"
               width={1536}
               height={1024}
               priority
-              className="w-full h-auto"
+              className="h-auto w-full"
             />
           </div>
           <figcaption className="mt-3 text-center text-sm text-muted">
-            Ashwagandha vs magnesium — two different mechanisms for better sleep.
+            Different evidence bases, preparations, and safety constraints make a same-night “winner” ranking misleading.
           </figcaption>
         </figure>
       </section>
 
-      {/* Affiliate disclosure */}
-      <div className="mt-4 rounded-[1rem] border border-brand-900/10 bg-brand-50/60 px-5 py-3 text-xs leading-6 text-muted">
-        <strong className="text-ink">Affiliate disclosure:</strong> This article contains affiliate
-        links. If you purchase through these links, we may earn a commission at no additional cost to
-        you. We only link to extract forms and dose ranges consistent with the clinical protocols
-        reviewed on this page.
-      </div>
-
-      {/* Body + sidebar */}
-      <div className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1fr)_240px]">
-        {/* Main content */}
-        <div className="space-y-6">
-
-          {/* Fastest useful choice */}
-          <section className="rounded-[1rem] border border-brand-700/20 bg-brand-50/60 p-6 shadow-sm sm:p-8">
-            <p className="eyebrow-label">Fastest useful choice</p>
-            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
-              If you only try one tonight: magnesium glycinate
-            </h2>
-            <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
-              <strong>Magnesium glycinate is the faster, lower-friction starting point.</strong> It is
-              inexpensive, has a broad safety record, and can help with muscle tension and restlessness
-              within days. Ashwagandha is the better fit when stress is the main reason you cannot sleep,
-              but it typically needs 2&ndash;4 weeks of daily use to build an effect &mdash; so it is a
-              commitment, not a same-night fix. If you are unsure, start with{' '}
-              <Link href="/compounds/magnesium-glycinate/" className="font-semibold text-brand-700 hover:underline">magnesium glycinate</Link>{' '}
-              (100&ndash;300&nbsp;mg elemental, 30&ndash;60 minutes before bed), then add{' '}
-              <Link href="/herbs/ashwagandha/" className="font-semibold text-brand-700 hover:underline">ashwagandha</Link>{' '}
-              if stress-driven wakefulness persists. See the full{' '}
-              <Link href="/guides/sleep/best-natural-sleep-aids-that-work/" className="font-semibold text-brand-700 hover:underline">natural sleep aids guide</Link>{' '}
-              for how both fit a wider routine.
+      <div className="mt-6 space-y-6">
+        <section className="rounded-[1rem] border border-brand-700/20 bg-brand-50/60 p-6 shadow-sm sm:p-8">
+          <p className="eyebrow-label">Bottom line</p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">Ashwagandha has the broader direct sleep signal; magnesium evidence remains smaller and lower-certainty</h2>
+          <div className="mt-3 space-y-3 text-[1.01rem] leading-[1.85] text-muted">
+            <p>
+              Ashwagandha’s 2021 sleep meta-analysis pooled <strong>five randomized trials / 400 adults</strong> and found a small overall sleep benefit with moderate heterogeneity. That supports a cautious sleep signal, not a universal extract, dose, bedtime, or onset promise.
             </p>
-          </section>
+            <p>
+              Magnesium’s older insomnia review pooled only <strong>three randomized trials / 151 older adults</strong> and rated the evidence low to very low certainty. A newer 2025 magnesium-bisglycinate trial in <strong>155 adults</strong> found a statistically significant but small insomnia-severity effect (<strong>Cohen d=0.2</strong>) after four weeks; its separate sleep-quality measure was not significantly different and objective sleep was not measured.
+            </p>
+          </div>
+        </section>
 
-          {/* Quick Verdict */}
-          <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
-            <p className="eyebrow-label">Quick Verdict</p>
-            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
-              Ashwagandha vs Magnesium: The Short Answer
-            </h2>
-            <ul className="mt-4 space-y-2">
-              <li className="flex gap-2 text-[1.01rem] leading-[1.85] text-muted">
-                <span className="mt-1 flex-shrink-0 text-brand-700">▸</span>
-                <span>
-                  <strong>Choose magnesium</strong> if you want the simplest first sleep supplement
-                  — particularly magnesium glycinate for muscle tension, restlessness, or general
-                  sleep quality.
-                </span>
-              </li>
-              <li className="flex gap-2 text-[1.01rem] leading-[1.85] text-muted">
-                <span className="mt-1 flex-shrink-0 text-brand-700">▸</span>
-                <span>
-                  <strong>Choose ashwagandha</strong> if stress is the main reason you cannot sleep
-                  — it has more direct evidence for sleep quality improvements in stressed
-                  populations.
-                </span>
-              </li>
-              <li className="flex gap-2 text-[1.01rem] leading-[1.85] text-muted">
-                <span className="mt-1 flex-shrink-0 text-brand-700">▸</span>
-                <span>
-                  <strong>Consider both</strong> if stress and physical tension overlap — they work
-                  through different mechanisms and the combination is generally reasonable for
-                  healthy adults.
-                </span>
-              </li>
-              <li className="flex gap-2 text-[1.01rem] leading-[1.85] text-muted">
-                <span className="mt-1 flex-shrink-0 text-brand-700">▸</span>
-                <span>
-                  <strong>Do not start both on the same night</strong> if you want to know what
-                  works — introduce one at a time over 1–2 weeks to identify the effect.
-                </span>
-              </li>
+        <section className="grid gap-5 md:grid-cols-2">
+          <EvidenceSummaryCard
+            title="Ashwagandha for sleep"
+            evidenceLevel="Limited"
+            humanEvidence="Five randomized trials / 400 adults were pooled in the 2021 meta-analysis, with a small significant overall sleep effect and moderate heterogeneity. Direct trials used different extracts, populations, schedules, and durations."
+            mechanisticEvidence="Stress and cortisol pathways may be relevant hypotheses, but symptoms do not diagnose a cortisol problem and do not identify who should receive ashwagandha."
+            safetyProfile="NCCIH notes short-term tolerability for many users but uncertain long-term safety, rare liver injury, pregnancy/breastfeeding avoidance, thyroid/autoimmune cautions, surgery concerns, and medication interactions."
+          />
+          <EvidenceSummaryCard
+            title="Magnesium for sleep"
+            evidenceLevel="Limited"
+            humanEvidence="The 2021 review found only three randomized trials / 151 older adults and low-to-very-low certainty. A 2025 trial in 155 adults found a small four-week insomnia-severity benefit with magnesium bisglycinate, without a significant separate sleep-quality difference or objective sleep measurement."
+            mechanisticEvidence="Magnesium is physiologically essential, but plausible roles in neurotransmission or deficiency do not establish that magnesium treats insomnia in people without a demonstrated deficiency."
+            safetyProfile="Supplemental magnesium can cause gastrointestinal effects, and toxicity risk rises when kidney function is impaired. It can also interfere with absorption of oral bisphosphonates and tetracycline/quinolone antibiotics."
+          />
+        </section>
+
+        <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+          <h2 className="text-2xl font-semibold tracking-tight text-ink">What was actually studied?</h2>
+          <ResponsiveTable label="Ashwagandha vs magnesium sleep evidence comparison">
+            <table className="mt-5 min-w-[820px] w-full text-sm">
+              <thead>
+                <tr className="border-b border-brand-900/10">
+                  <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">Evidence question</th>
+                  <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">Ashwagandha</th>
+                  <th className="pb-2 text-left text-xs font-bold uppercase tracking-wider text-muted">Magnesium</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-brand-900/5">
+                <tr className="align-top">
+                  <td className="py-3 pr-4 font-semibold text-ink">Pooled sleep evidence</td>
+                  <td className="py-3 pr-4 text-muted">5 RCTs / 400 adults; small significant pooled sleep effect, moderate heterogeneity.</td>
+                  <td className="py-3 text-muted">3 older-adult RCTs / 151 participants; possible sleep-onset-latency benefit, but low-to-very-low certainty.</td>
+                </tr>
+                <tr className="align-top">
+                  <td className="py-3 pr-4 font-semibold text-ink">Newer direct trial</td>
+                  <td className="py-3 pr-4 text-muted">Multiple preparation-specific sleep trials already contribute to the meta-analysis.</td>
+                  <td className="py-3 text-muted">2025 magnesium-bisglycinate RCT: 155 adults, 4 weeks, small insomnia-severity effect (d=0.2); separate sleep-quality measure not significant.</td>
+                </tr>
+                <tr className="align-top">
+                  <td className="py-3 pr-4 font-semibold text-ink">Same-night effect?</td>
+                  <td className="py-3 pr-4 text-muted">Not established; relevant trials generally studied repeated use over weeks.</td>
+                  <td className="py-3 text-muted">Not established; the newer bisglycinate trial studied daily use for four weeks, not an as-needed bedtime rescue dose.</td>
+                </tr>
+                <tr className="align-top">
+                  <td className="py-3 pr-4 font-semibold text-ink">Best form?</td>
+                  <td className="py-3 pr-4 text-muted">No universal winner across KSM-66, Sensoril, Shoden, raw powder, or other preparations.</td>
+                  <td className="py-3 text-muted">Bisglycinate now has one direct RCT, but that does not prove superiority over glycinate/citrate/other forms or establish a universal sleep form.</td>
+                </tr>
+              </tbody>
+            </table>
+          </ResponsiveTable>
+        </section>
+
+        <section className="rounded-[1rem] border border-amber-200 bg-amber-50/70 p-6 shadow-sm sm:p-8">
+          <h2 className="text-xl font-semibold text-amber-950">Why “try magnesium tonight” overreaches the evidence</h2>
+          <div className="mt-3 space-y-3 text-sm leading-7 text-amber-950">
+            <p>
+              The 2025 magnesium-bisglycinate trial is useful because it directly studies a popular form, but it was a <strong>four-week daily intervention</strong> with a small effect size—not a trial of one bedtime dose. It therefore cannot establish a same-night rescue effect or a universal “magnesium first” sequence.
+            </p>
+            <p>
+              Likewise, ashwagandha trials do not prove that people with “stress-driven” insomnia should automatically choose ashwagandha. Clinical populations overlap, mechanisms are indirect, and persistent sleep trouble needs a broader assessment than a symptom-matching supplement flowchart.
+            </p>
+          </div>
+        </section>
+
+        <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+          <h2 className="text-2xl font-semibold tracking-tight text-ink">No direct evidence establishes the combination as better</h2>
+          <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
+            Separate ashwagandha and magnesium trials do not prove that combining them improves sleep more, works faster, or is safer. A combination is a different intervention with its own interaction and attribution problems. This page therefore does not recommend starting one and automatically adding the other after a fixed number of days or weeks.
+          </p>
+          <Link href="/guides/sleep/sleep-stack-guide/" className="mt-3 inline-block text-sm font-semibold text-brand-700 hover:underline">Sleep stack evidence guide →</Link>
+        </section>
+
+        <section>
+          <SafetyNotice title="Safety and medication boundaries">
+            <ul className="ml-5 space-y-2 list-disc">
+              <li><strong>Ashwagandha:</strong> NCCIH lists rare liver injury, pregnancy/breastfeeding avoidance, thyroid and autoimmune cautions, surgery concerns, and possible interactions with diabetes, blood-pressure, immunosuppressant, sedative, anticonvulsant, and thyroid medicines.</li>
+              <li><strong>Magnesium:</strong> supplemental magnesium can cause diarrhea, nausea, and cramping; toxicity risk rises with impaired kidney function.</li>
+              <li><strong>Magnesium + medicines:</strong> magnesium can reduce absorption of oral bisphosphonates and tetracycline/quinolone antibiotics, so medication timing should be reviewed with a pharmacist or prescriber rather than guessed.</li>
+              <li><strong>Persistent insomnia:</strong> loud snoring/gasping, dangerous daytime sleepiness, restless-legs symptoms, severe mood symptoms, or chronic insomnia are reasons to seek assessment rather than escalating supplements.</li>
             </ul>
-          </section>
+          </SafetyNotice>
+        </section>
 
-          {/* Main article body */}
-          <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8 space-y-8">
+        <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+          <h2 className="text-2xl font-semibold tracking-tight text-ink">Chronic insomnia has a stronger first-line treatment</h2>
+          <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
+            AASM describes cognitive behavioral therapy for insomnia (CBT-I) as the first-line, evidence-based treatment for chronic insomnia. Persistent poor sleep can also reflect sleep apnea, restless legs, circadian disorders, medication effects, mood disorders, substance use, pain, or insufficient sleep opportunity. A supplement comparison should not obscure those possibilities.
+          </p>
+        </section>
 
-            {/* Side-by-Side Comparison Table */}
-            <div id="comparison-table">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                Side-by-Side Comparison
-              </h2>
-              <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-5 shadow-sm">
-                <ResponsiveTable label="Ashwagandha vs magnesium for sleep — full comparison table">
-                  <table className="min-w-[680px] w-full text-sm">
-                    <thead>
-                      <tr className="border-b border-brand-900/10">
-                        <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                          Feature
-                        </th>
-                        <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                          Ashwagandha
-                        </th>
-                        <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                          Magnesium
-                        </th>
-                        <th className="pb-2 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                          Winner / Best Fit
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody className="divide-y divide-brand-900/5">
-                      <tr className="align-top">
-                        <td className="py-3 pr-4 font-medium text-ink">Best for</td>
-                        <td className="py-3 pr-4 text-muted">Stress-driven poor sleep</td>
-                        <td className="py-3 pr-4 text-muted">Tension, restlessness, deficiency</td>
-                        <td className="py-3 text-muted">Depends on your situation</td>
-                      </tr>
-                      <tr className="align-top">
-                        <td className="py-3 pr-4 font-medium text-ink">Main mechanism</td>
-                        <td className="py-3 pr-4 text-muted">HPA axis, cortisol, GABA-A</td>
-                        <td className="py-3 pr-4 text-muted">NMDA antagonism, GABA support, melatonin pathway</td>
-                        <td className="py-3 text-muted">Different — complementary</td>
-                      </tr>
-                      <tr className="align-top">
-                        <td className="py-3 pr-4 font-medium text-ink">Speed of effect</td>
-                        <td className="py-3 pr-4 text-muted">6–8 weeks (most trials)</td>
-                        <td className="py-3 pr-4 text-muted">1–4 weeks (some notice sooner)</td>
-                        <td className="py-3 text-muted">Magnesium (early onset possible)</td>
-                      </tr>
-                      <tr className="align-top">
-                        <td className="py-3 pr-4 font-medium text-ink">Evidence strength</td>
-                        <td className="py-3 pr-4 text-muted">Moderate (multiple RCTs in stressed adults)</td>
-                        <td className="py-3 pr-4 text-muted">Limited–Moderate (smaller RCTs, older adults)</td>
-                        <td className="py-3 text-muted">Ashwagandha (for direct sleep outcomes)</td>
-                      </tr>
-                      <tr className="align-top">
-                        <td className="py-3 pr-4 font-medium text-ink">Safety profile</td>
-                        <td className="py-3 pr-4 text-muted">Good; rare hepatotoxicity, thyroid concerns</td>
-                        <td className="py-3 pr-4 text-muted">Good; kidney disease caution, GI upset</td>
-                        <td className="py-3 text-muted">Magnesium (fewer contraindications)</td>
-                      </tr>
-                      <tr className="align-top">
-                        <td className="py-3 pr-4 font-medium text-ink">Cost</td>
-                        <td className="py-3 pr-4 text-muted">Moderate</td>
-                        <td className="py-3 pr-4 text-muted">Lower</td>
-                        <td className="py-3 text-muted">Magnesium (typically cheaper)</td>
-                      </tr>
-                      <tr className="align-top">
-                        <td className="py-3 pr-4 font-medium text-ink">Best user</td>
-                        <td className="py-3 pr-4 text-muted">Stressed adult with racing thoughts at night</td>
-                        <td className="py-3 pr-4 text-muted">Anyone; especially with tension or deficiency</td>
-                        <td className="py-3 text-muted">Depends on root cause</td>
-                      </tr>
-                      <tr className="align-top">
-                        <td className="py-3 pr-4 font-medium text-ink">Main drawback</td>
-                        <td className="py-3 pr-4 text-muted">Slow onset; thyroid, pregnancy contraindications</td>
-                        <td className="py-3 pr-4 text-muted">GI upset at higher doses; kidney caution</td>
-                        <td className="py-3 text-muted">Manageable for most healthy adults</td>
-                      </tr>
-                      <tr className="align-top">
-                        <td className="py-3 pr-4 font-medium text-ink">Can combine?</td>
-                        <td className="py-3 pr-4 text-muted">Yes, with magnesium</td>
-                        <td className="py-3 pr-4 text-muted">Yes, with ashwagandha</td>
-                        <td className="py-3 text-muted">Yes — start one, then add second</td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </ResponsiveTable>
+        <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+          <h2 className="text-2xl font-semibold tracking-tight text-ink">Product sourcing note</h2>
+          <p className="mt-3 text-sm leading-7 text-muted">
+            This broad comparison intentionally does not rank affiliate products. Study preparations are not automatically interchangeable with commercial products, and one magnesium-bisglycinate or ashwagandha-extract trial does not establish a retail winner. Ingredient-specific pages are the better place to evaluate preparation matching and quality signals.
+          </p>
+        </section>
+
+        <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+          <h2 className="text-2xl font-semibold tracking-tight text-ink">Frequently asked questions</h2>
+          <div className="mt-5 space-y-5">
+            {FAQS.map((faq) => (
+              <div key={faq.question} className="border-l-4 border-brand-600 pl-4">
+                <h3 className="font-semibold text-ink">{faq.question}</h3>
+                <p className="mt-2 text-sm leading-7 text-muted">{faq.answer}</p>
               </div>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* How Ashwagandha Works for Sleep */}
-            <div id="ashwagandha-mechanisms">
-              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">
-                How Ashwagandha Works for Sleep
-              </h2>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                Ashwagandha (<em>Withania somnifera</em>) is an adaptogenic herb with a specific
-                epithet — <em>somnifera</em> — that means &ldquo;sleep-inducing&rdquo; in Latin.
-                Despite this name, it does not act as a direct sedative. Its sleep benefit is
-                indirect, working primarily through stress adaptation pathways.
-              </p>
-
-              <h3 className="mt-5 mb-1 text-xl font-semibold tracking-tight text-ink">
-                Stress Adaptation and HPA Axis Modulation
-              </h3>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                Ashwagandha is most consistently documented to reduce perceived stress and, in many
-                trials, morning serum cortisol. Elevated cortisol at night is a primary driver of
-                hyperarousal-type insomnia — the kind where the mind stays activated and sleep onset
-                is delayed despite physical tiredness. By modulating the HPA axis stress response,
-                ashwagandha may reduce the physiological barrier to sleep onset and maintenance.
-              </p>
-              <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
-                This mechanism makes ashwagandha most useful for people whose sleep is disrupted by
-                stress and cognitive arousal, rather than for people with primary insomnia unrelated
-                to stress.
-              </p>
-
-              <h3 className="mt-5 mb-1 text-xl font-semibold tracking-tight text-ink">
-                Relaxation Without Sedation
-              </h3>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                Withanolides — the primary active constituents — have demonstrated GABA-A receptor
-                binding activity in preclinical studies. This may contribute to a mild relaxation
-                effect, though the magnitude at standard human doses is uncertain. Ashwagandha is
-                not a sedative in the pharmacological sense; it does not reliably induce drowsiness
-                the way benzodiazepines or antihistamines do.
-              </p>
-
-              <p className="mt-4 text-sm text-muted">
-                For the full clinical evidence review, mechanisms, and dosage protocols for
-                ashwagandha as a sleep supplement, see the{' '}
-                <Link
-                  href="/guides/sleep/ashwagandha-for-sleep/"
-                  className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
-                >
-                  Ashwagandha for Sleep article
-                </Link>
-                .
-              </p>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* How Magnesium Works for Sleep */}
-            <div id="magnesium-mechanisms">
-              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">
-                How Magnesium Works for Sleep
-              </h2>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                Magnesium is an essential mineral involved in over 300 enzymatic reactions. It
-                supports sleep through several neurological pathways, particularly by reducing
-                excitatory signaling and supporting the inhibitory systems that allow the nervous
-                system to quiet at night.
-              </p>
-
-              <h3 className="mt-5 mb-1 text-xl font-semibold tracking-tight text-ink">
-                Nervous System Relaxation
-              </h3>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                Magnesium ions block NMDA glutamate receptors, reducing excitatory
-                neurotransmission. It also supports GABA-A receptor activity — the same inhibitory
-                pathway targeted by common sleep medications. Together, these effects may lower
-                cortical excitability and ease the transition from wakefulness into sleep.
-              </p>
-
-              <h3 className="mt-5 mb-1 text-xl font-semibold tracking-tight text-ink">
-                Muscle Tension and Restlessness
-              </h3>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                Magnesium plays a role in muscle relaxation by competing with calcium at
-                neuromuscular junctions. Muscle tension, cramps, or restless sensations at night
-                are frequently reported by people with suboptimal magnesium status. Supplementation
-                may reduce these physical barriers to sleep.
-              </p>
-
-              <h3 className="mt-5 mb-1 text-xl font-semibold tracking-tight text-ink">
-                Form Matters
-              </h3>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                Magnesium glycinate is the most recommended form for sleep applications because the
-                glycine co-carrier has its own independent calming and sleep-promoting properties.
-                Magnesium L-threonate is used for its proposed CNS penetration, and magnesium
-                citrate is a lower-cost option. Magnesium oxide — the most common cheap form — has
-                poor bioavailability and is not preferred for sleep.
-              </p>
-
-              <p className="mt-4 text-sm text-muted">
-                For a full breakdown of each magnesium form and dosage protocols, see the{' '}
-                <Link
-                  href="/guides/sleep/magnesium-for-sleep/"
-                  className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
-                >
-                  Magnesium for Sleep article
-                </Link>{' '}
-                and the{' '}
-                <Link
-                  href="/guides/sleep/magnesium-types-for-sleep/"
-                  className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
-                >
-                  Magnesium Types for Sleep guide
-                </Link>
-                .
-              </p>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Which Works Faster */}
-            <div id="speed">
-              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">
-                Which Works Faster?
-              </h2>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                Speed of onset differs meaningfully between the two supplements, though individual
-                responses vary and neither should be evaluated on a single night.
-              </p>
-              <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
-                <strong>Magnesium</strong> may feel more immediate for some people — particularly
-                in the form of reduced physical tension or restlessness during the first days to
-                weeks of use. This is especially likely if low magnesium status is a contributing
-                factor. That said, consistent improvements in overall sleep quality are more
-                commonly reported after several weeks of daily use.
-              </p>
-              <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
-                <strong>Ashwagandha</strong> is typically evaluated over longer timeframes. Most
-                clinical trials measuring sleep outcomes report effects at 6–8 weeks, and some
-                only at 8–12 weeks. Expecting a notable effect in the first few nights is
-                unlikely. Adaptogens generally require sustained use before their regulatory
-                effects become apparent.
-              </p>
-              <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
-                Both supplements should be judged over consistent use rather than isolated nights.
-                Placebo responses and night-to-night sleep variability make single-night
-                assessments unreliable for any supplement.
-              </p>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Which Has Better Evidence */}
-            <div id="evidence">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                Which Has Better Evidence?
-              </h2>
-
-              <div className="space-y-4">
-                <EvidenceSummaryCard
-                  title="Ashwagandha — Sleep Evidence"
-                  evidenceLevel="Moderate"
-                  humanEvidence="Multiple randomized controlled trials (n=50–150 per study) show improvements in sleep quality scores (PSQI, ISI), sleep onset latency, and total sleep time over 6–10 weeks in adults with elevated stress. Consistent direction of effect across independent trials. Effect sizes moderate (Cohen's d approximately 0.5–0.8 in available trials). Most studied population: adults with perceived stress or subclinical insomnia."
-                  mechanisticEvidence="HPA axis modulation and cortisol reduction are well-documented in human trials. GABA-A binding demonstrated in vitro. Triethylene glycol-mediated non-REM induction in animal models. Human mechanistic data is still developing."
-                  safetyProfile="Generally well-tolerated at 300–600 mg/day for 8–12 weeks. Rare hepatotoxicity reports in post-market data. Contraindicated in pregnancy. Potential thyroid interactions."
-                />
-
-                <EvidenceSummaryCard
-                  title="Magnesium — Sleep Evidence"
-                  evidenceLevel="Limited"
-                  humanEvidence="Some RCTs and observational studies show improvements in sleep quality, efficiency, and early morning awakening. Evidence is most consistent in older adults and those with suboptimal dietary magnesium intake. Trial sizes are smaller and study populations more heterogeneous than ashwagandha sleep trials. Evidence in magnesium-replete healthy younger adults is limited."
-                  mechanisticEvidence="NMDA antagonism, GABA-A potentiation, and melatonin synthesis support are biologically plausible and supported by preclinical data. Human mechanistic evidence is mainly indirect, from deficiency correction rather than pharmacological dose effects."
-                  safetyProfile="Well-tolerated at 200–400 mg elemental per day in healthy adults. GI upset (especially with oxide/citrate forms at higher doses) is the main side effect. Kidney disease requires caution due to impaired excretion."
-                />
-              </div>
-
-              <p className="mt-4 text-sm text-muted">
-                Evidence grades above reflect current editorial assessments. They are updated as new trials are published.
-              </p>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Safety Comparison */}
-            <div id="safety">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                Safety Comparison
-              </h2>
-              <SafetyNotice title="Safety Summary — Ashwagandha vs Magnesium">
-                <p className="mb-3 font-semibold text-ink">Magnesium</p>
-                <ul className="ml-5 space-y-1.5 list-disc">
-                  <li>
-                    <strong>Kidney disease:</strong> Magnesium excretion depends on kidney
-                    function. Supplementation in people with reduced kidney function (CKD stage
-                    3+) can cause hypermagnesemia. Consult a physician before supplementing.
-                  </li>
-                  <li>
-                    <strong>GI upset:</strong> Diarrhea, loose stools, and cramping are the
-                    most common side effects, especially with oxide and citrate forms at higher
-                    doses. Starting low and taking with food reduces incidence.
-                  </li>
-                  <li>
-                    <strong>Medication spacing:</strong> May interfere with absorption of
-                    bisphosphonates, fluoroquinolone and tetracycline antibiotics, and some
-                    blood pressure medications. Separate doses by at least 2 hours.
-                  </li>
-                </ul>
-
-                <p className="mt-4 mb-3 font-semibold text-ink">Ashwagandha</p>
-                <ul className="ml-5 space-y-1.5 list-disc">
-                  <li>
-                    <strong>Pregnancy:</strong> Avoid. Animal studies show uterotonic effects;
-                    human safety data is absent.
-                  </li>
-                  <li>
-                    <strong>Thyroid conditions:</strong> Ashwagandha may increase T3/T4 levels.
-                    Use with caution if you have hyperthyroidism or take thyroid medication.
-                  </li>
-                  <li>
-                    <strong>Autoimmune disease:</strong> May stimulate immune function; use with
-                    caution in autoimmune conditions or on immunosuppressants.
-                  </li>
-                  <li>
-                    <strong>Rare hepatotoxicity:</strong> Multiple case reports of liver injury
-                    have been published, most resolving on discontinuation. Avoid with liver
-                    disease or hepatotoxic medications.
-                  </li>
-                  <li>
-                    <strong>Sedative medications:</strong> Ashwagandha may potentiate the effects
-                    of prescription sedatives and anxiolytics.
-                  </li>
-                </ul>
-
-                <p className="mt-4 mb-3 font-semibold text-ink">Both supplements</p>
-                <ul className="ml-5 space-y-1.5 list-disc">
-                  <li>Start at the lowest effective dose and assess tolerance before increasing.</li>
-                  <li>
-                    Avoid stacking either supplement with prescription sedatives (benzodiazepines,
-                    z-drugs, barbiturates) without medical guidance.
-                  </li>
-                  <li>
-                    &ldquo;Natural&rdquo; does not mean risk-free. Both can interact with
-                    medications and medical conditions.
-                  </li>
-                </ul>
-              </SafetyNotice>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Combining Ashwagandha and Magnesium */}
-            <div id="combining">
-              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">
-                Can You Take Ashwagandha and Magnesium Together?
-              </h2>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                For most healthy adults, combining ashwagandha and magnesium is generally
-                considered reasonable. They work through distinct primary mechanisms — ashwagandha
-                primarily through the HPA axis and stress-cortisol pathways, magnesium through
-                NMDA antagonism, GABA support, and mineral repletion. No significant adverse
-                interaction between the two is established in the literature.
-              </p>
-              <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
-                However, direct combination trials are limited. The evidence base for the specific
-                combination is thinner than for either supplement studied alone. Claims about
-                additive or synergistic sleep effects from taking both together are not
-                well-supported by clinical data at this time.
-              </p>
-              <div className="mt-4 rounded-[1rem] border border-brand-900/10 bg-brand-50/60 p-4 text-sm leading-7 text-muted">
-                <p className="font-semibold text-ink">Practical approach for combining:</p>
-                <ul className="mt-2 ml-5 space-y-1 list-disc">
-                  <li>
-                    Start with one supplement first. Assess your response over 1–2 weeks before
-                    adding the second.
-                  </li>
-                  <li>
-                    Starting both simultaneously makes it impossible to attribute effects or side
-                    effects to either supplement.
-                  </li>
-                  <li>
-                    If you take prescription sedatives, anxiolytics, or thyroid medications,
-                    consult a clinician before adding either supplement — let alone both.
-                  </li>
-                  <li>
-                    You do not need to take both at once. Magnesium 30–60 minutes before bed,
-                    ashwagandha 1–2 hours before bed, is a common approach when combining.
-                  </li>
-                </ul>
-              </div>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Cost and Buying Guide */}
-            <div id="buying-guide">
-              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">
-                Cost and Buying Guide
-              </h2>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                These products represent the extract forms and dose ranges most relevant to the
-                evidence reviewed in this article. Affiliate links support this site at no
-                additional cost to you.
-              </p>
-              <div className="mt-4 grid gap-4 sm:grid-cols-2">
-                <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
-                  <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
-                    Ashwagandha — Most Studied for Sleep
-                  </p>
-                  <p className="font-semibold text-ink">KSM-66 Ashwagandha Extract</p>
-                  <p className="mt-1 text-xs leading-5 text-muted">
-                    Patented full-spectrum root extract. The most-studied form for sleep quality
-                    outcomes. Look for ≥300 mg per capsule, standardized to ≥5% withanolides.
-                  </p>
-                  <a
-                    href={`https://www.amazon.com/s?k=KSM-66+ashwagandha&tag=${AFFILIATE_TAGS.amazon}`}
-                    target="_blank"
-                    rel="noopener noreferrer sponsored"
-                    className="mt-3 inline-flex items-center gap-1 rounded-full bg-brand-950 px-4 py-1.5 text-xs font-bold text-white transition hover:bg-brand-900"
-                  >
-                    View on Amazon →
-                  </a>
-                </div>
-                <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
-                  <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
-                    Ashwagandha — Lower Dose / Sensitive Users
-                  </p>
-                  <p className="font-semibold text-ink">Sensoril Ashwagandha Extract</p>
-                  <p className="mt-1 text-xs leading-5 text-muted">
-                    Root and leaf extract with strong clinical backing at lower mg doses. Well-suited
-                    for sensitive individuals or when stacking with magnesium.
-                  </p>
-                  <a
-                    href={`https://www.amazon.com/s?k=Sensoril+ashwagandha&tag=${AFFILIATE_TAGS.amazon}`}
-                    target="_blank"
-                    rel="noopener noreferrer sponsored"
-                    className="mt-3 inline-flex items-center gap-1 rounded-full bg-brand-950 px-4 py-1.5 text-xs font-bold text-white transition hover:bg-brand-900"
-                  >
-                    View on Amazon →
-                  </a>
-                </div>
-                <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
-                  <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
-                    Magnesium — Best for Sleep
-                  </p>
-                  <p className="font-semibold text-ink">Magnesium Glycinate</p>
-                  <p className="mt-1 text-xs leading-5 text-muted">
-                    High bioavailability, gentle on the stomach, with glycine co-carrier that has
-                    independent calming properties. Look for 200–400 mg elemental magnesium per
-                    serving.
-                  </p>
-                  <a
-                    href={`https://www.amazon.com/s?k=magnesium+glycinate+sleep&tag=${AFFILIATE_TAGS.amazon}`}
-                    target="_blank"
-                    rel="noopener noreferrer sponsored"
-                    className="mt-3 inline-flex items-center gap-1 rounded-full bg-brand-950 px-4 py-1.5 text-xs font-bold text-white transition hover:bg-brand-900"
-                  >
-                    View on Amazon →
-                  </a>
-                </div>
-                <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
-                  <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
-                    Magnesium — Sleep + Cognitive
-                  </p>
-                  <p className="font-semibold text-ink">Magnesium L-Threonate</p>
-                  <p className="mt-1 text-xs leading-5 text-muted">
-                    CNS-targeted delivery, proposed to cross the blood-brain barrier more readily.
-                    Higher price point than glycinate. Useful when cognitive benefits alongside
-                    sleep are a goal.
-                  </p>
-                  <a
-                    href={`https://www.amazon.com/s?k=magnesium+l-threonate+magtein&tag=${AFFILIATE_TAGS.amazon}`}
-                    target="_blank"
-                    rel="noopener noreferrer sponsored"
-                    className="mt-3 inline-flex items-center gap-1 rounded-full bg-brand-950 px-4 py-1.5 text-xs font-bold text-white transition hover:bg-brand-900"
-                  >
-                    View on Amazon →
-                  </a>
-                </div>
-              </div>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Decision Framework */}
-            <div id="decision-framework">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                Decision Framework
-              </h2>
-              <div className="rounded-[1rem] border border-brand-900/10 bg-brand-50/60 p-5">
-                <ul className="space-y-3 text-[1.01rem] leading-[1.85] text-muted">
-                  <li className="flex gap-3">
-                    <span className="flex-shrink-0 font-bold text-ink">If budget is tight:</span>
-                    <span>
-                      Start with magnesium glycinate — it is typically less expensive and a
-                      reasonable first step for most adults.
-                    </span>
-                  </li>
-                  <li className="flex gap-3">
-                    <span className="flex-shrink-0 font-bold text-ink">If stress is high:</span>
-                    <span>
-                      Start with ashwagandha (KSM-66 or Sensoril). The evidence for sleep
-                      improvement in stressed populations is more direct.
-                    </span>
-                  </li>
-                  <li className="flex gap-3">
-                    <span className="flex-shrink-0 font-bold text-ink">If body tension or restlessness is the main problem:</span>
-                    <span>
-                      Start with magnesium glycinate. It addresses the physical tension component
-                      more directly.
-                    </span>
-                  </li>
-                  <li className="flex gap-3">
-                    <span className="flex-shrink-0 font-bold text-ink">If racing thoughts and stress overlap:</span>
-                    <span>
-                      Start with ashwagandha first, then consider adding magnesium after 1–2 weeks
-                      if physical tension is also present.
-                    </span>
-                  </li>
-                  <li className="flex gap-3">
-                    <span className="flex-shrink-0 font-bold text-ink">If you want one simple start:</span>
-                    <span>
-                      Magnesium glycinate — lower cost, fewer contraindications, and reasonable
-                      evidence for sleep support.
-                    </span>
-                  </li>
-                  <li className="flex gap-3">
-                    <span className="flex-shrink-0 font-bold text-ink">If sleep problems are severe or chronic:</span>
-                    <span>
-                      Neither supplement replaces a medical evaluation. Chronic insomnia, sleep
-                      apnea symptoms, or significant daytime impairment warrant clinical assessment
-                      before or alongside any supplementation.
-                    </span>
-                  </li>
-                </ul>
-              </div>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* What Not To Do */}
-            <div id="what-not-to-do">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                What Not To Do
-              </h2>
-              <ul className="space-y-3 text-[1.01rem] leading-[1.85] text-muted">
-                <li className="flex gap-2">
-                  <span className="mt-1 flex-shrink-0 text-brand-700">✕</span>
-                  <span>
-                    <strong>Do not start five sleep supplements at once.</strong> You will have no
-                    idea what is working, and you increase the risk of interaction effects.
-                  </span>
-                </li>
-                <li className="flex gap-2">
-                  <span className="mt-1 flex-shrink-0 text-brand-700">✕</span>
-                  <span>
-                    <strong>Do not megadose either supplement</strong> in the hope of accelerating
-                    results. Evidence does not support dose escalation beyond studied ranges, and
-                    higher doses increase adverse effect risk.
-                  </span>
-                </li>
-                <li className="flex gap-2">
-                  <span className="mt-1 flex-shrink-0 text-brand-700">✕</span>
-                  <span>
-                    <strong>Do not assume natural means risk-free.</strong> Both supplements have
-                    contraindications, drug interactions, and population-specific cautions.
-                  </span>
-                </li>
-                <li className="flex gap-2">
-                  <span className="mt-1 flex-shrink-0 text-brand-700">✕</span>
-                  <span>
-                    <strong>Do not ignore sleep apnea symptoms</strong> (loud snoring,
-                    witnessed breathing pauses, gasping, excessive daytime sleepiness). No
-                    supplement addresses obstructive sleep apnea and the condition is
-                    underdiagnosed.
-                  </span>
-                </li>
-                <li className="flex gap-2">
-                  <span className="mt-1 flex-shrink-0 text-brand-700">✕</span>
-                  <span>
-                    <strong>Do not use supplements to cover up severe insomnia</strong> without
-                    evaluation. Persistent insomnia has treatable causes and effective
-                    non-pharmacological interventions (CBT-I) that supplements do not replicate.
-                  </span>
-                </li>
-              </ul>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* FAQ */}
-            <div id="faq">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                Frequently Asked Questions
-              </h2>
-              <div className="space-y-4">
-                {FAQS.map((faq, i) => (
-                  <div
-                    key={i}
-                    className="rounded-[0.75rem] border border-brand-900/10 bg-brand-50/40 p-4"
-                  >
-                    <h3 className="font-semibold text-ink">{faq.question}</h3>
-                    <p className="mt-2 text-sm leading-7 text-muted">{faq.answer}</p>
-                  </div>
-                ))}
-              </div>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Related Articles */}
-            <div id="related-articles">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                Related Articles
-              </h2>
-              <div className="grid gap-3 sm:grid-cols-2">
-                <Link
-                  href="/guides/sleep/ashwagandha-for-sleep/"
-                  className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
-                >
-                  <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
-                    Sleep Cluster
-                  </p>
-                  <p className="font-semibold text-ink transition group-hover:text-brand-700">
-                    Ashwagandha for Sleep
-                  </p>
-                  <p className="mt-1 text-xs text-muted">
-                    Full clinical evidence review: mechanisms, dosage, extract types, and safety
-                    for ashwagandha as a sleep supplement.
-                  </p>
-                </Link>
-                <Link
-                  href="/guides/sleep/magnesium-for-sleep/"
-                  className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
-                >
-                  <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
-                    Sleep Cluster
-                  </p>
-                  <p className="font-semibold text-ink transition group-hover:text-brand-700">
-                    Magnesium for Sleep
-                  </p>
-                  <p className="mt-1 text-xs text-muted">
-                    Evidence, magnesium types, dosage protocols, and safety for magnesium
-                    as a sleep supplement.
-                  </p>
-                </Link>
-                <Link
-                  href="/guides/sleep/magnesium-types-for-sleep/"
-                  className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
-                >
-                  <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
-                    Sleep Cluster
-                  </p>
-                  <p className="font-semibold text-ink transition group-hover:text-brand-700">
-                    Magnesium Types for Sleep
-                  </p>
-                  <p className="mt-1 text-xs text-muted">
-                    Deep dive: glycinate vs threonate vs citrate vs oxide — which form to
-                    choose for sleep.
-                  </p>
-                </Link>
-                <Link
-                  href="/guides/sleep/best-herbs-for-sleep/"
-                  className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
-                >
-                  <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
-                    Sleep Cluster Hub
-                  </p>
-                  <p className="font-semibold text-ink transition group-hover:text-brand-700">
-                    Best Herbs for Sleep
-                  </p>
-                  <p className="mt-1 text-xs text-muted">
-                    Evidence-ranked guide to magnesium, ashwagandha, L-theanine, valerian,
-                    passionflower, and more.
-                  </p>
-                </Link>
-                <Link
-                  href="/guides/sleep/l-theanine-for-sleep/"
-                  className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
-                >
-                  <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
-                    Sleep Cluster
-                  </p>
-                  <p className="font-semibold text-ink transition group-hover:text-brand-700">
-                    L-Theanine for Sleep
-                  </p>
-                  <p className="mt-1 text-xs text-muted">
-                    Evidence for L-theanine as a relaxation and sleep-quality supplement,
-                    and how it compares to ashwagandha and magnesium.
-                  </p>
-                </Link>
-                <Link
-                  href="/guides/sleep/sleep-stack-guide/"
-                  className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30"
-                >
-                  <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">
-                    Sleep Cluster
-                  </p>
-                  <p className="font-semibold text-ink transition group-hover:text-brand-700">
-                    Sleep Stack Guide
-                  </p>
-                  <p className="mt-1 text-xs text-muted">
-                    How to combine ashwagandha, magnesium, and other sleep supplements safely
-                    and effectively.
-                  </p>
-                </Link>
-              </div>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Sources */}
-            <div id="sources">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Sources</h2>
-              <ResponsiveTable label="Article references">
-                <table className="min-w-[600px] w-full text-sm">
-                  <thead>
-                    <tr className="border-b border-brand-900/10">
-                      <th className="pb-2 pr-3 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                        #
-                      </th>
-                      <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                        Study
-                      </th>
-                      <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                        Authors
-                      </th>
-                      <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                        Year
-                      </th>
-                      <th className="pb-2 text-left text-xs font-bold uppercase tracking-wider text-muted">
-                        Link
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-brand-900/5">
-                    <tr className="align-top">
-                      <td className="py-3 pr-3 text-muted">1</td>
-                      <td className="py-3 pr-4 leading-6 text-ink">
-                        Efficacy and Safety of Ashwagandha (Withania somnifera) Root Extract in
-                        Insomnia and Anxiety: A Double-blind, Randomized, Placebo-controlled Study
-                      </td>
-                      <td className="py-3 pr-4 text-muted">
-                        Langade D, Kanchi S, Salve J, Debnath K, Ambegaokar D
-                      </td>
-                      <td className="py-3 pr-4 text-muted">2019</td>
-                      <td className="py-3">
-                        <a
-                          href="https://pubmed.ncbi.nlm.nih.gov/31564735/"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
-                        >
-                          PMID 31564735
-                        </a>
-                      </td>
-                    </tr>
-                    <tr className="align-top">
-                      <td className="py-3 pr-3 text-muted">2</td>
-                      <td className="py-3 pr-4 leading-6 text-ink">
-                        A Randomized, Double Blind, Placebo Controlled, Cross-over Study to Evaluate
-                        the Efficacy and Safety of Ashwagandha (Withania somnifera) Extract on Sleep
-                        Quality in Healthy Adults
-                      </td>
-                      <td className="py-3 pr-4 text-muted">
-                        Cheah KL, Norhayati MN, Husniati Yaacob L, Abdul Rahman R
-                      </td>
-                      <td className="py-3 pr-4 text-muted">2021</td>
-                      <td className="py-3">
-                        <a
-                          href="https://pubmed.ncbi.nlm.nih.gov/34559859/"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
-                        >
-                          PMID 34559859
-                        </a>
-                      </td>
-                    </tr>
-                    <tr className="align-top">
-                      <td className="py-3 pr-3 text-muted">3</td>
-                      <td className="py-3 pr-4 leading-6 text-ink">
-                        The effect of magnesium supplementation on primary insomnia in elderly:
-                        A double-blind placebo-controlled clinical trial
-                      </td>
-                      <td className="py-3 pr-4 text-muted">
-                        Abbasi B, Kimiagar M, Sadeghniiat K, Shirazi MM, Hedayati M, Rashidkhani B
-                      </td>
-                      <td className="py-3 pr-4 text-muted">2012</td>
-                      <td className="py-3">
-                        <a
-                          href="https://pubmed.ncbi.nlm.nih.gov/23853635/"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
-                        >
-                          PMID 23853635
-                        </a>
-                      </td>
-                    </tr>
-                    <tr className="align-top">
-                      <td className="py-3 pr-3 text-muted">4</td>
-                      <td className="py-3 pr-4 leading-6 text-ink">
-                        Oral Mg(2+) supplementation reverses age-related neuroendocrine and sleep
-                        EEG changes in humans
-                      </td>
-                      <td className="py-3 pr-4 text-muted">
-                        Held K, Antonijevic IA, Künzel H, Uhr M, Wetter TC, Golly IC, Steiger A,
-                        Murck H
-                      </td>
-                      <td className="py-3 pr-4 text-muted">2002</td>
-                      <td className="py-3 text-muted">
-                        PMID 12163983
-                      </td>
-                    </tr>
-                    <tr className="align-top">
-                      <td className="py-3 pr-3 text-muted">5</td>
-                      <td className="py-3 pr-4 leading-6 text-ink">
-                        Magnesium deprivation disrupts sleep in rats: behavioral and EEG findings
-                      </td>
-                      <td className="py-3 pr-4 text-muted">Nielsen FH, Johnson LK, Zeng H</td>
-                      <td className="py-3 pr-4 text-muted">2010</td>
-                      <td className="py-3 text-muted">
-                        Animal study
-                      </td>
-                    </tr>
-                    <tr className="align-top">
-                      <td className="py-3 pr-3 text-muted">6</td>
-                      <td className="py-3 pr-4 leading-6 text-ink">
-                        Direct combination evidence (ashwagandha + magnesium co-administration)
-                      </td>
-                      <td className="py-3 pr-4 text-muted">—</td>
-                      <td className="py-3 pr-4 text-muted">—</td>
-                      <td className="py-3 text-muted">
-                        No combination trial identified in source registry
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </ResponsiveTable>
-              <p className="mt-3 text-xs text-muted">
-                Ashwagandha safety references are shared
-                with the{' '}
-                <Link
-                  href="/guides/sleep/ashwagandha-for-sleep/"
-                  className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
-                >
-                  Ashwagandha for Sleep article
-                </Link>
-                . Magnesium safety references are shared with the{' '}
-                <Link
-                  href="/guides/sleep/magnesium-for-sleep/"
-                  className="font-semibold text-brand-700 hover:text-brand-800 hover:underline"
-                >
-                  Magnesium for Sleep article
-                </Link>
-                .
-              </p>
-            </div>
-
-          </section>
-
-          <RecommendationSection products={getRevenueProductSet('ashwagandha')?.products ?? []} />
-
-          {/* Email capture */}
-          <EmailCapture
-            headline="Get future research notes by email"
-            description="Evidence-first supplement updates, safety context, and new guide announcements. No diagnosis, treatment, or personal medical advice."
-            location={`article-${SLUG}`}
-          />
-
-          <NewsletterCtaBlock
-            title="Continue with the newsletter archive"
-            description="Short notes built for cautious supplement decisions."
-            location={`article-${SLUG}-newsletter`}
-          />
-        </div>
-
-        {/* Sidebar */}
-        <aside className="space-y-4 lg:sticky lg:top-24 lg:self-start">
-          {/* Table of contents */}
-          <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
-            <p className="text-[10px] font-bold uppercase tracking-wider text-muted">
-              In this article
-            </p>
-            <nav className="mt-3 space-y-1.5" aria-label="Article sections">
-              {[
-                ['#comparison-table', 'Side-by-Side Table'],
-                ['#ashwagandha-mechanisms', 'How Ashwagandha Works'],
-                ['#magnesium-mechanisms', 'How Magnesium Works'],
-                ['#speed', 'Which Works Faster?'],
-                ['#evidence', 'Evidence Comparison'],
-                ['#safety', 'Safety Comparison'],
-                ['#combining', 'Taking Both Together'],
-                ['#buying-guide', 'Cost & Buying Guide'],
-                ['#decision-framework', 'Decision Framework'],
-                ['#what-not-to-do', 'What Not To Do'],
-                ['#faq', 'FAQ'],
-                ['#sources', 'Sources'],
-              ].map(([href, label]) => (
-                <a
-                  key={href}
-                  href={href}
-                  className="block text-sm text-brand-700 hover:text-brand-800 hover:underline">{label}</a>
-              ))}
-            </nav>
+            ))}
           </div>
+        </section>
 
-          {/* Related profiles */}
-          <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
-            <p className="text-[10px] font-bold uppercase tracking-wider text-muted">
-              Explore more
-            </p>
-            <div className="mt-3 space-y-2">
-              <Link
-                href="/guides/sleep/ashwagandha-for-sleep/"
-                className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
-              >
-                Ashwagandha for sleep →
-              </Link>
-              <Link
-                href="/guides/sleep/magnesium-for-sleep/"
-                className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
-              >
-                Magnesium for sleep →
-              </Link>
-              <Link
-                href="/guides/sleep/magnesium-types-for-sleep/"
-                className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
-              >
-                Magnesium types for sleep →
-              </Link>
-              <Link
-                href="/guides/sleep/best-herbs-for-sleep/"
-                className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
-              >
-                Best herbs for sleep →
-              </Link>
-              <Link
-                href="/guides/sleep/sleep-herbs-vs-melatonin/"
-                className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
-              >
-                Sleep herbs vs melatonin →
-              </Link>
-              <Link
-                href="/guides/"
-                className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline"
-              >
-                All articles →
-              </Link>
-            </div>
-          </div>
-        </aside>
-      </div>
+        <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+          <h2 className="text-2xl font-semibold tracking-tight text-ink">Sources and directness notes</h2>
+          <ol className="mt-4 space-y-4">
+            {SOURCES.map((source, index) => (
+              <li key={source.href} className="text-sm leading-7 text-muted">
+                <span className="font-semibold text-ink">{index + 1}. </span>
+                <a href={source.href} target="_blank" rel="noopener noreferrer" className="font-semibold text-brand-700 hover:underline">{source.label}</a>
+                <span> — {source.note}</span>
+              </li>
+            ))}
+          </ol>
+        </section>
 
-      <div className="mt-8">
-        <Link href="/guides/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
-          ← Back to Guides
-        </Link>
+        <section className="grid gap-3 sm:grid-cols-2">
+          <Link href="/guides/sleep/ashwagandha-for-sleep/" className="rounded-xl border border-brand-900/10 bg-white p-4 text-sm font-semibold text-brand-700 hover:underline">Ashwagandha for sleep →</Link>
+          <Link href="/compounds/magnesium/" className="rounded-xl border border-brand-900/10 bg-white p-4 text-sm font-semibold text-brand-700 hover:underline">Magnesium profile →</Link>
+          <Link href="/guides/compare/sleep-herbs-vs-melatonin/" className="rounded-xl border border-brand-900/10 bg-white p-4 text-sm font-semibold text-brand-700 hover:underline">Sleep supplements vs melatonin →</Link>
+          <Link href="/guides/sleep/" className="rounded-xl border border-brand-900/10 bg-white p-4 text-sm font-semibold text-brand-700 hover:underline">Sleep goal hub →</Link>
+        </section>
+
+        <EmailCapture
+          headline="Get future research notes by email"
+          description="Evidence-first supplement updates, safety context, and new guide announcements. No diagnosis, treatment, or personal medical advice."
+          location={`article-${SLUG}`}
+        />
+        <NewsletterCtaBlock
+          title="Continue with the newsletter archive"
+          description="Short notes built for cautious supplement decisions."
+          location={`article-${SLUG}-newsletter`}
+        />
       </div>
     </article>
   )


### PR DESCRIPTION
## Summary
- replaces the “try magnesium tonight” sequence, fixed bedtime timing, symptom-matching winner flowchart, and combination recommendation with an evidence-directness comparison
- preserves the original June 9 publication date and adds an August 12, 2026 evidence-review date
- compares the five-RCT ashwagandha sleep meta-analysis with the older low-certainty magnesium insomnia review and the newer 2025 magnesium-bisglycinate RCT
- treats the 2025 magnesium result as a small four-week signal rather than proof of an acute bedtime effect or preferred sleep form
- discloses the newer magnesium trial’s institutional funding and disclosed nutraceutical-industry ties
- rejects evidence-free ashwagandha + magnesium combination claims
- preserves ingredient-specific kidney, medication, liver, pregnancy, thyroid, and autoimmune safety boundaries
- keeps CBT-I as the first-line chronic-insomnia boundary
- removes broad comparison affiliate/product ranking while preserving FAQ, internal discovery, email capture, and newsletter conversion
- adds route-specific regression coverage

## Evidence anchors
- Ashwagandha sleep meta-analysis: PMID 34559859
- Magnesium insomnia meta-analysis: PMID 33865376
- Magnesium bisglycinate RCT (2025): PMID 40918053
- NCCIH ashwagandha/sleep guidance
- NIH ODS magnesium guidance
- AASM CBT-I guidance

## Scope
Exactly 2 files: the live comparison and its regression test.