### PR TITLE
Revenue governance: enforce monetization eligibility in buy guide

### DIFF
--- a/src/lib/affiliate.ts
+++ b/src/lib/affiliate.ts
@@ -51,6 +51,12 @@ function hasResearchPendingEffect(item: any) {
 export function canRenderAffiliateLinks(item: any) {
   if (!item) return false
 
+  // Compact buying payloads carry the central runtime governance decision so
+  // renderable-but-nonmonetizable records cannot regain purchase links client-side.
+  if (item.monetization_allowed === false || /^false$/i.test(text(item.monetization_allowed))) {
+    return false
+  }
+
   // Compliance gate: never monetize or promote records flagged in the master workbook governance columns.
   return !isRestrictedRecord(item)
 }

--- a/src/lib/tool-page-payloads.ts
+++ b/src/lib/tool-page-payloads.ts
@@ -1,4 +1,5 @@
 import type { RuntimeRecord } from '@/src/types/content'
+import { getRuntimeVisibility } from '@/lib/runtime-visibility'
 
 type ToolKind = 'herb' | 'compound'
 
@@ -75,6 +76,9 @@ export function toDosingToolRecord(record: RuntimeRecord, type: ToolKind) {
 export function toBuyingToolRecord(record: RuntimeRecord, type: ToolKind) {
   return {
     ...baseToolRecord(record, type),
+    // The product-quality client re-runs the affiliate gate after the server
+    // compacts records, so preserve the central governance decision explicitly.
+    monetization_allowed: getRuntimeVisibility(record).canMonetize,
     buying_criteria: textList(record.buying_criteria ?? record.buyingCriteria),
     amazon_affiliate_url: firstText(record, ['amazon_affiliate_url', 'amazonAffiliateUrl']),
     affiliate_url: firstText(record, ['affiliate_url', 'affiliateUrl']),


### PR DESCRIPTION
Carries the central runtime `canMonetize` decision into compact product-quality payloads and makes the client affiliate gate honor an explicit false value. This prevents renderable-but-nonmonetizable records from regaining Amazon purchase links after server-side payload compaction, while leaving educational visibility unchanged.