### PR TITLE
Privacy: align analytics with consent controls

### DIFF
--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,5 +1,7 @@
 'use client'
 
+import { getConsent, getSystemNoTracking } from '@/src/lib/consent'
+
 type Gtag = (
   command: 'event',
   eventName: 'affiliate_click' | 'email_signup' | 'guide_view' | 'lead_magnet_click',
@@ -14,6 +16,7 @@ export type GuideViewParams = {
 
 function getGtag(): Gtag | null {
   if (typeof window === 'undefined') return null
+  if (getConsent() !== 'granted' || getSystemNoTracking()) return null
 
   const candidate = (window as Window & { gtag?: unknown }).gtag
   return typeof candidate === 'function' ? (candidate as Gtag) : null


### PR DESCRIPTION
Gates the shared analytics helper behind explicit analytics consent and browser Do Not Track / Global Privacy Control signals. This aligns email, guide, lead-magnet, and affiliate analytics with the site's existing consent model without changing user-facing content.