### PR TITLE
Align search shortcut metadata

### DIFF
--- a/components/search/GlobalSearchModal.tsx
+++ b/components/search/GlobalSearchModal.tsx
@@ -131,7 +131,7 @@ export function GlobalSearchModal({ enableHotkeys = true }: { enableHotkeys?: bo
         aria-haspopup="dialog"
         aria-expanded={open}
         aria-controls={open ? dialogId : undefined}
-        aria-keyshortcuts="Meta+K Control+K /"
+        aria-keyshortcuts={enableHotkeys ? "Meta+K Control+K /" : undefined}
       >
         <Search className="h-4 w-4" aria-hidden="true" />
         <span className="hidden sm:inline">Search</span>


### PR DESCRIPTION
## What changed
- Expose `aria-keyshortcuts` only on a search instance that actually registers the global shortcuts.

## Why
The secondary mobile-drawer search correctly stopped owning global hotkeys, but its trigger still advertised Cmd/Ctrl+K and `/`. Its metadata now matches its behavior.

## Impact
The primary search trigger continues to disclose all shortcuts. Visual presentation and click behavior are unchanged.

## Validation
- One conditional ARIA attribute change in `components/search/GlobalSearchModal.tsx`.