### PR TITLE
SEO: suppress placeholder publication dates in entry schema

### DIFF
--- a/components/seo/SchemaGraphScript.tsx
+++ b/components/seo/SchemaGraphScript.tsx
@@ -4,6 +4,8 @@ type SchemaGraphScriptProps = {
   graph: Record<string, unknown>
 }
 
+const LEGACY_PLACEHOLDER_PUBLICATION_DATE = '2026-01-01'
+
 export type EntityArtifact = {
   href: string
   absoluteUrl: string
@@ -118,6 +120,33 @@ export function normalizeProfileReviewSemantics(
   return { ...graph, '@graph': nodes }
 }
 
+export function normalizePlaceholderPublicationDates(
+  graph: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!Array.isArray(graph['@graph'])) return graph
+
+  const nodes = graph['@graph'].map((node) => {
+    if (!node || typeof node !== 'object') return node
+    const record = node as Record<string, unknown>
+    const id = typeof record['@id'] === 'string' ? record['@id'] : ''
+    const types = Array.isArray(record['@type']) ? record['@type'] : [record['@type']]
+
+    const isEntryArticle = id.endsWith('#webpage') && types.includes('Article')
+    if (
+      isEntryArticle &&
+      record.datePublished === LEGACY_PLACEHOLDER_PUBLICATION_DATE &&
+      !record.dateModified
+    ) {
+      const { datePublished: _datePublished, ...rest } = record
+      return rest
+    }
+
+    return node
+  })
+
+  return { ...graph, '@graph': nodes }
+}
+
 export function attachEntityDataset(
   graph: Record<string, unknown>,
   artifact: EntityArtifact | null,
@@ -162,7 +191,8 @@ export default function SchemaGraphScript({ graph }: SchemaGraphScriptProps) {
   const artifact = getEntityArtifact(graph)
   const normalizedEntityGraph = normalizeProfileEntitySemantics(graph, artifact)
   const normalizedReviewGraph = normalizeProfileReviewSemantics(normalizedEntityGraph, artifact)
-  const enrichedGraph = attachEntityDataset(normalizedReviewGraph, artifact)
+  const normalizedPublicationGraph = normalizePlaceholderPublicationDates(normalizedReviewGraph)
+  const enrichedGraph = attachEntityDataset(normalizedPublicationGraph, artifact)
 
   return (
     <>

--- a/components/seo/__tests__/SchemaGraphPublicationDate.test.ts
+++ b/components/seo/__tests__/SchemaGraphPublicationDate.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { normalizePlaceholderPublicationDates } from '../SchemaGraphScript'
+
+describe('SEO entry schema publication dates', () => {
+  it('removes the legacy placeholder publication date from generated entry articles', () => {
+    const graph = {
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': 'Article',
+          '@id': 'https://thehippiescientist.net/guides/example/#webpage',
+          datePublished: '2026-01-01',
+        },
+      ],
+    }
+
+    const normalized = normalizePlaceholderPublicationDates(graph)
+    const article = (normalized['@graph'] as Record<string, unknown>[])[0]
+
+    expect(article.datePublished).toBeUndefined()
+  })
+
+  it('preserves explicit publication dates when modification metadata is present', () => {
+    const graph = {
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': 'Article',
+          '@id': 'https://thehippiescientist.net/guides/example/#webpage',
+          datePublished: '2026-01-01',
+          dateModified: '2026-08-14',
+        },
+      ],
+    }
+
+    const normalized = normalizePlaceholderPublicationDates(graph)
+    const article = (normalized['@graph'] as Record<string, unknown>[])[0]
+
+    expect(article.datePublished).toBe('2026-01-01')
+  })
+})


### PR DESCRIPTION
SEO entry-page schema currently injects a legacy hardcoded `2026-01-01` as `datePublished` even though those routes do not carry real publication provenance. At the shared JSON-LD render boundary, this change removes that placeholder only for Article `#webpage` nodes that have no `dateModified`; explicit dated content remains untouched. Includes regression coverage.