### PR TITLE
refactor(timing): unify child-guide eligibility

### DIFF
--- a/app/guides/timing/[slug]/morning-or-night/page.tsx
+++ b/app/guides/timing/[slug]/morning-or-night/page.tsx
@@ -3,64 +3,25 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 
 import Disclaimer from '@/src/components/Disclaimer'
-import { getUnifiedRuntimeRecords } from '@/src/lib/runtime-record-index'
 import { buildPageMetadata } from '@/src/lib/seo'
-
-type RuntimeIngredient = Record<string, unknown> & {
-  slug?: string
-  name?: string
-  best_taken?: unknown
-  evidence_grade?: unknown
-  evidence_level?: unknown
-}
-
-type EligibleIngredient = {
-  record: RuntimeIngredient
-  kind: 'herb' | 'compound'
-}
-
-const DAYPART_PATTERN = /\b(morning|night|evening|bedtime|daytime|afternoon|a\.m\.|p\.m\.)\b/i
-
-function clean(value: unknown): string {
-  if (typeof value !== 'string') return ''
-  return value.replace(/\s+/g, ' ').trim()
-}
-
-function getTiming(record: RuntimeIngredient): string {
-  return clean(record.best_taken)
-}
-
-async function getEligibleIngredients(): Promise<EligibleIngredient[]> {
-  const { herbs, compounds } = await getUnifiedRuntimeRecords()
-  const bySlug = new Map<string, EligibleIngredient>()
-
-  for (const [kind, records] of [
-    ['herb', herbs],
-    ['compound', compounds],
-  ] as const) {
-    for (const record of records as RuntimeIngredient[]) {
-      const slug = clean(record.slug)
-      const timing = getTiming(record)
-      if (!slug || !timing || !DAYPART_PATTERN.test(timing)) continue
-      if (!bySlug.has(slug)) bySlug.set(slug, { record, kind })
-    }
-  }
-
-  return [...bySlug.values()]
-}
+import {
+  cleanTimingValue,
+  getTiming,
+  loadDaypartTimingIngredients,
+} from '../../timing-data'
 
 export async function generateStaticParams() {
-  const ingredients = await getEligibleIngredients()
-  return ingredients.map(({ record }) => ({ slug: clean(record.slug) }))
+  const ingredients = await loadDaypartTimingIngredients()
+  return ingredients.map((record) => ({ slug: cleanTimingValue(record.slug) }))
 }
 
 export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {
   const { slug } = await params
-  const ingredients = await getEligibleIngredients()
-  const entry = ingredients.find(({ record }) => clean(record.slug) === slug)
-  if (!entry) return {}
+  const ingredients = await loadDaypartTimingIngredients()
+  const record = ingredients.find((item) => cleanTimingValue(item.slug) === slug)
+  if (!record) return {}
 
-  const name = clean(entry.record.name) || slug
+  const name = cleanTimingValue(record.name) || slug
   return buildPageMetadata({
     title: `${name}: Morning or Night? Evidence-Based Timing`,
     description: `Should you take ${name} in the morning or at night? A direct answer based only on explicit timing guidance in the structured evidence record.`,
@@ -70,15 +31,14 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
 
 export default async function MorningOrNightPage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params
-  const ingredients = await getEligibleIngredients()
-  const entry = ingredients.find(({ record }) => clean(record.slug) === slug)
-  if (!entry) notFound()
+  const ingredients = await loadDaypartTimingIngredients()
+  const record = ingredients.find((item) => cleanTimingValue(item.slug) === slug)
+  if (!record) notFound()
 
-  const { record, kind } = entry
-  const name = clean(record.name) || slug
+  const name = cleanTimingValue(record.name) || slug
   const timing = getTiming(record)
-  const grade = clean(record.evidence_grade) || clean(record.evidence_level)
-  const profileHref = kind === 'herb' ? `/herbs/${slug}/` : `/compounds/${slug}/`
+  const grade = cleanTimingValue(record.evidence_grade) || cleanTimingValue(record.evidence_level)
+  const profileHref = record.entityType === 'compound' ? `/compounds/${slug}/` : `/herbs/${slug}/`
 
   return (
     <main className="container-page space-y-8 py-10">

--- a/app/guides/timing/[slug]/with-or-without-food/page.tsx
+++ b/app/guides/timing/[slug]/with-or-without-food/page.tsx
@@ -3,67 +3,25 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 
 import Disclaimer from '@/src/components/Disclaimer'
-import { getUnifiedRuntimeRecords } from '@/src/lib/runtime-record-index'
 import { buildPageMetadata } from '@/src/lib/seo'
-
-type RuntimeIngredient = Record<string, unknown> & {
-  slug?: string
-  name?: string
-  best_taken?: unknown
-  bioavailability_notes?: unknown
-  evidence_grade?: unknown
-  evidence_level?: unknown
-}
-
-type EligibleIngredient = {
-  record: RuntimeIngredient
-  kind: 'herb' | 'compound'
-  guidance: string
-}
-
-const FOOD_PATTERN = /\b(food|meal|meals|fasting|fasted|empty stomach|with breakfast|with dinner|with lunch|fat-containing|dietary fat)\b/i
-
-function clean(value: unknown): string {
-  if (typeof value !== 'string') return ''
-  return value.replace(/\s+/g, ' ').trim()
-}
-
-function getFoodGuidance(record: RuntimeIngredient): string {
-  const candidates = [clean(record.best_taken), clean(record.bioavailability_notes)]
-  return candidates.find((value) => FOOD_PATTERN.test(value)) || ''
-}
-
-async function getEligibleIngredients(): Promise<EligibleIngredient[]> {
-  const { herbs, compounds } = await getUnifiedRuntimeRecords()
-  const bySlug = new Map<string, EligibleIngredient>()
-
-  for (const [kind, records] of [
-    ['herb', herbs],
-    ['compound', compounds],
-  ] as const) {
-    for (const record of records as RuntimeIngredient[]) {
-      const slug = clean(record.slug)
-      const guidance = getFoodGuidance(record)
-      if (!slug || !guidance) continue
-      if (!bySlug.has(slug)) bySlug.set(slug, { record, kind, guidance })
-    }
-  }
-
-  return [...bySlug.values()]
-}
+import {
+  cleanTimingValue,
+  getFoodTimingGuidance,
+  loadFoodTimingIngredients,
+} from '../../timing-data'
 
 export async function generateStaticParams() {
-  const ingredients = await getEligibleIngredients()
-  return ingredients.map(({ record }) => ({ slug: clean(record.slug) }))
+  const ingredients = await loadFoodTimingIngredients()
+  return ingredients.map((record) => ({ slug: cleanTimingValue(record.slug) }))
 }
 
 export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {
   const { slug } = await params
-  const ingredients = await getEligibleIngredients()
-  const entry = ingredients.find(({ record }) => clean(record.slug) === slug)
-  if (!entry) return {}
+  const ingredients = await loadFoodTimingIngredients()
+  const record = ingredients.find((item) => cleanTimingValue(item.slug) === slug)
+  if (!record) return {}
 
-  const name = clean(entry.record.name) || slug
+  const name = cleanTimingValue(record.name) || slug
   return buildPageMetadata({
     title: `${name}: With or Without Food? Evidence-Based Guidance`,
     description: `Whether to take ${name} with food, without food, or around meals, based only on explicit absorption or tolerability guidance in the structured evidence record.`,
@@ -73,14 +31,14 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
 
 export default async function WithOrWithoutFoodPage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params
-  const ingredients = await getEligibleIngredients()
-  const entry = ingredients.find(({ record }) => clean(record.slug) === slug)
-  if (!entry) notFound()
+  const ingredients = await loadFoodTimingIngredients()
+  const record = ingredients.find((item) => cleanTimingValue(item.slug) === slug)
+  if (!record) notFound()
 
-  const { record, kind, guidance } = entry
-  const name = clean(record.name) || slug
-  const grade = clean(record.evidence_grade) || clean(record.evidence_level)
-  const profileHref = kind === 'herb' ? `/herbs/${slug}/` : `/compounds/${slug}/`
+  const name = cleanTimingValue(record.name) || slug
+  const guidance = getFoodTimingGuidance(record)
+  const grade = cleanTimingValue(record.evidence_grade) || cleanTimingValue(record.evidence_level)
+  const profileHref = record.entityType === 'compound' ? `/compounds/${slug}/` : `/herbs/${slug}/`
 
   return (
     <main className="container-page space-y-8 py-10">

--- a/app/guides/timing/timing-data.ts
+++ b/app/guides/timing/timing-data.ts
@@ -9,6 +9,9 @@ export type RuntimeIngredient = RuntimeRecord & {
   evidence_level?: unknown
 }
 
+const DAYPART_PATTERN = /\b(?:morning|afternoon|evening|night|nighttime|bedtime|before bed|daytime|earlier in the day|later in the day|a\.m\.|p\.m\.)/i
+const FOOD_PATTERN = /\b(?:food|meal|meals|with fat|empty stomach|fasted|fasting|with breakfast|with dinner|with lunch|fat-containing|dietary fat)\b/i
+
 export function cleanTimingValue(value: unknown): string {
   if (typeof value !== 'string') return ''
   return value.replace(/\s+/g, ' ').trim()
@@ -16,6 +19,18 @@ export function cleanTimingValue(value: unknown): string {
 
 export function getTiming(record: RuntimeIngredient): string {
   return cleanTimingValue(record.best_taken)
+}
+
+export function hasDaypartTiming(record: RuntimeIngredient): boolean {
+  return DAYPART_PATTERN.test(getTiming(record))
+}
+
+export function getFoodTimingGuidance(record: RuntimeIngredient): string {
+  const candidates = [
+    getTiming(record),
+    cleanTimingValue(record.bioavailability_notes),
+  ]
+  return candidates.find((value) => FOOD_PATTERN.test(value)) || ''
 }
 
 export function selectIndexableTimingIngredients(records: RuntimeRecord[]): RuntimeIngredient[] {
@@ -34,10 +49,23 @@ export function selectIndexableTimingIngredients(records: RuntimeRecord[]): Runt
   return [...bySlug.values()]
 }
 
+export function selectDaypartTimingIngredients(records: RuntimeRecord[]): RuntimeIngredient[] {
+  return selectIndexableTimingIngredients(records).filter(hasDaypartTiming)
+}
+
+export function selectFoodTimingIngredients(records: RuntimeRecord[]): RuntimeIngredient[] {
+  return selectIndexableTimingIngredients(records).filter((record) => Boolean(getFoodTimingGuidance(record)))
+}
+
 export async function loadIndexableTimingIngredients(): Promise<RuntimeIngredient[]> {
-  const { herbs, compounds } = await getUnifiedRuntimeRecords()
-  return selectIndexableTimingIngredients([
-    ...(herbs as RuntimeRecord[]),
-    ...(compounds as RuntimeRecord[]),
-  ])
+  const { allRecords } = await getUnifiedRuntimeRecords()
+  return selectIndexableTimingIngredients(allRecords as RuntimeRecord[])
+}
+
+export async function loadDaypartTimingIngredients(): Promise<RuntimeIngredient[]> {
+  return (await loadIndexableTimingIngredients()).filter(hasDaypartTiming)
+}
+
+export async function loadFoodTimingIngredients(): Promise<RuntimeIngredient[]> {
+  return (await loadIndexableTimingIngredients()).filter((record) => Boolean(getFoodTimingGuidance(record)))
 }

--- a/app/guides/timing/timing-data.ts
+++ b/app/guides/timing/timing-data.ts
@@ -33,15 +33,14 @@ export function getFoodTimingGuidance(record: RuntimeIngredient): string {
   return candidates.find((value) => FOOD_PATTERN.test(value)) || ''
 }
 
-export function selectIndexableTimingIngredients(records: RuntimeRecord[]): RuntimeIngredient[] {
+export function selectIndexableGuideIngredients(records: RuntimeRecord[]): RuntimeIngredient[] {
   const bySlug = new Map<string, RuntimeIngredient>()
 
   for (const record of records as RuntimeIngredient[]) {
     if (!getRuntimeVisibility(record).canIndex) continue
 
     const slug = cleanTimingValue(record.slug)
-    const timing = getTiming(record)
-    if (!slug || !timing) continue
+    if (!slug) continue
 
     if (!bySlug.has(slug)) bySlug.set(slug, record)
   }
@@ -49,23 +48,31 @@ export function selectIndexableTimingIngredients(records: RuntimeRecord[]): Runt
   return [...bySlug.values()]
 }
 
+export function selectIndexableTimingIngredients(records: RuntimeRecord[]): RuntimeIngredient[] {
+  return selectIndexableGuideIngredients(records).filter((record) => Boolean(getTiming(record)))
+}
+
 export function selectDaypartTimingIngredients(records: RuntimeRecord[]): RuntimeIngredient[] {
   return selectIndexableTimingIngredients(records).filter(hasDaypartTiming)
 }
 
 export function selectFoodTimingIngredients(records: RuntimeRecord[]): RuntimeIngredient[] {
-  return selectIndexableTimingIngredients(records).filter((record) => Boolean(getFoodTimingGuidance(record)))
+  return selectIndexableGuideIngredients(records).filter((record) => Boolean(getFoodTimingGuidance(record)))
+}
+
+async function loadUnifiedIngredients(): Promise<RuntimeRecord[]> {
+  const { allRecords } = await getUnifiedRuntimeRecords()
+  return allRecords as RuntimeRecord[]
 }
 
 export async function loadIndexableTimingIngredients(): Promise<RuntimeIngredient[]> {
-  const { allRecords } = await getUnifiedRuntimeRecords()
-  return selectIndexableTimingIngredients(allRecords as RuntimeRecord[])
+  return selectIndexableTimingIngredients(await loadUnifiedIngredients())
 }
 
 export async function loadDaypartTimingIngredients(): Promise<RuntimeIngredient[]> {
-  return (await loadIndexableTimingIngredients()).filter(hasDaypartTiming)
+  return selectDaypartTimingIngredients(await loadUnifiedIngredients())
 }
 
 export async function loadFoodTimingIngredients(): Promise<RuntimeIngredient[]> {
-  return (await loadIndexableTimingIngredients()).filter((record) => Boolean(getFoodTimingGuidance(record)))
+  return selectFoodTimingIngredients(await loadUnifiedIngredients())
 }

--- a/tests/timing-guide-publication-gate.test.ts
+++ b/tests/timing-guide-publication-gate.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  getFoodTimingGuidance,
   getTiming,
+  selectDaypartTimingIngredients,
+  selectFoodTimingIngredients,
   selectIndexableTimingIngredients,
 } from '../app/guides/timing/timing-data'
 import type { RuntimeRecord } from '../src/types/content'
@@ -62,5 +65,56 @@ describe('timing guide publication gate', () => {
     expect(selected).toHaveLength(1)
     expect(selected[0]?.name).toBe('Published version')
     expect(getTiming(selected[0])).toBe('Night')
+  })
+
+  it('keeps morning-or-night subguides inside the same publication gate', () => {
+    const records: RuntimeRecord[] = [
+      {
+        slug: 'published-daypart',
+        best_taken: 'Take at bedtime',
+        indexability_status: 'PUBLISH',
+      },
+      {
+        slug: 'published-generic',
+        best_taken: 'Take consistently each day',
+        indexability_status: 'PUBLISH',
+      },
+      {
+        slug: 'noindex-daypart',
+        best_taken: 'Take in the morning',
+        indexability_status: 'NOINDEX',
+      },
+    ]
+
+    expect(selectDaypartTimingIngredients(records).map((record) => record.slug)).toEqual([
+      'published-daypart',
+    ])
+  })
+
+  it('keeps food subguides inside the same publication gate', () => {
+    const records: RuntimeRecord[] = [
+      {
+        slug: 'published-food',
+        best_taken: 'Take consistently',
+        bioavailability_notes: 'Take with a meal',
+        indexability_status: 'PUBLISH',
+      },
+      {
+        slug: 'published-no-food',
+        best_taken: 'Take in the morning',
+        indexability_status: 'PUBLISH',
+      },
+      {
+        slug: 'hidden-food',
+        best_taken: 'Take with food',
+        indexability_status: 'PUBLISH',
+        runtime_export_decision: 'hide',
+      },
+    ]
+
+    const selected = selectFoodTimingIngredients(records)
+
+    expect(selected.map((record) => record.slug)).toEqual(['published-food'])
+    expect(getFoodTimingGuidance(selected[0])).toBe('Take with a meal')
   })
 })

--- a/tests/timing-guide-publication-gate.test.ts
+++ b/tests/timing-guide-publication-gate.test.ts
@@ -91,11 +91,10 @@ describe('timing guide publication gate', () => {
     ])
   })
 
-  it('keeps food subguides inside the same publication gate', () => {
+  it('keeps food subguides inside the same publication gate without requiring best_taken', () => {
     const records: RuntimeRecord[] = [
       {
         slug: 'published-food',
-        best_taken: 'Take consistently',
         bioavailability_notes: 'Take with a meal',
         indexability_status: 'PUBLISH',
       },
@@ -106,7 +105,7 @@ describe('timing guide publication gate', () => {
       },
       {
         slug: 'hidden-food',
-        best_taken: 'Take with food',
+        bioavailability_notes: 'Take with food',
         indexability_status: 'PUBLISH',
         runtime_export_decision: 'hide',
       },


### PR DESCRIPTION
## Root cause
The morning/night and with/without-food timing routes independently reimplemented runtime loading, normalization, slug deduplication, and evidence eligibility. Neither inherited the canonical publication gate used by the parent timing route, creating both duplication and a path for NOINDEX/hidden records to generate indexable child pages.

## Change
- Extend the canonical timing-data module with a shared indexable ingredient base selector.
- Preserve `entityType` by loading unified `allRecords`.
- Add dedicated daypart and food selectors/loaders on top of that base gate.
- Migrate both timing child routes to those canonical loaders.
- Preserve food pages sourced from `bioavailability_notes` even when `best_taken` is absent.
- Extend regression tests for child-route publication gating and bioavailability-only food guidance.

## Scope
No page copy, layout, metadata wording, or source records are changed. The parent timing route remains untouched in this PR.