### PR TITLE
fix(ui): honor reduced motion in homepage evidence dial

### DIFF
--- a/styles/accessibility-wcag-22.css
+++ b/styles/accessibility-wcag-22.css
@@ -181,4 +181,11 @@ main th[scope='row'] {
   .skip-link {
     transition: none;
   }
+
+  /* Preserve the homepage evidence dial's composition without the continuous
+     spin/float motion for visitors who explicitly request less animation. */
+  .hs-home .hs-dial-ring--outer,
+  .hs-home .hs-dial-chip {
+    animation: none;
+  }
 }


### PR DESCRIPTION
## What changed
- stops the homepage evidence dial's continuous spin and floating chip animations when `prefers-reduced-motion: reduce` is enabled
- keeps the visual composition intact rather than hiding the decorative element
- leaves the normal animated experience unchanged

## Why
The shared WCAG stylesheet already respected reduced motion for the skip link, but the homepage's decorative dial continued animating indefinitely. This closes that visual-accessibility gap with a tightly scoped change.