### PR TITLE
fix(ui): size recommendation rails to their card count

### DIFF
--- a/components/ui/HorizontalCardRail.tsx
+++ b/components/ui/HorizontalCardRail.tsx
@@ -16,6 +16,16 @@ export default function HorizontalCardRail({
 
   if (items.length === 0) return null
 
+  const desktopGridColumns =
+    items.length === 1
+      ? 'md:grid-cols-1'
+      : items.length === 2
+        ? 'md:grid-cols-2'
+        : 'md:grid-cols-3'
+  const mobileItemWidth = items.length === 1
+    ? 'w-full max-w-none'
+    : 'w-[calc(100%-1rem)] max-w-[17rem]'
+
   return (
     <div className={`mt-4 ${className}`}>
       {items.length > 1 ? (
@@ -30,12 +40,12 @@ export default function HorizontalCardRail({
       <ul
         aria-label={label}
         tabIndex={0}
-        className="flex list-none snap-x snap-mandatory scroll-px-1 gap-3 overflow-x-auto overscroll-x-contain pb-2 [scrollbar-width:thin] focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40 md:grid md:grid-cols-3 md:gap-4 md:overflow-visible md:pb-0 md:focus-visible:ring-0"
+        className={`flex list-none snap-x snap-mandatory scroll-px-1 gap-3 overflow-x-auto overscroll-x-contain pb-2 [scrollbar-width:thin] focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40 md:grid ${desktopGridColumns} md:gap-4 md:overflow-visible md:pb-0 md:focus-visible:ring-0`}
       >
         {items.map((item, index) => (
           <li
             key={index}
-            className="flex w-[calc(100%-1rem)] min-w-0 max-w-[17rem] shrink-0 snap-start flex-col md:w-auto md:max-w-none"
+            className={`flex ${mobileItemWidth} min-w-0 shrink-0 snap-start flex-col md:w-auto md:max-w-none`}
           >
             {item}
           </li>


### PR DESCRIPTION
## What changed
- uses 1, 2, or 3 desktop grid columns based on the actual number of cards
- lets a single mobile card use the full available width instead of presenting as a partial carousel item
- preserves the existing swipe rail for 2+ cards on mobile

## Why
The shared rail always switched to three desktop columns, leaving awkward empty columns whenever only one or two recommendations were available. This makes sparse recommendation sets look intentional instead of incomplete.