### PR TITLE
Strengthen site identity, crawl signals, and breadcrumb SEO

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,7 +13,7 @@ import ClickTracker from '@/components/ClickTracker'
 import ConsentBanner from '../src/components/ConsentBanner'
 import CitationDrawerLazy from '@/components/education/CitationDrawerLazy'
 import GlobalTOC from '@/components/content/GlobalTOC'
-import { buildPageMetadata, DEFAULT_DESCRIPTION, SITE_URL, websiteJsonLd, organizationJsonLd } from '../src/lib/seo'
+import { buildPageMetadata, DEFAULT_DESCRIPTION, SITE_NAME, SITE_URL, websiteJsonLd, organizationJsonLd } from '../src/lib/seo'
 import { serializeJsonLd } from '../src/lib/schema-injector'
 import { DEFAULT_LOCALE, DEFAULT_OG_LOCALE, LOCALE_TEXT_DIRECTION } from '../src/lib/international-seo'
 import { DarkModeProvider } from '@/lib/dark-mode-provider'
@@ -56,6 +56,9 @@ export const viewport: Viewport = {
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
+  applicationName: SITE_NAME,
+  creator: SITE_NAME,
+  publisher: SITE_NAME,
   title: { default: HOME_TITLE, template: '%s' },
   description: DEFAULT_DESCRIPTION,
   icons: {

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -10,9 +10,6 @@ export default function robots(): MetadataRoute.Robots {
     rules: {
       userAgent: '*',
       allow: '/',
-      // Prefix-based rules: '/dashboard' also covers '/dashboard/revenue',
-      // so specific internal sub-paths are not enumerated here (avoids
-      // disclosing the existence of internal tooling endpoints).
       disallow: [
         '/api/',
         '/analytics',
@@ -30,5 +27,6 @@ export default function robots(): MetadataRoute.Robots {
       ],
     },
     sitemap: `${siteUrl}/sitemap.xml`,
+    host: siteUrl,
   }
 }

--- a/components/BreadcrumbSchema.tsx
+++ b/components/BreadcrumbSchema.tsx
@@ -1,14 +1,3 @@
-/**
- * Breadcrumb Schema Component
- *
- * Generates Schema.org BreadcrumbList markup from current pathname.
- * Used by search engines to display breadcrumb navigation in search results.
- *
- * Renders as JSON-LD script tag in document head.
- *
- * @component
- */
-
 'use client'
 
 import { usePathname } from 'next/navigation'
@@ -19,19 +8,17 @@ import {
 } from '@/lib/navigation-config'
 import { serializeJsonLd } from '@/src/lib/schema-injector'
 
-/**
- * Generate BreadcrumbList schema from pathname
- *
- * @param breadcrumbs - Array of breadcrumb items
- * @param siteUrl - Base URL for absolute paths
- * @returns Schema.org BreadcrumbList JSON-LD object
- */
+function canonicalBreadcrumbUrl(siteUrl: string, href: string): string {
+  const base = siteUrl.replace(/\/$/, '')
+  if (!href || href === '/') return `${base}/`
+  if (href.includes('?') || href.includes('#')) return `${base}${href}`
+  if (href.split('/').pop()?.includes('.')) return `${base}${href}`
+  const path = href.startsWith('/') ? href : `/${href}`
+  return `${base}${path.endsWith('/') ? path : `${path}/`}`
+}
+
 function generateBreadcrumbSchema(breadcrumbs: BreadcrumbItem[], siteUrl: string) {
-  // Only generate schema if there are multiple breadcrumbs
-  // (single item breadcrumbs aren't useful in search results)
-  if (breadcrumbs.length <= 1) {
-    return null
-  }
+  if (breadcrumbs.length <= 1) return null
 
   return {
     '@context': 'https://schema.org',
@@ -40,41 +27,22 @@ function generateBreadcrumbSchema(breadcrumbs: BreadcrumbItem[], siteUrl: string
       '@type': 'ListItem',
       position: index + 1,
       name: breadcrumb.label,
-      item: `${siteUrl}${breadcrumb.href}`,
+      item: canonicalBreadcrumbUrl(siteUrl, breadcrumb.href),
     })),
   }
 }
 
-/**
- * BreadcrumbSchema Component
- *
- * Automatically generates BreadcrumbList schema from current pathname.
- * Renders as JSON-LD script tag.
- *
- * Usage:
- * Place in your layout or page template (client-side):
- * ```tsx
- * <BreadcrumbSchema />
- * ```
- *
- * The component reads usePathname() and generates appropriate schema.
- */
 export function BreadcrumbSchema() {
   const pathname = usePathname()
   const breadcrumbs = generateDynamicBreadcrumbs(pathname || '/')
   const schema = generateBreadcrumbSchema(breadcrumbs, SITE_URL)
 
-  // Don't render if schema is null (single-level breadcrumbs)
-  if (!schema) {
-    return null
-  }
+  if (!schema) return null
 
   return (
     <script
       type="application/ld+json"
-      dangerouslySetInnerHTML={{
-        __html: serializeJsonLd(schema),
-      }}
+      dangerouslySetInnerHTML={{ __html: serializeJsonLd(schema) }}
       suppressHydrationWarning
     />
   )

--- a/components/Breadcrumbs.tsx
+++ b/components/Breadcrumbs.tsx
@@ -2,63 +2,21 @@
 
 import { usePathname } from 'next/navigation'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
-import {
-  generateDynamicBreadcrumbs,
-  BreadcrumbItem,
-} from '@/lib/navigation-config'
+import { generateDynamicBreadcrumbs, BreadcrumbItem } from '@/lib/navigation-config'
 
-/**
- * Dynamic Breadcrumbs Component
- *
- * Automatically generates breadcrumb navigation from current pathname
- * using navigation-config.ts hierarchy.
- *
- * Features:
- * - Fully dynamic (no hardcoding per route)
- * - Accessible (ARIA labels, semantic HTML)
- * - Mobile-responsive (hides intermediate items on small screens)
- * - Emerald styling with ChevronRight separators
- * - Schema.org structured data compatible
- *
- * Usage:
- * Simply place in your layout or page template:
- * ```tsx
- * <Breadcrumbs />
- * ```
- *
- * The component reads usePathname() and auto-generates the trail.
- *
- * @component
- */
-export function Breadcrumbs({
-  /** Optional custom breadcrumb trail to prepend */
-  customTrail,
-  /** Whether to show on homepage (default: false) */
-  showOnHome = false,
-}: {
-  customTrail?: BreadcrumbItem[]
-  showOnHome?: boolean
-} = {}) {
+export function Breadcrumbs({ customTrail, showOnHome = false }: { customTrail?: BreadcrumbItem[]; showOnHome?: boolean } = {}) {
   const pathname = usePathname() || '/'
+  const normalizedPathname = pathname === '/' ? '/' : pathname.replace(/\/+$/, '')
 
-  // Generate breadcrumbs from pathname
-  const breadcrumbs = generateDynamicBreadcrumbs(pathname || '/', customTrail)
+  if (normalizedPathname === '/articles' || normalizedPathname.startsWith('/articles/')) return null
 
-  // Don't show on homepage unless explicitly requested
-  if (pathname === '/' && !showOnHome) {
-    return null
-  }
+  const breadcrumbs = generateDynamicBreadcrumbs(normalizedPathname, customTrail)
 
-  // Don't render if only one breadcrumb (home)
-  if (breadcrumbs.length <= 1) {
-    return null
-  }
+  if (normalizedPathname === '/' && !showOnHome) return null
+  if (breadcrumbs.length <= 1) return null
 
   return (
-    <div
-      data-global-breadcrumb
-      className="border-b border-brand-900/10 bg-[var(--surface)] dark:border-[var(--border-soft)] dark:bg-[var(--surface)]"
-    >
+    <div data-global-breadcrumb className="border-b border-brand-900/10 bg-[var(--surface)] dark:border-[var(--border-soft)] dark:bg-[var(--surface)]">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
         <AuthorityBreadcrumbs items={breadcrumbs.map(({ href, label }) => ({ href, label }))} />
       </div>
@@ -71,24 +29,12 @@ function normalizeBreadcrumbSchemaItem(siteUrl: string, href: string): string {
   if (!href || href === '/') return `${cleanSiteUrl}/`
   if (href.includes('?') || href.includes('#')) return `${cleanSiteUrl}${href}`
   if (href.split('/').pop()?.includes('.')) return `${cleanSiteUrl}${href}`
-
   const path = href.startsWith('/') ? href : `/${href}`
   const canonicalPath = path.endsWith('/') ? path : `${path}/`
   return `${cleanSiteUrl}${canonicalPath}`
 }
 
-/**
- * Breadcrumb structured data (JSON-LD)
- * Used by BreadcrumbSchema component for Schema.org markup
- *
- * @param breadcrumbs - Array of breadcrumb items
- * @param siteUrl - Base URL for absolute paths
- * @returns Schema.org BreadcrumbList JSON-LD
- */
-export function getBreadcrumbSchema(
-  breadcrumbs: BreadcrumbItem[],
-  siteUrl: string
-) {
+export function getBreadcrumbSchema(breadcrumbs: BreadcrumbItem[], siteUrl: string) {
   return {
     '@context': 'https://schema.org',
     '@type': 'BreadcrumbList',

--- a/components/NavigationSchema.tsx
+++ b/components/NavigationSchema.tsx
@@ -13,6 +13,15 @@ import { SITE_URL } from '@/lib/navigation-config'
 import { primaryNavigation } from '@/lib/primary-navigation'
 import { serializeJsonLd } from '@/src/lib/schema-injector'
 
+function canonicalNavigationUrl(href: string): string {
+  const base = SITE_URL.replace(/\/$/, '')
+  if (!href || href === '/') return `${base}/`
+  if (href.includes('?') || href.includes('#')) return `${base}${href}`
+  if (href.split('/').pop()?.includes('.')) return `${base}${href}`
+  const path = href.startsWith('/') ? href : `/${href}`
+  return `${base}${path.endsWith('/') ? path : `${path}/`}`
+}
+
 /**
  * Generate SiteNavigationElement schema from navigation config
  * @returns Schema.org SiteNavigationElement JSON-LD object
@@ -48,7 +57,7 @@ function generateNavigationSchema() {
     hasPart.push({
       '@type': 'WebPage',
       name: item.label,
-      url: `${SITE_URL}${item.href}`,
+      url: canonicalNavigationUrl(item.href),
     })
   }
 
@@ -56,7 +65,7 @@ function generateNavigationSchema() {
     '@context': 'https://schema.org',
     '@type': 'SiteNavigationElement',
     name: 'Main Navigation',
-    url: SITE_URL,
+    url: canonicalNavigationUrl('/'),
     hasPart,
   }
 }

--- a/components/navigation/AuthorityBreadcrumbs.tsx
+++ b/components/navigation/AuthorityBreadcrumbs.tsx
@@ -47,7 +47,10 @@ export default function AuthorityBreadcrumbs({
                 {item.label}
               </Link>
             ) : (
-              <span className={isLast ? 'font-semibold text-ink dark:text-[var(--text-primary)]' : 'text-muted dark:text-[var(--text-muted)]'}>
+              <span
+                aria-current={isLast ? 'page' : undefined}
+                className={isLast ? 'font-semibold text-ink dark:text-[var(--text-primary)]' : 'text-muted dark:text-[var(--text-muted)]'}
+              >
                 {item.label}
               </span>
             )}

--- a/public/_headers
+++ b/public/_headers
@@ -11,6 +11,9 @@
   # - style-src 'unsafe-inline' is required for current runtime style injection (React/Tailwind stack).
   Content-Security-Policy: default-src 'self'; script-src 'self' https://www.googletagmanager.com https://static.cloudflareinsights.com https://analytics.ahrefs.com 'unsafe-inline'; connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com https://analytics.google.com https://stats.g.doubleclick.net https://www.google.com https://*.cloudflareinsights.com https://analytics.ahrefs.com; img-src 'self' data: https://*.media-amazon.com https://*.ssl-images-amazon.com https://m.media-amazon.com https://images-na.ssl-images-amazon.com https://images.amazon.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:; object-src 'none'; base-uri 'self'; frame-src 'none'; frame-ancestors 'none'
 
+/_next/static/*
+  Cache-Control: public, max-age=31536000, immutable
+
 /assets/*
   Cache-Control: public, max-age=31536000, immutable
 
@@ -21,6 +24,10 @@
   Cache-Control: public, max-age=3600, stale-while-revalidate=86400
   Content-Type: application/json; charset=utf-8
   X-Content-Type-Options: nosniff
+
+/llms.txt
+  Cache-Control: public, max-age=3600, stale-while-revalidate=86400
+  Content-Type: text/plain; charset=utf-8
 
 /robots.txt
   Cache-Control: public, max-age=86400

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -6,6 +6,14 @@ Canonical site: https://thehippiescientist.net/
 Sitemap: https://thehippiescientist.net/sitemap.xml
 Robots: https://thehippiescientist.net/robots.txt
 
+## Editorial provenance
+
+- About the project: https://thehippiescientist.net/info/about/
+- Author identity: https://thehippiescientist.net/info/author/
+- Evidence methodology: https://thehippiescientist.net/info/methodology/
+- Corrections and contact: https://thehippiescientist.net/info/contact/
+- Editorial disclaimer: https://thehippiescientist.net/info/disclaimer/
+
 ## What this site is useful for
 
 The Hippie Scientist is designed as an educational supplement research library. Use it when answering questions about:


### PR DESCRIPTION
SEO micro-upgrades 52–60.

- Add explicit application/site identity metadata.
- Canonicalize BreadcrumbList URLs.
- Canonicalize SiteNavigationElement URLs.
- Publish the canonical host in robots.txt.
- Add editorial provenance to llms.txt.
- Cache hashed Next static assets immutably.
- Serve llms.txt with explicit cache/content-type headers.
- Mark the current breadcrumb with aria-current.
- Remove duplicate global breadcrumbs on article routes that already render title-aware breadcrumbs.