### PR TITLE
Add focus visibility to modal filter clearing

### DIFF
--- a/components/search/GlobalSearchModal.tsx
+++ b/components/search/GlobalSearchModal.tsx
@@ -212,7 +212,7 @@ export function GlobalSearchModal({ enableHotkeys = true }: { enableHotkeys?: bo
                 <button
                   type="button"
                   onClick={search.clearFilters}
-                  className="ml-auto text-xs font-semibold text-brand-700 hover:text-brand-900"
+                  className="ml-auto rounded text-xs font-semibold text-brand-700 hover:text-brand-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-700"
                 >
                   Clear filters
                 </button>


### PR DESCRIPTION
Add a visible keyboard focus ring to the search modal's Clear filters action.