### PR TITLE
Recognize the legacy DNT yes value

### DIFF
--- a/src/lib/consent.ts
+++ b/src/lib/consent.ts
@@ -11,7 +11,7 @@ export function getSystemNoTracking(): boolean {
   const dnt =
     (navigator as any).doNotTrack || (window as any).doNotTrack || (navigator as any).msDoNotTrack
   const gpc = (navigator as any).globalPrivacyControl
-  return dnt == '1' || dnt === 1 || gpc === true
+  return dnt == '1' || dnt === 1 || dnt === 'yes' || gpc === true
 }
 
 export function getConsent(): ConsentStatus | null {


### PR DESCRIPTION
Treat the legacy `navigator.doNotTrack === "yes"` signal as an active no-tracking preference alongside `1` and Global Privacy Control. Existing detection behavior is unchanged.