### PR TITLE
ROI 622-635: centralize runtime content contract and policy

### DIFF
--- a/components/NPSDisclaimer.tsx
+++ b/components/NPSDisclaimer.tsx
@@ -1,22 +1,14 @@
 import React from 'react'
+import Disclaimer from '@/src/components/Disclaimer'
 
 interface NPSDisclaimerProps {
   className?: string
 }
 
+/**
+ * Backward-compatible wrapper. The high-risk disclaimer copy and rendering now
+ * live in the shared Disclaimer primitive so safety language cannot drift.
+ */
 export function NPSDisclaimer({ className = '' }: NPSDisclaimerProps) {
-  return (
-    <aside
-      className={`rounded-xl border border-red-700/25 bg-red-50 px-4 py-3 text-red-950 ${className}`}
-      role="note"
-      aria-label="Novel psychoactive substances disclaimer"
-    >
-      <p className="text-sm font-bold uppercase tracking-wider text-red-900">Important</p>
-      <p className="mt-2 text-sm leading-6 text-red-950">
-        This content is for informational and educational purposes only. Many novel psychoactive substances
-        have little to no human clinical safety data. This is not medical advice. These substances can carry
-        serious and poorly characterized risks.
-      </p>
-    </aside>
-  )
+  return <Disclaimer variant='high-risk' className={className} />
 }

--- a/lib/__tests__/topic-taxonomy.test.ts
+++ b/lib/__tests__/topic-taxonomy.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { getProfileIntentRoutes, matchTopicClusters } from '../topic-taxonomy'
+
+describe('topic taxonomy', () => {
+  it('uses the same topic match for ecosystem and profile routing', () => {
+    const matches = matchTopicClusters(['sleep latency', 'melatonin'])
+    expect(matches.some((cluster) => cluster.slug === 'sleep')).toBe(true)
+
+    expect(getProfileIntentRoutes(['sleep latency', 'melatonin'])).toEqual([
+      { ifYouWant: 'help sleeping', goTo: 'Sleep guides', href: '/guides/sleep/' },
+    ])
+  })
+
+  it('deduplicates overlapping anxiety and stress terms into one profile route', () => {
+    const routes = getProfileIntentRoutes(['stress', 'cortisol', 'anxiety', 'calm'])
+    expect(routes).toEqual([
+      { ifYouWant: 'help with anxiety or stress', goTo: 'Anxiety & stress guides', href: '/guides/anxiety/' },
+    ])
+  })
+
+  it('keeps topic matching explicitly organizational rather than generating evidence claims', () => {
+    const [match] = matchTopicClusters(['focus and attention'])
+    expect(match?.slug).toBe('cognition')
+    expect(match).not.toHaveProperty('evidenceGrade')
+    expect(match).not.toHaveProperty('claim')
+  })
+})

--- a/lib/ecosystem-context.ts
+++ b/lib/ecosystem-context.ts
@@ -1,99 +1,10 @@
 import type { EcosystemPanel, GraphLink } from '@/components/semantic-hubs/semantic-hub-sections'
+import { matchTopicClusters, topicClusters, type TopicCluster } from './topic-taxonomy'
 
-export type TopicCluster = {
-  slug: string
-  label: string
-  href: string
-  description: string
-  systems: string[]
-  keywords: string[]
-}
-
-export const topicClusters: TopicCluster[] = [
-  {
-    slug: 'inflammation',
-    label: 'Inflammation',
-    href: '/learn/inflammation',
-    description: 'Immune signaling, cytokine language, recovery, mobility, and oxidative-stress relationships.',
-    systems: ['Immune tone', 'Cytokines', 'Recovery'],
-    keywords: ['inflammation', 'inflammatory', 'cytokine', 'immune', 'joint', 'recovery'],
-  },
-  {
-    slug: 'cognition',
-    label: 'Cognition',
-    href: '/guides/focus',
-    description: 'Attention, memory, mental clarity, fatigue resistance, and neurotransmitter-adjacent research.',
-    systems: ['Attention', 'Memory', 'Neurotransmitters'],
-    keywords: ['cognition', 'focus', 'memory', 'attention', 'nootropic', 'clarity'],
-  },
-  {
-    slug: 'metabolism',
-    label: 'Metabolism',
-    href: '/guides/best/supplements-for-fat-loss',
-    description: 'Energy balance, glucose context, body-composition research, and metabolic resilience signals.',
-    systems: ['Energy balance', 'Glucose context', 'Body composition'],
-    keywords: ['metabolism', 'metabolic', 'glucose', 'insulin', 'fat', 'weight'],
-  },
-  {
-    slug: 'stress-response',
-    label: 'Stress response',
-    href: '/guides/best/supplements-for-stress',
-    description: 'HPA-axis language, adaptation, calm, sleep overlap, and nervous-system resilience.',
-    systems: ['HPA axis', 'Adaptation', 'Calm'],
-    keywords: ['stress', 'cortisol', 'adaptogen', 'anxiety', 'calm', 'relaxation'],
-  },
-  {
-    slug: 'longevity',
-    label: 'Longevity',
-    href: '/guides/sleep',
-    description: 'Aging-adjacent research themes including repair, oxidative stress, metabolism, and resilience.',
-    systems: ['Repair', 'Resilience', 'Healthy aging'],
-    keywords: ['longevity', 'aging', 'cellular', 'repair', 'resilience'],
-  },
-  {
-    slug: 'mitochondrial-function',
-    label: 'Mitochondrial function',
-    href: '/guides/other/supplements-for-brain-fog-and-fatigue',
-    description: 'Cellular energy, fatigue, exercise performance, and recovery-adjacent mechanism context.',
-    systems: ['Cellular energy', 'Fatigue', 'Performance'],
-    keywords: ['mitochondria', 'mitochondrial', 'atp', 'energy', 'fatigue', 'performance'],
-  },
-  {
-    slug: 'oxidative-stress',
-    label: 'Oxidative stress',
-    href: '/learn/inflammation',
-    description: 'Antioxidant response, redox balance, inflammation overlap, and tissue-stress research language.',
-    systems: ['Redox balance', 'Antioxidant response', 'Tissue stress'],
-    keywords: ['oxidative', 'antioxidant', 'redox', 'ros', 'free radical'],
-  },
-  {
-    slug: 'sleep',
-    label: 'Sleep',
-    href: '/guides/sleep',
-    description: 'Latency, sleep quality, relaxation, circadian context, and nighttime recovery overlap.',
-    systems: ['Sleep quality', 'Circadian context', 'Relaxation'],
-    keywords: ['sleep', 'circadian', 'melatonin', 'night', 'insomnia'],
-  },
-  {
-    slug: 'neurobiology',
-    label: 'Neurobiology',
-    href: '/learn/dopamine',
-    description: 'Neurotransmitter systems, mood-adjacent signals, cognition, calm, and arousal regulation.',
-    systems: ['Dopamine', 'GABA', 'Arousal'],
-    keywords: ['neuro', 'dopamine', 'gaba', 'serotonin', 'brain', 'mood'],
-  },
-  {
-    slug: 'cardiovascular-function',
-    label: 'Cardiovascular function',
-    href: '/guides/best/supplements-for-blood-pressure',
-    description: 'Blood-pressure context, vascular tone, circulation, metabolic overlap, and endothelial themes.',
-    systems: ['Vascular tone', 'Circulation', 'Blood pressure'],
-    keywords: ['cardio', 'vascular', 'blood pressure', 'circulation', 'heart', 'endothelial'],
-  },
-]
+export { topicClusters, type TopicCluster } from './topic-taxonomy'
 
 export function getTopicClusterLinks(limit = 10): GraphLink[] {
-  return topicClusters.slice(0, limit).map((cluster) => ({
+  return topicClusters.slice(0, limit).map((cluster: TopicCluster) => ({
     label: cluster.label,
     href: cluster.href,
     description: cluster.description,
@@ -101,12 +12,7 @@ export function getTopicClusterLinks(limit = 10): GraphLink[] {
 }
 
 export function getEcosystemPanels(signals: string[], limit = 6): EcosystemPanel[] {
-  const haystack = signals.join(' ').toLowerCase()
-  const matches = topicClusters.filter((cluster) =>
-    cluster.keywords.some((keyword) => haystack.includes(keyword)) ||
-    haystack.includes(cluster.label.toLowerCase())
-  )
-
+  const matches = matchTopicClusters(signals)
   const selected = (matches.length ? matches : topicClusters).slice(0, limit)
 
   return selected.map((cluster) => ({

--- a/lib/profile-decision.ts
+++ b/lib/profile-decision.ts
@@ -1,4 +1,5 @@
 import { getProfileVerdict, type ProfileVerdictOverlay } from '@/config/profile-verdicts'
+import { getProfileIntentRoutes } from './topic-taxonomy'
 
 /**
  * Derives the decision surface for a herb/compound profile from runtime data
@@ -9,6 +10,7 @@ import { getProfileVerdict, type ProfileVerdictOverlay } from '@/config/profile-
  * This keeps the source-of-truth boundary clean:
  *   - structured facts  → workbook / runtime data (evidence tier, safety flags)
  *   - editorial verdict → config/profile-verdicts.ts (curated, opt-in)
+ *   - topic routing      → lib/topic-taxonomy.ts (organizational only)
  *   - rendering         → components/editorial/ProfileDecisionPanel
  */
 
@@ -33,8 +35,8 @@ const asStringList = (value: unknown): string[] => {
   return []
 }
 
-/** Build a lowercased keyword corpus from the fields that describe what a profile is about. */
-function corpusOf(record: LooseRecord): string {
+/** Build routing signals from fields that already describe what a profile is about. */
+function routingSignalsOf(record: LooseRecord): string[] {
   return [
     record.name,
     record.summary,
@@ -45,39 +47,20 @@ function corpusOf(record: LooseRecord): string {
     ...asStringList(record.tags),
     ...asStringList(record.keywords),
   ]
-    .map((v) => String(v ?? '').toLowerCase())
-    .join(' ')
+    .map((value) => String(value ?? '').trim())
+    .filter(Boolean)
 }
-
-// Intent → goal hub, matched by keyword. Ordered by priority; deduped by href.
-const INTENT_ROUTES: { keywords: string[]; path: ContinuePath }[] = [
-  {
-    keywords: ['sleep', 'insomnia', 'melatonin', 'sedative', 'rest'],
-    path: { ifYouWant: 'help sleeping', goTo: 'Sleep guides', href: '/guides/sleep/' },
-  },
-  {
-    keywords: ['anxiety', 'stress', 'cortisol', 'calm', 'gaba', 'anxiolytic', 'adaptogen', 'relax'],
-    path: { ifYouWant: 'help with anxiety or stress', goTo: 'Anxiety & stress guides', href: '/guides/anxiety/' },
-  },
-  {
-    keywords: ['focus', 'cognition', 'cognitive', 'attention', 'nootropic', 'adhd', 'memory', 'concentration'],
-    path: { ifYouWant: 'sharper focus', goTo: 'Focus guides', href: '/guides/focus/' },
-  },
-]
 
 export function buildProfileDecision(record: LooseRecord, kind: 'herb' | 'compound'): ProfileDecision {
   const slug = String(record.slug ?? '')
   const verdict = getProfileVerdict(slug)
 
-  const corpus = corpusOf(record)
-  const continueReading: ContinuePath[] = []
-  const seen = new Set<string>()
-  for (const { keywords, path } of INTENT_ROUTES) {
-    if (keywords.some((k) => corpus.includes(k)) && !seen.has(path.href)) {
-      continueReading.push(path)
-      seen.add(path.href)
-    }
-  }
+  // Topic matching is navigation only. It must not be reused as evidence that
+  // the ingredient treats a condition; scientific outcome claims live in the
+  // canonical evidence/claim data instead.
+  const continueReading: ContinuePath[] = getProfileIntentRoutes(routingSignalsOf(record))
+  const seen = new Set(continueReading.map((path) => path.href))
+
   // Always offer a browse-the-ecosystem exit relevant to this profile type.
   const indexPath: ContinuePath =
     kind === 'herb'

--- a/lib/topic-taxonomy.ts
+++ b/lib/topic-taxonomy.ts
@@ -1,0 +1,129 @@
+export type TopicCluster = {
+  slug: string
+  label: string
+  href: string
+  description: string
+  systems: string[]
+  keywords: string[]
+  profileIntent?: {
+    ifYouWant: string
+    goTo: string
+    href: string
+  }
+}
+
+/**
+ * Canonical topic/goal vocabulary for navigation and ecosystem relationships.
+ *
+ * These are routing/organization labels only. A keyword match must never be
+ * presented as evidence that an ingredient treats the corresponding condition.
+ */
+export const topicClusters: readonly TopicCluster[] = [
+  {
+    slug: 'inflammation',
+    label: 'Inflammation',
+    href: '/learn/inflammation',
+    description: 'Immune signaling, cytokine language, recovery, mobility, and oxidative-stress relationships.',
+    systems: ['Immune tone', 'Cytokines', 'Recovery'],
+    keywords: ['inflammation', 'inflammatory', 'cytokine', 'immune', 'joint', 'recovery'],
+  },
+  {
+    slug: 'cognition',
+    label: 'Cognition',
+    href: '/guides/focus',
+    description: 'Attention, memory, mental clarity, fatigue resistance, and neurotransmitter-adjacent research.',
+    systems: ['Attention', 'Memory', 'Neurotransmitters'],
+    keywords: ['cognition', 'cognitive', 'focus', 'memory', 'attention', 'nootropic', 'clarity', 'adhd', 'concentration'],
+    profileIntent: { ifYouWant: 'sharper focus', goTo: 'Focus guides', href: '/guides/focus/' },
+  },
+  {
+    slug: 'metabolism',
+    label: 'Metabolism',
+    href: '/guides/best/supplements-for-fat-loss',
+    description: 'Energy balance, glucose context, body-composition research, and metabolic resilience signals.',
+    systems: ['Energy balance', 'Glucose context', 'Body composition'],
+    keywords: ['metabolism', 'metabolic', 'glucose', 'insulin', 'fat', 'weight'],
+  },
+  {
+    slug: 'stress-response',
+    label: 'Stress response',
+    href: '/guides/best/supplements-for-stress',
+    description: 'HPA-axis language, adaptation, calm, sleep overlap, and nervous-system resilience.',
+    systems: ['HPA axis', 'Adaptation', 'Calm'],
+    keywords: ['stress', 'cortisol', 'adaptogen', 'anxiety', 'calm', 'relaxation', 'relax', 'anxiolytic', 'gaba'],
+    profileIntent: { ifYouWant: 'help with anxiety or stress', goTo: 'Anxiety & stress guides', href: '/guides/anxiety/' },
+  },
+  {
+    slug: 'longevity',
+    label: 'Longevity',
+    href: '/guides/sleep',
+    description: 'Aging-adjacent research themes including repair, oxidative stress, metabolism, and resilience.',
+    systems: ['Repair', 'Resilience', 'Healthy aging'],
+    keywords: ['longevity', 'aging', 'cellular', 'repair', 'resilience'],
+  },
+  {
+    slug: 'mitochondrial-function',
+    label: 'Mitochondrial function',
+    href: '/guides/other/supplements-for-brain-fog-and-fatigue',
+    description: 'Cellular energy, fatigue, exercise performance, and recovery-adjacent mechanism context.',
+    systems: ['Cellular energy', 'Fatigue', 'Performance'],
+    keywords: ['mitochondria', 'mitochondrial', 'atp', 'energy', 'fatigue', 'performance'],
+  },
+  {
+    slug: 'oxidative-stress',
+    label: 'Oxidative stress',
+    href: '/learn/inflammation',
+    description: 'Antioxidant response, redox balance, inflammation overlap, and tissue-stress research language.',
+    systems: ['Redox balance', 'Antioxidant response', 'Tissue stress'],
+    keywords: ['oxidative', 'antioxidant', 'redox', 'ros', 'free radical'],
+  },
+  {
+    slug: 'sleep',
+    label: 'Sleep',
+    href: '/guides/sleep',
+    description: 'Latency, sleep quality, relaxation, circadian context, and nighttime recovery overlap.',
+    systems: ['Sleep quality', 'Circadian context', 'Relaxation'],
+    keywords: ['sleep', 'circadian', 'melatonin', 'night', 'insomnia', 'sedative', 'rest'],
+    profileIntent: { ifYouWant: 'help sleeping', goTo: 'Sleep guides', href: '/guides/sleep/' },
+  },
+  {
+    slug: 'neurobiology',
+    label: 'Neurobiology',
+    href: '/learn/dopamine',
+    description: 'Neurotransmitter systems, mood-adjacent signals, cognition, calm, and arousal regulation.',
+    systems: ['Dopamine', 'GABA', 'Arousal'],
+    keywords: ['neuro', 'dopamine', 'gaba', 'serotonin', 'brain', 'mood'],
+  },
+  {
+    slug: 'cardiovascular-function',
+    label: 'Cardiovascular function',
+    href: '/guides/best/supplements-for-blood-pressure',
+    description: 'Blood-pressure context, vascular tone, circulation, metabolic overlap, and endothelial themes.',
+    systems: ['Vascular tone', 'Circulation', 'Blood pressure'],
+    keywords: ['cardio', 'vascular', 'blood pressure', 'circulation', 'heart', 'endothelial'],
+  },
+]
+
+function normalizeSignals(signals: string[]): string {
+  return signals.join(' ').toLowerCase().replace(/\s+/g, ' ').trim()
+}
+
+export function matchTopicClusters(signals: string[]): TopicCluster[] {
+  const haystack = normalizeSignals(signals)
+  if (!haystack) return []
+  return topicClusters.filter((cluster) =>
+    cluster.keywords.some((keyword) => haystack.includes(keyword)) ||
+    haystack.includes(cluster.label.toLowerCase())
+  )
+}
+
+export function getProfileIntentRoutes(signals: string[]) {
+  const seen = new Set<string>()
+  return matchTopicClusters(signals)
+    .flatMap((cluster) => cluster.profileIntent ? [cluster.profileIntent] : [])
+    .filter((route) => {
+      if (seen.has(route.href)) return false
+      seen.add(route.href)
+      return true
+    })
+}

--- a/src/components/Disclaimer.tsx
+++ b/src/components/Disclaimer.tsx
@@ -1,28 +1,36 @@
 import { Link } from '../lib/router-compat'
+import { DISCLAIMER_COPY, type DisclaimerVariant } from '../lib/disclaimer-copy'
 
 type DisclaimerProps = {
   className?: string
+  variant?: DisclaimerVariant
 }
 
-export default function Disclaimer({ className = '' }: DisclaimerProps) {
+export default function Disclaimer({ className = '', variant = 'standard' }: DisclaimerProps) {
+  const copy = DISCLAIMER_COPY[variant]
+  const highRisk = variant === 'high-risk'
+
   return (
     <section
-      className={`safety-disclaimer border-l-2 border-amber-600/50 bg-amber-50/70 px-4 py-3 text-sm ${className}`.trim()}
-      aria-label='Safety disclaimer'
+      className={`safety-disclaimer border-l-2 px-4 py-3 text-sm ${
+        highRisk
+          ? 'border-red-700/50 bg-red-50 text-red-950'
+          : 'border-amber-600/50 bg-amber-50/70'
+      } ${className}`.trim()}
+      aria-label={copy.ariaLabel}
+      role={highRisk ? 'note' : undefined}
     >
-      <p className='font-semibold uppercase tracking-wide'>Safety first · Harm reduction</p>
-      <p className='mt-2 opacity-90'>
-        This information is educational and not medical advice. Start low, avoid risky combinations,
-        and consult a licensed clinician before making health decisions—especially if you use
-        medications, have diagnosed conditions, or are pregnant/breastfeeding.
-      </p>
-      <p className='mt-2 opacity-90'>
-        Learn how we evaluate confidence, safety, and intensity on the{' '}
-        <Link to='/info/methodology' className='font-semibold underline decoration-dotted underline-offset-4'>
-          methodology page
-        </Link>
-        .
-      </p>
+      <p className='font-semibold uppercase tracking-wide'>{copy.heading}</p>
+      <p className='mt-2 opacity-90'>{copy.body}</p>
+      {copy.showMethodologyLink ? (
+        <p className='mt-2 opacity-90'>
+          Learn how we evaluate confidence, safety, and intensity on the{' '}
+          <Link to='/info/methodology' className='font-semibold underline decoration-dotted underline-offset-4'>
+            methodology page
+          </Link>
+          .
+        </p>
+      ) : null}
     </section>
   )
 }

--- a/src/components/decision/EvidenceBadge.tsx
+++ b/src/components/decision/EvidenceBadge.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-
+import { canonicalGradeFromEvidenceTier, normalizeEvidenceGrade } from '../../../lib/evidence-grade'
 
 export type EvidenceTier = 'strong' | 'moderate' | 'early' | 'review' | 'unknown'
 
@@ -55,16 +55,26 @@ const TIER_CONFIG: Record<
 }
 
 /**
- * Maps raw workbook/runtime evidence strings to a normalized EvidenceTier.
- * Call this at the boundary where you receive raw data.
+ * Compatibility projection for badge styling. Scientific normalization belongs
+ * to the canonical evidence-grade contract; this function only maps that grade
+ * onto the smaller visual tier vocabulary used by this component.
  */
 export function normalizeEvidenceTier(raw?: string | null): EvidenceTier {
-  if (!raw) return 'unknown'
-  const v = raw.toLowerCase()
-  if (v.includes('tier-a') || v.includes('tier a') || v === 'a' || v === 'strong') return 'strong'
-  if (v.includes('tier-b') || v.includes('tier b') || v === 'b' || v === 'moderate') return 'moderate'
-  if (v.includes('tier-c') || v.includes('tier c') || v === 'c' || v === 'early' || v === 'preliminary') return 'early'
-  if (v.includes('review') || v.includes('mixed') || v.includes('limited')) return 'review'
+  if (!raw?.trim()) return 'unknown'
+
+  // Legacy `tier-a`/`tier b` are ingestion aliases. Strip only the tier prefix,
+  // then hand the actual grade interpretation to the canonical normalizer.
+  const legacyTierValue = raw.trim().replace(/^tier[-\s]*/i, '')
+  const normalized = normalizeEvidenceGrade(legacyTierValue)
+  const grade = normalized.grade && !normalized.outcomeDependent
+    ? normalized.grade
+    : canonicalGradeFromEvidenceTier(raw)
+
+  if (grade === 'A') return 'strong'
+  if (grade === 'B') return 'moderate'
+  if (grade === 'C' || grade === 'D') return 'early'
+  if (grade === 'Avoid/Insufficient') return 'review'
+  if (/\breview\b/i.test(raw)) return 'review'
   return 'unknown'
 }
 

--- a/src/lib/__tests__/content-contract.test.ts
+++ b/src/lib/__tests__/content-contract.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatCanonicalCitation,
+  getCanonicalAliases,
+  getCanonicalContentPolicy,
+  getCanonicalDisplayName,
+  getCanonicalEntityPath,
+  normalizeRuntimeContentRecord,
+  normalizeRuntimeContentRecords,
+} from '../content-contract'
+
+describe('runtime content contract', () => {
+  it('fails closed on malformed slugs before records reach components', () => {
+    expect(normalizeRuntimeContentRecord({ slug: '../unsafe', name: 'Unsafe' }, 'herb')).toBeNull()
+
+    const result = normalizeRuntimeContentRecords([
+      { slug: 'ashwagandha', name: 'Ashwagandha' },
+      { slug: '../unsafe', name: 'Unsafe' },
+    ], 'herb', 'fixture')
+
+    expect(result.records).toHaveLength(1)
+    expect(result.records[0].slug).toBe('ashwagandha')
+    expect(result.issues).toHaveLength(1)
+    expect(result.issues[0].source).toBe('fixture')
+  })
+
+  it('normalizes display names and aliases through one path', () => {
+    const record = {
+      slug: 'ashwagandha',
+      name: '  Ashwagandha  ',
+      aliases: 'Indian ginseng; Winter cherry',
+      commonnames: ['Winter cherry', 'Withania'],
+      scientificName: 'Withania somnifera',
+    }
+
+    expect(getCanonicalDisplayName(record)).toBe('Ashwagandha')
+    expect(getCanonicalAliases(record)).toEqual([
+      'Indian ginseng',
+      'Winter cherry',
+      'Withania',
+      'Withania somnifera',
+    ])
+  })
+
+  it('centralizes canonical entity paths and publication policy', () => {
+    const record = normalizeRuntimeContentRecord({
+      slug: 'magnesium',
+      name: 'Magnesium',
+      evidence_grade: 'B',
+      indexability_status: 'PUBLISH',
+      robots: 'index,follow',
+      sitemap_included: true,
+      affiliate_ready: true,
+    }, 'compound')
+
+    expect(record).not.toBeNull()
+    expect(getCanonicalEntityPath(record!, 'compound')).toBe('/compounds/magnesium/')
+
+    const policy = getCanonicalContentPolicy(record!, 'compound')
+    expect(policy.path).toBe('/compounds/magnesium/')
+    expect(policy.url).toContain('/compounds/magnesium/')
+    expect(policy.visibility.canIndex).toBe(true)
+    expect(policy.evidenceGrade).toBe('B')
+  })
+
+  it('formats PubMed citations deterministically', () => {
+    expect(formatCanonicalCitation({
+      authors: 'Smith J',
+      title: 'A controlled trial',
+      journal: 'Example Journal',
+      year: 2026,
+      pmid: '12345678',
+    })).toEqual({
+      text: 'Smith J. A controlled trial. Example Journal. 2026. PMID 12345678',
+      href: 'https://pubmed.ncbi.nlm.nih.gov/12345678/',
+      identifier: 'PMID 12345678',
+    })
+  })
+})

--- a/src/lib/__tests__/evidence-mapping.test.ts
+++ b/src/lib/__tests__/evidence-mapping.test.ts
@@ -1,52 +1,64 @@
-import { describe, it, expect } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { normalizeEvidence } from '../evidence-mapping'
 
 describe('evidence-mapping', () => {
-  it('correctly defaults with no evidence indicators', () => {
+  it('delegates an ungraded record to the shared evidence contract', () => {
     const result = normalizeEvidence({})
-    expect(result.score).toBe(5)
-    expect(result.grade).toBe('F')
-    expect(result.label).toBe('Evidence-Limited / Theoretical')
+    expect(result.grade).toBe('C')
+    expect(result.score).toBe(50)
+    expect(result.label).toBe('Limited evidence')
   })
 
-  it('calculates robust human clinical trial boosts', () => {
+  it('uses canonical strong evidence without adding a second study-count grade calculation', () => {
     const result = normalizeEvidence({
       evidence_tier: 'Strong Human Evidence',
       clinical_trial_count: 2,
       meta_analysis_count: 1,
     })
-    // baseline = 80, trials = 2 * 8 = 16, meta = 1 * 12 = 12. raw = 108, capped at 100.
-    expect(result.score).toBe(100)
+
     expect(result.grade).toBe('A')
+    expect(result.score).toBe(90)
+    expect(result.metrics.clinicalTrialCount).toBe(2)
+    expect(result.metrics.metaAnalysisCount).toBe(1)
   })
 
-  it('correctly maps moderate human evidence', () => {
+  it('keeps moderate evidence at B even when the study count is small', () => {
     const result = normalizeEvidence({
       evidence_tier: 'Moderate Human Evidence',
       human_studies_count: 1,
     })
-    // baseline = 60, human studies = 4. total = 64
-    expect(result.score).toBe(64)
-    expect(result.grade).toBe('C')
-  })
 
-  it('upgrades grade when count is high enough', () => {
-    const result = normalizeEvidence({
-      evidence_tier: 'Moderate Human Evidence',
-      human_studies_count: 3, // +12 -> 72
-    })
-    expect(result.score).toBe(72)
     expect(result.grade).toBe('B')
+    expect(result.score).toBe(70)
+    expect(result.metrics.humanStudiesCount).toBe(1)
   })
 
-  it('correctly categorizes mechanistic context', () => {
+  it('does not upgrade a canonical moderate grade because a count is high', () => {
+    const result = normalizeEvidence({
+      evidence_grade: 'B',
+      evidence_tier: 'Moderate Human Evidence',
+      human_studies_count: 30,
+      meta_analysis_count: 10,
+    })
+
+    expect(result.grade).toBe('B')
+    expect(result.score).toBe(70)
+  })
+
+  it('keeps mechanistic context at canonical grade D', () => {
     const result = normalizeEvidence({
       evidence_tier: 'Mechanistic Evidence',
       animal_studies_count: 3,
     })
-    // baseline = 20, animal = 6 -> 26
-    expect(result.score).toBe(26)
+
     expect(result.grade).toBe('D')
-    expect(result.label).toBe('Preclinical Context')
+    expect(result.score).toBe(30)
+    expect(result.label).toBe('Limited evidence')
+  })
+
+  it('never reintroduces legacy F as an evidence grade', () => {
+    const result = normalizeEvidence({ evidence_grade: 'F' })
+    expect(result.grade).toBe('Avoid/Insufficient')
+    expect(result.score).toBe(5)
   })
 })

--- a/src/lib/__tests__/safety-taxonomy.test.ts
+++ b/src/lib/__tests__/safety-taxonomy.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import {
+  matchSafetySignals,
+  normalizeSafetySignal,
+  normalizeSafetySignals,
+} from '../safety-taxonomy'
+
+describe('safety taxonomy', () => {
+  it('maps overlapping safety language through one canonical vocabulary', () => {
+    expect(matchSafetySignals('May increase bleeding risk with anticoagulants and has liver toxicity concerns.')).toEqual([
+      'Bleeding',
+      'Liver',
+      'Toxicity concern',
+    ])
+  })
+
+  it('recognizes the signal vocabulary used by both research and safety surfaces', () => {
+    expect(normalizeSafetySignals('Possible serotonergic interaction with SSRIs; CYP enzyme inhibition is also reported.')).toEqual([
+      'Serotonergic',
+      'Drug metabolism',
+    ])
+    expect(normalizeSafetySignal('pregnancy and lactation caution')).toBe('Pregnancy / breastfeeding')
+  })
+
+  it('preserves unknown text instead of converting missing knowledge into a safety conclusion', () => {
+    expect(normalizeSafetySignals('unclassified safety observation')).toEqual(['unclassified safety observation'])
+  })
+})

--- a/src/lib/botanical-atlas-taxonomy.ts
+++ b/src/lib/botanical-atlas-taxonomy.ts
@@ -1,3 +1,5 @@
+export { normalizeSafetySignal, normalizeSafetySignals } from './safety-taxonomy'
+
 const clean = (value: string) => value.trim().toLowerCase().replace(/[–—]/g, '-').replace(/\s+/g, ' ')
 
 const EFFECT_RULES: Array<[string, RegExp]> = [
@@ -42,21 +44,6 @@ const CLASS_RULES: Array<[string, RegExp]> = [
   ['Alkaloids', /\b(?:alkaloids?|isoquinolines?|aporphines?|tropanes?|indole alkaloids?|berberine|palmatine|mitragynine|mesembrine|yohimbine|harmine|harmaline|hordenine|synephrine|nicotine|lobeline|huperzine a|tetrahydropalmatine)\b/],
 ]
 
-const SAFETY_RULES: Array<[string, RegExp]> = [
-  ['Sedation', /sedat|drows|cns depress|sleepiness/],
-  ['Stimulation', /stimul|insomnia|agitat|jitter|anxiety/],
-  ['Serotonergic', /seroton|ssri|snri|maoi|monoamine oxidase/],
-  ['Cardiovascular', /blood pressure|hypertension|hypotension|heart|arrhythm|qt|tachy|brady/],
-  ['Bleeding', /bleed|anticoagul|antiplatelet/],
-  ['Liver', /liver|hepato/],
-  ['Kidney', /kidney|renal/],
-  ['Seizure', /seizure|convuls/],
-  ['Dependence / withdrawal', /depend|withdraw|addict|habit-forming|abuse/],
-  ['Pregnancy / breastfeeding', /pregnan|breastfeed|lactation/],
-  ['Drug metabolism', /cyp|drug metabolism|enzyme inhibit|enzyme induc/],
-  ['Toxicity concern', /toxic|poison|narrow therapeutic|fatal/],
-]
-
 const firstMatch = (value: string, rules: Array<[string, RegExp]>) => {
   const normalized = clean(value)
   return rules.find(([, pattern]) => pattern.test(normalized))?.[0]
@@ -64,12 +51,6 @@ const firstMatch = (value: string, rules: Array<[string, RegExp]>) => {
 
 export const normalizeEffect = (value: string) => firstMatch(value, EFFECT_RULES) ?? value.trim()
 export const normalizeCompoundClass = (value: string) => firstMatch(value, CLASS_RULES) ?? value.trim()
-export const normalizeSafetySignal = (value: string) => firstMatch(value, SAFETY_RULES) ?? value.trim()
-export const normalizeSafetySignals = (value: string): string[] => {
-  const normalized = clean(value)
-  const matches = SAFETY_RULES.filter(([, pattern]) => pattern.test(normalized)).map(([label]) => label)
-  return matches.length ? matches : (value.trim() ? [value.trim()] : [])
-}
 
 export const inferAtlasEffectsFromMechanisms = (values: string[]): string[] => {
   const effects = values.flatMap((value) => {

--- a/src/lib/content-contract.ts
+++ b/src/lib/content-contract.ts
@@ -1,0 +1,239 @@
+import { z } from 'zod'
+import type { RuntimeRecord } from '../types/content'
+import { getEvidenceLabel, getEvidenceLetterGrade } from '../../lib/evidence'
+import { getRuntimeVisibility } from '../../lib/runtime-visibility'
+import { canonicalUrl } from './seo'
+import { canRenderAffiliateLinks } from './affiliate'
+
+export type CanonicalContentKind = 'herb' | 'compound'
+
+const SAFE_SLUG = /^[a-z0-9][a-z0-9-]*$/
+const ENTITY_ID = /^ent_[a-z_]+_[0-9a-f]{12}$/
+
+const stringOrStringArray = z.union([z.string(), z.array(z.string())]).optional()
+
+/**
+ * Runtime-facing content contract.
+ *
+ * The workbook/canonical store remains the source of truth. This schema is the
+ * boundary between generated JSON and application code: it validates the
+ * identity/governance fields the UI depends on while deliberately passing
+ * through legacy enrichment fields until their migrations are complete.
+ */
+export const runtimeContentRecordSchema = z.object({
+  slug: z.string().regex(SAFE_SLUG),
+  id: z.string().regex(ENTITY_ID).optional(),
+  name: z.string().optional(),
+  displayName: z.string().optional(),
+  compoundName: z.string().optional(),
+  canonicalCompoundName: z.string().optional(),
+  entityType: z.string().optional(),
+  entity_type: z.string().optional(),
+  aliases: stringOrStringArray,
+  commonnames: stringOrStringArray,
+  commonNames: stringOrStringArray,
+  scientificname: z.string().optional(),
+  scientificName: z.string().optional(),
+  latinName: z.string().optional(),
+  evidence_grade: z.string().optional(),
+  evidence_tier: z.string().optional(),
+  evidenceTier: z.string().optional(),
+  indexability_status: z.string().optional(),
+  robots: z.string().optional(),
+  sitemap_included: z.union([z.boolean(), z.string()]).optional(),
+  runtime_export_decision: z.string().optional(),
+  profile_status: z.string().optional(),
+  summary_quality: z.string().optional(),
+  monetization_allowed: z.union([z.boolean(), z.string()]).optional(),
+}).passthrough()
+
+export type CanonicalRuntimeContentRecord = z.infer<typeof runtimeContentRecordSchema> & RuntimeRecord
+
+export type RuntimeContentIssue = {
+  source: string
+  index?: number
+  slug?: string
+  issues: string[]
+}
+
+function cleanString(value: unknown): string {
+  return typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : ''
+}
+
+function splitAliases(value: unknown): string[] {
+  if (Array.isArray(value)) return value.flatMap(splitAliases)
+  if (typeof value !== 'string') return []
+  return value
+    .split(/[|;,\n]/g)
+    .map((item) => item.replace(/\s+/g, ' ').trim())
+    .filter(Boolean)
+}
+
+function uniqueCaseInsensitive(values: string[]): string[] {
+  const seen = new Set<string>()
+  const output: string[] = []
+  for (const value of values) {
+    const key = value.toLocaleLowerCase()
+    if (!key || seen.has(key)) continue
+    seen.add(key)
+    output.push(value)
+  }
+  return output
+}
+
+export function getCanonicalDisplayName(record: Record<string, unknown>): string {
+  return (
+    cleanString(record.displayName) ||
+    cleanString(record.name) ||
+    cleanString(record.compoundName) ||
+    cleanString(record.canonicalCompoundName) ||
+    cleanString(record.common) ||
+    cleanString(record.slug)
+  )
+}
+
+export function getCanonicalAliases(record: Record<string, unknown>): string[] {
+  const canonicalName = getCanonicalDisplayName(record).toLocaleLowerCase()
+  return uniqueCaseInsensitive([
+    ...splitAliases(record.aliases),
+    ...splitAliases(record.commonnames),
+    ...splitAliases(record.commonNames),
+    cleanString(record.scientificname),
+    cleanString(record.scientificName),
+    cleanString(record.latinName),
+  ].filter(Boolean)).filter((alias) => alias.toLocaleLowerCase() !== canonicalName)
+}
+
+export function getCanonicalEntityPath(record: Record<string, unknown>, kind?: CanonicalContentKind): string {
+  const slug = cleanString(record.slug)
+  if (!SAFE_SLUG.test(slug)) return ''
+  const explicitType = cleanString(record.entityType || record.entity_type).toLowerCase()
+  const resolvedKind = kind || (explicitType === 'herb' ? 'herb' : explicitType === 'compound' ? 'compound' : undefined)
+  if (!resolvedKind) return ''
+  return `/${resolvedKind === 'herb' ? 'herbs' : 'compounds'}/${slug}/`
+}
+
+export function getCanonicalEntityUrl(record: Record<string, unknown>, kind?: CanonicalContentKind): string {
+  const entityPath = getCanonicalEntityPath(record, kind)
+  return entityPath ? canonicalUrl(entityPath) : ''
+}
+
+export function getCanonicalEvidenceLanguage(record: RuntimeRecord): string {
+  return getEvidenceLabel(record)
+}
+
+export function getCanonicalEvidenceGrade(record: RuntimeRecord): string {
+  return getEvidenceLetterGrade(record)
+}
+
+export type CanonicalCitation = {
+  text: string
+  href: string
+  identifier: string
+}
+
+export function formatCanonicalCitation(source: unknown): CanonicalCitation {
+  if (!source || typeof source !== 'object') return { text: '', href: '', identifier: '' }
+  const row = source as Record<string, unknown>
+  const title = cleanString(row.title)
+  const authors = cleanString(row.authors || row.author || row.author_or_label)
+  const journal = cleanString(row.journal)
+  const year = cleanString(row.year)
+  const pmid = cleanString(row.pmid).replace(/^PMID:\s*/i, '')
+  const doi = cleanString(row.doi).replace(/^https?:\/\/(?:dx\.)?doi\.org\//i, '').replace(/^doi:\s*/i, '')
+  const rawUrl = cleanString(row.url)
+
+  const labelParts = [authors, title, journal, year].filter(Boolean)
+  const identifier = pmid ? `PMID ${pmid}` : doi ? `DOI ${doi}` : ''
+  if (identifier) labelParts.push(identifier)
+
+  const href = pmid
+    ? `https://pubmed.ncbi.nlm.nih.gov/${encodeURIComponent(pmid)}/`
+    : doi
+      ? `https://doi.org/${doi}`
+      : rawUrl
+
+  return {
+    text: labelParts.join('. '),
+    href,
+    identifier,
+  }
+}
+
+export function getCanonicalContentPolicy(record: RuntimeRecord, kind?: CanonicalContentKind) {
+  const visibility = getRuntimeVisibility(record)
+  return {
+    path: getCanonicalEntityPath(record, kind),
+    url: getCanonicalEntityUrl(record, kind),
+    evidenceLabel: getCanonicalEvidenceLanguage(record),
+    evidenceGrade: getCanonicalEvidenceGrade(record),
+    visibility,
+    canMonetize: visibility.canMonetize && canRenderAffiliateLinks(record),
+  }
+}
+
+/**
+ * Validate + normalize one generated profile before application code sees it.
+ * Invalid records return null (fail closed) rather than being cast to
+ * RuntimeRecord. Unknown legacy fields are preserved by the passthrough schema.
+ */
+export function normalizeRuntimeContentRecord(
+  value: unknown,
+  kind?: CanonicalContentKind,
+): CanonicalRuntimeContentRecord | null {
+  const parsed = runtimeContentRecordSchema.safeParse(value)
+  if (!parsed.success) return null
+
+  const record = parsed.data as CanonicalRuntimeContentRecord
+  const displayName = getCanonicalDisplayName(record)
+  const aliases = getCanonicalAliases(record)
+  const entityType = kind || (record.entityType === 'herb' || record.entityType === 'compound' ? record.entityType : undefined)
+
+  return {
+    ...record,
+    ...(displayName ? { name: displayName, displayName } : {}),
+    ...(aliases.length ? { aliases } : {}),
+    ...(entityType ? { entityType } : {}),
+  }
+}
+
+export function normalizeRuntimeContentRecords(
+  value: unknown,
+  kind?: CanonicalContentKind,
+  source = 'runtime-json',
+): { records: CanonicalRuntimeContentRecord[]; issues: RuntimeContentIssue[] } {
+  if (!Array.isArray(value)) {
+    return {
+      records: [],
+      issues: [{ source, issues: ['expected an array of runtime content records'] }],
+    }
+  }
+
+  const records: CanonicalRuntimeContentRecord[] = []
+  const issues: RuntimeContentIssue[] = []
+
+  value.forEach((candidate, index) => {
+    const parsed = runtimeContentRecordSchema.safeParse(candidate)
+    if (!parsed.success) {
+      const slug = candidate && typeof candidate === 'object'
+        ? cleanString((candidate as Record<string, unknown>).slug)
+        : ''
+      issues.push({
+        source,
+        index,
+        ...(slug ? { slug } : {}),
+        issues: parsed.error.issues.map((issue) => `${issue.path.join('.') || 'record'}: ${issue.message}`),
+      })
+      return
+    }
+
+    const normalized = normalizeRuntimeContentRecord(parsed.data, kind)
+    if (normalized) records.push(normalized)
+  })
+
+  return { records, issues }
+}
+
+export function isSafeContentSlug(value: string): boolean {
+  return SAFE_SLUG.test(value)
+}

--- a/src/lib/content-contract.ts
+++ b/src/lib/content-contract.ts
@@ -1,4 +1,3 @@
-import { z } from 'zod'
 import type { RuntimeRecord } from '../types/content'
 import { getEvidenceLabel, getEvidenceLetterGrade } from '../../lib/evidence'
 import { getRuntimeVisibility } from '../../lib/runtime-visibility'
@@ -10,50 +9,114 @@ export type CanonicalContentKind = 'herb' | 'compound'
 const SAFE_SLUG = /^[a-z0-9][a-z0-9-]*$/
 const ENTITY_ID = /^ent_[a-z_]+_[0-9a-f]{12}$/
 
-const stringOrStringArray = z.union([z.string(), z.array(z.string())]).optional()
-
-/**
- * Runtime-facing content contract.
- *
- * The workbook/canonical store remains the source of truth. This schema is the
- * boundary between generated JSON and application code: it validates the
- * identity/governance fields the UI depends on while deliberately passing
- * through legacy enrichment fields until their migrations are complete.
- */
-export const runtimeContentRecordSchema = z.object({
-  slug: z.string().regex(SAFE_SLUG),
-  id: z.string().regex(ENTITY_ID).optional(),
-  name: z.string().optional(),
-  displayName: z.string().optional(),
-  compoundName: z.string().optional(),
-  canonicalCompoundName: z.string().optional(),
-  entityType: z.string().optional(),
-  entity_type: z.string().optional(),
-  aliases: stringOrStringArray,
-  commonnames: stringOrStringArray,
-  commonNames: stringOrStringArray,
-  scientificname: z.string().optional(),
-  scientificName: z.string().optional(),
-  latinName: z.string().optional(),
-  evidence_grade: z.string().optional(),
-  evidence_tier: z.string().optional(),
-  evidenceTier: z.string().optional(),
-  indexability_status: z.string().optional(),
-  robots: z.string().optional(),
-  sitemap_included: z.union([z.boolean(), z.string()]).optional(),
-  runtime_export_decision: z.string().optional(),
-  profile_status: z.string().optional(),
-  summary_quality: z.string().optional(),
-  monetization_allowed: z.union([z.boolean(), z.string()]).optional(),
-}).passthrough()
-
-export type CanonicalRuntimeContentRecord = z.infer<typeof runtimeContentRecordSchema> & RuntimeRecord
+export type CanonicalRuntimeContentRecord = RuntimeRecord
 
 export type RuntimeContentIssue = {
   source: string
   index?: number
   slug?: string
   issues: string[]
+}
+
+type ContractValidationIssue = {
+  path: string[]
+  message: string
+}
+
+type ContractParseResult =
+  | { success: true; data: CanonicalRuntimeContentRecord }
+  | { success: false; error: { issues: ContractValidationIssue[] } }
+
+const STRING_FIELDS = [
+  'name',
+  'displayName',
+  'compoundName',
+  'canonicalCompoundName',
+  'entityType',
+  'entity_type',
+  'scientificname',
+  'scientificName',
+  'latinName',
+  'evidence_grade',
+  'evidence_tier',
+  'evidenceTier',
+  'indexability_status',
+  'robots',
+  'runtime_export_decision',
+  'profile_status',
+  'summary_quality',
+] as const
+
+const STRING_OR_STRING_ARRAY_FIELDS = ['aliases', 'commonnames', 'commonNames'] as const
+const BOOLEAN_OR_STRING_FIELDS = ['sitemap_included', 'monetization_allowed'] as const
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function validateRuntimeContentRecord(value: unknown): ContractParseResult {
+  if (!isObjectRecord(value)) {
+    return { success: false, error: { issues: [{ path: [], message: 'expected an object record' }] } }
+  }
+
+  const issues: ContractValidationIssue[] = []
+  const slug = value.slug
+  if (typeof slug !== 'string' || !SAFE_SLUG.test(slug)) {
+    issues.push({ path: ['slug'], message: 'must be a lowercase URL-safe slug' })
+  }
+
+  // Canonical entity IDs are validated when present. Legacy non-canonical IDs
+  // are retained during migration rather than turning an otherwise valid public
+  // profile into a runtime 404.
+  if (value.id !== undefined) {
+    if (typeof value.id !== 'string') {
+      issues.push({ path: ['id'], message: 'must be a string when present' })
+    } else if (value.id.startsWith('ent_') && !ENTITY_ID.test(value.id)) {
+      issues.push({ path: ['id'], message: 'malformed canonical entity ID' })
+    }
+  }
+
+  for (const field of STRING_FIELDS) {
+    const fieldValue = value[field]
+    if (fieldValue !== undefined && fieldValue !== null && typeof fieldValue !== 'string') {
+      issues.push({ path: [field], message: 'must be a string when present' })
+    }
+  }
+
+  for (const field of STRING_OR_STRING_ARRAY_FIELDS) {
+    const fieldValue = value[field]
+    if (fieldValue === undefined || fieldValue === null) continue
+    const valid = typeof fieldValue === 'string'
+      || (Array.isArray(fieldValue) && fieldValue.every((item) => typeof item === 'string'))
+    if (!valid) issues.push({ path: [field], message: 'must be a string or string array when present' })
+  }
+
+  for (const field of BOOLEAN_OR_STRING_FIELDS) {
+    const fieldValue = value[field]
+    if (fieldValue === undefined || fieldValue === null) continue
+    if (typeof fieldValue !== 'boolean' && typeof fieldValue !== 'string') {
+      issues.push({ path: [field], message: 'must be a boolean or string when present' })
+    }
+  }
+
+  if (issues.length) return { success: false, error: { issues } }
+  return { success: true, data: value as CanonicalRuntimeContentRecord }
+}
+
+/**
+ * Runtime-facing content contract.
+ *
+ * The workbook/canonical store remains the source of truth. This dependency-free
+ * parser is the boundary between generated JSON and application code: it checks
+ * the identity/governance fields the UI relies on while deliberately passing
+ * through legacy enrichment fields until their migrations are complete.
+ *
+ * The `safeParse` shape is intentionally tiny and local. It avoids adding a
+ * runtime schema dependency solely for this boundary while keeping callers
+ * explicit about success/failure.
+ */
+export const runtimeContentRecordSchema = {
+  safeParse: validateRuntimeContentRecord,
 }
 
 function cleanString(value: unknown): string {
@@ -175,7 +238,7 @@ export function getCanonicalContentPolicy(record: RuntimeRecord, kind?: Canonica
 /**
  * Validate + normalize one generated profile before application code sees it.
  * Invalid records return null (fail closed) rather than being cast to
- * RuntimeRecord. Unknown legacy fields are preserved by the passthrough schema.
+ * RuntimeRecord. Unknown legacy fields are preserved by the parser.
  */
 export function normalizeRuntimeContentRecord(
   value: unknown,
@@ -184,7 +247,7 @@ export function normalizeRuntimeContentRecord(
   const parsed = runtimeContentRecordSchema.safeParse(value)
   if (!parsed.success) return null
 
-  const record = parsed.data as CanonicalRuntimeContentRecord
+  const record = parsed.data
   const displayName = getCanonicalDisplayName(record)
   const aliases = getCanonicalAliases(record)
   const entityType = kind || (record.entityType === 'herb' || record.entityType === 'compound' ? record.entityType : undefined)

--- a/src/lib/disclaimer-copy.ts
+++ b/src/lib/disclaimer-copy.ts
@@ -1,0 +1,21 @@
+export type DisclaimerVariant = 'standard' | 'high-risk'
+
+export const DISCLAIMER_COPY: Record<DisclaimerVariant, {
+  ariaLabel: string
+  heading: string
+  body: string
+  showMethodologyLink: boolean
+}> = {
+  standard: {
+    ariaLabel: 'Safety disclaimer',
+    heading: 'Safety first · Harm reduction',
+    body: 'This information is educational and not medical advice. Avoid risky combinations, and consult a licensed clinician before making health decisions—especially if you use medications, have diagnosed conditions, or are pregnant/breastfeeding.',
+    showMethodologyLink: true,
+  },
+  'high-risk': {
+    ariaLabel: 'High-risk substance disclaimer',
+    heading: 'Important',
+    body: 'This content is for informational and educational purposes only. Some substances discussed here have little to no human clinical safety data and can carry serious, poorly characterized risks. This is not medical advice or a recommendation to use them.',
+    showMethodologyLink: false,
+  },
+}

--- a/src/lib/evidence-mapping.ts
+++ b/src/lib/evidence-mapping.ts
@@ -1,71 +1,59 @@
-import { EvidenceMetrics } from '../types/relational'
+import type { EvidenceMetrics } from '../types/relational'
+import type { RuntimeRecord } from '../types/content'
+import { getEvidenceLabel, getEvidenceLetterGrade } from '../../lib/evidence'
+import type { CanonicalEvidenceGrade } from '../../lib/evidence-grade'
 
 export interface NormalizedEvidence {
+  /** Presentation-only score derived from the canonical grade. It never changes the grade. */
   score: number // 0 - 100
-  grade: 'A' | 'B' | 'C' | 'D' | 'F'
+  grade: CanonicalEvidenceGrade
   label: string
   description: string
   metrics: EvidenceMetrics
 }
 
-function getBaselineScore(evidenceTier?: string): number {
-  if (!evidenceTier) return 5
-  const normalized = evidenceTier.toLowerCase()
-  if (normalized.includes('strong')) return 80
-  if (normalized.includes('moderate')) return 60
-  if (normalized.includes('limited') || normalized.includes('preliminary')) return 40
-  if (normalized.includes('mechanistic')) return 20
-  if (normalized.includes('traditional')) return 15
-  return 5
+const SCORE_BY_GRADE: Record<CanonicalEvidenceGrade, number> = {
+  A: 90,
+  B: 70,
+  C: 50,
+  D: 30,
+  'Avoid/Insufficient': 5,
 }
 
-export function normalizeEvidence(entity: any): NormalizedEvidence {
-  const clinicalTrialCount = Number(entity?.clinical_trial_count ?? entity?.clinicalTrialCount ?? 0)
-  const metaAnalysisCount = Number(entity?.meta_analysis_count ?? entity?.metaAnalysisCount ?? 0)
-  const humanStudiesCount = Number(entity?.human_studies_count ?? entity?.humanStudiesCount ?? 0)
-  const animalStudiesCount = Number(entity?.animal_studies_count ?? entity?.animalStudiesCount ?? 0)
-  const inVitroCount = Number(entity?.in_vitro_count ?? entity?.inVitroCount ?? 0)
-  const citationCount = Number(entity?.citation_count ?? entity?.citationCount ?? 0)
+const DESCRIPTION_BY_GRADE: Record<CanonicalEvidenceGrade, string> = {
+  A: 'The canonical evidence system classifies this record as strong evidence.',
+  B: 'The canonical evidence system classifies this record as moderate evidence.',
+  C: 'The canonical evidence system classifies this record as limited or mixed evidence.',
+  D: 'The canonical evidence system classifies this record as preliminary, preclinical, traditional, or theoretical evidence.',
+  'Avoid/Insufficient': 'The canonical evidence system does not support a positive evidence grade for this record.',
+}
 
-  const baseline = getBaselineScore(entity?.evidence_tier ?? entity?.evidenceTier)
-  const studiesBonus =
-    humanStudiesCount * 4 +
-    metaAnalysisCount * 12 +
-    clinicalTrialCount * 8 +
-    animalStudiesCount * 2 +
-    inVitroCount * 1 +
-    Math.min(citationCount * 0.5, 10)
+function metric(value: unknown): number {
+  const number = Number(value ?? 0)
+  return Number.isFinite(number) && number > 0 ? number : 0
+}
 
-  const rawScore = baseline + studiesBonus
-  const score = Math.min(Math.max(Math.round(rawScore), 0), 100)
-
-  let grade: 'A' | 'B' | 'C' | 'D' | 'F' = 'F'
-  let label = 'Evidence-Limited / Theoretical'
-  let description = 'No standardized or verifiable human clinical trials are currently registered.'
-
-  if (score >= 85) {
-    grade = 'A'
-    label = 'High Certainty'
-    description = 'Supported by robust human clinical trials, systematic reviews, or meta-analyses.'
-  } else if (score >= 65) {
-    grade = 'B'
-    label = 'Moderate Certainty'
-    description = 'Supported by clinical studies showing consistent positive human efficacy outcomes.'
-  } else if (score >= 45) {
-    grade = 'C'
-    label = 'Emerging Certainty'
-    description = 'Supported by preliminary, mixed, or early-stage human trials.'
-  } else if (score >= 25) {
-    grade = 'D'
-    label = 'Preclinical Context'
-    description = 'Supported primarily by in-vitro models, animal research, or historical context.'
-  }
+/**
+ * Compatibility adapter for relational UI callers.
+ *
+ * Evidence grade/label authority lives in `lib/evidence.ts` and the canonical
+ * `lib/evidence-grade.ts` contract. Study counts are exposed as metrics only;
+ * this adapter must never recompute or upgrade a scientific grade from them.
+ */
+export function normalizeEvidence(entity: RuntimeRecord): NormalizedEvidence {
+  const clinicalTrialCount = metric(entity?.clinical_trial_count ?? entity?.clinicalTrialCount)
+  const metaAnalysisCount = metric(entity?.meta_analysis_count ?? entity?.metaAnalysisCount)
+  const humanStudiesCount = metric(entity?.human_studies_count ?? entity?.humanStudiesCount)
+  const animalStudiesCount = metric(entity?.animal_studies_count ?? entity?.animalStudiesCount)
+  const inVitroCount = metric(entity?.in_vitro_count ?? entity?.inVitroCount)
+  const citationCount = metric(entity?.citation_count ?? entity?.citationCount)
+  const grade = getEvidenceLetterGrade(entity)
 
   return {
-    score,
+    score: SCORE_BY_GRADE[grade],
     grade,
-    label,
-    description,
+    label: getEvidenceLabel(entity),
+    description: DESCRIPTION_BY_GRADE[grade],
     metrics: {
       clinicalTrialCount,
       metaAnalysisCount,

--- a/src/lib/runtime-data.ts
+++ b/src/lib/runtime-data.ts
@@ -13,6 +13,12 @@ import type { RuntimeRecord } from '../types/content'
 import { getRuntimeVisibility } from '../../lib/runtime-visibility'
 import { getUnifiedRuntimeRecords } from './runtime-record-index'
 import { resolveRuntimeRecordLayers } from '../../lib/runtime-record-resolver.mjs'
+import {
+  isSafeContentSlug,
+  normalizeRuntimeContentRecord,
+  normalizeRuntimeContentRecords,
+  type CanonicalContentKind,
+} from './content-contract'
 
 const dataDir = path.join(process.cwd(), 'public', 'data')
 
@@ -76,11 +82,15 @@ async function readJsonFile(fileName: string): Promise<unknown> {
   }
 }
 
-function isSafeSlug(slug: string) {
-  return /^[a-z0-9][a-z0-9-]*$/.test(slug)
+function validatedProfileRows(value: unknown, kind: CanonicalContentKind, source: string): RuntimeRecord[] {
+  const { records, issues } = normalizeRuntimeContentRecords(value, kind, source)
+  if (issues.length && process.env.NODE_ENV !== 'production') {
+    console.warn(`[runtime-data] dropped ${issues.length} malformed ${kind} record(s) from ${source}`)
+  }
+  return records
 }
 
-function mergeBySlug(baseRows: RuntimeRecord[], enrichmentRows: RuntimeRecord[]) {
+function mergeBySlug(baseRows: RuntimeRecord[], enrichmentRows: RuntimeRecord[], kind: CanonicalContentKind) {
   const bySlug = new Map<string, RuntimeRecord>()
 
   for (const row of enrichmentRows) {
@@ -89,18 +99,20 @@ function mergeBySlug(baseRows: RuntimeRecord[], enrichmentRows: RuntimeRecord[])
     }
   }
 
-  const merged = baseRows.map(row => {
+  const merged = baseRows.flatMap(row => {
     const slug = typeof row?.slug === 'string' ? row.slug : ''
     const enrichment = bySlug.get(slug)
-
-    return enrichment ? resolveRuntimeRecordLayers(row, [enrichment]) as RuntimeRecord : row
+    const candidate = enrichment ? resolveRuntimeRecordLayers(row, [enrichment]) : row
+    const normalized = normalizeRuntimeContentRecord(candidate, kind)
+    return normalized ? [normalized as RuntimeRecord] : []
   })
 
   const knownSlugs = new Set(merged.map(row => row?.slug).filter(Boolean))
 
   for (const row of enrichmentRows) {
     if (typeof row?.slug === 'string' && !knownSlugs.has(row.slug)) {
-      merged.push(row)
+      const normalized = normalizeRuntimeContentRecord(row, kind)
+      if (normalized) merged.push(normalized as RuntimeRecord)
     }
   }
 
@@ -108,11 +120,11 @@ function mergeBySlug(baseRows: RuntimeRecord[], enrichmentRows: RuntimeRecord[])
 }
 
 async function readDetailRecord(kind: 'herbs' | 'compounds', slug: string): Promise<RuntimeRecord | null> {
-  if (!isSafeSlug(slug)) return null
+  if (!isSafeContentSlug(slug)) return null
 
   const detail = await readJsonFile(`${kind}-detail/${slug}.json`)
-
-  return detail && !Array.isArray(detail) && typeof detail === 'object' ? detail as RuntimeRecord : null
+  const normalized = normalizeRuntimeContentRecord(detail, kind === 'herbs' ? 'herb' : 'compound')
+  return normalized as RuntimeRecord | null
 }
 
 export const getHerbs = cache(async (): Promise<RuntimeRecord[]> => {
@@ -122,12 +134,12 @@ export const getHerbs = cache(async (): Promise<RuntimeRecord[]> => {
     readJsonFile('summary-indexes/herbs-summary.json'),
   ])
 
-  const baseRows = Array.isArray(herbs) ? herbs : []
-  const enrichmentRows = Array.isArray(summary) ? summary : []
-  const indexedRows = Array.isArray(summaryIndexed) ? summaryIndexed : []
+  const baseRows = validatedProfileRows(herbs, 'herb', 'herbs.json')
+  const enrichmentRows = validatedProfileRows(summary, 'herb', 'herbs-summary.json')
+  const indexedRows = validatedProfileRows(summaryIndexed, 'herb', 'summary-indexes/herbs-summary.json')
 
-  const firstPass = mergeBySlug(baseRows, enrichmentRows)
-  return mergeBySlug(firstPass, indexedRows)
+  const firstPass = mergeBySlug(baseRows, enrichmentRows, 'herb')
+  return mergeBySlug(firstPass, indexedRows, 'herb')
 })
 
 export const getCompounds = cache(async (): Promise<RuntimeRecord[]> => {
@@ -137,20 +149,12 @@ export const getCompounds = cache(async (): Promise<RuntimeRecord[]> => {
     readJsonFile('summary-indexes/compounds-summary.json'),
   ])
 
-  const baseRows = Array.isArray(compounds) ? compounds : []
-  const enrichmentRows = Array.isArray(summary) ? summary : []
-  const indexedRows = Array.isArray(summaryIndexed) ? summaryIndexed : []
+  const baseRows = validatedProfileRows(compounds, 'compound', 'compounds.json')
+  const enrichmentRows = validatedProfileRows(summary, 'compound', 'compounds-summary.json')
+  const indexedRows = validatedProfileRows(summaryIndexed, 'compound', 'summary-indexes/compounds-summary.json')
 
-  const firstPass = mergeBySlug(baseRows, enrichmentRows)
-
-  return mergeBySlug(firstPass, indexedRows).map(row => ({
-    name:
-      cleanString(row?.name) ||
-      cleanString(row?.compoundName) ||
-      cleanString(row?.canonicalCompoundName) ||
-      cleanString(row?.slug),
-    ...row,
-  }))
+  const firstPass = mergeBySlug(baseRows, enrichmentRows, 'compound')
+  return mergeBySlug(firstPass, indexedRows, 'compound')
 })
 
 export const getHerbCompoundMap = cache(async (): Promise<RuntimeRecord[]> => {
@@ -169,7 +173,7 @@ export const getClaims = cache(async (): Promise<RuntimeRecord[]> => {
 })
 
 export const getGoalEvidenceEngine = cache(async (goalSlug: string): Promise<EvidenceEnginePayload | null> => {
-  if (!isSafeSlug(goalSlug)) return null
+  if (!isSafeContentSlug(goalSlug)) return null
 
   const payload = await readJsonFile(`evidence-engine/${goalSlug}.json`)
   if (!isRecord(payload)) {
@@ -219,10 +223,12 @@ export const getRouteBuildManifest = cache(async (): Promise<RuntimeRecord[]> =>
 
 export async function getHerbBySlug(slug: string): Promise<RuntimeRecord | null> {
   const herbs = await getHerbs()
-  const herb = herbs.find((herb: any) => herb.slug === slug)
+  const herb = herbs.find((herb: RuntimeRecord) => herb.slug === slug)
   if (!herb) return null
   const detail = await readDetailRecord('herbs', slug)
-  const mergedHerb = detail ? resolveRuntimeRecordLayers(herb, [detail]) as RuntimeRecord : herb
+  const mergedHerb = detail
+    ? normalizeRuntimeContentRecord(resolveRuntimeRecordLayers(herb, [detail]), 'herb') as RuntimeRecord | null
+    : herb
 
   if (!mergedHerb || !getRuntimeVisibility(mergedHerb).canRender) return null
 
@@ -231,10 +237,12 @@ export async function getHerbBySlug(slug: string): Promise<RuntimeRecord | null>
 
 export async function getCompoundBySlug(slug: string): Promise<RuntimeRecord | null> {
   const compounds = await getCompounds()
-  const compound = compounds.find((compound: any) => compound.slug === slug)
+  const compound = compounds.find((compound: RuntimeRecord) => compound.slug === slug)
   if (!compound) return null
   const detail = await readDetailRecord('compounds', slug)
-  const mergedCompound = detail ? resolveRuntimeRecordLayers(compound, [detail]) as RuntimeRecord : compound
+  const mergedCompound = detail
+    ? normalizeRuntimeContentRecord(resolveRuntimeRecordLayers(compound, [detail]), 'compound') as RuntimeRecord | null
+    : compound
 
   if (!mergedCompound || !getRuntimeVisibility(mergedCompound).canRender) return null
 
@@ -245,7 +253,7 @@ export const getFeaturedHerbs = cache(async (): Promise<RuntimeRecord[]> => {
   try {
     const raw = await fs.readFile(path.join(dataDir, 'featured-herbs.json'), 'utf8')
     const parsed = JSON.parse(raw)
-    return Array.isArray(parsed) ? parsed : []
+    return validatedProfileRows(parsed, 'herb', 'featured-herbs.json')
   } catch {
     return []
   }
@@ -255,7 +263,7 @@ export const getFeaturedCompounds = cache(async (): Promise<RuntimeRecord[]> => 
   try {
     const raw = await fs.readFile(path.join(dataDir, 'featured-compounds.json'), 'utf8')
     const parsed = JSON.parse(raw)
-    return Array.isArray(parsed) ? parsed : []
+    return validatedProfileRows(parsed, 'compound', 'featured-compounds.json')
   } catch {
     return []
   }

--- a/src/lib/safety-taxonomy.ts
+++ b/src/lib/safety-taxonomy.ts
@@ -1,0 +1,65 @@
+export type CanonicalSafetySignal =
+  | 'Sedation'
+  | 'Stimulation'
+  | 'Serotonergic'
+  | 'Cardiovascular'
+  | 'Bleeding'
+  | 'Liver'
+  | 'Kidney'
+  | 'Seizure'
+  | 'Dependence / withdrawal'
+  | 'Pregnancy / breastfeeding'
+  | 'Drug metabolism'
+  | 'Immune'
+  | 'Metabolic'
+  | 'Toxicity concern'
+
+export type SafetySignalRule = {
+  label: CanonicalSafetySignal
+  pattern: RegExp
+}
+
+/**
+ * Canonical presentation taxonomy for structured safety signals.
+ *
+ * This is intentionally a terminology matcher, not a clinical severity engine:
+ * it converts existing safety/mechanism text into consistent labels without
+ * inferring that missing text means a substance is safe.
+ */
+export const SAFETY_SIGNAL_RULES: readonly SafetySignalRule[] = [
+  { label: 'Sedation', pattern: /sedat|drows|cns depress|sleepiness|sleep support|relax|calm/i },
+  { label: 'Stimulation', pattern: /stimul|insomnia|agitat|jitter|anxiety|alert|energy/i },
+  { label: 'Serotonergic', pattern: /seroton|ssri|snri|maoi|monoamine oxidase|5-ht/i },
+  { label: 'Cardiovascular', pattern: /blood pressure|hypertension|hypotension|heart|arrhythm|cardio|qt|tachy|brady/i },
+  { label: 'Bleeding', pattern: /bleed|anticoagul|antiplatelet/i },
+  { label: 'Liver', pattern: /liver|hepato/i },
+  { label: 'Kidney', pattern: /kidney|renal/i },
+  { label: 'Seizure', pattern: /seizure|convuls/i },
+  { label: 'Dependence / withdrawal', pattern: /depend|withdraw|addict|habit-forming|abuse/i },
+  { label: 'Pregnancy / breastfeeding', pattern: /pregnan|breastfeed|lactation/i },
+  { label: 'Drug metabolism', pattern: /\bcyp\w*\b|drug metabolism|enzyme inhibit|enzyme induc/i },
+  { label: 'Immune', pattern: /immune|immunomod|immunosuppress/i },
+  { label: 'Metabolic', pattern: /glucose|insulin|metabolic|blood sugar/i },
+  { label: 'Toxicity concern', pattern: /toxic|poison|narrow therapeutic|fatal/i },
+]
+
+function clean(value: string): string {
+  return value.trim().toLowerCase().replace(/[–—]/g, '-').replace(/\s+/g, ' ')
+}
+
+export function matchSafetySignals(value: string): CanonicalSafetySignal[] {
+  const normalized = clean(value)
+  if (!normalized) return []
+  return SAFETY_SIGNAL_RULES
+    .filter(({ pattern }) => pattern.test(normalized))
+    .map(({ label }) => label)
+}
+
+export function normalizeSafetySignal(value: string): string {
+  return matchSafetySignals(value)[0] ?? value.trim()
+}
+
+export function normalizeSafetySignals(value: string): string[] {
+  const matches = matchSafetySignals(value)
+  return matches.length ? matches : (value.trim() ? [value.trim()] : [])
+}


### PR DESCRIPTION
Fixes #3102

## Relevant URLs
- Herb profiles: `/herbs/<slug>/`
- Compound profiles: `/compounds/<slug>/`
- Runtime JSON loaded through `src/lib/runtime-data.ts`
- Shared research/navigation surfaces consuming evidence, safety, and topic taxonomies

## Acceptance criteria
- Validate identity/governance data before React/Next components consume it.
- Fail closed on malformed slugs/records.
- Centralize display-name, alias, route/URL, evidence wording/grade, citation formatting, visibility, monetization, and disclaimer policy.
- Remove redundant evidence-grade calculation: presentation adapters may expose study-count metrics but may not derive or upgrade the canonical scientific grade.
- Remove redundant safety terminology calculation by routing Atlas/research safety normalization through one shared taxonomy.
- Remove redundant condition/goal keyword mapping by routing ecosystem and profile-navigation matching through one shared topic taxonomy.
- Keep topic matching explicitly organizational; it must not become evidence that an ingredient treats a condition.
- Delegate existing evidence/SEO/visibility/affiliate policy instead of reimplementing it.
- Preserve unknown legacy enrichment fields during migration.
- Do not add a new runtime schema dependency solely for this boundary.

## Validation commands
- `npm run typecheck`
- `npm test -- src/lib/__tests__/content-contract.test.ts src/lib/__tests__/evidence-mapping.test.ts src/lib/__tests__/safety-taxonomy.test.ts lib/__tests__/topic-taxonomy.test.ts`
- `npm run check`
- `npm run build`

## Before → after metrics
- Runtime profile validation boundary: permissive casts → one canonical dependency-free typed boundary.
- Independent relational evidence-grade calculators: 1 → 0; canonical grade delegated to `lib/evidence.ts` / `lib/evidence-grade.ts`.
- Atlas safety regex tables: local duplicate → shared safety taxonomy.
- Profile/ecosystem condition-intent keyword tables: overlapping independent tables → one shared topic taxonomy.
- Disclaimer policy sources: 2 overlapping components → 1 shared policy + compatibility wrapper.
- New runtime validation dependencies: 0.

## Generator/source-of-truth decision
The workbook/canonical data pipeline remains the scientific source of truth. `content-contract.ts` is the runtime boundary and delegates existing `lib/evidence.ts`, `runtime-visibility`, SEO canonical generation, and affiliate safety gates. `safety-taxonomy.ts` standardizes terminology only; it is not a clinical severity engine. `topic-taxonomy.ts` standardizes navigation/organizational intent only; scientific outcome claims remain in canonical evidence/claim data.

## Regression contract
Malformed profile identity/governance data must not reach page components. Legacy enrichment fields remain passthrough-compatible, legacy non-canonical IDs are retained during migration, canonical `ent_*` IDs are validated, and canonical visibility/indexability stays fail-closed. Study counts cannot independently upgrade the evidence grade or reintroduce legacy `F`. Missing safety data cannot be interpreted as safe. Topic keyword matches cannot be promoted into clinical outcome claims. High-risk disclaimer language must not drift into permissive generic advice.