### PR TITLE
Improve CTR snippet for ADHD blood tests

### DIFF
--- a/app/guides/adhd/adhd-blood-tests/page.tsx
+++ b/app/guides/adhd/adhd-blood-tests/page.tsx
@@ -1,8 +1,15 @@
-import FocusAdhdArticlePage, { focusAdhdMetadata } from '@/components/articles/FocusAdhdArticlePage'
+import FocusAdhdArticlePage from '@/components/articles/FocusAdhdArticlePage'
+import { buildPageMetadata } from '@/src/lib/seo'
 
 const SLUG = 'adhd-blood-tests'
 
-export const metadata = focusAdhdMetadata(SLUG)
+export const metadata = buildPageMetadata({
+  title: 'ADHD Blood Tests: Which Labs Are Actually Useful?',
+  description:
+    'No blood test diagnoses ADHD. See when clinicians may consider ferritin and iron, vitamin D, B12, thyroid, or other labs to investigate symptoms and possible deficiencies.',
+  path: `/guides/adhd/${SLUG}/`,
+  openGraphType: 'article',
+})
 
 export default function Page() {
   return <FocusAdhdArticlePage slug={SLUG} />


### PR DESCRIPTION
## Summary

- replace the generic lab-list title with a direct usefulness question
- state clearly that blood tests do not diagnose ADHD
- surface ferritin/iron, vitamin D, B12, thyroid, and deficiency-evaluation intent in the description
- preserve page body, canonical URL, and article schema

## Why

The current 30-day report shows `/guides/adhd/adhd-blood-tests/` with 17 impressions at an average position near 5.94 and 0 clicks. The page is already ranking within first-page range, so clearer intent matching is a low-risk CTR opportunity.

## Risk

Low. Metadata-only change.