### PR TITLE
Fail SEO audit on any duplicate title

### DIFF
--- a/scripts/ci/audit-metadata-duplicates.mjs
+++ b/scripts/ci/audit-metadata-duplicates.mjs
@@ -25,6 +25,6 @@ const dup = (m)=>[...m.entries()].filter(([,v])=>v.length>1).map(([k,v])=>({valu
 const report={generatedAt:new Date().toISOString(), duplicateTitles:dup(byTitle), duplicateDescriptions:dup(byDesc), duplicateCanonicals:dup(byCanonical)}
 fs.mkdirSync('public/data/reports',{recursive:true})
 fs.writeFileSync('public/data/reports/metadata-audit-report.json', JSON.stringify(report,null,2))
-if (report.duplicateCanonicals.length || report.duplicateTitles.length>10 || report.duplicateDescriptions.length > 0) { console.error('[metadata-audit] severe collisions found: unique descriptions assert failed'); process.exit(1)}
+if (report.duplicateCanonicals.length || report.duplicateTitles.length > 0 || report.duplicateDescriptions.length > 0) { console.error('[metadata-audit] severe collisions found: unique descriptions assert failed'); process.exit(1)}
 if (report.duplicateTitles.length) console.warn('[metadata-audit] warnings found')
 console.log('[metadata-audit] completed')


### PR DESCRIPTION
## What changed
The metadata audit now fails when it finds even one duplicate title among non-redirected routes. Previously CI allowed up to ten duplicate title groups.

## SEO impact
Title collisions can blur page intent and encourage search engines to rewrite result titles. This turns every future collision into a blocking regression instead of a warning.

## Validation
The current redirect-aware audit reports zero duplicate titles, descriptions, and canonicals.