### PR TITLE
Align PT-141 guide with current Vyleesi labeling

### DIFF
--- a/app/__tests__/pt141-label-accuracy.test.ts
+++ b/app/__tests__/pt141-label-accuracy.test.ts
@@ -1,0 +1,33 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const readGuide = () => fs
+  .readFileSync(path.join(process.cwd(), 'app/guides/other/pt-141/page.tsx'), 'utf8')
+  .replace(/\s+/g, ' ')
+
+describe('PT-141 / Vyleesi labeling accuracy', () => {
+  it('keeps the approved indication narrow and does not market sexual performance use', () => {
+    const page = readGuide()
+
+    expect(page).toMatch(/acquired, generalized hypoactive sexual desire disorder \(HSDD\) in premenopausal women/i)
+    expect(page).toMatch(/not indicated for HSDD in postmenopausal women or in men/i)
+    expect(page).toMatch(/not indicated to enhance sexual performance/i)
+  })
+
+  it('includes current cardiovascular and pigmentation safety boundaries', () => {
+    const page = readGuide()
+
+    expect(page).toMatch(/uncontrolled hypertension or known cardiovascular disease/i)
+    expect(page).toMatch(/blood pressure can rise transiently and heart rate can decrease/i)
+    expect(page).toMatch(/focal skin and mucosal pigmentation/i)
+  })
+
+  it('does not treat an RUO label as a categorical legality shortcut', () => {
+    const page = readGuide()
+
+    expect(page).toMatch(/research-use label does not convert an unapproved product into the FDA-approved drug/i)
+    expect(page).not.toMatch(/RUO-labeled product is not legally intended for human consumption/i)
+    expect(page).not.toMatch(/regulatory gray zone/i)
+  })
+})

--- a/app/guides/other/pt-141/page.tsx
+++ b/app/guides/other/pt-141/page.tsx
@@ -9,23 +9,24 @@ import type { Heading } from '@/components/articles'
 import References from '@/components/References'
 
 export const metadata: Metadata = buildPageMetadata({
-  title: 'PT-141 (Bremelanotide): Evidence & Safety Guide',
-  description: 'Evidence-based overview of PT-141 (bremelanotide) — melanocortin receptor mechanism, the FDA-approved Vyleesi indication, off-label/RUO use, and safety.',
+  title: 'Bremelanotide (PT-141/Vyleesi): Evidence, Safety, and FDA Status (2026)',
+  description: 'Evidence-first overview of bremelanotide (PT-141), including the FDA-approved Vyleesi indication, RECONNECT trial evidence, cardiovascular precautions, and gray-market product limitations.',
   path: '/guides/other/pt-141/',
 })
 
 const HEADINGS: Heading[] = [
-  { id: 'understanding', text: 'What Is PT-141?', level: 2 },
+  { id: 'understanding', text: 'What Is Bremelanotide?', level: 2 },
   { id: 'mechanism', text: 'Mechanism of Action', level: 2 },
   { id: 'evidence', text: 'What the Evidence Shows', level: 2 },
-  { id: 'legal', text: 'Legal & Regulatory Status', level: 2 },
+  { id: 'legal', text: 'FDA & Product Status', level: 2 },
   { id: 'safety', text: 'Safety Considerations', level: 2 },
   { id: 'bottom-line', text: 'Bottom Line', level: 2 },
 ]
 
 const PT_141_REFS = [
-  { n: 1, text: 'Molinoff PB, et al. (2003). PT-141: a melanocortin agonist for sexual dysfunction. Ann N Y Acad Sci, 994: 96-102.', url: 'https://pubmed.ncbi.nlm.nih.gov/12851303/' },
-  { n: 2, text: 'Diamond LE, et al. (2004). Bremelanotide for erectile dysfunction. Int J Impot Res, 16(1): 51-59.', url: 'https://pubmed.ncbi.nlm.nih.gov/14963472/' },
+  { n: 1, text: 'Kingsberg SA, et al. Bremelanotide for the treatment of hypoactive sexual desire disorder: two randomized phase 3 trials. Obstet Gynecol. 2019;134:899-908.', url: 'https://pubmed.ncbi.nlm.nih.gov/31599840/' },
+  { n: 2, text: 'DailyMed. Vyleesi (bremelanotide injection) current prescribing information.', url: 'https://dailymed.nlm.nih.gov/dailymed/drugInfo.cfm?setid=f1d0c1b5-2f39-4bad-a6a4-0066e3ad5dcf' },
+  { n: 3, text: 'Diamond LE, et al. Double-blind, placebo-controlled evaluation of intranasal PT-141 in men with erectile dysfunction. Int J Impot Res. 2004;16:51-59.', url: 'https://pubmed.ncbi.nlm.nih.gov/14963472/' },
 ]
 
 export default function Page() {
@@ -34,114 +35,118 @@ export default function Page() {
   const breadcrumbs = [
     { label: 'Home', href: '/' },
     { label: 'Guides', href: '/guides' },
-    { label: 'PT-141 (Bremelanotide/Vyleesi): Evidence, Mechanism, and Legal Status' },
+    { label: 'Bremelanotide (PT-141/Vyleesi): Evidence, Safety, and FDA Status' },
   ]
 
   return (
     <ArticleLayout toc={toc} zone="harm-reduction">
-    <div className="space-y-8">
-      <AuthorityBreadcrumbs items={breadcrumbs} />
+      <div className="space-y-8">
+        <AuthorityBreadcrumbs items={breadcrumbs} />
 
-      <section className="hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8">
-        <p className="eyebrow-label">Peptide &amp; Compound Guide</p>
-        <h1 className="mt-2 text-3xl font-semibold text-ink sm:text-4xl">PT-141 (Bremelanotide/Vyleesi): Evidence, Mechanism, and Legal Status</h1>
-        <p className="detail-reading mt-4 text-muted">Evidence-based overview of PT-141 (bremelanotide) — melanocortin receptor mechanism, the FDA-approved Vyleesi indication, off-label/RUO use, and safety.</p>
+        <section className="hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8">
+          <p className="eyebrow-label">Prescription Drug &amp; Gray-Market Context</p>
+          <h1 className="mt-2 text-3xl font-semibold text-ink sm:text-4xl">Bremelanotide (PT-141/Vyleesi): Evidence, Safety, and FDA Status</h1>
+          <p className="detail-reading mt-4 text-muted">
+            Bremelanotide is unusual among compounds marketed as “peptides”: an FDA-approved prescription product exists, but its evidence and labeling apply to a specific indication and product—not automatically to gray-market PT-141 sold online.
+          </p>
 
-        <figure className="mt-6">
-          <div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white">
-            <Image
-              src="/images/guides/pt-141.jpg"
-              alt="A glass vial of lyophilized research peptide powder in a lab setting"
-              width={1536}
-              height={1024}
-              priority
-              className="w-full h-auto"
-            />
+          <figure className="mt-6">
+            <div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white">
+              <Image
+                src="/images/guides/pt-141.jpg"
+                alt="A peptide vial on a clinical laboratory surface"
+                width={1536}
+                height={1024}
+                priority
+                className="w-full h-auto"
+              />
+            </div>
+            <figcaption className="mt-3 text-center text-sm text-muted">
+              Bremelanotide — distinguish FDA-reviewed Vyleesi from unapproved products marketed as PT-141.
+            </figcaption>
+          </figure>
+        </section>
+
+        <section className="rounded-2xl border border-rose-900/15 bg-rose-50/80 p-5 text-sm leading-6 text-rose-950">
+          <p className="font-semibold">Approved product vs. gray-market product</p>
+          <p className="mt-2">
+            Vyleesi is an FDA-approved prescription bremelanotide product. A vial or powder sold online as “PT-141,” including one labeled for research use, is not thereby Vyleesi and has not inherited the approved product's FDA review for identity, manufacturing quality, safety, or effectiveness.
+          </p>
+        </section>
+
+        <AffiliateDisclosure />
+
+        <section className="prose-section space-y-6">
+          <div className="card-premium p-6">
+            <p className="text-sm font-semibold text-brand-700 uppercase tracking-wide">Review status</p>
+            <p className="mt-3 text-sm text-muted">Clinical and labeling language reviewed August 12, 2026 against current Vyleesi prescribing information and the phase 3 RECONNECT publication.</p>
           </div>
-          <figcaption className="mt-3 text-center text-sm text-muted">
-            PT-141 — an educational, research-use-only overview.
-          </figcaption>
-        </figure>
-      </section>
 
-      <section className="rounded-2xl border border-rose-900/15 bg-rose-50/80 p-5 text-sm leading-6 text-rose-950">
-        <p className="font-semibold">Approved-drug vs. research-chemical notice</p>
-        <p className="mt-2">
-          Bremelanotide (Vyleesi) is FDA-approved only for hypoactive sexual desire disorder (HSDD) in premenopausal women. PT-141 sold as a research chemical is a separate regulatory category not intended for human consumption. This page is educational only and is not medical or legal advice.
-        </p>
-      </section>
+          <div id="understanding" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">What Is Bremelanotide?</h2>
+            <p className="text-muted leading-relaxed">
+              Bremelanotide is a melanocortin receptor agonist. “PT-141” is the development name still commonly used in research and gray-market advertising. The FDA-approved product, Vyleesi, is indicated for <strong>acquired, generalized hypoactive sexual desire disorder (HSDD) in premenopausal women</strong> when the low desire causes marked distress or interpersonal difficulty and is not due to another medical or psychiatric condition, relationship problems, or the effects of a medication or drug substance.
+            </p>
+            <p className="text-muted leading-relaxed">
+              The current label specifically says Vyleesi is not indicated for HSDD in postmenopausal women or in men and is not indicated to enhance sexual performance.
+            </p>
+          </div>
 
-      <AffiliateDisclosure />
+          <div id="mechanism" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Mechanism of Action</h2>
+            <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
+              <li><strong>Melanocortin receptor agonism:</strong> bremelanotide activates melanocortin receptors, including MC4R, in pathways involved in sexual desire and arousal.</li>
+              <li><strong>Central rather than PDE5-style vascular action:</strong> its pharmacology differs from sildenafil and other PDE5 inhibitors; that mechanistic difference does not make it an established substitute for erectile-dysfunction therapy.</li>
+              <li><strong>Mechanism is not the indication:</strong> activity in sexual-arousal pathways does not establish efficacy for every libido, erectile-function, or performance claim used in online marketing.</li>
+            </ul>
+          </div>
 
-      <section className="prose-section space-y-6">
-        <div className="card-premium p-6">
-          <p className="text-sm font-semibold text-brand-700 uppercase tracking-wide">Important Disclaimer</p>
-          <p className="mt-3 text-sm text-muted">This guide is for informational purposes only and does not constitute medical advice. Bremelanotide (Vyleesi) is FDA-approved only for HSDD in premenopausal women. Consult a licensed physician before considering any peptide therapy. Content last reviewed for regulatory accuracy: June 30, 2026.</p>
+          <div id="evidence" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">What the Evidence Shows</h2>
+            <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
+              <li><span className="font-semibold text-ink">Approved HSDD indication:</span> the two randomized, double-blind, placebo-controlled phase 3 RECONNECT trials enrolled premenopausal women with HSDD and found statistically significant improvements in sexual desire and reductions in distress related to low desire.</li>
+              <li><span className="font-semibold text-ink">Magnitude and endpoint matter:</span> the registration evidence supports a defined HSDD treatment effect; it should not be translated into a blanket “libido enhancer” or sexual-performance claim.</li>
+              <li><span className="font-semibold text-ink">Men / erectile dysfunction:</span> earlier studies explored PT-141 in men, but Vyleesi is not FDA-approved for men or for erectile dysfunction. Those exploratory data are a different evidence base from the phase 3 HSDD program.</li>
+            </ul>
+            <p className="text-muted leading-relaxed">
+              <strong>Evidence quality: strong for the FDA-reviewed indication and substantially weaker for the broader uses commonly attached to “PT-141” marketing.</strong>
+            </p>
+          </div>
+
+          <div id="legal" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">FDA &amp; Product Status</h2>
+            <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
+              <li><strong>Vyleesi:</strong> FDA-approved, prescription-only bremelanotide for the specific HSDD indication described above.</li>
+              <li><strong>Gray-market “PT-141”:</strong> a seller's research-use label does not convert an unapproved product into the FDA-approved drug and does not establish equivalent identity, sterility, concentration accuracy, or manufacturing quality.</li>
+              <li><strong>Off-label prescribing:</strong> lawful clinician prescribing questions are different from the status of an unapproved product sold directly to consumers. Do not treat the words “off label,” “research use,” and “FDA approved” as interchangeable.</li>
+            </ul>
+          </div>
+
+          <div id="safety" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Safety Considerations</h2>
+            <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
+              <li><strong>Cardiovascular contraindications:</strong> current Vyleesi labeling contraindicates use in people with uncontrolled hypertension or known cardiovascular disease.</li>
+              <li><strong>Blood pressure and heart rate:</strong> the approved label warns that blood pressure can rise transiently and heart rate can decrease after a dose, generally returning toward baseline within about 12 hours.</li>
+              <li><strong>Nausea:</strong> nausea was common in the clinical program and is one of the most important tolerability limitations.</li>
+              <li><strong>Focal hyperpigmentation:</strong> the label warns about focal skin and mucosal pigmentation; resolution was not confirmed in every affected patient after discontinuation.</li>
+              <li><strong>Product-quality uncertainty:</strong> these label data describe FDA-reviewed Vyleesi. They do not validate the purity, dose accuracy, sterility, or safety of a gray-market vial sold as PT-141.</li>
+            </ul>
+          </div>
+
+          <div id="bottom-line" className="scroll-mt-20">
+            <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Bottom Line</h2>
+            <p className="text-muted leading-relaxed">
+              Bremelanotide has real phase 3 evidence and an FDA-approved product, but only for a defined HSDD population. The existence of Vyleesi is not evidence that every PT-141 product or marketed use is FDA-reviewed. For this compound, the most important distinction is not “peptide vs. drug”; it is <strong>approved product and indication vs. unapproved product or unsupported use</strong>.
+            </p>
+          </div>
+        </section>
+
+        <div className="mt-8 flex gap-4 flex-wrap">
+          <Link href="/guides/" className="text-sm font-medium text-emerald-700 hover:underline">Back to guides &rarr;</Link>
+          <Link href="/compounds/pt-141/" className="text-sm font-medium text-emerald-700 hover:underline">View PT-141 compound profile &rarr;</Link>
         </div>
-
-        <div id="understanding" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">What Is PT-141?</h2>
-          <p className="text-muted leading-relaxed">
-            PT-141 is the research/gray-market name for <strong>bremelanotide</strong>, a melanocortin receptor agonist. Unlike most peptides in this series, bremelanotide has an actual FDA-approved product: <strong>Vyleesi</strong>, indicated for hypoactive sexual desire disorder (HSDD) in premenopausal women. Most PT-141 sold online as a research chemical, marketed more broadly (including to men, and for erectile dysfunction), falls outside that approved indication and is not the FDA-regulated product.
-          </p>
-        </div>
-
-        <div id="mechanism" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Mechanism of Action</h2>
-          <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
-            <li><strong>Melanocortin receptor agonism</strong> — activates MC3R and MC4R receptors in the central nervous system, distinct from the peripheral vascular mechanism used by PDE5 inhibitors like sildenafil</li>
-            <li><strong>Central, not vascular, pathway</strong> — because it works on brain melanocortin pathways involved in sexual arousal and desire rather than blood flow directly, it's mechanistically different from erectile dysfunction drugs, even though it's sometimes marketed as an alternative to them</li>
-            <li><strong>Non-hormonal</strong> — does not directly act on sex hormone pathways</li>
-          </ul>
-        </div>
-
-        <div id="evidence" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">What the Evidence Shows</h2>
-          <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
-            <li><span className="font-semibold text-ink">FDA-approved indication (Vyleesi):</span> Phase 3 trials in premenopausal women with HSDD showed statistically significant, though modest, improvements in desire and reduction in distress related to low desire, compared to placebo — the basis for FDA approval.</li>
-            <li><span className="font-semibold text-ink">Male sexual function:</span> Earlier-phase trials explored bremelanotide for erectile dysfunction; results were mixed, and the drug was ultimately developed and approved for the female HSDD indication rather than for ED. Off-label/gray-market use in men for this purpose is not backed by the same trial data that supports the approved indication.</li>
-            <li><span className="font-semibold text-ink">Side-effect trade-off:</span> Trials noted a meaningful rate of nausea (partly why the initial nasal-spray formulation was discontinued in favor of the current subcutaneous auto-injector) and increases in blood pressure that need monitoring, particularly relevant for anyone with hypertension.</li>
-          </ul>
-          <p className="text-muted leading-relaxed">
-            <strong>Evidence quality: moderate, and indication-specific.</strong> The FDA-approved use (HSDD in premenopausal women) has real Phase 3 data behind it. Broader marketed uses (general “libido enhancer,” male use) rely on much thinner evidence.
-          </p>
-        </div>
-
-        <div id="legal" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Legal & Regulatory Status</h2>
-          <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
-            <li>Bremelanotide is FDA-approved as <strong>Vyleesi</strong>, prescription-only, for HSDD in premenopausal women specifically.</li>
-            <li>PT-141 sold as a research chemical is a different regulatory category from Vyleesi — it is not FDA-approved for any use outside that narrow indication, and RUO-labeled product is not legally intended for human consumption.</li>
-            <li>PT-141/bremelanotide is not on the FDA's Category 1/2 peptide compounding lists discussed for BPC-157, TB-500, etc. — it sits in its own regulatory track as an approved-drug active ingredient with off-label/RUO gray-market use outside that approval.</li>
-          </ul>
-        </div>
-
-        <div id="safety" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Safety Considerations</h2>
-          <ul className="list-disc pl-5 space-y-2 text-muted leading-relaxed">
-            <li><strong>Blood pressure:</strong> Bremelanotide can transiently raise blood pressure and, in a subset of patients, may cause a notable spike — Vyleesi carries specific dosing-frequency limits partly for this reason. This is a meaningful consideration for anyone with cardiovascular risk factors.</li>
-            <li><strong>Nausea:</strong> One of the most commonly reported side effects in trials.</li>
-            <li><strong>Skin/mucosal hyperpigmentation:</strong> Melanocortin receptor activation can, with repeated use, cause focal skin darkening in some patients — a known class effect.</li>
-            <li><strong>Not evaluated for the off-label uses</strong> (e.g., male sexual enhancement, general libido) it's most often marketed for in the gray market.</li>
-          </ul>
-        </div>
-
-        <div id="bottom-line" className="scroll-mt-20">
-          <h2 className="text-2xl font-semibold text-ink mt-8 mb-4">Bottom Line</h2>
-          <p className="text-muted leading-relaxed">
-            PT-141 is unusual in this series: there's a genuinely FDA-approved product built on this molecule, but it's approved for one specific population and indication. Most gray-market marketing extends well beyond that approved use, on considerably thinner evidence, and RUO product isn't the same regulatory entity as Vyleesi.
-          </p>
-        </div>
-
-      </section>
-
-      <div className="mt-8 flex gap-4 flex-wrap">
-        <Link href="/guides/" className="text-sm font-medium text-emerald-700 hover:underline">Back to guides &rarr;</Link>
-        <Link href="/compounds/pt-141/" className="text-sm font-medium text-emerald-700 hover:underline">View PT-141 compound profile &rarr;</Link>
-
       </div>
-    </div>
-    <References refs={PT_141_REFS} />
+      <References refs={PT_141_REFS} />
     </ArticleLayout>
   )
 }


### PR DESCRIPTION
## Summary
- reframe PT-141 around the FDA-reviewed bremelanotide/Vyleesi product and its narrow approved indication
- add the phase 3 RECONNECT evidence rather than relying mainly on older exploratory male ED studies
- state current label limitations: not indicated for postmenopausal women, men, or sexual-performance enhancement
- strengthen cardiovascular, nausea, and focal-hyperpigmentation safety boundaries
- distinguish off-label prescribing from gray-market product status
- remove categorical RUO-as-legality shorthand and the vague “regulatory gray zone” framing
- add a focused regression test for approved-use and safety language

## Basis
Current Vyleesi prescribing information and the phase 3 RECONNECT publication.

## Scope
2 files: the standalone PT-141 guide and one regression test.