### PR TITLE
SEO: balance article related-link crawl equity

### DIFF
--- a/src/lib/__tests__/article-citation-metadata.test.ts
+++ b/src/lib/__tests__/article-citation-metadata.test.ts
@@ -37,6 +37,21 @@ describe('resolveRelatedArticles', () => {
     ])
   })
 
+  it('rotates category fallbacks around the current article', () => {
+    const pages = [
+      page('one', 'Research'),
+      page('two', 'Research'),
+      page('three', 'Research'),
+      page('four', 'Research'),
+    ]
+
+    expect(resolveRelatedArticles(pages[2], pages, 3).map((article) => article.slug)).toEqual([
+      'four',
+      'one',
+      'two',
+    ])
+  })
+
   it('ignores missing and self-referential slugs', () => {
     const current = page('current', 'Harm Reduction', [
       'missing',

--- a/src/lib/article-citation-metadata.ts
+++ b/src/lib/article-citation-metadata.ts
@@ -29,6 +29,30 @@ function getOverride(slug: string | undefined) {
   return slug ? articleCitationOverrides[slug] : undefined
 }
 
+function categoryFallbacks(
+  current: ArticleRelationshipRecord,
+  articles: ArticleRelationshipRecord[],
+  excludedSlugs: Set<string>
+): ArticleRelationshipRecord[] {
+  const categoryArticles = articles.filter((article) => article.category === current.category)
+  const currentIndex = categoryArticles.findIndex((article) => article.slug === current.slug)
+
+  if (currentIndex < 0) {
+    return categoryArticles.filter(
+      (article) => article.slug !== current.slug && !excludedSlugs.has(article.slug)
+    )
+  }
+
+  const rotated = [
+    ...categoryArticles.slice(currentIndex + 1),
+    ...categoryArticles.slice(0, currentIndex),
+  ]
+
+  return rotated.filter(
+    (article) => article.slug !== current.slug && !excludedSlugs.has(article.slug)
+  )
+}
+
 export function resolveRelatedArticles(
   current: ArticleRelationshipRecord,
   articles: ArticleRelationshipRecord[],
@@ -49,12 +73,7 @@ export function resolveRelatedArticles(
     )
 
   const seen = new Set(curated.map((article) => article.slug))
-  const fallback = articles.filter(
-    (article) =>
-      article.slug !== current.slug &&
-      article.category === current.category &&
-      !seen.has(article.slug)
-  )
+  const fallback = categoryFallbacks(current, articles, seen)
 
   return [...curated, ...fallback].slice(0, limit)
 }


### PR DESCRIPTION
Preserves curated related-article links, but changes same-category fallback links from a fixed first-N list to a circular neighborhood around the current article. This spreads inbound internal links across the article library instead of concentrating them on early records. Includes a wraparound regression test.