### PR TITLE
Replace magnesium-theanine sleep recipe with evidence review

### DIFF
--- a/app/__tests__/magnesium-l-theanine-combination-boundary.test.ts
+++ b/app/__tests__/magnesium-l-theanine-combination-boundary.test.ts
@@ -1,0 +1,37 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const readArticle = () => fs
+  .readFileSync(path.join(process.cwd(), 'content/articles/magnesium-l-theanine-sleep-stack.md'), 'utf8')
+  .replace(/\s+/g, ' ')
+
+describe('magnesium + L-theanine combination evidence boundary', () => {
+  it('does not present the pair as an evidence-based bedtime recipe', () => {
+    const article = readArticle()
+
+    expect(article).toMatch(/does not establish the two-ingredient combination as an evidence-based sleep stack/i)
+    expect(article).not.toMatch(/Together: 200–400 mg magnesium glycinate \+ 200 mg L-theanine/i)
+    expect(article).not.toMatch(/How to Take This Stack/i)
+    expect(article).not.toMatch(/30–60 minutes before bed for sleep support/i)
+  })
+
+  it('removes fabricated synergy and timeline claims', () => {
+    const article = readArticle()
+
+    expect(article).toMatch(/Different Mechanisms.*Does Not Prove Synergy/i)
+    expect(article).toMatch(/Mechanistic complementarity is a hypothesis/i)
+    expect(article).not.toMatch(/Why they pair perfectly/i)
+    expect(article).not.toMatch(/Night 1.*Easier to wind down/i)
+    expect(article).not.toMatch(/Week 2–4.*Sleep consolidates/i)
+  })
+
+  it('downgrades the combination evidence while preserving ingredient-specific evidence', () => {
+    const article = readArticle()
+
+    expect(article).toMatch(/evidence_grade: Limited/i)
+    expect(article).toMatch(/2025 systematic review and meta-analysis/i)
+    expect(article).toMatch(/effect was \*\*small\*\*/i)
+    expect(article).toMatch(/combination question has not been answered directly/i)
+  })
+})

--- a/content/articles/magnesium-l-theanine-sleep-stack.md
+++ b/content/articles/magnesium-l-theanine-sleep-stack.md
@@ -1,142 +1,158 @@
 ---
 slug: magnesium-l-theanine-sleep-stack
-title: "Magnesium + L-Theanine: The Evidence-Based Sleep & Anxiety Stack"
-description: "How magnesium glycinate and L-theanine work together for sleep and anxiety. Covers complementary mechanisms, dosing (200-400mg Mg + 200mg L-theanine), timing, and who this stack works best for."
+title: "Magnesium + L-Theanine for Sleep: Evidence and Combination Limits"
+description: "What human studies actually show about magnesium and L-theanine for sleep, what has not been tested about the two-ingredient combination, and the safety context that matters."
 date: '2026-06-30'
-updatedAt: '2026-07-05'
+updatedAt: '2026-08-12'
 author: Will
 category: Anxiety & Sleep
-evidence_grade: Moderate
+evidence_grade: Limited
 keywords:
   - magnesium l-theanine sleep
   - magnesium l-theanine stack
   - magnesium l-theanine anxiety
-  - best sleep stack supplement
   - magnesium glycinate sleep
   - l-theanine sleep
-  - natural sleep aid combination
-  - magnesium l-theanine dosage
+  - natural sleep combination
 featured_image: ''
 tags:
   - magnesium
   - l-theanine
   - sleep
-  - stack guide
+  - combination evidence
   - anxiety
 profile_status: published
 ai_assisted: false
 faqs:
-  - question: "Why combine magnesium and L-theanine?"
-    answer: "They work through complementary mechanisms. Magnesium glycinate supports GABA receptor function and reduces cortisol — addressing the physiological stress response. L-theanine increases alpha brain waves and promotes relaxation without sedation — addressing the cognitive/mental component of stress. Together they cover both the body and mind aspects of anxiety and sleep disruption."
-  - question: "What's the best time to take this stack?"
-    answer: "30–60 minutes before bed for sleep support. For daytime anxiety, split the dose: magnesium glycinate in the evening (it's mildly relaxing), L-theanine 200 mg as needed during the day for calm focus. L-theanine can be taken multiple times per day without building tolerance."
+  - question: "Do magnesium and L-theanine work better together for sleep?"
+    answer: "That has not been established. Both ingredients have separate human sleep research, but a direct randomized trial of the two-ingredient magnesium plus L-theanine combination was not identified for this review. Separate ingredient evidence should not be converted into a synergy claim."
+  - question: "Does L-theanine improve sleep?"
+    answer: "A 2025 systematic review and meta-analysis found improvements in several subjective sleep outcomes, but the authors noted that studies of pure L-theanine remain limited and that the appropriate dose and duration still need better research."
+  - question: "Does magnesium improve sleep?"
+    answer: "Some randomized trials report modest improvements in insomnia symptoms, but a 2021 systematic review judged the older evidence low to very low quality. A 2025 magnesium bisglycinate trial found a statistically significant but small improvement in insomnia severity."
+  - question: "Is a magnesium plus L-theanine stack proven safe?"
+    answer: "No blanket combination-safety conclusion is justified. Magnesium has medication interactions and greater toxicity risk when kidney function is impaired, while the exact two-ingredient combination has not been established across different populations, products, doses, or medication regimens."
 references:
-  - title: "The effects of magnesium supplementation on subjective anxiety and stress"
-    authors: "Boyle NB, Lawton C, Dye L"
-    year: "2017"
-    pmid: "28445426"
-    url: "https://pubmed.ncbi.nlm.nih.gov/28445426/"
-  - title: "L-theanine, a natural constituent in tea, and its effect on mental state"
-    authors: "Nobre AC, Rao A, Owen GN"
-    year: "2008"
-    pmid: "18296328"
-    url: "https://pubmed.ncbi.nlm.nih.gov/18296328/"
-  - title: "The effects of L-theanine on objective sleep quality"
-    authors: "Lyon MR, Kapoor MP, Juneja LR"
-    year: "2011"
-    pmid: "22214254"
-    url: "https://pubmed.ncbi.nlm.nih.gov/22214254/"
-  - title: "Magnesium and sleep: a systematic review"
-    authors: "Abbasi B, Kimiagar M, Sadeghniiat K, Shirazi MM, Hedayati M, Rashidkhani B"
-    year: "2012"
-    pmid: "23853635"
-    url: "https://pubmed.ncbi.nlm.nih.gov/23853635/"
-  - title: "L-theanine reduces psychological and physiological stress responses"
-    authors: "Kimura K, Ozeki M, Juneja LR, Ohira H"
-    year: "2007"
-    pmid: "16930802"
-    url: "https://pubmed.ncbi.nlm.nih.gov/16930802/"
+  - title: "Oral magnesium supplementation for insomnia in older adults: a Systematic Review & Meta-Analysis"
+    authors: "Mah J, Pitre T, et al."
+    year: "2021"
+    pmid: "33865376"
+    url: "https://pubmed.ncbi.nlm.nih.gov/33865376/"
+  - title: "Magnesium Bisglycinate Supplementation in Healthy Adults Reporting Poor Sleep: A Randomized, Placebo-Controlled Trial"
+    authors: "Randomized placebo-controlled trial"
+    year: "2025"
+    pmid: "40918053"
+    url: "https://pubmed.ncbi.nlm.nih.gov/40918053/"
+  - title: "The effects of L-theanine consumption on sleep outcomes: A systematic review and meta-analysis"
+    authors: "Bulman A, et al."
+    year: "2025"
+    pmid: "40056718"
+    url: "https://pubmed.ncbi.nlm.nih.gov/40056718/"
+  - title: "Effects of L-Theanine Administration on Stress-Related Symptoms and Cognitive Functions in Healthy Adults: A Randomized Controlled Trial"
+    authors: "Hidese S, et al."
+    year: "2019"
+    pmid: "31623400"
+    url: "https://pubmed.ncbi.nlm.nih.gov/31623400/"
+  - title: "L-theanine in the adjunctive treatment of generalized anxiety disorder: A double-blind, randomised, placebo-controlled trial"
+    authors: "Sarris J, et al."
+    year: "2019"
+    pmid: "30580081"
+    url: "https://pubmed.ncbi.nlm.nih.gov/30580081/"
+  - title: "Magnesium: Fact Sheet for Health Professionals"
+    authors: "NIH Office of Dietary Supplements"
+    year: "2026"
+    url: "https://ods.od.nih.gov/factsheets/Magnesium-HealthProfessional/"
 ---
 
-> **The bottom line:** Magnesium glycinate + L-theanine is the most evidence-supported, lowest-risk sleep and anxiety stack available without a prescription. Magnesium handles the body (muscle tension, cortisol, GABA function). L-theanine handles the mind (racing thoughts, alpha-wave relaxation). Together: 200–400 mg magnesium glycinate + 200 mg L-theanine, 30–60 minutes before bed. Both are well-tolerated, non-sedating, and non-habit-forming. Evidence grade: Moderate for each individually; the combination is mechanistically complementary.
+> **The bottom line:** Magnesium and L-theanine each have human research relevant to sleep, but that does **not** establish the two-ingredient combination as an evidence-based sleep stack. Magnesium's direct sleep evidence is mixed and historically low quality; L-theanine has encouraging subjective sleep findings, including a 2025 meta-analysis, but important gaps remain. No direct randomized trial of magnesium + L-theanine as a two-ingredient sleep combination was identified for this review.
 
-## Why This Stack Works
+## The Combination Question Comes First
 
-Magnesium and L-theanine don't just add together — they cover two distinct dimensions of sleep disruption.
+The previous version of this page treated separate ingredient mechanisms as proof that magnesium and L-theanine were "complementary." That is too strong.
 
-### Magnesium Glycinate: The Body
+A combination can be plausible without being clinically validated. To show that magnesium + L-theanine works better than either ingredient alone, researchers would need to test the combination directly against appropriate comparators. Studies of magnesium alone and L-theanine alone cannot answer that question.
 
-Magnesium is a cofactor for 300+ enzymatic reactions. For sleep and anxiety, three actions matter most:
+**What is supported:**
 
-- **GABA enhancement** — magnesium potentiates GABA-A receptors, increasing the brain's primary calming signal
-- **Cortisol regulation** — breaks the vicious cycle where stress depletes magnesium and low magnesium amplifies stress
-- **Muscle relaxation** — acts as a natural calcium channel blocker, reducing physical tension
+- Magnesium has randomized sleep trials in specific populations.
+- L-theanine has randomized trials and systematic-review evidence relevant to subjective sleep outcomes.
+- Both ingredients have plausible nervous-system mechanisms that researchers continue to study.
 
-Why glycinate specifically? It's the best-absorbed form for neurological use, and the glycine molecule it's bound to is itself a calming neurotransmitter that improves sleep quality.
+**What is not established:**
 
-### L-Theanine: The Mind
+- Superior sleep benefit from taking them together.
+- A specific bedtime schedule for the pair.
+- A universal dose for the combination.
+- Predictable Night-1, Week-1, or Month-1 effects.
+- Long-term safety of the pair across health conditions and medication regimens.
 
-L-theanine is an amino acid found almost exclusively in tea. It produces "alert relaxation" — calm without sedation:
-
-- **Alpha brain waves** — increases alpha activity within 30–40 minutes (the same state achieved during meditation)
-- **Glutamate modulation** — partially blocks excitatory glutamate receptors without impairing cognition
-- **Multi-pathway calming** — increases GABA, serotonin, and dopamine
-
-### Why they pair perfectly
-
-| | Magnesium Glycinate | L-Theanine |
-|---|---|---|
-| **Targets** | Body (muscles, cortisol, GABA receptors) | Mind (racing thoughts, alpha waves, cognitive relaxation) |
-| **Speed** | Mild relaxation night 1; full effects 2–4 weeks | Noticeable calm within 30–40 minutes |
-| **Sedation** | None — enables relaxation, doesn't force it | None — "alert relaxation," not drowsiness |
-| **Tolerance** | None | None |
-| **Cost** | ~$10–15/month | ~$5–10/month |
-
-
-![Magnesium L Theanine Sleep Stack](/images/guides/l-theanine-magnesium-adhd-stack.jpg)
+![Magnesium and L-Theanine Evidence Review](/images/guides/l-theanine-magnesium-adhd-stack.jpg)
 
 ---
 
-## How to Take This Stack
+## Magnesium: Possible Benefit, Important Uncertainty
 
-| Component | Dose | Timing | Notes |
-|-----------|------|--------|-------|
-| Magnesium glycinate | 200–400 mg **elemental** magnesium | 30–60 min before bed | Start at 200 mg; increase if needed |
-| L-theanine | 200 mg | 30–60 min before bed | Can take additional 100–200 mg during day for anxiety |
+Magnesium is essential for normal physiology, but that fact alone does not make supplemental magnesium a proven insomnia treatment.
 
-**For daytime anxiety only:** L-theanine 200 mg as needed (up to 3× daily). Reserve magnesium for evening — it's mildly relaxing.
+A 2021 systematic review and meta-analysis found only three randomized trials involving 151 older adults with insomnia. The pooled estimate suggested shorter sleep-onset latency, but the included trials had moderate-to-high risk of bias and the overall evidence quality was **low to very low**.[1]
 
-**Duration:** Both work acutely (night 1), but effects may improve over 1–2 weeks of consistent use.
+A newer 2025 randomized placebo-controlled trial in 155 adults with self-reported poor sleep found that magnesium bisglycinate produced a statistically greater improvement in insomnia severity than placebo over four weeks. The effect was **small**, and exploratory results suggested people with lower baseline dietary magnesium intake might respond differently.[2]
 
----
-
-## What to Expect
-
-| Timeframe | What you might notice |
-|---|---|
-| **Night 1** | Easier to wind down. L-theanine's alpha-wave effect kicks in within 30–40 minutes — some describe it as "the mental chatter quiets down." |
-| **Week 1** | Sleep onset may improve. Less muscle tension. If morning grogginess occurs, reduce magnesium dose or take it earlier. |
-| **Week 2–4** | Sleep consolidates. Fewer 3 AM awakenings. Morning anxiety may decrease as magnesium stores build. |
-| **Month 1+** | Effects stabilize. This isn't something that keeps getting stronger — it's nutritional support, not a drug. |
-
-> **This stack won't:** knock you out like a sedative, override a bad sleep environment, or fix sleep apnea. It works through natural pathway support — not forced shutdown.
+That makes "possible modest benefit in some populations" a better summary than "magnesium glycinate is the best sleep form" or a fixed sleep dose for everyone.
 
 ---
 
-## Who This Stack Is Best For
+## L-Theanine: Encouraging Subjective Sleep Data, Not a Knockout Effect
 
-| Best fit | Not ideal for |
-|---|---|
-| Stress-related insomnia ("can't turn off brain") | Primary sleep apnea or movement disorders |
-| Mild-to-moderate anxiety, especially at night | Severe anxiety requiring pharmacological treatment |
-| Muscle tension contributing to poor sleep | Sleep issues with no stress/anxiety component |
-| 3 AM awakenings with anxious rumination | People on sedating medications (additive effect possible) |
+The L-theanine evidence base is larger than the old version of this article suggested.
+
+A 2025 systematic review and meta-analysis of randomized trials found statistically significant improvements in overall subjective sleep quality, subjective sleep-onset latency, and daytime dysfunction. However, the authors emphasized that studies using **pure L-theanine** were limited and that better research is needed to establish appropriate dose and duration.[3]
+
+A small randomized crossover trial in healthy adults also reported improvements in several self-reported stress and sleep measures after L-theanine.[4] But not every clinical population shows the same result: in a randomized adjunctive trial in generalized anxiety disorder, L-theanine did not outperform placebo on insomnia severity, although one sleep-satisfaction item improved.[5]
+
+So the evidence is better described as **promising but heterogeneous**, especially when moving from subjective sleep measures to a claim that a particular person will sleep better.
 
 ---
+
+## Why "Different Mechanisms" Does Not Prove Synergy
+
+It is tempting to describe magnesium as handling the "body" and L-theanine as handling the "mind." That makes an appealing product story, but biology is not divided so neatly.
+
+Both substances can influence multiple neural and physiologic systems. Even if two ingredients act through partly different pathways, that does not demonstrate additive benefit, synergy, or a lower side-effect burden. Mechanistic complementarity is a hypothesis until a properly designed combination trial tests it.
+
+The same rule applies to other supplement stacks on this site: **separate evidence should stay separate unless the combination itself has been studied.**
+
+---
+
+## Safety Context
+
+Magnesium supplements can cause gastrointestinal adverse effects, and excessive magnesium from supplements or medications can be dangerous, especially when kidney function is impaired. Magnesium can also interfere with or be affected by several medication classes, including certain antibiotics, bisphosphonates, diuretics, and acid-suppressing medicines.[6]
+
+L-theanine is generally reported as well tolerated in many short-term trials, but that is not equivalent to proving every combination, product, dose, or long-term regimen safe. Trial populations often exclude people with significant medical complexity, and supplement quality can vary.
+
+If medicines, pregnancy or breastfeeding, kidney disease, persistent insomnia, or another important health condition are part of the picture, use ingredient-specific safety information rather than relying on the phrase "low-risk stack."
+
+[Open the interaction and safety checker →](/safety-checker/)
+
+---
+
+## What to Do With the Evidence
+
+This page is best used as a comparison of **two separate evidence bases**, not as a bedtime recipe.
+
+If you are evaluating magnesium, look at whether the specific population, formulation, and outcome in a study match the question you are asking. If you are evaluating L-theanine, distinguish studies of pure L-theanine from multi-ingredient formulas and separate subjective outcomes from objective sleep measures.
+
+If you are evaluating the pair, the honest evidence grade is lower because the combination question has not been answered directly.
+
+---
+
+## Bottom Line
+
+Magnesium + L-theanine is a popular idea with plausible biology, but popularity and mechanism do not create combination evidence. Magnesium has mixed sleep data with some modest positive trials. L-theanine has encouraging evidence for certain subjective sleep outcomes, alongside null findings in some populations. Until the two-ingredient pair is directly tested, claims about perfect synergy, exact bedtime dosing, guaranteed early effects, or long-term combination safety go beyond what the evidence can support.
 
 ## Related Articles
 
 - [Magnesium Glycinate: Full Evidence Guide](/articles/magnesium-glycinate/)
-- [L-Theanine: Calm Focus, Anxiety, and Sleep](/guides/herbs/l-theanine/)
-- [Ashwagandha: Benefits, Dosage & Evidence](/articles/ashwagandha/)
+- [L-Theanine: Evidence Guide](/articles/l-theanine/)
+- [Supplement Combination Safety](/guides/other/supplement-stacking-safety/)
 - [How to Choose a Quality Supplement](/articles/how-to-choose-supplement-quality/)


### PR DESCRIPTION
Superseded by #2645, which reapplied the same evidence-boundary update cleanly onto current `main` and was merged after validation.