### PR TITLE
Restore focus after mobile nav route change

### DIFF
--- a/src/components/mobile-bottom-nav.tsx
+++ b/src/components/mobile-bottom-nav.tsx
@@ -35,6 +35,9 @@ export default function MobileBottomNav() {
   // Close on route change so the panel never survives a navigation.
   useEffect(() => {
     setOpen(false)
+    if (panelRef.current?.contains(document.activeElement)) {
+      triggerRef.current?.focus()
+    }
   }, [pathname])
 
   useEffect(() => {


### PR DESCRIPTION
## What changed
- Return focus to the mobile navigation widget trigger when a route change closes the panel while one of its links still owns focus.

## Why
Client-side navigation hid the panel but could leave focus on the selected, now-hidden link.

## Impact
Navigation destinations and visual behavior are unchanged. Focus remains on a visible control after routing.

## Validation
- Focus moves only when the active element is inside the panel.
- Initial render and unrelated route changes do not steal focus.