### PR TITLE
Restore evidence-report baseline validation

### DIFF
--- a/app/learn/evidence-hierarchy/page.tsx
+++ b/app/learn/evidence-hierarchy/page.tsx
@@ -73,7 +73,7 @@ export default function EvidenceHierarchyPage() {
 
       <EvidenceSummaryCard
         title="Mechanistic, animal, and theoretical evidence"
-        evidenceLevel="Preliminary"
+        evidenceLevel="Limited"
         humanEvidence="Mechanistic or preclinical evidence alone does not establish a clinically meaningful human benefit, an effective oral dose, or long-term safety."
         mechanisticEvidence="Useful for understanding receptors, signaling pathways, metabolism, pharmacology, and biological plausibility."
         safetyProfile="A plausible pathway does not guarantee effectiveness or safety in humans."

--- a/content/articles/state-of-supplement-evidence-2026.md
+++ b/content/articles/state-of-supplement-evidence-2026.md
@@ -21,6 +21,11 @@ tags:
   - data
 profile_status: published
 ai_assisted: false
+references:
+  - title: "Supplement Evidence Report"
+    url: "https://thehippiescientist.net/evidence/evidence-report/"
+  - title: "The Hippie Scientist Evidence Methodology"
+    url: "https://thehippiescientist.net/info/methodology/"
 faqs:
   - question: "What does the Supplement Evidence Report measure?"
     answer: "The live report summarizes evidence-grade labels attached to herb and compound reference records that are currently renderable in the site runtime. It is a profile-level distribution, not a count or grading of individual studies."


### PR DESCRIPTION
Superseded by #2627, which fixes the same two current-main validation failures with the semantically correct supported `Theoretical` evidence badge and direct evidence-method references. #2627 passed the full CI/Build/Site Health/Lighthouse/Fast UI gate set and was merged.