### PR TITLE
feat(matrices): implement backlog 266-275 evidence and safety matrices

### DIFF
--- a/app/tools/evidence-matrices/page.tsx
+++ b/app/tools/evidence-matrices/page.tsx
@@ -1,0 +1,36 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import ResearchMatricesClient from '@/components/matrices/ResearchMatricesClient'
+import { getResearchMatrixRows } from '@/lib/research-matrices'
+import { buildPageMetadata } from '@/lib/seo'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Supplement Evidence & Safety Matrices',
+  description: 'Compare supplements across structured outcome mappings, evidence grades, human-study counts, and normalized safety signals.',
+  path: '/tools/evidence-matrices',
+})
+
+export default async function EvidenceMatricesPage() {
+  const rows = await getResearchMatrixRows()
+
+  return (
+    <main className='mx-auto max-w-7xl space-y-8 px-4 py-8 sm:py-10'>
+      <section className='rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8'>
+        <p className='eyebrow-label'>Research comparison tool</p>
+        <h1 className='mt-2 text-3xl font-bold tracking-tight text-ink sm:text-5xl'>Supplement Evidence & Safety Matrices</h1>
+        <p className='mt-4 max-w-4xl text-base leading-7 text-muted sm:text-lg'>One evidence matrix and eight safety-focused screening views built from the same canonical ingredient records. Use them to compare what is mapped, where evidence is stronger, and which safety signals deserve deeper review—without converting a database flag into medical advice.</p>
+        <div className='mt-5 flex flex-wrap gap-3 text-sm'><Link href='/tools/botanical-activity-atlas/' className='font-semibold text-indigo-800 hover:underline'>Open the Botanical Activity Atlas →</Link><Link href='/safety-checker/' className='font-semibold text-indigo-800 hover:underline'>Screen a combination →</Link></div>
+      </section>
+
+      <section className='grid gap-4 md:grid-cols-3'>
+        <article className='rounded-2xl border border-brand-900/10 bg-white/85 p-5 shadow-sm'><h2 className='font-bold text-ink'>Evidence stays separate</h2><p className='mt-2 text-sm leading-6 text-muted'>The profile grade and human-study count are displayed independently from outcome mappings and safety flags.</p></article>
+        <article className='rounded-2xl border border-brand-900/10 bg-white/85 p-5 shadow-sm'><h2 className='font-bold text-ink'>Flags are screening signals</h2><p className='mt-2 text-sm leading-6 text-muted'>A structured caution does not by itself establish severity, dose dependence, or a documented clinical interaction.</p></article>
+        <article className='rounded-2xl border border-brand-900/10 bg-white/85 p-5 shadow-sm'><h2 className='font-bold text-ink'>Missing is not safe</h2><p className='mt-2 text-sm leading-6 text-muted'>An empty field means the dataset does not currently contain that signal. It is never translated into a claim of no risk.</p></article>
+      </section>
+
+      <ResearchMatricesClient rows={rows} />
+
+      <section className='rounded-2xl border border-brand-900/10 bg-white/80 p-5 text-xs leading-relaxed text-muted'><p className='font-bold text-ink'>Educational research tool</p><p className='mt-1.5'>These matrices summarize structured reference data. They do not diagnose conditions, choose treatment, establish pregnancy safety, or determine whether a medication-supplement combination is appropriate for an individual.</p></section>
+    </main>
+  )
+}

--- a/src/components/matrices/ResearchMatricesClient.tsx
+++ b/src/components/matrices/ResearchMatricesClient.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import Link from 'next/link'
+import { useMemo, useState } from 'react'
+import {
+  RISK_MATRIX_DEFINITIONS,
+  rowsForRiskMatrix,
+  type ResearchMatrixRow,
+  type RiskMatrixId,
+} from '@/lib/research-matrices'
+
+type MatrixView = 'evidence' | RiskMatrixId
+
+type OutcomeColumn = {
+  id: string
+  label: string
+  matches: (row: ResearchMatrixRow) => boolean
+}
+
+const OUTCOME_COLUMNS: OutcomeColumn[] = [
+  { id: 'calming-sleep', label: 'Sleep / calming', matches: (row) => row.outcomes.includes('Calming') || row.outcomes.includes('Sedating / sleep') },
+  { id: 'focus', label: 'Cognition / focus', matches: (row) => row.outcomes.includes('Cognition / focus') },
+  { id: 'energy', label: 'Energy / stimulation', matches: (row) => row.outcomes.includes('Stimulating / energy') },
+  { id: 'mood', label: 'Mood', matches: (row) => row.outcomes.includes('Mood') },
+  { id: 'metabolic', label: 'Metabolic', matches: (row) => row.outcomes.includes('Metabolic') },
+]
+
+const normalize = (value: string) => value.trim().toLowerCase()
+
+function GradeBadge({ grade }: { grade: ResearchMatrixRow['evidenceGrade'] }) {
+  const label = grade === 'Avoid/Insufficient' ? 'Avoid / Insufficient' : grade
+  return <span className='inline-flex rounded-full border border-brand-900/10 bg-brand-50 px-2.5 py-1 text-xs font-bold text-ink'>{label}</span>
+}
+
+function OutcomeCell({ mapped }: { mapped: boolean }) {
+  return mapped
+    ? <span className='font-semibold text-ink' title='This outcome family is explicitly mapped in the structured profile. This does not make the profile-level evidence grade outcome-specific.'>Mapped</span>
+    : <span className='text-muted'>—</span>
+}
+
+export default function ResearchMatricesClient({ rows }: { rows: ResearchMatrixRow[] }) {
+  const [view, setView] = useState<MatrixView>('evidence')
+  const [query, setQuery] = useState('')
+  const definition = view === 'evidence' ? null : RISK_MATRIX_DEFINITIONS.find((item) => item.id === view) ?? null
+
+  const viewRows = useMemo(() => {
+    const base = view === 'evidence' ? rows : rowsForRiskMatrix(rows, view)
+    const needle = normalize(query)
+    if (!needle) return base
+    return base.filter((row) => [row.name, row.slug, row.evidenceGrade, ...row.outcomes, ...row.mechanisms, ...row.safetySignals].join(' ').toLowerCase().includes(needle))
+  }, [rows, view, query])
+
+  const evidenceRows = viewRows.slice(0, 60)
+  const safetyRows = viewRows.slice(0, 100)
+
+  return (
+    <section className='space-y-6'>
+      <div className='rounded-2xl border border-brand-900/10 bg-white/90 p-5 shadow-sm'>
+        <div className='flex flex-wrap items-end justify-between gap-4'>
+          <div>
+            <p className='eyebrow-label'>Matrix explorer</p>
+            <h2 className='mt-1 text-2xl font-bold text-ink'>Choose a comparison lens</h2>
+            <p className='mt-2 max-w-3xl text-sm leading-6 text-muted'>Each matrix is generated from the same canonical runtime records so evidence, outcome, and safety labels do not drift between tools.</p>
+          </div>
+          <label className='w-full sm:w-72'>
+            <span className='mb-1 block text-xs font-bold uppercase tracking-wide text-muted'>Search matrices</span>
+            <input value={query} onChange={(event) => setQuery(event.target.value)} placeholder='Ingredient, outcome, safety signal…' className='w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2 text-sm text-ink' />
+          </label>
+        </div>
+
+        <div className='mt-5 flex flex-wrap gap-2' role='group' aria-label='Research matrix view'>
+          <button type='button' onClick={() => setView('evidence')} aria-pressed={view === 'evidence'} className={`rounded-full border px-3 py-1.5 text-sm font-semibold ${view === 'evidence' ? 'border-indigo-900 bg-indigo-950 text-white' : 'border-brand-900/10 bg-white text-ink hover:bg-brand-50'}`}>Evidence Matrix</button>
+          {RISK_MATRIX_DEFINITIONS.map((item) => (
+            <button key={item.id} type='button' onClick={() => setView(item.id)} aria-pressed={view === item.id} className={`rounded-full border px-3 py-1.5 text-sm font-semibold ${view === item.id ? 'border-indigo-900 bg-indigo-950 text-white' : 'border-brand-900/10 bg-white text-ink hover:bg-brand-50'}`}>{item.title}</button>
+          ))}
+        </div>
+      </div>
+
+      {view === 'evidence' ? (
+        <section className='space-y-4'>
+          <div>
+            <p className='eyebrow-label'>Popular supplement evidence</p>
+            <h2 className='mt-1 text-2xl font-bold text-ink'>Evidence Matrix</h2>
+            <p className='mt-2 max-w-4xl text-sm leading-6 text-muted'>Compare popular and high-signal research records across common outcome families. “Mapped” means the canonical profile explicitly associates that ingredient with the outcome family. The profile evidence grade is shown separately and must not be read as an outcome-specific grade.</p>
+          </div>
+          <div className='overflow-x-auto rounded-2xl border border-brand-900/10 bg-white/90 shadow-sm'>
+            <table className='min-w-[1100px] w-full border-collapse text-left text-sm'>
+              <caption className='sr-only'>Popular supplements compared across structured outcome mappings and profile-level evidence</caption>
+              <thead className='bg-brand-50/80 text-xs uppercase tracking-wide text-muted'><tr><th className='p-4'>Ingredient</th><th className='p-4'>Profile evidence</th><th className='p-4'>Mapped human studies</th>{OUTCOME_COLUMNS.map((column) => <th key={column.id} className='p-4'>{column.label}</th>)}</tr></thead>
+              <tbody>{evidenceRows.map((row) => <tr key={`${row.entityType}:${row.slug}`} className='border-t border-brand-900/10 align-top'><td className='p-4'><Link href={row.href} className='font-bold text-indigo-900 hover:underline'>{row.name}</Link><p className='mt-1 text-xs uppercase tracking-wide text-muted'>{row.entityType}</p></td><td className='p-4'><GradeBadge grade={row.evidenceGrade} /></td><td className='p-4 font-semibold text-ink'>{row.humanEvidenceCount || '—'}</td>{OUTCOME_COLUMNS.map((column) => <td key={column.id} className='p-4'><OutcomeCell mapped={column.matches(row)} /></td>)}</tr>)}</tbody>
+            </table>
+          </div>
+          <p className='text-xs leading-5 text-muted'>A blank cell means that outcome is not mapped in this dataset—not that the ingredient has been proven ineffective for that outcome. Human-study counts are shown only when structured count data is available.</p>
+        </section>
+      ) : (
+        <section className='space-y-4'>
+          <div><p className='eyebrow-label'>Safety screening matrix</p><h2 className='mt-1 text-2xl font-bold text-ink'>{definition?.title}</h2><p className='mt-2 max-w-4xl text-sm leading-6 text-muted'>{definition?.description}</p></div>
+          <div className='rounded-2xl border border-amber-900/15 bg-amber-50/70 p-5 text-sm leading-6 text-amber-950'><strong>Screening tool, not a safety verdict.</strong> A flag can represent a documented concern, class effect, mechanism-based concern, or precaution depending on the underlying source. Missing data is unknown—not “safe.” Review the ingredient profile and primary sources, and use the <Link href='/safety-checker/' className='font-bold underline'>Safety Checker</Link> for combination screening.</div>
+          <div className='overflow-x-auto rounded-2xl border border-brand-900/10 bg-white/90 shadow-sm'>
+            <table className='min-w-[1050px] w-full border-collapse text-left text-sm'>
+              <caption className='sr-only'>{definition?.title} generated from normalized structured safety signals</caption>
+              <thead className='bg-brand-50/80 text-xs uppercase tracking-wide text-muted'><tr><th className='p-4'>Ingredient</th><th className='p-4'>Profile evidence</th><th className='p-4'>Human studies</th><th className='p-4'>Why included</th><th className='p-4'>Other structured safety signals</th></tr></thead>
+              <tbody>{safetyRows.map((row) => <tr key={`${row.entityType}:${row.slug}`} className='border-t border-brand-900/10 align-top'><td className='p-4'><Link href={row.href} className='font-bold text-indigo-900 hover:underline'>{row.name}</Link></td><td className='p-4'><GradeBadge grade={row.evidenceGrade} /></td><td className='p-4 font-semibold text-ink'>{row.humanEvidenceCount || '—'}</td><td className='p-4 text-ink'>{definition?.signal ? `Structured ${definition.signal} signal` : 'One or more structured safety / interaction signals'}</td><td className='p-4 text-muted'>{row.safetySignals.join(' · ') || 'No structured signal'}</td></tr>)}</tbody>
+            </table>
+          </div>
+          {!safetyRows.length ? <p className='rounded-xl border border-brand-900/10 bg-white p-5 text-sm text-muted'>No records match this matrix and search term.</p> : null}
+        </section>
+      )}
+    </section>
+  )
+}

--- a/src/lib/__tests__/research-matrices.test.ts
+++ b/src/lib/__tests__/research-matrices.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { rowsForRiskMatrix, type ResearchMatrixRow } from '../research-matrices'
+
+const row = (overrides: Partial<ResearchMatrixRow>): ResearchMatrixRow => ({
+  slug: 'example', name: 'Example', entityType: 'herb', href: '/herbs/example/', evidenceGrade: 'C', humanEvidenceCount: 0, outcomes: [], mechanisms: [], safetySignals: [], ...overrides,
+})
+
+const rows = [
+  row({ slug: 'sedative', name: 'Sedative herb', safetySignals: ['Sedation', 'Pregnancy / breastfeeding'] }),
+  row({ slug: 'serotonergic', name: 'Serotonergic herb', safetySignals: ['Serotonergic'] }),
+  row({ slug: 'bleeding', name: 'Bleeding herb', safetySignals: ['Bleeding', 'Liver'] }),
+  row({ slug: 'empty', name: 'No mapped flags' }),
+]
+
+describe('research safety matrices', () => {
+  it('includes any structured safety record in the interaction matrix', () => {
+    expect(rowsForRiskMatrix(rows, 'interaction').map((item) => item.slug)).toEqual(['sedative', 'serotonergic', 'bleeding'])
+  })
+
+  it('filters sedation without treating unrelated flags as matches', () => {
+    expect(rowsForRiskMatrix(rows, 'sedation').map((item) => item.slug)).toEqual(['sedative'])
+  })
+
+  it('filters pregnancy using the canonical normalized safety label', () => {
+    expect(rowsForRiskMatrix(rows, 'pregnancy').map((item) => item.slug)).toEqual(['sedative'])
+  })
+
+  it('does not convert missing safety data into a positive match', () => {
+    expect(rowsForRiskMatrix(rows, 'liver').some((item) => item.slug === 'empty')).toBe(false)
+  })
+})

--- a/src/lib/research-matrices.ts
+++ b/src/lib/research-matrices.ts
@@ -1,0 +1,158 @@
+import { cache } from '@/lib/react-cache'
+import { normalizeEvidenceGrade, canonicalGradeFromEvidenceTier, type CanonicalEvidenceGrade } from '../../lib/evidence-grade'
+import { getRuntimeVisibility } from '../../lib/runtime-visibility'
+import { getUnifiedRuntimeRecords } from '@/lib/runtime-record-index'
+import { normalizeEffect, normalizeSafetySignals, uniqueNormalized } from '@/lib/botanical-atlas-taxonomy'
+import type { RuntimeRecord } from '@/types/content'
+
+export const RISK_MATRIX_DEFINITIONS = [
+  { id: 'interaction', title: 'Interaction Matrix', signal: null, description: 'Structured interaction and safety signals across the research inventory.' },
+  { id: 'sedation', title: 'Sedation Risk Matrix', signal: 'Sedation', description: 'Screens for sedation, drowsiness, or CNS-depressant signals.' },
+  { id: 'stimulation', title: 'Stimulation Risk Matrix', signal: 'Stimulation', description: 'Screens for stimulant, agitation, insomnia, or jitteriness signals.' },
+  { id: 'serotonergic', title: 'Serotonergic Caution Matrix', signal: 'Serotonergic', description: 'Screens for serotonergic, SSRI/SNRI, or MAOI-related cautions.' },
+  { id: 'blood-pressure', title: 'Blood Pressure Effects Matrix', signal: 'Cardiovascular', description: 'Screens for blood-pressure, rhythm, heart-rate, or related cardiovascular signals; it does not infer direction.' },
+  { id: 'bleeding', title: 'Bleeding Risk Matrix', signal: 'Bleeding', description: 'Screens for bleeding, anticoagulant, or antiplatelet cautions.' },
+  { id: 'liver', title: 'Liver Caution Matrix', signal: 'Liver', description: 'Screens for liver or hepatotoxicity-related cautions.' },
+  { id: 'pregnancy', title: 'Pregnancy Evidence / Safety Matrix', signal: 'Pregnancy / breastfeeding', description: 'Screens for pregnancy, lactation, or breastfeeding cautions in the structured dataset.' },
+] as const
+
+export type RiskMatrixId = (typeof RISK_MATRIX_DEFINITIONS)[number]['id']
+
+export interface ResearchMatrixRow {
+  slug: string
+  name: string
+  entityType: 'herb' | 'compound'
+  href: string
+  evidenceGrade: CanonicalEvidenceGrade | 'Unassigned'
+  humanEvidenceCount: number
+  outcomes: string[]
+  mechanisms: string[]
+  safetySignals: string[]
+}
+
+const POPULAR_SLUG_PRIORITY = [
+  'ashwagandha', 'magnesium', 'melatonin', 'l-theanine', 'creatine', 'berberine',
+  'rhodiola-rosea', 'rhodiola', 'saffron', 'lions-mane', 'bacopa-monnieri', 'bacopa',
+  'valerian', 'chamomile', 'turmeric', 'curcumin', 'omega-3', 'fish-oil', 'caffeine',
+  'citicoline', 'alpha-gpc', 'inositol', 'cinnamon', 'st-johns-wort',
+]
+
+const list = (value: unknown): string[] => {
+  if (Array.isArray(value)) return value.map(String).map((item) => item.trim()).filter(Boolean)
+  if (typeof value === 'string') return value.split(/[;,|]/).map((item) => item.trim()).filter(Boolean)
+  return []
+}
+
+const collect = (...values: unknown[]) => values.flatMap(list)
+
+const text = (...values: unknown[]) => {
+  const found = values.find((value) => typeof value === 'string' && value.trim())
+  return typeof found === 'string' ? found.trim() : ''
+}
+
+const positiveInteger = (...values: unknown[]): number => {
+  for (const value of values) {
+    if (typeof value === 'number' && Number.isFinite(value) && value >= 0) return Math.floor(value)
+    if (Array.isArray(value) && value.length) return value.length
+    if (typeof value === 'string') {
+      const match = value.match(/\d+/)
+      if (match) return Number.parseInt(match[0], 10)
+    }
+  }
+  return 0
+}
+
+const canonicalEvidence = (record: RuntimeRecord): CanonicalEvidenceGrade | 'Unassigned' => {
+  const normalized = normalizeEvidenceGrade(record.evidence_grade ?? record.evidenceGrade)
+  if (normalized.grade) return normalized.grade
+  return canonicalGradeFromEvidenceTier(record.evidence_tier ?? record.evidenceTier ?? record.evidenceLevel) ?? 'Unassigned'
+}
+
+const toMatrixRow = (record: RuntimeRecord): ResearchMatrixRow => {
+  const entityType = record.entityType === 'compound' ? 'compound' : 'herb'
+  const outcomes = uniqueNormalized(
+    collect(record.primary_effects, record.effects, record.primaryActions, record.benefits, record.conditions),
+    normalizeEffect,
+  )
+  const mechanisms = Array.from(new Set(collect(
+    record.mechanisms,
+    record.raw_mechanisms,
+    record.canonical_mechanisms,
+    record.mechanism_target_systems,
+    record.mechanism_classes,
+  )))
+  const safetyRaw = collect(
+    record.safety_flags,
+    record.interactionTags,
+    record.contraindications,
+    record.interactions,
+    record.safety,
+    record.warnings,
+    record.side_effects,
+  )
+  const safetySignals = Array.from(new Set(safetyRaw.flatMap(normalizeSafetySignals)))
+  const name = text(record.displayName, record.name, record.compoundName, record.commonName, record.slug)
+  const slug = String(record.slug ?? '')
+
+  return {
+    slug,
+    name,
+    entityType,
+    href: entityType === 'compound' ? `/compounds/${slug}/` : `/herbs/${slug}/`,
+    evidenceGrade: canonicalEvidence(record),
+    humanEvidenceCount: positiveInteger(
+      record.human_trial_count,
+      record.humanTrialCount,
+      record.human_study_count,
+      record.humanStudyCount,
+      record.clinical_study_count,
+      record.clinicalStudyCount,
+      record.human_trials,
+      record.humanTrials,
+      record.clinical_trials,
+      record.clinicalTrials,
+    ),
+    outcomes,
+    mechanisms,
+    safetySignals,
+  }
+}
+
+const priorityIndex = (slug: string) => {
+  const index = POPULAR_SLUG_PRIORITY.indexOf(slug)
+  return index === -1 ? Number.MAX_SAFE_INTEGER : index
+}
+
+const evidenceRank: Record<ResearchMatrixRow['evidenceGrade'], number> = {
+  A: 5,
+  B: 4,
+  C: 3,
+  D: 2,
+  'Avoid/Insufficient': 1,
+  Unassigned: 0,
+}
+
+export const getResearchMatrixRows = cache(async (): Promise<ResearchMatrixRow[]> => {
+  const { allRecords } = await getUnifiedRuntimeRecords()
+
+  return (allRecords as RuntimeRecord[])
+    .filter((record) => Boolean(record.slug) && getRuntimeVisibility(record).canRender)
+    .map(toMatrixRow)
+    .filter((row) => row.outcomes.length || row.safetySignals.length || row.humanEvidenceCount > 0)
+    .sort((a, b) => {
+      const priorityDelta = priorityIndex(a.slug) - priorityIndex(b.slug)
+      if (priorityDelta) return priorityDelta
+      const humanDelta = b.humanEvidenceCount - a.humanEvidenceCount
+      if (humanDelta) return humanDelta
+      const evidenceDelta = evidenceRank[b.evidenceGrade] - evidenceRank[a.evidenceGrade]
+      if (evidenceDelta) return evidenceDelta
+      return a.name.localeCompare(b.name)
+    })
+})
+
+export const rowsForRiskMatrix = (rows: ResearchMatrixRow[], matrixId: RiskMatrixId) => {
+  const definition = RISK_MATRIX_DEFINITIONS.find((item) => item.id === matrixId)
+  if (!definition) return []
+  if (!definition.signal) return rows.filter((row) => row.safetySignals.length > 0)
+  return rows.filter((row) => row.safetySignals.includes(definition.signal))
+}


### PR DESCRIPTION
Implements backlog 266–275 as a canonical research-matrix system.

Coverage:
- Evidence Matrix across common structured outcome families
- Interaction, Sedation, Stimulation, Serotonergic, Blood Pressure, Bleeding, Liver, and Pregnancy Evidence/Safety matrices
- canonical evidence grades and structured human-study counts
- safety flags treated as screening signals; missing data remains unknown rather than “safe”
- profile evidence kept separate from outcome mappings to avoid fabricating outcome-specific certainty
- searchable explorer, profile links, and Safety Checker handoff
- regression tests for safety-matrix filtering and missing-data behavior