### PR TITLE
Calibrate evidence-literacy guidance around actual study appraisal

### DIFF
--- a/app/__tests__/evidence-literacy-calibration.test.ts
+++ b/app/__tests__/evidence-literacy-calibration.test.ts
@@ -4,13 +4,19 @@ import { describe, expect, it } from 'vitest'
 
 const read = (relativePath: string) => fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
 
+const METHOD_PAGES = [
+  'app/learn/how-to-read-scientific-studies/page.tsx',
+  'app/learn/evidence-literacy/page.tsx',
+  'app/info/methodology/page.tsx',
+  'app/learn/evidence-hierarchy/page.tsx',
+  'app/learn/study-design-snapshot/page.tsx',
+]
+
+const readMethodPages = () => METHOD_PAGES.map(read).join('\n')
+
 describe('evidence-literacy methods calibration', () => {
-  it('does not use magic participant thresholds or exaggerated sponsorship multipliers', () => {
-    const pages = [
-      read('app/learn/how-to-read-scientific-studies/page.tsx'),
-      read('app/learn/evidence-literacy/page.tsx'),
-      read('app/info/methodology/page.tsx'),
-    ].join('\n')
+  it('does not use magic thresholds, exaggerated multipliers, or categorical evidence-grade claims', () => {
+    const pages = readMethodPages()
 
     expect(pages).not.toMatch(/3-4x more likely/i)
     expect(pages).not.toMatch(/n\s*>\s*80/i)
@@ -20,14 +26,12 @@ describe('evidence-literacy methods calibration', () => {
     expect(pages).not.toMatch(/statistically significant positive outcomes/i)
     expect(pages).not.toMatch(/depending on individual neurochemistry/i)
     expect(pages).not.toMatch(/required to replicate clinical results/i)
+    expect(pages).not.toMatch(/the effect is real and replicated/i)
+    expect(pages).not.toMatch(/you can act on it with reasonable confidence/i)
   })
 
   it('teaches power, effect precision, surrogate validation, and funding scrutiny instead', () => {
-    const pages = [
-      read('app/learn/how-to-read-scientific-studies/page.tsx'),
-      read('app/learn/evidence-literacy/page.tsx'),
-      read('app/info/methodology/page.tsx'),
-    ].join('\n')
+    const pages = readMethodPages()
 
     expect(pages).toMatch(/Power depends on the expected effect/i)
     expect(pages).toMatch(/confidence interval/i)
@@ -37,6 +41,16 @@ describe('evidence-literacy methods calibration', () => {
     expect(pages).toContain('https://pubmed.ncbi.nlm.nih.gov/30132025/')
     expect(pages).toContain('https://pubmed.ncbi.nlm.nih.gov/37380118/')
     expect(pages).toContain('https://pubmed.ncbi.nlm.nih.gov/20352064/')
+  })
+
+  it('treats evidence hierarchies and strong grades as confidence frameworks rather than truth ladders', () => {
+    const hierarchy = read('app/learn/evidence-hierarchy/page.tsx')
+    const snapshot = read('app/learn/study-design-snapshot/page.tsx')
+
+    expect(hierarchy).toContain('They are not automatic rankings of truth')
+    expect(hierarchy).toContain('Different designs can be strongest for different questions')
+    expect(snapshot).toContain('it does not make the effect certain, universal, large, or automatically relevant to every product')
+    expect(snapshot).toContain('A grade should make the evidence easier to inspect, not replace that inspection')
   })
 
   it('keeps authorship and automated-validation limits explicit on methodology', () => {

--- a/app/__tests__/evidence-literacy-calibration.test.ts
+++ b/app/__tests__/evidence-literacy-calibration.test.ts
@@ -9,6 +9,7 @@ describe('evidence-literacy methods calibration', () => {
     const pages = [
       read('app/learn/how-to-read-scientific-studies/page.tsx'),
       read('app/learn/evidence-literacy/page.tsx'),
+      read('app/info/methodology/page.tsx'),
     ].join('\n')
 
     expect(pages).not.toMatch(/3-4x more likely/i)
@@ -16,19 +17,34 @@ describe('evidence-literacy methods calibration', () => {
     expect(pages).not.toMatch(/n\s*<\s*30/i)
     expect(pages).not.toMatch(/prove that an herb/i)
     expect(pages).not.toMatch(/expectation effects dominate/i)
+    expect(pages).not.toMatch(/statistically significant positive outcomes/i)
+    expect(pages).not.toMatch(/depending on individual neurochemistry/i)
+    expect(pages).not.toMatch(/required to replicate clinical results/i)
   })
 
   it('teaches power, effect precision, surrogate validation, and funding scrutiny instead', () => {
     const pages = [
       read('app/learn/how-to-read-scientific-studies/page.tsx'),
       read('app/learn/evidence-literacy/page.tsx'),
+      read('app/info/methodology/page.tsx'),
     ].join('\n')
 
     expect(pages).toMatch(/Power depends on the expected effect/i)
     expect(pages).toMatch(/confidence interval/i)
     expect(pages).toMatch(/surrogate/i)
     expect(pages).toMatch(/Funding does not automatically invalidate/i)
+    expect(pages).toMatch(/Statistical significance alone is not enough/i)
     expect(pages).toContain('https://pubmed.ncbi.nlm.nih.gov/30132025/')
     expect(pages).toContain('https://pubmed.ncbi.nlm.nih.gov/37380118/')
+    expect(pages).toContain('https://pubmed.ncbi.nlm.nih.gov/20352064/')
+  })
+
+  it('keeps authorship and automated-validation limits explicit on methodology', () => {
+    const methodology = read('app/info/methodology/page.tsx')
+
+    expect(methodology).toContain('Willie B. Randolph III')
+    expect(methodology).toContain('Founder and independent author')
+    expect(methodology).toContain('does not substitute for clinician judgment or independent medical review')
+    expect(methodology).not.toMatch(/collective of neurochemistry researchers/i)
   })
 })

--- a/app/__tests__/evidence-literacy-calibration.test.ts
+++ b/app/__tests__/evidence-literacy-calibration.test.ts
@@ -1,0 +1,34 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const read = (relativePath: string) => fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+
+describe('evidence-literacy methods calibration', () => {
+  it('does not use magic participant thresholds or exaggerated sponsorship multipliers', () => {
+    const pages = [
+      read('app/learn/how-to-read-scientific-studies/page.tsx'),
+      read('app/learn/evidence-literacy/page.tsx'),
+    ].join('\n')
+
+    expect(pages).not.toMatch(/3-4x more likely/i)
+    expect(pages).not.toMatch(/n\s*>\s*80/i)
+    expect(pages).not.toMatch(/n\s*<\s*30/i)
+    expect(pages).not.toMatch(/prove that an herb/i)
+    expect(pages).not.toMatch(/expectation effects dominate/i)
+  })
+
+  it('teaches power, effect precision, surrogate validation, and funding scrutiny instead', () => {
+    const pages = [
+      read('app/learn/how-to-read-scientific-studies/page.tsx'),
+      read('app/learn/evidence-literacy/page.tsx'),
+    ].join('\n')
+
+    expect(pages).toMatch(/Power depends on the expected effect/i)
+    expect(pages).toMatch(/confidence interval/i)
+    expect(pages).toMatch(/surrogate/i)
+    expect(pages).toMatch(/Funding does not automatically invalidate/i)
+    expect(pages).toContain('https://pubmed.ncbi.nlm.nih.gov/30132025/')
+    expect(pages).toContain('https://pubmed.ncbi.nlm.nih.gov/37380118/')
+  })
+})

--- a/app/info/methodology/page.tsx
+++ b/app/info/methodology/page.tsx
@@ -10,13 +10,14 @@ import References from '@/components/References'
 export const metadata: Metadata = {
   title: 'How We Grade Evidence & Methodology',
   description:
-    'Detailed review of The Hippie Scientist evidence grading levels, Conflict of Interest policy, conservative framing rules, and editorial credentials.',
+    'How The Hippie Scientist evaluates supplement evidence, separates mechanism from outcomes, handles uncertainty, and keeps commercial incentives from changing evidence conclusions.',
   alternates: { canonical: '/info/methodology/' },
 }
 
 const METHODOLOGY_REFS = [
-  { n: 1, text: 'Burns PB, et al. (2011). Levels of evidence. Plast Reconstr Surg, 128(1): 305-310.', url: 'https://pubmed.ncbi.nlm.nih.gov/21701348/' },
-  { n: 2, text: 'Ioannidis JPA. (2005). Why most published research findings are false. PLoS Med, 2(8): e124.', url: 'https://pubmed.ncbi.nlm.nih.gov/16060722/' },
+  { n: 1, text: 'Schulz KF, Altman DG, Moher D; CONSORT Group. (2010). CONSORT 2010 statement: updated guidelines for reporting parallel group randomised trials. PLoS Med, 7(3):e1000251.', url: 'https://pubmed.ncbi.nlm.nih.gov/20352064/' },
+  { n: 2, text: 'Lundh A, et al. (2018). Industry sponsorship and research outcome: systematic review with meta-analysis. Intensive Care Med, 44(10):1603-1612.', url: 'https://pubmed.ncbi.nlm.nih.gov/30132025/' },
+  { n: 3, text: 'Manyara AM, et al. (2023). Definitions, acceptability, limitations, and guidance in the use and reporting of surrogate end points in trials: a scoping review. J Clin Epidemiol, 160:83-99.', url: 'https://pubmed.ncbi.nlm.nih.gov/37380118/' },
 ]
 
 export default function MethodologyPage() {
@@ -24,32 +25,32 @@ export default function MethodologyPage() {
     {
       level: 'Strong Evidence',
       badgeColor: 'bg-emerald-100 text-emerald-800 border-emerald-200',
-      description: 'Multiple robust, randomized controlled trials (RCTs) in humans showing consistent, statistically significant positive outcomes. High confidence in reproducibility.',
+      description: 'A comparatively strong body of direct human evidence with acceptable study quality, consistency, precision, and applicability. Statistical significance alone is not enough, and one positive trial does not automatically qualify a profile for the highest-confidence label.',
     },
     {
       level: 'Moderate Evidence',
       badgeColor: 'bg-blue-100 text-blue-800 border-blue-200',
-      description: 'Supported by clinical cohort studies, well-conducted small-scale RCTs, or a single highly powered trial. Good evidence for efficacy, though further research is needed to resolve minor questions.',
+      description: 'Meaningful human evidence exists, but confidence is still limited by factors such as study count, replication, precision, duration, population breadth, or formulation specificity. Claims should stay narrower than they would for a more mature evidence base.',
     },
     {
       level: 'Limited Evidence',
       badgeColor: 'bg-amber-100 text-amber-800 border-amber-200',
-      description: 'Backed primarily by exploratory pilot trials, animal models, or in-vitro cell culture work establishing mechanistic plausibility. Should not be treated as clinically verified.',
+      description: 'Evidence is early, indirect, or materially uncertain. Human data may be sparse, or the case may rely mainly on mechanistic, animal, observational, uncontrolled, or exploratory findings. These sources can support hypotheses but not confident efficacy claims.',
     },
     {
       level: 'Mixed Evidence',
       badgeColor: 'bg-purple-100 text-purple-800 border-purple-200',
-      description: 'Contradictory findings in peer-reviewed clinical studies. Efficacy is highly variable depending on individual neurochemistry, dosage forms, or trial population configurations.',
+      description: 'Human findings are inconsistent or point in different directions. The disagreement is described rather than assigned to an assumed cause unless differences in population, preparation, dose, outcome, or study design are actually supported by the evidence.',
     },
     {
       level: 'Traditional Only',
       badgeColor: 'bg-neutral-100 text-neutral-800 border-neutral-200',
-      description: 'Based solely on historical botanical usage, ethnobotanical reports, or anecdotal case studies. Lacks modern validation via clinical double-blind protocols.',
+      description: 'Historical or ethnobotanical use is documented, but direct modern human evidence for the practical claim is absent or insufficient. Traditional use can guide research questions; it is not treated as demonstrated clinical efficacy.',
     },
     {
       level: 'Insufficient / Risk-Heavy',
       badgeColor: 'bg-rose-100 text-rose-800 border-rose-200',
-      description: 'No credible data to support efficacy, or carries significant toxicological and pharmaceutical interaction risks that outweigh potential benefits.',
+      description: 'Evidence is too weak, indirect, incomplete, or risk-limited to support a confident practical conclusion. Safety concerns and efficacy uncertainty are evaluated separately rather than collapsed into one claim.',
     },
   ]
 
@@ -57,7 +58,7 @@ export default function MethodologyPage() {
     path: '/info/methodology',
     title: 'How We Grade Evidence & Methodology',
     description:
-      'Detailed review of The Hippie Scientist evidence grading levels, conflict-of-interest policy, conservative framing rules, and editorial credentials.',
+      'Detailed review of The Hippie Scientist evidence grading levels, conflict-of-interest policy, conservative framing rules, and editorial workflow.',
     breadcrumbs: [
       { name: 'Home', url: `${SITE_URL}/` },
       { name: 'Methodology', url: `${SITE_URL}/info/methodology/` },
@@ -66,7 +67,7 @@ export default function MethodologyPage() {
       {
         question: 'How does The Hippie Scientist grade evidence?',
         answer:
-          'Evidence grades prioritize clinical human trials, consistency, study design, and reproducibility. Mechanistic, animal, and in-vitro findings are treated as limited or preliminary unless human outcome data support the claim.',
+          'Evidence labels weigh direct human evidence, study design, risk of bias, effect size and precision, consistency, replication, applicability, formulation, and important limitations. Mechanistic, animal, and in-vitro findings are kept separate from demonstrated human outcomes.',
       },
       {
         question: 'Do affiliate links affect evidence grades?',
@@ -76,7 +77,7 @@ export default function MethodologyPage() {
       {
         question: 'Why are some supplement claims framed conservatively?',
         answer:
-          'Supplement evidence often depends on population, dose, preparation, trial duration, and outcome measure. Conservative framing prevents preclinical mechanisms or small exploratory studies from being presented as settled clinical proof.',
+          'Supplement evidence often depends on population, dose, preparation, trial duration, outcome measure, study quality, and replication. Conservative framing prevents mechanisms or exploratory findings from being presented as settled clinical proof.',
       },
     ],
   })
@@ -84,25 +85,24 @@ export default function MethodologyPage() {
   return (
     <div className='container-page py-10 space-y-8 max-w-4xl mx-auto'>
       <SchemaGraphScript graph={schemaGraph} />
-      {/* Hero */}
+
       <section className='hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8 bg-white/95'>
-        <p className='eyebrow-label'>E-E-A-T Editorial Standard</p>
+        <p className='eyebrow-label'>Editorial evidence standard</p>
         <h1 className='mt-2 font-display text-3xl font-bold text-ink sm:text-4xl leading-tight'>
           Evidence Grading &amp; Research Methodology
         </h1>
         <p className='mt-4 text-sm leading-relaxed text-muted sm:text-base'>
-          Supplement science is cluttered with hype. At <strong>The Hippie Scientist</strong>, we operate under a strict, conservative evidence-first framework. We separate preclinical mechanisms from actual human outcomes, ensuring you make choices rooted in clinical science.
+          Supplement science is easy to oversimplify. At <strong>The Hippie Scientist</strong>, clinical outcomes, mechanisms, traditional use, safety data, and product comparability are treated as different evidence questions rather than blended into one confidence claim.
         </p>
       </section>
 
       <TrustMethodologyCallout />
 
-      {/* 1. Evidence Grading Levels */}
       <section className='card-premium p-6 sm:p-8 space-y-6'>
         <div className='space-y-2'>
           <h2 className='text-2xl font-bold tracking-tight text-ink font-display'>How We Grade Evidence</h2>
           <p className='text-sm text-muted'>
-            Every compound, herb, and stack recommendation is assigned an evidence tier to represent our confidence in clinical human trials.
+            Evidence labels are editorial summaries of confidence for a profile or practical claim. They are not mathematical scores, and they do not imply that every statement or cited study on a page has the same certainty.
           </p>
         </div>
 
@@ -120,39 +120,46 @@ export default function MethodologyPage() {
         </div>
       </section>
 
-      {/* 2. Conservative Framing Policies */}
       <section className='card-premium p-6 sm:p-8 space-y-6'>
         <h2 className='text-2xl font-bold tracking-tight text-ink font-display'>Conservative Framing Guidelines</h2>
         <div className='grid gap-6 sm:grid-cols-3 text-sm text-muted'>
           <div className='space-y-2'>
-            <h3 className='font-bold text-ink'>Human Trials Prioritization</h3>
+            <h3 className='font-bold text-ink'>Human outcomes before mechanisms</h3>
             <p className='text-xs leading-relaxed'>
-              We do not extrapolate rodent or test-tube mechanisms into human dosing instructions. If an ingredient only has mechanistic or animal studies, it is marked as having "limited" evidence.
+              Receptor, animal, and cell findings can explain plausibility but do not establish an effective human dose or clinically meaningful benefit. Human outcome evidence is required before mechanism is presented as efficacy.
             </p>
           </div>
           <div className='space-y-2'>
-            <h3 className='font-bold text-ink'>Emphasizing Limitations</h3>
+            <h3 className='font-bold text-ink'>Effect size, precision, and limitations</h3>
             <p className='text-xs leading-relaxed'>
-              We highlight clinical trials limitations, such as small sample sizes, brief study durations, self-reported metrics, and potential biases from industry sponsorships.
+              We look beyond whether a result crosses a statistical-significance threshold. Effect estimates, confidence intervals, missing data, duration, pre-specified outcomes, replication, and risk-of-bias concerns shape the conclusion. CONSORT reporting standards make many of those checks possible. [1]
             </p>
           </div>
           <div className='space-y-2'>
-            <h3 className='font-bold text-ink'>Dosage &amp; Bioavailability</h3>
+            <h3 className='font-bold text-ink'>Preparation and formulation</h3>
             <p className='text-xs leading-relaxed'>
-              Active constituents vary wildly across botanical products. We detail the exact standardized extracts (e.g. KSM-66 for ashwagandha) and bioavailable forms required to replicate clinical results.
+              Botanical studies may use a specific extract, plant part, standardization target, or formulation. We report those details when they affect applicability, but no retail product is described as guaranteed to reproduce a trial result simply because it uses a similar ingredient name.
             </p>
           </div>
         </div>
       </section>
 
-      {/* 3. Conflict of Interest */}
+      <section className='card-premium p-6 sm:p-8 space-y-5'>
+        <h2 className='text-2xl font-bold tracking-tight text-ink font-display'>Other interpretation rules</h2>
+        <div className='space-y-4 text-sm leading-7 text-muted'>
+          <p><strong className='text-ink'>Surrogate endpoints:</strong> A biomarker or intermediate outcome is not automatically equivalent to a patient-important benefit. Surrogates need evidence that they reliably predict the clinical outcome being inferred. [3]</p>
+          <p><strong className='text-ink'>Funding and conflicts:</strong> Industry funding does not automatically invalidate a study, and non-industry funding does not guarantee quality. Sponsor role, author conflicts, protocol transparency, and independent replication are considered as context. Reviews of drug and device research have found industry-sponsored studies more often report favorable efficacy results and conclusions than non-industry-sponsored studies. [2]</p>
+          <p><strong className='text-ink'>Safety is separate from efficacy:</strong> A profile can have comparatively strong efficacy evidence and still require substantial safety caution. Medication interactions, contraindications, pregnancy or breastfeeding considerations, surgery risk, organ-function concerns, and dose uncertainty are reviewed independently of benefit claims.</p>
+        </div>
+      </section>
+
       <section className='card-premium p-6 sm:p-8 space-y-4 border-l-4 border-emerald-600 bg-emerald-50/10'>
         <h2 className='text-2xl font-bold tracking-tight text-ink font-display'>Conflict of Interest &amp; Independence Statement</h2>
         <p className='text-sm leading-relaxed text-muted'>
           <strong>The Hippie Scientist</strong> is independently operated and editorially independent. We do not accept brand sponsorships, paid reviews, or direct compensation from supplement companies. Disclosed affiliate commissions may help support operating costs.
         </p>
         <p className='text-sm leading-relaxed text-muted'>
-          Editorial grades follow the documented evidence criteria on this page. Affiliate relationships do not change evidence grades, safety warnings, or editorial conclusions. If an ingredient carries risk or lacks convincing clinical support, we state that plainly.
+          Affiliate availability cannot raise an evidence grade, erase a safety warning, or convert limited evidence into a recommendation. Product modules are downstream of the evidence and safety review rather than inputs to it.
         </p>
         <div className='pt-2 flex flex-wrap gap-4'>
           <Link href='/info/affiliate-disclosure/' className='text-sm font-semibold text-emerald-800 hover:underline'>
@@ -164,7 +171,6 @@ export default function MethodologyPage() {
         </div>
       </section>
 
-      {/* 4. Author & workflow */}
       <section className='card-premium p-6 sm:p-8 space-y-4 bg-white/95'>
         <h2 className='text-2xl font-bold tracking-tight text-ink font-display'>Author &amp; Editorial Workflow</h2>
         <p className='text-sm leading-relaxed text-muted'>

--- a/app/learn/evidence-hierarchy/page.tsx
+++ b/app/learn/evidence-hierarchy/page.tsx
@@ -5,12 +5,12 @@ import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
 import EvidenceSummaryCard from '@/components/evidence/EvidenceSummaryCard'
 import ReferencedStudies from '@/components/evidence/ReferencedStudies'
 import References from '@/components/References'
-export const metadata: Metadata = buildPageMetadata({
-  title: "Evidence Hierarchy",
-  description: "Educational overview of evidence hierarchy, clinical trials, mechanistic evidence, ethnobotanical context, and scientific interpretation systems.",
-  path: "/learn/evidence-hierarchy/",
-})
 
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Evidence Hierarchy',
+  description: 'Educational overview of evidence hierarchy, clinical trials, mechanistic evidence, ethnobotanical context, and scientific interpretation systems.',
+  path: '/learn/evidence-hierarchy/',
+})
 
 const EVIDENCE_HIERARCHY_REFS = [
   { n: 1, text: 'Burns PB, et al. (2011). The levels of evidence. Plast Reconstr Surg, 128(1): 305-310.', url: 'https://pubmed.ncbi.nlm.nih.gov/21701348/' },
@@ -37,40 +37,54 @@ export default function EvidenceHierarchyPage() {
       <section className="space-y-6 max-w-4xl">
         <div className="space-y-3">
           <p className="eyebrow-label">Scientific Interpretation</p>
-
           <h1 className="font-display text-3xl font-bold tracking-tight text-ink sm:text-4xl lg:text-5xl">
             Evidence Hierarchy
           </h1>
         </div>
 
         <p className="text-xl leading-9 text-muted">
-          Evidence hierarchy systems help contextualize how strongly different types of scientific evidence support educational interpretation, neuropharmacology claims, and recovery-oriented discussions.
+          Evidence hierarchies are useful starting frameworks for matching a study design to the question it can answer. They are not automatic rankings of truth: review quality, risk of bias, directness, precision, consistency, and applicability can raise or lower confidence within any design category.
         </p>
       </section>
 
       <EvidenceSummaryCard
-        title="Meta-analyses and systematic reviews"
+        title="Systematic reviews and meta-analyses"
         evidenceLevel="Strong"
-        humanEvidence="Often considered among the strongest forms of clinical evidence when methodologies are rigorous and reproducible."
-        mechanisticEvidence="May synthesize findings across multiple mechanistic and clinical pathways."
-        safetyProfile="Still dependent on underlying study quality and interpretation limitations."
+        humanEvidence="Can provide high-confidence summaries when the question is well defined, eligible studies are appropriate, methods are transparent, and the underlying evidence is sufficiently trustworthy and comparable."
+        mechanisticEvidence="Can place clinical and mechanistic findings in broader context, but pooled estimates do not repair bias or indirectness in the included studies."
+        safetyProfile="Confidence still depends on the included populations, follow-up, adverse-event reporting, heterogeneity, publication bias, and review methods."
       />
 
       <EvidenceSummaryCard
         title="Randomized controlled trials"
         evidenceLevel="Strong"
-        humanEvidence="Human clinical trials may provide direct evidence regarding effects, tolerability, and measurable outcomes."
-        mechanisticEvidence="Can help validate mechanistic hypotheses in real-world populations."
-        safetyProfile="Sample size, duration, and participant diversity may influence reliability."
+        humanEvidence="Can provide direct causal evidence for the population, intervention, comparator, and outcomes actually studied when randomization and trial conduct are credible."
+        mechanisticEvidence="Can test whether a mechanistically plausible intervention produces measurable human outcomes, but the mechanism itself is not proven by a positive clinical result."
+        safetyProfile="Sample-size adequacy, duration, missing data, participant diversity, outcome selection, adherence, and adverse-event capture all affect confidence."
       />
 
       <EvidenceSummaryCard
-        title="Mechanistic and theoretical evidence"
+        title="Observational human evidence"
         evidenceLevel="Moderate"
-        humanEvidence="Mechanistic evidence alone may not establish clinical relevance."
-        mechanisticEvidence="Useful for understanding receptor systems, signaling pathways, and neurochemical plausibility."
-        safetyProfile="Theoretical mechanisms do not guarantee safety or effectiveness."
+        humanEvidence="Can identify associations, longer-term patterns, uncommon exposures, and real-world signals that trials may not capture."
+        mechanisticEvidence="May help connect biological hypotheses with human patterns, while residual confounding and selection bias can limit causal interpretation."
+        safetyProfile="Especially useful for generating and investigating safety signals, but associations still require careful control of confounding and measurement error."
       />
+
+      <EvidenceSummaryCard
+        title="Mechanistic, animal, and theoretical evidence"
+        evidenceLevel="Preliminary"
+        humanEvidence="Mechanistic or preclinical evidence alone does not establish a clinically meaningful human benefit, an effective oral dose, or long-term safety."
+        mechanisticEvidence="Useful for understanding receptors, signaling pathways, metabolism, pharmacology, and biological plausibility."
+        safetyProfile="A plausible pathway does not guarantee effectiveness or safety in humans."
+      />
+
+      <section className="card-premium max-w-4xl p-6 space-y-3">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Use the hierarchy with the research question</h2>
+        <p className="text-sm leading-7 text-muted">
+          Different designs can be strongest for different questions. Randomized trials are often preferred for causal treatment effects, while observational evidence may be essential for uncommon harms or long-term real-world patterns. A well-conducted study that directly answers the question can be more informative than a nominally “higher” design that is biased, indirect, or built from poor underlying studies.
+        </p>
+      </section>
 
       <ReferencedStudies
         studies={[

--- a/app/learn/evidence-literacy/page.tsx
+++ b/app/learn/evidence-literacy/page.tsx
@@ -17,34 +17,34 @@ export const metadata: Metadata = buildPageMetadata({
 const challenges = [
   {
     title: 'Chemical Complexity',
-    body: 'An herb is not a single chemical entity. For example, Panax ginseng contains over 30 different ginsenosides, each with potentially distinct pharmacology. The interaction of these compounds is often attributed to the "entourage effect," which is difficult to isolate in clinical models.',
+    body: 'Botanical preparations are mixtures rather than single standardized molecules. Different species, plant parts, extracts, and constituent profiles can produce meaningfully different exposures, so results from one preparation should not automatically be generalized to another.',
   },
   {
     title: 'Extract Standardization',
-    body: 'The concentration of active compounds varies based on soil conditions, harvest time, extraction solvents (water vs. ethanol), and drying methods. A study evaluating a raw root powder cannot be easily compared to one using a highly concentrated 10:1 extract.',
+    body: 'Constituent concentrations can vary with cultivation, harvest, processing, solvent, plant part, and manufacturing. A raw powder and a concentrated standardized extract may share a plant name while delivering very different chemical profiles.',
   },
   {
     title: 'Blinding & Organoleptic Properties',
-    body: 'Many herbs have strong, distinctive tastes, odors, or colors (e.g., Valerian root, Garlic, Turmeric). Creating a convincing placebo that matches these organoleptic properties is a significant challenge. If participants or researchers can identify the active herb by smell or taste, the trial is unblinded, introducing bias.',
+    body: 'Distinctive tastes, odors, colors, or sensations can make botanical trials difficult to blind. If participants or study staff can correctly guess treatment assignment, subjective outcomes and study behavior may be more vulnerable to expectation-related bias.',
   },
 ]
 
 const biases = [
   {
-    title: 'Funding Bias',
-    body: 'Studies funded directly by supplement manufacturers are significantly more likely to report positive results than independently funded research. Always review the "Conflict of Interest" disclosures.',
+    title: 'Funding & Conflicts of Interest',
+    body: 'Funding source does not automatically make a study invalid, but sponsor involvement and author conflicts deserve scrutiny. Systematic reviews of drug and device research have found industry-sponsored studies more often report favorable efficacy results and conclusions than non-industry-sponsored studies.',
   },
   {
-    title: 'Publication Bias',
-    body: 'Researchers and journals are far more likely to publish studies showing positive results than studies showing no effect (null results). Consequently, the published literature may look overwhelmingly positive, while dozens of negative trials remain hidden in drawers.',
+    title: 'Publication & Selective-Reporting Bias',
+    body: 'The published record can overrepresent favorable findings when null or unfavorable results are less likely to appear, or when only selected outcomes are emphasized. Trial registration, protocols, and pre-specified outcomes help readers check what was planned before the results were known.',
   },
   {
-    title: 'Expectation and Placebo Effects',
-    body: 'Subjective symptoms like anxiety, fatigue, sleep quality, and focus are highly susceptible to expectancy. If a participant expects an adaptogen to reduce their stress, their subjective rating of stress will often decrease, even on a placebo.',
+    title: 'Expectation and Measurement Bias',
+    body: 'Symptoms such as anxiety, fatigue, sleep quality, pain, and focus are often measured with patient-reported scales because the experience itself matters. Those outcomes are not inherently inferior, but blinding, validated instruments, missing-data handling, and clinically meaningful effect sizes become especially important.',
   },
   {
-    title: 'Self-Reporting Issues',
-    body: 'Many clinical trials rely on subjective questionnaires (e.g., Hamilton Anxiety Rating Scale) filled out by participants. Objective biomarkers (e.g., salivary cortisol levels, heart rate variability) should be measured alongside questionnaires to corroborate findings.',
+    title: 'Outcome Substitution',
+    body: 'Biomarkers and other intermediate outcomes can be useful, but a change in a surrogate does not automatically establish a patient-important benefit. Ask whether the surrogate has been validated for the clinical outcome being inferred.',
   },
 ]
 
@@ -57,7 +57,9 @@ const relatedSystems = [
 
 const EVIDENCE_LITERACY_REFS = [
   { n: 1, text: 'Ioannidis JPA. (2005). Why most published research findings are false. PLoS Med, 2(8): e124.', url: 'https://pubmed.ncbi.nlm.nih.gov/16060722/' },
-  { n: 2, text: 'Button KS, et al. (2013). Power failure in neuroscience. Nat Rev Neurosci, 14(5): 365-376.', url: 'https://pubmed.ncbi.nlm.nih.gov/23571845/' },
+  { n: 2, text: 'Button KS, et al. (2013). Power failure: why small sample size undermines the reliability of neuroscience. Nat Rev Neurosci, 14(5):365-376.', url: 'https://pubmed.ncbi.nlm.nih.gov/23571845/' },
+  { n: 3, text: 'Lundh A, et al. (2018). Industry sponsorship and research outcome: systematic review with meta-analysis. Intensive Care Med, 44(10):1603-1612.', url: 'https://pubmed.ncbi.nlm.nih.gov/30132025/' },
+  { n: 4, text: 'Manyara AM, et al. (2023). Definitions, acceptability, limitations, and guidance in the use and reporting of surrogate end points in trials: a scoping review. J Clin Epidemiol, 160:83-99.', url: 'https://pubmed.ncbi.nlm.nih.gov/37380118/' },
 ]
 
 export default function EvidenceLiteracyPage() {
@@ -71,13 +73,13 @@ export default function EvidenceLiteracyPage() {
       />
       <EducationPageLayout
         title="Evidence Literacy: How to Read and Evaluate Herbal Clinical Trials"
-        description="Evaluating scientific literature on herbs and dietary supplements requires a specific critical lens. Unlike synthetic pharmaceuticals, which typically contain a single, highly purified active ingredient, botanical preparations are chemically complex mixtures containing dozens or hundreds of compounds. This guide outlines how to evaluate clinical trial design, identify common research biases, and understand how the quality of a study translates to final evidence grades."
+        description="Botanical and supplement studies can be difficult to compare because products, constituent profiles, doses, populations, outcomes, and study designs vary. This guide focuses on the questions that determine how much confidence a result deserves rather than relying on one-size-fits-all rules."
       >
         <section className="space-y-6">
           <div className="space-y-2">
             <p className="eyebrow-label">1. The Unique Challenges of Botanical Research</p>
-            <h2 className="text-3xl font-semibold tracking-tight text-ink">Why botanical research is harder than single-molecule pharmaceutical research</h2>
-            <p className="text-sm leading-7 text-muted">Researching botanical substances presents several unique hurdles that do not exist in standard pharmaceutical development:</p>
+            <h2 className="text-3xl font-semibold tracking-tight text-ink">Why the exact preparation matters</h2>
+            <p className="text-sm leading-7 text-muted">A botanical name alone does not guarantee that two interventions are equivalent. Identity, plant part, extraction method, standardization, dose, and quality all affect how directly one study applies to another product.</p>
           </div>
           <div className="grid gap-6 lg:grid-cols-3">
             {challenges.map((item) => (
@@ -90,48 +92,48 @@ export default function EvidenceLiteracyPage() {
         </section>
 
         <TrialDesignInsight designType="In Vitro" title="Mechanistic Plausibility vs. Human Efficacy">
-          Many commercial supplement claims are based on laboratory cell cultures (in vitro research). While in vitro studies are vital for discovering biological mechanisms — such as how a specific compound binds to an adenosine receptor — they cannot predict bioavailability, liver metabolism, or blood-brain barrier penetration in a living human.
+          Cell and biochemical studies can identify plausible pathways and targets, but they do not establish that a swallowed product reaches the relevant tissue at a useful concentration or produces a meaningful benefit in people. Human pharmacokinetics, dose, formulation, and clinical outcomes are separate questions.
         </TrialDesignInsight>
 
         <section className="space-y-6">
           <div className="space-y-2">
             <p className="eyebrow-label">2. Key Elements of Clinical Trial Design</p>
             <h2 className="text-3xl font-semibold tracking-tight text-ink">What to look for when reading a study</h2>
-            <p className="text-sm leading-7 text-muted">To determine if an herb has real-world efficacy, researchers rely on human clinical trials. When reading a study, look for these foundational design features.</p>
+            <p className="text-sm leading-7 text-muted">No single design label settles the question. Read the trial as a chain: who was studied, what exactly was given, what it was compared with, how outcomes were measured, and how much uncertainty remains.</p>
           </div>
           <div className="grid gap-6 lg:grid-cols-2">
             <div className="card-premium p-6 space-y-3">
-              <h3 className="text-xl font-semibold tracking-tight text-ink">Control Groups</h3>
-              <p className="text-sm leading-7 text-muted">A study must compare the active substance against a control group to rule out natural healing, regression to the mean, and placebo effects.</p>
+              <h3 className="text-xl font-semibold tracking-tight text-ink">Comparators and Randomization</h3>
+              <p className="text-sm leading-7 text-muted">For causal treatment questions, a suitable comparison group and sound randomization can reduce important sources of bias. The right comparator depends on the question being asked.</p>
               <ul className="list-disc space-y-2 pl-5 text-sm leading-7 text-muted">
-                <li><strong className="text-ink">Placebo Control:</strong> The gold standard. The control group receives an inert substance (like cellulose or cornstarch) matching the appearance, taste, and smell of the active herb.</li>
-                <li><strong className="text-ink">Active Comparator:</strong> The herb is compared directly to an established standard treatment (e.g., comparing a standardized Lavender extract to a low-dose pharmaceutical anxiolytic).</li>
+                <li><strong className="text-ink">Placebo control:</strong> Helps separate treatment effects from expectations and changes that would have happened anyway when a credible placebo is feasible.</li>
+                <li><strong className="text-ink">Active comparator:</strong> Helps answer whether an intervention performs differently from an established treatment, but interpretation depends on dose, population, and whether the trial was designed for superiority, equivalence, or non-inferiority.</li>
               </ul>
             </div>
             <div className="card-premium p-6 space-y-3">
               <h3 className="text-xl font-semibold tracking-tight text-ink">Blinding</h3>
-              <p className="text-sm leading-7 text-muted">Blinding prevents expectations from coloring the study's outcomes.</p>
+              <p className="text-sm leading-7 text-muted">Blinding can reduce bias when knowledge of treatment assignment could influence behavior, co-interventions, outcome reporting, or assessment.</p>
               <ul className="list-disc space-y-2 pl-5 text-sm leading-7 text-muted">
-                <li><strong className="text-ink">Single-Blind:</strong> Only the participant does not know which treatment they are receiving.</li>
-                <li><strong className="text-ink">Double-Blind:</strong> Neither the participant nor the evaluating researcher knows who has the active compound or the placebo. This prevents researchers from unconsciously offering extra encouragement or interpreting subjective outcomes favorably.</li>
+                <li><strong className="text-ink">Participant blinding:</strong> Most relevant when expectations could change symptoms, adherence, or other behavior.</li>
+                <li><strong className="text-ink">Assessor blinding:</strong> Especially important when outcomes require judgment rather than an automated measurement.</li>
               </ul>
             </div>
           </div>
           <div className="card-premium p-6 space-y-3">
-            <h3 className="text-xl font-semibold tracking-tight text-ink">Sample Size and Statistical Power</h3>
-            <p className="text-sm leading-7 text-muted">Small sample sizes are vulnerable to statistical anomalies. If a study only evaluates 15 participants, a positive outcome in 2 people can skew the results, making it look highly effective. Larger sample sizes (n &gt; 80) provide the statistical power necessary to detect true therapeutic effects and identify rarer side effects.</p>
+            <h3 className="text-xl font-semibold tracking-tight text-ink">Sample Size, Power, and Precision</h3>
+            <p className="text-sm leading-7 text-muted">There is no universal participant-count threshold for a “good” study. Adequacy depends on the expected effect, outcome variability, design, attrition, and analysis plan. Check whether the sample-size calculation was pre-specified and whether confidence intervals are narrow enough to rule out clinically important alternatives.</p>
           </div>
         </section>
 
-        <TrialDesignInsight designType="RCT" sampleSize={120} duration="12 weeks" blinding="Double-blind" control="Placebo-controlled" title="Gold-Standard Design in Botanical Science">
-          A randomized, double-blind, placebo-controlled trial (RCT) with an adequate sample size (e.g., n = 120) and duration (e.g., 12 weeks) is the most reliable method to prove that an herb's physiological effects exceed the baseline placebo response.
+        <TrialDesignInsight designType="RCT" sampleSize={120} duration="12 weeks" blinding="Double-blind" control="Placebo-controlled" title="Strong design does not mean automatic certainty">
+          A randomized, double-blind, placebo-controlled trial can provide strong causal evidence when the randomization works, the intervention and comparator are appropriate, follow-up is adequate, missing data are handled well, and the outcomes answer the question readers care about. The design label is the beginning of appraisal, not the conclusion.
         </TrialDesignInsight>
 
         <section className="space-y-6">
           <div className="space-y-2">
             <p className="eyebrow-label">3. Identifying Common Biases in Supplement Research</p>
-            <h2 className="text-3xl font-semibold tracking-tight text-ink">Structural biases in a multi-billion dollar industry</h2>
-            <p className="text-sm leading-7 text-muted">Because the dietary supplement market is a multi-billion dollar industry, research is often vulnerable to structural biases:</p>
+            <h2 className="text-3xl font-semibold tracking-tight text-ink">Bias changes confidence, not truth by slogan</h2>
+            <p className="text-sm leading-7 text-muted">Potential bias should change how closely you inspect a study and how much confidence you place in it. It should not be used as an automatic rule that a result is true or false.</p>
           </div>
           <div className="grid gap-6 lg:grid-cols-2">
             {biases.map((item) => (
@@ -146,19 +148,19 @@ export default function EvidenceLiteracyPage() {
         <section className="space-y-6">
           <div className="space-y-2">
             <p className="eyebrow-label">4. How Design Quality Dictates Evidence Grades</p>
-            <h2 className="text-3xl font-semibold tracking-tight text-ink">Translating study design into evidence grades</h2>
-            <p className="text-sm leading-7 text-muted">At The Hippie Scientist, we translate clinical design parameters directly into structured evidence grades. This ensures that our claims are supported by the quality of the underlying literature, rather than marketing hype.</p>
+            <h2 className="text-3xl font-semibold tracking-tight text-ink">Translating studies into confidence</h2>
+            <p className="text-sm leading-7 text-muted">The site’s evidence grades are intended to summarize confidence across the body of evidence. Study design matters, but so do directness, consistency, precision, replication, product comparability, and limitations.</p>
           </div>
 
-          <EvidenceGradeRationale grade="A" designMatch="Multiple high-quality human RCTs" riskOfBias="Low" consistency="Consistent">
-            Grade A evidence represents the highest level of confidence. It requires multiple independently replicated, double-blind, placebo-controlled trials in humans, showing consistent positive outcomes with a very low risk of bias. Mechanistic plausibility must be backed by clear human pharmacokinetics.
+          <EvidenceGradeRationale grade="A" designMatch="Multiple high-quality human trials or equivalent strong evidence" riskOfBias="Low" consistency="Consistent">
+            Grade A should reflect a body of direct human evidence with consistent, reasonably precise findings and no major unresolved risk-of-bias or applicability problem. A single positive trial is not enough by itself.
           </EvidenceGradeRationale>
 
-          <EvidenceGradeRationale grade="C" designMatch="Small human RCTs or large cohorts" riskOfBias="Medium" consistency="Mixed">
-            Grade C evidence indicates limited or preliminary confidence. The herb may have demonstrated positive effects in small human trials (e.g., n &lt; 30) or observational cohort studies, but the findings are inconsistent, or the study methodologies suffer from minor blinding or control issues. Further research is required before drawing firm conclusions.
+          <EvidenceGradeRationale grade="C" designMatch="Limited, indirect, or inconsistent human evidence" riskOfBias="Medium" consistency="Mixed">
+            Grade C indicates material uncertainty. Human evidence may exist, but it can be small, indirect, inconsistent, imprecise, formulation-specific, or limited by design problems. The right response is narrower claims and more visible uncertainty—not a universal sample-size cutoff.
           </EvidenceGradeRationale>
 
-          <p className="text-sm leading-7 text-muted">By understanding these criteria, you can look beyond absolute claims ("clinically proven") and evaluate the actual strength of the science, empowering you to make safe, rational, and evidence-informed decisions.</p>
+          <p className="text-sm leading-7 text-muted">When a claim sounds absolute, work backward to the evidence: identify the exact preparation and population, inspect the comparison and outcomes, look at the effect size and uncertainty, and then ask whether independent evidence points in the same direction.</p>
         </section>
 
         <SafetyNotice>
@@ -182,7 +184,17 @@ export default function EvidenceLiteracyPage() {
           </div>
         </section>
 
-        <section className="card-premium p-6 space-y-4 mb-8"><h2 className="text-2xl font-semibold tracking-tight text-ink">Quick guide to study quality</h2><p className="text-sm leading-7 text-muted">Meta-analysis of RCTs is the highest quality. Single RCT: check sample size and funding (industry-funded trials are 3-4x more likely positive). Observational studies show correlation, not causation. Animal studies are hypothesis-generating only. Mechanistic speculation is not evidence. If a supplement claim is supported only by anecdotes, it is indistinguishable from placebo. Demand human RCTs before spending money.</p></section>
+        <section className="card-premium p-6 space-y-4 mb-8">
+          <h2 className="text-2xl font-semibold tracking-tight text-ink">A faster way to appraise a study</h2>
+          <ol className="list-decimal space-y-2 pl-5 text-sm leading-7 text-muted">
+            <li>Define the exact population, intervention, comparator, and outcome.</li>
+            <li>Check randomization, blinding where relevant, attrition, and pre-specified outcomes.</li>
+            <li>Read the effect size and confidence interval rather than stopping at “statistically significant.”</li>
+            <li>Ask whether the measured outcome is meaningful to patients or a validated surrogate.</li>
+            <li>Inspect funding, conflicts of interest, protocol changes, and selective reporting.</li>
+            <li>Compare the result with independent studies and systematic reviews before treating it as established.</li>
+          </ol>
+        </section>
 
         <References refs={EVIDENCE_LITERACY_REFS} />
       </EducationPageLayout>

--- a/app/learn/how-to-read-scientific-studies/page.tsx
+++ b/app/learn/how-to-read-scientific-studies/page.tsx
@@ -6,16 +6,18 @@ import EvidenceSection from '@/components/evidence/EvidenceSection'
 import ReferencedStudies from '@/components/evidence/ReferencedStudies'
 import ResearchLimitations from '@/components/evidence/ResearchLimitations'
 import References from '@/components/References'
-export const metadata: Metadata = buildPageMetadata({
-  title: "How to Read Scientific Studies",
-  description: "Educational overview of scientific interpretation, evidence quality, human trials, mechanistic evidence, and research limitations.",
-  path: "/learn/how-to-read-scientific-studies/",
-})
 
+export const metadata: Metadata = buildPageMetadata({
+  title: 'How to Read Scientific Studies',
+  description: 'Educational overview of scientific interpretation, evidence quality, human trials, mechanistic evidence, and research limitations.',
+  path: '/learn/how-to-read-scientific-studies/',
+})
 
 const HOW_TO_READ_SCIENTIFIC_STUDIES_REFS = [
   { n: 1, text: 'Greenhalgh T. (2014). How to Read a Paper, 5th ed. BMJ Books.', url: '' },
   { n: 2, text: 'Ioannidis JPA. (2005). Why most published research findings are false. PLoS Med, 2(8): e124.', url: 'https://pubmed.ncbi.nlm.nih.gov/16060722/' },
+  { n: 3, text: 'Lundh A, et al. (2018). Industry sponsorship and research outcome: systematic review with meta-analysis. Intensive Care Med, 44(10):1603-1612.', url: 'https://pubmed.ncbi.nlm.nih.gov/30132025/' },
+  { n: 4, text: 'Manyara AM, et al. (2023). Definitions, acceptability, limitations, and guidance in the use and reporting of surrogate end points in trials: a scoping review. J Clin Epidemiol, 160:83-99.', url: 'https://pubmed.ncbi.nlm.nih.gov/37380118/' },
 ]
 
 export default function ReadScientificStudiesPage() {
@@ -46,26 +48,26 @@ export default function ReadScientificStudiesPage() {
         </div>
 
         <p className="text-xl leading-9 text-muted">
-          Scientific interpretation involves evaluating evidence quality, study design, population size, limitations, reproducibility, mechanistic plausibility, and clinical relevance.
+          Scientific interpretation involves evaluating evidence quality, study design, population size, effect estimates, uncertainty, limitations, reproducibility, mechanistic plausibility, and clinical relevance.
         </p>
 
         <p className="text-base leading-8 text-[#5c6b63]">
-          Educational neuropharmacology and ethnobotanical interpretation should remain cautious, evidence aware, and transparent regarding uncertainty and limitations.
+          Educational neuropharmacology and ethnobotanical interpretation should remain cautious, evidence aware, and transparent about uncertainty and what a study can—and cannot—establish.
         </p>
       </section>
 
       <EvidenceSection
         title="Human trials and clinical relevance"
         evidenceLevel="Strong"
-        summary="Human clinical trials generally provide stronger evidence than isolated mechanistic or animal-only findings. Meta-analyses and systematic reviews may offer broader context across multiple studies."
-        limitations="Small sample sizes, short study durations, inconsistent methodologies, and publication bias may still influence interpretation quality."
+        summary="Well-designed human trials can provide direct evidence about outcomes in the populations studied. Systematic reviews and meta-analyses can add broader context when the included studies are sufficiently comparable and trustworthy."
+        limitations="Randomization does not erase every limitation. Sample-size adequacy, missing data, outcome selection, follow-up duration, adherence, selective reporting, conflicts of interest, and applicability to other populations still matter."
       />
 
       <EvidenceSection
         title="Mechanistic evidence"
         evidenceLevel="Moderate"
-        summary="Mechanistic studies may help explain receptor systems, signaling pathways, neurotransmitter interactions, and neurochemical plausibility."
-        limitations="Mechanistic plausibility alone does not prove real-world effectiveness or long-term safety."
+        summary="Mechanistic studies can help explain receptor systems, signaling pathways, metabolism, and biological plausibility."
+        limitations="A plausible mechanism does not by itself establish a meaningful benefit, an effective dose, or long-term safety in humans."
       />
 
       <ReferencedStudies
@@ -91,13 +93,23 @@ export default function ReadScientificStudiesPage() {
       <ResearchLimitations
         limitations={[
           'Single studies should rarely be interpreted in isolation.',
-          'Animal models may not translate directly to humans.',
-          'Many herbal systems still lack large-scale long-term human evidence.',
-          'Publication bias and selective reporting may affect interpretation quality.',
+          'Animal and cell models may clarify mechanisms but do not establish human efficacy.',
+          'Many herbal interventions still lack large, long-duration, independently replicated human trials.',
+          'Publication bias, selective reporting, and conflicts of interest can affect the available evidence base.',
         ]}
       />
 
-      <section className="card-premium p-6 space-y-4 mb-8"><h2 className="text-2xl font-semibold tracking-tight text-ink">Quick red flags in supplement studies</h2><p className="text-sm leading-7 text-muted">Industry funding: manufacturer-funded trials are 3-4x more likely to report positive results. Small sample size: n=20 cannot detect moderate effects. No placebo control: without blinding, expectation effects dominate. Surrogate endpoints: a supplement that lowers a blood marker has not been shown to improve health outcomes. Short duration: 4-week trials cannot assess long-term safety or sustained efficacy. Single study: one positive trial without replication is hypothesis-generating, not confirmatory. If a supplement claim rests on industry-funded, small, short, unreplicated studies using surrogate endpoints, apply extreme skepticism.</p></section>
+      <section className="card-premium p-6 space-y-4 mb-8">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Questions to ask before trusting a result</h2>
+        <div className="space-y-3 text-sm leading-7 text-muted">
+          <p><strong className="text-ink">Was the sample size justified?</strong> A participant count is not good or bad by itself. Power depends on the expected effect, outcome variability, design, attrition, and statistical plan.</p>
+          <p><strong className="text-ink">Was the comparison fair?</strong> Randomization, an appropriate comparator, allocation procedures, and blinding can reduce important biases when they are feasible. Lack of blinding raises concern most when outcomes or decisions are vulnerable to expectations.</p>
+          <p><strong className="text-ink">What outcome was actually measured?</strong> A change in a biomarker or intermediate endpoint is not automatically the same as a patient-important benefit. Surrogate outcomes need evidence that they reliably predict the outcome they are standing in for.</p>
+          <p><strong className="text-ink">How precise and reproducible is the effect?</strong> Look beyond the p-value. Check the effect size, confidence interval, missing data, pre-specified outcomes, replication, and consistency with the broader literature.</p>
+          <p><strong className="text-ink">Who funded the study?</strong> Funding does not automatically invalidate a trial, but conflicts of interest and sponsor involvement deserve scrutiny. Large reviews have found industry-sponsored drug and device studies more often report favorable efficacy results and conclusions than non-industry-sponsored studies.</p>
+          <p><strong className="text-ink">Is the follow-up long enough for the claim?</strong> A short trial can answer a short-term question. It generally cannot establish durability or uncommon long-term harms.</p>
+        </div>
+      </section>
 
       <References refs={HOW_TO_READ_SCIENTIFIC_STUDIES_REFS} />
     </div>

--- a/app/learn/study-design-snapshot/page.tsx
+++ b/app/learn/study-design-snapshot/page.tsx
@@ -49,11 +49,7 @@ export default function StudyDesignSnapshotHubPage() {
           </h1>
         </div>
         <p className="text-lg leading-8 text-muted">
-          Every grade on this site is shorthand for the quality of the human evidence behind a
-          claim. The <strong>Study Design Snapshot</strong> keeps the practical takeaway prominent
-          and tucks the &ldquo;why&rdquo; — trial design and limitations — into an optional,
-          expandable panel. The same component is embeddable inside our structured education
-          content. For the full methodology guide, see{' '}
+          A grade on this site is shorthand for editorial confidence in the evidence behind a claim or profile. The <strong>Study Design Snapshot</strong> keeps the practical takeaway prominent and tucks the “why” — design, population, comparator, duration, precision, and limitations — into an expandable panel. A grade should make the evidence easier to inspect, not replace that inspection. For the broader framework, see{' '}
           <Link href="/learn/evidence-hierarchy/" className="font-semibold text-brand-700 hover:text-brand-800">
             Evidence Hierarchy
           </Link>
@@ -63,52 +59,53 @@ export default function StudyDesignSnapshotHubPage() {
 
       <section className="max-w-4xl space-y-6">
         <h2 className="text-2xl font-semibold tracking-tight text-ink sm:text-3xl">
-          What each grade looks like
+          What different confidence levels can look like
         </h2>
 
         <StudyDesignSnapshot
           grade="Strong"
-          summary="When several large, well-run human trials agree, a claim earns the strongest grade — you can act on it with reasonable confidence."
-          gradeRationale="Multiple large randomized controlled trials and meta-analyses converge on the same direction and rough size of effect."
-          studyType="Multiple RCTs + meta-analysis"
-          population="Large, varied adult samples"
-          participants="Hundreds to thousands pooled"
-          duration="Weeks to months"
-          comparator="Placebo and/or active control"
+          summary="When several well-run human studies point in a similar direction and important limitations are small enough, confidence can be comparatively high — while uncertainty and individual variation still remain."
+          gradeRationale="Multiple direct human studies, ideally including independent replication or trustworthy synthesis, show reasonably consistent and precise findings without a major unresolved risk-of-bias or applicability problem."
+          studyType="Multiple human trials and/or systematic synthesis"
+          population="Relevant human populations"
+          participants="Adequate for the effect and design studied"
+          duration="Long enough for the outcome being claimed"
+          comparator="Appropriate to the research question"
           limitations={[
-            'Even strong evidence describes averages, not individual response.',
-            'Effect sizes can still be modest in practical terms.',
+            'Higher confidence still describes evidence about populations, not a guaranteed individual response.',
+            'A statistically detectable effect can still be small or unimportant in practice.',
+            'Formulation, population, follow-up, and outcome choice can limit how broadly the result applies.',
           ]}
-          context="A strong grade means the effect is real and replicated — not that it will be large for everyone."
+          context="A strong grade means the current evidence supports more confidence in a specific claim; it does not make the effect certain, universal, large, or automatically relevant to every product."
         />
 
         <StudyDesignSnapshot
           grade="Moderate"
-          summary="A handful of small human trials point the same way, but the evidence is thinner — promising, not settled."
-          gradeRationale="A few randomized trials show a consistent signal, but small samples, short durations, or funding concerns limit confidence."
-          studyType="Several small RCTs"
-          population="Modest adult samples"
-          participants="Dozens per trial"
-          duration="4–8 weeks"
-          comparator="Placebo"
+          summary="Human evidence points in a useful direction, but replication, precision, duration, formulation, or study quality still leaves meaningful uncertainty."
+          gradeRationale="Direct human evidence exists, but the body of evidence is not yet as mature or consistent as a higher-confidence grade would require."
+          studyType="One or more relevant human studies"
+          population="Study-specific human samples"
+          participants="Variable; adequacy depends on the design and expected effect"
+          duration="Study-specific"
+          comparator="Depends on the research question"
           limitations={[
-            'Small samples widen the uncertainty around the true effect.',
-            'Short trials cannot speak to long-term use.',
-            'Some trials are industry-funded.',
+            'Imprecise estimates can leave clinically important uncertainty even when a result is statistically significant.',
+            'Short trials generally cannot establish durability or uncommon long-term harms.',
+            'Funding, preparation-specific evidence, or lack of independent replication can affect confidence.',
           ]}
         />
 
         <StudyDesignSnapshot
           grade="Preliminary"
-          summary="The rationale is mostly mechanistic or traditional. Treat it as a hypothesis worth watching, not a recommendation."
-          gradeRationale="Support comes largely from lab, animal, or traditional-use evidence with little or no controlled human data."
-          studyType="Mechanistic / animal / traditional use"
-          population="Pre-clinical or anecdotal"
+          summary="The rationale is early, indirect, mechanistic, traditional, or based on limited human evidence. Treat the claim as uncertain rather than as a recommendation."
+          gradeRationale="Support is dominated by preclinical evidence, uncontrolled observations, traditional-use context, or exploratory human findings that are not sufficient for a confident practical conclusion."
+          studyType="Preclinical, observational, traditional, or exploratory human evidence"
+          population="Depends on the evidence source"
           limitations={[
-            'Mechanistic plausibility frequently fails to translate to human benefit.',
-            'No controlled human trials means effect and safety are unestablished.',
+            'Mechanistic plausibility often does not translate into a meaningful human benefit.',
+            'Sparse or uncontrolled human evidence cannot reliably separate an intervention effect from bias, confounding, or chance.',
           ]}
-          context="A low grade is not a verdict that something does not work — it means the human evidence is not there yet."
+          context="A preliminary grade is not proof that something does not work. It means the available evidence does not yet support a confident efficacy claim."
         />
       </section>
 
@@ -117,9 +114,7 @@ export default function StudyDesignSnapshotHubPage() {
           Why design factors matter
         </h2>
         <p className="text-base leading-8 text-[#5c6b63]">
-          Blinding, a placebo comparator, sample size, and duration are what separate a persuasive
-          trial from a misleading one. The snapshot surfaces these so a grade is never a black box —
-          and so you can judge the evidence for yourself.
+          Randomization, blinding where relevant, comparators, sample-size adequacy, follow-up, missing data, outcome selection, effect estimates, and applicability can all change how much confidence a study deserves. No single checkbox separates a persuasive trial from a misleading one; the snapshot surfaces the factors so the grade is never a black box.
         </p>
       </section>
       <References refs={STUDY_DESIGN_SNAPSHOT_REFS} />


### PR DESCRIPTION
## Summary
- remove unsupported “3–4x more likely positive” sponsorship claims from the research-literacy pages
- remove arbitrary sample-size cutoffs such as `n > 80` / `n < 30`
- replace “RCTs prove” and p-value-first language with calibrated causal-inference, effect-size, precision, and risk-of-bias guidance
- treat patient-reported outcomes as legitimate outcomes that require validated measurement rather than assuming biomarkers are inherently superior
- explain that surrogate endpoints need validation before standing in for patient-important outcomes
- teach effect size, confidence intervals, missing data, pre-specification, replication, applicability, funding, and conflicts of interest as an appraisal chain
- recalibrate the public methodology page so evidence grades depend on directness, study quality, consistency, precision, replication, formulation comparability, and safety context rather than “statistically significant positive outcomes”
- remove unsupported explanations that mixed findings reflect “individual neurochemistry”
- replace language that standardized extracts are “required to replicate” results with preparation-comparability language that does not guarantee product equivalence
- preserve the newer explicit Willie B. Randolph III authorship and documented automated-validation limits on methodology
- reframe the evidence hierarchy as a starting framework rather than an automatic ranking of truth
- rewrite Study Design Snapshots so a “Strong” grade means comparatively higher confidence with remaining uncertainty—not that “the effect is real” or that readers can simply act on it
- add CONSORT, Lundh et al., and Manyara et al. to the relevant reference sets
- expand regression tests so the same methodology shortcuts and categorical grade claims cannot return

## Evidence calibration
The 2018 systematic review/meta-analysis by Lundh et al. found industry-sponsored drug/device studies more often reported favorable efficacy results (RR 1.27) and conclusions (RR 1.34) than non-industry-sponsored studies—not a universal 3–4x multiplier. Surrogate-outcome guidance emphasizes validation and context rather than treating every biomarker change as a clinical benefit. CONSORT reporting guidance reinforces evaluating allocation, participant flow, pre-specified outcomes, effect estimates, uncertainty, adverse events, and transparent reporting rather than relying on a design label or p-value alone.

## Scope
6 files. Educational methods/methodology content only; no supplement efficacy, dose, interaction, safety, or workbook source-of-truth data changed.