### PR TITLE
Clarify search result count

### DIFF
--- a/components/search/GlobalSearchModal.tsx
+++ b/components/search/GlobalSearchModal.tsx
@@ -251,7 +251,7 @@ export function GlobalSearchModal({ enableHotkeys = true }: { enableHotkeys?: bo
             <div className="flex items-center justify-between border-t border-brand-900/10 bg-[var(--surface-subtle)] px-4 py-2 text-[11px] text-muted">
               <span aria-live="polite" aria-atomic="true">
                 {search.ready
-                  ? `${search.results.length} result${search.results.length === 1 ? '' : 's'}`
+                  ? `${search.results.length} result${search.results.length === 1 ? '' : 's'} shown`
                   : ''}
               </span>
               <span className="hidden items-center gap-3 sm:flex">


### PR DESCRIPTION
## What changed
- Change the search status from “N results” to “N results shown.”

## Why
The command-palette search limits the displayed set to 24 items. The previous wording could imply that the displayed count was the complete number of matches.

## Impact
The visible and live-region status is more precise. Search ranking and behavior are unchanged.

## Validation
- One text expression updated in `components/search/GlobalSearchModal.tsx`.
- Singular and plural grammar remain intact.