### PR TITLE
Revert axe-core downgrade — 4.13.0 is fine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "autoprefixer": "^10.4.19",
-        "axe-core": "4.12.1",
+        "axe-core": "4.13.0",
         "csv-parse": "5.6.0",
         "eslint": "^9.39.5",
         "eslint-config-prettier": "^9.0.0",
@@ -5750,9 +5750,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
-      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -232,7 +232,7 @@
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "autoprefixer": "^10.4.19",
-    "axe-core": "4.12.1",
+    "axe-core": "4.13.0",
     "csv-parse": "5.6.0",
     "eslint": "^9.39.5",
     "eslint-config-prettier": "^9.0.0",


### PR DESCRIPTION
Reverts #2859, which was based on bad evidence.

I downgraded `axe-core` 4.13.0 → 4.12.1 after `npm view axe-core@4.13.0` returned 404 and `npm install --package-lock-only` failed with `ETARGET`. That reasoning was wrong: this environment's npm **packument** metadata is stale, so `npm view` 404s for versions that genuinely exist. The same false 404 occurs for `vitest@4.1.10` and `tsx@4.23.1`, both of which are installed and working.

The decisive checks:

- `https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz` → **200**
- `npm ci` on main with 4.13.0 → **exit 0**, installs 4.13.0
- main at `5b1b2281` (with 4.13.0) → **Site Health Check succeeded**; the CI/Lighthouse runs I read as failures were `cancelled` by a subsequent push

`npm ci` resolves from the lockfile's tarball URLs, which is why it always worked. Main was never broken, so the downgrade is reverted and dependabot's intended bump is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)