### PR TITLE
Label search evidence badges

### DIFF
--- a/components/search/search-ui.tsx
+++ b/components/search/search-ui.tsx
@@ -33,7 +33,8 @@ export function TypeBadge({ type }: { type: SearchContentType }) {
 
 export function EvidenceBadge({ grade }: { grade: EvidenceGrade }) {
   return (
-    <span className={clsx(BADGE_BASE, EVIDENCE_STYLES[grade])} title={`Evidence: ${grade}`}>
+    <span className={clsx(BADGE_BASE, EVIDENCE_STYLES[grade])}>
+      <span className="sr-only">Evidence: </span>
       {grade}
     </span>
   )


### PR DESCRIPTION
## What changed
- Add a screen-reader-only “Evidence:” prefix to search-result evidence badges.
- Remove the mouse-only `title` tooltip from those badges.

## Why
Values such as “Strong” or “Limited” were visually understandable from their badge placement, but assistive technology could receive the value without its evidence context. The tooltip was not a reliable accessible label.

## Impact
Visible badge text and styling are unchanged. A “Strong” badge is now announced as “Evidence: Strong.”

## Validation
- One component updated in `components/search/search-ui.tsx`.