### PR TITLE
Make the Evidence Report data-driven instead of hard-coded

### DIFF
--- a/app/__tests__/evidence-report-data-driven.test.ts
+++ b/app/__tests__/evidence-report-data-driven.test.ts
@@ -28,4 +28,17 @@ describe('Evidence Report data integrity', () => {
     expect(client).toContain('A profile grade is not a study count')
     expect(client).toContain('Unclassified does not mean ineffective')
   })
+
+  it('keeps the linked annual article aligned with the generated report', () => {
+    const article = read('content/articles/state-of-supplement-evidence-2026.md')
+
+    expect(article).toContain('the distribution of evidence-grade labels across the herb and compound records currently rendered by the site')
+    expect(article).toContain('[Supplement Evidence Report](/evidence/evidence-report/)')
+    expect(article).not.toContain('816 peer-reviewed')
+    expect(article).not.toContain('Of 816')
+    expect(article).not.toContain('557 compounds')
+    expect(article).not.toContain('~15%')
+    expect(article).not.toContain('Typical Dose')
+    expect(article).not.toContain('all statistics are sourced from our public database')
+  })
 })

--- a/app/__tests__/evidence-report-data-driven.test.ts
+++ b/app/__tests__/evidence-report-data-driven.test.ts
@@ -1,0 +1,31 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const read = (relativePath: string) => fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+
+describe('Evidence Report data integrity', () => {
+  it('derives report counts from runtime records instead of hard-coded study statistics', () => {
+    const page = read('app/evidence/evidence-report/page.tsx')
+    const client = read('app/evidence/evidence-report/EvidenceReportClient.tsx')
+    const combined = `${page}\n${client}`
+
+    expect(page).toContain('getHerbs()')
+    expect(page).toContain('getCompounds()')
+    expect(page).toContain('getRuntimeVisibility(record).canRender')
+    expect(page).toContain('record.evidence_grade')
+    expect(combined).not.toContain('816 peer-reviewed studies')
+    expect(combined).not.toContain("pct: 15")
+    expect(combined).not.toContain("pct: 25")
+    expect(combined).not.toContain("pct: 30")
+    expect(combined).not.toContain('557 compounds')
+  })
+
+  it('labels the distribution as profile-level rather than study-level', () => {
+    const client = read('app/evidence/evidence-report/EvidenceReportClient.tsx')
+
+    expect(client).toContain('It is a profile-level distribution, not a count or grading of individual studies.')
+    expect(client).toContain('A profile grade is not a study count')
+    expect(client).toContain('Unclassified does not mean ineffective')
+  })
+})

--- a/app/evidence/evidence-report/EvidenceReportClient.tsx
+++ b/app/evidence/evidence-report/EvidenceReportClient.tsx
@@ -3,149 +3,141 @@
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
 
-type EvidenceGrade = 'A' | 'B' | 'C' | 'D' | 'Traditional'
+type GradeRow = {
+  label: string
+  count: number
+  pct: number
+}
 
-const gradeData: { grade: EvidenceGrade; label: string; pct: number; color: string; description: string; examples: string }[] = [
-  { grade: 'A', label: 'Strong', pct: 15, color: '#0d6b4e', description: 'Multiple large, independent RCTs with consistent results', examples: 'Creatine, caffeine, melatonin, omega-3s, vitamin D' },
-  { grade: 'B', label: 'Moderate', pct: 25, color: '#1a8a6a', description: 'Smaller RCTs or single large trials; needs replication', examples: 'Ashwagandha, berberine, magnesium, St. John\'s Wort' },
-  { grade: 'C', label: 'Limited', pct: 30, color: '#c9a82d', description: 'Small trials, mixed results, or primarily mechanistic data', examples: 'Rhodiola, saffron, NAC, lion\'s mane' },
-  { grade: 'D', label: 'Preliminary', pct: 20, color: '#d4852a', description: 'Animal studies, cell studies, or single small pilot trials', examples: 'Chaga, turkey tail, most adaptogens' },
-  { grade: 'Traditional', label: 'Traditional', pct: 10, color: '#8b7355', description: 'Historical use without modern clinical trials', examples: 'Many Ayurvedic and TCM herbs' },
-]
+type EvidenceReportClientProps = {
+  profileCount: number
+  gradedCount: number
+  gradeData: GradeRow[]
+}
 
-export default function EvidenceReportClient() {
+function formatPct(value: number) {
+  if (!Number.isFinite(value)) return '0%'
+  if (value >= 10) return `${Math.round(value)}%`
+  return `${value.toFixed(1)}%`
+}
+
+export default function EvidenceReportClient({ profileCount, gradedCount, gradeData }: EvidenceReportClientProps) {
   const [animated, setAnimated] = useState(false)
-  const [activeGrade, setActiveGrade] = useState<EvidenceGrade | null>(null)
+  const unclassifiedCount = Math.max(0, profileCount - gradedCount)
 
   useEffect(() => {
-    setTimeout(() => setAnimated(true), 200)
+    const timer = window.setTimeout(() => setAnimated(true), 200)
+    return () => window.clearTimeout(timer)
   }, [])
 
   return (
     <div className="mx-auto max-w-5xl px-4 py-10 sm:px-6 lg:px-8">
       <div className="space-y-10">
-        {/* Hero */}
         <section className="space-y-4">
+          <p className="eyebrow-label">Generated from current runtime data</p>
           <h1 className="font-display text-4xl font-bold tracking-tight text-ink sm:text-5xl">
             Supplement Evidence Report
           </h1>
-          <p className="max-w-2xl text-lg leading-8 text-muted">
-            We catalogued 816 peer-reviewed studies across 557 compounds and 200+ herbs.
-            Here's what the evidence actually looks like when you grade every study on the same scale.
+          <p className="max-w-3xl text-lg leading-8 text-muted">
+            This report summarizes the evidence-grade labels attached to the {profileCount} herb and compound reference records that are currently renderable in the site runtime. It is a profile-level distribution, not a count or grading of individual studies.
           </p>
         </section>
 
-        {/* Bar Chart */}
-        <section className="rounded-2xl border border-brand-900/10 bg-white p-6 shadow-sm sm:p-8">
-          <h2 className="mb-6 text-xl font-semibold text-ink">Evidence Distribution</h2>
-          <div className="space-y-4">
-            {gradeData.map((item) => (
-              <div
-                key={item.grade}
-                className="group cursor-pointer"
-                onMouseEnter={() => setActiveGrade(item.grade)}
-                onMouseLeave={() => setActiveGrade(null)}
-                onClick={() => setActiveGrade(activeGrade === item.grade ? null : item.grade)}
-                role="button"
-                tabIndex={0}
-                aria-expanded={activeGrade === item.grade}
-                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setActiveGrade(activeGrade === item.grade ? null : item.grade) }}}
-              >
-                <div className="mb-2 flex items-center justify-between text-sm">
-                  <div className="flex items-center gap-3">
-                    <span className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-brand-50 text-xs font-bold text-brand-800">
-                      {item.grade}
-                    </span>
-                    <span className="font-semibold text-ink">{item.label}</span>
-                    <span className="text-muted">{item.pct}% of studies</span>
-                  </div>
-                </div>
-                <div className="relative h-10 w-full overflow-hidden rounded-lg bg-brand-50">
-                  <div
-                    className="h-full rounded-lg transition-all duration-1000 ease-out"
-                    style={{
-                      width: animated ? `${item.pct * 2.5}%` : '0%',
-                      backgroundColor: item.color,
-                      opacity: activeGrade === item.grade ? 1 : activeGrade ? 0.5 : 0.85,
-                    }}
-                  />
-                </div>
-                {activeGrade === item.grade && (
-                  <div className="mt-3 rounded-lg border border-brand-900/10 bg-brand-50/50 p-4 text-sm">
-                    <p className="font-medium text-ink">{item.description}</p>
-                    <p className="mt-1 text-muted">Examples: {item.examples}</p>
-                  </div>
-                )}
-              </div>
-            ))}
+        <section className="grid gap-4 sm:grid-cols-3" aria-label="Evidence report summary">
+          <div className="rounded-2xl border border-brand-900/10 bg-white p-5 shadow-sm">
+            <p className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700">Renderable records</p>
+            <p className="mt-2 text-3xl font-bold text-ink">{profileCount}</p>
+          </div>
+          <div className="rounded-2xl border border-brand-900/10 bg-white p-5 shadow-sm">
+            <p className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700">Explicit grade</p>
+            <p className="mt-2 text-3xl font-bold text-ink">{gradedCount}</p>
+          </div>
+          <div className="rounded-2xl border border-brand-900/10 bg-white p-5 shadow-sm">
+            <p className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700">Unclassified</p>
+            <p className="mt-2 text-3xl font-bold text-ink">{unclassifiedCount}</p>
           </div>
         </section>
 
-        {/* Category Breakdown */}
         <section className="rounded-2xl border border-brand-900/10 bg-white p-6 shadow-sm sm:p-8">
-          <h2 className="mb-6 text-xl font-semibold text-ink">Evidence by Category</h2>
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b border-brand-900/10 text-left">
-                  <th className="pb-3 pr-4 font-semibold text-ink">Category</th>
-                  <th className="pb-3 pr-4 font-semibold text-ink">Strongest Evidence</th>
-                  <th className="pb-3 pr-4 font-semibold text-ink">Weakest Evidence</th>
-                  <th className="pb-3 font-semibold text-ink">Key Gap</th>
-                </tr>
-              </thead>
-              <tbody>
-                {[
-                  ['Adaptogens', 'Ashwagandha (stress)', 'Most adaptogens', 'Only ashwagandha has replicated RCTs'],
-                  ['Cognitive', 'Caffeine, creatine', 'Lion\'s Mane, Bacopa', 'Plausible mechanisms, few large trials'],
-                  ['Metabolic', 'Berberine (glucose)', 'Most fat burners', 'Berberine is the standout'],
-                  ['Sleep', 'Melatonin, magnesium', 'Valerian, passionflower', 'Herbal sleep aids are thin'],
-                  ['Mood', 'St. John\'s Wort', 'Saffron, NAC', 'St. John\'s Wort is well-studied; alternatives need data'],
-                  ['Immune', 'Vitamin D, zinc', 'Elderberry, echinacea', 'Micronutrients > botanicals'],
-                  ['Performance', 'Creatine, caffeine', 'Cordyceps, ashwagandha', 'Sports supplements strongest overall'],
-                ].map(([category, strong, weak, gap]) => (
-                  <tr key={category} className="border-b border-brand-900/5">
-                    <td className="py-3 pr-4 font-medium text-ink">{category}</td>
-                    <td className="py-3 pr-4 text-muted">{strong}</td>
-                    <td className="py-3 pr-4 text-muted">{weak}</td>
-                    <td className="py-3 text-muted">{gap}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+          <div className="max-w-3xl">
+            <h2 className="text-xl font-semibold text-ink">Evidence-label distribution</h2>
+            <p className="mt-2 text-sm leading-6 text-muted">
+              Percentages below are calculated at build time from the current renderable runtime records. They can change when profiles are added, removed, re-reviewed, or reclassified.
+            </p>
           </div>
+
+          {gradeData.length > 0 ? (
+            <div className="mt-7 space-y-5">
+              {gradeData.map((item) => (
+                <div key={item.label}>
+                  <div className="mb-2 flex flex-wrap items-baseline justify-between gap-3 text-sm">
+                    <div className="flex items-baseline gap-3">
+                      <span className="inline-flex min-w-8 justify-center rounded-full bg-brand-50 px-2 py-1 text-xs font-bold text-brand-800">
+                        {item.label}
+                      </span>
+                      <span className="font-semibold text-ink">{item.count} records</span>
+                    </div>
+                    <span className="text-muted">{formatPct(item.pct)}</span>
+                  </div>
+                  <div className="h-3 w-full overflow-hidden rounded-full bg-brand-50" aria-hidden="true">
+                    <div
+                      className="h-full rounded-full bg-brand-700 transition-all duration-700 ease-out"
+                      style={{ width: animated ? `${Math.max(0, Math.min(100, item.pct))}%` : '0%' }}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="mt-6 rounded-xl border border-brand-900/10 bg-brand-50/40 p-4 text-sm text-muted">
+              No evidence-grade labels are available in the current runtime data.
+            </p>
+          )}
         </section>
 
-        {/* Key takeaways */}
         <section className="rounded-2xl border border-brand-900/10 bg-brand-50/50 p-6 sm:p-8">
-          <h2 className="mb-4 text-xl font-semibold text-ink">What This Means</h2>
-          <div className="grid gap-4 sm:grid-cols-3">
-            {[
-              { n: '01', title: 'Most supplements are under-studied', body: '60% have limited, preliminary, or traditional-use evidence only. This doesn\'t mean they don\'t work — it means we don\'t know.' },
-              { n: '02', title: 'The strong-evidence list is short', body: 'Only ~15% of supplements have strong clinical evidence. Start with those if you want certainty.' },
-              { n: '03', title: 'Quality matters as much as evidence', body: 'A supplement with Grade A evidence is useless if the product in the bottle doesn\'t match the product in the study. Verify quality independently.' },
-            ].map((item) => (
-              <div key={item.n} className="flex gap-3">
-                <span className="mt-0.5 shrink-0 font-mono text-sm font-bold text-brand-400">{item.n}</span>
-                <div>
-                  <h3 className="font-semibold text-ink">{item.title}</h3>
-                  <p className="mt-1 text-sm leading-6 text-muted">{item.body}</p>
-                </div>
-              </div>
-            ))}
+          <h2 className="text-xl font-semibold text-ink">How to interpret this report</h2>
+          <div className="mt-4 grid gap-5 sm:grid-cols-2">
+            <div>
+              <h3 className="font-semibold text-ink">A profile grade is not a study count</h3>
+              <p className="mt-2 text-sm leading-6 text-muted">
+                A record’s evidence grade summarizes editorial confidence for that profile. It does not mean every claim or outcome on the page has the same evidence strength.
+              </p>
+            </div>
+            <div>
+              <h3 className="font-semibold text-ink">Distribution is not a product recommendation</h3>
+              <p className="mt-2 text-sm leading-6 text-muted">
+                A higher evidence grade does not establish that an ingredient is appropriate, safe, effective for every goal, or equivalent across products and formulations.
+              </p>
+            </div>
+            <div>
+              <h3 className="font-semibold text-ink">Unclassified does not mean ineffective</h3>
+              <p className="mt-2 text-sm leading-6 text-muted">
+                It means the current runtime record does not expose an explicit evidence-grade label. The underlying page may still contain research context that needs structured review.
+              </p>
+            </div>
+            <div>
+              <h3 className="font-semibold text-ink">The data is regenerated with the site</h3>
+              <p className="mt-2 text-sm leading-6 text-muted">
+                This page no longer relies on manually maintained percentages, fixed study totals, or hand-picked category winners that can drift away from the current library.
+              </p>
+            </div>
           </div>
         </section>
 
-        {/* CTA */}
-        <section className="text-center">
-          <p className="text-muted">
-            This data is updated annually. Full methodology at{' '}
-            <Link href="/info/methodology/" className="font-medium text-brand-700 hover:text-brand-800">/info/methodology</Link>.
-            Read the full report:{' '}
-            <Link href="/state-of-supplement-evidence-2026/" className="font-medium text-brand-700 hover:text-brand-800">
-              State of Supplement Evidence 2026
-            </Link>
+        <section className="rounded-2xl border border-brand-900/10 bg-white p-6 shadow-sm sm:p-8">
+          <h2 className="text-xl font-semibold text-ink">Go deeper</h2>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-muted">
+            Use the methodology and individual profile citations to understand why a specific grade was assigned. Evidence quality, directness, consistency, precision, safety, formulation, and applicability still need claim-level interpretation.
           </p>
+          <div className="mt-5 flex flex-wrap gap-3">
+            <Link href="/info/methodology/" className="rounded-full bg-brand-800 px-5 py-2.5 text-sm font-semibold text-white hover:bg-brand-900">
+              Read methodology
+            </Link>
+            <Link href="/evidence/evidence-checker/" className="rounded-full border border-brand-900/15 px-5 py-2.5 text-sm font-semibold text-ink hover:border-brand-700/30 hover:bg-brand-50">
+              Open evidence lookup
+            </Link>
+          </div>
         </section>
       </div>
     </div>

--- a/app/evidence/evidence-report/page.tsx
+++ b/app/evidence/evidence-report/page.tsx
@@ -1,15 +1,68 @@
 import type { Metadata } from 'next'
 
 import { buildPageMetadata } from '@/src/lib/seo'
+import { getHerbs, getCompounds } from '@/src/lib/runtime-data'
+import { getRuntimeVisibility } from '@/lib/runtime-visibility'
+import type { RuntimeRecord } from '@/src/types/content'
 import EvidenceReportClient from './EvidenceReportClient'
 
 export const metadata: Metadata = buildPageMetadata({
   title: 'Supplement Evidence Report',
-  description: 'Evidence distribution and grading summary across The Hippie Scientist supplement and herb research library.',
+  description: 'Current evidence-label distribution across renderable herb and compound reference records in The Hippie Scientist research library.',
   path: '/evidence/evidence-report/',
   openGraphType: 'article',
 })
 
-export default function EvidenceReportPage() {
-  return <EvidenceReportClient />
+function evidenceLabel(record: RuntimeRecord): string {
+  const grade = String(record.evidence_grade || '').trim()
+  if (grade) return grade
+  return 'Unclassified'
+}
+
+export default async function EvidenceReportPage() {
+  const [herbs, compounds] = await Promise.all([getHerbs(), getCompounds()])
+  const records = ([...herbs, ...compounds] as RuntimeRecord[]).filter((record) => {
+    try {
+      return getRuntimeVisibility(record).canRender
+    } catch {
+      return false
+    }
+  })
+
+  const counts = new Map<string, number>()
+  for (const record of records) {
+    const label = evidenceLabel(record)
+    counts.set(label, (counts.get(label) || 0) + 1)
+  }
+
+  const preferredOrder = ['A', 'B', 'C', 'D', 'Traditional', 'Unclassified']
+  const labels = Array.from(counts.keys()).sort((a, b) => {
+    const aIndex = preferredOrder.indexOf(a)
+    const bIndex = preferredOrder.indexOf(b)
+    if (aIndex !== -1 || bIndex !== -1) {
+      if (aIndex === -1) return 1
+      if (bIndex === -1) return -1
+      return aIndex - bIndex
+    }
+    return a.localeCompare(b)
+  })
+
+  const gradeData = labels.map((label) => {
+    const count = counts.get(label) || 0
+    return {
+      label,
+      count,
+      pct: records.length > 0 ? (count / records.length) * 100 : 0,
+    }
+  })
+
+  const gradedCount = records.length - (counts.get('Unclassified') || 0)
+
+  return (
+    <EvidenceReportClient
+      profileCount={records.length}
+      gradedCount={gradedCount}
+      gradeData={gradeData}
+    />
+  )
 }

--- a/content/articles/state-of-supplement-evidence-2026.md
+++ b/content/articles/state-of-supplement-evidence-2026.md
@@ -1,20 +1,17 @@
 ---
 slug: state-of-supplement-evidence-2026
-title: "State of Supplement Evidence 2026: What 816 Peer-Reviewed Studies Actually Show"
-description: "A data-driven analysis of the supplement evidence landscape — which herbs, compounds, and categories have the strongest clinical evidence, and what the research quality actually looks like when you grade every study."
+title: "State of Supplement Evidence 2026: What the Current Library Can and Can't Show"
+description: "A transparent guide to interpreting the evidence labels in The Hippie Scientist library, including what the live Evidence Report measures, what it does not measure, and why the distribution changes as profiles are reviewed."
 date: '2026-06-30'
-updatedAt: '2026-06-30'
+updatedAt: '2026-08-12'
 author: Will
 category: Research
 evidence_grade: Educational
 keywords:
   - supplement evidence 2026
   - supplement research review
-  - clinical evidence supplements
-  - supplement study analysis
   - evidence-based supplements
-  - supplement clinical trials
-  - state of supplement research
+  - evidence grading
   - supplement science review
 featured_image: ''
 tags:
@@ -25,149 +22,146 @@ tags:
 profile_status: published
 ai_assisted: false
 faqs:
-  - question: "How many supplement studies have strong evidence?"
-    answer: "Of the 816 studies catalogued in our database, approximately 15% provide strong evidence (Grade A: multiple large, independent RCTs with consistent results). Another 25% provide moderate evidence (Grade B: smaller RCTs or single large trials). The remaining 60% provide limited, preliminary, or traditional-use evidence only. This doesn't mean those supplements don't work — it means they haven't been rigorously studied yet."
-  - question: "Which supplement has the strongest evidence?"
-    answer: "Creatine monohydrate has by far the strongest evidence base — hundreds of RCTs confirming efficacy for strength, power, and muscle mass, with emerging data for brain health and depression. Among botanicals, ashwagandha has the most consistent clinical trial data for stress reduction, and berberine has the most replicated metabolic effects. But 'strongest evidence' depends on the specific outcome you're measuring."
-references:
-  - title: "DNA barcoding detects contamination and substitution in North American herbal products"
-    authors: "Newmaster SG, Grguric M, Shanmughanandhan D, Ramalingam S, Ragupathy S"
-    year: "2013"
-    pmid: "24132220"
-    url: "https://pubmed.ncbi.nlm.nih.gov/24132220/"
-  - title: "Variability in potency among commercial preparations of berberine"
-    authors: "Funk RS, Singh RK, Winefield RD, Kandel SE, Ruisinger JF, Moriarty PM, Backes JM"
-    year: "2018"
-    pmid: "28792254"
-    url: "https://pubmed.ncbi.nlm.nih.gov/28792254/"
+  - question: "What does the Supplement Evidence Report measure?"
+    answer: "The live report summarizes evidence-grade labels attached to herb and compound reference records that are currently renderable in the site runtime. It is a profile-level distribution, not a count or grading of individual studies."
+  - question: "Why can the evidence distribution change?"
+    answer: "The report is generated from the current runtime records at build time. Counts can change when profiles are added, removed, re-reviewed, or reclassified."
+  - question: "Does a higher evidence grade mean a supplement is appropriate for everyone?"
+    answer: "No. An evidence grade summarizes editorial confidence for a profile. It does not establish that every claim has the same support, that every product is equivalent, or that an ingredient is safe or appropriate for every person or goal."
 ---
 
 ## TL;DR
 
-**We catalogued 816 peer-reviewed supplement studies across 557 compounds and 200+ herbs.** Only 15% provide strong clinical evidence (multiple large, independent RCTs). Another 25% provide moderate evidence. The majority — 60% — have limited, preliminary, or traditional-use evidence only. This isn't because supplements don't work. It's because most haven't been rigorously studied. **The gap between what's marketed and what's proven is the single biggest problem in the supplement industry — and the reason we built this site.**
+The 2026 Evidence Report now measures something narrower and more defensible than the original version: **the distribution of evidence-grade labels across the herb and compound records currently rendered by the site.**
+
+It does **not** claim that every individual study in the library has been assigned one of those grades. It does not use a fixed study total, a hand-written percentage split, or a static list of “winning” supplements. The live distribution is calculated from the current runtime records and can change as the library changes.
+
+See the current numbers in the [Supplement Evidence Report](/evidence/evidence-report/).
 
 ---
 
-## Why This Report Exists
+## Why the Report Changed
 
-Walk into any supplement aisle and you'll find products claiming to boost immunity, sharpen focus, reduce stress, and optimize every biological function imaginable. The marketing is confident. The science is often not.
+An evidence dashboard should not look dynamic while its headline statistics are actually constants in a page component.
 
-We built The Hippie Scientist to answer one question: **what does the evidence actually show?** Not what traditional use suggests. Not what influencers claim. Not what the mechanism *might* do in theory. What happens when you give real humans a supplement and measure the outcome against a placebo in a properly controlled trial.
+The earlier version of this report used fixed totals and fixed percentages. That created a drift problem: the underlying herb and compound libraries could change while the report continued to display the same numbers. It also blurred two different units of analysis — **profiles** and **studies**.
 
-This report summarizes what we found after cataloguing 816 studies across 557 compounds and 200+ herbs. It's our attempt to map the evidence landscape honestly — including where the evidence is strong, where it's thin, and where it's essentially absent.
+That is now corrected.
 
----
+The live report asks a simpler question:
 
-## The Evidence Landscape: By the Numbers
+> Among the reference records the site can currently render, what evidence-grade labels are explicitly attached to those records?
 
-### Overall Distribution
-
-Of 816 peer-reviewed studies catalogued:
-
-| Evidence Grade | Description | % of Studies | Examples |
-|---------------|-------------|-------------|----------|
-| **A — Strong** | Multiple large, independent RCTs with consistent results | ~15% | Creatine for strength, caffeine for alertness, omega-3s for triglycerides |
-| **B — Moderate** | Smaller RCTs or single large trials; needs replication | ~25% | Ashwagandha for stress, berberine for glucose, lion's mane for cognition |
-| **C — Limited** | Small trials, mixed results, or primarily mechanistic data | ~30% | Rhodiola for fatigue, saffron for depression, NAC for psychiatry |
-| **D — Preliminary** | Animal studies, cell studies, or single small human trials | ~20% | Chaga for immunity, turkey tail for general wellness |
-| **Traditional** | Historical use without modern clinical trials | ~10% | Many Ayurvedic and TCM herbs with centuries of use but no RCTs |
-
-### Evidence Strength by Category
-
-| Category | Strongest Evidence | Weakest Evidence | Notable Gap |
-|----------|-------------------|------------------|-------------|
-| **Adaptogens** | Ashwagandha (stress, cortisol) | Most adaptogens | Only ashwagandha has replicated RCT data |
-| **Cognitive** | Caffeine, creatine (acute) | Lion's Mane, Bacopa | Many plausible mechanisms, few large trials |
-| **Metabolic** | Berberine (glucose, lipids) | Most "fat burners" | Berberine is the standout; most others are weak |
-| **Sleep** | Melatonin, magnesium | Valerian, passionflower | Melatonin data is robust; herbal sleep aids are thin |
-| **Mood** | St. John's Wort (depression) | Saffron, NAC | St. John's Wort is well-studied; alternatives need more data |
-| **Immune** | Vitamin D, zinc | Elderberry, echinacea | Micronutrients have better evidence than botanicals |
-| **Performance** | Creatine, caffeine, beta-alanine | Cordyceps, ashwagandha | Sports supplements have the strongest overall evidence |
+That question can be answered from the runtime data itself.
 
 ---
 
-## The Biggest Gaps in Supplement Research
+## What the Live Report Measures
 
-### 1. Most Botanicals Have Never Been Properly Studied
+The [Evidence Report](/evidence/evidence-report/) currently calculates:
 
-Of the 200+ herbs in our database, fewer than 30 have more than one independent, adequately powered RCT. The majority have either a single small trial, only animal/cell data, or no modern clinical research at all. This doesn't mean they're ineffective — it means we don't know.
+- the number of renderable herb and compound reference records;
+- how many of those records expose an explicit `evidence_grade` label;
+- how many are currently unclassified at that field; and
+- the distribution of the evidence-grade labels that are actually present.
 
-### 2. Quality Control Is Abysmal
+The calculation happens when the site is built, so the report follows the current runtime library instead of relying on manually maintained percentages.
 
-A 2013 DNA barcoding study found that 59% of tested herbal products contained plant species not listed on the label. A 2018 analysis of commercial berberine preparations found potency varied by up to 50% between brands. When the product in the bottle doesn't match the product in the study, the evidence is meaningless.
+### The unit is the profile
 
-### 3. Industry-Funded Research Dominates
+This distinction matters.
 
-The majority of clinical trials on specific branded extracts (KSM-66, Sensoril, etc.) are funded by the companies that sell them. This doesn't automatically invalidate the results — but it does mean independent replication is essential before we can consider the evidence robust.
-
-### 4. Long-Term Safety Data Is Rare
-
-Most supplement trials run 6–12 weeks. For compounds people take daily for years, we have essentially no long-term safety data. The rare but real liver injury signals with ashwagandha and green tea extract are a reminder that "natural" doesn't mean "safe at any dose forever."
-
-### 5. The "Nature's Ozempic" Problem
-
-When a prescription drug gains attention, supplements rush to position themselves as "natural alternatives." Berberine as "nature's Ozempic" is the most prominent example. The mechanisms are completely different (AMPK vs GLP-1), the effect sizes are an order of magnitude apart, and the marketing is misleading. This pattern repeats across categories.
+A profile can contain several claims, outcomes, mechanisms, preparations, populations, and citations. Those pieces may not all have the same evidence strength. A profile-level label is therefore a **summary signal**, not a substitute for reading the claim-level evidence and limitations.
 
 ---
 
-## What Actually Has Strong Evidence: The Short List
+## What the Report Does Not Measure
 
-If you want supplements where the evidence is genuinely strong — multiple large, independent, replicated RCTs — here's the honest short list:
+The report should **not** be read as:
 
-| Supplement | Outcome | Evidence Strength | Typical Dose |
-|-----------|---------|------------------|--------------|
-| Creatine monohydrate | Strength, power, muscle mass | A — Strong | 5 g/day |
-| Caffeine | Alertness, focus, exercise performance | A — Strong | 100–200 mg |
-| Melatonin | Sleep onset (jet lag, shift work) | A — Strong | 0.3–5 mg |
-| Omega-3 (EPA/DHA) | Triglyceride reduction | A — Strong | 2–4 g/day |
-| Vitamin D | Deficiency correction, bone health | A — Strong | 600–4,000 IU/day |
-| Magnesium | Sleep, anxiety (in deficient populations) | B — Moderate | 200–400 mg |
-| Ashwagandha | Stress, cortisol reduction | B — Moderate | 300–600 mg/day |
-| Berberine | Glucose metabolism, lipids | B — Moderate | 1,000–1,500 mg/day |
-| St. John's Wort | Mild-moderate depression | B — Moderate | 900 mg/day |
+- a count of all peer-reviewed studies about supplements;
+- a claim that every cited paper has been individually assigned the profile's grade;
+- a ranking of the “best” supplements;
+- proof that a higher-graded ingredient is effective for every outcome;
+- proof that commercial products are equivalent to the preparations used in research; or
+- a safety clearance for a particular person, medication list, dose, or medical condition.
 
-Everything else in the supplement aisle? The evidence is weaker, thinner, or nonexistent. It might work. It might not. We don't know — and "we don't know" is the most honest answer in most cases.
+Those are separate questions.
 
 ---
 
-## What This Means for You
+## How to Read an Evidence Grade
 
-### If You're a Consumer:
+An evidence label is most useful when it compresses a much larger appraisal without hiding the uncertainty behind it.
 
-1. Start with the Strong/M moderate evidence list above. These are the supplements where you're making an evidence-informed decision rather than gambling.
-2. If you're considering something not on this list, ask: "Would I be satisfied with 'we don't know if this works' as the answer?" If not, skip it.
-3. Verify quality: USP, NSF, or ConsumerLab certification. Without it, you don't know what you're taking.
-4. Talk to your doctor. Especially if you take prescription medications — supplement-drug interactions are real and underappreciated.
+When evaluating a specific claim, the important questions still include:
 
-### If You're a Researcher:
+1. **Directness:** Was the outcome studied in humans, in the population and context relevant to the claim?
+2. **Study design:** Was the comparison appropriate, and were important sources of bias addressed?
+3. **Consistency:** Do independent studies point in the same direction?
+4. **Precision:** Are the effect estimates precise enough to rule out clinically important alternatives?
+5. **Replication:** Has the finding been reproduced beyond one team, one branded extract, or one small trial?
+6. **Formulation:** Is the studied preparation meaningfully comparable with the ingredient or product being discussed?
+7. **Safety:** Do contraindications, interactions, population exclusions, or uncertainty change the practical conclusion?
 
-The biggest opportunities are independent replication trials for botanicals with promising but preliminary data — saffron for depression, lion's mane for cognition, ashwagandha for sleep quality. And long-term safety studies. The evidence base desperately needs both.
-
-### If You're a Journalist or Content Creator:
-
-You're welcome to cite this data. Link to `thehippiescientist.net/articles/state-of-supplement-evidence-2026`. All statistics are sourced from our public database. Attribution appreciated, not required.
-
----
-
-## Methodology
-
-This report is based on our internal database of 816 peer-reviewed studies across 557 compounds and 200+ herbs. Evidence grades are assigned using a standardized rubric:
-
-- **A (Strong):** 3+ independent, adequately powered RCTs with consistent results; or 1+ large, multi-center trial
-- **B (Moderate):** 1–2 RCTs with positive results; needs independent replication
-- **C (Limited):** Small trials, mixed results, or primarily mechanistic data
-- **D (Preliminary):** Animal studies, cell studies, single small pilot trial
-- **Traditional:** Historical use documented; no modern clinical trials identified
-
-Each study is graded on design quality (RCT > controlled > observational > case report), sample size, replication status, and funding source independence. The full methodology is documented at `/info/methodology`.
+A letter or tier is a starting point for those questions, not the final answer.
 
 ---
 
-*This report will be updated annually. Last updated: June 30, 2026. Data covers studies published through Q2 2026.*
+## The Most Important Gaps Are Often Not “Does It Work?”
 
-## Related Articles
+Supplement evidence can be weak in more than one way.
 
-- [How to Choose a Quality Supplement](/articles/how-to-choose-supplement-quality/)
-- [Adaptogenic Compounds: Clinical Evidence](/articles/adaptogenic-natural-compounds/)
-- [Ashwagandha: Stress, Cortisol, and Anxiety](/guides/herbs/ashwagandha/)
-- [Berberine: AMPK Activation and Metabolic Health](/articles/berberine/)
+### Product comparability
+
+A study can be internally sound while still applying only to a specific extract, formulation, constituent profile, or dose. A different commercial product may not reproduce the same exposure.
+
+### Independent replication
+
+A promising result is more convincing when independent researchers reproduce it under comparable conditions. Repetition by the same sponsor, extract, or research group can still be informative, but it does not answer every independence question.
+
+### Long-term safety
+
+Short trials are usually designed to answer short-term questions. They generally cannot establish the frequency of uncommon harms or the safety of years of continuous use.
+
+### Outcome specificity
+
+Evidence for one outcome does not automatically transfer to another. An ingredient can have credible evidence for a narrow endpoint and little evidence for broader marketing claims built around the same mechanism.
+
+### Missing or unstructured evidence labels
+
+An unclassified profile does not mean “ineffective.” It means the current runtime record does not expose an explicit evidence-grade label at the field the report measures. That is a data-quality and review-status signal, not a clinical verdict.
+
+---
+
+## What This Means for Readers
+
+Use the report to understand the **shape of the library**, then move from the profile-level label to the underlying evidence.
+
+For a specific herb or compound:
+
+1. open the profile;
+2. identify the exact outcome being discussed;
+3. check whether the evidence is human, preclinical, traditional, or mechanistic;
+4. read the limitations and safety section;
+5. inspect the cited sources when the decision matters; and
+6. avoid treating an evidence grade as personalized medical advice or as proof that a retail product matches the studied preparation.
+
+For medication combinations or higher-risk contexts, a site-level evidence label is not enough. Use the [Safety Interaction Checker](/safety-checker/) as an educational screen for possible caution flags and review the exact combination with a clinician or pharmacist when appropriate.
+
+---
+
+## Methodology and Reproducibility
+
+The live Evidence Report is intentionally generated from the current runtime records rather than copied from this article.
+
+- [View the current Evidence Report](/evidence/evidence-report/)
+- [Read the evidence methodology](/info/methodology/)
+- [Use the Evidence Lookup](/evidence/evidence-checker/)
+- [Learn how to read scientific studies](/learn/how-to-read-scientific-studies/)
+
+The report should be treated as a snapshot of the site's current structured evidence labels. When the data changes, the distribution should change with it.
+
+---
+
+*Last reviewed: August 12, 2026.*


### PR DESCRIPTION
## Summary
- remove the hard-coded `816 studies / 557 compounds` headline and manually authored 15/25/30/20/10% grade split from the Evidence Report
- calculate the evidence-label distribution at build time from current renderable herb and compound runtime records
- label the report explicitly as a profile-level evidence-grade distribution, not a grading/count of individual studies
- expose renderable, explicitly graded, and unclassified record counts from the current data
- remove hand-picked category winners/losers and fixed evidence percentages that can drift out of sync with the library
- explain that grades are editorial summary labels and do not imply universal efficacy, safety, or product equivalence
- rewrite the linked “State of Supplement Evidence 2026” article so it interprets the generated report rather than repeating fixed `816 / 557 / ~15%` claims
- remove the annual article’s static consumer dose table and its claim that all displayed statistics come from a public database
- add regression tests protecting both the generated report and annual article from stale fixed statistics

## Why
The previous report described itself as a current annual evidence summary but its major statistics and percentages were constants in the React component. The linked annual article repeated those same constants as if they were live dataset outputs. Data rebuilds could therefore change the library without changing either public summary. This patch makes the report self-updating and narrows both pages to what the runtime data actually supports.

## Scope
4 files. No workbook, dose, interaction, safety, or individual evidence-grade source data changed.