### PR TITLE
Rebuild Rhodiola canonical article around current evidence

### DIFF
--- a/app/__tests__/rhodiola-rosea-current-evidence.test.ts
+++ b/app/__tests__/rhodiola-rosea-current-evidence.test.ts
@@ -1,0 +1,115 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const ARTICLE = path.join(process.cwd(), 'content/articles/rhodiola-rosea.md')
+
+function source() {
+  return fs.readFileSync(ARTICLE, 'utf8').replace(/\s+/g, ' ').replace(/\*\*/g, '')
+}
+
+describe('Rhodiola rosea canonical article evidence calibration', () => {
+  it('preserves publication history and adds the current evidence review date', () => {
+    const text = source()
+
+    expect(text).toContain("date: '2026-06-06'")
+    expect(text).toContain("updatedAt: '2026-08-12'")
+    expect(text).toMatch(/Rhodiola Rosea: What the Human Evidence Supports in 2026/i)
+  })
+
+  it('corrects the two historical trial PMIDs and keeps auditable evidence anchors', () => {
+    const text = source()
+
+    expect(text).toContain('pmid: "11081987"')
+    expect(text).toContain('pmid: "10839209"')
+    expect(text).not.toContain('pmid: "11081995"')
+    expect(text).toContain('22643043')
+    expect(text).toContain('19016404')
+    expect(text).toContain('25268730')
+    expect(text).toContain('41906501')
+    expect(text).toContain('41080184')
+  })
+
+  it('makes the fatigue literature mixed rather than uniformly positive', () => {
+    const text = source()
+
+    expect(text).toMatch(/11 studies/i)
+    expect(text).toMatch(/2 of 6.*physical fatigue/i)
+    expect(text).toMatch(/3 of 5.*mental fatigue/i)
+    expect(text).toMatch(/evidence was contradictory/i)
+    expect(text).toMatch(/48 nursing students ages 18[–-]55/i)
+    expect(text).toMatch(/42 days/i)
+    expect(text).toMatch(/in favor of placebo/i)
+    expect(text).not.toMatch(/all 11 studies showed some benefit/i)
+    expect(text).not.toMatch(/Moderate for fatigue and cognitive performance/i)
+  })
+
+  it('keeps positive trials direct to their population, extract, comparator, and duration', () => {
+    const text = source()
+
+    expect(text).toMatch(/60 adults ages 20[–-]55/i)
+    expect(text).toMatch(/SHR-5 root extract, 576 mg\/day/i)
+    expect(text).toMatch(/Comparator: placebo/i)
+    expect(text).toMatch(/Duration: 28 days/i)
+    expect(text).toMatch(/56 young healthy physicians/i)
+    expect(text).toMatch(/two-week treatment periods/i)
+    expect(text).toMatch(/20-day examination period/i)
+  })
+
+  it('separates the endurance signal from burnout or mental-fatigue treatment', () => {
+    const text = source()
+
+    expect(text).toMatch(/26 randomized trials \/ 668 healthy participants/i)
+    expect(text).toMatch(/mean age of about 22 years/i)
+    expect(text).toMatch(/exercise\/endurance performance in healthy participants/i)
+    expect(text).toMatch(/should not be repackaged as proof that Rhodiola treats chronic fatigue, occupational burnout/i)
+  })
+
+  it('removes deterministic onset, dose, timing, and cycling protocols', () => {
+    const text = source()
+    const noPromiseRebuttal = text.replace(
+      /“No jitters” or “no crash” Those are consumer-experience promises, not established comparative outcomes\./i,
+      '',
+    )
+    const cyclingMentions = text.match(/[^.?!]*(?:6[–-]8 weeks on)[^.?!]*/gi) ?? []
+
+    expect(text).not.toMatch(/Some notice effects day 1/i)
+    expect(text).toMatch(/“No jitters” or “no crash” Those are consumer-experience promises, not established comparative outcomes\./i)
+    expect(noPromiseRebuttal).not.toMatch(/No jitters/i)
+    expect(noPromiseRebuttal).not.toMatch(/No crash/i)
+    expect(text).not.toMatch(/full effects stabilize/i)
+    expect(text).not.toMatch(/200[–-]400 mg\/day SHR-5, morning/i)
+    expect(text).not.toMatch(/400[–-]600 mg\/day SHR-5/i)
+    expect(text).not.toMatch(/100[–-]200 mg\/day.*maintenance/i)
+    expect(cyclingMentions.length).toBeGreaterThan(0)
+    for (const mention of cyclingMentions) {
+      expect(mention).toMatch(/\b(?:no|not)\b/i)
+    }
+    expect(text).not.toMatch(/Not within 6 hours of bedtime/i)
+    expect(text).toMatch(/No evidence-based cycling schedule is established/i)
+    expect(text).toMatch(/No reliable universal onset is established/i)
+  })
+
+  it('does not restore phenotype matching, mechanism certainty, or evidence-free stacks', () => {
+    const text = source()
+
+    expect(text).not.toMatch(/am I wired or tired/i)
+    expect(text).not.toMatch(/classic circadian adaptogen stack/i)
+    expect(text).not.toMatch(/Rhodiola smooths the edges of caffeine/i)
+    expect(text).not.toMatch(/HPA axis normalization begins/i)
+    expect(text).not.toMatch(/MAO inhibition \+ catecholamine preservation/i)
+    expect(text).toMatch(/Mechanisms are hypotheses, not treatment selectors/i)
+    expect(text).toMatch(/Separate studies of Rhodiola, ashwagandha, L-theanine, creatine, or caffeine do not prove/i)
+  })
+
+  it('keeps short-term safety uncertainty and persistent-fatigue stop rules visible', () => {
+    const text = source()
+
+    expect(text).toMatch(/Most Rhodiola trials are relatively short/i)
+    expect(text).toMatch(/Persistent or unexplained fatigue deserves evaluation/i)
+    expect(text).toMatch(/Do not infer medication compatibility from mechanism diagrams/i)
+    expect(text).toMatch(/Pregnancy\/breastfeeding and long-term use are evidence gaps/i)
+    expect(text).toMatch(/bipolar-spectrum illness/i)
+    expect(text).toContain('European Medicines Agency')
+  })
+})

--- a/content/articles/rhodiola-rosea.md
+++ b/content/articles/rhodiola-rosea.md
@@ -1,301 +1,310 @@
 ---
 slug: rhodiola-rosea
-title: "Rhodiola Rosea Benefits, Dosage & Evidence: The Fatigue-Fighting Adaptogen"
-description: "Evidence-based guide to rhodiola rosea for fatigue, burnout, and mental performance. Covers dosage (200-600mg), SHR-5 standardization, rosavin/salidroside, and what clinical trials actually found."
+title: "Rhodiola Rosea: What the Human Evidence Supports in 2026"
+description: "Evidence-first review of Rhodiola rosea for fatigue, stress-related performance, and endurance, including mixed trial results, extract directness, safety limits, and what studies do not establish."
 date: '2026-06-06'
-updatedAt: '2026-07-05'
+updatedAt: '2026-08-12'
 author: Will
 category: Adaptogens
 keywords:
   - rhodiola rosea
-  - rhodiola benefits
-  - rhodiola dosage
+  - rhodiola evidence
   - adaptogen
-  - salidroside
-  - rosavin
   - fatigue
   - stress
-  - mental performance
   - SHR-5
-  - energy supplement
+  - endurance
 featured_image: ''
 tags:
   - rhodiola
-  - energy
+  - fatigue
   - stress
   - adaptogen
   - evidence review
 profile_status: published
 ai_assisted: false
 references:
-  - title: "A randomised, double-blind, placebo-controlled, parallel-group study of the standardised extract SHR-5 of the roots of Rhodiola rosea in the treatment of subjects with stress-related fatigue"
-    authors: "Olsson EM, von Schéele B, Panossian AG"
-    year: "2009"
-    pmid: "19016404"
-    url: "https://pubmed.ncbi.nlm.nih.gov/19016404/"
   - title: "Rhodiola rosea for physical and mental fatigue: a systematic review"
     authors: "Ishaque S, Shamseer L, Bukutu C, Vohra S"
     year: "2012"
     pmid: "22643043"
     url: "https://pubmed.ncbi.nlm.nih.gov/22643043/"
-  - title: "Stress management and the role of Rhodiola rosea: a review"
-    authors: "Anghelescu IG, Edwards D, Seifritz E, Kasper S"
-    year: "2018"
-    pmid: "29325481"
-    url: "https://pubmed.ncbi.nlm.nih.gov/29325481/"
-  - title: "Rhodiola rosea in stress induced fatigue — a double blind cross-over study of a standardized extract SHR-5 with a repeated low-dose regimen on the mental performance of healthy physicians during night duty"
+  - title: "A randomised, double-blind, placebo-controlled, parallel-group study of the standardised extract SHR-5 in subjects with stress-related fatigue"
+    authors: "Olsson EM, von Schéele B, Panossian AG"
+    year: "2009"
+    pmid: "19016404"
+    url: "https://pubmed.ncbi.nlm.nih.gov/19016404/"
+  - title: "Rhodiola rosea for mental and physical fatigue in nursing students: a randomized controlled trial"
+    authors: "Punja S, Shamseer L, Olson K, Vohra S"
+    year: "2014"
+    pmid: "25268730"
+    url: "https://pubmed.ncbi.nlm.nih.gov/25268730/"
+  - title: "Clinical evidence for the adaptogenic effects of Withania somnifera and Rhodiola rosea - a systematic review"
+    authors: "Łuszczak J, Kocki J"
+    year: "2026"
+    pmid: "41906501"
+    url: "https://pubmed.ncbi.nlm.nih.gov/41906501/"
+  - title: "The effect of Rhodiola rosea supplementation on endurance performance and related biomarkers: a systematic review and meta-analysis"
+    authors: "Wang X, Yang X, Gao Z, Zeng J, Liu Y"
+    year: "2025"
+    pmid: "41080184"
+    url: "https://pubmed.ncbi.nlm.nih.gov/41080184/"
+  - title: "Rhodiola rosea in stress induced fatigue - a double blind cross-over study of SHR-5 in healthy physicians during night duty"
     authors: "Darbinyan V, Kteyan A, Panossian A, Gabrielian E, Wikman G, Wagner H"
-    year: "2000"
-    pmid: "11081995"
-    url: "https://pubmed.ncbi.nlm.nih.gov/11081995/"
-  - title: "A double-blind, placebo-controlled pilot study of the stimulating and adaptogenic effect of Rhodiola rosea SHR-5 extract on the fatigue of students"
-    authors: "Spasov AA, Wikman GK, Mandrikov VB, Mironova IA, Neumoin VV"
     year: "2000"
     pmid: "11081987"
     url: "https://pubmed.ncbi.nlm.nih.gov/11081987/"
-  - title: "Effects of Rhodiola rosea supplementation on exercise and sport: a systematic review"
-    authors: "Ballmann CG, Maze SB, Wells AC, Marshall MR, Rogers RR"
-    year: "2019"
-    pmid: "31370537"
-    url: "https://pubmed.ncbi.nlm.nih.gov/31370537/"
-  - title: "Rhodiola rosea L. as a putative botanical antidepressant"
-    authors: "Mao JJ, Xie SX, Zee J, Soeller I, Li QS, Rockwell K, Amsterdam JD"
-    year: "2015"
-    pmid: "25837277"
-    url: "https://pubmed.ncbi.nlm.nih.gov/25837277/"
-  - title: "Serotonin transporter and norepinephrine transporter inhibition by constituents of Rhodiola rosea"
-    authors: "van Diermen D, Marston A, Bravo J, Reist M, Carrupt PA, Hostettmann K"
-    year: "2009"
-    pmid: "18778739"
-    url: "https://pubmed.ncbi.nlm.nih.gov/18778739/"
+  - title: "A double-blind, placebo-controlled pilot study of Rhodiola rosea SHR-5 during an examination period"
+    authors: "Spasov AA, Wikman GK, Mandrikov VB, Mironova IA, Neumoin VV"
+    year: "2000"
+    pmid: "10839209"
+    url: "https://pubmed.ncbi.nlm.nih.gov/10839209/"
+  - title: "Rhodiolae roseae rhizoma et radix - European Union herbal monograph, Revision 1"
+    authors: "European Medicines Agency, Committee on Herbal Medicinal Products"
+    year: "2024"
+    url: "https://www.ema.europa.eu/en/medicines/herbal/rhodiolae-roseae-rhizoma-et-radix"
 ---
 
-> **The bottom line:** Rhodiola rosea is a stimulating adaptogen — best for fatigue-dominant stress, burnout, and brain fog. Human trials show 200–600 mg/day of SHR-5 extract reduces mental fatigue and improves cognitive performance under stress. Unlike ashwagandha (calming), rhodiola is mildly stimulating and best taken in the morning. Evidence grade: **Moderate** for fatigue and cognitive performance under stress; preliminary for depression.
-
-## At a Glance
-
-Rhodiola rosea (golden root, Arctic root) is a succulent perennial native to high-altitude Siberia and Scandinavia. It's a **stimulating adaptogen** — meaning it fights fatigue and improves mental performance under stress without being a stimulant like caffeine. Its effects are best characterized as "anti-fatigue" rather than "energy-boosting" — it helps you maintain function when fatigue would normally degrade it.
-
-| Question | Answer |
-|---|---|
-| Best fit | Fatigue-dominant stress, burnout, brain fog, mental exhaustion, afternoon crashes |
-| Evidence level | Moderate for fatigue and cognitive performance under stress; preliminary for depression |
-| Typical dose | 200–600 mg/day of SHR-5 or equivalent (3% rosavins, 1% salidroside) |
-| Onset | Some notice effects day 1; full benefits over 1–4 weeks |
-| Does it cause jitters? | No — it's stimulating but not like caffeine. No crash. |
-| Best time to take | Morning or early afternoon. Not within 6 hours of bedtime. |
-| Better for anxiety or sleep? | No — try [ashwagandha](/articles/ashwagandha/) for calming support |
-| Main caution | Can cause overstimulation/insomnia at high doses or if taken too late; bipolar caution (MAO inhibition) |
-
+> **Bottom line:** Rhodiola rosea has **mixed, outcome-specific human evidence**. Several small trials of standardized extracts reported improvements in fatigue or performance under stress, but the 2012 systematic review found contradictory results and substantial risk-of-bias/reporting problems. A later 42-day nursing-student trial found fatigue outcomes that **favored placebo**. A 2025 meta-analysis suggests a separate, small endurance-performance signal in mostly young healthy participants. Those findings do not establish Rhodiola as a predictable treatment for “burnout,” brain fog, depression, or everyday low energy.
 
 ![Rhodiola Rosea](/images/monographs/photos/rhodiola.jpg)
 
----
+## At a glance
 
-## What to Expect: Timeline and Sensation
-
-| Timeframe | What you might notice | What's happening |
-|---|---|---|
-| **Day 1–3** | Some people feel clearer-headed within hours of first dose — particularly those with significant fatigue. Mental stamina during long tasks may improve. No jitteriness. | Salidroside begins inhibiting MAO and modulating monoamine levels. Catecholamine preservation during stress begins. |
-| **Week 1–2** | Fatigue resistance builds. Fewer afternoon crashes. Motivation and mood may lift. Physical endurance during exercise may improve modestly. | HPA axis normalization begins. Cortisol response to awakening becomes more regulated. |
-| **Week 3–4** | Full effects stabilize. Cognitive endurance under stress is where rhodiola shines — the Darbinyan physician study showed significant anti-fatigue effects throughout night shifts. | Monoamine systems reach new steady state with preserved catecholamine levels under stress. |
-| **Month 2+** | Effects plateau. Many people cycle in a pattern that maintains sensitivity — 6–8 weeks on, 1–2 weeks off. | Rhodiola doesn't produce tolerance in the classical sense, but the perceived benefit may diminish as you acclimate to the new baseline. |
-
-> **If you feel nothing after 2 weeks:** rhodiola may not be the right adaptogen for your stress pattern. If your stress is anxiety-heavy (not fatigue-heavy), try [ashwagandha](/articles/ashwagandha/). If fatigue persists despite rhodiola, consider whether the root cause is sleep deprivation, overtraining, or nutritional deficiency rather than stress physiology.
-
----
-
-## Rhodiola vs. Ashwagandha: The Definitive Comparison
-
-This is the single most common adaptogen decision people face. The choice depends entirely on your stress phenotype.
-
-| | Rhodiola | Ashwagandha |
-|---|---|---|
-| **Adaptogen type** | Stimulating | Calming |
-| **Best for** | Fatigue, burnout, brain fog, low motivation, afternoon crashes | Anxiety, tension, stress-related sleep disruption, cortisol dysregulation |
-| **When to take** | Morning or early afternoon — can interfere with sleep if taken after 2 PM | Morning + evening, or evening only |
-| **Energy effect** | Mild stimulation — "anti-fatigue" more than "energy boost." No crash. | Neutral to mildly calming. Can reduce energy in some people at higher doses. |
-| **Onset** | Hours to days | Weeks |
-| **Key mechanism** | MAO inhibition + catecholamine preservation | Cortisol reduction + GABA-A modulation |
-| **Evidence for fatigue** | Strong — multiple RCTs in fatigued populations | Weak — cortisol reduction may indirectly help, but not a fatigue intervention |
-| **Evidence for anxiety** | Weak — stimulating effects may worsen anxiety in some | Strong — multiple RCTs showing anxiety reduction |
-| **Stack together?** | Yes — rhodiola AM + ashwagandha PM is a classic circadian adaptogen stack | |
-
-> **How to choose:** Ask yourself "am I wired or tired?" If you feel anxious, overstimulated, and cannot wind down — ashwagandha. If you feel exhausted, unmotivated, and burned out — rhodiola. If both: rhodiola in the morning, ashwagandha in the evening.
+| Question | Evidence-first answer |
+|---|---|
+| Does Rhodiola reliably treat fatigue? | **Not established.** Some trials are positive, but the systematic-review evidence is mixed and a later randomized trial favored placebo. |
+| Is there evidence in stress-related fatigue? | **Yes, but limited.** A 28-day SHR-5 trial in 60 adults found some between-group benefits; other outcomes improved in both groups. |
+| Does it improve mental performance? | **Possible in specific stressed populations.** Small historical studies in night-duty physicians and exam students reported some positive outcomes, but they do not establish a general cognitive-enhancer effect. |
+| Does it improve exercise endurance? | **A newer signal exists.** A 2025 meta-analysis of 26 RCTs / 668 healthy participants found small improvements in several endurance outcomes; this is a different evidence domain from fatigue or burnout treatment. |
+| How fast does it work? | **No reliable universal onset is established.** Study schedules range from acute/exercise contexts to multi-week repeated dosing. |
+| What is the best dose? | **No universal personal dose is established.** Trial doses describe the preparations researchers tested, not a prescribing range for every product. |
+| Does it need cycling? | **No evidence-based cycling schedule is established.** “6–8 weeks on, 1–2 weeks off” is not a validated clinical requirement. |
+| Is SHR-5 the same as every Rhodiola product? | **No.** Positive SHR-5 studies support that specific standardized extract in those study contexts; they do not prove a class effect for every root powder or extract. |
 
 ---
 
-## The Clinical Evidence: Study-by-Study
+## The most important evidence: the overall fatigue literature is contradictory
 
-> **Key finding:** Rhodiola has one of the more credible evidence bases among botanical adaptogens. The Darbinyan 2000 physician study represents a uniquely real-world model of cognitive fatigue under stress. The Olsson 2009 SHR-5 trial is the best-controlled modern RCT.
+The 2012 systematic review remains an important reality check because it looked across controlled Rhodiola trials rather than highlighting only positive studies.
 
-### Evidence Summary Table
+It included **11 studies** (10 described as randomized trials and one controlled clinical trial):
 
-| Study | Design | n | Population | Duration | Dose | Primary Outcomes | Quality |
-|---|---|---|---|---|---|---|---|
-| Olsson 2009 | RCT, DB, PC, parallel-group | 60 | Adults with diagnosed stress-related fatigue | 28 days | 576 mg SHR-5/day (2 tablets × 2 daily) | Fatigue scores ↓; attention ↑; salivary cortisol response to awakening ↓ | **Moderate-high** |
-| Darbinyan 2000 | RCT, DB, PC, crossover | 56 | Physicians during night duty | 2 weeks per phase | 170 mg SHR-5/day | Mental fatigue ↓; cognitive error rate ↓; short-term memory and attention ↑ | **Moderate** |
-| Spasov 2000 | RCT, DB, PC | 40 | Students during exam period | 20 days | 185 mg SHR-5/day | Physical fatigue ↓; mental fatigue ↓; general wellbeing ↑; no effects on exam grades | **Moderate** |
-| Ishaque 2012 | Systematic review | 11 studies pooled | Mixed populations | Varied | Various | Consistent anti-fatigue signal; all 11 studies showed some benefit; moderate overall evidence quality | **Moderate** |
+- **2 of 6** trials examining physical fatigue in healthy populations reported Rhodiola as effective.
+- **3 of 5** randomized trials examining mental fatigue reported positive findings.
+- Every included study had either a **high risk of bias** or reporting problems that made validity difficult to judge.
 
-### Deep Dive: The Landmark Trials
+The review concluded that the evidence was **contradictory** and that better-designed trials were needed.
 
-**Olsson 2009** — The definitive modern rhodiola trial. 60 adults (mean age ~42) with diagnosed stress-related fatigue (ICD-10 code F43.0, equivalent to "burnout" in common parlance) were randomized to SHR-5 extract (576 mg/day in four divided doses) or placebo for 28 days.
+That is a very different conclusion from “Rhodiola has moderate evidence for fatigue” or “all studies show some benefit.”
 
-Results:
-- **Fatigue:** Significant reduction on multiple validated fatigue scales (Pines Burnout Scale, Fatigue Severity Scale)
-- **Cortisol:** Salivary cortisol response to awakening was significantly reduced — a more nuanced finding than "lowers cortisol." Rhodiola appears to normalize the excessive cortisol awakening response characteristic of burnout, not suppress cortisol indiscriminately.
-- **Attention and concentration:** Significant improvements on cognitive testing
-- **Quality of life:** Significant improvement on SF-36
-- **Safety:** Well tolerated; no serious adverse events
+## Direct trial context matters
 
-This trial is methodologically important because it used a clinically diagnosed population (not just "stressed volunteers"), validated outcome measures, and a biomarker endpoint (cortisol awakening response) that aligns with the proposed mechanism.
+### Olsson 2009: stress-related fatigue
 
-**Darbinyan 2000** — One of the most ecologically valid adaptogen trials ever conducted. 56 physicians working night shifts (a real-world high-stress, high-cognitive-demand scenario) took 170 mg SHR-5 or placebo in a double-blind crossover design.
+This randomized, double-blind, placebo-controlled trial enrolled **60 adults ages 20–55** who met Swedish diagnostic criteria for stress-related fatigue syndrome.
 
-Results:
-- **Mental fatigue:** Significantly reduced throughout the night shift in the rhodiola condition
-- **Cognitive performance:** Error rate on a proofreading test was significantly lower; short-term memory and attention were preserved
-- **Effect timing:** Anti-fatigue effects were measurable within the first shift and sustained over the 2-week treatment period
-- **Dose:** 170 mg/day is at the lower end of the studied dose range — suggesting even moderate doses produce measurable effects in high-demand contexts
+- **Intervention:** standardized SHR-5 root extract, **576 mg/day**
+- **Comparator:** placebo
+- **Duration:** **28 days**
+- **Outcomes:** fatigue/burnout scales, mood, attention testing, quality of life, and cortisol awakening response
 
-**Spasov 2000** — 40 students during examination period took 185 mg SHR-5/day or placebo for 20 days. Physical and mental fatigue improved significantly; general wellbeing improved. Notably, exam grades did not differ between groups — rhodiola improved the experience of studying and test-taking but didn't directly improve test performance.
+Several outcomes improved in **both** groups. Between-group differences favored Rhodiola for the Pines burnout scale and some attention/cortisol measures.
 
----
+This is useful direct evidence for one standardized extract in one diagnosed fatigue population over four weeks. It is **not** proof that 576 mg is an optimal dose, that Rhodiola treats all forms of burnout, or that lowering cortisol is the mechanism a particular reader needs.
 
-## Dosage, Standardization, and Cycling
+### Darbinyan 2000: healthy physicians on night duty
 
-### How Much to Take
+A double-blind crossover study included **56 young healthy physicians** working night duty. Participants received SHR-5 or placebo during two-week treatment periods separated by a washout.
 
-| Protocol | Daily dose | Best for |
-|---|---|---|
-| **Standard** | 200–400 mg/day SHR-5, morning | General fatigue, daily cognitive support |
-| **Acute high-demand** | 400–600 mg/day SHR-5, split AM + early PM | Intense work periods, exams, deadlines |
-| **Athletic** | 200–500 mg/day, 30–60 min pre-exercise | Endurance, recovery |
-| **Low-dose maintenance** | 100–200 mg/day | Long-term adaptogenic support without cycling |
+Some composite mental-fatigue and cognitive measures improved during the Rhodiola period. This is an interesting stress-performance model, but it is a small historical study in a very specific occupational context.
 
-### Standardization: Why SHR-5 Matters
+**Correct PMID: 11081987.**
 
-Not all rhodiola extracts are equivalent. SHR-5 is the standardized extract used in most clinical trials, manufactured by the Swedish Herbal Institute. Its specification:
-- **3% rosavins** (rosavin, rosin, rosarin) — phenylpropanoid glycosides unique to *Rhodiola rosea*, serving as the species-authentication marker
-- **1% salidroside** (rhodioloside) — the most pharmacologically studied single compound; MAO inhibition, neuroprotection, anti-fatigue
+### Spasov 2000: students during examinations
 
-**Why this ratio matters:** Some cheaper products standardize only to salidroside. This can mask the use of other *Rhodiola* species (*R. crenulata*, *R. kirilowii*) that contain salidroside but lack rosavins — and have not been studied in the same clinical trials. Rosavin content confirms you're getting authentic *R. rosea*.
+This double-blind randomized placebo-controlled pilot studied students during a **20-day examination period**. Several physical-fitness, mental-fatigue, neuro-motor, and wellbeing outcomes favored SHR-5, while some performance tests did not differ significantly.
 
-**Price guide:**
-- Quality SHR-5 or equivalent (3% rosavins / 1% salidroside): $15–30/month at 200–400 mg/day
-- Generic "standardized rhodiola" (may not specify rosavins): $10–20/month
-- Budget rhodiola (unstandardized root powder): $8–12/month — potency unknown, likely subtherapeutic
+The paper itself described the tested dose as probably suboptimal. That makes it especially inappropriate to convert the trial into a universal “best dose.”
 
-### Cycling
+**Correct PMID: 10839209.**
 
-Rhodiola doesn't produce classical tolerance (receptor downregulation) the way stimulants do, but many users report diminished perceived effects after 2–3 months of continuous use. The most common cycling protocol:
-- **6–8 weeks on** at full dose
-- **1–2 weeks off** to reassess baseline and maintain sensitivity
-- Resume if benefits are still needed
+### Punja 2014: a negative randomized trial matters too
 
-For predictable high-demand periods (exam season, project deadlines, tax season), some people use rhodiola as-needed during the crunch and discontinue during lower-demand periods.
+This double-blind placebo-controlled trial randomized **48 nursing students ages 18–55** during clinical rotations.
+
+- **Intervention:** 364 mg Rhodiola or placebo at the start of the wakeful period, with an optional second capsule within four hours
+- **Duration:** **42 days**
+- **Primary outcome:** fatigue
+
+At day 42, the primary fatigue outcomes were significantly different **in favor of placebo**. Adverse-event counts did not differ between groups.
+
+The authors advised cautious interpretation, but the study is still important: a fair evidence review should not present Rhodiola’s fatigue literature as uniformly positive when a randomized trial produced the opposite result.
 
 ---
 
-<CollapsibleDetails title="How It Works — Complete Mechanism (tap to expand)" defaultOpen={false}>
+## What newer reviews add
 
-## How It Works (Complete Mechanism)
+### 2026 adaptogen systematic review
 
-Rhodiola's stimulating-adaptogen profile is driven by two compound classes working through three interconnected mechanisms.
+A 2026 systematic review included 24 randomized studies of ashwagandha and Rhodiola; only **five** involved Rhodiola.
 
-### 1. Monoamine Preservation (MAO + Reuptake Inhibition)
+The review described potentially favorable psychometric findings, but also emphasized familiar limitations: **methodological heterogeneity, short intervention periods, small samples, and a need for larger long-term trials**.
 
-This is rhodiola's signature mechanism and what distinguishes it from calming adaptogens.
+That supports a “possible signal with meaningful uncertainty” interpretation—not a predictable anti-fatigue protocol.
 
-**MAO inhibition:** Salidroside inhibits both MAO-A and MAO-B — the enzymes that break down serotonin, norepinephrine, and dopamine. The inhibition is **reversible and partial** (unlike irreversible pharmaceutical MAOIs), which means monoamine levels increase modestly rather than dramatically. Van Diermen et al. (2009) characterized this activity in radioligand binding assays.
+### 2025 endurance meta-analysis: a separate evidence domain
 
-**Reuptake inhibition:** Rhodiola compounds also directly block SERT (serotonin transporter) and NET (norepinephrine transporter) — the same targets as SSRI and SNRI antidepressants. This dual mechanism — prevent breakdown (MAO inhibition) AND prevent reuptake (transporter inhibition) — produces meaningful monoamine enhancement at moderate doses without the dietary restrictions or cardiovascular risks of pharmaceutical MAOIs.
+A 2025 systematic review/meta-analysis pooled **26 randomized trials / 668 healthy participants** with a mean age of about 22 years.
 
-The net effect: under stress (which normally depletes catecholamines), rhodiola preserves serotonin, dopamine, and norepinephrine levels, maintaining cognitive function when it would otherwise degrade.
+Small favorable effects were reported for:
 
-### 2. HPA Axis Normalization
+- VO2max
+- time to exhaustion
+- time-trial performance
 
-Under acute stress, the HPA axis activates cortisol production. Under chronic stress, the axis dysregulates — producing an exaggerated cortisol awakening response, blunted diurnal rhythm, and impaired negative feedback.
+The authors also noted heterogeneity across studies.
 
-Salidroside and rosavins have been shown in rodent models to:
-- Reduce stress-induced elevations in serum corticosterone (rodent cortisol equivalent)
-- Protect adrenal gland structure from the hypertrophy characteristic of chronic stress
-- Attenuate stress-induced depletion of catecholamines in cortical and limbic regions
-
-The Olsson 2009 human trial confirmed cortisol normalization: the exaggerated awakening response in burnout patients was reduced toward normal levels.
-
-### 3. AMPK Activation and Cellular Energy
-
-Salidroside activates AMP-activated protein kinase (AMPK) — the cellular energy sensor that shifts metabolism toward ATP production and away from energy storage. This may contribute to the "clean energy" sensation rhodiola users report: improved physical and mental capacity without the sympathetic activation of caffeine.
+This is relevant to **exercise/endurance performance in healthy participants**. It should not be repackaged as proof that Rhodiola treats chronic fatigue, occupational burnout, depression, or cognitive symptoms in the general population.
 
 ---
 
-## Stacking Rhodiola
+## What the evidence does **not** establish
 
-</CollapsibleDetails>
+### A predictable onset timeline
 
-## Stacking Rhodiola
+The current evidence does not justify a timeline such as:
 
-Rhodiola's stimulating profile makes it the morning anchor in adaptogen stacks.
+- “clearer-headed within hours”
+- “fatigue resistance by week two”
+- “full effects by week four”
+- “plateau after two months”
 
-| Stack | Protocol | Why | Best for |
-|---|---|---|---|
-| **Rhodiola (AM) + Ashwagandha (PM)** | Rh 200–400 mg AM / Ash 300–600 mg PM | Stimulating adaptogen for daytime + calming adaptogen for evening. Covers the full circadian stress cycle. | Burnout with both fatigue and anxiety |
-| **Rhodiola + L-Theanine** | Rh 200–400 mg AM / L-theanine 200 mg as needed | Rhodiola for fatigue resistance; L-theanine for acute calm without sedation. | High-demand days with intermittent anxiety spikes |
-| **Rhodiola + Creatine** | Rh 200–400 mg AM / Creatine 5 g/day | Cognitive + physical energy support with distinct mechanisms. Creatine supports ATP; rhodiola supports catecholamine preservation. | Athletes and high-cognitive-output professionals |
-| **Rhodiola + Caffeine** | Rh AM + caffeine as usual | Rhodiola smooths the edges of caffeine — similar to L-theanine but via a different mechanism. | Morning routine enhancement |
+Different trials used different populations, preparations, doses, schedules, and outcomes. A study detecting an effect at a particular time point does not establish a universal onset curve.
 
-**Avoid stacking with:** other MAO inhibitors (prescription or supplement), high-dose SSRIs/SNRIs (theoretical serotonin syndrome from additive mechanisms), or other stimulating supplements late in the day.
+### “No jitters” or “no crash”
 
----
+Those are consumer-experience promises, not established comparative outcomes. Rhodiola has not been shown to provide stimulant-like benefits while reliably eliminating jitteriness or crashes.
 
-<CollapsibleWarning title="Safety & Contraindications">
+### A universal dose or timing rule
 
-## Safety and Contraindications
+The literature includes specific research regimens, but they do not establish:
 
-Rhodiola has a favorable safety profile in trials up to 12 weeks. The most common side effects are dose-dependent and related to its stimulating properties:
+- a standard 200–400 mg daily dose for everyone
+- a 400–600 mg “high-demand” protocol
+- a pre-exercise dose
+- mandatory morning-only dosing
+- a “not within six hours of bedtime” rule
 
-- **Overstimulation/jitteriness** at high doses (>600 mg/day) or when taken too late in the day
-- **Insomnia** if taken within 6 hours of bedtime
-- **Dizziness or dry mouth** — mild and self-limiting
-- **Vivid dreams** — reported anecdotally, possibly related to enhanced REM sleep from catecholamine modulation
+Dose, timing, and extract identity are part of the intervention being studied—not automatically a consumer prescription.
 
-| Population | Guidance | Rationale |
-|---|---|---|
-| **Bipolar disorder** | Avoid | MAO inhibition + monoamine elevation can trigger manic switches |
-| **Pregnancy/breastfeeding** | Avoid | Insufficient safety data |
-| **SSRIs/SNRIs/MAOIs** | Caution — theoretical serotonin syndrome | Rhodiola's dual reuptake inhibition + MAO inhibition is additive with these medications |
-| **High blood pressure** | Monitor | Stimulating adaptogens can elevate BP in some individuals |
-| **Evening dosing** | Avoid within 6 hours of bedtime | Stimulating effects will interfere with sleep onset |
+### A cycling requirement
 
----
+There is no established clinical evidence that Rhodiola must be used for **6–8 weeks on followed by 1–2 weeks off** to prevent tolerance or preserve efficacy.
 
-</CollapsibleWarning>
+### A validated “wired vs tired” adaptogen algorithm
 
-## FAQ
+Feeling tired, anxious, unmotivated, wired, or unable to sleep does not identify a supplement. Those symptoms overlap with sleep loss, mood disorders, anemia, thyroid disease, medication effects, substance use, overtraining, infection, and many other causes.
 
-### Will rhodiola keep me awake if I take it too late?
-Yes — this is the most common user error. Rhodiola's catecholamine-preserving effects can interfere with sleep onset if taken within 6 hours of bedtime. Take it in the morning or by early afternoon at the latest.
-
-### Is rhodiola safe with caffeine?
-Yes — they're commonly combined. Rhodiola's anti-fatigue mechanism (catecholamine preservation) is distinct from caffeine's (adenosine receptor blockade). Many users find the combination provides cleaner energy than caffeine alone.
-
-### Does rhodiola build tolerance?
-Not in the classical sense (receptor downregulation). However, many users report the perceived benefit diminishes after 2–3 months. This is likely because you acclimate to your new baseline, not because the compound stops working. Cycling (6–8 weeks on, 1–2 weeks off) helps maintain perceived efficacy.
-
-### How is rhodiola different from ashwagandha?
-Rhodiola is stimulating and fights fatigue. Ashwagandha is calming and lowers cortisol. If you're exhausted and unmotivated → rhodiola. If you're anxious and can't relax → ashwagandha. If you're both → rhodiola AM, ashwagandha PM.
-
-### What's the difference between 3% rosavins and 3% salidroside extracts?
-Rosavins are the species-authentication marker (unique to *R. rosea*). Salidroside is the most pharmacologically active compound but is found in multiple *Rhodiola* species. An extract standardized to salidroside-only may use a different, less-studied species. Look for both — 3% rosavins AND 1% salidroside.
+Rhodiola-AM / ashwagandha-PM is therefore not an evidence-based treatment algorithm.
 
 ---
 
-## Related Articles
+## Extracts and standardization: study matching, not a universal winner
 
-- [Ashwagandha: Benefits, Dosage & Evidence](/articles/ashwagandha/)
-- [Rhodiola vs Ashwagandha Comparison](/guides/compare/rhodiola-vs-ashwagandha/)
-- [L-Theanine: Calm Focus Guide](/articles/l-theanine/)
-- [Bacopa Monnieri: Memory Evidence Guide](/articles/bacopa-monnieri/)
-- [Adaptogenic Compounds Guide](/articles/adaptogenic-natural-compounds/)
+Many older positive studies used the standardized extract **SHR-5**. That matters for evidence directness: a trial of SHR-5 is evidence about the studied SHR-5 preparation, population, comparator, and duration.
+
+It does **not** prove that:
+
+- every Rhodiola rosea powder is equivalent
+- every product labeled “3% rosavins / 1% salidroside” reproduces SHR-5 trial results
+- a salidroside-only extract is clinically interchangeable
+- one standardization ratio is the universally superior retail product
+
+Standardization can help identify what was tested. It does not turn one extract’s study results into a class effect.
+
+---
+
+## Mechanisms are hypotheses, not treatment selectors
+
+Rhodiola constituents have been studied in laboratory models involving monoamine transporters, monoamine oxidase, stress signaling, oxidative pathways, and other targets.
+
+Those findings can generate hypotheses. They do **not** establish that a retail Rhodiola product clinically “normalizes the HPA axis,” preserves catecholamines in a predictable way, acts like a mild antidepressant, or should be combined with other products based on receptor diagrams.
+
+Mechanistic plausibility should not outrank randomized human outcomes.
+
+---
+
+## Combination and “stack” evidence
+
+Separate studies of Rhodiola, ashwagandha, L-theanine, creatine, or caffeine do not prove that a combination is synergistic, cleaner, safer, or more effective.
+
+This article therefore does not recommend:
+
+- Rhodiola AM + ashwagandha PM
+- Rhodiola + L-theanine for anxiety spikes
+- Rhodiola + caffeine for “cleaner energy”
+- Rhodiola + creatine as a cognitive-performance stack
+
+A combination is a new intervention with its own efficacy, interaction, and attribution questions.
+
+---
+
+## Safety and uncertainty
+
+Most Rhodiola trials are relatively short, so “well tolerated in a trial” should not be translated into comprehensive long-term safety.
+
+The European Medicines Agency maintains a current EU herbal monograph for Rhodiola rosea root/rhizome. Its existence is useful regulatory context, but a traditional herbal indication is not the same as high-certainty randomized evidence for modern claims such as burnout treatment, cognitive enhancement, or antidepressant substitution.
+
+A few practical boundaries matter:
+
+- **Persistent or unexplained fatigue deserves evaluation.** Sleep disorders, anemia, thyroid disease, depression, medication effects, infection, nutrition problems, and other conditions can look like “stress fatigue.”
+- **Do not infer medication compatibility from mechanism diagrams.** Laboratory MAO/transporter findings do not establish that combining Rhodiola with antidepressants or stimulants is safe.
+- **Pregnancy/breastfeeding and long-term use are evidence gaps.** Limited data are not evidence of safety.
+- **Mood instability is not a self-treatment target.** People with bipolar-spectrum illness or significant mood symptoms should not use an “adaptogen” label as a substitute for appropriate care.
+
+If you take prescription medication, have a significant medical or psychiatric condition, or are considering Rhodiola for persistent fatigue, review the specific product and situation with a qualified healthcare professional.
+
+---
+
+## Frequently asked questions
+
+### Does Rhodiola work for burnout?
+
+There is a positive 28-day SHR-5 trial in 60 adults with diagnosed stress-related fatigue, but the broader fatigue literature is mixed and methodologically limited. “Burnout” is also not one uniform biological condition, so the evidence does not establish Rhodiola as a general burnout treatment.
+
+### Does Rhodiola work on the first day?
+
+A few studies tested acute or short-term performance contexts, but the evidence does not establish a reliable first-day effect for the general population. A study’s measurement window is not a universal onset promise.
+
+### What dose of Rhodiola should I take?
+
+The studies used different standardized extracts and regimens. Those research doses are useful for judging whether a retail product matches the studied intervention, but they do not establish one universal personal dose.
+
+### Should Rhodiola be taken only in the morning?
+
+The clinical literature does not establish a universal morning-only rule or a specific number of hours before bedtime that applies to everyone.
+
+### Does Rhodiola need to be cycled?
+
+No evidence-based “6–8 weeks on / 1–2 weeks off” requirement has been established.
+
+### Is Rhodiola better than ashwagandha?
+
+That is too broad. The two botanicals have different trial programs, preparations, and outcomes. Symptoms such as “wired” versus “tired” do not validate a supplement-selection algorithm. See the dedicated comparison for a directness-based review rather than a personality-style quiz.
+
+---
+
+## Related evidence guides
+
+- [Rhodiola vs Ashwagandha](/guides/compare/rhodiola-vs-ashwagandha/)
+- [Rhodiola Extract vs Powder](/guides/herbs/rhodiola-extract-vs-powder/)
+- [Best Adaptogens for Stress](/guides/stress/best-adaptogens-for-stress/)
+- [Ashwagandha Evidence Guide](/articles/ashwagandha/)
+- [L-Theanine Evidence Guide](/articles/l-theanine/)
+
+---
+
+## Evidence update note
+
+**Last evidence review: August 12, 2026.** This page was recalibrated to include the contradictory 2012 systematic review, the placebo-favoring 2014 nursing-student trial, the 2025 endurance meta-analysis, and the 2026 adaptogen systematic review; to correct the Darbinyan and Spasov PMIDs; and to remove universal dose, onset, cycling, mechanism, and stack claims that the human evidence does not establish.


### PR DESCRIPTION
## Summary
- rebuilds the canonical Rhodiola article around mixed, outcome-specific human evidence rather than a deterministic adaptogen protocol
- corrects the Darbinyan and Spasov 2000 PMIDs
- surfaces the contradictory 2012 fatigue systematic review and the placebo-favoring 2014 nursing-student RCT alongside positive older SHR-5 trials
- separates the 2025 endurance-performance signal in mostly young healthy participants from claims about burnout, brain fog, or chronic fatigue
- adds the 2026 adaptogen systematic-review context and its heterogeneity/small-sample limitations
- removes universal onset, 200–600 mg dose protocols, morning-only rules, 6–8 week cycling schedules, wired-vs-tired phenotype matching, mechanism certainty, and evidence-free Rhodiola stacks
- reframes SHR-5/standardization as study matching rather than a universal product winner
- strengthens persistent-fatigue and medication-safety boundaries
- adds focused regression coverage to prevent the old claims from returning

## Key evidence
- Ishaque 2012 systematic review — PMID 22643043
- Olsson 2009 stress-related fatigue RCT — PMID 19016404
- Punja 2014 nursing-student RCT — PMID 25268730
- 2026 adaptogen systematic review — PMID 41906501
- 2025 endurance meta-analysis — PMID 41080184
- Darbinyan night-duty physicians — corrected PMID 11081987
- Spasov exam students — corrected PMID 10839209
- EMA Rhodiola monograph, Revision 1 (2024)

## Scope
Exactly 2 files: the canonical markdown article and its regression test.