### PR TITLE
Fix identity-registry CI job and a Windows-only test failure

### DIFF
--- a/.github/workflows/evidence-graph-identity-check.yml
+++ b/.github/workflows/evidence-graph-identity-check.yml
@@ -49,8 +49,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # These specs import `describe`/`it`/`expect` from vitest, so they must run
+      # under vitest. Executing them with `node --test` loaded vitest's runner
+      # without initializing it, which crashed on every run with
+      # "Cannot read properties of undefined (reading 'config')" — failing this
+      # job on unrelated PRs.
       - name: Run identity unit tests
-        run: node --test scripts/evidence-graph/__tests__/*.test.mjs
+        run: npx vitest run scripts/evidence-graph/__tests__/
 
       - name: Build registry from workbook
         run: |

--- a/agent/orchestrator/prepare-comparison-assignments.test.js
+++ b/agent/orchestrator/prepare-comparison-assignments.test.js
@@ -1,3 +1,5 @@
+import path from 'node:path'
+
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -103,7 +105,10 @@ describe('parseComparisonAssignmentArgs', () => {
       action: 'research-first',
       packetId: 'comparison:a:b',
       limit: 50,
-      queuePath: '/repo/tmp/queue.json',
+      // Built with path.resolve rather than hardcoded: the source resolves the
+      // arg against the root, so a literal POSIX string asserted the separator
+      // rather than the behaviour and failed on Windows.
+      queuePath: path.resolve('/repo', 'tmp/queue.json'),
     })
   })
 


### PR DESCRIPTION
Two harness bugs that were failing checks on PRs which changed nothing related to them.

## `identity-registry` job crashed on every run

The job ran:

```
node --test scripts/evidence-graph/__tests__/*.test.mjs
```

but those specs import `describe`/`it`/`expect` from **vitest**. Node's built-in test runner loaded vitest's runner without initializing it, so every run died with:

```
TypeError: Cannot read properties of undefined (reading 'config')
    at validateTags(runner.config, suiteTags)
```

This is why the lucide-react bump (#1891) showed a red check despite touching no test code — the job is broken for any PR that triggers it. It now runs under vitest, where the specs pass.

## Windows-only test failure

`prepare-comparison-assignments.test.js` asserted `queuePath` as the literal `'/repo/tmp/queue.json'`. The source correctly uses `path.resolve`, so the test was asserting the *path separator* rather than the behaviour, and failed on Windows with `C:\repo\tmp\queue.json`. The expectation is now built with `path.resolve` too.

## Result

Full suite: **287 files / 1330 tests passing, zero failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)