### PR TITLE
Fix caffeine focus safety regression guard

### DIFF
--- a/app/__tests__/l-theanine-vs-caffeine-current-evidence.test.ts
+++ b/app/__tests__/l-theanine-vs-caffeine-current-evidence.test.ts
@@ -37,7 +37,7 @@ describe('L-theanine vs caffeine focus evidence calibration', () => {
     expect(text).toMatch(/attention accuracy \(Hedges g = 0\.27\).*reaction time \(g = 0\.28\)/i)
     expect(text).toMatch(/400 mg\/day is an amount not generally associated with negative effects for most adults/i)
     expect(text).toMatch(/broad population safety reference—not a recommended focus target/i)
-    expect(text).not.toMatch(/400 mg.*recommended.*focus/i)
+    expect(text).not.toMatch(/(?:take|use|aim for|target) 400 mg(?:\/day)?.{0,80}(?:focus|attention|performance)/i)
   })
 
   it('does not restore a universal L-theanine-caffeine ratio or dosing recipe', () => {


### PR DESCRIPTION
Superseded by #2615. #2615 now contains the stronger reviewed fix: it requires the exact corrective FDA population-safety sentence, removes only that sentence from the regression scan, then rejects remaining 400 mg focus/attention/performance recommendation language in either word order. Closing this duplicate to keep one baseline repair lane.