### PR TITLE
SEO: preserve real guide freshness metadata

### DIFF
--- a/app/guides/[slug]/page.tsx
+++ b/app/guides/[slug]/page.tsx
@@ -56,24 +56,26 @@ export default async function GuidePage({ params }: Props) {
   if (!guide) notFound();
 
   const pageUrl = `${SITE_URL}/guides/${slug}/`;
-  const publishDate = guide.publishDate || "2024-01-01";
   const contentBlocks = guide.content.split(/\n{2,}/).map((block) => block.trim()).filter(Boolean);
   const relatedGuides = RELATED_GUIDE_MAP[slug] ?? [];
   const atlasGuide = ATLAS_GUIDE_MAP[slug];
 
   return (
     <ArticleLayout zone="supplement">
-      <StructuredData
-        pageUrl={pageUrl}
-        headline={guide.title}
-        description={guide.description}
-        datePublished={publishDate}
-        breadcrumbs={[
-          { label: "Home", href: "/" },
-          { label: "Guides", href: "/guides/" },
-          { label: guide.title, href: `/guides/${slug}/` },
-        ]}
-      />
+      {guide.publishDate ? (
+        <StructuredData
+          pageUrl={pageUrl}
+          headline={guide.title}
+          description={guide.description}
+          datePublished={guide.publishDate}
+          dateModified={guide.lastUpdated}
+          breadcrumbs={[
+            { label: "Home", href: "/" },
+            { label: "Guides", href: "/guides/" },
+            { label: guide.title, href: `/guides/${slug}/` },
+          ]}
+        />
+      ) : null}
       {/*
         Guide views are emitted by <ClickTracker /> in app/layout.tsx, which waits for
         analytics consent. An inline gtag snippet here would fire before consent and

--- a/lib/guides.ts
+++ b/lib/guides.ts
@@ -9,6 +9,7 @@ export interface Guide {
   title: string;
   description: string;
   publishDate: string;
+  lastUpdated?: string;
   content: string;
 }
 
@@ -24,6 +25,7 @@ export async function getGuideBySlug(slug: string): Promise<Guide | null> {
     title: data.title ?? "",
     description: data.description ?? "",
     publishDate: data.publishDate ?? "",
+    lastUpdated: data.lastUpdated ?? undefined,
     content,
   };
 }


### PR DESCRIPTION
`content/guides/*.mdx` already carries a governed `lastUpdated` field, but `getGuideBySlug()` discarded it, so guide schema never emitted the real modification/review date. The guide route also fell back to an arbitrary `2024-01-01` publication date when frontmatter was missing. This change preserves `lastUpdated`, passes it into structured data as `dateModified`, and suppresses article schema rather than inventing a publication date if `publishDate` is absent.