### PR TITLE
Skip the invisible modal backdrop in tab navigation

### DIFF
--- a/src/components/ConsentManager.tsx
+++ b/src/components/ConsentManager.tsx
@@ -36,7 +36,7 @@ export default function ConsentManager({ open, onClose }: Props) {
 
       const focusable = Array.from(
         dialogRef.current.querySelectorAll<HTMLElement>(
-          'button:not([disabled]), a[href], [tabindex]:not([tabindex="-1"])'
+          'button:not([disabled]):not([tabindex="-1"]), a[href], [tabindex]:not([tabindex="-1"])'
         )
       );
       if (focusable.length === 0) return;
@@ -98,6 +98,7 @@ export default function ConsentManager({ open, onClose }: Props) {
     >
       <button
         type="button"
+        tabIndex={-1}
         aria-label="Close privacy settings"
         onClick={onClose}
         className="absolute inset-0 bg-black/60 backdrop-blur-sm"


### PR DESCRIPTION
## What changed
- Removed the click-only privacy-dialog backdrop from sequential keyboard navigation.
- Updated the dialog's focusable-control selector to exclude buttons with `tabIndex={-1}`.

## Why
The full-screen backdrop was the first focusable control inside the modal despite having no visible focus treatment. A separate visible Close button already provides the equivalent keyboard action.

## Impact
Tab now moves directly among visible privacy-dialog controls while pointer users can still click outside the panel to close it.

## Validation
- Reviewed the isolated backdrop/tab-trap diff.
- Confirmed the backdrop click handler remains unchanged.
- Confirmed the visible Close button remains in the focus loop.