### PR TITLE
feat(ui): rewrite editorial specimen palette

### DIFF
--- a/styles/editorial-botanical-refresh.css
+++ b/styles/editorial-botanical-refresh.css
@@ -1,20 +1,23 @@
-/* Editorial botanical visual refresh
-   Warm paper, evergreen ink, sage surfaces, and restrained gold accents. */
+/* Editorial specimen visual system
+   Warm paper, charcoal ink, muted indigo surfaces, and restrained brass accents.
+   Botanical geometry remains as a distinctive motif; green is reserved for
+   semantic evidence/safety states rather than generic brand chrome. */
 
 :root {
-  --editorial-paper: #fbf8f1;
-  --editorial-paper-strong: #fffdf8;
-  --editorial-cream: #f5efe2;
-  --editorial-sage: #dfe9dc;
-  --editorial-sage-strong: #cbdcc8;
-  --editorial-evergreen: #123c2f;
-  --editorial-evergreen-soft: #315f50;
-  --editorial-gold: #b88a42;
-  --editorial-gold-soft: #dec69b;
-  --editorial-charcoal: #24302b;
-  --editorial-border: rgba(18, 60, 47, 0.12);
-  --editorial-shadow: 0 18px 48px rgba(58, 45, 24, 0.09);
-  --editorial-shadow-soft: 0 8px 28px rgba(58, 45, 24, 0.07);
+  --editorial-paper: #fbf7f1;
+  --editorial-paper-strong: #fffaf3;
+  --editorial-cream: #f3ece4;
+  /* Legacy variable names retained for compatibility; values follow the new palette. */
+  --editorial-sage: #e8e2f0;
+  --editorial-sage-strong: #d5cce5;
+  --editorial-evergreen: #29272f;
+  --editorial-evergreen-soft: #514475;
+  --editorial-gold: #a9772f;
+  --editorial-gold-soft: #dfc59c;
+  --editorial-charcoal: #29272f;
+  --editorial-border: rgba(45, 42, 52, 0.12);
+  --editorial-shadow: 0 18px 48px rgba(49, 42, 52, 0.09);
+  --editorial-shadow-soft: 0 8px 28px rgba(49, 42, 52, 0.065);
 }
 
 html:not(.dark) body {
@@ -25,9 +28,9 @@ html:not(.dark) body {
   position: relative;
   overflow: hidden;
   background:
-    radial-gradient(circle at 92% 5%, rgba(203, 220, 200, 0.58), transparent 22rem),
-    radial-gradient(circle at 4% 30%, rgba(222, 198, 155, 0.18), transparent 24rem),
-    linear-gradient(180deg, #fffdf8 0%, #fbf8f1 42%, #f7f1e6 100%);
+    radial-gradient(circle at 92% 5%, rgba(125, 111, 187, 0.18), transparent 22rem),
+    radial-gradient(circle at 4% 30%, rgba(223, 197, 156, 0.18), transparent 24rem),
+    linear-gradient(180deg, #fffaf3 0%, #fbf7f1 42%, #f5eee7 100%);
 }
 
 .editorial-site-shell::before {
@@ -35,9 +38,9 @@ html:not(.dark) body {
   position: absolute;
   inset: 0;
   pointer-events: none;
-  opacity: 0.32;
+  opacity: 0.30;
   background-image:
-    radial-gradient(circle at 24px 24px, rgba(18, 60, 47, 0.045) 1px, transparent 1.5px);
+    radial-gradient(circle at 24px 24px, rgba(45, 42, 52, 0.045) 1px, transparent 1.5px);
   background-size: 46px 46px;
   mask-image: linear-gradient(to bottom, #000 0%, transparent 48%);
 }
@@ -46,11 +49,12 @@ html:not(.dark) body {
   position: relative;
   isolation: isolate;
   overflow: hidden;
-  border: 1px solid rgba(184, 138, 66, 0.20);
+  border: 1px solid rgba(169, 119, 47, 0.20);
   border-radius: clamp(1.5rem, 4vw, 2.5rem);
   background:
-    radial-gradient(circle at 82% 18%, rgba(255, 255, 255, 0.9), transparent 17rem),
-    linear-gradient(135deg, rgba(255, 253, 248, 0.98), rgba(245, 239, 226, 0.92));
+    radial-gradient(circle at 82% 18%, rgba(255, 255, 255, 0.88), transparent 17rem),
+    radial-gradient(circle at 100% 100%, rgba(125, 111, 187, 0.10), transparent 20rem),
+    linear-gradient(135deg, rgba(255, 250, 243, 0.98), rgba(243, 236, 228, 0.94));
   box-shadow: var(--editorial-shadow);
 }
 
@@ -61,7 +65,7 @@ html:not(.dark) body {
   z-index: -1;
   pointer-events: none;
   border-radius: 999px 0 999px 0;
-  background: linear-gradient(135deg, rgba(49, 95, 80, 0.17), rgba(203, 220, 200, 0.06));
+  background: linear-gradient(135deg, rgba(111, 102, 168, 0.17), rgba(213, 204, 229, 0.07));
   filter: blur(0.2px);
 }
 
@@ -87,7 +91,7 @@ html:not(.dark) body {
   bottom: -3.5rem;
   width: 16rem;
   height: 20rem;
-  opacity: 0.82;
+  opacity: 0.76;
   pointer-events: none;
 }
 
@@ -100,7 +104,7 @@ html:not(.dark) body {
   height: 18rem;
   transform: rotate(18deg);
   transform-origin: bottom;
-  background: linear-gradient(to top, rgba(18, 60, 47, 0.48), rgba(18, 60, 47, 0.06));
+  background: linear-gradient(to top, rgba(81, 68, 117, 0.46), rgba(169, 119, 47, 0.08));
 }
 
 .editorial-botanical-orbit span {
@@ -109,8 +113,8 @@ html:not(.dark) body {
   width: 5.5rem;
   height: 2.2rem;
   border-radius: 999px 0 999px 0;
-  background: linear-gradient(135deg, rgba(49, 95, 80, 0.58), rgba(203, 220, 200, 0.36));
-  box-shadow: inset 0 0 0 1px rgba(18, 60, 47, 0.08);
+  background: linear-gradient(135deg, rgba(111, 102, 168, 0.50), rgba(213, 204, 229, 0.30));
+  box-shadow: inset 0 0 0 1px rgba(45, 42, 52, 0.08);
 }
 
 .editorial-botanical-orbit span:nth-child(1) { right: 6.7rem; bottom: 4rem; transform: rotate(15deg); }
@@ -135,73 +139,73 @@ html:not(.dark) body {
 }
 
 .editorial-cta {
-  border: 1px solid rgba(222, 198, 155, 0.88);
-  background: linear-gradient(135deg, #123c2f, #1d5140);
-  color: #fffdf8;
-  box-shadow: 0 12px 28px rgba(18, 60, 47, 0.20), inset 0 0 0 1px rgba(255,255,255,0.06);
+  border: 1px solid rgba(223, 197, 156, 0.70);
+  background: linear-gradient(135deg, #4b4558, #302c39);
+  color: #fffaf3;
+  box-shadow: 0 12px 28px rgba(49, 42, 52, 0.20), inset 0 0 0 1px rgba(255, 255, 255, 0.07);
 }
 
 .editorial-cta:hover {
   transform: translateY(-2px);
-  background: linear-gradient(135deg, #0f3429, #174837);
-  box-shadow: 0 16px 36px rgba(18, 60, 47, 0.25), inset 0 0 0 1px rgba(255,255,255,0.08);
+  background: linear-gradient(135deg, #5d527d, #3a3348);
+  box-shadow: 0 16px 36px rgba(49, 42, 52, 0.24), inset 0 0 0 1px rgba(255, 255, 255, 0.09);
 }
 
 .editorial-card {
   border: 1px solid var(--editorial-border);
-  background: rgba(255, 253, 248, 0.88);
+  background: rgba(255, 250, 243, 0.88);
   box-shadow: var(--editorial-shadow-soft);
   backdrop-filter: blur(12px);
 }
 
 .editorial-card-strong {
-  border: 1px solid rgba(184, 138, 66, 0.20);
-  background: rgba(255, 253, 248, 0.96);
+  border: 1px solid rgba(169, 119, 47, 0.20);
+  background: rgba(255, 250, 243, 0.96);
   box-shadow: var(--editorial-shadow);
 }
 
 .editorial-trust-strip {
-  border-top: 1px solid rgba(18, 60, 47, 0.09);
-  border-bottom: 1px solid rgba(18, 60, 47, 0.09);
-  background: rgba(255, 253, 248, 0.54);
+  border-top: 1px solid rgba(45, 42, 52, 0.09);
+  border-bottom: 1px solid rgba(45, 42, 52, 0.09);
+  background: rgba(255, 250, 243, 0.54);
 }
 
 .editorial-icon-disc {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid rgba(18, 60, 47, 0.09);
+  border: 1px solid rgba(45, 42, 52, 0.09);
   border-radius: 999px;
-  background: linear-gradient(145deg, rgba(223, 233, 220, 0.9), rgba(255, 253, 248, 0.9));
+  background: linear-gradient(145deg, rgba(232, 226, 240, 0.90), rgba(255, 250, 243, 0.92));
   color: var(--editorial-evergreen-soft);
-  box-shadow: 0 4px 18px rgba(18, 60, 47, 0.06);
+  box-shadow: 0 4px 18px rgba(49, 42, 52, 0.055);
 }
 
 .editorial-link-tile {
-  border: 1px solid rgba(18, 60, 47, 0.09);
-  background: linear-gradient(145deg, rgba(245, 239, 226, 0.72), rgba(255, 253, 248, 0.96));
+  border: 1px solid rgba(45, 42, 52, 0.09);
+  background: linear-gradient(145deg, rgba(243, 236, 228, 0.74), rgba(255, 250, 243, 0.96));
 }
 
 .editorial-link-tile:hover {
-  border-color: rgba(184, 138, 66, 0.34);
-  background: #fffdf8;
+  border-color: rgba(169, 119, 47, 0.32);
+  background: #fffaf3;
   transform: translateY(-2px);
   box-shadow: var(--editorial-shadow-soft);
 }
 
 .interaction-section-shell {
   border-radius: 2rem;
-  border: 1px solid rgba(184, 138, 66, 0.18);
-  background: linear-gradient(145deg, rgba(255, 253, 248, 0.98), rgba(245, 239, 226, 0.90));
+  border: 1px solid rgba(169, 119, 47, 0.18);
+  background: linear-gradient(145deg, rgba(255, 250, 243, 0.98), rgba(243, 236, 228, 0.92));
   box-shadow: var(--editorial-shadow);
 }
 
 .interaction-severity-card {
   overflow: hidden;
-  border: 1px solid rgba(18, 60, 47, 0.10);
+  border: 1px solid rgba(45, 42, 52, 0.10);
   border-radius: 1.35rem;
-  background: rgba(255, 253, 248, 0.94);
-  box-shadow: 0 8px 26px rgba(58, 45, 24, 0.06);
+  background: rgba(255, 250, 243, 0.94);
+  box-shadow: 0 8px 26px rgba(49, 42, 52, 0.055);
 }
 
 .interaction-severity-card > summary {
@@ -220,24 +224,25 @@ html:not(.dark) body {
 }
 
 .interaction-chip {
-  border: 1px solid rgba(18, 60, 47, 0.08);
-  background: linear-gradient(145deg, rgba(223, 233, 220, 0.72), rgba(245, 239, 226, 0.88));
+  border: 1px solid rgba(45, 42, 52, 0.08);
+  background: linear-gradient(145deg, rgba(232, 226, 240, 0.70), rgba(243, 236, 228, 0.88));
   color: var(--editorial-evergreen);
-  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.35);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.34);
 }
 
 .interaction-chip:hover {
-  border-color: rgba(184, 138, 66, 0.32);
-  background: #fffdf8;
+  border-color: rgba(169, 119, 47, 0.30);
+  background: #fffaf3;
 }
 
 .editorial-footer {
   position: relative;
   overflow: hidden;
-  border-top: 1px solid rgba(184, 138, 66, 0.20);
+  border-top: 1px solid rgba(169, 119, 47, 0.20);
   background:
-    radial-gradient(circle at 94% 18%, rgba(203, 220, 200, 0.62), transparent 18rem),
-    linear-gradient(180deg, #fbf8f1, #f4eddf);
+    radial-gradient(circle at 94% 18%, rgba(125, 111, 187, 0.16), transparent 18rem),
+    radial-gradient(circle at 8% 90%, rgba(169, 119, 47, 0.08), transparent 20rem),
+    linear-gradient(180deg, #fbf7f1, #f2ebe4);
   color: var(--editorial-evergreen);
 }
 
@@ -249,23 +254,23 @@ html:not(.dark) body {
   width: 18rem;
   height: 8rem;
   border-radius: 999px 0 999px 0;
-  background: linear-gradient(135deg, rgba(49, 95, 80, 0.18), rgba(203, 220, 200, 0.08));
+  background: linear-gradient(135deg, rgba(111, 102, 168, 0.16), rgba(213, 204, 229, 0.07));
   transform: rotate(-18deg);
   pointer-events: none;
 }
 
 .editorial-mobile-dock {
-  border: 1px solid rgba(18, 60, 47, 0.16);
-  background: rgba(255, 253, 248, 0.98);
-  box-shadow: 0 -6px 24px rgba(58, 45, 24, 0.10);
+  border: 1px solid rgba(45, 42, 52, 0.15);
+  background: rgba(255, 250, 243, 0.98);
+  box-shadow: 0 -6px 24px rgba(49, 42, 52, 0.09);
   backdrop-filter: blur(14px);
 }
 
 .editorial-mobile-search {
-  border: 1px solid rgba(222, 198, 155, 0.82);
-  background: linear-gradient(145deg, #123c2f, #245846);
-  color: #fffdf8;
-  box-shadow: 0 3px 10px rgba(18, 60, 47, 0.18);
+  border: 1px solid rgba(223, 197, 156, 0.72);
+  background: linear-gradient(145deg, #4b4558, #302c39);
+  color: #fffaf3;
+  box-shadow: 0 3px 10px rgba(49, 42, 52, 0.17);
 }
 
 @media (max-width: 767px) {
@@ -279,14 +284,15 @@ html:not(.dark) body {
   .editorial-botanical-orbit {
     right: -6rem;
     bottom: -5rem;
-    opacity: 0.52;
+    opacity: 0.46;
   }
 }
 
 .dark .editorial-site-shell {
   background:
-    radial-gradient(circle at 90% 5%, rgba(66, 105, 86, 0.20), transparent 22rem),
-    linear-gradient(180deg, #102019, #0d1712 50%, #102019);
+    radial-gradient(circle at 90% 5%, rgba(125, 111, 187, 0.18), transparent 22rem),
+    radial-gradient(circle at 8% 90%, rgba(169, 119, 47, 0.06), transparent 22rem),
+    linear-gradient(180deg, #18161d, #121116 50%, #18161d);
 }
 
 .dark .editorial-hero,
@@ -294,36 +300,38 @@ html:not(.dark) body {
 .dark .editorial-card-strong,
 .dark .interaction-section-shell,
 .dark .interaction-severity-card {
-  border-color: rgba(180, 210, 190, 0.16);
-  background: rgba(24, 45, 36, 0.94);
+  border-color: rgba(225, 217, 232, 0.15);
+  background: rgba(32, 30, 37, 0.94);
 }
 
 .dark .editorial-display,
 .dark .editorial-footer,
 .dark .interaction-chip {
-  color: #f4f0e7;
+  color: #f5f0e8;
 }
 
 .dark .editorial-footer {
-  border-color: rgba(180, 210, 190, 0.16);
-  background: linear-gradient(180deg, #14261d, #0d1712);
+  border-color: rgba(213, 173, 108, 0.18);
+  background:
+    radial-gradient(circle at 94% 18%, rgba(125, 111, 187, 0.15), transparent 18rem),
+    linear-gradient(180deg, #201e25, #151319);
 }
 
 .dark .interaction-chip,
 .dark .editorial-link-tile,
 .dark .editorial-mobile-dock {
-  border-color: rgba(180, 210, 190, 0.14);
-  background: rgba(29, 53, 43, 0.92);
+  border-color: rgba(225, 217, 232, 0.14);
+  background: rgba(41, 38, 48, 0.92);
 }
 
 .dark .editorial-trust-strip {
-  border-color: rgba(180, 210, 190, 0.14);
-  background: rgba(12, 27, 21, 0.72);
+  border-color: rgba(225, 217, 232, 0.13);
+  background: rgba(27, 25, 32, 0.72);
 }
 
 .dark .editorial-trust-strip .editorial-icon-disc {
-  background: rgba(238, 242, 233, 0.92);
-  color: #174837;
+  background: rgba(235, 229, 241, 0.92);
+  color: #514475;
 }
 
 @media (max-width: 767px) {


### PR DESCRIPTION
Keep the distinctive botanical/specimen geometry while replacing the old evergreen/sage editorial layer with the premium ivory, charcoal, indigo, and brass system across hero, footer, interaction, CTA, and dark-mode surfaces.