### PR TITLE
Growth: add article-end newsletter signup

### DIFF
--- a/components/articles/ArticleMdx.tsx
+++ b/components/articles/ArticleMdx.tsx
@@ -1,5 +1,6 @@
 import { MDXContent } from '@content-collections/mdx/react'
 import type { ComponentPropsWithoutRef } from 'react'
+import NewsletterSignup from '@/components/NewsletterSignup'
 import { useMDXComponents } from '@/mdx-components'
 
 type ArticleMdxProps = {
@@ -13,5 +14,14 @@ function BodyHeadingOne({ children, ...props }: ComponentPropsWithoutRef<'h1'>) 
 export default function ArticleMdx({ code }: ArticleMdxProps) {
   const components = useMDXComponents({ h1: BodyHeadingOne })
 
-  return <MDXContent code={code} components={components} />
+  return (
+    <>
+      <MDXContent code={code} components={components} />
+      <NewsletterSignup
+        location='article-body-end'
+        variant='editorial'
+        className='mt-10'
+      />
+    </>
+  )
 }


### PR DESCRIPTION
Adds the existing safety-checklist/newsletter conversion component after article bodies, with a dedicated `article-body-end` analytics source. This targets organic article visitors without changing medical content.