### PR TITLE
Let banner decline use available mobile width

### DIFF
--- a/src/components/ConsentBanner.tsx
+++ b/src/components/ConsentBanner.tsx
@@ -47,7 +47,7 @@ export default function ConsentBanner() {
           <div className='flex shrink-0 flex-wrap items-center justify-end gap-2'>
             <button
               type='button'
-              className='inline-flex min-h-11 items-center justify-center rounded-lg px-3 text-sm font-semibold text-white/85 underline underline-offset-2 transition-colors hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white'
+              className='inline-flex min-h-11 flex-1 items-center sm:flex-none justify-center rounded-lg px-3 text-sm font-semibold text-white/85 underline underline-offset-2 transition-colors hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white'
               onClick={() => {
                 setConsent('denied')
                 setShow(false)


### PR DESCRIPTION
Allow the banner Decline action to flex across available small-screen width and return to intrinsic width at the small breakpoint.