### PR TITLE
Redirect five ranked /articles/ URLs that were serving 404s

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -233,6 +233,21 @@ https://www.thehippiescientist.net/* https://thehippiescientist.net/:splat 301
 /articles/l-theanine /guides/herbs/l-theanine/ 301
 /articles/l-theanine/ /guides/herbs/l-theanine/ 301
 
+# Missed by the taxonomy consolidation above: these five /articles/ URLs kept
+# ranking in Bing (positions 1.0-6.6, some earning clicks) while serving a hard
+# 404 — no page is exported for them and no rule covered them. Each maps to an
+# exact-slug guide that is live today.
+/articles/l-theanine-magnesium-adhd-stack /guides/adhd/l-theanine-magnesium-adhd-stack/ 301
+/articles/l-theanine-magnesium-adhd-stack/ /guides/adhd/l-theanine-magnesium-adhd-stack/ 301
+/articles/best-magnesium-supplement-for-adhd /guides/adhd/best-magnesium-supplement-for-adhd/ 301
+/articles/best-magnesium-supplement-for-adhd/ /guides/adhd/best-magnesium-supplement-for-adhd/ 301
+/articles/magnesium-glycinate-vs-citrate-for-adhd /guides/adhd/magnesium-glycinate-vs-citrate-for-adhd/ 301
+/articles/magnesium-glycinate-vs-citrate-for-adhd/ /guides/adhd/magnesium-glycinate-vs-citrate-for-adhd/ 301
+/articles/l-theanine-without-caffeine /guides/focus/l-theanine-without-caffeine/ 301
+/articles/l-theanine-without-caffeine/ /guides/focus/l-theanine-without-caffeine/ 301
+/articles/ashwagandha-vs-magnesium-for-sleep /guides/sleep/ashwagandha-vs-magnesium-for-sleep/ 301
+/articles/ashwagandha-vs-magnesium-for-sleep/ /guides/sleep/ashwagandha-vs-magnesium-for-sleep/ 301
+
 # Legacy best-of entry points consolidated under guide taxonomy.
 /best-supplements-for-stress /guides/best/supplements-for-stress/ 301
 /best-supplements-for-stress/ /guides/best/supplements-for-stress/ 301


### PR DESCRIPTION
## Summary

- The Bing Page Traffic Report for 8/15/2026 shows five `/articles/` URLs still earning impressions — two of them earning clicks — while returning a **hard 404**. No page is exported for any of them, and the "2026 guide taxonomy consolidation" block in `public/_redirects` missed them.

| URL | Impressions | Clicks | Avg. position |
|---|---|---|---|
| `/articles/ashwagandha-vs-magnesium-for-sleep/` | 13 | 0 | 6.2 |
| `/articles/best-magnesium-supplement-for-adhd/` | 8 | 0 | 6.6 |
| `/articles/l-theanine-magnesium-adhd-stack/` | 8 | **2** | 2.7 |
| `/articles/l-theanine-without-caffeine/` | 4 | **2** | 3.0 |
| `/articles/magnesium-glycinate-vs-citrate-for-adhd/` | 1 | 0 | 1.0 |

- Each maps to an **exact-slug** guide that is live and exported today, so these are one-to-one destinations rather than judgement calls:
  - → `/guides/sleep/ashwagandha-vs-magnesium-for-sleep/`
  - → `/guides/adhd/best-magnesium-supplement-for-adhd/`
  - → `/guides/adhd/l-theanine-magnesium-adhd-stack/`
  - → `/guides/focus/l-theanine-without-caffeine/`
  - → `/guides/adhd/magnesium-glycinate-vs-citrate-for-adhd/`
- Four of the five sit in the ADHD/focus cluster, which carries ~75% of the site's Bing impressions.
- Added to the existing consolidation block with both slash variants, matching the surrounding convention.

## Verification

- [x] `npm run lint`
- [x] `npm run test` — 1340 passed (290 files)
- [x] `npm run build` — full production pipeline, 21/21 steps
- [x] Cross-referenced every URL in the Bing Page Traffic Report against the production `out/`: URLs with Bing traffic that 404 drops **5 → 0**
- [x] `node scripts/verify-redirects.mjs` — 1404 rules, all targets resolve to exported pages, no sitemap URL shadowed, **no redirect chains** (the guard added in #2861)
- [x] `npm run validate:redirects-canonical` — file stays canonical
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs — one file changed
- [x] no generated file corruption
- [x] static export compatible — redirects file only, no app surface touched

## Risk Notes

- Very low. One file, 15 added lines, no code paths and no route/canonical/content changes.
- Every destination was confirmed to exist as exported HTML in a real production build before the rule was written, so none of these can introduce a redirect-to-404.
- Slug matches are exact, so there is no editorial judgement about intent — the target is the same topic under the current taxonomy.
- These URLs currently rank as high as position 1.0 in Bing. The redirect consolidates that standing onto the live guide rather than leaving it pointed at an error page; the trade-off is that Bing may take time to transfer the ranking, which is strictly better than the current state.

---
_Generated by [Claude Code](https://claude.ai/code/session_013u7z5tyQV1iE5LmVnEqd1j)_