### PR TITLE
refactor(evidence): establish canonical evidence-grade contract

### DIFF
--- a/components/education/EvidenceGradeRationale.tsx
+++ b/components/education/EvidenceGradeRationale.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { normalizeEvidenceGrade } from '@/lib/evidence-grade'
 
 export interface EvidenceGradeRationaleProps {
-  grade: 'A' | 'B' | 'C' | 'D' | 'F' | string
+  grade: 'A' | 'B' | 'C' | 'D' | 'Avoid/Insufficient' | string
   designMatch: string
   riskOfBias: 'Low' | 'Medium' | 'High' | string
   consistency: 'Consistent' | 'Mixed' | 'Inconsistent' | string
@@ -17,49 +17,55 @@ export default function EvidenceGradeRationale({
   consistency,
   children,
 }: EvidenceGradeRationaleProps) {
-  const gradeConfig: Record<string, { bg: string; text: string; border: string; label: string }> = {
+  const gradeConfig: Record<string, { bg: string; text: string; border: string; label: string; badge: string }> = {
     A: {
       bg: 'bg-emerald-50 dark:bg-emerald-300/10',
       text: 'text-emerald-800 dark:text-emerald-100',
       border: 'border-emerald-200 dark:border-emerald-200/20',
       label: 'Grade A: Strong Evidence',
+      badge: 'A',
     },
     B: {
       bg: 'bg-blue-50 dark:bg-blue-300/10',
       text: 'text-blue-800 dark:text-blue-100',
       border: 'border-blue-200 dark:border-blue-200/20',
       label: 'Grade B: Moderate Evidence',
+      badge: 'B',
     },
     C: {
       bg: 'bg-amber-50 dark:bg-amber-300/10',
       text: 'text-amber-800 dark:text-amber-100',
       border: 'border-amber-200 dark:border-amber-200/20',
       label: 'Grade C: Limited Evidence',
+      badge: 'C',
     },
     D: {
       bg: 'bg-slate-50 dark:bg-slate-300/10',
       text: 'text-slate-700 dark:text-slate-100',
       border: 'border-slate-200 dark:border-slate-200/20',
-      label: 'Grade D: Theoretical Evidence',
+      label: 'Grade D: Preliminary / Theoretical Evidence',
+      badge: 'D',
     },
-    F: {
+    'Avoid/Insufficient': {
       bg: 'bg-rose-50 dark:bg-rose-300/10',
       text: 'text-rose-800 dark:text-rose-100',
       border: 'border-rose-200 dark:border-rose-200/20',
-      label: 'Grade F: Insufficient or Contraindicated',
+      label: 'Avoid / Insufficient Evidence',
+      badge: '!',
     },
   }
 
-  // `evidence_grade` is free text in the workbook, so normalize before styling:
-  // a bare lowercase "c" must still read as Grade C, and a phrase like
-  // "B for PCOS; D for core goals" must never be painted inside the badge.
+  // `evidence_grade` is legacy free text at the ingestion boundary. Normalize
+  // before styling so lower-case/modifier values cannot create a second visual
+  // grade vocabulary and F migrates to Avoid/Insufficient.
   const normalized = normalizeEvidenceGrade(grade)
-  const badgeLetter = normalized.letter
-  const config = (badgeLetter && gradeConfig[badgeLetter]) || {
+  const canonicalGrade = normalized.grade
+  const config = (canonicalGrade && gradeConfig[canonicalGrade]) || {
     bg: 'bg-slate-50 dark:bg-slate-300/10',
     text: 'text-slate-700 dark:text-slate-100',
     border: 'border-slate-200 dark:border-slate-200/20',
     label: normalized.label,
+    badge: '–',
   }
 
   const biasColors: Record<string, string> = {
@@ -75,7 +81,7 @@ export default function EvidenceGradeRationale({
     Inconsistent: 'text-rose-700 font-semibold dark:text-rose-100',
   }
   const consistencyColor = consistencyColors[consistency] || 'font-semibold text-muted'
-  const headingId = `evidence-grade-${(badgeLetter ?? 'unassigned').toLowerCase()}`
+  const headingId = `evidence-grade-${(canonicalGrade ?? 'unassigned').toLowerCase().replace(/[^a-z0-9]+/g, '-')}`
 
   return (
     <section
@@ -84,14 +90,11 @@ export default function EvidenceGradeRationale({
     >
       <div className="grid items-start gap-5 md:grid-cols-[120px_1fr] md:gap-6">
         <div className="flex flex-row items-center gap-3 text-left md:flex-col md:justify-center md:text-center">
-          {/* Only a single canonical letter belongs in the badge. When the
-              source value cannot be reduced to one, show a neutral mark and let
-              the heading carry the real wording. */}
           <div
             className={`flex h-16 w-16 shrink-0 items-center justify-center rounded-full border-2 font-display text-2xl font-bold shadow-inner md:h-20 md:w-20 md:text-3xl ${config.bg} ${config.text} ${config.border}`}
             aria-hidden="true"
           >
-            {badgeLetter ?? '–'}
+            {config.badge}
           </div>
           <span className="block text-[0.65rem] font-bold uppercase tracking-wider text-muted md:mt-2">
             Evidence Grade

--- a/components/ui/EvidenceScoreBadge.tsx
+++ b/components/ui/EvidenceScoreBadge.tsx
@@ -2,6 +2,7 @@ import { getEvidenceLetterGrade, type EvidenceLetterGrade } from '@/lib/evidence
 import type { RuntimeRecord } from '@/src/types/content'
 
 const GRADE_CONFIG: Record<EvidenceLetterGrade, {
+  badge: string
   label: string
   meaning: string
   bg: string
@@ -11,6 +12,7 @@ const GRADE_CONFIG: Record<EvidenceLetterGrade, {
   solid: string
 }> = {
   A: {
+    badge: 'A',
     label: 'A',
     meaning: 'Strong Evidence — Multiple RCTs, consistent direction, adequate effect size',
     bg: 'bg-[var(--color-evidence-strong)]/10',
@@ -20,6 +22,7 @@ const GRADE_CONFIG: Record<EvidenceLetterGrade, {
     solid: 'bg-[var(--color-evidence-strong)]',
   },
   B: {
+    badge: 'B',
     label: 'B',
     meaning: 'Moderate Evidence — Some RCTs or consistent observational data',
     bg: 'bg-[var(--color-evidence-moderate)]/10',
@@ -29,8 +32,9 @@ const GRADE_CONFIG: Record<EvidenceLetterGrade, {
     solid: 'bg-[var(--color-evidence-moderate)]',
   },
   C: {
+    badge: 'C',
     label: 'C',
-    meaning: 'Preliminary / Mixed — Animal/in-vitro only, or inconsistent human data',
+    meaning: 'Limited Evidence — Early or mixed human evidence; stronger confirmation is needed',
     bg: 'bg-[var(--color-evidence-limited)]/10',
     text: 'text-[var(--color-evidence-limited)]',
     border: 'border-[var(--color-evidence-limited)]/20',
@@ -38,21 +42,33 @@ const GRADE_CONFIG: Record<EvidenceLetterGrade, {
     solid: 'bg-[var(--color-evidence-limited)]',
   },
   D: {
+    badge: 'D',
     label: 'D',
-    meaning: 'Traditional / Theoretical — Traditional use only; no human trials',
+    meaning: 'Preliminary / Theoretical — Mechanistic, preclinical, or traditional evidence without adequate clinical confirmation',
     bg: 'bg-[var(--color-evidence-theoretical)]/10',
     text: 'text-[var(--color-evidence-theoretical)]',
     border: 'border-[var(--color-evidence-theoretical)]/20',
     ringColor: 'ring-[var(--color-evidence-theoretical)]/20',
     solid: 'bg-[var(--color-evidence-theoretical)]',
   },
+  'Avoid/Insufficient': {
+    badge: '!',
+    label: 'Avoid / Insufficient',
+    meaning: 'Avoid / Insufficient — Evidence is inadequate for a positive grade, or the record is explicitly flagged to avoid',
+    bg: 'bg-rose-50 dark:bg-rose-300/10',
+    text: 'text-rose-800 dark:text-rose-100',
+    border: 'border-rose-200 dark:border-rose-200/20',
+    ringColor: 'ring-rose-200/40',
+    solid: 'bg-rose-700',
+  },
 }
 
 const GRADE_MEANING_SHORT: Record<EvidenceLetterGrade, string> = {
   A: 'Strong',
   B: 'Moderate',
-  C: 'Preliminary',
-  D: 'Traditional',
+  C: 'Limited',
+  D: 'Preliminary',
+  'Avoid/Insufficient': 'Avoid / Insufficient',
 }
 
 // Dark-mode-aware text color for the circle variant's label — the static
@@ -63,6 +79,7 @@ const GRADE_TEXT_ADAPTIVE: Record<EvidenceLetterGrade, string> = {
   B: 'text-blue-800 dark:text-blue-100',
   C: 'text-amber-800 dark:text-amber-100',
   D: 'text-stone-700 dark:text-stone-200',
+  'Avoid/Insufficient': 'text-rose-800 dark:text-rose-100',
 }
 
 type EvidenceScoreBadgeProps = {
@@ -80,8 +97,8 @@ export default function EvidenceScoreBadge({
   showLabel = true,
   className = '',
 }: EvidenceScoreBadgeProps) {
-  const letterGrade = grade ?? (record ? getEvidenceLetterGrade(record as RuntimeRecord) : 'C')
-  const config = GRADE_CONFIG[letterGrade]
+  const canonicalGrade = grade ?? (record ? getEvidenceLetterGrade(record as RuntimeRecord) : 'C')
+  const config = GRADE_CONFIG[canonicalGrade]
 
   if (size === 'circle') {
     return (
@@ -93,11 +110,11 @@ export default function EvidenceScoreBadge({
           aria-hidden="true"
           className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-sm font-bold text-white shadow-sm ${config.solid}`}
         >
-          {letterGrade}
+          {config.badge}
         </span>
         {showLabel && (
-          <span aria-label={`Evidence grade ${letterGrade}: ${config.meaning}`} className={`text-sm font-semibold ${GRADE_TEXT_ADAPTIVE[letterGrade]}`}>
-            {GRADE_MEANING_SHORT[letterGrade]}
+          <span aria-label={`Evidence grade ${canonicalGrade}: ${config.meaning}`} className={`text-sm font-semibold ${GRADE_TEXT_ADAPTIVE[canonicalGrade]}`}>
+            {GRADE_MEANING_SHORT[canonicalGrade]}
           </span>
         )}
       </span>
@@ -112,14 +129,14 @@ export default function EvidenceScoreBadge({
   return (
     <span
       title={config.meaning}
-      aria-label={`Evidence grade ${letterGrade}: ${config.meaning}`}
+      aria-label={`Evidence grade ${canonicalGrade}: ${config.meaning}`}
       className={`inline-flex items-center rounded-full border font-bold tracking-wide ${config.bg} ${config.text} ${config.border} ${sizeClasses} ${className}`}
     >
-      <span className={size === 'sm' ? 'text-[0.8rem]' : 'text-sm'}>{letterGrade}</span>
-      {showLabel && (
+      <span className={size === 'sm' ? 'text-[0.8rem]' : 'text-sm'}>{config.label}</span>
+      {showLabel && canonicalGrade !== 'Avoid/Insufficient' && (
         <span className="font-semibold">
           {' '}
-          {GRADE_MEANING_SHORT[letterGrade]}
+          {GRADE_MEANING_SHORT[canonicalGrade]}
         </span>
       )}
     </span>

--- a/lib/evidence-grade.ts
+++ b/lib/evidence-grade.ts
@@ -1,49 +1,37 @@
 /**
- * evidence-grade.ts
+ * Canonical evidence-grade contract.
  *
- * `evidence_grade` in the workbook is free text. Across the current corpus it
- * holds well over a hundred distinct values — `"a"`, `"C+"`, `"moderate-high"`,
- * `"Strong drug evidence"`, `"B for PCOS; D for core goals"` — because it has
- * been filled by different passes with different conventions.
+ * The workbook historically accepted free-text values such as `a`, `B+`,
+ * `moderate-high`, `Strong drug evidence`, and `F`. Those legacy values are
+ * still accepted at the ingestion boundary, but they must collapse into one
+ * canonical public/data contract:
  *
- * Templates previously passed that raw string straight into the grade badge,
- * which produced three separate defects:
+ *   A | B | C | D | Avoid/Insufficient
  *
- *   1. lowercase `"c"` never matched the `C` styling key, so most herb profiles
- *      rendered a generic "Grade c" instead of "Grade C: Limited Evidence";
- *   2. multi-word values were painted verbatim inside a 64px circular badge;
- *   3. a missing grade defaulted to `'C'`, asserting a specific evidence grade
- *      the data never supported.
- *
- * This module is the single normalization boundary. It maps any raw value to a
- * canonical letter when one is genuinely implied, and returns `null` when it is
- * not — callers must render the absence rather than invent a grade.
- *
- * `evidence_tier` ("Strong / Moderate / Limited / Mechanistic Human Evidence")
- * is already a clean taxonomy and remains the preferred signal; this exists to
- * stop the messier field from contradicting it on screen.
+ * Unknown or outcome-dependent values intentionally normalize to `null`; a
+ * caller must not invent a grade when the source does not support one.
  */
 
-export type EvidenceLetter = 'A' | 'B' | 'C' | 'D' | 'F'
+export const CANONICAL_EVIDENCE_GRADES = ['A', 'B', 'C', 'D', 'Avoid/Insufficient'] as const
 
+export type CanonicalEvidenceGrade = (typeof CANONICAL_EVIDENCE_GRADES)[number]
+export type EvidenceLetter = Exclude<CanonicalEvidenceGrade, 'Avoid/Insufficient'>
 export type EvidenceBand = 'strong' | 'moderate' | 'limited' | 'preliminary' | 'insufficient'
 
 export type NormalizedEvidenceGrade = {
-  /** Canonical letter, or null when the raw value does not imply one. */
+  /** Canonical grade, or null when no honest single grade can be assigned. */
+  grade: CanonicalEvidenceGrade | null
+  /** Single-letter badge value. Avoid/Insufficient intentionally has no letter. */
   letter: EvidenceLetter | null
-  /** Coarse band, usable even when no letter can be assigned. */
+  /** Coarse semantic band used for comparisons and presentation. */
   band: EvidenceBand | null
   /** Human-readable label for display. */
   label: string
-  /** The original value, preserved for tooltips and audit trails. */
+  /** Original source value preserved for audit/migration reporting. */
   raw: string
-  /** True when the raw value was already a clean letter grade. */
+  /** True only when the source already equals one canonical enum value. */
   canonical: boolean
-  /**
-   * True when the raw value describes different grades for different outcomes
-   * (e.g. "B for PCOS; D for core goals"). A single badge cannot represent
-   * these honestly, so callers should show the text rather than a letter.
-   */
+  /** True when the source grades different outcomes differently. */
   outcomeDependent: boolean
 }
 
@@ -55,74 +43,63 @@ const BAND_LABEL: Record<EvidenceBand, string> = {
   insufficient: 'Insufficient evidence',
 }
 
-const LETTER_FOR_BAND: Record<EvidenceBand, EvidenceLetter> = {
+export const CANONICAL_GRADE_LABEL: Record<CanonicalEvidenceGrade, string> = {
+  A: 'Grade A: Strong Evidence',
+  B: 'Grade B: Moderate Evidence',
+  C: 'Grade C: Limited Evidence',
+  D: 'Grade D: Preliminary / Theoretical Evidence',
+  'Avoid/Insufficient': 'Avoid / Insufficient Evidence',
+}
+
+/** Compatibility export for components that render only letter-grade badges. */
+export const LETTER_LABEL: Record<EvidenceLetter, string> = {
+  A: CANONICAL_GRADE_LABEL.A,
+  B: CANONICAL_GRADE_LABEL.B,
+  C: CANONICAL_GRADE_LABEL.C,
+  D: CANONICAL_GRADE_LABEL.D,
+}
+
+const GRADE_FOR_BAND: Record<EvidenceBand, CanonicalEvidenceGrade> = {
   strong: 'A',
   moderate: 'B',
   limited: 'C',
   preliminary: 'D',
-  insufficient: 'F',
+  insufficient: 'Avoid/Insufficient',
 }
 
-export const LETTER_LABEL: Record<EvidenceLetter, string> = {
-  A: 'Grade A: Strong Evidence',
-  B: 'Grade B: Moderate Evidence',
-  C: 'Grade C: Limited Evidence',
-  D: 'Grade D: Theoretical Evidence',
-  F: 'Grade F: Insufficient or Contraindicated',
+const BAND_FOR_GRADE: Record<CanonicalEvidenceGrade, EvidenceBand> = {
+  A: 'strong',
+  B: 'moderate',
+  C: 'limited',
+  D: 'preliminary',
+  'Avoid/Insufficient': 'insufficient',
 }
 
-/** A bare letter grade, optionally with a +/- modifier. */
-const BARE_LETTER_RE = /^([a-df])\s*[+-]?$/i
+/** A bare legacy letter grade, optionally with a +/- modifier. */
+const BARE_LETTER_RE = /^([a-d])\s*[+-]?$/i
+const LEGACY_FAIL_RE = /^f\s*[+-]?$/i
 
 /**
- * Values that grade different outcomes differently. Detected before anything
- * else, because picking one letter out of them would misrepresent the record.
+ * Values that grade different outcomes differently. Picking one grade from
+ * these would misrepresent the record, so they remain explicitly unassigned.
  */
 const OUTCOME_DEPENDENT_RE = /\b[a-df]\s*[+-]?\s+for\s+\w+.*;\s*[a-df]\s*[+-]?\s+for\s+/i
 
 /**
- * Phrase-level mappings, ordered most specific first.
- *
- * Hedged compounds round *down*, never up: "moderate-high" lands on `moderate`
- * and "limited-to-moderate" on `moderate` only because "moderate" is its weaker
- * ceiling. Overstating how strong the evidence is would be the costlier error
- * on health content, so ambiguity always resolves toward the weaker claim.
- *
- * Deliberately absent: "not applicable". A grade that does not apply — a blend,
- * a stack, a non-gradeable entity — is not the same as insufficient evidence,
- * so it falls through to an unassigned grade rather than being shown as "F".
+ * Legacy phrase mappings, ordered from strongest/specific to weakest. Ambiguous
+ * language resolves conservatively; explicit insufficiency/avoidance is never
+ * collapsed into D because the canonical model reserves its own state for it.
  */
 const PHRASE_BANDS: [RegExp, EvidenceBand][] = [
   [/\b(moderate[- ]to[- ]strong|strong|robust|high[- ]quality|well[- ]established)\b/i, 'strong'],
   [/\b(limited[- ]to[- ]moderate|moderate)\b/i, 'moderate'],
   [/\b(mixed|inconsistent|limited|low[- ]moderate|emerging)\b/i, 'limited'],
-  [/\b(preliminary|pilot|early|weak|mechanistic|theoretical|low)\b/i, 'preliminary'],
-  [/\b(insufficient|no human|none|avoid|blocked)\b/i, 'insufficient'],
+  [/\b(preliminary|pilot|early|weak|mechanistic|theoretical|preclinical|no human|low)\b/i, 'preliminary'],
+  [/\b(insufficient|no evidence|none|avoid|blocked|contraindicated)\b/i, 'insufficient'],
 ]
 
-function bandFromPhrase(value: string): EvidenceBand | null {
-  for (const [pattern, band] of PHRASE_BANDS) {
-    if (pattern.test(value)) return band
-  }
-  return null
-}
-
-function bandFromLetter(letter: EvidenceLetter): EvidenceBand {
-  switch (letter) {
-    case 'A':
-      return 'strong'
-    case 'B':
-      return 'moderate'
-    case 'C':
-      return 'limited'
-    case 'D':
-      return 'preliminary'
-    default:
-      return 'insufficient'
-  }
-}
-
 const EMPTY: NormalizedEvidenceGrade = {
+  grade: null,
   letter: null,
   band: null,
   label: 'Evidence grade not assigned',
@@ -131,71 +108,126 @@ const EMPTY: NormalizedEvidenceGrade = {
   outcomeDependent: false,
 }
 
+export function isCanonicalEvidenceGrade(value: unknown): value is CanonicalEvidenceGrade {
+  return CANONICAL_EVIDENCE_GRADES.includes(value as CanonicalEvidenceGrade)
+}
+
+export function bandFromCanonicalGrade(grade: CanonicalEvidenceGrade): EvidenceBand {
+  return BAND_FOR_GRADE[grade]
+}
+
+function bandFromPhrase(value: string): EvidenceBand | null {
+  for (const [pattern, band] of PHRASE_BANDS) {
+    if (pattern.test(value)) return band
+  }
+  return null
+}
+
+function normalizedFromGrade(
+  grade: CanonicalEvidenceGrade,
+  raw: string,
+  canonical: boolean,
+  sourceLabel?: string,
+): NormalizedEvidenceGrade {
+  const label = sourceLabel && sourceLabel !== grade
+    ? `${CANONICAL_GRADE_LABEL[grade]} — ${sourceLabel}`
+    : CANONICAL_GRADE_LABEL[grade]
+
+  return {
+    grade,
+    letter: grade === 'Avoid/Insufficient' ? null : grade,
+    band: BAND_FOR_GRADE[grade],
+    label,
+    raw,
+    canonical,
+    outcomeDependent: false,
+  }
+}
+
 /**
- * Normalize any raw `evidence_grade` value.
+ * Normalize any raw evidence-grade value to the canonical enum.
  *
- * Never invents a grade: an unrecognized or empty value yields `letter: null`,
- * and the caller is expected to render that absence rather than a default.
+ * Legacy values are accepted only at this boundary so migration and rendering
+ * can share one deterministic interpretation. Unrecognized values return null.
  */
 export function normalizeEvidenceGrade(raw: unknown): NormalizedEvidenceGrade {
   const value = String(raw ?? '').trim()
   if (!value) return EMPTY
 
   if (OUTCOME_DEPENDENT_RE.test(value)) {
-    return { letter: null, band: null, label: value, raw: value, canonical: false, outcomeDependent: true }
+    return {
+      grade: null,
+      letter: null,
+      band: null,
+      label: value,
+      raw: value,
+      canonical: false,
+      outcomeDependent: true,
+    }
+  }
+
+  if (isCanonicalEvidenceGrade(value)) {
+    return normalizedFromGrade(value, value, true)
+  }
+
+  if (/^avoid\s*\/\s*insufficient$/i.test(value)) {
+    return normalizedFromGrade('Avoid/Insufficient', value, false)
   }
 
   const bare = BARE_LETTER_RE.exec(value)
   if (bare) {
-    const letter = bare[1].toUpperCase() as EvidenceLetter
-    return {
-      letter,
-      band: bandFromLetter(letter),
-      label: LETTER_LABEL[letter],
-      raw: value,
-      canonical: true,
-      outcomeDependent: false,
-    }
+    const grade = bare[1].toUpperCase() as EvidenceLetter
+    return normalizedFromGrade(grade, value, false)
+  }
+
+  // F was a legacy pseudo-grade. Preserve the meaning while removing F from
+  // the canonical model entirely.
+  if (LEGACY_FAIL_RE.test(value)) {
+    return normalizedFromGrade('Avoid/Insufficient', value, false)
   }
 
   const band = bandFromPhrase(value)
   if (band) {
-    const letter = LETTER_FOR_BAND[band]
-    return {
-      letter,
-      band,
-      // Keep the source wording visible — "Strong drug evidence" says more than
-      // "Grade A", and flattening it would lose the qualifier.
-      label: `${LETTER_LABEL[letter]} — ${value}`,
-      raw: value,
-      canonical: false,
-      outcomeDependent: false,
-    }
+    const grade = GRADE_FOR_BAND[band]
+    return normalizedFromGrade(grade, value, false, value)
   }
 
   return { ...EMPTY, raw: value, label: value }
 }
 
 /**
- * Map a clean `evidence_tier` value ("Strong Human Evidence", "Mechanistic
- * Evidence", …) onto the same band scale, so the two fields can be compared.
+ * Map a legacy evidence-tier phrase onto the canonical grade contract. This is
+ * an adapter for older records; new persisted grade fields should already be
+ * canonical rather than storing these presentation labels.
  */
-export function bandFromEvidenceTier(tier: unknown): EvidenceBand | null {
-  const value = String(tier ?? '').toLowerCase()
+export function canonicalGradeFromEvidenceTier(tier: unknown): CanonicalEvidenceGrade | null {
+  const value = String(tier ?? '').toLowerCase().trim()
   if (!value) return null
-  if (value.includes('strong')) return 'strong'
-  if (value.includes('moderate')) return 'moderate'
-  if (value.includes('limited') || value.includes('early') || value.includes('contextual')) return 'limited'
-  if (value.includes('mechanistic') || value.includes('preclinical')) return 'preliminary'
+  if (/\b(insufficient|no evidence|none|avoid|blocked|contraindicat)/.test(value)) return 'Avoid/Insufficient'
+  if (value.includes('strong')) return 'A'
+  if (value.includes('moderate')) return 'B'
+  if (value.includes('limited') || value.includes('contextual') || value.includes('mixed')) return 'C'
+  if (
+    value.includes('mechanistic') ||
+    value.includes('preclinical') ||
+    value.includes('preliminary') ||
+    value.includes('traditional') ||
+    value.includes('theoretical') ||
+    value.includes('early')
+  ) {
+    return 'D'
+  }
   return null
+}
+
+export function bandFromEvidenceTier(tier: unknown): EvidenceBand | null {
+  const grade = canonicalGradeFromEvidenceTier(tier)
+  return grade ? BAND_FOR_GRADE[grade] : null
 }
 
 const BAND_ORDER: EvidenceBand[] = ['insufficient', 'preliminary', 'limited', 'moderate', 'strong']
 
-/**
- * How far apart the grade and tier fields sit, in bands. Two or more is a
- * contradiction a reader can see: the badge and the tier label disagree.
- */
+/** How far apart two evidence signals sit, in semantic bands. */
 export function gradeTierDistance(gradeBand: EvidenceBand | null, tierBand: EvidenceBand | null): number | null {
   if (!gradeBand || !tierBand) return null
   return Math.abs(BAND_ORDER.indexOf(gradeBand) - BAND_ORDER.indexOf(tierBand))

--- a/lib/evidence-strength.ts
+++ b/lib/evidence-strength.ts
@@ -4,6 +4,7 @@ import {
   getEvidenceLetterGrade,
   hasHumanEvidence,
   hasMechanismEvidence,
+  type EvidenceLetterGrade,
 } from './evidence'
 
 export type EvidenceStrengthTier =
@@ -22,7 +23,7 @@ export type EvidenceStrengthData = {
   tier: EvidenceStrengthTier
   /** Human-readable label e.g. "Strong Human Evidence" */
   label: string
-  grade: 'A' | 'B' | 'C' | 'D'
+  grade: EvidenceLetterGrade
   humanEvidence: boolean
   mechanismEvidence: boolean
   /** One-line confidence explanation shown in expanded detail */

--- a/lib/evidence.ts
+++ b/lib/evidence.ts
@@ -1,4 +1,9 @@
 import type { RuntimeRecord } from '../src/types/content'
+import {
+  canonicalGradeFromEvidenceTier,
+  normalizeEvidenceGrade,
+  type CanonicalEvidenceGrade,
+} from './evidence-grade'
 
 type EvidenceTier = 'strong' | 'moderate' | 'limited' | 'preliminary' | 'traditional' | 'mixed' | 'insufficient' | 'review'
 
@@ -134,64 +139,39 @@ export function getEvidenceColor(record: RuntimeRecord): EvidenceColor {
   return colors[getEvidenceTier(record)]
 }
 
-export type EvidenceLetterGrade = 'A' | 'B' | 'C' | 'D'
+/**
+ * Compatibility name retained for UI callers. The value now comes from the
+ * single canonical evidence-grade contract and may be Avoid/Insufficient.
+ */
+export type EvidenceLetterGrade = CanonicalEvidenceGrade
 
-function rawGradeToLetter(raw: string): EvidenceLetterGrade | null {
-  const n = raw.toLowerCase().trim()
-  if (/^a[+-]?$/.test(n)) return 'A'
-  if (/^b[+-]?$/.test(n)) return 'B'
-  if (/^c[+-]?$/.test(n)) return 'C'
-  if (/^d[+-]?$|insufficient/.test(n)) return 'D'
-  // Handle text labels like "high", "moderate-high", "moderate", "low-moderate", "low"
-  if (/^(high|strong|robust)$/.test(n)) return 'A'
-  if (/^(moderate-high|moderate high)$/.test(n)) return 'B'
-  if (/^(moderate)$/.test(n)) return 'B'
-  if (/^(low-moderate|low moderate|limited)$/.test(n)) return 'C'
-  if (/^(low|minimal|none|preliminary)$/.test(n)) return 'C'
-  return null
-}
-
-function tierTextToLetter(tier: string): EvidenceLetterGrade | null {
-  const n = tier.toLowerCase()
-  if (/strong/.test(n)) return 'A'
-  if (/moderate/.test(n)) return 'B'
-  if (/limited|mechanistic|preliminary|mixed/.test(n)) return 'C'
-  if (/traditional|insufficient|theoretical/.test(n)) return 'D'
-  return null
-}
-
+/**
+ * Resolve a record to the canonical evidence-grade enum.
+ *
+ * Explicit grade data wins, but all legacy parsing is delegated to
+ * `normalizeEvidenceGrade` so this file cannot drift into a second grading
+ * system. Legacy evidence-tier text is only a fallback adapter.
+ */
 export function getEvidenceLetterGrade(record: RuntimeRecord): EvidenceLetterGrade {
-  // Letter grades are unambiguous — prefer them first
-  const rawGrade = record?.evidence_grade
-  if (rawGrade && typeof rawGrade === 'string') {
-    const n = rawGrade.toLowerCase().trim()
-    if (/^[abcd][+-]?$/.test(n)) return rawGradeToLetter(rawGrade) ?? 'C'
-  }
+  const normalized = normalizeEvidenceGrade(record?.evidence_grade)
+  if (normalized.grade && !normalized.outcomeDependent) return normalized.grade
 
-  // evidence_tier uses a consistent vocabulary across all records
   const evidenceTierField = record?.evidence_tier || record?.evidenceTier
-  if (evidenceTierField && typeof evidenceTierField === 'string') {
-    const letter = tierTextToLetter(evidenceTierField)
-    if (letter) return letter
-  }
-
-  // Fall back to text-label grade (e.g. "high", "moderate-high")
-  if (rawGrade && typeof rawGrade === 'string') {
-    const letter = rawGradeToLetter(rawGrade)
-    if (letter) return letter
-  }
+  const gradeFromTier = canonicalGradeFromEvidenceTier(evidenceTierField)
+  if (gradeFromTier) return gradeFromTier
 
   const tierMap: Record<EvidenceTier, EvidenceLetterGrade> = {
     strong: 'A',
     moderate: 'B',
     limited: 'C',
-    preliminary: 'C',
     mixed: 'C',
+    preliminary: 'D',
     traditional: 'D',
-    insufficient: 'D',
-    review: 'D',
+    insufficient: 'Avoid/Insufficient',
+    review: 'Avoid/Insufficient',
   }
-  return tierMap[getEvidenceTier(record)] ?? 'C'
+
+  return tierMap[getEvidenceTier(record)]
 }
 
 export function hasStrongSafetyProfile(record: RuntimeRecord): boolean {

--- a/scripts/ci/validate-evidence-grade-consistency.ts
+++ b/scripts/ci/validate-evidence-grade-consistency.ts
@@ -1,37 +1,12 @@
-/**
- * validate-evidence-grade-consistency.ts
- *
- * Every profile carries two evidence signals:
- *
- *   evidence_tier   a clean taxonomy — "Strong / Moderate / Limited /
- *                   Mechanistic Human Evidence" — used for badges and filters
- *   evidence_grade  free text filled by several enrichment passes, rendered as
- *                   the letter grade in the evidence-rationale card
- *
- * When they disagree, one page shows a reader two different verdicts about the
- * same ingredient. For an evidence-first site that is a credibility defect, not
- * a cosmetic one.
- *
- * This reports:
- *   - contradictions, ranked by how far apart the two fields sit
- *   - grades that cannot be reduced to a single letter at all
- *   - grades that describe different outcomes differently
- *
- * Run with tsx so it shares the exact normalizer the templates use, rather than
- * a second copy that can drift:
- *   npx tsx scripts/ci/validate-evidence-grade-consistency.ts
- *   npx tsx scripts/ci/validate-evidence-grade-consistency.ts --strict
- *
- * Output: ops/reports/evidence-grade-consistency.json
- */
-
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 
 import {
+  CANONICAL_EVIDENCE_GRADES,
   bandFromEvidenceTier,
   gradeTierDistance,
   normalizeEvidenceGrade,
+  type CanonicalEvidenceGrade,
   type EvidenceBand,
 } from '../../lib/evidence-grade'
 
@@ -39,19 +14,31 @@ const ROOT = process.cwd()
 const DATA_DIR = path.join(ROOT, 'public', 'data')
 const REPORTS_DIR = path.join(ROOT, 'ops', 'reports')
 const REPORT_PATH = path.join(REPORTS_DIR, 'evidence-grade-consistency.json')
-
-const argv = process.argv.slice(2)
-const STRICT = argv.includes('--strict')
+const STRICT = process.argv.slice(2).includes('--strict')
 
 type ProfileRecord = {
   slug?: string
-  name?: string
   evidence_grade?: unknown
   evidence_tier?: unknown
   indexability_status?: unknown
   evidence_design_match?: unknown
   evidence_risk_of_bias?: unknown
   evidence_consistency?: unknown
+}
+
+type Finding = {
+  kind: 'herb' | 'compound'
+  slug: string
+  url: string
+  indexable: boolean
+  rawGrade: string
+  rawTier: string
+  canonicalGrade: CanonicalEvidenceGrade | null
+  gradeLetter: string | null
+  gradeBand: EvidenceBand | null
+  tierBand: EvidenceBand | null
+  distance: number | null
+  issues: string[]
 }
 
 function readJson(file: string): ProfileRecord[] {
@@ -63,26 +50,11 @@ function readJson(file: string): ProfileRecord[] {
   }
 }
 
-type Finding = {
-  kind: 'herb' | 'compound'
-  slug: string
-  url: string
-  indexable: boolean
-  rawGrade: string
-  rawTier: string
-  gradeLetter: string | null
-  gradeBand: EvidenceBand | null
-  tierBand: EvidenceBand | null
-  distance: number | null
-  issues: string[]
-}
-
 function main() {
   const records: [('herb' | 'compound'), ProfileRecord[]][] = [
     ['herb', readJson('herbs.json')],
     ['compound', readJson('compounds.json')],
   ]
-
   const findings: Finding[] = []
 
   for (const [kind, rows] of records) {
@@ -94,15 +66,14 @@ function main() {
       const tierBand = bandFromEvidenceTier(record.evidence_tier)
       const distance = gradeTierDistance(normalized.band, tierBand)
       const indexable = String(record.indexability_status ?? '').toUpperCase() === 'PUBLISH'
-
       const issues: string[] = []
+
       if (distance !== null && distance >= 2) issues.push('contradicts-evidence-tier')
       else if (distance === 1) issues.push('minor-disagreement')
       if (normalized.outcomeDependent) issues.push('outcome-dependent-grade')
-      if (normalized.raw && !normalized.letter && !normalized.outcomeDependent) issues.push('unmappable-grade')
+      if (normalized.raw && !normalized.grade && !normalized.outcomeDependent) issues.push('unmappable-grade')
       if (!normalized.raw) issues.push('missing-grade')
-      if (normalized.raw && !normalized.canonical && normalized.letter) issues.push('non-canonical-wording')
-
+      if (normalized.raw && normalized.grade && !normalized.canonical) issues.push('non-canonical-wording')
       if (!issues.length) continue
 
       findings.push({
@@ -112,6 +83,7 @@ function main() {
         indexable,
         rawGrade: normalized.raw,
         rawTier: String(record.evidence_tier ?? ''),
+        canonicalGrade: normalized.grade,
         gradeLetter: normalized.letter,
         gradeBand: normalized.band,
         tierBand,
@@ -121,31 +93,25 @@ function main() {
     }
   }
 
-  const indexableFindings = findings.filter((f) => f.indexable)
-  const counts: Record<string, number> = {}
+  const indexableFindings = findings.filter((finding) => finding.indexable)
+  const contradictions = indexableFindings
+    .filter((finding) => finding.issues.includes('contradicts-evidence-tier'))
+    .sort((a, b) => (b.distance ?? 0) - (a.distance ?? 0))
+  const issueCounts: Record<string, number> = {}
   for (const finding of indexableFindings) {
-    for (const issue of finding.issues) counts[issue] = (counts[issue] ?? 0) + 1
+    for (const issue of finding.issues) issueCounts[issue] = (issueCounts[issue] ?? 0) + 1
   }
 
-  const contradictions = indexableFindings
-    .filter((f) => f.issues.includes('contradicts-evidence-tier'))
-    .sort((a, b) => (b.distance ?? 0) - (a.distance ?? 0))
-
-  /**
-   * The profile templates only render `EvidenceGradeRationale` when all three
-   * rationale fields are present. If nothing populates them, the whole
-   * "why is it graded this way" surface is dead on every profile — a far bigger
-   * problem than any individual grade value, and invisible without this check.
-   */
   const indexableRecords = records.flatMap(([, rows]) =>
-    rows.filter((r) => String(r.indexability_status ?? '').toUpperCase() === 'PUBLISH'),
+    rows.filter((record) => String(record.indexability_status ?? '').toUpperCase() === 'PUBLISH'),
   )
   const gradeCardRenderable = indexableRecords.filter(
-    (r) => r.evidence_design_match && r.evidence_risk_of_bias && r.evidence_consistency,
+    (record) => record.evidence_design_match && record.evidence_risk_of_bias && record.evidence_consistency,
   ).length
 
   const report = {
     generatedAt: new Date().toISOString(),
+    canonicalEnum: CANONICAL_EVIDENCE_GRADES,
     totals: {
       profiles: records.reduce((sum, [, rows]) => sum + rows.length, 0),
       indexable: indexableRecords.length,
@@ -154,7 +120,7 @@ function main() {
       contradictionsIndexable: contradictions.length,
       gradeCardRenderable,
     },
-    issueCounts: counts,
+    issueCounts,
     contradictions,
     findings,
   }
@@ -167,36 +133,14 @@ function main() {
   console.log(`Profiles scanned            ${report.totals.profiles}`)
   console.log(`Indexable                   ${report.totals.indexable}`)
   console.log(`Flagged (indexable)         ${report.totals.flaggedIndexable}`)
-  console.log('')
-  console.log(
-    `Evidence-rationale card renders on ${gradeCardRenderable}/${report.totals.indexable} indexable profiles` +
-      (gradeCardRenderable === 0
-        ? '\n  ^ nothing populates evidence_design_match / evidence_risk_of_bias /' +
-          '\n    evidence_consistency, so the "why is it graded this way" surface is' +
-          '\n    currently dead on every profile page.'
-        : ''),
-  )
-  console.log('')
-  for (const [issue, count] of Object.entries(counts).sort((a, b) => b[1] - a[1])) {
+  console.log(`Rationale cards renderable  ${gradeCardRenderable}`)
+  for (const [issue, count] of Object.entries(issueCounts).sort((a, b) => b[1] - a[1])) {
     console.log(`  ${String(count).padStart(5)}  ${issue}`)
   }
-
-  if (contradictions.length) {
-    console.log(`\nGrade contradicts tier on ${contradictions.length} indexable page(s):`)
-    for (const finding of contradictions.slice(0, 15)) {
-      console.log(
-        `  ${finding.url.padEnd(44)} grade=${JSON.stringify(finding.rawGrade)} (${finding.gradeBand})` +
-          ` vs tier=${JSON.stringify(finding.rawTier)} (${finding.tierBand})`,
-      )
-    }
-  }
-
   console.log(`\nReport: ${path.relative(ROOT, REPORT_PATH)}`)
 
   if (STRICT && contradictions.length > 0) {
-    console.error(
-      `\n[evidence-grade] FAILED — ${contradictions.length} indexable page(s) show a grade that contradicts their evidence tier.`,
-    )
+    console.error(`\n[evidence-grade] FAILED — ${contradictions.length} indexable contradiction(s).`)
     process.exit(1)
   }
 }

--- a/src/lib/__tests__/evidence-grade.test.ts
+++ b/src/lib/__tests__/evidence-grade.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  CANONICAL_EVIDENCE_GRADES,
+  canonicalGradeFromEvidenceTier,
+  isCanonicalEvidenceGrade,
+  normalizeEvidenceGrade,
+} from '../../../lib/evidence-grade'
+
+describe('canonical evidence grade contract', () => {
+  it('exposes exactly the five persisted grades', () => {
+    expect(CANONICAL_EVIDENCE_GRADES).toEqual(['A', 'B', 'C', 'D', 'Avoid/Insufficient'])
+  })
+
+  it('recognizes only canonical persisted values as canonical', () => {
+    for (const grade of CANONICAL_EVIDENCE_GRADES) {
+      expect(isCanonicalEvidenceGrade(grade)).toBe(true)
+      expect(normalizeEvidenceGrade(grade).canonical).toBe(true)
+    }
+
+    expect(isCanonicalEvidenceGrade('F')).toBe(false)
+    expect(isCanonicalEvidenceGrade('b+')).toBe(false)
+  })
+
+  it('migrates legacy letters and modifiers to canonical grades', () => {
+    expect(normalizeEvidenceGrade('a').grade).toBe('A')
+    expect(normalizeEvidenceGrade('B+').grade).toBe('B')
+    expect(normalizeEvidenceGrade('c-').grade).toBe('C')
+    expect(normalizeEvidenceGrade('d+').grade).toBe('D')
+  })
+
+  it('retires F into Avoid/Insufficient rather than preserving a sixth grade', () => {
+    const normalized = normalizeEvidenceGrade('F')
+    expect(normalized.grade).toBe('Avoid/Insufficient')
+    expect(normalized.letter).toBeNull()
+    expect(normalized.canonical).toBe(false)
+  })
+
+  it('keeps preclinical/no-human wording distinct from explicit insufficiency', () => {
+    expect(normalizeEvidenceGrade('Preclinical / no human evidence').grade).toBe('D')
+    expect(normalizeEvidenceGrade('Insufficient evidence').grade).toBe('Avoid/Insufficient')
+  })
+
+  it('does not flatten outcome-dependent grades into one verdict', () => {
+    const normalized = normalizeEvidenceGrade('B for PCOS; D for core goals')
+    expect(normalized.grade).toBeNull()
+    expect(normalized.outcomeDependent).toBe(true)
+  })
+
+  it('adapts legacy evidence tiers to the same enum', () => {
+    expect(canonicalGradeFromEvidenceTier('Strong Human Evidence')).toBe('A')
+    expect(canonicalGradeFromEvidenceTier('Moderate Evidence')).toBe('B')
+    expect(canonicalGradeFromEvidenceTier('Limited Evidence')).toBe('C')
+    expect(canonicalGradeFromEvidenceTier('Mechanistic / preclinical')).toBe('D')
+    expect(canonicalGradeFromEvidenceTier('Insufficient evidence')).toBe('Avoid/Insufficient')
+  })
+})


### PR DESCRIPTION
## What changed
- Defines one canonical evidence-grade enum: `A`, `B`, `C`, `D`, `Avoid/Insufficient`.
- Retires legacy `F` by normalizing it to `Avoid/Insufficient`.
- Centralizes legacy grade/tier parsing in `lib/evidence-grade.ts`.
- Removes the duplicate grade-normalization logic from `lib/evidence.ts`.
- Propagates the canonical type into evidence-strength data and UI badges.
- Updates the evidence consistency audit so `Avoid/Insufficient` is a first-class grade rather than an unmappable value.
- Adds focused normalization tests, including modifiers, preclinical vs insufficient semantics, and outcome-dependent grades.

## Why
This is the first foundation step for the evidence-integrity backlog. It creates one deterministic contract before migrating workbook data or making canonical-grade validation fatal in CI.

## Validation
CI should run type/lint/tests on the PR. Focused tests added at `src/lib/__tests__/evidence-grade.test.ts`.

## Follow-up
Next atomic upgrade: migrate legacy stored values to the canonical enum and then make invalid persisted grades fail CI/build.