### PR TITLE
fix(ui): keep safety gauge labels centered and contained

### DIFF
--- a/components/ui/SafetyGaugeMeter.tsx
+++ b/components/ui/SafetyGaugeMeter.tsx
@@ -45,7 +45,7 @@ export default function SafetyGaugeMeter({ score, label, className = '' }: Safet
         <circle cx="50" cy="50" r="3.5" className="fill-ink dark:fill-white" />
       </svg>
       <p className="-mt-2 text-2xl font-bold text-ink">{clamped}%</p>
-      <p className="text-xs font-semibold uppercase tracking-wide text-muted">{label}</p>
+      <p className="max-w-full text-center text-xs font-semibold uppercase leading-5 tracking-wide text-muted">{label}</p>
     </div>
   )
 }


### PR DESCRIPTION
## What changed
- constrains safety-gauge labels to the available width
- centers multi-line labels and gives them a stable compact line-height

## Why
Profile safety labels can be fairly long while the meter is rendered in a narrow fixed-width column. Without width and alignment constraints, the label could spill or look visually off-center.