### PR TITLE
Expose search dialog open state

### DIFF
--- a/components/search/GlobalSearchModal.tsx
+++ b/components/search/GlobalSearchModal.tsx
@@ -126,6 +126,7 @@ export function GlobalSearchModal() {
         className="inline-flex min-h-[44px] items-center gap-2 rounded-full border border-brand-900/20 bg-white px-3 py-2.5 text-sm text-ink transition hover:border-brand-700/25 hover:bg-brand-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-700 dark:border-[var(--border-soft)] dark:bg-[var(--surface-card)] dark:text-[var(--text-primary)] dark:hover:border-[var(--border-strong)] dark:hover:bg-[var(--surface-subtle)] md:min-h-[auto] md:py-1.5"
         aria-label="Open search"
         aria-haspopup="dialog"
+        aria-expanded={open}
         aria-keyshortcuts="Meta+K Control+K /"
       >
         <Search className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
## What changed
- Add `aria-expanded={open}` to the global search trigger.

## Why
The trigger identifies that it opens a dialog, but it did not expose whether that controlled popup was currently open or closed.

## Impact
Visual presentation and search behavior are unchanged. Assistive technology receives the trigger’s current popup state.

## Validation
- One ARIA state added in `components/search/GlobalSearchModal.tsx`.
- The state is driven directly by the existing modal `open` value.