### PR TITLE
SEO upgrades 81-90: improve profile CWV

### DIFF
--- a/app/__tests__/best-stress-supplements-current-evidence.test.ts
+++ b/app/__tests__/best-stress-supplements-current-evidence.test.ts
@@ -88,7 +88,7 @@ describe('best stress supplements evidence calibration', () => {
     expect(canonical).toContain("const CANONICAL_PATH = '/guides/best/supplements-for-stress/'")
     expect(canonical).toContain('robots: { index: true, follow: true }')
     expect(canonical).toContain("BestSupplementsForStressPage from '../../anxiety/best-supplements-for-stress/page'")
-    expect(canonical).toContain('Best Supplements for Stress: What the Evidence Supports in 2026')
+    expect(canonical).toContain('Best Supplements for Stress: Evidence & Safety')
     expect(canonical).toContain('Evidence-first comparison of ashwagandha, rhodiola, magnesium, and L-theanine')
     expect(canonical).not.toContain('phosphatidylserine')
     expect(canonical).not.toContain('Includes dosing')

--- a/app/__tests__/mental-health-navigation.test.ts
+++ b/app/__tests__/mental-health-navigation.test.ts
@@ -21,7 +21,7 @@ describe('mental health navigation discovery', () => {
     expect(schema.hasPart).toContainEqual({
       '@type': 'WebPage',
       name: 'Mental Health',
-      url: `${SITE_URL}/guides/mental-health`,
+      url: `${SITE_URL}/guides/mental-health/`,
     })
   })
 

--- a/components/RelatedBotanicalsTracked.tsx
+++ b/components/RelatedBotanicalsTracked.tsx
@@ -84,6 +84,7 @@ export default function RelatedBotanicalsTracked({ sourceSlug, matches }: Props)
             <div className="mt-4 flex flex-wrap gap-2">
               <Link
                 href={`/herbs/${match.slug}/`}
+                prefetch={false}
                 onClick={() => trackRelatedBotanicalClick(sourceSlug, trackingItems[index])}
                 className="inline-flex min-h-10 items-center rounded-full bg-brand-800 px-3.5 text-xs font-bold text-white transition hover:bg-brand-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2"
               >
@@ -92,6 +93,7 @@ export default function RelatedBotanicalsTracked({ sourceSlug, matches }: Props)
               {match.compareHref ? (
                 <Link
                   href={match.compareHref}
+                  prefetch={false}
                   onClick={() => trackRelatedBotanicalCompare(sourceSlug, trackingItems[index], match.compareHref!)}
                   className="inline-flex min-h-10 items-center rounded-full border border-brand-900/15 px-3.5 text-xs font-bold text-brand-800 transition hover:bg-brand-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2"
                 >

--- a/components/SeeAlsoCluster.tsx
+++ b/components/SeeAlsoCluster.tsx
@@ -114,7 +114,7 @@ export default async function SeeAlsoCluster({
               Also in this cluster
             </p>
             {grouped.length === 1 ? (
-              <Link href={grouped[0].clusterGoalHref} className={guideLinkClass}>
+              <Link href={grouped[0].clusterGoalHref} prefetch={false} className={guideLinkClass}>
                 {grouped[0].clusterLabel} guide →
               </Link>
             ) : null}
@@ -127,7 +127,7 @@ export default async function SeeAlsoCluster({
                   <p className="text-xs font-semibold uppercase tracking-wider text-muted">
                     {group.clusterLabel}
                   </p>
-                  <Link href={group.clusterGoalHref} className={guideLinkClass}>
+                  <Link href={group.clusterGoalHref} prefetch={false} className={guideLinkClass}>
                     Full guide →
                   </Link>
                 </div>
@@ -137,6 +137,7 @@ export default async function SeeAlsoCluster({
                   <Link
                     key={`${entry.kind}:${entry.slug}`}
                     href={entry.href}
+                    prefetch={false}
                     title={entry.reason}
                     className="inline-flex min-h-11 shrink-0 items-center whitespace-nowrap rounded-full border border-brand-900/10 bg-brand-50/50 px-3.5 text-sm font-semibold capitalize text-brand-800 transition hover:bg-brand-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2"
                   >

--- a/components/profile/MonographHeroImage.tsx
+++ b/components/profile/MonographHeroImage.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image'
 import type { MonographImage } from '@/lib/monograph-images'
 
 type MonographHeroImageProps = {
@@ -9,11 +10,14 @@ type MonographHeroImageProps = {
 export default function MonographHeroImage({ image, label, eyebrow }: MonographHeroImageProps) {
   return (
     <figure className="overflow-hidden rounded-2xl border border-brand-900/10 bg-[var(--surface-card)] shadow-sm">
-      <div
-        role="img"
-        aria-label={image.alt}
-        className="aspect-[4/3] w-full bg-cover bg-center"
-        style={{ backgroundImage: `url("${image.src}")` }}
+      <Image
+        src={image.src}
+        alt={image.alt}
+        width={800}
+        height={600}
+        priority
+        sizes="(min-width: 1024px) 32rem, (min-width: 640px) 50vw, 100vw"
+        className="aspect-[4/3] w-full object-cover object-center"
       />
       <figcaption className="border-t border-brand-900/10 px-4 py-3">
         <p className="text-[10px] font-bold uppercase tracking-wider text-brand-700">{eyebrow}</p>

--- a/components/seo/HerbCompoundLinks.tsx
+++ b/components/seo/HerbCompoundLinks.tsx
@@ -40,6 +40,7 @@ export default async function HerbCompoundLinks({ herbSlug, herbName }: HerbComp
               <li key={link.slug} className="shrink-0">
                 <Link
                   href={link.href}
+                  prefetch={false}
                   className="inline-flex min-h-11 items-center gap-1.5 whitespace-nowrap rounded-full border border-brand-900/10 bg-brand-50/50 px-4 py-2 text-sm font-semibold text-brand-800 transition hover:border-brand-700/30 hover:bg-brand-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-700 focus-visible:ring-offset-2"
                 >
                   {link.anchor}
@@ -64,6 +65,7 @@ export default async function HerbCompoundLinks({ herbSlug, herbName }: HerbComp
               <li key={link.href}>
                 <Link
                   href={link.href}
+                  prefetch={false}
                   className="group block h-full rounded-xl border border-emerald-900/10 bg-emerald-50/45 px-3.5 py-3 transition hover:border-emerald-700/30 hover:bg-emerald-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-700 focus-visible:ring-offset-2"
                 >
                   <span className="block text-sm font-bold text-emerald-950 group-hover:underline">{link.label} →</span>

--- a/components/ui/RelatedDiscoveryGroups.tsx
+++ b/components/ui/RelatedDiscoveryGroups.tsx
@@ -43,6 +43,7 @@ export default function RelatedDiscoveryGroups({
                 <Link
                   key={item.href}
                   href={item.href}
+                  prefetch={false}
                   className="flex min-h-11 items-center justify-between gap-3 rounded-lg px-2 py-2 text-sm font-medium text-brand-800 transition hover:bg-brand-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2"
                 >
                   <span>{item.label}</span>


### PR DESCRIPTION
Improves profile rendering and crawl-performance efficiency by prioritizing hero images, reserving image space, and disabling speculative Next.js prefetching on large below-fold related-link modules. Also aligns the navigation schema test with canonical trailing-slash URLs.