### PR TITLE
fix(ci): audit clickable Amazon affiliate links only

### DIFF
--- a/scripts/ci/audit-affiliate-tag-production.mjs
+++ b/scripts/ci/audit-affiliate-tag-production.mjs
@@ -2,13 +2,15 @@
 /**
  * Production-safety guard for Amazon affiliate attribution.
  *
- * Refuse to ship built HTML that contains either:
+ * Refuse to ship clickable Amazon.com links in built HTML that contain either:
  * - the old development placeholder tag, or
- * - an Amazon.com commerce URL with no Associates `tag` parameter at all.
+ * - no Associates `tag` parameter at all.
  *
- * The configured production tag may come from AMAZON_AFFILIATE_TAG or the
- * repository default; this guard does not hard-code one valid production tag.
- * It only rejects known-bad placeholder attribution and missing attribution.
+ * Only actual <a href> destinations are audited. Next.js can serialize source
+ * data into script payloads inside HTML; those non-clickable strings must not
+ * be mistaken for outbound commerce links. The configured production tag may
+ * come from AMAZON_AFFILIATE_TAG or the repository default; this guard does
+ * not hard-code one valid production tag.
  *
  * Usage: node scripts/ci/audit-affiliate-tag-production.mjs
  *        npm run audit:affiliate-tag-production
@@ -33,25 +35,32 @@ let badRefs = 0;
 let untaggedRefs = 0;
 const badUrls = new Set();
 const untaggedUrls = new Set();
-const amazonUrlPattern = /https?:\/\/(?:www\.)?amazon\.com\/[^"'<>\s)]*/g;
+const anchorPattern = /<a\b[^>]*\bhref\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))[^>]*>/gi;
 
-function inspectAmazonUrl(rawUrl) {
-  amazonRefs++;
+function recordSample(target, file, rawUrl) {
+  if (target.size < 5) target.add(`${path.relative(ROOT, file)} :: ${rawUrl}`);
+}
+
+function inspectAmazonUrl(rawUrl, file) {
   const decodedUrl = rawUrl.replace(/&amp;/gi, '&');
 
   try {
     const url = new URL(decodedUrl);
+    const hostname = url.hostname.toLowerCase();
+    if (hostname !== 'amazon.com' && hostname !== 'www.amazon.com') return;
+
+    amazonRefs++;
     const tag = url.searchParams.get('tag');
 
     if (!tag) {
       untaggedRefs++;
-      if (untaggedUrls.size < 5) untaggedUrls.add(rawUrl);
+      recordSample(untaggedUrls, file, rawUrl);
       return;
     }
 
     if (tag === DEV_TAG) {
       badRefs++;
-      if (badUrls.size < 5) badUrls.add(rawUrl);
+      recordSample(badUrls, file, rawUrl);
     }
   } catch {
     // URL syntax is validated elsewhere; avoid turning unrelated malformed
@@ -66,31 +75,35 @@ function walk(dir) {
     else if (entry.isFile() && entry.name.endsWith('.html')) {
       htmlScanned++;
       const content = fs.readFileSync(full, 'utf8');
-      const matches = content.match(amazonUrlPattern) || [];
-      for (const match of matches) inspectAmazonUrl(match);
+      anchorPattern.lastIndex = 0;
+      let match;
+      while ((match = anchorPattern.exec(content)) !== null) {
+        const href = match[1] ?? match[2] ?? match[3] ?? '';
+        inspectAmazonUrl(href, full);
+      }
     }
   }
 }
 
 walk(OUT_DIR);
-console.log(`[affiliate-tag] scanned ${htmlScanned} HTML files and ${amazonRefs} Amazon.com URL references in out/`);
+console.log(`[affiliate-tag] scanned ${htmlScanned} HTML files and ${amazonRefs} clickable Amazon.com links in out/`);
 
 if (badRefs > 0) {
-  console.error(`[affiliate-tag] FAIL: ${badRefs} Amazon links still reference ${DEV_TAG}.`);
-  console.error('  Sample URLs with dev tag:');
+  console.error(`[affiliate-tag] FAIL: ${badRefs} clickable Amazon links still reference ${DEV_TAG}.`);
+  console.error('  Sample files/URLs with dev tag:');
   for (const url of badUrls) console.error(`    ${url}`);
   problems++;
 } else {
-  console.log(`[affiliate-tag] no ${DEV_TAG} references in built HTML OK`);
+  console.log(`[affiliate-tag] no clickable ${DEV_TAG} references in built HTML OK`);
 }
 
 if (untaggedRefs > 0) {
-  console.error(`[affiliate-tag] FAIL: ${untaggedRefs} Amazon.com links have no Associates tag parameter.`);
-  console.error('  Sample untagged URLs:');
+  console.error(`[affiliate-tag] FAIL: ${untaggedRefs} clickable Amazon.com links have no Associates tag parameter.`);
+  console.error('  Sample files/untagged URLs:');
   for (const url of untaggedUrls) console.error(`    ${url}`);
   problems++;
 } else {
-  console.log('[affiliate-tag] all built Amazon.com links include a tag parameter OK');
+  console.log('[affiliate-tag] all clickable built Amazon.com links include a tag parameter OK');
 }
 
 if (problems > 0) {


### PR DESCRIPTION
## Why
The production affiliate safety audit was scanning every Amazon-looking string in generated HTML, including non-clickable Next.js serialized data. That can block deployment even when the rendered outbound links are correctly tagged.

## Fix
- Audit actual `<a href>` destinations across every generated HTML file.
- Continue to hard-fail clickable Amazon.com links with the dev placeholder tag or no Associates `tag` parameter.
- Include generated file paths in failure samples for faster future diagnosis.

This preserves the production safety gate while removing false positives from serialized application data.