### PR TITLE
Expose full-search loading state

### DIFF
--- a/components/search/GlobalSearch.tsx
+++ b/components/search/GlobalSearch.tsx
@@ -209,6 +209,7 @@ export default function GlobalSearch() {
             id={listboxId}
             role="listbox"
             aria-label="Search results"
+            aria-busy={!search.ready}
             className="grid gap-3 sm:grid-cols-2"
           >
             {search.results.map((doc, index) => (


### PR DESCRIPTION
Mark the full-page search results list busy until the search engine is ready, matching the modal search semantics.