### PR TITLE
SEO: remove legacy sleep-guide redirect hop

### DIFF
--- a/app/guides/sleep/sleep-herbs-vs-melatonin/page.tsx
+++ b/app/guides/sleep/sleep-herbs-vs-melatonin/page.tsx
@@ -103,7 +103,7 @@ export default function SleepHerbsVsMelatoninPage() {
           <Link href="/guides/sleep/magnesium-vs-melatonin/" className="text-brand-700 hover:text-brand-800 hover:underline">
             Magnesium vs Melatonin Guide →
           </Link>
-          <Link href="/best-supplements-for-sleep/" className="text-brand-700 hover:text-brand-800 hover:underline">
+          <Link href="/guides/sleep/best-supplements-for-sleep/" className="text-brand-700 hover:text-brand-800 hover:underline">
             Browse Sleep Supplements →
           </Link>
         </div>


### PR DESCRIPTION
Updates an active internal link in the sleep herbs vs melatonin guide from the legacy top-level `/best-supplements-for-sleep/` URL to the canonical `/guides/sleep/best-supplements-for-sleep/` route. This removes an unnecessary redirect hop and keeps internal authority pointed directly at the canonical page.