### PR TITLE
Withhold unaudited commercial stack recommendations

### DIFF
--- a/src/lib/__tests__/recommendation-engine-stack-safety.test.ts
+++ b/src/lib/__tests__/recommendation-engine-stack-safety.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+
+import { getStackRecommendations } from '../recommendation-engine'
+
+describe('profile stack recommendation safety boundary', () => {
+  it('withholds legacy product-backed stack pairings until evidence and interactions are audited', () => {
+    for (const slug of ['ashwagandha', 'magnesium', '5-htp', 'sam-e', 'valerian', 'berberine']) {
+      expect(getStackRecommendations(slug)).toEqual([])
+    }
+  })
+})

--- a/src/lib/recommendation-engine.ts
+++ b/src/lib/recommendation-engine.ts
@@ -7,147 +7,14 @@ export interface StackRecommendation {
   targetSlug: string
 }
 
-const STACKS: Record<string, Array<{ slug: string; reason: string }>> = {
-  ashwagandha: [
-    { slug: 'l-theanine', reason: 'Dual cortisol + alpha-wave calm pathway' },
-    { slug: 'magnesium', reason: 'Supports the stress-to-sleep transition' },
-    { slug: 'rhodiola', reason: 'Complete adaptogen stack for stress resilience' },
-  ],
-  magnesium: [
-    { slug: 'l-theanine', reason: 'Alpha-wave relaxation synergy for sleep' },
-    { slug: 'glycine', reason: 'Combined sleep-onset support' },
-    { slug: 'melatonin', reason: 'Circadian rhythm + sleep quality combo' },
-  ],
-  'l-theanine': [
-    { slug: 'ashwagandha', reason: 'Cortisol + alpha-wave calm — paired adaptogen' },
-    { slug: 'magnesium', reason: 'Relaxation mineral plus amino acid pairing' },
-    { slug: 'glycine', reason: 'Sleep support amino acid stack' },
-  ],
-  rhodiola: [
-    { slug: 'ashwagandha', reason: 'Yin-yang adaptogen pairing (energy vs. grounding)' },
-    { slug: 'vitamin-b12', reason: 'Energy metabolism support from both angles' },
-    { slug: 'coenzyme-q10', reason: 'Mitochondrial energy enhancement stack' },
-  ],
-  'lions-mane': [
-    { slug: 'omega-3', reason: 'NGF + DHA brain health dual approach' },
-    { slug: 'bacopa', reason: 'Neurogenesis + memory formation pairing' },
-    { slug: 'coenzyme-q10', reason: 'Mitochondrial + neural energy combination' },
-  ],
-  valerian: [
-    { slug: 'magnesium', reason: 'Relaxation mineral + herb for deeper sleep' },
-    { slug: 'passionflower', reason: 'Complementary GABA-pathway herbs' },
-    { slug: 'melatonin', reason: 'Sleep timing + relaxation depth combination' },
-  ],
-  passionflower: [
-    { slug: 'magnesium', reason: 'GABA pathway + relaxation mineral' },
-    { slug: 'l-theanine', reason: 'Anxiety reduction from two pathways' },
-    { slug: 'valerian', reason: 'Complementary calming herb stack' },
-  ],
-  melatonin: [
-    { slug: 'magnesium', reason: 'Sleep quality + circadian timing together' },
-    { slug: 'glycine', reason: 'Body temperature + sleep onset support' },
-    { slug: 'l-theanine', reason: 'Wind-down + timing combination' },
-  ],
-  bacopa: [
-    { slug: 'lions-mane', reason: 'Memory formation + neurogenesis stack' },
-    { slug: 'omega-3', reason: 'DHA + bacosides cognitive pairing' },
-    { slug: 'ginkgo-biloba', reason: 'Cerebral circulation + neurotransmitter support' },
-  ],
-  'ginkgo-biloba': [
-    { slug: 'bacopa', reason: 'Cerebral blood flow + memory encoding stack' },
-    { slug: 'omega-3', reason: 'Vascular + structural brain support' },
-    { slug: 'vitamin-b12', reason: 'Nerve function + circulation combination' },
-  ],
-  'omega-3': [
-    { slug: 'vitamin-d', reason: 'Fat-soluble nutrient absorption co-factor' },
-    { slug: 'coenzyme-q10', reason: 'Mitochondrial + structural brain health' },
-    { slug: 'vitamin-k2', reason: 'Cardiovascular health synergy' },
-  ],
-  'vitamin-d': [
-    { slug: 'vitamin-k2', reason: 'K2 directs calcium where D3 raises it' },
-    { slug: 'magnesium', reason: 'Magnesium is required to activate vitamin D' },
-    { slug: 'omega-3', reason: 'Fat-soluble absorption + anti-inflammatory pairing' },
-  ],
-  'coenzyme-q10': [
-    { slug: 'omega-3', reason: 'Cardiovascular + mitochondrial dual support' },
-    { slug: 'vitamin-d', reason: 'Fat-soluble co-absorption pair' },
-    { slug: 'vitamin-b12', reason: 'Energy metabolism from both pathways' },
-  ],
-  turmeric: [
-    { slug: 'omega-3', reason: 'Anti-inflammatory synergy across pathways' },
-    { slug: 'quercetin', reason: 'Polyphenol anti-inflammatory stack' },
-    { slug: 'vitamin-c', reason: 'Antioxidant combination for inflammation' },
-  ],
-  'milk-thistle': [
-    { slug: 'nac', reason: 'Glutathione + silymarin liver support stack' },
-    { slug: 'alpha-lipoic-acid', reason: 'Regenerates antioxidants alongside silymarin' },
-    { slug: 'vitamin-c', reason: 'Water-soluble antioxidant complement' },
-  ],
-  nac: [
-    { slug: 'milk-thistle', reason: 'Dual liver + glutathione support' },
-    { slug: 'alpha-lipoic-acid', reason: 'Master antioxidant recycling stack' },
-    { slug: 'glycine', reason: 'Precursors for glutathione synthesis' },
-  ],
-  elderberry: [
-    { slug: 'vitamin-c', reason: 'Immune activation from two directions' },
-    { slug: 'zinc', reason: 'Classic immune support triple combination' },
-    { slug: 'vitamin-d', reason: 'Innate + adaptive immune support pairing' },
-  ],
-  zinc: [
-    { slug: 'vitamin-c', reason: 'Classic immune duo for acute support' },
-    { slug: 'vitamin-d', reason: 'Immune regulation combination' },
-    { slug: 'vitamin-b12', reason: 'Cell formation and immune function pair' },
-  ],
-  'vitamin-c': [
-    { slug: 'zinc', reason: 'Classic immune support combination' },
-    { slug: 'quercetin', reason: 'Polyphenol absorption enhancer + antioxidant' },
-    { slug: 'elderberry', reason: 'Immune activation triple stack' },
-  ],
-  '5-htp': [
-    { slug: 'sam-e', reason: 'Serotonin + methylation mood support' },
-    { slug: 'vitamin-b6', reason: 'B6 is the cofactor to convert 5-HTP to serotonin' },
-    { slug: 'magnesium', reason: 'Mood-mineral baseline to support 5-HTP' },
-  ],
-  'sam-e': [
-    { slug: '5-htp', reason: 'Methylation + serotonin precursor pairing' },
-    { slug: 'vitamin-b6', reason: 'Methylation cycle cofactor support' },
-    { slug: 'vitamin-b12', reason: 'SAMe recycling and methylation stack' },
-  ],
-  resveratrol: [
-    { slug: 'coenzyme-q10', reason: 'Sirtuin activation + mitochondrial function' },
-    { slug: 'quercetin', reason: 'Polyphenol longevity synergy stack' },
-    { slug: 'omega-3', reason: 'Anti-inflammatory longevity combination' },
-  ],
-  berberine: [
-    { slug: 'alpha-lipoic-acid', reason: 'Metabolic glucose support stack' },
-    { slug: 'quercetin', reason: 'AMPK activation + anti-inflammatory pair' },
-    { slug: 'vitamin-d', reason: 'Insulin sensitivity support combination' },
-  ],
-  creatine: [
-    { slug: 'vitamin-b12', reason: 'Cell energy metabolism on two fronts' },
-    { slug: 'glutamine', reason: 'Muscle recovery and synthesis stack' },
-    { slug: 'omega-3', reason: 'Anti-inflammatory recovery combination' },
-  ],
-  maca: [
-    { slug: 'ashwagandha', reason: 'Complementary adaptogen energy stack' },
-    { slug: 'zinc', reason: 'Reproductive and hormonal support pairing' },
-    { slug: 'vitamin-d', reason: 'Hormonal production foundational pair' },
-  ],
-  'vitamin-k2': [
-    { slug: 'vitamin-d', reason: 'D3 raises calcium; K2 directs it correctly' },
-    { slug: 'magnesium', reason: 'Three-way bone and cardiovascular stack' },
-    { slug: 'omega-3', reason: 'Vascular calcification protection pairing' },
-  ],
-  probiotics: [
-    { slug: 'glutamine', reason: 'Gut lining + microbiome combination' },
-    { slug: 'inositol', reason: 'Gut-brain axis support stack' },
-    { slug: 'ginger', reason: 'Digestive motility + microbiome pairing' },
-  ],
-  glycine: [
-    { slug: 'magnesium', reason: 'Sleep amino acid + relaxation mineral' },
-    { slug: 'melatonin', reason: 'Body temperature + circadian timing stack' },
-    { slug: 'nac', reason: 'Glutathione precursor combination' },
-  ],
+// Product-backed stack recommendations are intentionally withheld.
+// The previous implementation mixed editorial pairing claims with affiliate
+// availability and included pairings that had not been systematically checked
+// for interaction risk or direct combination evidence. Keep this function as a
+// stable API for profile pages while the stack layer is rebuilt around an
+// evidence + interaction review that is independent of monetization.
+export function getStackRecommendations(_slug: string, _limit = 3): StackRecommendation[] {
+  return []
 }
 
 const ALTERNATIVES: Record<string, Array<{ slug: string; reason: string }>> = {
@@ -199,27 +66,6 @@ const ALTERNATIVES: Record<string, Array<{ slug: string; reason: string }>> = {
     { slug: 'magnesium', reason: 'Relaxation and cardiovascular mineral alternative' },
     { slug: 'glycine', reason: 'Sleep-focused amino acid alternative' },
   ],
-}
-
-export function getStackRecommendations(slug: string, limit = 3): StackRecommendation[] {
-  const stackDefs = STACKS[slug] || []
-  const result: StackRecommendation[] = []
-
-  for (const def of stackDefs) {
-    if (result.length >= limit) break
-    const productSet = getRevenueProductSet(def.slug)
-    if (!productSet) continue
-    const product = productSet.products.find(p => p.slot === 'overall') ?? productSet.products[0]
-    if (product) {
-      result.push({
-        product: { ...product, notes: def.reason, trackingLocation: 'stack-recommendation' },
-        reason: def.reason,
-        targetSlug: def.slug,
-      })
-    }
-  }
-
-  return result
 }
 
 export function getAlternativeRecommendations(slug: string, limit = 2): StackRecommendation[] {


### PR DESCRIPTION
## Summary
- stop rendering legacy product-backed supplement stack recommendations on herb/compound profiles
- keep the existing API stable so profile pages require no route changes
- remove the hard-coded stack matrix whose pairing claims were not systematically interaction/evidence audited
- add a regression test proving known legacy stack slugs return no recommendations

## Why
The previous stack engine only surfaced a pairing when an affiliate revenue product existed, which let commercial availability determine editorial visibility. Several rationales also asserted synergy or combination benefit without a direct combination-evidence review. Until the feature is rebuilt around evidence + interaction screening independent of monetization, withholding it is safer and more consistent with the site's evidence-first decision-page standard.

## Scope
2 files. Alternative-product suggestions are unchanged in this PR.