### PR TITLE
Simplify default consent initialization

### DIFF
--- a/src/lib/consent.ts
+++ b/src/lib/consent.ts
@@ -47,8 +47,7 @@ export function initConsentDefault() {
     applyGaConsent(existing)
     return
   }
-  const status: ConsentStatus = getSystemNoTracking() ? 'denied' : 'denied'
-  applyGaConsent(status)
+  applyGaConsent('denied')
 }
 
 export function applyGaConsent(status: ConsentStatus, command: 'default' | 'update' = 'default') {


### PR DESCRIPTION
Remove the conditional whose two branches both returned denied and apply the denied default directly. The effective DNT/GPC checks remain enforced in GA consent application and analytics loading.