### PR TITLE
Revenue governance: guard generic conversion affiliate cards

### DIFF
--- a/components/conversion-affiliate-card.tsx
+++ b/components/conversion-affiliate-card.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { AFFILIATE_TAGS } from '@/config/affiliate'
+import { buildAmazonSearchUrl } from '@/src/lib/affiliate'
 
 type ConversionAffiliateCardProps = {
   title?: string
@@ -56,10 +56,13 @@ export default function ConversionAffiliateCard({
   variant = 'light',
 }: ConversionAffiliateCardProps) {
   const label = clean(name) || 'this supplement'
-  const query = encodeURIComponent(productQueryFor(label, intent))
-  const amazonLink = `https://www.amazon.com/s?k=${query}&tag=${AFFILIATE_TAGS.amazon}`
+  const amazonLink = buildAmazonSearchUrl(productQueryFor(label, intent))
   const compoundHref = slug ? `/compounds/${slug}` : ''
   const isDark = variant === 'dark'
+
+  // Restricted or otherwise blocked product queries return no commerce URL from
+  // the central affiliate helper. Keep education-only pages free of buying CTAs.
+  if (!amazonLink) return null
 
   return (
     <section className={isDark


### PR DESCRIPTION
Routes generic conversion-card Amazon searches through the central restricted-aware affiliate URL builder. Restricted queries now return no commerce URL and the card renders nothing, preventing education/harm-reduction pages such as the Kratom 7-OH withdrawal entry page from displaying a generic Amazon buying CTA.