### PR TITLE
Disable spellcheck in full-page search

### DIFF
--- a/components/search/GlobalSearch.tsx
+++ b/components/search/GlobalSearch.tsx
@@ -174,6 +174,7 @@ export default function GlobalSearch() {
               aria-activedescendant={activeOptionId}
               aria-autocomplete="list"
               autoComplete="off"
+              spellCheck={false}
               value={search.query}
               onChange={(e) => search.setQuery(e.target.value)}
               onKeyDown={onKeyDown}


### PR DESCRIPTION
Disable browser spellcheck for the full-page search query to avoid irrelevant correction underlines on herb, compound, and pathway names.