### PR TITLE
fix(ui): keep long breadcrumbs compact on mobile

### DIFF
--- a/components/navigation/AuthorityBreadcrumbs.tsx
+++ b/components/navigation/AuthorityBreadcrumbs.tsx
@@ -28,7 +28,7 @@ export default function AuthorityBreadcrumbs({
   return (
     <nav
       aria-label="Breadcrumb"
-      className="flex flex-wrap items-center gap-1.5 text-sm"
+      className="flex flex-nowrap items-center gap-1.5 overflow-x-auto whitespace-nowrap text-sm"
     >
       {items.map((item, index) => {
         const isLast = index === items.length - 1
@@ -37,7 +37,7 @@ export default function AuthorityBreadcrumbs({
         return (
           <div
             key={href ?? item.label}
-            className="flex items-center gap-1.5"
+            className="flex shrink-0 items-center gap-1.5"
           >
             {href && !isLast ? (
               <Link


### PR DESCRIPTION
## What changed
- keeps breadcrumb trails on one line instead of wrapping into multiple rows
- allows horizontal scrolling when a nested trail is wider than the viewport
- prevents individual breadcrumb segments from collapsing or awkwardly wrapping

## Why
Long breadcrumb trails can turn into a tall, visually noisy block on narrow pages. A single scrollable trail preserves context while keeping the page header compact.