### PR TITLE
Separate the modal no-tracking notice

### DIFF
--- a/src/components/ConsentManager.tsx
+++ b/src/components/ConsentManager.tsx
@@ -133,7 +133,7 @@ export default function ConsentManager({ open, onClose }: Props) {
         <p id="consent-description" className="mt-2 text-sm text-white/75">
           Control whether anonymous analytics are collected. We don’t collect personal data unless you opt in.
           {dnt && (
-            <span className="ml-1 text-amber-300">
+            <span className="mt-2 block text-amber-300">
               Detected Do Not Track / GPC — defaulting to no tracking.
             </span>
           )}


### PR DESCRIPTION
Render the DNT/GPC override message as a spaced block so it reads as a distinct status notice instead of attaching to the preceding sentence.