### PR TITLE
Restore baseline evidence-content contracts

### DIFF
--- a/app/learn/evidence-hierarchy/page.tsx
+++ b/app/learn/evidence-hierarchy/page.tsx
@@ -73,7 +73,7 @@ export default function EvidenceHierarchyPage() {
 
       <EvidenceSummaryCard
         title="Mechanistic, animal, and theoretical evidence"
-        evidenceLevel="Preliminary"
+        evidenceLevel="Theoretical"
         humanEvidence="Mechanistic or preclinical evidence alone does not establish a clinically meaningful human benefit, an effective oral dose, or long-term safety."
         mechanisticEvidence="Useful for understanding receptors, signaling pathways, metabolism, pharmacology, and biological plausibility."
         safetyProfile="A plausible pathway does not guarantee effectiveness or safety in humans."

--- a/content/articles/state-of-supplement-evidence-2026.md
+++ b/content/articles/state-of-supplement-evidence-2026.md
@@ -21,6 +21,27 @@ tags:
   - data
 profile_status: published
 ai_assisted: false
+references:
+  - title: "The levels of evidence and their role in evidence-based medicine"
+    authors: "Burns PB, Rohrich RJ, Chung KC"
+    year: "2011"
+    pmid: "21701348"
+    url: "https://pubmed.ncbi.nlm.nih.gov/21701348/"
+  - title: "CONSORT 2010 statement: updated guidelines for reporting parallel group randomised trials"
+    authors: "Schulz KF, Altman DG, Moher D; CONSORT Group"
+    year: "2010"
+    pmid: "20352064"
+    url: "https://pubmed.ncbi.nlm.nih.gov/20352064/"
+  - title: "Industry sponsorship and research outcome: systematic review with meta-analysis"
+    authors: "Lundh A, Lexchin J, Mintzes B, Schroll JB, Bero L"
+    year: "2018"
+    pmid: "30132025"
+    url: "https://pubmed.ncbi.nlm.nih.gov/30132025/"
+  - title: "Definitions, acceptability, limitations, and guidance in the use and reporting of surrogate end points in trials: a scoping review"
+    authors: "Manyara AM, et al."
+    year: "2023"
+    pmid: "37380118"
+    url: "https://pubmed.ncbi.nlm.nih.gov/37380118/"
 faqs:
   - question: "What does the Supplement Evidence Report measure?"
     answer: "The live report summarizes evidence-grade labels attached to herb and compound reference records that are currently renderable in the site runtime. It is a profile-level distribution, not a count or grading of individual studies."


### PR DESCRIPTION
Repairs two current-main baseline failures without weakening any gate:

- uses the supported `Theoretical` badge for mechanistic/animal/theoretical evidence instead of the unsupported `Preliminary` value
- restores structured, relevant references to `state-of-supplement-evidence-2026.md` after the data-driven Evidence Report rewrite removed the article references required by the article-quality gate

The references support the article's appraisal framework (levels of evidence, CONSORT reporting, sponsorship context, and surrogate-endpoint interpretation).