### PR TITLE
fix(ui): preserve library count guardrails

### DIFF
--- a/app/compounds/page.tsx
+++ b/app/compounds/page.tsx
@@ -64,7 +64,7 @@ export default async function CompoundsPage() {
         <p className="eyebrow-label">Compound Research Library</p>
         <h1 className="heading-premium mt-5 max-w-4xl">Compound Library</h1>
         <p className="text-reading mt-4 max-w-3xl">
-          Mechanism, evidence strength, and safety context for bioactive molecules and supplement constituents — evidence first, no hype.
+          Mechanism, evidence strength, and safety context for published compounds and supplement constituents — evidence first, no hype.
         </p>
 
         <dl className="mt-6 grid grid-cols-3 overflow-hidden rounded-2xl border border-[color:var(--hs-hairline)] bg-[color:color-mix(in_srgb,var(--hs-surface)_76%,transparent)] backdrop-blur-sm">

--- a/app/herbs/page.tsx
+++ b/app/herbs/page.tsx
@@ -69,7 +69,7 @@ export default async function HerbsPage() {
         <p className="eyebrow-label">Botanical Research Library</p>
         <h1 className="heading-premium mt-5 max-w-4xl">Herb Profiles</h1>
         <p className="text-reading mt-4 max-w-3xl">
-          Mechanisms, safety notes, active compounds, and research context for published herbs — plain language, conservative claims.
+          Mechanisms, safety notes, active compounds, and research context for {herbs.length} herbs — plain language, conservative claims.
         </p>
 
         <dl className="mt-6 grid grid-cols-3 overflow-hidden rounded-2xl border border-[color:var(--hs-hairline)] bg-[color:color-mix(in_srgb,var(--hs-surface)_76%,transparent)] backdrop-blur-sm">


### PR DESCRIPTION
Restores the public-inventory wording expected by the herb and compound library guardrail tests while keeping the new premium metric rails and research-folio intros intact.