### PR TITLE
CI: refresh manifest before fallback SEO audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,12 @@ jobs:
 
       - name: Generate SEO audit reports
         if: always()
-        run: npm run audit:seo-reports
+        run: |
+          if ! find out -type f -name '*.html' -print -quit 2>/dev/null | grep -q .; then
+            echo "No built HTML available; refreshing route manifest for fallback SEO audit."
+            node scripts/data/build-route-manifest.mjs --data-dir=public/data
+          fi
+          npm run audit:seo-reports
 
       - name: Generate indexability candidate report
         if: always()


### PR DESCRIPTION
When no built HTML is available (for example because a main CI run is superseded/cancelled), regenerate the deterministic route manifest before running the always-on SEO reports. This prevents fallback artifacts from auditing stale checked-in route metadata and reporting already-fixed long titles or missing hub metadata.