### PR TITLE
fix(ui): close global TOC breakpoint gap

### DIFF
--- a/components/content/GlobalTOC.tsx
+++ b/components/content/GlobalTOC.tsx
@@ -81,8 +81,8 @@ export default function GlobalTOC() {
 
   return (
     <>
-      {/* Mobile: compact dropdown at top */}
-      <div className="mb-6 rounded-xl border-2 border-brand-900/15 bg-white p-0 shadow-sm dark:border-[var(--border-strong)] dark:bg-[var(--surface-card-strong)] lg:hidden">
+      {/* Inline TOC stays available until the fixed XL sidebar takes over. */}
+      <div className="mx-4 mb-6 mt-4 rounded-xl border-2 border-brand-900/15 bg-white p-0 shadow-sm dark:border-[var(--border-strong)] dark:bg-[var(--surface-card-strong)] sm:mx-6 lg:mx-auto lg:w-[calc(100%-3rem)] lg:max-w-6xl xl:hidden">
         <button
           type="button"
           aria-expanded={mobileOpen}


### PR DESCRIPTION
## What changed
- keeps the inline table of contents visible through `lg` and hides it only when the fixed `xl` sidebar takes over
- aligns the inline TOC with normal page gutters on phones/tablets
- constrains it to the shared content width on larger tablet/small-desktop layouts

## Why
Previously the inline TOC disappeared at `lg` while the fixed sidebar did not appear until `xl`, leaving a 1024–1279px range with no TOC at all. The root-layout TOC also lacked its own page gutters because it sits outside route-level content containers.