### PR TITLE
research: rebuild omega-3 ADHD guide around 2026 biomarker evidence

### DIFF
--- a/app/guides/adhd/omega-3-and-adhd/page.tsx
+++ b/app/guides/adhd/omega-3-and-adhd/page.tsx
@@ -5,9 +5,9 @@ import { buildPageMetadata } from '@/src/lib/seo'
 const SLUG = 'omega-3-and-adhd'
 
 export const metadata = buildPageMetadata({
-  title: 'Omega-3 for ADHD: EPA vs DHA, Evidence & Dose',
+  title: 'Omega-3 for ADHD: 2026 Evidence, EPA vs DHA & Safety',
   description:
-    'Does omega-3 help ADHD? See what human trials show, whether higher-EPA formulas matter, studied dose ranges, side effects, and fish-oil quality checks.',
+    '2026 omega-3 ADHD evidence: conflicting meta-analyses, baseline EPA/DHA status, EPA-vs-DHA claims, study-dose limits, fish-oil quality, and safety.',
   path: `/guides/adhd/${SLUG}/`,
   openGraphType: 'article',
 })

--- a/docs/content/focus-cluster/omega-3-and-adhd.md
+++ b/docs/content/focus-cluster/omega-3-and-adhd.md
@@ -1,7 +1,7 @@
 ---
-title: "Omega-3 and ADHD: Fish Oil Supplements, EPA vs DHA, Dosage, and Quality"
-seoTitle: "Fish Oil Supplements for ADHD: EPA vs DHA and Dosage"
-metaDescription: "Evidence-based review of fish oil supplements for ADHD. Covers EPA vs DHA, omega-3 dosage, symptom research, fish oil quality, safety, and realistic expectations."
+title: "Omega-3 and ADHD: EPA, DHA, Baseline Status, and Evidence"
+seoTitle: "Omega-3 for ADHD: 2026 Evidence, EPA vs DHA, Safety"
+metaDescription: "2026 evidence review of omega-3 for ADHD: conflicting meta-analyses, baseline EPA/DHA status, EPA-vs-DHA claims, study-dose context, product quality, and safety."
 primaryKeyword: "omega-3 ADHD"
 secondaryKeywords:
   - "omega-3 for ADHD"
@@ -10,463 +10,237 @@ secondaryKeywords:
   - "DHA ADHD"
   - "omega-3 children ADHD"
   - "omega-3 supplementation ADHD"
-status: "draft-source"
+status: "published"
 cluster: "focus-adhd"
+updated: "2026-08-15"
 ---
 
-# Omega-3 and ADHD: Fish Oil Supplements, EPA vs DHA, Dosage, and Quality
+# Omega-3 for ADHD: What the 2026 Evidence Actually Supports
 
-## Introduction
+Omega-3 supplements are one of the most studied nutrition interventions in ADHD, but the literature is much less settled than many supplement pages imply.
 
-Omega-3 fatty acids, particularly eicosapentaenoic acid (EPA) and docosahexaenoic acid (DHA), are essential polyunsaturated fats that play important roles in brain structure and function. Observational research has consistently shown lower blood levels of these fatty acids in children with ADHD and adults with ADHD compared with neurotypical controls. This association has led to numerous clinical trials examining whether fish oil supplements for ADHD can support symptom management.
+The strongest broad syntheses disagree. A 2023 Cochrane review found **high-certainty evidence of no meaningful effect on parent-rated total ADHD symptoms** in the medium term, while another 2023 meta-analysis of 22 randomized trials found no statistically significant overall improvement in core ADHD symptoms but did report a signal in studies lasting at least four months. A new 2026 biomarker-stratified meta-analysis adds a more interesting possibility: response may be larger in children who begin with relatively low omega-3 status.
 
-This article reviews the human evidence on omega-3 fatty acids in ADHD, with attention to EPA vs DHA ADHD findings, effects on specific symptom domains, supplementation outcomes, omega-3 dosage ADHD questions, and practical considerations. It maintains a clear distinction between observational associations and intervention results, and emphasizes that any benefits are generally modest and most relevant when baseline omega-3 status is low. Omega-3 supplementation is discussed here strictly as potential adjunctive nutritional support, not as a replacement for established ADHD treatments.
+That does **not** yet create a validated blood-test cutoff, a universal EPA dose, or an ADHD-specific omega-3 target.
 
-## Important Medical Disclaimer
+**Bottom line:** omega-3 is better described as a plausible adjunctive nutritional intervention with heterogeneous evidence than as a proven ADHD treatment.
 
-This article is for educational purposes only and does not constitute medical advice. Omega-3 fatty acids do not treat or cure ADHD. Supplements should not replace established behavioral interventions or medication when clinically indicated. Benefits from omega-3 supplementation, when present, are generally modest, variable, and more likely in selected individuals with low baseline status. Individuals considering omega-3 supplementation should consult a qualified healthcare provider, especially when other medications are in use or when giving supplements to children.
+## Evidence at a glance
 
-## What Omega-3 Fatty Acids Are
+| Evidence source | Population / design | Main result | What it does not prove |
+|---|---|---|---|
+| 2026 biomarker-stratified meta-analysis | 7 pediatric ADHD RCTs / 10 analytical estimates | Small overall signal; larger estimate in low-baseline biomarker subgroup | No standardized biomarker cutoff or validated precision-nutrition protocol |
+| 2023 Cochrane review | 37 trials / more than 2,374 participants | High-certainty evidence of no effect on parent-rated total ADHD symptoms in medium term | Does not rule out benefit in narrower subgroups |
+| 2023 core-symptom meta-analysis | 22 RCTs / 1,789 participants | Overall core-symptom result not statistically significant; ≥4-month subgroup favored omega-3 | Longer duration was a subgroup finding, not proof of a universal treatment duration |
+| 2019 high-EPA RCT | Children/adolescents with ADHD | Attention/vigilance signals were stronger in participants with low baseline EPA | One trial cannot establish a universal EPA threshold or treatment rule |
+| 2014 three-way crossover | 90 randomized; 53 completed all periods | No significant treatment differences; blood EPA/DHA changes correlated with several outcomes | Correlation with achieved blood levels is not the same as randomized treatment efficacy |
 
-Omega-3 fatty acids are a family of polyunsaturated fats that include alpha-linolenic acid (ALA) from plant sources and the longer-chain forms EPA and DHA, which are primarily obtained from marine sources. EPA and DHA are the forms most relevant to brain health and the ones most commonly studied in ADHD research.
+## The 2026 update: baseline status may matter
 
-The body can convert ALA to EPA and DHA, but the conversion rate is low. Direct intake of EPA and DHA through diet or supplements is generally more effective for raising tissue levels.
+A 2026 systematic review and biomarker-stratified meta-analysis examined pediatric ADHD trials that measured baseline omega-3 status.
 
-## EPA
+Across seven randomized trials, the pooled effect was small. The subgroup categorized as having lower baseline omega-3 status showed a larger estimated benefit, while the normal/high or unstratified subgroup did not show a statistically significant effect.
 
-EPA is a 20-carbon omega-3 fatty acid strongly associated with the production of signaling molecules that help regulate inflammation and may influence mood and behavior. In ADHD research, formulas with higher EPA content relative to DHA have often shown more consistent signals for behavioral symptoms.
+This is one of the most useful developments in the omega-3/ADHD literature because it offers a possible explanation for years of conflicting trial results.
 
-## DHA
+But the authors were explicit about the limitation: the included trials used different biomarker matrices and different definitions of “low.” The result is therefore **hypothesis-generating**, not a validated clinical algorithm.
 
-DHA is a 22-carbon omega-3 fatty acid that is a major structural component of brain and retinal cell membranes. It supports membrane fluidity and is particularly important during periods of rapid brain development. DHA-dominant formulas have been studied less frequently for core ADHD behavioral symptoms than EPA-dominant preparations.
+### What this means in practice
 
-## ALA
+It is reasonable to say:
 
-ALA is an 18-carbon omega-3 fatty acid found in plant sources such as flaxseeds, chia seeds, and walnuts. The body converts ALA to EPA and DHA inefficiently. Direct intake of EPA and DHA from fish or supplements is more effective for raising relevant tissue levels.
+- baseline nutritional status may partly modify response;
+- future trials should prospectively stratify participants by a harmonized biomarker method;
+- people with low dietary or measured omega-3 status are scientifically more interesting candidates for future targeted research.
 
-## Fish Oil vs Algae Oil
+It is **not** reasonable to say:
 
-Traditional fish oil provides both EPA and DHA from marine sources. Algae oil offers a plant-based alternative that can deliver DHA and, in some formulations, EPA as well. Algae oil is suitable for vegetarians and vegans and avoids potential concerns about ocean contaminants when properly purified. Both sources can raise blood omega-3 levels effectively when the dose of EPA and DHA is equivalent.
+- an Omega-3 Index below a specific percentage predicts ADHD improvement;
+- every child with low EPA or DHA should be given a particular dose;
+- a blood test can diagnose an omega-3-responsive ADHD subtype;
+- normal blood status proves omega-3 cannot help an individual.
 
-## Dietary Fish vs Omega-3 Supplements
+## Why older meta-analyses look contradictory
 
-Regular consumption of fatty fish such as salmon, mackerel, and sardines can provide meaningful amounts of EPA and DHA. However, many individuals with ADHD show lower dietary intake of these foods. Supplement trials allow for controlled dosing and have been the primary source of evidence for behavioral outcomes in ADHD research.
+Omega-3/ADHD research varies substantially in:
 
-## How Omega-3s Work in the Brain
+- EPA and DHA composition;
+- trial duration;
+- baseline diet and biomarker status;
+- whether participants were also taking medication;
+- parent, teacher, clinician, or computerized outcomes;
+- ADHD severity and diagnostic criteria;
+- placebo oils;
+- adherence and achieved blood fatty-acid change.
 
-Omega-3 fatty acids are incorporated into neuronal membranes, where they influence membrane fluidity, receptor function, and signaling efficiency. They also serve as precursors for specialized pro-resolving mediators that help regulate inflammation in the brain. These actions support normal neurotransmission and may help modulate processes relevant to attention and emotional regulation.
+That makes a single headline such as “fish oil works for ADHD” or “fish oil does nothing for ADHD” too crude.
 
-## Omega-3s and Neuronal Membranes
+The 2023 Cochrane review included 37 trials and more than 2,374 participants. For parent-rated total ADHD symptoms in the medium term, it found high-certainty evidence of no effect versus placebo.
 
-DHA is highly concentrated in synaptic membranes. Adequate DHA supports efficient neurotransmitter release and receptor signaling. Lower DHA availability can affect membrane properties in ways that may influence cognitive and behavioral function, though the clinical implications in ADHD require further clarification through intervention studies.
+A separate 2023 meta-analysis of 22 trials and 1,789 participants likewise found that the overall core-symptom effect did not reach statistical significance. Its subgroup of trials lasting at least four months did favor omega-3, but neither higher EPA dose nor higher EPA:DHA ratio was a significant moderator in that analysis.
 
-## Omega-3s and Inflammation
+That last point matters because a common supplement-marketing claim is that **“high EPA is the proven ADHD formula.”** The evidence is not that simple.
 
-Chronic low-grade inflammation has been discussed in relation to ADHD symptoms. EPA-derived mediators can help resolve inflammation. Some researchers hypothesize that omega-3 supplementation may support better regulation of inflammatory pathways that could indirectly influence attention and behavior, though direct evidence linking this mechanism to ADHD outcomes remains limited.
+## EPA vs DHA: what is established and what is marketing shorthand
 
-## Omega-3s and Dopamine Signaling
+EPA and DHA are biologically different long-chain omega-3 fatty acids. DHA is highly represented in neural membranes; EPA participates in signaling and lipid-mediator pathways. Mechanistic plausibility, however, is not the same as proof that one commercial ratio is superior for ADHD.
 
-Omega-3 fatty acids may influence dopamine transporter function and receptor sensitivity in certain brain regions. These effects provide a plausible biological link to ADHD research, though the magnitude of any clinical impact on symptoms varies across studies.
+Earlier meta-analytic work suggested that higher EPA content might track with greater benefit. Later analyses have not consistently reproduced a dose or ratio effect.
 
-## Omega-3s and Neurodevelopment
+The most defensible interpretation is:
 
-Adequate omega-3 status during pregnancy and early childhood supports normal neuronal differentiation and brain development. Deficiency during critical developmental periods may affect neurodevelopmental trajectories, which has contributed to interest in omega-3 status in ADHD populations.
+| Claim | Evidence status |
+|---|---|
+| EPA and DHA are biologically distinct | Established |
+| Omega-3 status may matter to ADHD trial response | Emerging / plausible |
+| High-EPA products are universally superior for ADHD | Not established |
+| DHA-only products treat ADHD | Not established |
+| One EPA:DHA ratio is clinically validated for ADHD | Not established |
 
-## Why Researchers Became Interested in Omega-3 and ADHD
+## A high-EPA trial provides an important clue—not a dosing rule
 
-Interest developed from the combination of consistent observational findings of lower omega-3 levels in ADHD, the known importance of these fatty acids for brain development and function, and the relative safety of omega-3 supplementation. Early small trials suggested possible benefits, leading to larger studies and meta-analyses.
+A randomized 2019 trial studied high-dose EPA in children and adolescents with ADHD and measured erythrocyte fatty acids before treatment.
 
-## Omega-3 Status in ADHD
+The overall EPA group showed an improvement on one focused-attention measure. Participants with the lowest baseline EPA levels showed larger improvements on some attention/vigilance outcomes, while participants with high baseline EPA showed less favorable results on some measures.
 
-Multiple observational studies have documented lower blood levels of EPA and DHA in children and adults with ADHD. These differences appear across diverse populations and are consistent enough to have prompted substantial clinical research. However, observational data cannot determine whether low omega-3 status contributes to ADHD symptoms or results from dietary patterns and other factors associated with ADHD.
+This trial is highly relevant to the 2026 biomarker hypothesis. It is **not** a reason to copy the study exposure as an unsupervised pediatric protocol.
 
-## Blood Omega-3 Levels and ADHD
+The study was designed to test a research hypothesis under controlled conditions. It did not establish a universally safe or effective ADHD dose, a home-testing threshold, or a rule that more EPA is better.
 
-Case-control studies have repeatedly found lower plasma, serum, and red blood cell levels of EPA and DHA in children diagnosed with ADHD. Some studies also report associations between lower omega-3 levels and greater symptom severity.
+## The “Omega-3 Index” problem
 
-## Dietary Patterns and ADHD
+The Omega-3 Index generally refers to EPA + DHA in red-blood-cell membranes and can be useful as a longer-term fatty-acid biomarker.
 
-Children with ADHD sometimes show lower dietary intake of omega-3-rich foods, particularly fatty fish. Picky eating, sensory sensitivities, and family dietary patterns may contribute to lower intake. Improving overall diet quality remains an important foundational step.
+However, **there is no validated ADHD-specific Omega-3 Index target** in the current evidence base.
 
-## Direct ADHD Evidence
+Commercial or cardiovascular-oriented target ranges should not be imported into ADHD as though they were proven neuropsychiatric treatment thresholds. The 2026 biomarker review specifically called for harmonized assessments and standardized cutoffs before biomarker-guided supplementation can be recommended.
 
-Most omega-3 ADHD research has been conducted in school-age children. Randomized trials have used doses ranging from approximately 500 mg to over 1,000 mg combined EPA + DHA daily, with varying ratios. Some trials report improvements in parent- or teacher-rated hyperactivity and impulsivity after 8–16 weeks. Results for inattention are less consistent. Current evidence suggests greater likelihood of benefit when baseline status is low.
+That is a key distinction between measuring a biomarker and having a clinically validated decision threshold.
 
-## Pediatric ADHD Evidence
+## Fish-oil milligrams are not EPA + DHA milligrams
 
-Most supplementation research has been conducted in school-age children. Some trials report improvements in hyperactivity and impulsivity after 8–16 weeks. Results for inattention are less consistent. Current evidence suggests greater likelihood of benefit when baseline status is low.
+A front label may say “1,000 mg fish oil,” but that number is the mass of the oil—not necessarily the amount of EPA plus DHA.
 
-## Adult ADHD Evidence
+For evidence comparisons, the relevant quantities are the actual listed amounts of EPA and DHA per serving. FDA labeling rules require dietary ingredients without established Daily Values to be declared by quantity in the Supplement Facts panel when they are listed as dietary ingredients.
 
-High-quality randomized trials specifically in adults with confirmed ADHD are limited. Most cognitive and mood studies of omega-3 have been conducted in general adult populations or individuals with depression or anxiety rather than diagnosed ADHD. Adult-specific evidence remains preliminary.
+This matters because two “1,000 mg fish oil” products can deliver very different EPA/DHA exposures.
 
-## Evidence From Meta-Analyses
+When comparing a commercial label with a trial, compare **EPA and DHA amounts**, not the large fish-oil number printed on the front of the bottle.
 
-Meta-analyses of randomized controlled trials provide the strongest synthesis of supplementation outcomes. Several meta-analyses and systematic reviews have examined omega-3 supplementation for attention deficit hyperactivity disorder. Overall findings indicate small to modest improvements in hyperactivity symptoms and, to a lesser extent, inattention. Effect sizes are generally small compared with stimulant medication or comprehensive behavioral treatment.
+## Study doses are evidence descriptors, not consumer instructions
 
-## Evidence From Randomized Controlled Trials
+ADHD trials have used widely different EPA/DHA exposures, formulations, and durations. Reporting those exposures is useful for understanding the evidence, but converting them into a universal “ADHD dose” is not justified.
 
-Individual randomized controlled trials have produced mixed results. Some show statistically significant but modest reductions in hyperactivity. Others show minimal or no significant difference from placebo on core ADHD rating scales. Heterogeneity across studies is common due to differences in dose, EPA:DHA ratio, population characteristics, and study duration.
+This guide therefore does not provide:
 
-## EPA-Dominant Formulas
+- a pediatric start-and-titrate schedule;
+- an EPA:DHA ratio prescription;
+- an Omega-3 Index treatment target;
+- a claim that more EPA produces more benefit;
+- a recommendation to replace stimulant or non-stimulant treatment with fish oil.
 
-Many studies showing benefit have used preparations with higher EPA content relative to DHA. EPA’s role in producing anti-inflammatory and pro-resolving mediators may be more relevant to behavioral symptoms than DHA’s primary structural role in this context.
+## Medication context
 
-## DHA-Dominant Formulas
+Omega-3 trials include both monotherapy designs and studies where participants continued ADHD medication or another co-intervention.
 
-DHA-dominant formulas have been studied less frequently for core ADHD behavioral symptoms. DHA remains important for brain structure, but current evidence suggests EPA content may be more relevant for the behavioral outcomes most commonly measured in ADHD trials.
+That means the literature can address **adjunctive efficacy** to some extent, but it does not establish that every commercial omega-3 product is interchangeable or that adding fish oil will reduce a medication dose.
 
-## EPA + DHA Formulas
+No prescribed ADHD medication should be stopped, reduced, skipped, or replaced because of omega-3 use without the treating clinician.
 
-Many commercial products contain both EPA and DHA. Trials using combined formulas have produced variable results. Higher total EPA + DHA doses and longer durations (12+ weeks) have sometimes shown more consistent signals in meta-analyses.
+## Safety: the ADHD question is not the only question
 
-## EPA vs DHA Comparison Table
+NIH’s Office of Dietary Supplements notes that common omega-3 supplement adverse effects are usually mild and can include unpleasant taste, heartburn, nausea, gastrointestinal discomfort, diarrhea, and headache.
 
-| Fatty Acid | Main Role | ADHD-Relevant Interpretation |
-|---|---|---|
-| EPA | Inflammation regulation, mood/behavior signaling | Higher-EPA formulas show stronger signals in many ADHD trials |
-| DHA | Brain and retinal membrane structure | Important for neurodevelopment, but less consistently linked to short-term ADHD symptom change |
-| EPA + DHA | Combined membrane and signaling support | Common in commercial products; results depend on dose, ratio, duration, and baseline status |
-| ALA | Plant omega-3 precursor | Converts poorly to EPA/DHA; less useful as a direct ADHD supplement strategy |
+At higher exposures, omega-3s can affect platelet function. Large cardiovascular trials using 4 g/day for years also found a small increase in atrial-fibrillation risk in people with cardiovascular disease or high cardiovascular risk. Those populations and exposures are not equivalent to typical pediatric ADHD trials, but they are a useful reminder that “nutrient” does not mean “risk-free at any amount.”
 
-## Effects on Inattention
+People using anticoagulants, prescription omega-3 drugs, multiple supplements, or high-dose products should have the overall plan reviewed by a clinician or pharmacist.
 
-Evidence for improvements in inattention is weaker and more variable than for hyperactivity. Some studies show small benefits while others show no significant difference from placebo. Any inattention effects are typically smaller than those observed for hyperactivity.
+## Product quality is a real evidence variable
 
-## Effects on Hyperactivity
+The supplement a consumer buys is not automatically equivalent to the product used in a randomized trial.
 
-Meta-analyses and individual trials most consistently show modest reductions in hyperactivity symptoms with omega-3 supplementation. Effects are generally small but may be clinically meaningful for some children when combined with other supports.
+Commercial analyses have found substantial variability in EPA/DHA label accuracy and oxidation markers. A U.S. analysis of 47 fish, krill, and algal products found wide variation between measured and stated EPA/DHA content. A later multi-year analysis of 72 U.S. marine and microalgal products found that oxidation results varied sharply by formulation, with flavored products particularly difficult to evaluate because flavor compounds can interfere with standard oxidation measurements.
 
-## Effects on Impulsivity
+These studies do **not** tell you that a particular bottle on sale today is inaccurate or oxidized. They do show why product identity and independent quality verification matter when translating clinical research into the supplement marketplace.
 
-Some trials report modest reductions in impulsivity measures. Results are not uniform across studies.
+### A more defensible quality checklist
 
-## Effects on Emotional Regulation
+Prefer products that make it easy to verify:
 
-Limited data exist on emotional regulation outcomes. Some studies suggest possible benefits in irritability or emotional lability, particularly in individuals with co-occurring mood or anxiety symptoms, but evidence specific to ADHD remains emerging.
+- EPA amount per serving;
+- DHA amount per serving;
+- serving size;
+- lot-specific or current third-party testing when available;
+- contaminant and oxidation testing from a credible laboratory or certification program;
+- expiration/storage instructions.
 
-## Effects on Executive Function
+Do not assume that “pharmaceutical grade,” “molecularly distilled,” “high potency,” or “high EPA” is itself proof of clinical efficacy for ADHD.
 
-Evidence for direct improvements in executive function measures is limited. Any benefits are likely indirect through better sleep, reduced stress, or modest symptom improvements rather than primary enhancement of executive processes.
+## Evidence-applicability ledger
 
-## Effects on Academic Performance
+| Question | Current answer |
+|---|---|
+| Does omega-3 reliably improve core ADHD symptoms across all children? | No; pooled evidence is inconsistent and some high-certainty outcomes are null |
+| Could baseline omega-3 status modify response? | Possibly; 2026 biomarker-stratified evidence supports further study |
+| Is there a validated low-EPA/DHA cutoff for ADHD treatment decisions? | No |
+| Is high EPA proven superior to all other formulas? | No |
+| Is there a validated ADHD Omega-3 Index target? | No |
+| Can study doses be copied into a universal pediatric protocol? | No |
+| Are fish-oil supplements equivalent to prescription omega-3 drugs? | No |
+| Does a “1,000 mg fish oil” front label tell you EPA+DHA exposure? | No |
 
-Some studies have included academic or classroom behavior outcomes. Results are mixed and generally modest. Improvements, when present, are often secondary to reductions in hyperactivity or better emotional regulation.
+## Unanswered questions worth tracking
 
-## Effects on Sleep
+The highest-value research questions now are more specific than “does fish oil help ADHD?”
 
-Omega-3 fatty acids play roles in melatonin regulation and inflammatory pathways that influence sleep. A subset of ADHD trials that included sleep outcomes reported modest improvements in sleep quality with omega-3 supplementation, particularly in children. Evidence is not strong enough to position omega-3 as a primary sleep intervention.
+1. Can prospective trials confirm that low baseline EPA/DHA predicts response?
+2. Which biomarker matrix should be used—erythrocytes, plasma, or another measure?
+3. What cutoff, if any, identifies a clinically meaningful low-status subgroup?
+4. Does biomarker-guided supplementation outperform unselected supplementation?
+5. Are any benefits specific to attention, emotional regulation, or another symptom domain?
+6. Do medication-treated and medication-naive populations respond differently?
+7. Does achieved change in blood EPA/DHA predict clinical improvement better than assigned dose?
+8. How much of trial heterogeneity comes from product composition, adherence, or placebo choice?
 
-## Evidence Grade Assessment
+## Frequently asked questions
 
-Observational evidence linking lower omega-3 levels to ADHD is moderate. Intervention evidence from meta-analyses supports modest benefits for hyperactivity, particularly with higher-EPA formulations and when baseline status is low. Overall evidence quality is moderate, with clear limitations in consistency and effect magnitude. Benefits are usually modest and more likely in selected individuals.
+### Does omega-3 treat ADHD?
 
-## Why Results Are Mixed
+Current evidence does not establish omega-3 as a stand-alone ADHD treatment. Large reviews are mixed, and some high-certainty pooled outcomes are null. It may have a small adjunctive role in selected populations.
 
-Differences in study design, including dose, EPA:DHA ratio, duration, participant age, baseline nutrient status, and outcome measures, contribute to varying results. Studies using higher EPA content and longer durations have sometimes shown more consistent signals.
+### Does low omega-3 status mean supplementation will work?
 
-## Why Benefits Are Usually Modest
+Not necessarily. The 2026 biomarker-stratified meta-analysis suggests larger effects in lower-baseline groups, but definitions of “low” differed across trials and no validated ADHD treatment cutoff exists.
 
-Effect sizes in omega-3 ADHD meta-analyses are typically in the small range, approximately SMD 0.2–0.4 for hyperactivity in major meta-analyses. While average improvements can reach statistical significance, individual responses vary widely, and many participants show minimal change. Benefits are more noticeable when baseline omega-3 status is low.
+### Is EPA better than DHA for ADHD?
 
-## Who Responds Best
+That has not been firmly established. Some earlier analyses and individual trials favor an EPA hypothesis, while later meta-analysis did not find high EPA dose or EPA:DHA ratio to be a significant moderator of core symptoms.
 
-Current evidence suggests greater likelihood of benefit in the following groups:
+### What is the best EPA:DHA ratio for ADHD?
 
-| Response Predictor | Why It Matters | Practical Interpretation |
-|---|---|---|
-| Low dietary omega-3 intake | Lower intake may mean more room for improvement | Assess fatty fish intake before supplementing |
-| Low omega-3 index | Blood status may identify low baseline EPA/DHA | Testing can help target supplementation |
-| Higher EPA dose | EPA-dominant formulas show stronger behavioral signals | Consider EPA content, not just total fish oil amount |
-| Poor overall diet quality | Nutrient gaps may worsen symptom burden | Address diet quality alongside supplementation |
-| Emotional dysregulation or irritability | EPA may support mood-related pathways | Benefits may be more noticeable in selected profiles |
+No universal ratio has been validated.
 
-> **Practical note:** Omega-3 is most rational when dietary intake is low, baseline status is low, or the person has prominent hyperactivity/emotional dysregulation. It is less compelling as a random add-on when diet and blood status are already strong.
+### Should someone use an Omega-3 Index test for ADHD?
 
-## Omega-3 as an Adjunct to ADHD Medication
+A red-blood-cell omega-3 measure can describe fatty-acid status, but there is no validated ADHD-specific target or response threshold. Testing should not be presented as an established ADHD precision-treatment algorithm.
 
-Limited data exist on combining omega-3 with ADHD medications. Some theoretical rationale exists based on complementary mechanisms, but clinical evidence for additive benefits is preliminary. Omega-3 supplementation does not appear to interfere with stimulant medications in available studies.
+### How quickly does omega-3 work for ADHD?
 
-## Omega-3 and Stimulants
-
-No robust trials have established clear additive benefits of combining omega-3 with stimulant medications in ADHD. Any use in combination should occur under clinical guidance, with attention to overall treatment plan.
-
-## Omega-3 and Non-Stimulant Medications
-
-Even less evidence exists for combinations with non-stimulant ADHD medications. Professional guidance is recommended.
-
-## Omega-3 in ADHD Supplement Stacks
-
-Omega-3 is frequently included as a foundational nutrient support in broader approaches. It combines well with most other supplements and is often prioritized when dietary intake or blood levels are low. It should be introduced thoughtfully with clear tracking rather than in large untested combinations.
-
-## Dosing Considerations
-
-### Common Study Doses
-
-Trials have commonly used 500–1,500 mg combined EPA + DHA daily, with some using higher amounts.
-
-### EPA Dose
-
-Many studies showing benefit have used at least 500–1,000 mg EPA daily.
-
-### DHA Dose
-
-DHA doses in positive trials have varied but are often lower than EPA in ADHD-focused formulations.
-
-### Total EPA + DHA Dose
-
-Total daily doses in research have ranged from approximately 500 mg to over 2,000 mg combined EPA + DHA.
-
-### EPA:DHA Ratio
-
-No single ratio has been definitively established as superior across all ADHD presentations. Many studies showing benefit have used EPA-dominant preparations.
-
-## How Long Omega-3 Takes To Work
-
-Fish oil for ADHD is not an acute focus aid. Most studies measure symptom outcomes after 8–16 weeks of consistent use, because EPA and DHA gradually incorporate into cell membranes.
-
-Most ADHD supplementation studies have measured outcomes after 8–16 weeks of consistent use. Benefits on behavioral symptoms are generally evaluated over this timeframe rather than acutely. Incorporation of omega-3 fatty acids into cell membranes occurs gradually.
-
-## Omega-3 Index Testing
-
-The Omega-3 Index measures EPA + DHA in red blood cell membranes and can help estimate long-term omega-3 status. Levels below 4% are commonly considered low, while 8% or higher is often treated as an optimal target for general cardiometabolic health. ADHD-specific targets have not been firmly established.
-
-Testing is not required for everyone, but it may be useful when dietary intake is unclear, when someone wants a measurable baseline, or when deciding whether supplementation is likely to be worth a long 8–16 week trial. For the broader nutrient-assessment framework, this article should link naturally to Nutrient Deficiencies and ADHD, Zinc and ADHD, Iron/Ferritin and ADHD, and Vitamin D and ADHD.
-
-## Quality Considerations
-
-### Triglyceride vs Ethyl Ester Forms
-
-Triglyceride or re-esterified triglyceride forms with verified EPA and DHA content are often recommended. Ethyl ester forms may have lower absorption unless taken with food.
-
-### Third-Party Testing
-
-Independent verification helps confirm label accuracy and purity. Look for USP, NSF, IFOS, ConsumerLab, or equivalent third-party testing.
-
-### Oxidation and Rancidity
-
-Omega-3 oils are prone to oxidation. High-quality products are tested for oxidation markers such as peroxide value, anisidine value, and TOTOX. Rancid oil may reduce effectiveness and cause unpleasant side effects.
-
-### Mercury and Contaminants
-
-Properly purified fish oil supplements have very low mercury levels. Quality products from reputable manufacturers minimize this risk.
-
-### Fish Oil Burps and Tolerability
-
-Enteric-coated or flavored products may improve tolerability. Taking with food can reduce fishy aftertaste or gastrointestinal discomfort.
-
-## Fish Oil Quality Checklist
-
-| Criteria | What to Look For | Why It Matters |
-|---|---|---|
-| Form | Triglyceride or re-esterified triglyceride | Often better absorbed than ethyl ester forms |
-| Third-party testing | USP, NSF, IFOS, ConsumerLab, or equivalent | Verifies purity, potency, and contaminants |
-| Oxidation testing | Low peroxide, anisidine, and TOTOX values | Helps avoid rancid oil |
-| EPA + DHA content | Clearly labeled actual EPA and DHA amounts | Avoids under-dosed products |
-| Mercury and contaminants | Purified or independently tested | Supports long-term safety |
-| Smell and taste | Mild or neutral, not strongly fishy or rancid | Strong rancid odor suggests oxidation |
-
-## Safety Profile
-
-Omega-3 supplements are generally well tolerated at studied doses.
-
-## Common Side Effects
-
-Fishy aftertaste, gastrointestinal discomfort, and loose stools are the most frequently reported side effects. These are often dose-dependent and may improve with lower doses or higher-quality products.
-
-## Bleeding Risk
-
-High doses of omega-3 fatty acids may have mild blood-thinning effects. Clinical significance at typical supplemental doses is usually low but should be considered in individuals taking anticoagulant medications.
-
-## Medication Interactions
-
-Omega-3 supplements may enhance the effects of anticoagulant or antiplatelet medications. They can also interact with certain blood pressure medications. Full medication reconciliation with a healthcare provider is recommended.
-
-## Pediatric Considerations
-
-Most omega-3 ADHD research has been conducted in children. Doses in studies have varied widely. Supplementation should involve clinical guidance, and behavioral and dietary strategies should be addressed first.
-
-## Adult Considerations
-
-Adult-specific ADHD data are more limited. General evidence supports cardiovascular and mood benefits in adults, which may be relevant for some individuals with ADHD, but direct evidence for core ADHD symptoms remains preliminary.
-
-## Pregnancy and Breastfeeding Considerations
-
-Omega-3 fatty acids, particularly DHA, are important during pregnancy and breastfeeding for fetal and infant brain development. Individuals who are pregnant or breastfeeding should discuss supplementation with a healthcare provider.
-
-## Omega-3 vs Magnesium
-
-Omega-3 fatty acids have more consistent evidence for modest behavioral improvements across meta-analyses. Magnesium has broader observational associations and some evidence for sleep and calming support. They address different mechanisms and are sometimes used together.
-
-## Omega-3 vs Zinc
-
-Both have observational links to ADHD. Omega-3 has more intervention data from meta-analyses. Zinc evidence appears more dependent on correcting documented deficiency. Assessment of both may be relevant in comprehensive evaluation.
-
-## Omega-3 vs Iron/Ferritin
-
-Iron/ferritin status has been linked to symptom severity and medication response in some studies. Omega-3 has broader evidence for behavioral symptoms. Both may warrant attention when deficiency is suspected.
-
-## Omega-3 vs Vitamin D
-
-Vitamin D deficiency is common and has observational links to ADHD. Omega-3 has more direct intervention data in ADHD populations. Both can be relevant depending on individual status.
-
-## Omega-3 vs L-Theanine
-
-L-Theanine has evidence for calm focus and sleep support in selected contexts. Omega-3 has more consistent evidence for modest behavioral improvements across meta-analyses. They address different mechanisms and may be complementary.
-
-## Omega-3 vs Citicoline
-
-Citicoline primarily supports acetylcholine and membrane metabolism. Omega-3 supports membrane structure and inflammatory regulation. They have different primary mechanisms and may be used together in some stacks.
-
-## Who Might Benefit Most
-
-Individuals with low dietary omega-3 intake, low omega-3 index, or prominent hyperactivity may be more likely to experience modest benefits from supplementation.
-
-## Who Should Use Caution
-
-People taking anticoagulant medications, those with bleeding disorders, or individuals with fish allergies should use caution. Professional guidance is important for children and anyone considering high doses.
-
-## What Not To Expect
-
-> **Quick Summary — What Omega-3 Can and Cannot Do for ADHD**
->
-> - May modestly reduce hyperactivity, which is the strongest signal.
-> - Has small or inconsistent effects on inattention.
-> - May offer secondary support for emotional regulation or sleep in selected people.
-> - Does not replace medication, behavioral therapy, sleep optimization, or educational support.
-> - Is most rational when omega-3 intake or omega-3 status is low.
-
-Omega-3 supplementation produces modest average improvements in hyperactivity and does not dramatically improve core ADHD symptoms for most people. Benefits are generally smaller than those seen with established treatments. Not everyone will experience meaningful change. Omega-3 does not replace ADHD medication or behavioral treatment.
-
-## Practical Decision Framework
-
-A conservative approach includes assessing dietary omega-3 intake, considering targeted testing such as Omega-3 Index when clinically relevant, optimizing overall nutrition and behavioral strategies first, introducing a quality omega-3 supplement at studied doses if indicated, tracking symptoms over at least 8–12 weeks, and reassessing need periodically. This article should support the ADHD Stack Guide and Best Supplements for ADHD by showing omega-3 as a foundational but modest adjunct rather than a standalone intervention.
-
-## Research Gaps
-
-Larger trials with standardized high-EPA formulations, longer durations, and better characterization of baseline status are needed. More adult-specific data and studies examining optimal EPA:DHA ratios for different ADHD presentations would strengthen guidance. The interaction between omega-3 status and medication response deserves further investigation.
-
-## Conclusion
-
-Observational research consistently links lower omega-3 levels with ADHD, and meta-analyses of supplementation trials support modest benefits for hyperactivity, particularly with higher-EPA formulations and when baseline status is low. Effects on inattention are less consistent. Benefits are generally small in magnitude and most relevant as adjunctive support rather than primary treatment.
-
-Omega-3 supplementation has a favorable safety profile at studied doses and may be a reasonable consideration for individuals with low intake or low omega-3 index. A responsible approach prioritizes dietary quality, targeted assessment when indicated, and systematic evaluation of individual response. Expectations should remain realistic regarding the scope and magnitude of any benefits.
-
-## FAQ
-
-### Does omega-3 help ADHD?
-
-Meta-analyses show modest average improvements in hyperactivity. Benefits are generally small and more noticeable when baseline omega-3 status is low.
-
-### Is fish oil good for ADHD?
-
-Some individuals experience modest reductions in hyperactivity with consistent use of quality fish oil. Results vary, and benefits are usually modest compared with established treatments.
-
-### Is EPA or DHA better for ADHD?
-
-Many studies showing benefit have used higher EPA content. EPA appears more relevant for behavioral symptoms in current research, though both are important for brain health.
-
-### How much omega-3 should I take for ADHD?
-
-Studied doses have commonly included at least 500–1,000 mg EPA daily, with total EPA + DHA often ranging from 500–1,500 mg. Professional guidance is recommended.
-
-### How long does omega-3 take to work?
-
-Most studies measure outcomes after 8–16 weeks of consistent use. Benefits on behavioral symptoms are generally evaluated over this timeframe.
-
-### Can omega-3 improve inattention?
-
-Evidence for improvements in inattention is weaker and more variable than for hyperactivity. Some studies show small benefits while others show no significant difference.
-
-### Can omega-3 reduce hyperactivity?
-
-Meta-analyses most consistently show modest reductions in hyperactivity symptoms with omega-3 supplementation.
-
-### Can omega-3 help impulsivity?
-
-Some trials report modest reductions in impulsivity measures. Results are not uniform across studies.
-
-### Can omega-3 improve emotional regulation?
-
-Some studies suggest possible benefits in irritability or emotional lability, particularly in individuals with co-occurring mood symptoms, but evidence specific to ADHD is limited.
-
-### Is omega-3 safe for children?
-
-Omega-3 supplements are generally well tolerated in children at studied doses. Use should involve clinical guidance.
+The research evaluates outcomes over weeks to months rather than as an acute focus aid. A 2023 meta-analysis found a signal in trials lasting at least four months, but that subgroup result does not prove a universal minimum treatment duration.
 
 ### Can omega-3 replace ADHD medication?
 
-No. Omega-3 supplementation does not produce effects comparable to established treatments for core ADHD symptoms.
+No. Omega-3 should not be presented as a substitute for established ADHD treatment.
 
-### Can omega-3 be taken with stimulants?
+## Sources
 
-Limited clinical data exist on combinations. Professional guidance is recommended, with attention to overall treatment plan.
-
-### Is algae oil useful for ADHD?
-
-Algae oil can raise EPA and DHA levels effectively when the dose is equivalent to fish oil. It is a suitable option for vegetarians and vegans.
-
-### What is the best EPA:DHA ratio?
-
-No single ratio has been definitively established as superior. Many studies showing benefit have used EPA-dominant preparations.
-
-### Should omega-3 be taken with food?
-
-Taking omega-3 supplements with meals containing fat can improve absorption and reduce fishy aftertaste or gastrointestinal discomfort.
-
-### Can fish oil cause side effects?
-
-Fishy aftertaste, gastrointestinal discomfort, and loose stools are the most frequently reported side effects. These are often dose-dependent.
-
-### Does omega-3 help sleep?
-
-A subset of ADHD trials reported modest improvements in sleep quality with omega-3 supplementation. Evidence is not strong enough to position omega-3 as a primary sleep intervention.
-
-### How do I know if fish oil is rancid?
-
-Rancid oil often has a strong fishy or unpleasant odor and taste. High-quality products should not smell strongly rancid. Check for third-party testing of oxidation markers.
-
-### Is eating fish enough?
-
-Regular consumption of fatty fish can provide meaningful EPA and DHA. Supplementation may still be considered if intake is low or blood levels remain suboptimal.
-
-### Who should avoid omega-3?
-
-People taking anticoagulant medications, those with bleeding disorders, or individuals with fish allergies should use caution. Professional guidance is important for children and anyone considering high doses.
-
-### Can omega-3 improve academic performance in ADHD?
-
-Some studies show modest secondary benefits in classroom behavior or academic outcomes, usually linked to reductions in hyperactivity.
-
-### What is the Omega-3 Index and should I test it?
-
-The Omega-3 Index measures EPA + DHA in red blood cell membranes. Levels below 4% are considered low, while 8% or higher is commonly treated as optimal for general health. Testing can help identify individuals more likely to benefit from supplementation, but ADHD-specific targets are not firmly established.
-
-## Evidence Summary Table
-
-| Area | Population | Key Findings | Evidence Strength | Practical Interpretation |
-|---|---|---|---|---|
-| Lower omega-3 levels in ADHD | Children and adults | Consistent observational association | Moderate | Supports assessment of dietary intake and status |
-| Supplementation on hyperactivity | Children with ADHD | Modest reductions in meta-analyses | Moderate | More noticeable with higher EPA and low baseline status |
-| Supplementation on inattention | Children with ADHD | Mixed and generally weaker results | Low to Moderate | Less consistent benefit across studies |
-| EPA vs DHA | ADHD trials | Higher EPA formulations often show stronger signals | Moderate | EPA-dominant products frequently used in positive trials |
-| Adult ADHD evidence | Adults with ADHD | Very limited high-quality data | Limited | Most evidence is pediatric |
-| Safety | General populations | Generally well tolerated at studied doses | Moderate to High | Mild gastrointestinal effects most common |
-| Effect on medication response | Limited data | Some signals for adjunctive benefit | Preliminary | Requires further study |
-
-## Related Articles
-
-- Best Supplements for ADHD: Evidence-Based Options for Focus, Sleep, and Emotional Regulation
-- ADHD Stack Guide: Building an Evidence-Based Approach to Focus, Sleep, and Emotional Regulation
-- Nutrient Deficiencies and ADHD: What the Research Shows
-- Magnesium for ADHD: Forms, Evidence, Dosage, and Practical Use
-- Zinc and ADHD: What the Research Shows About Symptoms, Deficiency, and Supplementation
-- Iron/Ferritin and ADHD: What the Research Shows About Low Iron Stores, Symptoms, and Supplementation
-- Vitamin D and ADHD: What the Research Shows
-- L-Theanine and ADHD: What the Research Shows About Attention, Hyperactivity, Sleep, and Emotional Regulation
-- Citicoline and ADHD: What the Research Shows About Attention, Focus, and Cognitive Performance
-- Sleep and ADHD: Evidence-Based Strategies for Better Focus, Behavior, and Daily Functioning
-
-## Internal Linking Recommendations
-
-This article should function as one of the core ADHD supplement evidence pages within the Focus / ADHD cluster. It should link bidirectionally to the ADHD Stack Guide and Best Supplements for ADHD pillar. It should also connect strongly to Nutrient Deficiencies and ADHD, Zinc and ADHD, Iron/Ferritin and ADHD, and Vitamin D and ADHD. Supporting links should be created to Magnesium for ADHD, L-Theanine and ADHD, Citicoline and ADHD, and Sleep and ADHD. These connections help establish comprehensive topical authority around evidence-based nutrient assessment and targeted supplementation while guiding readers toward systematic, conservative decision-making across the cluster.
+1. Fu Y, Feng L, Jiang W, Li Y. Baseline omega-3 nutritional status and supplementation response in pediatric attention-deficit/hyperactivity disorder: a systematic review and biomarker-stratified meta-analysis. 2026. PMID 42433395. https://pubmed.ncbi.nlm.nih.gov/42433395/
+2. Gillies D, et al. Polyunsaturated fatty acids (PUFA) for attention deficit hyperactivity disorder (ADHD) in children and adolescents. Cochrane Database Syst Rev. 2023. PMID 37058600. https://pubmed.ncbi.nlm.nih.gov/37058600/
+3. Liu TH, et al. Omega-3 Polyunsaturated Fatty Acids for Core Symptoms of Attention-Deficit/Hyperactivity Disorder: A Meta-Analysis of Randomized Controlled Trials. 2023. PMID 37656283. https://pubmed.ncbi.nlm.nih.gov/37656283/
+4. Chang JPC, et al. High-dose eicosapentaenoic acid (EPA) improves attention and vigilance in children and adolescents with ADHD and low endogenous EPA levels. 2019. PMID 31745072. https://pubmed.ncbi.nlm.nih.gov/31745072/
+5. Milte CM, et al. Increased erythrocyte EPA and DHA are associated with improved attention and behavior in children with ADHD in a randomized three-way crossover trial. 2014. PMID 24214970. https://pubmed.ncbi.nlm.nih.gov/24214970/
+6. Puri BK, et al. Which polyunsaturated fatty acids are active in children with ADHD receiving PUFA supplementation? A fatty-acid validated meta-regression analysis. 2014. PMID 24560325. https://pubmed.ncbi.nlm.nih.gov/24560325/
+7. NIH Office of Dietary Supplements. Omega-3 Fatty Acids: Health Professional Fact Sheet. https://ods.od.nih.gov/factsheets/Omega3FattyAcids-HealthProfessional/
+8. U.S. Food and Drug Administration. Dietary Supplement Labeling Guide: Nutrition Labeling. https://www.fda.gov/food/dietary-supplements-guidance-documents-regulatory-information/dietary-supplement-labeling-guide-chapter-iv-nutrition-labeling
+9. Kleiner AC, et al. A comparison of actual versus stated label amounts of EPA and DHA in commercial omega-3 dietary supplements in the United States. 2015. PMID 25044306. https://pubmed.ncbi.nlm.nih.gov/25044306/
+10. Albert BB, et al. A Multi-Year Rancidity Analysis of 72 Marine and Microalgal Oil Omega-3 Supplements. 2023. PMID 37712532. https://pubmed.ncbi.nlm.nih.gov/37712532/


### PR DESCRIPTION
## Why
The omega-3/ADHD page had useful breadth but overstated several common claims: that higher-EPA formulas are generally superior, that baseline status can already be used as a validated treatment-selection tool, and that commercial Omega-3 Index targets translate directly into ADHD care.

## What changed
- adds the 2026 biomarker-stratified meta-analysis of pediatric ADHD RCTs
- contrasts that signal with the 2023 Cochrane review and 2023 22-trial core-symptom meta-analysis
- separates biomarker hypothesis from validated precision-nutrition guidance
- removes unsupported ADHD-specific Omega-3 Index targets
- recalibrates high-EPA / EPA:DHA superiority claims
- adds the 2019 low-baseline-EPA trial as hypothesis support rather than a dosing rule
- adds fish-oil-mg vs actual EPA+DHA-mg translation
- adds current NIH ODS safety context
- adds commercial label-accuracy / oxidation evidence with explicit limits on what product surveys prove
- adds evidence-applicability and unanswered-question ledgers
- updates SEO metadata around the 2026 evidence

## Safety calibration
No pediatric dosing protocol, ratio prescription, medication-replacement advice, or biomarker treatment cutoff is provided.