### PR TITLE
Keep hidden scroll-to-top button out of tab order

### DIFF
--- a/src/components/ScrollToTopButton.tsx
+++ b/src/components/ScrollToTopButton.tsx
@@ -18,6 +18,7 @@ export default function ScrollToTopButton() {
       onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
       className={`fixed bottom-[calc(env(safe-area-inset-bottom)+0.75rem)] right-3 z-[85] min-h-10 min-w-10 rounded-full border border-brand-900/15 bg-[var(--surface-card-strong)] p-2 text-brand-800 shadow-sm backdrop-blur transition-all motion-safe:hover:scale-105 md:bottom-8 md:right-6 md:flex ${visible ? 'opacity-100' : 'pointer-events-none opacity-0'}`}
       aria-label='Scroll to top'
+      tabIndex={visible ? 0 : -1}
     >
       <ArrowUp aria-hidden="true" className="h-5 w-5" />
     </button>


### PR DESCRIPTION
## What changed
- Set the scroll-to-top button's `tabIndex` from its visible state.

## Why
The button was visually hidden with opacity and pointer events below the scroll threshold, but those styles do not remove it from sequential keyboard navigation. Keyboard users could therefore tab to an invisible control.

## Impact
The control remains keyboard accessible whenever visible and is skipped while hidden.

## Validation
- Reviewed the isolated component diff.
- Confirmed the visible state maps to `tabIndex={0}` and the hidden state maps to `tabIndex={-1}`.