### PR TITLE
feat(ui): overhaul mobile homepage hero

### DIFF
--- a/styles/homepage-responsive.css
+++ b/styles/homepage-responsive.css
@@ -1,6 +1,193 @@
 /* Homepage responsive corrections that are easier to reason about outside the
    larger editorial skin. Keep these rules narrow and viewport-specific. */
 
+/* Mobile hero: give the first screen a deliberate editorial focal point instead
+   of a flat text stack. The desktop evidence dial remains untouched. */
+@media (max-width: 639px) {
+  .hs-home .hs-hero {
+    isolation: isolate;
+    margin-top: 0.75rem;
+    margin-inline: -0.25rem;
+    overflow: hidden;
+    border: 1px solid color-mix(in srgb, var(--hs-gold) 22%, var(--hs-hairline));
+    border-radius: 2rem;
+    padding: 1.35rem 1.1rem 1.1rem;
+    background:
+      radial-gradient(circle at 92% 8%, color-mix(in srgb, var(--hs-gold) 18%, transparent), transparent 34%),
+      radial-gradient(circle at 8% 18%, color-mix(in srgb, #6ea783 18%, transparent), transparent 36%),
+      linear-gradient(155deg, color-mix(in srgb, var(--hs-surface) 94%, transparent), var(--hs-surface-2));
+    box-shadow:
+      0 1px 0 rgba(255, 255, 255, 0.6) inset,
+      0 24px 60px -36px rgba(18, 60, 47, 0.55);
+  }
+
+  .dark .hs-home .hs-hero {
+    border-color: color-mix(in srgb, var(--hs-gold) 28%, transparent);
+    background:
+      radial-gradient(circle at 92% 8%, rgba(217, 178, 113, 0.14), transparent 34%),
+      radial-gradient(circle at 8% 18%, rgba(74, 145, 105, 0.18), transparent 38%),
+      linear-gradient(155deg, rgba(28, 55, 43, 0.98), rgba(14, 31, 24, 0.98));
+    box-shadow:
+      0 1px 0 rgba(255, 255, 255, 0.05) inset,
+      0 24px 64px -34px rgba(0, 0, 0, 0.75);
+  }
+
+  .hs-home .hs-hero::before {
+    left: -40%;
+    top: -18%;
+    width: 25rem;
+    height: 20rem;
+    filter: blur(50px);
+    opacity: 0.48;
+  }
+
+  .hs-home .hs-hero::after {
+    content: '';
+    position: absolute;
+    z-index: 0;
+    top: 0.85rem;
+    right: -4.3rem;
+    width: 11.5rem;
+    height: 11.5rem;
+    pointer-events: none;
+    border: 1px solid color-mix(in srgb, var(--hs-gold) 28%, transparent);
+    border-radius: 50%;
+    opacity: 0.48;
+    background:
+      repeating-conic-gradient(
+        from 8deg,
+        color-mix(in srgb, var(--hs-gold) 18%, transparent) 0deg 1deg,
+        transparent 1deg 15deg
+      ),
+      radial-gradient(circle, transparent 53%, color-mix(in srgb, var(--hs-gold) 9%, transparent) 54% 56%, transparent 57%);
+  }
+
+  .hs-home .hs-hero > * {
+    position: relative;
+    z-index: 1;
+  }
+
+  .hs-home .hs-hero > .grid {
+    gap: 0;
+  }
+
+  .hs-home .hs-hero .hs-eyebrow {
+    border: 1px solid color-mix(in srgb, var(--hs-gold) 24%, transparent);
+    border-radius: 999px;
+    padding: 0.55rem 0.72rem;
+    background: color-mix(in srgb, var(--hs-surface) 72%, transparent);
+    backdrop-filter: blur(10px);
+  }
+
+  .dark .hs-home .hs-hero .hs-eyebrow {
+    background: rgba(255, 255, 255, 0.055);
+  }
+
+  .hs-home .hs-hero .hs-eyebrow::before {
+    display: none;
+  }
+
+  .hs-home .hs-hero h1.hs-display {
+    max-width: 11.5ch;
+    margin-top: 1.15rem;
+    font-size: clamp(2.85rem, 13.7vw, 3.55rem);
+    line-height: 0.96;
+    letter-spacing: -0.045em;
+  }
+
+  .hs-home .hs-hero .hs-lede {
+    margin-top: 1.15rem;
+    max-width: 31rem;
+    font-size: 1rem;
+    line-height: 1.62;
+  }
+
+  .hs-home .hs-hero .hs-btn-primary,
+  .hs-home .hs-hero .hs-btn-ghost {
+    width: 100%;
+    min-height: 3.4rem;
+    padding-block: 0.88rem;
+    box-shadow: 0 12px 28px -18px rgba(18, 60, 47, 0.72);
+  }
+
+  .hs-home .hs-hero .hs-btn-ghost {
+    background: color-mix(in srgb, var(--hs-surface) 78%, transparent);
+  }
+
+  .dark .hs-home .hs-hero .hs-btn-ghost {
+    background: rgba(255, 255, 255, 0.06);
+  }
+
+  /* Turn the raw three-number row into one compact credibility module. */
+  .hs-home .hs-hero > dl.grid {
+    margin-top: 1.45rem;
+    gap: 0;
+    overflow: hidden;
+    border: 1px solid var(--hs-hairline);
+    border-radius: 1.25rem;
+    padding: 0.9rem 0.35rem;
+    background: color-mix(in srgb, var(--hs-surface) 74%, transparent);
+    box-shadow: 0 1px 0 rgba(255, 255, 255, 0.45) inset;
+    backdrop-filter: blur(12px);
+  }
+
+  .dark .hs-home .hs-hero > dl.grid {
+    background: rgba(255, 255, 255, 0.045);
+    box-shadow: 0 1px 0 rgba(255, 255, 255, 0.04) inset;
+  }
+
+  .hs-home .hs-hero > dl.grid > div {
+    padding-inline: 0.45rem;
+    text-align: center;
+  }
+
+  .hs-home .hs-hero > dl.grid > div + div {
+    border-left: 1px solid var(--hs-hairline);
+  }
+
+  .hs-home .hs-hero > dl.grid .hs-stat-num {
+    font-size: 1.55rem;
+    line-height: 1;
+  }
+
+  /* Make the credibility rail feel like a swipeable editorial strip instead of
+     three more paragraphs stacked underneath the hero. */
+  .hs-home .hs-hero .hs-rail {
+    display: flex;
+    gap: 0.75rem;
+    margin-top: 1rem;
+    margin-right: -1.1rem;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    border: 0;
+    padding: 0 1.1rem 0.25rem 0;
+    scrollbar-width: none;
+  }
+
+  .hs-home .hs-hero .hs-rail::-webkit-scrollbar {
+    display: none;
+  }
+
+  .hs-home .hs-hero .hs-rail > * {
+    min-width: min(78vw, 18.5rem);
+    scroll-snap-align: start;
+    border: 1px solid var(--hs-hairline);
+    border-radius: 1.15rem;
+    padding: 0.95rem 1rem;
+    background: color-mix(in srgb, var(--hs-surface) 76%, transparent);
+    box-shadow: 0 10px 26px -22px rgba(18, 60, 47, 0.65);
+    backdrop-filter: blur(10px);
+  }
+
+  .dark .hs-home .hs-hero .hs-rail > * {
+    background: rgba(255, 255, 255, 0.045);
+  }
+
+  .hs-home .hs-hero .hs-rail > * + * {
+    border-top: 1px solid var(--hs-hairline);
+  }
+}
+
 /* The goal-card copy becomes cramped when four cards stay two-up on narrow
    phones. Give each card the full reading width there, then let the existing
    Tailwind grid resume its two-column layout above this breakpoint. */


### PR DESCRIPTION
## What changed
- turns the mobile homepage hero into a deliberate editorial panel with layered botanical/evidence depth instead of a flat text stack
- strengthens mobile headline scale and CTA surfaces
- converts the raw stat row into a compact credibility module
- converts the long credibility rail into a swipeable, snap-aligned editorial strip
- keeps the desktop evidence dial and desktop layout untouched

## Why
The current desktop homepage has a strong visual focal point, but that evidence dial is hidden below the desktop breakpoint. Mobile therefore opens with mostly text, buttons, numbers, and stacked prose, which makes the first impression feel flatter and less premium than the desktop experience.