### PR TITLE
Clarify footer X link for screen readers

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -106,7 +106,7 @@ export default function Footer() {
             </p>
 
             <div className='mt-4 flex flex-wrap gap-2'>
-              <a href='https://x.com/TheHippieSci' target='_blank' rel='noopener noreferrer' className='rounded-full border border-[#123c2f]/10 bg-[#fffdf8]/75 px-4 py-2 text-xs font-bold text-[#315f50] transition hover:border-[#b88a42]/35 hover:bg-[#fffdf8] dark:border-white/10 dark:bg-white/5 dark:text-[#a9c6b3] dark:hover:border-[#dec69b]/30 dark:hover:bg-white/10 dark:hover:text-[#d9e8de]'>
+              <a href='https://x.com/TheHippieSci' target='_blank' rel='noopener noreferrer' aria-label='The Hippie Scientist on X (opens in a new tab)' className='rounded-full border border-[#123c2f]/10 bg-[#fffdf8]/75 px-4 py-2 text-xs font-bold text-[#315f50] transition hover:border-[#b88a42]/35 hover:bg-[#fffdf8] dark:border-white/10 dark:bg-white/5 dark:text-[#a9c6b3] dark:hover:border-[#dec69b]/30 dark:hover:bg-white/10 dark:hover:text-[#d9e8de]'>
                 X
               </a>
               <a href='https://www.instagram.com/thehippiesci' target='_blank' rel='noopener noreferrer' className='rounded-full border border-[#123c2f]/10 bg-[#fffdf8]/75 px-4 py-2 text-xs font-bold text-[#315f50] transition hover:border-[#b88a42]/35 hover:bg-[#fffdf8] dark:border-white/10 dark:bg-white/5 dark:text-[#a9c6b3] dark:hover:border-[#dec69b]/30 dark:hover:bg-white/10 dark:hover:text-[#d9e8de]'>


### PR DESCRIPTION
## What changed
- Add a descriptive accessible name to the footer’s X profile link.

## Why
The visible single-letter label “X” did not identify whose profile it opens or disclose that the link opens a new tab.

## Impact
Visual presentation is unchanged. Screen readers announce “The Hippie Scientist on X (opens in a new tab).”

## Validation
- One `aria-label` added in `src/components/Footer.tsx`.
- Existing URL, new-tab behavior, and security attributes are unchanged.