### PR TITLE
Privacy: centralize revenue tracking consent

### DIFF
--- a/src/lib/revenue-tracking.ts
+++ b/src/lib/revenue-tracking.ts
@@ -1,4 +1,4 @@
-import { getConsent, getSystemNoTracking } from '@/lib/consent'
+import { canTrackAnalytics } from '@/lib/consent'
 
 export type RevenueEventKind =
   | 'recommendation_impression'
@@ -59,7 +59,7 @@ export type RevenueEvent = {
 }
 
 function canSendAnalytics(): boolean {
-  return getConsent() === 'granted' && !getSystemNoTracking()
+  return canTrackAnalytics()
 }
 
 export function normalizeRevenueEventKind(kind: string): RevenueEventKind {


### PR DESCRIPTION
Uses the shared `canTrackAnalytics()` gate for revenue/event tracking instead of maintaining a second consent implementation. This keeps DNT/GPC and explicit-consent behavior aligned across analytics surfaces and reduces future drift. No visible UI or event schema changes.