### PR TITLE
feat(editorial): truthful review provenance and public correction standards

### DIFF
--- a/app/info/corrections/page.tsx
+++ b/app/info/corrections/page.tsx
@@ -1,0 +1,147 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { publicCorrections } from '@/data/editorial/corrections'
+import { correctionsForPage } from '@/lib/editorial-provenance'
+import { buildPageMetadata } from '@/src/lib/seo'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Corrections & Scientific Update History',
+  description: 'Public correction policy and correction history for material scientific, safety, dosing, citation, and evidence-grade changes on The Hippie Scientist.',
+  path: '/info/corrections/',
+  openGraphType: 'article',
+})
+
+function formatDate(value: string) {
+  return new Date(value).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}
+
+export default function CorrectionsPage() {
+  const sorted = [...publicCorrections].sort(
+    (a, b) => Date.parse(b.publishedAt) - Date.parse(a.publishedAt),
+  )
+  const affectedPages = new Set(sorted.map(correction => correction.pagePath)).size
+
+  return (
+    <main className="container-page mx-auto max-w-5xl space-y-10 py-10">
+      <section className="hero-shell rounded-[2rem] border p-6 sm:p-8 lg:p-10">
+        <p className="eyebrow-label">Scientific accountability</p>
+        <h1 className="heading-premium mt-4">Corrections &amp; scientific update history</h1>
+        <p className="text-reading mt-4 max-w-3xl">
+          Material corrections to evidence grades, safety conclusions, dosing context, study interpretation,
+          or citation attribution belong in a public record. Small copy edits do not need a scientific
+          correction entry; meaningful changes do.
+        </p>
+        <div className="mt-6 flex flex-wrap gap-3">
+          <Link
+            href="/info/contact/?topic=correction"
+            className="rounded-full bg-brand-800 px-5 py-2.5 text-sm font-bold text-white hover:bg-brand-900"
+          >
+            Submit a correction or missing study
+          </Link>
+          <Link
+            href="/info/editorial-policy/"
+            className="rounded-full border border-brand-900/15 px-5 py-2.5 text-sm font-semibold text-ink hover:bg-brand-50"
+          >
+            Read editorial standards
+          </Link>
+        </div>
+      </section>
+
+      <section className="grid gap-4 sm:grid-cols-3" aria-label="Correction ledger summary">
+        <div className="card-premium p-5">
+          <p className="eyebrow-label">Published corrections</p>
+          <p className="mt-2 text-3xl font-bold text-ink">{sorted.length}</p>
+        </div>
+        <div className="card-premium p-5">
+          <p className="eyebrow-label">Affected pages</p>
+          <p className="mt-2 text-3xl font-bold text-ink">{affectedPages}</p>
+        </div>
+        <div className="card-premium p-5">
+          <p className="eyebrow-label">History model</p>
+          <p className="mt-2 text-lg font-bold text-ink">Append-only</p>
+        </div>
+      </section>
+
+      <section className="rounded-[2rem] border border-brand-900/10 bg-white p-6 shadow-sm sm:p-8">
+        <h2 className="text-2xl font-semibold text-ink">What gets a public correction?</h2>
+        <div className="mt-5 grid gap-5 md:grid-cols-2 text-sm leading-7 text-muted">
+          <div>
+            <h3 className="font-bold text-ink">Recorded publicly</h3>
+            <p className="mt-2">
+              Evidence-grade changes, reversed or materially narrowed conclusions, safety-warning changes,
+              incorrect study characterization, meaningful dose/form corrections, citation misattribution,
+              and other changes that could alter a reader’s interpretation.
+            </p>
+          </div>
+          <div>
+            <h3 className="font-bold text-ink">Usually not recorded</h3>
+            <p className="mt-2">
+              Spelling, formatting, accessibility fixes, template changes, navigation changes, and other edits
+              that do not materially change the scientific meaning of a page.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-5" aria-labelledby="correction-ledger-title">
+        <div>
+          <p className="eyebrow-label">Public ledger</p>
+          <h2 id="correction-ledger-title" className="mt-2 text-3xl font-semibold tracking-tight text-ink">
+            Material corrections
+          </h2>
+        </div>
+
+        {sorted.length === 0 ? (
+          <div className="rounded-2xl border border-brand-900/10 bg-brand-50/50 p-6 text-sm leading-7 text-muted">
+            No material corrections have been entered in the public ledger yet. This is not a claim that the
+            site has never changed; routine edits and build/template changes are intentionally separate from
+            scientific correction events.
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {sorted.map(correction => {
+              const pageHistory = correctionsForPage(publicCorrections, correction.pagePath)
+              const sequence = pageHistory.findIndex(item => item.id === correction.id) + 1
+              return (
+                <article key={correction.id} id={correction.id} className="card-premium p-6">
+                  <div className="flex flex-wrap items-center gap-2 text-xs text-muted">
+                    <time dateTime={correction.publishedAt}>{formatDate(correction.publishedAt)}</time>
+                    <span aria-hidden="true">•</span>
+                    <Link href={correction.pagePath} className="font-semibold text-brand-700 hover:underline">
+                      {correction.pagePath}
+                    </Link>
+                    <span aria-hidden="true">•</span>
+                    <span>Correction #{sequence} for this page</span>
+                  </div>
+                  <h3 className="mt-3 text-xl font-semibold text-ink">{correction.summary}</h3>
+                  <p className="mt-3 text-sm leading-7 text-muted"><strong className="text-ink">Reason:</strong> {correction.reason}</p>
+                  {correction.before || correction.after ? (
+                    <div className="mt-4 grid gap-3 md:grid-cols-2">
+                      {correction.before ? <p className="rounded-xl bg-rose-50 p-4 text-sm leading-6"><strong>Before:</strong> {correction.before}</p> : null}
+                      {correction.after ? <p className="rounded-xl bg-emerald-50 p-4 text-sm leading-6"><strong>After:</strong> {correction.after}</p> : null}
+                    </div>
+                  ) : null}
+                </article>
+              )
+            })}
+          </div>
+        )}
+      </section>
+
+      <section className="rounded-[2rem] border border-brand-900/10 bg-brand-50/60 p-6 sm:p-8">
+        <h2 className="text-2xl font-semibold text-ink">Found a problem?</h2>
+        <p className="mt-3 max-w-3xl text-sm leading-7 text-muted">
+          Please include the page URL, the exact statement you think is wrong or incomplete, and a primary
+          source when possible. A correction submission does not require sharing personal health information.
+        </p>
+        <Link href="/info/contact/?topic=correction" className="mt-5 inline-flex rounded-full bg-brand-800 px-5 py-2.5 text-sm font-bold text-white hover:bg-brand-900">
+          Flag an error →
+        </Link>
+      </section>
+    </main>
+  )
+}

--- a/app/info/editorial-policy/page.tsx
+++ b/app/info/editorial-policy/page.tsx
@@ -1,0 +1,186 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { buildPageMetadata } from '@/src/lib/seo'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Editorial, Evidence & Automation Policy',
+  description: 'Exact evidence grading, source inclusion, conflict resolution, branded-extract, safety, dosing, affiliate, AI automation, review, and correction standards used by The Hippie Scientist.',
+  path: '/info/editorial-policy/',
+  openGraphType: 'article',
+})
+
+const gradeRules = [
+  {
+    grade: 'A',
+    label: 'Strong',
+    rule: 'Requires a mature, direct human evidence base: replicated relevant human outcomes or a high-quality synthesis of relevant human trials, acceptable consistency, and no major directness problem that would make the public claim broader than the evidence.',
+  },
+  {
+    grade: 'B',
+    label: 'Moderate',
+    rule: 'Meaningful direct human evidence exists, but replication, precision, duration, population breadth, consistency, formulation match, or study quality still limits confidence.',
+  },
+  {
+    grade: 'C',
+    label: 'Limited',
+    rule: 'Human evidence is sparse, small, indirect, inconsistent, exploratory, or strongly dependent on a narrow preparation/population. Mechanistic or preclinical evidence may add plausibility but cannot promote a claim to B by itself.',
+  },
+  {
+    grade: 'D',
+    label: 'Preliminary',
+    rule: 'Evidence is mainly mechanistic, animal, in-vitro, traditional, uncontrolled, or otherwise too indirect to support a practical efficacy conclusion. The page may remain useful as a research reference.',
+  },
+  {
+    grade: 'Avoid / Insufficient',
+    label: 'Do not infer benefit',
+    rule: 'Evidence is absent, materially unfavorable, too unreliable to support the claim, or the practical framing is limited by a safety context that makes casual recommendation inappropriate. Safety certainty and efficacy certainty remain separate fields.',
+  },
+]
+
+const standards = [
+  {
+    title: 'Evidence inclusion',
+    body: 'Include sources that actually test or materially inform the ingredient, preparation, outcome, population, safety question, interaction, or mechanism being discussed. Primary human studies are preferred for efficacy claims; high-quality systematic reviews and meta-analyses can summarize a body of evidence.',
+  },
+  {
+    title: 'Evidence exclusion',
+    body: 'Do not count a paper toward a claim when it studies a different ingredient without a defensible bridge, only mentions the ingredient in background text, is duplicate reporting of the same study population, or cannot be identified well enough to audit. Retracted or invalidated work should not support a current conclusion.',
+  },
+  {
+    title: 'Conflicting studies',
+    body: 'Do not average disagreement into a falsely smooth conclusion. Separate supporting, mixed, null, and contradicting evidence, then inspect study quality, preparation, dose, population, duration, outcome definition, and risk of bias. Strong wording is reduced when material disagreement remains unresolved.',
+  },
+  {
+    title: 'Animal and mechanistic evidence',
+    body: 'Animal, cell, receptor, pathway, and biochemical evidence can explain plausibility or generate hypotheses. It does not establish a human benefit, an effective consumer dose, or clinical equivalence. Mechanism and outcome labels remain visibly separate.',
+  },
+  {
+    title: 'Branded extracts and specific forms',
+    body: 'Evidence from a specific branded extract, standardized preparation, plant part, salt, chelate, delivery system, or formulation is labeled as such. Findings are not generalized to every product sharing the ingredient name unless the evidence supports that generalization.',
+  },
+  {
+    title: 'Safety evidence',
+    body: 'Safety is evaluated independently from efficacy. Contraindications, adverse events, pregnancy/lactation concerns, organ-specific cautions, dependence potential, dose-related toxicity, and high-risk populations require source-backed treatment appropriate to the seriousness of the risk.',
+  },
+  {
+    title: 'Interaction evidence',
+    body: 'Documented clinical interactions, pharmacokinetic interactions, pharmacodynamic additive risks, case evidence, and theoretical mechanisms are not presented as equivalent. Missing interaction data means “no documented interaction in our dataset,” not “safe.”',
+  },
+  {
+    title: 'Dose selection',
+    body: 'Studied doses are reported as research context, not automatically as medical dosing advice. Preparation, extract standardization, elemental amount, route, population, and duration must match the statement. “No standardized medical dose” is distinct from “doses studied in trials.”',
+  },
+  {
+    title: 'Affiliate selection',
+    body: 'Commercial eligibility comes after evidence and safety evaluation. Product-quality criteria may consider formulation match, label clarity, clinically studied form, third-party testing, and reliability, but affiliate payout cannot change an evidence grade, safety flag, or scientific conclusion.',
+  },
+]
+
+const automationRules = [
+  'Structured workbook/database fields are transformed into pages, tables, relationships, indexes, and quality reports by code. That transformation is automation, not scientific judgment.',
+  'Automated systems may normalize terminology, retrieve citation metadata, detect contradictions, calculate completeness, flag suspicious claims, and prepare review queues.',
+  'Automation must not silently promote an evidence grade, invent reviewer credentials, create a medical-review claim, or turn missing safety information into reassurance.',
+  'Material scientific conclusions should remain traceable to structured claims and sources. Changes that could alter a reader’s interpretation belong in review/correction provenance.',
+  'AI-assisted drafting or extraction is treated as an intermediate process. Public claims remain subject to source, evidence-language, safety, and production-content validation.',
+]
+
+export default function EditorialPolicyPage() {
+  return (
+    <main className="container-page mx-auto max-w-5xl space-y-12 py-10">
+      <section className="hero-shell rounded-[2rem] border p-6 sm:p-8 lg:p-10">
+        <p className="eyebrow-label">Public scientific standard</p>
+        <h1 className="heading-premium mt-4">Editorial, evidence &amp; automation policy</h1>
+        <p className="text-reading mt-4 max-w-3xl">
+          This is the operational contract behind the research pages: what can raise confidence, what cannot,
+          how conflicting evidence is handled, what automation is allowed to do, and which commercial
+          incentives are forbidden from affecting scientific conclusions.
+        </p>
+        <div className="mt-6 flex flex-wrap gap-3">
+          <Link href="/info/methodology/" className="rounded-full bg-brand-800 px-5 py-2.5 text-sm font-bold text-white hover:bg-brand-900">
+            Methodology overview
+          </Link>
+          <Link href="/info/corrections/" className="rounded-full border border-brand-900/15 px-5 py-2.5 text-sm font-semibold text-ink hover:bg-brand-50">
+            Corrections history
+          </Link>
+        </div>
+      </section>
+
+      <section aria-labelledby="grade-rules-title">
+        <p className="eyebrow-label">Canonical grading rules</p>
+        <h2 id="grade-rules-title" className="mt-2 text-3xl font-semibold tracking-tight text-ink">A / B / C / D / Avoid–Insufficient</h2>
+        <p className="mt-3 max-w-3xl text-sm leading-7 text-muted">
+          Grades describe confidence in a defined claim or profile conclusion. A strong grade cannot be created
+          by citation volume, mechanistic plausibility, popularity, or commercial value alone.
+        </p>
+        <div className="mt-6 divide-y divide-brand-900/10 rounded-2xl border border-brand-900/10 bg-white">
+          {gradeRules.map(item => (
+            <article key={item.grade} className="grid gap-3 p-5 md:grid-cols-[150px_1fr]">
+              <div>
+                <span className="inline-flex rounded-full border border-brand-900/10 bg-brand-50 px-3 py-1 text-xs font-bold text-brand-800">{item.grade}</span>
+                <p className="mt-2 text-sm font-semibold text-ink">{item.label}</p>
+              </div>
+              <p className="text-sm leading-7 text-muted">{item.rule}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section aria-labelledby="standards-title">
+        <p className="eyebrow-label">Inclusion, interpretation &amp; safety</p>
+        <h2 id="standards-title" className="mt-2 text-3xl font-semibold tracking-tight text-ink">Rules that constrain the conclusion</h2>
+        <div className="mt-6 grid gap-5 md:grid-cols-2">
+          {standards.map(item => (
+            <article key={item.title} className="card-premium p-6">
+              <h3 className="text-lg font-semibold text-ink">{item.title}</h3>
+              <p className="mt-3 text-sm leading-7 text-muted">{item.body}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-[2rem] border border-brand-900/10 bg-brand-50/60 p-6 sm:p-8" aria-labelledby="automation-title">
+        <p className="eyebrow-label">AI &amp; editorial automation</p>
+        <h2 id="automation-title" className="mt-2 text-3xl font-semibold tracking-tight text-ink">Automation can transform evidence; it cannot manufacture authority</h2>
+        <ul className="mt-5 space-y-3 text-sm leading-7 text-muted">
+          {automationRules.map(rule => <li key={rule}>• {rule}</li>)}
+        </ul>
+      </section>
+
+      <section className="grid gap-5 md:grid-cols-2">
+        <article className="card-premium p-6">
+          <p className="eyebrow-label">External review</p>
+          <h2 className="mt-2 text-2xl font-semibold text-ink">Reviewer claims are conditional on real review events</h2>
+          <p className="mt-3 text-sm leading-7 text-muted">
+            A page may display an external reviewer’s identity, qualifications, and review date only when a real,
+            page-specific review event has been recorded. The site does not imply physician, pharmacist, dietitian,
+            or other professional review where it did not occur.
+          </p>
+        </article>
+        <article className="card-premium p-6">
+          <p className="eyebrow-label">Funding &amp; independence</p>
+          <h2 className="mt-2 text-2xl font-semibold text-ink">Evidence rankings are not for sale</h2>
+          <p className="mt-3 text-sm leading-7 text-muted">
+            Supplement companies cannot pay to raise or alter an evidence grade. Affiliate commissions cannot
+            alter evidence grades, safety conclusions, source selection, or the scientific inclusion threshold.
+            Product-quality scoring, when used, remains separate from efficacy evidence.
+          </p>
+        </article>
+      </section>
+
+      <section className="rounded-[2rem] border border-brand-900/10 bg-white p-6 shadow-sm sm:p-8">
+        <p className="eyebrow-label">Why trust this page?</p>
+        <h2 className="mt-2 text-2xl font-semibold text-ink">The standard is designed to be auditable</h2>
+        <p className="mt-3 max-w-3xl text-sm leading-7 text-muted">
+          The useful question is not whether a page sounds confident; it is whether its claims can be traced to
+          identifiable evidence, whether limitations remain visible, whether review dates represent actual review,
+          and whether material corrections remain public. Those are the constraints this policy is designed to enforce.
+        </p>
+        <div className="mt-5 flex flex-wrap gap-4 text-sm font-semibold">
+          <Link href="/learn/citation-explorer/" className="text-brand-700 hover:underline">Citation Explorer →</Link>
+          <Link href="/evidence/evidence-report/" className="text-brand-700 hover:underline">Evidence Report →</Link>
+          <Link href="/info/affiliate-disclosure/" className="text-brand-700 hover:underline">Affiliate disclosure →</Link>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/data/editorial/corrections.ts
+++ b/data/editorial/corrections.ts
@@ -1,0 +1,11 @@
+import type { PublicCorrectionRecord } from '@/lib/editorial-provenance'
+
+/**
+ * Public scientific/content corrections ledger.
+ *
+ * Append meaningful corrections instead of silently rewriting this history.
+ * `supersedes` may point to an older correction when a correction itself needs
+ * clarification. The empty initial ledger intentionally makes no fabricated
+ * correction claims.
+ */
+export const publicCorrections: PublicCorrectionRecord[] = []

--- a/data/editorial/review-history.ts
+++ b/data/editorial/review-history.ts
@@ -1,0 +1,13 @@
+import type { EditorialReviewRecord } from '@/lib/editorial-provenance'
+
+/**
+ * Public editorial review ledger.
+ *
+ * Append new review events. Do not rewrite an old event to make a page appear
+ * more recently reviewed. If a prior entry needs correction, add a new event
+ * that explains the correction in its summary.
+ *
+ * Empty is truthful: reviewer identity and qualifications are only displayed
+ * after a real review event is recorded here.
+ */
+export const editorialReviewHistory: EditorialReviewRecord[] = []

--- a/lib/__tests__/editorial-provenance.test.ts
+++ b/lib/__tests__/editorial-provenance.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getRecordedEditorialReviewDate,
+  getRecordedEvidenceSearchDate,
+  getRecordedFactualUpdateDate,
+  normalizeEditorialFreshness,
+  validateReviewRecord,
+} from '@/lib/editorial-provenance'
+
+describe('editorial provenance', () => {
+  it('does not treat generic build/update timestamps as editorial review events', () => {
+    expect(getRecordedEditorialReviewDate({
+      updatedAt: '2026-08-15',
+      last_updated: '2026-08-15',
+      buildUpdatedAt: '2026-08-15',
+    })).toBe('')
+  })
+
+  it('accepts explicit review and evidence-search dates independently', () => {
+    const record = {
+      editorial_reviewed_at: '2026-08-10',
+      evidence_search_date: '2026-08-09',
+      factual_updated_at: '2026-08-11',
+    }
+
+    expect(getRecordedEditorialReviewDate(record)).toBe('2026-08-10')
+    expect(getRecordedEvidenceSearchDate(record)).toBe('2026-08-09')
+    expect(getRecordedFactualUpdateDate(record)).toBe('2026-08-11')
+  })
+
+  it('keeps review, factual update, template update and citation count separate', () => {
+    expect(normalizeEditorialFreshness({
+      lastReviewed: '2026-08-01',
+      contentUpdatedAt: '2026-08-02',
+      templateUpdatedAt: '2026-08-03',
+    }, 12)).toEqual({
+      lastReviewed: '2026-08-01',
+      evidenceSearchDate: '',
+      factualUpdatedAt: '2026-08-02',
+      templateUpdatedAt: '2026-08-03',
+      citationCount: 12,
+    })
+  })
+
+  it('requires qualifications before an external review may be represented publicly', () => {
+    const errors = validateReviewRecord({
+      id: 'review-1',
+      pagePath: '/herbs/example/',
+      reviewedAt: '2026-08-10',
+      kind: 'external',
+      reviewerName: 'Example Reviewer',
+    })
+
+    expect(errors).toContain('review-1: external review cannot be presented without qualifications.')
+  })
+})

--- a/lib/editorial-provenance.ts
+++ b/lib/editorial-provenance.ts
@@ -1,0 +1,162 @@
+export type EditorialReviewKind = 'evidence' | 'safety' | 'factual' | 'external'
+
+export type EditorialReviewRecord = {
+  id: string
+  pagePath: string
+  reviewedAt: string
+  kind: EditorialReviewKind
+  reviewerName: string
+  reviewerRole?: string
+  qualifications?: string
+  evidenceSearchDate?: string
+  summary?: string
+}
+
+export type PublicCorrectionRecord = {
+  id: string
+  pagePath: string
+  publishedAt: string
+  summary: string
+  before?: string
+  after?: string
+  reason: string
+  sources?: string[]
+  supersedes?: string
+}
+
+export type EditorialFreshness = {
+  lastReviewed: string
+  evidenceSearchDate: string
+  factualUpdatedAt: string
+  templateUpdatedAt: string
+  citationCount: number
+}
+
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/
+const ISO_DATE_TIME = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/
+
+export function isValidEditorialDate(value: unknown): value is string {
+  if (typeof value !== 'string') return false
+  const clean = value.trim()
+  if (!clean || (!DATE_ONLY.test(clean) && !ISO_DATE_TIME.test(clean))) return false
+  return !Number.isNaN(Date.parse(clean))
+}
+
+function firstDate(record: Record<string, unknown>, keys: string[]): string {
+  for (const key of keys) {
+    const value = record[key]
+    if (isValidEditorialDate(value)) return value.trim()
+  }
+  return ''
+}
+
+/**
+ * Editorial review dates are intentionally fail-closed.
+ * Generic updated/build timestamps are NOT accepted as evidence that a human
+ * review happened. This prevents deployments and data transforms from
+ * masquerading as scientific review events.
+ */
+export function getRecordedEditorialReviewDate(record: Record<string, unknown>): string {
+  return firstDate(record, [
+    'editorial_reviewed_at',
+    'editorialReviewedAt',
+    'evidence_reviewed_at',
+    'evidenceReviewedAt',
+    'last_reviewed',
+    'lastReviewed',
+    'reviewed_at',
+    'reviewedAt',
+  ])
+}
+
+export function getRecordedEvidenceSearchDate(record: Record<string, unknown>): string {
+  return firstDate(record, [
+    'last_evidence_search_date',
+    'lastEvidenceSearchDate',
+    'evidence_search_date',
+    'evidenceSearchDate',
+    'literature_search_date',
+    'literatureSearchDate',
+  ])
+}
+
+/**
+ * A factual update is a content/data event, not a template or deployment event.
+ * Generic updatedAt is deliberately excluded because its semantics vary across
+ * legacy sources.
+ */
+export function getRecordedFactualUpdateDate(record: Record<string, unknown>): string {
+  return firstDate(record, [
+    'factual_updated_at',
+    'factualUpdatedAt',
+    'content_updated_at',
+    'contentUpdatedAt',
+    'data_updated_at',
+    'dataUpdatedAt',
+  ])
+}
+
+export function getRecordedTemplateUpdateDate(record: Record<string, unknown>): string {
+  return firstDate(record, [
+    'template_updated_at',
+    'templateUpdatedAt',
+    'build_updated_at',
+    'buildUpdatedAt',
+  ])
+}
+
+export function normalizeEditorialFreshness(
+  record: Record<string, unknown>,
+  citationCount = 0,
+): EditorialFreshness {
+  return {
+    lastReviewed: getRecordedEditorialReviewDate(record),
+    evidenceSearchDate: getRecordedEvidenceSearchDate(record),
+    factualUpdatedAt: getRecordedFactualUpdateDate(record),
+    templateUpdatedAt: getRecordedTemplateUpdateDate(record),
+    citationCount: Number.isFinite(citationCount) && citationCount > 0 ? Math.floor(citationCount) : 0,
+  }
+}
+
+export function validateReviewRecord(record: EditorialReviewRecord): string[] {
+  const errors: string[] = []
+  if (!record.id.trim()) errors.push('Review record is missing id.')
+  if (!record.pagePath.startsWith('/')) errors.push(`${record.id}: pagePath must be site-relative.`)
+  if (!isValidEditorialDate(record.reviewedAt)) errors.push(`${record.id}: reviewedAt is invalid.`)
+  if (!record.reviewerName.trim()) errors.push(`${record.id}: reviewerName is required.`)
+  if (record.kind === 'external' && !record.qualifications?.trim()) {
+    errors.push(`${record.id}: external review cannot be presented without qualifications.`)
+  }
+  if (record.evidenceSearchDate && !isValidEditorialDate(record.evidenceSearchDate)) {
+    errors.push(`${record.id}: evidenceSearchDate is invalid.`)
+  }
+  return errors
+}
+
+export function validateCorrectionRecord(record: PublicCorrectionRecord): string[] {
+  const errors: string[] = []
+  if (!record.id.trim()) errors.push('Correction record is missing id.')
+  if (!record.pagePath.startsWith('/')) errors.push(`${record.id}: pagePath must be site-relative.`)
+  if (!isValidEditorialDate(record.publishedAt)) errors.push(`${record.id}: publishedAt is invalid.`)
+  if (!record.summary.trim()) errors.push(`${record.id}: summary is required.`)
+  if (!record.reason.trim()) errors.push(`${record.id}: reason is required.`)
+  return errors
+}
+
+export function latestReviewForPage(
+  reviews: EditorialReviewRecord[],
+  pagePath: string,
+): EditorialReviewRecord | undefined {
+  return reviews
+    .filter(review => review.pagePath === pagePath)
+    .sort((a, b) => Date.parse(b.reviewedAt) - Date.parse(a.reviewedAt))[0]
+}
+
+export function correctionsForPage(
+  corrections: PublicCorrectionRecord[],
+  pagePath: string,
+): PublicCorrectionRecord[] {
+  return corrections
+    .filter(correction => correction.pagePath === pagePath)
+    .sort((a, b) => Date.parse(b.publishedAt) - Date.parse(a.publishedAt))
+}

--- a/lib/freshness.ts
+++ b/lib/freshness.ts
@@ -1,29 +1,35 @@
 import freshnessData from '@/public/data/freshness-metadata.json'
 
-interface FreshnessInfo {
+export interface FreshnessInfo {
   lastReviewed: string
+  evidenceSearchDate: string
+  factualUpdatedAt: string
+  templateUpdatedAt: string
   citationCount: number
 }
 
-export function getHomepageFreshness(): FreshnessInfo {
+type PartialFreshnessInfo = Partial<FreshnessInfo>
+
+function normalizeFreshness(info: PartialFreshnessInfo | undefined): FreshnessInfo {
   return {
-    lastReviewed: freshnessData.homepage.lastReviewed,
-    citationCount: freshnessData.homepage.citationCount,
+    lastReviewed: info?.lastReviewed || '',
+    evidenceSearchDate: info?.evidenceSearchDate || '',
+    factualUpdatedAt: info?.factualUpdatedAt || '',
+    templateUpdatedAt: info?.templateUpdatedAt || '',
+    citationCount: info?.citationCount || 0,
   }
+}
+
+export function getHomepageFreshness(): FreshnessInfo {
+  return normalizeFreshness(freshnessData.homepage as PartialFreshnessInfo)
 }
 
 export function getGoalFreshness(goalSlug: string): FreshnessInfo {
-  const goal = (freshnessData.goals as Record<string, FreshnessInfo>)[goalSlug]
-  return {
-    lastReviewed: goal?.lastReviewed || '',
-    citationCount: goal?.citationCount || 0,
-  }
+  const goal = (freshnessData.goals as Record<string, PartialFreshnessInfo>)[goalSlug]
+  return normalizeFreshness(goal)
 }
 
 export function getProfileFreshness(slug: string): FreshnessInfo {
-  const profile = (freshnessData.profiles as Record<string, FreshnessInfo>)[slug]
-  return {
-    lastReviewed: profile?.lastReviewed || '',
-    citationCount: profile?.citationCount || 0,
-  }
+  const profile = (freshnessData.profiles as Record<string, PartialFreshnessInfo>)[slug]
+  return normalizeFreshness(profile)
 }

--- a/scripts/data/generate-freshness-metadata.mjs
+++ b/scripts/data/generate-freshness-metadata.mjs
@@ -1,311 +1,276 @@
 #!/usr/bin/env node
 
-import fs from 'node:fs';
-import path from 'node:path';
-import { readWorkbook, getSheet, sheetToRows } from './workbook-parser.mjs';
+import fs from 'node:fs'
+import path from 'node:path'
+import { readWorkbook, getSheet, sheetToRows } from './workbook-parser.mjs'
 
-const ROOT = process.cwd();
-const DATA_DIR = path.join(ROOT, 'public', 'data');
-const WORKBOOK_PATH = path.join(ROOT, 'data-sources', 'herb_monograph_master.xlsx');
-const OUTPUT_FILE = path.join(DATA_DIR, 'freshness-metadata.json');
+const ROOT = process.cwd()
+const DATA_DIR = path.join(ROOT, 'public', 'data')
+const WORKBOOK_PATH = path.join(ROOT, 'data-sources', 'herb_monograph_master.xlsx')
+const OUTPUT_FILE = path.join(DATA_DIR, 'freshness-metadata.json')
+
+const REVIEW_DATE_FIELDS = [
+  'editorial_reviewed_at',
+  'editorialReviewedAt',
+  'evidence_reviewed_at',
+  'evidenceReviewedAt',
+  'last_reviewed',
+  'lastReviewed',
+  'reviewed_at',
+  'reviewedAt',
+]
+const EVIDENCE_SEARCH_FIELDS = [
+  'last_evidence_search_date',
+  'lastEvidenceSearchDate',
+  'evidence_search_date',
+  'evidenceSearchDate',
+  'literature_search_date',
+  'literatureSearchDate',
+]
+const FACTUAL_UPDATE_FIELDS = [
+  'factual_updated_at',
+  'factualUpdatedAt',
+  'content_updated_at',
+  'contentUpdatedAt',
+  'data_updated_at',
+  'dataUpdatedAt',
+]
+const TEMPLATE_UPDATE_FIELDS = [
+  'template_updated_at',
+  'templateUpdatedAt',
+  'build_updated_at',
+  'buildUpdatedAt',
+]
 
 function parsePmid(value) {
-  if (!value) return undefined;
-  const match = String(value).match(/\b(\d{7,8})\b/);
-  return match?.[1];
+  if (!value) return undefined
+  const match = String(value).match(/\b(\d{7,8})\b/)
+  return match?.[1]
 }
 
-function getRecordedReviewDate(record) {
-  if (!record || typeof record !== 'object') return '';
-  return String(
-    record.last_reviewed ||
-      record.lastReviewed ||
-      record.reviewed_at ||
-      record.reviewedAt ||
-      record.last_updated ||
-      record.lastUpdated ||
-      record.updated_at ||
-      record.updatedAt ||
-      '',
-  ).trim();
+function validDate(value) {
+  if (!value) return ''
+  const clean = String(value).trim()
+  if (!clean || Number.isNaN(Date.parse(clean))) return ''
+  return clean
 }
 
-// Extract citations from a JSON record
+function firstDate(record, fields) {
+  if (!record || typeof record !== 'object') return ''
+  for (const field of fields) {
+    const value = validDate(record[field])
+    if (value) return value
+  }
+  return ''
+}
+
+/**
+ * Review freshness is fail-closed. Generic last_updated/updatedAt fields are
+ * intentionally excluded because deployments, migrations, and data transforms
+ * can touch them without any editorial/scientific review taking place.
+ */
+function getFreshness(record, citationCount) {
+  return {
+    lastReviewed: firstDate(record, REVIEW_DATE_FIELDS),
+    evidenceSearchDate: firstDate(record, EVIDENCE_SEARCH_FIELDS),
+    factualUpdatedAt: firstDate(record, FACTUAL_UPDATE_FIELDS),
+    templateUpdatedAt: firstDate(record, TEMPLATE_UPDATE_FIELDS),
+    citationCount,
+  }
+}
+
 function extractCitationsFromRecord(record) {
-  const results = [];
-  const parsePmidLocal = (val) => {
-    const m = String(val || '').match(/\b(\d{7,8})\b/);
-    return m?.[1];
-  };
+  const results = []
 
-  const addCit = (title, pmid, year, authors) => {
-    if (!title && !pmid) return;
-    const cleanTitle = String(title || '').trim();
-    const cleanPmid = cleanPmidField(pmid || parsePmidLocal(cleanTitle));
-    const key = cleanPmid || cleanTitle;
-    if (key && !results.some(c => (cleanPmid && c.pmid === cleanPmid) || c.title === cleanTitle)) {
-      results.push({ title: cleanTitle, pmid: cleanPmid, year, authors });
-    }
-  };
+  const addCitation = (title, pmid, year, authors) => {
+    if (!title && !pmid) return
+    const cleanTitle = String(title || '').trim()
+    const cleanPmid = parsePmid(pmid || cleanTitle)
+    const duplicate = results.some(citation =>
+      (cleanPmid && citation.pmid === cleanPmid) ||
+      (!cleanPmid && cleanTitle && citation.title === cleanTitle),
+    )
+    if (!duplicate) results.push({ title: cleanTitle, pmid: cleanPmid, year, authors })
+  }
 
-  const cleanPmidField = (val) => {
-    if (!val) return undefined;
-    const m = String(val).match(/\b(\d{7,8})\b/);
-    return m?.[1];
-  };
-
-  // Process sources
-  if (Array.isArray(record?.sources)) {
-    for (const src of record.sources) {
-      if (!src) continue;
-      if (typeof src === 'string') {
-        addCit(src, parsePmidLocal(src));
-      } else if (typeof src === 'object') {
-        addCit(src.title || src.citation || src.ref, src.pmid || src.pubmedId, src.year, src.authors);
-      }
+  for (const source of Array.isArray(record?.sources) ? record.sources : []) {
+    if (!source) continue
+    if (typeof source === 'string') addCitation(source, source)
+    else if (typeof source === 'object') {
+      addCitation(source.title || source.citation || source.ref, source.pmid || source.pubmedId, source.year, source.authors)
     }
   }
 
-  // Process references
-  if (Array.isArray(record?.references)) {
-    for (const ref of record.references) {
-      if (!ref) continue;
-      if (typeof ref === 'string') {
-        addCit(ref, parsePmidLocal(ref));
-      } else if (typeof ref === 'object') {
-        addCit(ref.title || ref.citation || ref.ref, ref.pmid || ref.pubmedId, ref.year, ref.authors);
-      }
+  for (const reference of Array.isArray(record?.references) ? record.references : []) {
+    if (!reference) continue
+    if (typeof reference === 'string') addCitation(reference, reference)
+    else if (typeof reference === 'object') {
+      addCitation(reference.title || reference.citation || reference.ref, reference.pmid || reference.pubmedId, reference.year, reference.authors)
     }
   }
 
-  // Process pmids
-  if (Array.isArray(record?.pmids)) {
-    for (const pmid of record.pmids) {
-      if (!pmid) continue;
-      const id = String(pmid).trim();
-      addCit(`PubMed ${id}`, id);
-    }
+  for (const pmid of Array.isArray(record?.pmids) ? record.pmids : []) {
+    if (pmid) addCitation(`PubMed ${String(pmid).trim()}`, pmid)
   }
 
-  return results;
+  return results
 }
 
-// Load Study Registry sheet from workbook (supports both old and new consolidated formats)
 async function loadStudyRegistryCitations() {
   if (!fs.existsSync(WORKBOOK_PATH)) {
-    console.warn('[freshness-metadata] Workbook not found at:', WORKBOOK_PATH);
-    return {};
+    console.warn('[freshness-metadata] Workbook not found at:', WORKBOOK_PATH)
+    return {}
   }
 
-  let wb;
+  let workbook
   try {
-    wb = await readWorkbook(WORKBOOK_PATH);
-  } catch (err) {
-    console.warn('[freshness-metadata] Could not read workbook:', err.message);
-    return {};
+    workbook = await readWorkbook(WORKBOOK_PATH)
+  } catch (error) {
+    console.warn('[freshness-metadata] Could not read workbook:', error.message)
+    return {}
   }
 
-  // Support both old 'Study Registry' and new 'Evidence_Register' / 'Sheet8'
-  const sheetCandidates = ['Study Registry', 'Evidence_Register', 'Sheet8'];
-  const sheetName = sheetCandidates.find((name) => getSheet(wb, name));
+  const sheetCandidates = ['Study Registry', 'Evidence_Register', 'Sheet8']
+  const sheetName = sheetCandidates.find(name => getSheet(workbook, name))
   if (!sheetName) {
-    console.warn('[freshness-metadata] No study registry sheet found');
-    return {};
+    console.warn('[freshness-metadata] No study registry sheet found')
+    return {}
   }
 
-  const rows = sheetToRows(getSheet(wb, sheetName));
-  const results = {};
+  const results = {}
+  for (const row of sheetToRows(getSheet(workbook, sheetName))) {
+    const slug = String(row.compound_slug || row.slug || row.herb_slug || row.entity_slug || '').trim().toLowerCase()
+    const source = String(row.pmid_or_source || row.pmid || row.doi || row.url_or_source || row.source || '').trim()
+    const notes = String(row.notes || row.study_title || row.title || row.supported_claim_language || '').trim()
+    const studyType = String(row.study_type || row.evidence_type || '').trim()
+    if (!slug || !source) continue
 
-  for (const row of rows) {
-    const slug = String(row.compound_slug || row.slug || row.herb_slug || row.entity_slug || '').trim().toLowerCase();
-    const pmidOrSource = String(row.pmid_or_source || row.pmid || row.doi || row.url_or_source || row.source || '').trim();
-    const notes = String(row.notes || row.study_title || row.title || row.supported_claim_language || '').trim();
-    const studyType = String(row.study_type || row.evidence_type || '').trim();
-
-    if (!slug || !pmidOrSource) continue;
-
-    const pmid = parsePmid(pmidOrSource);
-    const title = pmid ? `PubMed ${pmid}` : pmidOrSource;
-
-    if (!results[slug]) results[slug] = [];
-    const list = results[slug];
-    if (!list.some(c => (pmid && c.pmid === pmid) || c.title === title)) {
-      list.push({ title: notes || title, pmid, studyType });
+    const pmid = parsePmid(source)
+    const title = notes || (pmid ? `PubMed ${pmid}` : source)
+    if (!results[slug]) results[slug] = []
+    if (!results[slug].some(citation => (pmid && citation.pmid === pmid) || citation.title === title)) {
+      results[slug].push({ title, pmid, studyType })
     }
   }
 
-  return results;
+  return results
 }
 
-// Parse goals and option slugs from data/goals.ts
 function parseGoalsConfig() {
-  const goalsFilePath = path.join(ROOT, 'data', 'goals.ts');
-  if (!fs.existsSync(goalsFilePath)) {
-    console.warn('[freshness-metadata] goals.ts not found');
-    return [];
+  const goalsFilePath = path.join(ROOT, 'data', 'goals.ts')
+  if (!fs.existsSync(goalsFilePath)) return []
+
+  const content = fs.readFileSync(goalsFilePath, 'utf8')
+  const goals = []
+  const goalBlockRegex = /slug:\s*'([^']+)',[\s\S]*?options:\s*\[([\s\S]*?)\]/g
+  let match
+
+  while ((match = goalBlockRegex.exec(content)) !== null) {
+    const optionSlugs = []
+    const optionRegex = /slug:\s*'([^']+)'/g
+    let optionMatch
+    while ((optionMatch = optionRegex.exec(match[2])) !== null) optionSlugs.push(optionMatch[1])
+    goals.push({ slug: match[1], options: optionSlugs })
   }
 
-  const content = fs.readFileSync(goalsFilePath, 'utf8');
-  const goals = [];
-  
-  // Match each goal block
-  const goalBlockRegex = /slug:\s*'([^']+)',[\s\S]*?options:\s*\[([\s\S]*?)\]/g;
-  let match;
-  while ((match = goalBlockRegex.exec(content)) !== null) {
-    const goalSlug = match[1];
-    const optionsBlock = match[2];
-    
-    // Find options inside this block
-    const optionSlugs = [];
-    const optionRegex = /slug:\s*'([^']+)'/g;
-    let optMatch;
-    while ((optMatch = optionRegex.exec(optionsBlock)) !== null) {
-      optionSlugs.push(optMatch[1]);
+  return goals
+}
+
+function readJson(filePath, fallback) {
+  if (!fs.existsSync(filePath)) return fallback
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+}
+
+function combineCitations(...lists) {
+  const combined = []
+  for (const list of lists) {
+    for (const citation of list || []) {
+      const duplicate = combined.some(existing =>
+        (citation.pmid && existing.pmid === citation.pmid) ||
+        (!citation.pmid && citation.title && existing.title === citation.title),
+      )
+      if (!duplicate) combined.push(citation)
     }
-    
-    goals.push({
-      slug: goalSlug,
-      options: optionSlugs
-    });
   }
-  
-  return goals;
+  return combined
 }
 
 async function main() {
-  console.log('[freshness-metadata] Starting metadata compilation...');
-  
-  const studyRegistry = await loadStudyRegistryCitations();
-  const goalsConfig = parseGoalsConfig();
-  
-  // Load herbs and compounds lists
-  const herbsFile = path.join(DATA_DIR, 'herbs.json');
-  const compoundsFile = path.join(DATA_DIR, 'compounds.json');
-  
-  const herbs = fs.existsSync(herbsFile) ? JSON.parse(fs.readFileSync(herbsFile, 'utf8')) : [];
-  const compounds = fs.existsSync(compoundsFile) ? JSON.parse(fs.readFileSync(compoundsFile, 'utf8')) : [];
+  console.log('[freshness-metadata] Starting truthful freshness compilation...')
 
-  // Load all evidence engines
-  const goalSlugs = ['sleep', 'stress', 'focus', 'anxiety'];
-  const engines = {};
-  for (const g of goalSlugs) {
-    const p = path.join(DATA_DIR, 'evidence-engine', `${g}.json`);
-    if (fs.existsSync(p)) {
-      engines[g] = JSON.parse(fs.readFileSync(p, 'utf8'));
-    }
+  const studyRegistry = await loadStudyRegistryCitations()
+  const goalsConfig = parseGoalsConfig()
+  const herbs = readJson(path.join(DATA_DIR, 'herbs.json'), [])
+  const compounds = readJson(path.join(DATA_DIR, 'compounds.json'), [])
+
+  const engines = {}
+  for (const goal of ['sleep', 'stress', 'focus', 'anxiety']) {
+    const enginePath = path.join(DATA_DIR, 'evidence-engine', `${goal}.json`)
+    if (fs.existsSync(enginePath)) engines[goal] = readJson(enginePath, {})
   }
 
-  // Get citations from evidence engines for a specific slug
   function getEngineCitationsForSlug(slug) {
-    const citations = [];
-    const seen = new Set();
-    
+    const citations = []
     for (const engine of Object.values(engines)) {
-      const claims = engine.claims || [];
-      const sourcesByClaim = engine.sourcesByClaim || {};
-      
-      for (const claim of claims) {
-        if (claim.ingredient_slug === slug || claim.ingredientSlug === slug) {
-          const sources = sourcesByClaim[claim.claim_id] || sourcesByClaim[claim.claimId] || [];
-          for (const s of sources) {
-            const title = s.title || s.citation || '';
-            const pmid = s.pmid || parsePmid(s.url) || parsePmid(title);
-            const key = pmid || title;
-            if (key && !seen.has(key)) {
-              seen.add(key);
-              citations.push({ title, pmid, year: s.year, authors: s.authors || s.citation_label });
-            }
-          }
+      const sourcesByClaim = engine.sourcesByClaim || {}
+      for (const claim of engine.claims || []) {
+        if (claim.ingredient_slug !== slug && claim.ingredientSlug !== slug) continue
+        const sources = sourcesByClaim[claim.claim_id] || sourcesByClaim[claim.claimId] || []
+        for (const source of sources) {
+          const title = source.title || source.citation || ''
+          citations.push({
+            title,
+            pmid: source.pmid || parsePmid(source.url) || parsePmid(title),
+            year: source.year,
+            authors: source.authors || source.citation_label,
+          })
         }
       }
     }
-    return citations;
+    return combineCitations(citations)
   }
 
   const metadata = {
     homepage: {
+      // This is an explicitly maintained editorial date, not a deployment time.
       lastReviewed: '2026-06-06',
-      citationCount: 0
+      evidenceSearchDate: '',
+      factualUpdatedAt: '',
+      templateUpdatedAt: '',
+      citationCount: 0,
     },
     goals: {},
-    profiles: {}
-  };
-
-  const allUniqueStudies = [];
-  const addUniqueStudy = (cit) => {
-    const key = cit.pmid || cit.title;
-    if (key && !allUniqueStudies.some(c => (cit.pmid && c.pmid === cit.pmid) || c.title === cit.title)) {
-      allUniqueStudies.push(cit);
-    }
-  };
-
-  // Compile Profile Freshness & Citations
-  console.log('[freshness-metadata] Processing herbs...');
-  for (const h of herbs) {
-    const detailPath = path.join(DATA_DIR, 'herbs-detail', `${h.slug}.json`);
-    let detail = {};
-    if (fs.existsSync(detailPath)) {
-      detail = JSON.parse(fs.readFileSync(detailPath, 'utf8'));
-    }
-    
-    const merged = { ...h, ...detail };
-    const recordCits = extractCitationsFromRecord(merged);
-    const engineCits = getEngineCitationsForSlug(h.slug);
-    const registryCits = studyRegistry[h.slug] || [];
-    
-    // Combine and deduplicate
-    const combined = [...recordCits];
-    const addList = [...engineCits, ...registryCits];
-    for (const ec of addList) {
-      if (!combined.some(c => (ec.pmid && c.pmid === ec.pmid) || (ec.title && c.title === ec.title))) {
-        combined.push(ec);
-      }
-    }
-    
-    // Add to global list
-    combined.forEach(addUniqueStudy);
-    
-    metadata.profiles[h.slug] = {
-      lastReviewed: getRecordedReviewDate(merged),
-      citationCount: combined.length
-    };
+    profiles: {},
   }
 
-  console.log('[freshness-metadata] Processing compounds...');
-  for (const c of compounds) {
-    const detailPath = path.join(DATA_DIR, 'compounds-detail', `${c.slug}.json`);
-    let detail = {};
-    if (fs.existsSync(detailPath)) {
-      detail = JSON.parse(fs.readFileSync(detailPath, 'utf8'));
+  const allUniqueStudies = []
+  const addUniqueStudies = citations => {
+    for (const citation of citations) {
+      const duplicate = allUniqueStudies.some(existing =>
+        (citation.pmid && existing.pmid === citation.pmid) ||
+        (!citation.pmid && citation.title && existing.title === citation.title),
+      )
+      if (!duplicate) allUniqueStudies.push(citation)
     }
-    
-    const merged = { ...c, ...detail };
-    const recordCits = extractCitationsFromRecord(merged);
-    const engineCits = getEngineCitationsForSlug(c.slug);
-    const registryCits = studyRegistry[c.slug] || [];
-    
-    // Combine and deduplicate
-    const combined = [...recordCits];
-    const addList = [...engineCits, ...registryCits];
-    for (const ec of addList) {
-      if (!combined.some(rc => (ec.pmid && rc.pmid === ec.pmid) || (ec.title && rc.title === ec.title))) {
-        combined.push(ec);
-      }
-    }
-    
-    // Add to global list
-    combined.forEach(addUniqueStudy);
-    
-    metadata.profiles[c.slug] = {
-      lastReviewed: getRecordedReviewDate(merged),
-      citationCount: combined.length
-    };
   }
 
-  // Compile Goal Pathway Freshness & Citations
-  console.log('[freshness-metadata] Processing goals...');
-  
-  // Mapping of goals to Authority Freshness Registry dates
+  for (const [kind, records] of [['herbs', herbs], ['compounds', compounds]]) {
+    console.log(`[freshness-metadata] Processing ${kind}...`)
+    for (const record of records) {
+      const detailPath = path.join(DATA_DIR, `${kind}-detail`, `${record.slug}.json`)
+      const detail = readJson(detailPath, {})
+      const merged = { ...record, ...detail }
+      const citations = combineCitations(
+        extractCitationsFromRecord(merged),
+        getEngineCitationsForSlug(record.slug),
+        studyRegistry[record.slug] || [],
+      )
+
+      addUniqueStudies(citations)
+      metadata.profiles[record.slug] = getFreshness(merged, citations.length)
+    }
+  }
+
   const goalRegistryDates = {
     sleep: '2026-05-10',
     stress: '2026-05-10',
@@ -315,67 +280,58 @@ async function main() {
     longevity: '2026-05-10',
     cognition: '2026-05-10',
     inflammation: '2026-05-10',
-    pain: '2026-05-10'
-  };
+    pain: '2026-05-10',
+  }
 
   for (const goal of goalsConfig) {
-    const goalCitations = [];
-    const addGoalCitations = (cit) => {
-      const key = cit.pmid || cit.title;
-      if (key && !goalCitations.some(c => (cit.pmid && c.pmid === cit.pmid) || c.title === cit.title)) {
-        goalCitations.push(cit);
-      }
-    };
-    
-    // 1. Add citations from the goal options
-    for (const optSlug of goal.options) {
-      // Find herb or compound detail
-      let detail = {};
-      const herbDetailPath = path.join(DATA_DIR, 'herbs-detail', `${optSlug}.json`);
-      const compDetailPath = path.join(DATA_DIR, 'compounds-detail', `${optSlug}.json`);
-      
-      if (fs.existsSync(herbDetailPath)) {
-        detail = JSON.parse(fs.readFileSync(herbDetailPath, 'utf8'));
-      } else if (fs.existsSync(compDetailPath)) {
-        detail = JSON.parse(fs.readFileSync(compDetailPath, 'utf8'));
-      }
-      
-      const recordCits = extractCitationsFromRecord(detail);
-      const registryCits = studyRegistry[optSlug] || [];
-      const engineCits = getEngineCitationsForSlug(optSlug);
-      
-      [...recordCits, ...registryCits, ...engineCits].forEach(addGoalCitations);
+    const goalCitations = []
+    for (const optionSlug of goal.options) {
+      const herbDetail = path.join(DATA_DIR, 'herbs-detail', `${optionSlug}.json`)
+      const compoundDetail = path.join(DATA_DIR, 'compounds-detail', `${optionSlug}.json`)
+      const detail = fs.existsSync(herbDetail)
+        ? readJson(herbDetail, {})
+        : readJson(compoundDetail, {})
+      goalCitations.push(
+        ...extractCitationsFromRecord(detail),
+        ...(studyRegistry[optionSlug] || []),
+        ...getEngineCitationsForSlug(optionSlug),
+      )
     }
-    
-    // 2. Add citations from the goal's specific evidence engine sources
-    const engine = engines[goal.slug];
+
+    const engine = engines[goal.slug]
     if (engine) {
-      const sourcesByClaim = engine.sourcesByClaim || {};
-      for (const sources of Object.values(sourcesByClaim)) {
-        for (const s of sources) {
-          const title = s.title || s.citation || '';
-          const pmid = s.pmid || parsePmid(s.url) || parsePmid(title);
-          addGoalCitations({ title, pmid, year: s.year, authors: s.authors });
+      for (const sources of Object.values(engine.sourcesByClaim || {})) {
+        for (const source of sources) {
+          const title = source.title || source.citation || ''
+          goalCitations.push({
+            title,
+            pmid: source.pmid || parsePmid(source.url) || parsePmid(title),
+            year: source.year,
+            authors: source.authors,
+          })
         }
       }
     }
-    
+
     metadata.goals[goal.slug] = {
       lastReviewed: goalRegistryDates[goal.slug] || '',
-      citationCount: goalCitations.length
-    };
+      evidenceSearchDate: '',
+      factualUpdatedAt: '',
+      templateUpdatedAt: '',
+      citationCount: combineCitations(goalCitations).length,
+    }
   }
 
-  // Set homepage stats
-  metadata.homepage.citationCount = allUniqueStudies.length;
-  
-  // Write result to file
-  fs.writeFileSync(OUTPUT_FILE, JSON.stringify(metadata, null, 2) + '\n', 'utf8');
-  console.log(`[freshness-metadata] Successfully compiled and wrote freshness metadata to: ${OUTPUT_FILE}`);
-  console.log(`[freshness-metadata] Homepage: ${metadata.homepage.lastReviewed} • ${metadata.homepage.citationCount} human studies cited`);
+  metadata.homepage.citationCount = allUniqueStudies.length
+  fs.writeFileSync(OUTPUT_FILE, `${JSON.stringify(metadata, null, 2)}\n`, 'utf8')
+
+  const reviewedProfiles = Object.values(metadata.profiles).filter(profile => profile.lastReviewed).length
+  console.log(`[freshness-metadata] Wrote ${OUTPUT_FILE}`)
+  console.log(`[freshness-metadata] ${reviewedProfiles}/${Object.keys(metadata.profiles).length} profiles have an explicit editorial review date`)
+  console.log(`[freshness-metadata] ${metadata.homepage.citationCount} unique cited sources in the compiled library`)
 }
 
-main().catch((error) => {
-  console.error('[freshness-metadata] Compilation failed:', error);
-  process.exit(1);
-});
+main().catch(error => {
+  console.error('[freshness-metadata] Compilation failed:', error)
+  process.exit(1)
+})

--- a/src/components/editorial/LastUpdatedBadge.tsx
+++ b/src/components/editorial/LastUpdatedBadge.tsx
@@ -24,10 +24,11 @@ export default function LastUpdatedBadge({
 }: LastUpdatedBadgeProps) {
   const formatted = formatReviewDate(date)
   if (!formatted) return null
+  const sourceLabel = citationCount === 1 ? 'source cited' : 'sources cited'
 
   return (
     <p
-      aria-label={`${label}: ${formatted}${citationCount ? `. ${citationCount} human studies cited.` : ''}`}
+      aria-label={`${label}: ${formatted}${citationCount ? `. ${citationCount} ${sourceLabel}.` : ''}`}
       className={`inline-flex items-center gap-2 rounded-full border border-brand-900/10 bg-white/80 px-3 py-1 text-xs font-semibold text-muted ${className}`}
     >
       <span className='h-1.5 w-1.5 rounded-full bg-[var(--color-evidence-strong)]' aria-hidden='true' />
@@ -36,7 +37,7 @@ export default function LastUpdatedBadge({
         {citationCount !== undefined && citationCount > 0 ? (
           <>
             <span className='mx-1.5 text-muted/30'>•</span>
-            <span>{citationCount} human studies cited</span>
+            <span>{citationCount} {sourceLabel}</span>
           </>
         ) : null}
       </span>


### PR DESCRIPTION
Implements the 169–200 editorial trust/provenance tranche.

### Provenance and review truthfulness
- review dates now fail closed: generic `last_updated` / `updatedAt` build/data timestamps no longer count as editorial review events
- freshness metadata distinguishes editorial review, evidence-search date, factual update, and template/build update
- adds reusable review/correction provenance types and validation
- external review records require real reviewer identity and qualifications before they can be represented
- adds source-controlled append-only review and correction ledgers without fabricating historical entries

### Public accountability
- adds `/info/corrections/` with a conspicuous correction/missing-study submission path
- defines which changes require a public correction versus routine copy/template edits
- empty correction ledger is presented truthfully rather than inventing history

### Exact standards
- adds `/info/editorial-policy/` with canonical A/B/C/D/Avoid–Insufficient grading rules
- publishes source inclusion/exclusion rules
- publishes conflict-resolution rules and explicit heterogeneity handling
- separates animal/mechanistic evidence from human outcomes
- publishes branded-extract/form generalization rules
- publishes safety, interaction, dose-selection, and affiliate-selection standards
- publishes AI/editorial automation policy and explains structured workbook/database transformation vs scientific judgment
- states that companies cannot pay to alter rankings and affiliate commission cannot alter evidence grades
- reviewer claims are conditional on real recorded review events

### Tests
- regression coverage ensures build/update timestamps cannot masquerade as reviews and external review cannot be represented without qualifications.