### PR TITLE
Homepage: surface existing newsletter signup

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import HomepageV2 from '@/components/homepage-v2'
 import HomepageDecisionShortcuts from '@/components/HomepageDecisionShortcuts'
+import NewsletterSignup from '@/components/NewsletterSignup'
 import { buildPageMetadata } from '../src/lib/seo'
 
 export const metadata: Metadata = buildPageMetadata({
@@ -27,6 +28,9 @@ export default function Page() {
   return (
     <>
       <HomepageV2 />
+      <div className='mx-auto max-w-6xl px-5 py-10 sm:px-8 sm:py-16 lg:px-10'>
+        <NewsletterSignup location='homepage-editorial' variant='editorial' />
+      </div>
       <HomepageDecisionShortcuts />
     </>
   )


### PR DESCRIPTION
Adds the existing newsletter/safety-checklist signup component to the homepage with a unique analytics location. No medical content changes.