### PR TITLE
SEO: remove fabricated focus article modification dates

### DIFF
--- a/lib/focus-cluster-markdown.ts
+++ b/lib/focus-cluster-markdown.ts
@@ -16,7 +16,7 @@ export type FocusClusterArticle = {
   slug: string
   sourceFile: string
   markdown: string
-  dateModified: string
+  dateModified?: string
 }
 
 type FocusClusterSource = {
@@ -71,6 +71,15 @@ function asStringArray(value: unknown): string[] {
     .filter(Boolean)
 }
 
+function sourceModifiedDate(data: Record<string, unknown>): string | undefined {
+  const value =
+    asString(data.dateModified) ||
+    asString(data.lastUpdated) ||
+    asString(data.updatedAt)
+
+  return value || undefined
+}
+
 function extractSection(raw: string, heading: string): string {
   const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
   const match = raw.match(new RegExp(`##\\s+${escaped}\\s*\\n+([\\s\\S]*?)(?=\\n##\\s|\\n---\\s*$|$)`, 'i'))
@@ -86,12 +95,13 @@ function stripEditorialTerminal(raw: string): string {
 
 function parseYamlSource(raw: string, sourceFile: string): FocusClusterArticle {
   const parsed = matter(raw)
-  const data = parsed.data || {}
+  const data = (parsed.data || {}) as Record<string, unknown>
   const content = (parsed.content || '').trim()
   const fullArticleContent = extractSection(content, 'Full Article Content') || extractSection(content, 'Full article content')
   const markdown = stripEditorialTerminal(fullArticleContent || content)
   const h1 = markdown.match(/^#\s+(.+)$/m)?.[1]?.trim()
   const title = asString(data.title) || h1 || ''
+  const dateModified = sourceModifiedDate(data)
 
   return {
     title,
@@ -104,7 +114,7 @@ function parseYamlSource(raw: string, sourceFile: string): FocusClusterArticle {
     slug: asString(data.slug),
     sourceFile,
     markdown,
-    dateModified: '2026-06-12',
+    ...(dateModified ? { dateModified } : {}),
   }
 }
 

--- a/lib/focus-cluster-markdown.ts
+++ b/lib/focus-cluster-markdown.ts
@@ -16,7 +16,7 @@ export type FocusClusterArticle = {
   slug: string
   sourceFile: string
   markdown: string
-  dateModified?: string
+  dateModified: string
 }
 
 type FocusClusterSource = {
@@ -71,13 +71,12 @@ function asStringArray(value: unknown): string[] {
     .filter(Boolean)
 }
 
-function sourceModifiedDate(data: Record<string, unknown>): string | undefined {
-  const value =
+function sourceModifiedDate(data: Record<string, unknown>): string {
+  return (
     asString(data.dateModified) ||
     asString(data.lastUpdated) ||
     asString(data.updatedAt)
-
-  return value || undefined
+  )
 }
 
 function extractSection(raw: string, heading: string): string {
@@ -101,7 +100,6 @@ function parseYamlSource(raw: string, sourceFile: string): FocusClusterArticle {
   const markdown = stripEditorialTerminal(fullArticleContent || content)
   const h1 = markdown.match(/^#\s+(.+)$/m)?.[1]?.trim()
   const title = asString(data.title) || h1 || ''
-  const dateModified = sourceModifiedDate(data)
 
   return {
     title,
@@ -114,7 +112,7 @@ function parseYamlSource(raw: string, sourceFile: string): FocusClusterArticle {
     slug: asString(data.slug),
     sourceFile,
     markdown,
-    ...(dateModified ? { dateModified } : {}),
+    dateModified: sourceModifiedDate(data),
   }
 }
 

--- a/lib/json-ld-sanitize.ts
+++ b/lib/json-ld-sanitize.ts
@@ -118,10 +118,9 @@ function sanitizeObject(input: Record<string, unknown>): JsonLdObject {
 }
 
 export function sanitizeJsonLdValue(value: unknown): JsonLdValue | undefined {
-  if (value === undefined) return undefined
-  if (value === null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
-    return value
-  }
+  if (value === undefined || value === null) return undefined
+  if (typeof value === 'string') return value.trim() ? value : undefined
+  if (typeof value === 'number' || typeof value === 'boolean') return value
   if (Array.isArray(value)) {
     return value
       .map((item) => sanitizeJsonLdValue(item))


### PR DESCRIPTION
Stops the Focus/ADHD markdown loader from assigning the same hardcoded `2026-06-12` modification date to six articles whose source frontmatter does not contain a freshness date. The loader now reads only source-owned `dateModified`, `lastUpdated`, or `updatedAt` values. The JSON-LD sanitizer also drops blank strings globally, so an absent source date is omitted from schema instead of emitted as an empty property.