### PR TITLE
Improve three-way sleep comparison title

### DIFF
--- a/app/guides/compare/melatonin-vs-valerian-vs-magnesium-for-sleep/page.tsx
+++ b/app/guides/compare/melatonin-vs-valerian-vs-magnesium-for-sleep/page.tsx
@@ -3,7 +3,7 @@ import Image from 'next/image'
 import { buildPageMetadata } from '../../../../src/lib/seo'
 
 export const metadata: Metadata = buildPageMetadata({
-  title: 'Melatonin vs Valerian vs Magnesium for Sleep Support',
+  title: 'Melatonin vs Valerian vs Magnesium: Evidence & Safety',
   description: 'Evidence-informed 3-way comparison of melatonin, valerian root, and magnesium for sleep latency, circadian rhythm timing, safety, and supplement selection.',
   path: '/guides/compare/melatonin-vs-valerian-vs-magnesium-for-sleep/',
 })


### PR DESCRIPTION
Keeps all three compared ingredients visible while replacing vague `sleep support` wording with the page's concrete evidence-and-safety value proposition.