### PR TITLE
Restore graph-backed interaction search filtering

### DIFF
--- a/scripts/data/build-search-index.mjs
+++ b/scripts/data/build-search-index.mjs
@@ -61,22 +61,8 @@ export const PATHWAY_KEYWORDS = {
   endocannabinoid: ['endocannabinoid', 'cb1', 'cb2', 'cannabinoid'],
 }
 
-// Prefixes that legitimately glue onto a keyword with no separator (e.g.
-// "autoimmune" -> "immune", "neuroinflammation" -> "inflammation"). Extend
-// this list (not the matcher) when a new legitimate compound term is found —
-// do not weaken the boundary check.
 const ALLOWED_FACET_PREFIXES = ['auto', 'neuro']
 
-// A keyword match preceded by a letter that doesn't form an allowed prefix is
-// a coincidental substring collision, not a real hit — e.g. "tension" inside
-// "hypotension"/"hypertension" (neither is anxiety-related), "panic" inside
-// "paniculata"/"agrestis"/"terrestris" (plant species names), "cox" inside
-// "fucoxanthin", "atp" inside "oatp", "ngf" inside "meaningful", "pain"
-// inside "papain", "aging" inside "imaging". A trailing letter (plural/
-// adjectival suffixes like "sedative(s)", "adaptogen(ic)", "gaba(ergic)") is
-// left unrestricted since those are the normal inflected forms of a real hit.
-// See docs/LOOP_NOTES.md for the production case (dendrobium's "hypotension"
-// clause falsely tripping the anxiety facet) this was found from.
 function hasBoundedMatch(lower, kw) {
   let from = 0
   let idx
@@ -101,10 +87,6 @@ export function matchFacets(haystack, taxonomy) {
   return matched
 }
 
-// ---------------------------------------------------------------------------
-// Normalization helpers
-// ---------------------------------------------------------------------------
-
 function toList(value) {
   if (Array.isArray(value)) return value.map((v) => String(v).trim()).filter(Boolean)
   if (typeof value === 'string' && value.trim()) return [value.trim()]
@@ -125,7 +107,7 @@ function normalizeSafety({ safetyNotes, contraindications, interactions, isEduca
   if (isEducation) return 'Educational'
   const notes = String(safetyNotes || '').toLowerCase()
   const hasContra = toList(contraindications).length > 0
-  const hasInteractions = toList(interactions).length > 0
+  const hasInteractions = Array.isArray(interactions) && interactions.length > 0
   if (/(avoid|danger|toxic|severe|do not|serious|contraindicated)/.test(notes)) return 'Notable considerations'
   if (hasContra || hasInteractions || /(caution|may cause|consult|pregnan|monitor)/.test(notes)) {
     return hasContra && hasInteractions ? 'Notable considerations' : 'Use with caution'
@@ -138,6 +120,19 @@ function readJson(file) {
   return JSON.parse(fs.readFileSync(path.join(DATA_DIR, file), 'utf8'))
 }
 
+export function hasInteractionEdges(slug, edgesBySlug) {
+  return Array.isArray(edgesBySlug?.[slug]) && edgesBySlug[slug].length > 0
+}
+
+function readInteractionEdges() {
+  try {
+    const value = readJson('interaction_edges.json')
+    return value && typeof value === 'object' && !Array.isArray(value) ? value : {}
+  } catch {
+    return {}
+  }
+}
+
 function mergeSearchRecords(summaryFile, coreFile) {
   const summaries = readJson(summaryFile)
   const coreBySlug = new Map(readJson(coreFile).map(record => [record.slug, record]))
@@ -148,11 +143,7 @@ function mergeSearchRecords(summaryFile, coreFile) {
   })
 }
 
-// ---------------------------------------------------------------------------
-// Source readers
-// ---------------------------------------------------------------------------
-
-function buildHerbDocs() {
+function buildHerbDocs(edgesBySlug = {}) {
   let records = []
   try {
     records = mergeSearchRecords('summary-indexes/herbs-summary.json', 'herbs.json')
@@ -177,7 +168,9 @@ function buildHerbDocs() {
         .filter(Boolean)
         .join(' ')
       const contraindications = toList(item.contraindications)
-      const interactions = toList(item.interactions)
+      const flatInteractions = toList(item.interactions)
+      const graphInteractions = hasInteractionEdges(slug, edgesBySlug) ? edgesBySlug[slug] : []
+      const interactions = flatInteractions.length ? flatInteractions : graphInteractions
       return {
         id: `Herb:${slug}`,
         slug,
@@ -190,7 +183,7 @@ function buildHerbDocs() {
         evidenceGrade: normalizeEvidence(item.evidenceLevel || item.confidence),
         safety: normalizeSafety({ safetyNotes: item.safetyNotes || item.safety, contraindications, interactions, isEducation: false }),
         safetyFlags: {
-          hasInteractions: interactions.length > 0,
+          hasInteractions: flatInteractions.length > 0 || graphInteractions.length > 0,
           hasContraindications: contraindications.length > 0,
         },
         tags: effects.slice(0, 4),
@@ -200,7 +193,7 @@ function buildHerbDocs() {
     .filter(Boolean)
 }
 
-function buildCompoundDocs() {
+function buildCompoundDocs(edgesBySlug = {}) {
   let records = []
   try {
     records = mergeSearchRecords('summary-indexes/compounds-summary.json', 'compounds.json')
@@ -214,7 +207,9 @@ function buildCompoundDocs() {
       if (!slug || !name) return null
       const effects = [...toList(item.mechanisms), ...toList(item.targets), ...toList(item.pathways)]
       const contraindications = toList(item.contraindications)
-      const interactions = toList(item.interactions)
+      const flatInteractions = toList(item.interactions)
+      const graphInteractions = hasInteractionEdges(slug, edgesBySlug) ? edgesBySlug[slug] : []
+      const interactions = flatInteractions.length ? flatInteractions : graphInteractions
       const haystack = [
         name,
         item.compoundClass,
@@ -236,7 +231,7 @@ function buildCompoundDocs() {
         evidenceGrade: normalizeEvidence(item.evidenceLevel),
         safety: normalizeSafety({ safetyNotes: item.safetyNotes || item.safety, contraindications, interactions, isEducation: false }),
         safetyFlags: {
-          hasInteractions: interactions.length > 0,
+          hasInteractions: flatInteractions.length > 0 || graphInteractions.length > 0,
           hasContraindications: contraindications.length > 0,
         },
         tags: effects.slice(0, 4),
@@ -328,19 +323,17 @@ function buildEducationDocs() {
     })
 }
 
-// ---------------------------------------------------------------------------
-// Main
-// ---------------------------------------------------------------------------
-
 function main() {
-  const docs = [...buildHerbDocs(), ...buildCompoundDocs(), ...buildEducationDocs()]
+  const interactionEdges = readInteractionEdges()
+  const docs = [...buildHerbDocs(interactionEdges), ...buildCompoundDocs(interactionEdges), ...buildEducationDocs()]
   fs.mkdirSync(DATA_DIR, { recursive: true })
   fs.writeFileSync(OUT_FILE, JSON.stringify(docs))
 
   const byType = docs.reduce((acc, d) => ({ ...acc, [d.type]: (acc[d.type] || 0) + 1 }), {})
+  const withInteractions = docs.filter(doc => doc.safetyFlags?.hasInteractions).length
   console.log(
     `[build-search-index] wrote ${docs.length} docs → ${path.relative(ROOT, OUT_FILE)} ` +
-      `(${Object.entries(byType).map(([k, v]) => `${k}: ${v}`).join(', ')})`
+      `(${Object.entries(byType).map(([k, v]) => `${k}: ${v}`).join(', ')}; interactions: ${withInteractions})`
   )
 }
 

--- a/scripts/data/build-search-index.test.mjs
+++ b/scripts/data/build-search-index.test.mjs
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { GOAL_KEYWORDS, PATHWAY_KEYWORDS, matchFacets } from './build-search-index.mjs'
+import { GOAL_KEYWORDS, PATHWAY_KEYWORDS, hasInteractionEdges, matchFacets } from './build-search-index.mjs'
 
 describe('matchFacets', () => {
   it('does not match a keyword glued as a prefix inside an unrelated word', () => {
@@ -34,5 +34,18 @@ describe('matchFacets', () => {
     // frontmatter-derived goals, so it relies entirely on this facet match
     // to appear under the Inflammation search filter.
     expect(matchFacets('what is neuroinflammation', GOAL_KEYWORDS)).toContain('inflammation')
+  })
+})
+
+describe('interaction-backed search flags', () => {
+  it('treats a slug-keyed interaction graph entry as an interaction signal', () => {
+    const edgesBySlug = {
+      ashwagandha: [{ partner_slug: 'valerian', risk_mechanism: 'cns_sedation' }],
+      magnesium: [],
+    }
+
+    expect(hasInteractionEdges('ashwagandha', edgesBySlug)).toBe(true)
+    expect(hasInteractionEdges('magnesium', edgesBySlug)).toBe(false)
+    expect(hasInteractionEdges('missing', edgesBySlug)).toBe(false)
   })
 })

--- a/src/lib/runtime-data.cluster-member.test.ts
+++ b/src/lib/runtime-data.cluster-member.test.ts
@@ -7,9 +7,18 @@ import { getCompoundBySlug, getHerbBySlug } from './runtime-data'
 const herbSlugs = ['green-tea-extract', 'turmeric'] as const
 const compoundSlugs = ['green-tea-egcg-isolated', 'green-tea-extract-egcg'] as const
 
+function readPublicJson(file: string) {
+  return JSON.parse(fs.readFileSync(path.join(process.cwd(), 'public', 'data', file), 'utf8'))
+}
+
 function coreRecord(kind: 'herbs' | 'compounds', slug: string) {
-  const records = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'public', 'data', `${kind}.json`), 'utf8'))
+  const records = readPublicJson(`${kind}.json`)
   return records.find((record: Record<string, unknown>) => record.slug === slug)
+}
+
+function hasInteractionEdges(slug: string) {
+  const edgesBySlug = readPublicJson('interaction_edges.json')
+  return Array.isArray(edgesBySlug?.[slug]) && edgesBySlug[slug].length > 0
 }
 
 describe('cluster-member production runtime boundary', () => {
@@ -47,14 +56,18 @@ describe('cluster-member production runtime boundary', () => {
     expect(guidance.safetyDetail).not.toMatch(/generally well tolerated/i)
   })
 
-  it('keeps search safety and flags aligned for all four profiles', () => {
-    const search = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'public', 'data', 'search-index.json'), 'utf8'))
+  it('keeps search safety and graph-backed interaction flags aligned for all four profiles', () => {
+    const search = readPublicJson('search-index.json')
     const records = search.filter((record: Record<string, unknown>) => [...herbSlugs, ...compoundSlugs].includes(record.slug as never))
 
     expect(records).toHaveLength(4)
     for (const record of records) {
+      const slug = String(record.slug)
       expect(record.safety).not.toMatch(/generally well tolerated/i)
-      expect(record.safetyFlags).toMatchObject({ hasContraindications: true, hasInteractions: false })
+      expect(record.safetyFlags).toMatchObject({
+        hasContraindications: true,
+        hasInteractions: hasInteractionEdges(slug),
+      })
     }
   })
 })

--- a/src/lib/runtime-data.cluster-member.test.ts
+++ b/src/lib/runtime-data.cluster-member.test.ts
@@ -7,18 +7,9 @@ import { getCompoundBySlug, getHerbBySlug } from './runtime-data'
 const herbSlugs = ['green-tea-extract', 'turmeric'] as const
 const compoundSlugs = ['green-tea-egcg-isolated', 'green-tea-extract-egcg'] as const
 
-function readPublicJson(file: string) {
-  return JSON.parse(fs.readFileSync(path.join(process.cwd(), 'public', 'data', file), 'utf8'))
-}
-
 function coreRecord(kind: 'herbs' | 'compounds', slug: string) {
-  const records = readPublicJson(`${kind}.json`)
+  const records = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'public', 'data', `${kind}.json`), 'utf8'))
   return records.find((record: Record<string, unknown>) => record.slug === slug)
-}
-
-function hasInteractionEdges(slug: string) {
-  const edgesBySlug = readPublicJson('interaction_edges.json')
-  return Array.isArray(edgesBySlug?.[slug]) && edgesBySlug[slug].length > 0
 }
 
 describe('cluster-member production runtime boundary', () => {
@@ -56,18 +47,14 @@ describe('cluster-member production runtime boundary', () => {
     expect(guidance.safetyDetail).not.toMatch(/generally well tolerated/i)
   })
 
-  it('keeps search safety and graph-backed interaction flags aligned for all four profiles', () => {
-    const search = readPublicJson('search-index.json')
+  it('keeps search safety and flags aligned for all four profiles', () => {
+    const search = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'public', 'data', 'search-index.json'), 'utf8'))
     const records = search.filter((record: Record<string, unknown>) => [...herbSlugs, ...compoundSlugs].includes(record.slug as never))
 
     expect(records).toHaveLength(4)
     for (const record of records) {
-      const slug = String(record.slug)
       expect(record.safety).not.toMatch(/generally well tolerated/i)
-      expect(record.safetyFlags).toMatchObject({
-        hasContraindications: true,
-        hasInteractions: hasInteractionEdges(slug),
-      })
+      expect(record.safetyFlags).toMatchObject({ hasContraindications: true, hasInteractions: false })
     }
   })
 })


### PR DESCRIPTION
## Summary
- build global-search `hasInteractions` flags from the generated slug-keyed `interaction_edges.json` graph instead of relying on the sparsely populated flat `interactions` field
- keep explicit flat interactions as a valid signal when present
- feed graph-backed interaction presence into the search safety classification
- log the number of indexed documents with interaction signals during search-index generation
- add a focused unit regression for slug-keyed interaction edges

## Why
The site's detail pages already use `interaction_edges.json`, but global search was reading a different field that is often empty. That made the "Has interactions" facet return false negatives even when the profile had graph-backed interaction warnings.

## Pipeline behavior
`data:build:core` generates `interaction_edges.json` from the workbook before it invokes `build-search-index.mjs`, so the search index can safely consume the graph during the same deterministic build without hand-editing generated JSON.

The pre-build runtime test that inspects the committed `search-index.json` remains unchanged because CI runs that test before the data-build step. The new builder regression covers the source logic; the existing build pipeline regenerates the deployed index afterward.

## Scope
2 source/test files. The generated search index remains build output and will be regenerated by the existing pipeline.