### PR TITLE
Improve CTR snippet for Ashwagandha and ADHD

### DIFF
--- a/app/guides/adhd/ashwagandha-for-adhd/page.tsx
+++ b/app/guides/adhd/ashwagandha-for-adhd/page.tsx
@@ -1,8 +1,15 @@
-import FocusAdhdArticlePage, { focusAdhdMetadata } from '@/components/articles/FocusAdhdArticlePage'
+import FocusAdhdArticlePage from '@/components/articles/FocusAdhdArticlePage'
+import { buildPageMetadata } from '@/src/lib/seo'
 
 const SLUG = 'ashwagandha-for-adhd'
 
-export const metadata = focusAdhdMetadata(SLUG)
+export const metadata = buildPageMetadata({
+  title: 'Ashwagandha for ADHD: Does It Help Focus or Stress?',
+  description:
+    'Direct ADHD evidence is limited. See what human research shows for stress, sleep, and cognition, plus extract context, side effects, interactions, and realistic limits.',
+  path: `/guides/adhd/${SLUG}/`,
+  openGraphType: 'article',
+})
 
 export default function Page() {
   return <FocusAdhdArticlePage slug={SLUG} />


### PR DESCRIPTION
## Summary

- lead with the exact `Ashwagandha for ADHD` intent and a clear focus-vs-stress decision question
- state up front that direct ADHD evidence is limited rather than implying treatment evidence
- surface the human stress/sleep/cognition research, extract context, side effects, interactions, and evidence limits in the description
- preserve page body, canonical path, and article schema

## Why

The current 30-day page report shows `/guides/adhd/ashwagandha-for-adhd/` with 36 impressions at an average position of ~6.39 and 0 clicks. It is ranking close enough to benefit from a clearer, more trustworthy snippet.

## Risk

Low. Metadata-only change.