### PR TITLE
Privacy: unify analytics consent gating

### DIFF
--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { getConsent, getSystemNoTracking } from '@/lib/consent'
+import { canTrackAnalytics } from '@/lib/consent'
 
 type Gtag = (
   command: 'event',
@@ -20,8 +20,7 @@ export type GuideViewParams = {
 }
 
 function getGtag(): Gtag | null {
-  if (typeof window === 'undefined') return null
-  if (getConsent() !== 'granted' || getSystemNoTracking()) return null
+  if (!canTrackAnalytics()) return null
 
   const candidate = (window as Window & { gtag?: unknown }).gtag
   return typeof candidate === 'function' ? (candidate as Gtag) : null

--- a/lib/consent.ts
+++ b/lib/consent.ts
@@ -27,6 +27,12 @@ export function getConsent(): ConsentStatus | null {
   }
 }
 
+export function canTrackAnalytics(): boolean {
+  return (
+    typeof window !== 'undefined' && getConsent() === 'granted' && !getSystemNoTracking()
+  )
+}
+
 export function setConsent(status: ConsentStatus) {
   sessionConsent = status
   try {
@@ -51,6 +57,8 @@ export function initConsentDefault() {
 }
 
 export function applyGaConsent(status: ConsentStatus, command: 'default' | 'update' = 'default') {
+  if (typeof window === 'undefined') return
+
   const granted = status === 'granted' && !getSystemNoTracking()
   // GA4 Consent Mode v2 (safe no-op if gtag missing)
   try {

--- a/src/lib/growth.ts
+++ b/src/lib/growth.ts
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
+import { canTrackAnalytics } from '@/lib/consent'
 import { readStorage, writeStorage } from '@/utils/storageState'
 import { useLocation } from './router-compat'
 
@@ -97,7 +98,7 @@ export function trackEvent(name: AnalyticsEvent['name'], payload: AnalyticsEvent
   const next = [{ name, at: new Date().toISOString(), payload }, ...events].slice(0, 250)
   writeJson(EVENTS_KEY, next)
 
-  if (typeof window === 'undefined') return
+  if (!canTrackAnalytics()) return
   try {
     window.dispatchEvent(
       new CustomEvent('hs:analytics', {

--- a/src/lib/useGA.ts
+++ b/src/lib/useGA.ts
@@ -1,47 +1,5 @@
 import { useEffect } from "react";
 import { useLocation } from "./router-compat";
-import { CONSENT_CHANGE_EVENT, CONSENT_STORAGE_KEY, getConsent } from "@/lib/consent";
-import { loadAnalytics } from "./loadAnalytics";
-
-function hasGrantedConsentFromStorage(): boolean {
-  if (typeof window === "undefined") return false;
-  try {
-    const raw = window.localStorage.getItem(CONSENT_STORAGE_KEY);
-    if (!raw) return false;
-    const parsed = JSON.parse(raw);
-    return parsed?.status === "granted";
-  } catch {
-    return false;
-  }
-}
-
-export function useGA() {
-  const { pathname, search } = useLocation();
-
-  useEffect(() => {
-    if (!hasGrantedConsentFromStorage()) return;
-    loadAnalytics();
-  }, []);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const onConsentGranted = (event: Event) => {
-      const status = (event as CustomEvent<{ status?: string }>).detail?.status;
-      if (status === "granted" || getConsent() === "granted") {
-        loadAnalytics();
-      }
-    };
-    window.addEventListener(CONSENT_CHANGE_EVENT, onConsentGranted);
-    return () => window.removeEventListener(CONSENT_CHANGE_EVENT, onConsentGranted);
-  }, []);
-
-  useEffect(() => {
-    if (typeof window !== "undefined" && typeof window.gtag === "function") {
-      window.gtag("event", "page_view", {
-        page_location: window.location.href,
-        page_path: pathname + search,
-        page_title: document.title,
-      });
-    }
-  }, [pathname, search]);
-}
+import {
+  CAN_TRACK_ANALYTICS_EVENT,
+} from "./unused";

--- a/src/lib/useGA.ts
+++ b/src/lib/useGA.ts
@@ -1,5 +1,35 @@
-import { useEffect } from "react";
-import { useLocation } from "./router-compat";
-import {
-  CAN_TRACK_ANALYTICS_EVENT,
-} from "./unused";
+import { useEffect } from 'react'
+import { canTrackAnalytics, CONSENT_CHANGE_EVENT } from '@/lib/consent'
+import { useLocation } from './router-compat'
+import { loadAnalytics } from './loadAnalytics'
+
+export function useGA() {
+  const { pathname, search } = useLocation()
+
+  useEffect(() => {
+    if (!canTrackAnalytics()) return
+    loadAnalytics()
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const onConsentChanged = () => {
+      if (canTrackAnalytics()) {
+        loadAnalytics()
+      }
+    }
+    window.addEventListener(CONSENT_CHANGE_EVENT, onConsentChanged)
+    return () => window.removeEventListener(CONSENT_CHANGE_EVENT, onConsentChanged)
+  }, [])
+
+  useEffect(() => {
+    if (!canTrackAnalytics()) return
+    if (typeof window.gtag !== 'function') return
+
+    window.gtag('event', 'page_view', {
+      page_location: window.location.href,
+      page_path: pathname + search,
+      page_title: document.title,
+    })
+  }, [pathname, search])
+}


### PR DESCRIPTION
Closes the remaining legacy analytics paths that could emit before consent or despite DNT/GPC.

Changes:
- centralizes the consent + system no-tracking decision in `canTrackAnalytics()`
- reuses that gate in the primary analytics module
- gates legacy growth `gtag`/Plausible/custom analytics emissions while preserving local saved/recently-viewed functionality
- gates legacy `useGA` page views and analytics loading
- makes `applyGaConsent` SSR-safe with an explicit browser guard

This is intentionally surgical: no route, content, schema, or visible UI changes.