### PR TITLE
Clarify the privacy dialog close label

### DIFF
--- a/src/components/ConsentManager.tsx
+++ b/src/components/ConsentManager.tsx
@@ -115,7 +115,7 @@ export default function ConsentManager({ open, onClose }: Props) {
           </h2>
           <button
             type="button"
-            aria-label="Close"
+            aria-label="Close privacy settings"
             onClick={onClose}
             className="rounded border border-white/10 px-2 py-1 hover:bg-white/10"
           >


### PR DESCRIPTION
## What changed
- Changed the visible icon button's accessible name from `Close` to `Close privacy settings`.

## Why
The generic label did not identify what the icon closes, making the target less clear for screen-reader and voice-control users.

## Impact
Both modal-dismiss controls now expose the same specific action name.

## Validation
- Reviewed the isolated one-line label diff.
- Confirmed the visual icon and close behavior are unchanged.