### PR TITLE
feat(email): segment subscribers by research interest

### DIFF
--- a/app/__tests__/subscribe-safety.test.ts
+++ b/app/__tests__/subscribe-safety.test.ts
@@ -42,7 +42,7 @@ describe('/api/subscribe-safety segmentation', () => {
     vi.restoreAllMocks()
   })
 
-  it('uses the safety-checklist tag instead of the legacy ADHD tag', async () => {
+  it('keeps the safety-checklist tag and adds the general research segment', async () => {
     const calls: Array<{ url: string; body: string }> = []
     globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       calls.push({ url: String(input), body: String(init?.body || '') })
@@ -65,12 +65,16 @@ describe('/api/subscribe-safety segmentation', () => {
     expect(calls).toHaveLength(2)
     expect(calls[1].url).toMatch(/\/tags$/)
     expect(calls[1].body).toContain('safety-checklist')
+    expect(calls[1].body).toContain('Interest: General')
     expect(calls[1].body).not.toContain('adhd-tag')
   })
 
-  it('does not tag a generic subscriber as ADHD when no safety tag is configured', async () => {
-    const fetchSpy = vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 }))
-    globalThis.fetch = fetchSpy as typeof fetch
+  it('uses only the allowlisted general interest when no safety tag is configured', async () => {
+    const calls: Array<{ url: string; body: string }> = []
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ url: String(input), body: String(init?.body || '') })
+      return new Response(JSON.stringify({ ok: true }), { status: 200 })
+    }) as typeof fetch
 
     const response = await onRequest({
       request: request('generic@example.com'),
@@ -84,6 +88,8 @@ describe('/api/subscribe-safety segmentation', () => {
     } as Parameters<typeof onRequest>[0])
 
     expect(response.status).toBe(200)
-    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(calls).toHaveLength(2)
+    expect(calls[1].body).toContain('Interest: General')
+    expect(calls[1].body).not.toContain('adhd-tag')
   })
 })

--- a/app/info/newsletter/page.tsx
+++ b/app/info/newsletter/page.tsx
@@ -5,6 +5,7 @@ import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
 import FaqJsonLd from '@/components/seo/FaqJsonLd'
 import EmailCapture from '../../../components/EmailCapture'
+import NewsletterInterestSignup from '@/components/monetization/NewsletterInterestSignup'
 
 const TITLE = 'Supplement Research Newsletter: Evidence Notes and Safety Checklists'
 const DESCRIPTION =
@@ -55,6 +56,11 @@ const faqItems = [
     question: 'What is in the newsletter?',
     answer:
       'The newsletter focuses on supplement research notes, evidence-quality reminders, safety context, product-quality checks, and updates to major site guides.',
+  },
+  {
+    question: 'Can I choose which research topics I receive?',
+    answer:
+      'Yes. The research-interest selector lets you choose Sleep, Stress, Anxiety, Focus, or General research. It stores a newsletter content preference rather than asking for symptoms or medical details.',
   },
   {
     question: 'Is the newsletter sales-focused?',
@@ -124,6 +130,8 @@ export default function NewsletterArchivePage() {
         ctaLabel='Subscribe'
         location='newsletter-archive'
       />
+
+      <NewsletterInterestSignup />
 
       <section className='rounded-[2rem] border border-brand-900/10 bg-brand-50/60 p-6 shadow-sm sm:p-8'>
         <p className='eyebrow-label'>Archive preview</p>

--- a/components/monetization/NewsletterInterestSignup.tsx
+++ b/components/monetization/NewsletterInterestSignup.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { useState } from 'react'
+import { EmailCaptureBox } from './EmailCaptureBox'
+import type { EmailCaptureGoal } from '@/content/emailCapture'
+
+type InterestOption = {
+  label: string
+  goal: Extract<EmailCaptureGoal, 'sleep' | 'stress' | 'anxiety' | 'focus' | 'default'>
+  description: string
+}
+
+const INTEREST_OPTIONS: readonly InterestOption[] = [
+  { label: 'Sleep', goal: 'sleep', description: 'Sleep quality, timing, forms, and next-day tradeoffs.' },
+  { label: 'Stress', goal: 'stress', description: 'Calming, adaptogen-style research, and stress-related tradeoffs.' },
+  { label: 'Anxiety', goal: 'anxiety', description: 'Cautious evidence and safety context for anxiety-adjacent research.' },
+  { label: 'Focus', goal: 'focus', description: 'Attention, cognition, stimulation, and non-stimulant approaches.' },
+  { label: 'General research', goal: 'default', description: 'The broad evidence digest rather than one topic lane.' },
+]
+
+export default function NewsletterInterestSignup() {
+  const [selected, setSelected] = useState<InterestOption>(INTEREST_OPTIONS[4])
+
+  return (
+    <section id='research-interests' className='scroll-mt-24 rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8'>
+      <p className='eyebrow-label'>Research interests</p>
+      <h2 className='mt-2 text-3xl font-semibold tracking-tight text-ink'>What do you want to research?</h2>
+      <p className='mt-3 max-w-3xl text-sm leading-7 text-muted'>
+        Choose a content lane, then use your email below. Existing subscribers can enter the same address to update their research-interest tag. This records a newsletter content preference only; do not enter symptoms, diagnoses, medications, or other health information.
+      </p>
+
+      <div className='mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-5' role='group' aria-label='Newsletter research interest'>
+        {INTEREST_OPTIONS.map((option) => {
+          const active = selected.goal === option.goal
+          return (
+            <button
+              key={option.goal}
+              type='button'
+              onClick={() => setSelected(option)}
+              aria-pressed={active}
+              className={`rounded-2xl border p-4 text-left transition ${
+                active
+                  ? 'border-brand-700/30 bg-brand-50 shadow-sm'
+                  : 'border-brand-900/10 bg-white hover:border-brand-700/20 hover:bg-brand-50/40'
+              }`}
+            >
+              <span className='block text-sm font-bold text-ink'>{option.label}</span>
+              <span className='mt-1 block text-xs leading-5 text-muted'>{option.description}</span>
+            </button>
+          )
+        })}
+      </div>
+
+      <EmailCaptureBox
+        key={selected.goal}
+        goal={selected.goal}
+        variant='wide'
+        className='mt-6'
+        title={`Follow ${selected.label.toLowerCase()} research`}
+        description='Subscribe or update this email address so future evidence notes can be selected for this research-interest lane.'
+      />
+    </section>
+  )
+}

--- a/functions/_shared/__tests__/newsletter-segmentation.test.ts
+++ b/functions/_shared/__tests__/newsletter-segmentation.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import {
+  interestFromSignupMagnet,
+  newsletterInterestTag,
+  newsletterTagsForSignup,
+} from '../newsletter-segmentation'
+
+describe('newsletter segmentation', () => {
+  it.each([
+    ['sleep', 'Sleep'],
+    ['stress', 'Stress'],
+    ['anxiety', 'Anxiety'],
+    ['focus', 'Focus'],
+    ['brain-fog', 'Focus'],
+    ['supplement-safety-checklist', 'General'],
+    ['unknown-value', 'General'],
+  ] as const)('maps %s to %s', (magnet, expected) => {
+    expect(interestFromSignupMagnet(magnet)).toBe(expected)
+  })
+
+  it('never turns arbitrary user input into an arbitrary Mailchimp tag', () => {
+    expect(newsletterTagsForSignup('MAKE-ME-ADMIN')).toEqual(['Interest: General'])
+    expect(newsletterTagsForSignup('<script>alert(1)</script>')).toEqual(['Interest: General'])
+  })
+
+  it('keeps an explicitly configured provider tag alongside the canonical interest tag', () => {
+    expect(newsletterTagsForSignup('sleep', 'Safety Checklist')).toEqual([
+      'Safety Checklist',
+      'Interest: Sleep',
+    ])
+  })
+
+  it('uses a stable human-readable tag namespace', () => {
+    expect(newsletterInterestTag('Anxiety')).toBe('Interest: Anxiety')
+  })
+})

--- a/functions/_shared/newsletter-segmentation.ts
+++ b/functions/_shared/newsletter-segmentation.ts
@@ -1,0 +1,40 @@
+export const NEWSLETTER_INTERESTS = ['Sleep', 'Stress', 'Anxiety', 'Focus', 'General'] as const
+export type NewsletterInterest = (typeof NEWSLETTER_INTERESTS)[number]
+
+const MAGNET_TO_INTEREST: Record<string, NewsletterInterest> = {
+  sleep: 'Sleep',
+  stress: 'Stress',
+  anxiety: 'Anxiety',
+  focus: 'Focus',
+  'brain-fog': 'Focus',
+  fatigue: 'General',
+  overthinking: 'Stress',
+  pain: 'General',
+  inflammation: 'General',
+  'safety-checklist': 'General',
+  'supplement-safety-checklist': 'General',
+  default: 'General',
+  general: 'General',
+}
+
+function normalizeKey(value: unknown): string {
+  return typeof value === 'string'
+    ? value.trim().toLowerCase().replace(/[_\s]+/g, '-')
+    : ''
+}
+
+export function interestFromSignupMagnet(magnet: unknown): NewsletterInterest {
+  const key = normalizeKey(magnet)
+  return MAGNET_TO_INTEREST[key] ?? 'General'
+}
+
+export function newsletterInterestTag(interest: NewsletterInterest): string {
+  return `Interest: ${interest}`
+}
+
+export function newsletterTagsForSignup(magnet: unknown, configuredTag?: string): string[] {
+  const tags = [configuredTag?.trim(), newsletterInterestTag(interestFromSignupMagnet(magnet))]
+    .filter((tag): tag is string => Boolean(tag))
+
+  return Array.from(new Set(tags))
+}

--- a/functions/api/subscribe.ts
+++ b/functions/api/subscribe.ts
@@ -1,3 +1,5 @@
+import { newsletterTagsForSignup } from '../_shared/newsletter-segmentation'
+
 interface KVNamespace {
   get(key: string): Promise<string | null>
   put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>
@@ -141,7 +143,6 @@ function maskEmail(email: string): string {
   return `${local.slice(0, 2)}***@${domain}`
 }
 
-
 function isProduction(env?: Env): boolean {
   const value = env?.ENVIRONMENT || ''
   return value === 'production' || value === 'prod' || value === 'true'
@@ -204,7 +205,7 @@ async function checkRateLimit(ip: string, env: Env): Promise<boolean> {
 
   const now = Date.now()
   if (!data || now > data.reset) {
-    data = { count: 1, reset: now + 600000 } // 10 minutes reset window
+    data = { count: 1, reset: now + 600000 }
   } else {
     data.count += 1
   }
@@ -225,18 +226,15 @@ async function checkRateLimit(ip: string, env: Env): Promise<boolean> {
 }
 
 export const onRequest = async ({ request, env }: PagesFunctionContext): Promise<Response> => {
-  // 1. Method Validation
   if (request.method !== 'POST') {
     return jsonResponse({ ok: false, error: 'Method not allowed.' }, 405)
   }
 
-  // 2. Content-Type Validation
   const contentType = request.headers.get('Content-Type') || ''
   if (!contentType.includes('application/json')) {
     return jsonResponse({ ok: false, error: 'Unsupported Content-Type. Expected application/json.' }, 415)
   }
 
-  // 3. Body Size Limit
   const contentLengthHeader = request.headers.get('Content-Length')
   if (contentLengthHeader && parseInt(contentLengthHeader, 10) > 10240) {
     return jsonResponse({ ok: false, error: 'Request body too large.' }, 413)
@@ -247,7 +245,6 @@ export const onRequest = async ({ request, env }: PagesFunctionContext): Promise
     return jsonResponse({ ok: false, error: 'Request body too large.' }, 413)
   }
 
-  // 4. JSON parsing and structured fields check
   let body: { email?: unknown; firstName?: unknown; magnet?: unknown; confirmEmail?: unknown; turnstileToken?: unknown }
   try {
     body = JSON.parse(text)
@@ -255,13 +252,11 @@ export const onRequest = async ({ request, env }: PagesFunctionContext): Promise
     return jsonResponse({ ok: false, error: 'Invalid JSON body.' }, 400)
   }
 
-  // 5. Honeypot check
   if (body.confirmEmail) {
     console.warn('Honeypot triggered by bot submission.')
     return jsonResponse({ ok: true, message: 'Subscribed successfully.' }, 200)
   }
 
-  // 6. Origin / Referer Validation
   const origin = request.headers.get('Origin')
   const referer = request.headers.get('Referer')
   const isLocalDev = request.url.includes('localhost') || request.url.includes('127.0.0.1')
@@ -290,14 +285,12 @@ export const onRequest = async ({ request, env }: PagesFunctionContext): Promise
     }
   }
 
-  // 7. Rate Limiting
   const clientIp = request.headers.get('CF-Connecting-IP') || '127.0.0.1'
   const rateLimitOk = await checkRateLimit(clientIp, env)
   if (!rateLimitOk) {
     return jsonResponse({ ok: false, error: 'Too many requests. Please try again later.' }, 429)
   }
 
-  // 8. Turnstile Token verification (optional, when secret key is defined)
   const turnstileSecret = env.TURNSTILE_SECRET_KEY?.trim()
   if (!turnstileSecret && isProduction(env)) {
     return jsonResponse({ ok: false, error: 'Security verification is not configured.' }, 503)
@@ -314,7 +307,7 @@ export const onRequest = async ({ request, env }: PagesFunctionContext): Promise
   const apiKey = env.MAILCHIMP_API_KEY?.trim()
   const serverPrefix = (env.MAILCHIMP_API_SERVER || env.MAILCHIMP_SERVER_PREFIX)?.trim()
   const audienceId = (env.MAILCHIMP_LIST_ID || env.MAILCHIMP_AUDIENCE_ID)?.trim()
-  const adhdTag = env.MAILCHIMP_ADHD_TAG?.trim()
+  const configuredTag = env.MAILCHIMP_ADHD_TAG?.trim()
 
   if (!apiKey || !serverPrefix || !audienceId) {
     console.error('Mailchimp subscription is missing required environment variables:', {
@@ -325,7 +318,6 @@ export const onRequest = async ({ request, env }: PagesFunctionContext): Promise
     return jsonResponse({ ok: false, error: 'Email subscription is not configured.' }, 500)
   }
 
-  // 9. Input normalization
   const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : ''
   const firstName = typeof body.firstName === 'string' ? body.firstName.trim() : ''
   const magnet = typeof body.magnet === 'string' ? body.magnet.trim() : ''
@@ -334,7 +326,6 @@ export const onRequest = async ({ request, env }: PagesFunctionContext): Promise
     return jsonResponse({ ok: false, error: 'Enter a valid email address.' }, 400)
   }
 
-  // 10. Mailchimp Integration
   const subscriberHash = md5Hex(email)
   const baseUrl = `https://${serverPrefix}.api.mailchimp.com/3.0/lists/${audienceId}/members/${subscriberHash}`
   const headers = {
@@ -361,17 +352,17 @@ export const onRequest = async ({ request, env }: PagesFunctionContext): Promise
     if (!memberResponse.ok) {
       const detail = await memberResponse.json().catch(() => null) as { detail?: string; title?: string } | null
       console.error('Mailchimp API Error:', detail?.detail || detail?.title || 'Unknown Error')
-      // Sanitize upstream errors
       return jsonResponse({ ok: false, error: 'Could not subscribe this email right now. Please try again.' }, 500)
     }
 
-    if (adhdTag) {
+    const subscriberTags = newsletterTagsForSignup(magnet, configuredTag)
+    if (subscriberTags.length > 0) {
       try {
         const tagResponse = await fetch(`${baseUrl}/tags`, {
           method: 'POST',
           headers,
           body: JSON.stringify({
-            tags: [{ name: adhdTag, status: 'active' }],
+            tags: subscriberTags.map((name) => ({ name, status: 'active' })),
           }),
         })
 


### PR DESCRIPTION
## Backlog
Covers 361–362.

## What changed
- maps signup magnets into exactly five canonical Mailchimp segments: Sleep, Stress, Anxiety, Focus, General
- preserves configured campaign tags while adding the canonical interest tag
- falls unknown or malicious magnet input back to General instead of creating arbitrary provider tags
- adds a public research-interest selector on the newsletter page
- existing subscribers can re-enter the same address to update their research-interest tag
- adds unit coverage for the allowlist and updates safety-signup integration expectations

## Privacy guardrail
The selector asks for a content preference only and explicitly tells readers not to provide symptoms, diagnoses, medications, or other health information.