### PR TITLE
ROI 751-765: research maturity and relationship semantics

### DIFF
--- a/src/lib/__tests__/research-maturity.test.ts
+++ b/src/lib/__tests__/research-maturity.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import {
+  canLabelAsPracticalAlternative,
+  canMapToCondition,
+  displayRelationshipLabel,
+  policyForResearchMaturity,
+  validateResearchRelationship,
+} from '../research-maturity'
+
+describe('research maturity', () => {
+  it('visually and commercially separates theoretical research from established evidence', () => {
+    const established = policyForResearchMaturity('established')
+    const theoretical = policyForResearchMaturity('theoretical')
+
+    expect(established.rank).toBeGreaterThan(theoretical.rank)
+    expect(established.commercialAllowed).toBe(true)
+    expect(theoretical.commercialAllowed).toBe(false)
+    expect(theoretical.purchaseIntentAllowed).toBe(false)
+    expect(theoretical.visualWeight).toBe('research-only')
+  })
+
+  it('blocks mechanism-only evidence from becoming a supported condition mapping', () => {
+    const relationship = {
+      fromId: 'compound:a',
+      toId: 'condition:anxiety',
+      kind: 'outcome-supported' as const,
+      outcomeEvidenceCount: 0,
+      mechanismEvidenceCount: 4,
+    }
+
+    expect(canMapToCondition(relationship)).toBe(false)
+    expect(validateResearchRelationship(relationship).map((issue) => issue.code)).toContain(
+      'mechanism-mapped-as-clinical-outcome',
+    )
+  })
+
+  it('allows mechanism-derived condition relationships only when labeled exploratory', () => {
+    expect(
+      canMapToCondition({
+        fromId: 'compound:a',
+        toId: 'condition:anxiety',
+        kind: 'exploratory-outcome',
+        outcomeEvidenceCount: 0,
+        mechanismEvidenceCount: 4,
+      }),
+    ).toBe(true)
+  })
+
+  it('does not call chemical similarity a practical alternative', () => {
+    const chemical = {
+      fromId: 'a',
+      toId: 'b',
+      kind: 'similar-chemistry' as const,
+      outcomeEvidenceCount: 0,
+      mechanismEvidenceCount: 2,
+    }
+    const unsupportedAlternative = { ...chemical, kind: 'practical-alternative' as const }
+
+    expect(displayRelationshipLabel(chemical.kind)).toBe('Similar chemistry')
+    expect(canLabelAsPracticalAlternative(chemical)).toBe(false)
+    expect(validateResearchRelationship(unsupportedAlternative).map((issue) => issue.code)).toContain(
+      'alternative-without-outcome-evidence',
+    )
+  })
+
+  it('allows practical alternatives only when same-goal outcome evidence exists', () => {
+    expect(
+      canLabelAsPracticalAlternative({
+        fromId: 'a',
+        toId: 'b',
+        kind: 'practical-alternative',
+        outcomeEvidenceCount: 3,
+      }),
+    ).toBe(true)
+  })
+})

--- a/src/lib/research-maturity.ts
+++ b/src/lib/research-maturity.ts
@@ -1,0 +1,134 @@
+export const RESEARCH_MATURITY_LEVELS = [
+  'established',
+  'emerging',
+  'preliminary',
+  'theoretical',
+] as const
+
+export type ResearchMaturity = (typeof RESEARCH_MATURITY_LEVELS)[number]
+
+export interface ResearchMaturityPolicy {
+  label: string
+  rank: number
+  visualWeight: 'full' | 'standard' | 'muted' | 'research-only'
+  commercialAllowed: boolean
+  purchaseIntentAllowed: boolean
+  outcomeLanguage: 'supported' | 'cautious' | 'preliminary' | 'mechanistic-only'
+}
+
+export const RESEARCH_MATURITY_POLICIES: Record<ResearchMaturity, ResearchMaturityPolicy> = {
+  established: {
+    label: 'Established research',
+    rank: 4,
+    visualWeight: 'full',
+    commercialAllowed: true,
+    purchaseIntentAllowed: true,
+    outcomeLanguage: 'supported',
+  },
+  emerging: {
+    label: 'Emerging research',
+    rank: 3,
+    visualWeight: 'standard',
+    commercialAllowed: true,
+    purchaseIntentAllowed: true,
+    outcomeLanguage: 'cautious',
+  },
+  preliminary: {
+    label: 'Preliminary research',
+    rank: 2,
+    visualWeight: 'muted',
+    commercialAllowed: false,
+    purchaseIntentAllowed: false,
+    outcomeLanguage: 'preliminary',
+  },
+  theoretical: {
+    label: 'Theoretical / mechanistic research',
+    rank: 1,
+    visualWeight: 'research-only',
+    commercialAllowed: false,
+    purchaseIntentAllowed: false,
+    outcomeLanguage: 'mechanistic-only',
+  },
+}
+
+export type RelationshipKind =
+  | 'outcome-supported'
+  | 'exploratory-outcome'
+  | 'practical-alternative'
+  | 'similar-clinical-effect'
+  | 'similar-chemistry'
+  | 'same-pathway'
+
+export interface ResearchRelationship {
+  fromId: string
+  toId: string
+  kind: RelationshipKind
+  outcomeEvidenceCount?: number
+  mechanismEvidenceCount?: number
+  label?: string
+}
+
+export interface RelationshipValidationIssue {
+  code:
+    | 'mechanism-mapped-as-clinical-outcome'
+    | 'alternative-without-outcome-evidence'
+    | 'clinical-effect-without-outcome-evidence'
+  message: string
+}
+
+export function policyForResearchMaturity(level: ResearchMaturity): ResearchMaturityPolicy {
+  return RESEARCH_MATURITY_POLICIES[level]
+}
+
+export function validateResearchRelationship(
+  relationship: ResearchRelationship,
+): RelationshipValidationIssue[] {
+  const issues: RelationshipValidationIssue[] = []
+  const outcomeEvidence = relationship.outcomeEvidenceCount ?? 0
+  const mechanismEvidence = relationship.mechanismEvidenceCount ?? 0
+
+  if (relationship.kind === 'outcome-supported' && outcomeEvidence === 0 && mechanismEvidence > 0) {
+    issues.push({
+      code: 'mechanism-mapped-as-clinical-outcome',
+      message: 'Mechanism evidence alone cannot create an outcome-supported condition mapping; use exploratory-outcome instead.',
+    })
+  }
+
+  if (relationship.kind === 'practical-alternative' && outcomeEvidence === 0) {
+    issues.push({
+      code: 'alternative-without-outcome-evidence',
+      message: 'A practical alternative requires outcome evidence for the same reader goal; chemical or pathway similarity is not enough.',
+    })
+  }
+
+  if (relationship.kind === 'similar-clinical-effect' && outcomeEvidence === 0) {
+    issues.push({
+      code: 'clinical-effect-without-outcome-evidence',
+      message: 'Similar clinical effect requires direct outcome evidence; otherwise use similar-chemistry or same-pathway.',
+    })
+  }
+
+  return issues
+}
+
+export function canMapToCondition(relationship: ResearchRelationship): boolean {
+  if (relationship.kind === 'exploratory-outcome') return true
+  if (relationship.kind !== 'outcome-supported') return false
+  return (relationship.outcomeEvidenceCount ?? 0) > 0
+}
+
+export function canLabelAsPracticalAlternative(relationship: ResearchRelationship): boolean {
+  return relationship.kind === 'practical-alternative' && (relationship.outcomeEvidenceCount ?? 0) > 0
+}
+
+export function displayRelationshipLabel(kind: RelationshipKind): string {
+  const labels: Record<RelationshipKind, string> = {
+    'outcome-supported': 'Supported for the same outcome',
+    'exploratory-outcome': 'Exploratory outcome connection',
+    'practical-alternative': 'Alternative for the same goal',
+    'similar-clinical-effect': 'Similar clinical effect',
+    'similar-chemistry': 'Similar chemistry',
+    'same-pathway': 'Same pathway',
+  }
+  return labels[kind]
+}


### PR DESCRIPTION
Rebased implementation of backlog 751-765 on current main.

- canonical research maturity levels: established, emerging, preliminary, theoretical
- design/commercial policies make immature compounds visually and commercially distinct
- theoretical/preliminary research cannot carry purchase-intent framing
- condition mappings require outcome evidence unless explicitly marked exploratory
- practical alternatives require same-goal outcome evidence
- chemistry, pathway, clinical-effect, exploratory, and supported-outcome relationships have distinct semantic labels
- regression tests prevent mechanism/pathway evidence from silently becoming clinical claims