### PR TITLE
fix(ui): stack scientific verdict content on narrow phones

### DIFF
--- a/components/editorial/ScientificVerdictCard.tsx
+++ b/components/editorial/ScientificVerdictCard.tsx
@@ -126,7 +126,7 @@ export function ScientificVerdictCard({
 
       <div className="px-5 py-4">
         {(best.length > 0 || not.length > 0) && (
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid gap-4 sm:grid-cols-2">
             {best.length > 0 && (
               <div>
                 <p className="text-xs font-bold uppercase tracking-wider text-emerald-700 dark:text-emerald-300">
@@ -165,7 +165,7 @@ export function ScientificVerdictCard({
         )}
 
         {stats.length > 0 && (
-          <dl className="mt-4 grid grid-cols-3 gap-3 border-t border-brand-900/10 pt-4 dark:border-white/10">
+          <dl className="mt-4 grid gap-3 border-t border-brand-900/10 pt-4 sm:grid-cols-3 dark:border-white/10">
             {stats.map((stat) => (
               <div key={stat.label}>
                 <dt className="text-[0.7rem] font-bold uppercase tracking-wider text-muted">{stat.label}</dt>


### PR DESCRIPTION
## What changed
- stacks the Best for / Not ideal for groups below the small breakpoint instead of forcing two narrow columns
- stacks verdict stats below the small breakpoint instead of forcing three tiny columns
- restores the existing 2-column and 3-column layouts at `sm+`

## Why
This card appears near the top of important herb, compound, comparison, and article surfaces. On narrow phones, long decision/safety text was being compressed into very narrow columns, hurting scanability at exactly the point where the page should answer quickly.