### PR TITLE
Stack the modal privacy policy link on mobile

### DIFF
--- a/src/components/ConsentManager.tsx
+++ b/src/components/ConsentManager.tsx
@@ -173,7 +173,7 @@ export default function ConsentManager({ open, onClose }: Props) {
           >
             {dnt ? "Continue without tracking" : "Accept"}
           </button>
-          <Link to="/info/privacy" className="ml-auto rounded underline text-white/70 hover:text-cyan-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300">
+          <Link to="/info/privacy" className="w-full rounded text-center underline sm:ml-auto sm:w-auto text-white/70 hover:text-cyan-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300">
             Privacy Policy
           </Link>
         </div>


### PR DESCRIPTION
Place the Privacy Policy link on a centered full-width row on small screens and restore right alignment at the small breakpoint.