### PR TITLE
Add focus visibility to the privacy policy link

### DIFF
--- a/src/components/ConsentManager.tsx
+++ b/src/components/ConsentManager.tsx
@@ -173,7 +173,7 @@ export default function ConsentManager({ open, onClose }: Props) {
           >
             {dnt ? "Continue without tracking" : "Accept"}
           </button>
-          <Link to="/info/privacy" className="ml-auto underline text-white/70 hover:text-cyan-300">
+          <Link to="/info/privacy" className="ml-auto rounded underline text-white/70 hover:text-cyan-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300">
             Privacy Policy
           </Link>
         </div>


### PR DESCRIPTION
Add a keyboard-only focus ring and a rounded focus boundary to the Privacy Policy link inside the settings modal.