### PR TITLE
Refresh peptide guides after 2026 FDA advisory reviews

### DIFF
--- a/app/__tests__/peptide-guide-regulatory-status.test.ts
+++ b/app/__tests__/peptide-guide-regulatory-status.test.ts
@@ -1,0 +1,57 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const read = (relativePath: string) => fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8').replace(/\s+/g, ' ')
+
+const guidePaths = [
+  'app/guides/other/bpc-157/page.tsx',
+  'app/guides/other/tb-500/page.tsx',
+  'app/guides/other/cjc-1295/page.tsx',
+  'app/guides/other/ipamorelin/page.tsx',
+]
+
+describe('peptide guide regulatory status', () => {
+  it('does not describe the July 2026 FDA meeting as a future event', () => {
+    const pages = guidePaths.map(read).join('\n')
+
+    expect(pages).not.toMatch(/scheduled (?:for|to).*July 2[34],? 2026/i)
+    expect(pages).not.toMatch(/pending the July 2026 PCAC/i)
+    expect(pages).not.toMatch(/likely to be clarified by the July 2026/i)
+    expect(pages).not.toMatch(/July 23–24, 2026:.*is scheduled/i)
+  })
+
+  it('does not turn RUO marketing or availability into legal authorization', () => {
+    const pages = guidePaths.map(read).join('\n')
+
+    expect(pages).not.toMatch(/legally sellable only as [“"]research use only/i)
+    expect(pages).not.toMatch(/not legally intended for human consumption regardless/i)
+    expect(pages).not.toMatch(/regulatory gray zone/i)
+    expect(pages).not.toMatch(/moving toward Category 1/i)
+    expect(pages).not.toMatch(/trending toward eventual compounding access/i)
+  })
+
+  it('keeps FDA approval and compounding status distinct', () => {
+    const bpc = read(guidePaths[0])
+    const tb500 = read(guidePaths[1])
+    const cjc = read(guidePaths[2])
+    const ipamorelin = read(guidePaths[3])
+
+    expect(bpc).toContain('advisory-committee discussion or recommendation is not FDA approval')
+    expect(tb500).toContain('Advisory-committee consideration does not equal FDA approval')
+    expect(cjc).toContain('CJC-1295 is not FDA-approved')
+    expect(ipamorelin).toContain('Ipamorelin is not FDA-approved as a finished drug product')
+  })
+
+  it('preserves current FDA safety signals instead of generic reassurance', () => {
+    const bpc = read(guidePaths[0])
+    const tb500 = read(guidePaths[1])
+    const cjc = read(guidePaths[2])
+    const ipamorelin = read(guidePaths[3])
+
+    expect(bpc).toMatch(/no or only limited safety information/i)
+    expect(tb500).toMatch(/not identified human exposure data/i)
+    expect(cjc).toMatch(/increased heart rate and a systemic vasodilatory reaction/i)
+    expect(ipamorelin).toMatch(/serious adverse events, including deaths/i)
+  })
+})

--- a/app/guides/other/bpc-157/page.tsx
+++ b/app/guides/other/bpc-157/page.tsx
@@ -9,158 +9,124 @@ import type { Heading } from '@/components/articles'
 import References from '@/components/References'
 
 export const metadata: Metadata = buildPageMetadata({
-  title: 'BPC-157: Benefits, Evidence, Legal Status, and Safety (2026)',
-  description: 'An evidence-based look at BPC-157 — mechanism, preclinical research, current FDA compounding status, and safety considerations.',
+  title: 'BPC-157: Human Evidence, FDA Status, and Safety (2026)',
+  description: 'Current evidence-first review of BPC-157, including the preclinical evidence gap, the July 2026 FDA advisory meeting, compounding status, and safety uncertainty.',
   path: '/guides/other/bpc-157/',
 })
 
 const HEADINGS: Heading[] = [
   { id: 'understanding', text: 'What Is BPC-157?', level: 2 },
-  { id: 'mechanism', text: 'Mechanism of Action', level: 2 },
-  { id: 'evidence', text: 'What the Evidence Shows', level: 2 },
-  { id: 'legal', text: 'Legal & Regulatory Status', level: 2 },
-  { id: 'safety', text: 'Safety Considerations', level: 2 },
+  { id: 'evidence', text: 'What the Evidence Can Show', level: 2 },
+  { id: 'legal', text: 'FDA & Compounding Status', level: 2 },
+  { id: 'safety', text: 'Safety Uncertainty', level: 2 },
   { id: 'bottom-line', text: 'Bottom Line', level: 2 },
 ]
 
 const BPC_157_REFS = [
-  { n: 1, text: 'Sikiric P, et al. (2014). BPC 157: from bench to bedside. Curr Pharm Des, 20(7): 1108-1118.', url: 'https://pubmed.ncbi.nlm.nih.gov/23782141/' },
-  { n: 2, text: 'Gwyer D, et al. (2019). Gastric pentadecapeptide BPC 157 and short bowel syndrome. World J Gastroenterol, 25(45): 6682-6696.', url: 'https://pubmed.ncbi.nlm.nih.gov/31832005/' },
+  { n: 1, text: 'FDA. Certain Bulk Drug Substances for Use in Compounding that May Present Significant Safety Risks.', url: 'https://www.fda.gov/drugs/human-drug-compounding/certain-bulk-drug-substances-use-compounding-may-present-significant-safety-risks' },
+  { n: 2, text: 'FDA. July 23-24, 2026 Meeting of the Pharmacy Compounding Advisory Committee.', url: 'https://www.fda.gov/advisory-committees/advisory-committee-calendar/july-23-24-2026-meeting-pharmacy-compounding-advisory-committee-07232026' },
+  { n: 3, text: 'FDA. Bulk Drug Substances Used in Compounding Under Section 503A of the FD&C Act.', url: 'https://www.fda.gov/drugs/human-drug-compounding/bulk-drug-substances-used-compounding-under-section-503a-fdc-act' },
+  { n: 4, text: 'Sikiric P, et al. BPC 157 research review. Curr Pharm Des. 2014.', url: 'https://pubmed.ncbi.nlm.nih.gov/23782141/' },
 ]
 
 export default function Page() {
   const toc = <TableOfContents headings={HEADINGS} />
-
   const breadcrumbs = [
     { label: 'Home', href: '/' },
     { label: 'Guides', href: '/guides' },
-    { label: 'BPC-157: Benefits, Evidence, Legal Status, and Safety' },
+    { label: 'BPC-157: Human Evidence, FDA Status, and Safety' },
   ]
 
   return (
     <ArticleLayout toc={toc} zone="harm-reduction">
-    <div className="space-y-8">
-      <AuthorityBreadcrumbs items={breadcrumbs} />
+      <div className="space-y-8">
+        <AuthorityBreadcrumbs items={breadcrumbs} />
 
-      <section className="hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8">
-        <p className="eyebrow-label">Peptide &amp; Compound Guide</p>
-        <h1 className="mt-2 text-3xl font-semibold text-ink sm:text-4xl">BPC-157: Benefits, Evidence, Legal Status, and Safety</h1>
-        <p className="detail-reading mt-4 text-muted">An evidence-based look at BPC-157 — mechanism, preclinical research, current FDA compounding status, and safety considerations.</p>
+        <section className="hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8">
+          <p className="eyebrow-label">Experimental Peptide Guide</p>
+          <h1 className="mt-2 text-3xl font-semibold text-ink sm:text-4xl">BPC-157: Human Evidence, FDA Status, and Safety</h1>
+          <p className="detail-reading mt-4 text-muted">
+            BPC-157 has extensive preclinical discussion but no established human efficacy profile. This guide separates animal findings, current FDA compounding information, and what remains unknown.
+          </p>
+          <figure className="mt-6">
+            <div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white">
+              <Image src="/images/guides/bpc-157.jpg" alt="A glass vial of lyophilized research peptide powder in a lab setting" width={1536} height={1024} priority className="w-full h-auto" />
+            </div>
+            <figcaption className="mt-3 text-center text-sm text-muted">BPC-157 — experimental peptide research, not an established human treatment.</figcaption>
+          </figure>
+        </section>
 
-        <figure className="mt-6">
-          <div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white">
-            <Image
-              src="/images/guides/bpc-157.jpg"
-              alt="A glass vial of lyophilized research peptide powder in a lab setting"
-              width={1536}
-              height={1024}
-              priority
-              className="w-full h-auto"
-            />
+        <section className="rounded-2xl border border-rose-900/15 bg-rose-50/80 p-5 text-sm leading-6 text-rose-950">
+          <p className="font-semibold">Unapproved-drug notice</p>
+          <p className="mt-2">
+            BPC-157 is not an FDA-approved drug product. A “research use only” label does not establish FDA approval, clinical effectiveness, product quality, or suitability for human use.
+          </p>
+        </section>
+
+        <AffiliateDisclosure />
+
+        <section className="prose-section space-y-6">
+          <div className="card-premium p-6">
+            <p className="text-sm font-semibold text-brand-700 uppercase tracking-wide">Review status</p>
+            <p className="mt-3 text-sm text-muted">Regulatory wording reviewed August 12, 2026 against current FDA compounding and advisory-committee material.</p>
           </div>
-          <figcaption className="mt-3 text-center text-sm text-muted">
-            BPC-157 — an educational, research-use-only overview.
-          </figcaption>
-        </figure>
-      </section>
 
-      <section className="rounded-2xl border border-rose-900/15 bg-rose-50/80 p-5 text-sm leading-6 text-rose-950">
-        <p className="font-semibold">Research-use-only (RUO) notice</p>
-        <p className="mt-2">
-          BPC-157 is not FDA-approved as a finished drug product. This page is educational only, does not endorse purchase or use, and is not medical or legal advice. Its FDA compounding status is actively evolving — verify against current FDA guidance before drawing conclusions.
-        </p>
-      </section>
+          <div id="understanding" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">What Is BPC-157?</h2>
+            <p className="text-muted leading-relaxed">
+              BPC-157 is a synthetic 15-amino-acid peptide widely marketed around tendon, muscle, gastrointestinal, and recovery claims. The research literature is dominated by animal and mechanistic studies. Those studies can generate hypotheses, but they do not establish a human treatment effect, human dose, pharmacokinetics, or long-term safety.
+            </p>
+          </div>
 
-      <AffiliateDisclosure />
+          <div id="evidence" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">What the Evidence Can Show</h2>
+            <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
+              <li><strong>Preclinical findings:</strong> rodent and laboratory models report signals involving wound healing, gastrointestinal injury, vascular signaling, and musculoskeletal repair.</li>
+              <li><strong>Human efficacy:</strong> controlled human evidence is insufficient to establish that BPC-157 heals tendons, muscles, ulcers, neurologic injury, or other conditions in people.</li>
+              <li><strong>Human dosing:</strong> online dose schedules are not supported by an established human pharmacokinetic and efficacy program.</li>
+              <li><strong>Product equivalence:</strong> a gray-market vial cannot be assumed to match the identity, purity, sterility, or formulation used in research.</li>
+            </ul>
+            <p className="text-muted leading-relaxed"><strong>Evidence quality: predominantly preclinical.</strong> Interesting animal findings are not a substitute for replicated human trials.</p>
+          </div>
 
-      <section className="prose-section space-y-6">
-        <div className="card-premium p-6">
-          <p className="text-sm font-semibold text-brand-700 uppercase tracking-wide">Important Disclaimer</p>
-          <p className="mt-3 text-sm text-muted">This guide is for informational purposes only and does not constitute medical advice. BPC-157 is not FDA-approved. Consult a licensed physician before considering any peptide therapy. Content last reviewed for regulatory accuracy: June 30, 2026.</p>
+          <div id="legal" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">FDA &amp; Compounding Status (August 2026)</h2>
+            <p className="text-muted leading-relaxed">
+              FDA's Pharmacy Compounding Advisory Committee met on <strong>July 23, 2026</strong> and discussed BPC-157-related bulk drug substances for possible inclusion on the section 503A Bulks List. That meeting has already occurred; describing it as an upcoming decision is now stale.
+            </p>
+            <p className="text-muted leading-relaxed">
+              An advisory-committee discussion or recommendation is not FDA approval and is not itself a final 503A listing. FDA's current 503A page explains that bulks-list decisions are addressed through the agency's notice-and-comment rulemaking process. The current FDA safety-risk page also continues to list BPC-157 among nominated-but-withdrawn substances and says safety information for proposed routes is absent or limited.
+            </p>
+            <p className="text-muted leading-relaxed">
+              <strong>Bottom line:</strong> BPC-157 is not FDA-approved. Do not convert the July advisory meeting, an RUO label, clinic availability, or online sale into a claim of FDA authorization or proven human use.
+            </p>
+          </div>
+
+          <div id="safety" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Safety Uncertainty</h2>
+            <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
+              <li>FDA identifies potential immunogenicity, peptide-impurity, and API-characterization concerns for compounded BPC-157.</li>
+              <li>FDA says it has no or only limited safety information for proposed routes and lacks sufficient information to know whether the drug would cause harm in humans.</li>
+              <li>Human chronic-toxicity, reproductive-safety, carcinogenicity, and route-specific safety data are inadequate for confident long-term use claims.</li>
+              <li>Injectable products add sterility, contamination, identity, and strength risks when product quality is uncertain.</li>
+            </ul>
+          </div>
+
+          <div id="bottom-line" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Bottom Line</h2>
+            <p className="text-muted leading-relaxed">
+              BPC-157 is a research-interest peptide with substantial preclinical literature and major human evidence gaps. The July 2026 FDA advisory meeting did not turn it into an approved treatment, and FDA's current safety material still emphasizes missing human safety information. This is a research topic to follow, not a protocol to infer from animal studies.
+            </p>
+          </div>
+        </section>
+
+        <div className="mt-8 flex gap-4 flex-wrap">
+          <Link href="/guides/" className="text-sm font-medium text-emerald-700 hover:underline">Back to guides &rarr;</Link>
+          <Link href="/compounds/bpc-157/" className="text-sm font-medium text-emerald-700 hover:underline">View BPC-157 compound profile &rarr;</Link>
+          <Link href="/guides/other/tb-500/" className="text-sm font-medium text-emerald-700 hover:underline">Read the TB-500 guide &rarr;</Link>
         </div>
-
-        <div id="understanding" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">What Is BPC-157?</h2>
-          <p className="text-muted leading-relaxed">
-            BPC-157 (Body Protection Compound-157) is a synthetic 15-amino-acid peptide derived from a partial sequence found in human gastric juice. It's one of the most widely discussed peptides in the recovery and longevity space, generally studied for its potential role in gut healing, tendon and ligament repair, and inflammation modulation.
-          </p>
-          <p className="text-muted leading-relaxed">
-            BPC-157 is <strong>not an FDA-approved drug</strong>. There is no commercially available, FDA-approved product containing it.
-          </p>
-        </div>
-
-        <div id="mechanism" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Mechanism of Action</h2>
-          <p className="text-muted leading-relaxed">
-            Preclinical research suggests BPC-157 may act through several overlapping pathways:
-          </p>
-          <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
-            <li><strong>Angiogenesis promotion</strong> — upregulation of VEGFR2 expression, supporting new blood vessel formation in damaged tissue</li>
-            <li><strong>Nitric oxide system modulation</strong> — interaction with the NO pathway, implicated in vascular and gut-lining repair</li>
-            <li><strong>Growth factor interaction</strong> — influence on the FAK-paxillin pathway involved in cell migration and wound healing</li>
-            <li><strong>Anti-inflammatory signaling</strong> — reduced pro-inflammatory cytokine activity in some animal models</li>
-          </ul>
-          <p className="text-muted leading-relaxed">
-            Almost all mechanistic data comes from rodent and <em>in vitro</em> studies. Human mechanistic confirmation is lacking.
-          </p>
-        </div>
-
-        <div id="evidence" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">What the Evidence Shows</h2>
-          <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
-            <li><span className="font-semibold text-ink">Gut healing:</span> Animal models show accelerated healing of gastric ulcers, fistulas, and inflammatory bowel-type injury.</li>
-            <li><span className="font-semibold text-ink">Tendon/ligament repair:</span> Rat studies report improved healing of transected Achilles tendons and ligament injuries when BPC-157 was administered locally or systemically.</li>
-            <li><span className="font-semibold text-ink">Muscle injury:</span> Some rodent data suggests faster recovery from crush and laceration injuries.</li>
-            <li><span className="font-semibold text-ink">Human data:</span> Human clinical trial data is essentially absent. Most human-facing claims are extrapolated from animal models, physician case reports, or anecdotal self-reported use. Treat any specific human dosing claim you encounter online with skepticism — it is not derived from controlled human trials.</li>
-          </ul>
-          <p className="text-muted leading-relaxed">
-            <strong>Evidence quality: preliminary/preclinical.</strong> This is not a “well-studied” compound in the way many herbs on this site are; it's a promising research molecule with a thin human evidence base.
-          </p>
-        </div>
-
-        <div id="legal" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Legal & Regulatory Status (Updated June 2026)</h2>
-          <p className="text-muted leading-relaxed">
-            BPC-157's regulatory status has changed significantly in 2026 and is still in motion:
-          </p>
-          <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
-            <li><span className="font-semibold text-ink">2023–April 2026:</span> The FDA placed BPC-157 on its Category 2 list of the 503A bulk drug substances list, effectively prohibiting licensed compounding pharmacies from preparing it.</li>
-            <li><span className="font-semibold text-ink">April 22, 2026:</span> The FDA removed BPC-157 from Category 2. This is <em>not</em> the same as approving it — it moved BPC-157 into a regulatory gray zone: no longer explicitly banned from compounding, but not yet on the Category 1 “approved to compound” list either.</li>
-            <li><span className="font-semibold text-ink">July 23–24, 2026:</span> The FDA's Pharmacy Compounding Advisory Committee (PCAC) is scheduled to formally review BPC-157 (alongside KPV, TB-500, and MOTS-C) for potential 503A compounding eligibility.</li>
-            <li><span className="font-semibold text-ink">World Anti-Doping Agency (WADA):</span> BPC-157 remains banned under WADA's S0 (non-approved substances) category year-round, in and out of competition. This is unaffected by the FDA compounding status change.</li>
-          </ul>
-          <p className="text-muted leading-relaxed">
-            <strong>Bottom line:</strong> As of this writing, BPC-157 is not FDA-approved, cannot be legally sold as a finished drug product for human use, and sits in regulatory limbo for compounding pharmacies pending the July 2026 PCAC decision. Products sold as “research use only” (RUO) are not legally intended or labeled for human consumption. This status is actively evolving — verify against current FDA guidance before drawing conclusions.
-          </p>
-        </div>
-
-        <div id="safety" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Safety Considerations</h2>
-          <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
-            <li>No large-scale human safety trials exist. Long-term safety in humans is unknown.</li>
-            <li>Animal toxicology studies to date have not identified major red flags at studied doses, but this does not establish human safety.</li>
-            <li>Because most BPC-157 available for purchase is sold RUO, sourced product purity, sterility, and actual peptide content are not independently verified or regulated. Contamination and mislabeling are documented risks in the gray-market research peptide industry.</li>
-            <li>Anyone considering BPC-157 for a therapeutic purpose should do so only under the guidance of a licensed physician, ideally through a legitimate compounding pathway once regulatory status clarifies — not through unregulated online vendors.</li>
-          </ul>
-        </div>
-
-        <div id="bottom-line" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Bottom Line</h2>
-          <p className="text-muted leading-relaxed">
-            BPC-157 has genuinely interesting preclinical data for tissue repair, but the human evidence base is thin, the regulatory status is unsettled, and the RUO supply chain carries real quality-control risk. This is a “watch closely” compound, not a “well-established” one — its FDA compounding status is likely to be clarified by the July 2026 PCAC decision.
-          </p>
-        </div>
-
-      </section>
-
-      <div className="mt-8 flex gap-4 flex-wrap">
-        <Link href="/guides/" className="text-sm font-medium text-emerald-700 hover:underline">Back to guides &rarr;</Link>
-        <Link href="/compounds/bpc-157/" className="text-sm font-medium text-emerald-700 hover:underline">View BPC-157 compound profile &rarr;</Link>
-        <Link href="/guides/other/tb-500/" className="text-sm font-medium text-emerald-700 hover:underline">Read the TB-500 guide &rarr;</Link>
-
       </div>
-    </div>
-    <References refs={BPC_157_REFS} />
+      <References refs={BPC_157_REFS} />
     </ArticleLayout>
   )
 }

--- a/app/guides/other/cjc-1295/page.tsx
+++ b/app/guides/other/cjc-1295/page.tsx
@@ -9,150 +9,123 @@ import type { Heading } from '@/components/articles'
 import References from '@/components/References'
 
 export const metadata: Metadata = buildPageMetadata({
-  title: 'CJC-1295: GHRH Analog Benefits, Evidence, and Legal Status',
-  description: 'Evidence-based overview of CJC-1295, a growth hormone releasing hormone (GHRH) analog — mechanism, DAC vs. no-DAC forms, research, and current legal status.',
+  title: 'CJC-1295: Human Evidence, FDA Status, and Safety (2026)',
+  description: 'Evidence-first overview of CJC-1295, including human GH/IGF-1 pharmacology, limits of benefit claims, FDA compounding safety concerns, and current regulatory context.',
   path: '/guides/other/cjc-1295/',
 })
 
 const HEADINGS: Heading[] = [
   { id: 'understanding', text: 'What Is CJC-1295?', level: 2 },
-  { id: 'mechanism', text: 'Mechanism of Action', level: 2 },
-  { id: 'evidence', text: 'What the Evidence Shows', level: 2 },
-  { id: 'legal', text: 'Legal & Regulatory Status', level: 2 },
-  { id: 'safety', text: 'Safety Considerations', level: 2 },
+  { id: 'evidence', text: 'What the Evidence Can Show', level: 2 },
+  { id: 'legal', text: 'FDA & Compounding Status', level: 2 },
+  { id: 'safety', text: 'Safety Uncertainty', level: 2 },
   { id: 'bottom-line', text: 'Bottom Line', level: 2 },
 ]
 
 const CJC_1295_REFS = [
-  { n: 1, text: 'Teichman SL, et al. (2006). Prolonged stimulation of GH and IGF-1 by CJC-1295. J Clin Endocrinol Metab, 91(3): 799-805.', url: 'https://pubmed.ncbi.nlm.nih.gov/16352683/' },
-  { n: 2, text: 'Sackmann-Sala L, et al. (2011). Heterogeneity of GH responsiveness to GHRH analogs. Endocrinology, 152(9): 3442-3450.', url: 'https://pubmed.ncbi.nlm.nih.gov/21712363/' },
+  { n: 1, text: 'FDA. Certain Bulk Drug Substances for Use in Compounding that May Present Significant Safety Risks.', url: 'https://www.fda.gov/drugs/human-drug-compounding/certain-bulk-drug-substances-use-compounding-may-present-significant-safety-risks' },
+  { n: 2, text: 'FDA. December 4, 2024 Meeting of the Pharmacy Compounding Advisory Committee.', url: 'https://www.fda.gov/advisory-committees/advisory-committee-calendar/updated-meeting-time-and-public-participation-information-december-4-2024-meeting-pharmacy' },
+  { n: 3, text: 'FDA. Bulk Drug Substances Used in Compounding Under Section 503A of the FD&C Act.', url: 'https://www.fda.gov/drugs/human-drug-compounding/bulk-drug-substances-used-compounding-under-section-503a-fdc-act' },
+  { n: 4, text: 'Teichman SL, et al. Prolonged stimulation of growth hormone and IGF-I secretion by CJC-1295. J Clin Endocrinol Metab. 2006.', url: 'https://pubmed.ncbi.nlm.nih.gov/16352683/' },
 ]
 
 export default function Page() {
   const toc = <TableOfContents headings={HEADINGS} />
-
   const breadcrumbs = [
     { label: 'Home', href: '/' },
     { label: 'Guides', href: '/guides' },
-    { label: 'CJC-1295: GHRH Analog Benefits, Evidence, and Legal Status' },
+    { label: 'CJC-1295: Human Evidence, FDA Status, and Safety' },
   ]
 
   return (
     <ArticleLayout toc={toc} zone="harm-reduction">
-    <div className="space-y-8">
-      <AuthorityBreadcrumbs items={breadcrumbs} />
+      <div className="space-y-8">
+        <AuthorityBreadcrumbs items={breadcrumbs} />
 
-      <section className="hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8">
-        <p className="eyebrow-label">Peptide &amp; Compound Guide</p>
-        <h1 className="mt-2 text-3xl font-semibold text-ink sm:text-4xl">CJC-1295: GHRH Analog Benefits, Evidence, and Legal Status</h1>
-        <p className="detail-reading mt-4 text-muted">Evidence-based overview of CJC-1295, a growth hormone releasing hormone (GHRH) analog — mechanism, DAC vs. no-DAC forms, research, and current legal status.</p>
+        <section className="hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8">
+          <p className="eyebrow-label">Experimental Peptide Guide</p>
+          <h1 className="mt-2 text-3xl font-semibold text-ink sm:text-4xl">CJC-1295: Human Evidence, FDA Status, and Safety</h1>
+          <p className="detail-reading mt-4 text-muted">
+            CJC-1295 can raise GH and IGF-1 in humans, but a measurable hormone response is not the same as proven benefit for recovery, sleep, body composition, or longevity.
+          </p>
+          <figure className="mt-6">
+            <div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white">
+              <Image src="/images/guides/cjc-1295.jpg" alt="A glass vial of lyophilized research peptide powder in a lab setting" width={1536} height={1024} priority className="w-full h-auto" />
+            </div>
+            <figcaption className="mt-3 text-center text-sm text-muted">CJC-1295 — human pharmacology exists, but broad clinical benefit claims remain unestablished.</figcaption>
+          </figure>
+        </section>
 
-        <figure className="mt-6">
-          <div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white">
-            <Image
-              src="/images/guides/cjc-1295.jpg"
-              alt="A glass vial of lyophilized research peptide powder in a lab setting"
-              width={1536}
-              height={1024}
-              priority
-              className="w-full h-auto"
-            />
+        <section className="rounded-2xl border border-rose-900/15 bg-rose-50/80 p-5 text-sm leading-6 text-rose-950">
+          <p className="font-semibold">Unapproved-drug notice</p>
+          <p className="mt-2">CJC-1295 is not an FDA-approved drug product. Online or RUO availability does not establish FDA authorization, clinical effectiveness, product quality, or suitability for human use.</p>
+        </section>
+
+        <AffiliateDisclosure />
+
+        <section className="prose-section space-y-6">
+          <div className="card-premium p-6">
+            <p className="text-sm font-semibold text-brand-700 uppercase tracking-wide">Review status</p>
+            <p className="mt-3 text-sm text-muted">Regulatory wording reviewed August 12, 2026 against current FDA compounding material.</p>
           </div>
-          <figcaption className="mt-3 text-center text-sm text-muted">
-            CJC-1295 — an educational, research-use-only overview.
-          </figcaption>
-        </figure>
-      </section>
 
-      <section className="rounded-2xl border border-rose-900/15 bg-rose-50/80 p-5 text-sm leading-6 text-rose-950">
-        <p className="font-semibold">Research-use-only (RUO) notice</p>
-        <p className="mt-2">
-          CJC-1295 is not FDA-approved for any human use. This page is educational only, does not endorse purchase or use, and is not medical or legal advice. Its compounding-pharmacy pathway is currently uncertain — verify against current FDA guidance before drawing conclusions.
-        </p>
-      </section>
+          <div id="understanding" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">What Is CJC-1295?</h2>
+            <p className="text-muted leading-relaxed">
+              CJC-1295 is a synthetic growth-hormone-releasing-hormone analogue. The name is often used loosely in peptide marketing, so readers should verify the exact molecule and formulation rather than assuming every product sold as “CJC-1295” matches the material studied in published human pharmacology research.
+            </p>
+            <p className="text-muted leading-relaxed">
+              CJC-1295 with a drug-affinity-complex modification was designed for prolonged exposure. Shorter-acting products marketed as “no DAC” or “Mod GRF 1-29” should not be treated as automatically equivalent to the long-acting molecule studied in the best-known CJC-1295 trial.
+            </p>
+          </div>
 
-      <AffiliateDisclosure />
+          <div id="evidence" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">What the Evidence Can Show</h2>
+            <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
+              <li><strong>Human pharmacology:</strong> early trials showed prolonged, dose-related increases in GH and IGF-1 after CJC-1295 administration.</li>
+              <li><strong>Clinical benefit:</strong> hormone changes do not by themselves establish improved recovery, sleep, body composition, anti-aging outcomes, or long-term health.</li>
+              <li><strong>Combination use:</strong> common CJC-1295 + ipamorelin protocols are not supported by robust controlled human outcome trials for the claims usually made online.</li>
+              <li><strong>Long-term safety:</strong> available clinical data are limited, particularly for repeated real-world use outside research settings.</li>
+            </ul>
+            <p className="text-muted leading-relaxed"><strong>Evidence quality: pharmacology established better than patient-important benefit.</strong></p>
+          </div>
 
-      <section className="prose-section space-y-6">
-        <div className="card-premium p-6">
-          <p className="text-sm font-semibold text-brand-700 uppercase tracking-wide">Important Disclaimer</p>
-          <p className="mt-3 text-sm text-muted">This guide is for informational purposes only and does not constitute medical advice. CJC-1295 is not FDA-approved. Consult a licensed physician before considering any peptide therapy. Content last reviewed for regulatory accuracy: June 30, 2026.</p>
+          <div id="legal" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">FDA &amp; Compounding Status (August 2026)</h2>
+            <p className="text-muted leading-relaxed">
+              FDA's Pharmacy Compounding Advisory Committee discussed CJC-1295-related substances at its <strong>December 4, 2024</strong> meeting. FDA's current significant-safety-risk page still lists CJC-1295 among substances whose nominations were withdrawn and notes limited clinical data plus safety concerns.
+            </p>
+            <p className="text-muted leading-relaxed">
+              FDA's 503A page explains that final bulks-list decisions are made through agency rulemaking. A past advisory-committee discussion, a withdrawn nomination, a clinic offering, or an RUO label should not be translated into a claim that CJC-1295 is FDA-approved or generally authorized for human use.
+            </p>
+            <p className="text-muted leading-relaxed"><strong>Bottom line:</strong> CJC-1295 is not FDA-approved, and the current FDA record does not support describing it as a settled or broadly authorized compounded therapy.</p>
+          </div>
+
+          <div id="safety" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Safety Uncertainty</h2>
+            <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
+              <li>FDA identifies potential immunogenicity and peptide/API-characterization concerns for compounded CJC-1295.</li>
+              <li>FDA reports serious adverse events associated with CJC-1295, including increased heart rate and a systemic vasodilatory reaction, while noting that available clinical data are limited.</li>
+              <li>Repeated GH/IGF-1 elevation can have metabolic and growth-signaling consequences; CJC-1295-specific long-term outcome data are inadequate to quantify those risks confidently.</li>
+              <li>Injectable products add sterility, contamination, identity, and strength risks when quality is uncertain.</li>
+            </ul>
+          </div>
+
+          <div id="bottom-line" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Bottom Line</h2>
+            <p className="text-muted leading-relaxed">
+              CJC-1295 has real human GH/IGF-1 pharmacology, but that is narrower than the recovery, sleep, physique, and longevity claims attached to it in marketing. FDA's current safety material remains cautious, and no regulatory shortcut turns a measurable hormone response into a proven or generally safe human therapy.
+            </p>
+          </div>
+        </section>
+
+        <div className="mt-8 flex gap-4 flex-wrap">
+          <Link href="/guides/" className="text-sm font-medium text-emerald-700 hover:underline">Back to guides &rarr;</Link>
+          <Link href="/compounds/cjc-1295/" className="text-sm font-medium text-emerald-700 hover:underline">View CJC-1295 compound profile &rarr;</Link>
+          <Link href="/guides/other/ipamorelin/" className="text-sm font-medium text-emerald-700 hover:underline">Read the Ipamorelin guide &rarr;</Link>
         </div>
-
-        <div id="understanding" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">What Is CJC-1295?</h2>
-          <p className="text-muted leading-relaxed">
-            CJC-1295 is a synthetic analog of growth hormone releasing hormone (GHRH), engineered for a longer half-life than natural GHRH. It works upstream of growth hormone secretagogues like Ipamorelin — rather than triggering GH release via the ghrelin receptor, it acts directly on GHRH receptors in the pituitary, and the two are commonly combined in gray-market protocols to produce a larger, more sustained GH pulse than either compound alone.
-          </p>
-          <p className="text-muted leading-relaxed">
-            There are two distinct forms sold under this name, and they are not interchangeable:
-          </p>
-          <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
-            <li><strong>CJC-1295 with DAC</strong> (Drug Affinity Complex) — modified to bind serum albumin, extending its half-life to several days and producing sustained, non-pulsatile GH/IGF-1 elevation</li>
-            <li><strong>CJC-1295 without DAC</strong> (also sold as “Mod GRF 1-29”) — a shorter-acting form with a half-life of roughly 30 minutes, producing a more natural pulsatile GH release closer to the body's endogenous pattern</li>
-          </ul>
-        </div>
-
-        <div id="mechanism" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Mechanism of Action</h2>
-          <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
-            <li><strong>GHRH receptor agonism</strong> — binds and activates GHRH receptors in the anterior pituitary, stimulating synthesis and release of growth hormone</li>
-            <li><strong>DAC modification</strong> — the DAC form's albumin-binding extends circulating half-life dramatically, trading the natural pulsatile GH pattern for sustained elevation</li>
-            <li><strong>Downstream IGF-1 increase</strong> — as with other GH-axis compounds, sustained use is associated with elevated IGF-1 levels, the main mediator of GH's tissue-building effects</li>
-          </ul>
-        </div>
-
-        <div id="evidence" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">What the Evidence Shows</h2>
-          <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
-            <li><span className="font-semibold text-ink">GH/IGF-1 elevation:</span> Early-phase human studies (largely from the compound's original pharmaceutical development in the 2000s, before development was discontinued) confirmed dose-dependent GH and IGF-1 increases with both DAC and non-DAC forms.</li>
-            <li><span className="font-semibold text-ink">Body composition:</span> Some human trial data from CJC-1295's original clinical development program showed modest increases in lean body mass over weeks of dosing, consistent with GH-axis activation.</li>
-            <li><span className="font-semibold text-ink">Combination protocols:</span> No controlled human trials exist for CJC-1295 combined with Ipamorelin specifically, despite this being the most common gray-market use pattern — the rationale is mechanistic (complementary GHRH + ghrelin receptor pathways) rather than trial-validated for the combination itself.</li>
-            <li><span className="font-semibold text-ink">Long-term outcomes:</span> No long-term human safety or efficacy data exists at any dose or protocol.</li>
-          </ul>
-          <p className="text-muted leading-relaxed">
-            <strong>Evidence quality: preliminary.</strong> The GH/IGF-1 mechanism is reasonably well established from early pharmaceutical development; specific downstream benefit claims (recovery, sleep, aesthetics) are not directly trial-validated.
-          </p>
-        </div>
-
-        <div id="legal" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Legal & Regulatory Status (Updated June 2026)</h2>
-          <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
-            <li><span className="font-semibold text-ink">2023–April 2026:</span> CJC-1295 was on the FDA's Category 2 restricted 503A bulk substances list.</li>
-            <li><span className="font-semibold text-ink">April 2026:</span> The FDA removed CJC-1295 from Category 2 following withdrawal of its nomination — but, as with BPC-157 and TB-500, this did <em>not</em> move it to Category 1. It is not FDA-approved, has no recognized USP/NF monograph, and sits in a regulatory gray zone: neither explicitly prohibited from compounding nor formally authorized.</li>
-            <li><span className="font-semibold text-ink">PCAC agenda:</span> CJC-1295 was <em>not</em> among the peptides scheduled for the July 23–24, 2026 PCAC meeting agenda (which covers BPC-157, KPV, TB-500, MOTS-C, Emideltide/DSIP, Semax, and Epitalon) — its longer-term compounding pathway remains less clear than those compounds.</li>
-          </ul>
-          <p className="text-muted leading-relaxed">
-            <strong>Bottom line:</strong> CJC-1295 is not FDA-approved for any human use. It is legally sellable only as “research use only” product; the compounding-pharmacy pathway is currently uncertain and not on the near-term PCAC review calendar.
-          </p>
-        </div>
-
-        <div id="safety" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Safety Considerations</h2>
-          <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
-            <li>The DAC form's sustained, non-pulsatile GH elevation is a meaningfully different physiological exposure than the body's natural pulsatile GH pattern, and this distinction matters for theoretical long-term risk — sustained supraphysiological GH/IGF-1 exposure is associated with known risks (insulin resistance, potential growth-factor-related concerns) in the broader GH-axis literature, though CJC-1295-specific long-term human data doesn't exist to confirm or rule out these effects.</li>
-            <li>No completed long-term human safety trials exist for either DAC or non-DAC forms.</li>
-            <li>RUO product sourcing carries the same purity and mislabeling risks as other gray-market peptides.</li>
-          </ul>
-        </div>
-
-        <div id="bottom-line" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Bottom Line</h2>
-          <p className="text-muted leading-relaxed">
-            CJC-1295 has legitimate GH-axis pharmacology behind it from its original (discontinued) clinical development, but current use is almost entirely off-label and unregulated. The DAC vs. non-DAC distinction matters for risk profile and is frequently glossed over in consumer-facing marketing.
-          </p>
-        </div>
-
-      </section>
-
-      <div className="mt-8 flex gap-4 flex-wrap">
-        <Link href="/guides/" className="text-sm font-medium text-emerald-700 hover:underline">Back to guides &rarr;</Link>
-        <Link href="/compounds/cjc-1295/" className="text-sm font-medium text-emerald-700 hover:underline">View CJC-1295 compound profile &rarr;</Link>
-        <Link href="/guides/other/ipamorelin/" className="text-sm font-medium text-emerald-700 hover:underline">Read the Ipamorelin guide &rarr;</Link>
-
       </div>
-    </div>
-    <References refs={CJC_1295_REFS} />
+      <References refs={CJC_1295_REFS} />
     </ArticleLayout>
   )
 }

--- a/app/guides/other/ipamorelin/page.tsx
+++ b/app/guides/other/ipamorelin/page.tsx
@@ -9,150 +9,119 @@ import type { Heading } from '@/components/articles'
 import References from '@/components/References'
 
 export const metadata: Metadata = buildPageMetadata({
-  title: 'Ipamorelin: Growth Hormone Secretagogue Benefits, Evidence & Legal Status',
-  description: 'Evidence-based overview of Ipamorelin, a selective growth-hormone secretagogue — mechanism, research on body composition and sleep, and current legal status.',
+  title: 'Ipamorelin: Human Evidence, FDA Status, and Safety (2026)',
+  description: 'Evidence-first overview of ipamorelin, including human GH-release pharmacology, limits of anti-aging and recovery claims, FDA compounding safety concerns, and current regulatory status.',
   path: '/guides/other/ipamorelin/',
 })
 
 const HEADINGS: Heading[] = [
   { id: 'understanding', text: 'What Is Ipamorelin?', level: 2 },
-  { id: 'mechanism', text: 'Mechanism of Action', level: 2 },
-  { id: 'evidence', text: 'What the Evidence Shows', level: 2 },
-  { id: 'legal', text: 'Legal & Regulatory Status', level: 2 },
-  { id: 'safety', text: 'Safety Considerations', level: 2 },
+  { id: 'evidence', text: 'What the Evidence Can Show', level: 2 },
+  { id: 'legal', text: 'FDA & Compounding Status', level: 2 },
+  { id: 'safety', text: 'Safety Uncertainty', level: 2 },
   { id: 'bottom-line', text: 'Bottom Line', level: 2 },
 ]
 
 const IPAMORELIN_REFS = [
-  { n: 1, text: 'Johannsson G, et al. (1997). GH secretagogues: pharmacology and clinical potential. Endocr Rev, 18(5): 646-677.', url: 'https://pubmed.ncbi.nlm.nih.gov/9331546/' },
-  { n: 2, text: 'Bowers CY. (1998). Growth hormone-releasing peptide (GHRP). Cell Mol Life Sci, 54(12): 1316-1329.', url: 'https://pubmed.ncbi.nlm.nih.gov/9893709/' },
+  { n: 1, text: 'FDA. Certain Bulk Drug Substances for Use in Compounding that May Present Significant Safety Risks.', url: 'https://www.fda.gov/drugs/human-drug-compounding/certain-bulk-drug-substances-use-compounding-may-present-significant-safety-risks' },
+  { n: 2, text: 'FDA. Bulk Drug Substances Used in Compounding Under Section 503A of the FD&C Act.', url: 'https://www.fda.gov/drugs/human-drug-compounding/bulk-drug-substances-used-compounding-under-section-503a-fdc-act' },
+  { n: 3, text: 'Raun K, et al. Ipamorelin, the first selective growth hormone secretagogue. Eur J Endocrinol. 1998.', url: 'https://pubmed.ncbi.nlm.nih.gov/9849822/' },
 ]
 
 export default function Page() {
   const toc = <TableOfContents headings={HEADINGS} />
-
   const breadcrumbs = [
     { label: 'Home', href: '/' },
     { label: 'Guides', href: '/guides' },
-    { label: 'Ipamorelin: Growth Hormone Secretagogue Benefits, Evidence & Legal Status' },
+    { label: 'Ipamorelin: Human Evidence, FDA Status, and Safety' },
   ]
 
   return (
     <ArticleLayout toc={toc} zone="harm-reduction">
-    <div className="space-y-8">
-      <AuthorityBreadcrumbs items={breadcrumbs} />
+      <div className="space-y-8">
+        <AuthorityBreadcrumbs items={breadcrumbs} />
 
-      <section className="hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8">
-        <p className="eyebrow-label">Peptide &amp; Compound Guide</p>
-        <h1 className="mt-2 text-3xl font-semibold text-ink sm:text-4xl">Ipamorelin: Growth Hormone Secretagogue Benefits, Evidence & Legal Status</h1>
-        <p className="detail-reading mt-4 text-muted">Evidence-based overview of Ipamorelin, a selective growth-hormone secretagogue — mechanism, research on body composition and sleep, and current legal status.</p>
+        <section className="hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8">
+          <p className="eyebrow-label">Experimental Peptide Guide</p>
+          <h1 className="mt-2 text-3xl font-semibold text-ink sm:text-4xl">Ipamorelin: Human Evidence, FDA Status, and Safety</h1>
+          <p className="detail-reading mt-4 text-muted">
+            Ipamorelin can stimulate growth-hormone release, but that pharmacology is much better established than the anti-aging, recovery, sleep, or body-composition outcomes used to market it.
+          </p>
+          <figure className="mt-6">
+            <div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white">
+              <Image src="/images/guides/ipamorelin.jpg" alt="A research peptide vial with a sterile syringe on a clinical surface" width={1536} height={1024} priority className="w-full h-auto" />
+            </div>
+            <figcaption className="mt-3 text-center text-sm text-muted">Ipamorelin — hormone-release pharmacology does not establish broad clinical benefit.</figcaption>
+          </figure>
+        </section>
 
-        <figure className="mt-6">
-          <div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white">
-            <Image
-              src="/images/guides/ipamorelin.jpg"
-              alt="A research peptide vial with a sterile syringe on a clinical surface"
-              width={1536}
-              height={1024}
-              priority
-              className="w-full h-auto"
-            />
+        <section className="rounded-2xl border border-rose-900/15 bg-rose-50/80 p-5 text-sm leading-6 text-rose-950">
+          <p className="font-semibold">Unapproved-drug notice</p>
+          <p className="mt-2">Ipamorelin is not an FDA-approved finished drug product. Clinic availability, a compounded preparation, or an RUO label does not establish FDA approval, broad clinical effectiveness, or long-term safety.</p>
+        </section>
+
+        <AffiliateDisclosure />
+
+        <section className="prose-section space-y-6">
+          <div className="card-premium p-6">
+            <p className="text-sm font-semibold text-brand-700 uppercase tracking-wide">Review status</p>
+            <p className="mt-3 text-sm text-muted">Regulatory wording reviewed August 12, 2026 against current FDA compounding safety material.</p>
           </div>
-          <figcaption className="mt-3 text-center text-sm text-muted">
-            Ipamorelin — an educational, research-use-only overview.
-          </figcaption>
-        </figure>
-      </section>
 
-      <section className="rounded-2xl border border-rose-900/15 bg-rose-50/80 p-5 text-sm leading-6 text-rose-950">
-        <p className="font-semibold">Research-use-only (RUO) notice</p>
-        <p className="mt-2">
-          Ipamorelin is not FDA-approved as a finished drug product. This page is educational only, does not endorse purchase or use, and is not medical or legal advice. Its compounding category is pending formal Federal Register rulemaking — verify against current FDA guidance before drawing conclusions.
-        </p>
-      </section>
+          <div id="understanding" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">What Is Ipamorelin?</h2>
+            <p className="text-muted leading-relaxed">
+              Ipamorelin is a synthetic growth-hormone secretagogue and ghrelin-receptor agonist. Older pharmacology studies support its ability to stimulate GH release with a different hormone-release profile from some earlier secretagogues. That does not make it a proven anti-aging or recovery treatment.
+            </p>
+          </div>
 
-      <AffiliateDisclosure />
+          <div id="evidence" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">What the Evidence Can Show</h2>
+            <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
+              <li><strong>GH release:</strong> pharmacology studies support that ipamorelin can stimulate GH secretion.</li>
+              <li><strong>Clinical outcomes:</strong> direct controlled evidence is insufficient for broad claims about sleep, injury recovery, anti-aging, fat loss, or physique improvement in generally healthy users.</li>
+              <li><strong>Combination protocols:</strong> common ipamorelin + CJC-1295 use is more strongly justified by mechanism than by replicated human outcome trials of the combination.</li>
+              <li><strong>“Cleaner” secretagogue claims:</strong> relative hormone selectivity in a pharmacology experiment is not a blanket safety conclusion.</li>
+            </ul>
+            <p className="text-muted leading-relaxed"><strong>Evidence quality: stronger for hormone-release pharmacology than for marketed lifestyle outcomes.</strong></p>
+          </div>
 
-      <section className="prose-section space-y-6">
-        <div className="card-premium p-6">
-          <p className="text-sm font-semibold text-brand-700 uppercase tracking-wide">Important Disclaimer</p>
-          <p className="mt-3 text-sm text-muted">This guide is for informational purposes only and does not constitute medical advice. Ipamorelin is not FDA-approved. Consult a licensed physician before considering any peptide therapy. Content last reviewed for regulatory accuracy: June 30, 2026.</p>
+          <div id="legal" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">FDA &amp; Compounding Status (August 2026)</h2>
+            <p className="text-muted leading-relaxed">
+              Ipamorelin is not FDA-approved as a finished drug product. FDA's current significant-safety-risk page lists <strong>ipamorelin acetate in category 2 under the 503B interim policy</strong> and separately describes important safety-information and peptide-characterization gaps.
+            </p>
+            <p className="text-muted leading-relaxed">
+              This is more reliable than predicting that ipamorelin is “moving toward Category 1” or broad compounding access. FDA's compounding categories and final bulks-list decisions are specific regulatory processes; a clinic offering or prescription does not convert an unapproved product into an FDA-approved drug.
+            </p>
+            <p className="text-muted leading-relaxed"><strong>Bottom line:</strong> describe the current FDA category and safety record as they are; do not forecast approval or broad access from prior announcements or marketing.</p>
+          </div>
+
+          <div id="safety" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Safety Uncertainty</h2>
+            <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
+              <li>FDA flags potential immunogenicity, aggregation, peptide-impurity, and characterization concerns for compounded ipamorelin acetate.</li>
+              <li>FDA notes serious adverse events, including deaths, in a study using intravenous ipamorelin for gastric-motility purposes. That route-specific signal should not be generalized mechanically to every route, but it also cannot be reconciled with blanket “well tolerated” marketing.</li>
+              <li>FDA says safety information is lacking for certain other injectable routes and therefore lacks sufficient information to know whether harm would occur through those routes.</li>
+              <li>Repeated manipulation of the GH/IGF-1 axis raises metabolic and growth-signaling questions that short pharmacology studies cannot resolve.</li>
+            </ul>
+          </div>
+
+          <div id="bottom-line" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Bottom Line</h2>
+            <p className="text-muted leading-relaxed">
+              Ipamorelin has a legitimate pharmacology literature showing GH release, but that is narrower than the wellness claims attached to it. It is not FDA-approved, FDA currently flags significant compounding safety questions, and the evidence does not justify treating common gray-market protocols as established therapy.
+            </p>
+          </div>
+        </section>
+
+        <div className="mt-8 flex gap-4 flex-wrap">
+          <Link href="/guides/" className="text-sm font-medium text-emerald-700 hover:underline">Back to guides &rarr;</Link>
+          <Link href="/compounds/ipamorelin/" className="text-sm font-medium text-emerald-700 hover:underline">View Ipamorelin compound profile &rarr;</Link>
+          <Link href="/guides/other/cjc-1295/" className="text-sm font-medium text-emerald-700 hover:underline">Read the CJC-1295 guide &rarr;</Link>
         </div>
-
-        <div id="understanding" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">What Is Ipamorelin?</h2>
-          <p className="text-muted leading-relaxed">
-            Ipamorelin is a synthetic pentapeptide classified as a growth-hormone secretagogue (GHS) — specifically a selective ghrelin receptor agonist. It stimulates the pituitary gland to release growth hormone (GH) with relatively minimal effect on cortisol, prolactin, or appetite compared to older secretagogues like GHRP-6. This selectivity is Ipamorelin's main claim to differentiation within the GHS class.
-          </p>
-          <p className="text-muted leading-relaxed">
-            It is often paired with CJC-1295 in combination protocols (see our CJC-1295 guide), since the two act on complementary pathways to produce a more sustained GH pulse.
-          </p>
-        </div>
-
-        <div id="mechanism" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Mechanism of Action</h2>
-          <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
-            <li><strong>Ghrelin receptor (GHS-R1a) agonism</strong> — Ipamorelin binds the ghrelin receptor in the pituitary and hypothalamus, triggering a pulsatile release of endogenous growth hormone</li>
-            <li><strong>Selectivity</strong> — unlike GHRP-2/6, Ipamorelin shows minimal cross-reactivity with ACTH/cortisol and prolactin pathways in study data, which is the basis for its reputation as a “cleaner” secretagogue</li>
-            <li><strong>Pulsatile, not continuous</strong> — it mimics the body's natural GH pulse pattern rather than producing sustained elevation, which is thought to reduce desensitization risk relative to continuous GH administration</li>
-          </ul>
-        </div>
-
-        <div id="evidence" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">What the Evidence Shows</h2>
-          <p className="text-muted leading-relaxed">
-            Ipamorelin has more human clinical data than most peptides on this list, largely from studies conducted in the 1990s–2000s (including some in postoperative ileus and GH-deficiency contexts, prior to its current “research/anti-aging” market positioning):
-          </p>
-          <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
-            <li><span className="font-semibold text-ink">GH release:</span> Human studies confirm reliable, dose-dependent GH secretion with minimal effect on other pituitary hormones.</li>
-            <li><span className="font-semibold text-ink">Body composition:</span> Animal and limited human data suggest potential for modest improvements in lean mass and fat metabolism with sustained use, consistent with GH's known physiological effects.</li>
-            <li><span className="font-semibold text-ink">Bone density:</span> Some rodent studies show positive effects on bone metabolism.</li>
-            <li><span className="font-semibold text-ink">GI motility:</span> Ipamorelin was originally studied for postoperative ileus (a related secretagogue mechanism affects gut motility), though this application did not lead to FDA approval.</li>
-            <li><span className="font-semibold text-ink">Sleep, recovery, anti-aging claims:</span> Widely marketed for these uses, but direct controlled human evidence for these specific outcomes at typical gray-market self-administration protocols is limited — most support is extrapolated from GH physiology generally rather than Ipamorelin-specific trials.</li>
-          </ul>
-          <p className="text-muted leading-relaxed">
-            <strong>Evidence quality: moderate for GH-release mechanism, limited for downstream lifestyle/aesthetic claims.</strong>
-          </p>
-        </div>
-
-        <div id="legal" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Legal & Regulatory Status</h2>
-          <p className="text-muted leading-relaxed">
-            Unlike BPC-157, TB-500, and CJC-1295, Ipamorelin was <strong>not</strong> removed from the FDA's Category 2 restricted 503A bulk substances list in the April 2026 action for the same three peptides — however, per the February 2026 HHS/FDA announcement, Ipamorelin was named among the ~14 of 19 originally restricted peptides expected to move back toward Category 1 (compoundable) status. As of mid-2026, formal Federal Register rulemaking confirming its final category had not yet published; treat its compounding-pharmacy status as pending, not settled.
-          </p>
-          <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
-            <li>Ipamorelin is <strong>not FDA-approved</strong> as a finished drug product for any indication.</li>
-            <li>No prescription form of Ipamorelin exists on the market; any product is either RUO or compounded (where currently accessible) under a physician's off-label prescription.</li>
-            <li>Ipamorelin is prohibited under WADA's S2 category (peptide hormones, growth factors, and related substances) for competitive athletes, independent of its FDA compounding status.</li>
-          </ul>
-        </div>
-
-        <div id="safety" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Safety Considerations</h2>
-          <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
-            <li>Short-term human studies have not identified major safety signals at studied doses; long-term (multi-year) safety data does not exist.</li>
-            <li>Because it stimulates endogenous GH release, theoretical concerns around GH's known effects (insulin sensitivity changes, potential growth-factor-driven proliferation effects) apply and are a reason for physician-supervised use and monitoring rather than self-directed protocols.</li>
-            <li>RUO-sourced product quality is not independently verified.</li>
-          </ul>
-        </div>
-
-        <div id="bottom-line" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Bottom Line</h2>
-          <p className="text-muted leading-relaxed">
-            Of the peptides covered in this series, Ipamorelin has one of the stronger direct human data trails for its core mechanism (GH secretion). The downstream claims around body composition, sleep, and anti-aging benefit are more extrapolated than proven. Regulatory status is trending toward eventual compounding access but is not yet finalized.
-          </p>
-        </div>
-
-      </section>
-
-      <div className="mt-8 flex gap-4 flex-wrap">
-        <Link href="/guides/" className="text-sm font-medium text-emerald-700 hover:underline">Back to guides &rarr;</Link>
-        <Link href="/compounds/ipamorelin/" className="text-sm font-medium text-emerald-700 hover:underline">View Ipamorelin compound profile &rarr;</Link>
-        <Link href="/guides/other/cjc-1295/" className="text-sm font-medium text-emerald-700 hover:underline">Read the CJC-1295 guide &rarr;</Link>
-
       </div>
-    </div>
-    <References refs={IPAMORELIN_REFS} />
+      <References refs={IPAMORELIN_REFS} />
     </ArticleLayout>
   )
 }

--- a/app/guides/other/ipamorelin/page.tsx
+++ b/app/guides/other/ipamorelin/page.tsx
@@ -92,7 +92,7 @@ export default function Page() {
               Ipamorelin is not FDA-approved as a finished drug product. FDA's current significant-safety-risk page lists <strong>ipamorelin acetate in category 2 under the 503B interim policy</strong> and separately describes important safety-information and peptide-characterization gaps.
             </p>
             <p className="text-muted leading-relaxed">
-              This is more reliable than predicting that ipamorelin is “moving toward Category 1” or broad compounding access. FDA's compounding categories and final bulks-list decisions are specific regulatory processes; a clinic offering or prescription does not convert an unapproved product into an FDA-approved drug.
+              This is more reliable than forecasting a future reclassification or broad compounding access. FDA's compounding categories and final bulks-list decisions are specific regulatory processes; a clinic offering or prescription does not convert an unapproved product into an FDA-approved drug.
             </p>
             <p className="text-muted leading-relaxed"><strong>Bottom line:</strong> describe the current FDA category and safety record as they are; do not forecast approval or broad access from prior announcements or marketing.</p>
           </div>

--- a/app/guides/other/tb-500/page.tsx
+++ b/app/guides/other/tb-500/page.tsx
@@ -9,150 +9,120 @@ import type { Heading } from '@/components/articles'
 import References from '@/components/References'
 
 export const metadata: Metadata = buildPageMetadata({
-  title: 'TB-500 (Thymosin Beta-4): Benefits, Evidence, Legal Status, and Safety',
-  description: 'Evidence-based overview of TB-500 — actin-binding mechanism, recovery/repair research, FDA compounding status update, and safety.',
+  title: 'TB-500: Human Evidence, FDA Status, and Safety (2026)',
+  description: 'Current evidence-first overview of the TB-500 thymosin-beta-4 fragment, including molecule-specific evidence, the July 2026 FDA advisory meeting, and safety uncertainty.',
   path: '/guides/other/tb-500/',
 })
 
 const HEADINGS: Heading[] = [
-  { id: 'understanding', text: 'What Is TB-500?', level: 2 },
-  { id: 'mechanism', text: 'Mechanism of Action', level: 2 },
-  { id: 'evidence', text: 'What the Evidence Shows', level: 2 },
-  { id: 'legal', text: 'Legal & Regulatory Status', level: 2 },
-  { id: 'safety', text: 'Safety Considerations', level: 2 },
+  { id: 'understanding', text: 'TB-500 vs. Thymosin Beta-4', level: 2 },
+  { id: 'evidence', text: 'What the Evidence Can Show', level: 2 },
+  { id: 'legal', text: 'FDA & Compounding Status', level: 2 },
+  { id: 'safety', text: 'Safety Uncertainty', level: 2 },
   { id: 'bottom-line', text: 'Bottom Line', level: 2 },
 ]
 
 const TB_500_REFS = [
-  { n: 1, text: 'Goldstein AL, et al. (2012). Thymosin β4: a multi-functional regenerative peptide. Expert Opin Biol Ther, 12(Suppl 1): S37-S44.', url: 'https://pubmed.ncbi.nlm.nih.gov/22500833/' },
-  { n: 2, text: 'Croft DR, et al. (2005). Thymosin β4 in wound healing. J Invest Dermatol, 124(4): 778-785.', url: 'https://pubmed.ncbi.nlm.nih.gov/15816838/' },
+  { n: 1, text: 'FDA. Certain Bulk Drug Substances for Use in Compounding that May Present Significant Safety Risks.', url: 'https://www.fda.gov/drugs/human-drug-compounding/certain-bulk-drug-substances-use-compounding-may-present-significant-safety-risks' },
+  { n: 2, text: 'FDA. July 23-24, 2026 Meeting of the Pharmacy Compounding Advisory Committee.', url: 'https://www.fda.gov/advisory-committees/advisory-committee-calendar/july-23-24-2026-meeting-pharmacy-compounding-advisory-committee-07232026' },
+  { n: 3, text: 'FDA. Bulk Drug Substances Used in Compounding Under Section 503A of the FD&C Act.', url: 'https://www.fda.gov/drugs/human-drug-compounding/bulk-drug-substances-used-compounding-under-section-503a-fdc-act' },
+  { n: 4, text: 'Goldstein AL, et al. Thymosin beta-4: a multi-functional regenerative peptide. Expert Opin Biol Ther. 2012.', url: 'https://pubmed.ncbi.nlm.nih.gov/22500833/' },
 ]
 
 export default function Page() {
   const toc = <TableOfContents headings={HEADINGS} />
-
   const breadcrumbs = [
     { label: 'Home', href: '/' },
     { label: 'Guides', href: '/guides' },
-    { label: 'TB-500 (Thymosin Beta-4): Benefits, Evidence, Legal Status, and Safety' },
+    { label: 'TB-500: Human Evidence, FDA Status, and Safety' },
   ]
 
   return (
     <ArticleLayout toc={toc} zone="harm-reduction">
-    <div className="space-y-8">
-      <AuthorityBreadcrumbs items={breadcrumbs} />
+      <div className="space-y-8">
+        <AuthorityBreadcrumbs items={breadcrumbs} />
 
-      <section className="hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8">
-        <p className="eyebrow-label">Peptide &amp; Compound Guide</p>
-        <h1 className="mt-2 text-3xl font-semibold text-ink sm:text-4xl">TB-500 (Thymosin Beta-4): Benefits, Evidence, Legal Status, and Safety</h1>
-        <p className="detail-reading mt-4 text-muted">Evidence-based overview of TB-500 — actin-binding mechanism, recovery/repair research, FDA compounding status update, and safety.</p>
+        <section className="hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8">
+          <p className="eyebrow-label">Experimental Peptide Guide</p>
+          <h1 className="mt-2 text-3xl font-semibold text-ink sm:text-4xl">TB-500: Human Evidence, FDA Status, and Safety</h1>
+          <p className="detail-reading mt-4 text-muted">
+            TB-500 is commonly discussed alongside full-length thymosin beta-4, but they are not interchangeable evidence targets. This guide keeps the fragment, the broader Tβ4 literature, and current FDA status separate.
+          </p>
+          <figure className="mt-6">
+            <div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white">
+              <Image src="/images/guides/tb-500.jpg" alt="A research peptide vial with a sterile syringe on a clinical surface" width={1536} height={1024} priority className="w-full h-auto" />
+            </div>
+            <figcaption className="mt-3 text-center text-sm text-muted">TB-500 — experimental fragment research, not established human therapy.</figcaption>
+          </figure>
+        </section>
 
-        <figure className="mt-6">
-          <div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white">
-            <Image
-              src="/images/guides/tb-500.jpg"
-              alt="A research peptide vial with a sterile syringe on a clinical surface"
-              width={1536}
-              height={1024}
-              priority
-              className="w-full h-auto"
-            />
+        <section className="rounded-2xl border border-rose-900/15 bg-rose-50/80 p-5 text-sm leading-6 text-rose-950">
+          <p className="font-semibold">Unapproved-drug notice</p>
+          <p className="mt-2">TB-500 is not an FDA-approved drug product. An RUO label or online sale does not establish approval, clinical effectiveness, product quality, or suitability for human use.</p>
+        </section>
+
+        <AffiliateDisclosure />
+
+        <section className="prose-section space-y-6">
+          <div className="card-premium p-6">
+            <p className="text-sm font-semibold text-brand-700 uppercase tracking-wide">Review status</p>
+            <p className="mt-3 text-sm text-muted">Regulatory wording reviewed August 12, 2026 against current FDA compounding and advisory-committee material.</p>
           </div>
-          <figcaption className="mt-3 text-center text-sm text-muted">
-            TB-500 — an educational, research-use-only overview.
-          </figcaption>
-        </figure>
-      </section>
 
-      <section className="rounded-2xl border border-rose-900/15 bg-rose-50/80 p-5 text-sm leading-6 text-rose-950">
-        <p className="font-semibold">Research-use-only (RUO) notice</p>
-        <p className="mt-2">
-          TB-500 is not FDA-approved for human use. This page is educational only, does not endorse purchase or use, and is not medical or legal advice. Its FDA compounding status is actively evolving — verify against current FDA guidance before drawing conclusions.
-        </p>
-      </section>
+          <div id="understanding" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">TB-500 vs. Thymosin Beta-4</h2>
+            <p className="text-muted leading-relaxed">
+              Full-length thymosin beta-4 (Tβ4) is a naturally occurring 43-amino-acid peptide with a substantial preclinical research literature. FDA's current compounding safety page identifies <strong>TB-500 as the thymosin beta-4 fragment LKKTETQ</strong>. Evidence for full-length Tβ4 should not be silently presented as human efficacy or safety evidence for the TB-500 fragment.
+            </p>
+          </div>
 
-      <AffiliateDisclosure />
+          <div id="evidence" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">What the Evidence Can Show</h2>
+            <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
+              <li><strong>Full-length Tβ4:</strong> animal and early research programs examine cell migration, wound repair, angiogenesis, cardiac injury, and other tissue-repair pathways.</li>
+              <li><strong>TB-500 fragment:</strong> the direct human evidence base is much thinner than the broader Tβ4 literature often cited in marketing.</li>
+              <li><strong>Human exposure:</strong> FDA says it has not identified human exposure data for drug products containing the TB-500 fragment.</li>
+              <li><strong>Sports-recovery claims:</strong> controlled human evidence does not establish that TB-500 accelerates tendon, ligament, or muscle recovery in athletes.</li>
+            </ul>
+            <p className="text-muted leading-relaxed"><strong>Evidence quality: preliminary and molecule-sensitive.</strong> Parent-peptide biology is not proof for the marketed fragment.</p>
+          </div>
 
-      <section className="prose-section space-y-6">
-        <div className="card-premium p-6">
-          <p className="text-sm font-semibold text-brand-700 uppercase tracking-wide">Important Disclaimer</p>
-          <p className="mt-3 text-sm text-muted">This guide is for informational purposes only and does not constitute medical advice. TB-500 is not FDA-approved. Consult a licensed physician before considering any peptide therapy. Content last reviewed for regulatory accuracy: June 30, 2026.</p>
+          <div id="legal" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">FDA &amp; Compounding Status (August 2026)</h2>
+            <p className="text-muted leading-relaxed">
+              FDA's Pharmacy Compounding Advisory Committee met on <strong>July 23, 2026</strong> and discussed TB-500-related bulk drug substances for possible inclusion on the section 503A Bulks List. The meeting is no longer an upcoming event.
+            </p>
+            <p className="text-muted leading-relaxed">
+              Advisory-committee consideration does not equal FDA approval or final inclusion on the 503A Bulks List. FDA's current 503A page describes the bulks-list process as agency rulemaking, and its current safety-risk page continues to list the TB-500 fragment among nominated-but-withdrawn substances with significant information gaps.
+            </p>
+            <p className="text-muted leading-relaxed"><strong>Bottom line:</strong> TB-500 is not FDA-approved. Do not turn the July advisory meeting, an RUO label, or product availability into a claim of legal authorization or established clinical use.</p>
+          </div>
+
+          <div id="safety" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Safety Uncertainty</h2>
+            <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
+              <li>FDA flags potential immunogenicity, aggregation, and peptide-related impurity concerns for compounded drug products containing the TB-500 fragment.</li>
+              <li>FDA says it has not identified human exposure data for drug products containing the fragment and lacks important information about whether it would cause harm in humans.</li>
+              <li>Safety findings from full-length Tβ4 cannot automatically be transferred to a different fragment, formulation, dose, or route.</li>
+              <li>Injectable products add sterility, contamination, identity, and strength risks when product quality is uncertain.</li>
+            </ul>
+          </div>
+
+          <div id="bottom-line" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Bottom Line</h2>
+            <p className="text-muted leading-relaxed">
+              TB-500 is often marketed using the scientific credibility of full-length thymosin beta-4, but the fragment has a much thinner direct human evidence trail. The July 2026 FDA advisory meeting did not make it an approved therapy, and FDA's current safety page still emphasizes missing human exposure and safety information.
+            </p>
+          </div>
+        </section>
+
+        <div className="mt-8 flex gap-4 flex-wrap">
+          <Link href="/guides/" className="text-sm font-medium text-emerald-700 hover:underline">Back to guides &rarr;</Link>
+          <Link href="/compounds/tb-500/" className="text-sm font-medium text-emerald-700 hover:underline">View TB-500 compound profile &rarr;</Link>
+          <Link href="/guides/other/bpc-157/" className="text-sm font-medium text-emerald-700 hover:underline">Read the BPC-157 guide &rarr;</Link>
         </div>
-
-        <div id="understanding" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">What Is TB-500?</h2>
-          <p className="text-muted leading-relaxed">
-            TB-500 is a synthetic fragment of thymosin beta-4 (Tβ4), a naturally occurring peptide found in nearly all human and animal cells. It's marketed primarily around muscle recovery, flexibility, and connective-tissue repair. TB-500 is often discussed alongside BPC-157, and the two are frequently stacked in gray-market use, though they act through different mechanisms.
-          </p>
-          <p className="text-muted leading-relaxed">
-            TB-500 is <strong>not FDA-approved</strong> for human use.
-          </p>
-        </div>
-
-        <div id="mechanism" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Mechanism of Action</h2>
-          <p className="text-muted leading-relaxed">
-            Tβ4/TB-500's proposed mechanism centers on actin regulation:
-          </p>
-          <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
-            <li><strong>Actin binding</strong> — Tβ4 binds monomeric G-actin, a core structural protein involved in cell migration, shape, and repair. This is thought to be central to its wound-healing effects.</li>
-            <li><strong>Cell migration promotion</strong> — supports migration of endothelial cells, keratinocytes, and other repair-related cell types to injury sites</li>
-            <li><strong>Angiogenesis support</strong> — like BPC-157, associated with new blood vessel formation in animal injury models</li>
-            <li><strong>Anti-fibrotic signaling</strong> — some animal data suggests reduced scar tissue formation after injury</li>
-          </ul>
-        </div>
-
-        <div id="evidence" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">What the Evidence Shows</h2>
-          <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
-            <li><span className="font-semibold text-ink">Wound healing:</span> Animal studies (including full-thickness skin wounds) show accelerated closure and reduced inflammation with Tβ4 administration.</li>
-            <li><span className="font-semibold text-ink">Cardiac tissue:</span> Some rodent cardiac-injury models show reduced fibrosis and improved cardiomyocyte survival — this is one of the more researched applications of the underlying Tβ4 molecule specifically (separate from the synthetic fragment sold as “TB-500,” which has a smaller and less-established evidence base).</li>
-            <li><span className="font-semibold text-ink">Tendon/ligament:</span> Limited animal data suggests possible benefit in soft-tissue repair, similar rationale to BPC-157.</li>
-            <li><span className="font-semibold text-ink">Human data:</span> No completed large-scale human RCTs on TB-500 specifically. Human evidence is essentially anecdotal or drawn from the broader (and more established) Tβ4 cardiac-repair literature, which studied a related but distinct molecule and delivery context.</li>
-          </ul>
-          <p className="text-muted leading-relaxed">
-            <strong>Evidence quality: preliminary.</strong> The underlying Tβ4 biology has real scientific grounding; TB-500 the synthetic fragment product, as sold in the gray market, has a much thinner direct evidence trail.
-          </p>
-        </div>
-
-        <div id="legal" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Legal & Regulatory Status (Updated June 2026)</h2>
-          <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
-            <li><span className="font-semibold text-ink">2023–April 2026:</span> TB-500 was on the FDA's Category 2 restricted 503A bulk substances list, alongside BPC-157 and 17 other peptides — compounding pharmacies were barred from preparing it.</li>
-            <li><span className="font-semibold text-ink">April 2026:</span> TB-500 was removed from Category 2, entering the same regulatory gray zone as BPC-157: not banned, not yet approved for compounding.</li>
-            <li><span className="font-semibold text-ink">July 23, 2026:</span> TB-500 is on the FDA Pharmacy Compounding Advisory Committee's agenda (alongside BPC-157, KPV, and MOTS-C) for a formal 503A eligibility review.</li>
-          </ul>
-          <p className="text-muted leading-relaxed">
-            <strong>Bottom line:</strong> TB-500 is not an FDA-approved drug. Its compounding-pharmacy legal status is unresolved pending the July 2026 PCAC review. Product sold online is almost universally labeled “research use only,” meaning it is not legally intended for human consumption regardless of marketing claims you may see elsewhere.
-          </p>
-        </div>
-
-        <div id="safety" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Safety Considerations</h2>
-          <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
-            <li>No controlled human safety data exists for the synthetic TB-500 fragment specifically.</li>
-            <li>Theoretical concern: because Tβ4 supports angiogenesis and cell migration broadly, some researchers have raised caution around use in anyone with a personal or family history of cancer, given the general biological plausibility of growth-promoting peptides interacting with abnormal cell growth — this has not been demonstrated for TB-500 in humans, but it's a reason for physician oversight rather than self-directed use.</li>
-            <li>RUO-sourced product carries the same purity/sterility/mislabeling risks common across the gray-market peptide industry.</li>
-          </ul>
-        </div>
-
-        <div id="bottom-line" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Bottom Line</h2>
-          <p className="text-muted leading-relaxed">
-            TB-500 borrows credibility from the genuinely interesting Tβ4 wound-healing literature, but the synthetic fragment sold under this name has thin direct evidence and an unresolved regulatory status. Treat it as an actively-reviewed compound to watch, not an established therapeutic.
-          </p>
-        </div>
-
-      </section>
-
-      <div className="mt-8 flex gap-4 flex-wrap">
-        <Link href="/guides/" className="text-sm font-medium text-emerald-700 hover:underline">Back to guides &rarr;</Link>
-        <Link href="/compounds/tb-500/" className="text-sm font-medium text-emerald-700 hover:underline">View TB-500 compound profile &rarr;</Link>
-        <Link href="/guides/other/bpc-157/" className="text-sm font-medium text-emerald-700 hover:underline">Read the BPC-157 guide &rarr;</Link>
-
       </div>
-    </div>
-    <References refs={TB_500_REFS} />
+      <References refs={TB_500_REFS} />
     </ArticleLayout>
   )
 }


### PR DESCRIPTION
## Summary
- update BPC-157 and TB-500 pages so the July 23, 2026 FDA advisory meeting is described as completed, not upcoming
- explain that advisory-committee consideration is not FDA approval or final 503A Bulks List inclusion
- replace regulatory-gray-zone / RUO-legality shortcuts with current FDA process language
- align CJC-1295 with FDA's current nominated-but-withdrawn safety-risk record and its prior December 2024 PCAC review
- replace unsupported forecasts that ipamorelin is moving toward Category 1 with FDA's current category-2 503B safety-status language
- surface current FDA safety signals for BPC-157, TB-500 fragment, CJC-1295, and ipamorelin
- keep animal/mechanistic or hormone-release findings separate from demonstrated human clinical benefit
- add regression coverage for expired meeting dates, legal-status shortcuts, and generic safety reassurance

## Primary-source basis
- FDA July 23-24, 2026 Pharmacy Compounding Advisory Committee meeting page
- FDA current Significant Safety Risks bulk-substance page
- FDA current 503A Bulks List process page
- FDA December 4, 2024 PCAC page for CJC-1295

## Scope
5 files: four standalone guides plus one regression test. No workbook or dynamic compound-profile data changed.