### PR TITLE
feat(ui): remove green from footer brand surfaces

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -79,6 +79,11 @@ export default function Footer() {
   const versionStampParts = [`v${appVersion}`, commitHash]
   if (buildDate) versionStampParts.push(buildDate)
 
+  const socialClass =
+    'rounded-full border border-[color:var(--hs-hairline)] bg-[color:var(--hs-surface-2)] px-4 py-2 text-xs font-bold text-[color:var(--tone-ink)] transition hover:border-[color:var(--hs-gold)] hover:bg-[color:var(--hs-surface)] hover:text-[color:var(--hs-ink)]'
+  const footerLinkClass =
+    'text-sm font-medium text-[color:var(--hs-body)] transition hover:text-[color:var(--hs-ink)]'
+
   return (
     <footer className='editorial-footer mt-12 w-full px-4 pb-28 pt-12 sm:px-6 sm:pt-16 md:pb-12'>
       <div className='relative z-10 mx-auto w-full max-w-6xl'>
@@ -95,34 +100,34 @@ export default function Footer() {
           <div>
             <div className='flex items-center gap-3'>
               <span className='editorial-icon-disc h-12 w-12'>
-                <Leaf aria-hidden='true' className='h-6 w-6 text-[#315f50]' strokeWidth={1.7} />
+                <Leaf aria-hidden='true' className='h-6 w-6 text-[color:var(--tone-ink)]' strokeWidth={1.7} />
               </span>
-              <p className='font-display text-2xl font-semibold tracking-[-0.025em] text-[#123c2f] dark:text-[var(--text-primary)]'>
+              <p className='font-display text-2xl font-semibold tracking-[-0.025em] text-[color:var(--hs-ink)]'>
                 The Hippie Scientist
               </p>
             </div>
-            <p className='mt-3 max-w-md text-sm leading-6 text-[#526159] dark:text-[var(--text-secondary)]'>
+            <p className='mt-3 max-w-md text-sm leading-6 text-[color:var(--hs-body)]'>
               Evidence-first botanical research for clearer, safer supplement decisions. Educational only — not medical advice.
             </p>
 
             <div className='mt-4 flex flex-wrap gap-2'>
-              <a href='https://x.com/TheHippieSci' target='_blank' rel='noopener noreferrer' aria-label='The Hippie Scientist on X (opens in a new tab)' className='rounded-full border border-[#123c2f]/10 bg-[#fffdf8]/75 px-4 py-2 text-xs font-bold text-[#315f50] transition hover:border-[#b88a42]/35 hover:bg-[#fffdf8] dark:border-white/10 dark:bg-white/5 dark:text-[#a9c6b3] dark:hover:border-[#dec69b]/30 dark:hover:bg-white/10 dark:hover:text-[#d9e8de]'>
+              <a href='https://x.com/TheHippieSci' target='_blank' rel='noopener noreferrer' aria-label='The Hippie Scientist on X (opens in a new tab)' className={socialClass}>
                 X
               </a>
-              <a href='https://www.instagram.com/thehippiesci' target='_blank' rel='noopener noreferrer' aria-label='The Hippie Scientist on Instagram (opens in a new tab)' className='rounded-full border border-[#123c2f]/10 bg-[#fffdf8]/75 px-4 py-2 text-xs font-bold text-[#315f50] transition hover:border-[#b88a42]/35 hover:bg-[#fffdf8] dark:border-white/10 dark:bg-white/5 dark:text-[#a9c6b3] dark:hover:border-[#dec69b]/30 dark:hover:bg-white/10 dark:hover:text-[#d9e8de]'>
+              <a href='https://www.instagram.com/thehippiesci' target='_blank' rel='noopener noreferrer' aria-label='The Hippie Scientist on Instagram (opens in a new tab)' className={socialClass}>
                 Instagram
               </a>
-              <a href='https://www.youtube.com/@TheHippieSci' target='_blank' rel='noopener noreferrer' aria-label='The Hippie Scientist on YouTube (opens in a new tab)' className='rounded-full border border-[#123c2f]/10 bg-[#fffdf8]/75 px-4 py-2 text-xs font-bold text-[#315f50] transition hover:border-[#b88a42]/35 hover:bg-[#fffdf8] dark:border-white/10 dark:bg-white/5 dark:text-[#a9c6b3] dark:hover:border-[#dec69b]/30 dark:hover:bg-white/10 dark:hover:text-[#d9e8de]'>
+              <a href='https://www.youtube.com/@TheHippieSci' target='_blank' rel='noopener noreferrer' aria-label='The Hippie Scientist on YouTube (opens in a new tab)' className={socialClass}>
                 YouTube
               </a>
             </div>
 
             <div className='editorial-card mt-6 rounded-2xl p-4 sm:p-5'>
               <p className='editorial-eyebrow'>Lost or not sure where to begin?</p>
-              <p className='mt-2 text-sm leading-6 text-[#526159] dark:text-[var(--text-secondary)]'>
+              <p className='mt-2 text-sm leading-6 text-[color:var(--hs-body)]'>
                 The master directory explains how the site is organized and links every major guide, article, profile, research, and safety collection.
               </p>
-              <Link className='mt-3 inline-flex text-sm font-bold text-[#315f50] hover:text-[#123c2f] dark:text-[#8dc49a] dark:hover:text-[#c9e4d2]' to={PUBLIC_ROUTES.library} prefetch={true}>
+              <Link className='mt-3 inline-flex text-sm font-bold text-[color:var(--tone-ink)] hover:text-[color:var(--hs-ink)]' to={PUBLIC_ROUTES.library} prefetch={true}>
                 Explore the complete site →
               </Link>
             </div>
@@ -136,9 +141,9 @@ export default function Footer() {
                   key={href}
                   to={href}
                   prefetch={true}
-                  className='editorial-link-tile group flex items-center gap-2.5 rounded-xl px-3 py-2.5 text-[#123c2f] transition dark:text-[var(--text-primary)]'
+                  className='editorial-link-tile group flex items-center gap-2.5 rounded-xl px-3 py-2.5 text-[color:var(--hs-ink)] transition'
                 >
-                  <Icon className='h-4 w-4 shrink-0 text-[#315f50] dark:text-[#8dc49a]' aria-hidden='true' strokeWidth={1.7} />
+                  <Icon className='h-4 w-4 shrink-0 text-[color:var(--tone-ink)]' aria-hidden='true' strokeWidth={1.7} />
                   <span className='text-sm font-bold leading-tight text-balance'>{label}</span>
                 </Link>
               ))}
@@ -146,11 +151,11 @@ export default function Footer() {
 
             <div className='mt-7 grid grid-cols-2 gap-x-5 gap-y-7 lg:grid-cols-4'>
               <div>
-                <h3 className='text-xs font-extrabold uppercase tracking-[0.15em] text-[#315f50] dark:text-[#8dc49a]'>Popular topics</h3>
+                <h3 className='text-xs font-extrabold uppercase tracking-[0.15em] text-[color:var(--tone-ink)]'>Popular topics</h3>
                 <ul className='mt-3 space-y-2'>
                   {priorityGoalLinks.map((link) => (
                     <li key={`${link.href}-${link.label}`}>
-                      <Link className='text-sm font-medium text-[#526159] transition hover:text-[#123c2f] dark:text-[var(--text-secondary)] dark:hover:text-[var(--text-primary)]' to={link.href} prefetch={true}>
+                      <Link className={footerLinkClass} to={link.href} prefetch={true}>
                         {link.label}
                       </Link>
                     </li>
@@ -159,11 +164,11 @@ export default function Footer() {
               </div>
 
               <div>
-                <h3 className='text-xs font-extrabold uppercase tracking-[0.15em] text-[#315f50] dark:text-[#8dc49a]'>Research</h3>
+                <h3 className='text-xs font-extrabold uppercase tracking-[0.15em] text-[color:var(--tone-ink)]'>Research</h3>
                 <ul className='mt-3 space-y-2'>
                   {researchLinks.map((link) => (
                     <li key={link.href}>
-                      <Link className='text-sm font-medium text-[#526159] transition hover:text-[#123c2f] dark:text-[var(--text-secondary)] dark:hover:text-[var(--text-primary)]' to={link.href} prefetch={true}>
+                      <Link className={footerLinkClass} to={link.href} prefetch={true}>
                         {link.label}
                       </Link>
                     </li>
@@ -172,17 +177,17 @@ export default function Footer() {
               </div>
 
               <div>
-                <h3 className='text-xs font-extrabold uppercase tracking-[0.15em] text-[#315f50] dark:text-[#8dc49a]'>Safety</h3>
+                <h3 className='text-xs font-extrabold uppercase tracking-[0.15em] text-[color:var(--tone-ink)]'>Safety</h3>
                 <ul className='mt-3 space-y-2'>
                   {safetyLinks.map((link) => (
                     <li key={link.href}>
-                      <Link className='text-sm font-medium text-[#526159] transition hover:text-[#123c2f] dark:text-[var(--text-secondary)] dark:hover:text-[var(--text-primary)]' to={link.href} prefetch={true}>
+                      <Link className={footerLinkClass} to={link.href} prefetch={true}>
                         {link.label}
                       </Link>
                     </li>
                   ))}
                   <li>
-                    <button className='text-sm font-medium text-[#526159] transition hover:text-[#123c2f] dark:text-[var(--text-secondary)] dark:hover:text-[var(--text-primary)]' type='button' onClick={() => setOpen(true)}>
+                    <button className={footerLinkClass} type='button' onClick={() => setOpen(true)}>
                       Privacy settings
                     </button>
                   </li>
@@ -190,11 +195,11 @@ export default function Footer() {
               </div>
 
               <div>
-                <h3 className='text-xs font-extrabold uppercase tracking-[0.15em] text-[#315f50] dark:text-[#8dc49a]'>About & legal</h3>
+                <h3 className='text-xs font-extrabold uppercase tracking-[0.15em] text-[color:var(--tone-ink)]'>About & legal</h3>
                 <ul className='mt-3 space-y-2'>
                   {availableLegalLinks.map((link) => (
                     <li key={link.href}>
-                      <Link className='text-sm font-medium text-[#526159] transition hover:text-[#123c2f] dark:text-[var(--text-secondary)] dark:hover:text-[var(--text-primary)]' to={link.href} prefetch={true}>
+                      <Link className={footerLinkClass} to={link.href} prefetch={true}>
                         {link.label}
                       </Link>
                     </li>
@@ -205,7 +210,7 @@ export default function Footer() {
           </div>
         </div>
 
-        <div className='mt-8 flex flex-col justify-between gap-3 border-t border-[#123c2f]/10 pt-6 text-xs text-[#647168] sm:flex-row dark:border-white/10 dark:text-[#93a89b]'>
+        <div className='mt-8 flex flex-col justify-between gap-3 border-t border-[color:var(--hs-hairline)] pt-6 text-xs text-[color:var(--hs-body)] sm:flex-row'>
           <div>© 2024–{copyrightYear} The Hippie Scientist. All rights reserved.</div>
           <div className='flex flex-wrap gap-x-4 gap-y-2'>
             <span>Educational use only</span>


### PR DESCRIPTION
## What changed
- replaces hard-coded forest/sage footer text, icons, links, social buttons, and divider colors with the new shared charcoal/ivory/brass/indigo tokens
- keeps footer structure and content unchanged
- centralizes repeated footer link/social styling so future palette changes propagate cleanly

## Why
The footer was one of the strongest remaining green holdouts and would visually snap the site back to the old wellness-blog identity at the end of every page.