### PR TITLE
Respect reduced motion when scrolling to top

### DIFF
--- a/src/components/ScrollToTopButton.tsx
+++ b/src/components/ScrollToTopButton.tsx
@@ -12,10 +12,15 @@ export default function ScrollToTopButton() {
     return () => window.removeEventListener('scroll', onScroll)
   }, [])
 
+  const scrollToTop = () => {
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    window.scrollTo({ top: 0, behavior: prefersReducedMotion ? 'auto' : 'smooth' })
+  }
+
   return (
     <button
       type="button"
-      onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+      onClick={scrollToTop}
       className={`fixed bottom-[calc(env(safe-area-inset-bottom)+0.75rem)] right-3 z-[85] min-h-10 min-w-10 rounded-full border border-brand-900/15 bg-[var(--surface-card-strong)] p-2 text-brand-800 shadow-sm backdrop-blur transition-all motion-safe:hover:scale-105 md:bottom-8 md:right-6 md:flex ${visible ? 'opacity-100' : 'pointer-events-none opacity-0'}`}
       aria-label='Scroll to top'
       tabIndex={visible ? 0 : -1}


### PR DESCRIPTION
## What changed
- Read the visitor's `prefers-reduced-motion` setting when the scroll-to-top control is activated.
- Use an instant scroll for reduced-motion users and preserve smooth scrolling for everyone else.

## Why
The control previously forced smooth viewport movement regardless of the visitor's operating-system accessibility preference.

## Impact
Visitors sensitive to motion can use the control without an unnecessary scrolling animation.

## Validation
- Reviewed the isolated component diff.
- Confirmed both branches use valid `ScrollBehavior` values (`auto` and `smooth`).