### PR TITLE
Mark search results busy while loading

### DIFF
--- a/components/search/GlobalSearchModal.tsx
+++ b/components/search/GlobalSearchModal.tsx
@@ -212,6 +212,7 @@ export function GlobalSearchModal() {
               id={listboxId}
               role="listbox"
               aria-label="Search results"
+              aria-busy={!search.ready}
               className="max-h-[50vh] space-y-0.5 overflow-y-auto overscroll-contain p-2"
             >
               {!search.ready ? (


### PR DESCRIPTION
## What changed
- Add `aria-busy` to the search results listbox while the search engine is loading.

## Why
The interface already displays “Loading search…,” but the controlled results region did not programmatically indicate that its contents were still being updated.

## Impact
Visual presentation and search behavior are unchanged. Assistive technology can distinguish the temporary loading row from a settled result state.

## Validation
- One ARIA state added in `components/search/GlobalSearchModal.tsx`.
- The busy state automatically clears when `search.ready` becomes true.