### PR TITLE
Label search content filters

### DIFF
--- a/components/search/GlobalSearchModal.tsx
+++ b/components/search/GlobalSearchModal.tsx
@@ -187,7 +187,7 @@ export function GlobalSearchModal() {
             </div>
 
             {/* Quick type filters */}
-            <div className="flex flex-wrap items-center gap-1.5 border-b border-brand-900/10 px-4 py-2">
+            <div role="group" aria-label="Filter by content type" className="flex flex-wrap items-center gap-1.5 border-b border-brand-900/10 px-4 py-2">
               {TYPE_FILTERS.map((type) => (
                 <FilterChip
                   key={type}


### PR DESCRIPTION
## What changed
- Expose the search type-filter controls as a named group: “Filter by content type.”

## Why
The Herb, Compound, and Education toggle buttons were grouped only visually. A programmatic group name gives assistive-technology users the same context.

## Impact
Visual presentation and filtering behavior are unchanged.

## Validation
- Added `role="group"` and an accessible label to the existing filter container in `components/search/GlobalSearchModal.tsx`.
- Individual buttons retain their `aria-pressed` state.