### PR TITLE
Recover main CI after evidence hierarchy type mismatch

### DIFF
--- a/app/learn/evidence-hierarchy/page.tsx
+++ b/app/learn/evidence-hierarchy/page.tsx
@@ -73,7 +73,7 @@ export default function EvidenceHierarchyPage() {
 
       <EvidenceSummaryCard
         title="Mechanistic, animal, and theoretical evidence"
-        evidenceLevel="Preliminary"
+        evidenceLevel="Limited"
         humanEvidence="Mechanistic or preclinical evidence alone does not establish a clinically meaningful human benefit, an effective oral dose, or long-term safety."
         mechanisticEvidence="Useful for understanding receptors, signaling pathways, metabolism, pharmacology, and biological plausibility."
         safetyProfile="A plausible pathway does not guarantee effectiveness or safety in humans."

--- a/content/articles/state-of-supplement-evidence-2026.md
+++ b/content/articles/state-of-supplement-evidence-2026.md
@@ -21,6 +21,22 @@ tags:
   - data
 profile_status: published
 ai_assisted: false
+references:
+  - title: "The levels of evidence and their role in evidence-based medicine"
+    authors: "Burns PB, Rohrich RJ, Chung KC"
+    year: "2011"
+    pmid: "21701348"
+    url: "https://pubmed.ncbi.nlm.nih.gov/21701348/"
+  - title: "CONSORT 2010 Statement: updated guidelines for reporting parallel group randomised trials"
+    authors: "Schulz KF, Altman DG, Moher D; CONSORT Group"
+    year: "2010"
+    pmid: "20352064"
+    url: "https://pubmed.ncbi.nlm.nih.gov/20352064/"
+  - title: "Industry sponsorship and research outcome"
+    authors: "Lundh A, Lexchin J, Mintzes B, Schroll JB, Bero L"
+    year: "2017"
+    pmid: "30132025"
+    url: "https://pubmed.ncbi.nlm.nih.gov/30132025/"
 faqs:
   - question: "What does the Supplement Evidence Report measure?"
     answer: "The live report summarizes evidence-grade labels attached to herb and compound reference records that are currently renderable in the site runtime. It is a profile-level distribution, not a count or grading of individual studies."


### PR DESCRIPTION
Superseded by #2627, which landed the same two recovery fixes on `main`:
- supported Evidence Hierarchy level
- grounded references required by the annual evidence article quality gate

This branch was independently validated with all five PR workflows green before being superseded. Closing to avoid duplicate history.