### PR TITLE
Guard no-tracking detection outside the browser

### DIFF
--- a/src/lib/consent.ts
+++ b/src/lib/consent.ts
@@ -4,6 +4,8 @@ export const CONSENT_STORAGE_KEY = 'consent.v1'
 export const CONSENT_GRANTED_EVENT = 'hs:consent-granted'
 
 export function getSystemNoTracking(): boolean {
+  if (typeof navigator === 'undefined' || typeof window === 'undefined') return false
+
   const dnt =
     (navigator as any).doNotTrack || (window as any).doNotTrack || (navigator as any).msDoNotTrack
   const gpc = (navigator as any).globalPrivacyControl


### PR DESCRIPTION
## What changed
- Return `false` before accessing `navigator` or `window` when the no-tracking helper runs outside a browser.

## Why
The shared helper directly dereferenced browser globals, making server-side or non-DOM use throw a reference error.

## Impact
Consent utilities remain safe across rendering and test environments while browser detection is unchanged.

## Validation
- Reviewed the isolated environment guard.
- Confirmed browser execution continues into the existing DNT/GPC checks.