### PR TITLE
feat(ui): replace green-led global palette

### DIFF
--- a/styles/editorial-global-tokens.css
+++ b/styles/editorial-global-tokens.css
@@ -1,37 +1,37 @@
-/* Global light-theme tokens for the editorial botanical direction. */
+/* Global light-theme tokens for the editorial research direction. */
 html:not(.dark) {
-  --color-background: #fbf8f1;
-  --color-surface: #f5efe2;
-  --color-ink: #123c2f;
-  --color-muted: #526159;
-  --bg: #fbf8f1;
-  --surface: #f5efe2;
-  --surface-elevated: #fffdf8;
-  --text-primary: #123c2f;
-  --text-secondary: #526159;
-  --text-muted: #647168;
-  --surface-card: rgba(255, 253, 248, 0.92);
-  --surface-card-strong: rgba(255, 253, 248, 0.98);
-  --surface-subtle: rgba(245, 239, 226, 0.78);
-  --surface-code: #f7f1e6;
+  --color-background: #fbf7f1;
+  --color-surface: #f2ece5;
+  --color-ink: #29272f;
+  --color-muted: #625e68;
+  --bg: #fbf7f1;
+  --surface: #f2ece5;
+  --surface-elevated: #fffaf3;
+  --text-primary: #29272f;
+  --text-secondary: #625e68;
+  --text-muted: #77717d;
+  --surface-card: rgba(255, 250, 243, 0.92);
+  --surface-card-strong: rgba(255, 250, 243, 0.98);
+  --surface-subtle: rgba(242, 236, 229, 0.8);
+  --surface-code: #f5efe8;
   --surface-warning: rgba(248, 240, 223, 0.92);
   --surface-danger: rgba(255, 241, 238, 0.92);
-  --surface-info: rgba(239, 246, 242, 0.92);
-  --surface-neutral: rgba(250, 247, 240, 0.94);
-  --border-soft: rgba(18, 60, 47, 0.10);
-  --border-strong: rgba(18, 60, 47, 0.18);
-  --ring-brand: rgba(184, 138, 66, 0.34);
-  --accent-primary: #123c2f;
-  --accent-secondary: #b88a42;
-  --accent-teal: #315f50;
+  --surface-info: rgba(241, 240, 249, 0.92);
+  --surface-neutral: rgba(249, 246, 241, 0.94);
+  --border-soft: rgba(45, 42, 52, 0.10);
+  --border-strong: rgba(45, 42, 52, 0.18);
+  --ring-brand: rgba(169, 119, 47, 0.34);
+  --accent-primary: #5f568f;
+  --accent-secondary: #a9772f;
+  --accent-teal: #5d6f8d;
 }
 
 html:not(.dark) body,
 html:not(.dark) main {
-  background-color: #fbf8f1;
+  background-color: #fbf7f1;
 }
 
 html:not(.dark) ::selection {
-  background: rgba(203, 220, 200, 0.78);
-  color: #123c2f;
+  background: rgba(210, 204, 232, 0.78);
+  color: #29272f;
 }

--- a/styles/premium-foundation.css
+++ b/styles/premium-foundation.css
@@ -5,69 +5,64 @@
  * what kept the rest of the site on an older, flatter surface vocabulary.
  *
  * This file lifts the palette, elevation, and hairline tokens to the document
- * root so every route can build on them, and paints the same warm canvas
- * behind the whole app. Component-level surfaces (cards, chips, eyebrows,
- * buttons) are adopted in a later pass; this file changes only the ground
- * they sit on.
- *
- * Load order matters: this is imported last in app/layout.tsx so it settles
- * the cascade against the older layers that also touch these hooks.
+ * root so every route can build on them. The visual direction is intentionally
+ * editorial rather than "wellness green": warm ivory, charcoal ink, muted brass,
+ * and restrained indigo carry the brand; botanical green is reserved for local
+ * category accents where it has semantic value.
  */
 
 :root {
-  --hs-gold: #b88a42;
-  --hs-gold-bright: #c99a4e;
-  --hs-gold-soft: #e2cba3;
-  --hs-ink: #10352a;
-  --hs-ink-soft: #315f50;
-  --hs-body: #4a5b52;
-  --hs-hairline: rgba(18, 60, 47, 0.12);
-  --hs-hairline-strong: rgba(18, 60, 47, 0.2);
-  --hs-surface: #fffdf8;
-  --hs-surface-2: rgba(255, 253, 248, 0.72);
-  --hs-lift: 0 1px 2px rgba(46, 38, 20, 0.05), 0 12px 32px -12px rgba(46, 38, 20, 0.16);
-  --hs-lift-hover: 0 2px 4px rgba(46, 38, 20, 0.06), 0 26px 56px -18px rgba(46, 38, 20, 0.26);
+  --hs-gold: #a9772f;
+  --hs-gold-bright: #bd8a3d;
+  --hs-gold-soft: #dfc59c;
+  --hs-ink: #29272f;
+  --hs-ink-soft: #514d59;
+  --hs-body: #625e68;
+  --hs-hairline: rgba(45, 42, 52, 0.11);
+  --hs-hairline-strong: rgba(45, 42, 52, 0.19);
+  --hs-surface: #fffaf3;
+  --hs-surface-2: rgba(255, 250, 243, 0.74);
+  --hs-lift: 0 1px 2px rgba(44, 37, 34, 0.045), 0 12px 32px -12px rgba(49, 42, 52, 0.14);
+  --hs-lift-hover: 0 2px 4px rgba(44, 37, 34, 0.055), 0 26px 56px -18px rgba(49, 42, 52, 0.23);
 
-  /* Canvas washes, kept as tokens so a route can opt into a different ground. */
-  --hs-canvas: radial-gradient(120% 60% at 50% -10%, rgba(203, 220, 200, 0.6), transparent 60%),
-    linear-gradient(180deg, #fffdf8 0%, #fbf8f1 30%, #f8f3e8 100%);
-  --hs-dot: rgba(18, 60, 47, 0.14);
-  --hs-dot-opacity: 0.5;
+  /* A quiet editorial ground: ivory first, with a soft indigo signal and a
+     brass warmth near the top. */
+  --hs-canvas: radial-gradient(105% 55% at 12% -8%, rgba(111, 101, 171, 0.15), transparent 58%),
+    radial-gradient(90% 48% at 88% -4%, rgba(189, 138, 61, 0.10), transparent 58%),
+    linear-gradient(180deg, #fffaf3 0%, #fbf7f1 34%, #f7f1ea 100%);
+  --hs-dot: rgba(64, 58, 75, 0.11);
+  --hs-dot-opacity: 0.42;
 }
 
 html.dark {
-  --hs-gold: #d9b271;
-  --hs-gold-bright: #e8c98f;
-  --hs-gold-soft: rgba(217, 178, 113, 0.28);
-  --hs-ink: #f3f0e6;
-  --hs-ink-soft: #a9c9b5;
-  --hs-body: #b6c7bb;
-  --hs-hairline: rgba(180, 210, 190, 0.16);
-  --hs-hairline-strong: rgba(180, 210, 190, 0.3);
-  --hs-surface: #16291f;
-  --hs-surface-2: rgba(24, 43, 33, 0.6);
-  --hs-lift: 0 1px 0 rgba(255, 255, 255, 0.05) inset, 0 16px 40px -16px rgba(0, 0, 0, 0.7);
-  --hs-lift-hover: 0 1px 0 rgba(255, 255, 255, 0.09) inset, 0 30px 64px -20px rgba(0, 0, 0, 0.85);
+  --hs-gold: #d5ad6c;
+  --hs-gold-bright: #e3c183;
+  --hs-gold-soft: rgba(213, 173, 108, 0.25);
+  --hs-ink: #f5f0e8;
+  --hs-ink-soft: #d5cedb;
+  --hs-body: #c4bec9;
+  --hs-hairline: rgba(225, 217, 232, 0.13);
+  --hs-hairline-strong: rgba(225, 217, 232, 0.24);
+  --hs-surface: #201e25;
+  --hs-surface-2: rgba(35, 32, 41, 0.68);
+  --hs-lift: 0 1px 0 rgba(255, 255, 255, 0.045) inset, 0 16px 40px -16px rgba(0, 0, 0, 0.68);
+  --hs-lift-hover: 0 1px 0 rgba(255, 255, 255, 0.08) inset, 0 30px 64px -20px rgba(0, 0, 0, 0.82);
 
-  --hs-canvas: radial-gradient(120% 55% at 50% -8%, rgba(46, 96, 74, 0.42), transparent 62%),
-    linear-gradient(180deg, #0a1610 0%, #081410 45%, #0a1712 100%);
-  --hs-dot: rgba(190, 224, 202, 0.16);
-  --hs-dot-opacity: 0.4;
+  --hs-canvas: radial-gradient(110% 55% at 12% -8%, rgba(105, 91, 172, 0.24), transparent 60%),
+    radial-gradient(80% 42% at 88% -4%, rgba(182, 132, 72, 0.11), transparent 60%),
+    linear-gradient(180deg, #151319 0%, #121116 48%, #17141b 100%);
+  --hs-dot: rgba(215, 207, 224, 0.12);
+  --hs-dot-opacity: 0.34;
 }
 
 /* ---------- Page canvas ---------- */
 
-/* The app shell owns the ground for every route. `isolation` makes it the
-   stacking context the dot field sits in, so the field paints above the
-   shell's own background but stays behind all content. */
 .hs-shell {
   position: relative;
   isolation: isolate;
   background: var(--hs-canvas);
 }
 
-/* Fine botanical dot field, fading out down the first screenful — the same
-   treatment the homepage hero sits on. Decorative only. */
 .hs-shell::before {
   content: '';
   position: absolute;
@@ -81,15 +76,10 @@ html.dark {
   mask-image: linear-gradient(to bottom, #000 0%, transparent 42%);
 }
 
-/* The homepage paints its own identical canvas inside the shell; skip the
-   second dot field so the texture does not double up there. */
 .hs-shell:has(.hs-home)::before {
   content: none;
 }
 
-/* styles/editorial-global-tokens.css painted <main> a flat #fbf8f1, which sat
-   on top of the shell and hid the canvas on every route but the homepage. The
-   shell owns the ground now, so main stays transparent. */
 html:not(.dark) main,
 html.dark main {
   background-color: transparent;
@@ -97,9 +87,6 @@ html.dark main {
 
 /* ---------- Measure and rhythm ---------- */
 
-/* The homepage reads at 72rem with a wider gutter; the rest of the site was
-   set to 80rem with a tighter one, which is what made those pages feel less
-   composed at desktop widths. One measure now. */
 .container-page {
   max-width: 72rem;
   padding-inline: 1.25rem;

--- a/styles/premium-surfaces.css
+++ b/styles/premium-surfaces.css
@@ -1,38 +1,23 @@
 /* Premium surfaces — phase 2 of promoting the homepage design language.
  *
- * Phase 0/1 (styles/premium-foundation.css) gave every route the homepage's
- * tokens and canvas. This file moves the shared component surfaces onto the
- * same vocabulary: the elevation model from .hs-goal, the eyebrow with its
- * rule, the pill chip, and the two button treatments.
- *
- * This file owns those surfaces outright. The competing definitions that used
- * to live in premium-cards, resonant-theme-lighting, editorial-content-surfaces,
- * foundation-readability, premium-library-polish, and globals were removed in
- * phase 4, so plain single-class selectors are enough here — no doubled classes
- * and no specificity arms race. Keep it that way: style a card surface here,
- * not in one of the older layers.
+ * Phase 0/1 (styles/premium-foundation.css) gave every route the shared tokens
+ * and canvas. This file moves shared component surfaces onto the same vocabulary.
  */
 
 :root {
-  /* Tone drives the per-surface wash. Routes override it; this is the default. */
-  --tone: #3f7c4a;
-  --tone-ink: #1f4d29;
-
-  /* --hs-gold is a decoration colour: it clears 3:1 against the canvas as a
-     rule or border, but only ~2.9:1 as text, which fails WCAG AA. Text that
-     wants to read as gold uses this darker cut (~5:1) instead. */
-  --hs-gold-ink: #7a5620;
+  /* Default surfaces use muted indigo. Green is reserved for semantic/local
+     botanical accents instead of acting as the site's universal brand color. */
+  --tone: #6f66a8;
+  --tone-ink: #514a87;
+  --hs-gold-ink: #76511c;
 }
 
 html.dark {
-  --tone: #78a380;
-  --tone-ink: #a9c9b5;
+  --tone: #9a90cf;
+  --tone-ink: #c4bce8;
   --hs-gold-ink: #d9b271;
 }
 
-/* Per-family tone, applied through the wrappers that already exist. Anything
-   without a hook keeps the default green. A route-family attribute on the
-   shell would let this cover every template; that is a follow-up. */
 .library-index-page {
   --tone: #5c4db8;
   --tone-ink: #4a3da3;
@@ -76,8 +61,6 @@ html .mobile-reading-card {
     border-color 260ms ease;
 }
 
-/* Dark surfaces swallow a 9% wash, so the tint is pushed harder there — the
-   same correction the homepage goal cards make. */
 html.dark .card-premium,
 html.dark .scientific-card,
 html.dark .library-card-premium,
@@ -93,8 +76,6 @@ html.dark .mobile-reading-card {
     var(--hs-surface);
 }
 
-/* Only lift cards that are actually interactive; a static content panel that
-   rises on hover reads as broken. */
 html a.card-premium:hover,
 html a .card-premium:hover,
 html button.card-premium:hover,
@@ -141,7 +122,6 @@ html .section-label {
   text-transform: uppercase;
 }
 
-/* The short rule that opens every homepage section label. */
 html .eyebrow-label::before,
 html .section-label::before {
   content: '';
@@ -203,24 +183,24 @@ html button.chip-readable:hover {
 html .button-primary {
   position: relative;
   overflow: hidden;
-  border: 1px solid rgba(18, 60, 47, 0.9);
-  background: linear-gradient(140deg, #1c5241 0%, #123c2f 55%, #0f3227 100%);
-  color: #fffdf8;
+  border: 1px solid rgba(48, 43, 58, 0.92);
+  background: linear-gradient(140deg, #454052 0%, #302c39 55%, #28242f 100%);
+  color: #fffaf3;
   box-shadow:
-    0 1px 0 rgba(255, 255, 255, 0.14) inset,
-    0 14px 30px -12px rgba(18, 60, 47, 0.7);
+    0 1px 0 rgba(255, 255, 255, 0.13) inset,
+    0 14px 30px -12px rgba(48, 43, 58, 0.58);
 }
 
 html.dark .button-primary {
-  border-color: rgba(217, 178, 113, 0.42);
-  background: linear-gradient(140deg, #256a52 0%, #17493a 55%, #123c2f 100%);
+  border-color: rgba(213, 173, 108, 0.38);
+  background: linear-gradient(140deg, #625985 0%, #433d59 55%, #302b3d 100%);
 }
 
 html .button-primary:hover {
   transform: translateY(-2px);
   box-shadow:
-    0 1px 0 rgba(255, 255, 255, 0.18) inset,
-    0 20px 40px -12px rgba(18, 60, 47, 0.6);
+    0 1px 0 rgba(255, 255, 255, 0.17) inset,
+    0 20px 40px -12px rgba(48, 43, 58, 0.48);
 }
 
 html .button-secondary {
@@ -259,8 +239,6 @@ html main hr {
 
 /* ---------- Mobile navigation widget ---------- */
 
-/* The corner widget grows from its trigger rather than sliding in from an
-   edge, so the button reads as the thing that opened it. */
 @keyframes hs-widget-in {
   from {
     opacity: 0;


### PR DESCRIPTION
## What changed
- replaces the site-wide forest-green ink/canvas bias with warm charcoal, ivory, brass, and muted indigo
- updates light and dark foundation tokens so cards, text, borders, and page ground inherit the new direction
- changes the default shared-card tone from green to indigo
- changes shared primary buttons from green gradients to charcoal/aubergine gradients

## Why
The existing palette made green the default for nearly every surface, which pushed the site toward a generic wellness aesthetic. Green is now reserved for local semantic/category accents instead of carrying the whole brand.