### PR TITLE
Analytics: classify the live product-quality route as buy guide

### DIFF
--- a/src/lib/__tests__/revenue-tracking.test.ts
+++ b/src/lib/__tests__/revenue-tracking.test.ts
@@ -25,6 +25,8 @@ describe('revenue tracking', () => {
     expect(classifyRevenueRoute('/compounds/magnesium-glycinate/')).toBe('compound-profile')
     expect(classifyRevenueRoute('/guides/compare/rhodiola-vs-ashwagandha/')).toBe('comparison')
     expect(classifyRevenueRoute('/guides/sleep/best-supplements-for-sleep/')).toBe('best-supplements')
+    expect(classifyRevenueRoute('/learn/product-quality/')).toBe('buy-guide')
+    expect(classifyRevenueRoute('/buy-guide/')).toBe('buy-guide')
     expect(classifyRevenueRoute('/guides/other/alkaloids-on-amazon/')).toBe('guide')
   })
 

--- a/src/lib/revenue-tracking.ts
+++ b/src/lib/revenue-tracking.ts
@@ -92,7 +92,12 @@ export function classifyRevenueRoute(pathname: string): RevenueRouteFamily {
   if (path.startsWith('/top/')) return 'top-list'
   if (path.startsWith('/goals/')) return 'goal'
   if (path.startsWith('/stacks/')) return 'stack'
-  if (path === '/buy-guide' || path.startsWith('/buy-guide/')) return 'buy-guide'
+  if (
+    path === '/buy-guide' ||
+    path.startsWith('/buy-guide/') ||
+    path === '/learn/product-quality' ||
+    path.startsWith('/learn/product-quality/')
+  ) return 'buy-guide'
   if (path.startsWith('/guides/')) return 'guide'
   return 'other'
 }


### PR DESCRIPTION
Updates revenue route classification so `/learn/product-quality/`—the site's actual product-quality/buying surface—is attributed to the `buy-guide` family instead of `other`. Retains support for the legacy `/buy-guide/` route and adds regression coverage for both.