### PR TITLE
Make comparison hub search title evergreen

### DIFF
--- a/app/guides/compare/page.tsx
+++ b/app/guides/compare/page.tsx
@@ -206,7 +206,7 @@ export default async function ComparePage() {
 
   const schemaGraph = buildCompareHubSchemaGraph({
     path: '/guides/compare/',
-    title: `Compare Supplements Side by Side ${SEO_YEAR} – Evidence & Safety`,
+    title: 'Compare Supplements Side by Side: Evidence & Safety',
     description: 'Compare herbs and supplements by evidence strength, mechanism, stimulation profile, safety, and dosing. Free research tool.',
     breadcrumbs: [
       { name: 'Home', url: `${SITE_URL}/` },


### PR DESCRIPTION
Removes the automatically changing year from the comparison hub metadata and keeps the stable primary intent first: compare supplements side by side by evidence and safety. This reduces artificial freshness churn and title truncation risk.