### PR TITLE
Guard active search option reference

### DIFF
--- a/components/search/GlobalSearchModal.tsx
+++ b/components/search/GlobalSearchModal.tsx
@@ -118,7 +118,7 @@ export function GlobalSearchModal({ enableHotkeys = true }: { enableHotkeys?: bo
     [close],
   )
 
-  const activeOptionId = search.results.length ? `${optionPrefix}-${activeIndex}` : undefined
+  const activeOptionId = search.results[activeIndex] ? `${optionPrefix}-${activeIndex}` : undefined
 
   useEffect(() => {
     if (!activeOptionId) return


### PR DESCRIPTION
## What changed
- Set `aria-activedescendant` only when a search result actually exists at the current active index.

## Why
When a query or filter sharply reduces the result count, index clamping occurs after render. The previous length-only check could briefly point the combobox at a removed option ID.

## Impact
Visual presentation and navigation behavior are unchanged. The combobox no longer exposes a transient invalid ARIA reference.

## Validation
- One guard condition changed in `components/search/GlobalSearchModal.tsx`.
- The existing index-clamping effect still selects the nearest valid result.