### PR TITLE
research: turn melatonin ADHD draft into a cited evidence review

### DIFF
--- a/app/guides/adhd/melatonin-for-adhd-sleep/page.tsx
+++ b/app/guides/adhd/melatonin-for-adhd-sleep/page.tsx
@@ -6,7 +6,7 @@ const SLUG = 'melatonin-for-adhd-sleep'
 export const metadata = buildPageMetadata({
   title: 'Melatonin for ADHD Sleep: Does It Help & Is It Safe?',
   description:
-    'What ADHD sleep studies show about melatonin for sleep onset, timing, and dose context, including children, side effects, long-term uncertainty, and safety.',
+    'Research-grade review of melatonin for ADHD sleep: pediatric and adult trials, circadian timing, stimulant-treated data, long-term uncertainty, label accuracy, and child-safety risks.',
   path: `/guides/adhd/${SLUG}/`,
   openGraphType: 'article',
 })

--- a/docs/content/focus-cluster/melatonin-for-adhd-sleep-content-v1.md
+++ b/docs/content/focus-cluster/melatonin-for-adhd-sleep-content-v1.md
@@ -1,347 +1,272 @@
-# Melatonin for ADHD Sleep Content v1
+# Melatonin for ADHD Sleep Content v2
 
-Status: Approved for implementation
+Status: Evidence-calibrated / literature-surveilled
 Cluster: Focus / ADHD
 Type: Sleep Support Article
-Target URL: /articles/melatonin-for-adhd-sleep
-Version: 1
-
----
-
-## SEO Title
-
-Melatonin for ADHD Sleep: What the Research Shows
-
-## Meta Description
-
-Evidence-based review of melatonin for ADHD-related sleep problems. Covers sleep onset insomnia, delayed sleep phase, pediatric and adult evidence, dosing considerations, safety, side effects, and realistic expectations.
-
-## Primary Keyword
-
-melatonin ADHD sleep
-
-## Secondary Keywords
-
-melatonin for ADHD, ADHD sleep onset insomnia, melatonin children ADHD, delayed sleep phase ADHD, ADHD insomnia treatment
-
-## Search Intent
-
-Informational + commercial investigation. Readers want to know whether melatonin helps ADHD-related sleep problems, how effective it is, how it compares to other options, what doses are studied, and whether it is safe for children and adults.
-
-## H1
-
-Melatonin for ADHD Sleep: What the Research Shows
+Target URL: /guides/adhd/melatonin-for-adhd-sleep/
+Version: 2
+Updated: 2026-08-15
+Literature check: 2026-08-15
 
 ---
 
 ## Full Article Content
 
-### Introduction
+## Melatonin for ADHD Sleep: What the Research Actually Shows
 
-Sleep onset difficulties are among the most frequently reported challenges for individuals with ADHD. Research indicates higher rates of insomnia, delayed sleep phase, and prolonged sleep onset latency in both children and adults with ADHD compared with the general population. These sleep problems can significantly affect next-day attention, emotional regulation, and overall functioning.
+Melatonin has one of the more useful evidence bases among supplements discussed for **sleep-onset problems in ADHD**, especially in children. But three different questions are often blurred together online:
 
-Melatonin is a hormone naturally produced by the pineal gland that helps regulate the sleep-wake cycle. Supplemental melatonin is commonly discussed as a potential support for sleep onset difficulties. This article reviews the available human evidence on melatonin use specifically in the context of ADHD-related sleep problems, with attention to pediatric and adult data, dosing and timing considerations, safety, and realistic expectations.
+1. **Can melatonin shift sleep/circadian timing?** Evidence says it can in selected ADHD populations.
+2. **Can it help some people with ADHD fall asleep earlier?** Pediatric randomized trials support that conclusion.
+3. **Does it treat ADHD itself?** The better trials do **not** establish that.
 
-Melatonin is examined here strictly as a sleep support tool. It is not presented as a treatment for ADHD itself.
+The strongest pediatric ADHD trial enrolled **105 medication-free children ages 6–12** with ADHD and chronic sleep-onset insomnia. After four weeks, sleep onset advanced by about 27 minutes in the melatonin group while it became later in the placebo group; total sleep time also increased relative to placebo. The same trial found **no significant improvement in behavior, cognition, or quality of life**.[1]
 
-### Important Medical Disclaimer
+A separate trial in **27 stimulant-treated children** found that sleep hygiene helped some participants before medication was added; among nonresponders, pharmaceutical-grade melatonin reduced initial insomnia relative to placebo. Again, improved sleep did not translate into a demonstrated ADHD-symptom benefit.[2]
 
-This article is for educational purposes only and does not constitute medical advice. Melatonin is not a treatment for ADHD. Sleep difficulties in ADHD can have multiple causes, including circadian rhythm misalignment, medication effects, anxiety, or primary sleep disorders. Individuals experiencing significant or persistent sleep problems—particularly children, those taking ADHD medications, or anyone with symptoms suggestive of sleep apnea or restless legs syndrome—should consult a qualified healthcare provider for proper evaluation before using melatonin or any supplement.
+**Bottom line:** melatonin is better supported as a targeted sleep/circadian intervention than as an “ADHD supplement.” Its evidence is strongest when the problem is specifically **late sleep onset or delayed circadian timing**, not when the goal is direct daytime focus enhancement.
 
-### What Melatonin Is
+## Evidence at a glance
 
-Melatonin is a naturally occurring hormone primarily produced by the pineal gland in response to darkness. It helps signal the body that it is time to prepare for sleep. Supplemental melatonin is synthetically produced and available in various forms, including immediate-release and extended-release tablets, gummies, and liquids.
+| Evidence | Population / design | Main result | What it does **not** prove |
+|---|---|---|---|
+| Van der Heijden 2007 | 105 medication-free children, ADHD + chronic sleep-onset insomnia; randomized double-blind placebo-controlled, 4 weeks | Sleep onset advanced; total sleep time increased; DLMO shifted earlier | Direct improvement in ADHD behavior, cognition, or quality of life |
+| Weiss 2006 | 27 stimulant-treated children with >60-minute initial insomnia; sleep hygiene then double-blind crossover in nonresponders | Sleep hygiene helped some; melatonin reduced initial insomnia vs placebo | A general rule for every stimulant-treated child or every sleep problem |
+| van Andel 2021 | 51 adults with ADHD + delayed sleep phase syndrome; randomized chronotherapy trial | Individually timed 0.5 mg melatonin advanced DLMO; symptom effect was temporary and not reproduced in the melatonin+bright-light arm | A universal adult ADHD melatonin dose or durable ADHD treatment effect |
+| Long-term pediatric follow-up | Follow-up of children with ADHD/chronic sleep-onset insomnia after longer use | Many families reported persistent sleep benefit and no serious treatment-related events | Randomized long-term safety; endocrine/developmental certainty |
+| U.S. product-content survey | 110 melatonin supplements marketed toward children | Actual content ranged from **0% to 667%** of label declaration | That a label dose reliably equals the swallowed dose |
 
-In clinical and research settings, melatonin is most often studied for its ability to reduce the time it takes to fall asleep (sleep onset latency) and, in some cases, to help shift circadian timing in individuals with delayed sleep phase.
+## The pediatric ADHD trial that matters most
 
-TODO: Verify melatonin physiology and formulation claims.
+The 2007 randomized trial is unusually informative because it measured both **sleep timing** and **circadian timing**.
 
-### How Melatonin Works
+A total of 105 medication-free children ages 6–12 with rigorously diagnosed ADHD and chronic sleep-onset insomnia received melatonin or placebo for four weeks. The melatonin dose in the experiment was 3 mg or 6 mg depending on body weight.[1]
 
-Melatonin binds to melatonin receptors in the brain and helps regulate the circadian rhythm. It does not act as a sedative in the same way as some sleep medications. Instead, it facilitates the natural transition to sleep when taken at an appropriate time relative to an individual’s internal clock.
+Compared with placebo:
 
-In people with delayed sleep phase or difficulty initiating sleep, exogenous melatonin can help advance sleep onset when taken in the early evening, several hours before the desired bedtime. The effectiveness depends heavily on timing relative to the individual’s dim-light melatonin onset rather than on dose alone.
+- actigraphic sleep onset shifted earlier;
+- dim-light melatonin onset (DLMO), a circadian marker, shifted earlier;
+- total time asleep increased;
+- there was **no significant effect on behavior, cognition, or quality of life**; and
+- significant adverse events were not reported during the short trial.[1]
 
-TODO: Verify receptor, circadian phase-shift, and dim-light melatonin onset timing claims.
+The distinction is important. A sleep benefit can be meaningful without being evidence that melatonin directly treats core ADHD symptoms.
 
-### Why Sleep Problems Are Common in ADHD
+### Trial dose is not a consumer protocol
 
-Multiple factors contribute to the high prevalence of sleep difficulties in ADHD. These include differences in circadian rhythm regulation, heightened physiological and cognitive arousal at bedtime, difficulty establishing and maintaining consistent routines, and the alerting effects of stimulant medications when taken later in the day. Sensory sensitivities and emotional dysregulation can further complicate the transition to sleep.
+The 3 mg/6 mg regimen tells us what the researchers tested. It does not establish that those are optimal doses for every child, that more is better, or that a parent should reproduce the protocol without clinical guidance.
 
-These issues often create a cycle in which poor sleep worsens daytime ADHD symptoms, which in turn make consistent sleep routines more difficult to maintain.
+That caution matters even more in the U.S. because the amount inside an over-the-counter melatonin product may not match the number printed on the label.
 
-TODO: Verify ADHD sleep prevalence, circadian, arousal, stimulant-medication, sensory, and bidirectional claims.
+## What we know in stimulant-treated children
 
-### Delayed Melatonin Onset in ADHD
+The 2006 Weiss study is useful because all 27 participants were already receiving stimulant medication and had substantial initial insomnia.[2]
 
-Some research suggests that individuals with ADHD may have a delayed dim-light melatonin onset compared with neurotypical peers. This circadian misalignment can contribute to later natural sleep times and difficulty falling asleep at conventional bedtimes. When combined with early required wake times for school or work, it often results in chronic sleep restriction.
+The study first used a sleep-hygiene intervention. Five children improved enough that their initial insomnia fell below the study threshold. Nonresponders then entered a double-blind placebo-controlled crossover trial of **5 mg pharmaceutical-grade melatonin** supplied for the study.[2]
 
-Melatonin supplementation, when timed appropriately, has been studied as one approach to help advance sleep onset in individuals with delayed phase patterns.
+Among evaluable trial data, melatonin reduced initial insomnia by about 16 minutes relative to placebo. Adverse events were generally mild and not different from placebo. The combined sleep-hygiene plus melatonin pathway produced a much larger change from the original baseline by follow-up, but **ADHD symptoms did not demonstrably improve**.[2]
 
-TODO: Verify delayed dim-light melatonin onset studies in ADHD.
+This is stronger evidence than simply saying “melatonin can be taken with stimulants,” but it still has limits:
 
-### Sleep Onset Insomnia and ADHD
+- the sample was small;
+- the product was pharmaceutical-grade research material, not an arbitrary retail gummy;
+- it was not designed to establish every possible drug-supplement interaction; and
+- it does not prove that insomnia on stimulants should automatically be treated with melatonin rather than first reviewing medication timing, dose, sleep schedule, or another sleep disorder.
 
-Difficulty initiating sleep is a core complaint in many individuals with ADHD. Contributing factors can include racing thoughts, heightened arousal, medication effects, and circadian delay. Behavioral strategies focused on wind-down routines are typically recommended first. When these are insufficient, melatonin is frequently considered as a targeted support for sleep onset.
+Another randomized trial of melatonin added to methylphenidate also reported improvement in some sleep measures without a significant ADHD-score difference.[3]
 
-Evidence for melatonin in reducing sleep onset latency is generally stronger than evidence for improvements in other sleep parameters or in core ADHD symptoms.
+## Adult ADHD: a different evidence story
 
-TODO: Verify sleep-onset insomnia prevalence and melatonin outcome hierarchy.
+Adult evidence is smaller and more circadian-specific.
 
-### Pediatric ADHD Evidence
+A 2021 randomized clinical trial enrolled **51 adults ages 18–55 with ADHD and delayed sleep phase syndrome**. Participants received sleep education plus placebo, individually timed 0.5 mg melatonin, or melatonin plus morning bright-light therapy for three weeks.[4]
 
-Several randomized controlled trials have examined melatonin in children with ADHD and sleep onset difficulties. Many of these studies report reductions in sleep onset latency with melatonin use compared with placebo. Some trials have also noted improvements in total sleep time or parent-reported sleep quality.
+At baseline, 77% had DLMO after 9 p.m. Melatonin advanced DLMO by about **1 hour 28 minutes**, and melatonin plus bright light advanced it by about **1 hour 58 minutes**. A 14% reduction in self-reported ADHD symptoms occurred immediately after melatonin alone, but not in the placebo or melatonin-plus-light group; two weeks after treatment ended, both DLMO and ADHD symptoms had returned to baseline.[4]
 
-Results are not uniform across all studies, and effect sizes are generally modest. Benefits appear more consistent for sleep onset than for other sleep domains or for daytime ADHD symptoms. Most pediatric trials have been relatively short in duration.
+That pattern is interesting but not proof that melatonin is an adult ADHD medication. The clearest, most reproducible signal in the study was **circadian phase shifting**.
 
-Evidence Grade: Moderate for reducing sleep onset latency in children with ADHD.
+## Timing is part of the intervention—not a footnote
 
-TODO: Verify pediatric ADHD melatonin RCTs: specific sample sizes, doses, durations, and effect sizes on sleep onset latency.
+Melatonin is a circadian signal as well as a sleep-promoting hormone. That means “what time was it taken relative to the person’s internal clock?” can be scientifically more important than a generic “take it before bed” rule.
 
-### Adult ADHD Evidence
+The adult ADHD trial did not use one fixed clock time. It scheduled melatonin relative to each participant’s measured DLMO and changed the schedule over time.[4] The pediatric 2007 study also measured DLMO and showed that melatonin shifted that circadian marker.[1]
 
-Data on melatonin use specifically in adults with ADHD are more limited than pediatric data. Available studies are generally smaller and often focus on related populations or outcomes. Some research in adults with insomnia or delayed sleep phase, including those with ADHD features, shows benefits for sleep onset when melatonin is appropriately timed.
+This page therefore does **not** convert research timing into a universal at-home schedule. The correct timing depends on the target problem—sleep initiation versus circadian phase delay—and, in clinical chronotherapy, may depend on the person’s internal circadian phase.
 
-Adult-specific ADHD trials with melatonin are fewer and tend to show more variable results. Individual response in adults appears to depend heavily on circadian timing, dose, and concurrent factors such as medication use and anxiety.
+## Product quality is part of the dose question
 
-Evidence Grade: Preliminary for adult ADHD populations.
+This is one of the biggest gaps in ordinary melatonin articles.
 
-TODO: Verify adult ADHD or insomnia trials involving melatonin with sample sizes and outcomes.
+An FDA-associated laboratory survey analyzed **110 dietary supplements labeled to contain melatonin and marketed toward children**. Melatonin was detected in 108 products. Across the products tested, actual melatonin content ranged from **0% to 667% of the label declaration**; measured servings ranged from 0.042 mg to 50 mg, with a median of 1.7 mg per serving.[5]
 
-### Effects on Sleep Onset Latency
+That means a discussion of “dose” is incomplete if it assumes label accuracy.
 
-The most consistent finding across studies of melatonin in ADHD is a reduction in the time it takes to fall asleep. This effect is generally modest but can be meaningful for individuals who struggle significantly with sleep initiation. The magnitude of improvement varies by study, dose, timing, and population.
+AASM’s pediatric melatonin health advisory specifically warns that U.S. melatonin products are regulated as dietary supplements rather than like approved prescription/OTC drugs and recommends discussing use with a pediatric health professional. The advisory also recommends choosing products with the **USP Verified Mark** when melatonin is used.[6]
 
-Melatonin does not typically produce rapid sedation. Its primary action is to facilitate the natural sleep process when taken at the right time relative to an individual’s circadian rhythm.
+### Why gummies deserve extra caution
 
-TODO: Verify sleep onset latency effect sizes and sedation distinction.
+NCCIH highlights a 2023 analysis in which **22 of 25 melatonin gummy products were inaccurately labeled**; among products containing detectable melatonin, measured amounts ranged from 74% to 347% of the label claim.[7]
 
-### Effects on Total Sleep Time
+This is not evidence that every gummy is inaccurate. It is evidence that formulation and manufacturer quality are part of the real-world risk calculation.
 
-Some studies report increases in total sleep time with melatonin use in children with ADHD, often secondary to earlier sleep onset. However, results are less consistent than for sleep onset latency. In adults, effects on total sleep time are more variable and often modest.
+## Pediatric ingestion risk is not theoretical
 
-Melatonin is generally more effective at helping people fall asleep than at substantially extending sleep duration once asleep.
+The most important modern safety issue around melatonin may be **access and accidental ingestion**, not a rare pharmacologic side effect at a studied dose.
 
-TODO: Verify total sleep time outcomes.
+NCCIH summarizes CDC surveillance estimating roughly **11,000 emergency-department visits from 2019–2022** for unsupervised melatonin ingestion by children age 5 and younger.[7] AASM likewise advises treating melatonin like medication and keeping it out of children’s reach.[6]
 
-### Effects on Sleep Quality
+For families, child-resistant storage is not an optional afterthought—especially for flavored gummies that can look like candy.
 
-Parent-reported or subjective sleep quality sometimes improves with melatonin in pediatric ADHD studies. Objective measures such as actigraphy show more mixed results. Improvements in sleep quality appear linked to reduced sleep onset latency and fewer bedtime struggles rather than fundamental changes in sleep architecture.
+## Short-term safety versus long-term uncertainty
 
-TODO: Verify subjective vs objective sleep quality findings and sleep architecture language.
+Short ADHD trials generally reported good tolerability, and a long-term follow-up study of children previously treated for ADHD-associated chronic sleep-onset insomnia reported persistent perceived benefit with no serious treatment-related adverse events identified.[8]
 
-### Effects on Daytime ADHD Symptoms
+But a follow-up study is not equivalent to a long-duration randomized safety trial.
 
-Improvements in daytime ADHD symptoms following melatonin use are generally modest and indirect. Better sleep can support improved attention, emotional regulation, and behavior the following day. However, melatonin does not appear to produce direct effects on core ADHD symptoms comparable to established treatments.
+NCCIH’s current position is appropriately cautious: **short-term melatonin use appears relatively safe for most people, while long-term safety is not established**, particularly in children.[7] NCCIH also notes theoretical concern about hormonal development because melatonin is itself a hormone; current evidence is not sufficient to determine whether supplemental use affects puberty or other endocrine development.[7]
 
-Any daytime benefits are best understood as secondary to improved sleep rather than as a primary treatment effect on ADHD.
+So the evidence supports two statements at the same time:
 
-TODO: Verify daytime ADHD symptom outcomes.
+- serious problems were not prominent in the available ADHD trials and follow-up data; and
+- the evidence is still too limited to claim that years of routine pediatric use are fully characterized.
 
-### Melatonin and Circadian Rhythm Support
+## Side effects: report what is established, not what is assumed
 
-When taken several hours before desired bedtime, often in the early evening, melatonin can help advance the circadian rhythm in individuals with delayed sleep phase. This effect is distinct from its sleep-onset action and requires consistent timing over multiple days to weeks.
+NCCIH lists pediatric side effects that have usually been mild, including **drowsiness, headache, dizziness, agitation, and increased bedwetting/urination in the evening**.[7]
 
-For people with ADHD who have a strong eveningness preference, appropriately timed melatonin combined with morning light exposure and consistent wake times can support gradual shifts toward earlier sleep timing.
+The existence of a favorable short-term trial record should not be converted into “melatonin has no side effects.” It also should not be converted into “melatonin is dangerous” simply because poison-center calls have increased. Therapeutic-use safety and unsupervised-ingestion surveillance answer different questions.
 
-TODO: Verify phase-shifting timing and combined light-exposure guidance.
+## Medication context: evidence boundaries
 
-### Immediate Release vs Extended Release
+| Medication context | Evidence on this page | What remains uncertain |
+|---|---|---|
+| Stimulant-treated children | Small randomized studies exist, including stimulant-treated ADHD cohorts | Not a blanket interaction-safety guarantee; individual stimulant timing/dose and sleep diagnosis still matter |
+| Methylphenidate specifically | Melatonin has been studied as an add-on in randomized pediatric trials | Optimal long-term co-use, product-specific dosing, and applicability to every child |
+| Other ADHD medicines | No broad rule should be inferred from methylphenidate studies | Drug-specific interaction and sedation/blood-pressure effects require medication-level review |
+| Anticoagulants / epilepsy medicines | NCCIH specifically advises medical supervision for people using blood thinners or with epilepsy | Individual drug and dose interactions |
+| Other sedating agents / polypharmacy | General supplement-medication caution applies | Additive effects and person-specific risk |
 
-Immediate-release melatonin is most commonly studied for sleep onset difficulties. Extended-release formulations are sometimes used when both sleep onset and sleep maintenance are concerns, though evidence specifically in ADHD populations is more limited for extended-release forms.
+The safe interpretation is not “melatonin interacts with ADHD medication” or “melatonin does not interact with ADHD medication.” The evidence supports a narrower statement: **some stimulant-treated children have been studied, but medication-specific co-use still deserves clinician or pharmacist review**.
 
-Choice of formulation should consider the primary sleep complaint, onset versus maintenance, and individual response. Immediate-release is more frequently studied for reducing sleep onset latency.
+## Melatonin is not FDA-approved as an ADHD treatment
 
-TODO: Verify immediate-release versus extended-release evidence.
+In the United States, melatonin sold as a dietary supplement is not reviewed and approved for safety and effectiveness before marketing in the same way an approved drug is. FDA’s dietary-supplement framework also means a supplement should not be marketed as though it were an approved treatment for a disease.[9]
 
-### Dosing Considerations
+That matters because “clinically studied,” “natural hormone,” and “available over the counter” can sound like regulatory endorsements when they are not.
 
-Studied doses in pediatric ADHD trials have varied widely, commonly ranging from 1 mg to 6 mg or higher in some cases, taken before bedtime. Lower doses are sometimes as effective as higher doses when timing is appropriate, and higher doses do not always produce proportionally greater benefits.
+The evidence supports describing melatonin as a researched sleep/circadian intervention—not as an FDA-approved ADHD therapy.
 
-In adults, doses commonly range from 1 mg to 5 mg or more, again with emphasis on timing. Individual sensitivity varies significantly. Starting with a lower dose and adjusting based on response and tolerability is a common practical approach.
+## Evidence applicability ledger
 
-TODO: Verify specific dose ranges and response curves from key pediatric and adult studies.
+| Question | Best evidence located | Conclusion |
+|---|---|---|
+| Can melatonin help sleep onset in children with ADHD + chronic sleep-onset insomnia? | 105-child RCT plus smaller stimulant-treated trial | **Supported for selected pediatric sleep-onset problems** |
+| Does melatonin directly improve core ADHD symptoms in children? | Pediatric RCTs | **Not established; key trials found no significant ADHD/behavior/cognition benefit** |
+| Can melatonin shift circadian timing? | Pediatric DLMO trial + adult ADHD/DSPS trial | **Yes, in studied circadian-delay populations** |
+| Does it work for all insomnia in ADHD? | Trials are concentrated in sleep-onset/circadian-delay phenotypes | **No—do not generalize to every sleep disorder** |
+| Is a retail label a precise dose measurement? | 110-product analytical survey | **No** |
+| Is long-term pediatric safety completely characterized? | Follow-up data + safety reviews | **No; reassuring signals but important uncertainty remains** |
+| Is there one evidence-based dose/timing schedule for everyone with ADHD? | Heterogeneous pediatric/adult protocols | **No** |
 
-### Timing Considerations
+## What the old version of this page got wrong
 
-Timing of melatonin administration is often more important than dose. For sleep onset support, it is typically taken 30–60 minutes before desired bedtime. For circadian phase shifting in delayed sleep phase, it is often taken earlier in the evening, several hours before desired bedtime.
+The previous draft contained more than a dozen unresolved “TODO: verify” notes while still making practical claims about dose ranges, timing, formulations, autoimmune cautions, medication interactions, and comparisons with magnesium/L-theanine.
 
-Taking melatonin too late in the evening may be less effective for phase shifting and can sometimes delay sleep onset further in sensitive individuals. Consistent timing across nights supports better results.
+Those unsupported specifics have been removed or replaced with directly sourced evidence.
 
-TODO: Verify timing recommendations and late-evening caution.
+In particular, this version no longer tells readers to:
 
-### Safety Profile
+- start at a particular consumer dose;
+- automatically take melatonin 30–60 minutes before bed;
+- escalate dose based on response;
+- use an extended-release product for a particular complaint without ADHD-specific evidence;
+- assume melatonin and magnesium or L-theanine are “complementary”; or
+- infer interaction safety from the absence of a warning.
 
-Melatonin has a generally favorable safety profile in short- to medium-term use at studied doses. It is one of the more commonly recommended supplements for pediatric sleep difficulties when behavioral approaches are insufficient. Long-term safety data at supplemental doses continue to be studied, particularly in children.
+Study doses and schedules are still reported because they are essential to interpreting research. They are labeled as **study context**, not a personalized protocol.
 
-Melatonin is not a sedative and does not appear to produce dependence in the same way as some sleep medications. However, it should still be used thoughtfully and under guidance when appropriate.
+## The diagnostic gap competitors often skip
 
-TODO: Verify safety profile, pediatric guidance, and dependence claims.
+“ADHD + can’t sleep” is not one diagnosis.
 
-### Side Effects
+The melatonin trials on this page are most relevant to **chronic sleep-onset insomnia and delayed circadian timing**. They do not establish that melatonin is the right response to every nighttime problem in a person with ADHD.
 
-Reported side effects of melatonin are generally mild and can include daytime drowsiness, especially if dosing or timing is not optimal, headache, or gastrointestinal discomfort. In children, some studies note possible effects on mood or morning grogginess, though these are not universal.
+Persistent sleep difficulty can also coexist with medication timing effects, restless legs/periodic limb movement, sleep-disordered breathing, anxiety, inconsistent schedules, insufficient sleep opportunity, or other sleep disorders. A supplement can reduce sleep latency while leaving the actual driver of a sleep problem unrecognized.
 
-Most side effects are dose- and timing-dependent. Adjusting the dose or timing often resolves issues when they occur.
+That is why the evidence should be matched to the sleep phenotype rather than treating “insomnia” as a single interchangeable condition.
 
-TODO: Verify adverse effect profile.
+## Unanswered-question ledger
 
-### Medication Interactions
+As of the August 15, 2026 literature check, important gaps remain:
 
-Melatonin may have additive effects with other sedating substances or medications. It can interact with certain medications metabolized through the liver or those affecting hormone levels. Individuals taking prescription medications—particularly those for ADHD, mood, blood pressure, or immune function—should discuss melatonin use with a healthcare provider or pharmacist.
+1. What is the best long-term strategy for children who respond to melatonin for years rather than weeks?
+2. What are the long-term endocrine/developmental outcomes of routine pediatric exposure?
+3. Which ADHD sleep phenotypes predict response—circadian delay, stimulant-associated insomnia, behavioral insomnia, or a mixture?
+4. How much of real-world variability in benefit or side effects comes from inaccurate product content?
+5. Do lower-dose, accurately manufactured products perform as well as higher-dose products for specific circadian targets?
+6. How should clinicians best distinguish sleep-promotion dosing from circadian phase-shifting protocols in ADHD?
+7. What are the long-term outcomes of melatonin used alongside different stimulant and non-stimulant ADHD medications?
+8. Which objective outcomes beyond sleep onset—daytime functioning, school/work performance, mood, and quality of life—meaningfully improve?
 
-TODO: Verify interaction claims and medication categories.
+## Frequently asked questions
 
-### Long-Term Use Questions
+### Does melatonin help children with ADHD fall asleep?
 
-Many studies of melatonin in ADHD have been short- to medium-term. Questions remain about optimal duration of use, whether tolerance develops in some individuals, and the best approach to discontinuation. Some clinicians recommend periodic reassessment and trials off melatonin to evaluate ongoing need.
+In selected children with ADHD and chronic sleep-onset insomnia, randomized trials show earlier sleep onset. The 105-child trial also found increased total sleep time relative to placebo.[1]
 
-Long-term daily use should be discussed with a clinician, especially in children.
+### Does melatonin improve ADHD symptoms?
 
-TODO: Verify long-term use evidence, tolerance, and discontinuation guidance.
+The strongest pediatric trial found no significant effect on behavior, cognition, or quality of life, and the stimulant-treated sleep-hygiene/melatonin study did not demonstrate an ADHD-symptom improvement.[1][2]
 
-### Melatonin vs Magnesium
+### Does melatonin work in adults with ADHD?
 
-Melatonin primarily supports sleep onset and circadian signaling. Magnesium is involved in GABA activity and muscle relaxation and may support sleep quality, particularly when status is low. The two have different mechanisms and are sometimes used together.
+There is adult evidence in ADHD with delayed sleep phase syndrome. A 51-person randomized trial showed that individually timed melatonin shifted DLMO earlier. The study is better evidence for circadian phase shifting than for a durable direct ADHD treatment effect.[4]
 
-Evidence for melatonin in reducing sleep onset latency in ADHD is generally stronger than evidence for magnesium as a primary sleep onset agent. Magnesium may offer broader calming or muscle-relaxation benefits for some individuals.
+### What dose should someone with ADHD take?
 
-TODO: Verify comparison claims and magnesium evidence.
+There is no universal evidence-based ADHD dose. Pediatric and adult studies used different regimens for different sleep/circadian targets, and retail product content may differ substantially from label claims.[1][4][5] Dose selection for a child or a person taking medication is a clinician/pharmacist question rather than something this evidence review can personalize.
 
-### Melatonin vs L-Theanine
+### When should melatonin be taken?
 
-L-Theanine promotes relaxed wakefulness through alpha wave activity and GABA/glutamate modulation. It has shown benefits for objective sleep quality in one pediatric ADHD trial. Melatonin more directly targets sleep onset timing.
+There is no single timing rule that fits both sleep-onset support and circadian phase shifting. Research protocols have timed melatonin relative to bedtime or measured DLMO depending on the target. Copying a trial clock time without matching the underlying sleep problem can miss the point of the intervention.[1][4]
 
-The two can be complementary. L-Theanine may help with bedtime arousal and stress, while melatonin supports the circadian signal for sleep. Individual response determines which or both may be useful.
+### Is melatonin safe for children?
 
-TODO: Verify L-theanine comparison and Lyon 2011 details.
+Short-term pediatric studies are generally reassuring, but long-term safety is not fully established. Product-content variability and accidental ingestion are major practical safety issues in the U.S.[5][6][7]
 
-### Melatonin vs Sleep Hygiene
+### Can melatonin be taken with stimulant medication?
 
-Sleep hygiene practices—consistent schedules, appropriate light exposure, reduced evening stimulation, and structured wind-down routines—form the foundation of sleep support. Melatonin is most effective when used alongside good sleep hygiene rather than as a replacement for it.
+Some randomized ADHD sleep studies included stimulant-treated children, so the combination has been studied in limited settings.[2][3] That is not the same as proving universal interaction safety or an ideal regimen for every stimulant product and child.
 
-Behavioral strategies often produce meaningful improvements on their own. Melatonin can provide additional support when hygiene measures are insufficient or when circadian factors are prominent.
+### Are melatonin gummies reliable?
 
-### Who Might Benefit Most
+Not necessarily. Analytical studies have found substantial label inaccuracy in some U.S. melatonin products, including gummies.[5][7] That does not mean every product is inaccurate, but it means manufacturing verification is a meaningful part of product selection.
 
-Melatonin may be most relevant for individuals with ADHD who experience prominent sleep onset insomnia or delayed sleep phase that significantly affects daytime functioning. It may be particularly useful when behavioral strategies alone have not been sufficient and when circadian misalignment is suspected.
+### Is more melatonin better?
 
-Children with ADHD and well-documented sleep onset difficulties have the strongest body of supporting research. Adults with similar patterns may also benefit, though evidence is more limited.
+The ADHD evidence does not establish that escalating dose produces proportionally greater benefit. Study regimens should not be turned into “more is better” consumer advice—especially when actual product content can differ from the label.
 
-### Who Should Use Caution
+### Is melatonin a sleeping pill?
 
-Caution is warranted in individuals with certain autoimmune conditions, those taking medications that may interact with melatonin, and anyone with complex sleep disorders that have not been properly evaluated. In children, use should always involve clinical guidance. People with severe daytime sleepiness or symptoms suggestive of other sleep disorders should seek professional evaluation rather than self-treating with melatonin.
+It is better understood as a hormone involved in circadian timing that can also facilitate sleep under certain conditions. The ADHD studies are especially informative because some directly measured DLMO, showing a shift in internal circadian timing rather than only subjective sedation.[1][4]
 
-TODO: Verify autoimmune, interaction, and caution criteria.
+## Sources
 
-### What Not to Expect
-
-Melatonin is not expected to dramatically improve core ADHD symptoms or replace established treatments. It primarily supports sleep onset and, in some cases, circadian alignment. Improvements in daytime functioning, when they occur, are generally secondary to better sleep rather than direct effects on attention or behavior.
-
-Not everyone will experience meaningful benefits. Response varies based on individual circadian timing, dose, timing of administration, and other contributing factors to sleep difficulties.
-
-### Practical Decision Framework
-
-When considering melatonin for ADHD-related sleep problems:
-
-1. Prioritize consistent sleep hygiene and circadian support strategies first.
-2. Consider melatonin when sleep onset difficulties persist despite behavioral efforts and significantly affect daytime function.
-3. Use the lowest effective dose with appropriate timing relative to desired bedtime or circadian goals.
-4. Track sleep onset, total sleep time, sleep quality, and next-day functioning systematically.
-5. Reassess after several weeks and periodically evaluate ongoing need with a clinician.
-6. In children or when other medications are in use, involve a healthcare provider for guidance on dosing and monitoring.
-
-This approach emphasizes targeted, time-limited, and monitored use rather than indefinite daily supplementation without review.
-
-### Research Gaps
-
-Current evidence has limitations, including relatively short trial durations, variability in dosing and timing protocols, limited adult-specific ADHD data, and incomplete understanding of long-term effects and optimal discontinuation strategies. More research is needed on extended-release formulations in ADHD, head-to-head comparisons with other sleep supports, and the interaction between melatonin and ADHD medications over time.
-
-### Conclusion
-
-Melatonin has moderate evidence supporting its use for reducing sleep onset latency in children with ADHD and sleep initiation difficulties. Effects on total sleep time and sleep quality are more variable. Adult data are more limited. Benefits are generally modest and most relevant for sleep onset and circadian support rather than as a broad treatment for ADHD symptoms.
-
-Melatonin is best used as one component of a comprehensive approach that includes sleep hygiene, consistent routines, appropriate light exposure, and clinical oversight when needed. Timing of administration is often as important as dose. Expectations should remain realistic: melatonin can support better sleep initiation for some individuals but does not treat ADHD itself and will not produce large or universal improvements in daytime symptoms.
-
-Professional guidance is recommended for children, when other medications are involved, or when sleep problems are severe or accompanied by other concerning symptoms.
-
-## FAQ
-
-### Does melatonin help with ADHD sleep problems?
-
-Research shows it can reduce sleep onset latency in many children with ADHD who have difficulty falling asleep. Effects on other sleep parameters and on daytime ADHD symptoms are generally more modest.
-
-### Is melatonin safe for children with ADHD?
-
-Melatonin has been studied in pediatric ADHD populations and is generally considered to have a favorable short- to medium-term safety profile when used appropriately. Clinical guidance is recommended for children.
-
-### How much melatonin should I take for ADHD sleep?
-
-Studied doses vary. Lower doses are sometimes as effective as higher doses when timing is appropriate. Individual response varies, and professional guidance on dosing is advisable, especially for children.
-
-### When should I take melatonin?
-
-For sleep onset support, it is typically taken 30–60 minutes before desired bedtime. For circadian shifting in delayed sleep phase, it may be taken earlier in the evening. Consistent timing is important.
-
-### Will melatonin make me sleepy during the day?
-
-Daytime drowsiness can occur if the dose is too high or timing is not optimal. Most people do not experience significant next-day effects when using appropriate doses and timing.
-
-### Can I take melatonin every night long-term?
-
-Many studies have been short- to medium-term. Questions remain about optimal long-term use. Periodic reassessment with a clinician is recommended rather than indefinite daily use without review.
-
-### Does melatonin interact with ADHD medications?
-
-Potential interactions exist. Stimulant medications can affect sleep timing, and melatonin may have additive effects with other sedating substances. Discuss use with a healthcare provider.
-
-### How does melatonin compare to sleep hygiene for ADHD sleep?
-
-Sleep hygiene and behavioral strategies form the foundation. Melatonin is most effective when used alongside good sleep practices rather than as a replacement for them.
-
-### Can melatonin improve ADHD symptoms directly?
-
-Melatonin primarily supports sleep. Any improvements in daytime attention or behavior are generally secondary to better sleep rather than direct effects on ADHD.
-
-### Is extended-release melatonin better than immediate-release?
-
-Immediate-release is more commonly studied for sleep onset. Extended-release may be considered when both onset and maintenance are concerns, though ADHD-specific data are more limited for extended-release forms.
-
-### What if melatonin doesn’t work for me?
-
-Response varies. Factors such as timing, dose, underlying circadian issues, anxiety, or other sleep disorders may influence effectiveness. Professional evaluation can help identify contributing factors.
-
-### Should I try sleep hygiene before using melatonin?
-
-Yes. Consistent sleep hygiene, routines, light exposure, and stimulation management are foundational. Melatonin is best considered when these strategies are insufficient.
-
-## Evidence Summary Table
-
-| Outcome | Population | Key Findings | Evidence Strength | Notes / TODO |
-|---|---|---|---|---|
-| Sleep onset latency | Children with ADHD | Reduction in time to fall asleep in multiple trials | Moderate | TODO: Pediatric RCTs: sample sizes, doses, effect sizes |
-| Total sleep time | Children with ADHD | Modest increases in some studies | Low to Moderate | TODO: More variable than onset effects |
-| Sleep quality | Children with ADHD | Some parent-reported improvements | Preliminary to Moderate | TODO: Often linked to easier sleep onset |
-| Daytime ADHD symptoms | Children with ADHD | Modest secondary improvements via better sleep | Preliminary | TODO: Not a direct ADHD treatment effect |
-| Adult ADHD sleep data | Adults with ADHD | Limited high-quality trials | Preliminary | TODO: Adult-specific studies and outcomes |
-| Circadian phase shifting | Delayed sleep phase | Can advance sleep timing when appropriately timed | Moderate | TODO: Requires consistent early-evening use |
-| Long-term safety | General populations | Generally favorable in studied durations | Moderate | TODO: Longer-term ADHD-specific data limited |
+1. Van der Heijden KB, Smits MG, Van Someren EJW, Ridderinkhof KR, Gunning WB. Effect of melatonin on sleep, behavior, and cognition in ADHD and chronic sleep-onset insomnia. *J Am Acad Child Adolesc Psychiatry*. 2007;46(2):233-241. PMID 17242627. DOI: 10.1097/01.chi.0000246055.76167.0d. https://pubmed.ncbi.nlm.nih.gov/17242627/
+2. Weiss MD, Wasdell MB, Bomben MM, Rea KJ, Freeman RD. Sleep hygiene and melatonin treatment for children and adolescents with ADHD and initial insomnia. *J Am Acad Child Adolesc Psychiatry*. 2006;45(5):512-519. PMID 16670647. https://pubmed.ncbi.nlm.nih.gov/16670647/
+3. Mohammadi MR, et al. Melatonin effects in methylphenidate treated children with attention deficit hyperactivity disorder: a randomized double blind clinical trial. 2012. PMID 22952551. https://pubmed.ncbi.nlm.nih.gov/22952551/
+4. van Andel E, et al. Effects of chronotherapy on circadian rhythm and ADHD symptoms in adults with attention-deficit/hyperactivity disorder and delayed sleep phase syndrome: a randomized clinical trial. *Chronobiology International*. 2021;38(2):260-269. PMID 33121289. DOI: 10.1080/07420528.2020.1835943. https://pubmed.ncbi.nlm.nih.gov/33121289/
+5. Pawar RS, et al. A Survey of Melatonin in Dietary Supplement Products Sold in the United States. *Drug Testing and Analysis*. 2025. PMID 39482109. DOI: 10.1002/dta.3823. https://pubmed.ncbi.nlm.nih.gov/39482109/
+6. American Academy of Sleep Medicine. Health Advisory: Melatonin Use in Children and Adolescents. Adopted September 9, 2022; page current in 2026. https://aasm.org/advocacy/position-statements/melatonin-use-in-children-and-adolescents-health-advisory/
+7. National Center for Complementary and Integrative Health. Melatonin: What You Need To Know; Sleep Disorders and Complementary Health Approaches. Accessed August 15, 2026. https://www.nccih.nih.gov/health/melatonin-what-you-need-to-know
+8. Hoebert M, et al. Long-term follow-up of melatonin treatment in children with ADHD and chronic sleep onset insomnia. 2009. PMID 19486273. https://pubmed.ncbi.nlm.nih.gov/19486273/
+9. U.S. Food and Drug Administration. FDA 101: Dietary Supplements; Information for Consumers on Using Dietary Supplements. Accessed August 15, 2026. https://www.fda.gov/consumers/consumer-updates/fda-101-dietary-supplements
+10. National Center for Complementary and Integrative Health. 9 Things To Know About Complementary Health Approaches for ADHD for Children and Teens. Updated 2026. https://www.nccih.nih.gov/health/tips/things-to-know-about-complementary-health-approaches-for-adhd-for-children-and-teens
 
 ## Related Articles
 
 - Sleep and ADHD: Evidence-Based Strategies for Better Focus, Behavior, and Daily Functioning
-- Best Supplements for ADHD: Evidence-Based Options for Focus, Sleep, and Emotional Regulation
-- L-Theanine for ADHD: Evidence on Attention and Sleep
-- Magnesium for ADHD: Forms, Evidence, and Practical Use
-- ADHD Stack Guide
-- Circadian Rhythm and ADHD
-- Natural Sleep Support Strategies
-
-## Internal Linking Recommendations
-
-- Link heavily to the Sleep and ADHD article as a central hub for comprehensive strategies.
-- Link to the ADHD Stack Guide for practical integration of sleep supports.
-- Create bidirectional links to L-Theanine for ADHD, Magnesium for ADHD, and Omega-3 and ADHD where sleep overlap is discussed.
-- Link to any existing Sleep-focused content cluster pages.
-- Connect to Circadian Rhythm and ADHD content if available.
-- Position this article as a focused, evidence-based reference on melatonin within the broader Focus / ADHD cluster, supporting navigation between sleep-specific and supplement-specific content.
+- L-Theanine for ADHD: What the Evidence Supports in 2026
+- Magnesium for ADHD: Evidence, Forms, Sleep, Calm, and Practical Use
+- ADHD Stack Guide: Evidence-Based Supplement Combinations
+- Nutrient Deficiencies and ADHD


### PR DESCRIPTION
## Why
The ranking melatonin/ADHD page still contained numerous unresolved TODO verification notes while presenting practical claims about timing, dosing, interactions, formulations, and long-term use.

## What changed
- removes the unresolved TODO scaffold and replaces it with sourced evidence
- anchors pediatric efficacy to the 105-child randomized trial and the stimulant-treated crossover study
- adds the 51-adult ADHD + delayed sleep phase randomized chronotherapy trial
- separates sleep/circadian effects from direct ADHD-treatment claims
- adds a product-quality section using the 110-product U.S. analytical survey (0%-667% of label claim)
- adds pediatric ingestion/safe-storage context from NCCIH/AASM
- adds medication-context and evidence-applicability ledgers
- removes unsourced consumer dosing/timing escalation instructions
- adds a current 10-source bibliography and an August 15, 2026 literature-check marker
- updates SEO description to surface the differentiated research coverage

## Safety calibration
Study doses/timing are reported only as research context. The article does not personalize a dose, tell parents to self-treat, or claim melatonin treats core ADHD.