### PR TITLE
Flatten redirect chains created by the build-time override merge

### DIFF
--- a/app/__tests__/redirect-override-chain-flattening.test.ts
+++ b/app/__tests__/redirect-override-chain-flattening.test.ts
@@ -1,0 +1,94 @@
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const repoRoot = process.cwd()
+const script = path.join(repoRoot, 'scripts', 'seo', 'apply-redirect-overrides.mjs')
+
+const workspaces: string[] = []
+
+function makeWorkspace(redirects: string, overrides: Record<string, string>) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'redirect-overrides-'))
+  workspaces.push(dir)
+
+  fs.mkdirSync(path.join(dir, 'out'), { recursive: true })
+  fs.writeFileSync(path.join(dir, 'out', '_redirects'), redirects)
+
+  const overridesDir = path.join(dir, 'public', 'redirect-overrides')
+  fs.mkdirSync(overridesDir, { recursive: true })
+  for (const [name, contents] of Object.entries(overrides)) {
+    fs.writeFileSync(path.join(overridesDir, name), contents)
+  }
+
+  return dir
+}
+
+function run(dir: string) {
+  execFileSync('node', [script], { cwd: dir, stdio: 'pipe' })
+  return fs.readFileSync(path.join(dir, 'out', '_redirects'), 'utf8')
+}
+
+function activeRules(contents: string) {
+  return contents
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'))
+}
+
+afterEach(() => {
+  while (workspaces.length) {
+    fs.rmSync(workspaces.pop()!, { recursive: true, force: true })
+  }
+})
+
+describe('apply-redirect-overrides chain flattening', () => {
+  it('collapses rules that an override turns into a two-hop chain', () => {
+    // The override retires /guides/focus/old/, which turns the pre-existing
+    // rule pointing at it into a chain. Cloudflare does not follow chains
+    // server-side, so both rules must land on the final destination directly.
+    const dir = makeWorkspace(
+      '/legacy-focus/ /guides/focus/old/ 301\n',
+      { '001-consolidation.txt': '/guides/focus/old/ /guides/focus/new/ 301\n' },
+    )
+
+    const rules = activeRules(run(dir))
+
+    expect(rules).toContain('/legacy-focus/ /guides/focus/new/ 301')
+    expect(rules).not.toContain('/legacy-focus/ /guides/focus/old/ 301')
+  })
+
+  it('flattens absolute www rules without mistaking the protocol colon for a placeholder', () => {
+    const dir = makeWorkspace(
+      'https://www.thehippiescientist.net/x https://thehippiescientist.net/guides/focus/old/ 301\n',
+      { '001-consolidation.txt': '/guides/focus/old/ /guides/focus/new/ 301\n' },
+    )
+
+    const rules = activeRules(run(dir))
+
+    expect(rules).toContain(
+      'https://www.thehippiescientist.net/x https://thehippiescientist.net/guides/focus/new/ 301',
+    )
+  })
+
+  it('leaves splat rules untouched', () => {
+    const splat = 'https://www.thehippiescientist.net/* https://thehippiescientist.net/:splat 301'
+    const dir = makeWorkspace(`${splat}\n`, {
+      '001-consolidation.txt': '/guides/focus/old/ /guides/focus/new/ 301\n',
+    })
+
+    expect(activeRules(run(dir))).toContain(splat)
+  })
+
+  it('is idempotent so repeated builds cannot grow the file past the Cloudflare rule ceiling', () => {
+    const dir = makeWorkspace('/legacy-focus/ /guides/focus/old/ 301\n', {
+      '001-consolidation.txt': '/guides/focus/old/ /guides/focus/new/ 301\n',
+    })
+
+    const first = activeRules(run(dir))
+    const second = activeRules(run(dir))
+
+    expect(second).toEqual(first)
+  })
+})

--- a/scripts/seo/apply-redirect-overrides.mjs
+++ b/scripts/seo/apply-redirect-overrides.mjs
@@ -64,15 +64,29 @@ if (rules.length === 0) {
   process.exit(0)
 }
 
-const existing = fs.readFileSync(redirectsPath, 'utf8').trimStart()
+const BLOCK_START = '# >>> redirect-overrides (generated, do not edit)'
+const BLOCK_END = '# <<< redirect-overrides'
+
+// Incremental rebuilds can reach this script with an out/_redirects that already
+// carries a merged block (the public/ copy step is cached and does not reset the
+// file). Without stripping it first, every rebuild prepends another copy and the
+// rule count grows without bound — past Cloudflare's 2000-rule ceiling for Pages,
+// where the excess is silently dropped.
+function stripPreviousBlock(contents) {
+  const start = contents.indexOf(BLOCK_START)
+  if (start === -1) return contents
+  const end = contents.indexOf(BLOCK_END, start)
+  if (end === -1) return contents
+  return contents.slice(0, start) + contents.slice(end + BLOCK_END.length)
+}
+
+const existing = stripPreviousBlock(fs.readFileSync(redirectsPath, 'utf8')).trimStart()
 const header = [
-  '# Redirect overrides merged during build.',
+  BLOCK_START,
   '# These rules are intentionally prepended so exact audit-cleanup rules win over older wildcard or stale targets.',
   '# Exact slash and non-slash variants are generated automatically for path redirects.',
 ]
-const mergedRedirects = `${header.join('\n')}\n${rules.join('\n')}\n\n${existing}`
-
-fs.writeFileSync(redirectsPath, mergedRedirects)
+const mergedRedirects = `${header.join('\n')}\n${rules.join('\n')}\n${BLOCK_END}\n\n${existing}`
 
 function normalizeRoute(value) {
   const clean = String(value || '').split(/[?#]/)[0].trim()
@@ -157,6 +171,75 @@ function resolveRedirectTarget(source, redirectMap) {
   return current === source ? null : current
 }
 
+const CANONICAL_HOST = 'thehippiescientist.net'
+
+// `:splat`/`:param` placeholders must survive verbatim. Match a colon that
+// starts a path segment so the `https://` protocol colon in the absolute
+// www -> apex rules is not mistaken for a placeholder.
+const hasPlaceholder = (value) => value.includes('*') || /(^|\/):[a-z]/i.test(value)
+
+/**
+ * Returns the pathname a redirect target points at, but only when that target
+ * is a path or an absolute URL on our own host. Cross-host targets are left
+ * alone: their final destination is decided by the other host, not by this file.
+ */
+function targetPathname(target) {
+  if (target.startsWith('/')) return normalizeRoute(target)
+
+  try {
+    const url = new URL(target)
+    if (url.hostname.replace(/^www\./, '') !== CANONICAL_HOST) return null
+    return normalizeRoute(url.pathname)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Collapse multi-hop rules so every source reaches its final destination in one
+ * hop.
+ *
+ * Overrides are *prepended*, so an override that retires page B silently turns
+ * every pre-existing `A -> B` rule into a two-hop chain. Cloudflare does not
+ * follow chains server-side, so each hop is a real round trip for crawlers and
+ * users. `normalize-redirects.mjs` cannot catch these: it checks
+ * `public/_redirects`, and these chains only exist after the merge that happens
+ * here, at build time.
+ */
+function flattenRedirectRules(contents, redirectMap) {
+  let flattenedCount = 0
+
+  const lines = contents.split(/\r?\n/).map((line) => {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) return line
+
+    const [source, target, status = '301'] = trimmed.split(/\s+/)
+    if (!source || !target || !/^30[1278]$/.test(status)) return line
+    // Placeholder rules carry a :splat/wildcard through to the target; the
+    // resolved path of a template is not a real route, so leave them intact.
+    if (hasPlaceholder(source) || hasPlaceholder(target)) return line
+
+    const currentPath = targetPathname(target)
+    if (!currentPath) return line
+
+    const finalPath = resolveRedirectTarget(currentPath, redirectMap)
+    if (!finalPath) return line
+
+    // A chain that loops back to its own source cannot be flattened into a
+    // single hop without creating a self-redirect. Leave it for a human.
+    if (finalPath === normalizeRoute(source)) return line
+
+    const rewrittenTarget = target.startsWith('/')
+      ? canonicalHref(finalPath)
+      : new URL(canonicalHref(finalPath), `https://${CANONICAL_HOST}`).toString()
+
+    flattenedCount += 1
+    return `${source} ${rewrittenTarget} ${status}`
+  })
+
+  return { contents: lines.join('\n'), flattenedCount }
+}
+
 function* walkHtmlFiles(dir) {
   if (!fs.existsSync(dir)) return
 
@@ -208,8 +291,12 @@ function rewriteRedirectingInternalLinks(redirectMap) {
 }
 
 const exactRedirectMap = parseExactRedirects(mergedRedirects)
+const flattenResult = flattenRedirectRules(mergedRedirects, exactRedirectMap)
+
+fs.writeFileSync(redirectsPath, flattenResult.contents)
+
 const repairResult = rewriteRedirectingInternalLinks(exactRedirectMap)
 
 console.log(
-  `[redirect-overrides] Prepended ${rules.length} redirect override rules, rewrote ${repairResult.rewrittenLinks} internal redirect links, repaired ${repairResult.repairedCompareLinks} stale comparison links (${repairResult.collapsedUnbuiltCompareLinks} unbuilt pairs sent to the comparison hub), and touched ${repairResult.touchedFiles} HTML files.`,
+  `[redirect-overrides] Prepended ${rules.length} redirect override rules, flattened ${flattenResult.flattenedCount} multi-hop redirect rules, rewrote ${repairResult.rewrittenLinks} internal redirect links, repaired ${repairResult.repairedCompareLinks} stale comparison links (${repairResult.collapsedUnbuiltCompareLinks} unbuilt pairs sent to the comparison hub), and touched ${repairResult.touchedFiles} HTML files.`,
 )

--- a/scripts/verify-redirects.mjs
+++ b/scripts/verify-redirects.mjs
@@ -207,6 +207,71 @@ if (fs.existsSync(sitemapPath)) {
   }
 }
 
+// Cloudflare does not follow redirect chains server-side: a rule whose target
+// is itself a redirect source costs crawlers and users a second round trip.
+// `normalize-redirects.mjs` flattens chains in public/_redirects, but it runs
+// before `apply-redirect-overrides.mjs` prepends the override rules — and a
+// prepended override that retires page B turns every existing `A -> B` rule
+// into a chain. Those chains only exist in the built file, so they are checked
+// here.
+// `:splat`/`:param` placeholders must not be resolved as literal routes. Match
+// a colon that starts a path segment so the `https://` protocol colon in the
+// absolute www rules is not mistaken for one.
+const hasPlaceholder = (value) => value.includes('*') || /(^|\/):[a-z]/i.test(value)
+
+/** Pathname of a redirect target, or null if it is not a route on our host. */
+const routeOfTarget = (target) => {
+  if (target.startsWith('/')) return target.replace(/\/+$/, '') || '/'
+  if (!/^https?:\/\//i.test(target)) return null
+  try {
+    const url = new URL(target)
+    if (url.hostname.replace(/^www\./, '') !== 'thehippiescientist.net') return null
+    return url.pathname.replace(/\/+$/, '') || '/'
+  } catch {
+    return null
+  }
+}
+
+const redirectSourcePaths = new Map()
+for (const line of lines) {
+  const [source, target = '', status = ''] = line.split(/\s+/)
+  if (!/^30[1278]$/.test(status)) continue
+  if (hasPlaceholder(source) || !source.startsWith('/')) continue
+
+  const normalized = source.replace(/\/+$/, '') || '/'
+  // A rule that only adds the trailing slash is the canonicalization itself
+  // (`/safety-checker -> /safety-checker/`), not a hop to a different page.
+  if (routeOfTarget(target) === normalized) continue
+  if (!redirectSourcePaths.has(normalized)) redirectSourcePaths.set(normalized, target)
+}
+
+const chained = []
+for (const line of lines) {
+  const [source, target = '', status = ''] = line.split(/\s+/)
+  if (!/^30[1278]$/.test(status)) continue
+  if (hasPlaceholder(source) || hasPlaceholder(target)) continue
+
+  const normalizedTarget = routeOfTarget(target)
+  if (!normalizedTarget) continue
+
+  const normalizedSource = source.replace(/\/+$/, '') || '/'
+  if (normalizedTarget === normalizedSource) continue
+
+  const nextHop = redirectSourcePaths.get(normalizedTarget)
+  if (nextHop) chained.push(`${line}  ->  ${normalizedTarget} then redirects to ${nextHop}`)
+}
+
+if (chained.length) {
+  console.error(
+    `[verify-redirects] ${chained.length} redirect rule(s) point at another redirect source (multi-hop chain):`,
+  )
+  for (const rule of chained.slice(0, 25)) {
+    console.error(`[verify-redirects]   ${rule}`)
+  }
+  process.exit(1)
+}
+
 console.log(`[verify-redirects] OK: ${requiredRedirects.length} required rules verified`)
 console.log(`[verify-redirects] OK: all ${lines.length} redirect targets resolve to exported pages`)
 console.log('[verify-redirects] OK: no sitemap URL is shadowed by a redirect')
+console.log('[verify-redirects] OK: no redirect rule chains through another redirect')


### PR DESCRIPTION
## Summary

- `apply-redirect-overrides.mjs` prepends `public/redirect-overrides/*` into `out/_redirects` at build time. An override that retires page B silently turns every pre-existing `A -> B` rule into a two-hop chain, and Cloudflare does not follow chains server-side, so each hop is a real round trip for crawlers.
- `normalize-redirects.mjs` already flattens chains, but it checks `public/_redirects` — it runs *before* the merge, so these chains are structurally invisible to it. Four were shipping in the built output:
  - `/guides/natural-alternatives-to-anxiety-medication{,/}` → `/guides/anxiety/natural-alternatives-to-anxiety-medication/` → `/guides/anxiety/best-herbs-for-anxiety/`
  - `https://www.thehippiescientist.net/best-supplements-for-focus{,/}` → `/guides/focus/best-supplements-for-focus/` → `/guides/focus/best-nootropics-for-focus/`
- The merge step now collapses each rule onto its final destination, reusing the chain resolution it already applies to internal hrefs. Splat rules and rules that loop back to their own source are left alone.
- Two related defects surfaced while fixing this:
  - Placeholder detection used `value.includes(':')`, which matches the protocol colon in the absolute `www` rules, so those were skipped entirely. Now matches a colon that starts a path segment.
  - The merge was not idempotent: an incremental rebuild reaching an already-merged `out/_redirects` prepended a second copy, growing 1394 rules to **2520** — past Cloudflare's 2000-rule ceiling for Pages, where the excess is silently dropped. The generated block is now delimited and stripped before re-merging.
- `verify-redirects.mjs` gains a chain assertion so this cannot regress. It runs against the built file, which is where these chains actually exist.
- New test `app/__tests__/redirect-override-chain-flattening.test.ts` covers flattening, the absolute-`www` case, splat preservation, and idempotency against a temp fixture.

Only the two build scripts and the new test change; no route, content, canonical, or data changes.

## Verification

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` — 1340 passed (289 files), including the 4 new cases
- [x] `npm run build` — production pipeline passes 21/21 steps
- [x] `node scripts/verify-redirects.mjs` — chains 0, rule count back to 1394, all four assertions pass
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs — build-regenerated artifacts were discarded, diff is 3 files
- [x] no generated file corruption
- [x] static export compatible — build-time Node scripts only, no runtime/app surface touched

## Risk Notes

- Low. The change is confined to build tooling that rewrites `out/_redirects`; no app route, canonical, or content is modified.
- The flattener deliberately declines two cases rather than guessing: rules carrying `*`/`:splat` placeholders, and chains that loop back to their own source (flattening those would create a self-redirect). Both are left for a human, and the new `verify-redirects` assertion will fail loudly if a self-loop chain ever appears.
- The new chain assertion is a build-blocking check. It passes on `main`'s current output after this fix; if a future override introduces a chain the build will fail rather than ship the extra hop, which is the intended behavior.
- Cross-host redirect targets are skipped by design — their final destination is decided by the other host, not by this file.

---
_Generated by [Claude Code](https://claude.ai/code/session_013u7z5tyQV1iE5LmVnEqd1j)_