### PR TITLE
Privacy: gate persistent behavioral analytics storage

### DIFF
--- a/src/components/ConsentManager.tsx
+++ b/src/components/ConsentManager.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Link } from "../lib/router-compat";
 import { getConsent, setConsent, getSystemNoTracking } from "@/lib/consent";
+import { clearAnalyticsEvents } from "@/lib/analyticsEventStorage";
 
 type Props = { open: boolean; onClose: () => void };
 
@@ -70,16 +71,25 @@ export default function ConsentManager({ open, onClose }: Props) {
   const dnt = typeof window !== "undefined" ? getSystemNoTracking() : false;
 
   async function accept() {
+    const hadGrantedConsent = getConsent() === "granted";
     const nextStatus = dnt ? "denied" : "granted";
     setConsent(nextStatus);
     setStatus(nextStatus);
 
-    if (!dnt) {
-      try {
-        (await import("../lib/loadAnalytics")).loadAnalytics();
-      } catch {
-        // Ignore analytics load failures.
+    if (nextStatus === "denied") {
+      clearAnalyticsEvents();
+      if (hadGrantedConsent) {
+        window.location.reload();
+        return;
       }
+      onClose();
+      return;
+    }
+
+    try {
+      (await import("../lib/loadAnalytics")).loadAnalytics();
+    } catch {
+      // Ignore analytics load failures.
     }
 
     onClose();
@@ -89,6 +99,7 @@ export default function ConsentManager({ open, onClose }: Props) {
     const hadGrantedConsent = getConsent() === "granted";
     setConsent("denied");
     setStatus("denied");
+    clearAnalyticsEvents();
 
     if (hadGrantedConsent) {
       // A full reload is the only reliable way to tear down third-party analytics

--- a/src/lib/analyticsEventStorage.ts
+++ b/src/lib/analyticsEventStorage.ts
@@ -1,10 +1,12 @@
+import { canTrackAnalytics } from '@/lib/consent'
+
 type AnalyticsEvent = Record<string, unknown>
 
 const STORAGE_KEY = 'hs_analytics_events'
 const MAX_EVENTS = 200
 
 export function appendAnalyticsEvent(event: AnalyticsEvent): void {
-  if (typeof window === 'undefined') return
+  if (typeof window === 'undefined' || !canTrackAnalytics()) return
 
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY)
@@ -21,5 +23,14 @@ export function appendAnalyticsEvent(event: AnalyticsEvent): void {
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
   } catch {
     // Ignore storage failures to avoid disrupting the current interaction.
+  }
+}
+
+export function clearAnalyticsEvents(): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    // Ignore storage failures to avoid disrupting privacy controls.
   }
 }


### PR DESCRIPTION
Closes a separate analytics path that persisted up to 200 behavioral events in localStorage without consulting consent. `appendAnalyticsEvent()` now uses the same centralized consent + DNT/GPC gate as the rest of analytics. Explicit denial also clears that persistent analytics queue, and choosing “Continue without tracking” under DNT/GPC now handles a prior granted session like withdrawal: clear stored events and reload to tear down already-loaded third-party analytics.