### PR TITLE
Improve CTR snippet for Omega-3 and ADHD

### DIFF
--- a/app/guides/adhd/omega-3-and-adhd/page.tsx
+++ b/app/guides/adhd/omega-3-and-adhd/page.tsx
@@ -1,9 +1,16 @@
-import FocusAdhdArticlePage, { focusAdhdMetadata } from '@/components/articles/FocusAdhdArticlePage'
+import FocusAdhdArticlePage from '@/components/articles/FocusAdhdArticlePage'
 import { Omega3AdhdSeoAppendix } from '@/components/articles/AdhdSeoIdeaAppendix'
+import { buildPageMetadata } from '@/src/lib/seo'
 
 const SLUG = 'omega-3-and-adhd'
 
-export const metadata = focusAdhdMetadata(SLUG)
+export const metadata = buildPageMetadata({
+  title: 'Omega-3 for ADHD: EPA vs DHA, Evidence & Dose',
+  description:
+    'Does omega-3 help ADHD? See what human trials show, whether higher-EPA formulas matter, studied dose ranges, side effects, and fish-oil quality checks.',
+  path: `/guides/adhd/${SLUG}/`,
+  openGraphType: 'article',
+})
 
 export default function Page() {
   return (


### PR DESCRIPTION
## Summary

- lead the SEO title with the exact `Omega-3 for ADHD` intent instead of the broader `Fish Oil Supplements` wording
- surface EPA vs DHA, evidence, dose, side effects, and product-quality questions in the snippet
- preserve the existing page body, appendix, canonical path, and article schema generation

## Why

The current 30-day page report shows `/guides/adhd/omega-3-and-adhd/` with 50 impressions at an average position of ~5.58 but 0 clicks. That is a strong candidate for a query-alignment/CTR improvement because it is already ranking on the first page range.

## Risk

Low. Metadata-only change.