### PR TITLE
Trust: stop implying unverified medical review metadata

### DIFF
--- a/components/StructuredData.tsx
+++ b/components/StructuredData.tsx
@@ -146,7 +146,7 @@ export default function StructuredData({
       url: canonicalPageUrl,
       datePublished,
       dateModified: dateModified ?? datePublished,
-      lastReviewed: dateModified ?? datePublished,
+      ...(dateModified ? { lastReviewed: dateModified } : {}),
       author: {
         '@type': 'Person',
         '@id': AUTHOR_ID,
@@ -169,12 +169,6 @@ export default function StructuredData({
       medicalAudience: {
         '@type': 'MedicalAudience',
         audienceType: 'Patient',
-      },
-      reviewedBy: {
-        '@type': 'Person',
-        '@id': AUTHOR_ID,
-        name: authorName,
-        url: AUTHOR_URL,
       },
       mainEntityOfPage: {
         '@type': 'WebPage',


### PR DESCRIPTION
The shared MedicalWebPage/Article schema currently emits `reviewedBy` as the page author on every harm-reduction page and sets `lastReviewed` to the publication date when no explicit review date exists. That can imply a review event that did not actually occur. This change removes the automatic `reviewedBy` claim and only emits `lastReviewed` when a real `dateModified` value is supplied. Author, publisher, publication date, canonical URL, breadcrumbs, and FAQ schema remain unchanged.