### PR TITLE
Handle consent storage write failures

### DIFF
--- a/src/lib/consent.ts
+++ b/src/lib/consent.ts
@@ -22,7 +22,11 @@ export function getConsent(): ConsentStatus | null {
 }
 
 export function setConsent(status: ConsentStatus) {
-  localStorage.setItem(CONSENT_STORAGE_KEY, JSON.stringify({ status, ts: Date.now() }))
+  try {
+    localStorage.setItem(CONSENT_STORAGE_KEY, JSON.stringify({ status, ts: Date.now() }))
+  } catch {
+    // Continue with session consent when browser storage is unavailable.
+  }
   if (typeof window !== 'undefined') {
     window.dispatchEvent(new CustomEvent(CONSENT_GRANTED_EVENT, { detail: { status } }))
   }


### PR DESCRIPTION
## What changed
- Wrapped consent persistence in a narrow `try/catch`.
- Continue dispatching the consent event and applying the in-page GA consent state when storage is unavailable.

## Why
`getConsent()` already treats blocked storage as unavailable, but `setConsent()` allowed `localStorage.setItem()` to throw. That interrupted both consent button handlers before the banner could close.

## Impact
Visitors in restricted storage contexts can still accept or decline for the current page session without a broken control.

## Validation
- Reviewed the isolated `setConsent()` diff.
- Confirmed only the persistence operation is caught; event dispatch and consent application still run.