### PR TITLE
Skip unconfigured analytics loads

### DIFF
--- a/src/lib/loadAnalytics.ts
+++ b/src/lib/loadAnalytics.ts
@@ -26,6 +26,7 @@ function injectScriptOnce(id: string, src: string, attrs: Record<string, string>
 export function loadAnalytics() {
   if (loaded) return
   if (typeof window === 'undefined') return
+  if (!GA_ID && !AHREFS_ANALYTICS_KEY) return
   if (getSystemNoTracking()) return
 
   const consent = getConsent()


### PR DESCRIPTION
Return before mutating loader state when neither GA nor Ahrefs Analytics is configured. This prevents a no-op call from permanently marking analytics loaded while preserving configured-provider behavior.