### PR TITLE
Correct footer anxiety link label

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -22,7 +22,7 @@ const priorityGoalLinks = [
   { href: '/guides/mental-health/', label: 'Mental Health' },
   { href: '/guides/sleep/', label: 'Sleep' },
   { href: '/guides/adhd/', label: 'ADHD' },
-  { href: '/guides/anxiety/', label: 'Anxiety & Stress' },
+  { href: '/guides/anxiety/', label: 'Anxiety' },
   { href: '/guides/focus/', label: 'Focus & Cognition' },
   { href: '/guides/other/', label: 'More topics' },
 ]


### PR DESCRIPTION
## What changed
- Rename the footer’s “Anxiety & Stress” link to “Anxiety.”

## Why
The link routes only to `/guides/anxiety/`, so the previous combined label incorrectly implied that it also opened the Stress guide.

## Validation
- One text-only change in `src/components/Footer.tsx`.
- Destination remains unchanged and accurately matches the new label.