### PR TITLE
Privacy: gate analytics-owned session state

### DIFF
--- a/src/lib/__tests__/botanical-atlas-engagement.test.ts
+++ b/src/lib/__tests__/botanical-atlas-engagement.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { appendAnalyticsEvent } = vi.hoisted(() => ({ appendAnalyticsEvent: vi.fn() }))
+const { appendAnalyticsEvent, canTrackAnalytics } = vi.hoisted(() => ({
+  appendAnalyticsEvent: vi.fn(),
+  canTrackAnalytics: vi.fn(() => true),
+}))
 vi.mock('@/lib/analyticsEventStorage', () => ({ appendAnalyticsEvent }))
+vi.mock('@/lib/consent', () => ({ canTrackAnalytics }))
 
 import {
   getAtlasEngagementState,
@@ -14,6 +18,8 @@ import {
 describe('botanical atlas engagement depth', () => {
   beforeEach(() => {
     appendAnalyticsEvent.mockClear()
+    canTrackAnalytics.mockReset()
+    canTrackAnalytics.mockReturnValue(true)
     window.sessionStorage.clear()
   })
 
@@ -51,6 +57,16 @@ describe('botanical atlas engagement depth', () => {
 
   it('fails safely when stored session data is malformed', () => {
     window.sessionStorage.setItem('botanical-atlas-engagement', '{bad json')
+    expect(getAtlasEngagementState()).toMatchObject({ firstFilter: null, distinctFilters: [], profileOpened: false, recoveryAccepted: null })
+  })
+
+  it('does not persist atlas engagement state without consent', () => {
+    canTrackAnalytics.mockReturnValue(false)
+    trackAtlasFilter({ filter: 'effect', value: 'Calming', resultCount: 12 })
+    trackAtlasProfileClick({ slug: 'kanna', position: 1, activeFilterCount: 1 })
+
+    expect(appendAnalyticsEvent).not.toHaveBeenCalled()
+    expect(window.sessionStorage.length).toBe(0)
     expect(getAtlasEngagementState()).toMatchObject({ firstFilter: null, distinctFilters: [], profileOpened: false, recoveryAccepted: null })
   })
 })

--- a/src/lib/__tests__/compare-hub-tracking.test.ts
+++ b/src/lib/__tests__/compare-hub-tracking.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { appendAnalyticsEvent } = vi.hoisted(() => ({ appendAnalyticsEvent: vi.fn() }))
+const { appendAnalyticsEvent, canTrackAnalytics } = vi.hoisted(() => ({
+  appendAnalyticsEvent: vi.fn(),
+  canTrackAnalytics: vi.fn(() => true),
+}))
 vi.mock('@/lib/analyticsEventStorage', () => ({ appendAnalyticsEvent }))
+vi.mock('@/lib/consent', () => ({ canTrackAnalytics }))
 
 import {
   trackCompareHubCategoryShown,
@@ -13,6 +17,8 @@ import {
 describe('comparison hub tracking', () => {
   beforeEach(() => {
     appendAnalyticsEvent.mockClear()
+    canTrackAnalytics.mockReset()
+    canTrackAnalytics.mockReturnValue(true)
     sessionStorage.clear()
   })
 
@@ -61,5 +67,14 @@ describe('comparison hub tracking', () => {
     expect(appendAnalyticsEvent).toHaveBeenCalledWith(expect.objectContaining({
       type: 'comparison_outcome_click', slug: 'coffee-vs-green-tea', item: '/herbs/coffea-arabica/', context: expect.stringContaining('outcome:herb_profile'),
     }))
+  })
+
+  it('does not create comparison analytics session state without consent', () => {
+    canTrackAnalytics.mockReturnValue(false)
+    trackCompareHubClick({ source: 'featured_category', href: '/guides/compare/coffee-vs-green-tea/', label: 'Coffee vs Green Tea', category: 'Energy & focus' })
+    trackComparisonPageViewed('coffee-vs-green-tea')
+
+    expect(appendAnalyticsEvent).not.toHaveBeenCalled()
+    expect(sessionStorage.length).toBe(0)
   })
 })

--- a/src/lib/__tests__/related-botanical-tracking.test.ts
+++ b/src/lib/__tests__/related-botanical-tracking.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { appendAnalyticsEvent } = vi.hoisted(() => ({ appendAnalyticsEvent: vi.fn() }))
+const { appendAnalyticsEvent, canTrackAnalytics } = vi.hoisted(() => ({
+  appendAnalyticsEvent: vi.fn(),
+  canTrackAnalytics: vi.fn(() => true),
+}))
 vi.mock('@/lib/analyticsEventStorage', () => ({ appendAnalyticsEvent }))
+vi.mock('@/lib/consent', () => ({ canTrackAnalytics }))
 
 import {
   trackRelatedBotanicalClick,
@@ -12,6 +16,8 @@ import {
 describe('related botanical tracking', () => {
   beforeEach(() => {
     appendAnalyticsEvent.mockClear()
+    canTrackAnalytics.mockReset()
+    canTrackAnalytics.mockReturnValue(true)
     sessionStorage.clear()
   })
 
@@ -46,5 +52,15 @@ describe('related botanical tracking', () => {
     expect(appendAnalyticsEvent).toHaveBeenLastCalledWith(expect.objectContaining({
       type: 'related_botanical_compare_click', targetType: 'comparison', context: expect.stringContaining('profile_depth:1'),
     }))
+  })
+
+  it('does not persist exploration sessions without consent', () => {
+    canTrackAnalytics.mockReturnValue(false)
+    const item = { slug: 'rhodiola', position: 1, score: 10.5, reasonTypes: ['explicit-effect'] }
+    trackRelatedBotanicalsShown('ashwagandha', [item])
+    trackRelatedBotanicalClick('ashwagandha', item)
+
+    expect(appendAnalyticsEvent).not.toHaveBeenCalled()
+    expect(sessionStorage.length).toBe(0)
   })
 })

--- a/src/lib/analyticsEventStorage.ts
+++ b/src/lib/analyticsEventStorage.ts
@@ -3,6 +3,14 @@ import { canTrackAnalytics } from '@/lib/consent'
 type AnalyticsEvent = Record<string, unknown>
 
 const STORAGE_KEY = 'hs_analytics_events'
+const ANALYTICS_SESSION_KEYS = [
+  'hs_related_botanical_session',
+  'hs_compare_hub_session',
+  'hs_compare_hub_seen_categories',
+  'hs_compare_seen_pages',
+  'hs_compare_pending_entry',
+  'botanical-atlas-engagement',
+] as const
 const MAX_EVENTS = 200
 
 export function appendAnalyticsEvent(event: AnalyticsEvent): void {
@@ -30,6 +38,9 @@ export function clearAnalyticsEvents(): void {
   if (typeof window === 'undefined') return
   try {
     window.localStorage.removeItem(STORAGE_KEY)
+    for (const key of ANALYTICS_SESSION_KEYS) {
+      window.sessionStorage.removeItem(key)
+    }
   } catch {
     // Ignore storage failures to avoid disrupting privacy controls.
   }

--- a/src/lib/botanicalAtlasTracking.ts
+++ b/src/lib/botanicalAtlasTracking.ts
@@ -1,4 +1,5 @@
 import { appendAnalyticsEvent } from '@/lib/analyticsEventStorage'
+import { canTrackAnalytics } from '@/lib/consent'
 import type { AtlasRecoveryAction, AtlasRecoverySuggestion } from '@/lib/botanical-atlas-recovery'
 
 type AtlasFilterName = 'search' | 'effect' | 'chemistry' | 'evidence' | 'noticeability' | 'safety'
@@ -47,7 +48,7 @@ export function getAtlasLandingSource(referrer = typeof document !== 'undefined'
 }
 
 export function getAtlasEngagementState(): AtlasEngagementState {
-  if (typeof window === 'undefined') return emptyEngagement()
+  if (typeof window === 'undefined' || !canTrackAnalytics()) return emptyEngagement()
   try {
     const parsed = JSON.parse(window.sessionStorage.getItem(ENGAGEMENT_KEY) || 'null')
     if (!parsed || !Array.isArray(parsed.distinctFilters)) {
@@ -68,7 +69,7 @@ export function getAtlasEngagementState(): AtlasEngagementState {
 }
 
 function saveAtlasEngagementState(state: AtlasEngagementState) {
-  if (typeof window === 'undefined') return
+  if (typeof window === 'undefined' || !canTrackAnalytics()) return
   try { window.sessionStorage.setItem(ENGAGEMENT_KEY, JSON.stringify(state)) } catch { /* analytics must never block UX */ }
 }
 
@@ -86,18 +87,18 @@ function withEngagementDepth(context: string, state = getAtlasEngagementState())
 }
 
 export function trackAtlasFilter(params: { filter: AtlasFilterName; value: string; resultCount: number }) {
-  if (typeof window === 'undefined') return
+  if (typeof window === 'undefined' || !canTrackAnalytics()) return
   const engagement = recordFilterDepth(params.filter)
   appendAnalyticsEvent({ type: 'botanical_atlas_filter', slug: 'botanical-activity-atlas', item: params.value || 'cleared', context: withLandingSource(withEngagementDepth(`${params.filter}:${params.resultCount}`, engagement)), sourceType: 'collection', targetType: 'collection' })
 }
 
 export function trackAtlasReset(activeFilterCount: number) {
-  if (typeof window === 'undefined') return
+  if (typeof window === 'undefined' || !canTrackAnalytics()) return
   appendAnalyticsEvent({ type: 'botanical_atlas_reset', slug: 'botanical-activity-atlas', item: String(activeFilterCount), context: withLandingSource(withEngagementDepth('reset-filters')), sourceType: 'collection', targetType: 'collection' })
 }
 
 export function trackAtlasRecoveryShown(suggestions: AtlasRecoverySuggestion[]) {
-  if (typeof window === 'undefined' || !suggestions.length) return
+  if (typeof window === 'undefined' || !suggestions.length || !canTrackAnalytics()) return
   const state = getAtlasEngagementState()
   appendAnalyticsEvent({
     type: 'botanical_atlas_recovery_shown',
@@ -109,7 +110,7 @@ export function trackAtlasRecoveryShown(suggestions: AtlasRecoverySuggestion[]) 
 }
 
 export function trackAtlasRecoveryAccepted(suggestion: AtlasRecoverySuggestion) {
-  if (typeof window === 'undefined') return
+  if (typeof window === 'undefined' || !canTrackAnalytics()) return
   const state = { ...getAtlasEngagementState(), recoveryAccepted: suggestion.action }
   saveAtlasEngagementState(state)
   appendAnalyticsEvent({
@@ -122,7 +123,7 @@ export function trackAtlasRecoveryAccepted(suggestion: AtlasRecoverySuggestion) 
 }
 
 export function trackAtlasProfileClick(params: { slug: string; position: number; activeFilterCount: number }) {
-  if (typeof window === 'undefined') return
+  if (typeof window === 'undefined' || !canTrackAnalytics()) return
   const engagement = { ...getAtlasEngagementState(), profileOpened: true }
   saveAtlasEngagementState(engagement)
   appendAnalyticsEvent({ type: 'botanical_atlas_profile_click', slug: 'botanical-activity-atlas', item: params.slug, context: withLandingSource(withEngagementDepth(`position:${params.position};filters:${params.activeFilterCount}`, engagement)), sourceType: 'collection', targetType: 'herb' })

--- a/src/lib/compareHubTracking.ts
+++ b/src/lib/compareHubTracking.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { appendAnalyticsEvent } from '@/lib/analyticsEventStorage'
+import { canTrackAnalytics } from '@/lib/consent'
 
 const SESSION_KEY = 'hs_compare_hub_session'
 const SEEN_CATEGORY_KEY = 'hs_compare_hub_seen_categories'
@@ -77,7 +78,7 @@ function consumePendingEntry(pageSlug: string): PendingEntry | undefined {
 }
 
 export function trackCompareHubCategoryShown(category: string) {
-  if (typeof window === 'undefined' || !category) return
+  if (typeof window === 'undefined' || !category || !canTrackAnalytics()) return
   const seen = readStringSet(SEEN_CATEGORY_KEY)
   if (seen.has(category)) return
   seen.add(category)
@@ -105,7 +106,7 @@ export function trackCompareHubClick({
   label: string
   category?: string
 }) {
-  if (typeof window === 'undefined') return
+  if (typeof window === 'undefined' || !canTrackAnalytics()) return
   const session = getSession()
   const pageSlug = comparisonSlugFromHref(href)
   if (pageSlug) {
@@ -129,7 +130,7 @@ export function trackCompareHubClick({
 export type ComparisonOutcomeType = 'herb_profile' | 'compound_profile' | 'safety_checker' | 'reference' | 'another_comparison' | 'compare_hub'
 
 export function trackComparisonPageViewed(pageSlug: string) {
-  if (typeof window === 'undefined' || !pageSlug) return
+  if (typeof window === 'undefined' || !pageSlug || !canTrackAnalytics()) return
   const session = getSession()
   const seen = readStringSet(SEEN_COMPARISON_KEY)
   const key = `${session.sessionId}|${pageSlug}`
@@ -157,7 +158,7 @@ export function trackComparisonOutcome({
   href: string
   label?: string
 }) {
-  if (typeof window === 'undefined' || !pageSlug || !href) return
+  if (typeof window === 'undefined' || !pageSlug || !href || !canTrackAnalytics()) return
   const session = getSession()
   appendAnalyticsEvent({
     type: 'comparison_outcome_click',

--- a/src/lib/relatedBotanicalTracking.ts
+++ b/src/lib/relatedBotanicalTracking.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { appendAnalyticsEvent } from '@/lib/analyticsEventStorage'
+import { canTrackAnalytics } from '@/lib/consent'
 
 const SESSION_KEY = 'hs_related_botanical_session'
 
@@ -29,7 +30,7 @@ function readSession(): RelatedBotanicalSession {
 }
 
 function saveSession(session: RelatedBotanicalSession) {
-  if (typeof window === 'undefined') return
+  if (typeof window === 'undefined' || !canTrackAnalytics()) return
   try { window.sessionStorage.setItem(SESSION_KEY, JSON.stringify(session)) } catch { /* ignore */ }
 }
 
@@ -51,7 +52,7 @@ export type RelatedBotanicalTrackingItem = {
 }
 
 export function trackRelatedBotanicalsShown(sourceSlug: string, items: RelatedBotanicalTrackingItem[]) {
-  if (typeof window === 'undefined' || !items.length) return
+  if (typeof window === 'undefined' || !items.length || !canTrackAnalytics()) return
   const session = ensureSourceVisited(sourceSlug)
   appendAnalyticsEvent({
     type: 'related_botanicals_shown',
@@ -64,7 +65,7 @@ export function trackRelatedBotanicalsShown(sourceSlug: string, items: RelatedBo
 }
 
 export function trackRelatedBotanicalClick(sourceSlug: string, item: RelatedBotanicalTrackingItem) {
-  if (typeof window === 'undefined') return
+  if (typeof window === 'undefined' || !canTrackAnalytics()) return
   const session = ensureSourceVisited(sourceSlug)
   const visitedProfiles = session.visitedProfiles.includes(item.slug)
     ? session.visitedProfiles
@@ -83,7 +84,7 @@ export function trackRelatedBotanicalClick(sourceSlug: string, item: RelatedBota
 }
 
 export function trackRelatedBotanicalCompare(sourceSlug: string, item: RelatedBotanicalTrackingItem, compareHref: string) {
-  if (typeof window === 'undefined') return
+  if (typeof window === 'undefined' || !canTrackAnalytics()) return
   const session = ensureSourceVisited(sourceSlug)
   appendAnalyticsEvent({
     type: 'related_botanical_compare_click',


### PR DESCRIPTION
Completes the consent sweep for active client analytics. Compare-hub, related-botanical, and Botanical Activity Atlas trackers were still creating session IDs and browsing-path state in sessionStorage before the gated event sink ran. Each active tracker now exits before creating or mutating analytics session state unless centralized consent + DNT/GPC checks allow tracking. Consent denial also clears the six analytics-owned sessionStorage keys while leaving unrelated UX session state alone. Adds regression coverage proving no event or analytics session state is created without consent.