### PR TITLE
Apply consent before notifying listeners

### DIFF
--- a/src/lib/consent.ts
+++ b/src/lib/consent.ts
@@ -29,10 +29,10 @@ export function setConsent(status: ConsentStatus) {
   } catch {
     // Continue with session consent when browser storage is unavailable.
   }
+  applyGaConsent(status)
   if (typeof window !== 'undefined') {
     window.dispatchEvent(new CustomEvent(CONSENT_CHANGE_EVENT, { detail: { status } }))
   }
-  applyGaConsent(status)
 }
 
 export function initConsentDefault() {


### PR DESCRIPTION
Apply the effective GA consent state before dispatching the consent-change event, so subscribers observe a fully updated privacy state. The isolated ordering diff preserves persistence and payload behavior.