### PR TITLE
fix(ui): show full product imagery in recommendation cards

### DIFF
--- a/components/AffiliateProductCard.tsx
+++ b/components/AffiliateProductCard.tsx
@@ -53,7 +53,7 @@ export default function AffiliateProductCard({ product, compact = false }: Affil
   return (
     <article className={`flex h-full flex-col overflow-hidden rounded-2xl border border-brand-900/10 bg-white/80 shadow-sm dark:border-white/10 dark:bg-white/5 ${compact ? 'p-4' : 'p-5'}`}>
       {imageUrl && isOptimizableRemoteImage(imageUrl) ? (
-        <div className='mb-4 aspect-[4/3] overflow-hidden rounded-xl border border-brand-900/10 bg-brand-50 dark:border-white/10 dark:bg-white/5'>
+        <div className='mb-4 aspect-[4/3] overflow-hidden rounded-xl border border-brand-900/10 bg-brand-50 p-3 dark:border-white/10 dark:bg-white/5'>
           <Image
             src={imageUrl}
             alt={title}
@@ -62,7 +62,7 @@ export default function AffiliateProductCard({ product, compact = false }: Affil
             sizes="(max-width: 767px) 272px, (max-width: 1024px) 33vw, 320px"
             quality={78}
             decoding="async"
-            className="h-full w-full object-cover"
+            className="h-full w-full object-contain"
           />
         </div>
       ) : null}


### PR DESCRIPTION
## What changed
- switches affiliate recommendation images from `object-cover` to `object-contain`
- adds a small amount of internal image padding so bottles/boxes have breathing room inside the existing 4:3 frame

## Why
Product packaging is informational UI: cropping a bottle, box, label, or logo to fill the frame can make recommendations look broken or less trustworthy. Contained imagery keeps the complete product visible while preserving consistent card dimensions.