### PR TITLE
Wrap privacy dialog actions on narrow screens

### DIFF
--- a/src/components/ConsentManager.tsx
+++ b/src/components/ConsentManager.tsx
@@ -158,7 +158,7 @@ export default function ConsentManager({ open, onClose }: Props) {
           </div>
         </div>
 
-        <div className="mt-4 flex items-center gap-2">
+        <div className="mt-4 flex flex-wrap items-center gap-2">
           <button
             type="button"
             onClick={decline}


### PR DESCRIPTION
Allow the privacy actions to wrap rather than overflow when labels or viewport width require more space.