### PR TITLE
Trust: normalize profile review schema at render boundary

### DIFF
--- a/components/seo/SchemaGraphScript.tsx
+++ b/components/seo/SchemaGraphScript.tsx
@@ -91,6 +91,33 @@ export function normalizeProfileEntitySemantics(
   return { ...graph, '@graph': nodes }
 }
 
+export function normalizeProfileReviewSemantics(
+  graph: Record<string, unknown>,
+  artifact: EntityArtifact | null,
+): Record<string, unknown> {
+  if (!artifact || !Array.isArray(graph['@graph'])) return graph
+
+  const nodes = graph['@graph'].map((node) => {
+    if (!node || typeof node !== 'object') return node
+    const record = node as Record<string, unknown>
+    const id = typeof record['@id'] === 'string' ? record['@id'] : ''
+
+    if (id === `${artifact.canonicalUrl}#webpage` && !record.dateReviewed) {
+      const { reviewedBy: _reviewedBy, ...rest } = record
+      return rest
+    }
+
+    if (id === `${artifact.canonicalUrl}#evidence-review` && 'datePublished' in record) {
+      const { datePublished: _datePublished, ...rest } = record
+      return rest
+    }
+
+    return node
+  })
+
+  return { ...graph, '@graph': nodes }
+}
+
 export function attachEntityDataset(
   graph: Record<string, unknown>,
   artifact: EntityArtifact | null,
@@ -133,8 +160,9 @@ export function attachEntityDataset(
 
 export default function SchemaGraphScript({ graph }: SchemaGraphScriptProps) {
   const artifact = getEntityArtifact(graph)
-  const normalizedGraph = normalizeProfileEntitySemantics(graph, artifact)
-  const enrichedGraph = attachEntityDataset(normalizedGraph, artifact)
+  const normalizedEntityGraph = normalizeProfileEntitySemantics(graph, artifact)
+  const normalizedReviewGraph = normalizeProfileReviewSemantics(normalizedEntityGraph, artifact)
+  const enrichedGraph = attachEntityDataset(normalizedReviewGraph, artifact)
 
   return (
     <>

--- a/components/seo/__tests__/SchemaGraphScript.test.ts
+++ b/components/seo/__tests__/SchemaGraphScript.test.ts
@@ -3,6 +3,7 @@ import {
   attachEntityDataset,
   getEntityArtifact,
   normalizeProfileEntitySemantics,
+  normalizeProfileReviewSemantics,
 } from '../SchemaGraphScript'
 
 describe('SchemaGraphScript AI entity data discovery', () => {
@@ -83,6 +84,89 @@ describe('SchemaGraphScript AI entity data discovery', () => {
     expect(normalizeProfileEntitySemantics(graph, artifact)).toEqual(graph)
   })
 
+  it('removes reviewedBy when a profile has no actual review date', () => {
+    const reviewGraph = {
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': ['MedicalWebPage', 'WebPage'],
+          '@id': 'https://thehippiescientist.net/compounds/magnesium/#webpage',
+          url: 'https://thehippiescientist.net/compounds/magnesium/',
+          reviewedBy: { '@type': 'Organization', name: 'The Hippie Scientist' },
+        },
+        {
+          '@type': ['ChemicalSubstance', 'Thing'],
+          '@id': 'https://thehippiescientist.net/compounds/magnesium/#entity',
+          name: 'Magnesium',
+          url: 'https://thehippiescientist.net/compounds/magnesium/',
+        },
+      ],
+    }
+
+    const artifact = getEntityArtifact(reviewGraph)
+    const normalized = normalizeProfileReviewSemantics(reviewGraph, artifact)
+    const nodes = normalized['@graph'] as Record<string, unknown>[]
+    const webpage = nodes.find((node) => node['@id'] === 'https://thehippiescientist.net/compounds/magnesium/#webpage')
+
+    expect(webpage?.reviewedBy).toBeUndefined()
+  })
+
+  it('keeps reviewedBy when a profile has an explicit review date', () => {
+    const reviewGraph = {
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': ['MedicalWebPage', 'WebPage'],
+          '@id': 'https://thehippiescientist.net/compounds/magnesium/#webpage',
+          url: 'https://thehippiescientist.net/compounds/magnesium/',
+          dateReviewed: '2026-08-01',
+          reviewedBy: { '@type': 'Organization', name: 'The Hippie Scientist' },
+        },
+        {
+          '@type': ['ChemicalSubstance', 'Thing'],
+          '@id': 'https://thehippiescientist.net/compounds/magnesium/#entity',
+          name: 'Magnesium',
+          url: 'https://thehippiescientist.net/compounds/magnesium/',
+        },
+      ],
+    }
+
+    const artifact = getEntityArtifact(reviewGraph)
+    const normalized = normalizeProfileReviewSemantics(reviewGraph, artifact)
+    const nodes = normalized['@graph'] as Record<string, unknown>[]
+    const webpage = nodes.find((node) => node['@id'] === 'https://thehippiescientist.net/compounds/magnesium/#webpage')
+
+    expect(webpage?.reviewedBy).toEqual({ '@type': 'Organization', name: 'The Hippie Scientist' })
+  })
+
+  it('does not mislabel a review date as an evidence article publication date', () => {
+    const reviewGraph = {
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': ['ChemicalSubstance', 'Thing'],
+          '@id': 'https://thehippiescientist.net/compounds/magnesium/#entity',
+          name: 'Magnesium',
+          url: 'https://thehippiescientist.net/compounds/magnesium/',
+        },
+        {
+          '@type': 'Article',
+          '@id': 'https://thehippiescientist.net/compounds/magnesium/#evidence-review',
+          datePublished: '2026-08-01',
+          dateModified: '2026-08-01',
+        },
+      ],
+    }
+
+    const artifact = getEntityArtifact(reviewGraph)
+    const normalized = normalizeProfileReviewSemantics(reviewGraph, artifact)
+    const nodes = normalized['@graph'] as Record<string, unknown>[]
+    const evidenceArticle = nodes.find((node) => node['@id'] === 'https://thehippiescientist.net/compounds/magnesium/#evidence-review')
+
+    expect(evidenceArticle?.datePublished).toBeUndefined()
+    expect(evidenceArticle?.dateModified).toBe('2026-08-01')
+  })
+
   it('ignores non-profile schema graphs', () => {
     const collectionGraph = {
       '@context': 'https://schema.org',
@@ -90,5 +174,6 @@ describe('SchemaGraphScript AI entity data discovery', () => {
     }
     expect(getEntityArtifact(collectionGraph)).toBeNull()
     expect(attachEntityDataset(collectionGraph, null)).toBe(collectionGraph)
+    expect(normalizeProfileReviewSemantics(collectionGraph, null)).toBe(collectionGraph)
   })
 })


### PR DESCRIPTION
Tightens herb/compound profile JSON-LD at the final profile-only rendering boundary. If a profile has no explicit `dateReviewed`, the emitted graph no longer carries a `reviewedBy` claim. The evidence-summary Article also no longer uses the profile review date as `datePublished`; `dateModified` remains intact. Added focused regression tests for both behaviors. Non-profile schema graphs are untouched.