### PR TITLE
Keep search shortcut focus in mobile drawer

### DIFF
--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -196,7 +196,7 @@ export function Navigation() {
           </div>
 
           <div className='flex shrink-0 items-center gap-2'>
-            <GlobalSearchModal />
+            <GlobalSearchModal enableHotkeys={!mobileOpen} />
             <div className='hidden md:block'>
               <DarkModeToggle />
             </div>
@@ -245,7 +245,7 @@ export function Navigation() {
             </div>
 
             <div className='mb-5'>
-              <GlobalSearchModal enableHotkeys={false} />
+              <GlobalSearchModal />
             </div>
 
             <nav className='flex flex-col gap-2 text-base' aria-label='Mobile primary links'>


### PR DESCRIPTION
## What changed
- Let the header search own global shortcuts while the mobile drawer is closed.
- Transfer shortcut ownership to the drawer’s search instance while the drawer is open.

## Why
Opening search by shortcut from an open drawer previously used the header instance. Closing search then restored focus to a trigger behind the still-open modal drawer.

## Impact
Exactly one shortcut listener remains active. Search now restores focus within the drawer when launched there.

## Validation
- Existing `enableHotkeys` support prevents duplicate listeners.
- Visible search buttons and click behavior are unchanged.