### PR TITLE
research: recalibrate ashwagandha ADHD evidence and 2026 safety

### DIFF
--- a/app/guides/adhd/ashwagandha-for-adhd/page.tsx
+++ b/app/guides/adhd/ashwagandha-for-adhd/page.tsx
@@ -4,9 +4,9 @@ import { buildPageMetadata } from '@/src/lib/seo'
 const SLUG = 'ashwagandha-for-adhd'
 
 export const metadata = buildPageMetadata({
-  title: 'Ashwagandha for ADHD: Does It Help Focus or Stress?',
+  title: 'Ashwagandha for ADHD: 2026 Evidence, Liver Risk & Safety',
   description:
-    'Direct ADHD evidence is limited. See what human research shows for stress, sleep, and cognition, plus extract context, side effects, interactions, and realistic limits.',
+    'Ashwagandha ADHD evidence is preliminary. Review the pediatric preprint, non-ADHD cognition data, stress/sleep evidence, liver-injury reports, thyroid cautions, and medication limits.',
   path: `/guides/adhd/${SLUG}/`,
   openGraphType: 'article',
 })

--- a/docs/content/focus-cluster/ashwagandha-for-adhd.md
+++ b/docs/content/focus-cluster/ashwagandha-for-adhd.md
@@ -1,400 +1,216 @@
 ---
-title: "Ashwagandha and ADHD: What the Research Shows About Stress, Focus, Sleep, and Emotional Regulation"
-seoTitle: "Ashwagandha and ADHD: What the Research Shows About Stress, Focus, Sleep, and Emotional Regulation"
-metaDescription: "Evidence-based review of ashwagandha and ADHD. Covers stress response, cortisol, attention, sleep, emotional regulation, pediatric and adult evidence, dosing, safety, and realistic expectations."
+title: "Ashwagandha for ADHD: Direct Evidence, Stress, Sleep, and 2026 Safety"
+seoTitle: "Ashwagandha for ADHD: 2026 Evidence and Safety"
+metaDescription: "Evidence-first review of ashwagandha for ADHD: the small pediatric preprint, non-ADHD cognition studies, stress/sleep evidence, liver-injury reports, thyroid cautions, and medication limits."
 primaryKeyword: "ashwagandha ADHD"
 secondaryKeywords:
   - "ashwagandha for ADHD"
   - "ashwagandha attention ADHD"
   - "ashwagandha focus ADHD"
   - "ashwagandha sleep ADHD"
-  - "ashwagandha cortisol ADHD"
-  - "ashwagandha emotional regulation ADHD"
-status: "draft-source"
+  - "ashwagandha safety liver"
+  - "ashwagandha stimulant interaction"
+status: "published"
 cluster: "focus-adhd"
+updated: "2026-08-15"
 ---
 
-# Ashwagandha and ADHD: What the Research Shows About Stress, Focus, Sleep, and Emotional Regulation
+# Ashwagandha for ADHD: What the Evidence Supports in 2026
 
-## Introduction
+Ashwagandha has a growing human literature for stress, sleep, and some cognitive outcomes. The direct ADHD evidence is much thinner.
 
-Ashwagandha (*Withania somnifera*) is a traditional Ayurvedic herb classified as an adaptogen, meaning it may help the body manage stress. It has been studied for effects on cortisol levels, anxiety, sleep quality, and cognitive function. Because stress, anxiety, and sleep difficulties commonly co-occur with ADHD and can worsen symptoms, ashwagandha has attracted interest as a potential adjunctive support.
+As of the **August 15, 2026** literature check for this guide, the most directly relevant pediatric ADHD study we found is a small randomized study of **58 children ages 5–12** that is available as a **preprint**, not a peer-reviewed PubMed-indexed clinical paper. A separate 2026 randomized trial enrolled 85 healthy children with parent-reported attention, concentration, or memory concerns, but those children were not an ADHD treatment cohort.
 
-This article reviews the human clinical evidence on ashwagandha in relation to ADHD symptoms, with attention to stress reduction, emotional regulation, sleep, and attention. It distinguishes stress and sleep studies from true ADHD trials and emphasizes that any potential benefits are uncertain, preliminary, context-dependent, or modest. Ashwagandha is discussed here strictly as potential adjunctive support for stress-related symptoms, not as a treatment for ADHD.
+That distinction matters. A positive stress trial, a healthy-child cognition trial, and a small ADHD preprint are three different levels of evidence.
 
-## Important Medical Disclaimer
+**Bottom line:** ashwagandha should not currently be presented as an established ADHD treatment or stimulant alternative. The stronger evidence is indirect—stress and sleep—and the 2026 safety literature makes product identity, liver risk, thyroid status, pregnancy, and medication context especially important.
 
-This article is for educational purposes only and does not constitute medical advice. Ashwagandha does not treat or cure ADHD. Supplements should not replace established behavioral interventions, medication, sleep optimization, or nutritional correction when clinically indicated. Evidence for ashwagandha in ADHD populations is limited and largely indirect. Individuals considering ashwagandha should consult a qualified healthcare provider before use, especially when taking other medications or giving supplements to children.
+## Evidence at a glance
 
-## What Ashwagandha Is
+| Evidence source | Population / design | What it found | Applicability to ADHD |
+|---|---|---|---|
+| Mild-ADHD pediatric preprint | 58 children ages 5–12, randomized placebo-controlled, 56 days | Reported improvements in ADHD-RS and several secondary outcomes | **Direct but preliminary:** small and currently a preprint |
+| 2026 healthy-child RCT | 85 healthy children ages 6–12 with parent-reported attention/memory concerns | Improved speed of information processing; several other outcomes were assessed | **Indirect:** not an ADHD-treatment trial |
+| Stress/anxiety trials and meta-analyses | Mostly stressed or anxious adults | Signals for perceived stress, cortisol, and some anxiety outcomes | **Indirect:** cannot be relabeled as core ADHD efficacy |
+| Sleep meta-analysis | Adults, small number of RCTs | Small overall sleep benefit | **Indirect:** sleep improvement is not ADHD treatment |
+| 2026 standardized-root safety review | 23 trials / 2,317 generally healthy adults | No serious attributable events in studied root-only trials up to 180 days | Reassuring for those products/populations, not proof of universal safety |
+| 2026 liver-injury scoping review | 25 published liver-injury cases | Reproducible idiosyncratic, often cholestatic/mixed liver injury pattern | Important rare-harm signal across real-world products |
 
-Ashwagandha is a small shrub native to parts of India, Africa, and the Middle East. The root is the most commonly used part in modern supplements. It contains withanolides, a group of steroidal lactones thought to contribute to its adaptogenic and anti-inflammatory properties.
+## The direct ADHD evidence is not yet mature
 
-## Traditional Uses
+The pediatric ADHD study frequently cited online randomized 58 children with mild ADHD to an ashwagandha root aqueous extract or placebo for 56 days and reported favorable ADHD Rating Scale and executive-function outcomes.
 
-In Ayurvedic medicine, ashwagandha has been used for centuries to promote vitality, reduce stress, support sleep, and enhance overall resilience. Modern research has focused on its effects on the stress response, anxiety, and cognitive function.
+That is scientifically interesting. It is also important to label the evidence correctly:
 
-## Key Active Compounds
+- the study is small;
+- the treatment period was short;
+- the population was children with mild ADHD;
+- the formulation was a defined aqueous root extract;
+- the report is currently available as a preprint;
+- there is not yet a replicated body of peer-reviewed ADHD trials establishing efficacy, dose, long-term safety, or medication-combination safety.
 
-### Withanolides
+A preprint can justify **further research**. It should not be treated as settled pediatric treatment evidence.
 
-Withanolides are the primary bioactive compounds in ashwagandha. They are often used as marker compounds for standardization in commercial extracts. Different extracts vary in their withanolide profiles and concentrations.
+## The 2026 healthy-child cognition trial is not an ADHD trial
 
-## How Ashwagandha Works
+A 2026 randomized, double-blind, placebo-controlled study enrolled 85 healthy children ages 6–12 whose parents reported concerns about attention, concentration, or memory.
 
-Ashwagandha appears to influence the hypothalamic-pituitary-adrenal (HPA) axis, which regulates the stress response. Human studies have shown reductions in cortisol levels in stressed individuals. It may also support GABA activity and modulate inflammatory pathways. These mechanisms provide a plausible basis for effects on stress, anxiety, and sleep, though direct links to ADHD core symptoms require further research.
+The ashwagandha group improved on speed of information processing. That finding is relevant to cognition research, but the study did not establish that ashwagandha treats diagnosed ADHD, reduces core ADHD symptoms, or can replace medication.
 
-## Ashwagandha and Cortisol
+This is a common evidence-conversion error on supplement sites: **“attention improved in a non-ADHD sample” becomes “supplement treats ADHD.”** This guide does not make that jump.
 
-Multiple human trials have demonstrated that ashwagandha supplementation can reduce cortisol levels in stressed or anxious adults. Lower cortisol is associated with reduced physiological stress load, which may indirectly support emotional regulation and sleep quality.
+## Stress evidence may still matter—indirectly
 
-## Ashwagandha and the Stress Response
+Stress can worsen sleep, irritability, perceived cognitive load, and day-to-day functioning in people with ADHD. Ashwagandha has substantially more research for stress than for ADHD.
 
-Ashwagandha has been shown in several studies to reduce perceived stress and improve stress resilience. These effects are generally modest and support its traditional use as an adaptogen for managing daily stressors.
+That can make stress a relevant **co-occurring target**. It does not mean ADHD is caused by high cortisol or that lowering cortisol treats the disorder.
 
-## Ashwagandha and the HPA Axis
+A stress outcome should stay a stress outcome.
 
-The HPA axis controls the body’s response to stress. Ashwagandha may help normalize HPA activity, potentially reducing excessive stress hormone output while supporting adaptive responses. This mechanism is frequently discussed in relation to its effects on anxiety and fatigue.
+## Sleep evidence may matter—indirectly
 
-## Ashwagandha and Sleep
+Sleep problems are common in ADHD, and poor sleep can worsen attention and emotional regulation the next day. Ashwagandha has a small randomized-trial literature for sleep in adults.
 
-Ashwagandha has shown benefits for sleep quality in stressed or anxious populations. Some trials report improvements in sleep latency, sleep efficiency, and overall sleep quality. These effects are often linked to reduced stress and better relaxation rather than direct hypnotic action.
+If a sleep outcome improves, that may improve daytime function. It should not be converted into evidence of a direct effect on ADHD neurobiology or executive function.
 
-## Ashwagandha and Anxiety
+For ADHD-specific sleep evidence, see the dedicated [melatonin for ADHD sleep](/guides/adhd/melatonin-for-adhd-sleep/) guide.
 
-Multiple randomized controlled trials have demonstrated ashwagandha’s ability to reduce anxiety symptoms in stressed or anxious adults. Reductions on validated anxiety scales and improvements in overall well-being have been reported. These findings are among the strongest areas of evidence for ashwagandha.
+## The 2026 safety picture looks contradictory—but it is not
 
-## Ashwagandha and Neurotransmitters
+Two recent evidence streams can appear to conflict:
 
-Ashwagandha may influence GABA activity and other neurotransmitter systems involved in mood and stress regulation. These effects are thought to contribute to its calming and anxiolytic properties, though the precise mechanisms in humans continue to be studied.
+1. A 2026 systematic review of **23 trials / 2,317 participants** found standardized root-only extracts were generally well tolerated in healthy adults across the studied doses and durations, with no serious adverse events attributed to the extracts.
+2. A separate 2026 scoping review identified **25 patients** with published ashwagandha-associated liver injury, usually appearing after weeks of use and often showing a cholestatic or mixed injury pattern.
 
-## Why Stress Reduction Does Not Automatically Treat ADHD
+Both findings can be true.
 
-ADHD involves complex neurobiological features beyond simple stress or anxiety. While ashwagandha may support stress resilience and emotional regulation, reducing stress does not address the core attention, hyperactivity, and executive function challenges that define ADHD. Evidence for core symptom improvement in ADHD populations remains limited.
+Randomized trials are useful for common short-term adverse effects in defined products and selected populations. They are usually too small to reliably detect rare idiosyncratic liver injury. Case reports and case series are much better at flagging unusual harms, but they cannot calculate a precise population incidence.
 
-## Why Researchers Became Interested in Ashwagandha and ADHD
+That is why “trials looked safe” does **not** mean “rare liver injury is disproven.”
 
-Interest developed from ashwagandha’s established research in stress, anxiety, and sleep, combined with the observation that many individuals with ADHD experience significant stress reactivity, emotional dysregulation, and sleep difficulties that can worsen core symptoms. Limited direct ADHD trials exist, so much of the discussion relies on indirect evidence from general stress and anxiety studies.
+## What the liver-injury literature actually shows
 
-## Direct ADHD Evidence
+The 2026 scoping review synthesized 13 publications covering 25 patients.
 
-High-quality randomized controlled trials specifically in diagnosed ADHD populations are limited but include some promising pediatric studies. Most available data come from general stress, anxiety, and sleep studies in non-ADHD populations rather than large-scale ADHD clinical trials. Direct applicability to ADHD must be interpreted cautiously.
+Reported features included:
 
-## Pediatric ADHD Evidence
+- onset usually after weeks of use;
+- jaundice and itching in many cases;
+- cholestatic or mixed biochemical patterns more often than purely hepatocellular injury;
+- recovery in most patients after stopping the product and supportive care;
+- severe outcomes in a minority, including liver transplantation in one case and deaths among patients with pre-existing cirrhosis who decompensated.
 
-Several randomized trials have evaluated ashwagandha in children with ADHD or parent-reported attention difficulties. One prospective double-blind study in children aged 5–12 with mild ADHD found significant improvements in ADHD rating scale scores after 56 days compared with placebo. Reductions were observed in both inattention and hyperactivity domains. Another trial in children with ADHD and comorbid anxiety reported reductions in anxiety symptoms. A study in healthy children aged 6–12 with attention and memory concerns found improvements in information processing speed and parent-reported sleep quality after eight weeks. These findings suggest potential adjunctive value for stress, anxiety, and sleep in pediatric populations, though larger confirmatory trials are needed.
+This does not mean liver injury is common. It means there is now enough repeated clinical reporting that the risk should not be omitted from an evidence-based safety section.
 
-## Adult ADHD Evidence
+## Root-only standardized extracts are not interchangeable with every product
 
-High-quality randomized trials of ashwagandha specifically in adults with confirmed ADHD are very limited. Most cognitive and stress-reduction studies have been conducted in healthy adults or stressed populations rather than diagnosed ADHD cohorts. Direct evidence in adult ADHD remains preliminary.
+The reassuring 2026 safety review deliberately focused on **single-ingredient standardized root-only extracts** in generally healthy adults.
 
-## Evidence From Stress Studies
+That evidence cannot automatically be generalized to:
 
-Ashwagandha has consistent evidence for reducing perceived stress in stressed adults. Reductions in cortisol and improvements on validated stress scales have been reported in multiple trials. These findings are among the strongest areas of support for ashwagandha and may be relevant for individuals with ADHD whose symptoms are worsened by chronic stress.
+- root-and-leaf extracts;
+- multi-ingredient “adaptogen” blends;
+- gummies with additional actives;
+- raw powders of uncertain identity;
+- products with different withanolide profiles;
+- products with poor quality control;
+- children;
+- pregnancy or breastfeeding;
+- people with liver, thyroid, autoimmune, or other chronic disease;
+- long-term use beyond the durations studied.
 
-## Evidence From Anxiety Studies
+“Contains ashwagandha” is not a sufficient description of a research intervention.
 
-Multiple randomized controlled trials have demonstrated ashwagandha’s ability to reduce anxiety symptoms in stressed or anxious adults. These effects are generally modest and support its use for anxiety-related symptoms rather than as a primary ADHD intervention.
+## Medication and condition context
 
-## Evidence From Sleep Studies
+NCCIH advises caution or avoidance in several situations and notes potential interactions with medications.
 
-Ashwagandha has shown benefits for sleep quality in stressed or anxious populations. Some trials report improvements in sleep latency, sleep efficiency, and overall sleep quality. In ADHD contexts, improvements in parent-reported sleep have been noted in some pediatric trials. Benefits appear linked to reduced stress and better relaxation.
+| Context | Why it matters |
+|---|---|
+| ADHD stimulants | Direct coadministration evidence is limited; absence of a known interaction is not proof of safety for a particular patient |
+| Sedatives / anticonvulsants | Ashwagandha can cause drowsiness and may have additive effects |
+| Thyroid disease / thyroid medication | Ashwagandha may affect thyroid function; NCCIH lists thyroid disorders and thyroid hormone medicines as caution areas |
+| Autoimmune disease / immunosuppressants | Immunomodulatory effects may be relevant |
+| Diabetes or blood-pressure medicines | Potential additive effects are possible |
+| Pregnancy | NCCIH recommends avoiding ashwagandha during pregnancy |
+| Breastfeeding | NCCIH recommends against use while breastfeeding because safety data are inadequate |
+| Existing liver disease | The 2026 liver-injury review raises particular concern in advanced chronic liver disease |
 
-## Evidence From Cognitive Performance Studies
+If someone takes prescription ADHD medication, the prescriber or pharmacist managing that treatment is the appropriate person to review supplement co-use.
 
-Some cognitive studies show benefits for information processing and memory in certain populations. Direct evidence for attention or executive function improvements in ADHD populations is limited. Any cognitive benefits are likely secondary to stress reduction or better sleep rather than direct enhancement.
+## Why this page does not give a pediatric ADHD dose
 
-## Effects on Attention
+A trial needs a defined dose and formulation. That does not convert the study exposure into a consumer protocol.
 
-Evidence for direct improvements in attention is limited. Some pediatric trials report modest changes in inattention scores, but results are not consistent across all measures. Any attention-related benefits should be viewed as uncertain or modest.
+The direct ADHD evidence is too preliminary to establish:
 
-## Effects on Focus
+- a universal pediatric dose;
+- a mg/kg rule;
+- a withanolide target;
+- a morning-versus-evening ADHD schedule;
+- an “as-needed” focus dose;
+- a stimulant-combination protocol;
+- a long-term maintenance regimen.
 
-Ashwagandha is sometimes discussed for supporting focus through stress reduction. Direct evidence in ADHD for improved focus is preliminary. Benefits, if present, are likely indirect through reduced stress or better sleep.
+This page reports study designs as evidence context rather than turning them into instructions.
 
-## Effects on Hyperactivity
+## Evidence-applicability ledger
 
-Some pediatric trials report modest reductions in hyperactivity scores. Effects are generally small and more noticeable in children with co-occurring stress or anxiety. Evidence remains preliminary.
+| Claim | Current evidence status |
+|---|---|
+| Ashwagandha is an established treatment for ADHD | **Not established** |
+| There is direct pediatric ADHD research | **Yes, but currently very limited and preliminary** |
+| Healthy-child cognition data prove ADHD efficacy | **No** |
+| Stress reduction may be relevant to some people with ADHD | **Plausible indirect benefit** |
+| Sleep improvement may indirectly help daytime function | **Plausible indirect benefit** |
+| Ashwagandha is universally liver-safe because RCTs looked reassuring | **No** |
+| Rare idiosyncratic liver injury is a credible safety signal | **Yes** |
+| Every ashwagandha product is equivalent to standardized root extract | **No** |
+| A universal ADHD dose or extract is established | **No** |
 
-## Effects on Impulsivity
+## Unanswered questions worth tracking
 
-Limited data exist on impulsivity outcomes with ashwagandha. Any potential effects are speculative and not well supported by robust ADHD-specific research.
+1. Will the pediatric ADHD findings survive peer review and independent replication?
+2. Are benefits specific to mild ADHD, a stress-heavy subgroup, or the tested product?
+3. Do teacher-rated and objective attention outcomes replicate parent/clinician ratings?
+4. Does ashwagandha add benefit to stimulant or non-stimulant treatment?
+5. What is the long-term pediatric safety profile?
+6. Which preparation characteristics matter: root-only versus root-and-leaf, withanolide profile, or extraction method?
+7. Can any biomarkers predict benefit or liver risk?
+8. What is the true incidence of ashwagandha-associated liver injury in real-world users?
 
-## Effects on Emotional Regulation
+## Frequently asked questions
 
-Ashwagandha has been studied for mood and stress resilience. Some trials report improvements in emotional stability and reduced irritability under stress. Direct evidence in ADHD for emotional regulation improvements is preliminary but promising in pediatric studies with co-occurring anxiety.
+### Does ashwagandha treat ADHD?
 
-## Effects on Anxiety
+Not on current evidence. Direct ADHD data are very limited, and the most directly relevant pediatric randomized report is currently a small preprint.
 
-Multiple trials demonstrate reductions in anxiety symptoms with ashwagandha in stressed or anxious adults. In pediatric ADHD contexts with comorbid anxiety, some studies report reductions in anxiety scores. These findings represent one of the stronger areas of evidence for ashwagandha.
+### Is there any direct ADHD study?
 
-## Effects on Sleep Quality
+Yes. A 58-child randomized study reported favorable results over 56 days, but it has not yet become a replicated peer-reviewed ADHD evidence base.
 
-Ashwagandha has shown benefits for sleep quality in stressed populations. In ADHD contexts, improvements in parent-reported sleep have been noted in some pediatric trials. Benefits appear linked to reduced stress and better relaxation rather than direct hypnotic effects.
+### Does ashwagandha improve focus?
 
-## Effects on Sleep Latency
+A 2026 randomized trial in healthy children with parent-reported attention or memory concerns found an improvement in speed of information processing. That is not the same as proving treatment of diagnosed ADHD.
 
-Some studies report improvements in sleep onset latency with ashwagandha. Effects are generally modest and most relevant when stress or anxiety contributes to delayed sleep onset.
+### Is ashwagandha safe for the liver?
 
-## Effects on Executive Function
+Most people in short controlled trials of standardized root extracts did not develop clinically important liver abnormalities, but rare idiosyncratic liver injury is now supported by repeated published case reports and case series. Those two facts are not contradictory.
 
-Evidence for direct improvements in executive function is limited. Any benefits are likely indirect through stress reduction or better sleep rather than primary enhancement of executive processes.
+### Can ashwagandha be combined with stimulant medication?
 
-## Effects on Working Memory
+Direct interaction and coadministration evidence is limited. Review co-use with the prescriber or pharmacist managing the ADHD medication rather than assuming a supplement is interaction-free.
 
-Limited data exist on working memory outcomes with ashwagandha. Any potential effects are speculative and not well supported by robust ADHD-specific research.
+### What dose should a child with ADHD take?
 
-## Evidence Grade Assessment
+There is no evidence-based universal pediatric ADHD dose for ashwagandha. A dose used in a small trial should not be converted into an unsupervised protocol.
 
-Direct ADHD clinical trial evidence for ashwagandha is limited but includes some promising pediatric studies showing improvements in symptom scores, anxiety, and sleep. Most supportive data come from general stress, anxiety, and sleep studies in non-ADHD populations. Overall evidence strength for ADHD symptom improvement is low to preliminary. Benefits, if any, should be described as uncertain, context-dependent, or modest, with stronger signals for stress reduction, anxiety reduction, sleep support, and cortisol regulation.
+## Sources
 
-## Why Results Are Mixed
-
-Variability in study populations, extracts, doses, durations, and outcome measures contributes to mixed results. Many studies are small or conducted in non-ADHD groups, limiting applicability to ADHD.
-
-## Why ADHD-Specific Evidence Is Limited
-
-ADHD research on ashwagandha has been less extensive than research on nutrients such as omega-3 or iron. Practical and ethical considerations have resulted in fewer large-scale, well-controlled ADHD trials for this adaptogen.
-
-## Ashwagandha as an Adjunct to ADHD Medication
-
-Limited data exist on combining ashwagandha with ADHD medications. Some theoretical rationale exists based on stress and anxiety support, but clinical evidence for additive benefits or safety in combination is preliminary.
-
-## Ashwagandha and Stimulants
-
-No robust trials have established clear benefits or risks of combining ashwagandha with stimulant medications in ADHD. Any use in combination should occur only under clinical supervision.
-
-## Ashwagandha and Non-Stimulant Medications
-
-Even less evidence exists for combinations with non-stimulant ADHD medications. Professional guidance is essential.
-
-## Ashwagandha in ADHD Supplement Stacks
-
-Ashwagandha is sometimes included in broader stress or cognitive support stacks. It should be evaluated individually rather than added to large untested combinations. Evidence for synergistic effects with other common ADHD supplements remains limited.
-
-## Dosing Considerations
-
-### Standardized Extracts
-
-Most high-quality research uses standardized root extracts.
-
-### KSM-66
-
-KSM-66 is a full-spectrum root extract often standardized to 5% withanolides. It has been used in several relevant studies.
-
-### Sensoril
-
-Sensoril is a root-and-leaf extract with a different withanolide profile. It has also been studied for stress and cognitive outcomes.
-
-### Common Study Doses
-
-Doses in research have commonly ranged from 300 mg to 600 mg per day of standardized extract, sometimes divided into two doses.
-
-### Lower-Dose Use
-
-Some practical use involves 300 mg daily for general stress support.
-
-### Higher-Dose Use
-
-Doses up to 600 mg or more have been studied in stress and anxiety trials, though higher doses increase cost and potential side effect risk.
-
-## Timing Considerations
-
-### Morning Use
-
-Morning dosing is sometimes used when daytime stress resilience or focus support is the goal.
-
-### Evening Use
-
-Evening or split dosing is common when sleep support or stress reduction before bed is the primary aim.
-
-## How Long Ashwagandha Takes To Work
-
-Acute effects on stress or relaxation are sometimes reported within days to a week. Benefits for anxiety, sleep, or behavioral symptoms in research are typically assessed after 6–8 weeks of consistent use.
-
-## Acute vs Daily Use
-
-Most positive stress and anxiety studies examine daily use over several weeks. Acute single-dose effects are less commonly studied for ashwagandha compared with some other compounds.
-
-## Safety Profile
-
-Ashwagandha is generally well tolerated at studied doses.
-
-## Common Side Effects
-
-Reported side effects are usually mild and may include gastrointestinal discomfort, drowsiness, or headache in sensitive individuals. Side effects are often dose-dependent.
-
-## Sedation and Fatigue
-
-Some individuals report mild sedation or fatigue, particularly at higher doses or when taken in the evening. This effect is not universal.
-
-## Gastrointestinal Effects
-
-Mild stomach upset or nausea can occur, especially when taken on an empty stomach. Taking with food often improves tolerability.
-
-## Thyroid Considerations
-
-Ashwagandha may influence thyroid hormone levels in some individuals. People with thyroid disorders should consult a healthcare provider before use.
-
-## Autoimmune Considerations
-
-Ashwagandha has immunomodulatory properties. Individuals with autoimmune conditions should use caution and consult a healthcare provider.
-
-## Medication Interactions
-
-Ashwagandha may have additive sedative effects with other central nervous system depressants. It may also interact with medications affecting thyroid function, blood pressure, or blood sugar. Professional guidance is recommended.
-
-## Pediatric Considerations
-
-Several trials have used ashwagandha in school-age children with generally good tolerability. Use in children should involve clinical supervision. Behavioral and foundational strategies should be optimized first.
-
-## Adult Considerations
-
-Most research on ashwagandha has been conducted in adults. Adult use should still be approached conservatively with attention to individual response and potential interactions.
-
-## Ashwagandha vs Rhodiola
-
-Both are adaptogens used for stress resilience. Ashwagandha tends to have more calming properties and stronger evidence for anxiety and sleep. Rhodiola often has more stimulating effects and stronger evidence for acute fatigue and mental performance under demand. They may be complementary or chosen based on individual response and primary symptoms.
-
-## Ashwagandha vs L-Theanine
-
-L-Theanine more directly influences brain wave patterns and GABA/glutamate balance for calm focus. Ashwagandha has broader adaptogenic effects on cortisol and stress resilience. They have different primary mechanisms and may be complementary for some individuals.
-
-## Ashwagandha vs Magnesium
-
-Magnesium has broader observational associations with ADHD and may offer muscle relaxation benefits. Ashwagandha has more data for stress, anxiety, and sleep in general populations. Individual response varies; some people prefer one over the other or find them complementary.
-
-## Ashwagandha vs Omega-3
-
-Omega-3 fatty acids have more consistent meta-analysis support for modest behavioral improvements in ADHD. Ashwagandha evidence is stronger for stress reduction, anxiety, and sleep support. Both may be considered in broader approaches depending on individual needs.
-
-## Ashwagandha vs L-Tyrosine
-
-L-Tyrosine primarily supports catecholamine synthesis under demand. Ashwagandha targets stress resilience and cortisol regulation. They address different mechanisms and may be used together in some stacks. Evidence for either in ADHD is limited.
-
-## Who Might Benefit Most
-
-Individuals with ADHD who experience prominent stress, anxiety, emotional dysregulation, or stress-related sleep difficulties may consider ashwagandha as one potential adjunctive option. Evidence remains uncertain and context-dependent, with stronger signals for stress reduction, anxiety reduction, sleep support, and cortisol regulation.
-
-## Who Should Use Caution
-
-People with autoimmune conditions, thyroid disorders, or those taking medications affecting the central nervous system, thyroid, blood pressure, or blood sugar should use caution. Professional guidance is essential for children and anyone with complex medical conditions.
-
-## What Not To Expect
-
-Ashwagandha does not produce large, consistent, or universal improvements in ADHD symptoms. Evidence for benefits in attention, hyperactivity, or executive function in ADHD populations is preliminary and largely indirect. It should not be expected to replace medication, therapy, sleep optimization, or nutritional correction. Benefits are most relevant for stress reduction, anxiety reduction, sleep support, and cortisol regulation.
-
-## Practical Decision Framework
-
-A conservative approach includes optimizing sleep hygiene, stress management, and overall nutrition first; considering ashwagandha when stress, anxiety, or stress-related sleep issues are prominent and significantly affect functioning; using a standardized root extract at studied doses (typically 300–600 mg daily); tracking target symptoms such as stress levels, emotional regulation, or sleep quality over 6–8 weeks; and reassessing with a clinician and discontinuing if no clear benefit is observed.
-
-## Research Gaps
-
-Large, well-controlled randomized trials specifically in diagnosed ADHD populations are needed. Direct comparisons with other adaptogens and sleep supports in ADHD contexts are lacking. Better understanding of optimal dosing, extract standardization, and which ADHD presentations (stress-related symptoms, anxiety, sleep difficulties) are most likely to respond would improve guidance. Long-term safety and efficacy data in pediatric ADHD populations are also limited.
-
-## Conclusion
-
-Ashwagandha shows promising signals for reducing stress, supporting emotional regulation, and improving sleep quality in some individuals with ADHD, particularly when stress or anxiety plays a significant role. Evidence is stronger in pediatric populations than in adults, though overall data remain preliminary compared with established ADHD treatments. Ashwagandha is generally well tolerated and may serve as a reasonable adjunctive option for selected individuals under clinical guidance. Benefits are typically modest and should be viewed as supportive rather than primary. As with any supplement, realistic expectations, systematic tracking, and professional oversight are essential.
-
-## FAQ
-
-### Does ashwagandha help ADHD?
-
-Some randomized trials in children with ADHD show improvements in symptom scores, anxiety, and sleep. Evidence is promising but preliminary. It does not treat ADHD directly.
-
-### Can ashwagandha improve focus?
-
-Evidence for direct improvements in attention or focus is limited. Any focus-related benefits are likely secondary to reduced stress or better sleep.
-
-### Can ashwagandha reduce hyperactivity?
-
-Some pediatric trials report modest reductions in hyperactivity scores. Effects are generally small and more noticeable in children with co-occurring stress or anxiety.
-
-### Can ashwagandha improve emotional regulation?
-
-Ashwagandha has been studied for mood and stress resilience. Some trials report improvements in emotional stability and reduced irritability under stress. Direct evidence in ADHD is preliminary but promising in pediatric studies with co-occurring anxiety.
-
-### Can ashwagandha improve sleep?
-
-Ashwagandha has shown benefits for sleep quality in stressed populations. In ADHD contexts, improvements in parent-reported sleep have been noted in some pediatric trials. Benefits appear linked to reduced stress and better relaxation.
-
-### Is ashwagandha good for anxiety in ADHD?
-
-Multiple trials demonstrate reductions in anxiety symptoms with ashwagandha in stressed or anxious adults. In pediatric ADHD contexts with comorbid anxiety, some studies report reductions in anxiety scores.
-
-### Can ashwagandha replace ADHD medication?
-
-No. Ashwagandha does not have evidence comparable to established treatments for core ADHD symptoms.
-
-### Can ashwagandha be taken with stimulants?
-
-Limited clinical data exist on combinations. Professional supervision is recommended due to potential additive sedative effects.
-
-### Can ashwagandha cause sleepiness?
-
-Some individuals report mild sedation or drowsiness, particularly at higher doses or when taken in the evening. This effect is not universal.
-
-### Can ashwagandha lower cortisol?
-
-Multiple human trials have demonstrated that ashwagandha supplementation can reduce cortisol levels in stressed or anxious adults.
-
-### How much ashwagandha should I take?
-
-Studied doses typically range from 300 mg to 600 mg per day of standardized root extract. Individual needs vary. Professional guidance is recommended.
-
-### Should I take ashwagandha morning or night?
-
-Morning dosing is sometimes used for daytime stress resilience. Evening or split dosing is common when sleep support or stress reduction before bed is the primary aim.
-
-### How long does ashwagandha take to work?
-
-Acute effects on stress or relaxation are sometimes reported within days to a week. Benefits for anxiety, sleep, or behavioral symptoms in research are typically assessed after 6–8 weeks of consistent use.
-
-### Is ashwagandha safe for children?
-
-Several trials have used ashwagandha in school-age children with generally good tolerability. Use in children should involve clinical supervision.
-
-### Is KSM-66 better than Sensoril?
-
-Both are standardized extracts with different withanolide profiles. KSM-66 has been used in several relevant studies. Choice often depends on individual response and product quality.
-
-### Can ashwagandha affect thyroid hormones?
-
-Ashwagandha may influence thyroid hormone levels in some individuals. People with thyroid disorders should consult a healthcare provider before use.
-
-### Can ashwagandha cause emotional blunting?
-
-Some individuals report mild sedation or reduced emotional intensity. This effect is not universal and may resolve with dose adjustment.
-
-### Who should avoid ashwagandha?
-
-People with autoimmune conditions, thyroid disorders, or those taking medications affecting the central nervous system, thyroid, blood pressure, or blood sugar should use caution. Professional guidance is essential for children and anyone with complex medical conditions.
-
-## Evidence Summary Table
-
-| Area | Population | Key Findings | Evidence Strength | Practical Interpretation |
-|---|---|---|---|---|
-| ADHD symptom scores | Children with mild ADHD | Significant improvement vs placebo in one RCT | Low to Moderate | One key double-blind study |
-| Anxiety symptoms | Children with ADHD + anxiety | Reductions in anxiety scores | Low to Moderate | Specific comorbid population |
-| Sleep quality | Children with attention concerns | Improvements in parent-reported sleep | Low to Moderate | Secondary outcome in cognitive study |
-| Stress and anxiety | Stressed adults | Consistent reductions in perceived stress | Moderate | Multiple trials in non-ADHD populations |
-| Emotional regulation | Stressed or anxious adults | Improvements in emotional stability | Preliminary | Limited direct ADHD data |
-| Adult ADHD evidence | Adults with ADHD | Very limited high-quality trials | Limited | Most data from general or stressed populations |
-| Cortisol reduction | Stressed adults | Reductions in cortisol levels | Moderate | Consistent finding across stress studies |
-
-## Related Articles
-
-- Best Supplements for ADHD: Evidence-Based Options for Focus, Sleep, and Emotional Regulation
-- ADHD Stack Guide: Building an Evidence-Based Approach to Focus, Sleep, and Emotional Regulation
-- L-Theanine and ADHD: What the Research Shows About Attention, Hyperactivity, Sleep, and Emotional Regulation
-- Rhodiola and ADHD: What the Research Shows About Stress, Fatigue, Focus, and Cognitive Performance
-- Magnesium for ADHD: Forms, Evidence, Dosage, and Practical Use
-- Sleep and ADHD: Evidence-Based Strategies for Better Focus, Behavior, and Daily Functioning
-- Omega-3 and ADHD: What the Research Shows About EPA, DHA, Symptoms, and Supplementation
-- L-Tyrosine and ADHD: What the Research Shows About Dopamine, Focus, Stress, and Cognitive Performance
-- Citicoline and ADHD: What the Research Shows About Attention, Focus, and Cognitive Performance
-- Nutrient Deficiencies and ADHD: What the Research Shows
-
-## Internal Linking Recommendations
-
-This article should serve as the core stress-regulation ADHD supplement page within the Focus / ADHD cluster. It should link bidirectionally to the ADHD Stack Guide and Best Supplements for ADHD pillar. It should also connect strongly to the L-Theanine and ADHD article, the Rhodiola and ADHD article, and the Sleep and ADHD article. Supporting links should be created to L-Tyrosine and ADHD, Citicoline and ADHD, Omega-3 and ADHD, Magnesium for ADHD, and Nutrient Deficiencies and ADHD. These connections help establish comprehensive topical authority around evidence-based adaptogenic and stress-support options while guiding readers toward conservative, assessment-driven decision-making across the cluster.
+1. Jain M, et al. Ashwagandha Root Extract in Treatment of Mild Attention Deficit Hyperactivity Disorder (ADHD) in Children Aged 5–12 Years: A Prospective, Double-Blind, Randomized, Placebo Controlled Study. Preprint. https://figshare.com/articles/preprint/_b_Ashwagandha_Root_Extract_in_Treatment_of_Mild_Attention_Deficit_Hyperactivity_Disorder_ADHD_in_Children_Aged_5_12_Years_A_Prospective_b_b_Double-Blind_Randomized_Placebo_Controlled_Study_b_/27302499
+2. A clinical assessment of the therapeutic effects of Ashwagandha root extract on cognitive performance, sleep, and fatigue in children aged 6–12 years. 2026. PMID 41889719. https://pubmed.ncbi.nlm.nih.gov/41889719/
+3. McIntyre D, et al. Ashwagandha (Withania somnifera)-Associated Liver Injury: A Scoping Review of Clinical Characteristics and Safety Considerations. 2026. PMID 42367407. https://pubmed.ncbi.nlm.nih.gov/42367407/
+4. Coope OC, et al. Back to the Roots: Safety and Tolerability of Standardised Ashwagandha Root Extract in Healthy Adults—A Systematic Review of Biomarkers and Adverse Events. 2026. PMID 42198398. https://pubmed.ncbi.nlm.nih.gov/42198398/
+5. National Center for Complementary and Integrative Health. Ashwagandha: Usefulness and Safety. https://www.nccih.nih.gov/health/ashwagandha
+6. Thanawala S, et al. Efficacy and safety of Ashwagandha root extract sustained-release capsules in healthy adult stressed subjects. 2026. PMID 41824889. https://pubmed.ncbi.nlm.nih.gov/41824889/
+7. Safety and tolerability of Ashwagandha root extract in healthy adults: a prospective, non-comparative study. 2026. PMID 42253745. https://pubmed.ncbi.nlm.nih.gov/42253745/


### PR DESCRIPTION
## Why
The ashwagandha/ADHD page blurred three different evidence levels: a small direct pediatric ADHD preprint, a 2026 healthy-child cognition trial, and broader adult stress/sleep studies. It also underrepresented the now-clear 2026 liver-injury safety signal.

## What changed
- identifies the 58-child ADHD randomized study as a preprint rather than settled peer-reviewed evidence
- separates the 85-child healthy-cognition RCT from diagnosed-ADHD treatment evidence
- removes language implying multiple established pediatric ADHD RCTs
- keeps stress and sleep findings explicitly indirect
- adds the 2026 standardized-root safety review (23 trials / 2,317 adults)
- adds the 2026 liver-injury scoping review (25 published cases)
- explains why reassuring short RCT safety and rare idiosyncratic liver injury can both be true
- adds root-only vs root-and-leaf / blend / product-equivalence limits
- expands thyroid, autoimmune, pregnancy, liver, sedative, blood-pressure, diabetes, and medication context using NCCIH
- removes universal pediatric dose/timing/stack guidance
- adds evidence-applicability and unanswered-question ledgers
- updates SEO metadata around directness and safety

## Safety calibration
No pediatric dosing protocol or stimulant-combination protocol is provided. The page does not diagnose liver injury or recommend medication changes.