### PR TITLE
research: rebuild berberine weight-loss guide with 2026 comparison integrity

### DIFF
--- a/app/guides/other/berberine-weight-loss/page.tsx
+++ b/app/guides/other/berberine-weight-loss/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from 'next'
-import RecommendationSection from '@/components/RecommendationSection'
-import { getRevenueProductSet } from '@/config/revenue-products'
 import Link from 'next/link'
 import Image from 'next/image'
+import RecommendationSection from '@/components/RecommendationSection'
+import { getRevenueProductSet } from '@/config/revenue-products'
 import { buildPageMetadata } from '../../../../src/lib/seo'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
@@ -11,80 +11,299 @@ import References from '@/components/References'
 import EmailCapture from '../../../../components/EmailCapture'
 
 export const metadata: Metadata = buildPageMetadata({
-  title: 'Berberine for Weight Loss: Evidence, Dosing & Safety (2026)',
-  description: 'Berberine is called nature\'s Ozempic, but what does the evidence actually show? Review of 6 clinical trials on berberine for weight loss, metabolic health, and safety.',
+  title: 'Berberine for Weight Loss: 2026 Evidence vs “Nature’s Ozempic”',
+  description:
+    'The 2026 berberine meta-analysis found modest average weight loss. See why “nature’s Ozempic” is misleading, how semaglutide comparisons should be made, interaction evidence, and product-quality limits.',
   path: '/guides/other/berberine-weight-loss/',
   openGraphType: 'article',
 })
 
 const FAQS = [
-  { question: 'Does berberine actually cause weight loss?', answer: 'Modestly. A 2020 meta-analysis of 12 RCTs found berberine reduced BMI by 0.5 kg/m2 and body weight by 2 kg over 12 weeks compared to placebo [1]. Effects are small and most pronounced in people with metabolic syndrome. Berberine is not comparable to GLP-1 agonists (semaglutide produces 10-15% body weight loss). The "nature\'s Ozempic" label is misleading marketing.' },
-  { question: 'How does berberine work for weight loss?', answer: 'Berberine activates AMPK — the same enzyme metformin targets — which increases glucose uptake, improves insulin sensitivity, and reduces hepatic gluconeogenesis [2]. It also modestly inhibits fat absorption and alters gut microbiota composition. The weight loss effect is likely secondary to improved glycemic control and reduced appetite (possibly via GLP-1 secretion), not a direct fat-burning mechanism.' },
-  { question: 'How much berberine should I take?', answer: '500 mg 2-3 times daily (1,000-1,500 mg/day total), taken with meals to reduce GI side effects. This is the most studied dosing regimen. Start at 500 mg once daily and titrate up over 1-2 weeks. Do not exceed 2,000 mg/day. Take for at least 8-12 weeks to assess effect — berberine works cumulatively, not acutely.' },
-  { question: 'What are the side effects of berberine?', answer: 'GI effects are common: constipation, diarrhea, abdominal cramping — particularly in the first 1-2 weeks. More importantly, berberine inhibits CYP3A4 and CYP2D6 liver enzymes, which can increase blood levels of many medications (cyclosporine, statins, antidepressants). Contraindicated in pregnancy (crosses placenta, causes neonatal jaundice). Do not combine with metformin or other diabetes medications without prescriber approval.' },
-  { question: 'Can I take berberine instead of Ozempic?', answer: 'No. Berberine (2 kg weight loss) is not remotely comparable to semaglutide (10-15% body weight, ~10-15 kg). Berberine is a modest metabolic support supplement — appropriate for prediabetes, insulin resistance, and mild weight loss support. It is not a replacement for GLP-1 agonists or metformin. The comparison is marketing, not science.' },
-]
+  {
+    question: 'Does berberine cause meaningful weight loss?',
+    answer:
+      'The newest 2026 meta-analysis of 23 randomized-trial articles found a statistically significant but modest average reduction in body weight of about 0.88 kg versus control. That is evidence of a small average effect, not evidence that most people will lose a large amount of weight.',
+  },
+  {
+    question: 'Is berberine really “nature’s Ozempic”?',
+    answer:
+      'No. Berberine is not semaglutide and is not an FDA-approved GLP-1 receptor agonist. There is no head-to-head randomized trial showing that berberine is an alternative to Wegovy or Ozempic. The phrase is marketing shorthand, not a pharmacologic equivalence.',
+  },
+  {
+    question: 'How does berberine compare with semaglutide for weight loss?',
+    answer:
+      'The evidence bases cannot be directly compared as if they were one trial. The 2026 berberine meta-analysis pooled heterogeneous randomized trials and estimated about 0.88 kg average weight reduction. STEP 1 randomized 1,961 adults to 68 weeks of semaglutide 2.4 mg or placebo plus lifestyle intervention and reported -14.9% versus -2.4% mean body-weight change. These are different studies, populations, durations, and effect measures—not a head-to-head comparison.',
+  },
+  {
+    question: 'What dose of berberine should someone take for weight loss?',
+    answer:
+      'There is no universally validated berberine weight-loss dose. Trials have used different products, exposures, populations, and durations. Study regimens are evidence descriptors, not a personalized start-and-titrate protocol.',
+  },
+  {
+    question: 'Does berberine interact with medications?',
+    answer:
+      'Interaction potential is real. In a small controlled human crossover study, repeated berberine exposure reduced CYP2D6, CYP2C9, and CYP3A4 activity. The clinical importance depends on the medication and patient, so people taking prescription drugs should have co-use reviewed by a pharmacist or prescriber rather than relying on a generic interaction list.',
+  },
+  {
+    question: 'Can berberine be combined with a GLP-1 drug?',
+    answer:
+      'There is not a robust evidence base establishing extra weight-loss benefit or long-term safety from combining retail berberine supplements with GLP-1 anti-obesity drugs. Combination use should be reviewed with the prescribing clinician or pharmacist instead of being treated as an evidence-based stack.',
+  },
+] as const
 
 const BERBERINE_REFS = [
-  { n: 1, text: 'Xu Y, et al. (2020). Berberine for weight loss: a systematic review and meta-analysis. Front Pharmacol, 11: 1234.', url: 'https://pubmed.ncbi.nlm.nih.gov/32903504/' },
-  { n: 2, text: 'Yin J, et al. (2012). Berberine improves glucose metabolism. Metabolism, 57(5): 712-717.', url: 'https://pubmed.ncbi.nlm.nih.gov/18442639/' },
-  { n: 3, text: 'Lan J, et al. (2015). Meta-analysis of berberine in type 2 diabetes. J Ethnopharmacol, 161: 69-81.', url: 'https://pubmed.ncbi.nlm.nih.gov/25498346/' },
-  { n: 4, text: 'Zhang Y, et al. (2014). Berberine for dyslipidemia: meta-analysis. PLoS ONE, 9(8): e104490.', url: 'https://pubmed.ncbi.nlm.nih.gov/25122653/' },
-  { n: 5, text: 'Dong H, et al. (2012). Berberine in T2DM: systematic review. Evid Based Complement Alternat Med, 2012: 591654.', url: 'https://pubmed.ncbi.nlm.nih.gov/23118793/' },
-
+  {
+    n: 1,
+    text: 'Vahed IE, et al. The effect of berberine on obesity indices: a systematic review and meta-analysis. Int J Obes (Lond). 2026;50(1):53-73. PMID 41310257.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/41310257/',
+  },
+  {
+    n: 2,
+    text: 'Wilding JPH, et al. Once-Weekly Semaglutide in Adults with Overweight or Obesity (STEP 1). N Engl J Med. 2021;384:989-1002. PMID 33567185.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/33567185/',
+  },
+  {
+    n: 3,
+    text: 'Guo Y, et al. Repeated administration of berberine inhibits cytochromes P450 in humans. Eur J Clin Pharmacol. 2012;68(2):213-217. PMID 21870106.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/21870106/',
+  },
+  {
+    n: 4,
+    text: 'U.S. Food and Drug Administration. Wegovy (semaglutide) is a GLP-1 receptor agonist approved for chronic weight management in indicated populations; FDA also approved a higher-dose Wegovy option in March 2026.',
+    url: 'https://www.fda.gov/news-events/press-announcements/fda-approves-fourth-product-under-national-priority-voucher-program-higher-dose-semaglutide',
+  },
+  {
+    n: 5,
+    text: 'Asbaghi O, et al. Effects of berberine supplementation on obesity indices: a dose-response meta-analysis and systematic review of randomized controlled trials. Clin Nutr ESPEN. 2020. PMID 32379652.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/32379652/',
+  },
 ]
 
 export default function BerberineWeightLossPage() {
   return (
-    <div className="container-page py-10 space-y-10">
-      <AuthorityJsonLd title="Berberine for Weight Loss" description="Evidence-based review of berberine for weight loss and metabolic health." url="https://thehippiescientist.net/guides/other/berberine-weight-loss" type="Article" />
-      <AuthorityBreadcrumbs items={[{ label: 'Home', href: '/' }, { label: 'Guides', href: '/guides/' }, { label: 'Berberine for Weight Loss' }]} />
-      <FAQSchema pagePath="/guides/other/berberine-weight-loss/" questions={FAQS} />
+    <div className="container-page space-y-10 py-10">
+      <AuthorityJsonLd
+        title="Berberine for Weight Loss: 2026 Evidence vs Nature’s Ozempic"
+        description="Evidence-calibrated review of berberine for body weight, comparison integrity versus GLP-1 drugs, human interaction data, and supplement-quality limits."
+        url="https://thehippiescientist.net/guides/other/berberine-weight-loss/"
+        type="MedicalWebPage"
+        faqItems={[...FAQS]}
+        citationUrls={BERBERINE_REFS.map((reference) => reference.url)}
+      />
+      <AuthorityBreadcrumbs
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Guides', href: '/guides/' },
+          { label: 'Berberine for Weight Loss' },
+        ]}
+      />
+      <FAQSchema pagePath="/guides/other/berberine-weight-loss/" questions={[...FAQS]} />
 
-      <section className="space-y-5 max-w-4xl">
-        <p className="eyebrow-label">Evidence Review · 5 References</p>
-        <h1 className="text-5xl font-bold tracking-tight text-ink">Berberine for Weight Loss: Nature&apos;s Ozempic or Marketing Hype?</h1>
-        <p className="text-lg leading-8 text-muted">Berberine has been branded &ldquo;nature&apos;s Ozempic&rdquo; on social media — a plant compound that supposedly mimics GLP-1 agonists at a fraction of the cost. The reality: berberine produces modest weight loss through AMPK activation, not GLP-1 agonism. It is not comparable to semaglutide. Here is what the evidence actually shows.</p>
-      
-        <figure className="mt-6"><div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white"><Image src="/images/guides/berberine-weight-loss.jpg" alt="Berberine capsules beside berberis plant with yellow flowers" width={1536} height={1024} priority className="w-full h-auto" /></div><figcaption className="mt-3 text-center text-sm text-muted">Berberine — nature\'s Ozempic is marketing, not science.</figcaption></figure></section>
+      <section className="max-w-4xl space-y-5">
+        <p className="eyebrow-label">2026 Evidence Review · Updated August 15, 2026</p>
+        <h1 className="text-4xl font-bold tracking-tight text-ink sm:text-5xl">
+          Berberine for Weight Loss: “Nature&apos;s Ozempic” or a Modest Metabolic Supplement?
+        </h1>
+        <p className="text-lg leading-8 text-muted">
+          Berberine is still promoted as “nature&apos;s Ozempic.” The newest randomized-trial synthesis gives a much less dramatic answer: a small average weight effect, substantial study heterogeneity, unresolved product-characterization problems, and no head-to-head evidence that makes berberine a substitute for a GLP-1 anti-obesity drug.
+        </p>
 
-      <section className="card-premium p-6 space-y-4">
-        <h2 className="text-2xl font-semibold">Quick answer</h2>
+        <figure className="mt-6">
+          <div className="overflow-hidden rounded-2xl border border-brand-900/10 bg-white shadow-sm">
+            <Image
+              src="/images/guides/berberine-weight-loss.jpg"
+              alt="Berberine capsules beside a berberis plant with yellow flowers"
+              width={1536}
+              height={1024}
+              priority
+              className="h-auto w-full"
+            />
+          </div>
+          <figcaption className="mt-3 text-center text-sm text-muted">
+            Berberine is a plant alkaloid with metabolic research behind it; “nature&apos;s Ozempic” is not an evidence category.
+          </figcaption>
+        </figure>
+      </section>
+
+      <section className="card-premium max-w-4xl space-y-4 p-6">
+        <p className="eyebrow-label">Quick answer</p>
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">The latest pooled effect is modest</h2>
         <p className="text-sm leading-7 text-muted">
-          <strong>Berberine at 1,000-1,500 mg/day produces about 2 kg (4.4 lbs) of weight loss over 12 weeks</strong> in people with metabolic syndrome [1]. This is modest but statistically significant. The mechanism: AMPK activation improves insulin sensitivity and glucose uptake [2]. Side effects: GI distress (common), CYP3A4/2D6 inhibition (drug interactions). Berberine is a reasonable supplement for prediabetes and insulin resistance — it is not a weight loss drug and the Ozempic comparison is marketing, not science [3].
+          A 2026 systematic review and meta-analysis included <strong>23 randomized-trial articles</strong>. Berberine reduced body weight by an average of <strong>0.88 kg versus control</strong> (95% CI -1.36 to -0.39), BMI by 0.48 kg/m², and waist circumference modestly; waist-to-hip ratio was not significantly different [1].
+        </p>
+        <p className="text-sm leading-7 text-muted">
+          The authors also highlighted inconsistent reporting of <strong>purity, potency, and gram amounts</strong> and common risk-of-bias problems. That makes “berberine works” a much less useful statement than “some randomized trials show a small average anthropometric effect, with product and design uncertainty.”
         </p>
       </section>
 
-      <section className="card-premium p-6 space-y-4 max-w-4xl border-l-4 border-brand-700 bg-brand-50/30">
-        <p className="text-xs font-bold uppercase tracking-wider text-brand-700">At a Glance · Berberine vs GLP-1 Agonists</p>
+      <section className="card-premium max-w-4xl space-y-5 border-l-4 border-brand-700 bg-brand-50/30 p-6">
+        <p className="eyebrow-label">Comparison integrity</p>
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Berberine vs semaglutide: do not fake a head-to-head trial</h2>
+        <p className="text-sm leading-7 text-muted">
+          The old version of this page compared a short berberine estimate with a much longer semaglutide trial as though both were measured over the same period. They were not. The scientifically defensible comparison is to show the evidence separately and label the mismatch.
+        </p>
+
         <div className="overflow-x-auto">
-          <table className="min-w-full text-sm">
-            <thead><tr className="border-b"><th className="text-left py-2 pr-4 font-semibold text-ink">Metric</th><th className="text-left py-2 pr-4 font-semibold text-ink">Berberine</th><th className="text-left py-2 font-semibold text-ink">Semaglutide (Wegovy)</th></tr></thead>
+          <table className="min-w-[720px] w-full text-sm">
+            <thead>
+              <tr className="border-b border-brand-900/10">
+                <th className="py-2 pr-4 text-left font-semibold text-ink">Evidence feature</th>
+                <th className="py-2 pr-4 text-left font-semibold text-ink">Berberine</th>
+                <th className="py-2 text-left font-semibold text-ink">Semaglutide 2.4 mg (STEP 1)</th>
+              </tr>
+            </thead>
             <tbody className="text-muted">
-              <tr className="border-b"><td className="py-2 pr-4 font-medium text-ink">Weight loss (12 weeks)</td><td className="py-2 pr-4">~2 kg (4.4 lbs)</td><td className="py-2">~10-15 kg (22-33 lbs)</td></tr>
-              <tr className="border-b"><td className="py-2 pr-4 font-medium text-ink">Mechanism</td><td className="py-2 pr-4">AMPK activation</td><td className="py-2">GLP-1 receptor agonism</td></tr>
-              <tr className="border-b"><td className="py-2 pr-4 font-medium text-ink">Cost/month</td><td className="py-2 pr-4">$15-30 (OTC)</td><td className="py-2">$1,000+ (prescription, uninsured)</td></tr>
-              <tr className="border-b"><td className="py-2 pr-4 font-medium text-ink">FDA approved for weight loss</td><td className="py-2 pr-4 text-red-600">No</td><td className="py-2 text-emerald-700">Yes</td></tr>
-              <tr><td className="py-2 pr-4 font-medium text-ink">Evidence quality</td><td className="py-2 pr-4"><span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-bold text-amber-800">Moderate (small trials)</span></td><td className="py-2"><span className="inline-flex items-center rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-bold text-emerald-800">Strong (large RCTs)</span></td></tr>
+              <tr className="border-b border-brand-900/5 align-top">
+                <td className="py-3 pr-4 font-medium text-ink">Design</td>
+                <td className="py-3 pr-4">2026 meta-analysis of 23 randomized-trial articles</td>
+                <td className="py-3">One large double-blind RCT, 1,961 adults</td>
+              </tr>
+              <tr className="border-b border-brand-900/5 align-top">
+                <td className="py-3 pr-4 font-medium text-ink">Weight result</td>
+                <td className="py-3 pr-4">Pooled mean difference: -0.88 kg versus control [1]</td>
+                <td className="py-3">Mean body-weight change at week 68: -14.9% versus -2.4% placebo [2]</td>
+              </tr>
+              <tr className="border-b border-brand-900/5 align-top">
+                <td className="py-3 pr-4 font-medium text-ink">Product</td>
+                <td className="py-3 pr-4">Multiple berberine interventions with variable characterization</td>
+                <td className="py-3">Defined prescription semaglutide regimen</td>
+              </tr>
+              <tr className="border-b border-brand-900/5 align-top">
+                <td className="py-3 pr-4 font-medium text-ink">FDA-approved anti-obesity drug?</td>
+                <td className="py-3 pr-4">No</td>
+                <td className="py-3">Yes; Wegovy is a GLP-1 receptor agonist approved for chronic weight management in indicated populations [4]</td>
+              </tr>
+              <tr className="align-top">
+                <td className="py-3 pr-4 font-medium text-ink">Head-to-head with the other?</td>
+                <td className="py-3 pr-4">No</td>
+                <td className="py-3">No</td>
+              </tr>
             </tbody>
           </table>
         </div>
-        <div className="mt-3 p-3 rounded-lg bg-white border border-brand-200">
-          <p className="text-xs font-semibold text-ink">Who is berberine a reasonable option for?</p>
-          <p className="mt-1 text-xs leading-5 text-muted">People with prediabetes or insulin resistance seeking modest metabolic support. People interested in AMPK activation as part of a broader health strategy. NOT for people expecting significant weight loss — that requires GLP-1 agonists, not supplements. Always discuss with your prescriber, especially if taking any medications metabolized by CYP3A4 or CYP2D6.</p>
+
+        <p className="rounded-xl border border-brand-900/10 bg-white p-4 text-sm leading-7 text-muted">
+          <strong className="text-ink">Do not calculate “X times stronger” from these rows.</strong> The designs, durations, populations, formulations, background interventions, and effect measures differ. The useful conclusion is directional: current berberine weight-loss evidence is modest, while semaglutide has a large dedicated anti-obesity trial program. It is not a direct efficacy ratio.
+        </p>
+      </section>
+
+      <section className="card-premium max-w-4xl space-y-4 p-6">
+        <p className="eyebrow-label">Mechanism ≠ equivalence</p>
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Why “GLP-1 alternative” is the wrong scientific category</h2>
+        <p className="text-sm leading-7 text-muted">
+          Berberine has been studied across glucose metabolism, lipid signaling, AMPK-related pathways, gut biology, and many other mechanisms. Mechanistic overlap with pathways relevant to metabolism does not make it a GLP-1 receptor agonist.
+        </p>
+        <p className="text-sm leading-7 text-muted">
+          Semaglutide is a defined GLP-1 receptor agonist with FDA-approved indications and a prescription-drug development program [4]. Berberine is sold as a dietary-supplement ingredient in products that can vary in formulation and characterization. A pathway diagram is not evidence of therapeutic interchangeability.
+        </p>
+      </section>
+
+      <section className="card-premium max-w-4xl space-y-4 p-6">
+        <p className="eyebrow-label">Study dose ≠ protocol</p>
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">There is no single validated weight-loss dose</h2>
+        <p className="text-sm leading-7 text-muted">
+          Randomized berberine trials use different regimens, durations, formulations, populations, and co-interventions. The 2026 meta-analysis specifically calls for better biochemical characterization of the products used in trials [1].
+        </p>
+        <p className="text-sm leading-7 text-muted">
+          For that reason, this page no longer gives a “start here, titrate to this, never exceed that” consumer schedule. A research exposure is useful for interpreting a study; it is not automatically a personalized weight-management prescription.
+        </p>
+      </section>
+
+      <section className="card-premium max-w-4xl space-y-4 p-6">
+        <p className="eyebrow-label">Human interaction evidence</p>
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">The interaction concern is not purely theoretical</h2>
+        <p className="text-sm leading-7 text-muted">
+          In a small two-phase randomized crossover study in healthy men, two weeks of repeated berberine exposure reduced measured <strong>CYP2D6, CYP2C9, and CYP3A4 activity</strong>. Midazolam exposure, used as a CYP3A4 probe, increased by about 40% [3].
+        </p>
+        <p className="text-sm leading-7 text-muted">
+          That study does not prove that every medication will have a clinically important interaction. It does establish enough human interaction potential that a person taking prescription drugs—especially multiple medicines or drugs with narrow therapeutic windows—should have berberine co-use reviewed by a pharmacist or prescriber instead of relying on a generic online “safe stack.”
+        </p>
+      </section>
+
+      <section className="card-premium max-w-4xl space-y-4 p-6">
+        <p className="eyebrow-label">Product equivalence</p>
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">A retail bottle is not automatically the intervention from a trial</h2>
+        <p className="text-sm leading-7 text-muted">
+          One of the most useful conclusions in the 2026 meta-analysis is methodological: future berberine trials need better reporting of purity, potency, and gram amounts [1]. If the literature itself does not consistently characterize the intervention, copying a front-label milligram number from one product to another creates false precision.
+        </p>
+        <ul className="list-disc space-y-2 pl-5 text-sm leading-7 text-muted">
+          <li>Do not assume different berberine salts or delivery systems are clinically interchangeable without evidence.</li>
+          <li>Do not treat “enhanced absorption” marketing as proof of better weight-loss outcomes.</li>
+          <li>Do not assume a retail supplement reproduces the identity, potency, adherence, or co-interventions of a randomized trial.</li>
+          <li>Affiliate availability is not evidence of clinical equivalence.</li>
+        </ul>
+      </section>
+
+      <section className="card-premium max-w-4xl space-y-4 p-6">
+        <p className="eyebrow-label">Evidence applicability</p>
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">What the evidence does and does not support</h2>
+        <div className="overflow-x-auto">
+          <table className="min-w-[680px] w-full text-sm">
+            <thead>
+              <tr className="border-b border-brand-900/10">
+                <th className="py-2 pr-4 text-left font-semibold text-ink">Claim</th>
+                <th className="py-2 text-left font-semibold text-ink">Current status</th>
+              </tr>
+            </thead>
+            <tbody className="text-muted">
+              <tr className="border-b border-brand-900/5"><td className="py-3 pr-4">Berberine has randomized weight-loss evidence</td><td className="py-3"><strong>Yes</strong> — pooled average effect is modest</td></tr>
+              <tr className="border-b border-brand-900/5"><td className="py-3 pr-4">Berberine is a natural GLP-1 drug</td><td className="py-3"><strong>No</strong></td></tr>
+              <tr className="border-b border-brand-900/5"><td className="py-3 pr-4">Berberine is proven equivalent to semaglutide</td><td className="py-3"><strong>No</strong> — no head-to-head trial</td></tr>
+              <tr className="border-b border-brand-900/5"><td className="py-3 pr-4">There is one established berberine weight-loss dose</td><td className="py-3"><strong>No</strong></td></tr>
+              <tr className="border-b border-brand-900/5"><td className="py-3 pr-4">Human drug-interaction evidence exists</td><td className="py-3"><strong>Yes</strong> — controlled CYP-probe data exist</td></tr>
+              <tr><td className="py-3 pr-4">Every retail berberine product is trial-equivalent</td><td className="py-3"><strong>No</strong></td></tr>
+            </tbody>
+          </table>
         </div>
       </section>
 
-      <section className="card-premium p-6 space-y-4 max-w-4xl">
-        <h2 className="text-2xl font-semibold tracking-tight text-ink">Bottom line</h2>
-        <p className="text-sm leading-7 text-muted">Berberine at 1,000-1,500 mg/day produces modest, statistically significant weight loss (~2 kg) in people with metabolic syndrome [1]. It is a reasonable supplement for prediabetes and insulin resistance. It is not &ldquo;nature&rsquo;s Ozempic&rdquo; — semaglutide produces 5-7x more weight loss through a completely different mechanism. The comparison is misleading and does a disservice to both compounds. Berberine has drug interaction risks that GLP-1 agonists do not — disclose it to your prescriber [3].</p>
+      <section className="card-premium max-w-4xl space-y-4 p-6">
+        <p className="eyebrow-label">Research gaps</p>
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Questions competitors usually skip</h2>
+        <ol className="list-decimal space-y-2 pl-5 text-sm leading-7 text-muted">
+          <li>Which berberine formulation and purity specifications should future obesity trials standardize?</li>
+          <li>Which populations, if any, have clinically meaningful—not merely statistically significant—weight loss?</li>
+          <li>How much of the observed effect is mediated by glycemic change versus appetite, gastrointestinal effects, or other pathways?</li>
+          <li>What is the long-term weight-maintenance effect after discontinuation?</li>
+          <li>Are there robust interaction studies in people taking common metabolic and psychiatric medications?</li>
+          <li>Does adding berberine to an approved anti-obesity drug improve outcomes enough to justify additional interaction and tolerability risk?</li>
+        </ol>
       </section>
+
+      <section className="card-premium max-w-4xl space-y-4 p-6">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Bottom line</h2>
+        <p className="text-sm leading-7 text-muted">
+          Berberine has real randomized human research, but the newest pooled estimate is a <strong>small average weight effect</strong>, not a supplement version of GLP-1 pharmacotherapy [1]. The strongest competitive edge is precision: keep metabolic biomarkers separate from weight loss, keep mechanisms separate from clinical equivalence, keep study products separate from retail bottles, and never manufacture a head-to-head comparison from unrelated trials.
+        </p>
+      </section>
+
       <References refs={BERBERINE_REFS} />
+
+      <div className="max-w-4xl rounded-xl border border-brand-900/10 bg-brand-50/40 p-4 text-xs leading-6 text-muted">
+        <strong className="text-ink">Commercial-links boundary:</strong> product links below are optional sourcing links, not endorsements that a retail supplement reproduces the purity, formulation, exposure, or clinical effect of any study cited above.
+      </div>
       <div className="max-w-4xl">
         <RecommendationSection products={getRevenueProductSet('berberine')?.products ?? []} />
       </div>
-      <EmailCapture headline="Get evidence reviews like this" description="Berberine, weight loss, Ozempic — evidence, not hype." ctaLabel="Get the evidence" location="guide-berberine-weight-loss" />
-      <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between"><Link href="/guides/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">← Back to guides</Link><Link href="/herbs/" className="text-sm font-bold text-brand-800 hover:underline">Herb library →</Link></div>
+
+      <EmailCapture
+        headline="Get evidence reviews like this"
+        description="Current health, drug, and supplement evidence—with the comparison errors and safety gaps called out."
+        ctaLabel="Get the evidence"
+        location="guide-berberine-weight-loss"
+      />
+
+      <div className="flex items-center justify-between border-t border-brand-900/10 pt-4">
+        <Link
+          href="/guides/"
+          className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50"
+        >
+          ← Back to guides
+        </Link>
+        <Link href="/guides/compare/berberine-vs-metformin/" className="text-sm font-bold text-brand-800 hover:underline">
+          Berberine vs metformin →
+        </Link>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Why
The berberine weight-loss guide used a stale ~2 kg pooled estimate, compared short berberine evidence with 68-week semaglutide data as though the durations matched, and converted study regimens into a consumer titration protocol.

## What changed
- updates the page to the 2026 23-article randomized-trial meta-analysis: pooled body-weight MD -0.88 kg vs control
- replaces the invalid same-row weight-loss comparison with a comparison-integrity table that labels study design, duration, effect measure, and lack of head-to-head evidence
- uses STEP 1 correctly: 1,961 adults, 68 weeks, -14.9% vs -2.4% placebo
- explicitly prevents “X times stronger” arithmetic across incompatible studies
- distinguishes berberine mechanism research from GLP-1 receptor agonism and FDA drug approval
- removes the consumer start/titrate/max-dose protocol
- adds human CYP2D6/CYP2C9/CYP3A4 interaction evidence and calibrates what it does/not prove
- surfaces the 2026 meta-analysis call for better purity/potency/gram characterization
- adds product-equivalence, evidence-applicability, and unanswered-question ledgers
- adds a commercial-links boundary so affiliate availability is not presented as trial equivalence
- updates metadata around the current “nature’s Ozempic” search intent

## Safety calibration
No individualized weight-loss dosing protocol or medication-combination stack is provided. Medication co-use is routed to prescriber/pharmacist review rather than a generic interaction blacklist.