### PR TITLE
Enforce system no-tracking signals in analytics loader

### DIFF
--- a/src/lib/loadAnalytics.ts
+++ b/src/lib/loadAnalytics.ts
@@ -1,4 +1,4 @@
-import { getConsent } from './consent'
+import { getConsent, getSystemNoTracking } from './consent'
 
 const GA_ID = process.env.NEXT_PUBLIC_GA4_ID?.trim() ?? ''
 const AHREFS_ANALYTICS_KEY = process.env.NEXT_PUBLIC_AHREFS_ANALYTICS_KEY?.trim() ?? ''
@@ -26,6 +26,7 @@ function injectScriptOnce(id: string, src: string, attrs: Record<string, string>
 export function loadAnalytics() {
   if (loaded) return
   if (typeof window === 'undefined') return
+  if (getSystemNoTracking()) return
 
   const consent = getConsent()
   if (consent !== 'granted') return


### PR DESCRIPTION
## What changed
- Added a DNT/GPC guard to the central analytics loader.

## Why
The consent banner promises that tracking stays off when a system no-tracking signal is detected, but the loader previously checked only stored consent. A visitor could press Accept and analytics scripts would still be injected.

## Impact
Google Analytics and Ahrefs Analytics are not loaded while DNT or Global Privacy Control is active, even if stored consent says granted.

## Validation
- Reviewed the isolated loader diff.
- Confirmed the browser-environment guard runs before `getSystemNoTracking()`.
- Confirmed all existing analytics entry points pass through `loadAnalytics()`.