### PR TITLE
Prefer substantive compound safety notes over generic fallback

### DIFF
--- a/app/__tests__/compound-safety-summary-priority.test.ts
+++ b/app/__tests__/compound-safety-summary-priority.test.ts
@@ -1,0 +1,29 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const PAGE = path.join(process.cwd(), 'app/compounds/[slug]/page.tsx')
+
+function source() {
+  return fs.readFileSync(PAGE, 'utf8')
+}
+
+describe('compound safety summary priority', () => {
+  it('prefers a substantive safety note before the avoid-if fallback', () => {
+    const text = source()
+    const helper = text.match(/function getSafetySummary[\s\S]*?\n}\n\nfunction getMechanismHints/)?.[0] || ''
+
+    expect(helper).toContain("const note = cleanText(compound.safetyNotes || compound.safety_notes || compound.safety)")
+    expect(helper.indexOf('if (note)')).toBeGreaterThan(-1)
+    expect(helper.indexOf('if (avoidIf.length)')).toBeGreaterThan(-1)
+    expect(helper.indexOf('if (note)')).toBeLessThan(helper.indexOf('if (avoidIf.length)'))
+  })
+
+  it('keeps avoid-if cautions visible as their own quick-stat surface', () => {
+    const text = source()
+
+    expect(text).toContain('Avoid / review if')
+    expect(text).toContain("{avoidIf.slice(0, 3).join(', ')}")
+    expect(text).toContain('Review before use if any apply:')
+  })
+})

--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -403,8 +403,8 @@ function getAvoidIf(compound: Record<string, unknown>) {
 
 function getSafetySummary(compound: Record<string, unknown>, avoidIf: string[]) {
   const note = cleanText(compound.safetyNotes || compound.safety_notes || compound.safety)
-  if (avoidIf.length) return `Review before use if any apply: ${avoidIf.slice(0, 3).join(', ').replace(/[.!?]+$/, '')}.`
   if (note) return firstSentences(note, 2)
+  if (avoidIf.length) return `Review before use if any apply: ${avoidIf.slice(0, 3).join(', ').replace(/[.!?]+$/, '')}.`
   return 'Review medications, pregnancy status, chronic conditions, and clinician guidance before use.'
 }
 


### PR DESCRIPTION
## Summary
- prefer an available substantive compound safety note before the generic `avoidIf` summary fallback
- keep `avoidIf` cautions visible in the existing dedicated Quick Stats surface
- add a regression test that locks the priority order and preserves the fallback

## Why
The compound page previously returned `Review before use if...` whenever `avoidIf` existed, even when a richer safety note was available. Because the same avoid list is already displayed separately, that duplicated caution text and could hide more informative safety context.

## Scope
Exactly 2 files: one one-line behavior change in the compound route and one focused regression test.