### PR TITLE
Keep active search result visible

### DIFF
--- a/components/search/GlobalSearchModal.tsx
+++ b/components/search/GlobalSearchModal.tsx
@@ -120,6 +120,11 @@ export function GlobalSearchModal({ enableHotkeys = true }: { enableHotkeys?: bo
 
   const activeOptionId = search.results.length ? `${optionPrefix}-${activeIndex}` : undefined
 
+  useEffect(() => {
+    if (!activeOptionId) return
+    document.getElementById(activeOptionId)?.scrollIntoView({ block: 'nearest' })
+  }, [activeOptionId])
+
   return (
     <>
       <button


### PR DESCRIPTION
## What changed
- Scroll the active search option into the nearest visible position whenever keyboard selection changes.

## Why
The result list is height-limited and scrollable. Arrow, Home, and End navigation could move `aria-activedescendant` to an off-screen option without scrolling the list, hiding the current selection from sighted keyboard users.

## Impact
Keyboard navigation now keeps the highlighted result visible. Pointer behavior and selection logic are unchanged.

## Validation
- Uses the existing unique active-option ID.
- `scrollIntoView({ block: 'nearest' })` avoids unnecessary movement when the option is already visible.