### PR TITLE
ROI 711-730: canonical study classes and effect context

### DIFF
--- a/components/evidence/StudyDesignSnapshot.tsx
+++ b/components/evidence/StudyDesignSnapshot.tsx
@@ -1,33 +1,13 @@
 import type { ReactNode } from 'react'
+import {
+  getStudyClassDefinition,
+  type StudyClass,
+} from '@/src/lib/study-evidence-context'
 
 /**
- * StudyDesignSnapshot
- *
- * A reusable, accessible evidence-transparency block designed for clean
- * embedding inside structured `content/learn/` MDX files (and any server or
- * client page). It keeps the practical takeaway prominent while tucking the
- * "why" — grade rationale, clinical trial design factors, and limitations —
- * into a native, keyboard-accessible disclosure that also works without JS.
- *
- * The component holds **no study data of its own**: every fact is passed in via
- * props, so it is safe to reuse across profiles, goals, and education content.
- *
- * Minimal usage (MDX):
- *   <StudyDesignSnapshot
- *     grade="Moderate"
- *     summary="A few small human trials suggest a real but modest effect."
- *   />
- *
- * Fuller usage:
- *   <StudyDesignSnapshot
- *     grade="Moderate"
- *     gradeRationale="Several randomized trials, but small and short."
- *     summary="..."
- *     studyType="Randomized, double-blind, placebo-controlled"
- *     participants="~60 adults per trial"
- *     duration="6–8 weeks"
- *     limitations={["Small samples", "Often manufacturer-funded"]}
- *   />
+ * Reusable evidence-transparency block for clinical-study context.
+ * Every displayed fact is supplied by the caller; the component never invents
+ * or infers study characteristics.
  */
 
 export type StudyEvidenceGrade =
@@ -48,32 +28,30 @@ export interface StudyDesignSource {
 }
 
 export interface StudyDesignSnapshotProps {
-  /** The prominent, always-visible practical takeaway. */
   summary: ReactNode
-  /** Evidence grade assigned to the claim. */
   grade?: StudyEvidenceGrade
-  /** Plain-language explanation of *why* the grade was assigned. */
   gradeRationale?: ReactNode
-  /** e.g. "Randomized, double-blind, placebo-controlled". */
+  /** Canonical source-quality class; preferred over a free-form studyType alone. */
+  studyClass?: StudyClass
+  /** Optional design detail such as "double-blind, placebo-controlled". */
   studyType?: string
-  /** Convenience design factors — rendered if provided. */
   participants?: string
   duration?: string
   population?: string
   blinding?: string
   comparator?: string
   dosing?: string
-  /** Additional / custom design factors appended after the convenience ones. */
+  effectSize?: string
+  confidenceInterval?: string
+  statisticalSignificance?: string
+  absoluteDifference?: string
+  clinicalMagnitude?: string
+  replication?: string
   design?: StudyDesignFactor[]
-  /** Transparency about what the evidence does not establish. */
   limitations?: string[]
-  /** Extra interpretive context. */
   context?: ReactNode
-  /** Optional citations (kept generic — pass real references per use). */
   sources?: StudyDesignSource[]
-  /** Open the disclosure by default. */
   defaultOpen?: boolean
-  /** Heading shown above the summary. */
   title?: string
 }
 
@@ -99,6 +77,7 @@ export default function StudyDesignSnapshot({
   summary,
   grade,
   gradeRationale,
+  studyClass,
   studyType,
   participants,
   duration,
@@ -106,6 +85,12 @@ export default function StudyDesignSnapshot({
   blinding,
   comparator,
   dosing,
+  effectSize,
+  confidenceInterval,
+  statisticalSignificance,
+  absoluteDifference,
+  clinicalMagnitude,
+  replication,
   design,
   limitations,
   context,
@@ -113,19 +98,28 @@ export default function StudyDesignSnapshot({
   defaultOpen = false,
   title = 'Study design snapshot',
 }: StudyDesignSnapshotProps) {
+  const classDefinition = studyClass ? getStudyClassDefinition(studyClass) : null
   const factors: StudyDesignFactor[] = [
-    studyType ? { label: 'Study type', value: studyType } : null,
+    classDefinition ? { label: 'Source quality', value: classDefinition.label } : null,
+    studyType ? { label: 'Study design', value: studyType } : null,
     population ? { label: 'Population', value: population } : null,
     participants ? { label: 'Participants', value: participants } : null,
     duration ? { label: 'Duration', value: duration } : null,
     blinding ? { label: 'Blinding', value: blinding } : null,
     comparator ? { label: 'Comparator', value: comparator } : null,
     dosing ? { label: 'Dosing', value: dosing } : null,
+    effectSize ? { label: 'Effect size', value: effectSize } : null,
+    confidenceInterval ? { label: 'Confidence interval', value: confidenceInterval } : null,
+    absoluteDifference ? { label: 'Absolute difference', value: absoluteDifference } : null,
+    statisticalSignificance ? { label: 'Statistical significance', value: statisticalSignificance } : null,
+    clinicalMagnitude ? { label: 'Magnitude in context', value: clinicalMagnitude } : null,
+    replication ? { label: 'Replication', value: replication } : null,
     ...(design ?? []),
-  ].filter((f): f is StudyDesignFactor => f !== null)
+  ].filter((factor): factor is StudyDesignFactor => factor !== null)
 
   const hasDetail =
     Boolean(gradeRationale) ||
+    Boolean(classDefinition) ||
     factors.length > 0 ||
     (limitations?.length ?? 0) > 0 ||
     Boolean(context) ||
@@ -136,22 +130,25 @@ export default function StudyDesignSnapshot({
       className="not-prose my-6 overflow-hidden rounded-2xl border border-brand-900/10 bg-white/85 shadow-sm"
       aria-label={title}
     >
-      {/* Always-visible practical summary */}
       <div className="space-y-3 p-5 sm:p-6">
         <div className="flex flex-wrap items-center gap-3">
           <p className="text-[11px] font-bold uppercase tracking-[0.16em] text-brand-800">
             {title}
           </p>
           {grade ? <GradePill grade={grade} /> : null}
+          {classDefinition ? (
+            <span className="inline-flex items-center rounded-full border border-stone-300 bg-stone-100 px-3 py-1 text-xs font-semibold tracking-wide text-stone-800">
+              {classDefinition.label}
+            </span>
+          ) : null}
         </div>
         <p className="text-base font-semibold leading-7 text-ink sm:text-lg">{summary}</p>
       </div>
 
-      {/* Optional depth — native disclosure, accessible and no-JS friendly */}
       {hasDetail ? (
         <details open={defaultOpen} className="group border-t border-brand-900/10">
           <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-5 py-3 text-sm font-semibold text-brand-800 transition hover:bg-brand-50/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-700/40 sm:px-6">
-            <span>Why this grade — design &amp; limitations</span>
+            <span>Why this grade — design, magnitude &amp; limitations</span>
             <span
               aria-hidden="true"
               className="text-brand-700 transition-transform duration-200 group-open:rotate-180"
@@ -163,24 +160,24 @@ export default function StudyDesignSnapshot({
           <div className="space-y-5 px-5 pb-5 pt-1 sm:px-6 sm:pb-6">
             {gradeRationale ? (
               <div className="space-y-1.5">
-                <p className="text-xs font-bold uppercase tracking-wider text-[#5c6b63]">
-                  Why this grade
-                </p>
+                <p className="text-xs font-bold uppercase tracking-wider text-[#5c6b63]">Why this grade</p>
                 <p className="text-sm leading-7 text-muted">{gradeRationale}</p>
+              </div>
+            ) : null}
+
+            {classDefinition ? (
+              <div className="space-y-1.5">
+                <p className="text-xs font-bold uppercase tracking-wider text-[#5c6b63]">What this source type means</p>
+                <p className="text-sm leading-7 text-muted">{classDefinition.plainEnglish}</p>
               </div>
             ) : null}
 
             {factors.length > 0 ? (
               <div className="space-y-1.5">
-                <p className="text-xs font-bold uppercase tracking-wider text-[#5c6b63]">
-                  Pivotal study design
-                </p>
+                <p className="text-xs font-bold uppercase tracking-wider text-[#5c6b63]">Study context</p>
                 <dl className="grid gap-2 sm:grid-cols-2">
                   {factors.map((factor) => (
-                    <div
-                      key={factor.label}
-                      className="rounded-xl bg-[#f5f3ec] px-3 py-2"
-                    >
+                    <div key={factor.label} className="rounded-xl bg-[#f5f3ec] px-3 py-2">
                       <dt className="text-[11px] font-semibold uppercase tracking-wide text-[#6b7a72]">
                         {factor.label}
                       </dt>
@@ -193,15 +190,10 @@ export default function StudyDesignSnapshot({
 
             {limitations && limitations.length > 0 ? (
               <div className="space-y-1.5">
-                <p className="text-xs font-bold uppercase tracking-wider text-[#5c6b63]">
-                  Limitations &amp; context
-                </p>
+                <p className="text-xs font-bold uppercase tracking-wider text-[#5c6b63]">Limitations &amp; context</p>
                 <ul className="space-y-2">
                   {limitations.map((limitation) => (
-                    <li
-                      key={limitation}
-                      className="flex gap-2 text-sm leading-6 text-muted"
-                    >
+                    <li key={limitation} className="flex gap-2 text-sm leading-6 text-muted">
                       <span aria-hidden="true" className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500" />
                       <span>{limitation}</span>
                     </li>

--- a/components/evidence/__tests__/StudyDesignSnapshot.test.tsx
+++ b/components/evidence/__tests__/StudyDesignSnapshot.test.tsx
@@ -27,12 +27,36 @@ describe('StudyDesignSnapshot', () => {
         limitations={['Tiny sample', 'No replication']}
       />,
     )
-    // Native <details> disclosure keeps depth optional and keyboard-accessible.
     const details = container.querySelector('details')
     expect(details).not.toBeNull()
     expect(screen.getByText('Only one small trial.')).toBeTruthy()
     expect(screen.getByText('Single RCT')).toBeTruthy()
     expect(screen.getByText('Tiny sample')).toBeTruthy()
+  })
+
+  it('renders canonical source-quality and magnitude context', () => {
+    render(
+      <StudyDesignSnapshot
+        summary="Small average benefit with bounded uncertainty."
+        studyClass="rct"
+        studyType="Double-blind, placebo-controlled"
+        population="Adults with elevated stress"
+        duration="8 weeks"
+        effectSize="SMD -0.35"
+        confidenceInterval="95% CI -0.52 to -0.18"
+        absoluteDifference="About 3 points"
+        statisticalSignificance="p < 0.01"
+        clinicalMagnitude="Small-to-moderate average difference"
+        replication="Three independent trials"
+      />,
+    )
+
+    expect(screen.getAllByText('Randomized controlled trial').length).toBeGreaterThan(0)
+    expect(screen.getByText(/Randomly assigns participants/)).toBeTruthy()
+    expect(screen.getByText('SMD -0.35')).toBeTruthy()
+    expect(screen.getByText('95% CI -0.52 to -0.18')).toBeTruthy()
+    expect(screen.getByText('Small-to-moderate average difference')).toBeTruthy()
+    expect(screen.getByText('Three independent trials')).toBeTruthy()
   })
 
   it('omits the disclosure when only a summary is provided', () => {

--- a/src/lib/__tests__/study-evidence-context.test.ts
+++ b/src/lib/__tests__/study-evidence-context.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import {
+  filterByStudyClass,
+  getStudyClassDefinition,
+  rankStudyClasses,
+  validateEffectContext,
+} from '../study-evidence-context'
+
+describe('study evidence context', () => {
+  it('labels the canonical source classes in a stable hierarchy', () => {
+    expect(rankStudyClasses(['case-report', 'rct', 'meta-analysis', 'preclinical'])).toEqual([
+      'meta-analysis',
+      'rct',
+      'preclinical',
+      'case-report',
+    ])
+    expect(getStudyClassDefinition('rct').label).toBe('Randomized controlled trial')
+    expect(getStudyClassDefinition('preclinical').humanEvidence).toBe(false)
+  })
+
+  it('filters evidence tables by study class without changing source order', () => {
+    const studies = [
+      { id: 'a', studyClass: 'rct' as const },
+      { id: 'b', studyClass: 'observational' as const },
+      { id: 'c', studyClass: 'rct' as const },
+    ]
+
+    expect(filterByStudyClass(studies, ['rct']).map((study) => study.id)).toEqual(['a', 'c'])
+  })
+
+  it('prevents p-values from becoming the whole evidence story', () => {
+    const issues = validateEffectContext({
+      statisticalSignificance: 'p = 0.03',
+      duration: '8 weeks',
+      population: 'Adults with elevated stress',
+      replication: 'Not independently replicated',
+    })
+
+    expect(issues.map((issue) => issue.code)).toEqual(
+      expect.arrayContaining(['p-value-without-effect-size', 'p-value-without-magnitude-context']),
+    )
+  })
+
+  it('requires duration, population, replication and uncertainty context', () => {
+    const issues = validateEffectContext({
+      effectSize: 'SMD -0.35',
+      clinicalMagnitude: 'Small average reduction',
+    })
+
+    expect(issues.map((issue) => issue.code)).toEqual(
+      expect.arrayContaining([
+        'effect-size-without-uncertainty',
+        'missing-duration-context',
+        'missing-population-context',
+        'missing-replication-context',
+      ]),
+    )
+  })
+
+  it('accepts a fully contextualized effect summary', () => {
+    expect(
+      validateEffectContext({
+        effectSize: 'SMD -0.35',
+        confidenceInterval: '95% CI -0.52 to -0.18',
+        statisticalSignificance: 'p < 0.01',
+        absoluteDifference: 'About 3 points on the measured scale',
+        clinicalMagnitude: 'Small-to-moderate average difference',
+        duration: '8 weeks',
+        population: 'Adults with elevated stress',
+        replication: 'Observed across three independent trials',
+      }),
+    ).toEqual([])
+  })
+})

--- a/src/lib/study-evidence-context.ts
+++ b/src/lib/study-evidence-context.ts
@@ -1,0 +1,163 @@
+export const STUDY_CLASSES = [
+  'meta-analysis',
+  'systematic-review',
+  'rct',
+  'controlled-trial',
+  'observational',
+  'preclinical',
+  'narrative-review',
+  'case-report',
+] as const
+
+export type StudyClass = (typeof STUDY_CLASSES)[number]
+
+export interface StudyClassDefinition {
+  label: string
+  hierarchyRank: number
+  plainEnglish: string
+  humanEvidence: boolean
+}
+
+export const STUDY_CLASS_DEFINITIONS: Record<StudyClass, StudyClassDefinition> = {
+  'meta-analysis': {
+    label: 'Meta-analysis',
+    hierarchyRank: 8,
+    plainEnglish: 'Statistically combines results from multiple eligible studies; confidence depends on the quality and similarity of those studies.',
+    humanEvidence: true,
+  },
+  'systematic-review': {
+    label: 'Systematic review',
+    hierarchyRank: 7,
+    plainEnglish: 'Uses a predefined method to find and evaluate the relevant literature, but may or may not pool results statistically.',
+    humanEvidence: true,
+  },
+  rct: {
+    label: 'Randomized controlled trial',
+    hierarchyRank: 6,
+    plainEnglish: 'Randomly assigns participants to interventions or controls, reducing many sources of bias when conducted well.',
+    humanEvidence: true,
+  },
+  'controlled-trial': {
+    label: 'Controlled trial',
+    hierarchyRank: 5,
+    plainEnglish: 'Compares an intervention with a control group but may lack random assignment or other safeguards of a strong RCT.',
+    humanEvidence: true,
+  },
+  observational: {
+    label: 'Observational research',
+    hierarchyRank: 4,
+    plainEnglish: 'Observes real-world associations without assigning treatment, so confounding can limit causal conclusions.',
+    humanEvidence: true,
+  },
+  preclinical: {
+    label: 'Preclinical research',
+    hierarchyRank: 2,
+    plainEnglish: 'Laboratory, cell, animal, or mechanistic evidence that can explain plausibility but does not establish a human clinical benefit.',
+    humanEvidence: false,
+  },
+  'narrative-review': {
+    label: 'Narrative review',
+    hierarchyRank: 3,
+    plainEnglish: 'Summarizes literature without the full prespecified search and selection methods of a systematic review.',
+    humanEvidence: true,
+  },
+  'case-report': {
+    label: 'Case report',
+    hierarchyRank: 1,
+    plainEnglish: 'Describes one person or a very small series and can identify signals, but cannot establish typical effects or causality.',
+    humanEvidence: true,
+  },
+}
+
+export interface StudyEffectContext {
+  effectSize?: string
+  confidenceInterval?: string
+  statisticalSignificance?: string
+  absoluteDifference?: string
+  clinicalMagnitude?: string
+  duration?: string
+  population?: string
+  replication?: string
+}
+
+export interface EffectContextIssue {
+  code:
+    | 'p-value-without-effect-size'
+    | 'p-value-without-magnitude-context'
+    | 'effect-size-without-uncertainty'
+    | 'missing-duration-context'
+    | 'missing-population-context'
+    | 'missing-replication-context'
+  message: string
+}
+
+export function getStudyClassDefinition(studyClass: StudyClass): StudyClassDefinition {
+  return STUDY_CLASS_DEFINITIONS[studyClass]
+}
+
+export function rankStudyClasses(classes: StudyClass[]): StudyClass[] {
+  return [...classes].sort(
+    (a, b) => STUDY_CLASS_DEFINITIONS[b].hierarchyRank - STUDY_CLASS_DEFINITIONS[a].hierarchyRank,
+  )
+}
+
+export function filterByStudyClass<T extends { studyClass: StudyClass }>(
+  studies: T[],
+  allowed: StudyClass[] | Set<StudyClass>,
+): T[] {
+  const wanted = allowed instanceof Set ? allowed : new Set(allowed)
+  return studies.filter((study) => wanted.has(study.studyClass))
+}
+
+export function validateEffectContext(context: StudyEffectContext): EffectContextIssue[] {
+  const issues: EffectContextIssue[] = []
+
+  if (context.statisticalSignificance && !context.effectSize && !context.absoluteDifference) {
+    issues.push({
+      code: 'p-value-without-effect-size',
+      message: 'Statistical significance must not be presented without an effect size or absolute difference.',
+    })
+  }
+
+  if (context.statisticalSignificance && !context.clinicalMagnitude) {
+    issues.push({
+      code: 'p-value-without-magnitude-context',
+      message: 'Statistical significance should be accompanied by clinically meaningful magnitude context.',
+    })
+  }
+
+  if (context.effectSize && !context.confidenceInterval) {
+    issues.push({
+      code: 'effect-size-without-uncertainty',
+      message: 'Effect sizes should include a confidence interval when the source reports one.',
+    })
+  }
+
+  if (!context.duration) {
+    issues.push({
+      code: 'missing-duration-context',
+      message: 'Study duration is required for interpreting whether an effect was acute, short term, or sustained.',
+    })
+  }
+
+  if (!context.population) {
+    issues.push({
+      code: 'missing-population-context',
+      message: 'Studied population is required so findings are not generalized beyond the participants actually studied.',
+    })
+  }
+
+  if (!context.replication) {
+    issues.push({
+      code: 'missing-replication-context',
+      message: 'Replication context is required to distinguish one-off findings from repeatedly observed results.',
+    })
+  }
+
+  return issues
+}
+
+export function studyClassPlainEnglish(studyClass: StudyClass): string {
+  const definition = STUDY_CLASS_DEFINITIONS[studyClass]
+  return `${definition.label}: ${definition.plainEnglish}`
+}


### PR DESCRIPTION
Implements backlog 711-730 as a reusable evidence-quality layer.

- canonical source-quality labels for meta-analysis, systematic review, RCT, controlled trial, observational, preclinical, narrative review, and case report
- plain-English hierarchy explanations
- study-class ranking and filtering helpers for evidence tables
- effect-size, confidence-interval, absolute-difference, statistical-significance, clinical-magnitude, duration, population, and replication fields
- validation that prevents p-values from standing alone and flags missing uncertainty/context
- StudyDesignSnapshot now exposes these fields without inventing or inferring study facts
- adds unit and component regression coverage