### PR TITLE
Growth: enrich commerce click attribution

### DIFF
--- a/components/RecommendedProduct.tsx
+++ b/components/RecommendedProduct.tsx
@@ -62,6 +62,10 @@ export default function RecommendedProduct({
                   href={product.affiliateUrl}
                   target='_blank'
                   rel='nofollow sponsored noopener noreferrer'
+                  data-ingredient={slug}
+                  data-product-slot={product.slot}
+                  data-product-asin={product.asin || undefined}
+                  data-tracking-location='recommended-product'
                   className='inline-flex min-h-11 shrink-0 items-center justify-center rounded-full bg-brand-950 px-5 py-2.5 text-sm font-bold text-white transition hover:bg-brand-900'
                 >
                   Check price

--- a/components/StackCard.tsx
+++ b/components/StackCard.tsx
@@ -73,6 +73,8 @@ export default function StackCard({
             href={affiliateUrl}
             target="_blank"
             rel="nofollow sponsored noopener noreferrer"
+            data-ingredient={compoundSlug || undefined}
+            data-tracking-location="stack-card"
             className="inline-flex w-full items-center justify-center rounded-full bg-brand-950 px-3.5 py-2 text-xs font-bold text-white transition hover:bg-brand-900"
           >
             {affiliateLabel || 'Shop sourcing options'} →

--- a/src/components/affiliate-cta-card.tsx
+++ b/src/components/affiliate-cta-card.tsx
@@ -50,6 +50,7 @@ export default function AffiliateCTACard({
   const affiliateUrl = getAffiliateUrl(record, displayName)
   const affiliateLabel = getAffiliateLabel(record)
   const criteria = getBuyingCriteria(record)
+  const recordSlug = text(record?.slug)
 
   if (!affiliateUrl) return null
 
@@ -75,6 +76,8 @@ export default function AffiliateCTACard({
           href={affiliateUrl}
           target="_blank"
           rel="nofollow sponsored noopener noreferrer"
+          data-ingredient={recordSlug || undefined}
+          data-tracking-location="affiliate-cta-sidebar"
           className="mt-4 block w-full rounded-xl bg-brand-950 px-4 py-2.5 text-center text-sm font-bold text-white shadow-sm transition motion-safe:hover:-translate-y-0.5 hover:bg-brand-900"
         >
           {affiliateLabel} →
@@ -106,6 +109,8 @@ export default function AffiliateCTACard({
           href={affiliateUrl}
           target="_blank"
           rel="nofollow sponsored noopener noreferrer"
+          data-ingredient={recordSlug || undefined}
+          data-tracking-location="affiliate-cta-inline"
           className="inline-flex shrink-0 items-center gap-2 rounded-full bg-brand-950 px-5 py-3 text-sm font-bold text-white shadow-sm transition motion-safe:hover:-translate-y-0.5 hover:bg-brand-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-700"
         >
           {affiliateLabel}

--- a/src/components/sourcing/SourcingCta.tsx
+++ b/src/components/sourcing/SourcingCta.tsx
@@ -60,6 +60,8 @@ export function SourcingCta({ record, displayName }: SourcingCtaProps) {
             href={finalUrl}
             target="_blank"
             rel="nofollow sponsored noopener noreferrer"
+            data-ingredient={profileSlug || undefined}
+            data-tracking-location="sourcing-cta-fallback"
             className="inline-flex shrink-0 items-center justify-center gap-2 rounded-full bg-[#358f52] hover:bg-[#2d7a46] px-5 py-3 text-sm font-bold text-white shadow-sm transition motion-safe:hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-700"
           >
             <span>Check sourcing options</span>


### PR DESCRIPTION
Adds tracking metadata to four existing outbound commerce CTAs so the current click tracker can preserve placement and product context. Destinations and visible content are unchanged.