### PR TITLE
Replace personalized dose scaling with source-context math

### DIFF
--- a/app/info/dosing/page.tsx
+++ b/app/info/dosing/page.tsx
@@ -9,8 +9,8 @@ import { toDosingToolRecord } from '../../../src/lib/tool-page-payloads'
 import type { RuntimeRecord } from '../../../src/types/content'
 
 export const metadata: Metadata = buildPageMetadata({
-  title: 'Dynamic Dosage & Active Molecular Yield Calculator',
-  description: 'Compute conservative educational supplement dosing ranges based on body weight and extract concentration. Calculate active chemical yields and cycle notes.',
+  title: 'Supplement Dose Math & Active-Marker Calculator',
+  description: 'Translate recorded supplement amounts and product-label standardization percentages into transparent active-marker math without personalized dose scaling.',
   path: '/info/dosing/',
 })
 
@@ -38,54 +38,54 @@ export default async function DosingPage() {
   return (
     <div className='mx-auto max-w-6xl space-y-8 px-4 py-8 sm:py-10'>
       <AuthorityJsonLd
-        title="Dynamic Dosage & Active Molecular Yield Calculator"
-        description="Calculate personalized dosing ranges and active marker compounds for cognitive and physical supplements."
-        url="https://thehippiescientist.net/info/dosing"
-        type="MedicalWebPage"
+        title='Supplement Dose Math & Active-Marker Calculator'
+        description='Translate recorded supplement amounts and product-label percentages into active-marker arithmetic without personalized dose recommendations.'
+        url='https://thehippiescientist.net/info/dosing'
+        type='MedicalWebPage'
       />
 
-      <section className='rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8 space-y-4'>
-        <p className='eyebrow-label'>Dosing Auditor</p>
-        <h1 className='text-3xl font-bold tracking-tight text-ink sm:text-5xl mt-2'>
-          Supplement Dosage Calculator
+      <section className='space-y-4 rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8'>
+        <p className='eyebrow-label'>Dose Math Tool</p>
+        <h1 className='mt-2 text-3xl font-bold tracking-tight text-ink sm:text-5xl'>
+          Supplement Dose Math &amp; Active-Marker Calculator
         </h1>
         <div className='rounded-2xl border border-rose-900/15 bg-rose-50 p-4 text-sm font-semibold leading-relaxed text-rose-950'>
-          This tool is for educational purposes only. Consult a qualified healthcare provider before using any supplement, especially if you have medical conditions or take medications.
+          This tool does not calculate a dose for you. It converts simple recorded amounts and product-label percentages into transparent arithmetic so you can inspect the numbers without inventing a personalized regimen.
         </div>
         <p className='mt-4 max-w-3xl text-base leading-7 text-muted sm:text-lg'>
-          Dosage requirements depend heavily on extract concentration, body weight, medical history, and concurrent medications. Use this educational tool to map published supplement ranges to conservative reference parameters.
+          Supplement records can mix raw-herb weight, extract weight, standardization percentage, serving size, and study context. Use this page to separate those quantities before deciding what evidence or safety information you still need.
         </p>
       </section>
 
-      <section className='grid gap-4 md:grid-cols-3' aria-label='How to interpret supplement dose estimates'>
+      <section className='grid gap-4 md:grid-cols-3' aria-label='How to interpret supplement dose math'>
         <article className='rounded-2xl border border-brand-900/10 bg-white/85 p-5 shadow-sm'>
-          <h2 className='text-base font-bold text-ink'>Separate label dose from active yield</h2>
+          <h2 className='text-base font-bold text-ink'>Source amount is not a personal dose</h2>
           <p className='mt-2 text-sm leading-6 text-muted'>
-            A capsule can list 500 mg of extract while delivering a much smaller amount of the active marker compound. Standardization, extract ratio, and marker percentage matter more than the front-label milligram number when comparing products.
+            A number recorded from a study, monograph, or product context belongs to that population, formulation, duration, and outcome. The calculator keeps the source amount visible instead of converting it into a body-weight recommendation.
           </p>
         </article>
         <article className='rounded-2xl border border-brand-900/10 bg-white/85 p-5 shadow-sm'>
-          <h2 className='text-base font-bold text-ink'>Treat ranges as starting context</h2>
+          <h2 className='text-base font-bold text-ink'>Separate extract weight from marker yield</h2>
           <p className='mt-2 text-sm leading-6 text-muted'>
-            Published ranges are not personal prescriptions. Individual sensitivity, medications, sleep debt, caffeine use, body size, liver metabolism, and health conditions can shift what feels too weak, useful, or too strong.
+            A label can list 500 mg of extract while the standardized marker is only a fraction of that amount. Enter the percentage printed on the specific product to see the arithmetic rather than assuming a universal standardization.
           </p>
         </article>
         <article className='rounded-2xl border border-brand-900/10 bg-white/85 p-5 shadow-sm'>
-          <h2 className='text-base font-bold text-ink'>Avoid stacking unknowns</h2>
+          <h2 className='text-base font-bold text-ink'>Ambiguous units stay ambiguous</h2>
           <p className='mt-2 text-sm leading-6 text-muted'>
-            When testing a new supplement, changing multiple ingredients at once makes side effects harder to trace. A conservative approach changes one variable, starts low, tracks response, and avoids combining similar mechanisms too quickly.
+            If a source mixes units or does not provide a clean numeric amount, the tool leaves it uninterpreted. A missing or messy field should not silently become a made-up default range.
           </p>
         </article>
       </section>
 
       <section className='rounded-2xl border border-brand-900/10 bg-white/85 p-5 shadow-sm'>
-        <h2 className='text-xl font-bold tracking-tight text-ink'>Why supplement dose math gets confusing</h2>
+        <h2 className='text-xl font-bold tracking-tight text-ink'>What this calculator is for</h2>
         <div className='mt-4 space-y-4 text-sm leading-7 text-muted'>
           <p>
-            Supplement labels often mix several measurement systems: raw herb weight, extract weight, extract ratio, standardized marker percentage, and serving size. Two products can look similar on the front label while delivering very different amounts of the compounds most likely to drive the effect.
+            The useful part of dose math is often dimensional: converting grams to milligrams, understanding whether a number refers to total extract or an active marker, and checking what a stated percentage actually yields. Those calculations can expose label confusion without pretending to answer what a particular person should take.
           </p>
           <p>
-            The safest use of this calculator is comparison, not escalation. It helps translate a product label into a conservative reference estimate so you can compare forms, spot unusually aggressive serving sizes, and decide whether a product deserves more safety review before use.
+            For any real-world decision, use the full profile to check the studied population, formulation, evidence quality, medication interactions, contraindications, and uncertainty. A larger body size does not automatically justify a larger supplement amount unless the underlying evidence specifically establishes weight-based dosing.
           </p>
         </div>
       </section>
@@ -96,11 +96,9 @@ export default async function DosingPage() {
       />
 
       <section className='rounded-2xl border border-rose-900/15 bg-rose-50/50 p-5 text-xs leading-relaxed text-rose-950'>
-        <p className='font-bold flex items-center gap-1.5'>
-          ⚠️ Dosing Safety Warning:
-        </p>
+        <p className='font-bold'>⚠️ Safety boundary</p>
         <p className='mt-1.5'>
-          Calculations are purely educational models based on published monograph ranges. Individual biochemistry can cause varying sensitivities. Always start at the lower bound (or below) to test for idiosyncratic hypersensitivity or allergen triggers before scaling up. Never exceed recommendations without consulting a physician.
+          Do not use the arithmetic on this page as a prescription, escalation rule, cycling plan, or substitute for product-specific and person-specific medical guidance. Recorded ranges can be inappropriate outside the exact context in which they were studied or documented.
         </p>
       </section>
     </div>

--- a/src/components/dosing/DosageCalculatorClient.tsx
+++ b/src/components/dosing/DosageCalculatorClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState, useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
 import { isRestrictedRecord } from '../../lib/restricted-ingredients'
 
@@ -10,10 +10,6 @@ interface DosageItem {
   type: 'herb' | 'compound'
   dosage?: string
   dose?: string
-  activeMarker?: string
-  defaultPct?: number
-  administration?: string
-  cycling?: string
 }
 
 interface DosageCalculatorClientProps {
@@ -21,283 +17,208 @@ interface DosageCalculatorClientProps {
   compounds: any[]
 }
 
-const EXTRACT_METADATA: Record<string, { activeMarker: string; defaultPct: number }> = {
-  ashwagandha: { activeMarker: 'Withanolides', defaultPct: 5 },
-  bacopa: { activeMarker: 'Bacosides', defaultPct: 45 },
-  rhodiola: { activeMarker: 'Rosavins / Salidroside', defaultPct: 3 },
-  lion: { activeMarker: 'Hericenones / Erinacines', defaultPct: 10 },
-  ginseng: { activeMarker: 'Ginsenosides', defaultPct: 15 },
-  kanna: { activeMarker: 'Mesembrine alkaloids', defaultPct: 0.5 },
-  curcumin: { activeMarker: 'Curcuminoids', defaultPct: 95 },
-  ginkgo: { activeMarker: 'Flavone Glycosides', defaultPct: 24 },
-  green: { activeMarker: 'EGCG', defaultPct: 50 },
-  cordyceps: { activeMarker: 'Cordycepin', defaultPct: 1 },
+type ParsedDose = {
+  minMg: number
+  maxMg: number
+  isRange: boolean
+}
+
+function parseRecordedDose(value?: string): ParsedDose | null {
+  const source = String(value || '').trim()
+  if (!source) return null
+
+  const lower = source.toLowerCase()
+  const hasMg = /\bmg\b/.test(lower)
+  const hasGram = /\bg\b|grams?/.test(lower)
+
+  // Mixed-unit strings need source-specific interpretation. Do not guess.
+  if (hasMg && hasGram) return null
+  if (!hasMg && !hasGram) return null
+
+  const matches = source.match(/\d+(?:\.\d+)?/g)
+  if (!matches?.length) return null
+
+  const values = matches.slice(0, 2).map(Number)
+  if (values.some(value => !Number.isFinite(value) || value < 0)) return null
+
+  const multiplier = hasGram ? 1000 : 1
+  const first = values[0] * multiplier
+  const second = (values[1] ?? values[0]) * multiplier
+
+  return {
+    minMg: Math.min(first, second),
+    maxMg: Math.max(first, second),
+    isRange: values.length > 1,
+  }
+}
+
+function formatMg(value: number) {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1).replace(/\.0$/, '')
 }
 
 export default function DosageCalculatorClient({ herbs, compounds }: DosageCalculatorClientProps) {
-  // Combine items
   const allItems = useMemo(() => {
-    const combined = [
+    return [
       ...herbs.map(item => ({ ...item, type: 'herb' as const })),
       ...compounds.map(item => ({ ...item, type: 'compound' as const })),
-    ].filter(item => !isRestrictedRecord(item))
-
-    return combined.map(item => {
-      // Check if we have pre-defined extract markers
-      let activeMarker = 'Active molecules'
-      let defaultPct = 10
-      const matchedKey = Object.keys(EXTRACT_METADATA).find(key => item.slug.toLowerCase().includes(key))
-      if (matchedKey) {
-        activeMarker = EXTRACT_METADATA[matchedKey].activeMarker
-        defaultPct = EXTRACT_METADATA[matchedKey].defaultPct
-      }
-
-      return {
+    ]
+      .filter(item => !isRestrictedRecord(item))
+      .map(item => ({
         slug: item.slug,
         name: item.displayName || item.name || item.slug,
         type: item.type,
-        dosage: item.dosage || item.dose || '300 - 600 mg',
-        activeMarker,
-        defaultPct,
-        administration: item.administration || item.time_of_day || 'Take with food/water',
-        cycling: item.cycling || item.cycling_notes || 'No cycle required, but periodic breaks are healthy.'
-      } as DosageItem
-    })
+        dosage: item.dosage || item.dose,
+      }) as DosageItem)
   }, [herbs, compounds])
 
   const [selectedSlug, setSelectedSlug] = useState<string>(allItems[0]?.slug || '')
-  const [weight, setWeight] = useState<number>(150)
-  const [weightUnit, setWeightUnit] = useState<'lbs' | 'kg'>('lbs')
   const [extractPct, setExtractPct] = useState<number>(0)
 
-  // Find selected item details
   const selectedItem = useMemo(() => {
-    return allItems.find(i => i.slug === selectedSlug) || allItems[0]
+    return allItems.find(item => item.slug === selectedSlug) || allItems[0]
   }, [selectedSlug, allItems])
 
-  // Sync extract percentage when item changes
   useEffect(() => {
-    if (selectedItem) {
-      setExtractPct(selectedItem.defaultPct || 10)
-    }
-  }, [selectedItem])
+    setExtractPct(0)
+  }, [selectedSlug])
 
-  // Set default extract percent when item changes
-  const handleItemChange = (slug: string) => {
-    setSelectedSlug(slug)
-    const item = allItems.find(i => i.slug === slug)
-    if (item) {
-      setExtractPct(item.defaultPct || 10)
-    }
-  }
+  const parsedDose = useMemo(
+    () => parseRecordedDose(selectedItem?.dosage || selectedItem?.dose),
+    [selectedItem],
+  )
 
-  // Parse dosage string to extract base bounds
-  const baseRange = useMemo(() => {
-    if (!selectedItem) return { min: 100, max: 500 }
-
-    const doseStr = selectedItem.dosage || selectedItem.dose || ''
-    // Regex to match numbers in strings (e.g. "300 - 600", "500mg", "1.5g")
-    const matches = doseStr.match(/(\d+(?:\.\d+)?)/g)
-
-    if (matches && matches.length >= 2) {
-      let min = parseFloat(matches[0])
-      let max = parseFloat(matches[1])
-      // Handle gram scaling
-      if (doseStr.toLowerCase().includes('g') && !doseStr.toLowerCase().includes('mg') && min < 10) {
-        min *= 1000
-        max *= 1000
-      }
-      return { min, max }
-    } else if (matches && matches.length === 1) {
-      let val = parseFloat(matches[0])
-      if (doseStr.toLowerCase().includes('g') && !doseStr.toLowerCase().includes('mg') && val < 10) {
-        val *= 1000
-      }
-      return { min: val * 0.8, max: val * 1.2 }
-    }
-
-    return { min: 300, max: 600 }
-  }, [selectedItem])
-
-  // Calculate customized dosage
-  const calculatedDosage = useMemo(() => {
-    // Weight factor (standardized around 150 lbs / 68 kg)
-    const weightInLbs = weightUnit === 'lbs' ? weight : weight * 2.20462
-    let weightFactor = 1.0
-
-    if (weightInLbs < 120) {
-      weightFactor = 0.8
-    } else if (weightInLbs > 190) {
-      weightFactor = 1.2
-    }
-
-    const minDose = Math.round(baseRange.min * weightFactor)
-    const maxDose = Math.round(baseRange.max * weightFactor)
-
-    // active yield based on extract percentage
-    const minYield = Math.round(minDose * (extractPct / 100))
-    const maxYield = Math.round(maxDose * (extractPct / 100))
-
+  const activeYield = useMemo(() => {
+    if (!parsedDose || extractPct <= 0) return null
     return {
-      minDose,
-      maxDose,
-      minYield,
-      maxYield
+      min: parsedDose.minMg * (extractPct / 100),
+      max: parsedDose.maxMg * (extractPct / 100),
     }
-  }, [baseRange, weight, weightUnit, extractPct])
+  }, [parsedDose, extractPct])
+
+  if (!selectedItem) {
+    return (
+      <div className='rounded-2xl border border-brand-900/10 bg-white/90 p-5 text-sm text-muted'>
+        No published ingredient records are available for this tool yet.
+      </div>
+    )
+  }
 
   return (
     <div className='grid gap-8 lg:grid-cols-3'>
-      {/* Parameter Settings Card */}
-      <div className='lg:col-span-1 space-y-6'>
-        <div className='rounded-3xl border border-brand-900/10 bg-white/90 p-5 shadow-sm space-y-4'>
-          <h2 className='text-lg font-bold text-slate-800'>Dosing Parameters</h2>
+      <div className='space-y-6 lg:col-span-1'>
+        <div className='space-y-4 rounded-3xl border border-brand-900/10 bg-white/90 p-5 shadow-sm'>
+          <h2 className='text-lg font-bold text-slate-800'>Dose-math inputs</h2>
 
-          {/* Ingredient Selector */}
           <div className='space-y-1.5'>
-            <label htmlFor="ingredient-select" className='text-xs font-bold uppercase tracking-wider text-slate-400'>
-              Select Ingredient
+            <label htmlFor='ingredient-select' className='text-xs font-bold uppercase tracking-wider text-slate-400'>
+              Select ingredient
             </label>
             <select
-              id="ingredient-select"
+              id='ingredient-select'
               value={selectedSlug}
-              onChange={e => handleItemChange(e.target.value)}
-              className='w-full rounded-2xl border border-slate-200 px-4 py-2.5 text-sm focus:border-emerald-500 focus:outline-none bg-white'
+              onChange={event => setSelectedSlug(event.target.value)}
+              className='w-full rounded-2xl border border-slate-200 bg-white px-4 py-2.5 text-sm focus:border-emerald-500 focus:outline-none'
             >
               {allItems.map(item => (
-                <option key={item.slug} value={item.slug}>
+                <option key={`${item.type}:${item.slug}`} value={item.slug}>
                   {item.name} ({item.type})
                 </option>
               ))}
             </select>
           </div>
 
-          {/* Weight Input */}
           <div className='space-y-1.5'>
-            <div className='flex items-center justify-between'>
-              <label htmlFor="body-weight-input" className='text-xs font-bold uppercase tracking-wider text-slate-400'>
-                Body Weight
-              </label>
-              <div className='flex rounded-lg overflow-hidden border border-slate-200 text-xs'>
-                <button
-                  onClick={() => setWeightUnit('lbs')}
-                  type='button'
-                  className={`px-2 py-0.5 font-bold ${weightUnit === 'lbs' ? 'bg-slate-200 text-slate-700' : 'text-slate-400'}`}
-                >
-                  LBS
-                </button>
-                <button
-                  onClick={() => setWeightUnit('kg')}
-                  type='button'
-                  className={`px-2 py-0.5 font-bold ${weightUnit === 'kg' ? 'bg-slate-200 text-slate-700' : 'text-slate-400'}`}
-                >
-                  KG
-                </button>
-              </div>
-            </div>
-            <input
-              id="body-weight-input"
-              type='number'
-              value={weight}
-              onChange={e => setWeight(Math.max(1, parseInt(e.target.value) || 0))}
-              className='w-full rounded-2xl border border-slate-200 px-4 py-2.5 text-sm focus:border-emerald-500 focus:outline-none'
-            />
-          </div>
-
-          {/* Extract Percentage */}
-          <div className='space-y-1.5'>
-            <div className='flex items-center justify-between'>
-              <label className='text-xs font-bold uppercase tracking-wider text-slate-400'>
-                Extract Active Concentration (%)
+            <div className='flex items-center justify-between gap-3'>
+              <label htmlFor='active-marker-percent' className='text-xs font-bold uppercase tracking-wider text-slate-400'>
+                Active marker on your label (%)
               </label>
               <span className='text-xs font-bold text-slate-500'>{extractPct}%</span>
             </div>
             <input
+              id='active-marker-percent'
               type='range'
-              min='0.1'
-              max='98'
+              min='0'
+              max='100'
               step='0.1'
               value={extractPct}
-              onChange={e => setExtractPct(parseFloat(e.target.value))}
+              onChange={event => setExtractPct(Number(event.target.value))}
               className='w-full accent-emerald-600'
             />
+            <p className='text-xs leading-5 text-slate-500'>
+              Enter the percentage printed on the specific product label. The tool does not assume a standardization for you.
+            </p>
           </div>
         </div>
       </div>
 
-      {/* Calculated Output Card */}
-      <div className='lg:col-span-2 space-y-6'>
-        <div className='rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8 space-y-6'>
-          {/* Header */}
+      <div className='space-y-6 lg:col-span-2'>
+        <div className='space-y-6 rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8'>
           <div className='border-b border-slate-100 pb-5'>
-            <span className='rounded-full bg-emerald-100 px-2.5 py-1 text-xs font-bold uppercase tracking-wider text-emerald-800'>
-              Customized Dosage Guide
+            <span className='rounded-full bg-slate-100 px-2.5 py-1 text-xs font-bold uppercase tracking-wider text-slate-700'>
+              Study / monograph context only
             </span>
-            <h2 className='mt-2 text-2xl font-bold text-slate-800 sm:text-3xl'>{selectedItem.name} Guide</h2>
-            <p className='text-xs text-slate-400 mt-1'>
-              Standard reference dose: <span className='font-semibold'>{selectedItem.dosage}</span>
+            <h2 className='mt-2 text-2xl font-bold text-slate-800 sm:text-3xl'>{selectedItem.name} dose math</h2>
+            <p className='mt-2 text-sm leading-6 text-slate-600'>
+              This tool does not calculate a personalized dose. It only translates a recorded amount into milligrams and, when you provide a label percentage, estimates the corresponding active-marker amount.
             </p>
           </div>
 
-          {/* Big Output Dosage Display */}
-          <div className='rounded-2xl bg-slate-50/60 border border-slate-100 p-6 flex flex-col items-center justify-center text-center space-y-2'>
-            <span className='text-[10px] font-bold uppercase tracking-wider text-slate-400'>
-              Your Customized Educational Dose Range
-            </span>
-            <p className='text-3xl font-black text-emerald-800 sm:text-4xl'>
-              {calculatedDosage.minDose} – {calculatedDosage.maxDose} mg
-            </p>
-            <p className='text-xs text-slate-500'>
-              Scale factor applied: Weight ({weight} {weightUnit})
+          <div className='rounded-2xl border border-slate-100 bg-slate-50/60 p-6'>
+            <p className='text-[10px] font-bold uppercase tracking-wider text-slate-400'>Recorded source context</p>
+            {selectedItem.dosage ? (
+              <p className='mt-2 text-xl font-bold text-slate-800'>{selectedItem.dosage}</p>
+            ) : (
+              <p className='mt-2 text-sm font-semibold text-slate-600'>No dose range is recorded for this profile.</p>
+            )}
+            <p className='mt-2 text-xs leading-5 text-slate-500'>
+              Population, formulation, extract, indication, and study design can make one published amount inappropriate to generalize to another person or product.
             </p>
           </div>
 
-          {/* Molecular Active Yield */}
           <div className='grid gap-6 sm:grid-cols-2'>
-            <div className='rounded-2xl border border-slate-100 bg-white p-5 space-y-2.5'>
-              <h3 className='text-xs font-bold uppercase tracking-wider text-slate-400'>
-                {selectedItem.activeMarker} Yield
-              </h3>
-              <p className='text-xl font-bold text-slate-800'>
-                {calculatedDosage.minYield} – {calculatedDosage.maxYield} mg
-              </p>
-              <p className='text-xs text-slate-500 leading-relaxed'>
-                Based on your {extractPct}% active chemical marker extract input, taking this range yields these actual active molecules.
+            <div className='space-y-2.5 rounded-2xl border border-slate-100 bg-white p-5'>
+              <h3 className='text-xs font-bold uppercase tracking-wider text-slate-400'>Parsed amount</h3>
+              {parsedDose ? (
+                <p className='text-xl font-bold text-slate-800'>
+                  {formatMg(parsedDose.minMg)}{parsedDose.isRange ? ` – ${formatMg(parsedDose.maxMg)}` : ''} mg
+                </p>
+              ) : (
+                <p className='text-sm font-semibold text-slate-600'>No safe automatic conversion available.</p>
+              )}
+              <p className='text-xs leading-relaxed text-slate-500'>
+                Automatic conversion is limited to simple all-mg or all-gram source strings. Mixed or ambiguous units are left uninterpreted rather than guessed.
               </p>
             </div>
 
-            {/* Cycling notes */}
-            <div className='rounded-2xl border border-slate-100 bg-white p-5 space-y-2.5'>
-              <h3 className='text-xs font-bold uppercase tracking-wider text-slate-400'>
-                Cycling Recommendations
-              </h3>
-              <p className='text-xs leading-relaxed text-slate-700 font-medium'>
-                {selectedItem.cycling}
-              </p>
-              <p className='text-[10px] text-slate-400 leading-normal'>
-                Periodic breaks prevent receptor down-regulation or adaptation.
+            <div className='space-y-2.5 rounded-2xl border border-slate-100 bg-white p-5'>
+              <h3 className='text-xs font-bold uppercase tracking-wider text-slate-400'>Active-marker arithmetic</h3>
+              {activeYield ? (
+                <p className='text-xl font-bold text-slate-800'>
+                  {formatMg(activeYield.min)}{parsedDose?.isRange ? ` – ${formatMg(activeYield.max)}` : ''} mg
+                </p>
+              ) : (
+                <p className='text-sm font-semibold text-slate-600'>Set the label percentage to calculate.</p>
+              )}
+              <p className='text-xs leading-relaxed text-slate-500'>
+                This is multiplication only: recorded amount × the percentage you entered. It is not a potency, efficacy, or safety recommendation.
               </p>
             </div>
           </div>
 
-          {/* Administration instructions */}
-          <div className='rounded-2xl bg-emerald-50/20 border border-emerald-100/50 p-5 space-y-2 text-sm text-slate-700'>
-            <h3 className='font-bold text-emerald-800 text-xs uppercase tracking-wider'>
-              Administration & Bioavailability
-            </h3>
-            <p className='text-xs leading-relaxed opacity-95'>
-              {selectedItem.administration}
+          <div className='rounded-2xl border border-amber-200 bg-amber-50/60 p-5 text-sm leading-6 text-amber-950'>
+            <p className='font-bold'>Do not scale this number by body weight.</p>
+            <p className='mt-1'>
+              Unless the underlying source explicitly studied weight-based dosing, body size alone is not a valid reason to multiply a supplement amount up or down. Check the full profile for formulation, interactions, population, and safety context.
             </p>
           </div>
 
-          {/* Internal Navigation links */}
-          <div className='pt-3 flex items-center justify-between border-t border-slate-100 text-xs'>
-            <span className='text-slate-400'>Need detailed safety warning context?</span>
+          <div className='flex items-center justify-between gap-4 border-t border-slate-100 pt-3 text-xs'>
+            <span className='text-slate-400'>Need the evidence and safety context behind the record?</span>
             <Link
               href={selectedItem.type === 'herb' ? `/herbs/${selectedItem.slug}` : `/compounds/${selectedItem.slug}`}
-              className='text-emerald-700 hover:underline font-bold'
+              className='font-bold text-emerald-700 hover:underline'
             >
-              Open Full Monograph Profile →
+              Open full profile →
             </Link>
           </div>
         </div>

--- a/src/components/dosing/__tests__/DosageCalculatorClient.test.tsx
+++ b/src/components/dosing/__tests__/DosageCalculatorClient.test.tsx
@@ -23,42 +23,46 @@ const mockCompounds = [
     slug: 'l-theanine',
     name: 'L-Theanine',
     dosage: '100 - 200 mg',
-    cycling: 'No cycle required.',
-    administration: 'Take with caffeine to balance stimulation.',
+  },
+  {
+    slug: 'unknown-compound',
+    name: 'Unknown Compound',
   },
 ]
 
 describe('DosageCalculatorClient', () => {
-  it('renders ingredient selection and conservative default calculations', () => {
+  it('shows recorded source context without personalized weight scaling or protocol advice', () => {
     render(<DosageCalculatorClient herbs={mockHerbs} compounds={mockCompounds} />)
 
-    expect(screen.getByLabelText(/Select Ingredient/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Select ingredient/i)).toBeInTheDocument()
+    expect(screen.getByText(/300 - 600 mg/i)).toBeInTheDocument()
     expect(screen.getByText(/300 – 600 mg/i)).toBeInTheDocument()
-    expect(screen.queryByText(/Beginner/i)).not.toBeInTheDocument()
-    expect(screen.queryByText(/Intermediate/i)).not.toBeInTheDocument()
-    expect(screen.queryByText(/Advanced/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/Body Weight/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Customized Dosage/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Cycling Recommendations/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Take with fat-soluble meal/i)).not.toBeInTheDocument()
   })
 
-  it('calculates molecular yields based on extract slider concentration changes', () => {
+  it('calculates active-marker arithmetic only after the user supplies a label percentage', () => {
     render(<DosageCalculatorClient herbs={mockHerbs} compounds={mockCompounds} />)
 
-    // Ashwagandha default is 5% withanolides.
-    // Standard reference dose: 300 - 600 mg.
-    // 5% of 300 is 15. 5% of 600 is 30.
+    expect(screen.getByText(/Set the label percentage to calculate/i)).toBeInTheDocument()
+
+    const slider = screen.getByLabelText(/Active marker on your label/i)
+    fireEvent.change(slider, { target: { value: 5 } })
+
     expect(screen.getByText(/15 – 30 mg/i)).toBeInTheDocument()
-
-    const slider = screen.getByRole('slider')
-    fireEvent.change(slider, { target: { value: 10 } })
-
-    expect(screen.getByText(/30 – 60 mg/i)).toBeInTheDocument()
   })
 
-  it('adjusts dosage calculations based on weight scale bounds', () => {
+  it('does not fabricate a fallback range when a profile has no recorded dose', () => {
     render(<DosageCalculatorClient herbs={mockHerbs} compounds={mockCompounds} />)
 
-    const weightInput = screen.getByLabelText(/Body Weight/i)
-    fireEvent.change(weightInput, { target: { value: 100 } })
+    fireEvent.change(screen.getByLabelText(/Select ingredient/i), {
+      target: { value: 'unknown-compound' },
+    })
 
-    expect(screen.getByText(/240 – 480 mg/i)).toBeInTheDocument()
+    expect(screen.getByText(/No dose range is recorded for this profile/i)).toBeInTheDocument()
+    expect(screen.getByText(/No safe automatic conversion available/i)).toBeInTheDocument()
+    expect(screen.queryByText(/300 – 600 mg/i)).not.toBeInTheDocument()
   })
 })

--- a/src/components/search/DosingSafetyChecker.tsx
+++ b/src/components/search/DosingSafetyChecker.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useState, useMemo } from 'react'
-import { AlertTriangle, Info, Weight, ShieldAlert } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import Link from 'next/link'
+import { AlertTriangle, Info, ShieldAlert } from 'lucide-react'
 import { isRestrictedRecord } from '../../lib/restricted-ingredients'
 
 type SubstanceItem = {
@@ -25,10 +26,7 @@ type DosingSafetyCheckerProps = {
 
 export default function DosingSafetyChecker({ items }: DosingSafetyCheckerProps) {
   const [selectedSlug, setSelectedSlug] = useState('')
-  const [weight, setWeight] = useState<number | ''>('')
-  const [weightUnit, setWeightUnit] = useState<'kg' | 'lbs'>('kg')
 
-  // Filter list to only items that have name/slug; exclude restricted (no dosing UI for controlled/high-risk substances)
   const selectableItems = useMemo(() => {
     return items
       .filter(item => item.name && item.slug && !isRestrictedRecord(item))
@@ -39,142 +37,62 @@ export default function DosingSafetyChecker({ items }: DosingSafetyCheckerProps)
     return items.find(item => item.slug === selectedSlug)
   }, [selectedSlug, items])
 
-  const weightInKg = useMemo(() => {
-    if (weight === '' || Number.isNaN(weight) || weight <= 0) return null
-    return weightUnit === 'kg' ? weight : weight * 0.45359237
-  }, [weight, weightUnit])
-
-  // Weight-based dosing calculations for specific high-signal compounds
-  const weightBasedDosing = useMemo(() => {
-    if (!selectedItem || !weightInKg) return null
-
-    const slug = selectedItem.slug.toLowerCase()
-
-    if (slug === 'creatine') {
-      const maintenanceMin = (weightInKg * 0.03).toFixed(1)
-      const maintenanceMax = (weightInKg * 0.05).toFixed(1)
-      const loading = (weightInKg * 0.3).toFixed(1)
-      return {
-        title: 'Creatine Monohydrate Weight-Scaled Guidance',
-        calc: `Based on your weight (${weightInKg.toFixed(1)} kg):`,
-        formulas: [
-          { label: 'Maintenance Dose', value: `${maintenanceMin}g – ${maintenanceMax}g per day`, note: 'Standard daily support dose.' },
-          { label: 'Loading Phase Dose', value: `${loading}g per day`, note: 'Optional. Split into 4 daily doses (e.g. 5g each) for 5–7 days.' }
-        ]
-      }
-    }
-
-    if (slug === 'theanine' || slug === 'l-theanine') {
-      const theanineMin = (weightInKg * 1.5).toFixed(0)
-      const theanineMax = (weightInKg * 3.0).toFixed(0)
-      return {
-        title: 'L-Theanine Weight-Scaled Guidance',
-        calc: `Based on your weight (${weightInKg.toFixed(1)} kg):`,
-        formulas: [
-          { label: 'Calm Focus Dose', value: `${theanineMin}mg – ${theanineMax}mg`, note: 'Often paired with caffeine in a 2:1 ratio to balance jitters.' }
-        ]
-      }
-    }
-
-    if (slug === 'caffeine') {
-      const caffeineMin = (weightInKg * 1.0).toFixed(0)
-      const caffeineMax = (weightInKg * 3.0).toFixed(0)
-      return {
-        title: 'Caffeine Weight-Scaled Guidance',
-        calc: `Based on your weight (${weightInKg.toFixed(1)} kg):`,
-        formulas: [
-          { label: 'Mild to Moderate Stimulation', value: `${caffeineMin}mg – ${caffeineMax}mg`, note: 'A standard single cup of coffee contains ~80–100mg caffeine.' }
-        ]
-      }
-    }
-
-    if (slug === 'ashwagandha') {
-      const ashMin = (weightInKg * 4.0).toFixed(0)
-      const ashMax = (weightInKg * 8.0).toFixed(0)
-      return {
-        title: 'Ashwagandha Standardized Extract Guidance',
-        calc: `Based on your weight (${weightInKg.toFixed(1)} kg):`,
-        formulas: [
-          { label: 'Standardized Extract (KSM-66 style)', value: `${ashMin}mg – ${ashMax}mg per day`, note: 'Typically split into two daily doses. Review liver warnings.' }
-        ]
-      }
-    }
-
-    return null
-  }, [selectedItem, weightInKg])
-
   const avoidIfList = useMemo(() => {
     if (!selectedItem) return []
     return [
       ...(selectedItem.avoid_if || []),
       ...(selectedItem.contraindications || []),
-      ...(selectedItem.interactions || [])
+      ...(selectedItem.interactions || []),
     ].filter(Boolean)
   }, [selectedItem])
 
+  const profileHref = selectedItem
+    ? selectedItem.type === 'Herb'
+      ? `/herbs/${selectedItem.slug}`
+      : `/compounds/${selectedItem.slug}`
+    : null
+
   return (
-    <section className="rounded-[1.5rem] border border-amber-200/70 bg-amber-50/15 p-4 sm:p-6 shadow-sm" aria-labelledby="dosing-calculator-heading">
+    <section className="rounded-[1.5rem] border border-amber-200/70 bg-amber-50/15 p-4 shadow-sm sm:p-6" aria-labelledby="dosing-calculator-heading">
       <div className="space-y-2">
         <p className="eyebrow-label text-amber-800">Safety Reference</p>
-        <h2 id="dosing-calculator-heading" className="compact-heading text-ink">Dosing & Safety Reference Checker</h2>
+        <h2 id="dosing-calculator-heading" className="compact-heading text-ink">Dose Context &amp; Safety Checker</h2>
         <p className="text-sm leading-6 text-muted">
-          Select an herb or compound to view monograph-derived typical dosages, safety alerts, and weight-scaled calculations.
+          Select an herb or compound to inspect the dose text and safety constraints currently mapped to its profile. This checker does not calculate a personalized dose.
         </p>
       </div>
 
       <div className="mt-5 grid gap-4 md:grid-cols-[1fr_auto_1fr]">
-        {/* Input Controls */}
         <div className="space-y-4">
           <div className="space-y-1.5">
             <label htmlFor="substance-select" className="text-xs font-bold uppercase tracking-wider text-muted">Choose substance</label>
             <select
               id="substance-select"
               value={selectedSlug}
-              onChange={(e) => setSelectedSlug(e.target.value)}
+              onChange={(event) => setSelectedSlug(event.target.value)}
               className="min-h-11 w-full rounded-xl border border-brand-900/10 bg-white px-3 py-2 text-sm text-ink outline-none transition focus:border-brand-700/30 focus:ring-2 focus:ring-brand-700/20"
             >
               <option value="">-- Select Substance --</option>
               {selectableItems.map(item => (
-                <option key={item.slug} value={item.slug}>
+                <option key={`${item.type}:${item.slug}`} value={item.slug}>
                   {item.name} ({item.type})
                 </option>
               ))}
             </select>
           </div>
 
-          <div className="space-y-1.5">
-            <label htmlFor="weight-input" className="text-xs font-bold uppercase tracking-wider text-muted">Your weight (Optional)</label>
-            <div className="flex gap-2">
-              <input
-                id="weight-input"
-                type="number"
-                min="1"
-                placeholder="e.g. 70"
-                value={weight}
-                onChange={(e) => setWeight(e.target.value === '' ? '' : Number(e.target.value))}
-                className="min-h-11 flex-1 rounded-xl border border-brand-900/10 bg-white px-3 py-2 text-sm text-ink outline-none transition focus:border-brand-700/30 focus:ring-2 focus:ring-brand-700/20"
-              />
-              <button
-                type="button"
-                onClick={() => setWeightUnit(u => u === 'kg' ? 'lbs' : 'kg')}
-                className="min-h-11 inline-flex items-center justify-center rounded-xl border border-brand-900/10 bg-white px-3 text-xs font-bold text-ink hover:bg-slate-50 transition"
-              >
-                <Weight className="mr-1 h-3.5 w-3.5 text-muted" />
-                {weightUnit.toUpperCase()}
-              </button>
-            </div>
+          <div className="rounded-xl border border-brand-900/10 bg-white/70 p-3 text-xs leading-5 text-muted">
+            <strong className="text-ink">No body-weight scaling.</strong> A dose from one study or monograph should not be multiplied up or down from body size unless that exact source establishes a weight-based regimen.
           </div>
         </div>
 
-        {/* Vertical Separator */}
-        <div className="hidden md:block w-px bg-brand-900/10 self-stretch" />
+        <div className="hidden w-px self-stretch bg-brand-900/10 md:block" />
 
-        {/* Results Panel */}
-        <div className="rounded-xl border border-brand-900/5 bg-white/70 p-4 min-h-[14rem]">
+        <div className="min-h-[14rem] rounded-xl border border-brand-900/5 bg-white/70 p-4">
           {!selectedItem ? (
-            <div className="flex h-full flex-col items-center justify-center text-center text-muted p-4">
-              <Info className="h-8 w-8 mb-2 text-brand-900/25" />
-              <p className="text-sm">Select a substance on the left to show dosage guidelines and safety checks.</p>
+            <div className="flex h-full flex-col items-center justify-center p-4 text-center text-muted">
+              <Info className="mb-2 h-8 w-8 text-brand-900/25" />
+              <p className="text-sm">Select a substance to show recorded dose context and mapped safety information.</p>
             </div>
           ) : (
             <div className="space-y-4">
@@ -184,75 +102,66 @@ export default function DosingSafetyChecker({ items }: DosingSafetyCheckerProps)
                     ? 'border-emerald-700/10 bg-emerald-50 text-emerald-800'
                     : 'border-blue-700/10 bg-blue-50 text-blue-800'
                 }`}>
-                  {selectedItem.type} Monograph
+                  {selectedItem.type} Profile
                 </span>
                 <h3 className="mt-1 text-lg font-bold tracking-tight text-ink">{selectedItem.name}</h3>
               </div>
 
-              {/* Monograph Dosage */}
               <div>
-                <p className="text-[10px] font-bold uppercase tracking-wider text-muted">Typical Dosage Guideline</p>
+                <p className="text-[10px] font-bold uppercase tracking-wider text-muted">Recorded dose context</p>
                 <p className="mt-1 text-sm font-semibold text-ink">
-                  {selectedItem.typical_dosage || selectedItem.dosage || 'Refer to detail page for specific preparation forms.'}
+                  {selectedItem.typical_dosage || selectedItem.dosage || 'No dose context is mapped in this quick index.'}
+                </p>
+                <p className="mt-1 text-[11px] leading-5 text-muted">
+                  Treat this as source context, not an instruction. Formulation, population, indication, duration, and study design determine whether a number is transferable.
                 </p>
               </div>
 
-              {/* Weight-Scaled Custom Dosing */}
-              {weightBasedDosing ? (
-                <div className="rounded-lg border border-emerald-600/10 bg-emerald-50/30 p-3 space-y-2">
-                  <p className="text-xs font-bold text-emerald-800">{weightBasedDosing.title}</p>
-                  <p className="text-[10px] text-muted leading-none">{weightBasedDosing.calc}</p>
-                  <div className="space-y-2">
-                    {weightBasedDosing.formulas.map(f => (
-                      <div key={f.label} className="text-xs">
-                        <span className="font-semibold text-emerald-950">{f.label}: </span>
-                        <span className="font-bold text-emerald-900 bg-emerald-100/50 px-1 rounded">{f.value}</span>
-                        <p className="text-[10px] text-muted mt-0.5 leading-relaxed">{f.note}</p>
-                      </div>
-                    ))}
-                  </div>
+              {selectedItem.safety ? (
+                <div className="rounded-lg border border-slate-200 bg-slate-50/60 p-3">
+                  <p className="text-[10px] font-bold uppercase tracking-wider text-slate-600">Mapped safety summary</p>
+                  <p className="mt-1 text-[11px] leading-relaxed text-slate-700">{selectedItem.safety}</p>
                 </div>
-              ) : weightInKg && (
-                <div className="rounded-lg border border-brand-900/5 bg-slate-50/50 p-3">
-                  <p className="text-xs text-muted leading-relaxed">
-                    No weight-based formulas are clinically standardized for {selectedItem.name}. Standard dosing is independent of body weight; refer to typical guidelines.
-                  </p>
-                </div>
-              )}
+              ) : null}
 
-              {/* Safety Alerts */}
               {avoidIfList.length > 0 ? (
-                <div className="rounded-lg border border-amber-600/10 bg-amber-50/45 p-3 space-y-2">
+                <div className="space-y-2 rounded-lg border border-amber-600/10 bg-amber-50/45 p-3">
                   <div className="flex items-center gap-1.5 text-xs font-bold text-amber-900">
                     <ShieldAlert className="h-4 w-4 text-amber-700" />
-                    <span>Safety Constraints & Avoid If:</span>
+                    <span>Mapped constraints &amp; interactions</span>
                   </div>
-                  <ul className="list-disc list-inside space-y-1 text-[11px] leading-relaxed text-amber-950/85">
-                    {avoidIfList.slice(0, 3).map((item, idx) => (
-                      <li key={idx} className="truncate" title={item}>{item}</li>
+                  <ul className="list-inside list-disc space-y-1 text-[11px] leading-relaxed text-amber-950/85">
+                    {avoidIfList.slice(0, 3).map((item, index) => (
+                      <li key={`${item}:${index}`}>{item}</li>
                     ))}
-                    {avoidIfList.length > 3 && (
-                      <li className="list-none text-[10px] text-muted italic mt-1">
-                        + {avoidIfList.length - 3} more. Check the full profile page.
+                    {avoidIfList.length > 3 ? (
+                      <li className="mt-1 list-none text-[10px] italic text-muted">
+                        + {avoidIfList.length - 3} more. Open the full profile for the complete mapped list.
                       </li>
-                    )}
+                    ) : null}
                   </ul>
                 </div>
               ) : (
-                <div className="rounded-lg border border-emerald-600/10 bg-emerald-50/20 p-3 flex items-start gap-2 text-[11px] text-muted leading-relaxed">
-                  <Info className="h-3.5 w-3.5 text-emerald-700 shrink-0 mt-0.5" />
-                  <span>No severe specific warnings mapped in quick index. Standard dietary supplement cautions apply.</span>
+                <div className="flex items-start gap-2 rounded-lg border border-slate-300/60 bg-slate-50/70 p-3 text-[11px] leading-relaxed text-slate-700">
+                  <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-slate-600" />
+                  <span>No detailed constraints are mapped in this quick index. That is a missing-data state, not evidence that the substance is low risk.</span>
                 </div>
               )}
+
+              {profileHref ? (
+                <Link href={profileHref} className="inline-flex text-xs font-bold text-emerald-700 hover:underline">
+                  Open full evidence &amp; safety profile →
+                </Link>
+              ) : null}
             </div>
           )}
         </div>
       </div>
 
-      <div className="mt-5 rounded-lg border border-amber-200/50 bg-amber-50/30 p-3 flex gap-2.5">
-        <AlertTriangle className="h-4 w-4 text-amber-700 shrink-0 mt-0.5" />
+      <div className="mt-5 flex gap-2.5 rounded-lg border border-amber-200/50 bg-amber-50/30 p-3">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-700" />
         <p className="text-[11px] leading-relaxed text-amber-900">
-          <strong>Clinical Disclaimer:</strong> Personalized supplement dosing must take into account medical history, medications, pregnancy status, and product standardization targets. These calculations are strictly educational starting benchmarks. Never scale doses beyond standard manufacturer specifications without consulting a licensed physician.
+          <strong>Safety boundary:</strong> This quick checker can surface what is already mapped, but it cannot determine an appropriate personal dose, rule out interactions, or substitute for product-specific and person-specific medical guidance.
         </p>
       </div>
     </section>

--- a/src/components/search/__tests__/DosingSafetyChecker.test.tsx
+++ b/src/components/search/__tests__/DosingSafetyChecker.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import DosingSafetyChecker from '../DosingSafetyChecker'
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+}))
+
+const items = [
+  {
+    slug: 'ashwagandha',
+    name: 'Ashwagandha',
+    type: 'Herb' as const,
+    dosage: '300–600 mg in selected studies',
+    effects: ['stress'],
+    evidence: 'moderate',
+    avoid_if: ['Pregnancy'],
+  },
+  {
+    slug: 'plain-example',
+    name: 'Plain Example',
+    type: 'Compound' as const,
+    dosage: '100 mg',
+    effects: [],
+    evidence: 'limited',
+  },
+]
+
+describe('DosingSafetyChecker', () => {
+  it('does not request body weight or emit personalized dose formulas', () => {
+    render(<DosingSafetyChecker items={items} />)
+
+    expect(screen.queryByLabelText(/weight/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/weight-scaled/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/loading phase/i)).not.toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText(/Choose substance/i), { target: { value: 'ashwagandha' } })
+    expect(screen.getByText(/300–600 mg in selected studies/i)).toBeInTheDocument()
+    expect(screen.getByText(/Pregnancy/i)).toBeInTheDocument()
+  })
+
+  it('treats an empty quick-index warning list as missing data rather than reassurance', () => {
+    render(<DosingSafetyChecker items={items} />)
+
+    fireEvent.change(screen.getByLabelText(/Choose substance/i), { target: { value: 'plain-example' } })
+
+    expect(screen.getByText(/missing-data state, not evidence that the substance is low risk/i)).toBeInTheDocument()
+    expect(screen.queryByText(/standard dietary supplement cautions apply/i)).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- remove body-weight multipliers from the dedicated supplement dose calculator
- remove weight-scaled ashwagandha, L-theanine, caffeine, and creatine protocol formulas from the Search safety checker
- remove invented 300–600 mg fallback ranges when a record lacks usable dose data
- remove cycling and administration recommendations from calculator output
- stop assuming extract standardization percentages from ingredient names
- require the reader to enter the percentage printed on their own label before active-marker arithmetic is shown
- limit automatic unit parsing to simple all-mg or all-gram source strings; mixed/ambiguous units are left uninterpreted
- replace empty quick-index safety reassurance with an explicit missing-data state
- reframe both surfaces around source/study context rather than personalized dosing
- add focused regression coverage for both tools

## Why
Two separate site surfaces were converting heterogeneous dose records into personalized guidance from body weight alone. The dedicated calculator also fabricated a default range for missing data, while Search contained hard-coded protocols such as creatine loading and weight-scaled ashwagandha/L-theanine/caffeine guidance. Those behaviors exceed what the underlying records can justify.

## Scope
5 files across the dedicated dose tool and Search safety checker. No workbook or runtime source data changed.