### PR TITLE
research: add 2026 L-theanine ADHD trial and evidence ledger

### DIFF
--- a/app/guides/adhd/l-theanine-for-adhd/page.tsx
+++ b/app/guides/adhd/l-theanine-for-adhd/page.tsx
@@ -6,7 +6,7 @@ const SLUG = 'l-theanine-for-adhd'
 export const metadata = buildPageMetadata({
   title: 'L-Theanine for ADHD: Does It Help Focus or Sleep?',
   description:
-    'What human studies actually show about L-theanine for ADHD, attention, and sleep, plus dose limits, stimulant interactions, side effects, and who should be cautious.',
+    '2026 evidence review of L-theanine for ADHD, including the new 21-adolescent crossover vs methylphenidate, older pediatric trials, sleep evidence, dose limits, and medication-safety gaps.',
   path: `/guides/adhd/${SLUG}/`,
   openGraphType: 'article',
 })

--- a/docs/content/focus-cluster/l-theanine-for-adhd-content-v1.md
+++ b/docs/content/focus-cluster/l-theanine-for-adhd-content-v1.md
@@ -1,11 +1,12 @@
-# L-Theanine for ADHD Content v2
+# L-Theanine for ADHD Content v3
 
-Status: Evidence-calibrated
+Status: Evidence-calibrated / literature-surveilled
 Cluster: Focus / ADHD
 Type: Evidence Guide
 Target URL: /guides/adhd/l-theanine-for-adhd/
-Version: 2
-Updated: 2026-08-12
+Version: 3
+Updated: 2026-08-15
+Literature check: 2026-08-15
 
 ---
 
@@ -13,36 +14,88 @@ Updated: 2026-08-12
 
 ## L-Theanine for ADHD: What the Evidence Supports in 2026
 
-L-theanine has human research on attention, stress, sleep, and cognition, but the ADHD-specific evidence is much smaller than the broader supplement literature. The most important distinction is **general L-theanine evidence versus direct ADHD evidence**.
+L-theanine has human research on attention, stress, sleep, and cognition, but the ADHD-specific evidence is still much smaller than the broader supplement literature. The most important distinction is **general L-theanine evidence versus direct ADHD evidence—and L-theanine alone versus L-theanine combined with caffeine**.
 
 A 2026 systematic review and meta-analysis pooled **31 randomized trials / 1,168 participants** across healthy and clinical populations. A single-dose cognitive-testing signal was found for choice reaction time, but that does not establish L-theanine as an ADHD treatment or create an evidence-based ADHD dose.
 
-The most directly relevant acute ADHD cognition study involved only **five boys ages 8–15**. A larger randomized trial involved **98 boys ages 8–12 with ADHD**, but that study evaluated sleep over six weeks rather than daytime attention or core ADHD symptoms.
+Direct ADHD evidence now includes two small acute cognition studies plus an older pediatric sleep trial. A 2020 proof-of-concept crossover involved only **five boys ages 8–15**. A newer 2026 double-blind crossover involved **21 adolescents ages 10–19** and compared a high-dose L-theanine-caffeine combination with methylphenidate and placebo. Separately, a randomized sleep trial enrolled **98 boys ages 8–12 with ADHD** and evaluated sleep over six weeks rather than daytime attention or core ADHD symptoms.
 
-**Bottom line:** L-theanine remains an interesting research compound, but current evidence does not justify presenting it as a proven non-stimulant ADHD treatment, a same-day focus tool, or a fixed-dose protocol.
+**Bottom line:** the 2026 adolescent study makes the ADHD evidence base more interesting, but it does not turn L-theanine into a proven ADHD treatment. The positive intervention in that study was **L-theanine plus caffeine**, not L-theanine alone, the sample was small, the outcomes were acute laboratory measures, and methylphenidate still produced a reaction-time benefit the supplement combination did not.
+
+## What changed in 2026
+
+A May 2026 study materially changed the direct ADHD evidence base and is now included in this review.
+
+In a double-blind, placebo-controlled, counterbalanced three-way crossover study, **21 adolescents with ADHD (ages 10–19; 18 boys)** completed a visual selective-attention task and EEG testing before and about 50 minutes after each study condition: an L-theanine-caffeine combination, their prescribed methylphenidate condition, and placebo.
+
+Compared with placebo:
+
+- the L-theanine-caffeine combination reduced false alarms;
+- methylphenidate also reduced false alarms;
+- only methylphenidate significantly improved hit reaction time;
+- both active conditions counteracted slowing of reaction time over the task; and
+- both active conditions changed P3b EEG measures in a direction the investigators interpreted as enhanced attentive processing.
+
+That is a meaningful new signal, but it needs calibration. The study tested **one acute laboratory session per treatment**, not weeks or months of real-world symptom control, school performance, quality of life, or functional outcomes. It also studied the **combination**, so the result cannot be credited to L-theanine alone.
+
+### A research-integrity detail worth noticing
+
+The Sri Lanka Clinical Trials Registry entry for SLCTR/2023/004 listed a **target sample size of 42**. The published paper reports **21 participants**. A smaller-than-planned published sample does not invalidate a study, but it reduces precision and makes replication especially important before translating the result into treatment advice.
+
+The registry also documents that the experimental combination was weight-based—**2.5 mg/kg L-theanine plus 2.0 mg/kg caffeine as a single dose**—and that methylphenidate was used as a positive-control condition. Those numbers describe the experiment; they are **not a consumer dosing recommendation**.
 
 ## Evidence at a glance
 
 | Evidence source | Population / design | What it found | Main limit |
 |---|---|---|---|
 | 2026 L-theanine meta-analysis | 31 RCTs / 1,168 healthy and clinical participants | A single-dose choice-reaction-time signal; modest acute-stress signal | Not an ADHD-specific efficacy analysis |
+| 2026 ADHD selective-attention crossover | 21 adolescents ages 10–19 with ADHD; L-theanine+caffeine vs methylphenidate vs placebo | Combination and methylphenidate reduced false alarms; only methylphenidate improved reaction time vs placebo | Small, acute lab study; combination cannot establish L-theanine-alone efficacy |
 | 2020 ADHD proof-of-concept crossover | 5 boys ages 8–15 with ADHD | Some cognition outcomes improved under certain conditions; inhibitory-control findings were mixed | Far too small for treatment or dosing conclusions |
 | 2011 ADHD sleep RCT | 98 boys ages 8–12 with ADHD, six weeks | Some actigraphy-based sleep measures improved | Studied sleep, not daytime ADHD focus or core symptoms |
+| 2025 sleep meta-analysis | 19 articles / 897 participants; 18 included in meta-analysis | Small improvements in several subjective sleep outcomes | Included mixed interventions/populations; authors noted too few pure L-theanine studies |
 | 2025 tea/L-theanine review | Healthy participants; tea, L-theanine, and combination studies | Small, outcome-specific cognition/mood signals | Does not establish ADHD treatment efficacy |
+
+## Evidence applicability ledger
+
+A study can be well designed and still answer the wrong question for a particular reader. This ledger separates **what was actually tested** from what is often implied online.
+
+| Question | Best direct evidence located | How far the evidence travels |
+|---|---|---|
+| Does L-theanine alone treat core ADHD symptoms? | No adequately powered ADHD efficacy trial identified in this evidence set | **Not established** |
+| Can L-theanine alone change acute cognition in ADHD? | 2020 crossover, N=5 | **Exploratory only** |
+| Can L-theanine+caffeine change acute selective attention in ADHD? | 2026 crossover, N=21 | **Promising but preliminary** |
+| Is the combination comparable to methylphenidate? | Same 2026 crossover included methylphenidate as a positive control | **Not equivalent**: both reduced false alarms, but only methylphenidate improved reaction time vs placebo |
+| Can L-theanine affect sleep in children with ADHD? | 2011 RCT, 98 boys | **Some sleep-efficiency evidence**, not proof of daytime ADHD benefit |
+| Does broader adult/healthy-population attention research prove ADHD efficacy? | 2026 meta-analysis, 31 RCTs / 1,168 participants | **No**—population and clinical target differ |
+| Is there a validated universal ADHD dose? | No | **No evidence-based universal dose** |
+| Is long-term medication-combination safety established? | No dedicated long-term interaction trial identified in this evidence set | **Unknown / insufficient evidence** |
 
 ## What the 2026 meta-analysis means—and what it does not
 
 The 2026 review is the strongest broad L-theanine evidence anchor currently available. It included 31 randomized controlled trials and 1,168 participants.
 
-A single 200 mg dose taken before cognitive testing improved choice reaction time in pooled analysis. That is useful **study context**, but it is not evidence that every person with ADHD should take 200 mg before work, school, or medication wear-off.
+A single 200 mg dose taken 30–60 minutes before cognitive testing improved choice reaction time in pooled analysis. That is useful **study context**, but it is not evidence that every person with ADHD should take 200 mg before work, school, or medication wear-off.
 
 The review also found that acute stress reduction was modest and substantially influenced by studies at high risk of bias. Anxiety findings were inconsistent. No serious adverse events were reported, but trial safety does not establish unlimited long-term use or safety for every child, pregnancy, medical condition, or medication combination.
 
 One author disclosed founding a dietary-supplement company. That conflict does not invalidate the analysis, but it is relevant context when interpreting a commercially popular supplement.
 
-## The direct ADHD cognition evidence is exploratory
+## The 2026 adolescent study: promising, but not a head-to-head replacement trial
 
-The 2020 ADHD proof-of-concept study used a randomized four-condition crossover of L-theanine, caffeine, their combination, and placebo.
+The newer ADHD study deserves attention because it directly compared an L-theanine-caffeine intervention with methylphenidate and placebo in the same participants.
+
+It should **not** be summarized as “L-theanine works as well as methylphenidate.” The result was outcome-specific:
+
+- both active conditions reduced false alarms relative to placebo;
+- only methylphenidate significantly improved hit reaction time relative to placebo;
+- other behavioral measures, including hits and target-distractor discrimination sensitivity, were not significantly different;
+- EEG P3b changes occurred with both active conditions.
+
+The study therefore supports a hypothesis about acute selective attention. It does not establish symptom remission, medication replacement, long-term effectiveness, academic benefit, or safety of routine combined use with prescription stimulants.
+
+## The 2020 direct ADHD cognition evidence remains exploratory
+
+The 2020 proof-of-concept study used a randomized four-condition crossover of L-theanine, caffeine, their combination, and placebo.
 
 Only **five boys** completed the study.
 
@@ -55,24 +108,39 @@ Some cognition outcomes improved under certain conditions, but inhibitory-contro
 - long-term efficacy,
 - or medication-combination safety.
 
+The 2026 N=21 study is a useful step beyond N=5, but it is still a small acute crossover—not the large, longer-duration replication needed to settle those questions.
+
 ## The larger ADHD trial was a sleep study
 
 The 2011 randomized trial enrolled **98 boys ages 8–12 with diagnosed ADHD** and compared a defined L-theanine product with placebo for six weeks.
+
+Randomization was stratified by stimulant-medication use so stimulant-treated and non-stimulant-treated children were distributed across groups. That is useful context, but the trial was **not designed as a dedicated drug-supplement interaction study**.
 
 Some objective sleep measures improved. That is relevant to sleep research in ADHD, but it should not be repackaged as evidence that L-theanine improves daytime executive function, school performance, working memory, or core ADHD symptom severity.
 
 Sleep improvement can matter greatly for daytime functioning, but a sleep endpoint and an ADHD-treatment endpoint are not interchangeable.
 
-## Why this page no longer gives a 200–400 mg “starting protocol”
+## The broader sleep literature adds context, not an ADHD treatment claim
+
+A 2025 systematic review and meta-analysis identified 19 articles involving 897 participants, with 18 studies included in meta-analysis. It found small statistically significant improvements in subjective sleep-onset latency, subjective daytime dysfunction, and overall subjective sleep-quality scores.
+
+The authors also highlighted an important limitation: too few studies isolated **pure L-theanine**, making it harder to know how much of the observed effect belongs to L-theanine itself when products or interventions differ.
+
+That evidence makes sleep a legitimate area of investigation. It still does not justify converting sleep findings from mixed populations into a claim that L-theanine treats ADHD.
+
+## Why this page does not give a 200–400 mg “starting protocol”
 
 Published studies use defined doses because a trial needs a standardized intervention. A research dose is not automatically a consumer recommendation.
 
 Older versions of this guide translated study regimens into a practical 200–400 mg starting range and gave 30–60-minute timing guidance. The direct ADHD evidence is not strong enough to support that conversion.
 
+The same rule applies to the 2026 adolescent trial. Its weight-based L-theanine+caffeine regimen is reported here to make the experiment reproducible and interpretable, **not to create a DIY protocol**.
+
 This page therefore does **not** recommend:
 
 - a universal ADHD dose,
 - a “start low, then increase” schedule,
+- copying a weight-based research dose,
 - taking L-theanine a fixed number of minutes before a focus task,
 - using it as medication wears off,
 - using it on stimulant off-days or weekends,
@@ -82,35 +150,80 @@ This page therefore does **not** recommend:
 
 Studies of L-theanine plus caffeine cannot be treated as proof that L-theanine alone works the same way.
 
-A 2025 systematic review/meta-analysis of tea, L-theanine, and L-theanine plus caffeine found some small short-term cognitive signals in healthy participants. The combination literature is larger than the ADHD-specific literature, but it still does not establish an ADHD treatment or a universal dose ratio.
+A 2025 systematic review/meta-analysis of tea, L-theanine, and L-theanine plus caffeine found some small short-term cognitive signals in healthy participants. Confidence intervals frequently showed substantial uncertainty around the magnitude and sometimes direction of effects.
 
-The five-person ADHD crossover included a combination arm, but it is much too small to settle whether the combination is beneficial, which ratio would be best, or which children might be harmed.
+The 2026 ADHD study strengthens the case for studying the combination specifically, but it still does not establish a universal dose ratio, long-term benefit, or routine use alongside prescription stimulants.
 
 Caffeine can also worsen sleep, anxiety, jitteriness, heart rate, or blood pressure in sensitive people. L-theanine should not be assumed to cancel those effects.
+
+## Medication-context matrix: what is known versus unknown
+
+This is **not an interaction checker**. It is an evidence-boundary map designed to prevent “no documented interaction” from being misread as “proven safe.”
+
+| Medication context | What the evidence here actually tells us | What remains unknown |
+|---|---|---|
+| Methylphenidate | 2026 crossover compared separate L-theanine+caffeine and methylphenidate conditions; 2011 sleep trial stratified randomization by stimulant use | Safety/effectiveness of routinely taking the combination *together* with methylphenidate; long-term interaction data |
+| Other prescription stimulants / amphetamine products | No direct efficacy or interaction result can be inferred from the methylphenidate comparison | Dedicated coadministration, cardiovascular, sleep, anxiety, and dose-interaction data |
+| Atomoxetine / guanfacine / clonidine | The cited ADHD trials do not establish combination safety or benefit | Dedicated pharmacodynamic and clinical coadministration evidence |
+| Antidepressants or other psychoactive medicines | Broad L-theanine trials do not establish safety for every medication combination | Drug-specific interaction and long-term clinical data |
+
+FDA advises that dietary supplements can interact with medicines and that supplements are not FDA-approved to treat or prevent disease. That regulatory distinction matters especially on an ADHD page: evidence about a supplement is not equivalent to an approved indication.
+
+## Regulatory status: evidence is not approval
+
+In the United States, dietary supplements are not FDA-approved for safety and effectiveness before marketing in the way prescription drugs are. FDA also states that vitamins, minerals, herbs, and other dietary supplements are **not FDA-approved to treat or prevent disease**.
+
+For this page, that means:
+
+- L-theanine is being reviewed as a dietary-supplement ingredient with emerging research;
+- the existence of ADHD studies does not create an FDA-approved ADHD indication;
+- a product marketed as a supplement should not be interpreted as having passed the premarket efficacy review required for an approved ADHD drug; and
+- “natural,” “clinically studied,” or “used in a trial” should never be treated as synonyms for “proven treatment.”
 
 ## Mechanism is not clinical efficacy
 
 L-theanine is often described through alpha-wave, glutamate, GABA, dopamine, or “relaxed alertness” mechanisms. Those mechanisms may be scientifically interesting, but they do not establish that ADHD is caused by a deficit L-theanine corrects.
 
-A brain-wave finding is not the same endpoint as reduced ADHD symptoms. A calmer subjective state is not automatically better inhibitory control, working memory, or executive function.
+A brain-wave finding is not the same endpoint as reduced ADHD symptoms. The 2026 study’s P3b EEG findings are useful mechanistic/physiologic evidence, but they do not by themselves prove meaningful long-term clinical benefit.
 
 Mechanism should help explain a clinical result after that result is established—not substitute for one.
 
 ## Safety and medication boundaries
 
-- **ADHD medications:** direct interaction and coadministration evidence is limited. Do not interpret the absence of a known interaction as proof that a supplement-medication combination is safe for a particular person.
-- **Children:** pediatric studies used defined research products and supervised protocols. They are not a basis for unsupervised pediatric supplementation.
-- **Long-term use:** the 2026 meta-analysis reported no serious adverse events, but the trial literature does not establish unlimited long-term safety.
+- **ADHD medications:** direct long-term interaction and coadministration evidence is limited. Do not interpret the absence of a known interaction as proof that a supplement-medication combination is safe for a particular person.
+- **Caffeine-containing combinations:** the newest direct ADHD cognition study used L-theanine with caffeine. That introduces caffeine-specific effects and risks; it is not interchangeable with L-theanine alone.
+- **Children and adolescents:** pediatric/adolescent studies used defined research products or protocols and supervised procedures. They are not a basis for unsupervised pediatric supplementation.
+- **Long-term use:** the 2026 broad meta-analysis reported no serious adverse events in included RCTs, but the trial literature does not establish unlimited long-term safety.
 - **Pregnancy and health conditions:** evidence is not broad enough to assume safety across pregnancy, breastfeeding, complex medical conditions, or polypharmacy.
 - **Treatment changes:** do not stop, skip, lower, or otherwise change prescribed ADHD medication because of supplement use without the prescribing clinician.
 
 If someone takes prescription ADHD medication, the prescriber or pharmacist managing that treatment is the appropriate person to review supplement co-use.
 
+## The unanswered-question ledger
+
+The strongest way to read emerging supplement science is to track what a study **did not answer**.
+
+As of the August 15, 2026 literature check, the major unanswered questions include:
+
+1. Can the 2026 selective-attention findings be replicated in a substantially larger sample?
+2. Would benefits persist beyond a single acute testing session?
+3. Do laboratory attention/EEG changes translate into validated ADHD symptom scales, school/work function, or quality of life?
+4. Does L-theanine alone have a reproducible ADHD effect independent of caffeine?
+5. What are the long-term cardiovascular, sleep, anxiety, and tolerability outcomes of repeated L-theanine+caffeine use in adolescents?
+6. What happens when L-theanine or the combination is **coadministered** with methylphenidate rather than tested as a separate condition?
+7. Are effects different across sex, age, ADHD presentation, comorbidity, baseline caffeine use, or stimulant response?
+8. Is there any validated dose-response relationship that improves benefit without increasing caffeine-related harms?
+9. Are there clinically meaningful outcomes beyond reaction-time tasks and EEG markers?
+
+This ledger is intentionally stricter than a “pros and cons” list. A missing answer stays labeled as missing rather than being filled with mechanism, anecdote, or marketing claims.
+
 ## Where L-theanine may still be worth studying
 
 The evidence is stronger for **research questions** than for a clinical recommendation.
 
-Reasonable questions include whether L-theanine changes attention under specific laboratory conditions, whether sleep improvement matters in selected ADHD populations, and whether certain combinations affect cognition differently from their individual ingredients.
+The 2026 adolescent crossover gives researchers a clearer signal to replicate: whether an L-theanine-caffeine combination can reduce false alarms and stabilize attention during demanding tasks, and whether the EEG signal persists in larger studies.
+
+Other reasonable questions include whether L-theanine changes attention under specific laboratory conditions, whether sleep improvement matters in selected ADHD populations, and whether certain combinations affect cognition differently from their individual ingredients.
 
 Those are useful questions. They are not the same as “L-theanine treats ADHD.”
 
@@ -118,35 +231,54 @@ Those are useful questions. They are not the same as “L-theanine treats ADHD.�
 
 ### Does L-theanine treat ADHD?
 
-Current evidence does not establish L-theanine as an ADHD treatment. Direct ADHD cognition data are extremely small, and the larger pediatric randomized trial studied sleep rather than daytime ADHD symptoms.
+Current evidence does not establish L-theanine as an ADHD treatment. Direct ADHD cognition data remain small, the newer 2026 trial tested L-theanine **with caffeine**, and the larger pediatric randomized trial studied sleep rather than daytime ADHD symptoms.
+
+### What did the new 2026 ADHD study find?
+
+In 21 adolescents with ADHD, an acute L-theanine-caffeine combination and methylphenidate each reduced false alarms versus placebo during a selective-attention task. Only methylphenidate significantly improved hit reaction time versus placebo. The study also reported EEG P3b changes with both active conditions. It was small and acute, so it does not establish long-term treatment effectiveness or equivalence to medication.
+
+### Was L-theanine as effective as methylphenidate?
+
+That conclusion is not supported. The treatments overlapped on some outcomes, but **only methylphenidate improved reaction time versus placebo**, and the trial was not large or long enough to establish treatment equivalence.
 
 ### Does L-theanine improve attention?
 
-A 2026 meta-analysis found a short-term choice-reaction-time signal in broader healthy and clinical populations. That supports general attention research but not a guaranteed ADHD benefit.
+A 2026 meta-analysis found a short-term choice-reaction-time signal in broader healthy and clinical populations. Small ADHD studies also provide exploratory signals, especially for L-theanine plus caffeine, but that is not the same as a proven ADHD benefit.
 
 ### What dose should someone with ADHD take?
 
-There is no evidence-based universal ADHD dose. Trial doses should be reported as study context, not converted into a personalized protocol.
+There is no evidence-based universal ADHD dose. Trial doses—including weight-based doses—should be reported as study context, not converted into a personalized protocol.
 
 ### How fast does L-theanine work for ADHD?
 
-No reliable ADHD onset time has been established. A cognitive-testing window in a general-population trial is not the same thing as a predictable treatment onset for ADHD.
+No reliable ADHD treatment-onset time has been established. Acute testing windows in crossover trials are experimental conditions, not a predictable clinical onset for everyday ADHD management.
 
 ### Can L-theanine be combined with stimulant medication?
 
-Direct interaction and coadministration evidence is limited. The pediatric sleep trial included boys with and without stimulant treatment, but it was not designed to establish medication-interaction safety. Review co-use with the prescriber or pharmacist managing the medication.
+Direct long-term coadministration evidence is insufficient. The 2011 sleep trial stratified participants by stimulant use, and the 2026 cognition study compared a supplement-combination condition with methylphenidate, but neither establishes a general rule that routine co-use is safe. Review co-use with the prescriber or pharmacist managing the medication.
 
 ### Is L-theanine plus caffeine better for ADHD?
 
-That has not been established. The most directly relevant ADHD crossover involved only five boys, which is far too small to support a dependable combination recommendation or ratio.
+It is a more evidence-supported research question than it was a year ago, but “better” has not been established. The 2026 N=21 trial found improvements on selected acute attention measures, while other outcomes did not significantly differ and only methylphenidate improved reaction time versus placebo.
 
 ### Did the 98-boy ADHD trial show better focus?
 
 No. That randomized trial studied sleep outcomes. It should not be cited as proof of improved daytime attention or core ADHD symptoms.
 
+### Is L-theanine FDA-approved for ADHD?
+
+No dietary supplement is FDA-approved to treat ADHD merely because it is sold as a supplement or studied in ADHD. FDA does not approve dietary supplements for safety and effectiveness before marketing in the same way it approves drugs.
+
 ## Sources
 
-1. Cognitive and affective effects of L-Theanine: a systematic review and meta-analysis of 31 randomized trials. 2026. PMID 42410082. https://pubmed.ncbi.nlm.nih.gov/42410082/
-2. Kahathuduwa CN, et al. Effects of L-theanine-caffeine combination on sustained attention and inhibitory control among children with ADHD. 2020. PMID 32753637. https://pubmed.ncbi.nlm.nih.gov/32753637/
-3. Lyon MR, et al. The effects of L-theanine on objective sleep quality in boys with ADHD. 2011. PMID 22214254. https://pubmed.ncbi.nlm.nih.gov/22214254/
-4. Payne ER, et al. Effects of Tea, L-Theanine, or L-Theanine plus Caffeine on Cognition, Sleep, and Mood in Healthy Participants. 2025. PMID 40314930. https://pubmed.ncbi.nlm.nih.gov/40314930/
+1. Gerolymos C, et al. Cognitive and affective effects of L-Theanine: a systematic review and meta-analysis of 31 randomized trials. *Molecular Psychiatry*. 2026. PMID 42410082. DOI: 10.1038/s41380-026-03727-9. https://pubmed.ncbi.nlm.nih.gov/42410082/
+2. Nawarathna GS, et al. Effects of L-theanine-caffeine combination on selective attention among adolescents with attention-deficit hyperactivity disorder: a double-blind, placebo-controlled, crossover study. *Nutritional Neuroscience*. Published online May 7, 2026. DOI: 10.1080/1028415X.2026.2659148. https://doi.org/10.1080/1028415X.2026.2659148
+3. Sri Lanka Clinical Trials Registry. SLCTR/2023/004: Acute effects of L-theanine and caffeine combination on selective attention in adolescents with attention deficit hyperactivity disorder. Registered March 10, 2023. https://www.slctr.lk/trials/slctr-2023-004
+4. Kahathuduwa CN, et al. Effects of L-theanine-caffeine combination on sustained attention and inhibitory control among children with ADHD. *Scientific Reports*. 2020. PMID 32753637. DOI: 10.1038/s41598-020-70037-7. https://pubmed.ncbi.nlm.nih.gov/32753637/
+5. Lyon MR, et al. The effects of L-theanine on objective sleep quality in boys with ADHD. *Alternative Medicine Review*. 2011. PMID 22214254. https://pubmed.ncbi.nlm.nih.gov/22214254/
+6. Bulman A, et al. The effects of L-theanine consumption on sleep outcomes: A systematic review and meta-analysis. *Sleep Medicine Reviews*. 2025;81:102076. PMID 40056718. DOI: 10.1016/j.smrv.2025.102076. https://pubmed.ncbi.nlm.nih.gov/40056718/
+7. Payne ER, et al. Effects of Tea, L-Theanine, or L-Theanine plus Caffeine on Cognition, Sleep, and Mood in Healthy Participants. *Nutrition Reviews*. 2025. PMID 40314930. DOI: 10.1093/nutrit/nuaf054. https://pubmed.ncbi.nlm.nih.gov/40314930/
+8. Dashwood R, Visioli F. L-theanine: from tea leaf to trending supplement—does the science match the hype for brain health and relaxation? *Nutrition Research*. 2025;134:39-48. PMID 39854799. DOI: 10.1016/j.nutres.2024.12.008. https://pubmed.ncbi.nlm.nih.gov/39854799/
+9. U.S. Food and Drug Administration. FDA 101: Dietary Supplements. Accessed August 15, 2026. https://www.fda.gov/consumers/consumer-updates/fda-101-dietary-supplements
+10. U.S. Food and Drug Administration. 10 Facts about What FDA Does and Does Not Approve. Accessed August 15, 2026. https://www.fda.gov/consumers/consumer-updates/10-facts-about-what-fda-does-and-does-not-approve
+11. U.S. Food and Drug Administration. Mixing Medications and Dietary Supplements Can Endanger Your Health. Accessed August 15, 2026. https://www.fda.gov/consumers/consumer-updates/mixing-medications-and-dietary-supplements-can-endanger-your-health


### PR DESCRIPTION
## Why
The L-theanine ADHD guide was missing a May 2026 double-blind crossover study in 21 adolescents comparing L-theanine+caffeine with methylphenidate and placebo.

## What changed
- adds the new 2026 ADHD trial and outcome-specific interpretation
- surfaces trial-registry provenance (planned N=42 vs published N=21)
- adds an evidence-applicability ledger and unanswered-question ledger
- adds a medication-context matrix that distinguishes comparison data from actual coadministration evidence
- adds 2025 sleep meta-analysis context
- adds FDA regulatory / supplement-medication safety context
- expands primary/authoritative references to 11 sources
- updates page metadata to reflect the new evidence

## Evidence calibration
No consumer dosing protocol is added. Trial doses are explicitly labeled as experimental context, and the page does not claim equivalence to methylphenidate or established long-term coadministration safety.