### PR TITLE
Initialize scroll-to-top visibility on mount

### DIFF
--- a/src/components/ScrollToTopButton.tsx
+++ b/src/components/ScrollToTopButton.tsx
@@ -8,6 +8,7 @@ export default function ScrollToTopButton() {
 
   useEffect(() => {
     const onScroll = () => setVisible(window.scrollY > 300)
+    onScroll()
     window.addEventListener('scroll', onScroll, { passive: true })
     return () => window.removeEventListener('scroll', onScroll)
   }, [])


### PR DESCRIPTION
## What changed
- Run the existing scroll-position handler once when the component mounts.

## Why
The button previously depended entirely on a future `scroll` event. When the browser restored a page at a position beyond the 300px threshold, the control remained hidden until the visitor scrolled again.

## Impact
The button now immediately reflects the restored or initial scroll position.

## Validation
- Reviewed the isolated one-line component diff.
- Confirmed the same handler still owns both initial and subsequent visibility updates.