### PR TITLE
Harden runtime and audit guards against leaked pipeline prose

### DIFF
--- a/lib/__tests__/runtime-record-resolver.test.mjs
+++ b/lib/__tests__/runtime-record-resolver.test.mjs
@@ -136,6 +136,30 @@ describe('standard runtime record resolver', () => {
     expect(isLeakedPresentationText('Conservative evidence framing applied.', 'description')).toBe(true)
   })
 
+  it('quarantines leaked canonical presentation scaffolding before detail layers are applied', () => {
+    const result = resolveRuntimeRecordLayers({
+      ...standardRecord,
+      summary: 'Decision ready summary: this ingredient is best framed for calm focus.',
+      description: 'It should be framed modestly because evidence is limited.',
+    }, [])
+
+    expect(result.summary).toBeUndefined()
+    expect(result.description).toBeUndefined()
+  })
+
+  it('drops generic canonical safety reassurance while preserving structured cautions', () => {
+    const result = resolveRuntimeRecordLayers({
+      ...standardRecord,
+      safety: 'Generally well tolerated for most users.',
+      safety_summary: 'Generally well tolerated.',
+    }, [])
+
+    expect(result.safety).toBeUndefined()
+    expect(result.safety_summary).toBeUndefined()
+    expect(result.contraindications).toEqual(standardRecord.contraindications)
+    expect(result.interactions).toEqual(standardRecord.interactions)
+  })
+
   it('does not classify ordinary evidence-aware copy as pipeline leakage', () => {
     expect(isLeakedPresentationText('Human evidence is preliminary and condition-specific.', 'summary')).toBe(false)
     expect(isLeakedPresentationText('Decision-ready summary: internal text', 'summary')).toBe(true)

--- a/lib/__tests__/runtime-record-resolver.test.mjs
+++ b/lib/__tests__/runtime-record-resolver.test.mjs
@@ -121,6 +121,21 @@ describe('standard runtime record resolver', () => {
     expect(isLeakedPresentationText(result.description, 'description')).toBe(false)
   })
 
+  it('rejects framing instructions and generic profile placeholders from detail overlays', () => {
+    const result = resolveRuntimeRecordLayers(standardRecord, [{
+      slug: standardRecord.slug,
+      summary: 'It should be framed modestly because traditional use is much stronger than modern evidence.',
+      description: 'Evidence-aware botanical profile with mechanism, safety, and practical context.',
+    }])
+
+    expect(result.summary).toBe(standardRecord.summary)
+    expect(result.description).toBe(standardRecord.description)
+    expect(isLeakedPresentationText('It is best framed as a vitamin C rich fruit botanical.', 'summary')).toBe(true)
+    expect(isLeakedPresentationText('It should be framed modestly because evidence is limited.', 'summary')).toBe(true)
+    expect(isLeakedPresentationText('Evidence-aware compound profile with mechanism, safety, and practical context.', 'description')).toBe(true)
+    expect(isLeakedPresentationText('Conservative evidence framing applied.', 'description')).toBe(true)
+  })
+
   it('does not classify ordinary evidence-aware copy as pipeline leakage', () => {
     expect(isLeakedPresentationText('Human evidence is preliminary and condition-specific.', 'summary')).toBe(false)
     expect(isLeakedPresentationText('Decision-ready summary: internal text', 'summary')).toBe(true)

--- a/lib/runtime-record-resolver.mjs
+++ b/lib/runtime-record-resolver.mjs
@@ -3,6 +3,7 @@ import { CLUSTER_MEMBER_RUNTIME_DECISION } from '../config/cluster-member-runtim
 const PLACEHOLDERS = new Set(['', '-', '--', 'n/a', 'na', 'none', 'null', 'tbd', 'unknown', 'undefined'])
 const GENERIC_SAFETY = /^generally well tolerated(?: for most users)?\.?$/i
 const SAFETY_ALIASES = new Set(['safety', 'runtime_safety', 'safetyNotes', 'safety_notes'])
+const GENERIC_SAFETY_FIELDS = new Set(['safety', 'runtime_safety', 'safetyNotes', 'safety_notes', 'safety_summary', 'safety_note'])
 const LIST_FIELDS = new Set([
   'contraindications',
   'interactions',
@@ -22,6 +23,9 @@ const PRESENTATION_TEXT_FIELDS = new Set([
   'dosage',
   'typical_dosage',
 ])
+const QUARANTINED_BASE_PRESENTATION_FIELDS = new Set(
+  [...PRESENTATION_TEXT_FIELDS].filter((field) => field !== 'name' && field !== 'displayName'),
+)
 const LEAKED_PRESENTATION_PATTERNS = [
   /lean bulk ingestion row/i,
   /lean bulk/i,
@@ -139,6 +143,22 @@ export function resolveRuntimeRecordLayers(base, layers = [], options = {}) {
   const resolved = { ...base }
   const isClusterMember = base.runtime_export_decision === CLUSTER_MEMBER_RUNTIME_DECISION
 
+  // Canonical records can contain legacy presentation scaffolding even when the
+  // detail overlay is clean. Quarantine those display fields before layering so
+  // renderers fall back to their conservative copy rather than exposing pipeline prose.
+  for (const field of QUARANTINED_BASE_PRESENTATION_FIELDS) {
+    if (isLeakedPresentationText(resolved[field], field)) delete resolved[field]
+  }
+
+  // “Generally well tolerated” is not a useful safety summary when medication,
+  // contraindication, or population cautions may exist elsewhere on the record.
+  // Remove the generic reassurance and let richer structured safety context render.
+  for (const field of GENERIC_SAFETY_FIELDS) {
+    if (typeof resolved[field] === 'string' && GENERIC_SAFETY.test(text(resolved[field]))) {
+      delete resolved[field]
+    }
+  }
+
   for (const layer of layers) {
     if (!layer || typeof layer !== 'object' || Array.isArray(layer)) continue
     const layerSlug = text(layer.slug || layer.id)
@@ -167,7 +187,7 @@ export function resolveRuntimeRecordLayers(base, layers = [], options = {}) {
   // canonical safety field. Non-cluster records keep their existing aliases,
   // while stale overlays are prevented from replacing canonical safety above.
   if (isClusterMember) {
-    const safety = resolveTrustValue(undefined, resolved.safety || base.safety || base.runtime_safety, { field: 'safety', allowLocal: true })
+    const safety = resolveTrustValue(undefined, resolved.safety || resolved.runtime_safety, { field: 'safety', allowLocal: true })
     if (safety !== undefined) {
       resolved.safety = safety
       resolved.runtime_safety = safety

--- a/lib/runtime-record-resolver.mjs
+++ b/lib/runtime-record-resolver.mjs
@@ -36,12 +36,14 @@ const LEAKED_PRESENTATION_PATTERNS = [
   /high.speed phytochemical/i,
   /internal cross-linking supports/i,
   /\bis tracked for\b/i,
-  /it is best framed (as|around|for)/i,
+  /it\s+(?:is|should be)\s+(?:best\s+)?framed\b/i,
   /decision[-\s]?ready summary/i,
   /merged decision layer/i,
   /evidence level:/i,
   /scispace evidence pass|evidence pass/i,
   /enriched in bulk|bulk mode/i,
+  /evidence-aware\s+(?:compound|botanical)\s+profile\s+with\s+mechanism,?\s+safety,?\s+and\s+practical\s+context/i,
+  /^conservative evidence framing applied\.?$/i,
 ]
 const CORE_OWNED_FIELDS = new Set([
   'id',

--- a/scripts/audit/find-leaked-pipeline-text.mjs
+++ b/scripts/audit/find-leaked-pipeline-text.mjs
@@ -1,7 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 
-// Helper to ensure directory exists
+const strictMode = process.argv.includes('--strict');
+
 function ensureDirExists(dirPath) {
   if (!fs.existsSync(dirPath)) {
     fs.mkdirSync(dirPath, { recursive: true });
@@ -22,26 +23,37 @@ const LEAK_PATTERNS = [
   { regex: /high.speed phytochemical/i, name: 'phytochemical ingestion template' },
   { regex: /internal cross-linking supports/i, name: 'cross-linking template' },
   { regex: /\bis tracked for\b/i, name: 'tracked-for template' },
-  { regex: /it is best framed (as|around|for)/i, name: 'best-framed template' },
+  { regex: /it\s+(?:is|should be)\s+(?:best\s+)?framed\b/i, name: 'framing-instruction template' },
   { regex: /decision-ready summary/i, name: 'decision-ready summary prefix' },
   { regex: /evidence level:/i, name: 'evidence-level template' },
   { regex: /scispace evidence pass|evidence pass/i, name: 'evidence-pass template' },
-  { regex: /enriched in bulk|bulk mode/i, name: 'bulk-enrichment template' }
+  { regex: /enriched in bulk|bulk mode/i, name: 'bulk-enrichment template' },
+  {
+    regex: /evidence-aware\s+(?:compound|botanical)\s+profile\s+with\s+mechanism,?\s+safety,?\s+and\s+practical\s+context/i,
+    name: 'generic evidence-aware profile placeholder',
+  },
+  { regex: /^conservative evidence framing applied\.?$/i, name: 'conservative-framing placeholder' },
+  { regex: /^varying compliance\.?$/i, name: 'varying-compliance placeholder' },
+  { regex: /canonical profile pending.*static route exists/i, name: 'build-system route message' },
 ];
 
-// Fields that are displayed on the frontend to users
 const USER_FACING_FIELDS = [
   'name',
   'summary',
   'description',
+  'overview',
   'safety',
+  'safety_summary',
   'dosage',
   'typical_dosage',
   'contraindications',
   'interactions',
   'side_effects',
   'effects',
-  'primary_effects'
+  'primary_effects',
+  'evidence_summary',
+  'best_for',
+  'why_people_stop',
 ];
 
 function runAudit() {
@@ -60,7 +72,6 @@ function runAudit() {
   const affectedSlugs = new Set();
 
   const scanItem = (item, type) => {
-    // Check for short description
     const desc = item.description || '';
     if (desc.trim().length > 0 && desc.trim().length < 15) {
       results.push({
@@ -70,12 +81,11 @@ function runAudit() {
         field: 'description',
         value: desc,
         issue: 'Description under 15 characters',
-        severity: 'CRITICAL'
+        severity: 'CRITICAL',
       });
       affectedSlugs.add(item.slug);
     }
 
-    // Scan all properties
     for (const [key, value] of Object.entries(item)) {
       if (!value) continue;
 
@@ -90,7 +100,7 @@ function runAudit() {
               field: fieldName,
               value: str,
               issue: `Leaked text pattern: "${pattern.name}"`,
-              severity: isUserFacing ? 'CRITICAL' : 'LOW'
+              severity: isUserFacing ? 'CRITICAL' : 'LOW',
             });
             affectedSlugs.add(item.slug);
           }
@@ -106,7 +116,6 @@ function runAudit() {
           }
         });
       } else if (typeof value === 'object') {
-        // Nested properties
         try {
           const strVal = JSON.stringify(value);
           for (const pattern of LEAK_PATTERNS) {
@@ -118,13 +127,13 @@ function runAudit() {
                 field: key,
                 value: strVal,
                 issue: `Leaked text pattern in object: "${pattern.name}"`,
-                severity: 'LOW' // nested objects are usually internal/metadata
+                severity: 'LOW',
               });
               affectedSlugs.add(item.slug);
             }
           }
-        } catch (e) {
-          // ignore cyclic or non-stringifiable
+        } catch {
+          // Ignore non-stringifiable metadata objects.
         }
       }
     }
@@ -133,31 +142,15 @@ function runAudit() {
   herbs.forEach(item => scanItem(item, 'herb'));
   compounds.forEach(item => scanItem(item, 'compound'));
 
-  // Ensure reports dir exists
   ensureDirExists('reports');
 
-  // Write reports/leaked-slugs.json
   fs.writeFileSync('reports/leaked-slugs.json', JSON.stringify(Array.from(affectedSlugs), null, 2));
   console.log(`Wrote reports/leaked-slugs.json with ${affectedSlugs.size} affected slugs.`);
 
-  // Write reports/leaked-pipeline-text.md
-  let md = `# Leaked Pipeline Text Audit Report
-
-Generated on: ${new Date().toISOString()}
-
-## Summary Statistics
-
-- **Total Issues Identified**: ${results.length}
-- **Critical (User-Facing)**: ${results.filter(r => r.severity === 'CRITICAL').length}
-- **Low (Internal/Metadata)**: ${results.filter(r => r.severity === 'LOW').length}
-- **Unique Affected Slugs**: ${affectedSlugs.size}
-
-## Details of Identified Issues
-
-`;
-
   const criticalIssues = results.filter(r => r.severity === 'CRITICAL');
   const lowIssues = results.filter(r => r.severity === 'LOW');
+
+  let md = `# Leaked Pipeline Text Audit Report\n\nGenerated on: ${new Date().toISOString()}\n\n## Summary Statistics\n\n- **Total Issues Identified**: ${results.length}\n- **Critical (User-Facing)**: ${criticalIssues.length}\n- **Low (Internal/Metadata)**: ${lowIssues.length}\n- **Unique Affected Slugs**: ${affectedSlugs.size}\n\n## Details of Identified Issues\n\n`;
 
   if (criticalIssues.length > 0) {
     md += `### CRITICAL — User-Facing Fields\n\n`;
@@ -184,7 +177,12 @@ Generated on: ${new Date().toISOString()}
   }
 
   fs.writeFileSync('reports/leaked-pipeline-text.md', md);
-  console.log(`Wrote reports/leaked-pipeline-text.md.`);
+  console.log('Wrote reports/leaked-pipeline-text.md.');
+
+  if (strictMode && criticalIssues.length > 0) {
+    console.error(`Strict audit failed: ${criticalIssues.length} critical user-facing leak(s) detected.`);
+    process.exitCode = 1;
+  }
 }
 
 runAudit();


### PR DESCRIPTION
## Summary
- expand the runtime presentation-text quarantine to catch both “it is best framed…” and “it should be framed…” instruction leakage
- reject generic “evidence-aware compound/botanical profile…” and “conservative evidence framing applied” placeholders from detail overlays
- quarantine leaked presentation scaffolding already present in canonical runtime records before detail layers are applied
- remove generic canonical safety reassurance such as “Generally well tolerated for most users” so richer structured contraindication/interaction context can render instead
- preserve names, structured contraindications, interactions, evidence grades, and other trust fields
- add regression coverage for overlay leaks, canonical leaks, and generic safety fallbacks
- expand the standalone leak auditor with the same missing patterns plus known placeholder/build-system phrases
- add opt-in `--strict` mode so the audit can become a CI gate after legacy source data is cleaned, without breaking current builds by default

## Why
The full-site audit and live search crawl showed that existing guards shared a blind spot for sibling framing phrases and that some leaked text is canonical rather than overlay-only. Search results also exposed generic “well tolerated” safety text on profiles that list meaningful medication cautions elsewhere. Central runtime quarantine fixes those presentation defects without silently rewriting the workbook or inventing efficacy claims.

## Safety
This change filters presentation-layer pipeline prose and generic reassurance only. It does not modify dosage, interaction, evidence-grade, contraindication, or workbook source-of-truth data.