### PR TITLE
Revenue governance: block nonmonetizable profile CTAs

### DIFF
--- a/src/lib/__tests__/affiliate-governance.test.ts
+++ b/src/lib/__tests__/affiliate-governance.test.ts
@@ -56,6 +56,28 @@ describe('affiliate governance gates', () => {
     expect(getAffiliateShopLinks(record, record.displayName, 'compound')).toEqual([])
   })
 
+  it('blocks full records that runtime governance marks nonmonetizable', () => {
+    const record = {
+      ...baseAffiliateRecord,
+      summary_quality: 'weak',
+    }
+
+    expect(isRestrictedRecord(record)).toBe(false)
+    expect(canRenderAffiliateLinks(record)).toBe(false)
+    expect(canShowAffiliateModule(record)).toBe(false)
+    expect(getAffiliateShopLinks(record, record.displayName, 'compound')).toEqual([])
+  })
+
+  it('honors an explicit compact-payload monetization denial', () => {
+    const compactRecord = {
+      slug: 'l-theanine',
+      name: 'L-Theanine',
+      monetization_allowed: false,
+    }
+
+    expect(canRenderAffiliateLinks(compactRecord)).toBe(false)
+  })
+
   it('allows affiliate links only when governance flags are clear', () => {
     expect(canRenderAffiliateLinks(baseAffiliateRecord)).toBe(true)
 

--- a/src/lib/affiliate.ts
+++ b/src/lib/affiliate.ts
@@ -1,4 +1,5 @@
 import { isClean, list, text } from '@/lib/display-utils'
+import { getRuntimeVisibility } from '@/lib/runtime-visibility'
 import { isRestrictedIngredient, isRestrictedRecord } from './restricted-ingredients'
 import { AFFILIATE_TAGS } from '@/config/affiliate'
 
@@ -54,6 +55,12 @@ export function canRenderAffiliateLinks(item: any) {
   // Compact buying payloads carry the central runtime governance decision so
   // renderable-but-nonmonetizable records cannot regain purchase links client-side.
   if (item.monetization_allowed === false || /^false$/i.test(text(item.monetization_allowed))) {
+    return false
+  }
+
+  // Full profile records do not carry the compact flag. Enforce the same central
+  // runtime monetization decision before profile-level sourcing CTAs are rendered.
+  if (item.monetization_allowed == null && !getRuntimeVisibility(item).canMonetize) {
     return false
   }
 


### PR DESCRIPTION
Extends the shared affiliate gate to consult central runtime visibility for full profile records, while retaining the explicit compact-payload monetization flag added for the buy guide. Adds regressions proving weak/nonmonetizable full records and compact explicit denials cannot render affiliate links.