### PR TITLE
Enforce no-tracking signals in GA consent mode

### DIFF
--- a/src/lib/consent.ts
+++ b/src/lib/consent.ts
@@ -45,7 +45,7 @@ export function initConsentDefault() {
 }
 
 export function applyGaConsent(status: ConsentStatus) {
-  const granted = status === 'granted'
+  const granted = status === 'granted' && !getSystemNoTracking()
   // GA4 Consent Mode v2 (safe no-op if gtag missing)
   try {
     ;(window as any).gtag?.('consent', 'default', {


### PR DESCRIPTION
## What changed
- Require both explicit consent and the absence of DNT/GPC before granting GA consent-mode storage categories.

## Why
The analytics script loader already blocks DNT/GPC, but `applyGaConsent()` could still tell an existing `gtag` instance that analytics and ad storage were granted.

## Impact
System no-tracking signals now keep GA consent mode denied at the consent API boundary as well as at script loading.

## Validation
- Reviewed the isolated one-line consent calculation diff.
- Confirmed essential functionality and security storage settings remain unchanged.