### PR TITLE
Announce privacy status changes

### DIFF
--- a/src/components/ConsentManager.tsx
+++ b/src/components/ConsentManager.tsx
@@ -143,6 +143,7 @@ export default function ConsentManager({ open, onClose }: Props) {
           <div className="text-white/70">
             Current status:
             <strong
+              aria-live="polite"
               className={`ml-2 ${
                 dnt
                   ? "text-amber-300"


### PR DESCRIPTION
Mark the current privacy status as a polite live region so effective consent changes can be announced without interrupting assistive-technology speech.