### PR TITLE
Prioritize strongest entities in the public AI manifest

### DIFF
--- a/scripts/data/ai-entity-artifacts.mjs
+++ b/scripts/data/ai-entity-artifacts.mjs
@@ -94,6 +94,31 @@ async function hydrateRecords(records, dataDir, detailDir) {
   return output
 }
 
+function manifestDiscoveryOrder(a, b) {
+  const scoreDifference = Number(b?.score || 0) - Number(a?.score || 0)
+  if (scoreDifference) return scoreDifference
+
+  const reviewedDifference = Number(Boolean(b?.lastReviewedAt)) - Number(Boolean(a?.lastReviewedAt))
+  if (reviewedDifference) return reviewedDifference
+
+  return String(a?.canonicalUrl || a?.dataUrl || '').localeCompare(String(b?.canonicalUrl || b?.dataUrl || ''))
+}
+
+async function prioritizePublicManifest(dataDir) {
+  const manifestPath = path.join(dataDir, 'ai-entities', 'manifest.json')
+  let manifest
+  try {
+    manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'))
+  } catch {
+    return
+  }
+
+  if (!Array.isArray(manifest?.entities) || manifest.entities.length < 2) return
+
+  manifest.entities = [...manifest.entities].sort(manifestDiscoveryOrder)
+  await fs.writeFile(manifestPath, `${JSON.stringify(manifest)}\n`, 'utf8')
+}
+
 export async function normalizeAiEntitySchemaTypes(dataDir = 'public/data') {
   const root = path.resolve(process.cwd(), dataDir, 'ai-entities')
   await Promise.all([
@@ -116,5 +141,6 @@ export async function buildAiEntityArtifacts(args = {}) {
     compounds,
   })
   await normalizeAiEntitySchemaTypes(dataDir)
+  await prioritizePublicManifest(dataDir)
   return report
 }

--- a/scripts/data/ai-entity-enrichment-smoke.mjs
+++ b/scripts/data/ai-entity-enrichment-smoke.mjs
@@ -109,6 +109,12 @@ try {
   assert.ok(!JSON.stringify(herbArtifact).includes('MedicalSubstance'))
   assert.ok(!JSON.stringify(compoundArtifact).includes('MedicalSubstance'))
   assert.equal(manifest.entities.find((entry) => entry.slug === 'test-herb')?.dataUrl, '/data/ai-entities/herb/test-herb.json')
+  for (let index = 1; index < manifest.entities.length; index += 1) {
+    assert.ok(
+      Number(manifest.entities[index - 1]?.score || 0) >= Number(manifest.entities[index]?.score || 0),
+      'public AI entity manifest should sort strongest completeness scores first',
+    )
+  }
 
   console.log('AI entity enrichment smoke test passed.')
 } finally {


### PR DESCRIPTION
## Summary

- keep the internal completeness report ordered weakest-first for editorial triage
- reorder the public `/data/ai-entities/manifest.json` discovery list strongest-first by completeness score
- prefer reviewed entries on score ties, then use canonical URL for deterministic ordering
- add a smoke-test assertion that public manifest scores are descending

## Why

The manifest was built directly from the editorial `priorities` array, which intentionally sorts weakest-first. That is useful for internal enrichment work but backwards for public machine discovery now that the AI entity subtree is crawlable.

## Risk

Low. No artifact content, canonical URL, indexability decision, or completeness score changes; only public manifest ordering changes.