### PR TITLE
Governance: fail closed on runtime visibility errors

### DIFF
--- a/app/__tests__/runtime-visibility.test.ts
+++ b/app/__tests__/runtime-visibility.test.ts
@@ -73,4 +73,19 @@ describe('getRuntimeVisibility', () => {
     expect(visibility.canRender).toBe(false)
     expect(visibility.canIndex).toBe(false)
   })
+
+  it('fails closed if evaluating a malformed record throws', () => {
+    const malformed = new Proxy({}, {
+      get() {
+        throw new Error('malformed runtime record')
+      },
+    }) as Record<string, unknown>
+
+    expect(getRuntimeVisibility(malformed)).toEqual({
+      canRender: false,
+      canIndex: false,
+      canFeature: false,
+      canMonetize: false,
+    })
+  })
 })

--- a/lib/runtime-visibility.ts
+++ b/lib/runtime-visibility.ts
@@ -1,5 +1,12 @@
 import { list, text } from '@/lib/display-utils'
 
+const HIDDEN_VISIBILITY = {
+  canRender: false,
+  canIndex: false,
+  canFeature: false,
+  canMonetize: false,
+} as const
+
 function hasResearchPending(record: Record<string, unknown>) {
   return list(record?.primary_effects).some((effect) =>
     /research-pending/i.test(effect)
@@ -39,7 +46,7 @@ function isEvidenceSupported(evidenceTier: string): boolean {
   return /\b(strong|moderate|human|clinical|commercial_ready)\b/i.test(evidenceTier)
 }
 
-export function getRuntimeVisibility(record: Record<string, unknown>) {
+function evaluateRuntimeVisibility(record: Record<string, unknown>) {
   const exportDecision = text(record?.runtime_export_decision)
   const profileStatus = text(record?.profile_status)
   const summaryQuality = text(record?.summary_quality)
@@ -92,5 +99,16 @@ export function getRuntimeVisibility(record: Record<string, unknown>) {
     canIndex: !hidden && strong,
     canFeature: !hidden && strong,
     canMonetize: !hidden && !weak,
+  }
+}
+
+export function getRuntimeVisibility(record: Record<string, unknown>) {
+  try {
+    return evaluateRuntimeVisibility(record)
+  } catch {
+    // Governance must fail closed. Interactive tools historically wrapped this
+    // helper in fail-open catches; containing evaluation errors here prevents an
+    // unreadable or malformed record from becoming visible by accident.
+    return HIDDEN_VISIBILITY
   }
 }


### PR DESCRIPTION
Hardens the central runtime visibility boundary so malformed/unreadable records cannot become visible because a downstream caller catches an evaluation error and defaults to true. Visibility evaluation now contains unexpected errors and returns canRender/canIndex/canFeature/canMonetize=false, with a regression using a throwing Proxy record.