### PR TITLE
ROI 701-710: competitor gap and differentiated intent engine

### DIFF
--- a/src/lib/__tests__/competitor-content-gap.test.ts
+++ b/src/lib/__tests__/competitor-content-gap.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import { buildCompetitorContentGapReport } from '../competitor-content-gap'
+
+describe('competitor content gap strategy', () => {
+  it('avoids generic head terms already owned by medical authorities', () => {
+    const [gap] = buildCompetitorContentGapReport([], [
+      {
+        topic: 'What is ashwagandha',
+        publisher: 'NIH/NCCIH',
+        intent: 'generic-definition',
+        authorityTier: 'medical-authority',
+      },
+    ])
+
+    expect(gap.decision).toBe('avoid-generic-head-term')
+    expect(gap.distinctivenessScore).toBeLessThan(0)
+  })
+
+  it('prioritizes long-tail decision gaps large publishers underserve', () => {
+    const [gap] = buildCompetitorContentGapReport([], [
+      {
+        topic: 'Ashwagandha morning or night',
+        publisher: 'Healthline',
+        intent: 'long-tail-decision',
+        authorityTier: 'consumer-publisher',
+      },
+    ])
+
+    expect(gap.decision).toBe('pursue')
+    expect(gap.intent).toBe('long-tail-decision')
+    expect(gap.distinctivenessScore).toBeGreaterThanOrEqual(7)
+  })
+
+  it('protects existing topics while rewarding differentiated site capabilities', () => {
+    const [gap] = buildCompetitorContentGapReport(
+      [
+        {
+          topic: 'Magnesium glycinate vs citrate',
+          url: '/guides/compare/magnesium-glycinate-vs-citrate/',
+          intent: 'comparison',
+          capabilities: ['comparison', 'evidence-synthesis', 'structured-data'],
+        },
+      ],
+      [
+        {
+          topic: 'Magnesium glycinate vs citrate',
+          publisher: 'Examine',
+          intent: 'comparison',
+          authorityTier: 'evidence-specialist',
+        },
+      ],
+    )
+
+    expect(gap.decision).toBe('protect')
+    expect(gap.distinctivenessScore).toBeGreaterThan(10)
+    expect(gap.siteUrls).toContain('/guides/compare/magnesium-glycinate-vs-citrate/')
+  })
+
+  it('infers form, evidence and interaction intents when explicit labels are absent', () => {
+    const results = buildCompetitorContentGapReport([], [
+      { topic: 'Ashwagandha extract differences', publisher: 'Examine' },
+      { topic: 'Ashwagandha mechanism vs human evidence', publisher: 'Healthline' },
+      { topic: 'Ashwagandha drug interaction research', publisher: 'NIH/NCCIH' },
+    ])
+
+    expect(results.map((result) => result.intent)).toEqual(
+      expect.arrayContaining(['form-extract', 'mechanism-vs-human-evidence', 'interaction-research']),
+    )
+    expect(results.every((result) => result.decision === 'pursue')).toBe(true)
+  })
+})

--- a/src/lib/competitor-content-gap.ts
+++ b/src/lib/competitor-content-gap.ts
@@ -1,0 +1,193 @@
+export const CORE_COMPETITOR_PUBLISHERS = [
+  'Examine',
+  'NIH/NCCIH',
+  'Healthline',
+] as const
+
+export type CompetitorPublisher = (typeof CORE_COMPETITOR_PUBLISHERS)[number] | string
+
+export type GapIntent =
+  | 'generic-definition'
+  | 'long-tail-decision'
+  | 'form-extract'
+  | 'evidence-comparison'
+  | 'mechanism-vs-human-evidence'
+  | 'interaction-research'
+  | 'comparison'
+  | 'structured-data'
+  | 'interactive-tool'
+  | 'evidence-synthesis'
+  | 'other'
+
+export interface TopicCoverage {
+  topic: string
+  publisher: CompetitorPublisher
+  url?: string
+  intent?: GapIntent
+  authorityTier?: 'medical-authority' | 'evidence-specialist' | 'consumer-publisher' | 'other'
+}
+
+export interface SiteTopic {
+  topic: string
+  url: string
+  intent?: GapIntent
+  capabilities?: Array<
+    'structured-data' | 'comparison' | 'interactive-tool' | 'evidence-synthesis' | 'source-level-safety'
+  >
+}
+
+export interface CompetitorGap {
+  topic: string
+  normalizedTopic: string
+  competitorPublishers: string[]
+  competitorUrls: string[]
+  siteUrls: string[]
+  intent: GapIntent
+  distinctivenessScore: number
+  decision: 'pursue' | 'protect' | 'avoid-generic-head-term'
+  reasons: string[]
+}
+
+const DISTINCTIVE_INTENTS = new Set<GapIntent>([
+  'long-tail-decision',
+  'form-extract',
+  'evidence-comparison',
+  'mechanism-vs-human-evidence',
+  'interaction-research',
+  'comparison',
+  'structured-data',
+  'interactive-tool',
+  'evidence-synthesis',
+])
+
+const CAPABILITY_WEIGHTS: Record<NonNullable<SiteTopic['capabilities']>[number], number> = {
+  'structured-data': 3,
+  comparison: 3,
+  'interactive-tool': 4,
+  'evidence-synthesis': 4,
+  'source-level-safety': 4,
+}
+
+export function normalizeTopicKey(topic: string): string {
+  return topic
+    .trim()
+    .toLowerCase()
+    .replace(/[’']/g, '')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+}
+
+function inferIntent(topic: string): GapIntent {
+  const value = topic.toLowerCase()
+  if (/\b(vs|versus|compare|comparison)\b/.test(value)) return 'comparison'
+  if (/\b(extract|glycinate|citrate|oxide|threonate|standardized|form)\b/.test(value)) return 'form-extract'
+  if (/\b(interaction|together|with medication|drug)\b/.test(value)) return 'interaction-research'
+  if (/\b(mechanism|pathway|human evidence|clinical evidence)\b/.test(value)) {
+    return 'mechanism-vs-human-evidence'
+  }
+  if (/\b(which|should|better|best time|morning|night|with food|without food|how long)\b/.test(value)) {
+    return 'long-tail-decision'
+  }
+  if (/\b(what is|definition|overview)\b/.test(value)) return 'generic-definition'
+  return 'other'
+}
+
+function strongerIntent(intents: GapIntent[]): GapIntent {
+  return intents.find((intent) => DISTINCTIVE_INTENTS.has(intent)) ?? intents[0] ?? 'other'
+}
+
+export function buildCompetitorContentGapReport(
+  siteTopics: SiteTopic[],
+  competitorTopics: TopicCoverage[],
+): CompetitorGap[] {
+  const siteByTopic = new Map<string, SiteTopic[]>()
+  const competitorByTopic = new Map<string, TopicCoverage[]>()
+
+  for (const item of siteTopics) {
+    const key = normalizeTopicKey(item.topic)
+    if (!key) continue
+    const bucket = siteByTopic.get(key) ?? []
+    bucket.push(item)
+    siteByTopic.set(key, bucket)
+  }
+
+  for (const item of competitorTopics) {
+    const key = normalizeTopicKey(item.topic)
+    if (!key) continue
+    const bucket = competitorByTopic.get(key) ?? []
+    bucket.push(item)
+    competitorByTopic.set(key, bucket)
+  }
+
+  const keys = new Set([...siteByTopic.keys(), ...competitorByTopic.keys()])
+  const gaps: CompetitorGap[] = []
+
+  for (const key of keys) {
+    const site = siteByTopic.get(key) ?? []
+    const competitors = competitorByTopic.get(key) ?? []
+    if (!competitors.length) continue
+
+    const topic = competitors[0]?.topic ?? site[0]?.topic ?? key
+    const intents = [...competitors.map((item) => item.intent), ...site.map((item) => item.intent)].filter(
+      (intent): intent is GapIntent => Boolean(intent),
+    )
+    const intent = strongerIntent(intents.length ? intents : [inferIntent(topic)])
+    const capabilities = new Set(site.flatMap((item) => item.capabilities ?? []))
+    const hasMedicalAuthority = competitors.some((item) => item.authorityTier === 'medical-authority')
+
+    let distinctivenessScore = 0
+    const reasons: string[] = []
+
+    if (!site.length) {
+      distinctivenessScore += 2
+      reasons.push('Competitors cover this topic but The Hippie Scientist does not yet have a matching indexed topic.')
+    } else {
+      distinctivenessScore += 1
+      reasons.push('The site already covers this topic, so the opportunity is to protect or deepen the winning URL.')
+    }
+
+    if (DISTINCTIVE_INTENTS.has(intent)) {
+      distinctivenessScore += 5
+      reasons.push('The query supports a differentiated decision, evidence, comparison, form, or interaction experience.')
+    }
+
+    for (const capability of capabilities) {
+      distinctivenessScore += CAPABILITY_WEIGHTS[capability]
+    }
+
+    if (capabilities.size) {
+      reasons.push(`Existing site capabilities can add a moat: ${[...capabilities].join(', ')}.`)
+    }
+
+    if (intent === 'generic-definition' && hasMedicalAuthority) {
+      distinctivenessScore -= 8
+      reasons.push('A medical authority already owns this generic-definition intent; avoid a me-too definition page.')
+    }
+
+    const decision: CompetitorGap['decision'] = site.length
+      ? 'protect'
+      : intent === 'generic-definition' && hasMedicalAuthority
+        ? 'avoid-generic-head-term'
+        : 'pursue'
+
+    gaps.push({
+      topic,
+      normalizedTopic: key,
+      competitorPublishers: [...new Set(competitors.map((item) => item.publisher))].sort(),
+      competitorUrls: [...new Set(competitors.map((item) => item.url).filter((url): url is string => Boolean(url)))],
+      siteUrls: [...new Set(site.map((item) => item.url))],
+      intent,
+      distinctivenessScore,
+      decision,
+      reasons,
+    })
+  }
+
+  return gaps.sort(
+    (a, b) =>
+      (a.decision === 'pursue' ? 0 : a.decision === 'protect' ? 1 : 2) -
+        (b.decision === 'pursue' ? 0 : b.decision === 'protect' ? 1 : 2) ||
+      b.distinctivenessScore - a.distinctivenessScore ||
+      a.normalizedTopic.localeCompare(b.normalizedTopic),
+  )
+}


### PR DESCRIPTION
Implements backlog 701-710 as one canonical strategy engine instead of scattered page heuristics.

- registers Examine, NIH/NCCIH, and Healthline as core comparison publishers
- normalizes site/competitor topics into comparable keys
- distinguishes generic head terms from long-tail decision, form/extract, evidence-comparison, mechanism-vs-human-evidence, interaction, comparison, structured-data, interactive-tool, and synthesis opportunities
- explicitly avoids me-too generic definitions where medical authorities already dominate
- rewards differentiated Hippie Scientist capabilities such as structured data, comparisons, interactive tools, evidence synthesis, and source-level safety
- emits pursue/protect/avoid decisions with reasons and deterministic scoring
- adds focused Vitest coverage for the guardrails