### PR TITLE
Disclose full-search keyboard shortcuts

### DIFF
--- a/components/search/GlobalSearch.tsx
+++ b/components/search/GlobalSearch.tsx
@@ -173,6 +173,7 @@ export default function GlobalSearch() {
               aria-controls={listboxId}
               aria-activedescendant={activeOptionId}
               aria-autocomplete="list"
+              aria-keyshortcuts="ArrowDown ArrowUp Enter"
               autoComplete="off"
               spellCheck={false}
               value={search.query}


### PR DESCRIPTION
Expose the Arrow Up, Arrow Down, and Enter commands supported by the full-page search combobox through `aria-keyshortcuts`.