### PR TITLE
feat(atlas): implement backlog 251-265 research moat

### DIFF
--- a/app/tools/botanical-activity-atlas/embed/page.tsx
+++ b/app/tools/botanical-activity-atlas/embed/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next'
+import BotanicalAtlasEmbed from '@/components/atlas/BotanicalAtlasEmbed'
+import { getBotanicalAtlasRecords } from '@/lib/botanical-atlas-data'
+
+export const metadata: Metadata = {
+  title: 'Botanical Activity Atlas Embed | The Hippie Scientist',
+  robots: { index: false, follow: true },
+}
+
+export default async function BotanicalAtlasEmbedPage() {
+  const records = await getBotanicalAtlasRecords()
+  return <BotanicalAtlasEmbed records={records} />
+}

--- a/src/components/atlas/AtlasFilterRobotsGuard.tsx
+++ b/src/components/atlas/AtlasFilterRobotsGuard.tsx
@@ -6,21 +6,30 @@ export default function AtlasFilterRobotsGuard({ active }: { active: boolean }) 
   useEffect(() => {
     const selector = 'meta[name="robots"]'
     let meta = document.head.querySelector<HTMLMetaElement>(selector)
-    if (!meta) {
-      meta = document.createElement('meta')
-      meta.name = 'robots'
-      document.head.appendChild(meta)
-    }
 
     if (active) {
+      if (!meta) {
+        meta = document.createElement('meta')
+        meta.name = 'robots'
+        document.head.appendChild(meta)
+      }
+      if (meta.dataset.atlasFilterGuard !== 'true') {
+        meta.dataset.atlasPreviousContent = meta.content
+      }
       meta.content = 'noindex,follow'
       meta.dataset.atlasFilterGuard = 'true'
       return
     }
 
-    if (meta.dataset.atlasFilterGuard === 'true') {
-      meta.content = 'index,follow'
+    if (meta?.dataset.atlasFilterGuard === 'true') {
+      const previous = meta.dataset.atlasPreviousContent
+      if (previous) {
+        meta.content = previous
+      } else {
+        meta.remove()
+      }
       delete meta.dataset.atlasFilterGuard
+      delete meta.dataset.atlasPreviousContent
     }
   }, [active])
 

--- a/src/components/atlas/AtlasFilterRobotsGuard.tsx
+++ b/src/components/atlas/AtlasFilterRobotsGuard.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export default function AtlasFilterRobotsGuard({ active }: { active: boolean }) {
+  useEffect(() => {
+    const selector = 'meta[name="robots"]'
+    let meta = document.head.querySelector<HTMLMetaElement>(selector)
+    if (!meta) {
+      meta = document.createElement('meta')
+      meta.name = 'robots'
+      document.head.appendChild(meta)
+    }
+
+    if (active) {
+      meta.content = 'noindex,follow'
+      meta.dataset.atlasFilterGuard = 'true'
+      return
+    }
+
+    if (meta.dataset.atlasFilterGuard === 'true') {
+      meta.content = 'index,follow'
+      delete meta.dataset.atlasFilterGuard
+    }
+  }, [active])
+
+  return null
+}

--- a/src/components/atlas/BotanicalActivityAtlasClient.tsx
+++ b/src/components/atlas/BotanicalActivityAtlasClient.tsx
@@ -3,6 +3,8 @@
 import Link from 'next/link'
 import { useEffect, useMemo, useState } from 'react'
 import AtlasEmptyResultRecovery from '@/components/atlas/AtlasEmptyResultRecovery'
+import AtlasFilterRobotsGuard from '@/components/atlas/AtlasFilterRobotsGuard'
+import BotanicalAtlasGraph from '@/components/atlas/BotanicalAtlasGraph'
 import type { AtlasRecoveryAction } from '@/lib/botanical-atlas-recovery'
 import { trackAtlasFilter, trackAtlasProfileClick, trackAtlasReset } from '@/lib/botanicalAtlasTracking'
 import {
@@ -20,17 +22,20 @@ export interface BotanicalAtlasRecord {
   effects: string[]
   explicitEffects?: string[]
   inferredEffects?: string[]
+  mechanisms?: string[]
   compounds: string[]
   compoundClasses: string[]
   evidence: string
+  humanEvidenceCount?: number
   intensity: string
   safety: string[]
   onset?: string
   duration?: string
+  sourceRelationships?: string[]
 }
 
 interface Props { records: BotanicalAtlasRecord[] }
-type AtlasFilters = {
+export type AtlasFilters = {
   query: string
   effect: string
   effectSource: AtlasEffectSource
@@ -51,7 +56,15 @@ export function effectsForSource(record: BotanicalAtlasRecord, source: AtlasEffe
 
 export function matchesFilters(record: BotanicalAtlasRecord, filters: AtlasFilters) {
   const availableEffects = effectsForSource(record, filters.effectSource)
-  const searchable = [record.name, record.scientificName ?? '', ...availableEffects, ...record.compounds, ...record.compoundClasses, ...record.safety].join(' ').toLowerCase()
+  const searchable = [
+    record.name,
+    record.scientificName ?? '',
+    ...availableEffects,
+    ...(record.mechanisms ?? []),
+    ...record.compounds,
+    ...record.compoundClasses,
+    ...record.safety,
+  ].join(' ').toLowerCase()
   const needle = normalize(filters.query)
   return (!needle || searchable.includes(needle))
     && (filters.effect === 'all' || availableEffects.includes(filters.effect))
@@ -71,6 +84,11 @@ function EffectTags({ record, limit = 5, source = 'all' }: { record: BotanicalAt
   })}</span>
 }
 
+function escapeCsv(value: string | number | undefined) {
+  const text = String(value ?? '')
+  return `"${text.replaceAll('"', '""')}"`
+}
+
 export default function BotanicalActivityAtlasClient({ records }: Props) {
   const [query, setQuery] = useState('')
   const [effect, setEffect] = useState('all')
@@ -82,6 +100,7 @@ export default function BotanicalActivityAtlasClient({ records }: Props) {
   const [sort, setSort] = useState<AtlasSortOption>('name')
   const [urlReady, setUrlReady] = useState(false)
   const [copyStatus, setCopyStatus] = useState<'idle' | 'copied' | 'failed'>('idle')
+  const [embedStatus, setEmbedStatus] = useState<'idle' | 'copied' | 'failed'>('idle')
 
   useEffect(() => {
     const initial = parseAtlasUrlState(window.location.search)
@@ -96,11 +115,13 @@ export default function BotanicalActivityAtlasClient({ records }: Props) {
     setUrlReady(true)
   }, [])
 
+  const currentUrlState = useMemo(() => ({ query, effect, effectSource, evidence, intensity, compoundClass, safety, sort }), [query, effect, effectSource, evidence, intensity, compoundClass, safety, sort])
+  const serializedState = useMemo(() => serializeAtlasUrlState(currentUrlState), [currentUrlState])
+
   useEffect(() => {
     if (!urlReady) return
-    const search = serializeAtlasUrlState({ query, effect, effectSource, evidence, intensity, compoundClass, safety, sort })
-    window.history.replaceState(null, '', `${window.location.pathname}${search}${window.location.hash}`)
-  }, [urlReady, query, effect, effectSource, evidence, intensity, compoundClass, safety, sort])
+    window.history.replaceState(null, '', `${window.location.pathname}${serializedState}${window.location.hash}`)
+  }, [urlReady, serializedState])
 
   const effects = useMemo(() => sortedUnique(records.flatMap((record) => effectsForSource(record, effectSource))), [records, effectSource])
   const evidenceLevels = useMemo(() => sortedUnique(records.map((record) => record.evidence)), [records])
@@ -110,12 +131,14 @@ export default function BotanicalActivityAtlasClient({ records }: Props) {
   const filters = useMemo(() => ({ query, effect, effectSource, evidence, intensity, compoundClass, safety }), [query, effect, effectSource, evidence, intensity, compoundClass, safety])
 
   const filtered = useMemo(() => records.filter((record) => matchesFilters(record, filters)).sort((a, b) => {
-    if (sort === 'evidence') return (evidenceRank[b.evidence] ?? 0) - (evidenceRank[a.evidence] ?? 0) || a.name.localeCompare(b.name)
+    if (sort === 'evidence') return (evidenceRank[b.evidence] ?? 0) - (evidenceRank[a.evidence] ?? 0) || (b.humanEvidenceCount ?? 0) - (a.humanEvidenceCount ?? 0) || a.name.localeCompare(b.name)
+    if (sort === 'human-evidence') return (b.humanEvidenceCount ?? 0) - (a.humanEvidenceCount ?? 0) || (evidenceRank[b.evidence] ?? 0) - (evidenceRank[a.evidence] ?? 0) || a.name.localeCompare(b.name)
     if (sort === 'noticeability') return (intensityRank[b.intensity] ?? 0) - (intensityRank[a.intensity] ?? 0) || a.name.localeCompare(b.name)
     return a.name.localeCompare(b.name)
   }), [records, filters, sort])
 
   const activeFilters = [query && `Search: ${query}`, effect !== 'all' && `Effect: ${effect}`, effectSource === 'explicit' && 'Effect source: explicit only', evidence !== 'all' && `Evidence: ${evidence}`, intensity !== 'all' && `Noticeability: ${intensity}`, compoundClass !== 'all' && `Chemistry: ${compoundClass}`, safety !== 'all' && `Safety: ${safety}`].filter(Boolean) as string[]
+  const arbitraryFilterState = Boolean(activeFilters.length || sort !== 'name')
 
   const setTrackedFilter = (filter: 'effect' | 'chemistry' | 'evidence' | 'noticeability' | 'safety', value: string, setter: (value: string) => void) => {
     const nextFilters = { ...filters, effect: filter === 'effect' ? value : effect, compoundClass: filter === 'chemistry' ? value : compoundClass, evidence: filter === 'evidence' ? value : evidence, intensity: filter === 'noticeability' ? value : intensity, safety: filter === 'safety' ? value : safety }
@@ -133,7 +156,14 @@ export default function BotanicalActivityAtlasClient({ records }: Props) {
 
   const reset = () => {
     trackAtlasReset(activeFilters.length)
-    setQuery(DEFAULT_ATLAS_URL_STATE.query); setEffect(DEFAULT_ATLAS_URL_STATE.effect); setEffectSource(DEFAULT_ATLAS_URL_STATE.effectSource); setEvidence(DEFAULT_ATLAS_URL_STATE.evidence); setIntensity(DEFAULT_ATLAS_URL_STATE.intensity); setCompoundClass(DEFAULT_ATLAS_URL_STATE.compoundClass); setSafety(DEFAULT_ATLAS_URL_STATE.safety); setSort(DEFAULT_ATLAS_URL_STATE.sort)
+    setQuery(DEFAULT_ATLAS_URL_STATE.query)
+    setEffect(DEFAULT_ATLAS_URL_STATE.effect)
+    setEffectSource(DEFAULT_ATLAS_URL_STATE.effectSource)
+    setEvidence(DEFAULT_ATLAS_URL_STATE.evidence)
+    setIntensity(DEFAULT_ATLAS_URL_STATE.intensity)
+    setCompoundClass(DEFAULT_ATLAS_URL_STATE.compoundClass)
+    setSafety(DEFAULT_ATLAS_URL_STATE.safety)
+    setSort(DEFAULT_ATLAS_URL_STATE.sort)
   }
 
   const recover = (action: AtlasRecoveryAction) => {
@@ -156,13 +186,39 @@ export default function BotanicalActivityAtlasClient({ records }: Props) {
     window.setTimeout(() => setCopyStatus('idle'), 1800)
   }
 
+  const copyEmbed = async () => {
+    const embedUrl = `${window.location.origin}/tools/botanical-activity-atlas/embed/${serializedState}`
+    const snippet = `<iframe src="${embedUrl}" title="Botanical Activity Atlas" loading="lazy" style="width:100%;min-height:520px;border:0" referrerpolicy="strict-origin-when-cross-origin"></iframe>`
+    try {
+      await navigator.clipboard.writeText(snippet)
+      setEmbedStatus('copied')
+    } catch {
+      setEmbedStatus('failed')
+    }
+    window.setTimeout(() => setEmbedStatus('idle'), 1800)
+  }
+
+  const downloadCsv = () => {
+    const header = ['Botanical', 'Scientific name', 'Evidence', 'Human evidence count', 'Constituents', 'Mechanisms', 'Outcomes', 'Safety signals']
+    const rows = filtered.map((record) => [record.name, record.scientificName, record.evidence, record.humanEvidenceCount ?? 0, record.compounds.join('; '), (record.mechanisms ?? []).join('; '), (record.explicitEffects ?? record.effects).join('; '), record.safety.join('; ')])
+    const csv = [header, ...rows].map((row) => row.map(escapeCsv).join(',')).join('\n')
+    const url = URL.createObjectURL(new Blob([csv], { type: 'text/csv;charset=utf-8' }))
+    const link = document.createElement('a')
+    link.href = url
+    link.download = 'botanical-activity-atlas.csv'
+    link.click()
+    URL.revokeObjectURL(url)
+  }
+
   const trackProfile = (record: BotanicalAtlasRecord, index: number) => trackAtlasProfileClick({ slug: record.slug, position: index + 1, activeFilterCount: activeFilters.length })
   const selectClass = 'w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2 text-sm text-ink'
   const labelClass = 'mb-1 block text-xs font-bold uppercase tracking-wide text-muted'
 
   return <section className='space-y-5'>
+    <AtlasFilterRobotsGuard active={arbitraryFilterState} />
+
     <div className='grid gap-3 rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm md:grid-cols-2 xl:grid-cols-4'>
-      <label><span className={labelClass}>Search</span><input value={query} onChange={(event) => setQuery(event.target.value)} onBlur={() => query.trim() && trackAtlasFilter({ filter: 'search', value: query.trim(), resultCount: filtered.length })} placeholder='Herb, compound, effect…' className={selectClass} /></label>
+      <label><span className={labelClass}>Search</span><input value={query} onChange={(event) => setQuery(event.target.value)} onBlur={() => query.trim() && trackAtlasFilter({ filter: 'search', value: query.trim(), resultCount: filtered.length })} placeholder='Herb, compound, pathway, effect…' className={selectClass} /></label>
       <label><span className={labelClass}>Effect source</span><select value={effectSource} onChange={(event) => changeEffectSource(event.target.value as AtlasEffectSource)} className={selectClass}><option value='all'>Include pathway-derived</option><option value='explicit'>Explicit effects only</option></select></label>
       <label><span className={labelClass}>Effect</span><select value={effect} onChange={(event) => setTrackedFilter('effect', event.target.value, setEffect)} className={selectClass}><option value='all'>All effects</option>{effects.map((item) => <option key={item}>{item}</option>)}</select></label>
       <label><span className={labelClass}>Chemistry</span><select value={compoundClass} onChange={(event) => setTrackedFilter('chemistry', event.target.value, setCompoundClass)} className={selectClass}><option value='all'>All classes</option>{compoundClasses.map((item) => <option key={item}>{item}</option>)}</select></label>
@@ -171,29 +227,34 @@ export default function BotanicalActivityAtlasClient({ records }: Props) {
       <label><span className={labelClass}>Safety concern</span><select value={safety} onChange={(event) => setTrackedFilter('safety', event.target.value, setSafety)} className={selectClass}><option value='all'>All signals</option>{safetySignals.map((item) => <option key={item}>{item}</option>)}</select></label>
     </div>
 
-    <div className='rounded-xl border border-sky-900/10 bg-sky-50/70 px-4 py-3 text-sm text-sky-950'><strong>Effect provenance:</strong> solid green labels come from explicit effect data. Dashed blue “pathway” labels are inferred from structured mechanisms and should not be read as demonstrated clinical outcomes.</div>
+    <div className='rounded-xl border border-sky-900/10 bg-sky-50/70 px-4 py-3 text-sm text-sky-950'><strong>Evidence boundary:</strong> solid effect labels are explicit outcome/effect data. Dashed pathway labels and the mechanism column are mechanistic context only and are never presented as demonstrated clinical benefits.</div>
 
     <div className='flex flex-wrap items-end justify-between gap-3 text-sm text-muted'>
       <p><strong className='text-ink'>{filtered.length}</strong> of {records.length} botanicals shown</p>
       <div className='flex flex-wrap items-end gap-3'>
-        <label><span className={labelClass}>Sort</span><select value={sort} onChange={(event) => setSort(event.target.value as AtlasSortOption)} className={selectClass}><option value='name'>Name A–Z</option><option value='evidence'>Strongest evidence</option><option value='noticeability'>Most noticeable</option></select></label>
-        <button type='button' onClick={copyLink} className='mb-2 font-semibold text-emerald-800 hover:underline' aria-live='polite'>{copyStatus === 'copied' ? 'Link copied ✓' : copyStatus === 'failed' ? 'Copy failed' : 'Copy link'}</button>
-        <button type='button' onClick={reset} disabled={!activeFilters.length && sort === 'name'} className='mb-2 font-semibold text-emerald-800 hover:underline disabled:opacity-40'>Reset</button>
+        <label><span className={labelClass}>Sort</span><select value={sort} onChange={(event) => setSort(event.target.value as AtlasSortOption)} className={selectClass}><option value='name'>Name A–Z</option><option value='evidence'>Strongest evidence</option><option value='human-evidence'>Most human evidence</option><option value='noticeability'>Most noticeable</option></select></label>
+        <button type='button' onClick={downloadCsv} className='mb-2 font-semibold text-indigo-800 hover:underline'>Download CSV</button>
+        <button type='button' onClick={copyEmbed} className='mb-2 font-semibold text-indigo-800 hover:underline' aria-live='polite'>{embedStatus === 'copied' ? 'Embed copied ✓' : embedStatus === 'failed' ? 'Embed copy failed' : 'Copy embed'}</button>
+        <button type='button' onClick={copyLink} className='mb-2 font-semibold text-indigo-800 hover:underline' aria-live='polite'>{copyStatus === 'copied' ? 'Link copied ✓' : copyStatus === 'failed' ? 'Copy failed' : 'Copy link'}</button>
+        <button type='button' onClick={reset} disabled={!arbitraryFilterState} className='mb-2 font-semibold text-indigo-800 hover:underline disabled:opacity-40'>Reset</button>
       </div>
     </div>
 
-    {activeFilters.length ? <div className='flex flex-wrap gap-2' aria-label='Active filters'>{activeFilters.map((item) => <span key={item} className='rounded-full border border-emerald-900/10 bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-950'>{item}</span>)}</div> : null}
+    {activeFilters.length ? <div className='flex flex-wrap gap-2' aria-label='Active filters'>{activeFilters.map((item) => <span key={item} className='rounded-full border border-brand-900/10 bg-brand-50 px-3 py-1 text-xs font-semibold text-ink'>{item}</span>)}</div> : null}
 
     {!filtered.length ? <AtlasEmptyResultRecovery records={records} filters={filters} onRecover={recover} onReset={reset} /> : null}
 
+    {filtered.length ? <BotanicalAtlasGraph records={filtered.slice(0, 150)} /> : null}
+
     <div className='grid gap-4 md:hidden'>{filtered.map((record, index) => <article key={record.slug} className='rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm'>
-      <div className='flex items-start justify-between gap-3'><div><Link href={`/herbs/${record.slug}/`} onClick={() => trackProfile(record, index)} className='text-lg font-bold text-emerald-900 hover:underline'>{record.name}</Link>{record.scientificName ? <p className='mt-1 text-xs italic text-muted'>{record.scientificName}</p> : null}</div><span className='rounded-full bg-brand-50 px-2.5 py-1 text-xs font-bold text-ink'>{record.evidence}</span></div>
-      <div className='mt-4 grid grid-cols-2 gap-3 text-sm'><div><p className={labelClass}>Noticeability</p><p className='font-semibold text-ink'>{record.intensity}</p></div><div><p className={labelClass}>Chemistry</p><p className='text-ink'>{record.compoundClasses.slice(0, 2).join(', ') || 'Not mapped'}</p></div></div>
+      <div className='flex items-start justify-between gap-3'><div><Link href={`/herbs/${record.slug}/`} onClick={() => trackProfile(record, index)} className='text-lg font-bold text-indigo-900 hover:underline'>{record.name}</Link>{record.scientificName ? <p className='mt-1 text-xs italic text-muted'>{record.scientificName}</p> : null}</div><span className='rounded-full bg-brand-50 px-2.5 py-1 text-xs font-bold text-ink'>{record.evidence}</span></div>
+      <div className='mt-4 grid grid-cols-2 gap-3 text-sm'><div><p className={labelClass}>Human evidence</p><p className='font-semibold text-ink'>{record.humanEvidenceCount ? `${record.humanEvidenceCount} mapped studies` : 'Not counted'}</p></div><div><p className={labelClass}>Chemistry</p><p className='text-ink'>{record.compoundClasses.slice(0, 2).join(', ') || 'Not mapped'}</p></div></div>
       <div className='mt-4'><p className={labelClass}>Effects</p><EffectTags record={record} limit={4} source={effectSource} /></div>
+      {(record.mechanisms ?? []).length ? <div className='mt-4'><p className={labelClass}>Mechanisms · not outcomes</p><p className='text-sm text-muted'>{record.mechanisms?.slice(0, 3).join(' · ')}</p></div> : null}
       {record.safety.length ? <div className='mt-4 rounded-xl bg-amber-50 p-3'><p className='text-xs font-bold uppercase tracking-wide text-amber-950'>Safety signals</p><p className='mt-1 text-sm text-amber-950'>{record.safety.slice(0, 3).join(' · ')}</p></div> : null}
-      <Link href={`/herbs/${record.slug}/`} onClick={() => trackProfile(record, index)} className='mt-4 inline-flex font-semibold text-emerald-800 hover:underline'>Open full profile →</Link>
+      <Link href={`/herbs/${record.slug}/`} onClick={() => trackProfile(record, index)} className='mt-4 inline-flex font-semibold text-indigo-800 hover:underline'>Open full profile →</Link>
     </article>)}</div>
 
-    <div className='hidden overflow-x-auto rounded-2xl border border-brand-900/10 bg-white/90 shadow-sm md:block'><table className='min-w-[1100px] w-full border-collapse text-left text-sm'><thead className='bg-brand-50/80 text-xs uppercase tracking-wide text-muted'><tr><th className='p-4'>Botanical</th><th className='p-4'>Active chemistry</th><th className='p-4'>Effect profile</th><th className='p-4'>Noticeability</th><th className='p-4'>Evidence</th><th className='p-4'>Safety signals</th><th className='p-4'>Timing</th></tr></thead><tbody>{filtered.map((record, index) => <tr key={record.slug} className='border-t border-brand-900/10 align-top'><td className='p-4'><Link href={`/herbs/${record.slug}/`} onClick={() => trackProfile(record, index)} className='font-bold text-emerald-900 hover:underline'>{record.name}</Link>{record.scientificName ? <p className='mt-1 text-xs italic text-muted'>{record.scientificName}</p> : null}</td><td className='p-4'><p className='font-medium text-ink'>{record.compounds.slice(0, 4).join(', ') || 'Not yet mapped'}</p>{record.compoundClasses.length ? <p className='mt-1 text-xs text-muted'>{record.compoundClasses.join(', ')}</p> : null}</td><td className='p-4'><EffectTags record={record} source={effectSource} /></td><td className='p-4 font-semibold text-ink'>{record.intensity}</td><td className='p-4'>{record.evidence}</td><td className='p-4 text-muted'>{record.safety.slice(0, 4).join(' · ') || 'No structured flags'}</td><td className='p-4 text-muted'>{[record.onset && `Onset: ${record.onset}`, record.duration && `Duration: ${record.duration}`].filter(Boolean).join(' · ') || 'Not established'}</td></tr>)}</tbody></table></div>
+    <div className='hidden overflow-x-auto rounded-2xl border border-brand-900/10 bg-white/90 shadow-sm md:block'><table className='min-w-[1450px] w-full border-collapse text-left text-sm'><thead className='bg-brand-50/80 text-xs uppercase tracking-wide text-muted'><tr><th className='p-4'>Botanical</th><th className='p-4'>Constituent chemistry</th><th className='p-4'>Mechanisms · not outcomes</th><th className='p-4'>Outcome / effect profile</th><th className='p-4'>Noticeability</th><th className='p-4'><button type='button' onClick={() => setSort('evidence')} className='font-bold hover:underline'>Evidence ↕</button></th><th className='p-4'><button type='button' onClick={() => setSort('human-evidence')} className='font-bold hover:underline'>Human evidence ↕</button></th><th className='p-4'>Safety signals</th><th className='p-4'>Timing</th></tr></thead><tbody>{filtered.map((record, index) => <tr key={record.slug} className='border-t border-brand-900/10 align-top'><td className='p-4'><Link href={`/herbs/${record.slug}/`} onClick={() => trackProfile(record, index)} className='font-bold text-indigo-900 hover:underline'>{record.name}</Link>{record.scientificName ? <p className='mt-1 text-xs italic text-muted'>{record.scientificName}</p> : null}</td><td className='p-4'><p className='font-medium text-ink'>{record.compounds.slice(0, 4).join(', ') || 'Not yet mapped'}</p>{record.compoundClasses.length ? <p className='mt-1 text-xs text-muted'>{record.compoundClasses.join(', ')}</p> : null}{record.sourceRelationships?.length ? <p className='mt-2 text-xs text-muted'>{record.sourceRelationships.slice(0, 2).join(' · ')}</p> : null}</td><td className='p-4 text-muted'>{record.mechanisms?.slice(0, 4).join(' · ') || 'Not yet mapped'}</td><td className='p-4'><EffectTags record={record} source={effectSource} /></td><td className='p-4 font-semibold text-ink'>{record.intensity}</td><td className='p-4'>{record.evidence}</td><td className='p-4 font-semibold text-ink'>{record.humanEvidenceCount || '—'}</td><td className='p-4 text-muted'>{record.safety.slice(0, 4).join(' · ') || 'No structured flags'}</td><td className='p-4 text-muted'>{[record.onset && `Onset: ${record.onset}`, record.duration && `Duration: ${record.duration}`].filter(Boolean).join(' · ') || 'Not established'}</td></tr>)}</tbody></table></div>
   </section>
 }

--- a/src/components/atlas/BotanicalAtlasEmbed.tsx
+++ b/src/components/atlas/BotanicalAtlasEmbed.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import BotanicalAtlasGraph from '@/components/atlas/BotanicalAtlasGraph'
+import { matchesFilters, type AtlasFilters, type BotanicalAtlasRecord } from '@/components/atlas/BotanicalActivityAtlasClient'
+import { DEFAULT_ATLAS_URL_STATE, parseAtlasUrlState } from '@/lib/botanical-atlas-url-state'
+
+export default function BotanicalAtlasEmbed({ records }: { records: BotanicalAtlasRecord[] }) {
+  const [filters, setFilters] = useState<AtlasFilters>({
+    query: DEFAULT_ATLAS_URL_STATE.query,
+    effect: DEFAULT_ATLAS_URL_STATE.effect,
+    effectSource: DEFAULT_ATLAS_URL_STATE.effectSource,
+    evidence: DEFAULT_ATLAS_URL_STATE.evidence,
+    intensity: DEFAULT_ATLAS_URL_STATE.intensity,
+    compoundClass: DEFAULT_ATLAS_URL_STATE.compoundClass,
+    safety: DEFAULT_ATLAS_URL_STATE.safety,
+  })
+
+  useEffect(() => {
+    const state = parseAtlasUrlState(window.location.search)
+    setFilters({
+      query: state.query,
+      effect: state.effect,
+      effectSource: state.effectSource,
+      evidence: state.evidence,
+      intensity: state.intensity,
+      compoundClass: state.compoundClass,
+      safety: state.safety,
+    })
+  }, [])
+
+  const filtered = useMemo(() => records.filter((record) => matchesFilters(record, filters)), [records, filters])
+  const filterSummary = [
+    filters.query && `Search: ${filters.query}`,
+    filters.effect !== 'all' && `Effect: ${filters.effect}`,
+    filters.evidence !== 'all' && `Evidence: ${filters.evidence}`,
+    filters.compoundClass !== 'all' && `Chemistry: ${filters.compoundClass}`,
+    filters.safety !== 'all' && `Safety: ${filters.safety}`,
+  ].filter(Boolean).join(' · ')
+
+  return (
+    <main className='mx-auto max-w-5xl p-4'>
+      <header className='mb-3 flex flex-wrap items-end justify-between gap-3'>
+        <div>
+          <p className='text-xs font-bold uppercase tracking-wide text-muted'>The Hippie Scientist</p>
+          <h1 className='text-xl font-bold text-ink'>Botanical Activity Atlas</h1>
+          <p className='mt-1 text-xs text-muted'>{filterSummary || 'Unfiltered atlas visualization'} · {filtered.length} matching botanicals</p>
+        </div>
+        <a href='/tools/botanical-activity-atlas/' target='_blank' rel='noreferrer' className='text-sm font-semibold text-indigo-800 hover:underline'>Open full atlas ↗</a>
+      </header>
+      {filtered.length ? <BotanicalAtlasGraph records={filtered.slice(0, 150)} compact /> : <p className='rounded-xl border border-brand-900/10 bg-white p-4 text-sm text-muted'>No botanicals match this embedded filter state.</p>}
+      <p className='mt-3 text-[11px] leading-4 text-muted'>Mechanism nodes are context, not clinical outcome claims. Educational reference only.</p>
+    </main>
+  )
+}

--- a/src/components/atlas/BotanicalAtlasGraph.tsx
+++ b/src/components/atlas/BotanicalAtlasGraph.tsx
@@ -1,0 +1,106 @@
+'use client'
+
+import { useMemo, useRef, useState } from 'react'
+
+export interface AtlasGraphRecord {
+  slug: string
+  name: string
+  compounds: string[]
+  mechanisms?: string[]
+  explicitEffects?: string[]
+  effects: string[]
+}
+
+interface Props {
+  records: AtlasGraphRecord[]
+  compact?: boolean
+}
+
+const trimLabel = (value: string, max = 25) => value.length > max ? `${value.slice(0, max - 1)}…` : value
+
+export default function BotanicalAtlasGraph({ records, compact = false }: Props) {
+  const svgRef = useRef<SVGSVGElement>(null)
+  const [selectedSlug, setSelectedSlug] = useState(records[0]?.slug ?? '')
+
+  const record = useMemo(
+    () => records.find((item) => item.slug === selectedSlug) ?? records[0],
+    [records, selectedSlug],
+  )
+
+  if (!record) return null
+
+  const compounds = record.compounds.slice(0, 4)
+  const mechanisms = (record.mechanisms ?? []).slice(0, 4)
+  const outcomes = (record.explicitEffects?.length ? record.explicitEffects : record.effects).slice(0, 4)
+  const columns = [
+    { title: 'Botanical', items: [record.name], x: 12 },
+    { title: 'Constituents', items: compounds.length ? compounds : ['Not mapped'], x: 242 },
+    { title: 'Mechanisms', items: mechanisms.length ? mechanisms : ['Not mapped'], x: 472 },
+    { title: 'Observed / assigned outcomes', items: outcomes.length ? outcomes : ['Not mapped'], x: 702 },
+  ]
+
+  const downloadSvg = () => {
+    const svg = svgRef.current
+    if (!svg) return
+    const source = new XMLSerializer().serializeToString(svg)
+    const blob = new Blob([source], { type: 'image/svg+xml;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.href = url
+    link.download = `botanical-atlas-${record.slug}.svg`
+    link.click()
+    URL.revokeObjectURL(url)
+  }
+
+  return (
+    <section className={compact ? 'space-y-3' : 'space-y-4 rounded-2xl border border-brand-900/10 bg-white/90 p-5'}>
+      <div className='flex flex-wrap items-end justify-between gap-3'>
+        <div>
+          {!compact ? <p className='eyebrow-label'>Relationship graph</p> : null}
+          <h2 className={compact ? 'text-lg font-bold text-ink' : 'mt-1 text-2xl font-bold text-ink'}>Botanical → chemistry → pathway → outcome</h2>
+          <p className='mt-1 max-w-3xl text-xs leading-5 text-muted'>Mechanisms are shown as mechanistic context, not as proof of a clinical outcome. Outcome nodes use explicit effect data when available.</p>
+        </div>
+        {!compact ? (
+          <div className='flex flex-wrap items-end gap-2'>
+            <label className='text-xs font-bold uppercase tracking-wide text-muted'>
+              Botanical
+              <select className='mt-1 block rounded-lg border border-brand-900/15 bg-white px-2 py-1.5 text-sm font-medium normal-case tracking-normal text-ink' value={record.slug} onChange={(event) => setSelectedSlug(event.target.value)}>
+                {records.slice(0, 150).map((item) => <option key={item.slug} value={item.slug}>{item.name}</option>)}
+              </select>
+            </label>
+            <button type='button' onClick={downloadSvg} className='rounded-lg border border-brand-900/15 px-3 py-2 text-sm font-semibold text-ink hover:bg-brand-50'>Download SVG</button>
+          </div>
+        ) : null}
+      </div>
+
+      <div className='overflow-x-auto' aria-label={`Relationship graph for ${record.name}`}>
+        <svg ref={svgRef} viewBox='0 0 920 300' role='img' aria-labelledby={`atlas-graph-title-${record.slug}`} className='min-w-[760px] w-full rounded-xl bg-brand-50/40'>
+          <title id={`atlas-graph-title-${record.slug}`}>{record.name} constituent, mechanism, and outcome relationships</title>
+          {columns.slice(0, -1).map((column, columnIndex) => {
+            const currentItems = column.items
+            const nextItems = columns[columnIndex + 1].items
+            return currentItems.flatMap((_, currentIndex) => nextItems.map((__, nextIndex) => {
+              const y1 = 82 + currentIndex * 48
+              const y2 = 82 + nextIndex * 48
+              return <line key={`${columnIndex}-${currentIndex}-${nextIndex}`} x1={column.x + 190} y1={y1} x2={columns[columnIndex + 1].x} y2={y2} stroke='currentColor' strokeOpacity='0.18' strokeWidth='1.5' />
+            }))
+          })}
+          {columns.map((column, columnIndex) => (
+            <g key={column.title}>
+              <text x={column.x} y='28' fontSize='12' fontWeight='700' opacity='0.66'>{column.title}</text>
+              {column.items.map((item, index) => {
+                const y = 60 + index * 48
+                const isMechanism = columnIndex === 2
+                return <g key={`${column.title}-${item}-${index}`}>
+                  <rect x={column.x} y={y} width='190' height='36' rx='9' fill='white' stroke='currentColor' strokeOpacity={isMechanism ? '0.28' : '0.14'} strokeDasharray={isMechanism ? '5 4' : undefined} />
+                  <text x={column.x + 10} y={y + 22} fontSize='11' fontWeight={columnIndex === 0 ? '700' : '500'}>{trimLabel(item)}</text>
+                </g>
+              })}
+            </g>
+          ))}
+          <text x='472' y='284' fontSize='10' opacity='0.65'>Dashed nodes = mechanism/pathway context, not demonstrated benefit.</text>
+        </svg>
+      </div>
+    </section>
+  )
+}

--- a/src/lib/__tests__/botanical-atlas-url-state.test.ts
+++ b/src/lib/__tests__/botanical-atlas-url-state.test.ts
@@ -20,7 +20,7 @@ describe('Botanical Activity Atlas URL state', () => {
       intensity: 'Pronounced',
       compoundClass: 'Methylxanthines',
       safety: 'Cardiovascular',
-      sort: 'evidence' as const,
+      sort: 'human-evidence' as const,
     }
 
     expect(parseAtlasUrlState(serializeAtlasUrlState(state))).toEqual(state)

--- a/src/lib/botanical-atlas-data.ts
+++ b/src/lib/botanical-atlas-data.ts
@@ -26,6 +26,18 @@ const text = (...values: unknown[]): string => {
   return typeof value === 'string' ? value.trim() : ''
 }
 
+const positiveInteger = (...values: unknown[]): number => {
+  for (const value of values) {
+    if (Array.isArray(value)) return value.length
+    if (typeof value === 'number' && Number.isFinite(value) && value >= 0) return Math.floor(value)
+    if (typeof value === 'string') {
+      const match = value.match(/\d+/)
+      if (match) return Number.parseInt(match[0], 10)
+    }
+  }
+  return 0
+}
+
 const KNOWN_COMPOUND_CLASSES = new Set([
   'Methylxanthines',
   'Alkaloids',
@@ -46,13 +58,13 @@ export const toAtlasRecord = (herb: RuntimeRecord): BotanicalAtlasRecord => {
     collect(herb.primary_effects, herb.effects, herb.primaryActions, herb.benefits),
     normalizeEffect,
   )
-  const mechanisms = collect(
+  const mechanisms = Array.from(new Set(collect(
     herb.mechanisms,
     herb.raw_mechanisms,
     herb.canonical_mechanisms,
     herb.mechanism_target_systems,
     herb.mechanism_classes,
-  )
+  )))
   const inferredEffects = inferAtlasEffectsFromMechanisms(mechanisms)
     .filter((effect) => !explicitEffects.includes(effect))
   const effects = [...explicitEffects, ...inferredEffects]
@@ -93,9 +105,22 @@ export const toAtlasRecord = (herb: RuntimeRecord): BotanicalAtlasRecord => {
     effects,
     explicitEffects,
     inferredEffects,
+    mechanisms,
     compounds,
     compoundClasses,
     evidence: normalizeEvidence(text(herb.evidence_tier, herb.evidenceTier, herb.evidence_grade, herb.evidenceLevel)),
+    humanEvidenceCount: positiveInteger(
+      herb.human_trial_count,
+      herb.humanTrialCount,
+      herb.human_study_count,
+      herb.humanStudyCount,
+      herb.clinical_study_count,
+      herb.clinicalStudyCount,
+      herb.human_trials,
+      herb.humanTrials,
+      herb.clinical_trials,
+      herb.clinicalTrials,
+    ),
     intensity: normalizeIntensity(
       text(
         herb.intensityLabel,
@@ -111,21 +136,31 @@ export const toAtlasRecord = (herb: RuntimeRecord): BotanicalAtlasRecord => {
     safety: Array.from(new Set(rawSafety.flatMap(normalizeSafetySignals))),
     onset: text(herb.time_to_effect, herb.onset, herb.onsetTime) || undefined,
     duration: text(herb.duration, herb.effectDuration) || undefined,
+    sourceRelationships: [],
   }
 }
 
-export function buildMappedCompoundsByHerb(rows: RuntimeRecord[]): Map<string, string[]> {
-  const compoundsByHerb = new Map<string, string[]>()
+export interface AtlasCompoundRelationship {
+  compound: string
+  relationship: string
+}
+
+export function buildMappedCompoundsByHerb(rows: RuntimeRecord[]): Map<string, AtlasCompoundRelationship[]> {
+  const compoundsByHerb = new Map<string, AtlasCompoundRelationship[]>()
 
   for (const row of rows) {
     const herbSlug = text(row.herb_slug, row.herbSlug)
     const compound = text(row.compound, row.compound_name, row.compoundName, row.compound_slug, row.compoundSlug)
-    const relationship = text(row.relationship, row.relationship_type, row.relationshipType).toLowerCase()
+    const rawRelationship = text(row.relationship, row.relationship_type, row.relationshipType)
+    const relationship = rawRelationship.toLowerCase()
     if (!herbSlug || !compound) continue
     if (relationship && !relationship.includes('contains')) continue
 
     const existing = compoundsByHerb.get(herbSlug) ?? []
-    compoundsByHerb.set(herbSlug, collect(existing, compound))
+    if (!existing.some((item) => item.compound.toLowerCase() === compound.toLowerCase())) {
+      existing.push({ compound, relationship: rawRelationship || 'contains' })
+    }
+    compoundsByHerb.set(herbSlug, existing)
   }
 
   return compoundsByHerb
@@ -133,8 +168,9 @@ export function buildMappedCompoundsByHerb(rows: RuntimeRecord[]): Map<string, s
 
 export function enrichAtlasRecordWithMappedCompounds(
   record: BotanicalAtlasRecord,
-  mappedCompounds: string[] = [],
+  mappedRelationships: AtlasCompoundRelationship[] = [],
 ): BotanicalAtlasRecord {
+  const mappedCompounds = mappedRelationships.map((item) => item.compound)
   const compounds = Array.from(new Map(
     collect(record.compounds, mappedCompounds).map((compound) => [compound.toLowerCase(), compound]),
   ).values())
@@ -142,7 +178,12 @@ export function enrichAtlasRecordWithMappedCompounds(
     ? record.compoundClasses
     : inferCompoundClasses(compounds)
 
-  return { ...record, compounds, compoundClasses }
+  return {
+    ...record,
+    compounds,
+    compoundClasses,
+    sourceRelationships: mappedRelationships.map((item) => `${record.name} ${item.relationship} ${item.compound}`),
+  }
 }
 
 export const getBotanicalAtlasRecords = cache(async (): Promise<BotanicalAtlasRecord[]> => {
@@ -155,13 +196,7 @@ export const getBotanicalAtlasRecords = cache(async (): Promise<BotanicalAtlasRe
   const mappedCompoundsByHerb = buildMappedCompoundsByHerb(compoundMapRows)
 
   return herbRecords
-    .filter((herb: RuntimeRecord) => {
-      try {
-        return getRuntimeVisibility(herb).canRender
-      } catch {
-        return true
-      }
-    })
+    .filter((herb: RuntimeRecord) => getRuntimeVisibility(herb).canRender)
     .map(toAtlasRecord)
     .map((record: BotanicalAtlasRecord) => enrichAtlasRecordWithMappedCompounds(record, mappedCompoundsByHerb.get(record.slug)))
     .filter((herb: BotanicalAtlasRecord) => herb.effects.length || herb.compounds.length || herb.safety.length)

--- a/src/lib/botanical-atlas-url-state.ts
+++ b/src/lib/botanical-atlas-url-state.ts
@@ -1,5 +1,5 @@
 export type AtlasEffectSource = 'all' | 'explicit'
-export type AtlasSortOption = 'name' | 'evidence' | 'noticeability'
+export type AtlasSortOption = 'name' | 'evidence' | 'human-evidence' | 'noticeability'
 
 export type AtlasUrlState = {
   query: string
@@ -25,7 +25,7 @@ export const DEFAULT_ATLAS_URL_STATE: AtlasUrlState = {
 
 const validEffectSource = (value: string | null): AtlasEffectSource => value === 'explicit' ? 'explicit' : 'all'
 const validSort = (value: string | null): AtlasSortOption =>
-  value === 'evidence' || value === 'noticeability' ? value : 'name'
+  value === 'evidence' || value === 'human-evidence' || value === 'noticeability' ? value : 'name'
 
 export function parseAtlasUrlState(search: string): AtlasUrlState {
   const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search)


### PR DESCRIPTION
Implements backlog 251–265 as one independently mergeable Atlas upgrade.

Coverage:
- enriches Atlas records with human-evidence counts, mechanisms, and explicit botanical→compound relationships
- keeps mechanism/pathway signals visibly separate from clinical/outcome labels
- adds sortable evidence and human-evidence columns
- preserves safety and constituent-chemistry comparison surfaces
- adds a botanical→constituent→mechanism→outcome relationship graph
- makes the relationship graph downloadable as SVG and filtered rows downloadable as CSV
- preserves shareable, human-readable filter URLs
- noindexes arbitrary filter states while retaining curated static Atlas category landing pages for indexable intent
- adds a noindex embeddable Atlas visualization endpoint and one-click embed snippet
- removes the Atlas loader's prior fail-open visibility fallback
- extends URL-state tests for human-evidence sorting

Validation target: existing TypeScript/lint/test/route checks plus Atlas URL-state regression coverage.