### PR TITLE
Short-circuit unused batched stack hydration

### DIFF
--- a/lib/__tests__/batched-stack-short-circuit.test.ts
+++ b/lib/__tests__/batched-stack-short-circuit.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getRuntimeMapEntriesForSlugs } = vi.hoisted(() => ({
+  getRuntimeMapEntriesForSlugs: vi.fn(),
+}))
+
+vi.mock('../../src/lib/runtime-related-maps', () => ({
+  getRuntimeMapEntries: vi.fn(),
+  getRuntimeMapEntriesForSlugs,
+}))
+
+import { getBatchedRuntimeRecords } from '../related-runtime'
+
+const source = { slug: 'magnesium', name: 'Magnesium' }
+const candidate = { slug: 'glycine', name: 'Glycine' }
+
+describe('getBatchedRuntimeRecords stack short-circuit', () => {
+  beforeEach(() => {
+    getRuntimeMapEntriesForSlugs.mockReset()
+  })
+
+  it('returns immediately for batched stack preloads without reading runtime maps', async () => {
+    const result = await getBatchedRuntimeRecords('stack', [source], [candidate], 6)
+
+    expect(result).toEqual({})
+    expect(getRuntimeMapEntriesForSlugs).not.toHaveBeenCalled()
+  })
+
+  it('continues to hydrate supported batched relationship kinds', async () => {
+    getRuntimeMapEntriesForSlugs.mockResolvedValue({
+      magnesium: [{ slug: 'glycine', score: 0.8 }],
+    })
+
+    const result = await getBatchedRuntimeRecords('related', [source], [candidate], 6)
+
+    expect(getRuntimeMapEntriesForSlugs).toHaveBeenCalledWith('related', ['magnesium'])
+    expect(result.magnesium?.[0]).toMatchObject({ slug: 'glycine', relatedScore: 0.8 })
+  })
+})

--- a/lib/related-runtime.ts
+++ b/lib/related-runtime.ts
@@ -119,6 +119,12 @@ export async function getBatchedRuntimeRecords(
   candidateRecords: RuntimeRecord[],
   limit = MAX_RELATED_PROFILES,
 ): Promise<Record<string, RuntimeRecord[]>> {
+  // The only current batched stack callers are profile-page preload slots whose
+  // results are intentionally discarded; visible stack recommendations come from
+  // the separate recommendation engine. Avoid map I/O, record indexing, hydration,
+  // and sorting for those dead preloads while leaving non-batched stack lookups intact.
+  if (kind === 'stack') return {}
+
   const requestedLimit = clampLimit(limit, MAX_RELATED_PROFILES, MAX_RELATED_PROFILES)
 
   if (requestedLimit === 0) return {}


### PR DESCRIPTION
## Summary
- short-circuits batched `stack` relationship requests before runtime-map I/O, candidate indexing, hydration, sorting, or slicing
- preserves non-batched stack lookups and the separate user-facing stack recommendation engine
- adds a behavioral regression test proving `stack` avoids runtime-map reads while `related` batching still hydrates normally

## Why
The only current batched `stack` callers are profile-page preload slots whose results are discarded. This removes repeated build-time work across herb and compound profile generation without changing visible stack recommendations.

## Scope
Exactly 2 net files: `lib/related-runtime.ts` plus one focused regression test.