### PR TITLE
Rebuild peptide guide around current FDA and evidence boundaries

### DIFF
--- a/app/__tests__/peptide-guide-regulatory-integrity.test.ts
+++ b/app/__tests__/peptide-guide-regulatory-integrity.test.ts
@@ -1,0 +1,57 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const ARTICLE = path.join(process.cwd(), 'content/articles/peptides-research-guide.md')
+
+function source() {
+  return fs.readFileSync(ARTICLE, 'utf8').replace(/\s+/g, ' ')
+}
+
+describe('peptide research guide regulatory integrity', () => {
+  it('separates collagen, approved drugs, compounded drugs, and experimental peptides', () => {
+    const text = source()
+
+    expect(text).toContain('Food-derived collagen peptides')
+    expect(text).toContain('FDA-approved peptide drugs')
+    expect(text).toContain('Compounded peptide-containing drugs')
+    expect(text).toContain('Experimental or unapproved peptides')
+    expect(text).toContain('compounded drugs are not FDA-approved')
+  })
+
+  it('does not use misleading off-label or research-chemical legal-status shortcuts', () => {
+    const text = source()
+
+    expect(text).not.toMatch(/not FDA-approved for off-label use/i)
+    expect(text).not.toMatch(/sold legally only as research chemicals/i)
+    expect(text).not.toMatch(/regulatory status as a research chemical only/i)
+    expect(text).not.toMatch(/established clinical records for specific conditions/i)
+    expect(text).not.toMatch(/legitimate clinical applications in medically diagnosed GH deficiency/i)
+  })
+
+  it('keeps current FDA safety uncertainty visible for high-risk peptide claims', () => {
+    const text = source()
+
+    expect(text).toMatch(/BPC-157.*no or only limited safety information/i)
+    expect(text).toMatch(/TB-500.*not identified human exposure data/i)
+    expect(text).toMatch(/ipamorelin.*serious adverse events/i)
+    expect(text).toMatch(/CJC-1295.*limited clinical data/i)
+    expect(text).toMatch(/Compounded drugs are not FDA-approved/i)
+  })
+
+  it('prevents protocolization of experimental peptides', () => {
+    const text = source()
+
+    expect(text).toContain('does not provide injection instructions, reconstitution instructions, cycle schedules, stacks, or personal dosing protocols')
+    expect(text).not.toMatch(/ipamorelin \+ CJC-1295.*protocol/i)
+    expect(text).not.toMatch(/BPC-157.*therapeutic range/i)
+  })
+
+  it('keeps collagen trial doses as study context rather than universal dosing advice', () => {
+    const text = source()
+
+    expect(text).toContain('Trial doses are **study context, not universal personal dosing instructions**')
+    expect(text).not.toMatch(/For any individual interested in connective tissue health.*5[–-]15 g\/day/i)
+    expect(text).not.toMatch(/Adding vitamin C \(500[–-]1000 mg\).*enhances/i)
+  })
+})

--- a/content/articles/peptides-research-guide.md
+++ b/content/articles/peptides-research-guide.md
@@ -102,7 +102,7 @@ That chain does not hold.
 
 For a human treatment claim, the relevant questions are still ordinary evidence questions: **what exact molecule, formulation, route, population, comparator, outcome, duration, and safety monitoring were studied?**
 
-Regulatory status also has to be stated precisely. “Not FDA-approved for off-label use” is not a useful category. *Off-label* use generally refers to use of an **approved drug** outside its approved labeling. A compounded or otherwise unapproved drug does not become FDA-approved because a clinician prescribes it.
+Regulatory status also has to be stated precisely. FDA approval and off-label prescribing are separate concepts. *Off-label* use generally refers to use of an **approved drug** outside its approved labeling. A compounded or otherwise unapproved drug does not become FDA-approved because a clinician prescribes it.
 
 ---
 

--- a/content/articles/peptides-research-guide.md
+++ b/content/articles/peptides-research-guide.md
@@ -1,34 +1,38 @@
 ---
 slug: peptides-research-guide
-title: "Peptides Research Guide: Clinical Evidence, Mechanisms & Safety"
-description: "Evidence-based guide to bioactive peptides covering collagen, growth hormone secretagogues, BPC-157, and thymosin beta-4 — with mechanisms, clinical data, and safety considerations."
+title: "Peptides Research Guide: Collagen, Approved Drugs & Experimental Peptides"
+description: "Evidence-first guide to a confusing peptide landscape: food-derived collagen peptides, FDA-approved peptide drugs, compounded drugs, and experimental peptides such as BPC-157, TB-500, ipamorelin, and CJC-1295."
 date: '2026-06-08'
-updatedAt: '2026-07-05'
+updatedAt: '2026-08-12'
 author: Will
 category: Research
 keywords:
   - peptides
-  - bioactive peptides
-  - BPC-157
-  - collagen peptides
-  - growth hormone secretagogues
-  - peptide therapy
   - peptide research
-  - thymosin
-  - CJC-1295
+  - collagen peptides
+  - BPC-157
+  - TB-500
   - ipamorelin
-  - peptide benefits
-  - peptide side effects
-featured_image: ''
+  - CJC-1295
+  - compounded peptides
+  - peptide safety
+  - peptide evidence
 tags:
   - peptides
-  - performance
-  - recovery
   - evidence review
-  - research
+  - safety
+  - regulation
 profile_status: published
 ai_assisted: false
 references:
+  - title: "Compounding and the FDA: Questions and Answers"
+    authors: "U.S. Food and Drug Administration"
+    year: "2026"
+    url: "https://www.fda.gov/drugs/human-drug-compounding/compounding-and-fda-questions-and-answers"
+  - title: "Certain Bulk Drug Substances for Use in Compounding that May Present Significant Safety Risks"
+    authors: "U.S. Food and Drug Administration"
+    year: "2026"
+    url: "https://www.fda.gov/drugs/human-drug-compounding/certain-bulk-drug-substances-use-compounding-may-present-significant-safety-risks"
   - title: "Collagen peptide supplementation in combination with resistance training improves body composition and increases muscle strength in elderly sarcopenic men: a randomised controlled trial"
     authors: "Zdzieblik D, Oesser S, Baumstark MW, Gollhofer A, König D"
     year: "2015"
@@ -44,365 +48,277 @@ references:
     year: "2018"
     pmid: "29337906"
     url: "https://pubmed.ncbi.nlm.nih.gov/29337906/"
-  - title: "Stable gastric pentadecapeptide BPC 157 in trials for inflammatory bowel disease (PL-10, PLD-116, PL 14736, Pliva, Croatia) and wound healing"
-    authors: "Sikiric P, Seiwerth S, Rucman R, Turkovic B, Rokotov DS, Brcic L, Sever M, Klicek R, Radic B, Drmic D, Ilic S, Kolenc D, Stambolija V, George O, Sijacki A, Krstonijevic Z, Pavlov KH, Dubovecak M, Grigorov GG, Uzun S"
-    year: "2013"
-    pmid: "23930283"
-    url: "https://pubmed.ncbi.nlm.nih.gov/23930283/"
-  - title: "BPC 157 counteracts QTc prolongation induced by haloperidol, fluphenazine, clozapine, olanzapine, quetiapine, sulpiride, and metoclopramide in rats"
-    authors: "Sikiric P, Rucman R, Turkovic B, Rokotov DS, Brcic L, Sever M, Klicek R, Radic B, Drmic D, Ilic S, Kolenc D, Stambolija V"
-    year: "2017"
-    pmid: "28349572"
-    url: "https://pubmed.ncbi.nlm.nih.gov/28349572/"
-  - title: "Ipamorelin, the first selective growth hormone secretagogue"
-    authors: "Raun K, Hansen BS, Johansen NL, Thøgersen H, Madsen K, Ankersen M, Andersen PH"
-    year: "1998"
-    pmid: "9849822"
-    url: "https://pubmed.ncbi.nlm.nih.gov/9849822/"
-  - title: "Growth hormone-releasing hormone and growth hormone secretagogues in normal aging: Fountain of Youth or Pool of Tantalus?"
-    authors: "Garcia JM, Merriam GR, Kargi AY"
-    year: "2013"
-    pmid: "24672499"
-    url: "https://pubmed.ncbi.nlm.nih.gov/24672499/"
-  - title: "The effects of growth hormone-releasing peptide-6 on insulin release and amino acid-induced glucagon secretion in humans"
-    authors: "Arvat E, Gianotti L, Broglio F, Maccario M, Baffoni C, Arvat E, Camanni F, Ghigo E"
-    year: "1997"
-    pmid: "9351474"
-    url: "https://pubmed.ncbi.nlm.nih.gov/9351474/"
-  - title: "Sermorelin: a better approach to management of adult-onset growth hormone insufficiency?"
-    authors: "Walker RF"
-    year: "2006"
-    pmid: "17255569"
-    url: "https://pubmed.ncbi.nlm.nih.gov/17255569/"
-  - title: "Thymosin beta 4 activates integrin-linked kinase and promotes cardiac cell migration, survival and cardiac repair"
-    authors: "Bock-Marquette I, Saxena A, White MD, DiMaio JM, Srivastava D"
-    year: "2004"
-    pmid: "15283668"
-    url: "https://pubmed.ncbi.nlm.nih.gov/15283668/"
-  - title: "The role of thymosin beta 4 in cardiac repair"
-    authors: "Smart N, Riley PR"
-    year: "2008"
-    pmid: "18434030"
-    url: "https://pubmed.ncbi.nlm.nih.gov/18434030/"
-  - title: "Collagen peptides boosts recovery post-exercise: a meta-analysis"
-    authors: "Shaw G, Lee-Barthel A, Ross ML, Wang B, Baar K"
-    year: "2017"
-    pmid: "27852613"
-    url: "https://pubmed.ncbi.nlm.nih.gov/27852613/"
-  - title: "Specific collagen peptides improve joint mobility and reduce knee pain: a 6-month randomized, double-blind, placebo-controlled study"
-    authors: "Clark KL, Sebastianelli W, Flechsenhar KR, Aukermann DF, Meza F, Millard RL, Deitch JR, Sherbondy PS, Albert A"
+  - title: "24-Week study on the use of collagen hydrolysate as a dietary supplement in athletes with activity-related joint pain"
+    authors: "Clark KL, Sebastianelli W, Flechsenhar KR, et al."
     year: "2008"
     pmid: "18416885"
     url: "https://pubmed.ncbi.nlm.nih.gov/18416885/"
-  - title: "BPC-157 and the Central Nervous System: Neuroprotective and Neuroregenerative Effects"
-    authors: "Sikiric P, Seiwerth S, Rucman R, Drmic D, Stupnisek M, Kokot A, Brcic L, Sever M, Klicek R, Radic B, Ilic S, Kolenc D, Pavlov KH"
-    year: "2016"
-    pmid: "26874808"
-    url: "https://pubmed.ncbi.nlm.nih.gov/26874808/"
-  - title: "Growth hormone secretagogue receptor in energy and glucose homeostasis: Therapeutic potential for diabetes and obesity"
-    authors: "Zhang G, Yin X, Qi Y, Pendyala L, Chen J, Hou D, Zhang C"
-    year: "2010"
-    pmid: "21048778"
-    url: "https://pubmed.ncbi.nlm.nih.gov/21048778/"
+  - title: "Stable gastric pentadecapeptide BPC 157 in trials for inflammatory bowel disease and wound healing"
+    authors: "Sikiric P, Seiwerth S, Rucman R, et al."
+    year: "2013"
+    pmid: "23930283"
+    url: "https://pubmed.ncbi.nlm.nih.gov/23930283/"
+  - title: "Ipamorelin, the first selective growth hormone secretagogue"
+    authors: "Raun K, Hansen BS, Johansen NL, et al."
+    year: "1998"
+    pmid: "9849822"
+    url: "https://pubmed.ncbi.nlm.nih.gov/9849822/"
 faqs:
-  - question: "Are peptides safe to use?"
-    answer: "The safety profile varies widely by peptide type. Collagen peptides have an excellent safety record with extensive human clinical data. Research peptides like BPC-157 and thymosin beta-4 have primarily animal data; human trials are limited, and most are not FDA-approved for off-label use. Growth hormone secretagogues (ipamorelin, sermorelin) have established clinical records for specific conditions. Always consult a licensed physician, as unregulated injectable peptides carry infection and contamination risks."
-  - question: "Do collagen peptides actually work for skin and joints?"
-    answer: "Yes — multiple randomized controlled trials and meta-analyses show statistically significant improvements in skin hydration, elasticity, and wrinkle depth, as well as reductions in joint pain, with 2.5–10 g/day supplementation over 8–24 weeks. The effect sizes are moderate but consistent across studies."
-  - question: "What is the difference between BPC-157 and TB-500?"
-    answer: "BPC-157 (Body Protection Compound) is a synthetic peptide derived from a protein found in gastric juice, studied primarily for GI healing and musculoskeletal repair in animal models. TB-500 (Thymosin Beta-4) is a synthetic fragment of the naturally occurring protein thymosin beta-4, studied for cardiac and wound healing applications. Neither has completed human clinical trials, and both are sold legally only as research chemicals, not for human use."
-  - question: "What are growth hormone secretagogues?"
-    answer: "Growth hormone secretagogues (GHS) are peptides or small molecules that stimulate the pituitary gland to release growth hormone. Examples include ipamorelin, sermorelin (GHRH analogs), and GHRP-2/GHRP-6. They work by mimicking ghrelin or growth hormone-releasing hormone. Some have FDA-approved analogs used clinically for growth hormone deficiency; others are used off-label or as research compounds."
+  - question: "Are peptide products FDA-approved?"
+    answer: "It depends on the exact product. Some peptide medicines have FDA-approved applications for specific indications. Food-derived collagen peptides are sold as dietary supplements rather than approved drugs. Compounded drugs are not FDA-approved, and experimental peptides such as BPC-157, TB-500, ipamorelin, and CJC-1295 should not be described as approved simply because they can be found online or through a clinic."
+  - question: "Is BPC-157 proven to heal injuries in humans?"
+    answer: "No. BPC-157 has extensive preclinical literature, but that does not establish human efficacy, dosing, pharmacokinetics, or long-term safety. FDA says it has no or only limited safety information for proposed compounded routes and lacks sufficient information to know whether BPC-157 would cause harm in humans."
+  - question: "Is TB-500 the same as thymosin beta-4?"
+    answer: "No. TB-500 is commonly used to refer to a thymosin beta-4 fragment (LKKTETQ), while full-length thymosin beta-4 is a different molecule studied in separate research programs. FDA says it has not identified human exposure data for drug products containing the TB-500 fragment and lacks important safety information for it."
+  - question: "Are compounded peptides the same as FDA-approved peptide drugs?"
+    answer: "No. FDA states that compounded drugs are not FDA-approved and are not reviewed before marketing for safety, effectiveness, or quality. Compounding can serve a legitimate medical need in specific situations, but approval status and evidence for an approved product cannot be transferred automatically to a compounded product."
 ---
 
-## Introduction
+## Bottom line
 
-Peptides have become one of the most discussed topics in sports medicine, anti-aging research, and regenerative medicine — and one of the most misunderstood. The word "peptide" refers simply to a chain of two or more amino acids linked by peptide bonds. Proteins are peptides; insulin is a peptide; the signaling molecules that regulate growth, hunger, and tissue repair are peptides. The supplement and clinical research landscape encompasses a wide spectrum ranging from well-characterized collagen peptides with robust RCT data, to experimental growth hormone secretagogues used in endocrinology clinics, to largely unregulated research compounds like BPC-157 that have compelling animal data but very limited human trial evidence.
+**“Peptide” is a chemical description, not an evidence grade or a regulatory category.** A collagen hydrolysate sold as a dietary supplement, an FDA-approved peptide medicine, a pharmacy-compounded drug, and an experimental injectable peptide can all contain peptides while having completely different evidence, manufacturing, legal, and safety contexts.
 
-This article systematically reviews the research on the most commonly discussed peptide categories: collagen peptides, growth hormone secretagogues (GHS), body protection compound (BPC-157), thymosin beta-4 (TB-500), and related compounds. For each, we examine the proposed mechanisms, the quality and strength of the available evidence, the clinical applications where evidence exists, and the safety and regulatory context. Citations are drawn from PubMed-indexed peer-reviewed literature, NIH-supported research, and government databases.
+That distinction is the most important thing to understand before comparing peptide claims.
 
-Understanding the hierarchy of evidence is essential when evaluating peptide research. A randomized, double-blind, placebo-controlled trial (RCT) in humans provides the highest quality of causal evidence. Observational studies, case series, and animal studies form a lower tier. Much of the compelling peptide research — particularly for BPC-157 — sits at the animal study level, which makes mechanistic extrapolation to humans speculative. Where human RCT data exists (collagen peptides, sermorelin), the evidence is considerably stronger and supports more confident clinical conclusions.
+This guide therefore separates four categories:
 
----
-
-## What Are Peptides? Biology and Classification
-
-Peptides are defined by their length: conventionally, chains of 2–50 amino acids are peptides; longer chains are proteins, though the boundary is not fixed. Biologically, peptides function as hormones, neurotransmitters, growth factors, antimicrobial agents, and signaling molecules. The human genome encodes thousands of peptides with regulatory functions.
-
-### Endogenous vs. Exogenous Peptides
-
-**Endogenous peptides** are produced naturally by the body. Examples include:
-- **Insulin** (51 amino acids) — regulates glucose uptake
-- **Glucagon** (29 amino acids) — raises blood glucose
-- **Growth hormone** (191 amino acids, technically a protein) — promotes growth and metabolism
-- **Ghrelin** (28 amino acids) — appetite-stimulating peptide secreted by the stomach
-- **Thymosin beta-4** — actin-sequestering peptide with roles in wound healing and tissue repair
-
-**Exogenous peptides** are taken from outside the body — either through food, oral supplements, or injection. Collagen peptides consumed orally are absorbed as short-chain amino acids and dipeptides; they do not function like a drug but rather supply raw material for endogenous collagen synthesis. Injectable peptides like growth hormone secretagogues or BPC-157 operate via receptor-mediated pharmacological mechanisms and carry a fundamentally different risk and evidence profile.
-
-### Peptide Stability and Delivery
-
-A key pharmacological challenge with peptides is bioavailability. Most peptides are rapidly degraded by gastrointestinal proteases when taken orally. This is why:
-- Collagen peptides are specifically hydrolyzed to be stable and bioavailable when consumed orally
-- Growth hormone secretagogues are typically injected subcutaneously to bypass first-pass degradation
-- Pharmaceutical peptides like insulin require injection for the same reason
-
-Research into oral peptide delivery — including enteric coatings, nanoparticle encapsulation, and cyclization — is active but has not yet yielded widely available commercial products with proven clinical efficacy matching injectable forms.
+1. **Food-derived collagen peptides** — dietary-supplement products with human randomized trials for selected outcomes.
+2. **FDA-approved peptide drugs** — prescription products whose approval applies to a specific product, indication, dose, route, and labeling.
+3. **Compounded peptide-containing drugs** — drugs prepared for particular medical needs under compounding law; **compounded drugs are not FDA-approved** and FDA does not pre-review them for safety, effectiveness, or quality.
+4. **Experimental or unapproved peptides** — substances such as BPC-157, the TB-500 thymosin-beta-4 fragment, ipamorelin, and CJC-1295, where online availability or clinic marketing should not be mistaken for FDA approval or established human efficacy.
 
 ---
 
-## Collagen Peptides: The Best-Evidenced Category
+## Why the category distinction matters
 
-Collagen is the most abundant protein in the human body, constituting the structural scaffold of skin, bone, cartilage, tendons, and ligaments. It is synthesized from procollagen precursors by fibroblasts and chondrocytes, in a process requiring vitamin C, zinc, copper, and specific amino acids — primarily glycine, proline, and hydroxyproline.
+A common peptide-marketing shortcut is to move evidence across categories:
 
-Collagen peptides (also called hydrolyzed collagen or collagen hydrolysate) are derived from animal sources — bovine, marine, or porcine — by enzymatic hydrolysis that breaks the protein into short-chain peptides of 2–9 amino acids. These short fragments are absorbed across the intestinal wall, enter systemic circulation, and accumulate in connective tissue.
+- an endogenous peptide has an important biological role;
+- an animal experiment shows an interesting mechanism;
+- a different peptide drug has an approved medical use;
+- therefore an unapproved peptide sold online is described as “clinically used,” “regenerative,” or “proven.”
 
-### Mechanism: How Collagen Peptides Work
+That chain does not hold.
 
-The mechanism by which collagen peptides exert biological effects involves two pathways:
+For a human treatment claim, the relevant questions are still ordinary evidence questions: **what exact molecule, formulation, route, population, comparator, outcome, duration, and safety monitoring were studied?**
 
-**1. Substrate supply:** Collagen peptides are particularly rich in glycine (~33% by weight), proline, and hydroxyproline — the three amino acids most critical to collagen triple-helix formation. Supplementation increases the availability of these specific building blocks for fibroblast and chondrocyte collagen synthesis.
-
-**2. Cell signaling:** Specific dipeptides and tripeptides derived from collagen hydrolysis — particularly hydroxyproline-containing fragments — have been shown in vitro to stimulate fibroblast proliferation and increase collagen type I synthesis directly. This suggests collagen peptides act as partial agonists at fibroblast receptors, functioning more like bioactive signaling molecules than passive amino acid sources.
-
-### Clinical Evidence: Skin
-
-Proksch et al. (2014, PMID 24401291) conducted a randomized, double-blind, placebo-controlled study in 69 women aged 35–55, examining the effects of 2.5 g/day bioactive collagen peptides for 8 weeks versus placebo on skin elasticity, moisture, and wrinkle depth. The collagen peptide group showed a statistically significant 15% improvement in skin elasticity (p < 0.05), a 20% reduction in eye wrinkle depth on ultrasound measurement, and improved skin moisture retention. These effects persisted at 4-week post-supplementation follow-up, suggesting durable changes in the dermal extracellular matrix rather than transient hydration effects.
-
-Meta-analyses of collagen peptide supplementation for skin aging (multiple RCTs pooled) consistently find moderate but statistically significant improvements in skin hydration, elasticity, and wrinkle depth at doses of 2.5–10 g/day. The effect sizes are comparable to those achieved with topical retinoids but without the irritation profile.
-
-### Clinical Evidence: Joints
-
-Clark et al. (2008, PMID 18416885) conducted a 24-week, randomized, double-blind study in 147 athletes at Penn State University examining 10 g/day collagen hydrolysate versus placebo on joint pain at rest, during activity, and after exercise, measured by visual analog scale. The collagen peptide group showed statistically significant improvements in joint pain at rest (p < 0.05), during ambulation (p < 0.05), and with activity (p < 0.05), with the greatest absolute differences seen in knee pain with activity. This was an athlete population, suggesting potential utility for both clinical and performance-oriented joint protection.
-
-Shaw et al. (2017, PMID 27852613) demonstrated in an RCT that 15 g/day collagen peptides combined with vitamin C taken one hour before exercise led to significantly higher collagen synthesis markers (blood aminoterminal propeptide of collagen type I — N-terminal telopeptide) compared to placebo, along with improvements in collagen fibril formation in engineered ligament models ex vivo. This provides mechanistic support for pre-exercise collagen loading as a joint protection strategy.
-
-### Clinical Evidence: Muscle and Body Composition
-
-Zdzieblik et al. (2015, PMID 26353786) enrolled 53 elderly sarcopenic men in a 12-week randomized, double-blind, placebo-controlled trial comparing 15 g/day collagen peptides plus resistance training against resistance training alone. The collagen peptide group showed significantly greater gains in fat-free mass (+4.2 kg vs. +2.9 kg, p < 0.05) and greater loss of fat mass, as well as increased muscle strength (leg press, p < 0.05). This result suggests collagen peptides may synergize with resistance training for muscle hypertrophy and fat loss, particularly in older populations with compromised collagen synthetic capacity.
-
-### Clinical Evidence: Bone
-
-König et al. (2018, PMID 29337906) randomized 102 postmenopausal women with primary osteopenia to 5 g/day specific collagen peptides or placebo for 12 months. Bone mineral density at the spine increased significantly in the collagen group (+3.16% vs. −0.03% for placebo, p < 0.05), and bone marker profiles showed increased bone formation (procollagen type I N-terminal propeptide) and decreased bone resorption (C-terminal telopeptide of collagen type I). This is one of the stronger intervention studies in bone health for any natural compound.
-
-### Summary Table: Collagen Peptide Evidence
-
-| Outcome | # RCTs | Dose | Duration | Effect Size | Quality |
-|---|---|---|---|---|---|
-| Skin elasticity/wrinkles | 8+ | 2.5–10 g/day | 8–24 wk | Moderate | Moderate–High |
-| Joint pain | 4+ | 10 g/day | 12–24 wk | Moderate | Moderate |
-| Muscle (elderly) | 2 | 15 g/day | 12 wk | Moderate | Moderate |
-| Bone mineral density | 1 | 5 g/day | 12 mo | Moderate | Moderate |
+Regulatory status also has to be stated precisely. “Not FDA-approved for off-label use” is not a useful category. *Off-label* use generally refers to use of an **approved drug** outside its approved labeling. A compounded or otherwise unapproved drug does not become FDA-approved because a clinician prescribes it.
 
 ---
 
-## Growth Hormone Secretagogues
+## Category 1: food-derived collagen peptides
 
-Growth hormone secretagogues (GHS) are a class of peptides and small molecules that stimulate the pituitary gland to release endogenous growth hormone (GH). Unlike direct GH administration, GHS preserve the pulsatile, physiological pattern of GH release and do not shut down the hypothalamic-pituitary-somatotropic axis. This distinction has important implications for safety and clinical appropriateness.
+Hydrolyzed collagen is a protein-derived dietary ingredient, not an injectable “peptide therapy.” Human randomized trials have examined specific collagen products for skin, joint symptoms, bone markers or density, and body composition in selected populations.
 
-### The GH Axis: A Brief Primer
+### What the trials can support
 
-Growth hormone is released from the anterior pituitary in pulsatile bursts — primarily during deep slow-wave sleep — in response to two upstream signals:
+| Trial context | Studied intervention | What it can reasonably tell us |
+|---|---|---|
+| Women ages 35–55; skin outcomes | 2.5 g/day of a specific bioactive collagen-peptide product for 8 weeks | Product-specific evidence for selected skin measurements; not proof that every collagen powder produces the same result. |
+| Athletes with activity-related joint pain | 10 g/day collagen hydrolysate for 24 weeks | A signal for some joint-pain outcomes in that population; not a treatment claim for arthritis or structural joint repair. |
+| Older men with sarcopenia plus resistance training | 15 g/day collagen peptides for 12 weeks | The tested collagen + training program improved several body-composition/strength outcomes relative to placebo + training; it does not make collagen a complete-protein substitute. |
+| Postmenopausal women with osteopenia | 5 g/day specific collagen peptides for 12 months | Product- and population-specific bone-density/marker evidence; not a universal osteoporosis treatment protocol. |
 
-- **Growth hormone-releasing hormone (GHRH)** from the hypothalamus — stimulates GH release
-- **Somatostatin** from the hypothalamus — inhibits GH release
-- **Ghrelin** (and its receptor, GHSR-1a) — potently stimulates GH release, primarily from the stomach but also expressed centrally
+### Important limits
 
-GHS work by mimicking either GHRH (GHRH analogs: sermorelin, tesamorelin, CJC-1295) or ghrelin (GHRPs: ipamorelin, GHRP-2, GHRP-6, hexarelin). Some protocols combine both a GHRH analog and a GHRP to achieve synergistic GH release.
+Collagen products vary in source, molecular-weight distribution, manufacturing, co-ingredients, and studied formulation. Trial doses are **study context, not universal personal dosing instructions**.
 
-### Sermorelin
+Collagen is also an incomplete protein and should not be framed as interchangeable with adequate dietary protein for muscle protein synthesis.
 
-Sermorelin (GHRH 1–29 NH₂) is the synthetic form of the first 29 amino acids of endogenous GHRH. It was FDA-approved in 1990 for the diagnosis of GH deficiency and later for treatment of idiopathic GH deficiency in children. It is sometimes used off-label by clinicians for adult GH deficiency and age-related GH decline.
+The most defensible conclusion is narrow: **specific collagen preparations have human trial evidence for some outcomes, but the result belongs to the studied product and population.**
 
-Walker (2006, PMID 17255569) reviewed the pharmacology and clinical use of sermorelin, noting that because it stimulates the pituitary through the natural GHRH receptor, GH release remains subject to the normal feedback loops from IGF-1 and somatostatin — a built-in safety mechanism absent with direct GH injection. Clinical effects include improvements in body composition, sleep quality, energy, and lean mass in GH-deficient adults, with fewer adverse effects than exogenous GH. The main limitation is that pituitary responsiveness must be preserved for sermorelin to be effective.
+---
+
+## Category 2: FDA-approved peptide drugs
+
+There are many FDA-approved medicines that are peptides or peptide-related molecules. Approval, however, attaches to a particular drug product and labeled use—not to the idea of “peptide therapy” as a class.
+
+Sermorelin is a useful example of why historical and current status must not be blurred. FDA records show that Geref (sermorelin acetate) received a marketing approval for pediatric growth-hormone-deficiency use in the 1990s. That historical approval does **not** mean every current sermorelin product marketed by a clinic or online seller is itself an FDA-approved product, nor does it establish anti-aging, body-composition, or wellness claims.
+
+Likewise, evidence or approval for one growth-hormone-axis drug cannot be transferred to ipamorelin or CJC-1295 merely because they affect related signaling.
+
+### Approval is product-specific
+
+When a peptide claim invokes “FDA-approved peptide therapy,” ask:
+
+- What is the exact approved product?
+- Is the molecule the same?
+- Is the route the same?
+- What indication is on the label?
+- Is the product being discussed actually the approved product, or a compounded/unapproved preparation?
+
+Those questions prevent approval-by-association.
+
+---
+
+## Category 3: compounded peptide-containing drugs
+
+FDA is explicit: **compounded drugs are not FDA-approved.** The agency does not review compounded drugs before marketing to verify safety, effectiveness, or quality.
+
+Compounding can meet a legitimate medical need—for example, when an FDA-approved product cannot meet an individual patient’s needs—but that is different from saying a compounded drug has passed the FDA approval process.
+
+Poor compounding can also create separate risks such as contamination, incorrect strength, sterility failures, or other quality problems. Those manufacturing risks matter especially for injectable products.
+
+### “Available from a clinic” is not an evidence tier
+
+A prescription, clinic offering, or compounded vial does not by itself establish:
+
+- FDA approval;
+- efficacy for the promoted outcome;
+- equivalence to an approved drug;
+- sterility or potency beyond the applicable manufacturing controls; or
+- long-term safety.
+
+For public-facing health content, the safest rule is simple: **describe approval, compounding status, and evidence separately.**
+
+---
+
+## Category 4: experimental and unapproved peptides
+
+### BPC-157
+
+BPC-157 is heavily discussed for tendon, muscle, gastrointestinal, neurological, and wound-healing claims. Much of the literature is **preclinical**, including rodent injury models and mechanistic work.
+
+That literature can support research hypotheses. It does not establish human injury-healing efficacy, a human dose, pharmacokinetics, or long-term safety.
+
+FDA’s current compounding safety-risk page states that compounded drugs containing BPC-157 may present immunogenicity and peptide-impurity/API-characterization concerns. FDA says it has **no or only limited safety information for the proposed routes** and lacks sufficient information to know whether BPC-157 would cause harm in humans.
+
+That is a materially different message from “promising animal data plus no known toxicity.” Absence of established human harm is not evidence of human safety.
+
+#### What not to infer from animal studies
+
+Rodent findings involving angiogenesis, nitric-oxide signaling, tendon healing, gastric injury, CNS models, or drug-induced QT changes do not establish that BPC-157 will heal a human tendon, protect a human heart, treat IBD, or improve mood.
+
+Animal evidence is hypothesis-generating here.
+
+### TB-500 and thymosin beta-4 are not interchangeable labels
+
+Full-length thymosin beta-4 is a naturally occurring 43-amino-acid peptide studied in a variety of preclinical and early research contexts.
+
+**TB-500**, in FDA’s compounding safety material, refers to the thymosin beta-4 fragment **LKKTETQ**. Evidence about full-length thymosin beta-4 should not be silently presented as clinical evidence for the TB-500 fragment.
+
+FDA says it has **not identified human exposure data for drug products containing the TB-500 fragment** and lacks important information about whether it would cause harm in humans. It also flags potential immunogenicity, aggregation, and peptide-related impurity concerns.
+
+That makes claims such as “excellent safety record” or “human cardiac trials support TB-500” inappropriate unless the exact molecule and product are matched.
 
 ### Ipamorelin
 
-Ipamorelin is a pentapeptide (Aib-His-D-2-Nal-D-Phe-Lys-NH₂) that selectively activates the ghrelin receptor (GHSR-1a) to stimulate GH release without significantly increasing cortisol, prolactin, or ACTH — a key selectivity advantage over earlier GHRPs like GHRP-2 or GHRP-6, which produce more broad hormonal stimulation.
+Ipamorelin is a growth-hormone secretagogue with older pharmacology research, including animal characterization and limited human research in specific contexts. That is not the same as an established wellness or anti-aging treatment.
 
-Raun et al. (1998, PMID 9849822) characterized ipamorelin as the first selective GH secretagogue, demonstrating in animal studies that it produced a robust GH pulse comparable to GHRP-6 while having minimal effect on cortisol and prolactin — a profile suggesting greater clinical tolerability. Garcia, Merriam, and Kargi (2013, PMID 24672499) reviewed the use of GHS in aging, noting that the blunted GH secretion in older adults (somatopause) correlates with sarcopenia, increased adiposity, and reduced quality of life, and that GHS may partially restore pulsatile GH secretion without the risks associated with supraphysiological GH replacement.
+FDA currently lists **ipamorelin acetate** in its category of bulk substances that may present significant safety risks for compounding. The agency highlights immunogenicity/impurity concerns and notes serious adverse events, including deaths, in a study involving intravenous administration for gastric-motility purposes. FDA also says it lacks enough safety information for certain other injectable routes to know whether harm would occur.
 
-### CJC-1295 with DAC
+The responsible conclusion is not that every route has the same demonstrated risk. It is that **the evidence is too incomplete to market injectable ipamorelin as a well-established, generally safe peptide therapy.**
 
-CJC-1295 is a synthetic GHRH analog modified with a Drug Affinity Complex (DAC) that enables binding to plasma albumin, extending its half-life from minutes (for native GHRH) to approximately 8 days. This dramatically changes its pharmacokinetic profile — from producing physiological pulses to maintaining elevated GH and IGF-1 levels continuously.
+### CJC-1295
 
-This longer half-life is pharmacologically consequential: rather than simulating the natural pulsatile GH release that occurs during sleep, CJC-1295 with DAC produces tonic GH elevation. Whether this is preferable to the pulsatile profile (which is preferred by most endocrinologists for safety) is debated. CJC-1295 without DAC (also called Mod GRF 1-29) has a shorter half-life and produces more physiological GH pulses. The distinction matters clinically: chronic tonic GH stimulation may carry greater long-term risks (including potential IGF-1-mediated cell proliferation) compared to pulsatile administration.
+CJC-1295 is a synthetic growth-hormone-releasing-hormone analogue. Mechanistic plausibility and early human pharmacology do not establish broad anti-aging, recovery, sleep, or body-composition benefits.
 
-### Growth Hormone Secretagogue Receptor and Metabolic Effects
+FDA’s current compounding safety-risk page cites potential immunogenicity and peptide-characterization concerns and says serious adverse events associated with CJC-1295 have included increased heart rate and a systemic vasodilatory reaction; available clinical data are limited.
 
-Zhang et al. (2010, PMID 21048778) reviewed the role of the GHSR (ghrelin receptor) in energy and glucose homeostasis, noting that GHSR activation modulates insulin secretion, adipogenesis, and glucose uptake. This dual role — promoting GH release while also affecting metabolic set points — is why GHS research intersects with both endocrinology and metabolic medicine. The authors identified the GHSR as a therapeutic target for obesity and metabolic dysfunction, beyond its traditional role in GH axis management.
-
-Arvat et al. (1997, PMID 9351474) examined the acute hormonal effects of GHRP-6 in humans, finding that while it stimulates GH release, it also transiently decreases insulin levels and modestly increases glucagon — metabolic effects that warrant monitoring in diabetic or pre-diabetic individuals using GHS.
+A long half-life or measurable GH/IGF-1 response is a pharmacology observation, not proof of net health benefit.
 
 ---
 
-## BPC-157: Body Protection Compound
+## Growth-hormone secretagogues: keep pharmacology separate from clinical benefit
 
-BPC-157 (Body Protection Compound 157) is a synthetic pentadecapeptide (15 amino acids) derived from a sequence found in the human gastric juice protein BPC. It is designated a stable gastric pentadecapeptide because unlike most peptides, it resists gastric acid degradation. It is not FDA-approved for any human indication; all published human-relevant clinical trials have been conducted with earlier, less stable analogs for inflammatory bowel disease.
+It is true that the GH axis can be stimulated by GHRH analogues or ghrelin-receptor agonists. It does **not** follow that restoring or increasing a hormone signal in an otherwise healthy adult improves health, longevity, sleep, recovery, or body composition enough to outweigh risk.
 
-### Mechanisms
+The older ipamorelin paper commonly cited in peptide marketing primarily characterized receptor selectivity and hormone release. It should not be summarized as a clinical efficacy trial for anti-aging or physique outcomes.
 
-BPC-157 has been studied extensively in rodent models across a range of injury paradigms. Proposed mechanisms include:
+Similarly, literature discussing age-related changes in GH/IGF-1 is not proof that treating age-related hormone changes with an unapproved secretagogue improves patient-important outcomes.
 
-- **Nitric oxide (NO) pathway modulation:** BPC-157 appears to upregulate endothelial nitric oxide synthase (eNOS) and NO production in endothelial cells, which promotes vasodilation, angiogenesis, and tissue perfusion — critical to wound healing.
-- **Growth factor upregulation:** Animal studies show BPC-157 increases local expression of EGR-1 (early growth response protein 1), a transcription factor that upregulates VEGF, collagen, and fibronectin synthesis. This mechanism could explain accelerated wound healing and tendon repair observed in rodent models.
-- **Gut-brain axis effects:** BPC-157 interacts with dopaminergic and serotonergic systems in animal models, producing anxiolytic-like behavior in the elevated plus maze and reducing depressive-like behavior in the forced swim test.
-- **Cytoprotection:** The compound was originally studied for gastrointestinal cytoprotection, where it shows remarkable protective effects against NSAID-induced gastric ulceration, alcohol-induced gut injury, and inflammatory bowel conditions in rats.
+### Common overclaims to avoid
 
-### The Animal Evidence
+- “Preserves physiological GH pulses, therefore safer.”
+- “Does not shut down the GH axis.”
+- “Fewer adverse effects than growth hormone.”
+- “Established clinical record for anti-aging.”
+- “CJC-1295 + ipamorelin is synergistic and therefore preferable.”
 
-Sikiric et al. (2013, PMID 23930283) summarized the trajectory of BPC-157 research, noting that the compound has been studied in trials for inflammatory bowel disease under designations PL-10, PLD-116, and PL 14736, but that published human trial data remains limited. The animal literature — primarily in rat models of colitis, tendon injury, bone fracture, muscle tear, and spinal cord injury — consistently shows accelerated healing, reduced inflammation, and improved functional recovery across injury types. The compound appears remarkably non-toxic in animal studies, with no lethal dose identified in rodents at doses many times the proposed therapeutic range.
-
-Sikiric et al. (2016, PMID 26874808) specifically reviewed BPC-157's central nervous system effects, reporting neuroprotective properties in models of traumatic brain injury, stroke, Parkinson's disease-like lesions, and antipsychotic-induced extrapyramidal effects — effects again consistently shown in rodents. In a particularly interesting observation, BPC-157 counteracted the QTc-prolonging effects of multiple antipsychotic drugs in rats (PMID 28349572), suggesting possible cardioprotective properties.
-
-### The Evidence Gap: Animal to Human
-
-The critical issue with BPC-157 is the enormous gap between animal study evidence and human clinical data. Animal models of injury and healing do not reliably predict human outcomes — the history of medicine contains dozens of compounds that showed dramatic efficacy in rodent healing models but failed or showed unexpected harms in human trials. BPC-157 has:
-- No completed Phase II or Phase III human RCTs published in peer-reviewed journals for any indication
-- No FDA approval or IND (Investigational New Drug) designation for human use
-- No established human pharmacokinetic data (dosing, half-life, metabolism, clearance)
-- Regulatory status as a research chemical only — not for human use
-
-This does not mean BPC-157 is ineffective in humans — it means we do not have the evidence to know. The robust and consistent animal data justifies further human research, which appears to be progressing. However, individuals using BPC-157 obtained as a research chemical and self-administering without medical supervision are doing so with essentially no evidence-based human dosing guidance and meaningful contamination and infection risk from unregulated injectable products.
+Each of those requires direct human comparative evidence for the exact product and use—not a mechanism diagram.
 
 ---
 
-## Thymosin Beta-4 (TB-500)
+## Evidence map
 
-Thymosin beta-4 (Tβ4) is a naturally occurring 43-amino acid peptide originally isolated from thymic tissue and subsequently found to be ubiquitously expressed throughout the body. It is one of the most abundant intracellular peptides in mammalian tissues, where it functions primarily as an actin-sequestering molecule — binding to G-actin monomers to regulate the dynamic equilibrium of the actin cytoskeleton. This function connects it to cell motility, wound healing, angiogenesis, and tissue repair.
-
-TB-500 is a synthetic fragment of Tβ4, specifically the actin-binding domain sequence LKKTETQ. It is marketed as a research chemical (not for human use) and has attracted significant interest in athletic and anti-aging communities for its purported wound-healing, anti-inflammatory, and muscle repair properties.
-
-### Cardiac Repair Research
-
-The most rigorous research on Tβ4 has focused on cardiac regeneration following myocardial infarction. Bock-Marquette et al. (2004, PMID 15283668) demonstrated that thymosin beta-4 activates integrin-linked kinase (ILK) and promotes cardiac cell migration and survival in mouse models of myocardial infarction. Mice treated with Tβ4 showed significantly improved cardiac function and reduced infarct size. This study established a mechanistic basis for Tβ4's cardioprotective effects — the ILK/Akt signaling pathway governing cell survival and migration.
-
-Smart and Riley (2008, PMID 18434030) reviewed the role of thymosin beta-4 in cardiac repair, highlighting its capacity to activate the epicardium — a quiescent cell layer covering the heart — causing epicardial cells to undergo epithelial-to-mesenchymal transition and migrate into the myocardium where they contribute to new vessel formation and potentially cardiomyocyte regeneration. This was a significant finding because epicardial activation was thought to be a developmentally restricted process. Human trials for cardiac repair using Tβ4 are ongoing but have not yet yielded published efficacy data from Phase II/III RCTs.
-
-### Wound Healing and Tissue Repair
-
-Beyond cardiac applications, animal studies document Tβ4's ability to accelerate dermal wound healing, reduce inflammation in corneal injury models, promote nerve regeneration after peripheral nerve crush injury, and reduce fibrotic scarring in multiple organ models. The common thread is cytoskeletal reorganization: by modulating actin dynamics, Tβ4 promotes cell migration into wound sites, facilitates matrix deposition, and reduces the inflammatory-to-fibrotic transition that causes scarring.
-
-### Evidence Limitations
-
-Like BPC-157, the human evidence base for TB-500 is minimal. The athletic community has generated anecdotal reports of accelerated tendon and muscle injury recovery, but these are not controlled observations. No published RCTs in human athletes exist. The natural endogenous Tβ4 peptide has an excellent safety record in animal toxicology, and early-phase human trials for cardiac indications have not flagged serious safety signals — but the compound is uncharacterized at the doses and frequency used for musculoskeletal applications outside formal trial settings.
-
----
-
-## Peptide Safety, Regulation, and Practical Considerations
-
-### Regulatory Framework
-
-The regulatory status of peptides varies enormously by compound and jurisdiction:
-
-**FDA-approved peptides for human use (selected examples):**
-- Sermorelin — previously approved for GH deficiency
-- Tesamorelin (Egrifta) — approved for HIV-associated lipodystrophy
-- Bremelanotide (Vyleesi) — melanocortin receptor agonist approved for HSDD
-- Semaglutide (Ozempic/Wegovy) — GLP-1 receptor agonist approved for type 2 diabetes and obesity
-
-**Research chemicals (not for human use):**
-- BPC-157, TB-500 (thymosin beta-4 fragment), ipamorelin (when obtained without prescription), CJC-1295 without DAC
-
-**Compounded peptides:**
-The FDA's 2023 regulatory actions placed several peptides on a list of substances that cannot be compounded for human use, including BPC-157, TB-500, and several GHRPs, citing insufficient evidence of safety and efficacy outside approved indications.
-
-### Safety Considerations by Category
-
-**Collagen peptides** have an excellent safety record. No serious adverse events have been reported in clinical trials at doses of 2.5–15 g/day. Gastrointestinal side effects (bloating, heaviness) are occasionally reported but mild. Individuals with severe fish or shellfish allergies should choose bovine rather than marine-sourced products. There are no significant drug interactions.
-
-**Growth hormone secretagogues** (medically supervised use): Side effects include transient water retention, tingling at injection sites, and mild hypoglycemia. Elevated IGF-1 carries theoretical cancer-risk implications in individuals with pre-existing neoplastic conditions; this is why oncologists screen for GH therapy prior to initiation. In properly screened patients, short-term GHS use appears well-tolerated. Long-term safety data beyond 6–12 months is limited.
-
-**BPC-157 and TB-500 (self-administered, unregulated):** The primary concerns are:
-- **Contamination risk:** Unregulated research chemical products are not manufactured under pharmaceutical GMP standards. Bacterial contamination, incorrect dosing (labeled vs. actual content), and improper lyophilization have been documented in independent testing of grey-market peptide vials.
-- **Infection risk:** Subcutaneous or intramuscular injection with non-sterile technique is a known vector for soft-tissue infections, including MRSA.
-- **Unknown long-term effects:** No human chronic toxicology data exists for these compounds at doses used recreationally.
-
-### Distinguishing Evidence Tiers
-
-| Peptide | Human RCTs | FDA Status | Evidence Grade |
+| Category / example | Human efficacy evidence | FDA / regulatory context | Appropriate interpretation |
 |---|---|---|---|
-| Collagen peptides (oral) | Many (20+) | Dietary supplement | Strong |
-| Sermorelin | Moderate (GH deficiency) | Approved (Rx) | Strong (indicated use) |
-| Ipamorelin | Limited | Not approved | Moderate (animal) |
-| BPC-157 | None published (Phase II) | Research chemical | Low (animal only) |
-| Thymosin beta-4 | Phase I/II cardiac only | Research/IND | Low–Moderate |
-| GLP-1 agonists (semaglutide) | Many (large Phase III) | FDA approved | Very Strong |
+| Oral collagen peptides | Multiple product-specific human RCTs for selected outcomes | Dietary-supplement/food-derived category, not an approved peptide drug | Some direct human evidence; formulation and outcome matter. |
+| FDA-approved peptide medicine | Product- and indication-specific clinical development | FDA-approved only for the specific approved application | Use the approved label and evidence for that product; do not generalize to a class. |
+| Compounded peptide-containing drug | Varies by substance and indication | **Not FDA-approved**; no FDA premarket verification of safety, effectiveness, or quality | May serve a legitimate patient need, but approval claims and product equivalence are inappropriate. |
+| BPC-157 | Predominantly preclinical; human efficacy not established | FDA flags substantial safety-information and characterization gaps for compounded use | Experimental; animal findings should not be converted into human treatment claims. |
+| TB-500 fragment | Human exposure data not identified by FDA for drug products containing the fragment | FDA flags immunogenicity/impurity concerns and insufficient safety information | Do not substitute full-length thymosin beta-4 evidence for TB-500. |
+| Ipamorelin acetate | Limited and context-specific human data; no broad anti-aging efficacy base | FDA category-2 compounding safety concerns | Not an established general wellness therapy. |
+| CJC-1295 | Limited clinical data; pharmacology is better established than patient-important benefit | FDA identifies safety concerns and limited clinical data | Experimental/unapproved framing is appropriate. |
 
 ---
 
-## Collagen Peptide Dosing and Practical Protocol
+## Safety: route and manufacturing matter
 
-For the evidence-supported use of collagen peptides — skin, joints, muscle, and bone — the following practical guidance derives from the clinical trial literature:
+Peptide safety is not just about the amino-acid sequence.
 
-### Skin and Dermal Health
+For injectable products, relevant risks can include:
 
-A dose of **2.5–5 g/day** of hydrolyzed collagen peptides is supported by multiple skin RCTs. Effects develop over 8–12 weeks of consistent use. Adding vitamin C (500–1000 mg) at the same time as collagen peptides enhances hydroxylation of proline and lysine, which is rate-limiting for collagen triple-helix formation. Evening administration alongside a protein-rich meal appears reasonable for amino acid co-delivery.
+- sterility failures and microbial contamination;
+- incorrect strength or identity;
+- peptide aggregation and immunogenicity;
+- impurities or incomplete API characterization;
+- injection-site infection or injury;
+- route-specific pharmacokinetics; and
+- interactions with medical conditions or other drugs.
 
-### Joint Health and Tendon/Ligament Support
+This is why “it is just amino acids” is not a meaningful safety argument.
 
-**10 g/day** is the dose used in the Clark et al. athlete trial showing joint pain reduction. For tendon and ligament applications, Shaw et al. suggest taking **15 g collagen + 50 mg vitamin C approximately 60 minutes before exercise** to maximize collagen synthesis during the post-exercise repair window — when fibroblasts are most active. This pre-exercise loading strategy is supported by the ex vivo ligament synthesis data in their study.
-
-### Body Composition (Sarcopenia)
-
-The Zdzieblik et al. protocol used **15 g/day** combined with progressive resistance training 3 times/week for 12 weeks. Collagen peptides are not a replacement for complete protein sources (they lack adequate tryptophan and are low in branched-chain amino acids) but appear to synergize with resistance training for connective tissue adaptation in older adults.
-
-### Bone Health
-
-König et al. used **5 g/day** for 12 months in postmenopausal women with osteopenia. The bone effect appears to require sustained supplementation, consistent with the slow turnover rate of bone matrix. This dose is appropriate to combine with vitamin D and calcium if those are also deficient.
+FDA has repeatedly emphasized that compounded drugs are not pre-reviewed for safety, effectiveness, or quality. Compounded products can be clinically appropriate in specific circumstances, but unnecessary use can expose people to avoidable risk.
 
 ---
 
-## What Peptide Research Cannot Yet Answer
+## How to evaluate a peptide claim
 
-The field of peptide research is advancing rapidly, and several important questions remain open:
+Before treating a peptide claim as decision-ready, ask:
 
-**1. Oral vs. injectable bioavailability of research peptides.** Some researchers and clinicians argue that BPC-157, in particular, may be effective orally given its stability in gastric juice — this is consistent with its origin as a gastric protein-derived fragment. If this holds in human pharmacokinetic studies, the risk profile of BPC-157 would be fundamentally different from injectable use. No published human PK data confirms this.
+1. **Exact molecule:** Is the evidence for this molecule, or a related parent peptide/fragment?
+2. **Exact product:** Is the marketed product the same preparation studied?
+3. **Human evidence:** Are there controlled human outcomes, or mainly cells/animals?
+4. **Route:** Oral, subcutaneous, intravenous, nasal, and topical evidence are not interchangeable.
+5. **Outcome:** Is the evidence about a patient-important benefit, or only a biomarker/hormone response?
+6. **Approval status:** Is there an FDA-approved application for this exact product and use?
+7. **Compounding status:** If compounded, is the page clearly stating that compounded drugs are not FDA-approved?
+8. **Safety evidence:** How long were participants followed, and how were adverse events captured?
+9. **Manufacturing:** Is identity, strength, sterility, and quality controlled in a way that matches the research product?
+10. **Marketing leap:** Is an animal mechanism being presented as though it were a human treatment result?
 
-**2. Long-term IGF-1 safety.** Growth hormone secretagogues elevate IGF-1, which is mitogenic (promotes cell growth). The long-term implications for cancer risk in healthy individuals are not resolved by existing data. Short-term and medium-term (1–2 year) data from GH-deficient patients on GHS does not show elevated cancer incidence, but these are medically supervised patients with baseline screening that recreational users lack.
+If several of those questions cannot be answered, uncertainty should be the headline—not a protocol.
 
-**3. Peptide stacking and interactions.** Many practitioners combine GHRPs with GHRH analogs (e.g., ipamorelin + CJC-1295), but synergistic effect data in humans is sparse, and the additive hormonal burden of such combinations on feedback loops has not been characterized long-term.
+---
 
-**4. BPC-157 in human clinical trials.** The most pressing unmet need in peptide research is the translation of BPC-157 animal data into rigorous human RCTs, particularly for musculoskeletal injury, IBD, and neurological applications. Given the consistent animal evidence, this research gap is a priority for academic and pharmaceutical investigation.
+## What this guide does not provide
+
+This page does not provide injection instructions, reconstitution instructions, cycle schedules, stacks, or personal dosing protocols for experimental peptides.
+
+That omission is deliberate. For BPC-157, TB-500, ipamorelin, CJC-1295, and similar unapproved products, the central evidence problem is not choosing the “right” dose from online practice. It is that human efficacy, route-specific safety, product quality, and long-term risk are inadequately established.
+
+For collagen peptides, study doses can help readers understand the trials, but they still should not be converted into guarantees that every retail product will reproduce a particular result.
 
 ---
 
 ## Conclusion
 
-Peptides represent one of the most heterogeneous and rapidly evolving areas in sports medicine, anti-aging science, and regenerative biology. The evidence spectrum is wide:
+The peptide landscape becomes much easier to reason about once the categories stop being blended together.
 
-At one end, **collagen peptides** stand out as one of the most rigorously studied natural compounds in human clinical trials, with consistent evidence across skin elasticity, joint pain, bone mineral density, and muscle composition outcomes at accessible oral doses. Their safety is excellent and their mechanism — substrate supply plus cell signaling — is well-characterized. For any individual interested in connective tissue health, collagen peptide supplementation at 5–15 g/day is supported by multiple high-quality RCTs.
+**Collagen peptides** have direct human trial evidence for selected, product-specific outcomes and belong in a dietary-supplement discussion.
 
-In the middle, **growth hormone secretagogues** like sermorelin and ipamorelin have legitimate clinical applications in medically diagnosed GH deficiency and are managed appropriately with physician oversight, regular IGF-1 monitoring, and screening for contraindications. Their off-label use requires careful patient selection and is not appropriate for self-administration without medical supervision.
+**FDA-approved peptide drugs** belong in a prescription-drug discussion where the exact approved product, indication, route, and label matter.
 
-At the other end, **BPC-157 and thymosin beta-4** have fascinating and consistent animal data that justifies research interest and enthusiasm — but these compounds have not completed human clinical trials, lack established human pharmacokinetics, and are currently sold only as unregulated research chemicals carrying real infection and contamination risks when self-administered by injection. The intellectual excitement of the animal data should not be confused with clinical evidence of human efficacy and safety.
+**Compounded drugs** may meet specific medical needs but are not FDA-approved and are not pre-reviewed by FDA for safety, effectiveness, or quality.
 
-For anyone navigating the peptide landscape, the key intellectual discipline is tracking evidence tiers: animal data is hypothesis-generating, not confirmatory. Human RCT data — ideally replicated, blinded, and in relevant populations — is what should guide decisions about personal use. The peptide field is producing that data at an accelerating pace. Collagen peptides already have it; GHRPs are accumulating it; BPC-157 desperately needs it.
+**BPC-157, the TB-500 fragment, ipamorelin, CJC-1295, and similar experimental peptides** should be discussed with explicit evidence and regulatory uncertainty. Interesting mechanisms and animal results can justify research; they do not establish a safe or effective human protocol.
 
----
-
-## References
-
-| # | Authors | Title | Journal | Year | PMID |
-|---|---------|-------|---------|------|------|
-| 1 | Zdzieblik D et al. | Collagen peptide supplementation with resistance training in elderly sarcopenic men | Br J Nutr | 2015 | [26353786](https://pubmed.ncbi.nlm.nih.gov/26353786/) |
-| 2 | Proksch E et al. | Oral intake of specific bioactive collagen peptides reduces skin wrinkles | Skin Pharmacol Physiol | 2014 | [24401291](https://pubmed.ncbi.nlm.nih.gov/24401291/) |
-| 3 | König D et al. | Specific collagen peptides improve bone mineral density in postmenopausal women | Nutrients | 2018 | [29337906](https://pubmed.ncbi.nlm.nih.gov/29337906/) |
-| 4 | Sikiric P et al. | Stable gastric pentadecapeptide BPC 157 in trials for inflammatory bowel disease | Curr Pharm Des | 2013 | [23930283](https://pubmed.ncbi.nlm.nih.gov/23930283/) |
-| 5 | Sikiric P et al. | BPC 157 counteracts QTc prolongation induced by antipsychotics | CNS Neurosci Ther | 2017 | [28349572](https://pubmed.ncbi.nlm.nih.gov/28349572/) |
-| 6 | Raun K et al. | Ipamorelin, the first selective growth hormone secretagogue | Eur J Endocrinol | 1998 | [9849822](https://pubmed.ncbi.nlm.nih.gov/9849822/) |
-| 7 | Garcia JM et al. | GH-releasing hormone and GH secretagogues in normal aging | Clin Interv Aging | 2013 | [24672499](https://pubmed.ncbi.nlm.nih.gov/24672499/) |
-| 8 | Arvat E et al. | Effects of growth hormone-releasing peptide-6 on insulin release in humans | J Clin Endocrinol Metab | 1997 | [9351474](https://pubmed.ncbi.nlm.nih.gov/9351474/) |
-| 9 | Walker RF | Sermorelin: a better approach to adult-onset GH insufficiency | Clin Interv Aging | 2006 | [17255569](https://pubmed.ncbi.nlm.nih.gov/17255569/) |
-| 10 | Bock-Marquette I et al. | Thymosin beta 4 activates integrin-linked kinase and promotes cardiac repair | Nature | 2004 | [15283668](https://pubmed.ncbi.nlm.nih.gov/15283668/) |
-| 11 | Smart N, Riley PR | The role of thymosin beta 4 in cardiac repair | Cell Cycle | 2008 | [18434030](https://pubmed.ncbi.nlm.nih.gov/18434030/) |
-| 12 | Shaw G et al. | Vitamin C-enriched gelatin supplementation before intermittent activity augments collagen synthesis | Am J Clin Nutr | 2017 | [27852613](https://pubmed.ncbi.nlm.nih.gov/27852613/) |
-| 13 | Clark KL et al. | 24-week study on the use of collagen hydrolysate as a dietary supplement in athletes | Curr Med Res Opin | 2008 | [18416885](https://pubmed.ncbi.nlm.nih.gov/18416885/) |
-| 14 | Sikiric P et al. | BPC-157 and the Central Nervous System: neuroprotective effects | Curr Neuropharmacol | 2016 | [26874808](https://pubmed.ncbi.nlm.nih.gov/26874808/) |
-| 15 | Zhang G et al. | Growth hormone secretagogue receptor in energy and glucose homeostasis | Prog Mol Biol Transl Sci | 2010 | [21048778](https://pubmed.ncbi.nlm.nih.gov/21048778/) |
+That distinction is less exciting than peptide marketing, but it is much more useful for making evidence-aware decisions.
 
 ## Related Articles
 
-- [Creatine for Brain Health](/articles/creatine-brain-health/)
 - [How to Choose a Quality Supplement](/articles/how-to-choose-supplement-quality/)
-- [Natural Compounds Research Clusters](/articles/natural-compounds-research-clusters/)
+- [Evidence Hierarchy](/learn/evidence-hierarchy/)
+- [How to Read Scientific Studies](/learn/how-to-read-scientific-studies/)
+- [Medical Disclaimer](/info/disclaimer/)


### PR DESCRIPTION
## Summary
- separate food-derived collagen peptides, FDA-approved peptide drugs, compounded drugs, and experimental/unapproved peptides instead of treating “peptide therapy” as one evidence category
- correct misleading regulatory language such as “not FDA-approved for off-label use” and “sold legally only as research chemicals”
- state clearly that compounded drugs are not FDA-approved and FDA does not pre-review them for safety, effectiveness, or quality
- update BPC-157, TB-500, ipamorelin, and CJC-1295 sections around FDA’s current compounding safety-risk material
- prevent full-length thymosin beta-4 research from being silently transferred to the TB-500 fragment
- remove experimental injection/reconstitution/cycling/stack protocols
- keep collagen trial doses as research context rather than universal dosing advice
- add regression coverage preventing the old regulatory/evidence shortcuts from returning

## Current FDA anchors
- FDA Compounding and FDA Q&A: compounded drugs are not FDA-approved and are not premarket-reviewed for safety, effectiveness, or quality
- FDA bulk-substance safety-risk page: BPC-157 has limited/no safety information for proposed routes; TB-500 fragment lacks identified human exposure data; ipamorelin has route-specific safety gaps and serious adverse-event reports; CJC-1295 has limited clinical data and reported safety concerns

## Scope
2 files: the canonical peptide research article and a focused regression test. No workbook or runtime profile data changed.