### PR TITLE
CI: align analytics tests with centralized consent gate

### DIFF
--- a/lib/__tests__/analytics.test.ts
+++ b/lib/__tests__/analytics.test.ts
@@ -1,11 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/lib/consent', () => ({
-  getConsent: vi.fn(() => 'granted'),
-  getSystemNoTracking: vi.fn(() => false),
+  canTrackAnalytics: vi.fn(() => true),
 }))
 
-import { getConsent, getSystemNoTracking } from '@/lib/consent'
+import { canTrackAnalytics } from '@/lib/consent'
 import {
   getGuideTrackingContext,
   trackAtlasCalloutClick,
@@ -15,8 +14,7 @@ import {
 } from '../analytics'
 
 beforeEach(() => {
-  vi.mocked(getConsent).mockReturnValue('granted')
-  vi.mocked(getSystemNoTracking).mockReturnValue(false)
+  vi.mocked(canTrackAnalytics).mockReturnValue(true)
 })
 
 afterEach(() => {
@@ -100,10 +98,10 @@ describe('guide analytics', () => {
     })
   })
 
-  it('does not emit analytics when consent is denied', () => {
+  it('does not emit analytics when centralized consent denies tracking', () => {
     const gtag = vi.fn()
     ;(window as Window & { gtag?: unknown }).gtag = gtag
-    vi.mocked(getConsent).mockReturnValue('denied')
+    vi.mocked(canTrackAnalytics).mockReturnValue(false)
 
     trackGuideView({
       slug: 'magnesium-for-sleep',
@@ -114,10 +112,10 @@ describe('guide analytics', () => {
     expect(gtag).not.toHaveBeenCalled()
   })
 
-  it('does not emit analytics when DNT or GPC is active', () => {
+  it('does not emit signup analytics when centralized consent blocks tracking', () => {
     const gtag = vi.fn()
     ;(window as Window & { gtag?: unknown }).gtag = gtag
-    vi.mocked(getSystemNoTracking).mockReturnValue(true)
+    vi.mocked(canTrackAnalytics).mockReturnValue(false)
 
     trackEmailSignup({
       source: 'article-adhd-checklist',
@@ -154,10 +152,10 @@ describe('atlas callout analytics', () => {
     })
   })
 
-  it('leaves dataLayer untouched when consent is denied', () => {
+  it('leaves dataLayer untouched when centralized consent blocks tracking', () => {
     const gtag = vi.fn()
     ;(window as Window & { gtag?: unknown }).gtag = gtag
-    vi.mocked(getConsent).mockReturnValue('denied')
+    vi.mocked(canTrackAnalytics).mockReturnValue(false)
 
     trackAtlasCalloutClick({
       source: 'anxiety_hub',


### PR DESCRIPTION
Fixes the current Vitest blocker without weakening production privacy behavior. The analytics implementation now relies on centralized `canTrackAnalytics()`, but the test harness still mocked the old `getConsent()` / `getSystemNoTracking()` internals, causing all granted-consent assertions to run as blocked. Tests now mock the public gate directly and still verify both allowed and blocked analytics paths.