### PR TITLE
Reframe supplement stacking guide around interaction screening

### DIFF
--- a/app/__tests__/supplement-stacking-safety-boundary.test.ts
+++ b/app/__tests__/supplement-stacking-safety-boundary.test.ts
@@ -1,0 +1,33 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const readGuide = () => fs
+  .readFileSync(path.join(process.cwd(), 'app/guides/other/supplement-stacking-safety/page.tsx'), 'utf8')
+  .replace(/\s+/g, ' ')
+
+describe('supplement combination safety guide', () => {
+  it('does not present a fixed waiting period as a general stacking protocol', () => {
+    const page = readGuide()
+
+    expect(page).toMatch(/no universal one-week, two-week, or four-week rule/i)
+    expect(page).not.toMatch(/assess for 1-2 weeks, then add the next/i)
+    expect(page).not.toMatch(/assess for 2-4 weeks before adding another/i)
+  })
+
+  it('does not label an adaptogen combination broadly safe', () => {
+    const page = readGuide()
+
+    expect(page).toMatch(/not enough direct combination evidence to label adaptogen stacks broadly safe/i)
+    expect(page).not.toMatch(/ashwagandha \+ rhodiola.*generally safe/i)
+    expect(page).not.toMatch(/adaptogen stacking.*generally safe/i)
+  })
+
+  it('distinguishes documented interactions from mechanism-only screening signals', () => {
+    const page = readGuide()
+
+    expect(page).toMatch(/mechanism alone does not prove the magnitude of a specific pairwise interaction/i)
+    expect(page).toMatch(/documented clinical interaction should be labeled differently from a plausible additive mechanism/i)
+    expect(page).toMatch(/No interaction listed ≠ interaction ruled out/i)
+  })
+})

--- a/app/guides/other/supplement-stacking-safety/page.tsx
+++ b/app/guides/other/supplement-stacking-safety/page.tsx
@@ -9,8 +9,8 @@ import References from '@/components/References'
 import EmailCapture from '../../../../components/EmailCapture'
 
 export const metadata: Metadata = buildPageMetadata({
-  title: 'Supplement Stacking Safety: Interactions & Risks (2026 Guide)',
-  description: 'Combining supplements can create unexpected interactions. Evidence-based guide to serotonergic, sedative, stimulant, and metabolic stacking risks.',
+  title: 'Supplement Combination Safety: Interaction Screening (2026)',
+  description: 'Evidence-first guide to screening supplement combinations for medication interactions, additive effects, missing data, and product-quality uncertainty.',
   path: '/guides/other/supplement-stacking-safety/',
   openGraphType: 'article',
 })
@@ -18,53 +18,159 @@ export const metadata: Metadata = buildPageMetadata({
 const SEROTONERGIC_ATLAS_HREF = '/tools/botanical-activity-atlas/serotonergic-interaction-risk/?safety=Serotonergic&sort=evidence'
 
 const FAQS = [
-  { question: 'Can I take multiple supplements together?', answer: 'Yes, many supplements can be safely combined. But some combinations create additive or synergistic effects that amplify risks — particularly with sedatives (kava + valerian + alcohol), serotonergic agents (5-HTP + St. John\'s Wort + SSRIs), and stimulants (caffeine + synephrine + yohimbine). Start one supplement at a time, assess for 1-2 weeks, then add the next.' },
-  { question: 'What is the most dangerous supplement combination?', answer: 'Serotonergic stacking is the highest-risk: combining multiple serotonin-elevating substances (SSRIs + 5-HTP + St. John\'s Wort + MAOIs) can cause serotonin syndrome — confusion, agitation, hyperthermia, and potentially death. This is a medical emergency. Never combine serotonergic supplements with prescription antidepressants without explicit clinician approval.' },
-  { question: 'How do I check if my supplements interact?', answer: 'Check the mechanism of action for each supplement. If two supplements affect the same system (GABA, serotonin, norepinephrine, blood pressure, blood sugar), they may interact additively. Use our safety interaction checker at /safety-checker/. Review medication interactions with your pharmacist. When in doubt, separate new supplements by at least 2 weeks.' },
-  { question: 'Are adaptogens safe to stack?', answer: 'Generally yes, but with nuance. Ashwagandha + rhodiola is a common and generally safe combination [1]. However, both can lower blood pressure and affect thyroid function. Ashwagandha can stimulate thyroid hormone production — avoid combining with thyroid medication without monitoring. Start one adaptogen at a time and assess for 2-4 weeks before adding another.' },
-  { question: 'Should I take supplements with food?', answer: 'Depends on the supplement. Fat-soluble vitamins (A, D, E, K) need dietary fat for absorption. Magnesium is better absorbed with food. Iron is best absorbed on an empty stomach with vitamin C but causes GI upset in many people. Zinc competes with iron and calcium for absorption — take at different times. Probiotics survive better with food. Creatine absorption is slightly enhanced with carbohydrates.' },
+  {
+    question: 'Can multiple supplements be taken together safely?',
+    answer: 'Sometimes, but safety depends on the exact ingredients, doses, product quality, medicines, health conditions, and evidence for the combination. The absence of a known interaction is not proof that a combination has been studied or shown safe.',
+  },
+  {
+    question: 'Which supplement combinations deserve the most caution?',
+    answer: 'Combinations deserve extra scrutiny when ingredients affect the same physiologic system, when one ingredient has well-documented drug interactions, or when a person also uses prescription or over-the-counter medicines. Examples include serotonergic agents, sedatives, stimulants, anticoagulant or antiplatelet effects, blood-pressure effects, and blood-glucose effects.',
+  },
+  {
+    question: 'How should supplement interactions be checked?',
+    answer: 'Use ingredient-specific interaction information rather than a generic stack rule. Check each supplement against prescription and over-the-counter medicines, health conditions, pregnancy or breastfeeding status, and the other supplements in the combination. A pharmacist or other qualified health professional can help review a complete list.',
+  },
+  {
+    question: 'Are adaptogen stacks generally safe?',
+    answer: 'There is not enough direct combination evidence to label adaptogen stacks broadly safe. Individual ingredients may have different thyroid, blood-pressure, sedative, metabolic, pregnancy, or medication considerations, so each combination should be evaluated on its own evidence and interaction profile.',
+  },
+  {
+    question: 'Does separating supplements by a week or two prevent interactions?',
+    answer: 'No universal waiting period can establish that a combination is safe. Onset, half-life, enzyme effects, accumulation, and delayed adverse effects differ across ingredients and medicines. Timing can matter for some specific products, but it should not be used as a general interaction-clearance rule.',
+  },
 ]
 
 const STACKING_SAFETY_REFS = [
-  { n: 1, text: 'Panossian A, Wikman G. (2010). Effects of adaptogens on the CNS. Pharmaceuticals, 3(1): 188-224.', url: 'https://pubmed.ncbi.nlm.nih.gov/27713248/' },
-  { n: 2, text: 'Boyer EW, Shannon M. (2005). The serotonin syndrome. N Engl J Med, 352(11): 1112-1120.', url: 'https://pubmed.ncbi.nlm.nih.gov/15784664/' },
-  { n: 3, text: 'Teschke R, et al. (2011). Kava hepatotoxicity: a six-point plan for new kava standardization. Phytomedicine, 18(2-3): 96-103.', url: 'https://pubmed.ncbi.nlm.nih.gov/21112196/' },
-  { n: 4, text: 'Gillman PK. (2010). Triptans, serotonin agonists, and serotonin syndrome. Headache, 50(2): 264-272.', url: 'https://pubmed.ncbi.nlm.nih.gov/19925619/' },
-  { n: 5, text: 'Izzo AA, Ernst E. (2009). Interactions between herbal medicines and prescribed drugs. Drugs, 69(13): 1777-1798.', url: 'https://pubmed.ncbi.nlm.nih.gov/19719333/' },
-  { n: 6, text: 'Haller CA, Benowitz NL. (2000). Adverse cardiovascular events from ephedra and caffeine. N Engl J Med, 343(25): 1833-1838.', url: 'https://pubmed.ncbi.nlm.nih.gov/11117974/' },
-  { n: 7, text: 'Chandrasekhar K, et al. (2012). Ashwagandha safety and efficacy. Indian J Psychol Med, 34(3): 255-262.', url: 'https://pubmed.ncbi.nlm.nih.gov/23439798/' },
+  { n: 1, text: 'FDA. FDA 101: Dietary Supplements. Current consumer safety guidance.', url: 'https://www.fda.gov/consumers/consumer-updates/fda-101-dietary-supplements' },
+  { n: 2, text: 'FDA. Mixing Medications and Dietary Supplements Can Endanger Your Health.', url: 'https://www.fda.gov/consumers/consumer-updates/mixing-medications-and-dietary-supplements-can-endanger-your-health' },
+  { n: 3, text: 'NCCIH. Herb-Drug Interactions: What the Science Says.', url: 'https://www.nccih.nih.gov/health/providers/digest/herb-drug-interactions-science' },
+  { n: 4, text: 'NCCIH. St. John’s Wort: Usefulness and Safety.', url: 'https://www.nccih.nih.gov/health/st-johns-wort' },
+  { n: 5, text: 'NCCIH. Kava: Usefulness and Safety.', url: 'https://www.nccih.nih.gov/health/kava' },
+  { n: 6, text: 'Izzo AA, Ernst E. Interactions between herbal medicines and prescribed drugs. Drugs. 2009;69(13):1777-1798.', url: 'https://pubmed.ncbi.nlm.nih.gov/19719333/' },
+  { n: 7, text: 'Boyer EW, Shannon M. The serotonin syndrome. N Engl J Med. 2005;352(11):1112-1120.', url: 'https://pubmed.ncbi.nlm.nih.gov/15784664/' },
 ]
 
 export default function StackingSafetyPage() {
   return (
     <div className="container-page py-10 space-y-10">
-      <AuthorityJsonLd title="Supplement Stacking Safety" description="Evidence-based guide to supplement interactions and safe combinations." url="https://thehippiescientist.net/guides/other/supplement-stacking-safety" type="Article" />
-      <AuthorityBreadcrumbs items={[{ label: 'Home', href: '/' }, { label: 'Guides', href: '/guides/' }, { label: 'Stacking Safety' }]} />
+      <AuthorityJsonLd
+        title="Supplement Combination Safety"
+        description="Evidence-first guide to screening supplement combinations for interactions and uncertainty."
+        url="https://thehippiescientist.net/guides/other/supplement-stacking-safety"
+        type="Article"
+      />
+      <AuthorityBreadcrumbs items={[{ label: 'Home', href: '/' }, { label: 'Guides', href: '/guides/' }, { label: 'Combination Safety' }]} />
       <FAQSchema pagePath="/guides/other/supplement-stacking-safety/" questions={FAQS} />
 
-      <section className="space-y-5 max-w-4xl"><p className="eyebrow-label">Evidence Review · 7 References</p><h1 className="text-5xl font-bold tracking-tight text-ink">Supplement Stacking: The Safety Guide Nobody Reads</h1><p className="text-lg leading-8 text-muted">Most supplement guides tell you what to take. Few tell you what happens when you combine them. Supplements are pharmacologically active — they affect neurotransmitters, liver enzymes, blood pressure, and glucose metabolism. Combining them without understanding their mechanisms can create additive effects, amplify side effects, or produce dangerous interactions. This guide covers the most important stacking risks, organized by biological system.</p>
-
-      <section className="card-premium p-6 space-y-4 max-w-4xl border-l-4 border-red-500 bg-red-50/30"><p className="text-xs font-bold uppercase tracking-wider text-red-700">At a Glance · Stacking Risk Levels</p><p className="text-sm leading-7 text-red-900"><strong>HIGHEST RISK:</strong> Serotonergic stacking (SSRIs + 5-HTP + St. John's Wort → serotonin syndrome). <strong>MODERATE:</strong> Sedative stacking (kava + valerian + alcohol → excessive CNS depression). Stimulant stacking (caffeine + synephrine + yohimbine → cardiovascular strain). <strong>LOW:</strong> Adaptogen stacking (ashwagandha + rhodiola — generally safe with monitoring). <strong>RULE:</strong> One supplement at a time. 1-2 week assessment period. Check mechanisms before combining.</p></section>
-        <figure className="mt-6"><div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white"><Image src="/images/guides/supplement-stacking-safety.jpg" alt="Supplement bottles with caution concept" width={1536} height={1024} priority className="w-full h-auto" /></div><figcaption className="mt-3 text-center text-sm text-muted">Stacking supplements — the safety guide most people skip.</figcaption></figure></section>
-
-      <section className="card-premium p-6 space-y-5 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">High-risk combinations by system</h2>
-
-        <div className="p-4 rounded-xl border-2 border-red-400 bg-red-50"><p className="text-sm font-black uppercase tracking-wider text-red-800">Serotonergic stacking — Highest risk</p><div className="mt-3 space-y-2 text-sm leading-7 text-red-900"><p><strong>Why it is dangerous:</strong> Excessive serotonin activity causes serotonin syndrome — a potentially fatal condition with confusion, agitation, hyperthermia, muscle rigidity, and seizures [2].</p><p><strong>Do NOT combine:</strong> SSRIs/SNRIs + 5-HTP + St. John&rsquo;s Wort + MAOIs + MDMA + tramadol. Any two serotonergic agents create additive risk [4].</p><p><strong>If you take an SSRI:</strong> Do not add 5-HTP, St. John&rsquo;s Wort, or SAM-e without explicit prescriber approval. Even &ldquo;natural&rdquo; serotonergic supplements can trigger serotonin syndrome when combined with pharmaceuticals [2,4].</p><Link href={SEROTONERGIC_ATLAS_HREF} className="mt-3 inline-flex min-h-[44px] items-center rounded-full bg-red-800 px-5 text-sm font-bold text-white transition hover:bg-red-900">Compare serotonergic-risk botanicals →</Link></div></div>
-
-        <div className="p-4 rounded-xl border-2 border-amber-400 bg-amber-50"><p className="text-sm font-black uppercase tracking-wider text-amber-800">Sedative stacking — Moderate risk</p><div className="mt-3 space-y-2 text-sm leading-7 text-amber-900"><p><strong>Risk:</strong> Additive CNS depression — excessive sedation, impaired coordination, respiratory depression at extremes.</p><p><strong>Caution with:</strong> Kava + valerian + passionflower + alcohol + benzodiazepines + antihistamines. These all enhance GABA signaling [3,5].</p><p><strong>Kava + alcohol:</strong> Particularly dangerous. Both are hepatically metabolized; combined use amplifies liver stress and sedation [3].</p></div></div>
-
-        <div className="p-4 rounded-xl border-2 border-amber-400 bg-amber-50"><p className="text-sm font-black uppercase tracking-wider text-amber-800">Stimulant stacking — Moderate risk</p><div className="mt-3 space-y-2 text-sm leading-7 text-amber-900"><p><strong>Risk:</strong> Cardiovascular strain — elevated heart rate, blood pressure, arrhythmia risk [6].</p><p><strong>Caution with:</strong> Caffeine + synephrine + yohimbine + ephedrine + DMAA. Multiple stimulants create additive cardiovascular load [6].</p><p><strong>ADHD medication + stimulants:</strong> Particularly dangerous — amphetamine-based medications plus caffeine or yohimbine amplify cardiac risk.</p></div></div>
-
-        <div className="p-4 rounded-xl bg-brand-50/60"><p className="text-sm font-black uppercase tracking-wider text-ink">Adaptogen stacking — Generally safe with monitoring</p><div className="mt-3 space-y-2 text-sm leading-7 text-muted"><p>Ashwagandha + rhodiola is a common and generally well-tolerated combination [1,7]. However: ashwagandha can stimulate thyroid hormone (caution with hyperthyroidism or thyroid medication) [7]; both can lower blood pressure (monitor if on antihypertensives); ashwagandha may increase testosterone (caution with PCOS or hormone-sensitive conditions).</p></div></div>
+      <section className="space-y-5 max-w-4xl">
+        <p className="eyebrow-label">Safety Review · 7 References</p>
+        <h1 className="text-5xl font-bold tracking-tight text-ink">Supplement Combination Safety: Screen the Risks Before the Stack</h1>
+        <p className="text-lg leading-8 text-muted">
+          A supplement combination is not automatically safer because every ingredient is sold over the counter or described as natural. FDA notes that problems can occur when supplements are combined with each other or with medicines, and many potential combinations have never been tested directly. The useful question is not “Is this stack safe?” in the abstract; it is “What interaction signals, evidence gaps, and person-specific risks apply to these exact ingredients?”
+        </p>
+        <figure className="mt-6">
+          <div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white">
+            <Image src="/images/guides/supplement-stacking-safety.jpg" alt="Supplement bottles with caution concept" width={1536} height={1024} priority className="w-full h-auto" />
+          </div>
+          <figcaption className="mt-3 text-center text-sm text-muted">Combination safety depends on the exact ingredients, medicines, and evidence—not a generic stacking rule.</figcaption>
+        </figure>
       </section>
 
-      <section className="card-premium p-6 space-y-4 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">Safe stacking principles</h2>
-        <div className="space-y-3 text-sm leading-7 text-muted"><p><strong>1. One at a time.</strong> Introduce one new supplement at a time. Assess for 1-2 weeks before adding another. If you have a reaction, you will know which one caused it.</p><p><strong>2. Check mechanisms.</strong> Before combining, research whether supplements affect the same system. Two &ldquo;natural&rdquo; supplements that both lower blood pressure can cause hypotension together.</p><p><strong>3. Medication interactions first.</strong> Supplements can inhibit or induce liver enzymes (CYP450) that metabolize prescription drugs [5]. St. John&rsquo;s Wort is the most notorious — it renders oral contraceptives, warfarin, and many other drugs less effective by inducing CYP3A4.</p><p><strong>4. Start low, go slow.</strong> Begin with the lowest effective dose. Many supplement side effects are dose-dependent and resolve with dose reduction.</p><p><strong>5. Disclose everything to your doctor.</strong> Most supplement-drug interactions go unreported because patients do not mention supplements to their physicians [5].</p></div></section>
+      <section className="card-premium p-6 space-y-4 max-w-4xl border-l-4 border-red-500 bg-red-50/30">
+        <p className="text-xs font-bold uppercase tracking-wider text-red-700">Core safety boundary</p>
+        <p className="text-sm leading-7 text-red-900">
+          <strong>No combination gets a blanket “safe” label here.</strong> A missing interaction report can mean “not studied,” not “no interaction.” Medication use, pregnancy or breastfeeding, surgery, liver or kidney disease, cardiovascular conditions, and product quality can materially change the risk picture. FDA advises discussing supplements with a health professional, particularly when medicines are involved [1,2].
+        </p>
+      </section>
 
-      <section className="card-premium p-6 space-y-4 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">Bottom line</h2><p className="text-sm leading-7 text-muted">Supplements are pharmacologically active. Combining them without understanding their mechanisms is taking an unregulated polypharmacy approach. The highest-risk combination is serotonergic stacking — never combine SSRIs with 5-HTP, St. John&rsquo;s Wort, or other serotonergic supplements without prescriber approval [2,4]. For most other combinations, the risk is moderate and manageable with the principles above: one at a time, check mechanisms, start low, go slow, and tell your doctor [5].</p><Link href={SEROTONERGIC_ATLAS_HREF} className="inline-flex min-h-[44px] items-center rounded-full border border-brand-900/10 px-5 text-sm font-bold text-brand-800 transition hover:bg-brand-50">Compare serotonergic-risk botanicals →</Link></section>
+      <section className="card-premium p-6 space-y-5 max-w-4xl">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Five interaction screens that matter</h2>
+
+        <div className="rounded-xl border border-red-300 bg-red-50 p-4">
+          <p className="text-sm font-black uppercase tracking-wider text-red-800">1. Serotonergic overlap</p>
+          <div className="mt-3 space-y-2 text-sm leading-7 text-red-900">
+            <p>
+              St. John&apos;s wort has documented drug-interaction risk and can contribute to serious serotonin-related effects with some antidepressants [3,4]. Other serotonergic supplements or medicines may also create additive concerns, but mechanism alone does not prove the magnitude of a specific pairwise interaction.
+            </p>
+            <p><strong>Higher-priority review:</strong> antidepressants, MAO inhibitors, tramadol and other serotonergic medicines, plus supplements marketed for serotonin support.</p>
+            <Link href={SEROTONERGIC_ATLAS_HREF} className="mt-3 inline-flex min-h-[44px] items-center rounded-full bg-red-800 px-5 text-sm font-bold text-white transition hover:bg-red-900">Compare serotonergic-risk botanicals →</Link>
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-amber-300 bg-amber-50 p-4">
+          <p className="text-sm font-black uppercase tracking-wider text-amber-800">2. Sedative overlap</p>
+          <div className="mt-3 space-y-2 text-sm leading-7 text-amber-900">
+            <p>
+              Multiple sedating ingredients can increase impairment or drowsiness. NCCIH specifically advises against combining kava with substances that have sedative effects, including benzodiazepines or alcohol [5]. Similar caution is appropriate when several products independently cause sedation, even when direct trials of the exact combination are absent.
+            </p>
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-amber-300 bg-amber-50 p-4">
+          <p className="text-sm font-black uppercase tracking-wider text-amber-800">3. Cardiovascular or stimulant overlap</p>
+          <div className="mt-3 space-y-2 text-sm leading-7 text-amber-900">
+            <p>
+              Ingredients that can raise heart rate or blood pressure deserve extra scrutiny when combined with other stimulants, decongestants, or prescription medicines that affect the cardiovascular system. The actual risk depends on the ingredients, dose, baseline health, and co-medications; a broad “stimulant stack” rule cannot substitute for those specifics.
+            </p>
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-amber-300 bg-amber-50 p-4">
+          <p className="text-sm font-black uppercase tracking-wider text-amber-800">4. Bleeding, glucose, or blood-pressure overlap</p>
+          <div className="mt-3 space-y-2 text-sm leading-7 text-amber-900">
+            <p>
+              FDA gives examples in which supplements and medicines can combine to increase bleeding risk or alter drug effects [2]. Similar additive concerns can arise when several products affect blood glucose or blood pressure. These are especially important when prescription anticoagulants, diabetes medicines, or antihypertensives are present.
+            </p>
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-slate-200 bg-slate-50/70 p-4">
+          <p className="text-sm font-black uppercase tracking-wider text-slate-700">5. Pharmacokinetic interactions</p>
+          <div className="mt-3 space-y-2 text-sm leading-7 text-slate-700">
+            <p>
+              Some supplements change drug metabolism or transport rather than simply adding the same effect. St. John&apos;s wort is a well-documented example: it can lower exposure to multiple medicines by inducing drug-metabolizing enzymes and transporters [2-4]. That means a stack can create risk even when its ingredients do not “feel” pharmacologically similar.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="card-premium p-6 space-y-4 max-w-4xl">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">What not to infer from missing evidence</h2>
+        <div className="space-y-3 text-sm leading-7 text-muted">
+          <p><strong>No interaction listed ≠ interaction ruled out.</strong> Many supplement-supplement combinations lack direct clinical testing.</p>
+          <p><strong>Same mechanism ≠ proven dangerous interaction.</strong> Mechanistic overlap is a screening signal, not proof of a clinically important interaction. It should prompt a closer evidence review rather than a fabricated certainty.</p>
+          <p><strong>“Common stack” ≠ validated stack.</strong> Popularity, anecdotal use, or simultaneous sale in a product bundle does not establish combination efficacy or safety.</p>
+          <p><strong>A fixed waiting period ≠ clearance.</strong> There is no universal one-week, two-week, or four-week rule that proves one supplement has been assessed or cleared before another is added. Pharmacokinetics and delayed effects differ substantially.</p>
+          <p><strong>Individual ingredient evidence ≠ combination evidence.</strong> Two separately studied ingredients do not automatically produce a studied or beneficial combination.</p>
+        </div>
+      </section>
+
+      <section className="card-premium p-6 space-y-4 max-w-4xl">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">A better combination-check workflow</h2>
+        <div className="space-y-3 text-sm leading-7 text-muted">
+          <p><strong>1. Inventory everything.</strong> Include prescription medicines, over-the-counter medicines, supplements, energy products, and relevant substances—not only the products you think are “medications.”</p>
+          <p><strong>2. Check each ingredient, not just the product name.</strong> Multi-ingredient blends can hide duplicate stimulants, sedatives, minerals, or botanicals.</p>
+          <p><strong>3. Review high-consequence contexts first.</strong> Pregnancy or breastfeeding, upcoming surgery, anticoagulants, transplant medicines, seizure medicines, antidepressants, cardiovascular drugs, and diabetes medicines deserve especially careful review.</p>
+          <p><strong>4. Separate known evidence from mechanistic caution.</strong> A documented clinical interaction should be labeled differently from a plausible additive mechanism.</p>
+          <p><strong>5. Use a pharmacist or qualified health professional when medicines are involved.</strong> FDA and NCCIH both emphasize medication-supplement interaction review [1-4].</p>
+        </div>
+        <Link href="/safety-checker/" className="inline-flex min-h-[44px] items-center rounded-full border border-brand-900/10 px-5 text-sm font-bold text-brand-800 transition hover:bg-brand-50">Open the safety checker →</Link>
+      </section>
+
+      <section className="card-premium p-6 space-y-4 max-w-4xl">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Bottom line</h2>
+        <p className="text-sm leading-7 text-muted">
+          Supplement-combination safety is an evidence and interaction-screening problem, not a recipe problem. Prioritize documented medication interactions and high-consequence physiologic overlap, mark mechanism-only concerns as uncertain, and do not convert popularity or a generic waiting period into a safety claim. When medication use or important health conditions are part of the picture, use a complete ingredient list for professional interaction review [1-5].
+        </p>
+        <Link href={SEROTONERGIC_ATLAS_HREF} className="inline-flex min-h-[44px] items-center rounded-full border border-brand-900/10 px-5 text-sm font-bold text-brand-800 transition hover:bg-brand-50">Compare serotonergic-risk botanicals →</Link>
+      </section>
+
       <References refs={STACKING_SAFETY_REFS} />
-      <EmailCapture headline="Get evidence reviews like this" description="Safety guides, stacking risks, interactions — evidence, not fear." ctaLabel="Get the evidence" location="guide-stacking-safety" />
-      <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between"><Link href="/guides/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">← Back to guides</Link><Link href="/safety-checker/" className="text-sm font-bold text-brand-800 hover:underline">Safety checker →</Link></div>
+      <EmailCapture headline="Get evidence reviews like this" description="Safety guides, interaction context, and evidence boundaries without stack hype." ctaLabel="Get the evidence" location="guide-stacking-safety" />
+      <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between">
+        <Link href="/guides/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">← Back to guides</Link>
+        <Link href="/safety-checker/" className="text-sm font-bold text-brand-800 hover:underline">Safety checker →</Link>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- replace fixed 1–2 week / 2–4 week add-on schedules with an explicit statement that no universal waiting period proves a combination safe
- remove the broad “ashwagandha + rhodiola is generally safe” stack claim
- distinguish documented clinical interactions from mechanism-only screening signals
- center the guide on medication review, high-consequence physiologic overlap, missing combination evidence, and product/ingredient specificity
- update references toward current FDA and NCCIH interaction guidance while retaining key peer-reviewed interaction literature
- add a regression test guarding against generic stack protocols and blanket adaptogen-safety claims

## Why
The guide’s previous protocol-style language conflicted with the site’s evidence-first standard and with the recent removal of unaudited product-backed stack recommendations. Popularity or a fixed waiting period should not be converted into a combination-safety claim.

## Scope
2 files: the guide and one focused source regression test.