### PR TITLE
Hide the modal backdrop from assistive technology

### DIFF
--- a/src/components/ConsentManager.tsx
+++ b/src/components/ConsentManager.tsx
@@ -101,6 +101,7 @@ export default function ConsentManager({ open, onClose }: Props) {
       <button
         type="button"
         tabIndex={-1}
+        aria-hidden="true"
         aria-label="Close privacy settings"
         onClick={onClose}
         className="absolute inset-0 bg-black/60 backdrop-blur-sm"


### PR DESCRIPTION
## What changed
- Marked the click-only privacy-dialog backdrop `aria-hidden="true"`.

## Why
The backdrop is intentionally excluded from keyboard navigation but remained exposed as a second, redundant close button to assistive technology.

## Impact
Screen-reader users encounter only the visible close control, while pointer users retain click-outside dismissal.

## Validation
- Reviewed the isolated attribute diff.
- Confirmed backdrop click behavior and the visible close button are unchanged.