### PR TITLE
Safety checker: preserve contraindication and interaction context

### DIFF
--- a/src/lib/tool-page-payloads.ts
+++ b/src/lib/tool-page-payloads.ts
@@ -35,6 +35,24 @@ function textList(value: unknown): string[] | undefined {
   return cleaned.length ? cleaned : undefined
 }
 
+function safetyContext(record: RuntimeRecord): string | undefined {
+  const values = [
+    firstText(record, ['safety', 'safetyNotes', 'safety_notes']),
+    ...(textList(record.contraindications) || []),
+    ...(textList(record.interactions ?? record.drugInteractions) || []),
+  ].filter((item): item is string => Boolean(item))
+
+  const seen = new Set<string>()
+  const unique = values.filter((item) => {
+    const key = item.toLowerCase()
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+
+  return unique.length ? unique.join('; ') : undefined
+}
+
 function baseToolRecord(record: RuntimeRecord, type: ToolKind) {
   return {
     slug: firstText(record, ['slug']) || '',
@@ -70,7 +88,7 @@ export function toSafetyToolRecord(record: RuntimeRecord, type: ToolKind) {
   const { displayName: _displayName, ...base } = baseToolRecord(record, type)
   return {
     ...base,
-    safety: firstText(record, ['safety', 'safetyNotes', 'safety_notes']),
+    safety: safetyContext(record),
     safety_flags: textList(record.safety_flags ?? record.safetyFlags),
     mechanism: firstText(record, ['mechanism', 'mechanismOfAction']),
     mechanisms: textList(record.mechanisms ?? record.primary_mechanisms ?? record.pathways),


### PR DESCRIPTION
Fixes a data-loss gap in the safety-checker payload. Existing structured contraindications and interaction strings are now folded into the compact safety context already analyzed by the checker, with case-insensitive deduplication. No new clinical rules or severity claims are introduced; the existing high-sensitivity screening rules simply receive the safety fields the page says they evaluate.