### PR TITLE
ROI 612-621: compare build quality against previous state

### DIFF
--- a/.github/workflows/build-quality-regression.yml
+++ b/.github/workflows/build-quality-regression.yml
@@ -18,10 +18,21 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Fetch base branch
+      - name: Fetch base branch without losing merge history
         env:
           BASE_REF: ${{ github.base_ref }}
-        run: git fetch origin "$BASE_REF" --depth=1
+        run: |
+          git fetch origin "$BASE_REF"
+          git merge-base "origin/$BASE_REF" HEAD >/dev/null
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies once
+        run: npm ci
 
       - name: Extract major automated change explanation
         id: explanation

--- a/.github/workflows/build-quality-regression.yml
+++ b/.github/workflows/build-quality-regression.yml
@@ -1,0 +1,40 @@
+name: Build quality regression
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  compare-generated-quality:
+    name: Compare generated quality with base
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository with history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch base branch
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: git fetch origin "$BASE_REF" --depth=1
+
+      - name: Compare build-quality signals
+        env:
+          QUALITY_CHANGE_REASON: ${{ github.event.pull_request.body }}
+        run: node scripts/ci/compare-build-quality.mjs --base="origin/${{ github.base_ref }}" --require-base
+
+      - name: Upload human-readable quality diff
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-quality-diff-${{ github.run_id }}
+          if-no-files-found: ignore
+          retention-days: 30
+          path: |
+            public/data/reports/build-quality-diff.md
+            public/data/reports/build-quality-diff.json

--- a/.github/workflows/build-quality-regression.yml
+++ b/.github/workflows/build-quality-regression.yml
@@ -31,10 +31,14 @@ jobs:
           node <<'NODE'
           const fs = require('node:fs')
           const body = process.env.PR_BODY || ''
-          const heading = 'Major automated change explanation'
-          const pattern = new RegExp(`^##\\s+${heading}\\s*$([\\s\\S]*?)(?=^##\\s+|\\Z)`, 'im')
-          const match = body.match(pattern)
-          const reason = (match?.[1] || '').trim()
+          const headingPattern = /^##\s+Major automated change explanation\s*$/im
+          const match = headingPattern.exec(body)
+          let reason = ''
+          if (match) {
+            const remainder = body.slice(match.index + match[0].length)
+            const nextHeading = remainder.search(/^##\s+/m)
+            reason = (nextHeading >= 0 ? remainder.slice(0, nextHeading) : remainder).trim()
+          }
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `reason<<EOF\n${reason}\nEOF\n`)
           NODE
 

--- a/.github/workflows/build-quality-regression.yml
+++ b/.github/workflows/build-quality-regression.yml
@@ -23,9 +23,24 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: git fetch origin "$BASE_REF" --depth=1
 
+      - name: Extract major automated change explanation
+        id: explanation
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs')
+          const body = process.env.PR_BODY || ''
+          const heading = 'Major automated change explanation'
+          const pattern = new RegExp(`^##\\s+${heading}\\s*$([\\s\\S]*?)(?=^##\\s+|\\Z)`, 'im')
+          const match = body.match(pattern)
+          const reason = (match?.[1] || '').trim()
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `reason<<EOF\n${reason}\nEOF\n`)
+          NODE
+
       - name: Compare build-quality signals
         env:
-          QUALITY_CHANGE_REASON: ${{ github.event.pull_request.body }}
+          QUALITY_CHANGE_REASON: ${{ steps.explanation.outputs.reason }}
         run: node scripts/ci/compare-build-quality.mjs --base="origin/${{ github.base_ref }}" --require-base
 
       - name: Upload human-readable quality diff

--- a/.github/workflows/build-quality-regression.yml
+++ b/.github/workflows/build-quality-regression.yml
@@ -11,7 +11,7 @@ jobs:
   compare-generated-quality:
     name: Compare generated quality with base
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Check out repository with history
         uses: actions/checkout@v4
@@ -47,7 +47,10 @@ jobs:
           QUALITY_CHANGE_REASON: ${{ steps.explanation.outputs.reason }}
         run: node scripts/ci/compare-build-quality.mjs --base="origin/${{ github.base_ref }}" --require-base
 
-      - name: Upload human-readable quality diff
+      - name: Regenerate and compare internal-link graphs
+        run: node scripts/ci/compare-internal-link-quality.mjs --base="origin/${{ github.base_ref }}" --strict
+
+      - name: Upload human-readable quality diffs
         if: always()
         uses: actions/upload-artifact@v4
         with:
@@ -57,3 +60,5 @@ jobs:
           path: |
             public/data/reports/build-quality-diff.md
             public/data/reports/build-quality-diff.json
+            public/data/reports/internal-link-quality-diff.md
+            public/data/reports/internal-link-quality-diff.json

--- a/scripts/ci/compare-build-quality.mjs
+++ b/scripts/ci/compare-build-quality.mjs
@@ -1,0 +1,435 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { execFileSync } from 'node:child_process'
+
+const ROOT = process.cwd()
+const REPORT_DIR = path.join(ROOT, 'public', 'data', 'reports')
+const argv = process.argv.slice(2)
+const flagValue = (name) => argv.find((arg) => arg.startsWith(`--${name}=`))?.split('=').slice(1).join('=')
+const REQUIRE_BASE = argv.includes('--require-base')
+const EXPLICIT_BASE = flagValue('base')
+const CHANGE_REASON = flagValue('reason') || process.env.QUALITY_CHANGE_REASON || ''
+
+const FILES = {
+  routeManifest: 'public/data/runtime-manifests/route-manifest.json',
+  herbsSummary: ['public/data/summary-indexes/herbs-summary.json', 'public/data/herbs-summary.json'],
+  compoundsSummary: ['public/data/summary-indexes/compounds-summary.json', 'public/data/compounds-summary.json'],
+  internalLinks: 'public/data/runtime-maps/internal-link-map.json',
+  claims: 'public/data/claims.json',
+}
+
+function pct(delta, before) {
+  if (!before) return delta === 0 ? 0 : null
+  return delta / before
+}
+
+function readJson(relativePath, fallback) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(ROOT, relativePath), 'utf8'))
+  } catch {
+    return fallback
+  }
+}
+
+function readFirstJson(paths, fallback) {
+  for (const relativePath of paths) {
+    const value = readJson(relativePath, undefined)
+    if (value !== undefined) return value
+  }
+  return fallback
+}
+
+function baseCandidates() {
+  const values = []
+  if (EXPLICIT_BASE) values.push(EXPLICIT_BASE)
+  if (process.env.GITHUB_BASE_REF) values.push(`origin/${process.env.GITHUB_BASE_REF}`)
+  values.push('HEAD^')
+  return [...new Set(values.filter(Boolean))]
+}
+
+function gitShowJson(ref, relativePath) {
+  try {
+    const raw = execFileSync('git', ['show', `${ref}:${relativePath}`], {
+      cwd: ROOT,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      maxBuffer: 25 * 1024 * 1024,
+    })
+    return JSON.parse(raw)
+  } catch {
+    return undefined
+  }
+}
+
+function readBaseFirst(ref, paths, fallback) {
+  const choices = Array.isArray(paths) ? paths : [paths]
+  for (const relativePath of choices) {
+    const value = gitShowJson(ref, relativePath)
+    if (value !== undefined) return value
+  }
+  return fallback
+}
+
+function normalizeRoute(route) {
+  const value = String(route ?? '').trim()
+  if (!value) return ''
+  const pathOnly = value.split(/[?#]/)[0]
+  const withSlash = pathOnly.startsWith('/') ? pathOnly : `/${pathOnly}`
+  return withSlash.length > 1 ? withSlash.replace(/\/+$/, '') : '/'
+}
+
+function firstText(record, keys) {
+  for (const key of keys) {
+    const value = record?.[key]
+    if (value !== undefined && value !== null && String(value).trim()) return String(value).trim()
+  }
+  return ''
+}
+
+function gradeOf(record) {
+  return firstText(record, [
+    'evidence_grade',
+    'evidenceGrade',
+    'grade',
+    'evidence_tier',
+    'evidenceTier',
+    'tier',
+    'evidence_level',
+    'evidenceLevel',
+  ]) || 'unknown'
+}
+
+function statusOf(record) {
+  const status = firstText(record, ['indexability_status', 'indexabilityStatus']) || 'unknown'
+  const robots = firstText(record, ['robots']) || 'unknown'
+  const sitemap = record?.sitemap_included ?? record?.sitemapIncluded
+  return `${status}|${robots}|${sitemap === undefined ? 'unknown' : String(Boolean(sitemap))}`
+}
+
+function isPublished(status) {
+  const [indexability, robots, sitemap] = status.split('|')
+  return indexability.toUpperCase() === 'PUBLISH' || (robots.toLowerCase().includes('index') && !robots.toLowerCase().includes('noindex') && sitemap === 'true')
+}
+
+function buildEntityState(herbs, compounds) {
+  const grades = new Map()
+  const indexability = new Map()
+  const add = (rows, kind) => {
+    for (const row of Array.isArray(rows) ? rows : []) {
+      const slug = firstText(row, ['slug'])
+      if (!slug) continue
+      const route = `/${kind}/${slug}`
+      const grade = gradeOf(row)
+      grades.set(grade, (grades.get(grade) ?? 0) + 1)
+      indexability.set(route, statusOf(row))
+    }
+  }
+  add(herbs, 'herbs')
+  add(compounds, 'compounds')
+  return {
+    gradeDistribution: Object.fromEntries([...grades.entries()].sort(([a], [b]) => a.localeCompare(b))),
+    indexability: Object.fromEntries([...indexability.entries()].sort(([a], [b]) => a.localeCompare(b))),
+  }
+}
+
+function buildSnapshot({ routes, herbs, compounds, internalLinks, claims }) {
+  const routeRows = Array.isArray(routes) ? routes : []
+  const titles = {}
+  for (const row of routeRows) {
+    const route = normalizeRoute(row?.route || row?.path)
+    if (!route) continue
+    titles[route] = firstText(row, ['meta_title', 'title'])
+  }
+
+  const entityState = buildEntityState(herbs, compounds)
+  const linkRows = internalLinks && typeof internalLinks === 'object' ? Object.values(internalLinks) : []
+  const linkCounts = {}
+  let totalInternalLinks = 0
+  for (const row of linkRows) {
+    const route = normalizeRoute(row?.route || row?.href)
+    if (!route) continue
+    const totalLinks = Number(row?.totalLinks ?? row?.total_links ?? row?.links?.length ?? 0) || 0
+    linkCounts[route] = totalLinks
+    totalInternalLinks += totalLinks
+  }
+
+  let citationReferences = 0
+  const citationIds = new Set()
+  for (const claim of Array.isArray(claims) ? claims : []) {
+    const ids = Array.isArray(claim?.source_ids) ? claim.source_ids.filter(Boolean) : []
+    citationReferences += ids.length
+    ids.forEach((id) => citationIds.add(String(id)))
+  }
+
+  return {
+    routeCount: routeRows.length,
+    titles,
+    gradeDistribution: entityState.gradeDistribution,
+    indexability: entityState.indexability,
+    internalLinks: {
+      total: totalInternalLinks,
+      byRoute: linkCounts,
+    },
+    citations: {
+      claimSourceReferences: citationReferences,
+      uniqueSourceIds: citationIds.size,
+    },
+  }
+}
+
+function currentSnapshot() {
+  return buildSnapshot({
+    routes: readJson(FILES.routeManifest, []),
+    herbs: readFirstJson(FILES.herbsSummary, []),
+    compounds: readFirstJson(FILES.compoundsSummary, []),
+    internalLinks: readJson(FILES.internalLinks, {}),
+    claims: readJson(FILES.claims, []),
+  })
+}
+
+function baseSnapshot(ref) {
+  return buildSnapshot({
+    routes: readBaseFirst(ref, FILES.routeManifest, []),
+    herbs: readBaseFirst(ref, FILES.herbsSummary, []),
+    compounds: readBaseFirst(ref, FILES.compoundsSummary, []),
+    internalLinks: readBaseFirst(ref, FILES.internalLinks, {}),
+    claims: readBaseFirst(ref, FILES.claims, []),
+  })
+}
+
+function compareMaps(before, after) {
+  const changed = []
+  const keys = new Set([...Object.keys(before), ...Object.keys(after)])
+  for (const key of [...keys].sort()) {
+    if ((before[key] ?? null) !== (after[key] ?? null)) {
+      changed.push({ key, before: before[key] ?? null, after: after[key] ?? null })
+    }
+  }
+  return changed
+}
+
+function compareSnapshots(before, after) {
+  const routeDelta = after.routeCount - before.routeCount
+  const titleChanges = compareMaps(before.titles, after.titles).filter((row) => row.before !== null && row.after !== null)
+  const indexabilityChanges = compareMaps(before.indexability, after.indexability)
+  const publishToNonIndex = indexabilityChanges.filter((row) => row.before && row.after && isPublished(row.before) && !isPublished(row.after))
+
+  const gradeKeys = new Set([...Object.keys(before.gradeDistribution), ...Object.keys(after.gradeDistribution)])
+  const beforeEntityCount = Object.values(before.gradeDistribution).reduce((sum, value) => sum + Number(value || 0), 0)
+  const afterEntityCount = Object.values(after.gradeDistribution).reduce((sum, value) => sum + Number(value || 0), 0)
+  const gradeChanges = [...gradeKeys].sort().map((grade) => {
+    const beforeCount = Number(before.gradeDistribution[grade] ?? 0)
+    const afterCount = Number(after.gradeDistribution[grade] ?? 0)
+    const beforeShare = beforeEntityCount ? beforeCount / beforeEntityCount : 0
+    const afterShare = afterEntityCount ? afterCount / afterEntityCount : 0
+    return {
+      grade,
+      before: beforeCount,
+      after: afterCount,
+      delta: afterCount - beforeCount,
+      shareDelta: afterShare - beforeShare,
+    }
+  })
+
+  const lostInternalLinks = []
+  const reducedInternalLinks = []
+  for (const [route, beforeCount] of Object.entries(before.internalLinks.byRoute)) {
+    const afterCount = Number(after.internalLinks.byRoute[route] ?? 0)
+    if (beforeCount > 0 && afterCount === 0) lostInternalLinks.push({ route, before: beforeCount, after: afterCount })
+    else if (afterCount < beforeCount) reducedInternalLinks.push({ route, before: beforeCount, after: afterCount })
+  }
+
+  const citationDelta = after.citations.claimSourceReferences - before.citations.claimSourceReferences
+  const internalLinkDelta = after.internalLinks.total - before.internalLinks.total
+  const major = []
+
+  const routePct = pct(routeDelta, before.routeCount)
+  if (routePct !== null && Math.abs(routePct) >= 0.1 && Math.abs(routeDelta) >= 20) {
+    major.push(`${routeDelta > 0 ? 'page-count explosion' : 'page-count drop'}: ${before.routeCount} → ${after.routeCount}`)
+  }
+
+  for (const change of gradeChanges) {
+    if (Math.abs(change.shareDelta) >= 0.1 && Math.abs(change.delta) >= 20) {
+      major.push(`evidence-grade distribution shift for ${change.grade}: ${change.before} → ${change.after}`)
+    }
+  }
+
+  const citationPct = pct(citationDelta, before.citations.claimSourceReferences)
+  if (citationPct !== null && citationPct <= -0.1 && citationDelta <= -25) {
+    major.push(`citation-count decrease: ${before.citations.claimSourceReferences} → ${after.citations.claimSourceReferences}`)
+  }
+
+  const linkPct = pct(internalLinkDelta, before.internalLinks.total)
+  if ((linkPct !== null && linkPct <= -0.1 && internalLinkDelta <= -50) || lostInternalLinks.length >= 10) {
+    major.push(`internal-link regression: ${before.internalLinks.total} → ${after.internalLinks.total}; ${lostInternalLinks.length} routes lost all links`)
+  }
+
+  const titleChangeLimit = Math.max(25, Math.ceil(before.routeCount * 0.05))
+  if (titleChanges.length > titleChangeLimit) {
+    major.push(`unexpected title churn: ${titleChanges.length} existing routes changed titles`)
+  }
+
+  const indexabilityLimit = Math.max(10, Math.ceil(Object.keys(before.indexability).length * 0.02))
+  if (publishToNonIndex.length > indexabilityLimit) {
+    major.push(`unexpected indexability change: ${publishToNonIndex.length} published entity routes became non-indexable`)
+  }
+
+  return {
+    routeCount: { before: before.routeCount, after: after.routeCount, delta: routeDelta, pct: routePct },
+    evidenceGrades: gradeChanges,
+    citations: {
+      before: before.citations,
+      after: after.citations,
+      referenceDelta: citationDelta,
+      referencePct: citationPct,
+    },
+    internalLinks: {
+      before: before.internalLinks.total,
+      after: after.internalLinks.total,
+      delta: internalLinkDelta,
+      pct: linkPct,
+      lostRoutes: lostInternalLinks,
+      reducedRoutes: reducedInternalLinks.slice(0, 200),
+    },
+    titles: {
+      changedCount: titleChanges.length,
+      changes: titleChanges.slice(0, 200),
+    },
+    indexability: {
+      changedCount: indexabilityChanges.length,
+      publishToNonIndexCount: publishToNonIndex.length,
+      changes: indexabilityChanges.slice(0, 200),
+      publishToNonIndex: publishToNonIndex.slice(0, 200),
+    },
+    majorChanges: major,
+  }
+}
+
+function renderMarkdown(report) {
+  const c = report.comparison
+  const lines = [
+    '# Build quality comparison',
+    '',
+    `Base: \`${report.baseRef}\``,
+    '',
+    '| Signal | Previous | Current | Delta |',
+    '| --- | ---: | ---: | ---: |',
+    `| Indexable route manifest | ${c.routeCount.before} | ${c.routeCount.after} | ${c.routeCount.delta >= 0 ? '+' : ''}${c.routeCount.delta} |`,
+    `| Claim→source citation references | ${c.citations.before.claimSourceReferences} | ${c.citations.after.claimSourceReferences} | ${c.citations.referenceDelta >= 0 ? '+' : ''}${c.citations.referenceDelta} |`,
+    `| Unique citation source IDs | ${c.citations.before.uniqueSourceIds} | ${c.citations.after.uniqueSourceIds} | ${c.citations.after.uniqueSourceIds - c.citations.before.uniqueSourceIds} |`,
+    `| Internal links | ${c.internalLinks.before} | ${c.internalLinks.after} | ${c.internalLinks.delta >= 0 ? '+' : ''}${c.internalLinks.delta} |`,
+    `| Existing titles changed | — | ${c.titles.changedCount} | — |`,
+    `| Indexability records changed | — | ${c.indexability.changedCount} | — |`,
+    `| Published → non-indexable | — | ${c.indexability.publishToNonIndexCount} | — |`,
+    '',
+    '## Evidence-grade distribution',
+    '',
+    '| Grade | Previous | Current | Delta | Share Δ |',
+    '| --- | ---: | ---: | ---: | ---: |',
+    ...c.evidenceGrades.map((row) => `| ${row.grade} | ${row.before} | ${row.after} | ${row.delta >= 0 ? '+' : ''}${row.delta} | ${(row.shareDelta * 100).toFixed(1)} pp |`),
+    '',
+  ]
+
+  if (c.majorChanges.length) {
+    lines.push('## Major automated changes', '')
+    for (const change of c.majorChanges) lines.push(`- ${change}`)
+    lines.push('', `Explanation: ${report.changeReason || '**MISSING — merge gate should fail**'}`, '')
+  } else {
+    lines.push('## Major automated changes', '', 'None detected.', '')
+  }
+
+  if (c.internalLinks.lostRoutes.length) {
+    lines.push('## Routes that lost all internal links', '')
+    for (const row of c.internalLinks.lostRoutes.slice(0, 100)) lines.push(`- \`${row.route}\`: ${row.before} → ${row.after}`)
+    lines.push('')
+  }
+
+  return `${lines.join('\n')}\n`
+}
+
+function printSummary(report) {
+  const c = report.comparison
+  console.log('\nBuild quality comparison')
+  console.log('='.repeat(72))
+  console.log(`Base ref             ${report.baseRef}`)
+  console.log(`Routes               ${c.routeCount.before} → ${c.routeCount.after} (${c.routeCount.delta >= 0 ? '+' : ''}${c.routeCount.delta})`)
+  console.log(`Citation references  ${c.citations.before.claimSourceReferences} → ${c.citations.after.claimSourceReferences} (${c.citations.referenceDelta >= 0 ? '+' : ''}${c.citations.referenceDelta})`)
+  console.log(`Internal links        ${c.internalLinks.before} → ${c.internalLinks.after} (${c.internalLinks.delta >= 0 ? '+' : ''}${c.internalLinks.delta})`)
+  console.log(`Title changes         ${c.titles.changedCount}`)
+  console.log(`Indexability changes  ${c.indexability.changedCount}`)
+  console.log(`Publish → nonindex    ${c.indexability.publishToNonIndexCount}`)
+  console.log(`Major changes         ${c.majorChanges.length}`)
+  if (c.majorChanges.length) {
+    c.majorChanges.forEach((change) => console.log(`  - ${change}`))
+    console.log(`Change explanation    ${report.changeReason || 'MISSING'}`)
+  }
+  console.log('Report                public/data/reports/build-quality-diff.md')
+}
+
+function selfTest() {
+  const before = {
+    routeCount: 100,
+    titles: Object.fromEntries(Array.from({ length: 100 }, (_, i) => [`/r${i}`, `Title ${i}`])),
+    gradeDistribution: { A: 50, B: 50 },
+    indexability: Object.fromEntries(Array.from({ length: 100 }, (_, i) => [`/r${i}`, 'PUBLISH|index,follow|true'])),
+    internalLinks: { total: 1000, byRoute: Object.fromEntries(Array.from({ length: 100 }, (_, i) => [`/r${i}`, 10])) },
+    citations: { claimSourceReferences: 500, uniqueSourceIds: 200 },
+  }
+  const after = structuredClone(before)
+  after.routeCount = 70
+  after.citations.claimSourceReferences = 400
+  after.internalLinks.total = 800
+  for (let i = 0; i < 30; i += 1) after.titles[`/r${i}`] = `Changed ${i}`
+  for (let i = 0; i < 15; i += 1) after.indexability[`/r${i}`] = 'NOINDEX|noindex,follow|false'
+  const result = compareSnapshots(before, after)
+  if (result.majorChanges.length < 4) throw new Error('self-test failed to detect expected major regressions')
+  console.log('[build-quality] self-test passed')
+}
+
+if (argv.includes('--self-test')) {
+  selfTest()
+  process.exit(0)
+}
+
+const current = currentSnapshot()
+let selectedBase = ''
+let previous
+for (const candidate of baseCandidates()) {
+  const candidateSnapshot = baseSnapshot(candidate)
+  if (candidateSnapshot.routeCount > 0 || Object.keys(candidateSnapshot.indexability).length > 0) {
+    selectedBase = candidate
+    previous = candidateSnapshot
+    break
+  }
+}
+
+if (!previous) {
+  const message = '[build-quality] unable to load a previous generated-data state from Git'
+  if (REQUIRE_BASE) {
+    console.error(`${message}; pass --base=<ref> or fetch the base ref before running`)
+    process.exit(1)
+  }
+  console.log(`${message}; skipping comparison`)
+  process.exit(0)
+}
+
+const comparison = compareSnapshots(previous, current)
+const report = {
+  generatedAt: new Date().toISOString(),
+  baseRef: selectedBase,
+  changeReason: CHANGE_REASON,
+  comparison,
+}
+
+fs.mkdirSync(REPORT_DIR, { recursive: true })
+fs.writeFileSync(path.join(REPORT_DIR, 'build-quality-diff.json'), `${JSON.stringify(report, null, 2)}\n`)
+fs.writeFileSync(path.join(REPORT_DIR, 'build-quality-diff.md'), renderMarkdown(report))
+printSummary(report)
+
+if (comparison.majorChanges.length && !CHANGE_REASON) {
+  console.error('\nMajor automated changes require an explanation before merge.')
+  console.error('Re-run with --reason="..." or set QUALITY_CHANGE_REASON.')
+  process.exit(1)
+}

--- a/scripts/ci/compare-internal-link-quality.mjs
+++ b/scripts/ci/compare-internal-link-quality.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { execFileSync } from 'node:child_process'
+
+const ROOT = process.cwd()
+const REPORT_DIR = path.join(ROOT, 'public', 'data', 'reports')
+const argv = process.argv.slice(2)
+const flagValue = (name) => argv.find((arg) => arg.startsWith(`--${name}=`))?.split('=').slice(1).join('=')
+const BASE_REF = flagValue('base') || (process.env.GITHUB_BASE_REF ? `origin/${process.env.GITHUB_BASE_REF}` : 'HEAD^')
+const STRICT = argv.includes('--strict')
+
+function run(command, args, cwd = ROOT, options = {}) {
+  return execFileSync(command, args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: options.quiet ? ['ignore', 'pipe', 'pipe'] : ['ignore', 'inherit', 'inherit'],
+    maxBuffer: 50 * 1024 * 1024,
+  })
+}
+
+function normalizeRoute(value) {
+  const raw = String(value ?? '').trim().split(/[?#]/)[0]
+  if (!raw) return ''
+  const withSlash = raw.startsWith('/') ? raw : `/${raw}`
+  return withSlash.length > 1 ? withSlash.replace(/\/+$/, '') : '/'
+}
+
+function readMap(worktree) {
+  const file = path.join(worktree, 'public', 'data', 'runtime-maps', 'internal-link-map.json')
+  const raw = fs.readFileSync(file, 'utf8').trim()
+  if (!raw) throw new Error(`generated internal-link map is empty in ${worktree}`)
+  const parsed = JSON.parse(raw)
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`generated internal-link map is not an object in ${worktree}`)
+  }
+  return parsed
+}
+
+function snapshot(map) {
+  const byRoute = {}
+  let total = 0
+  for (const [mapKey, row] of Object.entries(map)) {
+    const route = normalizeRoute(row?.route || mapKey)
+    if (!route) continue
+    const links = Number(row?.totalLinks ?? row?.total_links ?? row?.links?.length ?? row?.groups?.flatMap?.((group) => group?.links || [])?.length ?? 0) || 0
+    byRoute[route] = links
+    total += links
+  }
+  return { total, routes: Object.keys(byRoute).length, byRoute }
+}
+
+function compare(before, after) {
+  const lostRoutes = []
+  const reducedRoutes = []
+  const addedRoutes = []
+  for (const [route, count] of Object.entries(before.byRoute)) {
+    const next = Number(after.byRoute[route] ?? 0)
+    if (count > 0 && next === 0) lostRoutes.push({ route, before: count, after: next })
+    else if (next < count) reducedRoutes.push({ route, before: count, after: next })
+  }
+  for (const [route, count] of Object.entries(after.byRoute)) {
+    if (!(route in before.byRoute) && count > 0) addedRoutes.push({ route, before: 0, after: count })
+  }
+
+  const delta = after.total - before.total
+  const pct = before.total ? delta / before.total : null
+  const majorRegression = (pct !== null && pct <= -0.1 && delta <= -50) || lostRoutes.length >= 10
+  return {
+    before: { total: before.total, routes: before.routes },
+    after: { total: after.total, routes: after.routes },
+    delta,
+    pct,
+    majorRegression,
+    lostRoutes: lostRoutes.sort((a, b) => b.before - a.before || a.route.localeCompare(b.route)),
+    reducedRoutes: reducedRoutes.sort((a, b) => (b.before - b.after) - (a.before - a.after) || a.route.localeCompare(b.route)),
+    addedRoutes: addedRoutes.sort((a, b) => b.after - a.after || a.route.localeCompare(b.route)),
+  }
+}
+
+function renderMarkdown(report) {
+  const c = report.comparison
+  const pct = c.pct === null ? 'n/a' : `${(c.pct * 100).toFixed(1)}%`
+  const lines = [
+    '# Internal-link regression comparison',
+    '',
+    `Base: \`${report.baseRef}\``,
+    '',
+    `Both maps were **regenerated from their own Git worktrees** before comparison; this audit does not trust the currently tracked empty/stale map artifact.`,
+    '',
+    '| Signal | Previous | Current | Delta |',
+    '| --- | ---: | ---: | ---: |',
+    `| Routes represented | ${c.before.routes} | ${c.after.routes} | ${c.after.routes - c.before.routes} |`,
+    `| Related internal links | ${c.before.total} | ${c.after.total} | ${c.delta >= 0 ? '+' : ''}${c.delta} (${pct}) |`,
+    `| Routes losing all related links | — | ${c.lostRoutes.length} | — |`,
+    `| Routes with reduced related links | — | ${c.reducedRoutes.length} | — |`,
+    '',
+  ]
+  if (c.lostRoutes.length) {
+    lines.push('## Routes that lost all generated related links', '')
+    for (const row of c.lostRoutes.slice(0, 100)) lines.push(`- \`${row.route}\`: ${row.before} → ${row.after}`)
+    lines.push('')
+  }
+  if (c.majorRegression) lines.push('## Result', '', '**FAIL:** major internal-link regression detected.', '')
+  else lines.push('## Result', '', 'No major internal-link regression detected.', '')
+  return `${lines.join('\n')}\n`
+}
+
+function createWorktree(ref, label) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `ths-${label}-`))
+  // mkdtemp creates the directory, while git worktree add requires the target not
+  // to exist. Remove it and let Git recreate the worktree atomically.
+  fs.rmSync(dir, { recursive: true, force: true })
+  run('git', ['worktree', 'add', '--detach', dir, ref], ROOT, { quiet: true })
+  return dir
+}
+
+function removeWorktree(dir) {
+  if (!dir) return
+  try {
+    run('git', ['worktree', 'remove', '--force', dir], ROOT, { quiet: true })
+  } catch {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+let baseWorktree = ''
+let currentWorktree = ''
+try {
+  baseWorktree = createWorktree(BASE_REF, 'links-base')
+  currentWorktree = createWorktree('HEAD', 'links-current')
+
+  run(process.execPath, ['scripts/data/build-internal-link-engine.mjs'], baseWorktree, { quiet: true })
+  run(process.execPath, ['scripts/data/build-internal-link-engine.mjs'], currentWorktree, { quiet: true })
+
+  const before = snapshot(readMap(baseWorktree))
+  const after = snapshot(readMap(currentWorktree))
+  const comparison = compare(before, after)
+  const report = {
+    generatedAt: new Date().toISOString(),
+    baseRef: BASE_REF,
+    comparison,
+  }
+
+  fs.mkdirSync(REPORT_DIR, { recursive: true })
+  fs.writeFileSync(path.join(REPORT_DIR, 'internal-link-quality-diff.json'), `${JSON.stringify(report, null, 2)}\n`)
+  fs.writeFileSync(path.join(REPORT_DIR, 'internal-link-quality-diff.md'), renderMarkdown(report))
+
+  console.log('\nInternal-link regression comparison')
+  console.log('='.repeat(72))
+  console.log(`Base ref            ${BASE_REF}`)
+  console.log(`Routes              ${before.routes} → ${after.routes}`)
+  console.log(`Internal links       ${before.total} → ${after.total} (${comparison.delta >= 0 ? '+' : ''}${comparison.delta})`)
+  console.log(`Lost-link routes     ${comparison.lostRoutes.length}`)
+  console.log(`Reduced-link routes  ${comparison.reducedRoutes.length}`)
+  console.log('Report               public/data/reports/internal-link-quality-diff.md')
+
+  if (STRICT && comparison.majorRegression) process.exitCode = 1
+} finally {
+  removeWorktree(currentWorktree)
+  removeWorktree(baseWorktree)
+}

--- a/scripts/ci/compare-internal-link-quality.mjs
+++ b/scripts/ci/compare-internal-link-quality.mjs
@@ -110,11 +110,19 @@ function renderMarkdown(report) {
 
 function createWorktree(ref, label) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), `ths-${label}-`))
-  // mkdtemp creates the directory, while git worktree add requires the target not
-  // to exist. Remove it and let Git recreate the worktree atomically.
   fs.rmSync(dir, { recursive: true, force: true })
   run('git', ['worktree', 'add', '--detach', dir, ref], ROOT, { quiet: true })
   return dir
+}
+
+function shareDependencies(worktree) {
+  const source = path.join(ROOT, 'node_modules')
+  const target = path.join(worktree, 'node_modules')
+  if (!fs.existsSync(source)) {
+    throw new Error('node_modules is missing in the root checkout; install dependencies before running the worktree comparison')
+  }
+  if (fs.existsSync(target)) fs.rmSync(target, { recursive: true, force: true })
+  fs.symlinkSync(source, target, process.platform === 'win32' ? 'junction' : 'dir')
 }
 
 function removeWorktree(dir) {
@@ -131,6 +139,8 @@ let currentWorktree = ''
 try {
   baseWorktree = createWorktree(BASE_REF, 'links-base')
   currentWorktree = createWorktree('HEAD', 'links-current')
+  shareDependencies(baseWorktree)
+  shareDependencies(currentWorktree)
 
   run(process.execPath, ['scripts/data/build-internal-link-engine.mjs'], baseWorktree, { quiet: true })
   run(process.execPath, ['scripts/data/build-internal-link-engine.mjs'], currentWorktree, { quiet: true })


### PR DESCRIPTION
Fixes #3100

## Relevant URLs
- Generated route manifest, profile summary indexes, claims, and regenerated internal-link graph
- `public/data/reports/build-quality-diff.md`
- `public/data/reports/internal-link-quality-diff.md`

## Acceptance criteria
- Compare current generated quality state with the PR base/previous Git state.
- Detect route-count explosions/drops, evidence-grade shifts, citation decreases, lost internal links, title churn, and indexability regressions.
- Produce JSON + human-readable reports.
- Require a deliberate explanation section when a major automated change is detected.
- Enforce the comparators in pull requests with full Git history available.
- Do not trust the currently tracked empty/stale internal-link map: regenerate the internal-link graph independently in HEAD and base Git worktrees before comparing link loss.
- Install dependencies once in CI and share the same dependency tree into both detached worktrees so base/head regeneration is deterministic.

## Validation commands
- `node scripts/ci/compare-build-quality.mjs --self-test`
- `node scripts/ci/compare-build-quality.mjs --base=origin/main --require-base`
- `node scripts/ci/compare-internal-link-quality.mjs --base=origin/main --strict`
- GitHub workflow: `Build quality regression`

## Before → after metrics
- Build-to-build quality comparator: 0 → 1.
- Regenerated base-vs-head internal-link comparator: 0 → 1.
- Regression classes explicitly monitored: 0 → 6.
- PR merge-path enforcement: optional → automatic workflow.

## Generator/source-of-truth decision
Tracked route/profile/claim artifacts are compared directly against the Git base. For internal links, the tracked `runtime-maps/internal-link-map.json` is currently empty/stale on main, so it is not accepted as a baseline. The workflow creates detached base and HEAD worktrees, links each to the single `npm ci` dependency installation, runs the repository's existing `build-internal-link-engine.mjs` in each, and compares those freshly generated maps. Git history + the existing link generator remain the source of truth; no second hand-maintained baseline is introduced.

## Regression contract
Major route-count, evidence-distribution, citation, title, or indexability changes must be visible in the generated diff. Internal-link regressions must be measured from regenerated base/head maps using the same installed dependency set, including routes that lose all generated links. Large automated shifts fail unless the PR contains an explicit major-change explanation.

## Major automated change explanation
None expected from this PR: it adds comparators and enforcement workflows but does not intentionally alter generated content. If either comparator reports a major content shift, treat that as a regression and investigate rather than accepting it under this explanation.