### PR TITLE
Validate llms.txt citation targets before deployment

### DIFF
--- a/scripts/ci/validate-deploy-readiness.mjs
+++ b/scripts/ci/validate-deploy-readiness.mjs
@@ -4,6 +4,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 const ROOT = process.cwd()
+const CANONICAL_ORIGIN = 'https://thehippiescientist.net'
 
 function warn(msg) {
   console.warn(`[deploy-readiness] WARN ${msg}`)
@@ -39,6 +40,132 @@ function validateGeneratedSitemap() {
   }
 }
 
+function normalizeRoutePath(pathname) {
+  if (!pathname || pathname === '/') return '/'
+  return `/${pathname.replace(/^\/+|\/+$/g, '')}/`
+}
+
+function routeToHtmlPath(outDir, pathname) {
+  const normalized = normalizeRoutePath(pathname)
+  if (normalized === '/') return path.join(outDir, 'index.html')
+  return path.join(outDir, normalized.replace(/^\/+|\/+$/g, ''), 'index.html')
+}
+
+function renderedRobotsNoindex(html) {
+  const tags = html.match(/<meta\b[^>]*>/gi) || []
+  return tags.some((tag) =>
+    /\bname\s*=\s*["'](?:robots|googlebot)["']/i.test(tag) &&
+    /\bcontent\s*=\s*["'][^"']*\bnoindex\b[^"']*["']/i.test(tag),
+  )
+}
+
+function renderedCanonical(html) {
+  const tags = html.match(/<link\b[^>]*>/gi) || []
+  const canonicalTag = tags.find((tag) => /\brel\s*=\s*["']canonical["']/i.test(tag))
+  return canonicalTag?.match(/\bhref\s*=\s*["']([^"']+)["']/i)?.[1]?.trim() || null
+}
+
+function exactRedirectSources(outDir) {
+  const redirectsPath = path.join(outDir, '_redirects')
+  const sources = new Set()
+  if (!fs.existsSync(redirectsPath)) return sources
+
+  for (const line of fs.readFileSync(redirectsPath, 'utf8').split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) continue
+    const [source, target, status] = trimmed.split(/\s+/)
+    if (!source || !target || !/^30[1278]$/.test(status || '') || source.includes('*')) continue
+    const sourcePath = normalizeRoutePath(source.split(/[?#]/)[0])
+    const targetPath = normalizeRoutePath(target.split(/[?#]/)[0])
+    if (sourcePath !== targetPath) sources.add(sourcePath)
+  }
+
+  return sources
+}
+
+function validateLlmsCitationTargets() {
+  const outDir = path.join(ROOT, 'out')
+  if (!fs.existsSync(outDir)) return
+
+  const llmsPath = path.join(outDir, 'llms.txt')
+  if (!fs.existsSync(llmsPath)) {
+    console.error('[deploy-readiness] out/llms.txt missing')
+    process.exit(1)
+  }
+
+  const text = fs.readFileSync(llmsPath, 'utf8')
+  const urls = [...new Set(text.match(/https:\/\/thehippiescientist\.net\/[^\s)\]}>"']*/g) || [])]
+  const redirectSources = exactRedirectSources(outDir)
+  const failures = []
+  let checkedHtmlTargets = 0
+
+  for (const rawUrl of urls) {
+    let url
+    try {
+      url = new URL(rawUrl)
+    } catch {
+      failures.push(`invalid URL: ${rawUrl}`)
+      continue
+    }
+
+    if (url.origin !== CANONICAL_ORIGIN) {
+      failures.push(`non-canonical origin: ${rawUrl}`)
+      continue
+    }
+
+    // llms.txt also advertises machine resources such as sitemap.xml,
+    // robots.txt, and JSON-LD artifacts. The checks below are specifically for
+    // user-facing citation targets that should resolve to canonical HTML pages.
+    if (/\.(?:xml|txt|json)$/i.test(url.pathname)) continue
+
+    checkedHtmlTargets++
+    const routePath = normalizeRoutePath(url.pathname)
+    const htmlPath = routeToHtmlPath(outDir, routePath)
+
+    if (redirectSources.has(routePath)) {
+      failures.push(`redirect source advertised as citation target: ${rawUrl}`)
+      continue
+    }
+
+    if (!fs.existsSync(htmlPath)) {
+      failures.push(`missing built HTML target: ${rawUrl}`)
+      continue
+    }
+
+    const html = fs.readFileSync(htmlPath, 'utf8')
+    if (renderedRobotsNoindex(html)) {
+      failures.push(`noindex HTML target: ${rawUrl}`)
+    }
+
+    const canonical = renderedCanonical(html)
+    if (!canonical) {
+      failures.push(`missing canonical on HTML target: ${rawUrl}`)
+      continue
+    }
+
+    let canonicalUrl
+    try {
+      canonicalUrl = new URL(canonical, CANONICAL_ORIGIN)
+    } catch {
+      failures.push(`invalid rendered canonical for ${rawUrl}: ${canonical}`)
+      continue
+    }
+
+    const expected = `${CANONICAL_ORIGIN}${routePath}`
+    if (canonicalUrl.href !== expected) {
+      failures.push(`canonical mismatch for ${rawUrl}: ${canonicalUrl.href}`)
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error(`[deploy-readiness] llms.txt citation-target validation failed (${failures.length} issue(s)):`)
+    failures.forEach((failure) => console.error(`  - ${failure}`))
+    process.exit(1)
+  }
+
+  console.log(`[deploy-readiness] llms.txt citation targets valid (${checkedHtmlTargets} canonical HTML targets checked)`)
+}
+
 function main() {
   const herbs = readJsonSafe(path.join(ROOT, 'public/data/herbs.json'))
   const compounds = readJsonSafe(path.join(ROOT, 'public/data/compounds.json'))
@@ -54,6 +181,7 @@ function main() {
   }
 
   validateGeneratedSitemap()
+  validateLlmsCitationTargets()
 
   const outDir = path.join(ROOT, 'out')
   if (fs.existsSync(outDir)) {


### PR DESCRIPTION
## Summary

- parse first-party URLs advertised in the built `llms.txt`
- validate every user-facing HTML citation target exists in the static export
- reject redirect-source targets, rendered `noindex`, missing canonicals, and canonical mismatches
- leave machine resources such as XML/TXT/JSON artifacts outside the HTML-specific checks
- run this through the existing deploy-readiness validator that is part of production verification

## Why

`llms.txt` is a curated machine-discovery surface. A stale, redirected, noindex, or non-canonical URL there can waste crawler attention and weaken the site's AI citation hints. This turns those failures into release blockers.

## Risk

Moderate-low. It adds validation only. If an advertised citation target is stale, deployment will correctly stop until the target or `llms.txt` is fixed.