### PR TITLE
Improve CTR snippet for Melatonin and ADHD Sleep

### DIFF
--- a/app/guides/adhd/melatonin-for-adhd-sleep/page.tsx
+++ b/app/guides/adhd/melatonin-for-adhd-sleep/page.tsx
@@ -1,10 +1,16 @@
-import FocusAdhdArticlePage, { focusAdhdMetadata } from '@/components/articles/FocusAdhdArticlePage'
+import FocusAdhdArticlePage from '@/components/articles/FocusAdhdArticlePage'
+import { buildPageMetadata } from '@/src/lib/seo'
 
 const SLUG = 'melatonin-for-adhd-sleep'
 
-export const metadata = focusAdhdMetadata(SLUG)
+export const metadata = buildPageMetadata({
+  title: 'Melatonin for ADHD Sleep: Does It Help & Is It Safe?',
+  description:
+    'What ADHD sleep studies show about melatonin for sleep onset, timing, and dose context, including children, side effects, long-term uncertainty, and safety.',
+  path: `/guides/adhd/${SLUG}/`,
+  openGraphType: 'article',
+})
 
 export default function Page() {
   return <FocusAdhdArticlePage slug={SLUG} />
 }
-


### PR DESCRIPTION
## Summary

- make the title answer the searcher's two immediate questions: whether melatonin helps ADHD-related sleep problems and whether it is safe
- focus the description on sleep onset, timing, dose context, pediatric evidence, side effects, and long-term uncertainty
- preserve the existing canonical URL, page body, and article schema path

## Why

The current 30-day page report shows `/guides/adhd/melatonin-for-adhd-sleep/` with 62 impressions at an average position of ~5.68 but only 1 click (1.61% CTR). This is already in a first-page position range where stronger snippet intent matching can pay off quickly.

## Risk

Low. Metadata-only change.