### PR TITLE
Privacy: stop loaded analytics after consent withdrawal

### DIFF
--- a/src/components/ConsentManager.tsx
+++ b/src/components/ConsentManager.tsx
@@ -86,8 +86,19 @@ export default function ConsentManager({ open, onClose }: Props) {
   }
 
   function decline() {
+    const hadGrantedConsent = getConsent() === "granted";
     setConsent("denied");
     setStatus("denied");
+
+    if (hadGrantedConsent) {
+      // A full reload is the only reliable way to tear down third-party analytics
+      // code that may already be resident after a previous opt-in (for example,
+      // GA4 or Ahrefs). The persisted denied state prevents those scripts from
+      // loading again after the reload.
+      window.location.reload();
+      return;
+    }
+
     onClose();
   }
 


### PR DESCRIPTION
If a visitor previously opted in and later changes privacy settings to Decline, third-party analytics code may already be resident in the page even though subsequent app events are gated. This change detects that granted→denied transition and reloads once after persisting denial, which reliably tears down already-loaded GA4/Ahrefs code. Because the denied preference is stored first, analytics do not reload afterward. First-time declines do not reload.