### PR TITLE
ROI 601-611: unify production content quality gate

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -56,5 +56,8 @@ jobs:
       - name: Build and verify
         run: npm run build:deploy
 
+      - name: Run merge-grade production content lint
+        run: node scripts/ci/production-content-lint.mjs --require-built
+
       - name: Report internal route-reference integrity
         run: node scripts/ci/audit-route-reference-integrity.mjs

--- a/scripts/ci/audit-built-page-semantics.mjs
+++ b/scripts/ci/audit-built-page-semantics.mjs
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+const ROOT = process.cwd()
+const OUT_DIR = path.join(ROOT, 'out')
+const REPORT_DIR = path.join(ROOT, 'public', 'data', 'reports')
+const STRICT = process.argv.includes('--strict')
+const REQUIRE_BUILT = process.argv.includes('--require-built')
+const SITE_ORIGIN = 'https://thehippiescientist.net'
+
+function walk(dir) {
+  const files = []
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const absolute = path.join(dir, entry.name)
+    if (entry.isDirectory()) files.push(...walk(absolute))
+    else if (entry.isFile() && entry.name.endsWith('.html')) files.push(absolute)
+  }
+  return files
+}
+
+function decodeHtml(value) {
+  return String(value ?? '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;|&apos;/gi, "'")
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function attr(tag, name) {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const match = tag.match(new RegExp(`\\b${escaped}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s>]+))`, 'i'))
+  return decodeHtml(match?.[1] ?? match?.[2] ?? match?.[3] ?? '')
+}
+
+function firstTagContent(html, tagName) {
+  const match = html.match(new RegExp(`<${tagName}\\b[^>]*>([\\s\\S]*?)<\\/${tagName}>`, 'i'))
+  return decodeHtml(match?.[1] ?? '')
+}
+
+function allTagContents(html, tagName) {
+  return [...html.matchAll(new RegExp(`<${tagName}\\b[^>]*>([\\s\\S]*?)<\\/${tagName}>`, 'gi'))]
+    .map((match) => decodeHtml(match[1]))
+    .filter(Boolean)
+}
+
+function routeForFile(file) {
+  const relative = path.relative(OUT_DIR, file).replaceAll(path.sep, '/')
+  if (relative === 'index.html') return '/'
+  if (relative.endsWith('/index.html')) return `/${relative.slice(0, -'/index.html'.length)}/`
+  return `/${relative.replace(/\.html$/, '')}/`
+}
+
+function normalizeRoute(route) {
+  return route === '/' ? '/' : `/${route.replace(/^\/+|\/+$/g, '')}/`
+}
+
+function pushGrouped(map, key, route) {
+  if (!key) return
+  const normalized = key.toLowerCase().replace(/\s+/g, ' ').trim()
+  map.set(normalized, [...(map.get(normalized) ?? []), route])
+}
+
+function duplicateGroups(map, minCount = 2) {
+  return [...map.entries()]
+    .filter(([, routes]) => routes.length >= minCount)
+    .map(([value, routes]) => ({ value, routes }))
+    .sort((a, b) => b.routes.length - a.routes.length || a.value.localeCompare(b.value))
+}
+
+function markdown(report) {
+  const lines = [
+    '# Built page semantics audit',
+    '',
+    `Scanned **${report.summary.pages}** HTML pages; **${report.summary.indexablePages}** were indexable.`,
+    '',
+    `- Errors: **${report.summary.errors}**`,
+    `- Warnings: **${report.summary.warnings}**`,
+    `- Duplicate H1 groups: **${report.summary.duplicateH1Groups}**`,
+    `- Duplicate title groups: **${report.summary.duplicateTitleGroups}**`,
+    `- Excessively duplicated description groups: **${report.summary.excessiveDescriptionGroups}**`,
+    '',
+  ]
+
+  if (report.errors.length) {
+    lines.push('## Errors', '')
+    for (const issue of report.errors) lines.push(`- \`${issue.route}\` — ${issue.message}`)
+    lines.push('')
+  }
+  if (report.warnings.length) {
+    lines.push('## Warnings', '')
+    for (const issue of report.warnings.slice(0, 100)) lines.push(`- \`${issue.route}\` — ${issue.message}`)
+    lines.push('')
+  }
+  if (report.duplicateH1s.length) {
+    lines.push('## Repeated H1s', '')
+    for (const group of report.duplicateH1s.slice(0, 50)) {
+      lines.push(`- **${group.value}** — ${group.routes.map((route) => `\`${route}\``).join(', ')}`)
+    }
+    lines.push('')
+  }
+  return `${lines.join('\n')}\n`
+}
+
+if (!fs.existsSync(OUT_DIR)) {
+  const message = '[built-page-semantics] out/ does not exist; run a production build first'
+  if (REQUIRE_BUILT) {
+    console.error(message)
+    process.exit(1)
+  }
+  console.log(`${message}; skipping built HTML audit`)
+  process.exit(0)
+}
+
+const files = walk(OUT_DIR)
+const errors = []
+const warnings = []
+const h1ByText = new Map()
+const titleByText = new Map()
+const descriptionByText = new Map()
+const canonicalByUrl = new Map()
+let indexablePages = 0
+
+for (const file of files) {
+  const html = fs.readFileSync(file, 'utf8')
+  const route = routeForFile(file)
+  const metaTags = html.match(/<meta\b[^>]*>/gi) ?? []
+  const linkTags = html.match(/<link\b[^>]*>/gi) ?? []
+  const robotsTag = metaTags.find((tag) => attr(tag, 'name').toLowerCase() === 'robots')
+  const robots = attr(robotsTag ?? '', 'content').toLowerCase()
+  const indexable = !robots.includes('noindex') && !['/404/', '/500/'].includes(normalizeRoute(route))
+  if (!indexable) continue
+  indexablePages += 1
+
+  const title = firstTagContent(html, 'title')
+  const descriptionTag = metaTags.find((tag) => attr(tag, 'name').toLowerCase() === 'description')
+  const description = attr(descriptionTag ?? '', 'content')
+  const h1s = allTagContents(html, 'h1')
+  const canonicalTags = linkTags.filter((tag) => attr(tag, 'rel').toLowerCase().split(/\s+/).includes('canonical'))
+  const canonical = attr(canonicalTags[0] ?? '', 'href')
+
+  if (!title) errors.push({ route, message: 'missing <title>' })
+  if (!description) errors.push({ route, message: 'missing meta description' })
+  if (h1s.length === 0) errors.push({ route, message: 'missing H1' })
+  if (h1s.length > 1) warnings.push({ route, message: `contains ${h1s.length} H1 elements; prefer one page-level H1` })
+  if (canonicalTags.length !== 1) errors.push({ route, message: `expected exactly one canonical tag; found ${canonicalTags.length}` })
+
+  if (canonical) {
+    try {
+      const url = new URL(canonical)
+      if (url.origin !== SITE_ORIGIN) errors.push({ route, message: `canonical uses unexpected origin: ${url.origin}` })
+      if (url.search || url.hash) errors.push({ route, message: 'canonical contains query parameters or a fragment' })
+      pushGrouped(canonicalByUrl, canonical, route)
+    } catch {
+      errors.push({ route, message: `canonical is not a valid absolute URL: ${canonical}` })
+    }
+  }
+
+  if (!/<html\b[^>]*\blang\s*=\s*["'][^"']+["']/i.test(html)) {
+    errors.push({ route, message: 'missing html[lang] accessibility attribute' })
+  }
+  if (!/<main\b/i.test(html)) warnings.push({ route, message: 'missing semantic <main> landmark' })
+
+  const imageTags = html.match(/<img\b[^>]*>/gi) ?? []
+  const imagesWithoutAlt = imageTags.filter((tag) => {
+    const role = attr(tag, 'role').toLowerCase()
+    const ariaHidden = attr(tag, 'aria-hidden').toLowerCase()
+    return !/\balt\s*=/.test(tag) && role !== 'presentation' && ariaHidden !== 'true'
+  })
+  if (imagesWithoutAlt.length) {
+    warnings.push({ route, message: `${imagesWithoutAlt.length} image(s) lack alt text or an explicit decorative role` })
+  }
+
+  const jsonLdBlocks = [...html.matchAll(/<script\b[^>]*type\s*=\s*["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi)]
+  for (const [, rawJson] of jsonLdBlocks) {
+    try {
+      JSON.parse(rawJson.trim())
+    } catch {
+      errors.push({ route, message: 'contains malformed JSON-LD structured data' })
+    }
+  }
+
+  pushGrouped(titleByText, title, route)
+  pushGrouped(descriptionByText, description, route)
+  for (const h1 of h1s) pushGrouped(h1ByText, h1, route)
+}
+
+const duplicateTitles = duplicateGroups(titleByText, 2)
+const duplicateH1s = duplicateGroups(h1ByText, 2)
+const excessiveDescriptions = duplicateGroups(descriptionByText, 3)
+const duplicateCanonicals = duplicateGroups(canonicalByUrl, 2)
+
+for (const group of duplicateTitles) {
+  errors.push({ route: group.routes.join(', '), message: `duplicate page title: “${group.value}”` })
+}
+for (const group of duplicateCanonicals) {
+  errors.push({ route: group.routes.join(', '), message: `duplicate canonical URL: ${group.value}` })
+}
+for (const group of duplicateH1s) {
+  const issue = { route: group.routes.join(', '), message: `repeated H1 across ${group.routes.length} indexable pages: “${group.value}”` }
+  if (group.routes.length >= 3) errors.push(issue)
+  else warnings.push(issue)
+}
+for (const group of excessiveDescriptions) {
+  errors.push({ route: group.routes.join(', '), message: `meta description repeated across ${group.routes.length} indexable pages` })
+}
+
+const report = {
+  generatedAt: new Date().toISOString(),
+  strict: STRICT,
+  summary: {
+    pages: files.length,
+    indexablePages,
+    errors: errors.length,
+    warnings: warnings.length,
+    duplicateH1Groups: duplicateH1s.length,
+    duplicateTitleGroups: duplicateTitles.length,
+    excessiveDescriptionGroups: excessiveDescriptions.length,
+  },
+  duplicateTitles,
+  duplicateH1s,
+  excessiveDescriptions,
+  duplicateCanonicals,
+  errors,
+  warnings,
+}
+
+fs.mkdirSync(REPORT_DIR, { recursive: true })
+fs.writeFileSync(path.join(REPORT_DIR, 'built-page-semantics.json'), `${JSON.stringify(report, null, 2)}\n`)
+fs.writeFileSync(path.join(REPORT_DIR, 'built-page-semantics.md'), markdown(report))
+
+console.log('\nBuilt page semantics audit')
+console.log('='.repeat(60))
+console.log(`HTML pages       ${report.summary.pages}`)
+console.log(`Indexable pages  ${report.summary.indexablePages}`)
+console.log(`Errors           ${report.summary.errors}`)
+console.log(`Warnings         ${report.summary.warnings}`)
+console.log(`Repeated H1s     ${report.summary.duplicateH1Groups}`)
+console.log(`Report           public/data/reports/built-page-semantics.md`)
+
+if (STRICT && errors.length) process.exit(1)

--- a/scripts/ci/production-content-lint.mjs
+++ b/scripts/ci/production-content-lint.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import { spawnSync } from 'node:child_process'
+
+const REQUIRE_BUILT = process.argv.includes('--require-built')
+const HAS_BUILD = fs.existsSync('out')
+const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+
+const checks = [
+  {
+    id: '601-602,604',
+    name: 'titles, descriptions, canonicals',
+    command: process.execPath,
+    args: ['scripts/ci/audit-metadata-duplicates.mjs'],
+  },
+  {
+    id: '605',
+    name: 'index/noindex logic',
+    command: process.execPath,
+    args: ['scripts/ci/validate-indexability-metadata.mjs'],
+  },
+  {
+    id: '604',
+    name: 'route SEO/canonical contract',
+    command: process.execPath,
+    args: ['scripts/ci/validate-route-seo.mjs'],
+  },
+  {
+    id: '600',
+    name: 'production language leaks',
+    command: process.execPath,
+    args: ['scripts/audit/find-leaked-pipeline-text.mjs'],
+  },
+  {
+    id: '610',
+    name: 'component accessibility basics',
+    command: npm,
+    args: ['run', '-s', 'test:a11y'],
+  },
+]
+
+if (HAS_BUILD) {
+  checks.push(
+    {
+      id: '601-604,609-610',
+      name: 'built HTML semantics and H1 uniqueness',
+      command: process.execPath,
+      args: ['scripts/ci/audit-built-page-semantics.mjs', '--strict', '--require-built'],
+    },
+    {
+      id: '606',
+      name: 'internal links',
+      command: process.execPath,
+      args: ['scripts/ci/audit-internal-links.mjs'],
+    },
+    {
+      id: '607',
+      name: 'sitemap',
+      command: process.execPath,
+      args: ['scripts/ci/validate-sitemap.mjs', '--require-built'],
+    },
+    {
+      id: '608',
+      name: 'redirects',
+      command: process.execPath,
+      args: ['scripts/verify-redirects.mjs'],
+    },
+    {
+      id: '609',
+      name: 'structured data',
+      command: process.execPath,
+      args: ['scripts/ci/audit-structured-data.mjs'],
+    },
+    {
+      id: '605,607',
+      name: 'built robots directives',
+      command: process.execPath,
+      args: ['scripts/ci/validate-robots.mjs', '--require-built'],
+    },
+  )
+} else if (REQUIRE_BUILT) {
+  console.error('[production-content-lint] out/ is required but missing. Run the production build first.')
+  process.exit(1)
+}
+
+const results = []
+let failures = 0
+
+console.log('\nProduction content lint')
+console.log('='.repeat(72))
+console.log(`Mode: ${HAS_BUILD ? 'built-output + source/data checks' : 'source/data checks only'}`)
+console.log('')
+
+for (const check of checks) {
+  const started = Date.now()
+  const result = spawnSync(check.command, check.args, {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    env: process.env,
+    maxBuffer: 20 * 1024 * 1024,
+  })
+  const elapsedMs = Date.now() - started
+  const passed = result.status === 0
+  if (!passed) failures += 1
+
+  results.push({
+    id: check.id,
+    name: check.name,
+    passed,
+    status: result.status,
+    elapsedMs,
+  })
+
+  const mark = passed ? 'PASS' : 'FAIL'
+  console.log(`${mark.padEnd(5)} [${check.id}] ${check.name} (${elapsedMs}ms)`)
+
+  if (!passed) {
+    const output = [result.stdout, result.stderr].filter(Boolean).join('\n').trim()
+    if (output) {
+      console.log(output.split(/\r?\n/).slice(-40).map((line) => `       ${line}`).join('\n'))
+    }
+  }
+}
+
+console.log('\n' + '-'.repeat(72))
+console.log(`Checks: ${results.length} · Passed: ${results.length - failures} · Failed: ${failures}`)
+if (!HAS_BUILD) {
+  console.log('Built-output checks were skipped because out/ is absent.')
+  console.log('For the merge-grade gate run: node scripts/ci/production-content-lint.mjs --require-built')
+}
+
+if (failures) {
+  console.error('\nProduction content lint failed. Fix the failing invariant(s) before merging.')
+  process.exit(1)
+}
+
+console.log('\nProduction content lint passed.')


### PR DESCRIPTION
Fixes #3098

## Relevant URLs
- All canonical/indexable production pages in the static `out/` export
- `public/data/reports/built-page-semantics.md`

## Acceptance criteria
- Reuse existing metadata, canonical, indexability, internal-link, sitemap, redirect, schema, robots, and accessibility validators.
- Add built-HTML H1/semantic checks rather than another competing policy layer.
- Provide one merge-grade production-content lint command.
- Enforce that command in the existing Build Check after the production/static export exists.
- Fail on production invariants while preserving warnings for lower-severity issues.

## Validation commands
- `npm run build`
- `node scripts/ci/audit-built-page-semantics.mjs --strict --require-built`
- `node scripts/ci/production-content-lint.mjs --require-built`
- `npm run check`
- GitHub workflow: `Build Check`

## Before → after metrics
- Unified production-content gate: 0 → 1.
- Dedicated built-H1/semantic audit: 0 → 1.
- Existing validators reused by the gate: 10+.
- Merge-path enforcement: manual convention → Build Check step after static export.

## Generator/source-of-truth decision
Existing specialist validators remain the source of truth for their domains. The new lint script is an orchestration layer; the built-page audit owns only rendered-HTML semantics that were not centrally checked before.

## Regression contract
Indexable production HTML must retain a title, description, H1, one valid canonical, valid JSON-LD, language semantics, and pass the repository's existing link/sitemap/redirect/schema/indexability/accessibility gates before merge. Build Check must invoke the unified gate only after `out/` exists so no built-output invariant can be silently skipped.