### PR TITLE
fix(ui): theme guide related-resource cards in dark mode

### DIFF
--- a/components/guides/InternalLinks.tsx
+++ b/components/guides/InternalLinks.tsx
@@ -24,9 +24,9 @@ export default function InternalLinks({ links, heading = 'Related Resources' }: 
           <Link
             key={link.href}
             href={link.href}
-            className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white"
+            className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm transition hover:border-brand-700/20 hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2 dark:border-white/10 dark:bg-white/5 dark:hover:border-white/20 dark:hover:bg-white/10 dark:focus-visible:ring-offset-[var(--surface-card)]"
           >
-            <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700">
+            <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-700 dark:text-brand-200">
               {TYPE_LABELS[link.type]}
             </p>
             <p className="mt-1 text-sm font-semibold text-ink">{link.label}</p>


### PR DESCRIPTION
## What changed
- adds dark-theme surfaces, borders, hover states, and label contrast to the shared guide related-resource cards
- adds visible keyboard focus treatment

## Why
This component is live through the shared GuidePage and was still rendering pale white related-resource cards inside dark pages. The layout already scales appropriately for multiple links, so this change stays focused on theme and interaction polish.