### PR TITLE
SEO upgrades 91-100: unify structured-data identity graph

### DIFF
--- a/components/StructuredData.tsx
+++ b/components/StructuredData.tsx
@@ -3,6 +3,10 @@ import JsonLd from './seo/JsonLd'
 const SITE_URL = 'https://thehippiescientist.net'
 const SITE_NAME = 'The Hippie Scientist'
 const DEFAULT_AUTHOR = 'Willie B. Randolph III'
+const WEBSITE_ID = `${SITE_URL}/#website`
+const ORGANIZATION_ID = `${SITE_URL}/#organization`
+const AUTHOR_URL = `${SITE_URL}/info/author/`
+const AUTHOR_ID = `${AUTHOR_URL}#person`
 const MIN_FAQ_SCHEMA_ITEMS = 2
 
 const FAQ_FALLBACK_ANSWER_PREFIXES = [
@@ -88,12 +92,17 @@ export default function StructuredData({
 
   const isMonetized = zone === 'monetized'
   const meaningfulFaqs = faqs?.filter(isMeaningfulFaq) ?? []
+  const hasFaqSchema = meaningfulFaqs.length >= MIN_FAQ_SCHEMA_ITEMS
+  const hasBreadcrumbs = Boolean(breadcrumbs?.length)
+  const webpageId = isMonetized ? `${canonicalPageUrl}#supplement` : `${canonicalPageUrl}#webpage`
+  const breadcrumbId = `${canonicalPageUrl}#breadcrumb`
+  const faqId = `${canonicalPageUrl}#faq`
 
   if (isMonetized) {
     schemas.push({
       '@context': 'https://schema.org',
       '@type': ['DietarySupplement', 'WebPage'],
-      '@id': `${canonicalPageUrl}#supplement`,
+      '@id': webpageId,
       name: headline,
       headline,
       description,
@@ -103,11 +112,13 @@ export default function StructuredData({
       dateModified: dateModified ?? datePublished,
       author: {
         '@type': 'Person',
+        '@id': AUTHOR_ID,
         name: authorName,
-        url: `${SITE_URL}/info/author/`,
+        url: AUTHOR_URL,
       },
       publisher: {
         '@type': 'Organization',
+        '@id': ORGANIZATION_ID,
         name: SITE_NAME,
         url: SITE_URL,
         logo: {
@@ -115,6 +126,9 @@ export default function StructuredData({
           url: `${SITE_URL}/logo.svg`,
         },
       },
+      isPartOf: { '@id': WEBSITE_ID },
+      ...(hasBreadcrumbs ? { breadcrumb: { '@id': breadcrumbId } } : {}),
+      ...(hasFaqSchema ? { hasPart: { '@id': faqId } } : {}),
       mainEntityOfPage: {
         '@type': 'WebPage',
         '@id': canonicalPageUrl,
@@ -124,7 +138,7 @@ export default function StructuredData({
     schemas.push({
       '@context': 'https://schema.org',
       '@type': ['MedicalWebPage', 'Article'],
-      '@id': `${canonicalPageUrl}#webpage`,
+      '@id': webpageId,
       name: headline,
       headline,
       description,
@@ -135,11 +149,13 @@ export default function StructuredData({
       lastReviewed: dateModified ?? datePublished,
       author: {
         '@type': 'Person',
+        '@id': AUTHOR_ID,
         name: authorName,
-        url: `${SITE_URL}/info/about/`,
+        url: AUTHOR_URL,
       },
       publisher: {
         '@type': 'Organization',
+        '@id': ORGANIZATION_ID,
         name: SITE_NAME,
         url: SITE_URL,
         logo: {
@@ -147,13 +163,18 @@ export default function StructuredData({
           url: `${SITE_URL}/logo.svg`,
         },
       },
+      isPartOf: { '@id': WEBSITE_ID },
+      ...(hasBreadcrumbs ? { breadcrumb: { '@id': breadcrumbId } } : {}),
+      ...(hasFaqSchema ? { hasPart: { '@id': faqId } } : {}),
       medicalAudience: {
         '@type': 'MedicalAudience',
         audienceType: 'Patient',
       },
       reviewedBy: {
         '@type': 'Person',
+        '@id': AUTHOR_ID,
         name: authorName,
+        url: AUTHOR_URL,
       },
       mainEntityOfPage: {
         '@type': 'WebPage',
@@ -165,10 +186,13 @@ export default function StructuredData({
   // FAQPage should only be emitted when there are enough meaningful Q&A pairs
   // for rich-result eligibility. A one-item FAQ block creates avoidable schema
   // noise across thin/partial pages without adding search value.
-  if (meaningfulFaqs.length >= MIN_FAQ_SCHEMA_ITEMS) {
+  if (hasFaqSchema) {
     schemas.push({
       '@context': 'https://schema.org',
       '@type': 'FAQPage',
+      '@id': faqId,
+      url: canonicalPageUrl,
+      isPartOf: { '@id': webpageId },
       mainEntity: meaningfulFaqs.map((faq) => ({
         '@type': 'Question',
         name: faq.question,
@@ -184,6 +208,7 @@ export default function StructuredData({
     schemas.push({
       '@context': 'https://schema.org',
       '@type': 'BreadcrumbList',
+      '@id': breadcrumbId,
       itemListElement: breadcrumbs.map((crumb, i) => ({
         '@type': 'ListItem',
         position: i + 1,

--- a/components/seo/AuthorityJsonLd.tsx
+++ b/components/seo/AuthorityJsonLd.tsx
@@ -2,6 +2,9 @@ import { buildSchemaGraph } from '../../src/lib/schema-graph'
 import { serializeJsonLd } from '../../src/lib/schema-injector'
 import { SITE_URL } from '../../src/lib/seo'
 
+const WEBSITE_ID = `${SITE_URL}/#website`
+const ORGANIZATION_ID = `${SITE_URL}/#organization`
+
 type FaqItem = { question: string; answer: string }
 
 type AuthorityJsonLdProps = {
@@ -69,7 +72,8 @@ export default function AuthorityJsonLd({
     headline: title,
     description,
     url: canonical,
-    isPartOf: { '@type': 'WebSite', name: 'The Hippie Scientist', url: SITE_URL },
+    isPartOf: { '@id': WEBSITE_ID },
+    publisher: { '@id': ORGANIZATION_ID },
     ...(type !== 'Article' && breadcrumbs.length ? { breadcrumb: { '@id': breadcrumbId } } : {}),
     ...(meaningfulFaqItems.length ? { hasPart: { '@id': faqId } } : {}),
     ...(citationUrls.length ? { citation: [...new Set(citationUrls)].filter(Boolean) } : {}),
@@ -91,16 +95,16 @@ export default function AuthorityJsonLd({
   const faq =
     meaningfulFaqItems.length > 0
       ? {
-          '@type': 'FAQPage',
-          '@id': faqId,
-          url: canonical,
-          isPartOf: { '@id': webpageId },
-          mainEntity: meaningfulFaqItems.map((item) => ({
-            '@type': 'Question',
-            name: item.question,
-            acceptedAnswer: { '@type': 'Answer', text: item.answer },
-          })),
-        }
+        '@type': 'FAQPage',
+        '@id': faqId,
+        url: canonical,
+        isPartOf: { '@id': webpageId },
+        mainEntity: meaningfulFaqItems.map((item) => ({
+          '@type': 'Question',
+          name: item.question,
+          acceptedAnswer: { '@type': 'Answer', text: item.answer },
+        })),
+      }
       : null
 
   const graph = buildSchemaGraph([webpage, breadcrumb, faq])


### PR DESCRIPTION
## SEO 91–100

This batch tightens structured-data entity identity across shared guide schemas and authority pages without changing robots/indexability or adding synthetic freshness.

91. Point shared guide author URLs to the canonical `/info/author/` profile.
92. Give shared guide author nodes a stable Person `@id`.
93. Reuse the root Organization `@id` for shared guide publishers.
94. Connect shared guide page nodes to the root WebSite entity.
95. Give shared guide BreadcrumbList nodes stable page-specific IDs.
96. Link shared guide page nodes to their breadcrumb entities.
97. Give qualifying shared FAQPage nodes stable page-specific IDs.
98. Link qualifying FAQ schema into the canonical page graph with `hasPart`/`isPartOf`.
99. Make AuthorityJsonLd pages reference the canonical root WebSite ID.
100. Make AuthorityJsonLd pages reference the canonical root Organization publisher ID.

No content padding, indexability loosening, SearchAction, or fake last-modified dates.