### PR TITLE
Fix homepage article library CTA

### DIFF
--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -452,7 +452,7 @@ export default function HomepageV2() {
                 eyebrow='Fresh from the library'
                 title='Latest guides & research'
                 subtitle='A short, current set of practical explainers and evidence reviews — not an endless feed.'
-                action={{ href: '/guides/', label: 'Browse the library' }}
+                action={{ href: '/articles/', label: 'Browse the library' }}
               />
 
               <div className='mt-8 grid gap-4 sm:mt-10 sm:gap-5 sm:grid-cols-2 lg:grid-cols-3'>


### PR DESCRIPTION
## What changed
- Point the homepage “Browse the library” CTA in the latest research section to `/articles/`.

## Why
The CTA described the article library but incorrectly routed visitors to the guides index.

## Validation
- Confirmed the change is limited to one href in `components/homepage-v2.tsx`.
- Destination `/articles/` is the live article library linked elsewhere in site navigation.