### PR TITLE
feat(evidence): structure study-level evidence and heterogeneity

### DIFF
--- a/components/ui/ShowMeTheStudies.tsx
+++ b/components/ui/ShowMeTheStudies.tsx
@@ -1,115 +1,202 @@
+import {
+  evidenceConsistencyLabel,
+  evidenceRelationshipLabel,
+  evidenceSourceUrl,
+  formatEvidenceStudyClass,
+  normalizeEvidenceStudyClass,
+  summarizeEvidenceStudies,
+  type EvidenceConfidence,
+  type EvidenceRelationship,
+  type EvidenceStudyClass,
+  type EvidenceStudyRecord,
+} from '@/lib/evidence-study'
+
 export interface Citation {
+  id?: string
   title: string
   pmid?: string
   doi?: string
   url?: string
   year?: number | string
   authors?: string
+  journal?: string
   studyType?: string
+  evidenceClass?: EvidenceStudyClass
   sampleSize?: string | number
+  dose?: string
+  duration?: string
+  population?: string
+  outcome?: string
+  result?: string
+  limitation?: string
+  relationship?: EvidenceRelationship
+  confidence?: EvidenceConfidence
+  statisticalConsistency?: string
+  extractName?: string
+  ingredients?: string[]
+  conditions?: string[]
+  safetyOutcome?: string
 }
 
 interface Props {
   citations: Citation[]
+  conclusion?: string
+  evidenceGrade?: string
+  confidence?: EvidenceConfidence
+  whatWouldChangeConclusion?: string
 }
 
-const STUDY_TYPE_ORDER = ['Randomized controlled trial', 'Systematic review', 'Meta-analysis', 'Observational', 'Mechanistic', 'Animal', 'In vitro']
+const STUDY_CLASS_ORDER: EvidenceStudyClass[] = [
+  'meta_analysis',
+  'systematic_review',
+  'randomized_controlled_trial',
+  'controlled_trial',
+  'observational',
+  'case_report',
+  'narrative_review',
+  'mechanistic',
+  'animal',
+  'in_vitro',
+  'other',
+]
 const VISIBLE_ROWS = 6
 
-function StudyTypeBadge({ type }: { type: string }) {
+function normalizedStudy(citation: Citation): EvidenceStudyRecord {
+  const evidenceClass = citation.evidenceClass || normalizeEvidenceStudyClass(citation.studyType)
+  return {
+    id: citation.id || citation.pmid || citation.doi || citation.url || citation.title,
+    title: citation.title,
+    authors: citation.authors,
+    journal: citation.journal,
+    year: citation.year,
+    pmid: citation.pmid,
+    doi: citation.doi,
+    url: citation.url,
+    studyType: citation.studyType,
+    evidenceClass,
+    sampleSize: citation.sampleSize,
+    dose: citation.dose,
+    duration: citation.duration,
+    population: citation.population,
+    outcome: citation.outcome,
+    result: citation.result,
+    limitation: citation.limitation,
+    relationship: citation.relationship || 'background',
+    confidence: citation.confidence || 'unknown',
+    statisticalConsistency: citation.statisticalConsistency,
+    extractName: citation.extractName,
+    ingredients: citation.ingredients,
+    conditions: citation.conditions,
+    safetyOutcome: citation.safetyOutcome,
+  }
+}
+
+function StudyTypeBadge({ study }: { study: EvidenceStudyRecord }) {
+  const type = formatEvidenceStudyClass(study.evidenceClass)
   const lower = type.toLowerCase()
   let classes = 'border-stone-300/50 bg-stone-50 text-stone-700 dark:border-stone-200/20 dark:bg-stone-300/10 dark:text-stone-100'
 
-  if (lower.includes('randomized') || lower.includes('rct') || lower.includes('placebo-controlled')) {
+  if (study.evidenceClass === 'randomized_controlled_trial' || study.evidenceClass === 'controlled_trial') {
     classes = 'border-emerald-600/25 bg-emerald-50 text-emerald-800 dark:border-emerald-200/20 dark:bg-emerald-300/10 dark:text-emerald-100'
-  } else if (
-    lower.includes('meta-analysis') ||
-    lower.includes('meta analysis') ||
-    lower.includes('systematic review')
-  ) {
+  } else if (study.evidenceClass === 'meta_analysis' || study.evidenceClass === 'systematic_review') {
     classes = 'border-blue-600/25 bg-blue-50 text-blue-800 dark:border-blue-200/20 dark:bg-blue-300/10 dark:text-blue-100'
-  } else if (
-    lower.includes('observational') ||
-    lower.includes('cohort') ||
-    lower.includes('cross-sectional')
-  ) {
+  } else if (study.evidenceClass === 'observational') {
     classes = 'border-violet-600/25 bg-violet-50 text-violet-800 dark:border-violet-200/20 dark:bg-violet-300/10 dark:text-violet-100'
-  } else if (lower.includes('human') || lower.includes('clinical trial')) {
-    classes = 'border-emerald-500/20 bg-emerald-50/70 text-emerald-700 dark:border-emerald-200/20 dark:bg-emerald-300/10 dark:text-emerald-100'
-  } else if (
-    lower.includes('mechanistic') ||
-    lower.includes('in vitro') ||
-    lower.includes('cell')
-  ) {
+  } else if (lower.includes('mechanistic') || study.evidenceClass === 'in_vitro') {
     classes = 'border-amber-500/30 bg-amber-50 text-amber-800 dark:border-amber-200/20 dark:bg-amber-300/10 dark:text-amber-100'
-  } else if (
-    lower.includes('animal') ||
-    lower.includes('rodent') ||
-    lower.includes('in vivo') ||
-    lower.includes('murine')
-  ) {
+  } else if (study.evidenceClass === 'animal') {
     classes = 'border-orange-400/30 bg-orange-50/70 text-orange-700 dark:border-orange-200/20 dark:bg-orange-300/10 dark:text-orange-100'
   }
 
   return (
-    <span
-      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold tracking-wide ${classes}`}
-    >
+    <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold tracking-wide ${classes}`}>
       {type}
     </span>
   )
 }
 
-function sortByStudyType(a: Citation, b: Citation) {
-  const aIdx = STUDY_TYPE_ORDER.findIndex(t => a.studyType?.toLowerCase().includes(t.toLowerCase()))
-  const bIdx = STUDY_TYPE_ORDER.findIndex(t => b.studyType?.toLowerCase().includes(t.toLowerCase()))
-  const aRank = aIdx === -1 ? STUDY_TYPE_ORDER.length : aIdx
-  const bRank = bIdx === -1 ? STUDY_TYPE_ORDER.length : bIdx
+function RelationshipBadge({ relationship }: { relationship: EvidenceRelationship }) {
+  const tone = relationship === 'supports'
+    ? 'border-emerald-600/20 bg-emerald-50 text-emerald-800'
+    : relationship === 'contradicts'
+      ? 'border-rose-600/20 bg-rose-50 text-rose-800'
+      : relationship === 'mixed' || relationship === 'no_clear_effect'
+        ? 'border-amber-600/20 bg-amber-50 text-amber-800'
+        : 'border-stone-300/60 bg-stone-50 text-stone-700'
+
+  return (
+    <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold ${tone}`}>
+      {evidenceRelationshipLabel(relationship)}
+    </span>
+  )
+}
+
+function sortByStudyType(a: EvidenceStudyRecord, b: EvidenceStudyRecord) {
+  const aRank = STUDY_CLASS_ORDER.indexOf(a.evidenceClass)
+  const bRank = STUDY_CLASS_ORDER.indexOf(b.evidenceClass)
   return aRank - bRank
 }
 
-function citationKey(citation: Citation, index: number) {
-  return citation.pmid || citation.doi || citation.url || citation.title || index
+function citationKey(citation: EvidenceStudyRecord, index: number) {
+  return citation.id || citation.pmid || citation.doi || citation.url || citation.title || index
 }
 
-function StudyRow({ citation, index }: { citation: Citation; index: number }) {
-  const pubmedUrl = citation.pmid ? `https://pubmed.ncbi.nlm.nih.gov/${citation.pmid}/` : null
-  const doiLink = citation.doi ? `https://doi.org/${citation.doi}` : null
-  const sourceUrl = citation.url || pubmedUrl || doiLink
-  const sourceLabel = citation.pmid ? 'PubMed' : citation.doi ? 'DOI' : sourceUrl ? 'Source' : ''
+function previewText(study: EvidenceStudyRecord) {
+  return [
+    study.population && `Population: ${study.population}`,
+    study.dose && `Dose: ${study.dose}`,
+    study.duration && `Duration: ${study.duration}`,
+    study.outcome && `Outcome: ${study.outcome}`,
+    study.result && `Result: ${study.result}`,
+    study.limitation && `Limitation: ${study.limitation}`,
+  ].filter(Boolean).join(' • ')
+}
+
+function StudyRow({ study, index }: { study: EvidenceStudyRecord; index: number }) {
+  const sourceUrl = evidenceSourceUrl(study)
+  const sourceLabel = study.pmid ? 'PubMed' : study.doi ? 'DOI' : sourceUrl ? 'Source' : ''
+  const preview = previewText(study)
 
   return (
-    <tr
-      key={citationKey(citation, index)}
-      className="border-t border-brand-900/10 dark:border-white/10"
-    >
-      <td className="px-3 py-3 align-top sm:px-4">
+    <tr key={citationKey(study, index)} className="border-t border-brand-900/10 dark:border-white/10">
+      <td className="min-w-[260px] px-3 py-3 align-top sm:px-4">
         <p className="text-[13px] font-semibold leading-snug text-ink">
           {sourceUrl ? (
             <a
               href={sourceUrl}
               target="_blank"
               rel="noopener noreferrer"
+              title={preview || undefined}
               className="hover:text-brand-700 hover:underline dark:hover:text-brand-100"
             >
-              {citation.title}
+              {study.title}
             </a>
-          ) : (
-            citation.title
-          )}
+          ) : study.title}
         </p>
-        {(citation.authors || citation.year) && (
+        {(study.authors || study.journal || study.year) && (
           <p className="mt-0.5 text-[11px] text-muted">
-            {citation.authors}
-            {citation.year ? ` (${citation.year})` : ''}
+            {[study.authors, study.journal, study.year ? String(study.year) : ''].filter(Boolean).join(' · ')}
           </p>
         )}
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          <RelationshipBadge relationship={study.relationship} />
+          {study.extractName ? <span className="text-[10px] font-medium text-muted">Extract: {study.extractName}</span> : null}
+        </div>
+        {study.limitation ? (
+          <p className="mt-2 text-[11px] leading-5 text-muted"><strong>Limitation:</strong> {study.limitation}</p>
+        ) : null}
       </td>
-      <td className="px-3 py-3 align-top sm:px-4">
-        {citation.studyType ? <StudyTypeBadge type={citation.studyType} /> : <span className="text-xs text-muted">—</span>}
-      </td>
+      <td className="min-w-[170px] px-3 py-3 align-top sm:px-4"><StudyTypeBadge study={study} /></td>
       <td className="whitespace-nowrap px-3 py-3 align-top text-[12px] text-muted sm:px-4">
-        {citation.sampleSize ? `n=${citation.sampleSize}` : '—'}
+        {study.sampleSize ? `n=${study.sampleSize}` : '—'}
+      </td>
+      <td className="min-w-[150px] px-3 py-3 align-top text-[12px] leading-5 text-muted sm:px-4">{study.dose || '—'}</td>
+      <td className="min-w-[130px] px-3 py-3 align-top text-[12px] leading-5 text-muted sm:px-4">{study.duration || '—'}</td>
+      <td className="min-w-[190px] px-3 py-3 align-top text-[12px] leading-5 text-muted sm:px-4">{study.population || '—'}</td>
+      <td className="min-w-[180px] px-3 py-3 align-top text-[12px] leading-5 text-muted sm:px-4">{study.outcome || '—'}</td>
+      <td className="min-w-[200px] px-3 py-3 align-top text-[12px] leading-5 text-muted sm:px-4">
+        {study.result || '—'}
+        {study.statisticalConsistency ? <p className="mt-1 text-[10px] text-muted">{study.statisticalConsistency}</p> : null}
       </td>
       <td className="px-3 py-3 text-right align-top sm:px-4">
         {sourceUrl ? (
@@ -121,20 +208,28 @@ function StudyRow({ citation, index }: { citation: Citation; index: number }) {
           >
             {sourceLabel} →
           </a>
-        ) : (
-          <span className="text-xs text-muted">—</span>
-        )}
+        ) : <span className="text-xs text-muted">—</span>}
       </td>
     </tr>
   )
 }
 
-export default function ShowMeTheStudies({ citations }: Props) {
+export default function ShowMeTheStudies({
+  citations,
+  conclusion,
+  evidenceGrade,
+  confidence,
+  whatWouldChangeConclusion,
+}: Props) {
   if (!citations || citations.length === 0) return null
 
-  const sorted = [...citations].sort(sortByStudyType)
-  const visible = sorted.slice(0, VISIBLE_ROWS)
-  const overflow = sorted.slice(VISIBLE_ROWS)
+  const studies = citations.map(normalizedStudy).sort(sortByStudyType)
+  const metrics = summarizeEvidenceStudies(studies)
+  const visible = studies.slice(0, VISIBLE_ROWS)
+  const overflow = studies.slice(VISIBLE_ROWS)
+  const participantLabel = metrics.studiesWithParticipantCounts > 0
+    ? `~${metrics.approximateParticipants.toLocaleString()} participants across ${metrics.studiesWithParticipantCounts} human sources with reported N`
+    : 'Participant totals not consistently reported'
 
   return (
     <details className="group/studies overflow-hidden rounded-2xl border-2 border-brand-900/10 bg-[var(--surface-card)] p-0 shadow-none backdrop-blur-none dark:border-white/10">
@@ -142,28 +237,56 @@ export default function ShowMeTheStudies({ citations }: Props) {
         <span>
           <span className="block text-sm font-bold text-ink">Clinical Study Summaries ({citations.length})</span>
           <span className="mt-0.5 block text-[11px] leading-5 text-muted">
-            Cited studies informing this profile. RCTs and reviews shown first.
+            {metrics.humanTrials} human trial{metrics.humanTrials === 1 ? '' : 's'} · {participantLabel} · {evidenceConsistencyLabel(metrics.consistency)}
           </span>
         </span>
         <span aria-hidden="true" className="shrink-0 text-brand-500 transition-transform group-open/studies:rotate-180">v</span>
       </summary>
+
+      {(conclusion || evidenceGrade || confidence || whatWouldChangeConclusion) ? (
+        <div className="grid gap-3 border-t border-brand-900/10 bg-white/80 p-4 md:grid-cols-2 dark:border-white/10 dark:bg-white/5">
+          <div className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+            <p className="text-[10px] font-bold uppercase tracking-[0.12em] text-brand-700">Why we believe this</p>
+            {conclusion ? <p className="mt-2 text-sm leading-6 text-ink">{conclusion}</p> : null}
+            <p className="mt-2 text-xs leading-5 text-muted">
+              {metrics.supportive} supporting · {metrics.mixed} mixed · {metrics.contradicting} contradicting · {metrics.noClearEffect} no-clear-effect sources.
+            </p>
+            {(evidenceGrade || confidence) ? (
+              <p className="mt-2 text-xs font-semibold text-ink">
+                {evidenceGrade ? `Evidence grade: ${evidenceGrade}` : ''}{evidenceGrade && confidence ? ' · ' : ''}{confidence ? `Confidence: ${confidence}` : ''}
+              </p>
+            ) : null}
+          </div>
+          <div className="rounded-xl border border-brand-900/10 bg-white p-4 dark:bg-white/5">
+            <p className="text-[10px] font-bold uppercase tracking-[0.12em] text-brand-700">What would change our conclusion?</p>
+            <p className="mt-2 text-sm leading-6 text-muted">
+              {whatWouldChangeConclusion || 'Larger, well-controlled human trials using comparable populations, doses, preparations, and clinically meaningful outcomes could materially strengthen or weaken this conclusion.'}
+            </p>
+          </div>
+        </div>
+      ) : null}
+
       <div className="overflow-x-auto border-t border-brand-900/10 dark:border-white/10">
-        <table className="w-full min-w-[560px] border-collapse text-left text-sm">
+        <table className="w-full min-w-[1500px] border-collapse text-left text-sm">
           <thead>
             <tr className="bg-[var(--surface-card)] text-[10px] font-bold uppercase tracking-wider text-muted">
               <th className="px-3 py-2 sm:px-4">Study</th>
-              <th className="px-3 py-2 sm:px-4">Type</th>
-              <th className="px-3 py-2 sm:px-4">Sample</th>
+              <th className="px-3 py-2 sm:px-4">Design</th>
+              <th className="px-3 py-2 sm:px-4">N</th>
+              <th className="px-3 py-2 sm:px-4">Dose</th>
+              <th className="px-3 py-2 sm:px-4">Duration</th>
+              <th className="px-3 py-2 sm:px-4">Population</th>
+              <th className="px-3 py-2 sm:px-4">Outcome</th>
+              <th className="px-3 py-2 sm:px-4">Result</th>
               <th className="px-3 py-2 text-right sm:px-4">Source</th>
             </tr>
           </thead>
           <tbody>
-            {visible.map((citation, index) => (
-              <StudyRow key={citationKey(citation, index)} citation={citation} index={index} />
-            ))}
+            {visible.map((study, index) => <StudyRow key={citationKey(study, index)} study={study} index={index} />)}
           </tbody>
         </table>
       </div>
+
       {overflow.length > 0 && (
         <details className="group border-x-0 border-b-0 border-t border-brand-900/10 bg-transparent p-0 shadow-none backdrop-blur-none dark:border-white/10">
           <summary className="flex cursor-pointer select-none items-center gap-1.5 px-4 py-2.5 text-xs font-semibold text-brand-700 hover:text-brand-800 dark:text-brand-100 dark:hover:text-white">
@@ -171,11 +294,9 @@ export default function ShowMeTheStudies({ citations }: Props) {
             Show {overflow.length} more stud{overflow.length === 1 ? 'y' : 'ies'}
           </summary>
           <div className="overflow-x-auto">
-            <table className="w-full min-w-[560px] border-collapse text-left text-sm">
+            <table className="w-full min-w-[1500px] border-collapse text-left text-sm">
               <tbody>
-                {overflow.map((citation, index) => (
-                  <StudyRow key={citationKey(citation, index)} citation={citation} index={index} />
-                ))}
+                {overflow.map((study, index) => <StudyRow key={citationKey(study, index)} study={study} index={index} />)}
               </tbody>
             </table>
           </div>

--- a/lib/__tests__/evidence-study.test.ts
+++ b/lib/__tests__/evidence-study.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import {
+  evidenceStudyId,
+  normalizeEvidenceRelationship,
+  normalizeEvidenceStudyClass,
+  parseSampleSize,
+  summarizeEvidenceStudies,
+  type EvidenceStudyRecord,
+} from '@/lib/evidence-study'
+
+function study(overrides: Partial<EvidenceStudyRecord> = {}): EvidenceStudyRecord {
+  return {
+    id: 'study:test',
+    title: 'Test study',
+    evidenceClass: 'randomized_controlled_trial',
+    relationship: 'supports',
+    confidence: 'moderate',
+    ...overrides,
+  }
+}
+
+describe('evidence-study', () => {
+  it('normalizes common evidence classes without flattening preclinical work into human evidence', () => {
+    expect(normalizeEvidenceStudyClass('double-blind randomized placebo-controlled trial')).toBe('randomized_controlled_trial')
+    expect(normalizeEvidenceStudyClass('systematic review')).toBe('systematic_review')
+    expect(normalizeEvidenceStudyClass('murine in vivo study')).toBe('animal')
+    expect(normalizeEvidenceStudyClass('in vitro cell assay')).toBe('in_vitro')
+  })
+
+  it('normalizes directional evidence relationships', () => {
+    expect(normalizeEvidenceRelationship('supportive')).toBe('supports')
+    expect(normalizeEvidenceRelationship('partially supports')).toBe('mixed')
+    expect(normalizeEvidenceRelationship('contradicting')).toBe('contradicts')
+    expect(normalizeEvidenceRelationship('null')).toBe('no_clear_effect')
+  })
+
+  it('parses participant counts conservatively', () => {
+    expect(parseSampleSize('n=1,240 adults')).toBe(1240)
+    expect(parseSampleSize(72)).toBe(72)
+    expect(parseSampleSize('not reported')).toBeNull()
+  })
+
+  it('prefers stable source identifiers for study identity', () => {
+    expect(evidenceStudyId({ pmid: '12345678', doi: '10.1000/test' })).toBe('pmid:12345678')
+    expect(evidenceStudyId({ doi: '10.1000/Test' })).toBe('doi:10.1000/test')
+  })
+
+  it('surfaces heterogeneity instead of averaging disagreement away', () => {
+    const metrics = summarizeEvidenceStudies([
+      study({ id: 'a', relationship: 'supports', sampleSize: 100 }),
+      study({ id: 'b', relationship: 'contradicts', sampleSize: 120 }),
+      study({ id: 'c', evidenceClass: 'animal', relationship: 'background', sampleSize: 40 }),
+    ])
+
+    expect(metrics.humanTrials).toBe(2)
+    expect(metrics.approximateParticipants).toBe(220)
+    expect(metrics.supportive).toBe(1)
+    expect(metrics.contradicting).toBe(1)
+    expect(metrics.consistency).toBe('conflicting')
+  })
+})

--- a/lib/citations.ts
+++ b/lib/citations.ts
@@ -1,4 +1,10 @@
 import type { Citation } from '@/components/ui/ShowMeTheStudies'
+import {
+  evidenceStudyId,
+  normalizeEvidenceConfidence,
+  normalizeEvidenceRelationship,
+  normalizeEvidenceStudyClass,
+} from '@/lib/evidence-study'
 
 function parsePmid(value: string): string | undefined {
   const match = value.match(/\b(\d{7,8})\b/)
@@ -12,6 +18,29 @@ function parseDoi(value: string): string | undefined {
 
 function doiUrl(doi: string | undefined): string | undefined {
   return doi ? `https://doi.org/${doi}` : undefined
+}
+
+function firstString(src: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = src[key]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  return undefined
+}
+
+function stringArray(src: Record<string, unknown>, keys: string[]): string[] | undefined {
+  for (const key of keys) {
+    const value = src[key]
+    if (Array.isArray(value)) {
+      const normalized = value.map(item => String(item).trim()).filter(Boolean)
+      if (normalized.length) return normalized
+    }
+    if (typeof value === 'string' && value.trim()) {
+      const normalized = value.split(/[;,|]/).map(item => item.trim()).filter(Boolean)
+      if (normalized.length) return normalized
+    }
+  }
+  return undefined
 }
 
 function sourceObjectToCitation(src: Record<string, unknown>): Citation {
@@ -30,17 +59,38 @@ function sourceObjectToCitation(src: Record<string, unknown>): Citation {
       ? String(src.pmid)
       : parsePmid(rawUrl) || parsePmid(citationText)
   const url = rawUrl || doiUrl(doi) || (pmid ? `https://pubmed.ncbi.nlm.nih.gov/${pmid}/` : undefined)
+  const studyType = firstString(src, ['studyType', 'study_type', 'design', 'design_type', 'publication_type', 'type'])
+  const relationshipRaw = firstString(src, ['relationship', 'evidence_direction', 'direction', 'direction_of_effect'])
+  const confidenceRaw = firstString(src, ['confidence', 'evidence_confidence', 'certainty'])
 
-  return {
+  const citation: Citation = {
+    id: evidenceStudyId({ pmid, doi, url, title }),
     title,
     pmid,
     doi,
     url,
     year: src.year as number | string | undefined,
     authors: (src.authors || src.author_or_label) as string | undefined,
-    studyType: (src.studyType || src.study_type || src.type) as string | undefined,
-    sampleSize: (src.sampleSize || src.sample_size || src.n) as string | number | undefined,
+    journal: firstString(src, ['journal', 'source', 'publication', 'venue']),
+    studyType,
+    evidenceClass: normalizeEvidenceStudyClass(src.evidenceClass || src.evidence_class || studyType),
+    sampleSize: (src.sampleSize || src.sample_size || src.n || src.participants) as string | number | undefined,
+    dose: firstString(src, ['dose', 'dose_range', 'studied_dose', 'intervention_dose']),
+    duration: firstString(src, ['duration', 'study_duration', 'timeframe']),
+    population: firstString(src, ['population', 'participants_description', 'population_context']),
+    outcome: firstString(src, ['outcome', 'primary_outcome', 'endpoint']),
+    result: firstString(src, ['result', 'finding', 'result_summary', 'effect']),
+    limitation: firstString(src, ['limitation', 'limitations', 'study_limitation', 'extraction_note']),
+    relationship: normalizeEvidenceRelationship(relationshipRaw),
+    confidence: normalizeEvidenceConfidence(confidenceRaw),
+    statisticalConsistency: firstString(src, ['statistical_consistency', 'statisticalSignal', 'statistical_signal']),
+    extractName: firstString(src, ['extract', 'extract_name', 'branded_extract', 'preparation']),
+    ingredients: stringArray(src, ['ingredients', 'ingredient_slugs', 'entities']),
+    conditions: stringArray(src, ['conditions', 'outcomes', 'condition_slugs']),
+    safetyOutcome: firstString(src, ['safety_outcome', 'adverse_events', 'safety_result']),
   }
+
+  return citation
 }
 
 function stringToCitation(src: string): Citation {
@@ -48,17 +98,26 @@ function stringToCitation(src: string): Citation {
   const doi = parseDoi(src)
   const directUrl = /^https?:\/\//i.test(src.trim()) ? src.trim() : undefined
   const url = directUrl || doiUrl(doi) || (pmid ? `https://pubmed.ncbi.nlm.nih.gov/${pmid}/` : undefined)
-  return { title: src, pmid, doi, url }
+  return {
+    id: evidenceStudyId({ pmid, doi, url, title: src }),
+    title: src,
+    pmid,
+    doi,
+    url,
+    evidenceClass: 'other',
+    relationship: 'background',
+    confidence: 'unknown',
+  }
 }
 
 function citationKey(citation: Citation): string {
-  return citation.pmid
+  return citation.id || (citation.pmid
     ? `pmid:${citation.pmid}`
     : citation.doi
       ? `doi:${citation.doi.toLowerCase()}`
       : citation.url
         ? `url:${citation.url.toLowerCase()}`
-        : `title:${citation.title.trim().toLowerCase()}`
+        : `title:${citation.title.trim().toLowerCase()}`)
 }
 
 export function extractCitationsFromRecord(record: Record<string, unknown>): Citation[] {
@@ -91,9 +150,13 @@ export function extractCitationsFromRecord(record: Record<string, unknown>): Cit
       if (!pmid) continue
       const id = String(pmid)
       pushCitation({
+        id: `pmid:${id}`,
         title: `PubMed ${id}`,
         pmid: id,
         url: `https://pubmed.ncbi.nlm.nih.gov/${id}/`,
+        evidenceClass: 'other',
+        relationship: 'background',
+        confidence: 'unknown',
       })
     }
   }

--- a/lib/evidence-study.ts
+++ b/lib/evidence-study.ts
@@ -1,0 +1,263 @@
+export type EvidenceStudyClass =
+  | 'meta_analysis'
+  | 'systematic_review'
+  | 'randomized_controlled_trial'
+  | 'controlled_trial'
+  | 'observational'
+  | 'case_report'
+  | 'animal'
+  | 'in_vitro'
+  | 'mechanistic'
+  | 'narrative_review'
+  | 'other'
+
+export type EvidenceRelationship =
+  | 'supports'
+  | 'mixed'
+  | 'contradicts'
+  | 'no_clear_effect'
+  | 'background'
+
+export type EvidenceConfidence = 'high' | 'moderate' | 'low' | 'unknown'
+
+export type EvidenceStudyRecord = {
+  id: string
+  title: string
+  authors?: string
+  journal?: string
+  year?: number | string
+  pmid?: string
+  doi?: string
+  url?: string
+  studyType?: string
+  evidenceClass: EvidenceStudyClass
+  sampleSize?: number | string
+  dose?: string
+  duration?: string
+  population?: string
+  outcome?: string
+  result?: string
+  limitation?: string
+  relationship: EvidenceRelationship
+  confidence: EvidenceConfidence
+  statisticalConsistency?: string
+  extractName?: string
+  ingredients?: string[]
+  conditions?: string[]
+  safetyOutcome?: string
+}
+
+const HUMAN_CLASSES = new Set<EvidenceStudyClass>([
+  'meta_analysis',
+  'systematic_review',
+  'randomized_controlled_trial',
+  'controlled_trial',
+  'observational',
+  'case_report',
+])
+
+export function normalizeEvidenceStudyClass(value: unknown): EvidenceStudyClass {
+  const lower = String(value || '').trim().toLowerCase()
+
+  if (!lower) return 'other'
+  if (lower.includes('meta-analysis') || lower.includes('meta analysis') || lower.includes('meta_analysis')) return 'meta_analysis'
+  if (lower.includes('systematic review') || lower.includes('systematic_review')) return 'systematic_review'
+  if (
+    lower.includes('randomized') ||
+    lower.includes('randomised') ||
+    lower.includes('rct') ||
+    lower.includes('placebo-controlled') ||
+    lower.includes('placebo controlled')
+  ) return 'randomized_controlled_trial'
+  if (lower.includes('controlled trial') || lower.includes('clinical trial') || lower.includes('intervention')) return 'controlled_trial'
+  if (
+    lower.includes('observational') ||
+    lower.includes('cohort') ||
+    lower.includes('cross-sectional') ||
+    lower.includes('cross sectional') ||
+    lower.includes('case-control') ||
+    lower.includes('case control')
+  ) return 'observational'
+  if (lower.includes('case report') || lower.includes('case series')) return 'case_report'
+  if (lower.includes('animal') || lower.includes('rodent') || lower.includes('murine') || lower.includes('in vivo')) return 'animal'
+  if (lower.includes('in vitro') || lower.includes('cell') || lower.includes('cellular')) return 'in_vitro'
+  if (lower.includes('mechanistic') || lower.includes('mechanism')) return 'mechanistic'
+  if (lower.includes('review')) return 'narrative_review'
+
+  return 'other'
+}
+
+export function formatEvidenceStudyClass(value: EvidenceStudyClass): string {
+  const labels: Record<EvidenceStudyClass, string> = {
+    meta_analysis: 'Meta-analysis',
+    systematic_review: 'Systematic review',
+    randomized_controlled_trial: 'Randomized controlled trial',
+    controlled_trial: 'Controlled trial',
+    observational: 'Observational research',
+    case_report: 'Case report',
+    animal: 'Animal research',
+    in_vitro: 'In-vitro research',
+    mechanistic: 'Mechanistic research',
+    narrative_review: 'Narrative review',
+    other: 'Other / unclear',
+  }
+  return labels[value]
+}
+
+export function normalizeEvidenceRelationship(value: unknown): EvidenceRelationship {
+  const lower = String(value || '').trim().toLowerCase().replace(/[\s-]+/g, '_')
+  if (lower === 'support' || lower === 'supportive' || lower === 'supports' || lower === 'positive') return 'supports'
+  if (lower === 'mixed' || lower === 'partially_supports' || lower === 'partial') return 'mixed'
+  if (lower === 'contradict' || lower === 'contradicting' || lower === 'contradicts' || lower === 'negative') return 'contradicts'
+  if (lower === 'no_effect' || lower === 'null' || lower === 'neutral' || lower === 'no_clear_effect') return 'no_clear_effect'
+  return 'background'
+}
+
+export function normalizeEvidenceConfidence(value: unknown): EvidenceConfidence {
+  const lower = String(value || '').trim().toLowerCase()
+  if (lower === 'high' || lower === 'strong') return 'high'
+  if (lower === 'moderate' || lower === 'medium') return 'moderate'
+  if (lower === 'low' || lower === 'limited') return 'low'
+  return 'unknown'
+}
+
+export function isHumanEvidenceClass(value: EvidenceStudyClass): boolean {
+  return HUMAN_CLASSES.has(value)
+}
+
+export function isHumanTrialClass(value: EvidenceStudyClass): boolean {
+  return value === 'randomized_controlled_trial' || value === 'controlled_trial'
+}
+
+export function parseSampleSize(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) return Math.round(value)
+  const text = String(value || '').trim()
+  if (!text) return null
+
+  const explicitN = text.match(/\bn\s*=\s*([\d,]+)/i)
+  const firstNumber = explicitN?.[1] || text.match(/([\d,]+)/)?.[1]
+  if (!firstNumber) return null
+
+  const parsed = Number(firstNumber.replace(/,/g, ''))
+  return Number.isFinite(parsed) && parsed > 0 ? Math.round(parsed) : null
+}
+
+export function evidenceStudyId(input: {
+  pmid?: string
+  doi?: string
+  url?: string
+  title?: string
+}): string {
+  if (input.pmid) return `pmid:${String(input.pmid).trim()}`
+  if (input.doi) return `doi:${String(input.doi).trim().toLowerCase()}`
+  if (input.url) return `url:${String(input.url).trim().toLowerCase()}`
+
+  const slug = String(input.title || 'untitled')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 96)
+
+  return `title:${slug || 'untitled'}`
+}
+
+export function evidenceSourceUrl(input: { pmid?: string; doi?: string; url?: string }): string | undefined {
+  const rawUrl = String(input.url || '').trim()
+  if (rawUrl) return rawUrl
+  if (input.pmid) return `https://pubmed.ncbi.nlm.nih.gov/${String(input.pmid).trim()}/`
+  if (input.doi) return `https://doi.org/${String(input.doi).trim()}`
+  return undefined
+}
+
+export function evidenceRelationshipLabel(value: EvidenceRelationship): string {
+  const labels: Record<EvidenceRelationship, string> = {
+    supports: 'Supports',
+    mixed: 'Mixed',
+    contradicts: 'Contradicts',
+    no_clear_effect: 'No clear effect',
+    background: 'Background',
+  }
+  return labels[value]
+}
+
+export type EvidenceStudyMetrics = {
+  totalStudies: number
+  humanStudies: number
+  humanTrials: number
+  approximateParticipants: number
+  studiesWithParticipantCounts: number
+  supportive: number
+  mixed: number
+  contradicting: number
+  noClearEffect: number
+  background: number
+  consistency: 'consistent' | 'mostly_consistent' | 'mixed' | 'conflicting' | 'unclear'
+}
+
+export function summarizeEvidenceStudies(studies: EvidenceStudyRecord[]): EvidenceStudyMetrics {
+  let humanStudies = 0
+  let humanTrials = 0
+  let approximateParticipants = 0
+  let studiesWithParticipantCounts = 0
+  let supportive = 0
+  let mixed = 0
+  let contradicting = 0
+  let noClearEffect = 0
+  let background = 0
+
+  for (const study of studies) {
+    if (isHumanEvidenceClass(study.evidenceClass)) humanStudies += 1
+    if (isHumanTrialClass(study.evidenceClass)) humanTrials += 1
+
+    const n = parseSampleSize(study.sampleSize)
+    if (n && isHumanEvidenceClass(study.evidenceClass)) {
+      approximateParticipants += n
+      studiesWithParticipantCounts += 1
+    }
+
+    switch (study.relationship) {
+      case 'supports': supportive += 1; break
+      case 'mixed': mixed += 1; break
+      case 'contradicts': contradicting += 1; break
+      case 'no_clear_effect': noClearEffect += 1; break
+      default: background += 1
+    }
+  }
+
+  const directional = supportive + mixed + contradicting + noClearEffect
+  let consistency: EvidenceStudyMetrics['consistency'] = 'unclear'
+  if (directional > 0) {
+    const supportShare = supportive / directional
+    const contradictionShare = (contradicting + noClearEffect) / directional
+    if (supportShare >= 0.8 && contradictionShare <= 0.1) consistency = 'consistent'
+    else if (supportShare >= 0.6 && contradictionShare <= 0.25) consistency = 'mostly_consistent'
+    else if (supportive > 0 && contradicting > 0) consistency = 'conflicting'
+    else consistency = 'mixed'
+  }
+
+  return {
+    totalStudies: studies.length,
+    humanStudies,
+    humanTrials,
+    approximateParticipants,
+    studiesWithParticipantCounts,
+    supportive,
+    mixed,
+    contradicting,
+    noClearEffect,
+    background,
+    consistency,
+  }
+}
+
+export function evidenceConsistencyLabel(value: EvidenceStudyMetrics['consistency']): string {
+  const labels: Record<EvidenceStudyMetrics['consistency'], string> = {
+    consistent: 'Statistically directionally consistent',
+    mostly_consistent: 'Mostly consistent',
+    mixed: 'Mixed / heterogeneous',
+    conflicting: 'Material disagreement present',
+    unclear: 'Consistency not yet classifiable',
+  }
+  return labels[value]
+}


### PR DESCRIPTION
Implements the first 151–250 evidence tranche foundation.

### What changed
- canonical study classes for meta-analyses, systematic reviews, RCTs, controlled trials, observational, case reports, animal, in-vitro, mechanistic and narrative review evidence
- explicit supports / mixed / contradicts / no-clear-effect / background relationships
- stable study IDs and source URL resolution
- normalized participant counts, confidence and study direction
- human-trial counts, approximate participant totals, and disagreement/heterogeneity metrics
- richer citation extraction: journal, dose, duration, population, outcome, result, limitation, extract, safety and relationship metadata
- shared evidence table now shows Study / Design / N / Dose / Duration / Population / Outcome / Result
- one-sentence study limitations when available
- lightweight citation previews
- separate evidence grade vs confidence plus “Why we believe this” / “What would change our conclusion?” support
- regression coverage for classification, participant parsing, stable IDs and conflicting evidence

Designed as shared/generator-level infrastructure so later backlog items 169–250 can reuse one contract.