### PR TITLE
Block noncanonical internal links in CI

### DIFF
--- a/scripts/ci/audit-internal-links.mjs
+++ b/scripts/ci/audit-internal-links.mjs
@@ -235,7 +235,7 @@ async function run() {
     console.log(`[internal-links] top non-canonical source: ${topNonCanonicalSource.value} (${topNonCanonicalSource.count})`)
   }
   if (nonCanonicalInternalLinks.length) {
-    console.warn(`[internal-links] non-blocking warning: found ${nonCanonicalInternalLinks.length} non-canonical internal hrefs`)
+    console.error(`[internal-links] found ${nonCanonicalInternalLinks.length} non-canonical internal hrefs`)\n    if (process.env.CI === 'true') process.exitCode = 1
   }
   if (blockingOrphans.length) {
     console.warn(`[internal-links] non-blocking warning: found ${blockingOrphans.length} potentially orphaned crawlable routes`)


### PR DESCRIPTION
The full post-build link audit now fails CI when rendered pages link to noncanonical URL variants. This prevents redirect hops from re-entering navigation and preserves cleaner crawl paths and internal authority flow.