### PR TITLE
Label search content type badges

### DIFF
--- a/components/search/search-ui.tsx
+++ b/components/search/search-ui.tsx
@@ -28,7 +28,12 @@ const BADGE_BASE =
   'inline-flex items-center rounded-full border px-2 py-0.5 text-[0.75rem] font-semibold leading-snug'
 
 export function TypeBadge({ type }: { type: SearchContentType }) {
-  return <span className={clsx(BADGE_BASE, TYPE_STYLES[type])}>{type}</span>
+  return (
+    <span className={clsx(BADGE_BASE, TYPE_STYLES[type])}>
+      <span className="sr-only">Content type: </span>
+      {type}
+    </span>
+  )
 }
 
 export function EvidenceBadge({ grade }: { grade: EvidenceGrade }) {


### PR DESCRIPTION
## What changed
- Add a screen-reader-only “Content type:” prefix to search-result type badges.

## Why
Values such as “Herb,” “Compound,” and especially “Education” relied on their visual badge placement for meaning. Assistive technology now receives explicit context consistent with the evidence and safety badges.

## Impact
Visible badge text and styling are unchanged. “Herb” is announced as “Content type: Herb.”

## Validation
- One shared badge component updated in `components/search/search-ui.tsx`.