### PR TITLE
fix(safety): keep visibility filtering fail-closed

### DIFF
--- a/app/safety-checker/page.tsx
+++ b/app/safety-checker/page.tsx
@@ -26,21 +26,13 @@ export const metadata: Metadata = buildPageMetadata({
 export default async function SafetyCheckerPage() {
   const [rawHerbs, rawCompounds] = await Promise.all([getHerbs(), getCompounds()])
 
-  const herbs: RuntimeRecord[] = rawHerbs.filter((h: RuntimeRecord) => {
-    try {
-      return getRuntimeVisibility(h).canRender
-    } catch {
-      return true
-    }
-  })
+  const herbs: RuntimeRecord[] = rawHerbs.filter(
+    (herb: RuntimeRecord) => getRuntimeVisibility(herb).canRender,
+  )
 
-  const compounds: RuntimeRecord[] = rawCompounds.filter((c: RuntimeRecord) => {
-    try {
-      return getRuntimeVisibility(c).canRender
-    } catch {
-      return true
-    }
-  })
+  const compounds: RuntimeRecord[] = rawCompounds.filter(
+    (compound: RuntimeRecord) => getRuntimeVisibility(compound).canRender,
+  )
 
   const schemaGraph = buildToolPageSchemaGraph({
     path: '/safety-checker',


### PR DESCRIPTION
## Root cause
`getRuntimeVisibility` already contains the canonical fail-closed governance behavior, but the safety checker wrapped each call in a local `try/catch` that returned `true` on error. That duplicated policy and encoded the opposite fallback in a high-stakes safety tool.

## Change
- Remove the two fail-open caller wrappers.
- Filter herb and compound records directly through the canonical `getRuntimeVisibility(...).canRender` result.

## Why this is safer
Malformed visibility evaluation is already covered by the central helper, which returns all visibility flags false. The safety checker now has one source of truth instead of a contradictory local fallback.

## Scope
One file. No route, schema, data, or rendering-model changes.