### PR TITLE
Fix Safety Checker MAO self-overlap false positive

### DIFF
--- a/src/components/safety/SafetyCheckerClient.tsx
+++ b/src/components/safety/SafetyCheckerClient.tsx
@@ -328,13 +328,31 @@ export default function SafetyCheckerClient({ herbs, compounds }: SafetyCheckerC
       return safetyText.includes('stimulant') || safetyText.includes('insomnia') || safetyText.includes('hypertension') || mechText.includes('stimulant') || mechText.includes('caffeine') || mechText.includes('ephedrine') || mechText.includes('yohimbine') || flags.includes('stimulant')
     })
 
+    const hasDistinctMaoiSupplementOverlap = selectedItems.some((maoiItem, maoiIndex) => {
+      const maoiSafetyText = (maoiItem.safety || '').toLowerCase()
+      const maoiMechText = (maoiItem.mechanism || '').toLowerCase() + ' ' + (maoiItem.mechanisms || []).join(' ').toLowerCase()
+      const maoiFlags = maoiItem.safety_flags || []
+      const isMaoi = maoiSafetyText.includes('maoi') || maoiSafetyText.includes('monoamine oxidase') || maoiMechText.includes('mao inhibitor') || maoiMechText.includes('maoi') || maoiFlags.includes('maoi')
+      if (!isMaoi) return false
+
+      return selectedItems.some((otherItem, otherIndex) => {
+        if (otherIndex === maoiIndex) return false
+        const safetyText = (otherItem.safety || '').toLowerCase()
+        const mechText = (otherItem.mechanism || '').toLowerCase() + ' ' + (otherItem.mechanisms || []).join(' ').toLowerCase()
+        const flags = otherItem.safety_flags || []
+        const isSerotonergic = safetyText.includes('serotonin syndrome') || safetyText.includes('ssri') || safetyText.includes('maoi') || mechText.includes('serotonin reuptake') || mechText.includes('5-ht') || mechText.includes('serotonergic') || mechText.includes('kanna') || flags.includes('serotonergic')
+        const isStimulant = safetyText.includes('stimulant') || safetyText.includes('insomnia') || safetyText.includes('hypertension') || mechText.includes('stimulant') || mechText.includes('caffeine') || mechText.includes('ephedrine') || mechText.includes('yohimbine') || flags.includes('stimulant')
+        return isSerotonergic || isStimulant
+      })
+    })
+
     if (hasMaoiMed && (hasSerotonergicSupp || hasStimulantSupp)) {
       alerts.push({
         type: 'danger',
         title: 'MAOI medication overlap — pharmacist review advised',
         desc: `A selected MAOI medication class overlaps with supplement(s) carrying serotonergic or stimulant signals. MAO inhibitors can have serious medication and dietary interactions, and this ruleset cannot determine whether a specific supplement signal is clinically meaningful. Do not use this screen as clearance; review the exact medicine, supplement, and dose with a pharmacist or prescribing clinician.`
       })
-    } else if (hasMaoiSupp && (hasSerotonergicMed || hasStimulantMed || hasSerotonergicSupp || hasStimulantSupp)) {
+    } else if ((hasMaoiSupp && (hasSerotonergicMed || hasStimulantMed)) || hasDistinctMaoiSupplementOverlap) {
       alerts.push({
         type: 'warning',
         title: 'MAO-related mechanism flag',

--- a/src/components/safety/__tests__/SafetyCheckerClient.mao-distinct.test.tsx
+++ b/src/components/safety/__tests__/SafetyCheckerClient.mao-distinct.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import SafetyCheckerClient from '../SafetyCheckerClient'
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}))
+
+const herbs = [
+  {
+    slug: 'rhodiola-rosea',
+    name: 'Rhodiola Rosea',
+    safety: 'Caution: Mild MAOI-like activity. Avoid with strong stimulants or SSRIs.',
+    mechanism: 'Inhibits monoamine oxidase (MAOI) enzymes.',
+  },
+]
+
+const compounds = [
+  {
+    slug: 'kanna-extract',
+    name: 'Kanna Extract',
+    safety: 'Caution: Serotonergic modulation. Avoid with SSRIs or MAOIs.',
+    mechanism: 'Serotonin reuptake inhibitor. 5-HT signaling increase.',
+  },
+]
+
+function addIngredient(name: string) {
+  const input = screen.getByPlaceholderText(/Type herb or compound/i)
+  fireEvent.focus(input)
+  fireEvent.change(input, { target: { value: name } })
+  fireEvent.click(screen.getByText(name))
+}
+
+describe('SafetyCheckerClient MAO overlap requires a distinct selection', () => {
+  it('does not let one MAOI-tagged supplement satisfy both sides of its own overlap rule', () => {
+    render(<SafetyCheckerClient herbs={herbs} compounds={compounds} />)
+
+    addIngredient('Rhodiola Rosea')
+
+    expect(screen.queryByText(/MAO-related mechanism flag/i)).not.toBeInTheDocument()
+    expect(screen.getByText(/No rule-based overlap flags found/i)).toBeInTheDocument()
+    expect(screen.getByText(/Screening: No rule flags/i)).toBeInTheDocument()
+  })
+
+  it('still flags a MAO-related supplement when a different selected item has a serotonergic signal', () => {
+    render(<SafetyCheckerClient herbs={herbs} compounds={compounds} />)
+
+    addIngredient('Rhodiola Rosea')
+    addIngredient('Kanna Extract')
+
+    expect(screen.getByText(/MAO-related mechanism flag/i)).toBeInTheDocument()
+    expect(screen.getByText(/alongside another serotonergic or stimulant signal/i)).toBeInTheDocument()
+    expect(screen.getByText(/Screening: Caution flags/i)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- fixes the merged Safety Checker rule that allowed one MAOI-tagged supplement to satisfy both sides of its own “alongside another serotonergic or stimulant signal” condition
- requires the supplement-side serotonergic/stimulant signal to come from a distinct selected supplement
- preserves MAOI medication + supplement escalation and genuine multi-supplement MAO overlap behavior
- adds regression coverage for both the single-item no-flag case and the Rhodiola + Kanna caution case

## Why
The current `main` can show an MAO-related caution for a single item such as a MAOI-tagged botanical because `maoi` is also treated as a serotonergic text match. The alert text says “alongside another” signal, so the rule must actually require another selection.

## Scope
2 files: SafetyCheckerClient logic + focused regression test.