### PR TITLE
ROI 731-750: separate safety certainty from severity and gate risky pages

### DIFF
--- a/src/lib/__tests__/safety-governance.test.ts
+++ b/src/lib/__tests__/safety-governance.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+import {
+  evaluatePageQualityGate,
+  hasCompleteSafetyProvenance,
+  safetyPolicyForFlag,
+  type SafetyFlag,
+} from '../safety-governance'
+
+function flag(overrides: Partial<SafetyFlag> = {}): SafetyFlag {
+  return {
+    id: 'flag-1',
+    severity: 'moderate',
+    certainty: 'theoretical',
+    riskClass: 'general',
+    provenance: { sourceIds: ['PMID:123'], reviewedAt: '2026-08-15' },
+    ...overrides,
+  }
+}
+
+describe('safety governance', () => {
+  it('keeps severity separate from certainty', () => {
+    const policy = safetyPolicyForFlag(flag({ severity: 'high', certainty: 'unknown' }))
+    expect(policy.messageMode).toBe('high-risk-harm-reduction')
+    expect(policy.reviewLevel).toBe('standard')
+  })
+
+  it('suppresses commerce and start-low language when unsupervised use is inappropriate', () => {
+    const policy = safetyPolicyForFlag(
+      flag({
+        severity: 'critical',
+        certainty: 'known',
+        riskClass: 'high-risk-compound',
+        unsupervisedUseInappropriate: true,
+      }),
+    )
+
+    expect(policy.suppressCommercialModules).toBe(true)
+    expect(policy.allowStartLowLanguage).toBe(false)
+    expect(policy.messageMode).toBe('avoid-unsupervised-use')
+  })
+
+  it.each(['addiction-risk', 'pregnancy', 'pediatric', 'major-medication-interaction'] as const)(
+    'requires expert review for %s content',
+    (riskClass) => {
+      expect(safetyPolicyForFlag(flag({ riskClass })).reviewLevel).toBe('expert')
+    },
+  )
+
+  it('requires source ids and review dates for safety provenance', () => {
+    expect(hasCompleteSafetyProvenance(flag())).toBe(true)
+    expect(hasCompleteSafetyProvenance(flag({ provenance: { sourceIds: [] } }))).toBe(false)
+  })
+
+  it('gates commercial pages on complete evidence, safety and sourcing', () => {
+    expect(
+      evaluatePageQualityGate('commercial', {
+        evidenceComplete: true,
+        safetyComplete: false,
+        sourcingComplete: true,
+      }),
+    ).toEqual({
+      publishable: false,
+      commercialAllowed: false,
+      failures: ['safety-incomplete'],
+    })
+  })
+
+  it('requires complete data for both sides of comparisons', () => {
+    const result = evaluatePageQualityGate('comparison', {
+      evidenceComplete: true,
+      safetyComplete: true,
+      sourcingComplete: true,
+      bothComparisonSidesComplete: false,
+    })
+    expect(result.publishable).toBe(false)
+    expect(result.failures).toContain('comparison-side-incomplete')
+  })
+
+  it('requires source-backed interaction data on safety pages', () => {
+    const result = evaluatePageQualityGate('safety', {
+      evidenceComplete: true,
+      safetyComplete: true,
+      sourcingComplete: true,
+      interactionDataSourceBacked: false,
+    })
+    expect(result.failures).toContain('interaction-data-not-source-backed')
+  })
+
+  it('requires ranking methodology for best-of guides and stronger evidence for disease pages', () => {
+    expect(
+      evaluatePageQualityGate('best-of', {
+        evidenceComplete: true,
+        safetyComplete: true,
+        sourcingComplete: true,
+        rankingMethodologyPublished: false,
+      }).failures,
+    ).toContain('ranking-methodology-missing')
+
+    expect(
+      evaluatePageQualityGate('disease-related', {
+        evidenceComplete: true,
+        safetyComplete: true,
+        sourcingComplete: true,
+        diseaseEvidenceStandardMet: false,
+      }).failures,
+    ).toContain('disease-evidence-standard-not-met')
+  })
+
+  it('keeps mechanism-only references non-commercial', () => {
+    const result = evaluatePageQualityGate('mechanism-reference', {
+      evidenceComplete: false,
+      safetyComplete: false,
+      sourcingComplete: false,
+      commercialFramingPresent: true,
+    })
+    expect(result.publishable).toBe(false)
+    expect(result.commercialAllowed).toBe(false)
+    expect(result.failures).toContain('mechanism-reference-has-commercial-framing')
+  })
+})

--- a/src/lib/safety-governance.ts
+++ b/src/lib/safety-governance.ts
@@ -1,0 +1,156 @@
+export const SAFETY_SEVERITIES = ['low', 'moderate', 'high', 'critical'] as const
+export type SafetySeverity = (typeof SAFETY_SEVERITIES)[number]
+
+export const SAFETY_CERTAINTIES = ['known', 'probable', 'theoretical', 'unknown'] as const
+export type SafetyCertainty = (typeof SAFETY_CERTAINTIES)[number]
+
+export type SafetyRiskClass =
+  | 'general'
+  | 'high-risk-compound'
+  | 'addiction-risk'
+  | 'pregnancy'
+  | 'pediatric'
+  | 'major-medication-interaction'
+
+export interface SafetyProvenance {
+  sourceIds: string[]
+  reviewedAt?: string
+  reviewer?: string
+  note?: string
+}
+
+export interface SafetyFlag {
+  id: string
+  severity: SafetySeverity
+  certainty: SafetyCertainty
+  riskClass: SafetyRiskClass
+  provenance: SafetyProvenance
+  unsupervisedUseInappropriate?: boolean
+}
+
+export interface SafetyPolicy {
+  reviewLevel: 'standard' | 'enhanced' | 'expert'
+  suppressCommercialModules: boolean
+  allowStartLowLanguage: boolean
+  messageMode: 'routine-caution' | 'uncertainty-forward' | 'high-risk-harm-reduction' | 'avoid-unsupervised-use'
+}
+
+const REVIEW_LEVEL: Record<SafetyRiskClass, SafetyPolicy['reviewLevel']> = {
+  general: 'standard',
+  'high-risk-compound': 'enhanced',
+  'addiction-risk': 'expert',
+  pregnancy: 'expert',
+  pediatric: 'expert',
+  'major-medication-interaction': 'expert',
+}
+
+export function safetyPolicyForFlag(flag: SafetyFlag): SafetyPolicy {
+  const reviewLevel = REVIEW_LEVEL[flag.riskClass]
+  const severe = flag.severity === 'high' || flag.severity === 'critical'
+  const established = flag.certainty === 'known' || flag.certainty === 'probable'
+  const suppressCommercialModules =
+    flag.unsupervisedUseInappropriate === true ||
+    flag.riskClass === 'addiction-risk' ||
+    flag.riskClass === 'pregnancy' ||
+    flag.riskClass === 'pediatric' ||
+    (severe && established)
+
+  const allowStartLowLanguage = flag.unsupervisedUseInappropriate !== true && !suppressCommercialModules
+
+  let messageMode: SafetyPolicy['messageMode'] = 'routine-caution'
+  if (flag.unsupervisedUseInappropriate) messageMode = 'avoid-unsupervised-use'
+  else if (flag.riskClass !== 'general' || severe) messageMode = 'high-risk-harm-reduction'
+  else if (flag.certainty === 'theoretical' || flag.certainty === 'unknown') messageMode = 'uncertainty-forward'
+
+  return {
+    reviewLevel,
+    suppressCommercialModules,
+    allowStartLowLanguage,
+    messageMode,
+  }
+}
+
+export function hasCompleteSafetyProvenance(flag: SafetyFlag): boolean {
+  return flag.provenance.sourceIds.length > 0 && Boolean(flag.provenance.reviewedAt)
+}
+
+export type PageCategory =
+  | 'commercial'
+  | 'comparison'
+  | 'safety'
+  | 'best-of'
+  | 'disease-related'
+  | 'mechanism-reference'
+  | 'informational'
+
+export interface PageQualityInputs {
+  evidenceComplete: boolean
+  safetyComplete: boolean
+  sourcingComplete: boolean
+  bothComparisonSidesComplete?: boolean
+  interactionDataSourceBacked?: boolean
+  rankingMethodologyPublished?: boolean
+  diseaseEvidenceStandardMet?: boolean
+  commercialFramingPresent?: boolean
+}
+
+export interface PageQualityGateResult {
+  publishable: boolean
+  commercialAllowed: boolean
+  failures: string[]
+}
+
+export function evaluatePageQualityGate(
+  category: PageCategory,
+  input: PageQualityInputs,
+): PageQualityGateResult {
+  const failures: string[] = []
+
+  const requireCore = () => {
+    if (!input.evidenceComplete) failures.push('evidence-incomplete')
+    if (!input.safetyComplete) failures.push('safety-incomplete')
+    if (!input.sourcingComplete) failures.push('sourcing-incomplete')
+  }
+
+  if (category === 'commercial') {
+    requireCore()
+  }
+
+  if (category === 'comparison') {
+    requireCore()
+    if (!input.bothComparisonSidesComplete) failures.push('comparison-side-incomplete')
+  }
+
+  if (category === 'safety') {
+    if (!input.safetyComplete) failures.push('safety-incomplete')
+    if (!input.sourcingComplete) failures.push('sourcing-incomplete')
+    if (!input.interactionDataSourceBacked) failures.push('interaction-data-not-source-backed')
+  }
+
+  if (category === 'best-of') {
+    requireCore()
+    if (!input.rankingMethodologyPublished) failures.push('ranking-methodology-missing')
+  }
+
+  if (category === 'disease-related') {
+    requireCore()
+    if (!input.diseaseEvidenceStandardMet) failures.push('disease-evidence-standard-not-met')
+  }
+
+  if (category === 'mechanism-reference' && input.commercialFramingPresent) {
+    failures.push('mechanism-reference-has-commercial-framing')
+  }
+
+  const publishable = failures.length === 0
+  const commercialAllowed =
+    publishable && category !== 'mechanism-reference' && category !== 'safety'
+
+  return { publishable, commercialAllowed, failures }
+}
+
+export function safetyAxesAreIndependent(flag: SafetyFlag): boolean {
+  // Deliberately tautological at runtime: this helper exists to make callers
+  // consume severity and certainty as separate fields rather than deriving one
+  // from the other.
+  return SAFETY_SEVERITIES.includes(flag.severity) && SAFETY_CERTAINTIES.includes(flag.certainty)
+}


### PR DESCRIPTION
Implements backlog 731-750 as canonical safety governance.

- independent safety severity and certainty axes (`known`, `probable`, `theoretical`, `unknown`)
- provenance requirements for safety flags
- risk-class-specific review levels for addiction, pregnancy, pediatric, high-risk compounds, and major medication interactions
- automatic commercial suppression and removal of `start low` framing when unsupervised use is inappropriate
- risk-class-specific messaging modes instead of universal boilerplate
- page-category quality gates for commercial, comparison, safety, best-of, disease-related, and mechanism-reference pages
- regression tests for all of the above