### PR TITLE
Clarify semaglutide 503A and 503B regulatory status

### DIFF
--- a/app/__tests__/semaglutide-regulatory-status.test.ts
+++ b/app/__tests__/semaglutide-regulatory-status.test.ts
@@ -1,0 +1,34 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const readGuide = () => fs
+  .readFileSync(path.join(process.cwd(), 'app/guides/other/semaglutide/page.tsx'), 'utf8')
+  .replace(/\s+/g, ' ')
+
+describe('semaglutide regulatory status', () => {
+  it('keeps 503A patient-specific rules distinct from 503B bulk-compounding rules', () => {
+    const page = readGuide()
+
+    expect(page).toContain('Section 503A pharmacies and physicians')
+    expect(page).toContain('Section 503B outsourcing facilities')
+    expect(page).toMatch(/restriction against regularly or in inordinate amounts compounding products that are essentially copies/i)
+    expect(page).not.toMatch(/generally need an individualized, physician-documented clinical justification/i)
+  })
+
+  it('describes the April 2026 503B action as a proposal rather than a final exclusion', () => {
+    const page = readGuide()
+
+    expect(page).toContain('on April 30, 2026, FDA proposed excluding semaglutide')
+    expect(page).toMatch(/proposal rather than a final blanket rule/i)
+    expect(page).not.toMatch(/FDA finally excluded semaglutide/i)
+  })
+
+  it('keeps approved semaglutide evidence separate from compounded-product status', () => {
+    const page = readGuide()
+
+    expect(page).toMatch(/Compounded semaglutide is not FDA-approved/i)
+    expect(page).toMatch(/clinical-trial evidence for branded, FDA-approved semaglutide does not establish equivalent quality/i)
+    expect(page).toContain('shortage was resolved on February 21, 2025')
+  })
+})

--- a/app/guides/other/semaglutide/page.tsx
+++ b/app/guides/other/semaglutide/page.tsx
@@ -9,8 +9,8 @@ import type { Heading } from '@/components/articles'
 import References from '@/components/References'
 
 export const metadata: Metadata = buildPageMetadata({
-  title: 'Semaglutide (Ozempic/Wegovy): Evidence, Mechanism, and What to Know',
-  description: 'Evidence-based overview of semaglutide — GLP-1 mechanism, clinical trial data for weight management and diabetes, side effects, and the compounded-vs-brand landscape.',
+  title: 'Semaglutide (Ozempic/Wegovy): Evidence, Safety, and FDA Status (2026)',
+  description: 'Evidence-first overview of semaglutide, including GLP-1 pharmacology, major clinical outcomes, safety considerations, and the current FDA compounding framework.',
   path: '/guides/other/semaglutide/',
 })
 
@@ -18,15 +18,18 @@ const HEADINGS: Heading[] = [
   { id: 'understanding', text: 'What Is Semaglutide?', level: 2 },
   { id: 'mechanism', text: 'Mechanism of Action', level: 2 },
   { id: 'evidence', text: 'What the Evidence Shows', level: 2 },
-  { id: 'legal', text: 'Legal & Regulatory Status', level: 2 },
+  { id: 'legal', text: 'FDA & Compounding Status', level: 2 },
   { id: 'safety', text: 'Safety Considerations', level: 2 },
   { id: 'bottom-line', text: 'Bottom Line', level: 2 },
 ]
 
 const SEMAGLUTIDE_REFS = [
-  { n: 1, text: 'Wilding JPH, et al. (2021). Once-weekly semaglutide in adults with overweight or obesity. N Engl J Med, 384(11): 989-1002.', url: 'https://pubmed.ncbi.nlm.nih.gov/33567185/' },
-  { n: 2, text: 'Marso SP, et al. (2016). Semaglutide and cardiovascular outcomes in type 2 diabetes. N Engl J Med, 375(19): 1834-1844.', url: 'https://pubmed.ncbi.nlm.nih.gov/27633186/' },
-  { n: 3, text: 'Davies MJ, et al. (2015). Efficacy of semaglutide vs placebo for weight management. Lancet, 397(10278): 971-984.', url: 'https://pubmed.ncbi.nlm.nih.gov/33667415/' },
+  { n: 1, text: 'Wilding JPH, et al. Once-weekly semaglutide in adults with overweight or obesity. N Engl J Med. 2021;384:989-1002.', url: 'https://pubmed.ncbi.nlm.nih.gov/33567185/' },
+  { n: 2, text: 'Marso SP, et al. Semaglutide and cardiovascular outcomes in patients with type 2 diabetes. N Engl J Med. 2016;375:1834-1844.', url: 'https://pubmed.ncbi.nlm.nih.gov/27633186/' },
+  { n: 3, text: 'Lincoff AM, et al. Semaglutide and cardiovascular outcomes in obesity without diabetes. N Engl J Med. 2023;389:2221-2232.', url: 'https://pubmed.ncbi.nlm.nih.gov/37952131/' },
+  { n: 4, text: 'Perkovic V, et al. Effects of semaglutide on chronic kidney disease in patients with type 2 diabetes. N Engl J Med. 2024;391:109-121.', url: 'https://pubmed.ncbi.nlm.nih.gov/38785209/' },
+  { n: 5, text: 'FDA. FDA clarifies policies for compounders as national GLP-1 supply begins to stabilize. Updated April 1, 2026.', url: 'https://www.fda.gov/drugs/drug-alerts-and-statements/fda-clarifies-policies-compounders-national-glp-1-supply-begins-stabilize' },
+  { n: 6, text: 'FDA. FDA proposes to exclude semaglutide, tirzepatide, and liraglutide on 503B Bulks List. April 30, 2026.', url: 'https://www.fda.gov/news-events/press-announcements/fda-proposes-exclude-semaglutide-tirzepatide-and-liraglutide-503b-bulks-list' },
 ]
 
 export default function Page() {
@@ -35,121 +38,125 @@ export default function Page() {
   const breadcrumbs = [
     { label: 'Home', href: '/' },
     { label: 'Guides', href: '/guides' },
-    { label: 'Semaglutide (Ozempic/Wegovy): Evidence, Mechanism, and What to Know' },
+    { label: 'Semaglutide: Evidence, Safety, and FDA Status' },
   ]
 
   return (
     <ArticleLayout toc={toc}>
-    <div className="space-y-8">
-      <AuthorityBreadcrumbs items={breadcrumbs} />
+      <div className="space-y-8">
+        <AuthorityBreadcrumbs items={breadcrumbs} />
 
-      <section className="hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8">
-        <p className="eyebrow-label">Peptide &amp; Compound Guide</p>
-        <h1 className="mt-2 text-3xl font-semibold text-ink sm:text-4xl">Semaglutide (Ozempic/Wegovy): Evidence, Mechanism, and What to Know</h1>
-        <p className="detail-reading mt-4 text-muted">Evidence-based overview of semaglutide — GLP-1 mechanism, clinical trial data for weight management and diabetes, side effects, and the compounded-vs-brand landscape.</p>
+        <section className="hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8">
+          <p className="eyebrow-label">Prescription GLP-1 Guide</p>
+          <h1 className="mt-2 text-3xl font-semibold text-ink sm:text-4xl">Semaglutide: Evidence, Safety, and FDA Status</h1>
+          <p className="detail-reading mt-4 text-muted">
+            Semaglutide has a large randomized-trial evidence base and multiple FDA-approved uses. The approved-drug evidence should be kept separate from questions about compounded products, which follow a different regulatory framework.
+          </p>
 
-        <figure className="mt-6">
-          <div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white">
-            <Image
-              src="/images/guides/semaglutide.jpg"
-              alt="A GLP-1 metabolic medication injection pen on a clinical surface"
-              width={1536}
-              height={1024}
-              priority
-              className="w-full h-auto"
-            />
+          <figure className="mt-6">
+            <div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white">
+              <Image
+                src="/images/guides/semaglutide.jpg"
+                alt="A GLP-1 metabolic medication injection pen on a clinical surface"
+                width={1536}
+                height={1024}
+                priority
+                className="w-full h-auto"
+              />
+            </div>
+            <figcaption className="mt-3 text-center text-sm text-muted">
+              Semaglutide — approved-drug evidence and compounded-product rules are separate questions.
+            </figcaption>
+          </figure>
+        </section>
+
+        <section className="rounded-2xl border border-rose-900/15 bg-rose-50/80 p-5 text-sm leading-6 text-rose-950">
+          <p className="font-semibold">Prescription-drug notice</p>
+          <p className="mt-2">
+            FDA-approved semaglutide products are prescription medicines. Compounded semaglutide is not FDA-approved and does not undergo FDA premarket review for safety, effectiveness, or manufacturing quality.
+          </p>
+        </section>
+
+        <AffiliateDisclosure />
+
+        <section className="prose-section space-y-6">
+          <div className="card-premium p-6">
+            <p className="text-sm font-semibold text-brand-700 uppercase tracking-wide">Review status</p>
+            <p className="mt-3 text-sm text-muted">Regulatory wording reviewed August 12, 2026 against current FDA compounding and GLP-1 shortage material.</p>
           </div>
-          <figcaption className="mt-3 text-center text-sm text-muted">
-            Semaglutide — mechanism, evidence, and safety context.
-          </figcaption>
-        </figure>
-      </section>
 
-      <section className="rounded-2xl border border-rose-900/15 bg-rose-50/80 p-5 text-sm leading-6 text-rose-950">
-        <p className="font-semibold">Prescription-drug notice</p>
-        <p className="mt-2">
-          Semaglutide is a prescription medication and is not sold as a research peptide. This page is educational only and is not medical advice or a substitute for a prescribing clinician.
-        </p>
-      </section>
+          <div id="understanding" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">What Is Semaglutide?</h2>
+            <p className="text-muted leading-relaxed">
+              Semaglutide is a glucagon-like peptide-1 (GLP-1) receptor agonist used in FDA-approved prescription products including Ozempic, Wegovy, and Rybelsus. Its evidence base includes large randomized trials in type 2 diabetes, chronic weight management, cardiovascular outcomes, and chronic kidney disease populations. That puts the approved drug in a very different evidence category from experimental peptides marketed through gray-market channels.
+            </p>
+          </div>
 
-      <AffiliateDisclosure />
+          <div id="mechanism" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Mechanism of Action</h2>
+            <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
+              <li><strong>GLP-1 receptor agonism:</strong> reproduces several actions of endogenous GLP-1 signaling.</li>
+              <li><strong>Glucose-dependent insulin secretion:</strong> supports insulin release when glucose is elevated.</li>
+              <li><strong>Glucagon suppression:</strong> can reduce inappropriate glucagon signaling and hepatic glucose output.</li>
+              <li><strong>Gastric emptying and satiety:</strong> slows gastric emptying and affects appetite-related signaling, especially around treatment initiation and dose escalation.</li>
+              <li><strong>Central appetite regulation:</strong> GLP-1 receptor signaling in the nervous system contributes to reduced energy intake.</li>
+            </ul>
+          </div>
 
-      <section className="prose-section space-y-6">
-        <div className="card-premium p-6">
-          <p className="text-sm font-semibold text-brand-700 uppercase tracking-wide">Important Disclaimer</p>
-          <p className="mt-3 text-sm text-muted">This guide is for informational purposes only and does not constitute medical advice. Semaglutide is a prescription medication. Consult a licensed physician before considering any peptide therapy. Content last reviewed for regulatory accuracy: June 30, 2026.</p>
+          <div id="evidence" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">What the Evidence Shows</h2>
+            <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
+              <li><span className="font-semibold text-ink">Chronic weight management:</span> STEP 1 found substantially greater mean weight loss with once-weekly semaglutide 2.4 mg than placebo over 68 weeks in adults with overweight or obesity without diabetes.</li>
+              <li><span className="font-semibold text-ink">Type 2 diabetes:</span> the SUSTAIN program established clinically meaningful glycemic effects and supplied part of the cardiovascular-outcomes evidence base.</li>
+              <li><span className="font-semibold text-ink">Cardiovascular outcomes:</span> SELECT found fewer major adverse cardiovascular events with semaglutide than placebo in adults with established cardiovascular disease and overweight or obesity without diabetes.</li>
+              <li><span className="font-semibold text-ink">Kidney outcomes:</span> FLOW found a lower risk of major kidney-disease outcomes in people with type 2 diabetes and chronic kidney disease.</li>
+            </ul>
+            <p className="text-muted leading-relaxed">
+              <strong>Evidence quality: strong for approved, studied indications and populations.</strong> That does not mean every semaglutide formulation, compounded product, dose, or off-label use inherits the same evidence automatically.
+            </p>
+          </div>
+
+          <div id="legal" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">FDA &amp; Compounding Status (August 2026)</h2>
+            <p className="text-muted leading-relaxed">
+              FDA determined the semaglutide injection shortage was resolved on February 21, 2025. The temporary shortage-related enforcement discretion for making essentially copies of FDA-approved semaglutide products has ended.
+            </p>
+            <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
+              <li><strong>Section 503A pharmacies and physicians:</strong> patient-specific compounding can still qualify for statutory exemptions when all 503A conditions are met, including the restriction against regularly or in inordinate amounts compounding products that are essentially copies of commercially available drugs. The rule is more specific than saying all compounded access simply requires a generic “medical necessity” note.</li>
+              <li><strong>Section 503B outsourcing facilities:</strong> FDA states that semaglutide is not currently on the 503B bulks list and is not on the drug-shortage list. Those facilities therefore cannot rely on shortage status as a basis for routine bulk compounding of semaglutide.</li>
+              <li><strong>503B bulks-list proposal:</strong> on April 30, 2026, FDA proposed excluding semaglutide, tirzepatide, and liraglutide from the 503B bulks list after finding no clinical need for outsourcing-facility bulk compounding. FDA described that action as a proposal and said it would consider public comments before a final determination.</li>
+            </ul>
+            <p className="text-muted leading-relaxed">
+              <strong>Practical reading:</strong> “shortage resolved” does not mean every form of patient-specific compounding became categorically illegal, and a compounded product is not the same thing as an FDA-approved generic. The applicable pathway and statutory conditions matter.
+            </p>
+          </div>
+
+          <div id="safety" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Safety Considerations</h2>
+            <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
+              <li><strong>Common adverse effects:</strong> nausea, vomiting, diarrhea, constipation, and abdominal symptoms are common, particularly during dose escalation.</li>
+              <li><strong>Important clinical risks:</strong> labeling and clinical guidance address issues including gallbladder disease, pancreatitis concerns, delayed gastric emptying, and peri-procedural aspiration risk.</li>
+              <li><strong>Boxed warning:</strong> semaglutide labeling carries a thyroid C-cell tumor warning based on rodent findings and contraindicates use in people with a personal or family history of medullary thyroid carcinoma or MEN 2.</li>
+              <li><strong>Pregnancy:</strong> weight-loss treatment with semaglutide is not appropriate during pregnancy; product-specific labeling should guide discontinuation timing and other reproductive questions.</li>
+              <li><strong>Compounded products:</strong> the clinical-trial evidence for branded, FDA-approved semaglutide does not establish equivalent quality, concentration accuracy, or delivery performance for a compounded preparation.</li>
+            </ul>
+          </div>
+
+          <div id="bottom-line" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Bottom Line</h2>
+            <p className="text-muted leading-relaxed">
+              Semaglutide is an FDA-approved prescription drug with strong randomized evidence in several defined populations. The more complicated question in 2026 is compounding: the injection shortage is resolved, shortage-based copy policies have ended, 503A and 503B operate under different statutory conditions, and FDA's April 2026 503B bulks-list action remains a proposal rather than a final blanket rule. Keep those regulatory questions separate from the efficacy evidence for approved products.
+            </p>
+          </div>
+        </section>
+
+        <div className="mt-8 flex gap-4 flex-wrap">
+          <Link href="/guides/" className="text-sm font-medium text-emerald-700 hover:underline">Back to guides &rarr;</Link>
+          <Link href="/compounds/semaglutide/" className="text-sm font-medium text-emerald-700 hover:underline">View Semaglutide compound profile &rarr;</Link>
+          <Link href="/guides/other/tirzepatide/" className="text-sm font-medium text-emerald-700 hover:underline">Read the Tirzepatide guide &rarr;</Link>
         </div>
-
-        <div id="understanding" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">What Is Semaglutide?</h2>
-          <p className="text-muted leading-relaxed">
-            Semaglutide is a GLP-1 (glucagon-like peptide-1) receptor agonist, FDA-approved under the brand names <strong>Ozempic</strong> (type 2 diabetes) and <strong>Wegovy</strong> (chronic weight management), with an oral form marketed as <strong>Rybelsus</strong>. Unlike most peptides covered elsewhere in this series, semaglutide is a fully FDA-approved prescription drug backed by a large randomized controlled trial program — it belongs in a different evidence tier entirely.
-          </p>
-        </div>
-
-        <div id="mechanism" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Mechanism of Action</h2>
-          <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
-            <li><strong>GLP-1 receptor agonism</strong> — mimics the incretin hormone GLP-1, which the gut releases after eating</li>
-            <li><strong>Glucose-dependent insulin secretion</strong> — stimulates insulin release from the pancreas specifically when blood glucose is elevated, reducing hypoglycemia risk relative to some other diabetes drugs</li>
-            <li><strong>Glucagon suppression</strong> — reduces glucagon secretion, lowering hepatic glucose output</li>
-            <li><strong>Gastric emptying delay</strong> — slows stomach emptying, contributing to increased satiety</li>
-            <li><strong>Central appetite regulation</strong> — acts on GLP-1 receptors in the hypothalamus and brainstem to reduce hunger signaling and food reward response</li>
-          </ul>
-        </div>
-
-        <div id="evidence" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">What the Evidence Shows</h2>
-          <p className="text-muted leading-relaxed">
-            Semaglutide has one of the strongest evidence bases of any drug covered on this site:
-          </p>
-          <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
-            <li><span className="font-semibold text-ink">Weight loss (STEP trial program):</span> In the pivotal STEP 1 trial, participants without diabetes lost an average of ~15% of body weight over 68 weeks at the 2.4mg/week dose, versus ~2.4% with placebo.</li>
-            <li><span className="font-semibold text-ink">Type 2 diabetes (SUSTAIN trial program):</span> Consistent, clinically meaningful reductions in HbA1c across multiple trials, generally outperforming other GLP-1 class comparators at equivalent doses.</li>
-            <li><span className="font-semibold text-ink">Cardiovascular outcomes (SELECT trial):</span> In adults with cardiovascular disease and overweight/obesity but without diabetes, semaglutide reduced major adverse cardiovascular events (heart attack, stroke, cardiovascular death) versus placebo — this expanded its approved indication beyond weight loss alone.</li>
-            <li><span className="font-semibold text-ink">Kidney outcomes (FLOW trial):</span> Demonstrated benefit in reducing kidney disease progression in type 2 diabetes patients with chronic kidney disease.</li>
-          </ul>
-          <p className="text-muted leading-relaxed">
-            <strong>Evidence quality: strong.</strong> This is Phase 3 RCT-backed, FDA-approved data across multiple large trial programs — categorically different from the preclinical/gray-market peptides elsewhere in this series.
-          </p>
-        </div>
-
-        <div id="legal" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Regulatory & Market Status (Updated June 2026)</h2>
-          <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
-            <li>Semaglutide is FDA-approved and commercially available by prescription (Ozempic, Wegovy, Rybelsus).</li>
-            <li>The nationwide semaglutide shortage that drove a wave of 503A/503B <strong>compounded semaglutide</strong> has resolved — the FDA determined semaglutide is no longer in shortage, and per current FDA guidance, 503B outsourcing facilities can no longer compound semaglutide in bulk since it's not on the 503B bulks list and is no longer shortage-eligible. Patients seeking a compounded version now generally need an individualized, physician-documented clinical justification (e.g., an allergy to a brand-name excipient, or a dose not commercially available) rather than simple cost or availability.</li>
-            <li>Semaglutide is not sold as a “research peptide” — legitimate access is prescription-only through a licensed pharmacy.</li>
-          </ul>
-        </div>
-
-        <div id="safety" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Side Effects & Safety</h2>
-          <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
-            <li><strong>Common:</strong> nausea, vomiting, diarrhea, constipation — most pronounced during dose escalation and often improve over time</li>
-            <li><strong>Less common but notable:</strong> gallbladder disease, pancreatitis (rare), risk of aspiration under anesthesia due to delayed gastric emptying (relevant for pre-surgical planning)</li>
-            <li><strong>Boxed warning:</strong> risk of thyroid C-cell tumors observed in rodent studies; contraindicated in patients with a personal or family history of medullary thyroid carcinoma or Multiple Endocrine Neoplasia syndrome type 2</li>
-            <li><strong>Not for use in pregnancy</strong></li>
-          </ul>
-        </div>
-
-        <div id="bottom-line" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Bottom Line</h2>
-          <p className="text-muted leading-relaxed">
-            Semaglutide is a genuinely well-studied, FDA-approved drug with strong outcomes data across weight management, diabetes, cardiovascular risk, and kidney disease — it's an outlier in this peptide series in terms of evidence quality. The main current landscape shift is the wind-down of the compounded/shortage-era supply, pushing most patients back toward branded, prescription-only access.
-          </p>
-        </div>
-
-      </section>
-
-      <div className="mt-8 flex gap-4 flex-wrap">
-        <Link href="/guides/" className="text-sm font-medium text-emerald-700 hover:underline">Back to guides &rarr;</Link>
-        <Link href="/compounds/semaglutide/" className="text-sm font-medium text-emerald-700 hover:underline">View Semaglutide compound profile &rarr;</Link>
-        <Link href="/guides/other/tirzepatide/" className="text-sm font-medium text-emerald-700 hover:underline">Read the Tirzepatide guide &rarr;</Link>
-
       </div>
-    </div>
-    <References refs={SEMAGLUTIDE_REFS} />
+      <References refs={SEMAGLUTIDE_REFS} />
     </ArticleLayout>
   )
 }


### PR DESCRIPTION
## Summary
- update semaglutide's regulatory section through August 2026
- distinguish 503A patient-specific compounding restrictions from 503B outsourcing-facility bulk-substance rules
- remove the overbroad shortcut that compounded access generally requires a generic physician-documented clinical justification
- describe FDA's April 30, 2026 503B bulks-list action as a proposal, not a final exclusion
- keep FDA-approved semaglutide trial evidence separate from compounded-product quality and approval status
- correct and expand the major-trial reference list for STEP 1, SELECT, and FLOW
- add a focused regression test for the regulatory distinctions

## Primary-source basis
- FDA April 1, 2026 GLP-1 compounding policy clarification
- FDA April 30, 2026 proposed 503B bulks-list exclusion
- PubMed records for STEP 1, SELECT, and FLOW

## Scope
2 files: the standalone semaglutide guide and one regulatory regression test.