### PR TITLE
Cache valid stored consent for the session

### DIFF
--- a/src/lib/consent.ts
+++ b/src/lib/consent.ts
@@ -19,7 +19,9 @@ export function getConsent(): ConsentStatus | null {
     const raw = localStorage.getItem(CONSENT_STORAGE_KEY)
     if (!raw) return sessionConsent
     const parsed = JSON.parse(raw)
-    return parsed?.status === 'granted' || parsed?.status === 'denied' ? parsed.status : null
+    if (parsed?.status !== 'granted' && parsed?.status !== 'denied') return null
+    sessionConsent = parsed.status
+    return sessionConsent
   } catch {
     return sessionConsent
   }


### PR DESCRIPTION
Cache a validated stored consent value in the in-memory fallback before returning it. If storage becomes unavailable later in the page lifecycle, consent checks continue using the last known valid choice.