### PR TITLE
Prevent duplicate search shortcut dialogs

### DIFF
--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -245,7 +245,7 @@ export function Navigation() {
             </div>
 
             <div className='mb-5'>
-              <GlobalSearchModal />
+              <GlobalSearchModal enableHotkeys={false} />
             </div>
 
             <nav className='flex flex-col gap-2 text-base' aria-label='Mobile primary links'>

--- a/components/search/GlobalSearchModal.tsx
+++ b/components/search/GlobalSearchModal.tsx
@@ -19,7 +19,7 @@ const TYPE_FILTERS: SearchContentType[] = ['Herb', 'Compound', 'Education']
  *   scroll lock, and focus restoration.
  * - Loads the search engine lazily on first open (code-split index + Fuse).
  */
-export function GlobalSearchModal() {
+export function GlobalSearchModal({ enableHotkeys = true }: { enableHotkeys?: boolean } = {}) {
   const [open, setOpen] = useState(false)
   const router = useRouter()
   const inputRef = useRef<HTMLInputElement>(null)
@@ -55,6 +55,8 @@ export function GlobalSearchModal() {
 
   // Global hotkeys: Cmd/Ctrl+K, and "/" when not focused in an input.
   useEffect(() => {
+    if (!enableHotkeys) return
+
     const onKey = (event: KeyboardEvent) => {
       const mod = event.metaKey || event.ctrlKey
       if (mod && event.key.toLowerCase() === 'k') {
@@ -76,7 +78,7 @@ export function GlobalSearchModal() {
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [open, close])
+  }, [open, close, enableHotkeys])
 
   // Scroll lock + focus input on open.
   useEffect(() => {


### PR DESCRIPTION
## What changed
- Add an `enableHotkeys` option to the reusable global-search component.
- Disable global keyboard listeners on the secondary search instance inside the mobile navigation drawer.

## Why
The header search and drawer search were both mounted while the drawer was open. Each registered Cmd/Ctrl+K and `/`, allowing one shortcut to open two overlapping dialogs.

## Impact
The mobile drawer’s visible search button continues to work normally. Global shortcuts are handled once by the primary header instance.

## Validation
- Default search behavior remains unchanged for all existing instances.
- Only the mobile drawer instance opts out of global shortcuts.