### PR TITLE
fix(ui): theme mechanism explainer cards in dark mode

### DIFF
--- a/components/MechanismBox.tsx
+++ b/components/MechanismBox.tsx
@@ -10,13 +10,13 @@ interface Props {
 
 export default function MechanismBox({ summary, points }: Props) {
   return (
-    <div className="rounded-2xl border border-brand-900/10 bg-white/90 p-5 shadow-sm space-y-4">
+    <div className="space-y-4 rounded-2xl border border-brand-900/10 bg-white/90 p-5 shadow-sm dark:border-white/10 dark:bg-white/5">
       <p className="text-sm leading-7 text-muted">{summary}</p>
       {points && points.length > 0 && (
         <dl className="grid gap-3 sm:grid-cols-2">
           {points.map((point, i) => (
-            <div key={i} className="rounded-xl border border-brand-900/5 bg-brand-50/20 p-3">
-              <dt className="text-xs font-bold uppercase tracking-[0.12em] text-brand-700">
+            <div key={i} className="rounded-xl border border-brand-900/5 bg-brand-50/20 p-3 dark:border-white/10 dark:bg-white/5">
+              <dt className="text-xs font-bold uppercase tracking-[0.12em] text-brand-700 dark:text-brand-200">
                 {point.label}
               </dt>
               <dd className="mt-1 text-xs leading-5 text-muted">{point.description}</dd>


### PR DESCRIPTION
## What changed
- adds dark-theme surface and border styling to the shared mechanism explainer
- adds matching dark styling to the individual mechanism-point cards and labels

## Why
MechanismBox is live across multiple high-intent herb guides and was still rendered as pale white cards inside dark pages. This makes the guide reading surface visually consistent without changing content or layout.