### PR TITLE
Focus a visible privacy dialog control

### DIFF
--- a/src/components/ConsentManager.tsx
+++ b/src/components/ConsentManager.tsx
@@ -9,6 +9,7 @@ type ConsentState = "granted" | "denied" | "unknown";
 export default function ConsentManager({ open, onClose }: Props) {
   const [status, setStatus] = useState<ConsentState>("unknown");
   const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -16,7 +17,7 @@ export default function ConsentManager({ open, onClose }: Props) {
     setStatus(consent ?? "unknown");
 
     const previousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
-    dialogRef.current?.focus();
+    closeButtonRef.current?.focus();
     const previousOverflow = document.body.style.overflow;
     document.body.style.overflow = "hidden";
     return () => {
@@ -115,6 +116,7 @@ export default function ConsentManager({ open, onClose }: Props) {
             Privacy settings
           </h2>
           <button
+            ref={closeButtonRef}
             type="button"
             aria-label="Close privacy settings"
             onClick={onClose}


### PR DESCRIPTION
## What changed
- Focus the visible close control when privacy settings opens instead of the nonvisual dialog container.

## Why
Initial focus was programmatically placed on a container with no visible focus indicator.

## Impact
Keyboard users immediately see where focus is while screen readers still receive the dialog name and description.

## Validation
- Reviewed the isolated ref/focus diff.
- Focus restoration and focus containment remain unchanged.