### PR TITLE
Improve CTR snippet for L-Theanine for ADHD

### DIFF
--- a/app/guides/adhd/l-theanine-for-adhd/page.tsx
+++ b/app/guides/adhd/l-theanine-for-adhd/page.tsx
@@ -1,8 +1,15 @@
-import FocusAdhdArticlePage, { focusAdhdMetadata } from '@/components/articles/FocusAdhdArticlePage'
+import FocusAdhdArticlePage from '@/components/articles/FocusAdhdArticlePage'
+import { buildPageMetadata } from '@/src/lib/seo'
 
 const SLUG = 'l-theanine-for-adhd'
 
-export const metadata = focusAdhdMetadata(SLUG)
+export const metadata = buildPageMetadata({
+  title: 'L-Theanine for ADHD: Does It Help Focus or Sleep?',
+  description:
+    'What human studies actually show about L-theanine for ADHD, attention, and sleep, plus dose limits, stimulant interactions, side effects, and who should be cautious.',
+  path: `/guides/adhd/${SLUG}/`,
+  openGraphType: 'article',
+})
 
 export default function Page() {
   return <FocusAdhdArticlePage slug={SLUG} />


### PR DESCRIPTION
## Summary

- replace the generic L-theanine/ADHD search title with a clearer query-matched decision title
- tighten the meta description around what human studies show, dose limits, stimulant interactions, side effects, and caution context
- keep canonical URL and article metadata generation intact

## Why

The current 30-day page report shows `/guides/adhd/l-theanine-for-adhd/` with 109 impressions at an average position of ~6.57 but only 1 click (0.92% CTR). This is the highest-impression URL in the export and is already ranking close enough that snippet improvement can create incremental clicks without requiring a large ranking move.

## Risk

Low. Metadata-only change; page body, evidence claims, canonical, and routing are unchanged.