### PR TITLE
Align the consent banner with no-tracking signals

### DIFF
--- a/src/components/ConsentBanner.tsx
+++ b/src/components/ConsentBanner.tsx
@@ -59,16 +59,18 @@ export default function ConsentBanner() {
               type='button'
               className='inline-flex min-h-11 items-center justify-center rounded-lg border border-[#d8c08d]/50 bg-[#fffdf8] px-4 text-sm font-bold text-[#123c2f] transition-colors hover:bg-[#f5efe2]'
               onClick={() => {
-                setConsent('granted')
+                setConsent(dnt ? 'denied' : 'granted')
                 setShow(false)
-                import('../lib/loadAnalytics')
-                  .then(module => module.loadAnalytics())
-                  .catch(() => {
-                    // Ignore analytics load failures.
-                  })
+                if (!dnt) {
+                  import('../lib/loadAnalytics')
+                    .then(module => module.loadAnalytics())
+                    .catch(() => {
+                      // Ignore analytics load failures.
+                    })
+                }
               }}
             >
-              Accept
+              {dnt ? 'Continue without tracking' : 'Accept'}
             </button>
           </div>
         </div>


### PR DESCRIPTION
## What changed
- Replace `Accept` with `Continue without tracking` when DNT/GPC is detected.
- Record denied consent and skip the analytics import on that path.
- Preserve the existing Accept behavior when no system override is active.

## Why
The banner promised tracking would remain off but still presented an Accept action that implied the opposite.

## Impact
The primary action now accurately describes and enforces the effective privacy outcome.

## Validation
- Reviewed the isolated conditional action diff.
- Confirmed normal opt-in behavior is unchanged without DNT/GPC.