### PR TITLE
Restore focus after mobile nav dismissal

### DIFF
--- a/src/components/mobile-bottom-nav.tsx
+++ b/src/components/mobile-bottom-nav.tsx
@@ -52,6 +52,7 @@ export default function MobileBottomNav() {
       const target = event.target as Node
       if (panelRef.current?.contains(target) || triggerRef.current?.contains(target)) return
       setOpen(false)
+      triggerRef.current?.focus()
     }
 
     document.addEventListener('keydown', onKeyDown)


### PR DESCRIPTION
## What changed
- Return focus to the mobile navigation widget trigger when its panel is dismissed by an outside pointer action.

## Why
Opening the widget intentionally focuses its first link. Outside dismissal previously hid the panel while focus remained on that now-hidden link.

## Impact
Outside dismissal now matches Escape dismissal’s focus behavior. If the outside target is independently focusable, the browser can still move focus to it as the pointer action completes.

## Validation
- One focus-restoration call added in `src/components/mobile-bottom-nav.tsx`.
- Trigger clicks and route-link behavior are unchanged.