### PR TITLE
Revenue governance: block restricted product-pick slugs

### DIFF
--- a/lib/product-ranking.ts
+++ b/lib/product-ranking.ts
@@ -1,8 +1,10 @@
 import { productPicks } from '@/data/product-picks'
+import { isRestrictedIngredient } from '@/src/lib/restricted-ingredients'
 
 type RuntimeRecord = Record<string, unknown>
 
 export function getProductPicks(slug: string) {
+  if (isRestrictedIngredient(slug)) return []
   return productPicks.filter(p => p.compound_slug === slug)
 }
 

--- a/src/lib/__tests__/product-ranking.test.ts
+++ b/src/lib/__tests__/product-ranking.test.ts
@@ -12,6 +12,12 @@ describe('getProductPicks', () => {
   it('returns an empty array for a slug with no product picks', () => {
     expect(getProductPicks('not-a-real-compound-slug')).toEqual([])
   })
+
+  it('fails closed for restricted product slugs regardless of configured picks', () => {
+    expect(getProductPicks('kava')).toEqual([])
+    expect(getProductPicks('kratom')).toEqual([])
+    expect(getProductPicks('7-oh')).toEqual([])
+  })
 })
 
 describe('groupProductPicks', () => {


### PR DESCRIPTION
Adds a central restricted-ingredient gate to `getProductPicks()` so hardcoded product-pick data cannot surface commerce for restricted slugs. Includes regression coverage for kava, kratom, and 7-OH while preserving normal product grouping behavior.