### PR TITLE
feat(growth): A/B test article email capture heading and placement

### DIFF
--- a/components/NewsletterSignup.tsx
+++ b/components/NewsletterSignup.tsx
@@ -5,7 +5,7 @@ import { usePathname } from 'next/navigation'
 import { type FormEvent, useEffect, useId, useRef, useState } from 'react'
 import { safetyChecklistLeadMagnet } from '@/lib/lead-magnet'
 import { mailchimpSignupConfig } from '@/lib/mailchimp-integration'
-import { trackEmailSignup } from '@/lib/analytics'
+import { trackEmailSignup, trackExperimentConversion } from '@/lib/analytics'
 import { trackRevenueEvent } from '@/src/lib/revenue-tracking'
 
 type TurnstileApi = {
@@ -19,6 +19,12 @@ declare global {
   }
 }
 
+type NewsletterExperiment = {
+  id: string
+  variant: string
+  location?: string
+}
+
 type NewsletterSignupProps = {
   title?: string
   description?: string
@@ -26,6 +32,7 @@ type NewsletterSignupProps = {
   location?: string
   variant?: 'card' | 'inline' | 'footer' | 'compact' | 'editorial'
   className?: string
+  experiment?: NewsletterExperiment
 }
 
 const turnstileSiteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY?.trim() || ''
@@ -58,6 +65,7 @@ export default function NewsletterSignup({
   location = 'newsletter-signup',
   variant = 'card',
   className = '',
+  experiment,
 }: NewsletterSignupProps) {
   const pathname = usePathname()
   const resolvedLocation =
@@ -157,6 +165,13 @@ export default function NewsletterSignup({
       }
       setMessage('You are subscribed. Open the safety checklist while the next evidence note is prepared.')
       trackEmailSignup({ source: resolvedLocation })
+      if (experiment) {
+        trackExperimentConversion({
+          experimentId: experiment.id,
+          variant: experiment.variant,
+          location: experiment.location ?? resolvedLocation,
+        })
+      }
     } catch (error) {
       if (usesTurnstile) {
         window.turnstile?.reset(turnstileWidgetIdRef.current)

--- a/components/articles/ArticleMdx.tsx
+++ b/components/articles/ArticleMdx.tsx
@@ -1,6 +1,6 @@
 import { MDXContent } from '@content-collections/mdx/react'
 import type { ComponentPropsWithoutRef } from 'react'
-import NewsletterSignup from '@/components/NewsletterSignup'
+import ArticleEmailCaptureExperiment from '@/components/monetization/ArticleEmailCaptureExperiment'
 import { useMDXComponents } from '@/mdx-components'
 
 type ArticleMdxProps = {
@@ -16,10 +16,11 @@ export default function ArticleMdx({ code }: ArticleMdxProps) {
 
   return (
     <>
-      <MDXContent code={code} components={components} />
-      <NewsletterSignup
-        location='article-body-end'
-        variant='editorial'
+      <div data-article-body>
+        <MDXContent code={code} components={components} />
+      </div>
+      <ArticleEmailCaptureExperiment
+        location='article-body'
         className='mt-10'
       />
     </>

--- a/components/monetization/ArticleEmailCaptureExperiment.tsx
+++ b/components/monetization/ArticleEmailCaptureExperiment.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
 import NewsletterSignup from '@/components/NewsletterSignup'
 import { trackExperimentImpression } from '@/lib/analytics'
 import { assignExperimentVariant } from '@/lib/experiment-assignment'
@@ -16,12 +17,19 @@ const VARIANTS = [
 ] as const
 
 type ArticleCaptureVariant = (typeof VARIANTS)[number]['id']
-type ArticleCaptureSlot = 'inline' | 'end'
+type ArticleCapturePlacement = 'inline' | 'end'
 
 type ArticleEmailCaptureExperimentProps = {
-  slot: ArticleCaptureSlot
   location: string
   className?: string
+}
+
+let volatileSubject: string | null = null
+
+function makeAnonymousSubject(): string {
+  return typeof window.crypto?.randomUUID === 'function'
+    ? window.crypto.randomUUID()
+    : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
 }
 
 function getAnonymousExperimentSubject(): string {
@@ -29,21 +37,19 @@ function getAnonymousExperimentSubject(): string {
     const existing = window.localStorage.getItem(SUBJECT_STORAGE_KEY)
     if (existing) return existing
 
-    const generated =
-      typeof window.crypto?.randomUUID === 'function'
-        ? window.crypto.randomUUID()
-        : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
-
+    const generated = makeAnonymousSubject()
     window.localStorage.setItem(SUBJECT_STORAGE_KEY, generated)
     return generated
   } catch {
-    // Storage can be unavailable in strict privacy modes. A session-stable
-    // fallback avoids collecting identity while keeping the experience usable.
-    return 'storage-unavailable'
+    // Storage can be unavailable in strict privacy modes. Keep a volatile,
+    // page-session identifier rather than collapsing those readers into one
+    // shared experiment bucket.
+    volatileSubject ??= makeAnonymousSubject()
+    return volatileSubject
   }
 }
 
-function placementFor(variant: ArticleCaptureVariant): ArticleCaptureSlot {
+function placementFor(variant: ArticleCaptureVariant): ArticleCapturePlacement {
   return variant.startsWith('inline-') ? 'inline' : 'end'
 }
 
@@ -53,12 +59,38 @@ function titleFor(variant: ArticleCaptureVariant): string {
     : 'Get weekly supplement evidence updates'
 }
 
+function createInlineMount(): HTMLElement | null {
+  const articleBody = document.querySelector<HTMLElement>('[data-article-body]')
+  if (!articleBody) return null
+
+  const mount = document.createElement('div')
+  mount.dataset.articleEmailCapture = 'inline'
+  mount.className = 'my-10'
+
+  const headings = Array.from(articleBody.querySelectorAll<HTMLElement>('h2'))
+  const insertionHeading = headings[1] ?? headings[0]
+  if (insertionHeading?.parentElement) {
+    insertionHeading.parentElement.insertBefore(mount, insertionHeading)
+    return mount
+  }
+
+  const children = Array.from(articleBody.children)
+  if (!children.length) {
+    articleBody.appendChild(mount)
+    return mount
+  }
+
+  const insertionIndex = Math.min(children.length - 1, Math.max(0, Math.floor(children.length * 0.4)))
+  children[insertionIndex].insertAdjacentElement('afterend', mount)
+  return mount
+}
+
 export default function ArticleEmailCaptureExperiment({
-  slot,
   location,
   className = '',
 }: ArticleEmailCaptureExperimentProps) {
   const [variant, setVariant] = useState<ArticleCaptureVariant | null>(null)
+  const [inlineMount, setInlineMount] = useState<HTMLElement | null>(null)
 
   useEffect(() => {
     const subject = getAnonymousExperimentSubject()
@@ -66,25 +98,43 @@ export default function ArticleEmailCaptureExperiment({
   }, [])
 
   useEffect(() => {
-    if (!variant || placementFor(variant) !== slot) return
+    if (!variant || placementFor(variant) !== 'inline') return
+
+    const mount = createInlineMount()
+    setInlineMount(mount)
+
+    return () => {
+      mount?.remove()
+      setInlineMount(null)
+    }
+  }, [variant])
+
+  const placement = variant ? placementFor(variant) : null
+  const isRenderable = placement === 'end' || (placement === 'inline' && Boolean(inlineMount))
+
+  useEffect(() => {
+    if (!variant || !isRenderable) return
     trackExperimentImpression({
       experimentId: EXPERIMENT_ID,
       variant,
       location,
     })
-  }, [location, slot, variant])
+  }, [isRenderable, location, variant])
 
-  if (!variant || placementFor(variant) !== slot) return null
+  if (!variant || !isRenderable) return null
 
-  return (
+  const signup = (
     <NewsletterSignup
       title={titleFor(variant)}
       description='One practical email on evidence quality, safety flags, and better supplement decisions. Includes the free safety checklist.'
       ctaLabel='Get the checklist'
       location={location}
-      variant={slot === 'inline' ? 'editorial' : 'card'}
+      variant={placement === 'inline' ? 'editorial' : 'card'}
       className={className}
       experiment={{ id: EXPERIMENT_ID, variant, location }}
     />
   )
+
+  if (placement === 'inline' && inlineMount) return createPortal(signup, inlineMount)
+  return signup
 }

--- a/components/monetization/ArticleEmailCaptureExperiment.tsx
+++ b/components/monetization/ArticleEmailCaptureExperiment.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import NewsletterSignup from '@/components/NewsletterSignup'
+import { trackExperimentImpression } from '@/lib/analytics'
+import { assignExperimentVariant } from '@/lib/experiment-assignment'
+
+const EXPERIMENT_ID = 'article-email-capture-v1'
+const SUBJECT_STORAGE_KEY = 'ths:experiment-subject:v1'
+
+const VARIANTS = [
+  { id: 'inline-weekly' },
+  { id: 'inline-safety' },
+  { id: 'end-weekly' },
+  { id: 'end-safety' },
+] as const
+
+type ArticleCaptureVariant = (typeof VARIANTS)[number]['id']
+type ArticleCaptureSlot = 'inline' | 'end'
+
+type ArticleEmailCaptureExperimentProps = {
+  slot: ArticleCaptureSlot
+  location: string
+  className?: string
+}
+
+function getAnonymousExperimentSubject(): string {
+  try {
+    const existing = window.localStorage.getItem(SUBJECT_STORAGE_KEY)
+    if (existing) return existing
+
+    const generated =
+      typeof window.crypto?.randomUUID === 'function'
+        ? window.crypto.randomUUID()
+        : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+
+    window.localStorage.setItem(SUBJECT_STORAGE_KEY, generated)
+    return generated
+  } catch {
+    // Storage can be unavailable in strict privacy modes. A session-stable
+    // fallback avoids collecting identity while keeping the experience usable.
+    return 'storage-unavailable'
+  }
+}
+
+function placementFor(variant: ArticleCaptureVariant): ArticleCaptureSlot {
+  return variant.startsWith('inline-') ? 'inline' : 'end'
+}
+
+function titleFor(variant: ArticleCaptureVariant): string {
+  return variant.endsWith('-safety')
+    ? 'Get the safety checklist + weekly evidence updates'
+    : 'Get weekly supplement evidence updates'
+}
+
+export default function ArticleEmailCaptureExperiment({
+  slot,
+  location,
+  className = '',
+}: ArticleEmailCaptureExperimentProps) {
+  const [variant, setVariant] = useState<ArticleCaptureVariant | null>(null)
+
+  useEffect(() => {
+    const subject = getAnonymousExperimentSubject()
+    setVariant(assignExperimentVariant(EXPERIMENT_ID, subject, VARIANTS))
+  }, [])
+
+  useEffect(() => {
+    if (!variant || placementFor(variant) !== slot) return
+    trackExperimentImpression({
+      experimentId: EXPERIMENT_ID,
+      variant,
+      location,
+    })
+  }, [location, slot, variant])
+
+  if (!variant || placementFor(variant) !== slot) return null
+
+  return (
+    <NewsletterSignup
+      title={titleFor(variant)}
+      description='One practical email on evidence quality, safety flags, and better supplement decisions. Includes the free safety checklist.'
+      ctaLabel='Get the checklist'
+      location={location}
+      variant={slot === 'inline' ? 'editorial' : 'card'}
+      className={className}
+      experiment={{ id: EXPERIMENT_ID, variant, location }}
+    />
+  )
+}

--- a/lib/__tests__/experiment-assignment.test.ts
+++ b/lib/__tests__/experiment-assignment.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { assignExperimentVariant, experimentBucket } from '@/lib/experiment-assignment'
+
+describe('experiment assignment', () => {
+  it('returns a stable bucket for the same experiment and anonymous subject', () => {
+    expect(experimentBucket('newsletter-v1', 'anonymous-123')).toBe(
+      experimentBucket('newsletter-v1', 'anonymous-123'),
+    )
+  })
+
+  it('keeps the bucket inside the half-open unit interval', () => {
+    for (let index = 0; index < 100; index += 1) {
+      const bucket = experimentBucket('newsletter-v1', `subject-${index}`)
+      expect(bucket).toBeGreaterThanOrEqual(0)
+      expect(bucket).toBeLessThan(1)
+    }
+  })
+
+  it('assigns the same variant repeatedly for a subject', () => {
+    const variants = [{ id: 'a' }, { id: 'b' }] as const
+    const first = assignExperimentVariant('newsletter-v1', 'anonymous-123', variants)
+    const second = assignExperimentVariant('newsletter-v1', 'anonymous-123', variants)
+    expect(second).toBe(first)
+  })
+
+  it('respects a zero-weight variant', () => {
+    const variants = [
+      { id: 'disabled', weight: 0 },
+      { id: 'active', weight: 1 },
+    ] as const
+
+    for (let index = 0; index < 50; index += 1) {
+      expect(assignExperimentVariant('weighted-v1', `subject-${index}`, variants)).toBe('active')
+    }
+  })
+
+  it('rejects experiments without a usable allocation', () => {
+    expect(() => assignExperimentVariant('empty-v1', 'subject', [])).toThrow(/at least one variant/)
+    expect(() =>
+      assignExperimentVariant('zero-v1', 'subject', [
+        { id: 'a', weight: 0 },
+        { id: 'b', weight: 0 },
+      ]),
+    ).toThrow(/positive variant weight/)
+  })
+})

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -8,6 +8,8 @@ type Gtag = (
     | 'affiliate_click'
     | 'atlas_callout_click'
     | 'email_signup'
+    | 'experiment_conversion'
+    | 'experiment_impression'
     | 'guide_view'
     | 'lead_magnet_click',
   params: Record<string, string | number | boolean | undefined>,
@@ -17,6 +19,13 @@ export type GuideViewParams = {
   slug: string
   cluster?: string
   pagePath: string
+}
+
+export type ExperimentAnalyticsParams = {
+  experimentId: string
+  variant: string
+  location?: string
+  pagePath?: string
 }
 
 function getGtag(): Gtag | null {
@@ -63,6 +72,32 @@ export function trackEmailSignup(params: { source: string; pagePath?: string }):
       signup_source: params.source,
       page_path: pagePath,
       source_path: pagePath,
+    })
+  } catch {
+    // Analytics must never block signup flow.
+  }
+}
+
+export function trackExperimentImpression(params: ExperimentAnalyticsParams): void {
+  try {
+    getGtag()?.('event', 'experiment_impression', {
+      experiment_id: params.experimentId,
+      experiment_variant: params.variant,
+      experiment_location: params.location,
+      page_path: getCurrentPagePath(params.pagePath),
+    })
+  } catch {
+    // Analytics must never affect the experiment experience.
+  }
+}
+
+export function trackExperimentConversion(params: ExperimentAnalyticsParams): void {
+  try {
+    getGtag()?.('event', 'experiment_conversion', {
+      experiment_id: params.experimentId,
+      experiment_variant: params.variant,
+      experiment_location: params.location,
+      page_path: getCurrentPagePath(params.pagePath),
     })
   } catch {
     // Analytics must never block signup flow.

--- a/lib/experiment-assignment.ts
+++ b/lib/experiment-assignment.ts
@@ -1,0 +1,47 @@
+export type WeightedExperimentVariant<T extends string> = {
+  id: T
+  weight?: number
+}
+
+/**
+ * Stable FNV-1a style hash used only for deterministic experiment bucketing.
+ * This is deliberately not an identity hash and must never receive email,
+ * account IDs, or other personal data.
+ */
+export function experimentBucket(experimentId: string, anonymousSubject: string): number {
+  const input = `${experimentId}:${anonymousSubject}`
+  let hash = 0x811c9dc5
+
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index)
+    hash = Math.imul(hash, 0x01000193)
+  }
+
+  return (hash >>> 0) / 0x100000000
+}
+
+export function assignExperimentVariant<T extends string>(
+  experimentId: string,
+  anonymousSubject: string,
+  variants: readonly WeightedExperimentVariant<T>[],
+): T {
+  if (!variants.length) {
+    throw new Error(`Experiment ${experimentId} must define at least one variant.`)
+  }
+
+  const weights = variants.map((variant) => Math.max(0, variant.weight ?? 1))
+  const totalWeight = weights.reduce((sum, weight) => sum + weight, 0)
+  if (totalWeight <= 0) {
+    throw new Error(`Experiment ${experimentId} must have positive variant weight.`)
+  }
+
+  const target = experimentBucket(experimentId, anonymousSubject) * totalWeight
+  let cumulative = 0
+
+  for (let index = 0; index < variants.length; index += 1) {
+    cumulative += weights[index]
+    if (target < cumulative) return variants[index].id
+  }
+
+  return variants[variants.length - 1].id
+}


### PR DESCRIPTION
## Backlog
Covers 351–352.

## What changed
- adds deterministic anonymous experiment assignment with weighted variants
- launches a four-cell article email capture test: inline vs end-of-article × weekly-evidence vs safety-first heading
- keeps assignment sticky without using email/account identity
- injects inline capture after early article content while preserving static MDX output
- records experiment impressions and successful signup conversions in the existing consent-gated analytics layer
- adds unit coverage for bucketing stability and weighting

## Guardrails
- no personal data is used for experiment assignment
- strict privacy/storage failures fall back to a volatile anonymous subject
- analytics failures never block rendering or signup
- existing signup endpoint and Turnstile behavior remain unchanged