### PR TITLE
Allow analytics scripts to retry after failure

### DIFF
--- a/src/lib/loadAnalytics.ts
+++ b/src/lib/loadAnalytics.ts
@@ -14,6 +14,14 @@ function injectScript(src: string, attrs: Record<string, string> = {}) {
   script.src = src
   script.async = true
   Object.entries(attrs).forEach(([key, value]) => script.setAttribute(key, value))
+  script.addEventListener(
+    'error',
+    () => {
+      script.remove()
+      loaded = false
+    },
+    { once: true },
+  )
   document.head.appendChild(script)
 }
 


### PR DESCRIPTION
Remove an analytics script when its load fails and reset the loader state. A later consent-driven call can then retry instead of being blocked by a failed element and stale `loaded` flag.