### PR TITLE
Show the effective no-tracking status

### DIFF
--- a/src/components/ConsentManager.tsx
+++ b/src/components/ConsentManager.tsx
@@ -141,14 +141,16 @@ export default function ConsentManager({ open, onClose }: Props) {
             Current status:
             <strong
               className={`ml-2 ${
-                status === "granted"
+                dnt
+                  ? "text-amber-300"
+                  : status === "granted"
                   ? "text-lime-300"
                   : status === "denied"
                   ? "text-rose-300"
                   : "text-white/60"
               }`}
             >
-              {status === "granted" ? "Accepted" : status === "denied" ? "Declined" : "Not set"}
+              {dnt ? "Blocked by DNT/GPC" : status === "granted" ? "Accepted" : status === "denied" ? "Declined" : "Not set"}
             </strong>
           </div>
         </div>


### PR DESCRIPTION
## What changed
- Display `Blocked by DNT/GPC` as the current privacy status whenever a system no-tracking signal is active.
- Use the existing amber status treatment for that override.

## Why
The dialog could report `Accepted` from stored consent even though DNT/GPC prevents analytics from loading and keeps GA consent denied.

## Impact
The status now describes the effective tracking behavior rather than a superseded stored preference.

## Validation
- Reviewed the isolated status text/color diff.
- Stored status behavior is unchanged when no system override is present.