### PR TITLE
Fix search listbox status roles

### DIFF
--- a/components/search/GlobalSearchModal.tsx
+++ b/components/search/GlobalSearchModal.tsx
@@ -214,9 +214,9 @@ export function GlobalSearchModal() {
               className="max-h-[50vh] space-y-0.5 overflow-y-auto overscroll-contain p-2"
             >
               {!search.ready ? (
-                <li className="px-3 py-6 text-center text-sm text-muted">Loading search…</li>
+                <li role="option" aria-disabled="true" className="px-3 py-6 text-center text-sm text-muted">Loading search…</li>
               ) : search.results.length === 0 ? (
-                <li className="px-3 py-6 text-center text-sm text-muted">
+                <li role="option" aria-disabled="true" className="px-3 py-6 text-center text-sm text-muted">
                   {search.query ? `No matches for “${search.query}”.` : 'Start typing to search.'}
                 </li>
               ) : (


### PR DESCRIPTION
## What changed
- Mark the search loading and empty-state rows as disabled listbox options.

## Why
A `role="listbox"` must expose owned rows with valid option semantics. The previous plain list items created an invalid ARIA structure during loading, initial, and no-match states.

## Impact
Visual presentation and search behavior are unchanged. Assistive technology can interpret every listbox state consistently.

## Validation
- Added `role="option"` and `aria-disabled="true"` to the two non-selectable status rows in `components/search/GlobalSearchModal.tsx`.