### PR TITLE
Fix blank affiliate tag blocking production deploys

### DIFF
--- a/config/affiliate.ts
+++ b/config/affiliate.ts
@@ -1,6 +1,9 @@
 // Centralised affiliate tag config
-// Override via environment variables in production
+// Override via environment variables in production. Treat blank/whitespace
+// values as unset so CI/CD systems that materialize missing variables as an
+// empty string cannot silently erase affiliate attribution.
+const amazonAffiliateTag = process.env.AMAZON_AFFILIATE_TAG?.trim() || 'razzleberry02-20'
 
 export const AFFILIATE_TAGS = {
-  amazon: process.env.AMAZON_AFFILIATE_TAG ?? 'razzleberry02-20',
+  amazon: amazonAffiliateTag,
 } as const


### PR DESCRIPTION
## Summary

- treat blank or whitespace `AMAZON_AFFILIATE_TAG` values as unset
- fall back to the repository's production-safe Associates tag instead of emitting empty `tag=` parameters
- keep the production affiliate safety audit unchanged

## Why

GitHub Actions materializes a missing repository variable as an empty string. The previous nullish-coalescing fallback only handled `undefined`/`null`, so an empty Actions variable overrode the safe fallback and caused the production affiliate audit to block Cloudflare deployment.

## Risk

Low. A valid non-empty environment override still wins; only blank values now use the existing safe fallback.