### PR TITLE
Align profile JSON-LD with Schema.org property domains

### DIFF
--- a/lib/__tests__/json-ld-sanitize-profile-domains.test.ts
+++ b/lib/__tests__/json-ld-sanitize-profile-domains.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { sanitizeJsonLdPayload } from '../json-ld-sanitize'
+
+describe('profile JSON-LD property domains', () => {
+  it('removes profile-only editorial fields from chemical entity schema', () => {
+    const result = sanitizeJsonLdPayload({
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': ['ChemicalSubstance', 'MolecularEntity'],
+          '@id': 'https://thehippiescientist.net/compounds/example/#entity',
+          name: 'Example',
+          category: 'Example class',
+          additionalProperty: [{ '@type': 'PropertyValue', name: 'Evidence', value: 'Moderate' }],
+          mechanismOfAction: 'Example pathway',
+          molecularFormula: 'C1H2',
+        },
+      ],
+    }) as Record<string, unknown>
+
+    const entity = (result['@graph'] as Record<string, unknown>[])[0]
+    expect(entity.category).toBeUndefined()
+    expect(entity.additionalProperty).toBeUndefined()
+    expect(entity.mechanismOfAction).toBeUndefined()
+    expect(entity.molecularFormula).toBe('C1H2')
+  })
+
+  it('normalizes the legacy review-date field on webpage nodes', () => {
+    const result = sanitizeJsonLdPayload({
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': ['MedicalWebPage', 'WebPage'],
+          '@id': 'https://thehippiescientist.net/herbs/example/#webpage',
+          dateReviewed: '2026-08-13',
+        },
+      ],
+    }) as Record<string, unknown>
+
+    const page = (result['@graph'] as Record<string, unknown>[])[0]
+    expect(page.dateReviewed).toBeUndefined()
+    expect(page.lastReviewed).toBe('2026-08-13')
+  })
+
+  it('does not strip category from unrelated schema types', () => {
+    const result = sanitizeJsonLdPayload({
+      '@type': 'Service',
+      '@id': 'https://example.com/#service',
+      category: 'Research',
+    }) as Record<string, unknown>
+
+    expect(result.category).toBe('Research')
+  })
+})

--- a/lib/json-ld-sanitize.ts
+++ b/lib/json-ld-sanitize.ts
@@ -14,11 +14,13 @@ const NON_CREATIVE_ENTITY_TYPES = new Set([
   'MedicalSubstance',
   'MedicalTherapy',
   'MolecularEntity',
+  'Substance',
   'Thing',
 ])
 
 const ARTICLE_TYPES = new Set(['Article', 'BlogPosting', 'NewsArticle'])
 const PRODUCT_SNIPPET_TYPES = new Set(['Product', 'DietarySupplement'])
+const WEBPAGE_TYPES = new Set(['WebPage', 'MedicalWebPage'])
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
@@ -44,6 +46,15 @@ function isArticleLike(types: string[]): boolean {
 
 function isPureEntityNode(types: string[]): boolean {
   return types.length > 0 && types.every((type) => NON_CREATIVE_ENTITY_TYPES.has(type))
+}
+
+function isWebPageNode(types: string[]): boolean {
+  return types.some((type) => WEBPAGE_TYPES.has(type))
+}
+
+function isProfileEntityNode(node: Record<string, unknown>): boolean {
+  const id = typeof node['@id'] === 'string' ? node['@id'] : ''
+  return id.endsWith('#entity') && /\/(?:herbs|compounds)\//.test(id)
 }
 
 function hasProductRichResultSupport(node: Record<string, unknown>): boolean {
@@ -79,6 +90,28 @@ function sanitizeObject(input: Record<string, unknown>): JsonLdObject {
   }
 
   const nextTypes = typeList(output['@type'])
+
+  // Profile entity artifacts carry richer editorial fields than Schema.org's
+  // ChemicalSubstance/MolecularEntity/Substance property domains permit. Keep
+  // those details in the site's machine-readable entity artifact instead of
+  // emitting validator-invalid properties in the public Schema.org graph.
+  if (isProfileEntityNode(output)) {
+    delete output.additionalProperty
+    delete output.category
+    if (!nextTypes.includes('Drug') && !nextTypes.includes('DietarySupplement')) {
+      delete output.mechanismOfAction
+    }
+  }
+
+  // Schema.org exposes `lastReviewed` on WebPage. Some legacy builders still
+  // emit `dateReviewed`; normalize that field at the common serialization edge.
+  if (isWebPageNode(nextTypes)) {
+    const reviewed = output.dateReviewed
+    delete output.dateReviewed
+    if (typeof reviewed === 'string' && reviewed.trim() && !output.lastReviewed) {
+      output.lastReviewed = reviewed
+    }
+  }
 
   // Google reports `breadcrumb` as invalid on Article rich-result nodes. Keep the
   // standalone BreadcrumbList node in the @graph; do not attach it directly to Article.


### PR DESCRIPTION
## Summary
- extends the existing shared JSON-LD sanitizer rather than adding a second schema layer
- removes profile-only editorial properties from herb/compound entity nodes when those properties are outside the emitted entity type domains
- preserves `mechanismOfAction` when the surviving type is Drug or DietarySupplement
- normalizes legacy `dateReviewed` on WebPage/MedicalWebPage nodes to `lastReviewed`
- adds focused behavioral regression tests

## Why
The Aug 12 Ahrefs crawl reports 852 Schema.org validation errors, closely matching the herb + compound profile surface. The profile builders intentionally carry richer evidence metadata, but the public Schema.org graph needs to stay within Schema.org's property domains. The site already centralizes JSON-LD sanitation in `lib/json-ld-sanitize.ts`, so this fixes the common serialization boundary.

## Validation
Merge only after CI, Build Check, Site Health, Fast UI (if triggered), and Lighthouse are green.