### PR TITLE
Align manifest site name signal

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "The Hippie Scientist",
-  "short_name": "HippieScientist",
+  "short_name": "Hippie Scientist",
   "description": "Evidence-first herb and supplement reference — mechanisms, safety, and research context in plain language.",
   "lang": "en",
   "start_url": "/",


### PR DESCRIPTION
Makes the web-app manifest short name match the site's human-readable brand for cleaner site identity consistency. SEO micro-upgrade 51.