### PR TITLE
Allow crawlers to access public AI entity data

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -9,7 +9,11 @@ export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
       userAgent: '*',
-      allow: '/',
+      // Keep the generated runtime-data surface private from crawlers while
+      // explicitly exposing the public AI entity graph advertised in llms.txt.
+      // Robots matching uses the most-specific path rule, so this allow safely
+      // overrides the broader /data/ disallow only for /data/ai-entities/.
+      allow: ['/', '/data/ai-entities/'],
       disallow: [
         '/api/',
         '/analytics',

--- a/scripts/ci/validate-robots.mjs
+++ b/scripts/ci/validate-robots.mjs
@@ -7,6 +7,7 @@ const OUT_DIR = path.join(ROOT, 'out')
 const ROBOTS_PATH = path.join(OUT_DIR, 'robots.txt')
 const REQUIRE_BUILT = process.argv.includes('--require-built')
 const CANONICAL_SITEMAP = 'https://thehippiescientist.net/sitemap.xml'
+const PUBLIC_AI_ENTITY_ALLOW = '/data/ai-entities/'
 
 const REQUIRED_DISALLOWS = [
   '/api/',
@@ -73,6 +74,10 @@ function main() {
     errors.push('Missing Allow: / rule.')
   }
 
+  if (!allows.includes(PUBLIC_AI_ENTITY_ALLOW)) {
+    errors.push(`Missing public AI entity allow: ${PUBLIC_AI_ENTITY_ALLOW}`)
+  }
+
   if (disallows.includes('/')) {
     errors.push('Robots.txt disallows the whole site.')
   }
@@ -99,7 +104,7 @@ function main() {
     process.exit(1)
   }
 
-  console.log(`[validate-robots] PASS: robots.txt allows crawl, protects internal surfaces, and advertises ${CANONICAL_SITEMAP}.`)
+  console.log(`[validate-robots] PASS: robots.txt allows crawl, exposes public AI entity data, protects internal surfaces, and advertises ${CANONICAL_SITEMAP}.`)
 }
 
 main()


### PR DESCRIPTION
## Summary

- explicitly allow `/data/ai-entities/` in robots while keeping the broader `/data/` runtime surface blocked
- add a deploy-time robots validation guard so the public AI entity graph cannot be accidentally hidden again

## Why

`public/llms.txt` advertises `/data/ai-entities/manifest.json` and the per-entity JSON-LD artifacts as machine-readable support for entity resolution and claim verification, but the wildcard robots policy currently disallows all of `/data/`. The more-specific allow resolves that contradiction without exposing unrelated runtime data.

## Risk

Low. HTML indexability is unchanged; only the explicitly public AI entity subtree becomes crawlable.