### PR TITLE
fix(herbs): align library with publication gate

### DIFF
--- a/app/herbs/library-data.ts
+++ b/app/herbs/library-data.ts
@@ -1,0 +1,28 @@
+import type { RuntimeRecord } from '../../src/types/content'
+
+import { getHerbSummaryIndex } from '../../src/lib/runtime-summary-indexes'
+import { getRuntimeVisibility } from '../../lib/runtime-visibility'
+import { formatDisplayLabel } from '@/lib/display-utils'
+import { isRedirectedDuplicate } from '@/lib/deprecated-herb-canonicals'
+
+export function getHerbName(herb: RuntimeRecord) {
+  return formatDisplayLabel(herb.displayName) || formatDisplayLabel(herb.name) || formatDisplayLabel(herb.slug)
+}
+
+export function selectPublishedHerbs(allHerbs: RuntimeRecord[]): RuntimeRecord[] {
+  const presentSlugs = new Set(allHerbs.map((herb) => String(herb.slug || '')))
+
+  return allHerbs
+    .filter(
+      (herb) =>
+        herb.slug &&
+        getRuntimeVisibility(herb).canIndex &&
+        !isRedirectedDuplicate(String(herb.slug), presentSlugs),
+    )
+    .sort((a, b) => getHerbName(a).localeCompare(getHerbName(b)))
+}
+
+export async function loadPublishedHerbs(): Promise<RuntimeRecord[]> {
+  const allHerbs = (await getHerbSummaryIndex()) as RuntimeRecord[]
+  return selectPublishedHerbs(allHerbs)
+}

--- a/app/herbs/page.tsx
+++ b/app/herbs/page.tsx
@@ -3,13 +3,10 @@ import type { RuntimeRecord } from '../../src/types/content'
 import Link from 'next/link'
 import { Suspense } from 'react'
 
-import { getHerbSummaryIndex } from '../../src/lib/runtime-summary-indexes'
-import { getRuntimeVisibility } from '../../lib/runtime-visibility'
 import { HERBS_PAGE_SIZE, paginateItems } from '@/lib/pagination'
 import { buildPageMetadata } from '../../src/lib/seo'
-import { formatDisplayLabel } from '@/lib/display-utils'
-import { isRedirectedDuplicate } from '@/lib/deprecated-herb-canonicals'
 import { toLeanProfileIndexRecords } from '@/lib/profile-index-records'
+import { getHerbName, loadPublishedHerbs } from './library-data'
 import HerbsIndexClient from './HerbsIndexClient'
 import Pagination from '@/components/Pagination'
 
@@ -21,10 +18,6 @@ export const metadata: Metadata = buildPageMetadata({
 })
 
 export const dynamic = 'force-static'
-
-function getHerbName(herb: RuntimeRecord) {
-  return formatDisplayLabel(herb.displayName) || formatDisplayLabel(herb.name) || formatDisplayLabel(herb.slug)
-}
 
 function HerbsLoadingSkeleton() {
   return (
@@ -43,16 +36,7 @@ function HerbsLoadingSkeleton() {
 }
 
 export default async function HerbsPage() {
-  const allHerbs = (await getHerbSummaryIndex()) as RuntimeRecord[]
-  const presentSlugs = new Set(allHerbs.map((herb) => String(herb.slug || '')))
-  const herbs = allHerbs
-    .filter(
-      (herb) =>
-        herb.slug &&
-        getRuntimeVisibility(herb).canRender &&
-        !isRedirectedDuplicate(String(herb.slug), presentSlugs),
-    )
-    .sort((a, b) => getHerbName(a).localeCompare(getHerbName(b)))
+  const herbs = await loadPublishedHerbs()
   const pageData = paginateItems(herbs, 1, HERBS_PAGE_SIZE)
   const leanHerbs = toLeanProfileIndexRecords(herbs)
   const leanPageItems = toLeanProfileIndexRecords(pageData.pageItems as RuntimeRecord[])

--- a/app/herbs/page/[page]/page.tsx
+++ b/app/herbs/page/[page]/page.tsx
@@ -1,28 +1,14 @@
 import type { Metadata } from 'next'
 import { Suspense } from 'react'
-import { getHerbSummaryIndex } from '../../../../src/lib/runtime-summary-indexes'
-import { getRuntimeVisibility } from '../../../../lib/runtime-visibility'
 import { HERBS_PAGE_SIZE, clampPositiveInt, paginateItems } from '@/lib/pagination'
-import { isRedirectedDuplicate } from '@/lib/deprecated-herb-canonicals'
 import { toLeanProfileIndexRecords } from '@/lib/profile-index-records'
+import { loadPublishedHerbs } from '../../library-data'
 import HerbsIndexClient from '../../HerbsIndexClient'
 import type { RuntimeRecord } from '../../../../src/types/content'
-import { formatDisplayLabel } from '@/lib/display-utils'
 import Pagination from '@/components/Pagination'
 
 type P={params:Promise<{page:string}>}
-async function loadBrowseHerbs(): Promise<RuntimeRecord[]> {
-  const all = (await getHerbSummaryIndex()) as RuntimeRecord[]
-  const present = new Set(all.map((h) => String(h.slug || '')))
-  return all
-    .filter((h) => h.slug && getRuntimeVisibility(h).canRender && !isRedirectedDuplicate(String(h.slug), present))
-    .sort((a, b) => {
-      const aName = formatDisplayLabel(a.displayName) || formatDisplayLabel(a.name) || formatDisplayLabel(a.slug)
-      const bName = formatDisplayLabel(b.displayName) || formatDisplayLabel(b.name) || formatDisplayLabel(b.slug)
-      return aName.localeCompare(bName)
-    })
-}
-export async function generateStaticParams(){ const herbs=await loadBrowseHerbs(); const total=Math.max(1,Math.ceil(herbs.length/HERBS_PAGE_SIZE)); return Array.from({length:Math.max(total-1,0)},(_,i)=>({page:String(i+2)})) }
+export async function generateStaticParams(){ const herbs=await loadPublishedHerbs(); const total=Math.max(1,Math.ceil(herbs.length/HERBS_PAGE_SIZE)); return Array.from({length:Math.max(total-1,0)},(_,i)=>({page:String(i+2)})) }
 export async function generateMetadata({ params }: P): Promise<Metadata> {
   const n = clampPositiveInt((await params).page, 2)
 
@@ -45,7 +31,7 @@ function HerbsPageSkeleton() {
 
 export default async function HerbsPageN({params}:P){
   const n=clampPositiveInt((await params).page,2);
-  const herbs=await loadBrowseHerbs();
+  const herbs=await loadPublishedHerbs();
   const p=paginateItems(herbs,n,HERBS_PAGE_SIZE);
   const leanHerbs = toLeanProfileIndexRecords(herbs)
   const leanPageItems = toLeanProfileIndexRecords(p.pageItems as RuntimeRecord[])

--- a/tests/herbs-metadata-count.test.ts
+++ b/tests/herbs-metadata-count.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { selectPublishedHerbs } from '../app/herbs/library-data'
 
 function read(relativePath: string) {
   return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
@@ -14,5 +15,26 @@ describe('herbs metadata inventory semantics', () => {
     expect(page).toContain('Browse published herb profiles')
     expect(page).toContain('for {herbs.length} herbs')
     expect(page).not.toContain('buildReport.counts.herbs')
+  })
+
+  it('selects only canonical published herbs and sorts them for the library', () => {
+    const herbs = selectPublishedHerbs([
+      { slug: 'z-published', displayName: 'Zed', indexability_status: 'PUBLISH' },
+      { slug: 'noindex', displayName: 'Noindex', indexability_status: 'NOINDEX' },
+      { slug: 'hidden', displayName: 'Hidden', indexability_status: 'PUBLISH', runtime_export_decision: 'hide' },
+      { slug: 'garlic', displayName: 'Garlic', indexability_status: 'PUBLISH' },
+      { slug: 'allium-sativum', displayName: 'Allium sativum', indexability_status: 'PUBLISH' },
+      { slug: 'a-published', displayName: 'Alpha', indexability_status: 'PUBLISH' },
+    ])
+
+    expect(herbs.map((herb) => herb.slug)).toEqual(['a-published', 'garlic', 'z-published'])
+  })
+
+  it('uses the canonical published-herb loader on every library page', () => {
+    const firstPage = read('app/herbs/page.tsx')
+    const paginatedPage = read('app/herbs/page/[page]/page.tsx')
+
+    expect(firstPage).toContain('loadPublishedHerbs')
+    expect(paginatedPage).toContain('loadPublishedHerbs')
   })
 })


### PR DESCRIPTION
Superseded by the equivalent herb publication-gate implementation that landed on `main` as commit `10c2f6d88492d0da8ed689847df6e410a387f216`. Closing to avoid duplicating the same canonical loader, publication filter, and regression coverage.