### PR TITLE
CI: stop flagging trailing-slash canonical redirects as bad links

### DIFF
--- a/scripts/ci/audit-internal-links.mjs
+++ b/scripts/ci/audit-internal-links.mjs
@@ -43,14 +43,30 @@ function readRedirectSourcePatterns() {
   const redirectsPath = candidates.find((candidate) => fs.existsSync(candidate))
   if (!redirectsPath) return { redirectsPath: null, sources: [] }
 
+  const comparablePath = (value) => {
+    if (!value || !value.startsWith('/')) return value || ''
+    const pathOnly = value.split(/[?#]/)[0]
+    if (pathOnly === '/') return '/'
+    return pathOnly.replace(/\/+$/, '') || '/'
+  }
+
   const sources = fs.readFileSync(redirectsPath, 'utf8')
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter((line) => line && !line.startsWith('#'))
     .map((line) => line.split(/\s+/))
     .filter((parts) => parts.length >= 3 && /^30[1278]$/.test(parts[2]))
-    .map(([source]) => source)
-    .filter((source) => source?.startsWith('/'))
+    .map(([source, target]) => ({ source, target }))
+    .filter(({ source }) => source?.startsWith('/'))
+    // A no-slash -> trailing-slash redirect is canonicalization of the same
+    // route, not a legacy/migrated destination. Treating it as a redirect
+    // source makes every correct canonical trailing-slash href look invalid
+    // after route normalization (for example /safety-checker ->
+    // /safety-checker/). Non-canonical no-slash hrefs are audited separately.
+    .filter(({ source, target }) => !(
+      target?.startsWith('/') && comparablePath(source) === comparablePath(target)
+    ))
+    .map(({ source }) => source)
 
   return { redirectsPath, sources }
 }


### PR DESCRIPTION
Fixes the post-build internal-link verifier false positive that reported 5,844 valid `/safety-checker/` links as redirect-source links. `/safety-checker` redirects only to `/safety-checker/`, so this is same-route trailing-slash canonicalization, not a legacy destination. The audit now excludes same-path local canonicalization redirects from its redirect-source table while continuing to flag true migrations to different paths. Non-canonical no-slash hrefs remain covered by the existing canonical-href check.