### PR TITLE
Keep pending safety reviews from becoming reassuring badges

### DIFF
--- a/lib/safety-enum.ts
+++ b/lib/safety-enum.ts
@@ -4,8 +4,8 @@ const SAFETY_SYNONYM_RULES: Array<{ pattern: RegExp; value: StandardSafetyLabel 
   { pattern: /\b(interaction|interacts|warfarin|ssri|maoi|anticoagul|antiplatelet|polypharmacy|cns depressant)\b/i, value: 'Interaction risk' },
   { pattern: /\b(limited safety|limited data|low data|no safety data|insufficient safety)\b/i, value: 'Limited safety data' },
   { pattern: /\b(avoid|contraindicat|caution|consult|clinician|pregnan|breastfeeding|liver|kidney|seizure|bleed|sedat|toxic|risk|do not)\b/i, value: 'Use caution' },
+  { pattern: /\b(needs? review|review needed|unknown|tbd|draft|placeholder|profile pending|safety review pending)\b/i, value: 'Safety review pending' },
   { pattern: /\b(generally|well tolerated|low concern|low risk|food use|food derived|safe|standard caution)\b/i, value: 'Generally well tolerated' },
-  { pattern: /\b(needs? review|review needed|unknown|tbd|draft|placeholder|profile pending)\b/i, value: 'Safety review pending' },
 ]
 
 export type SafetyNormalizationResult = {

--- a/lib/safety-enum.ts
+++ b/lib/safety-enum.ts
@@ -2,7 +2,7 @@ import { STANDARD_SAFETY_LABELS, type StandardSafetyLabel } from './decision-pri
 
 const SAFETY_SYNONYM_RULES: Array<{ pattern: RegExp; value: StandardSafetyLabel }> = [
   { pattern: /\b(interaction|interacts|warfarin|ssri|maoi|anticoagul|antiplatelet|polypharmacy|cns depressant)\b/i, value: 'Interaction risk' },
-  { pattern: /\b(limited safety|limited data|low data|no safety data|insufficient safety)\b/i, value: 'Limited safety data' },
+  { pattern: /\b(limited safety|limited data|low data|no safety data|insufficient safety|safety (?:data|information) (?:are |is )?limited)\b/i, value: 'Limited safety data' },
   { pattern: /\b(avoid|contraindicat|caution|consult|clinician|pregnan|breastfeeding|liver|kidney|seizure|bleed|sedat|toxic|risk|do not)\b/i, value: 'Use caution' },
   { pattern: /\b(needs? review|review needed|unknown|tbd|draft|placeholder|profile pending|safety review pending)\b/i, value: 'Safety review pending' },
   { pattern: /\b(generally|well tolerated|low concern|low risk|food use|food derived|safe|standard caution)\b/i, value: 'Generally well tolerated' },

--- a/tests/safety-enum-priority.test.ts
+++ b/tests/safety-enum-priority.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeSafetyEnum } from '../lib/safety-enum'
+
+describe('safety enum priority', () => {
+  it('does not let reassuring language override a pending safety review', () => {
+    expect(normalizeSafetyEnum('Generally well tolerated; safety review pending').value).toBe('Safety review pending')
+    expect(normalizeSafetyEnum('Safe in typical use, but profile pending review').value).toBe('Safety review pending')
+  })
+
+  it('keeps explicit risk signals above pending-review language', () => {
+    expect(normalizeSafetyEnum('Safety review pending; avoid during pregnancy').value).toBe('Use caution')
+    expect(normalizeSafetyEnum('Review needed; potential warfarin interaction').value).toBe('Interaction risk')
+    expect(normalizeSafetyEnum('Generally well tolerated, but safety data are limited').value).toBe('Limited safety data')
+  })
+})


### PR DESCRIPTION
## Summary
- prioritize unresolved/pending safety-review language before reassuring safety synonyms
- preserve stronger interaction, limited-data, and caution signals above pending status
- add focused regression coverage for mixed reassuring + unresolved safety text

## Why
A mixed source string such as `Generally well tolerated; safety review pending` could previously normalize to the reassuring `Generally well tolerated` badge. Until review is complete, the public decision primitive should not imply reviewed safety.

## Scope
2 files: `lib/safety-enum.ts` and one focused regression test.

## Impact
High trust/safety value, very small code surface. No data pipeline or generated artifacts changed.