### PR TITLE
feat(email): make seven-message welcome sequence canonical

### DIFF
--- a/content/__tests__/emailWelcomeSequence.test.ts
+++ b/content/__tests__/emailWelcomeSequence.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import {
+  REQUIRED_WELCOME_PURPOSES,
+  welcomeEmailSequence,
+  withWelcomeTracking,
+} from '@/content/emailWelcomeSequence'
+
+describe('welcome email sequence', () => {
+  it('contains exactly seven ordered emails', () => {
+    expect(welcomeEmailSequence).toHaveLength(7)
+    expect(welcomeEmailSequence.map((email) => email.sequence)).toEqual([1, 2, 3, 4, 5, 6, 7])
+  })
+
+  it('covers every required welcome purpose exactly once', () => {
+    expect(welcomeEmailSequence.map((email) => email.purpose)).toEqual(REQUIRED_WELCOME_PURPOSES)
+    expect(new Set(welcomeEmailSequence.map((email) => email.purpose)).size).toBe(7)
+  })
+
+  it('starts immediately and never moves backward in cadence', () => {
+    expect(welcomeEmailSequence[0].delayDays).toBe(0)
+    for (let index = 1; index < welcomeEmailSequence.length; index += 1) {
+      expect(welcomeEmailSequence[index].delayDays).toBeGreaterThan(
+        welcomeEmailSequence[index - 1].delayDays,
+      )
+    }
+  })
+
+  it('gives every message a useful primary CTA with email attribution', () => {
+    for (const email of welcomeEmailSequence) {
+      expect(email.subject.trim().length).toBeGreaterThan(10)
+      expect(email.previewText.trim().length).toBeGreaterThan(20)
+      expect(email.body.length).toBeGreaterThanOrEqual(2)
+      expect(email.cta.href).toContain('utm_source=newsletter')
+      expect(email.cta.href).toContain('utm_medium=email')
+      expect(email.cta.href).toContain('utm_campaign=welcome_sequence')
+      expect(email.cta.href).toContain(`utm_content=email_${email.sequence}`)
+    }
+  })
+
+  it('preserves existing query strings when adding attribution', () => {
+    expect(withWelcomeTracking('/search/?q=magnesium', 3)).toContain('&utm_source=newsletter')
+  })
+})

--- a/content/emailWelcomeSequence.ts
+++ b/content/emailWelcomeSequence.ts
@@ -1,0 +1,168 @@
+export type WelcomeEmailPurpose =
+  | 'deliver-resource'
+  | 'explain-evidence-grades'
+  | 'evaluate-label'
+  | 'demonstrate-safety-checker'
+  | 'show-research-resources'
+  | 'highlight-comparison'
+  | 'invite-topic-selection'
+
+export type WelcomeEmail = {
+  sequence: number
+  purpose: WelcomeEmailPurpose
+  delayDays: number
+  subject: string
+  previewText: string
+  body: readonly string[]
+  cta: {
+    label: string
+    href: string
+  }
+  secondaryCtas?: readonly {
+    label: string
+    href: string
+  }[]
+}
+
+const EMAIL_MEDIUM = 'email'
+const CAMPAIGN = 'welcome_sequence'
+
+export function withWelcomeTracking(href: string, sequence: number): string {
+  const separator = href.includes('?') ? '&' : '?'
+  return `${href}${separator}utm_source=newsletter&utm_medium=${EMAIL_MEDIUM}&utm_campaign=${CAMPAIGN}&utm_content=email_${sequence}`
+}
+
+export const welcomeEmailSequence: readonly WelcomeEmail[] = [
+  {
+    sequence: 1,
+    purpose: 'deliver-resource',
+    delayDays: 0,
+    subject: 'Your supplement safety checklist is here',
+    previewText: 'Start with the promised resource, then keep the same safety-first workflow for anything you research.',
+    body: [
+      'Thanks for joining The Hippie Scientist. Here is the supplement safety checklist you asked for.',
+      'Use it as a pre-purchase workflow: check medications and contraindications, verify the dose and form, look for stacking risks, and confirm product-quality details before treating a label as trustworthy.',
+      'The site is educational and does not replace medical care. When a question involves a medication, pregnancy, a serious condition, or a high-risk substance, use the checklist to identify what needs professional review rather than to self-clear the combination.',
+    ],
+    cta: {
+      label: 'Open the safety checklist',
+      href: withWelcomeTracking('/info/supplement-safety-checklist/', 1),
+    },
+  },
+  {
+    sequence: 2,
+    purpose: 'explain-evidence-grades',
+    delayDays: 1,
+    subject: 'What an evidence grade actually tells you',
+    previewText: 'A mechanism, one positive study, and a replicated human effect are not the same thing.',
+    body: [
+      'The evidence grade is meant to answer a narrow question: how much confidence should the current human evidence support for a specific conclusion?',
+      'Human trials, systematic reviews, observational research, animal work, mechanisms, and traditional use are separated because they answer different questions. Mechanistic plausibility can explain why an effect might happen; it cannot substitute for replicated clinical evidence that it does happen.',
+      'When evidence is mixed or preliminary, the useful response is not hype or dismissal. It is a smaller conclusion with the uncertainty kept visible.',
+    ],
+    cta: {
+      label: 'See the grading methodology',
+      href: withWelcomeTracking('/info/methodology/', 2),
+    },
+    secondaryCtas: [
+      { label: 'Evidence levels in plain English', href: withWelcomeTracking('/learn/evidence-levels/', 2) },
+    ],
+  },
+  {
+    sequence: 3,
+    purpose: 'evaluate-label',
+    delayDays: 3,
+    subject: 'How to read a supplement label before buying',
+    previewText: 'Form, elemental amount, extract standardization, and proprietary blends can change what the label really means.',
+    body: [
+      'A product can contain the right ingredient name and still fail to resemble what was studied. Start by identifying the exact form, serving size, active or elemental amount, and any extract standardization.',
+      'Watch for proprietary blends that hide individual amounts, mineral labels that emphasize compound weight instead of elemental content, and botanical extracts whose marker percentage or extraction method is not disclosed.',
+      'Then compare the label with the form and dose used in the evidence. A research result for one standardized extract should not automatically be generalized to every product carrying the same plant name.',
+    ],
+    cta: {
+      label: 'Open the product-quality guide',
+      href: withWelcomeTracking('/learn/product-quality/', 3),
+    },
+    secondaryCtas: [
+      { label: 'Review dosing basics', href: withWelcomeTracking('/info/dosing/', 3) },
+    ],
+  },
+  {
+    sequence: 4,
+    purpose: 'demonstrate-safety-checker',
+    delayDays: 5,
+    subject: 'Use the Safety Checker before you stack supplements',
+    previewText: 'The useful result is not “safe” or “unsafe” — it is why a combination deserves attention.',
+    body: [
+      'The Safety Checker is designed as a screening tool. It surfaces documented or plausible caution flags, shows why a pair was flagged, and points back to the underlying ingredient safety context.',
+      'A blank result should never be interpreted as proof of no interaction. The right wording is that no documented interaction was found in the current dataset, because evidence can be incomplete.',
+      'Try it with supplements you are already researching, then open each ingredient profile for the fuller interaction and contraindication context.',
+    ],
+    cta: {
+      label: 'Open the Safety Checker',
+      href: withWelcomeTracking('/safety-checker/', 4),
+    },
+  },
+  {
+    sequence: 5,
+    purpose: 'show-research-resources',
+    delayDays: 8,
+    subject: 'The strongest research tools on the site',
+    previewText: 'Go beyond individual profiles with the evidence report, lookup tools, and citation resources.',
+    body: [
+      'Ingredient pages are only one layer of the site. The research tools are built to make the underlying structure easier to inspect across many ingredients at once.',
+      'Use the Evidence Report for the big-picture view, Evidence Lookup to filter by evidence level, and the Citation Explorer when you want to trace claims back toward their sources.',
+      'These resources are most useful when they make uncertainty easier to see, not when they manufacture a single score that hides disagreement.',
+    ],
+    cta: {
+      label: 'Open the Evidence Report',
+      href: withWelcomeTracking('/evidence/evidence-report/', 5),
+    },
+    secondaryCtas: [
+      { label: 'Use Evidence Lookup', href: withWelcomeTracking('/evidence/evidence-checker/', 5) },
+      { label: 'Explore citations', href: withWelcomeTracking('/learn/citation-explorer/', 5) },
+    ],
+  },
+  {
+    sequence: 6,
+    purpose: 'highlight-comparison',
+    delayDays: 11,
+    subject: 'A better way to compare supplement options',
+    previewText: 'The important differences are evidence, safety, form, dose, and fit — not who wins a generic ranking.',
+    body: [
+      'Comparison pages should make tradeoffs explicit. Two supplements can target a similar goal while differing sharply in evidence strength, sedation or stimulation risk, medication concerns, studied forms, and the time horizon of the trials.',
+      'The comparison below is a useful example because it separates calming strategies instead of pretending the ingredients are interchangeable.',
+      'Use the quick verdict to orient yourself, then read the evidence and safety differences before treating either option as a fit.',
+    ],
+    cta: {
+      label: 'Compare ashwagandha, L-theanine, and magnesium',
+      href: withWelcomeTracking('/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium/', 6),
+    },
+  },
+  {
+    sequence: 7,
+    purpose: 'invite-topic-selection',
+    delayDays: 14,
+    subject: 'What should The Hippie Scientist research next?',
+    previewText: 'Choose the topics you want more of: Sleep, Stress, Anxiety, Focus, or general research.',
+    body: [
+      'The best research queue should be driven partly by what readers are actually trying to understand.',
+      'Choose the topic closest to what you want to follow. This is a content preference, not a request for symptoms, diagnoses, medications, or other health information.',
+      'Your selection can be used to send relevant research notes more selectively instead of sending every topic to everyone.',
+    ],
+    cta: {
+      label: 'Choose research topics',
+      href: withWelcomeTracking('/info/newsletter/#research-interests', 7),
+    },
+  },
+] as const
+
+export const REQUIRED_WELCOME_PURPOSES: readonly WelcomeEmailPurpose[] = [
+  'deliver-resource',
+  'explain-evidence-grades',
+  'evaluate-label',
+  'demonstrate-safety-checker',
+  'show-research-resources',
+  'highlight-comparison',
+  'invite-topic-selection',
+]

--- a/docs/marketing/welcome-email-sequence.md
+++ b/docs/marketing/welcome-email-sequence.md
@@ -1,80 +1,31 @@
 # Welcome Email Sequence
 
-## Email 1: Deliver Guide / Set Expectations
+The canonical welcome sequence lives in `content/emailWelcomeSequence.ts`. That typed manifest is the source of truth for order, cadence, subject/preview copy, body copy, destinations, and campaign attribution. This document describes the operating contract rather than duplicating email copy that can drift.
 
-Subject: Your supplement decision guide
+## Sequence contract
 
-Preview text: A practical way to compare supplements without hype.
+| Email | Timing | Purpose | Primary destination |
+| --- | ---: | --- | --- |
+| 1 | Immediately | Deliver the promised supplement safety checklist | `/info/supplement-safety-checklist/` |
+| 2 | Day 1 | Explain what evidence grades do and do not mean | `/info/methodology/` |
+| 3 | Day 3 | Show how to evaluate a supplement label | `/learn/product-quality/` |
+| 4 | Day 5 | Demonstrate the Safety Checker | `/safety-checker/` |
+| 5 | Day 8 | Introduce the strongest research resources | `/evidence/evidence-report/` |
+| 6 | Day 11 | Demonstrate a high-value evidence/safety comparison | `/guides/compare/ashwagandha-vs-l-theanine-vs-magnesium/` |
+| 7 | Day 14 | Invite readers to choose research interests | `/info/newsletter/#research-interests` |
 
-Body:
-Thanks for joining The Hippie Scientist list. The goal here is simple: help you compare herbs, supplements, and compounds with evidence, safety context, and uncertainty visible.
+## Editorial rules
 
-Start with the free guide, then use the site pages for deeper comparisons. Nothing here is medical advice, diagnosis, or treatment. It is decision support for better questions.
+- The sequence is evidence-first and educational; it must not become a disguised product funnel.
+- Email 1 must deliver the promised resource before asking for anything else.
+- Evidence grades and mechanism language must keep their limitations visible.
+- Trial doses, safety warnings, and medication context must not be converted into personalized medical instructions.
+- Email 7 asks only for content interests (Sleep, Stress, Anxiety, Focus, or General research), not symptoms, diagnoses, medications, or other health information.
+- Product or affiliate links are not part of the canonical welcome sequence. If a later commercial campaign is created, it must use the site affiliate-disclosure and safety gates independently.
+- Every primary and secondary site link in the canonical sequence carries `utm_source=newsletter`, `utm_medium=email`, `utm_campaign=welcome_sequence`, and an email-number `utm_content` value so return traffic can be measured without placing email addresses in URLs.
 
-CTA: Read the free guide: `/free-guide`
+## Provider implementation
 
-Implementation notes: Send immediately after provider integration is connected. Include the sitewide medical disclaimer footer.
+The repository owns the content contract; the email provider owns delivery timing. Provider automation should mirror the seven `delayDays` values from `content/emailWelcomeSequence.ts` rather than maintaining a second handwritten schedule.
 
-## Email 2: Evidence-Aware Supplement Decisions
-
-Subject: Strong evidence, weak evidence, and useful uncertainty
-
-Preview text: Interesting is not the same as proven.
-
-Body:
-Supplement decisions get messy because human trials, mechanisms, traditional use, and product marketing often get blended together. The Hippie Scientist separates those layers.
-
-When evidence is limited, the point is not to ignore the option. The point is to make a smaller, more cautious decision.
-
-CTA: See the methodology: `/methodology`
-
-Implementation notes: Link to the methodology page and avoid product links in this email.
-
-## Email 3: Sleep / Stress / Focus Segmentation
-
-Subject: Which supplement problem are you actually solving?
-
-Preview text: Sleep, stress, and focus need different filters.
-
-Body:
-Most people shop by ingredient. Better decisions start with the job:
-
-Sleep support asks about timing, next-day grogginess, sedatives, and alcohol.
-
-Stress support asks whether the goal is situational calm, evening downshift, or stress-linked fatigue.
-
-Focus support asks whether you need alertness, calmer concentration, or baseline energy support.
-
-CTA: Choose a guide: `/top/sleep`, `/top/stress`, or `/top/focus`
-
-Implementation notes: Use three clear text links. Do not personalize medical guidance.
-
-## Email 4: Supplement Buying Mistakes
-
-Subject: Five supplement buying mistakes worth avoiding
-
-Preview text: Labels, doses, stacking, and claims matter.
-
-Body:
-Common mistakes include buying before checking safety context, assuming every extract is equivalent, stacking multiple calming or stimulating products, ignoring medication interactions, and treating affiliate recommendations as medical advice.
-
-A better process is slower: choose one goal, compare evidence level, read the safety note, check the label, and change one variable at a time.
-
-CTA: Read the affiliate checklist: `/affiliate-disclosure`
-
-Implementation notes: This is a trust-building email. Keep product links out unless a later compliant campaign is intentionally added.
-
-## Email 5: Soft Recommendation / Affiliate Disclosure
-
-Subject: How product links work on The Hippie Scientist
-
-Preview text: Affiliate links support the site, but they do not set the rankings.
-
-Body:
-Some recommendation sections include affiliate links. The site may earn a commission if you buy through those links, at no extra cost to you.
-
-Affiliate relationships do not change evidence labels, safety notes, or uncertainty language. Product links are sourcing paths, not prescriptions.
-
-CTA: Review affiliate disclosure: `/affiliate-disclosure`
-
-Implementation notes: Include FTC disclosure language near any monetized CTA. Use `rel="sponsored nofollow noopener noreferrer"` for external affiliate links.
+When provider automation is changed, validate that all seven purposes still exist exactly once and that Email 1 remains immediate. The Vitest contract in `content/__tests__/emailWelcomeSequence.test.ts` guards those invariants.


### PR DESCRIPTION
## Backlog
Covers 353–360.

## What changed
- replaces the five-message planning-only welcome sequence with a typed seven-message canonical manifest
- Email 1 delivers the safety checklist
- Email 2 explains evidence grading
- Email 3 teaches supplement-label evaluation
- Email 4 demonstrates the Safety Checker
- Email 5 introduces flagship research resources
- Email 6 highlights a high-value comparison
- Email 7 invites non-medical research-interest selection
- adds deterministic UTM attribution to every sequence CTA
- adds Vitest contract coverage for sequence count, order, cadence, purpose uniqueness, and campaign tracking
- updates the marketing doc so it references the typed source of truth instead of duplicating copy

## Guardrails
No personalized medical guidance, no health-data collection, and no affiliate/product funnel is introduced into the canonical welcome sequence.