### PR TITLE
Fix search combobox expanded state

### DIFF
--- a/components/search/GlobalSearchModal.tsx
+++ b/components/search/GlobalSearchModal.tsx
@@ -159,7 +159,7 @@ export function GlobalSearchModal() {
                 ref={inputRef}
                 type="text"
                 role="combobox"
-                aria-expanded={search.results.length > 0}
+                aria-expanded='true'
                 aria-controls={listboxId}
                 aria-activedescendant={activeOptionId}
                 aria-autocomplete="list"


### PR DESCRIPTION
## What changed
- Keep the search combobox’s `aria-expanded` state true while its controlled listbox is displayed.

## Why
The results list remains visibly open when it is loading, empty, or has no matches. The previous result-count condition incorrectly announced the listbox as collapsed in those states.

## Impact
Visual presentation and search behavior are unchanged. Assistive technology receives state that matches the interface.

## Validation
- One ARIA state change in `components/search/GlobalSearchModal.tsx`.
- `aria-controls` continues to reference the visible listbox.