### PR TITLE
feat(ui): upgrade herb and compound library intros

### DIFF
--- a/app/compounds/page.tsx
+++ b/app/compounds/page.tsx
@@ -52,24 +52,43 @@ export default async function CompoundsPage() {
   const pageData = paginateItems(allCompounds, 1, COMPOUNDS_PAGE_SIZE)
   const leanCompounds = toLeanProfileIndexRecords(allCompounds)
   const leanPageItems = toLeanProfileIndexRecords(pageData.pageItems as RuntimeRecord[])
+  const heroMetrics = [
+    { value: allCompounds.length, label: 'profiles' },
+    { value: pageData.totalPages, label: 'index pages' },
+    { value: 'A–Z', label: 'searchable' },
+  ]
 
   return (
-    <div className="mx-auto max-w-6xl space-y-6 px-4 py-6 sm:py-8">
-      {/* Hero */}
-      <section className="hero-shell rounded-[0.95rem] border border-brand-900/10 px-4 py-5 shadow-sm sm:px-6 sm:py-6">
-        <p className="eyebrow-label">Compound research library</p>
-        <h1 className="mt-2 max-w-3xl font-display text-3xl font-semibold tracking-tight text-ink sm:text-5xl">
-          Compound Library
-        </h1>
-        <p className="mt-2 max-w-2xl text-sm leading-6 text-muted">
-          Mechanism, evidence strength, and safety context for bioactive molecules and supplement constituents.
+    <div className="mx-auto max-w-6xl space-y-6 px-4 py-4 sm:py-6">
+      <section className="hero-shell rounded-[2rem] border px-5 py-6 sm:p-8">
+        <p className="eyebrow-label">Compound Research Library</p>
+        <h1 className="heading-premium mt-5 max-w-4xl">Compound Library</h1>
+        <p className="text-reading mt-4 max-w-3xl">
+          Mechanism, evidence strength, and safety context for bioactive molecules and supplement constituents — evidence first, no hype.
         </p>
-        <p className="mt-2 text-sm font-semibold text-muted">Browsing {allCompounds.length} published compounds</p>
+
+        <dl className="mt-6 grid grid-cols-3 overflow-hidden rounded-2xl border border-[color:var(--hs-hairline)] bg-[color:color-mix(in_srgb,var(--hs-surface)_76%,transparent)] backdrop-blur-sm">
+          {heroMetrics.map((metric, index) => (
+            <div
+              key={metric.label}
+              className={`px-3 py-3.5 text-center sm:px-5 sm:py-4 ${index > 0 ? 'border-l border-[color:var(--hs-hairline)]' : ''}`}
+            >
+              <dt className="sr-only">{metric.label}</dt>
+              <dd>
+                <span className="block font-display text-2xl font-semibold tracking-[-0.035em] text-[color:var(--hs-ink)] sm:text-[1.7rem]">
+                  {metric.value}
+                </span>
+                <span className="mt-1 block text-[0.62rem] font-bold uppercase tracking-[0.1em] text-[color:var(--hs-body)] sm:text-[0.7rem] sm:tracking-[0.12em]">
+                  {metric.label}
+                </span>
+              </dd>
+            </div>
+          ))}
+        </dl>
       </section>
 
       <Pagination basePath="/compounds" currentPage={1} totalPages={pageData.totalPages} itemLabel="Compound profiles" />
 
-      {/* SEO-crawlable index (hidden from visual users, served to Googlebot) */}
       <nav aria-label="Published compound profiles index" className="sr-only">
         <ul>
           {allCompounds.map((c) => (
@@ -80,7 +99,6 @@ export default async function CompoundsPage() {
         </ul>
       </nav>
 
-      {/* Client-side filtered + searchable compound grid */}
       <Suspense
         fallback={
           <div className="py-12 text-center text-sm text-muted">Loading compounds…</div>

--- a/app/herbs/page.tsx
+++ b/app/herbs/page.tsx
@@ -30,11 +30,11 @@ function HerbsLoadingSkeleton() {
   return (
     <div className="px-2 py-2 sm:px-3 sm:py-3">
       <div className="mx-auto max-w-7xl space-y-4">
-        <div className="hero-shell animate-pulse rounded-[0.95rem] border border-brand-900/10 px-3 py-4 shadow-sm sm:px-4 sm:py-5 h-32" />
-        <div className="animate-pulse rounded-[0.85rem] border border-brand-900/10 bg-white/85 p-3 shadow-sm h-24" />
+        <div className="hero-shell animate-pulse h-32 rounded-[1.5rem] border border-[color:var(--hs-hairline)]" />
+        <div className="h-24 animate-pulse rounded-[0.85rem] border border-brand-900/10 bg-white/85 p-3 shadow-sm" />
         <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
           {Array.from({ length: 6 }).map((_, i) => (
-            <div key={i} className="animate-pulse rounded-[0.85rem] border border-brand-900/10 bg-white/60 p-4 shadow-sm h-36" />
+            <div key={i} className="h-36 animate-pulse rounded-[0.85rem] border border-brand-900/10 bg-white/60 p-4 shadow-sm" />
           ))}
         </div>
       </div>
@@ -57,14 +57,39 @@ export default async function HerbsPage() {
   const leanHerbs = toLeanProfileIndexRecords(herbs)
   const leanPageItems = toLeanProfileIndexRecords(pageData.pageItems as RuntimeRecord[])
 
+  const heroMetrics = [
+    { value: herbs.length, label: 'profiles' },
+    { value: pageData.totalPages, label: 'index pages' },
+    { value: 'A–Z', label: 'searchable' },
+  ]
+
   return (
-    <div className="mx-auto max-w-6xl space-y-5 px-4 py-4 sm:py-6">
-      <header className="hero-shell rounded-[0.95rem] border border-brand-900/10 px-4 py-5 shadow-sm sm:px-6 sm:py-6">
+    <div className="mx-auto max-w-6xl space-y-6 px-4 py-4 sm:py-6">
+      <header className="hero-shell rounded-[2rem] border px-5 py-6 sm:p-8">
         <p className="eyebrow-label">Botanical Research Library</p>
-        <h1 className="mt-2 max-w-3xl text-balance font-display text-3xl font-semibold leading-[1.08] text-ink sm:text-5xl">Herb Profiles</h1>
-        <p className="mt-2 max-w-2xl text-pretty text-sm leading-6 text-muted">
-          Mechanisms, safety notes, active compounds, and research context for {herbs.length} herbs — plain language, conservative claims.
+        <h1 className="heading-premium mt-5 max-w-4xl">Herb Profiles</h1>
+        <p className="text-reading mt-4 max-w-3xl">
+          Mechanisms, safety notes, active compounds, and research context for published herbs — plain language, conservative claims.
         </p>
+
+        <dl className="mt-6 grid grid-cols-3 overflow-hidden rounded-2xl border border-[color:var(--hs-hairline)] bg-[color:color-mix(in_srgb,var(--hs-surface)_76%,transparent)] backdrop-blur-sm">
+          {heroMetrics.map((metric, index) => (
+            <div
+              key={metric.label}
+              className={`px-3 py-3.5 text-center sm:px-5 sm:py-4 ${index > 0 ? 'border-l border-[color:var(--hs-hairline)]' : ''}`}
+            >
+              <dt className="sr-only">{metric.label}</dt>
+              <dd>
+                <span className="block font-display text-2xl font-semibold tracking-[-0.035em] text-[color:var(--hs-ink)] sm:text-[1.7rem]">
+                  {metric.value}
+                </span>
+                <span className="mt-1 block text-[0.62rem] font-bold uppercase tracking-[0.1em] text-[color:var(--hs-body)] sm:text-[0.7rem] sm:tracking-[0.12em]">
+                  {metric.label}
+                </span>
+              </dd>
+            </div>
+          ))}
+        </dl>
       </header>
 
       <Pagination basePath="/herbs" currentPage={1} totalPages={pageData.totalPages} itemLabel="Herb profiles" />


### PR DESCRIPTION
## What changed
- upgrades the main herb and compound library heroes to the shared research-folio system
- adds matching metric rails for published profile count, index-page depth, and A–Z searchability
- strengthens headline/deck hierarchy and tightens mobile top spacing
- aligns the herb loading skeleton with the new hero shape

## Why
The two main research libraries should immediately communicate scale and organization. These intros make them feel like curated research indexes instead of generic archive pages.