### PR TITLE
Align public inventory claims with published library semantics

### DIFF
--- a/app/__tests__/alkaloid-guide-authorship.test.ts
+++ b/app/__tests__/alkaloid-guide-authorship.test.ts
@@ -1,0 +1,15 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const SOURCE = path.join(process.cwd(), 'app/guides/other/alkaloids-on-amazon/page.tsx')
+
+describe('alkaloid marketplace guide authorship', () => {
+  it('names the reviewer instead of implying an unnamed editorial team', () => {
+    const page = fs.readFileSync(SOURCE, 'utf8')
+
+    expect(page).toContain('Willie B. Randolph III')
+    expect(page).toContain('href="/info/about/"')
+    expect(page).not.toContain('The Hippie Scientist editorial team')
+  })
+})

--- a/app/guides/other/alkaloids-on-amazon/page.tsx
+++ b/app/guides/other/alkaloids-on-amazon/page.tsx
@@ -210,7 +210,10 @@ export default function AlkaloidsOnAmazonPage() {
 
           <div className="mt-5 flex flex-wrap gap-x-5 gap-y-2 text-sm text-muted">
             <span><strong className="text-ink">Reviewed:</strong> {REVIEWED_ON}</span>
-            <span><strong className="text-ink">By:</strong> The Hippie Scientist editorial team</span>
+            <span>
+              <strong className="text-ink">By:</strong>{' '}
+              <Link href="/info/about/" className="font-semibold text-brand-800 hover:underline">Willie B. Randolph III</Link>
+            </span>
             <Link href="/info/methodology/" className="font-semibold text-brand-800 hover:underline">Review methodology →</Link>
           </div>
 

--- a/app/guides/page.tsx
+++ b/app/guides/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { SITE_URL } from '@/lib/navigation-config'
-import buildReport from '@/public/data/build-report.json'
 import { AtlasComparisonCallout } from '@/components/guides/AtlasComparisonCallout'
 
 export const metadata: Metadata = {
@@ -103,8 +102,6 @@ const FEATURED_DECISION_ROUTES = [
   },
 ]
 
-const counts = buildReport.counts
-
 export default function LibraryHub() {
   return (
     <div className="mx-auto max-w-5xl px-4 pb-24 pt-8">
@@ -165,7 +162,7 @@ export default function LibraryHub() {
       <div className="mt-16 rounded-2xl border border-brand-900/10 bg-brand-50/50 p-8 text-center">
         <h2 className="text-xl font-bold text-ink">Browse the reference databases</h2>
         <p className="mt-2 text-muted">
-          Prefer structured profiles? Explore {counts.herbs} herbs and {counts.compounds} active compounds.
+          Prefer structured profiles? Browse the published herb and compound libraries, where public eligibility rules keep source inventory separate from what readers can actually browse.
         </p>
         <div className="mt-4 flex justify-center gap-3">
           <Link href="/herbs/" className="rounded-full bg-brand-700 px-6 py-2.5 text-sm font-semibold text-white transition hover:bg-brand-800">Browse Herbs →</Link>

--- a/app/herbs/page.tsx
+++ b/app/herbs/page.tsx
@@ -10,13 +10,13 @@ import { buildPageMetadata } from '../../src/lib/seo'
 import { formatDisplayLabel } from '@/lib/display-utils'
 import { isRedirectedDuplicate } from '@/lib/deprecated-herb-canonicals'
 import { toLeanProfileIndexRecords } from '@/lib/profile-index-records'
-import buildReport from '@/public/data/build-report.json'
 import HerbsIndexClient from './HerbsIndexClient'
 import Pagination from '@/components/Pagination'
 
 export const metadata: Metadata = buildPageMetadata({
   title: 'Herb Profiles & Research Library',
-  description: `Browse ${buildReport.counts.herbs} herb profiles — mechanisms, safety notes, active compounds, and research context in plain language.`,
+  description:
+    'Browse published herb profiles — mechanisms, safety notes, active compounds, and research context in plain language.',
   path: '/herbs',
 })
 

--- a/app/info/about/AboutClient.tsx
+++ b/app/info/about/AboutClient.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
-import { TOTAL_PROFILE_COUNT } from '@/lib/profile-counts'
 import AuthorCredentials from '@/components/AuthorCredentials'
 import JsonLd from '@/components/seo/JsonLd'
 
@@ -59,7 +58,7 @@ export default function AboutClient() {
         <div className="mt-5 grid gap-6 lg:grid-cols-[1.2fr_0.8fr] lg:items-start">
           <div>
             <p className="max-w-3xl text-base leading-7 text-muted sm:text-lg">
-              The Hippie Scientist is an evidence-first reference for herbs, supplements, and compounds. We publish mechanism, safety, and practical context for {TOTAL_PROFILE_COUNT}+ profiles - plain-English, conservative on claims, and grounded in the strength of available research.
+              The Hippie Scientist is an evidence-first reference for herbs, supplements, and compounds. We publish mechanism, safety, and practical context across a growing research library — plain English, conservative on claims, and grounded in the strength of available evidence.
             </p>
 
             <div className="mt-7 flex flex-wrap gap-3">
@@ -120,7 +119,7 @@ export default function AboutClient() {
             <span className="text-emerald-700">✓</span> Evidence-First Synthesis
           </h2>
           <p className="mt-3 text-sm leading-6 text-muted">
-            We map natural compounds back to peer-reviewed studies and human clinical trials, stating evidence levels (strong, moderate, limited) with total integrity.
+            We map natural compounds back to peer-reviewed studies and human clinical trials, stating evidence levels with the limitations and uncertainty kept visible.
           </p>
         </div>
 
@@ -129,7 +128,7 @@ export default function AboutClient() {
             <span className="text-emerald-700">✓</span> Safety-First Governance
           </h2>
           <p className="mt-3 text-sm leading-6 text-muted">
-            We list precise medication interactions, contraindications, and precautions. We programmatically suppress product links for high-caution substances.
+            We surface known and potential medication interactions, contraindications, and precautions, and keep uncertainty visible when evidence is incomplete. Product links are suppressed for high-caution substances where appropriate.
           </p>
         </div>
 
@@ -138,7 +137,7 @@ export default function AboutClient() {
             <span className="text-emerald-700">✓</span> Anti-Oversimplification
           </h2>
           <p className="mt-3 text-sm leading-6 text-muted">
-            We explain preclinical mechanisms of action to outline pathways, but differentiate them clearly from guaranteed human outcomes.
+            We explain preclinical mechanisms of action to outline pathways, but differentiate them clearly from demonstrated human outcomes.
           </p>
         </div>
       </section>
@@ -155,7 +154,7 @@ export default function AboutClient() {
           <p className="text-sm text-muted mt-2 max-w-2xl">
             We use a documented editorial process to audit monograph data, evidence language, safety cautions, and affiliate separation before publication.
           </p>
-          <p className="text-xs text-muted mt-1">Last reviewed: June 2026</p>
+          <p className="text-xs text-muted mt-1">Last reviewed: August 2026</p>
         </div>
 
         <div className="grid gap-6 md:grid-cols-3">
@@ -227,17 +226,17 @@ export default function AboutClient() {
           <h2 className="text-2xl font-bold text-ink">How We Build Monograph Content</h2>
           <div className="space-y-4 text-sm leading-7 text-muted">
             <p>
-              Our process is rigorous, transparent, and completely decoupled from any commercial product sponsors:
+              Our process is designed to be transparent and separated from commercial product incentives:
             </p>
             <ul className="list-disc pl-5 space-y-2">
               <li>
-                <strong className="font-semibold text-ink">Source Review:</strong> All ingredient entries are sourced from our structured evidence database, ensuring uniform metrics.
+                <strong className="font-semibold text-ink">Source Review:</strong> Ingredient entries draw from our structured evidence data and cited sources so fields can be reviewed consistently.
               </li>
               <li>
-                <strong className="font-semibold text-ink">Evidence Grading:</strong> We grade evidence strictly according to study design: double-blind human RCTs and meta-analyses score highest.
+                <strong className="font-semibold text-ink">Evidence Grading:</strong> We weigh study design, directness, replication, sample size, and limitations. Human randomized trials and high-quality syntheses generally carry more weight than mechanistic or preclinical evidence.
               </li>
               <li>
-                <strong className="font-semibold text-ink">FTC Affiliate Transparency:</strong> Affiliate links (configured via config/affiliate.ts) are strictly secondary. No brand can pay to improve their evidence grade.
+                <strong className="font-semibold text-ink">Affiliate Transparency:</strong> Affiliate links are secondary to the evidence review. Commercial availability cannot improve an ingredient's evidence grade or remove safety cautions.
               </li>
             </ul>
           </div>
@@ -250,7 +249,7 @@ export default function AboutClient() {
           </p>
           <h2 className="text-xl font-bold text-ink mt-2">Send us a Message</h2>
           <p className="text-xs text-muted mt-1 leading-relaxed">
-            Have scientific feedback or found a bug? Send us a message, and our review team will respond.
+            Have scientific feedback or found a bug? Send a message and we’ll review it.
           </p>
 
           <form onSubmit={handleSubmit} className="mt-4 space-y-3.5">

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -12,7 +12,7 @@ const GlobalSearch = dynamic(() => import('@/components/search/GlobalSearch'), {
 
 export const metadata: Metadata = {
   title: 'Search Herbs & Supplements',
-  description: `Search ${HERB_COUNT} herb profiles and ${COMPOUND_COUNT} compound profiles by name, goal, mechanism, or safety context. Evidence-weighted results with conservative safety labels.`,
+  description: `Search the herb and compound research index by name, goal, mechanism, or safety context. Evidence-weighted results with conservative safety labels.`,
   alternates: {
     canonical: '/search/',
   },
@@ -84,7 +84,7 @@ export default function SearchPage() {
           offers enhanced filtering and discovery. */}
       <div className="mb-8 space-y-6 rounded-2xl border border-brand-900/10 bg-white/90 p-6 shadow-sm">
         <p className="text-sm leading-6 text-muted">
-          Our search database indexes {HERB_COUNT} herb profiles and {COMPOUND_COUNT} compound profiles. Compare primary active constituents, traditional uses, clinical human evidence levels, safety warnings, and drug interactions across popular adaptogens, amino acids, and minerals.
+          The structured search index currently contains {HERB_COUNT} herb records and {COMPOUND_COUNT} compound records. Publication and browse eligibility are stricter than raw index coverage, so the herb and compound libraries may show smaller public totals. Compare active constituents, traditional-use context, human evidence, safety warnings, and drug-interaction notes across the index.
         </p>
         
         <div className="space-y-2">
@@ -116,12 +116,12 @@ export default function SearchPage() {
             <ul className="space-y-1">
               <li>
                 <Link href="/herbs/" className="text-sm font-semibold text-brand-800 hover:underline">
-                  Herb & Botanical Library ({HERB_COUNT} Profiles)
+                  Herb & Botanical Library
                 </Link>
               </li>
               <li>
                 <Link href="/compounds/" className="text-sm font-semibold text-brand-800 hover:underline">
-                  Compound & Nootropic Library ({COMPOUND_COUNT} Profiles)
+                  Compound & Nootropic Library
                 </Link>
               </li>
             </ul>

--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -107,8 +107,6 @@ const toolLinks = [
   },
 ]
 
-// Tone per article category so the cards carry colour rather than reading as a
-// row of identical dark panels.
 const CATEGORY_TONES: Record<string, string> = {
   'metabolic health': 'amber',
   'cognitive health': 'blue',
@@ -143,8 +141,8 @@ const methodSteps = [
 const counts = buildReport.counts
 
 const heroStats = [
-  { value: `${counts.herbs}`, label: 'herb profiles' },
-  { value: `${counts.compounds}`, label: 'compound profiles' },
+  { value: `${counts.herbs}`, label: 'herb records' },
+  { value: `${counts.compounds}`, label: 'compound records' },
   { value: `${counts.claims}`, label: 'sourced claims' },
 ]
 
@@ -189,7 +187,6 @@ export default function HomepageV2() {
   return (
     <div className='hs-home'>
       <div className='mx-auto max-w-6xl px-5 sm:px-8 lg:px-10'>
-        {/* ---------------- Hero ---------------- */}
         <section className='hs-hero pb-10 pt-8 sm:pb-20 sm:pt-16 lg:pt-20'>
           <div className='grid items-center gap-12 lg:grid-cols-[1.08fr_0.92fr] lg:gap-10'>
             <div>
@@ -237,9 +234,6 @@ export default function HomepageV2() {
             </div>
           </div>
 
-          {/* Real counts from the generated build report — credibility without a card. */}
-          {/* Three across on a phone with the label stacked, so the row never
-              breaks 2 + 1; inline once there is width for it. */}
           <dl className='mt-10 grid grid-cols-3 gap-x-4 sm:mt-12 sm:flex sm:flex-wrap sm:items-baseline sm:gap-x-8'>
             {heroStats.map((stat) => (
               <div key={stat.label} className='sm:flex sm:items-baseline sm:gap-2'>
@@ -274,7 +268,6 @@ export default function HomepageV2() {
           </dl>
         </section>
 
-        {/* ---------------- Goal paths — the colour anchor ---------------- */}
         <section id='choose-a-path' className='scroll-mt-24 py-11 sm:py-20'>
           <SectionHeader
             eyebrow='Start here'
@@ -318,16 +311,13 @@ export default function HomepageV2() {
 
         <hr className='hs-divider' />
 
-        {/* ---------------- Popular starting points ---------------- */}
         <section className='py-11 sm:py-20'>
           <SectionHeader
-            eyebrow='Popular starting points'
+            eyebrow='Familiar starting points'
             title='Look up a familiar name'
-            subtitle='These are the most common first searches — not endorsements. Each profile opens with evidence, mechanism, dosing context, and safety.'
+            subtitle='These widely researched ingredients are useful entry points — not endorsements. Each profile opens with evidence, mechanism, dosing context, and safety.'
           />
 
-          {/* A specimen shelf: one jewel tone per entry so the row reads as a
-              collection rather than six identical grey pills. */}
           <div className='mt-8 grid grid-cols-2 gap-3 sm:mt-10 sm:grid-cols-3 sm:gap-4 lg:grid-cols-6'>
             {popularProfiles.map((profile) => {
               const Icon = profile.type === 'Herb' ? Leaf : Atom
@@ -352,17 +342,16 @@ export default function HomepageV2() {
 
           <div className='mt-8 flex flex-wrap gap-x-8 gap-y-3'>
             <Link href='/herbs/' className='hs-link text-sm'>
-              Browse all {counts.herbs} herbs <ArrowRight className='h-4 w-4' aria-hidden='true' />
+              Browse herb library <ArrowRight className='h-4 w-4' aria-hidden='true' />
             </Link>
             <Link href='/compounds/' className='hs-link text-sm'>
-              Browse all {counts.compounds} compounds <ArrowRight className='h-4 w-4' aria-hidden='true' />
+              Browse compound library <ArrowRight className='h-4 w-4' aria-hidden='true' />
             </Link>
           </div>
         </section>
 
         <hr className='hs-divider' />
 
-        {/* ---------------- Decide / check — hairline lists, no nested tiles ---------------- */}
         <section className='grid gap-11 py-11 sm:gap-12 sm:py-20 lg:grid-cols-2 lg:gap-16'>
           <div>
             <p className='hs-eyebrow'>Make a decision</p>
@@ -373,46 +362,42 @@ export default function HomepageV2() {
 
             <div className='@container mt-7 space-y-3.5'>
               {comparisonLinks.map((comparison) => {
-                // A three-way comparison is too wide for one line at the card's normal
-                // type size, so it runs at a reduced scale that steps back up as the
-                // card widens (see .hs-vs--multi). Only the very narrowest phones still
-                // fall back to a stacked column.
                 const isMultiWay = comparison.parts.length > 2
                 return (
-                <Link
-                  key={comparison.href}
-                  href={comparison.href}
-                  data-tone={comparison.tone}
-                  className={`hs-vs group${isMultiWay ? ' hs-vs--multi' : ''} focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--tone)] focus-visible:ring-offset-2`}
-                >
-                  <span
-                    className={
-                      isMultiWay
-                        ? 'hs-vs-parts'
-                        : 'flex min-w-0 flex-1 flex-wrap items-center gap-x-2.5 gap-y-1.5'
-                    }
+                  <Link
+                    key={comparison.href}
+                    href={comparison.href}
+                    data-tone={comparison.tone}
+                    className={`hs-vs group${isMultiWay ? ' hs-vs--multi' : ''} focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--tone)] focus-visible:ring-offset-2`}
                   >
-                    {comparison.parts.map((part, index) => (
-                      <span
-                        key={part}
-                        className={isMultiWay ? 'hs-vs-part' : 'flex items-center gap-2.5'}
-                      >
-                        {index > 0 ? <span className='hs-vs-mark'>vs</span> : null}
+                    <span
+                      className={
+                        isMultiWay
+                          ? 'hs-vs-parts'
+                          : 'flex min-w-0 flex-1 flex-wrap items-center gap-x-2.5 gap-y-1.5'
+                      }
+                    >
+                      {comparison.parts.map((part, index) => (
                         <span
-                          className={
-                            isMultiWay ? 'hs-vs-name' : 'hs-vs-name text-[1.02rem] sm:text-[1.1rem]'
-                          }
+                          key={part}
+                          className={isMultiWay ? 'hs-vs-part' : 'flex items-center gap-2.5'}
                         >
-                          {part}
+                          {index > 0 ? <span className='hs-vs-mark'>vs</span> : null}
+                          <span
+                            className={
+                              isMultiWay ? 'hs-vs-name' : 'hs-vs-name text-[1.02rem] sm:text-[1.1rem]'
+                            }
+                          >
+                            {part}
+                          </span>
                         </span>
-                      </span>
-                    ))}
-                  </span>
-                  <ArrowRight
-                    className='h-4 w-4 shrink-0 text-[color:var(--tone-ink)] transition'
-                    aria-hidden='true'
-                  />
-                </Link>
+                      ))}
+                    </span>
+                    <ArrowRight
+                      className='h-4 w-4 shrink-0 text-[color:var(--tone-ink)] transition'
+                      aria-hidden='true'
+                    />
+                  </Link>
                 )
               })}
             </div>
@@ -459,7 +444,6 @@ export default function HomepageV2() {
           </div>
         </section>
 
-        {/* ---------------- Latest ---------------- */}
         {latestArticles.length > 0 && (
           <>
             <hr className='hs-divider' />
@@ -489,8 +473,6 @@ export default function HomepageV2() {
                         <span className='text-[0.72rem] text-[color:var(--hs-body)]'>{article.readingTime}</span>
                       ) : null}
                     </div>
-                    {/* These articles carry no excerpt, so the title has to hold the
-                        card on its own — keep it large and the gaps tight. */}
                     <h3 className='hs-article-title mt-3.5 text-[1.22rem] leading-[1.3]'>{article.title}</h3>
                     {article.excerpt ? (
                       <p className='mt-2.5 line-clamp-3 text-[0.85rem] leading-6 text-[color:var(--hs-body)]'>
@@ -508,7 +490,6 @@ export default function HomepageV2() {
         )}
       </div>
 
-      {/* ---------------- Full-bleed methodology band — the page's closing moment ---------------- */}
       <section className='hs-method py-14 sm:py-24'>
         <div className='mx-auto grid max-w-6xl gap-10 px-5 sm:gap-12 sm:px-8 lg:grid-cols-[0.85fr_1.15fr] lg:gap-20 lg:px-10'>
           <div>

--- a/lib/profile-counts.ts
+++ b/lib/profile-counts.ts
@@ -1,6 +1,7 @@
 import buildReport from '@/public/data/build-report.json'
 
+// These are structured source/search inventory counts from the generated build report.
+// They are not guaranteed to equal the stricter public browse/publish totals.
 export const HERB_COUNT = buildReport.counts.herbs
 export const COMPOUND_COUNT = buildReport.counts.compounds
 export const TOTAL_PROFILE_COUNT = HERB_COUNT + COMPOUND_COUNT
-

--- a/tests/guides-library-counts.test.ts
+++ b/tests/guides-library-counts.test.ts
@@ -6,12 +6,14 @@ function read(relativePath: string) {
   return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
 }
 
-describe('guides library counts', () => {
-  it('uses generated build counts instead of hardcoded totals', () => {
+describe('guides library inventory semantics', () => {
+  it('does not present raw source inventory as public library totals', () => {
     const guidesPage = read('app/guides/page.tsx')
 
-    expect(guidesPage).toContain("import buildReport from '@/public/data/build-report.json'")
-    expect(guidesPage).toContain('Explore {counts.herbs} herbs and {counts.compounds} active compounds.')
-    expect(guidesPage).not.toMatch(/Explore \d+ herbs and \d+ active compounds\./)
+    expect(guidesPage).not.toContain("import buildReport from '@/public/data/build-report.json'")
+    expect(guidesPage).not.toContain('{counts.herbs}')
+    expect(guidesPage).not.toContain('{counts.compounds}')
+    expect(guidesPage).toContain('Browse the published herb and compound libraries')
+    expect(guidesPage).toContain('keep source inventory separate from what readers can actually browse')
   })
 })

--- a/tests/herbs-metadata-count.test.ts
+++ b/tests/herbs-metadata-count.test.ts
@@ -6,12 +6,13 @@ function read(relativePath: string) {
   return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
 }
 
-describe('herbs metadata inventory count', () => {
-  it('uses the canonical build report instead of a hardcoded public total', () => {
+describe('herbs metadata inventory semantics', () => {
+  it('does not present raw build inventory as the published herb total', () => {
     const page = read('app/herbs/page.tsx')
 
-    expect(page).toContain("import buildReport from '@/public/data/build-report.json'")
-    expect(page).toContain('buildReport.counts.herbs')
-    expect(page).not.toContain('100+ herbs')
+    expect(page).not.toContain("import buildReport from '@/public/data/build-report.json'")
+    expect(page).toContain('Browse published herb profiles')
+    expect(page).toContain('for {herbs.length} herbs')
+    expect(page).not.toContain('buildReport.counts.herbs')
   })
 })


### PR DESCRIPTION
## Summary
- stop presenting raw build/search inventory counts as published profile totals on the homepage, search, guides, herb metadata, and About page
- keep raw counts visible where useful, but label them as records rather than public profiles
- remove count-bearing browse CTAs that drift from stricter publication eligibility
- tighten About-page safety/evidence language so uncertainty, directness, and commercial separation are described more accurately
- name Willie B. Randolph III explicitly as reviewer on the alkaloid marketplace guide instead of using an unnamed “editorial team” byline
- update review date to August 2026
- add regression coverage for herb metadata, guide-library inventory semantics, and explicit alkaloid-guide authorship
- document `profile-counts.ts` as source/search inventory, not publish totals

## Why
The public site can expose a larger structured source/search inventory than the stricter herb/compound browse libraries. That distinction is valid internally, but labeling both as published profiles creates a credibility inconsistency on an evidence-focused health site. Unnamed institutional-sounding authorship creates a similar trust problem.

## Scope
10 files, focused on trust semantics, authorship transparency, and regression coverage. No route changes or deployment-model changes.