### PR TITLE
Align L-theanine ADHD routes with current evidence

### DIFF
--- a/app/__tests__/l-theanine-without-caffeine-adhd-current-evidence.test.ts
+++ b/app/__tests__/l-theanine-without-caffeine-adhd-current-evidence.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest'
 const FOCUS_PAGE = path.join(process.cwd(), 'app/guides/focus/l-theanine-without-caffeine/page.tsx')
 const ADHD_SOURCE = path.join(process.cwd(), 'docs/content/focus-cluster/l-theanine-for-adhd-content-v1.md')
 const RENDERER = path.join(process.cwd(), 'components/articles/FocusAdhdArticlePage.tsx')
+const WIDGETS = path.join(process.cwd(), 'components/articles/AdhdMonetizationWidgets.tsx')
 
 const read = (file: string) =>
   fs.readFileSync(file, 'utf8').replace(/\s+/g, ' ').replace(/\*\*/g, '')
@@ -123,7 +124,11 @@ describe('L-theanine ADHD route evidence calibration', () => {
   it('keeps both L-theanine ADHD routes commercially neutral', () => {
     const focus = read(FOCUS_PAGE)
     const renderer = read(RENDERER)
+    const widgets = read(WIDGETS)
     const products = renderer.match(/const ADHD_ARTICLE_PRODUCTS:[\s\S]*?\}\s*\/\/ Per-slug hero images/)?.[0] ?? ''
+    const magnesiumTheanineCard = widgets.match(
+      /if \(slug === 'best-supplements-for-adhd'[\s\S]*?else if \(slug === 'sleep-and-adhd'/,
+    )?.[0] ?? ''
 
     expect(focus).not.toContain('AFFILIATE_TAGS')
     expect(focus).not.toContain('RecommendationSection')
@@ -131,6 +136,7 @@ describe('L-theanine ADHD route evidence calibration', () => {
     expect(focus).not.toMatch(/amazon\.com/i)
     expect(focus).toMatch(/intentionally does not rank affiliate products/i)
     expect(products).not.toContain("'l-theanine-for-adhd': 'l-theanine'")
+    expect(magnesiumTheanineCard).not.toContain("slug === 'l-theanine-for-adhd'")
   })
 
   it('keeps visible FAQ content and discovery/conversion on the caffeine-free page', () => {

--- a/app/__tests__/l-theanine-without-caffeine-adhd-current-evidence.test.ts
+++ b/app/__tests__/l-theanine-without-caffeine-adhd-current-evidence.test.ts
@@ -98,10 +98,9 @@ describe('L-theanine ADHD route evidence calibration', () => {
   it('removes the old ADHD-route starting protocol, timing script, and off-day advice', () => {
     const text = read(ADHD_SOURCE)
 
-    expect(text).not.toMatch(/200[–-]400\s*mg starting/i)
-    expect(text).not.toMatch(/starting range.*200[–-]400\s*mg/i)
+    expect(text).toMatch(/Older versions of this guide translated study regimens into a practical 200[–-]400 mg starting range and gave 30[–-]60-minute timing guidance/i)
+    expect(text).toMatch(/The direct ADHD evidence is not strong enough to support that conversion/i)
     expect(text).not.toMatch(/start at the lower end of studied ranges/i)
-    expect(text).not.toMatch(/30[–-]60 minutes before/i)
     expect(text).not.toMatch(/use L-theanine during stimulant off-periods or on weekends/i)
     expect(text).toMatch(/does not recommend:/i)
     expect(text).toMatch(/a universal ADHD dose/i)

--- a/app/__tests__/l-theanine-without-caffeine-adhd-current-evidence.test.ts
+++ b/app/__tests__/l-theanine-without-caffeine-adhd-current-evidence.test.ts
@@ -6,7 +6,8 @@ const FOCUS_PAGE = path.join(process.cwd(), 'app/guides/focus/l-theanine-without
 const ADHD_SOURCE = path.join(process.cwd(), 'docs/content/focus-cluster/l-theanine-for-adhd-content-v1.md')
 const RENDERER = path.join(process.cwd(), 'components/articles/FocusAdhdArticlePage.tsx')
 
-const read = (file: string) => fs.readFileSync(file, 'utf8').replace(/\s+/g, ' ')
+const read = (file: string) =>
+  fs.readFileSync(file, 'utf8').replace(/\s+/g, ' ').replace(/\*\*/g, '')
 
 describe('L-theanine ADHD route evidence calibration', () => {
   it('preserves publication history and anchors the caffeine-free page to current evidence', () => {
@@ -101,10 +102,10 @@ describe('L-theanine ADHD route evidence calibration', () => {
     expect(text).not.toMatch(/start at the lower end of studied ranges/i)
     expect(text).not.toMatch(/30[–-]60 minutes before/i)
     expect(text).not.toMatch(/use L-theanine during stimulant off-periods or on weekends/i)
-    expect(text).not.toMatch(/medication wears off/i)
     expect(text).toMatch(/does not recommend:/i)
     expect(text).toMatch(/a universal ADHD dose/i)
     expect(text).toMatch(/taking L-theanine a fixed number of minutes before a focus task/i)
+    expect(text).toMatch(/using it as medication wears off/i)
     expect(text).toMatch(/using it on stimulant off-days or weekends/i)
     expect(text).toMatch(/unsupervised pediatric dosing/i)
   })

--- a/app/__tests__/l-theanine-without-caffeine-adhd-current-evidence.test.ts
+++ b/app/__tests__/l-theanine-without-caffeine-adhd-current-evidence.test.ts
@@ -1,0 +1,144 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const FOCUS_PAGE = path.join(process.cwd(), 'app/guides/focus/l-theanine-without-caffeine/page.tsx')
+const ADHD_SOURCE = path.join(process.cwd(), 'docs/content/focus-cluster/l-theanine-for-adhd-content-v1.md')
+const RENDERER = path.join(process.cwd(), 'components/articles/FocusAdhdArticlePage.tsx')
+
+const read = (file: string) => fs.readFileSync(file, 'utf8').replace(/\s+/g, ' ')
+
+describe('L-theanine ADHD route evidence calibration', () => {
+  it('preserves publication history and anchors the caffeine-free page to current evidence', () => {
+    const text = read(FOCUS_PAGE)
+
+    expect(text).toContain("const DATE = '2026-06-12'")
+    expect(text).toContain("const UPDATED_DATE = '2026-08-12'")
+    expect(text).toMatch(/date: DATE, updated: UPDATED_DATE/)
+    expect(text).toContain('42410082')
+    expect(text).toContain('32753637')
+    expect(text).toContain('22214254')
+    expect(text).toContain('40314930')
+    expect(text).toMatch(/31 randomized trials \/ 1,168 participants/i)
+    expect(text).toMatch(/only five boys/i)
+    expect(text).toMatch(/98-boy/i)
+  })
+
+  it('keeps general attention evidence separate from ADHD efficacy on the caffeine-free route', () => {
+    const text = read(FOCUS_PAGE)
+
+    expect(text).toMatch(/title="General attention evidence" evidenceLevel="Limited"/i)
+    expect(text).toMatch(/title="ADHD-specific evidence" evidenceLevel="Limited"/i)
+    expect(text).toMatch(/pooled population was not an ADHD population/i)
+    expect(text).toMatch(/supports general attention research—not an ADHD protocol/i)
+    expect(text).toMatch(/far too small to establish an ADHD treatment effect/i)
+    expect(text).toMatch(/studied sleep quality over six weeks, not daytime focus or core ADHD symptoms/i)
+  })
+
+  it('does not restore a caffeine-free ADHD dose, onset, or rescue protocol', () => {
+    const text = read(FOCUS_PAGE)
+
+    expect(text).not.toMatch(/Fastest useful choice/i)
+    expect(text).not.toMatch(/If you only try one thing: L-theanine 100 mg alone/i)
+    expect(text).not.toMatch(/100\s*mg.*increase to 200\s*mg/i)
+    expect(text).not.toMatch(/take L-theanine 30[–-]60 minutes before a planned focus session/i)
+    expect(text).not.toMatch(/effects within 30[–-]60 minutes, no crash, no sleep disruption, no dependency/i)
+    expect(text).not.toMatch(/acute calm focus \(L-theanine\)/i)
+    expect(text).toMatch(/study regimen and outcome—not evidence that every person with ADHD should take a specific milligram amount/i)
+    expect(text).toMatch(/too small to turn its weight-based experimental dosing into a consumer ADHD protocol/i)
+  })
+
+  it('does not generalize the caffeine combination literature to L-theanine alone or ADHD treatment', () => {
+    const text = read(FOCUS_PAGE)
+
+    expect(text).toMatch(/L-theanine plus caffeine is a different intervention/i)
+    expect(text).toMatch(/cannot be used as proof that L-theanine alone works the same way/i)
+    expect(text).toMatch(/much of it is in healthy participants/i)
+    expect(text).toMatch(/ADHD-specific combination study was only a five-person proof-of-concept crossover/i)
+    expect(text).not.toMatch(/L-theanine blunts caffeine's jitteriness while preserving its attentional benefits/i)
+  })
+
+  it('removes blanket stimulant-interaction reassurance and preserves medication boundaries', () => {
+    const text = read(FOCUS_PAGE)
+
+    expect(text).not.toMatch(/No established adverse interaction between supplemental L-theanine and common ADHD medications/i)
+    expect(text).not.toMatch(/use L-theanine during stimulant off-periods or on weekends/i)
+    expect(text).toMatch(/direct interaction and coadministration evidence is limited/i)
+    expect(text).toMatch(/not designed to establish medication-interaction safety/i)
+    expect(text).toMatch(/should not be used to stop, skip, or alter prescribed ADHD medication/i)
+    expect(text).toMatch(/prescriber or pharmacist managing treatment/i)
+  })
+
+  it('keeps safety language conservative and transparent on the caffeine-free route', () => {
+    const text = read(FOCUS_PAGE)
+
+    expect(text).toMatch(/No serious adverse events were reported in the 2026 meta-analysis/i)
+    expect(text).toMatch(/does not establish unlimited long-term safety/i)
+    expect(text).toMatch(/pediatric trials used defined products and research protocols/i)
+    expect(text).toMatch(/not a basis for unsupervised pediatric dosing/i)
+    expect(text).toMatch(/One author disclosed founding a dietary-supplement company/i)
+  })
+
+  it('keeps the existing ADHD route aligned to the same directness boundary', () => {
+    const text = read(ADHD_SOURCE)
+
+    expect(text).toContain('42410082')
+    expect(text).toContain('32753637')
+    expect(text).toContain('22214254')
+    expect(text).toContain('40314930')
+    expect(text).toMatch(/31 randomized trials \/ 1,168 participants/i)
+    expect(text).toMatch(/Only five boys/i)
+    expect(text).toMatch(/98 boys ages 8[–-]12 with diagnosed ADHD/i)
+    expect(text).toMatch(/evaluated sleep over six weeks rather than daytime attention or core ADHD symptoms/i)
+    expect(text).toMatch(/current evidence does not justify presenting it as a proven non-stimulant ADHD treatment/i)
+  })
+
+  it('removes the old ADHD-route starting protocol, timing script, and off-day advice', () => {
+    const text = read(ADHD_SOURCE)
+
+    expect(text).not.toMatch(/200[–-]400\s*mg starting/i)
+    expect(text).not.toMatch(/starting range.*200[–-]400\s*mg/i)
+    expect(text).not.toMatch(/start at the lower end of studied ranges/i)
+    expect(text).not.toMatch(/30[–-]60 minutes before/i)
+    expect(text).not.toMatch(/use L-theanine during stimulant off-periods or on weekends/i)
+    expect(text).not.toMatch(/medication wears off/i)
+    expect(text).toMatch(/does not recommend:/i)
+    expect(text).toMatch(/a universal ADHD dose/i)
+    expect(text).toMatch(/taking L-theanine a fixed number of minutes before a focus task/i)
+    expect(text).toMatch(/using it on stimulant off-days or weekends/i)
+    expect(text).toMatch(/unsupervised pediatric dosing/i)
+  })
+
+  it('keeps the ADHD route medication and pediatric safety boundaries explicit', () => {
+    const text = read(ADHD_SOURCE)
+
+    expect(text).toMatch(/direct interaction and coadministration evidence is limited/i)
+    expect(text).toMatch(/pediatric studies used defined research products and supervised protocols/i)
+    expect(text).toMatch(/not a basis for unsupervised pediatric supplementation/i)
+    expect(text).toMatch(/do not stop, skip, lower, or otherwise change prescribed ADHD medication/i)
+    expect(text).toMatch(/prescriber or pharmacist managing that treatment/i)
+  })
+
+  it('keeps both L-theanine ADHD routes commercially neutral', () => {
+    const focus = read(FOCUS_PAGE)
+    const renderer = read(RENDERER)
+    const products = renderer.match(/const ADHD_ARTICLE_PRODUCTS:[\s\S]*?\}\s*\/\/ Per-slug hero images/)?.[0] ?? ''
+
+    expect(focus).not.toContain('AFFILIATE_TAGS')
+    expect(focus).not.toContain('RecommendationSection')
+    expect(focus).not.toContain('getRevenueProductSet')
+    expect(focus).not.toMatch(/amazon\.com/i)
+    expect(focus).toMatch(/intentionally does not rank affiliate products/i)
+    expect(products).not.toContain("'l-theanine-for-adhd': 'l-theanine'")
+  })
+
+  it('keeps visible FAQ content and discovery/conversion on the caffeine-free page', () => {
+    const text = read(FOCUS_PAGE)
+
+    expect(text).toContain('{FAQS.map((faq) => (')
+    expect(text).toMatch(/faqPageJsonLd\(\{ pagePath: `\/guides\/focus\/\$\{SLUG\}\/`, questions: FAQS \}\)/)
+    expect(text).toContain('/guides/herbs/l-theanine/')
+    expect(text).toContain('<EmailCapture')
+    expect(text).toContain('<NewsletterCtaBlock')
+  })
+})

--- a/app/guides/focus/l-theanine-without-caffeine/page.tsx
+++ b/app/guides/focus/l-theanine-without-caffeine/page.tsx
@@ -2,30 +2,28 @@ import Link from 'next/link'
 import Image from 'next/image'
 import JsonLd from '@/components/seo/JsonLd'
 import type { Metadata } from 'next'
-import { buildPageMetadata, blogJsonLd, breadcrumbJsonLd, faqPageJsonLd, compactMetaTitle } from '../../../../src/lib/seo'
+import {
+  buildPageMetadata,
+  blogJsonLd,
+  breadcrumbJsonLd,
+  faqPageJsonLd,
+  compactMetaTitle,
+} from '../../../../src/lib/seo'
 import LastUpdatedBadge from '../../../../src/components/editorial/LastUpdatedBadge'
 import ResponsiveTable from '@/components/ui/ResponsiveTable'
 import SafetyNotice from '@/components/evidence/SafetyNotice'
 import EvidenceSummaryCard from '@/components/evidence/EvidenceSummaryCard'
 import EmailCapture from '@/components/EmailCapture'
 import NewsletterCtaBlock from '@/components/NewsletterCtaBlock'
-import PathwayDiagram from '@/components/PathwayDiagram'
-import EvidenceLegend from '@/components/EvidenceLegend'
-import { pathwayDiagrams } from '@/lib/pathway-data'
-import { getRevenueProductSet } from '@/config/revenue-products'
-import RecommendationSection, { type RecommendationProduct } from '@/components/RecommendationSection'
-import { AFFILIATE_TAGS } from '@/config/affiliate'
-import References from '@/components/References'
 
 const SLUG = 'l-theanine-without-caffeine'
-const TITLE = 'L-Theanine Without Caffeine for ADHD: Calm Focus Without the Jitters'
+const TITLE = 'L-Theanine Without Caffeine for ADHD: What the Evidence Supports in 2026'
 const DESCRIPTION =
-  'Evidence guide to using L-theanine alone for ADHD — without caffeine. Covers how it produces calm alertness, alpha-wave effects, who benefits most, dosage, safety, and how it compares to the caffeine combination.'
+  'Evidence-first guide to L-theanine alone for ADHD-related focus questions, separating general attention data from the very limited ADHD-specific trials and avoiding universal dose or onset claims.'
 const DATE = '2026-06-12'
+const UPDATED_DATE = '2026-08-12'
 const AUTHOR = 'Will'
-const READING_TIME = '10 min read'
-const TAGS = ['L-theanine', 'ADHD', 'focus', 'caffeine-free', 'calm']
-const CATEGORY = 'Focus'
+const READING_TIME = '9 min read'
 
 export const metadata: Metadata = buildPageMetadata({
   title: compactMetaTitle(TITLE),
@@ -34,68 +32,70 @@ export const metadata: Metadata = buildPageMetadata({
   openGraphType: 'article',
 })
 
-const FAQS = [
+const SOURCES = [
   {
-    question: 'Does L-theanine work for ADHD without caffeine?',
-    answer:
-      'L-theanine without caffeine can support a state of calm alertness by increasing alpha-wave brain activity, which may help with the mentally overactivated pattern common in ADHD. It is not a stimulant and does not increase dopamine or norepinephrine in the way ADHD medications do — so expectations should be calibrated accordingly. It is most likely to be noticeable for people whose ADHD presentation includes anxiety, stress-driven mental noise, or difficulty settling the mind for focused work. For primarily inattentive ADHD without high mental arousal, the benefit may be more subtle.',
+    label: 'L-theanine systematic review and meta-analysis (2026)',
+    href: 'https://pubmed.ncbi.nlm.nih.gov/42410082/',
+    note: 'Thirty-one randomized trials / 1,168 participants across healthy and clinical populations. A single 200 mg dose 30–60 minutes before cognitive testing improved choice reaction time, but anxiety findings were inconsistent and the authors said clinical relevance still needs confirmation. No serious adverse events were reported. One author disclosed founding a dietary-supplement company.',
   },
   {
-    question: 'Is L-theanine plus caffeine better than L-theanine alone for ADHD?',
-    answer:
-      'The L-theanine + caffeine combination has more published clinical evidence for cognitive outcomes than L-theanine alone. Caffeine provides direct alerting effects (adenosine antagonism), and L-theanine blunts caffeine\'s jitteriness while preserving its attentional benefits. For adults with ADHD who tolerate caffeine well, the combination is supported by stronger evidence. L-theanine alone is more appropriate for those who cannot tolerate caffeine, experience anxiety or sleep problems with caffeine, or prefer a stimulant-free approach.',
+    label: 'L-theanine/caffeine proof-of-concept ADHD crossover (2020)',
+    href: 'https://pubmed.ncbi.nlm.nih.gov/32753637/',
+    note: 'Only five boys ages 8–15 with ADHD completed a four-condition crossover of L-theanine, caffeine, the combination, and placebo. Some cognition outcomes improved, but inhibitory-control findings were mixed. The sample is far too small to establish an ADHD treatment effect or dosing protocol.',
   },
   {
-    question: 'What dose of L-theanine for daytime focus without caffeine?',
-    answer:
-      'Studies on daytime calm focus and attention typically use 100–200 mg of L-theanine. Starting at 100 mg and assessing response before increasing to 200 mg is a reasonable approach. L-theanine at these doses does not typically cause sedation in the daytime — the alpha-wave effect is described as relaxed wakefulness, not drowsiness. If you notice sedation at 200 mg, reduce to 100 mg.',
+    label: 'L-theanine sleep trial in boys with ADHD (2011)',
+    href: 'https://pubmed.ncbi.nlm.nih.gov/22214254/',
+    note: 'Ninety-eight boys ages 8–12 with diagnosed ADHD received 400 mg/day of Suntheanine or placebo for six weeks. The trial studied objective sleep quality, not daytime ADHD focus or core symptom treatment.',
   },
   {
-    question: 'When should I take L-theanine without caffeine for ADHD?',
-    answer:
-      'For daytime focus use, taking L-theanine 30–60 minutes before a planned focus session or work period is a common approach. It can also be taken in the morning as part of a routine. Because it does not contain caffeine, it can also be taken later in the day without affecting sleep — unlike caffeinated focus supplements.',
-  },
-  {
-    question: 'Can L-theanine be taken alongside ADHD medication?',
-    answer:
-      'No established adverse interaction between supplemental L-theanine and common ADHD medications (methylphenidate, amphetamine salts, atomoxetine) has been identified. Some adults with ADHD use L-theanine during stimulant off-periods or on weekends when not taking medication. Inform your prescribing clinician about supplements you are taking; they can advise in the context of your specific medication regimen.',
-  },
-  {
-    question: 'How is L-theanine different from ashwagandha for ADHD focus?',
-    answer:
-      'L-theanine works faster — effects may be noticeable within 30–60 minutes — and is more suitable for acute mental calm and daytime focus support. Ashwagandha works over weeks by reducing chronic HPA axis activation and cortisol, making it better suited for stress-driven ADHD difficulties over a longer time horizon. L-theanine is caffeine-free and can be taken as needed; ashwagandha is typically taken daily for weeks to months. Both are reasonable for ADHD; the choice depends on whether you need acute calm focus (L-theanine) or chronic stress management (ashwagandha).',
+    label: 'Tea/L-theanine cognition, sleep, and mood meta-analysis (2025)',
+    href: 'https://pubmed.ncbi.nlm.nih.gov/40314930/',
+    note: 'Systematic review of tea, L-theanine, and L-theanine plus caffeine in healthy participants. This helps contextualize cognition claims but does not establish efficacy for ADHD.',
   },
 ]
 
-// The shared `l-theanine` revenue set only stocks 200 mg picks, but this page's stated
-// starter dose is 100 mg — swap in a page-specific 100 mg budget option so the buying
-// module doesn't push readers toward double the recommended first trial dose.
-const L_THEANINE_100MG_BUDGET_PRODUCT: RecommendationProduct = {
-  slot: 'budget',
-  brand: 'NOW Foods',
-  title: 'NOW L-Theanine 100 mg (Caffeine-Free)',
-  rationale: 'Matches this page\'s recommended 100 mg starting dose for first-timers and caffeine-sensitive readers.',
-  affiliateUrl: `https://www.amazon.com/s?k=${encodeURIComponent('NOW Foods L-Theanine 100mg caffeine free')}&tag=${AFFILIATE_TAGS.amazon}`,
-}
-
-const L_THEANINE_WITHOUT_CAFFEINE_REFS = [
-  { n: 1, text: 'Nobre AC, et al. (2008). L-theanine and mental state. Asia Pac J Clin Nutr, 17(S1): 167-168.', url: 'https://pubmed.ncbi.nlm.nih.gov/18296328/' },
-  { n: 2, text: 'Haskell CF, et al. (2008). L-theanine, caffeine and cognition. Biol Psychol, 77(2): 113-122.', url: 'https://pubmed.ncbi.nlm.nih.gov/18006208/' },
-  { n: 3, text: 'Kimura K, et al. (2007). L-theanine reduces stress responses. Biol Psychol, 74(1): 39-45.', url: 'https://pubmed.ncbi.nlm.nih.gov/16930802/' },
-  { n: 4, text: 'Giesbrecht T, et al. (2010). L-theanine and caffeine on cognitive performance. Nutr Neurosci, 13(6): 283-290.', url: 'https://pubmed.ncbi.nlm.nih.gov/21040626/' },
+const FAQS = [
+  {
+    question: 'Does L-theanine without caffeine treat ADHD?',
+    answer:
+      'Current evidence does not establish L-theanine alone as an ADHD treatment. The strongest recent pooled evidence for L-theanine comes mostly from healthy and mixed clinical populations, while the ADHD-specific acute cognition study involved only five boys.',
+  },
+  {
+    question: 'Does L-theanine help attention without caffeine?',
+    answer:
+      'A 2026 meta-analysis found a short-term improvement in choice reaction time after a single L-theanine dose in cognitive-testing studies. That supports a general attention signal, but it should not be converted into a universal ADHD benefit, dose, or onset promise.',
+  },
+  {
+    question: 'What dose of L-theanine should someone with ADHD take?',
+    answer:
+      'There is no evidence-based universal ADHD dose. Published studies used different populations, formulations, doses, and outcomes. A dose used in a healthy-adult attention experiment or a pediatric sleep trial is study context, not a personalized ADHD protocol.',
+  },
+  {
+    question: 'Can L-theanine be taken with ADHD medication?',
+    answer:
+      'Direct interaction and coadministration evidence is limited. The pediatric sleep trial included boys with and without stimulant treatment, but it was not designed to establish medication-interaction safety. People taking prescription ADHD medication should review supplement use with the prescriber or pharmacist managing that treatment.',
+  },
+  {
+    question: 'Is L-theanine plus caffeine better for ADHD than L-theanine alone?',
+    answer:
+      'The combination has more cognition research than L-theanine alone, but most of that literature is not ADHD-specific. One ADHD proof-of-concept crossover involved only five boys, so it is too small to establish that the combination is an effective ADHD treatment.',
+  },
+  {
+    question: 'What did the larger ADHD L-theanine trial actually show?',
+    answer:
+      'The larger randomized trial involved 98 boys with ADHD and studied sleep. It found improvements in some actigraphy-based sleep measures after six weeks, but it did not establish an effect on daytime attention, executive function, or core ADHD symptoms.',
+  },
 ]
 
 export default function LTheanineWithoutCaffeinePage() {
-  const lTheanineProducts = getRevenueProductSet('l-theanine')
-  const lTheanineProductsWith100mgStart = lTheanineProducts
-    ? [L_THEANINE_100MG_BUDGET_PRODUCT, ...lTheanineProducts.products.filter((product) => product.slot !== 'budget')]
-    : []
   const breadcrumbLd = breadcrumbJsonLd([
     { name: 'Guides', url: 'https://thehippiescientist.net/guides/' },
+    { name: 'Focus', url: 'https://thehippiescientist.net/guides/focus/' },
     { name: TITLE, url: `https://thehippiescientist.net/guides/focus/${SLUG}/` },
   ])
   const articleLd = blogJsonLd(
-    { title: TITLE, slug: SLUG, date: DATE, description: DESCRIPTION },
+    { title: TITLE, slug: SLUG, date: DATE, updated: UPDATED_DATE, description: DESCRIPTION },
     `/guides/focus/${SLUG}/`,
   )
   const faqLd = faqPageJsonLd({ pagePath: `/guides/focus/${SLUG}/`, questions: FAQS })
@@ -104,468 +104,191 @@ export default function LTheanineWithoutCaffeinePage() {
     <article className="mx-auto max-w-5xl space-y-0 px-4 pb-20 pt-6 sm:px-6 lg:px-8">
       <JsonLd schema={articleLd} />
       <JsonLd schema={breadcrumbLd} />
-      {faqLd && <JsonLd schema={faqLd} />}
+      {faqLd ? <JsonLd schema={faqLd} /> : null}
 
-      <nav className="mb-6 flex items-center gap-2 text-sm text-muted">
+      <nav className="mb-6 flex items-center gap-2 text-sm text-muted" aria-label="Breadcrumb">
         <Link href="/guides/" className="transition hover:text-ink">Guides</Link>
         <span>/</span>
-        <span className="text-ink line-clamp-1">{TITLE}</span>
+        <Link href="/guides/focus/" className="transition hover:text-ink">Focus</Link>
+        <span>/</span>
+        <span className="line-clamp-1 text-ink">L-theanine without caffeine</span>
       </nav>
 
       <section className="rounded-[1.5rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8 lg:p-10">
         <div className="flex flex-wrap items-center gap-2 text-xs">
-          <span className="rounded-full border border-brand-900/10 bg-brand-50 px-2.5 py-0.5 font-bold uppercase tracking-wider text-brand-800">
-            {CATEGORY}
-          </span>
-          {TAGS.slice(0, 3).map((tag) => (
-            <span key={tag} className="rounded-full border border-brand-900/10 bg-white px-2.5 py-0.5 font-semibold text-muted capitalize">
-              {tag}
-            </span>
-          ))}
-          <span className="text-muted">June 12, 2026</span>
-          <span className="text-muted">·</span>
+          <span className="rounded-full border border-brand-900/10 bg-brand-50 px-2.5 py-0.5 font-bold uppercase tracking-wider text-brand-800">Focus evidence</span>
           <span className="text-muted">{READING_TIME}</span>
         </div>
-        <h1 className="mt-4 font-display text-3xl font-bold leading-tight tracking-tight text-ink sm:text-4xl lg:text-5xl">
-          {TITLE}
-        </h1>
-        <p className="mt-2 text-sm text-muted">
-          By{' '}
-          <Link href="/info/about/" rel="author" className="font-medium text-ink hover:underline">
-            {AUTHOR}
-          </Link>
-        </p>
-        <div className="mt-3">
-          <LastUpdatedBadge date={DATE} label="Last updated" />
-        </div>
+        <h1 className="mt-4 font-display text-3xl font-bold leading-tight tracking-tight text-ink sm:text-4xl lg:text-5xl">{TITLE}</h1>
+        <p className="mt-2 text-sm text-muted">By <Link href="/info/about/" rel="author" className="font-medium text-ink hover:underline">{AUTHOR}</Link></p>
+        <div className="mt-3"><LastUpdatedBadge date={UPDATED_DATE} label="Last evidence review" /></div>
         <p className="mt-4 max-w-3xl text-base leading-7 text-muted">{DESCRIPTION}</p>
 
         <figure className="mt-6">
-          <div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white">
+          <div className="overflow-hidden rounded-2xl border border-brand-900/10 bg-white shadow-sm">
             <Image
               src="/images/guides/l-theanine-without-caffeine.jpg"
-              alt="Caffeine-free L-theanine capsules with green tea leaves for calm focus"
+              alt="Caffeine-free L-theanine capsules with green tea leaves"
               width={1536}
               height={1024}
               priority
-              className="w-full h-auto"
+              className="h-auto w-full"
             />
           </div>
           <figcaption className="mt-3 text-center text-sm text-muted">
-            L-theanine without caffeine — calm focus without the stimulant.
+            General attention evidence should not be mistaken for proof that L-theanine treats ADHD.
           </figcaption>
         </figure>
       </section>
 
-      <div className="mt-4 rounded-[1rem] border border-brand-900/10 bg-brand-50/60 px-5 py-3 text-xs leading-6 text-muted">
-        <strong className="text-ink">Affiliate disclosure:</strong> This article contains affiliate
-        links. Purchases may earn us a commission at no additional cost to you.
-      </div>
-
-      <div className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1fr)_240px]">
-        <div className="space-y-6">
-
-          {/* Fastest useful choice */}
-          <section className="rounded-[1rem] border border-brand-700/20 bg-brand-50/60 p-6 shadow-sm sm:p-8">
-            <p className="eyebrow-label">Fastest useful choice</p>
-            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
-              If you only try one thing: L-theanine 100 mg alone
-            </h2>
-            <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
-              <strong>L-theanine 100&nbsp;mg alone (no caffeine) is itself the fastest useful choice for
-              stimulant-free ADHD focus.</strong> Effects within 30–60 minutes, no crash, no sleep
-              disruption, no dependency. If 100&nbsp;mg is not enough, increase to 200&nbsp;mg before
-              considering other compounds. For comparison with the caffeine combination, see{' '}
-              <Link href="/guides/focus/l-theanine-vs-caffeine-for-focus/" className="font-semibold text-brand-700 hover:underline">
-                L-Theanine vs Caffeine for Focus
-              </Link>
-              . For the broader evidence review, see the{' '}
-              <Link href="/guides/herbs/l-theanine/" className="font-semibold text-brand-700 hover:underline">
-                full L-theanine article
-              </Link>
-              .
+      <div className="mt-6 space-y-6">
+        <section className="rounded-[1rem] border border-brand-700/20 bg-brand-50/60 p-6 shadow-sm sm:p-8">
+          <p className="eyebrow-label">Bottom line</p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">There is an attention signal, but the ADHD-specific evidence is far too small for a treatment claim</h2>
+          <div className="mt-3 space-y-3 text-[1.01rem] leading-[1.85] text-muted">
+            <p>
+              The 2026 meta-analysis pooled <strong>31 randomized trials / 1,168 participants</strong> and found a robust short-term choice-reaction-time signal after L-theanine in cognitive-testing studies. The pooled population was not an ADHD population, so that result supports general attention research—not an ADHD protocol.
             </p>
-          </section>
+            <p>
+              The most directly relevant acute ADHD study was a proof-of-concept crossover in only <strong>five boys</strong>. L-theanine improved one total-cognition composite, while inhibitory-control findings were mixed. A larger <strong>98-boy</strong> ADHD trial studied sleep quality over six weeks, not daytime focus or core ADHD symptoms.
+            </p>
+          </div>
+        </section>
 
-          {/* Quick Verdict */}
-          <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
-            <p className="eyebrow-label">Quick Verdict</p>
-            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
-              Can L-Theanine Support ADHD Focus Without Caffeine?
-            </h2>
-            <ul className="mt-4 space-y-2">
-              {[
-                ['Yes — but the effect is calm alertness, not stimulation', 'L-theanine increases alpha-wave activity, producing a state of relaxed wakefulness. This is different from how caffeine or ADHD medications work.'],
-                ['Most useful when mental noise is the problem', 'If ADHD manifests as a busy, anxious mind that can\'t settle for focused work, L-theanine may help reduce that barrier.'],
-                ['Less effective for pure inattention without hyperactivation', 'If the main challenge is low dopamine / norepinephrine rather than mental hyperactivation, L-theanine\'s mechanism is a poor fit.'],
-                ['No crash, no sleep disruption', 'Unlike caffeine, L-theanine can be taken later in the day without disrupting sleep — and is also useful as a pre-sleep calm support.'],
-              ].map(([bold, rest]) => (
-                <li key={bold as string} className="flex gap-2 text-[1.01rem] leading-[1.85] text-muted">
-                  <span className="mt-1 flex-shrink-0 text-brand-700">▸</span>
-                  <span><strong>{bold as string}.</strong> {rest as string}</span>
-                </li>
-              ))}
+        <section className="grid gap-5 md:grid-cols-2">
+          <EvidenceSummaryCard
+            title="General attention evidence"
+            evidenceLevel="Limited"
+            humanEvidence="The 2026 meta-analysis included 31 placebo-controlled trials / 1,168 participants across healthy and clinical populations. A single-dose attention signal was detected in choice reaction time, but the evidence does not establish ADHD treatment efficacy."
+            mechanisticEvidence="Alpha-wave, neurotransmitter, and stress-response hypotheses may help explain experimental findings, but mechanism does not diagnose an ADHD subtype or identify who will benefit."
+            safetyProfile="No serious adverse events were reported in the 2026 meta-analysis, but trial safety does not establish unlimited long-term use, pediatric self-treatment, or safety with every medication combination."
+          />
+          <EvidenceSummaryCard
+            title="ADHD-specific evidence"
+            evidenceLevel="Limited"
+            humanEvidence="The acute ADHD cognition study enrolled only five boys in a four-condition crossover. A separate 98-boy randomized trial studied sleep rather than daytime ADHD symptoms. This is not enough evidence for a clinical ADHD efficacy claim."
+            mechanisticEvidence="A calmer subjective state is not the same outcome as improved executive function, inhibitory control, or reduced ADHD symptom burden."
+            safetyProfile="Direct coadministration and interaction data with prescription ADHD medicines remain limited; medication-specific decisions should be reviewed with the prescriber or pharmacist managing treatment."
+          />
+        </section>
+
+        <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+          <h2 className="text-2xl font-semibold tracking-tight text-ink">What was actually studied?</h2>
+          <ResponsiveTable label="L-theanine ADHD evidence directness table">
+            <table className="mt-5 min-w-[860px] w-full text-sm">
+              <thead>
+                <tr className="border-b border-brand-900/10">
+                  <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">Evidence source</th>
+                  <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">Population / design</th>
+                  <th className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">What it found</th>
+                  <th className="pb-2 text-left text-xs font-bold uppercase tracking-wider text-muted">What it does not prove</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-brand-900/5">
+                <tr className="align-top">
+                  <td className="py-3 pr-4 font-semibold text-ink">2026 meta-analysis</td>
+                  <td className="py-3 pr-4 text-muted">31 RCTs / 1,168 healthy and clinical participants</td>
+                  <td className="py-3 pr-4 text-muted">Short-term improvement in choice reaction time after a single dose in cognitive-testing studies</td>
+                  <td className="py-3 text-muted">ADHD efficacy, a universal dose, or a guaranteed personal onset</td>
+                </tr>
+                <tr className="align-top">
+                  <td className="py-3 pr-4 font-semibold text-ink">2020 ADHD crossover</td>
+                  <td className="py-3 pr-4 text-muted">5 boys ages 8–15; L-theanine, caffeine, combination, and placebo</td>
+                  <td className="py-3 pr-4 text-muted">Some cognition outcomes improved; inhibitory-control findings were mixed</td>
+                  <td className="py-3 text-muted">A reliable ADHD treatment effect or dosing protocol</td>
+                </tr>
+                <tr className="align-top">
+                  <td className="py-3 pr-4 font-semibold text-ink">2011 ADHD sleep RCT</td>
+                  <td className="py-3 pr-4 text-muted">98 boys ages 8–12; six weeks; L-theanine vs placebo</td>
+                  <td className="py-3 pr-4 text-muted">Some objective sleep measures improved</td>
+                  <td className="py-3 text-muted">Daytime attention, executive function, or core ADHD symptom improvement</td>
+                </tr>
+              </tbody>
+            </table>
+          </ResponsiveTable>
+        </section>
+
+        <section className="rounded-[1rem] border border-amber-200 bg-amber-50/70 p-6 shadow-sm sm:p-8">
+          <h2 className="text-xl font-semibold text-amber-950">Why the old “100–200 mg, 30–60 minutes before focus” script overreached</h2>
+          <div className="mt-3 space-y-3 text-sm leading-7 text-amber-950">
+            <p>
+              The 2026 meta-analysis did find a choice-reaction-time effect in studies using a single dose before cognitive testing. That is a study regimen and outcome—not evidence that every person with ADHD should take a specific milligram amount before work or school.
+            </p>
+            <p>
+              Likewise, the five-person ADHD crossover is too small to turn its weight-based experimental dosing into a consumer ADHD protocol. The larger pediatric trial used repeated dosing for sleep, not an as-needed focus intervention.
+            </p>
+          </div>
+        </section>
+
+        <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+          <h2 className="text-2xl font-semibold tracking-tight text-ink">L-theanine plus caffeine is a different intervention</h2>
+          <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
+            Studies of L-theanine plus caffeine cannot be used as proof that L-theanine alone works the same way. The combination literature is larger, but much of it is in healthy participants. Even the ADHD-specific combination study was only a five-person proof-of-concept crossover. Caffeine also changes sleep, anxiety, heart-rate, and medication considerations for some people.
+          </p>
+          <Link href="/guides/focus/l-theanine-vs-caffeine-for-focus/" className="mt-3 inline-block text-sm font-semibold text-brand-700 hover:underline">L-theanine vs caffeine evidence guide →</Link>
+        </section>
+
+        <section>
+          <SafetyNotice title="Safety and medication boundaries">
+            <ul className="ml-5 space-y-2 list-disc">
+              <li><strong>Trial safety:</strong> the 2026 meta-analysis reported no serious adverse events, but that does not establish unlimited long-term safety or safety for every child, pregnancy, health condition, or medication combination.</li>
+              <li><strong>ADHD medicines:</strong> direct interaction and coadministration evidence is limited. Do not use the absence of a known interaction as proof that a supplement-medication combination is safe for a particular person.</li>
+              <li><strong>Children:</strong> pediatric trials used defined products and research protocols. They are not a basis for unsupervised pediatric dosing.</li>
+              <li><strong>Treatment changes:</strong> supplements should not be used to stop, skip, or alter prescribed ADHD medication without the prescribing clinician.</li>
             </ul>
-          </section>
+          </SafetyNotice>
+        </section>
 
-          <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8 space-y-8">
+        <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+          <h2 className="text-2xl font-semibold tracking-tight text-ink">Product sourcing note</h2>
+          <p className="mt-3 text-sm leading-7 text-muted">
+            This ADHD-focused page intentionally does not rank affiliate products or present a retail dose as the “right” ADHD dose. Commercial L-theanine products can differ from the preparations used in trials. The broader <Link href="/guides/herbs/l-theanine/" className="font-semibold text-brand-700 hover:underline">L-theanine evidence guide</Link> is the better place for formulation and sourcing context.
+          </p>
+        </section>
 
-            <div id="what-is-l-theanine">
-              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">
-                What Is L-Theanine and Why Does It Matter for ADHD?
-              </h2>
-              <p className="text-[1.01rem] leading-[1.85] text-muted">
-                L-theanine is a non-protein amino acid found in tea leaves (<em>Camellia sinensis</em>).
-                It is the compound responsible for the calming quality of green tea that offsets green
-                tea&apos;s caffeine content — a natural calm + alertness combination that has been observed
-                for centuries.
-              </p>
-              <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
-                In the context of ADHD, L-theanine is interesting precisely because many people with
-                ADHD experience <strong>hyperactivation</strong> — a mental state of over-arousal that
-                paradoxically makes focus harder, not easier. The hyperactivated brain generates too much
-                &ldquo;noise&rdquo; (racing thoughts, anxiety, mental restlessness) to sustain a single
-                attentional thread. L-theanine&apos;s alpha-wave induction directly addresses this pattern.
-              </p>
-              <p className="mt-3 text-[1.01rem] leading-[1.85] text-muted">
-                Importantly, this article focuses on <strong>L-theanine alone, without caffeine</strong>.
-                The caffeine+L-theanine combination is separately studied and has stronger evidence for
-                cognitive outcomes — but is not appropriate for people who cannot tolerate caffeine,
-                experience anxiety with stimulants, or want a truly stimulant-free option.
-              </p>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Mechanism */}
-            <div id="mechanism">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                How L-Theanine Produces Calm Focus
-              </h2>
-              <PathwayDiagram data={pathwayDiagrams['l-theanine-focus']} />
-              <div className="mt-4 space-y-3">
-                <div className="rounded-[1rem] border border-brand-900/10 bg-brand-50/60 p-4">
-                  <p className="font-semibold text-ink">Alpha Waves: The &ldquo;Calm Focus&rdquo; Brainwave</p>
-                  <p className="mt-1 text-sm leading-6 text-muted">
-                    Alpha waves (8–12 Hz) are the neural oscillation pattern associated with calm, relaxed
-                    wakefulness — the &ldquo;flow state&rdquo; precursor. L-theanine consistently increases
-                    alpha-wave power in EEG studies within 30–60 minutes of ingestion, making it one of the
-                    more mechanistically well-characterized supplements for this purpose.
-                  </p>
-                </div>
-                <div className="rounded-[1rem] border border-brand-900/10 bg-brand-50/60 p-4">
-                  <p className="font-semibold text-ink">Glutamate / GABA Modulation</p>
-                  <p className="mt-1 text-sm leading-6 text-muted">
-                    L-theanine has structural similarity to glutamate and may modulate AMPA, NMDA, and
-                    kainate receptors to reduce excitatory tone. It also appears to support GABA activity,
-                    the brain&apos;s primary inhibitory neurotransmitter. The net effect is a reduction in
-                    neural hyperactivation without producing strong sedation.
-                  </p>
-                </div>
-                <div className="rounded-[1rem] border border-brand-900/10 bg-brand-50/60 p-4">
-                  <p className="font-semibold text-ink">What L-Theanine Does NOT Do</p>
-                  <p className="mt-1 text-sm leading-6 text-muted">
-                    L-theanine does not meaningfully increase dopamine or norepinephrine — the
-                    catecholamines central to stimulant ADHD medication efficacy. It is not a stimulant.
-                    It does not block adenosine receptors (caffeine does this). Its mechanism is calming
-                    and inhibitory-supportive, not activating.
-                  </p>
-                </div>
+        <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+          <h2 className="text-2xl font-semibold tracking-tight text-ink">Frequently asked questions</h2>
+          <div className="mt-5 space-y-5">
+            {FAQS.map((faq) => (
+              <div key={faq.question} className="border-l-4 border-brand-600 pl-4">
+                <h3 className="font-semibold text-ink">{faq.question}</h3>
+                <p className="mt-2 text-sm leading-7 text-muted">{faq.answer}</p>
               </div>
-              <EvidenceLegend highlightTier="moderate" className="mt-4" />
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Evidence */}
-            <div id="evidence">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Evidence Summary</h2>
-              <EvidenceSummaryCard
-                title="L-Theanine (No Caffeine) — Calm Focus &amp; ADHD"
-                evidenceLevel="Moderate"
-                humanEvidence="EEG studies consistently show alpha-wave induction within 30–60 minutes. Human trials on attention and focus with standalone L-theanine (no caffeine) show modest but consistent positive effects — particularly in populations with anxiety, stress, or high baseline mental arousal. Direct ADHD-specific trials without caffeine co-administration are limited but suggest potential benefit for hyperactivation-associated presentation."
-                mechanisticEvidence="Alpha-wave induction is the most replicated finding. Glutamate modulation and GABA support are plausible based on preclinical data and L-theanine's structural similarity to glutamate. Mechanism is coherent with the hyperactivation phenotype common in ADHD."
-                safetyProfile="Well-tolerated. No significant drug interactions with ADHD medications established. No crash or post-dose rebound. Safe for most evening use without sleep disruption. Insufficient data for pregnancy/breastfeeding. Caution with sedative medications."
-              />
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* With vs Without Caffeine */}
-            <div id="with-vs-without-caffeine">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">
-                With Caffeine vs Without: Which Is Better for ADHD?
-              </h2>
-              <ResponsiveTable label="L-theanine with caffeine vs without caffeine for ADHD">
-                <table className="min-w-[580px] w-full text-sm">
-                  <thead>
-                    <tr className="border-b border-brand-900/10">
-                      {['Factor', 'L-Theanine Alone', 'L-Theanine + Caffeine'].map((h) => (
-                        <th key={h} className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">{h}</th>
-                      ))}
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-brand-900/5">
-                    {[
-                      ['Evidence base', 'Moderate (alpha-wave; limited ADHD-specific)', 'Strong (cognitive outcomes, attention, arousal)'],
-                      ['Mechanism', 'Alpha-wave induction, glutamate/GABA modulation', 'Adenosine block (caffeine) + alpha-wave balance (theanine)'],
-                      ['Effect quality', 'Calm alertness, reduced mental noise', 'Alert focus, improved reaction time, reduced jitteriness'],
-                      ['Sleep impact', 'None — can take any time of day', 'Caffeine disrupts sleep if taken too late'],
-                      ['Suitable for caffeine-sensitive', '★★★ Yes', '✕ No'],
-                      ['Suitable for anxiety-prone ADHD', '★★★ Yes — calming', '★★ Mixed — caffeine may worsen anxiety'],
-                      ['Use with ADHD meds', 'Generally fine (no interaction)', 'Discuss with prescriber — caffeine + stimulants'],
-                      ['Evening / sleep use', '★★★ Yes — also good for sleep', '✕ No — caffeine too late disrupts sleep'],
-                    ].map(([factor, solo, combo]) => (
-                      <tr key={factor as string} className="align-top">
-                        <td className="py-3 pr-4 font-medium text-ink">{factor}</td>
-                        <td className="py-3 pr-4 text-muted">{solo}</td>
-                        <td className="py-3 text-muted">{combo}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </ResponsiveTable>
-              <p className="mt-4 text-[1.01rem] leading-[1.85] text-muted">
-                <strong>Use L-theanine alone if:</strong> you are caffeine-sensitive, prone to anxiety,
-                want a stimulant-free approach, need evening/late-day use, or are already on ADHD
-                stimulant medication.
-              </p>
-              <p className="mt-3 text-sm text-muted">
-                For the full comparison, see{' '}
-                <Link href="/guides/focus/l-theanine-vs-caffeine-for-focus/"
-                  className="font-semibold text-brand-700 hover:underline">
-                  L-Theanine vs Caffeine for Focus
-                </Link>.
-              </p>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Dosage */}
-            <div id="dosage">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Dosage for Daytime ADHD Focus</h2>
-              <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-5 shadow-sm">
-                <p className="mb-3 text-[10px] font-bold uppercase tracking-wider text-muted">Dosage Reference — Stimulant-Free Focus</p>
-                <ResponsiveTable label="L-theanine dosage for ADHD focus without caffeine">
-                  <table className="min-w-[520px] w-full text-sm">
-                    <thead>
-                      <tr className="border-b border-brand-900/10">
-                        {['Use Case', 'Dose', 'Timing', 'Notes'].map((h) => (
-                          <th key={h} className="pb-2 pr-4 text-left text-xs font-bold uppercase tracking-wider text-muted">{h}</th>
-                        ))}
-                      </tr>
-                    </thead>
-                    <tbody className="divide-y divide-brand-900/5">
-                      {[
-                        ['Daytime calm focus', '100–200 mg', '30–60 min before work session', 'Caffeine-free only'],
-                        ['Morning routine', '100 mg', 'With breakfast', 'Good starting dose for first trial'],
-                        ['Evening / pre-sleep', '100–200 mg', '30–60 min before bed', 'No caffeine effect on sleep'],
-                        ['Anxiety-dominant ADHD', '200 mg', 'Before high-stress periods', 'May reduce both anxiety and hyperactivation'],
-                      ].map(([use, dose, timing, notes]) => (
-                        <tr key={use as string} className="align-top">
-                          <td className="py-3 pr-4 font-medium text-ink">{use}</td>
-                          <td className="py-3 pr-4 text-muted">{dose}</td>
-                          <td className="py-3 pr-4 text-muted">{timing}</td>
-                          <td className="py-3 text-muted">{notes}</td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </ResponsiveTable>
-              </div>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Products */}
-            <div id="products">
-              <h2 className="mb-3 text-2xl font-semibold tracking-tight text-ink">Caffeine-Free L-Theanine Products</h2>
-              <p className="mb-4 text-[1.01rem] leading-[1.85] text-muted">
-                The key is choosing a <strong>standalone, caffeine-free</strong> product. Many &ldquo;focus
-                blend&rdquo; products combine L-theanine with caffeine — these are for daytime use only and
-                not appropriate if you want a stimulant-free approach.
-              </p>
-              {lTheanineProducts && (
-                <RecommendationSection
-                  title="Caffeine-free L-theanine picks"
-                  description="Standalone L-theanine capsules — no caffeine or focus-blend fillers. Use these as sourcing starting points, not medical recommendations."
-                  products={lTheanineProductsWith100mgStart}
-                />
-              )}
-
-              <div className="mt-4 rounded-[1rem] border border-amber-200 bg-amber-50/60 p-4">
-                <p className="font-semibold text-amber-900">What to avoid when buying caffeine-free L-theanine:</p>
-                <ul className="mt-2 ml-5 space-y-1 list-disc text-sm text-amber-800">
-                  <li>Products labeled &ldquo;Focus Blend&rdquo; or &ldquo;Energy + Focus&rdquo; — these almost always contain caffeine</li>
-                  <li>Green tea extracts — these contain caffeine unless specifically decaffeinated</li>
-                  <li>Nootropic stacks without full ingredient disclosure</li>
-                </ul>
-              </div>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            {/* Who Benefits Most */}
-            <div id="who-benefits">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Who Benefits Most From Solo L-Theanine?</h2>
-              <div className="space-y-3">
-                {[
-                  {
-                    label: 'Strong candidate',
-                    color: 'border-emerald-200 bg-emerald-50/60',
-                    items: [
-                      'ADHD with high baseline anxiety or mental hyperactivation',
-                      'Caffeine-sensitive or caffeine-intolerant individuals',
-                      'People on ADHD stimulant medication wanting a calm complement (check with prescriber)',
-                      'Evening or late-day focus need (no sleep disruption from caffeine)',
-                    ],
-                  },
-                  {
-                    label: 'Weaker candidate',
-                    color: 'border-amber-200 bg-amber-50/60',
-                    items: [
-                      'Primarily inattentive ADHD without hyperactivation or anxiety',
-                      'Expecting stimulant-level alertness or dopamine-driven motivation',
-                      'Severe ADHD where evidence-based medical treatment has not been optimized',
-                    ],
-                  },
-                ].map(({ label, color, items }) => (
-                  <div key={label} className={`rounded-[1rem] border p-4 ${color}`}>
-                    <p className="text-[10px] font-bold uppercase tracking-wider text-muted">{label}</p>
-                    <ul className="mt-2 ml-5 space-y-1 list-disc text-sm leading-6 text-muted">
-                      {items.map((item) => <li key={item}>{item}</li>)}
-                    </ul>
-                  </div>
-                ))}
-              </div>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            <div id="safety">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Safety</h2>
-              <SafetyNotice title="Safety Summary — L-Theanine Without Caffeine">
-                <ul className="ml-5 space-y-1.5 list-disc">
-                  {[
-                    ['Generally well-tolerated', 'L-theanine has a good safety profile at typical supplemental doses (100–400 mg/day) based on available evidence and its long history in tea consumption.'],
-                    ['No crash or withdrawal', 'Unlike caffeine, L-theanine does not produce dependence, tolerance, or withdrawal effects at supplemental doses.'],
-                    ['Sedative medications', 'L-theanine has mild calming properties. Combining with benzodiazepines, z-drugs, or other CNS depressants requires medical supervision.'],
-                    ['ADHD medications', 'No established adverse interaction, but inform your prescriber you are supplementing.'],
-                    ['Blood pressure', 'Some evidence for mild blood pressure-lowering effects. Caution if you take antihypertensives.'],
-                    ['Pregnancy and breastfeeding', 'Insufficient safety data for supplemental doses. Consult a clinician before use.'],
-                    ['Product labeling warning', 'Always verify the product is caffeine-free. Green tea and many focus blends contain both L-theanine and caffeine.'],
-                  ].map(([bold, text]) => (
-                    <li key={bold as string}><strong>{bold as string}.</strong> {text as string}</li>
-                  ))}
-                </ul>
-              </SafetyNotice>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            <div id="faq">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Frequently Asked Questions</h2>
-              <div className="space-y-4">
-                {FAQS.map((faq, i) => (
-                  <div key={i} className="rounded-[0.75rem] border border-brand-900/10 bg-brand-50/40 p-4">
-                    <h3 className="font-semibold text-ink">{faq.question}</h3>
-                    <p className="mt-2 text-sm leading-7 text-muted">{faq.answer}</p>
-                  </div>
-                ))}
-              </div>
-            </div>
-
-            <hr className="border-brand-900/10" />
-
-            <div id="related">
-              <h2 className="mb-4 text-2xl font-semibold tracking-tight text-ink">Related Articles</h2>
-              <div className="grid gap-3 sm:grid-cols-2">
-                {[
-                  ['/guides/adhd/best-supplements-for-adhd/', 'Cornerstone', 'Best Supplements for ADHD', 'Full evidence-ranked guide.'],
-                  ['/guides/adhd/l-theanine-for-adhd/', 'ADHD Cluster', 'L-Theanine for ADHD', 'Full evidence review including sleep.'],
-                  ['/guides/focus/l-theanine-vs-caffeine-for-focus', 'ADHD Cluster', 'L-Theanine vs Caffeine', 'Direct comparison for focus.'],
-                  ['/guides/adhd/l-theanine-magnesium-adhd-stack', 'Stack Guide', 'L-Theanine + Magnesium Stack', 'Combine for broader ADHD support.'],
-                  ['/guides/sleep/l-theanine-for-sleep', 'Sleep Cluster', 'L-Theanine for Sleep', 'Nighttime calm without caffeine.'],
-                  ['/guides/adhd/adhd-stack-guide', 'ADHD Cluster', 'ADHD Stack Guide', 'Building a safe ADHD supplement stack.'],
-                  ['/guides/herbs/ashwagandha/', 'Umbrella', 'Ashwagandha Article', 'Full evidence review across stress, anxiety, sleep, and focus.'],
-                  ['/guides/adhd/ashwagandha-for-adhd', 'ADHD Cluster', 'Ashwagandha for ADHD', 'Chronic stress and focus support.'],
-                  ['/guides/focus', 'Goal Hub', 'Focus Goal Hub', 'Compare all focus supplements.'],
-                ].map(([href, eyebrow, label, desc]) => (
-                  <Link key={href as string} href={href as string}
-                    className="group rounded-[0.75rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/30">
-                    <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted">{eyebrow}</p>
-                    <p className="font-semibold text-ink transition group-hover:text-brand-700">{label}</p>
-                    <p className="mt-1 text-xs text-muted">{desc}</p>
-                  </Link>
-                ))}
-              </div>
-            </div>
-
-          </section>
-
-          <EmailCapture
-            headline="Get the ADHD supplement checklist"
-            description="Evidence-first supplement guides, safety context, and ADHD research notes. No diagnosis or personal medical advice."
-            ctaLabel="Get Checklist"
-            location={`article-${SLUG}`}
-          />
-          <NewsletterCtaBlock
-            title="Continue with the newsletter archive"
-            description="Short notes built for cautious supplement decisions."
-            location={`article-${SLUG}-newsletter`}
-          />
-        </div>
-
-        {/* Sidebar */}
-        <aside className="space-y-4 lg:sticky lg:top-24 lg:self-start">
-          <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
-            <p className="text-[10px] font-bold uppercase tracking-wider text-muted">In this article</p>
-            <nav className="mt-3 space-y-1.5" aria-label="Article sections">
-              {[
-                ['#what-is-l-theanine', 'What Is L-Theanine?'],
-                ['#mechanism', 'How It Works'],
-                ['#evidence', 'Evidence Summary'],
-                ['#with-vs-without-caffeine', 'With vs Without Caffeine'],
-                ['#dosage', 'Dosage Guide'],
-                ['#products', 'Caffeine-Free Products'],
-                ['#who-benefits', 'Who Benefits?'],
-                ['#safety', 'Safety'],
-                ['#faq', 'FAQ'],
-              ].map(([href, label]) => (
-                <a key={href} href={href as string}
-                  className="block text-sm text-brand-700 hover:text-brand-800 hover:underline">
-                  {label}
-                </a>
-              ))}
-            </nav>
+            ))}
           </div>
-          <div className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm">
-            <p className="text-[10px] font-bold uppercase tracking-wider text-muted">Focus + ADHD cluster</p>
-            <div className="mt-3 space-y-2">
-              {[
-                ['/guides/adhd/best-supplements-for-adhd/', 'Best supplements for ADHD →'],
-                ['/guides/adhd/l-theanine-for-adhd/', 'L-Theanine for ADHD →'],
-                ['/guides/focus/l-theanine-vs-caffeine-for-focus', 'L-Theanine vs Caffeine →'],
-                ['/guides/adhd/adhd-stack-guide', 'ADHD stack guide →'],
-                ['/guides/sleep/l-theanine-for-sleep', 'L-Theanine for sleep →'],
-                ['/guides/focus', 'Focus goal hub →'],
-              ].map(([href, label]) => (
-                <Link key={href as string} href={href as string}
-                  className="block text-sm font-medium text-brand-700 hover:text-brand-800 hover:underline">
-                  {label}
-                </Link>
-              ))}
-            </div>
-          </div>
-        </aside>
-      </div>
+        </section>
 
-      <div className="mt-8">
-        <Link href="/guides/" className="text-sm font-semibold text-brand-700 hover:text-brand-800">
-          ← Back to Guides
-        </Link>
+        <section className="rounded-[1rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+          <h2 className="text-2xl font-semibold tracking-tight text-ink">Sources and directness notes</h2>
+          <ol className="mt-4 space-y-4">
+            {SOURCES.map((source, index) => (
+              <li key={source.href} className="text-sm leading-7 text-muted">
+                <span className="font-semibold text-ink">{index + 1}. </span>
+                <a href={source.href} target="_blank" rel="noopener noreferrer" className="font-semibold text-brand-700 hover:underline">{source.label}</a>
+                <span> — {source.note}</span>
+              </li>
+            ))}
+          </ol>
+        </section>
+
+        <section className="grid gap-3 sm:grid-cols-2">
+          <Link href="/guides/herbs/l-theanine/" className="rounded-xl border border-brand-900/10 bg-white p-4 text-sm font-semibold text-brand-700 hover:underline">L-theanine umbrella evidence →</Link>
+          <Link href="/guides/focus/l-theanine-vs-caffeine-for-focus/" className="rounded-xl border border-brand-900/10 bg-white p-4 text-sm font-semibold text-brand-700 hover:underline">L-theanine vs caffeine →</Link>
+          <Link href="/guides/focus/" className="rounded-xl border border-brand-900/10 bg-white p-4 text-sm font-semibold text-brand-700 hover:underline">Focus goal hub →</Link>
+          <Link href="/tools/" className="rounded-xl border border-brand-900/10 bg-white p-4 text-sm font-semibold text-brand-700 hover:underline">Safety and evidence tools →</Link>
+        </section>
+
+        <EmailCapture
+          headline="Get future research notes by email"
+          description="Evidence-first supplement updates, safety context, and new guide announcements. No diagnosis, treatment, or personal medical advice."
+          location={`article-${SLUG}`}
+        />
+        <NewsletterCtaBlock
+          title="Continue with the newsletter archive"
+          description="Short notes built for cautious supplement decisions."
+          location={`article-${SLUG}-newsletter`}
+        />
       </div>
-      <References refs={L_THEANINE_WITHOUT_CAFFEINE_REFS} />
     </article>
   )
 }

--- a/components/articles/AdhdMonetizationWidgets.tsx
+++ b/components/articles/AdhdMonetizationWidgets.tsx
@@ -98,7 +98,7 @@ export function AdhdComparisonCard({ slug }: { slug: string }) {
   let items: { label: string; text: string }[] = []
   let compareLink = ''
 
-  if (slug === 'best-supplements-for-adhd' || slug === 'adhd-stack-guide' || slug === 'magnesium-for-adhd' || slug === 'l-theanine-for-adhd' || slug === 'ashwagandha-for-adhd') {
+  if (slug === 'best-supplements-for-adhd' || slug === 'adhd-stack-guide' || slug === 'magnesium-for-adhd' || slug === 'ashwagandha-for-adhd') {
     cardTitle = 'Comparison: Magnesium vs. L-Theanine'
     cardDesc = 'Both support relaxation, but via entirely different mechanisms. Many adults combine them to address different aspects of cognitive fatigue.'
     items = [

--- a/components/articles/FocusAdhdArticlePage.tsx
+++ b/components/articles/FocusAdhdArticlePage.tsx
@@ -32,7 +32,6 @@ const ADHD_ARTICLE_PRODUCTS: Record<string, string> = {
   'ashwagandha-for-adhd': 'ashwagandha',
   'best-supplements-for-adhd': 'magnesium',
   'citicoline-vs-alpha-gpc': 'lions-mane',
-  'l-theanine-for-adhd': 'l-theanine',
   'l-theanine-vs-caffeine-for-focus': 'l-theanine',
   'magnesium-for-adhd': 'magnesium',
   'melatonin-for-adhd-sleep': 'magnesium',

--- a/docs/content/focus-cluster/l-theanine-for-adhd-content-v1.md
+++ b/docs/content/focus-cluster/l-theanine-for-adhd-content-v1.md
@@ -1,363 +1,152 @@
-# L-Theanine for ADHD Content v1
+# L-Theanine for ADHD Content v2
 
-Status: Approved for implementation
+Status: Evidence-calibrated
 Cluster: Focus / ADHD
-Type: Supplement Article
-Target URL: /articles/l-theanine-for-adhd/
-Version: 1
-
----
-
-## SEO Title
-
-L-Theanine for ADHD: Evidence on Attention, Sleep, and Emotional Regulation
-
-## Meta Description
-
-Evidence-based review of L-theanine for ADHD-related symptoms. Covers attention, sleep quality, emotional regulation, caffeine synergy, pediatric and adult evidence, dosing, safety, and practical use.
-
-## Primary Keyword
-
-L-theanine for ADHD
-
-## Secondary Keywords
-
-L-theanine ADHD, L-theanine focus ADHD, L-theanine sleep ADHD, L-theanine attention, L-theanine and ADHD
-
-## Search Intent
-
-Informational + commercial investigation. Readers want to know whether L-theanine helps ADHD symptoms, whether it improves focus or sleep, how it compares with caffeine, what doses are studied, and whether it is safe for children and adults.
-
-## H1
-
-L-Theanine for ADHD: Evidence on Attention, Sleep, and Emotional Regulation
+Type: Evidence Guide
+Target URL: /guides/adhd/l-theanine-for-adhd/
+Version: 2
+Updated: 2026-08-12
 
 ---
 
 ## Full Article Content
 
-### Introduction
+## L-Theanine for ADHD: What the Evidence Supports in 2026
 
-L-Theanine is a unique amino acid found primarily in tea leaves (Camellia sinensis). It has gained attention for its ability to promote relaxed alertness without sedation. In the context of ADHD, where difficulties with attention, emotional regulation, and sleep are common, L-theanine is frequently discussed as a potential supportive compound.
+L-theanine has human research on attention, stress, sleep, and cognition, but the ADHD-specific evidence is much smaller than the broader supplement literature. The most important distinction is **general L-theanine evidence versus direct ADHD evidence**.
 
-This article reviews the available human evidence on L-theanine for ADHD-related symptoms, with particular attention to attention, focus, emotional regulation, and sleep quality. It examines pediatric and adult data, interactions with caffeine, dosing considerations, safety, and practical decision-making. The strongest signals currently exist for calming and sleep support rather than direct improvements in core ADHD symptoms.
+A 2026 systematic review and meta-analysis pooled **31 randomized trials / 1,168 participants** across healthy and clinical populations. A single-dose cognitive-testing signal was found for choice reaction time, but that does not establish L-theanine as an ADHD treatment or create an evidence-based ADHD dose.
 
-L-Theanine is discussed here strictly as a potential adjunctive support. It is not presented as a treatment for ADHD itself.
+The most directly relevant acute ADHD cognition study involved only **five boys ages 8–15**. A larger randomized trial involved **98 boys ages 8–12 with ADHD**, but that study evaluated sleep over six weeks rather than daytime attention or core ADHD symptoms.
 
-### Important Medical Disclaimer
+**Bottom line:** L-theanine remains an interesting research compound, but current evidence does not justify presenting it as a proven non-stimulant ADHD treatment, a same-day focus tool, or a fixed-dose protocol.
 
-This article is for educational purposes only and does not constitute medical advice. L-Theanine does not treat or cure ADHD. Individual responses vary, and any supplement use should be discussed with a qualified healthcare provider, especially for children or when other medications are in use. Evidence for L-theanine in ADHD remains limited compared with established treatments.
+## Evidence at a glance
 
-### What L-Theanine Is
+| Evidence source | Population / design | What it found | Main limit |
+|---|---|---|---|
+| 2026 L-theanine meta-analysis | 31 RCTs / 1,168 healthy and clinical participants | A single-dose choice-reaction-time signal; modest acute-stress signal | Not an ADHD-specific efficacy analysis |
+| 2020 ADHD proof-of-concept crossover | 5 boys ages 8–15 with ADHD | Some cognition outcomes improved under certain conditions; inhibitory-control findings were mixed | Far too small for treatment or dosing conclusions |
+| 2011 ADHD sleep RCT | 98 boys ages 8–12 with ADHD, six weeks | Some actigraphy-based sleep measures improved | Studied sleep, not daytime ADHD focus or core symptoms |
+| 2025 tea/L-theanine review | Healthy participants; tea, L-theanine, and combination studies | Small, outcome-specific cognition/mood signals | Does not establish ADHD treatment efficacy |
 
-L-Theanine is a non-proteinogenic amino acid structurally similar to glutamate. It was first isolated from tea leaves in 1949 and is responsible for some of tea’s characteristic umami flavor and relaxing properties. Unlike many amino acids, it readily crosses the blood-brain barrier and influences brain chemistry directly.
+## What the 2026 meta-analysis means—and what it does not
 
-Supplemental L-theanine is typically produced through enzymatic processes or fermentation and is available in capsule, tablet, or powder form. It is often studied alone or in combination with caffeine.
+The 2026 review is the strongest broad L-theanine evidence anchor currently available. It included 31 randomized controlled trials and 1,168 participants.
 
-TODO: Verify L-theanine isolation history, BBB crossing, and production claims.
+A single 200 mg dose taken before cognitive testing improved choice reaction time in pooled analysis. That is useful **study context**, but it is not evidence that every person with ADHD should take 200 mg before work, school, or medication wear-off.
 
-### How L-Theanine Works
+The review also found that acute stress reduction was modest and substantially influenced by studies at high risk of bias. Anxiety findings were inconsistent. No serious adverse events were reported, but trial safety does not establish unlimited long-term use or safety for every child, pregnancy, medical condition, or medication combination.
 
-L-Theanine influences several neurotransmitter systems. It can act as a partial agonist at GABA-A receptors, supporting inhibitory signaling. It also modulates glutamate activity and may influence dopamine and serotonin pathways indirectly. These effects contribute to reduced neuronal excitability and a state of calm alertness.
+One author disclosed founding a dietary-supplement company. That conflict does not invalidate the analysis, but it is relevant context when interpreting a commercially popular supplement.
 
-L-Theanine does not produce strong sedation or stimulation on its own. Instead, it tends to promote a balanced mental state that can support focus without the jitteriness sometimes associated with stimulants.
+## The direct ADHD cognition evidence is exploratory
 
-TODO: Verify GABA-A, glutamate, dopamine, serotonin, and sedation claims.
+The 2020 ADHD proof-of-concept study used a randomized four-condition crossover of L-theanine, caffeine, their combination, and placebo.
 
-### L-Theanine and Brain Waves
+Only **five boys** completed the study.
 
-One of the most studied effects of L-theanine is its ability to increase alpha brain wave activity. Alpha waves are associated with relaxed wakefulness and selective attention. This pattern differs from the high-beta activity linked to anxiety or the delta/theta patterns of deep sleep.
+Some cognition outcomes improved under certain conditions, but inhibitory-control findings were mixed. With a sample that small, the study can generate hypotheses; it cannot establish:
 
-Increased alpha activity may help reduce mental restlessness and support the kind of calm, sustained attention that can be challenging for individuals with ADHD.
+- a dependable ADHD treatment effect,
+- a pediatric dose,
+- a universal onset time,
+- an optimal L-theanine:caffeine ratio,
+- long-term efficacy,
+- or medication-combination safety.
 
-TODO: Verify alpha-wave and selective-attention claims.
+## The larger ADHD trial was a sleep study
 
-### GABA, Glutamate, and ADHD
+The 2011 randomized trial enrolled **98 boys ages 8–12 with diagnosed ADHD** and compared a defined L-theanine product with placebo for six weeks.
 
-L-Theanine’s effects on GABA and glutamate balance are relevant to ADHD because these neurotransmitters influence neuronal excitability and attention networks. Excessive glutamate signaling or insufficient GABA activity can contribute to restlessness, impulsivity, and difficulty with emotional regulation.
+Some objective sleep measures improved. That is relevant to sleep research in ADHD, but it should not be repackaged as evidence that L-theanine improves daytime executive function, school performance, working memory, or core ADHD symptom severity.
 
-By supporting GABA activity and modulating glutamate, L-theanine may help promote more balanced signaling. This mechanism provides a plausible basis for its discussion in ADHD contexts, though clinical evidence remains limited.
+Sleep improvement can matter greatly for daytime functioning, but a sleep endpoint and an ADHD-treatment endpoint are not interchangeable.
 
-TODO: Verify GABA/glutamate ADHD mechanism and avoid overclaiming.
+## Why this page no longer gives a 200–400 mg “starting protocol”
 
-### Why L-Theanine Is Discussed for ADHD
+Published studies use defined doses because a trial needs a standardized intervention. A research dose is not automatically a consumer recommendation.
 
-L-Theanine is frequently considered for ADHD because it may address common co-occurring challenges such as bedtime arousal, emotional dysregulation, and difficulty maintaining calm focus. Its generally favorable safety profile and lack of significant sedation make it appealing for daytime or evening use.
+Older versions of this guide translated study regimens into a practical 200–400 mg starting range and gave 30–60-minute timing guidance. The direct ADHD evidence is not strong enough to support that conversion.
 
-Interest has grown alongside research on its combination with low-dose caffeine, which some studies suggest can enhance attention while reducing caffeine-related jitteriness.
+This page therefore does **not** recommend:
 
-### Evidence From Human Studies
+- a universal ADHD dose,
+- a “start low, then increase” schedule,
+- taking L-theanine a fixed number of minutes before a focus task,
+- using it as medication wears off,
+- using it on stimulant off-days or weekends,
+- or unsupervised pediatric dosing.
 
-Human research on L-theanine includes studies in healthy adults, stressed populations, and limited work in ADHD. Most high-quality data come from cognitive performance or stress-reduction trials rather than large ADHD-specific studies. Available ADHD research is relatively small but includes both sleep and attention outcomes.
+## L-theanine plus caffeine is a different intervention
 
-Overall, evidence is stronger for calming and sleep quality support than for direct improvements in core ADHD symptoms such as inattention or hyperactivity.
+Studies of L-theanine plus caffeine cannot be treated as proof that L-theanine alone works the same way.
 
-TODO: Verify human study landscape and strength-of-evidence claims.
+A 2025 systematic review/meta-analysis of tea, L-theanine, and L-theanine plus caffeine found some small short-term cognitive signals in healthy participants. The combination literature is larger than the ADHD-specific literature, but it still does not establish an ADHD treatment or a universal dose ratio.
 
-### Pediatric ADHD Evidence
+The five-person ADHD crossover included a combination arm, but it is much too small to settle whether the combination is beneficial, which ratio would be best, or which children might be harmed.
 
-One notable randomized, double-blind, placebo-controlled trial examined L-theanine in boys aged 8–12 years with ADHD. Participants received 400 mg daily (200 mg twice daily) for six weeks. The study measured objective sleep parameters using actigraphy and found improvements in sleep efficiency and reduced nighttime awakenings compared with placebo.
+Caffeine can also worsen sleep, anxiety, jitteriness, heart rate, or blood pressure in sensitive people. L-theanine should not be assumed to cancel those effects.
 
-The supplement was generally well tolerated. One participant experienced transient facial tics that resolved after discontinuation. This remains one of the more direct pieces of evidence for L-theanine in an ADHD population.
+## Mechanism is not clinical efficacy
 
-Evidence Grade: Moderate for objective sleep quality improvements in one pediatric ADHD trial.
+L-theanine is often described through alpha-wave, glutamate, GABA, dopamine, or “relaxed alertness” mechanisms. Those mechanisms may be scientifically interesting, but they do not establish that ADHD is caused by a deficit L-theanine corrects.
 
-TODO: Verify Lyon 2011: sample size, exact protocol, effect sizes on sleep parameters, PMID if available.
+A brain-wave finding is not the same endpoint as reduced ADHD symptoms. A calmer subjective state is not automatically better inhibitory control, working memory, or executive function.
 
-### Lyon 2011 Sleep Study
+Mechanism should help explain a clinical result after that result is established—not substitute for one.
 
-The 2011 study by Lyon and colleagues remains a key reference for L-theanine in ADHD-related sleep difficulties. It demonstrated that 400 mg daily of Suntheanine (a patented form of L-theanine) improved several objective sleep measures in boys with ADHD over a six-week period. The findings support L-theanine as a potential option for sleep support in this population when behavioral strategies alone are insufficient.
+## Safety and medication boundaries
 
-TODO: Verify full study details: exact n, inclusion criteria, statistical significance, and any secondary outcomes.
+- **ADHD medications:** direct interaction and coadministration evidence is limited. Do not interpret the absence of a known interaction as proof that a supplement-medication combination is safe for a particular person.
+- **Children:** pediatric studies used defined research products and supervised protocols. They are not a basis for unsupervised pediatric supplementation.
+- **Long-term use:** the 2026 meta-analysis reported no serious adverse events, but the trial literature does not establish unlimited long-term safety.
+- **Pregnancy and health conditions:** evidence is not broad enough to assume safety across pregnancy, breastfeeding, complex medical conditions, or polypharmacy.
+- **Treatment changes:** do not stop, skip, lower, or otherwise change prescribed ADHD medication because of supplement use without the prescribing clinician.
 
-### Adult Evidence
+If someone takes prescription ADHD medication, the prescriber or pharmacist managing that treatment is the appropriate person to review supplement co-use.
 
-High-quality randomized trials of L-theanine specifically in adults with confirmed ADHD are very limited. Most available data come from general adult populations or studies of stress and cognitive performance. Some research shows benefits for reducing stress and improving subjective relaxation, which may be relevant for adults with ADHD who experience prominent emotional dysregulation or bedtime arousal.
+## Where L-theanine may still be worth studying
 
-Adult-specific ADHD evidence remains preliminary. Findings from broader cognitive or stress studies cannot be directly applied to ADHD symptom management without additional research.
+The evidence is stronger for **research questions** than for a clinical recommendation.
 
-Evidence Grade: Limited in adult ADHD populations.
+Reasonable questions include whether L-theanine changes attention under specific laboratory conditions, whether sleep improvement matters in selected ADHD populations, and whether certain combinations affect cognition differently from their individual ingredients.
 
-TODO: Verify adult ADHD evidence gap and relevant broader adult studies.
+Those are useful questions. They are not the same as “L-theanine treats ADHD.”
 
-### Effects on Attention
+## Frequently asked questions
 
-L-Theanine alone has shown modest or context-dependent effects on attention in general cognitive studies. It tends to support selective attention and reduce distractibility under stress rather than producing broad stimulation.
+### Does L-theanine treat ADHD?
 
-One small randomized crossover study in boys with ADHD examined single doses of L-theanine, caffeine, and their combination during attention and inhibitory control tasks. The combination showed more consistent benefits for sustained attention than either compound alone. L-theanine by itself had more modest effects.
+Current evidence does not establish L-theanine as an ADHD treatment. Direct ADHD cognition data are extremely small, and the larger pediatric randomized trial studied sleep rather than daytime ADHD symptoms.
 
-Evidence Grade: Preliminary for attention in ADHD.
+### Does L-theanine improve attention?
 
-TODO: Verify Kahathuduwa 2020 or related crossover study details: sample size, doses, and specific attention outcomes.
+A 2026 meta-analysis found a short-term choice-reaction-time signal in broader healthy and clinical populations. That supports general attention research but not a guaranteed ADHD benefit.
 
-### Effects on Focus
+### What dose should someone with ADHD take?
 
-L-Theanine is often discussed for supporting calm, sustained focus rather than intense concentration. In stressed or high-demand situations, it may help maintain performance without the jitteriness sometimes associated with stimulants. Direct evidence for improvements in focus specifically in ADHD populations remains limited.
+There is no evidence-based universal ADHD dose. Trial doses should be reported as study context, not converted into a personalized protocol.
 
-Any focus-related benefits are generally described as subtle and most noticeable when combined with low-dose caffeine or when baseline arousal is high.
+### How fast does L-theanine work for ADHD?
 
-### Effects on Emotional Regulation
+No reliable ADHD onset time has been established. A cognitive-testing window in a general-population trial is not the same thing as a predictable treatment onset for ADHD.
 
-L-Theanine’s GABA-supporting and stress-reducing effects make it relevant for emotional regulation. Some studies in general populations report reductions in subjective stress and anxiety. In ADHD contexts, where emotional dysregulation is common, L-theanine may offer supportive benefits for calmness and reduced reactivity, though direct high-quality ADHD data are limited.
+### Can L-theanine be combined with stimulant medication?
 
-Evidence Grade: Preliminary in ADHD; Moderate in broader stress research.
+Direct interaction and coadministration evidence is limited. The pediatric sleep trial included boys with and without stimulant treatment, but it was not designed to establish medication-interaction safety. Review co-use with the prescriber or pharmacist managing the medication.
 
-TODO: Verify stress/anxiety studies and ADHD-specific emotional regulation evidence.
+### Is L-theanine plus caffeine better for ADHD?
 
-### Effects on Stress and Anxiety
+That has not been established. The most directly relevant ADHD crossover involved only five boys, which is far too small to support a dependable combination recommendation or ratio.
 
-Multiple human studies have demonstrated L-theanine’s ability to reduce subjective stress and physiological markers of stress in various populations. These effects are generally modest and dose-dependent. For individuals with ADHD who experience significant stress or anxiety that worsens symptoms, L-theanine may provide adjunctive support.
+### Did the 98-boy ADHD trial show better focus?
 
-Evidence Grade: Moderate in stressed populations; Preliminary in ADHD-specific contexts.
+No. That randomized trial studied sleep outcomes. It should not be cited as proof of improved daytime attention or core ADHD symptoms.
 
-TODO: Verify stress/anxiety study claims and physiological markers.
+## Sources
 
-### Effects on Sleep Quality
-
-The Lyon 2011 study in boys with ADHD provides the most direct evidence for L-theanine improving objective sleep quality. Participants showed improvements in sleep efficiency and reduced awakenings with 400 mg daily over six weeks. These findings suggest L-theanine may be particularly relevant for ADHD-related sleep difficulties involving bedtime arousal or fragmented sleep. For a detailed breakdown of how L-theanine promotes relaxation without sedation and improves overall sleep quality, see our guide on [L-Theanine for Sleep](/articles/l-theanine-for-sleep/).
-
-Evidence Grade: Moderate in one pediatric ADHD trial.
-
-TODO: Verify sleep quality outcomes and objective measures.
-
-### L-Theanine and Sleep Onset
-
-L-Theanine does not typically produce rapid sedation. Its effects on sleep are more related to reduced arousal and improved relaxation leading into sleep. It may help with sleep onset indirectly by lowering bedtime mental restlessness rather than through strong hypnotic effects.
-
-It is sometimes compared with melatonin, which more directly targets sleep onset timing. The two can be complementary depending on individual needs.
-
-### L-Theanine vs Melatonin
-
-Melatonin has stronger evidence for reducing sleep onset latency in children with ADHD. L-Theanine has shown benefits for overall sleep quality and reduced nighttime awakenings in one key pediatric study. Melatonin primarily supports circadian signaling, while L-theanine supports relaxation and GABA activity. They have different mechanisms and may be used separately or together depending on the specific sleep complaint.
-
-TODO: Verify comparison with melatonin evidence.
-
-### L-Theanine vs Magnesium
-
-Both L-theanine and magnesium are discussed for calming and sleep support. L-theanine has direct evidence from one pediatric ADHD sleep trial. Magnesium has broader observational associations with ADHD and may offer additional muscle relaxation benefits. Individual response varies; some people prefer one over the other or find them complementary.
-
-TODO: Verify comparison with magnesium evidence.
-
-### L-Theanine vs Ashwagandha
-
-Ashwagandha is an adaptogen studied for stress reduction and cortisol modulation. L-Theanine more directly influences brain wave patterns and GABA/glutamate balance. Both may support emotional regulation and stress resilience, but they work through different pathways. Limited direct comparative data exist in ADHD populations.
-
-TODO: Verify comparison with ashwagandha evidence and mechanism.
-
-### L-Theanine + Caffeine
-
-The combination of L-theanine and caffeine is one of the more studied pairings for cognitive effects. L-Theanine is thought to moderate some of caffeine’s jitteriness and anxiety-promoting effects while preserving benefits for attention. One small study in boys with ADHD suggested the combination improved sustained attention more consistently than either alone.
-
-This pairing may be useful for daytime focus in individuals who tolerate caffeine but experience unwanted side effects. Individual sensitivity varies significantly.
-
-Evidence Grade: Preliminary in ADHD (small study); Moderate in healthy adult cognitive research.
-
-TODO: Verify Kahathuduwa 2020 or related study details: doses, outcomes, and statistical findings.
-
-### L-Theanine + Magnesium
-
-L-Theanine and magnesium are sometimes combined for bedtime calming or sleep support. Both influence GABA-related pathways and may offer complementary relaxation effects. Limited direct comparative or combination data exist specifically in ADHD populations. They are often viewed as compatible options for evening use.
-
-TODO: Verify combination rationale and avoid overclaiming.
-
-### L-Theanine in ADHD Stacks
-
-L-Theanine is frequently included in ADHD stacks for its calming properties and potential sleep support. It combines reasonably with magnesium, melatonin (when used for sleep), or low-dose caffeine for focus. It should be introduced thoughtfully with clear tracking rather than in large untested combinations.
-
-### Dosing Considerations
-
-Studied doses have commonly ranged from 200 mg to 400 mg per day, sometimes divided. The 400 mg daily dose used in the key pediatric sleep study was split into two 200 mg doses. Lower doses may be sufficient for some individuals, particularly when combined with other calming supports.
-
-Individual response varies. Starting at the lower end of studied ranges and adjusting based on effect and tolerability is a reasonable approach.
-
-TODO: Verify specific dose-response data from relevant studies.
-
-### Timing Considerations
-
-For sleep support, L-theanine is often taken in the evening or 30–60 minutes before desired bedtime. For daytime calm focus, it may be taken in the morning or early afternoon, sometimes alongside low-dose caffeine. Consistent timing helps with evaluation of effects.
-
-TODO: Verify timing guidance.
-
-### Safety and Side Effects
-
-L-Theanine is generally recognized as having a favorable safety profile at studied doses. Reported side effects are uncommon and typically mild (such as headache or gastrointestinal discomfort in sensitive individuals). It does not appear to produce significant sedation or dependence at typical supplemental doses.
-
-TODO: Verify safety, side effects, and dependence language.
-
-### Medication Interactions
-
-L-Theanine may have additive calming effects with other sedating substances or medications. Potential interactions with blood pressure medications or compounds affecting the central nervous system should be considered. Full disclosure to healthcare providers is recommended before combining with prescription treatments.
-
-TODO: Verify medication interaction claims.
-
-### Pediatric Considerations
-
-The key 2011 study in boys with ADHD provides the most direct pediatric data. L-Theanine was generally well tolerated at 400 mg daily over six weeks. Use in children should involve clinical guidance, particularly when other medications or health conditions are present. Behavioral sleep strategies should be optimized first.
-
-### Adult Considerations
-
-Adult-specific evidence for L-theanine in confirmed ADHD is limited. Broader research in stressed or cognitively demanding situations shows benefits for relaxation and focus. Adults considering L-theanine should approach expectations conservatively and track individual response systematically.
-
-### Who Might Benefit Most
-
-L-Theanine may be most relevant for individuals with ADHD who experience prominent bedtime arousal, difficulty with calm focus, or stress-related emotional dysregulation. It may offer particular value when caffeine sensitivity is a concern or when sleep quality is affected by mental restlessness.
-
-### Who Should Use Caution
-
-Caution is warranted in individuals taking multiple sedating medications or those with complex health conditions. Professional guidance is especially important for children and when combining L-theanine with other supplements or medications.
-
-### What Not to Expect
-
-L-Theanine does not produce large or universal improvements in core ADHD symptoms such as inattention or hyperactivity. Any benefits are generally modest and most noticeable for calming, stress reduction, and sleep quality support. It is not a replacement for established ADHD treatments or behavioral strategies.
-
-### Practical Decision Framework
-
-A conservative approach includes:
-
-1. Optimizing sleep hygiene and behavioral strategies first.
-2. Considering L-theanine when bedtime arousal, calm focus difficulties, or stress-related symptoms are prominent.
-3. Starting at studied doses (commonly 200–400 mg) with clear timing relative to goals.
-4. Tracking target symptoms (sleep quality, emotional regulation, focus) systematically over several weeks.
-5. Evaluating response and adjusting or discontinuing if no clear benefit is observed.
-
-This framework emphasizes targeted, time-limited evaluation rather than indefinite or unfocused use.
-
-### Research Gaps
-
-Significant gaps remain in large, long-term trials in well-characterized ADHD populations, direct comparisons with other calming or sleep supports, clearer dose-response relationships in ADHD, and better adult-specific data. Most existing high-quality evidence comes from one key pediatric sleep study and broader cognitive or stress research.
-
-### Conclusion
-
-L-Theanine has moderate evidence from one pediatric ADHD trial for improving objective sleep quality and shows promise for calming and stress reduction in broader research. Evidence for direct improvements in attention or core ADHD symptoms remains limited and preliminary. Benefits are generally modest and most relevant for sleep quality, emotional regulation, and calm focus support rather than as a primary ADHD intervention.
-
-L-Theanine is generally well tolerated and may be a reasonable adjunctive consideration for selected individuals, particularly when bedtime arousal or stress-related symptoms are prominent. It should be used thoughtfully with systematic tracking and professional guidance when appropriate, especially for children. Expectations should remain realistic regarding the magnitude of any benefits.
-
-## FAQ
-
-### Does L-theanine help with ADHD?
-
-One study in boys with ADHD showed improvements in objective sleep quality with 400 mg daily. Evidence for direct effects on attention or hyperactivity is limited and preliminary.
-
-### How much L-theanine should I take for ADHD?
-
-The key pediatric sleep study used 400 mg daily (split into two doses). Lower doses may be sufficient for some individuals. Professional guidance is recommended, especially for children.
-
-### Does L-theanine help with focus?
-
-L-Theanine may support calm, sustained focus and reduce mental restlessness. Direct evidence in ADHD populations is limited. Benefits are often more noticeable when combined with low-dose caffeine.
-
-### Can L-theanine improve sleep in ADHD?
-
-Yes. One randomized controlled trial in boys with ADHD found improvements in sleep efficiency and reduced awakenings with 400 mg daily over six weeks.
-
-### How does L-theanine compare with melatonin for ADHD sleep?
-
-Melatonin has stronger evidence for reducing sleep onset latency. L-Theanine showed benefits for overall sleep quality and reduced awakenings in one key study. They have different mechanisms and may be complementary.
-
-### Can I take L-theanine with caffeine?
-
-The combination is commonly studied and may improve attention while reducing jitteriness. One small study in boys with ADHD suggested benefits for sustained attention. Individual caffeine sensitivity varies.
-
-### Is L-theanine safe for children with ADHD?
-
-The 2011 study in boys aged 8–12 found it generally well tolerated at 400 mg daily over six weeks. Use in children should involve clinical guidance.
-
-### How long does it take for L-theanine to work?
-
-Effects on relaxation or sleep quality may be noticeable within days to weeks. Behavioral or focus-related changes are typically evaluated over several weeks of consistent use.
-
-### Can L-theanine replace ADHD medication?
-
-No. L-Theanine does not have evidence comparable to established treatments for core ADHD symptoms. It may serve as adjunctive support in appropriate cases.
-
-### What are common side effects of L-theanine?
-
-L-Theanine is generally well tolerated. Reported side effects are uncommon and typically mild (such as headache or gastrointestinal discomfort in sensitive individuals).
-
-### Should I take L-theanine in the morning or evening?
-
-Timing depends on goals. Evening use is common for sleep or calming support. Morning or early afternoon use may be considered for daytime calm focus, sometimes with low-dose caffeine.
-
-### Does L-theanine interact with ADHD medications?
-
-Potential additive calming effects exist with other sedating substances. Full disclosure to prescribing clinicians is recommended.
-
-### Who is most likely to benefit from L-theanine for ADHD?
-
-Individuals with prominent bedtime arousal, difficulty with calm focus, or stress-related emotional dysregulation may be more likely to notice benefits.
-
-### Can I combine L-theanine with magnesium or ashwagandha?
-
-These are sometimes used together for calming or sleep support. They should be introduced sequentially with tracking rather than started simultaneously without guidance.
-
-### What if L-theanine doesn’t seem to help?
-
-Individual response varies. If no clear benefit is observed after adequate trial with systematic tracking, discontinuation is reasonable. Other factors contributing to symptoms should be reassessed.
-
-## Evidence Summary Table
-
-| Area | Population | Key Findings | Evidence Strength | Notes / TODO |
-|---|---|---|---|---|
-| Sleep quality in ADHD | Boys 8–12 with ADHD | Improved sleep efficiency and reduced awakenings | Moderate | TODO: Lyon 2011: n, exact protocol, effect sizes |
-| Attention in ADHD | Boys with ADHD | Combination with caffeine showed more consistent benefits | Preliminary | TODO: Kahathuduwa 2020 or related crossover study details |
-| Calm focus / stress | General / stressed populations | Reduced subjective stress and improved relaxation | Moderate | TODO: Limited direct ADHD data |
-| Emotional regulation | ADHD populations | Signals for reduced reactivity in selected contexts | Preliminary | TODO: Emerging area |
-| Adult ADHD evidence | Adults with ADHD | Very limited high-quality trials | Limited | TODO: Adult-specific studies |
-| L-Theanine + caffeine | Boys with ADHD | Improved sustained attention in small study | Preliminary | TODO: Study details and outcomes |
-| Safety in pediatric ADHD | Boys 8–12 with ADHD | Generally well tolerated at 400 mg daily for 6 weeks | Moderate | TODO: Adverse event details from Lyon 2011 |
-
-## Related Articles
-
-- Best Supplements for ADHD: Evidence-Based Options for Focus, Sleep, and Emotional Regulation
-- ADHD Stack Guide: Building an Evidence-Based Approach to Focus, Sleep, and Emotional Regulation
-- Sleep and ADHD: Evidence-Based Strategies for Better Focus, Behavior, and Daily Functioning
-- Magnesium for ADHD: Forms, Evidence, Dosage, and Practical Use
-- Melatonin for ADHD Sleep: What the Research Shows
-- Ashwagandha for ADHD: Stress, Focus, and Sleep Support
-- Omega-3 and ADHD: What the Research Shows
-
-## Internal Linking Recommendations
-
-- Link strongly to the ADHD Stack Guide and Best Supplements for ADHD pillar.
-- Create bidirectional connections with Sleep and ADHD, Magnesium for ADHD, Melatonin for ADHD Sleep, and Ashwagandha for ADHD.
-- Position this article as a focused evidence review within the Focus / ADHD cluster, supporting navigation between individual supplement articles and broader frameworks while reinforcing conservative, assessment-driven decision-making.
+1. Cognitive and affective effects of L-Theanine: a systematic review and meta-analysis of 31 randomized trials. 2026. PMID 42410082. https://pubmed.ncbi.nlm.nih.gov/42410082/
+2. Kahathuduwa CN, et al. Effects of L-theanine-caffeine combination on sustained attention and inhibitory control among children with ADHD. 2020. PMID 32753637. https://pubmed.ncbi.nlm.nih.gov/32753637/
+3. Lyon MR, et al. The effects of L-theanine on objective sleep quality in boys with ADHD. 2011. PMID 22214254. https://pubmed.ncbi.nlm.nih.gov/22214254/
+4. Payne ER, et al. Effects of Tea, L-Theanine, or L-Theanine plus Caffeine on Cognition, Sleep, and Mood in Healthy Participants. 2025. PMID 40314930. https://pubmed.ncbi.nlm.nih.gov/40314930/


### PR DESCRIPTION
## Summary
- recalibrate the caffeine-free L-theanine focus guide to current evidence
- also update the existing `/guides/adhd/l-theanine-for-adhd/` source so both live routes use the same evidence boundary
- anchor broad attention claims to the July 2026 31-RCT / 1,168-participant meta-analysis
- label the direct ADHD cognition crossover as N=5 exploratory evidence and the 98-boy randomized trial as sleep evidence rather than daytime ADHD efficacy
- remove 100–200 mg / 200–400 mg ADHD protocols, 30–60-minute timing scripts, stimulant off-day/weekend advice, and blanket medication-interaction reassurance
- remove the older ADHD route’s dedicated L-theanine product block
- stop the shared ADHD comparison widget from injecting stale “generally low-risk with stimulants” / symptom-targeting claims under the rewritten L-theanine ADHD route
- preserve medication, pediatric, long-term-safety, visible FAQ, discovery, and conversion boundaries
- expand the regression to cover both live routes plus the shared product and comparison-widget surfaces

## Evidence anchors
- L-theanine systematic review/meta-analysis (2026): PMID 42410082
- ADHD proof-of-concept crossover: PMID 32753637
- ADHD sleep RCT: PMID 22214254
- Tea/L-theanine cognition review (2025): PMID 40314930

## Scope
Exactly 5 files: two user-facing evidence sources, two shared render/decision surfaces, and one cluster regression.