### PR TITLE
ROI 786-800: forecasting dashboard and backlog impact/effort scores

### DIFF
--- a/components/ops/ForecastingDashboard.tsx
+++ b/components/ops/ForecastingDashboard.tsx
@@ -1,0 +1,65 @@
+import type { ForecastDashboard as ForecastDashboardData } from '@/src/lib/forecasting-dashboard'
+
+function percent(value: number): string {
+  return `${(value * 100).toFixed(1)}%`
+}
+
+function money(value: number): string {
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value)
+}
+
+export default function ForecastingDashboard({ dashboard }: { dashboard: ForecastDashboardData }) {
+  return (
+    <section className="space-y-4" aria-labelledby="forecasting-dashboard-title">
+      <div>
+        <h2 id="forecasting-dashboard-title" className="text-2xl font-bold text-ink">
+          Content-cluster forecasting dashboard
+        </h2>
+        <p className="mt-1 text-sm text-muted">
+          Search, indexation, conversion, revenue, backlink, and AI-citation signals in one view.
+        </p>
+      </div>
+
+      <div className="overflow-x-auto rounded-2xl border border-brand-900/10 bg-white/80">
+        <table className="min-w-[1200px] w-full text-left text-sm">
+          <thead className="bg-brand-50/70 text-xs uppercase tracking-wide text-brand-900">
+            <tr>
+              <th scope="col" className="px-3 py-3">Cluster</th>
+              <th scope="col" className="px-3 py-3">Impressions</th>
+              <th scope="col" className="px-3 py-3">Clicks</th>
+              <th scope="col" className="px-3 py-3">Avg position</th>
+              <th scope="col" className="px-3 py-3">Indexed URLs</th>
+              <th scope="col" className="px-3 py-3">Crawled / not indexed</th>
+              <th scope="col" className="px-3 py-3">Affiliate clicks</th>
+              <th scope="col" className="px-3 py-3">Email signups</th>
+              <th scope="col" className="px-3 py-3">Revenue</th>
+              <th scope="col" className="px-3 py-3">Referring domains</th>
+              <th scope="col" className="px-3 py-3">AI citations</th>
+              <th scope="col" className="px-3 py-3">Conversion rate</th>
+              <th scope="col" className="px-3 py-3">Momentum</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-brand-900/10">
+            {dashboard.clusters.map((row) => (
+              <tr key={row.cluster}>
+                <th scope="row" className="px-3 py-3 font-semibold text-ink">{row.cluster}</th>
+                <td className="px-3 py-3">{row.impressions.toLocaleString()}</td>
+                <td className="px-3 py-3">{row.clicks.toLocaleString()}</td>
+                <td className="px-3 py-3">{row.averagePosition.toFixed(1)}</td>
+                <td className="px-3 py-3">{row.indexedUrls.toLocaleString()}</td>
+                <td className="px-3 py-3">{row.crawledNotIndexedUrls.toLocaleString()}</td>
+                <td className="px-3 py-3">{row.affiliateClicks.toLocaleString()}</td>
+                <td className="px-3 py-3">{row.emailSignups.toLocaleString()}</td>
+                <td className="px-3 py-3">{money(row.revenue)}</td>
+                <td className="px-3 py-3">{row.referringDomains.toLocaleString()}</td>
+                <td className="px-3 py-3">{row.aiCitations.toLocaleString()}</td>
+                <td className="px-3 py-3">{percent(row.conversionRate)}</td>
+                <td className="px-3 py-3">{row.momentumScore.toFixed(2)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  )
+}

--- a/src/lib/__tests__/forecasting-dashboard.test.ts
+++ b/src/lib/__tests__/forecasting-dashboard.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildClusterForecast,
+  buildForecastDashboard,
+  scoreBacklogTask,
+} from '../forecasting-dashboard'
+
+const sleepNow = {
+  cluster: 'Sleep',
+  impressions: 1200,
+  clicks: 90,
+  averagePosition: 7,
+  indexedUrls: 40,
+  crawledNotIndexedUrls: 5,
+  affiliateClicks: 12,
+  emailSignups: 8,
+  revenue: 75,
+  referringDomains: 18,
+  aiCitations: 9,
+  conversionRate: 0.1,
+}
+
+const sleepBefore = {
+  ...sleepNow,
+  impressions: 1000,
+  clicks: 70,
+  averagePosition: 9,
+  revenue: 50,
+  referringDomains: 15,
+  aiCitations: 5,
+  conversionRate: 0.08,
+}
+
+describe('forecasting dashboard', () => {
+  it('displays every requested metric per content cluster and computes momentum', () => {
+    const [row] = buildClusterForecast([sleepNow], [sleepBefore])
+
+    expect(row.cluster).toBe('Sleep')
+    expect(row.impressions).toBe(1200)
+    expect(row.clicks).toBe(90)
+    expect(row.averagePosition).toBe(7)
+    expect(row.indexedUrls).toBe(40)
+    expect(row.crawledNotIndexedUrls).toBe(5)
+    expect(row.affiliateClicks).toBe(12)
+    expect(row.emailSignups).toBe(8)
+    expect(row.revenue).toBe(75)
+    expect(row.referringDomains).toBe(18)
+    expect(row.aiCitations).toBe(9)
+    expect(row.conversionRate).toBe(0.1)
+    expect(row.deltas.averagePosition).toBe(2)
+    expect(row.momentumScore).toBeGreaterThan(0)
+  })
+
+  it('builds site totals without averaging cluster positions naively', () => {
+    const dashboard = buildForecastDashboard(
+      [
+        sleepNow,
+        {
+          ...sleepNow,
+          cluster: 'Focus',
+          impressions: 300,
+          clicks: 20,
+          averagePosition: 3,
+        },
+      ],
+      [],
+      '2026-08-15T00:00:00.000Z',
+    )
+
+    expect(dashboard.generatedAt).toBe('2026-08-15T00:00:00.000Z')
+    expect(dashboard.totals.impressions).toBe(1500)
+    expect(dashboard.totals.averagePosition).toBeCloseTo(6.2)
+    expect(dashboard.totals.revenue).toBe(150)
+  })
+})
+
+describe('backlog impact and effort scoring', () => {
+  it('normalizes impact and effort onto a 1-10 scale', () => {
+    const scored = scoreBacklogTask({
+      id: 799,
+      title: 'Add expected impact',
+      expectedImpact: 14,
+      effort: 0,
+    })
+
+    expect(scored.expectedImpact).toBe(10)
+    expect(scored.effort).toBe(1)
+    expect(scored.scoreCompleteness).toBe('complete')
+  })
+
+  it('makes missing scores explicit instead of silently pretending confidence', () => {
+    const scored = scoreBacklogTask({ id: 800, title: 'Add effort score' })
+    expect(scored.scoreCompleteness).toBe('missing-both')
+    expect(scored.expectedImpact).toBe(1)
+    expect(scored.effort).toBe(10)
+  })
+})

--- a/src/lib/forecasting-dashboard.ts
+++ b/src/lib/forecasting-dashboard.ts
@@ -1,0 +1,200 @@
+export const FORECAST_METRICS = [
+  'impressions',
+  'clicks',
+  'averagePosition',
+  'indexedUrls',
+  'crawledNotIndexedUrls',
+  'affiliateClicks',
+  'emailSignups',
+  'revenue',
+  'referringDomains',
+  'aiCitations',
+  'conversionRate',
+] as const
+
+export type ForecastMetric = (typeof FORECAST_METRICS)[number]
+
+export interface ClusterMetrics {
+  cluster: string
+  impressions: number
+  clicks: number
+  averagePosition: number
+  indexedUrls: number
+  crawledNotIndexedUrls: number
+  affiliateClicks: number
+  emailSignups: number
+  revenue: number
+  referringDomains: number
+  aiCitations: number
+  conversionRate: number
+}
+
+export interface ClusterForecastRow extends ClusterMetrics {
+  previous?: ClusterMetrics
+  deltas: Partial<Record<ForecastMetric, number>>
+  momentumScore: number
+}
+
+function safePctChange(current: number, previous: number): number {
+  if (previous === 0) return current === 0 ? 0 : 1
+  return (current - previous) / Math.abs(previous)
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+export function buildClusterForecast(
+  current: ClusterMetrics[],
+  previous: ClusterMetrics[] = [],
+): ClusterForecastRow[] {
+  const previousByCluster = new Map(previous.map((row) => [row.cluster, row]))
+
+  return current
+    .map((row) => {
+      const prior = previousByCluster.get(row.cluster)
+      const deltas: Partial<Record<ForecastMetric, number>> = {}
+
+      if (prior) {
+        for (const metric of FORECAST_METRICS) {
+          if (metric === 'averagePosition') {
+            // Lower average position is better, so invert the sign for momentum.
+            deltas[metric] = prior.averagePosition - row.averagePosition
+          } else if (metric === 'conversionRate') {
+            deltas[metric] = row.conversionRate - prior.conversionRate
+          } else {
+            deltas[metric] = safePctChange(row[metric], prior[metric])
+          }
+        }
+      }
+
+      const impressionMomentum = prior ? safePctChange(row.impressions, prior.impressions) : 0
+      const clickMomentum = prior ? safePctChange(row.clicks, prior.clicks) : 0
+      const revenueMomentum = prior ? safePctChange(row.revenue, prior.revenue) : 0
+      const citationMomentum = prior ? safePctChange(row.aiCitations, prior.aiCitations) : 0
+      const backlinkMomentum = prior ? safePctChange(row.referringDomains, prior.referringDomains) : 0
+      const positionMomentum = prior ? clamp((prior.averagePosition - row.averagePosition) / 10, -1, 1) : 0
+
+      const momentumScore =
+        impressionMomentum * 0.2 +
+        clickMomentum * 0.2 +
+        revenueMomentum * 0.2 +
+        citationMomentum * 0.15 +
+        backlinkMomentum * 0.1 +
+        positionMomentum * 0.15
+
+      return {
+        ...row,
+        previous: prior,
+        deltas,
+        momentumScore: Number(momentumScore.toFixed(4)),
+      }
+    })
+    .sort((a, b) => b.momentumScore - a.momentumScore || b.impressions - a.impressions)
+}
+
+export interface BacklogTaskInput {
+  id: string | number
+  title: string
+  expectedImpact?: number
+  effort?: number
+  cluster?: string
+  rationale?: string
+}
+
+export interface ScoredBacklogTask extends BacklogTaskInput {
+  expectedImpact: number
+  effort: number
+  scoreCompleteness: 'complete' | 'missing-impact' | 'missing-effort' | 'missing-both'
+}
+
+function normalizeTenPointScore(value: number | undefined): number | undefined {
+  if (value === undefined || !Number.isFinite(value)) return undefined
+  return Number(clamp(value, 1, 10).toFixed(1))
+}
+
+export function scoreBacklogTask(task: BacklogTaskInput): ScoredBacklogTask {
+  const expectedImpact = normalizeTenPointScore(task.expectedImpact)
+  const effort = normalizeTenPointScore(task.effort)
+
+  let scoreCompleteness: ScoredBacklogTask['scoreCompleteness'] = 'complete'
+  if (expectedImpact === undefined && effort === undefined) scoreCompleteness = 'missing-both'
+  else if (expectedImpact === undefined) scoreCompleteness = 'missing-impact'
+  else if (effort === undefined) scoreCompleteness = 'missing-effort'
+
+  return {
+    ...task,
+    expectedImpact: expectedImpact ?? 1,
+    effort: effort ?? 10,
+    scoreCompleteness,
+  }
+}
+
+export function scoreBacklogTasks(tasks: BacklogTaskInput[]): ScoredBacklogTask[] {
+  return tasks.map(scoreBacklogTask)
+}
+
+export interface ForecastDashboard {
+  generatedAt: string
+  clusters: ClusterForecastRow[]
+  totals: Omit<ClusterMetrics, 'cluster' | 'averagePosition' | 'conversionRate'> & {
+    averagePosition: number
+    conversionRate: number
+  }
+}
+
+export function buildForecastDashboard(
+  current: ClusterMetrics[],
+  previous: ClusterMetrics[] = [],
+  generatedAt = new Date().toISOString(),
+): ForecastDashboard {
+  const clusters = buildClusterForecast(current, previous)
+  const totals = current.reduce(
+    (acc, row) => {
+      acc.impressions += row.impressions
+      acc.clicks += row.clicks
+      acc.indexedUrls += row.indexedUrls
+      acc.crawledNotIndexedUrls += row.crawledNotIndexedUrls
+      acc.affiliateClicks += row.affiliateClicks
+      acc.emailSignups += row.emailSignups
+      acc.revenue += row.revenue
+      acc.referringDomains += row.referringDomains
+      acc.aiCitations += row.aiCitations
+      acc.positionWeight += row.averagePosition * row.impressions
+      return acc
+    },
+    {
+      impressions: 0,
+      clicks: 0,
+      indexedUrls: 0,
+      crawledNotIndexedUrls: 0,
+      affiliateClicks: 0,
+      emailSignups: 0,
+      revenue: 0,
+      referringDomains: 0,
+      aiCitations: 0,
+      positionWeight: 0,
+    },
+  )
+
+  const conversionDenominator = totals.clicks || totals.impressions
+  return {
+    generatedAt,
+    clusters,
+    totals: {
+      impressions: totals.impressions,
+      clicks: totals.clicks,
+      averagePosition: totals.impressions ? totals.positionWeight / totals.impressions : 0,
+      indexedUrls: totals.indexedUrls,
+      crawledNotIndexedUrls: totals.crawledNotIndexedUrls,
+      affiliateClicks: totals.affiliateClicks,
+      emailSignups: totals.emailSignups,
+      revenue: totals.revenue,
+      referringDomains: totals.referringDomains,
+      aiCitations: totals.aiCitations,
+      conversionRate: conversionDenominator
+        ? (totals.affiliateClicks + totals.emailSignups) / conversionDenominator
+        : 0,
+    },
+  }
+}


### PR DESCRIPTION
Implements backlog 786-800.

- canonical forecasting metrics for impressions, clicks, average position, indexed URLs, crawled-not-indexed URLs, affiliate clicks, email signups, revenue, referring domains, AI citations, and conversion rate
- aggregates and compares those metrics per content cluster
- computes cluster momentum without treating lower search position as worse
- adds a reusable accessible dashboard table that displays every requested metric by cluster
- adds normalized 1-10 expected-impact and effort fields for backlog tasks, with explicit missing-score states rather than fake certainty
- regression tests cover metric aggregation, weighted average position, momentum, and task score normalization