### PR TITLE
Contain keyboard focus in the privacy dialog

### DIFF
--- a/src/components/ConsentManager.tsx
+++ b/src/components/ConsentManager.tsx
@@ -29,6 +29,31 @@ export default function ConsentManager({ open, onClose }: Props) {
     function onKey(event: KeyboardEvent) {
       if (event.key === "Escape") {
         onClose();
+        return;
+      }
+
+      if (event.key !== "Tab" || !dialogRef.current) return;
+
+      const focusable = Array.from(
+        dialogRef.current.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), a[href], [tabindex]:not([tabindex="-1"])'
+        )
+      );
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+
+      if (!dialogRef.current.contains(active)) {
+        event.preventDefault();
+        (event.shiftKey ? last : first).focus();
+      } else if (event.shiftKey && (active === first || active === dialogRef.current)) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
       }
     }
 


### PR DESCRIPTION
## What changed
- Added Tab and Shift+Tab boundary handling to the privacy-settings dialog.
- Recover focus into the dialog if it is moved outside while the modal is open.

## Why
The dialog declares `aria-modal="true"`, but keyboard navigation could still advance to obscured controls behind the overlay.

## Impact
Keyboard users now remain within the available privacy actions until they close the modal.

## Validation
- Reviewed the isolated key-handler diff.
- Confirmed forward navigation wraps from the last control to the first and reverse navigation wraps from the first/dialog container to the last.
- Escape-to-close behavior remains intact.