### PR TITLE
fix(interactions): apply publication gate to generated safety guides

### DIFF
--- a/app/guides/interactions/[slug]/page.tsx
+++ b/app/guides/interactions/[slug]/page.tsx
@@ -3,80 +3,24 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 
 import Disclaimer from '@/src/components/Disclaimer'
-import { getUnifiedRuntimeRecords } from '@/src/lib/runtime-record-index'
 import { buildPageMetadata } from '@/src/lib/seo'
-
-type RuntimeIngredient = Record<string, unknown> & {
-  slug?: string
-  name?: string
-  interactions?: unknown
-  safety?: unknown
-  safety_confidence?: unknown
-  evidence_grade?: unknown
-}
-
-type IngredientWithType = {
-  record: RuntimeIngredient
-  entityType: 'herb' | 'compound'
-}
-
-function clean(value: unknown): string {
-  if (typeof value !== 'string') return ''
-  return value.replace(/\s+/g, ' ').trim()
-}
-
-function labelKey(value: string): string {
-  return value.replace(/[_-]+/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase())
-}
-
-function toText(value: unknown): string {
-  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return clean(String(value))
-  if (Array.isArray(value)) return value.map(toText).filter(Boolean).join('; ')
-  if (value && typeof value === 'object') {
-    return Object.entries(value as Record<string, unknown>)
-      .map(([key, nested]) => {
-        const text = toText(nested)
-        return text ? `${labelKey(key)}: ${text}` : ''
-      })
-      .filter(Boolean)
-      .join('; ')
-  }
-  return ''
-}
-
-function hasMeaningfulInteractions(record: RuntimeIngredient): boolean {
-  const text = toText(record.interactions)
-  if (!text) return false
-  return !/^(none|none known|unknown|n\/?a|not available|no data|no known interactions?)\.?$/i.test(text)
-}
-
-async function getEligibleIngredients(): Promise<IngredientWithType[]> {
-  const { herbs, compounds } = await getUnifiedRuntimeRecords()
-  const bySlug = new Map<string, IngredientWithType>()
-
-  for (const record of herbs as RuntimeIngredient[]) {
-    const slug = clean(record.slug)
-    if (slug && hasMeaningfulInteractions(record) && !bySlug.has(slug)) bySlug.set(slug, { record, entityType: 'herb' })
-  }
-  for (const record of compounds as RuntimeIngredient[]) {
-    const slug = clean(record.slug)
-    if (slug && hasMeaningfulInteractions(record) && !bySlug.has(slug)) bySlug.set(slug, { record, entityType: 'compound' })
-  }
-
-  return [...bySlug.values()]
-}
+import {
+  cleanInteractionValue,
+  interactionValueToText,
+  loadIndexableInteractionIngredients,
+} from '../interaction-data'
 
 export async function generateStaticParams() {
-  const ingredients = await getEligibleIngredients()
-  return ingredients.map(({ record }) => ({ slug: clean(record.slug) }))
+  const ingredients = await loadIndexableInteractionIngredients()
+  return ingredients.map((record) => ({ slug: cleanInteractionValue(record.slug) }))
 }
 
 export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {
   const { slug } = await params
-  const ingredients = await getEligibleIngredients()
-  const match = ingredients.find(({ record }) => clean(record.slug) === slug)
-  if (!match) return {}
-  const name = clean(match.record.name) || slug
+  const ingredients = await loadIndexableInteractionIngredients()
+  const record = ingredients.find((item) => cleanInteractionValue(item.slug) === slug)
+  if (!record) return {}
+  const name = cleanInteractionValue(record.name) || slug
 
   return buildPageMetadata({
     title: `${name} Interactions: Evidence & Safety Context`,
@@ -87,17 +31,16 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
 
 export default async function IngredientInteractionsPage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params
-  const ingredients = await getEligibleIngredients()
-  const match = ingredients.find(({ record }) => clean(record.slug) === slug)
-  if (!match) notFound()
+  const ingredients = await loadIndexableInteractionIngredients()
+  const record = ingredients.find((item) => cleanInteractionValue(item.slug) === slug)
+  if (!record) notFound()
 
-  const { record, entityType } = match
-  const name = clean(record.name) || slug
-  const interactionText = toText(record.interactions)
-  const safetyText = toText(record.safety)
-  const safetyConfidence = toText(record.safety_confidence)
-  const grade = clean(record.evidence_grade)
-  const profileHref = `/${entityType === 'herb' ? 'herbs' : 'compounds'}/${slug}/`
+  const name = cleanInteractionValue(record.name) || slug
+  const interactionText = interactionValueToText(record.interactions)
+  const safetyText = interactionValueToText(record.safety)
+  const safetyConfidence = interactionValueToText(record.safety_confidence)
+  const grade = cleanInteractionValue(record.evidence_grade)
+  const profileHref = `/${record.entityType === 'compound' ? 'compounds' : 'herbs'}/${slug}/`
 
   return (
     <main className="container-page space-y-8 py-10">

--- a/app/guides/interactions/interaction-data.ts
+++ b/app/guides/interactions/interaction-data.ts
@@ -1,0 +1,68 @@
+import { getRuntimeVisibility } from '@/lib/runtime-visibility'
+import { getUnifiedRuntimeRecords } from '@/src/lib/runtime-record-index'
+import type { RuntimeRecord } from '@/src/types/content'
+
+export type InteractionIngredient = RuntimeRecord & {
+  interactions?: unknown
+  safety?: unknown
+  safety_confidence?: unknown
+  evidence_grade?: unknown
+}
+
+export function cleanInteractionValue(value: unknown): string {
+  if (typeof value !== 'string') return ''
+  return value.replace(/\s+/g, ' ').trim()
+}
+
+function labelInteractionKey(value: string): string {
+  return value.replace(/[_-]+/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase())
+}
+
+export function interactionValueToText(value: unknown): string {
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return cleanInteractionValue(String(value))
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(interactionValueToText).filter(Boolean).join('; ')
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.entries(value as Record<string, unknown>)
+      .map(([key, nested]) => {
+        const text = interactionValueToText(nested)
+        return text ? `${labelInteractionKey(key)}: ${text}` : ''
+      })
+      .filter(Boolean)
+      .join('; ')
+  }
+
+  return ''
+}
+
+export function hasMeaningfulInteractions(record: InteractionIngredient): boolean {
+  const text = interactionValueToText(record.interactions)
+  if (!text) return false
+
+  return !/^(none|none known|unknown|n\/?a|not available|no data|no known interactions?)\.?$/i.test(text)
+}
+
+export function selectIndexableInteractionIngredients(records: RuntimeRecord[]): InteractionIngredient[] {
+  const bySlug = new Map<string, InteractionIngredient>()
+
+  for (const record of records as InteractionIngredient[]) {
+    if (!getRuntimeVisibility(record).canIndex) continue
+
+    const slug = cleanInteractionValue(record.slug)
+    if (!slug || !hasMeaningfulInteractions(record)) continue
+
+    if (!bySlug.has(slug)) bySlug.set(slug, record)
+  }
+
+  return [...bySlug.values()]
+}
+
+export async function loadIndexableInteractionIngredients(): Promise<InteractionIngredient[]> {
+  const { allRecords } = await getUnifiedRuntimeRecords()
+  return selectIndexableInteractionIngredients(allRecords as RuntimeRecord[])
+}

--- a/tests/interaction-guide-publication-gate.test.ts
+++ b/tests/interaction-guide-publication-gate.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  interactionValueToText,
+  selectIndexableInteractionIngredients,
+} from '../app/guides/interactions/interaction-data'
+import type { RuntimeRecord } from '../src/types/content'
+
+describe('interaction guide publication gate', () => {
+  it('publishes only indexable records with meaningful interaction data', () => {
+    const records: RuntimeRecord[] = [
+      {
+        slug: 'published',
+        interactions: ['CYP3A4 substrate', 'Sedative medicines'],
+        indexability_status: 'PUBLISH',
+      },
+      {
+        slug: 'noindex',
+        interactions: 'Anticoagulants',
+        indexability_status: 'NOINDEX',
+      },
+      {
+        slug: 'hidden',
+        interactions: 'Stimulants',
+        indexability_status: 'PUBLISH',
+        runtime_export_decision: 'hide',
+      },
+      {
+        slug: 'placeholder',
+        interactions: 'None known',
+        indexability_status: 'PUBLISH',
+      },
+    ]
+
+    expect(selectIndexableInteractionIngredients(records).map((record) => record.slug)).toEqual([
+      'published',
+    ])
+  })
+
+  it('applies publication visibility before slug deduplication', () => {
+    const records: RuntimeRecord[] = [
+      {
+        slug: 'shared',
+        name: 'Noindex version',
+        interactions: 'Sedatives',
+        indexability_status: 'NOINDEX',
+      },
+      {
+        slug: 'shared',
+        name: 'Published version',
+        interactions: 'Anticoagulants',
+        indexability_status: 'PUBLISH',
+      },
+    ]
+
+    const selected = selectIndexableInteractionIngredients(records)
+
+    expect(selected).toHaveLength(1)
+    expect(selected[0]?.name).toBe('Published version')
+  })
+
+  it('preserves structured interaction text rendering', () => {
+    expect(
+      interactionValueToText({
+        medication_classes: ['Sedatives', 'Anticoagulants'],
+        evidence_note: 'Monitor clinically',
+      }),
+    ).toBe('Medication Classes: Sedatives; Anticoagulants; Evidence Note: Monitor clinically')
+  })
+})


### PR DESCRIPTION
## Root cause
The programmatic `/guides/interactions/[slug]` route independently loaded herb and compound records and generated indexable pages whenever interaction text existed, without applying the canonical runtime publication policy. Hidden or NOINDEX records could therefore expose standalone safety/interaction pages.

## Change
- Add one canonical interaction-guide data module.
- Apply `getRuntimeVisibility(record).canIndex` before interaction eligibility and slug deduplication.
- Consume unified runtime `allRecords` so entity type is preserved without separate herb/compound loops.
- Centralize interaction text normalization/structured serialization.
- Use the same loader for static params, metadata, and page rendering.
- Add focused regression coverage for PUBLISH/NOINDEX/hidden records, placeholder interaction values, visibility-before-deduplication, and structured interaction rendering.

## Scope
No safety copy, layout, metadata wording, or source records are changed.