### PR TITLE
Block crawlable orphan pages in CI

### DIFF
--- a/scripts/ci/audit-internal-links.mjs
+++ b/scripts/ci/audit-internal-links.mjs
@@ -238,7 +238,7 @@ async function run() {
     console.error(`[internal-links] found ${nonCanonicalInternalLinks.length} non-canonical internal hrefs`)\n    if (process.env.CI === 'true') process.exitCode = 1
   }
   if (blockingOrphans.length) {
-    console.warn(`[internal-links] non-blocking warning: found ${blockingOrphans.length} potentially orphaned crawlable routes`)
+    console.error(`[internal-links] found ${blockingOrphans.length} orphaned crawlable routes`)\n    if (process.env.CI === 'true') process.exitCode = 1
   }
 }
 


### PR DESCRIPTION
The full rendered-site link audit now fails CI when an indexable route has no inbound internal links. Known nonindexable utility routes remain excluded. This prevents future pages from entering the sitemap without a crawl path or internal authority.