### PR TITLE
Label search safety badges

### DIFF
--- a/components/search/search-ui.tsx
+++ b/components/search/search-ui.tsx
@@ -43,7 +43,8 @@ export function EvidenceBadge({ grade }: { grade: EvidenceGrade }) {
 export function SafetyBadge({ safety }: { safety: SafetySignal }) {
   if (safety === 'Educational') return null
   return (
-    <span className={clsx(BADGE_BASE, SAFETY_STYLES[safety])} title={`Safety: ${safety}`}>
+    <span className={clsx(BADGE_BASE, SAFETY_STYLES[safety])}>
+      <span className="sr-only">Safety: </span>
       {safety}
     </span>
   )


### PR DESCRIPTION
## What changed
- Add a screen-reader-only “Safety:” prefix to search safety badges.
- Remove the mouse-only `title` tooltip from those badges.

## Why
Safety values need explicit context for assistive technology. A hover tooltip is not a reliable accessible label.

## Impact
Visible badge text and styling are unchanged. “Use with caution” is now announced as “Safety: Use with caution.”

## Validation
- One component updated in `components/search/search-ui.tsx`.
- The existing omission of the non-informative “Educational” safety badge is unchanged.