### PR TITLE
Rename the consent status change event

### DIFF
--- a/components/ClickTracker.tsx
+++ b/components/ClickTracker.tsx
@@ -7,7 +7,7 @@ import {
   trackGuideView,
   trackLeadMagnetClick,
 } from '@/lib/analytics'
-import { CONSENT_GRANTED_EVENT, getConsent } from '../src/lib/consent'
+import { CONSENT_CHANGE_EVENT, getConsent } from '../src/lib/consent'
 import { loadAnalytics } from '../src/lib/loadAnalytics'
 import { trackRevenueEvent } from '../src/lib/revenue-tracking'
 
@@ -30,8 +30,8 @@ export default function ClickTracker() {
     }
 
     trackCurrentGuide()
-    window.addEventListener(CONSENT_GRANTED_EVENT, trackCurrentGuide)
-    return () => window.removeEventListener(CONSENT_GRANTED_EVENT, trackCurrentGuide)
+    window.addEventListener(CONSENT_CHANGE_EVENT, trackCurrentGuide)
+    return () => window.removeEventListener(CONSENT_CHANGE_EVENT, trackCurrentGuide)
   }, [pathname])
 
   useEffect(() => {

--- a/components/RevenueImpressionTracker.tsx
+++ b/components/RevenueImpressionTracker.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useRef, type ReactNode } from 'react'
-import { CONSENT_GRANTED_EVENT, getConsent } from '../src/lib/consent'
+import { CONSENT_CHANGE_EVENT, getConsent } from '../src/lib/consent'
 import { trackRevenueEvent } from '../src/lib/revenue-tracking'
 
 export const RECOMMENDATION_IMPRESSION_THRESHOLD = 0.5
@@ -82,12 +82,12 @@ export default function RevenueImpressionTracker({
     }
 
     observer.observe(element)
-    window.addEventListener(CONSENT_GRANTED_EVENT, handleConsentChange)
+    window.addEventListener(CONSENT_CHANGE_EVENT, handleConsentChange)
 
     return () => {
       clearPending()
       observer.disconnect()
-      window.removeEventListener(CONSENT_GRANTED_EVENT, handleConsentChange)
+      window.removeEventListener(CONSENT_CHANGE_EVENT, handleConsentChange)
     }
   }, [label, location, productAsin, productSlot, productSlug])
 

--- a/components/__tests__/ClickTracker.test.tsx
+++ b/components/__tests__/ClickTracker.test.tsx
@@ -21,7 +21,7 @@ vi.mock('@/lib/analytics', () => ({
 }))
 
 vi.mock('@/src/lib/consent', () => ({
-  CONSENT_GRANTED_EVENT: 'consent-granted',
+  CONSENT_CHANGE_EVENT: 'consent-granted',
   getConsent: mocks.getConsent,
 }))
 

--- a/components/__tests__/RevenueImpressionTracker.test.tsx
+++ b/components/__tests__/RevenueImpressionTracker.test.tsx
@@ -12,7 +12,7 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock('../../src/lib/consent', () => ({
-  CONSENT_GRANTED_EVENT: 'hs:consent-granted',
+  CONSENT_CHANGE_EVENT: 'hs:consent-changed',
   getConsent: mocks.getConsent,
 }))
 
@@ -118,7 +118,7 @@ describe('RevenueImpressionTracker', () => {
 
     mocks.getConsent.mockReturnValue('granted')
     act(() => {
-      window.dispatchEvent(new CustomEvent('hs:consent-granted'))
+      window.dispatchEvent(new CustomEvent('hs:consent-changed'))
       vi.advanceTimersByTime(RECOMMENDATION_IMPRESSION_DELAY_MS)
     })
 

--- a/src/lib/consent.ts
+++ b/src/lib/consent.ts
@@ -1,7 +1,7 @@
 export type ConsentStatus = 'granted' | 'denied'
 
 export const CONSENT_STORAGE_KEY = 'consent.v1'
-export const CONSENT_GRANTED_EVENT = 'hs:consent-granted'
+export const CONSENT_CHANGE_EVENT = 'hs:consent-changed'
 
 export function getSystemNoTracking(): boolean {
   if (typeof navigator === 'undefined' || typeof window === 'undefined') return false
@@ -30,7 +30,7 @@ export function setConsent(status: ConsentStatus) {
     // Continue with session consent when browser storage is unavailable.
   }
   if (typeof window !== 'undefined') {
-    window.dispatchEvent(new CustomEvent(CONSENT_GRANTED_EVENT, { detail: { status } }))
+    window.dispatchEvent(new CustomEvent(CONSENT_CHANGE_EVENT, { detail: { status } }))
   }
   applyGaConsent(status)
 }

--- a/src/lib/useGA.ts
+++ b/src/lib/useGA.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useLocation } from "./router-compat";
-import { CONSENT_GRANTED_EVENT, CONSENT_STORAGE_KEY, getConsent } from "./consent";
+import { CONSENT_CHANGE_EVENT, CONSENT_STORAGE_KEY, getConsent } from "./consent";
 import { loadAnalytics } from "./loadAnalytics";
 
 function hasGrantedConsentFromStorage(): boolean {
@@ -31,8 +31,8 @@ export function useGA() {
         loadAnalytics();
       }
     };
-    window.addEventListener(CONSENT_GRANTED_EVENT, onConsentGranted);
-    return () => window.removeEventListener(CONSENT_GRANTED_EVENT, onConsentGranted);
+    window.addEventListener(CONSENT_CHANGE_EVENT, onConsentGranted);
+    return () => window.removeEventListener(CONSENT_CHANGE_EVENT, onConsentGranted);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## What changed
- Renamed `CONSENT_GRANTED_EVENT` to `CONSENT_CHANGE_EVENT`.
- Renamed the browser event to `hs:consent-changed`.
- Updated all production consumers and related tests.

## Why
The event fires for both granted and denied states, so the old name incorrectly described half of its behavior.

## Impact
Consent consumers now subscribe to an accurate, status-neutral contract.

## Validation
- Repository code search identified six referencing files; all six were updated.
- Event payload and consent behavior are unchanged.