### PR TITLE
Restore focus after shortcut closes search

### DIFF
--- a/components/search/GlobalSearchModal.tsx
+++ b/components/search/GlobalSearchModal.tsx
@@ -58,7 +58,8 @@ export function GlobalSearchModal() {
       const mod = event.metaKey || event.ctrlKey
       if (mod && event.key.toLowerCase() === 'k') {
         event.preventDefault()
-        setOpen((v) => !v)
+        if (open) close()
+        else setOpen(true)
         return
       }
       const target = event.target as HTMLElement | null
@@ -74,7 +75,7 @@ export function GlobalSearchModal() {
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [open])
+  }, [open, close])
 
   // Scroll lock + focus input on open.
   useEffect(() => {


### PR DESCRIPTION
## What changed
- Route Cmd/Ctrl+K closing through the search modal’s shared `close()` function.

## Why
The shortcut previously toggled state directly. When used to close an open modal, it bypassed focus restoration and could leave keyboard focus on the removed search input or page body.

## Impact
Cmd/Ctrl+K still opens and closes search. Closing now returns focus to the search trigger, matching Escape, backdrop, result selection, and the explicit close button.

## Validation
- Added the stable `close` callback to the shortcut effect dependencies.