### PR TITLE
Add focus visibility to advanced search

### DIFF
--- a/components/search/GlobalSearchModal.tsx
+++ b/components/search/GlobalSearchModal.tsx
@@ -260,7 +260,7 @@ export function GlobalSearchModal({ enableHotkeys = true }: { enableHotkeys?: bo
                 <Link
                   href="/search/"
                   onClick={close}
-                  className="font-semibold text-brand-700 hover:text-brand-900"
+                  className="rounded font-semibold text-brand-700 hover:text-brand-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-700"
                 >
                   Advanced search →
                 </Link>


### PR DESCRIPTION
Add a visible keyboard-only focus ring to the Advanced search link in the modal footer.