### PR TITLE
fix(timing): apply publication gate to generated guides

### DIFF
--- a/app/guides/timing/[slug]/page.tsx
+++ b/app/guides/timing/[slug]/page.tsx
@@ -3,63 +3,36 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 
 import Disclaimer from '@/src/components/Disclaimer'
-import { getUnifiedRuntimeRecords } from '@/src/lib/runtime-record-index'
 import { buildPageMetadata } from '@/src/lib/seo'
-
-type RuntimeIngredient = Record<string, unknown> & {
-  slug?: string
-  name?: string
-  best_taken?: unknown
-  bioavailability_notes?: unknown
-  evidence_grade?: unknown
-  evidence_level?: unknown
-}
-
-function clean(value: unknown): string {
-  if (typeof value !== 'string') return ''
-  return value.replace(/\s+/g, ' ').trim()
-}
-
-function getTiming(record: RuntimeIngredient): string {
-  return clean(record.best_taken)
-}
+import {
+  cleanTimingValue,
+  getTiming,
+  loadIndexableTimingIngredients,
+  type RuntimeIngredient,
+} from '../timing-data'
 
 function hasDaypartDecision(timing: string): boolean {
   return /\b(morning|afternoon|evening|night|nighttime|bedtime|before bed|daytime|earlier in the day|later in the day)\b/i.test(timing)
 }
 
 function getFoodDecision(record: RuntimeIngredient, timing: string): string {
-  const bioavailability = clean(record.bioavailability_notes)
+  const bioavailability = cleanTimingValue(record.bioavailability_notes)
   const candidates = [bioavailability, timing].filter(Boolean)
   return candidates.find((value) => /\b(food|meal|meals|with fat|empty stomach|fasted|fasting)\b/i.test(value)) || ''
 }
 
-async function getEligibleIngredients(): Promise<RuntimeIngredient[]> {
-  const { herbs, compounds } = await getUnifiedRuntimeRecords()
-  const bySlug = new Map<string, RuntimeIngredient>()
-
-  for (const record of [...herbs, ...compounds] as RuntimeIngredient[]) {
-    const slug = clean(record.slug)
-    const timing = getTiming(record)
-    if (!slug || !timing) continue
-    if (!bySlug.has(slug)) bySlug.set(slug, record)
-  }
-
-  return [...bySlug.values()]
-}
-
 export async function generateStaticParams() {
-  const ingredients = await getEligibleIngredients()
-  return ingredients.map((record) => ({ slug: clean(record.slug) }))
+  const ingredients = await loadIndexableTimingIngredients()
+  return ingredients.map((record) => ({ slug: cleanTimingValue(record.slug) }))
 }
 
 export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {
   const { slug } = await params
-  const ingredients = await getEligibleIngredients()
-  const record = ingredients.find((item) => clean(item.slug) === slug)
+  const ingredients = await loadIndexableTimingIngredients()
+  const record = ingredients.find((item) => cleanTimingValue(item.slug) === slug)
   if (!record) return {}
 
-  const name = clean(record.name) || slug
+  const name = cleanTimingValue(record.name) || slug
   return buildPageMetadata({
     title: `Best Time to Take ${name}: Evidence-Based Timing`,
     description: `When to take ${name}, based only on timing guidance present in The Hippie Scientist's structured evidence record.`,
@@ -69,13 +42,13 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
 
 export default async function IngredientTimingPage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params
-  const ingredients = await getEligibleIngredients()
-  const record = ingredients.find((item) => clean(item.slug) === slug)
+  const ingredients = await loadIndexableTimingIngredients()
+  const record = ingredients.find((item) => cleanTimingValue(item.slug) === slug)
   if (!record) notFound()
 
-  const name = clean(record.name) || slug
+  const name = cleanTimingValue(record.name) || slug
   const timing = getTiming(record)
-  const grade = clean(record.evidence_grade) || clean(record.evidence_level)
+  const grade = cleanTimingValue(record.evidence_grade) || cleanTimingValue(record.evidence_level)
   const showDaypartDecision = hasDaypartDecision(timing)
   const foodDecision = getFoodDecision(record, timing)
 

--- a/app/guides/timing/timing-data.ts
+++ b/app/guides/timing/timing-data.ts
@@ -1,0 +1,43 @@
+import { getRuntimeVisibility } from '@/lib/runtime-visibility'
+import { getUnifiedRuntimeRecords } from '@/src/lib/runtime-record-index'
+import type { RuntimeRecord } from '@/src/types/content'
+
+export type RuntimeIngredient = RuntimeRecord & {
+  best_taken?: unknown
+  bioavailability_notes?: unknown
+  evidence_grade?: unknown
+  evidence_level?: unknown
+}
+
+export function cleanTimingValue(value: unknown): string {
+  if (typeof value !== 'string') return ''
+  return value.replace(/\s+/g, ' ').trim()
+}
+
+export function getTiming(record: RuntimeIngredient): string {
+  return cleanTimingValue(record.best_taken)
+}
+
+export function selectIndexableTimingIngredients(records: RuntimeRecord[]): RuntimeIngredient[] {
+  const bySlug = new Map<string, RuntimeIngredient>()
+
+  for (const record of records as RuntimeIngredient[]) {
+    if (!getRuntimeVisibility(record).canIndex) continue
+
+    const slug = cleanTimingValue(record.slug)
+    const timing = getTiming(record)
+    if (!slug || !timing) continue
+
+    if (!bySlug.has(slug)) bySlug.set(slug, record)
+  }
+
+  return [...bySlug.values()]
+}
+
+export async function loadIndexableTimingIngredients(): Promise<RuntimeIngredient[]> {
+  const { herbs, compounds } = await getUnifiedRuntimeRecords()
+  return selectIndexableTimingIngredients([
+    ...(herbs as RuntimeRecord[]),
+    ...(compounds as RuntimeRecord[]),
+  ])
+}

--- a/tests/timing-guide-publication-gate.test.ts
+++ b/tests/timing-guide-publication-gate.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getTiming,
+  selectIndexableTimingIngredients,
+} from '../app/guides/timing/timing-data'
+import type { RuntimeRecord } from '../src/types/content'
+
+describe('timing guide publication gate', () => {
+  it('publishes only indexable records with explicit timing guidance', () => {
+    const records: RuntimeRecord[] = [
+      {
+        slug: 'published',
+        name: 'Published',
+        best_taken: '  In the morning  ',
+        indexability_status: 'PUBLISH',
+      },
+      {
+        slug: 'noindex',
+        name: 'Noindex',
+        best_taken: 'At night',
+        indexability_status: 'NOINDEX',
+      },
+      {
+        slug: 'hidden',
+        name: 'Hidden',
+        best_taken: 'With food',
+        indexability_status: 'PUBLISH',
+        runtime_export_decision: 'hide',
+      },
+      {
+        slug: 'no-timing',
+        name: 'No timing',
+        indexability_status: 'PUBLISH',
+      },
+    ]
+
+    const selected = selectIndexableTimingIngredients(records)
+
+    expect(selected.map((record) => record.slug)).toEqual(['published'])
+    expect(getTiming(selected[0])).toBe('In the morning')
+  })
+
+  it('filters visibility before deduplicating slugs', () => {
+    const records: RuntimeRecord[] = [
+      {
+        slug: 'shared',
+        name: 'Hidden version',
+        best_taken: 'Morning',
+        indexability_status: 'NOINDEX',
+      },
+      {
+        slug: 'shared',
+        name: 'Published version',
+        best_taken: 'Night',
+        indexability_status: 'PUBLISH',
+      },
+    ]
+
+    const selected = selectIndexableTimingIngredients(records)
+
+    expect(selected).toHaveLength(1)
+    expect(selected[0]?.name).toBe('Published version')
+    expect(getTiming(selected[0])).toBe('Night')
+  })
+})


### PR DESCRIPTION
## Root cause
The programmatic `/guides/timing/[slug]` route generated static URLs and indexable metadata for any runtime herb/compound with `best_taken`, without applying the repository's canonical runtime publication policy. Renderable NOINDEX or hidden records could therefore produce SEO timing pages even though the underlying profile was not eligible for indexing.

## Change
- Add one canonical timing-guide data selector.
- Apply `getRuntimeVisibility(record).canIndex` before timing eligibility and slug deduplication.
- Share timing-value normalization between selection and rendering.
- Use the canonical loader for static params, metadata, and page rendering.
- Add focused regression coverage for PUBLISH, NOINDEX, hidden, missing-timing, and duplicate-slug behavior.

## Scope
No timing copy, layout, metadata wording, or runtime source data is changed.