### PR TITLE
Add focus visibility to the privacy close button

### DIFF
--- a/src/components/ConsentManager.tsx
+++ b/src/components/ConsentManager.tsx
@@ -124,7 +124,7 @@ export default function ConsentManager({ open, onClose }: Props) {
             type="button"
             aria-label="Close privacy settings"
             onClick={onClose}
-            className="rounded border border-white/10 px-2 py-1 hover:bg-white/10"
+            className="rounded border border-white/10 px-2 py-1 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
           >
             ✕
           </button>


### PR DESCRIPTION
Add a clear keyboard-only focus ring to the privacy settings close control. Pointer styling and behavior remain unchanged.