### PR TITLE
ROI 766-785: query-intent routing, CTR diagnostics and experiment protection

### DIFF
--- a/src/lib/__tests__/search-intent-routing.test.ts
+++ b/src/lib/__tests__/search-intent-routing.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+import {
+  canStartMetadataRewrite,
+  classifyQueryIntent,
+  compareCannibalization,
+  diagnoseCtr,
+  diagnoseQueryRouting,
+  routePolicyForIntent,
+  shouldPreserveMetadata,
+  type MetadataExperiment,
+} from '../search-intent-routing'
+
+describe('query intent routing', () => {
+  it.each([
+    ['what is ashwagandha', 'informational'],
+    ['ashwagandha side effects', 'safety'],
+    ['ashwagandha vs rhodiola', 'comparison'],
+    ['ashwagandha dosage mg', 'dose'],
+    ['ashwagandha morning or night', 'timing'],
+    ['best standardized ashwagandha extract', 'product-quality'],
+    ['ashwagandha receptor mechanism', 'mechanism'],
+    ['ashwagandha randomized trial evidence', 'research'],
+    ['best supplement to buy for stress', 'commercial'],
+  ] as const)('classifies %s as %s', (query, intent) => {
+    expect(classifyQueryIntent(query)).toBe(intent)
+  })
+
+  it('routes each intent to the page family designed for it', () => {
+    expect(routePolicyForIntent('comparison').routeFamily).toBe('/guides/compare')
+    expect(routePolicyForIntent('safety').commercialEligible).toBe(false)
+    expect(routePolicyForIntent('mechanism').commercialEligible).toBe(false)
+  })
+
+  it('detects when Google prefers a different URL and recommends corrective actions', () => {
+    const result = diagnoseQueryRouting({
+      query: 'magnesium for sleep',
+      intendedUrl: '/guides/sleep/magnesium-for-sleep/',
+      observedUrls: [
+        { url: '/herbs/magnesium/', impressions: 80 },
+        { url: '/guides/sleep/magnesium-for-sleep/', impressions: 20 },
+      ],
+    })
+
+    expect(result.mismatch).toBe(true)
+    expect(result.cannibalized).toBe(true)
+    expect(result.actions).toContain('align-internal-links-with-intended-url')
+  })
+
+  it('tracks query-to-page stability and release-introduced cannibalization', () => {
+    const before = diagnoseQueryRouting({
+      query: 'l theanine for sleep',
+      intendedUrl: '/guides/sleep/l-theanine-for-sleep/',
+      observedUrls: [{ url: '/guides/sleep/l-theanine-for-sleep/', impressions: 100 }],
+    })
+    const after = diagnoseQueryRouting({
+      query: 'l theanine for sleep',
+      intendedUrl: '/guides/sleep/l-theanine-for-sleep/',
+      observedUrls: [
+        { url: '/guides/sleep/l-theanine-for-sleep/', impressions: 55 },
+        { url: '/herbs/l-theanine/', impressions: 45 },
+      ],
+    })
+
+    expect(before.stability).toBe(1)
+    expect(after.stability).toBe(0.55)
+    expect(
+      compareCannibalization(
+        { releaseId: 'before', diagnostics: [before] },
+        { releaseId: 'after', diagnostics: [after] },
+      )[0].introduced,
+    ).toBe(true)
+  })
+})
+
+describe('CTR and metadata experiments', () => {
+  const experiments: MetadataExperiment[] = [
+    {
+      id: 'exp-1',
+      url: '/guides/sleep/magnesium-for-sleep/',
+      startedAt: '2026-08-01',
+      titleBefore: 'Old title',
+      titleAfter: 'Winning title',
+      baselineCtr: 0.02,
+      resultCtr: 0.04,
+      status: 'won',
+    },
+  ]
+
+  it('flags only material CTR underperformers for rewriting', () => {
+    const weak = diagnoseCtr({
+      url: '/weak/',
+      impressions: 1000,
+      clicks: 10,
+      position: 5,
+    })
+    const tinySample = diagnoseCtr({
+      url: '/tiny/',
+      impressions: 20,
+      clicks: 0,
+      position: 5,
+    })
+
+    expect(weak.underperforming).toBe(true)
+    expect(weak.rewriteEligible).toBe(true)
+    expect(tinySample.rewriteEligible).toBe(false)
+  })
+
+  it('preserves winning and running metadata instead of endlessly changing it', () => {
+    expect(shouldPreserveMetadata(experiments, '/guides/sleep/magnesium-for-sleep/')).toBe(true)
+
+    const ctr = diagnoseCtr({
+      url: '/guides/sleep/magnesium-for-sleep/',
+      impressions: 1000,
+      clicks: 10,
+      position: 5,
+    })
+    expect(canStartMetadataRewrite(ctr, experiments)).toBe(false)
+  })
+
+  it('allows a new experiment only for a real underperformer with no protected winner', () => {
+    const ctr = diagnoseCtr({ url: '/new-page/', impressions: 1000, clicks: 5, position: 4 })
+    expect(canStartMetadataRewrite(ctr, experiments)).toBe(true)
+  })
+})

--- a/src/lib/search-intent-routing.ts
+++ b/src/lib/search-intent-routing.ts
@@ -1,0 +1,200 @@
+export const QUERY_INTENTS = [
+  'informational',
+  'safety',
+  'comparison',
+  'dose',
+  'timing',
+  'product-quality',
+  'mechanism',
+  'research',
+  'commercial',
+] as const
+
+export type QueryIntent = (typeof QUERY_INTENTS)[number]
+
+export interface IntentRoutePolicy {
+  routeFamily: string
+  pageFormat: string
+  commercialEligible: boolean
+}
+
+export const INTENT_ROUTE_POLICIES: Record<QueryIntent, IntentRoutePolicy> = {
+  informational: { routeFamily: '/herbs|/compounds|/guides', pageFormat: 'answer-first profile or guide', commercialEligible: false },
+  safety: { routeFamily: '/safety|/interactions', pageFormat: 'source-backed safety explainer', commercialEligible: false },
+  comparison: { routeFamily: '/guides/compare', pageFormat: 'two-sided decision comparison', commercialEligible: true },
+  dose: { routeFamily: '/guides', pageFormat: 'studied-dose resource', commercialEligible: true },
+  timing: { routeFamily: '/guides', pageFormat: 'evidence-gated timing decision', commercialEligible: true },
+  'product-quality': { routeFamily: '/guides/best', pageFormat: 'buying-quality methodology guide', commercialEligible: true },
+  mechanism: { routeFamily: '/compounds|/evidence', pageFormat: 'mechanism research reference', commercialEligible: false },
+  research: { routeFamily: '/evidence|/learn', pageFormat: 'research synthesis or dataset', commercialEligible: false },
+  commercial: { routeFamily: '/guides/best|/guides/compare', pageFormat: 'evidence-first commercial decision page', commercialEligible: true },
+}
+
+const INTENT_RULES: Array<{ intent: QueryIntent; re: RegExp }> = [
+  { intent: 'comparison', re: /\b(vs|versus|compare|comparison|better than)\b/i },
+  { intent: 'safety', re: /\b(safe|safety|side effects?|interaction|contraindication|risk|together)\b/i },
+  { intent: 'dose', re: /\b(dose|dosage|how much|\d+\s?(?:mg|g|mcg))\b/i },
+  { intent: 'timing', re: /\b(when to take|morning|night|before bed|with food|empty stomach|how long.*work)\b/i },
+  { intent: 'product-quality', re: /\b(best form|best extract|brand|third party|coa|standardized|glycinate|citrate|threonate)\b/i },
+  { intent: 'mechanism', re: /\b(mechanism|pathway|receptor|nf-?κb|ampk|how does .* work)\b/i },
+  { intent: 'research', re: /\b(study|studies|trial|meta-analysis|systematic review|evidence grade|research)\b/i },
+  { intent: 'commercial', re: /\b(best supplement|buy|price|product|review|recommended brand)\b/i },
+]
+
+export function classifyQueryIntent(query: string): QueryIntent {
+  for (const rule of INTENT_RULES) {
+    if (rule.re.test(query)) return rule.intent
+  }
+  return 'informational'
+}
+
+export function routePolicyForIntent(intent: QueryIntent): IntentRoutePolicy {
+  return INTENT_ROUTE_POLICIES[intent]
+}
+
+export interface QueryPageObservation {
+  query: string
+  intendedUrl: string
+  observedUrls: Array<{ url: string; impressions: number; clicks?: number; position?: number }>
+  releaseId?: string
+}
+
+export interface QueryRoutingDiagnostic {
+  query: string
+  intendedUrl: string
+  preferredUrl: string | null
+  stability: number
+  cannibalized: boolean
+  mismatch: boolean
+  actions: string[]
+}
+
+export function diagnoseQueryRouting(observation: QueryPageObservation): QueryRoutingDiagnostic {
+  const totalImpressions = observation.observedUrls.reduce((sum, row) => sum + row.impressions, 0)
+  const ranked = [...observation.observedUrls].sort((a, b) => b.impressions - a.impressions)
+  const preferred = ranked[0] ?? null
+  const preferredUrl = preferred?.url ?? null
+  const stability = totalImpressions > 0 && preferred ? preferred.impressions / totalImpressions : 0
+  const meaningfulUrls = observation.observedUrls.filter((row) => row.impressions >= Math.max(5, totalImpressions * 0.15))
+  const cannibalized = meaningfulUrls.length > 1
+  const mismatch = Boolean(preferredUrl && preferredUrl !== observation.intendedUrl)
+  const actions: string[] = []
+
+  if (mismatch) actions.push('align-internal-links-with-intended-url', 'review-content-intent-and-canonical')
+  if (cannibalized) actions.push('consolidate-overlapping-intent-or-differentiate-pages')
+  if (stability < 0.7 && totalImpressions >= 20) actions.push('monitor-query-to-page-instability')
+  if (!actions.length) actions.push('preserve-current-routing')
+
+  return {
+    query: observation.query,
+    intendedUrl: observation.intendedUrl,
+    preferredUrl,
+    stability: Number(stability.toFixed(3)),
+    cannibalized,
+    mismatch,
+    actions,
+  }
+}
+
+export interface ReleaseQuerySnapshot {
+  releaseId: string
+  diagnostics: QueryRoutingDiagnostic[]
+}
+
+export interface CannibalizationChange {
+  query: string
+  before: boolean
+  after: boolean
+  introduced: boolean
+  resolved: boolean
+}
+
+export function compareCannibalization(
+  before: ReleaseQuerySnapshot,
+  after: ReleaseQuerySnapshot,
+): CannibalizationChange[] {
+  const beforeByQuery = new Map(before.diagnostics.map((item) => [item.query.toLowerCase(), item]))
+  return after.diagnostics.map((current) => {
+    const prior = beforeByQuery.get(current.query.toLowerCase())
+    const beforeValue = prior?.cannibalized ?? false
+    return {
+      query: current.query,
+      before: beforeValue,
+      after: current.cannibalized,
+      introduced: !beforeValue && current.cannibalized,
+      resolved: beforeValue && !current.cannibalized,
+    }
+  })
+}
+
+export function expectedCtrAtPosition(position: number): number {
+  if (!Number.isFinite(position) || position <= 0) return 0
+  const anchors: Array<[number, number]> = [
+    [1, 0.28], [2, 0.15], [3, 0.1], [4, 0.07], [5, 0.055], [6, 0.045], [7, 0.037], [8, 0.031], [9, 0.027], [10, 0.024], [15, 0.014], [20, 0.009],
+  ]
+  if (position >= 20) return 0.008
+  const upperIndex = anchors.findIndex(([rank]) => rank >= position)
+  if (upperIndex <= 0) return anchors[0][1]
+  const [upperRank, upperCtr] = anchors[upperIndex]
+  const [lowerRank, lowerCtr] = anchors[upperIndex - 1]
+  if (upperRank === position) return upperCtr
+  const share = (position - lowerRank) / (upperRank - lowerRank)
+  return lowerCtr + (upperCtr - lowerCtr) * share
+}
+
+export interface CtrObservation {
+  url: string
+  impressions: number
+  clicks: number
+  position: number
+}
+
+export interface CtrDiagnostic extends CtrObservation {
+  actualCtr: number
+  expectedCtr: number
+  gap: number
+  underperforming: boolean
+  rewriteEligible: boolean
+}
+
+export function diagnoseCtr(observation: CtrObservation): CtrDiagnostic {
+  const actualCtr = observation.impressions > 0 ? observation.clicks / observation.impressions : 0
+  const expectedCtr = expectedCtrAtPosition(observation.position)
+  const gap = expectedCtr - actualCtr
+  const underperforming = observation.impressions >= 50 && gap >= 0.01
+  return {
+    ...observation,
+    actualCtr,
+    expectedCtr,
+    gap,
+    underperforming,
+    rewriteEligible: underperforming,
+  }
+}
+
+export interface MetadataExperiment {
+  id: string
+  url: string
+  startedAt: string
+  titleBefore: string
+  titleAfter: string
+  descriptionBefore?: string
+  descriptionAfter?: string
+  baselineCtr: number
+  resultCtr?: number
+  status: 'running' | 'won' | 'lost' | 'inconclusive'
+}
+
+export function shouldPreserveMetadata(experiments: MetadataExperiment[], url: string): boolean {
+  const latest = [...experiments]
+    .filter((experiment) => experiment.url === url)
+    .sort((a, b) => b.startedAt.localeCompare(a.startedAt))[0]
+  return latest?.status === 'won' || latest?.status === 'running'
+}
+
+export function canStartMetadataRewrite(
+  ctr: CtrDiagnostic,
+  experiments: MetadataExperiment[],
+): boolean {
+  return ctr.rewriteEligible && !shouldPreserveMetadata(experiments, ctr.url)
+}


### PR DESCRIPTION
Implements backlog 766-785 as one search-intent governance layer.

- exact informational/safety/comparison/dose/timing/product-quality/mechanism/research/commercial taxonomy
- maps intents to the page families designed to satisfy them
- detects when Search Console shows Google preferring the wrong URL
- measures query-to-page stability and cannibalization, including release-to-release changes
- predicts expected CTR from average position and flags only material underperformers
- makes metadata rewrites conditional on underperformance
- protects winning/running metadata experiments from being casually overwritten
- records experiment structure for before/after CTR measurement
- regression coverage for routing, cannibalization, CTR and metadata rules