### PR TITLE
Validate stored consent status values

### DIFF
--- a/src/lib/consent.ts
+++ b/src/lib/consent.ts
@@ -15,7 +15,7 @@ export function getConsent(): ConsentStatus | null {
     const raw = localStorage.getItem(CONSENT_STORAGE_KEY)
     if (!raw) return null
     const parsed = JSON.parse(raw)
-    return parsed?.status === 'granted' ? 'granted' : 'denied'
+    return parsed?.status === 'granted' || parsed?.status === 'denied' ? parsed.status : null
   } catch {
     return null
   }


### PR DESCRIPTION
## What changed
- Return a stored consent value only when it is exactly `granted` or `denied`.
- Treat malformed, obsolete, or unknown status values as unset.

## Why
The parser previously mapped every non-`granted` value to `denied`, which could suppress the consent banner without an explicit visitor choice.

## Impact
Invalid stored data now safely reopens the consent choice instead of silently recording a decline.

## Validation
- Reviewed the isolated parser diff.
- Confirmed both valid values retain their existing behavior and JSON/storage failures still return `null`.