### PR TITLE
Pin axe-core to 4.12.1 — 4.13.0 does not exist on npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "autoprefixer": "^10.4.19",
-        "axe-core": "4.13.0",
+        "axe-core": "4.12.1",
         "csv-parse": "5.6.0",
         "eslint": "^9.39.5",
         "eslint-config-prettier": "^9.0.0",
@@ -5750,9 +5750,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
-      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -232,7 +232,7 @@
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "autoprefixer": "^10.4.19",
-    "axe-core": "4.13.0",
+    "axe-core": "4.12.1",
     "csv-parse": "5.6.0",
     "eslint": "^9.39.5",
     "eslint-config-prettier": "^9.0.0",


### PR DESCRIPTION
**Unbreaks `main`.**

Dependabot's bump to `axe-core@4.13.0` (#2523) was green when the PR was opened, but that version is no longer published to npm — the highest available is `4.12.1`. Once it merged, `npm ci` on `main` fails:

```
npm error code ETARGET
npm error notarget No matching version found for axe-core@4.13.0.
```

That breaks CI and the Cloudflare Pages production build.

Pinned to `4.12.1` — the newest version that actually resolves — which keeps the intent of the bump rather than reverting to 4.11.3.

## Verification
- `npm ci` exits 0
- `axe-core` resolves to 4.12.1 in both `package.json` and `package-lock.json`
- `app/__tests__/a11y.test.tsx` passes (5/5) on the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)