### PR TITLE
Clarify homepage articles CTA

### DIFF
--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -452,7 +452,7 @@ export default function HomepageV2() {
                 eyebrow='Fresh from the library'
                 title='Latest guides & research'
                 subtitle='A short, current set of practical explainers and evidence reviews — not an endless feed.'
-                action={{ href: '/articles/', label: 'Browse the library' }}
+                action={{ href: '/articles/', label: 'Browse all articles' }}
               />
 
               <div className='mt-8 grid gap-4 sm:mt-10 sm:gap-5 sm:grid-cols-2 lg:grid-cols-3'>


### PR DESCRIPTION
## What changed
- Rename the homepage CTA from “Browse the library” to “Browse all articles.”

## Why
The CTA routes specifically to `/articles/`. The new label describes the destination precisely and matches the site’s established “All articles” terminology.

## Validation
- One text-only change in `components/homepage-v2.tsx`.
- The previously corrected `/articles/` destination is unchanged.