### PR TITLE
Guard the full-search active option reference

### DIFF
--- a/components/search/GlobalSearch.tsx
+++ b/components/search/GlobalSearch.tsx
@@ -78,7 +78,7 @@ export default function GlobalSearch() {
     [],
   )
 
-  const activeOptionId = search.results.length ? `${optionPrefix}-${activeIndex}` : undefined
+  const activeOptionId = search.results[activeIndex] ? `${optionPrefix}-${activeIndex}` : undefined
 
   return (
     <div className="grid gap-6 lg:grid-cols-[260px_1fr]">


### PR DESCRIPTION
Expose `aria-activedescendant` only when the exact active result exists, preventing transient references to missing listbox options after result changes.