### PR TITLE
Let IndexNow discover the non-hex key that is already deployed

### DIFF
--- a/scripts/seo/indexnow-submit.mjs
+++ b/scripts/seo/indexnow-submit.mjs
@@ -54,10 +54,17 @@ const LIMIT = Number(flag('limit', 0))
 
 /* -------------------------------------------------------------------- key -- */
 
+// IndexNow keys are 8-128 characters of [a-zA-Z0-9-], not just hex. `--init`
+// happens to mint a hex key, so a hex-only pattern silently fails to discover a
+// valid non-hex key that is already committed and served — and `initKey()` would
+// then mint a *second* key file alongside the live one, which IndexNow rejects
+// because the signing key must be the one served from the site root.
+// The `contents === key` check below is what actually identifies a key file, so
+// widening the filename pattern does not misclassify other public/*.txt files.
 function findExistingKeyFile() {
   if (!existsSync(PUBLIC_DIR)) return null
   for (const file of readdirSync(PUBLIC_DIR)) {
-    const match = /^([a-f0-9]{8,128})\.txt$/i.exec(file)
+    const match = /^([a-z0-9-]{8,128})\.txt$/i.exec(file)
     if (!match) continue
     const contents = readFileSync(path.join(PUBLIC_DIR, file), 'utf8').trim()
     if (contents === match[1]) return { key: match[1], file }


### PR DESCRIPTION
## Summary

- `findExistingKeyFile()` matched `[a-f0-9]{8,128}\.txt`, but IndexNow keys are 8–128 characters of `[a-zA-Z0-9-]`. The key this site already serves — `public/q75x9kcaxtggsns59ddqzck3fbdqqzuj.txt` — is valid and present in the production export, but contains non-hex characters, so the script reported `No key found` and exited 1 on **every** invocation.
- Two consequences beyond the failed run:
  - The documented recovery, `--init`, would not have fixed it. `initKey()` calls the same discovery function, so it would have minted a **second** key file alongside the live one. IndexNow rejects submissions signed with a key other than the one served from the site root, so following the script's own advice would have produced a harder failure.
  - `seo:indexnow` has therefore never run successfully — `ops/indexnow-state.json` does not exist.
- Widened the filename pattern to the IndexNow charset. The existing `contents === key` check is what actually identifies a key file, so this does not misclassify other `public/*.txt` files.

Why this matters right now: the Bing Page Traffic Report shows ~62% of impressions split across duplicate URL pairs where Bing has not yet processed existing 301s. IndexNow is Bing's own protocol for prompting a recrawl, it was already wired up in this repo, and it was silently non-functional.

**No submission was made.** `api.indexnow.org` is blocked by this environment's egress policy, and submitting is an outward-facing action.

## Verification

- [x] `npm run lint`
- [x] `npm run test` — 1340 passed (290 files)
- [x] Dry run now resolves the key and reports 688 indexable pages, `Last submitted never`
- [x] Confirmed no false positives: `blend-guide.txt` and `llms.txt` are still rejected; only the real key file matches
- [x] no package-lock drift
- [x] no unexpected `public/data` diffs — one file changed
- [x] no generated file corruption
- [x] static export compatible — build-time Node script only, not part of the export

## Risk Notes

- Very low. One regex in a script that is not part of the build pipeline and not invoked by `build`, `check`, or CI.
- The widened pattern cannot cause a wrong key to be selected: a file only qualifies when its contents exactly equal its own filename stem, which is the IndexNow key-file format.
- This change makes the tool *able* to submit; it does not submit anything. Dry run remains the default.
- Worth knowing before anyone runs `--submit`: this would be a first-ever run, so all 688 URLs are classed as new. The script's own guidance warns against blasting the full set routinely and offers `--baseline` to record state without notifying. See the PR discussion for the recommended sequence.

---
_Generated by [Claude Code](https://claude.ai/code/session_013u7z5tyQV1iE5LmVnEqd1j)_