### PR TITLE
Improve CTR snippet for Zinc and ADHD

### DIFF
--- a/app/guides/adhd/zinc-and-adhd/page.tsx
+++ b/app/guides/adhd/zinc-and-adhd/page.tsx
@@ -1,8 +1,15 @@
-import FocusAdhdArticlePage, { focusAdhdMetadata } from '@/components/articles/FocusAdhdArticlePage'
+import FocusAdhdArticlePage from '@/components/articles/FocusAdhdArticlePage'
+import { buildPageMetadata } from '@/src/lib/seo'
 
 const SLUG = 'zinc-and-adhd'
 
-export const metadata = focusAdhdMetadata(SLUG)
+export const metadata = buildPageMetadata({
+  title: 'Zinc for ADHD: Does It Help? Evidence & Safety',
+  description:
+    'Does zinc help ADHD? Review human trials, who may benefit most when zinc is low, studied dose context, stimulant-combination evidence, side effects, and copper risk.',
+  path: `/guides/adhd/${SLUG}/`,
+  openGraphType: 'article',
+})
 
 export default function Page() {
   return <FocusAdhdArticlePage slug={SLUG} />


### PR DESCRIPTION
## Summary

- lead with the exact `Zinc for ADHD` search intent
- turn the title into a direct evidence question instead of a generic topic label
- make the description surface the highest-value decision points: low-zinc context, human trials, studied dose context, stimulant-combination evidence, side effects, and copper risk
- preserve page body, canonical path, and article schema

## Why

The current 30-day page report shows `/guides/adhd/zinc-and-adhd/` with 60 impressions at an average position of ~6.32 but only 1 click (1.67% CTR). This is another first-page-range URL where stronger snippet intent matching has near-term upside.

## Risk

Low. Metadata-only change.