### PR TITLE
Align indexation audit with the production canonical host

### DIFF
--- a/scripts/audit-indexation.mjs
+++ b/scripts/audit-indexation.mjs
@@ -4,8 +4,10 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 const ROOT = process.cwd()
-const SITE_URL = 'https://www.thehippiescientist.net'
-const SITEMAP_CAP = 450
+const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || 'https://thehippiescientist.net')
+  .replace(/\/$/, '')
+  .replace('https://www.thehippiescientist.net', 'https://thehippiescientist.net')
+const SITEMAP_CAP = 50_000
 
 function readJson(relativePath, fallback) {
   const filePath = path.join(ROOT, relativePath)
@@ -142,9 +144,9 @@ function main() {
     excludedGeneratedPages: generatedDecisions.filter((item) => !item.index).length,
     sitemapCap: SITEMAP_CAP,
     warnings: [
-      ...(urls.length > SITEMAP_CAP ? [`sitemap URL count ${urls.length} exceeds intended cap ${SITEMAP_CAP}`] : []),
+      ...(urls.length > SITEMAP_CAP ? [`sitemap URL count ${urls.length} exceeds protocol limit ${SITEMAP_CAP}`] : []),
       ...(noindexInSitemap.length ? [`sitemap includes ${noindexInSitemap.length} noindex generated URLs`] : []),
-      ...(sitemapNonCanonical.length ? [`sitemap includes ${sitemapNonCanonical.length} non-www/non-canonical URLs`] : []),
+      ...(sitemapNonCanonical.length ? [`sitemap includes ${sitemapNonCanonical.length} non-canonical-host URLs`] : []),
     ],
   }
 


### PR DESCRIPTION
## Summary

- align the indexation auditor with the apex canonical host used by production
- normalize an accidentally configured `www` environment value back to the canonical apex host, matching the site SEO helpers
- replace the stale 450-URL warning threshold with the standard 50,000-URL single-sitemap protocol limit
- make warning text describe canonical-host and protocol-limit failures accurately

## Why

The production sitemap writer and metadata use `https://thehippiescientist.net`, while this audit still hard-coded `https://www.thehippiescientist.net`. It could therefore flag a healthy production sitemap as entirely non-canonical. Its 450-URL threshold was also an internal historical constraint rather than the actual sitemap protocol limit.

Google documents a maximum of 50,000 URLs (or 50 MB uncompressed) per sitemap.

## Risk

Low. This changes audit diagnostics only; it does not change generated page indexability or sitemap contents.