### PR TITLE
research: recalibrate zinc ADHD guide with 2026 evidence and safety

### DIFF
--- a/app/guides/adhd/zinc-and-adhd/page.tsx
+++ b/app/guides/adhd/zinc-and-adhd/page.tsx
@@ -4,9 +4,9 @@ import { buildPageMetadata } from '@/src/lib/seo'
 const SLUG = 'zinc-and-adhd'
 
 export const metadata = buildPageMetadata({
-  title: 'Zinc for ADHD: Does It Help? Evidence & Safety',
+  title: 'Zinc for ADHD: 2026 Evidence, Deficiency & Safety',
   description:
-    'Does zinc help ADHD? Review human trials, who may benefit most when zinc is low, studied dose context, stimulant-combination evidence, side effects, and copper risk.',
+    '2026 review of zinc for ADHD: new zinc-status data, randomized trials, stimulant-adjunct evidence, serum-test limits, elemental-vs-salt dosing, copper risk, and medication interactions.',
   path: `/guides/adhd/${SLUG}/`,
   openGraphType: 'article',
 })

--- a/docs/content/focus-cluster/zinc-and-adhd.md
+++ b/docs/content/focus-cluster/zinc-and-adhd.md
@@ -1,127 +1,379 @@
 ---
-title: "Zinc and ADHD: Deficiency, Hyperactivity, Attention, and Supplementation"
-seoTitle: "Zinc and ADHD: Deficiency, Attention and Safety"
-metaDescription: "Evidence-based review of zinc and ADHD. Covers deficiency, hyperactivity, attention, stimulant response, dosing, safety, and copper balance."
+title: "Zinc and ADHD: Deficiency, Trials, Elemental Dose, and Safety"
+seoTitle: "Zinc for ADHD: 2026 Evidence, Deficiency & Safety"
+metaDescription: "2026 evidence review of zinc and ADHD: newest zinc-status meta-analysis, randomized trials, stimulant-adjunct data, serum-test limits, elemental-vs-salt dosing, copper risk, and medication interactions."
 primaryKeyword: "zinc ADHD"
 secondaryKeywords:
   - "zinc for ADHD"
   - "zinc deficiency ADHD"
   - "zinc supplementation ADHD"
   - "zinc children ADHD"
-  - "zinc and hyperactivity"
   - "zinc stimulant response ADHD"
+  - "elemental zinc ADHD"
 status: "published"
 cluster: "focus-adhd"
+updated: "2026-08-15"
+literatureCheck: "2026-08-15"
 ---
 
-# Zinc and ADHD: What the Research Shows About Deficiency, Supplementation, and Attention
+# Zinc for ADHD: What the Evidence Supports in 2026
 
 ## Quick Answer
 
-Zinc is an essential mineral involved in dopamine metabolism, neurotransmitter signaling, and the regulation of the transporter that clears dopamine from the synapse. Because dopamine is central to attention and impulse control, zinc has been studied as a possible support for ADHD.
+Zinc is an essential nutrient, and zinc status is scientifically relevant to ADHD research. But the strongest current interpretation is narrower than either “zinc treats ADHD” or “zinc only works if a blood test is low.”
 
-The evidence is mixed but points in a consistent direction: zinc deficiency is more common in some people with ADHD, and correcting a genuine deficiency may modestly help symptoms or improve the response to stimulant medication. Zinc is not a treatment for ADHD on its own, and adding zinc when levels are already adequate has not been shown to improve attention.
+A **2026 meta-analysis of 46 case-control studies** involving 5,515 children/adolescents with ADHD and 8,166 controls found lower zinc levels on average in the ADHD groups. The difference was more pronounced in children age 12 or younger and in studies from developing countries, but the studies were highly heterogeneous. That means lower zinc status is an **association**, not a diagnostic test for ADHD and not proof that zinc deficiency causes ADHD.[1]
 
-Zinc is best thought of as a deficiency-correction tool, not a stimulant substitute. If a blood test shows low zinc, supplementation is reasonable and well-supported. If levels are normal, the expected benefit is small.
+Treatment evidence is mixed. A 2021 meta-analysis of six randomized trials involving 489 school-aged children found a statistically borderline improvement in total ADHD scores, but **no significant pooled improvement in inattention or hyperactivity**, and the certainty of evidence ranged from moderate to very low.[2]
 
-## Best For / Not Best For
+Individual trials are inconsistent: some Middle Eastern studies reported symptom improvements when zinc was used alone or with methylphenidate, while a U.S. pilot found equivocal clinical outcomes except for a lower optimized amphetamine dose in a small higher-dose zinc subgroup.[3–8]
 
-Zinc may be worth considering when:
+**Bottom line:** correcting true zinc inadequacy is important nutrition care, but zinc should not be presented as a proven standalone ADHD treatment, a stimulant substitute, or a biomarker-guided ADHD therapy. The most defensible role is to identify and correct nutritional inadequacy when clinically appropriate while keeping expectations for direct ADHD effects modest.
 
-- A blood test shows low or low-normal zinc, or the diet is genuinely low in zinc
-- Diet is limited (restricted eating, low animal-protein intake, or high phytate intake)
-- The goal is to correct a deficiency that could be worsening focus, sleep, or mood
-- Supplementation is used as one part of a broader plan alongside sleep, nutrition, and medical care
-- Use in children is guided by a clinician who can check levels and dosing
+## What Changed in 2026
 
-Zinc is not a good fit when:
+The most important new evidence is not another supplement trial. It is a large updated analysis of zinc status.
 
-- Zinc levels are already normal and the aim is to boost attention beyond baseline
-- It is being used as a replacement for evidence-based ADHD care
-- High doses are taken long-term without monitoring copper status
-- The plan is to stack several minerals at once and guess what is helping
+The 2026 trace-element meta-analysis included **46 case-control studies**, with 5,515 ADHD cases and 8,166 controls. Zinc, iron, and ferritin were lower on average in ADHD groups; copper was not significantly different overall.[1]
 
-## What Zinc Is
+For zinc specifically:
 
-Zinc is an essential trace mineral the body cannot make or store in large amounts, so a steady dietary supply is needed. It is a cofactor for hundreds of enzymes and is involved in immune function, wound healing, growth, taste, and the synthesis and regulation of neurotransmitters.
+- the pooled difference favored lower zinc levels in ADHD groups;
+- the difference was larger in children age 12 or younger;
+- differences were more pronounced in studies from developing countries; and
+- heterogeneity across studies was high.[1]
 
-Dietary zinc comes mainly from oysters, red meat, poultry, beans, nuts, seeds, and whole grains. Plant sources contain phytates that reduce zinc absorption, which is one reason low intake can appear in restricted or largely plant-based diets. Zinc status is often assessed with serum or plasma zinc, though these markers have limitations and can be affected by inflammation, recent meals, and time of day.
+This strengthens the case that zinc status is worth studying in ADHD. It does **not** establish that a low zinc result diagnoses ADHD, that every child with ADHD is zinc deficient, or that supplementation will improve symptoms in a person whose zinc intake and status are already adequate.
 
-## How Zinc Works in ADHD
+## Evidence at a Glance
 
-Zinc's relevance to ADHD centers on dopamine. Zinc helps regulate the dopamine transporter, the protein that removes dopamine from the synapse — the same target that stimulant medications act on. Zinc is also a cofactor for enzymes involved in making neurotransmitters and in metabolizing fatty acids and melatonin, both of which are relevant to attention and sleep.
+| Evidence | Population / design | Main result | What it does **not** prove |
+|---|---|---|---|
+| 2026 trace-element meta-analysis | 46 case-control studies; 5,515 ADHD cases + 8,166 controls | Zinc was lower on average in ADHD groups; subgroup differences varied by age/geography | Zinc deficiency causes ADHD or serum zinc is an ADHD diagnostic biomarker |
+| 2021 zinc-treatment meta-analysis | 6 RCTs; 489 school-aged children | Borderline pooled benefit on total ADHD score; no significant pooled inattention or hyperactivity effect | Reliable clinically meaningful benefit for every child |
+| Bilici 2004 | 400 children; zinc sulfate monotherapy vs placebo, 12 weeks | Improvement in hyperactivity/impulsivity/socialization, not attention; response rate difference modest | Generalizability to well-nourished populations or modern U.S. dosing practice |
+| Akhondzadeh 2004 | 44 children; methylphenidate + zinc vs methylphenidate + placebo, 6 weeks | Parent/teacher rating scales favored adjunct zinc | Replication, long-term benefit, or benefit independent of regional nutritional status |
+| Arnold 2011 | 52 U.S. children; zinc glycinate then adjunct amphetamine | Clinical outcomes equivocal; 30-mg subgroup required lower optimized amphetamine dose | Zinc monotherapy efficacy or a validated medication-sparing protocol |
+| Chilean RCT | 40 children; methylphenidate + zinc vs placebo | Baseline plasma zinc was normal; teacher result trended but was not significant; parent result not significant | Clear benefit in zinc-adequate children |
+| Noorazar 2020 | 60 children on methylphenidate; zinc augmentation vs control | Inattention improved; total, hyperactivity and impulsivity outcomes were not significantly different | Broad improvement across core ADHD domains |
 
-The important nuance is that ADHD is not caused by simple zinc deficiency. Low zinc may worsen symptoms or reduce how well the system responds to treatment, but correcting it does not resolve the underlying condition. The strongest rationale for zinc is repletion: restoring an adequate level so that dopamine signaling, sleep, and overall function are not held back by a nutrient gap.
+## The Most Important Distinction: Zinc Status vs Zinc Treatment
 
-## What the Evidence Says
+There are two different scientific questions:
 
-Several lines of research connect zinc and ADHD:
+1. **Do people with ADHD have lower zinc levels on average?**
+2. **Does giving zinc improve ADHD symptoms?**
 
-- **Deficiency association.** Multiple studies report lower average zinc levels in children with ADHD compared with peers, though not every study agrees and populations differ widely. Deficiency appears more likely in regions and diets where zinc intake is generally low.
-- **Supplementation trials.** Randomized trials of zinc as a standalone therapy have shown small and inconsistent benefits. Some found modest improvements in hyperactivity and impulsivity; others found little effect, particularly in well-nourished populations.
-- **Stimulant response.** A notable line of evidence suggests zinc may work best as an adjunct: adding zinc alongside stimulant medication has, in some trials, been associated with a lower effective medication dose or slightly improved response. This fits the mechanism, since zinc and stimulants both influence the dopamine transporter.
+The answer to the first question is more consistently positive than the answer to the second.[1,2]
 
-The overall picture is that zinc is most useful when a deficiency exists. In people with adequate zinc, the benefit is generally small. This is why testing before supplementing is more rational than blanket use. For a broader look at which nutrients matter, see [nutrient deficiencies and ADHD](/guides/adhd/nutrient-deficiencies-and-adhd/) and [ADHD blood tests](/guides/adhd/adhd-blood-tests/).
+That distinction matters because an association can arise from many factors: diet quality, restricted eating, socioeconomic differences, inflammation, geography, food fortification, gastrointestinal conditions, developmental stage, or other health differences. Case-control data cannot prove which direction the relationship runs.
 
-## Zinc Deficiency and Assessment
+Similarly, a treatment trial can show benefit without proving that participants were deficient, and a low blood level can be clinically important without proving that correcting it will directly reduce ADHD symptoms.
 
-Zinc deficiency can be hard to pin down because standard blood markers are imperfect. Serum or plasma zinc is the most common test, but it can be lowered by inflammation, infection, stress, and recent food intake, and it does not always reflect tissue stores. Despite these limits, a clearly low result is meaningful and worth acting on.
+## Zinc Is Not an ADHD Blood Test
 
-Practical signals that zinc may be worth checking include a restricted or largely plant-based diet, frequent illness, poor wound healing, reduced sense of taste or smell, or poor appetite. In the context of ADHD, testing zinc alongside iron/ferritin, vitamin D, and magnesium gives a fuller nutritional picture than checking any one marker alone.
+Serum or plasma zinc is commonly used to assess zinc status in clinical practice, but NIH's Office of Dietary Supplements emphasizes that both measurements have important limitations.[9]
 
-## Copper Balance and Long-Term Use
+Zinc concentrations can vary with:
 
-Zinc and copper compete for absorption, and sustained high-dose zinc can lower copper levels over time, potentially causing anemia or neurological problems. This is the single most important safety consideration for ongoing zinc use.
+- age and sex;
+- time of day;
+- infection and inflammation;
+- changes in steroid hormones;
+- illness or muscle catabolism; and
+- recent dietary or supplemental exposure.[9]
 
-Short-term repletion at modest doses is low-risk. Long-term or higher-dose supplementation should be monitored, and some clinicians recommend a small amount of copper alongside extended zinc use. This is a decision to make with a healthcare provider rather than by self-directed high dosing.
+Serum/plasma zinc also does not always track dietary zinc intake closely.[9]
 
-## Forms and Dosing
+So a zinc result should not be interpreted as:
 
-Common supplemental forms include zinc gluconate, zinc citrate, zinc picolinate, zinc bisglycinate, and zinc sulfate. Absorption differences between well-formulated products are modest; tolerability and cost often matter more than the specific salt. Zinc sulfate is the most likely to cause stomach upset.
+> “Low zinc proves the ADHD is nutritional.”
 
-General principles rather than a prescription:
+or:
 
-- Supplemental doses in ADHD studies have typically fallen in a modest daily range, well below levels that risk copper depletion in the short term.
-- Taking zinc with food reduces nausea, though very high-phytate meals can lower absorption.
-- Dosing for children should always be set by a clinician, since needs and safe ranges differ by age and weight.
+> “Normal zinc proves zinc biology is irrelevant.”
 
-Because appropriate dosing depends on age, diet, measured levels, and other supplements, individual dosing is best confirmed with a healthcare provider — especially for children and anyone taking medication.
+A clearly abnormal result can still matter medically, but it should be interpreted in the context of diet, symptoms, inflammation/illness, age, and the laboratory's reference interval rather than used as a standalone ADHD marker.
 
-## Side Effects and Safety
+## What the Randomized Trials Actually Found
 
-At modest doses zinc is generally well tolerated. The most common short-term side effect is stomach upset or nausea, especially on an empty stomach or with zinc sulfate. Key safety points:
+### 1. Large zinc-sulfate monotherapy trial: positive, but population context matters
 
-- **Copper depletion** is the main long-term risk of higher-dose supplementation.
-- **Excess zinc** can impair immune function rather than help it — more is not better.
-- **Medication interactions** exist: zinc can reduce absorption of some antibiotics and can be affected by certain diuretics, so timing and clinician input matter.
-- **Pregnancy, nursing, and pediatric use** require professional guidance on dose.
+Bilici and colleagues randomized **400 children with ADHD** in Turkey to zinc sulfate or placebo for 12 weeks.[3]
 
-If you are combining zinc with other calming, stimulating, or mineral supplements, it is worth reviewing the overall stack for overlap and interactions. The [ADHD stack guide](/guides/adhd/adhd-stack-guide/) covers how to combine supports without overstacking.
+The zinc group improved more on hyperactivity, impulsivity, and impaired socialization measures, but not on attention-deficiency symptoms. Full therapeutic response rates were 28.7% with zinc and 20% with placebo.[3]
+
+The authors reported stronger response patterns in older children with higher BMI and lower zinc/free-fatty-acid levels.[3]
+
+This is one of the largest zinc ADHD trials, but it should not be flattened into “zinc works for ADHD.” The benefit was symptom-domain-specific, and nutritional context may differ substantially across countries and populations.
+
+### 2. Zinc added to methylphenidate: a small positive Iranian trial
+
+Akhondzadeh and colleagues randomized **44 children ages 5–11** to methylphenidate plus zinc sulfate or methylphenidate plus placebo for six weeks.[4]
+
+The zinc group showed greater improvement on parent and teacher ADHD rating scales. The investigators appropriately concluded that replication and additional dose research were needed.[4]
+
+This study supports zinc as an **adjunct hypothesis**, not as a replacement for methylphenidate.
+
+### 3. U.S. pilot: the clinical effect was mostly equivocal
+
+A U.S. randomized trial assigned **52 children ages 6–14** to zinc glycinate or placebo for eight weeks, followed by five weeks with added d-amphetamine.[5]
+
+The zinc dose was initially 15 mg/day elemental zinc; an interim analysis led to a 30 mg/day subgroup. The main clinical outcomes were equivocal, sometimes favoring zinc and sometimes placebo. The prespecified finding that did stand out was a **37% lower optimized amphetamine dose** in the 30-mg/day zinc subgroup—not the 15-mg group.[5]
+
+That is interesting, but it should not be converted into “zinc lets children use 37% less stimulant.” It came from a small pilot subgroup and requires replication.
+
+The authors themselves suggested that differences from Middle Eastern studies could reflect diet, zinc deficiency prevalence, genetics, formulation, or other population factors.[5]
+
+### 4. A zinc-adequate cohort did not show clear benefit
+
+A Chilean randomized trial enrolled **40 children ages 7–14** receiving methylphenidate. Baseline plasma zinc was normal in both groups.[6]
+
+After six weeks, the teacher-rated global index showed a nonsignificant trend favoring zinc (p=0.07), while parent ratings did not significantly differ between groups.[6]
+
+This small study is important because it pushes back against a simple universal-adjunct story.
+
+### 5. A later methylphenidate-augmentation trial found an inattention-specific signal
+
+A 2020 randomized trial of **60 children with ADHD receiving methylphenidate** found no significant between-group difference in total ADHD score, hyperactivity, or impulsivity after six weeks, but did report a significant improvement in the inattention score with zinc augmentation.[7]
+
+Again, the result was domain-specific rather than a clean global ADHD response.
+
+### 6. Other adjunct trials add signal but not certainty
+
+An 8-week randomized trial of 150 children compared methylphenidate plus placebo, zinc sulfate, or omega-3. The zinc group showed improvement in a subgroup with attention-deficit presentation, but the results did not establish a universally effective zinc adjunct strategy.[8]
+
+## Why the Meta-Analysis Is Less Exciting Than the Headline
+
+The 2021 treatment meta-analysis pooled six randomized trials with **489 children**.[2]
+
+The pooled result for total ADHD symptom scores was statistically significant but barely crossed the conventional threshold:
+
+- standardized mean difference: **-0.62**;
+- 95% CI: **-1.24 to -0.002**;
+- p = **0.04**.[2]
+
+But:
+
+- pooled hyperactivity scores were **not significantly improved**;
+- pooled inattention scores were **not significantly improved**; and
+- evidence certainty ranged from **moderate to very low** depending on the outcome.[2]
+
+That combination—borderline total-score significance, inconsistent domain outcomes, and low-certainty evidence—is exactly why zinc belongs in the “possible adjunct / nutritional correction” category rather than the “proven ADHD supplement” category.
+
+## Does Zinc Work Better When Zinc Is Low?
+
+This is plausible and often repeated, but the evidence needs careful wording.
+
+There are three reasons the hypothesis makes sense:
+
+1. ADHD case-control studies find lower average zinc status in some populations.[1]
+2. Some positive treatment trials were conducted in regions where zinc inadequacy is more common.[3–5,12]
+3. The large 2004 trial reported stronger response patterns in participants with lower zinc levels.[3]
+
+But the field still lacks a strong modern trial that prospectively does this:
+
+> screen a large ADHD population → define zinc deficiency using a prespecified method → randomize deficient participants to adequate repletion vs placebo/standard care → show that correcting zinc specifically produces clinically meaningful ADHD improvement.
+
+So the strongest defensible statement is:
+
+**Correcting confirmed zinc inadequacy is appropriate nutrition care; whether deficiency correction reliably improves ADHD symptoms beyond correcting the nutritional problem itself remains incompletely established.**
+
+NCCIH similarly describes zinc evidence as limited and notes that most ADHD studies were conducted in regions where zinc deficiency is more common than in Western populations.[12]
+
+## Elemental Zinc vs Zinc Sulfate: The Dose-Translation Trap
+
+This is one of the easiest ways for supplement articles to accidentally publish a dangerous or meaningless number.
+
+Older ADHD papers may report the mass of a **zinc salt**, such as “150 mg zinc sulfate,” while modern U.S. supplement labels declare the amount of **elemental zinc** in the Supplement Facts panel.[3,9]
+
+NIH explicitly states:
+
+- supplements can use zinc sulfate, acetate, gluconate, citrate, and other forms; and
+- the Supplement Facts panel declares **elemental zinc**, not the weight of the entire zinc-containing compound.[9]
+
+Therefore:
+
+**150 mg zinc sulfate is not the same thing as 150 mg elemental zinc.**
+
+Do not copy a milligram number from an ADHD paper onto a retail-product label without first determining whether the paper is reporting the compound weight or the elemental-zinc amount.
+
+This guide deliberately reports trial exposures as study context rather than turning them into a consumer protocol.
+
+## Trial Doses Can Exceed Ordinary Age-Based Upper Limits
+
+NIH's Food and Nutrition Board sets Tolerable Upper Intake Levels (ULs) for **total zinc intake from foods, beverages, supplements, and medications** in healthy people.[9]
+
+Current ULs include:[9]
+
+| Age | Zinc UL per day |
+|---|---:|
+| 1–3 years | 7 mg |
+| 4–8 years | 12 mg |
+| 9–13 years | 23 mg |
+| 14–18 years | 34 mg |
+| Adults 19+ | 40 mg |
+
+These ULs are not treatment targets, and they do not apply in the same way when zinc is being used medically under clinician supervision.[9]
+
+This matters for ADHD research because some experimental regimens used elemental-zinc exposures that were at or above ordinary age-specific ULs for at least some participants.[5,6]
+
+A research protocol can justify monitoring and exposures that should **not** be copied as casual long-term self-supplementation.
+
+## Copper Risk Is Not a Footnote
+
+High zinc intake can reduce intestinal copper absorption. NIH identifies copper depletion as one of the central reasons zinc has an upper intake limit.[9,10]
+
+NIH reports that **50 mg/day or more of elemental zinc for weeks** can inhibit copper absorption, reduce immune function, and lower HDL cholesterol. The copper fact sheet also notes changes in a copper-status marker with moderately high zinc intake around 60 mg/day for up to 10 weeks.[9,10]
+
+Copper deficiency can eventually cause anemia and neurologic problems.[9,10]
+
+That does **not** mean everyone taking zinc should automatically add a copper supplement. Unnecessary copper can also be harmful. It means prolonged/high-dose zinc deserves a real indication and clinical oversight rather than an improvised “zinc:copper ratio” copied from social media.
+
+## Medication Context
+
+### Stimulants
+
+Several ADHD trials administered zinc alongside methylphenidate or amphetamine without showing a major short-term adverse-event signal.[4–8]
+
+However, those trials were designed primarily to study ADHD outcomes—not to establish a comprehensive pharmacokinetic interaction profile for every stimulant formulation, age group, or long-term combination.
+
+The U.S. pilot's lower optimized amphetamine dose in one subgroup is an efficacy/titration observation, **not proof that zinc directly changes amphetamine metabolism**.[5]
+
+### Antibiotics
+
+Zinc can bind with quinolone and tetracycline antibiotics in the gastrointestinal tract and reduce absorption of both the mineral and the antibiotic.[9]
+
+### Penicillamine
+
+Zinc can reduce absorption/action of penicillamine, a medication used for conditions including rheumatoid arthritis and Wilson disease.[9]
+
+### Thiazide diuretics
+
+Thiazide diuretics can increase urinary zinc excretion and may lower zinc concentrations over time.[9]
+
+For anyone taking regular medication—especially a child—the full medication/supplement list is more useful to a clinician or pharmacist than asking whether “zinc interacts with ADHD medication” as a single yes/no question.
+
+## Food and Absorption Context
+
+Zinc is found in foods such as oysters and other seafood, meat, poultry, dairy, beans, nuts, seeds, and whole grains.[9]
+
+Plant-based diets can still provide zinc, but phytates in legumes and whole grains bind zinc and reduce absorption. People who eat vegetarian or vegan diets may therefore require more dietary planning to maintain adequate zinc status.[9]
+
+This is another reason a diet history can be as important as a supplement bottle.
+
+## Forms: What We Know and What We Do Not
+
+Common supplemental forms include zinc gluconate, citrate, acetate, sulfate, oxide, glycinate, and others.[9]
+
+NIH cites absorption data showing broadly similar absorption for zinc citrate and gluconate in young adults, with somewhat lower absorption for zinc oxide in that study.[9]
+
+ADHD-specific evidence does **not** establish that picolinate, bisglycinate, citrate, or glycinate is the uniquely superior ADHD form.
+
+The U.S. ADHD pilot used glycinate partly because investigators expected less gastrointestinal discomfort than sulfate, but the trial did not prove that glycinate is the best ADHD formulation.[5]
+
+Product tolerability, elemental dose, diet, cost, and quality may matter more than marketing claims around a particular salt.
+
+## Evidence Applicability Ledger
+
+| Question | Best evidence | Conclusion |
+|---|---|---|
+| Are zinc levels lower on average in pediatric ADHD cohorts? | 2026 meta-analysis, 46 studies | **Yes, on average; high heterogeneity** |
+| Is low zinc an ADHD diagnostic biomarker? | Case-control evidence + NIH testing limitations | **No** |
+| Does zinc monotherapy reliably improve core ADHD symptoms? | Large 2004 trial + pooled RCT evidence | **Not reliably established; effects vary by domain/population** |
+| Can zinc add benefit to stimulant treatment? | Several small RCTs | **Possible, inconsistent, preliminary** |
+| Does zinc reliably improve inattention? | Pooled 2021 result + individual trials | **Not established overall; some individual trials positive** |
+| Does zinc reliably improve hyperactivity? | Pooled 2021 result | **No significant pooled effect** |
+| Does a low zinc test predict who will respond? | Suggestive subgroup/population evidence | **Not prospectively validated** |
+| Is there one validated ADHD dose? | Heterogeneous trials using different salts/exposures | **No** |
+| Can trial “mg” numbers be copied directly to a supplement label? | NIH elemental-zinc labeling guidance | **No** |
+| Is long-term high-dose zinc harmless? | NIH safety data | **No; copper depletion is a key risk** |
 
 ## Practical Decision Framework
 
-A reasonable, evidence-aligned approach to zinc and ADHD:
+A research-aligned approach is less exciting than a supplement stack, but more useful:
 
-1. **Check before supplementing.** Ask about testing zinc, ideally alongside ferritin, vitamin D, and magnesium, rather than guessing.
-2. **Treat a real deficiency.** If levels are low, repletion is well-supported and low-risk in the short term.
-3. **Set modest expectations if levels are normal.** Benefit from adding zinc to an already-adequate diet is small.
-4. **Use it as an adjunct, not a replacement.** Zinc may support the response to established care; it does not substitute for it.
-5. **Monitor long-term use.** Watch copper status and involve a clinician for extended or higher-dose supplementation.
+1. **Start with diet and clinical context.** Restricted eating, low intake of zinc-rich foods, gastrointestinal disease, or other deficiency risks make zinc status more relevant.
+2. **Do not use zinc as an ADHD diagnostic test.** Serum/plasma testing can contribute information but has biologic and pre-analytic limitations.[9]
+3. **Treat nutritional deficiency because deficiency matters.** Do not promise that repletion will function like an ADHD medication.
+4. **Do not translate zinc-salt mass into elemental zinc by eyeballing it.** Check exactly what the paper and product label measure.[9]
+5. **Keep age-specific safety limits in view.** Pediatric upper limits are substantially lower than the adult 40-mg/day UL.[9]
+6. **Avoid indefinite high-dose use.** Copper depletion is a real biologic risk, not a theoretical disclaimer.[9,10]
+7. **Use zinc as an adjunct at most—not a replacement for evidence-based ADHD care.** NCCIH does not consider complementary approaches conclusively more effective than conventional treatment.[12]
 
-## FAQ
+## Unanswered-Question Ledger
 
-**Does zinc help ADHD?** It may modestly help when a genuine deficiency exists, and it may support the response to stimulant medication. In people with normal zinc levels, the benefit is generally small.
+As of the August 15, 2026 literature check, important questions remain:
 
-**Should I get tested before taking zinc?** Testing is the more rational path, especially because the clearest benefit is in correcting a measured deficiency. Testing zinc alongside iron, vitamin D, and magnesium gives a fuller picture.
+1. Can a large modern trial show that **biochemically confirmed zinc-deficient** children with ADHD gain a clinically meaningful ADHD-specific benefit from repletion?
+2. Which zinc-status measure—or combination of dietary and laboratory measures—best predicts response?
+3. Are the stronger signals in some Middle Eastern studies driven by baseline nutrition, genetics, study design, zinc form, or another population factor?
+4. Does zinc augmentation meaningfully reduce stimulant dose in a large replicated trial, or was the U.S. pilot finding unstable?[5]
+5. Are any benefits sustained beyond the short 6–13-week windows used by many trials?
+6. Do benefits differ by ADHD presentation, age, sex, restricted eating, socioeconomic status, or comorbid conditions?
+7. What is the best way to balance zinc repletion with copper safety when treatment extends for months?
+8. Does a particular zinc salt matter clinically after elemental dose and tolerability are matched?
+9. Can future trials report both compound mass and elemental zinc consistently so consumer translation is less error-prone?
 
-**Can zinc replace ADHD medication?** No. Zinc is a nutrient-repletion tool, not a treatment for ADHD, and should not replace evidence-based care.
+## Frequently Asked Questions
 
-**Is zinc safe to take long-term?** Modest short-term use is low-risk. Long-term or higher-dose use can deplete copper and should be monitored by a clinician.
+### Does zinc help ADHD?
 
-**Which form of zinc is best?** Differences between well-formulated forms are small. Zinc bisglycinate, citrate, and picolinate are generally well tolerated; zinc sulfate is more likely to cause stomach upset.
+Possibly in some children, but the evidence is inconsistent. A 2021 meta-analysis found a borderline improvement in total ADHD scores but no significant pooled effect on inattention or hyperactivity, with moderate-to-very-low certainty.[2] Some individual adjunct trials are positive.[4,7,8]
+
+### Are zinc levels lower in people with ADHD?
+
+A 2026 meta-analysis of 46 case-control studies found lower zinc levels on average in children and adolescents with ADHD, especially in some younger and developing-country subgroups.[1] That is an association, not a diagnostic test.
+
+### Should zinc be tested before supplementing?
+
+Testing can be useful when deficiency or inadequacy is clinically plausible, but serum/plasma zinc has important limitations and should be interpreted with diet and health context.[9] A normal or low value should not be used alone to explain ADHD symptoms.
+
+### Can zinc replace stimulant medication?
+
+No. Zinc has not been established as a replacement for evidence-based ADHD medication or behavioral treatment. Several zinc studies actually evaluated it **alongside** stimulant treatment.[4–8]
+
+### Does zinc make stimulants work better?
+
+Some trials found adjunct signals, but results are inconsistent. A small U.S. pilot found a lower optimized amphetamine dose in the 30-mg elemental-zinc subgroup, while overall clinical outcomes were equivocal.[5] That finding needs replication before it can be treated as a medication-sparing strategy.
+
+### What is the best zinc dose for ADHD?
+
+There is no validated universal ADHD dose. Trials used different zinc salts, elemental exposures, ages, populations, and treatment contexts. Some research exposures approach or exceed ordinary age-specific upper limits, so study doses should not be converted into a self-treatment protocol.[3–9]
+
+### Is “150 mg zinc sulfate” the same as 150 mg of zinc on a supplement label?
+
+No. U.S. Supplement Facts panels report **elemental zinc**, not the total weight of the zinc-containing compound.[9] Zinc sulfate includes both zinc and sulfate, so the numbers are not interchangeable.
+
+### Can zinc cause copper deficiency?
+
+Yes. Sustained high zinc intake can inhibit copper absorption. NIH identifies this as a major long-term safety issue and one reason zinc has a tolerable upper intake level.[9,10]
+
+### Which form of zinc is best for ADHD?
+
+No zinc form has been proven superior specifically for ADHD. Formulation can affect tolerability and absorption, but the clinical ADHD evidence does not establish a uniquely effective picolinate, glycinate, citrate, sulfate, or gluconate product.[5,9]
 
 ## Conclusion
 
-Zinc has a real but limited role in ADHD. It matters most as a way to correct a deficiency that could be holding back dopamine signaling, sleep, and overall function — and possibly as an adjunct that supports the response to established treatment. It is not a stimulant substitute, and adding it when levels are already adequate offers little.
+Zinc belongs in an ADHD evidence guide—but in a more precise role than supplement marketing usually gives it.
 
-The most useful next step is testing rather than guessing. If zinc is low, correcting it is sensible and safe in the short term; if it is normal, attention is better spent on sleep, nutrition, medication fit, and the other supports that carry stronger evidence. For related nutrients, see [nutrient deficiencies and ADHD](/guides/adhd/nutrient-deficiencies-and-adhd/), [iron, ferritin, and ADHD](/guides/adhd/iron-ferritin-and-adhd/), and the evidence-graded overview in [best supplements for ADHD](/guides/adhd/best-supplements-for-adhd/).
+The 2026 evidence strengthens the association between pediatric ADHD and lower average zinc status. Randomized treatment evidence, however, remains inconsistent and population-dependent. Some trials report modest or domain-specific benefits, particularly as an adjunct to stimulant treatment, while others are equivocal. The pooled evidence does not show a reliable inattention or hyperactivity benefit.[1–8]
+
+The highest-value clinical idea is therefore **nutritional adequacy**, not zinc optimization beyond normal. Correct genuine inadequacy when it exists, interpret blood testing carefully, distinguish elemental zinc from zinc-salt weight, and avoid prolonged high-dose use that can create a second mineral deficiency.
+
+For related evidence, see [iron and ferritin in ADHD](/guides/adhd/iron-ferritin-and-adhd/), [nutrient deficiencies and ADHD](/guides/adhd/nutrient-deficiencies-and-adhd/), [ADHD blood tests](/guides/adhd/adhd-blood-tests/), and the [best supplements for ADHD](/guides/adhd/best-supplements-for-adhd/) overview.
+
+## Sources
+
+1. Essential Trace Elements Zinc, Iron, Copper and Attention-Deficit/Hyperactivity Disorder in Children and Adolescents: A Systematic Review and Meta-Analysis of Case-Control Studies. 2026. PMID 42280439. https://pubmed.ncbi.nlm.nih.gov/42280439/
+2. The effect of zinc supplementation in children with attention deficit hyperactivity disorder: A systematic review and dose-response meta-analysis of randomized clinical trials. 2021. PMID 34184967. DOI: 10.1080/10408398.2021.1940833. https://pubmed.ncbi.nlm.nih.gov/34184967/
+3. Bilici M, et al. Double-blind, placebo-controlled study of zinc sulfate in the treatment of attention deficit hyperactivity disorder. *Prog Neuropsychopharmacol Biol Psychiatry*. 2004;28(1):181-190. PMID 14687872. DOI: 10.1016/j.pnpbp.2003.09.034. https://pubmed.ncbi.nlm.nih.gov/14687872/
+4. Akhondzadeh S, Mohammadi MR, Khademi M. Zinc sulfate as an adjunct to methylphenidate for the treatment of attention deficit hyperactivity disorder in children: a double blind and randomized trial. *BMC Psychiatry*. 2004;4:9. PMID 15070418. DOI: 10.1186/1471-244X-4-9. https://pubmed.ncbi.nlm.nih.gov/15070418/
+5. Arnold LE, et al. Zinc for attention-deficit/hyperactivity disorder: placebo-controlled double-blind pilot trial alone and combined with amphetamine. *J Child Adolesc Psychopharmacol*. 2011. PMID 21309695. DOI: 10.1089/cap.2010.0073. https://pubmed.ncbi.nlm.nih.gov/21309695/
+6. Zinc in the therapy of attention-deficit/hyperactivity disorder in children: a preliminary randomized controlled trial. PMID 22696891. https://pubmed.ncbi.nlm.nih.gov/22696891/
+7. Noorazar SG, et al. The efficacy of zinc augmentation in children with attention deficit hyperactivity disorder under treatment with methylphenidate: A randomized controlled trial. *Asian J Psychiatr*. 2020;48:101868. PMID 31841818. DOI: 10.1016/j.ajp.2019.101868. https://pubmed.ncbi.nlm.nih.gov/31841818/
+8. Omega-3 and Zinc supplementation as complementary therapies in children with attention-deficit/hyperactivity disorder. 2016. PMID 26985432. https://pubmed.ncbi.nlm.nih.gov/26985432/
+9. NIH Office of Dietary Supplements. Zinc — Fact Sheet for Health Professionals. Accessed August 15, 2026. https://ods.od.nih.gov/factsheets/Zinc-HealthProfessional/
+10. NIH Office of Dietary Supplements. Copper — Fact Sheet for Health Professionals. Accessed August 15, 2026. https://ods.od.nih.gov/factsheets/Copper-HealthProfessional/
+11. FDA. Dietary Supplement Labeling Guide: Nutrition Labeling. https://www.fda.gov/food/dietary-supplements-guidance-documents-regulatory-information/dietary-supplement-labeling-guide-chapter-iv-nutrition-labeling
+12. National Center for Complementary and Integrative Health. ADHD and Complementary Health Approaches: What the Science Says. Accessed August 15, 2026. https://www.nccih.nih.gov/health/providers/digest/adhd-and-complementary-health-approaches-science


### PR DESCRIPTION
## Why
The zinc/ADHD page already ranks well, but it overstated the idea that a low zinc blood test identifies who will benefit and did not clearly separate zinc-salt milligrams from elemental zinc. Those are important evidence and safety gaps on a pediatric-facing supplement page.

## What changed
- adds the 2026 trace-element meta-analysis (46 studies; 5,515 ADHD cases + 8,166 controls)
- separates zinc-status association from treatment efficacy and from ADHD diagnosis
- adds a trial-by-trial human evidence ledger across monotherapy and stimulant-adjunct RCTs
- calibrates the 2021 RCT meta-analysis: borderline total-score signal, no significant pooled inattention/hyperactivity effect, moderate-to-very-low certainty
- corrects the prior overstatement that measured deficiency reliably predicts ADHD response
- explains serum/plasma zinc limitations using NIH ODS guidance
- adds a dedicated elemental-zinc vs zinc-salt translation section
- adds age-specific UL context without converting research doses into consumer instructions
- strengthens copper-depletion safety and removes automatic copper-supplement implications
- adds medication context for stimulants, antibiotics, penicillamine, and thiazide diuretics
- adds evidence-applicability and unanswered-question ledgers
- expands references to 12 primary/authoritative sources
- updates SEO metadata around the 2026 evidence and elemental-dose safety angle

## Safety calibration
No pediatric dosing protocol is provided. Trial exposures are reported as study context and explicitly distinguished from ordinary unsupervised supplementation.