### PR TITLE
Privacy: quarantine dormant runtime analytics behind consent

### DIFF
--- a/src/lib/analyticsEventStorage.ts
+++ b/src/lib/analyticsEventStorage.ts
@@ -3,6 +3,7 @@ import { canTrackAnalytics } from '@/lib/consent'
 type AnalyticsEvent = Record<string, unknown>
 
 const STORAGE_KEY = 'hs_analytics_events'
+const ANALYTICS_LOCAL_STORAGE_KEYS = [STORAGE_KEY, 'ths_runtime_analytics'] as const
 const ANALYTICS_SESSION_KEYS = [
   'hs_related_botanical_session',
   'hs_compare_hub_session',
@@ -36,12 +37,20 @@ export function appendAnalyticsEvent(event: AnalyticsEvent): void {
 
 export function clearAnalyticsEvents(): void {
   if (typeof window === 'undefined') return
-  try {
-    window.localStorage.removeItem(STORAGE_KEY)
-    for (const key of ANALYTICS_SESSION_KEYS) {
-      window.sessionStorage.removeItem(key)
+
+  for (const key of ANALYTICS_LOCAL_STORAGE_KEYS) {
+    try {
+      window.localStorage.removeItem(key)
+    } catch {
+      // Continue clearing the remaining analytics-owned stores.
     }
-  } catch {
-    // Ignore storage failures to avoid disrupting privacy controls.
+  }
+
+  for (const key of ANALYTICS_SESSION_KEYS) {
+    try {
+      window.sessionStorage.removeItem(key)
+    } catch {
+      // Continue clearing the remaining analytics-owned stores.
+    }
   }
 }

--- a/src/lib/runtime-analytics.ts
+++ b/src/lib/runtime-analytics.ts
@@ -1,3 +1,5 @@
+import { canTrackAnalytics } from '@/lib/consent'
+
 export type RuntimeAnalyticsEvent = {
   type:
     | 'profile_view'
@@ -21,7 +23,7 @@ function canUseStorage() {
 }
 
 export function trackRuntimeEvent(event: RuntimeAnalyticsEvent) {
-  if (!canUseStorage()) return
+  if (!canUseStorage() || !canTrackAnalytics()) return
 
   try {
     const existing = getRuntimeAnalyticsEvents()
@@ -41,7 +43,7 @@ export function trackRuntimeEvent(event: RuntimeAnalyticsEvent) {
 }
 
 export function getRuntimeAnalyticsEvents(): RuntimeAnalyticsEvent[] {
-  if (!canUseStorage()) return []
+  if (!canUseStorage() || !canTrackAnalytics()) return []
 
   try {
     const raw = localStorage.getItem(STORAGE_KEY)


### PR DESCRIPTION
The dormant runtime analytics subsystem could persist up to 250 profile/search/compare/pathway events immediately if its hook were reintroduced, without consulting consent. This change routes both writes and reads through the centralized consent + DNT/GPC gate. Consent cleanup also removes its legacy `ths_runtime_analytics` localStorage key, with per-key error handling so one blocked storage surface cannot prevent the rest of the analytics cleanup.