### PR TITLE
Consolidate duplicate botanical profile aliases

### DIFF
--- a/lib/deprecated-herb-canonicals.ts
+++ b/lib/deprecated-herb-canonicals.ts
@@ -13,6 +13,8 @@ export const DEPRECATED_HERB_CANONICALS: Record<string, string> = {
   'passiflora-incarnata': 'passionflower',
   'piper-methysticum': 'kava',
   'ganoderma-lucidum': 'reishi',
+  'withania-somnifera': 'ashwagandha',
+  'silybum-marianum': 'milk-thistle',
   // Duplicate / thin near-identical profiles consolidated to a single canonical.
   'berberis-vulgaris': 'berberis',
   'berberis-aristata': 'berberis',

--- a/public/_redirects
+++ b/public/_redirects
@@ -153,6 +153,10 @@ https://www.thehippiescientist.net/* https://thehippiescientist.net/:splat 301
 /compounds/trans-resveratrol/ /herbs/resveratrol/ 301
 /herbs/ashwagandha-withania-somnifera /herbs/ashwagandha/ 301
 /herbs/ashwagandha-withania-somnifera/ /herbs/ashwagandha/ 301
+/herbs/withania-somnifera /herbs/ashwagandha/ 301
+/herbs/withania-somnifera/ /herbs/ashwagandha/ 301
+/herbs/silybum-marianum /herbs/milk-thistle/ 301
+/herbs/silybum-marianum/ /herbs/milk-thistle/ 301
 
 # Saw palmetto = Serenoa repens. The common-name record was promoted through
 # scripts/data/promote-profile.mjs and now carries the grounded profile, so the


### PR DESCRIPTION
## What changed
- Redirect `/herbs/withania-somnifera/` to the canonical Ashwagandha profile.
- Redirect `/herbs/silybum-marianum/` to the canonical Milk Thistle profile.
- Add both scientific-name aliases to the canonical herb map so generated browse, sitemap, and internal-link surfaces exclude the duplicate URLs.

## Why
The production metadata audit found duplicate indexable titles for both alias pairs. Consolidating each plant onto one URL prevents competing pages and concentrates internal and external signals.

## Validation
- `npm run validate:redirects-canonical`
- `npm run verify:redirects`
- `npx vitest run tests/herbs-metadata-count.test.ts`
- Production sitemap audit: 677/677 URLs indexable before the change