### PR TITLE
fix(forms): apply publication gate to generated comparison guides

### DIFF
--- a/app/guides/forms/[slug]/page.tsx
+++ b/app/guides/forms/[slug]/page.tsx
@@ -3,93 +3,25 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 
 import Disclaimer from '@/src/components/Disclaimer'
-import { getUnifiedRuntimeRecords } from '@/src/lib/runtime-record-index'
 import { buildPageMetadata } from '@/src/lib/seo'
-
-type RuntimeIngredient = Record<string, unknown> & {
-  slug?: string
-  name?: string
-  forms?: unknown
-  available_forms?: unknown
-  bioavailability_notes?: unknown
-  dosage?: unknown
-  typical_dosage?: unknown
-}
-
-type IngredientWithType = {
-  record: RuntimeIngredient
-  entityType: 'herb' | 'compound'
-}
-
-function clean(value: unknown): string {
-  if (typeof value !== 'string') return ''
-  return value.replace(/\s+/g, ' ').trim()
-}
-
-function toText(value: unknown): string {
-  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return clean(String(value))
-  if (Array.isArray(value)) return value.map(toText).filter(Boolean).join('; ')
-  if (value && typeof value === 'object') {
-    return Object.entries(value as Record<string, unknown>)
-      .map(([key, nested]) => {
-        const text = toText(nested)
-        return text ? `${key.replace(/[_-]+/g, ' ')}: ${text}` : ''
-      })
-      .filter(Boolean)
-      .join('; ')
-  }
-  return ''
-}
-
-function toFormItems(value: unknown): string[] {
-  if (Array.isArray(value)) return value.map(toText).filter(Boolean)
-  if (value && typeof value === 'object') {
-    return Object.entries(value as Record<string, unknown>)
-      .map(([key, nested]) => {
-        const detail = toText(nested)
-        return detail ? `${key.replace(/[_-]+/g, ' ')}: ${detail}` : key.replace(/[_-]+/g, ' ')
-      })
-      .filter(Boolean)
-  }
-  const text = toText(value)
-  if (!text) return []
-  const split = text.split(/\s*[;|]\s*/).map((item) => item.trim()).filter(Boolean)
-  return split.length >= 2 ? split : []
-}
-
-function getForms(record: RuntimeIngredient): string[] {
-  const primary = toFormItems(record.forms)
-  const fallback = toFormItems(record.available_forms)
-  return [...new Set([...primary, ...fallback])]
-}
-
-async function getEligibleIngredients(): Promise<IngredientWithType[]> {
-  const { herbs, compounds } = await getUnifiedRuntimeRecords()
-  const bySlug = new Map<string, IngredientWithType>()
-
-  for (const record of herbs as RuntimeIngredient[]) {
-    const slug = clean(record.slug)
-    if (slug && getForms(record).length >= 2 && !bySlug.has(slug)) bySlug.set(slug, { record, entityType: 'herb' })
-  }
-  for (const record of compounds as RuntimeIngredient[]) {
-    const slug = clean(record.slug)
-    if (slug && getForms(record).length >= 2 && !bySlug.has(slug)) bySlug.set(slug, { record, entityType: 'compound' })
-  }
-
-  return [...bySlug.values()]
-}
+import {
+  cleanFormValue,
+  formValueToText,
+  getForms,
+  loadIndexableFormIngredients,
+} from '../form-data'
 
 export async function generateStaticParams() {
-  const ingredients = await getEligibleIngredients()
-  return ingredients.map(({ record }) => ({ slug: clean(record.slug) }))
+  const ingredients = await loadIndexableFormIngredients()
+  return ingredients.map((record) => ({ slug: cleanFormValue(record.slug) }))
 }
 
 export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {
   const { slug } = await params
-  const ingredients = await getEligibleIngredients()
-  const match = ingredients.find(({ record }) => clean(record.slug) === slug)
-  if (!match) return {}
-  const name = clean(match.record.name) || slug
+  const ingredients = await loadIndexableFormIngredients()
+  const record = ingredients.find((item) => cleanFormValue(item.slug) === slug)
+  if (!record) return {}
+  const name = cleanFormValue(record.name) || slug
 
   return buildPageMetadata({
     title: `${name} Forms Compared: What Actually Differs?`,
@@ -100,16 +32,15 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
 
 export default async function IngredientFormsPage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params
-  const ingredients = await getEligibleIngredients()
-  const match = ingredients.find(({ record }) => clean(record.slug) === slug)
-  if (!match) notFound()
+  const ingredients = await loadIndexableFormIngredients()
+  const record = ingredients.find((item) => cleanFormValue(item.slug) === slug)
+  if (!record) notFound()
 
-  const { record, entityType } = match
-  const name = clean(record.name) || slug
+  const name = cleanFormValue(record.name) || slug
   const forms = getForms(record)
-  const bioavailability = toText(record.bioavailability_notes)
-  const dose = toText(record.typical_dosage) || toText(record.dosage)
-  const profileHref = `/${entityType === 'herb' ? 'herbs' : 'compounds'}/${slug}/`
+  const bioavailability = formValueToText(record.bioavailability_notes)
+  const dose = formValueToText(record.typical_dosage) || formValueToText(record.dosage)
+  const profileHref = `/${record.entityType === 'compound' ? 'compounds' : 'herbs'}/${slug}/`
 
   return (
     <main className="container-page space-y-8 py-10">

--- a/app/guides/forms/form-data.ts
+++ b/app/guides/forms/form-data.ts
@@ -1,0 +1,83 @@
+import { getRuntimeVisibility } from '@/lib/runtime-visibility'
+import { getUnifiedRuntimeRecords } from '@/src/lib/runtime-record-index'
+import type { RuntimeRecord } from '@/src/types/content'
+
+export type FormIngredient = RuntimeRecord & {
+  forms?: unknown
+  available_forms?: unknown
+  bioavailability_notes?: unknown
+  dosage?: unknown
+  typical_dosage?: unknown
+}
+
+export function cleanFormValue(value: unknown): string {
+  if (typeof value !== 'string') return ''
+  return value.replace(/\s+/g, ' ').trim()
+}
+
+export function formValueToText(value: unknown): string {
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return cleanFormValue(String(value))
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(formValueToText).filter(Boolean).join('; ')
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.entries(value as Record<string, unknown>)
+      .map(([key, nested]) => {
+        const text = formValueToText(nested)
+        return text ? `${key.replace(/[_-]+/g, ' ')}: ${text}` : ''
+      })
+      .filter(Boolean)
+      .join('; ')
+  }
+
+  return ''
+}
+
+export function toFormItems(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map(formValueToText).filter(Boolean)
+
+  if (value && typeof value === 'object') {
+    return Object.entries(value as Record<string, unknown>)
+      .map(([key, nested]) => {
+        const detail = formValueToText(nested)
+        return detail ? `${key.replace(/[_-]+/g, ' ')}: ${detail}` : key.replace(/[_-]+/g, ' ')
+      })
+      .filter(Boolean)
+  }
+
+  const text = formValueToText(value)
+  if (!text) return []
+
+  const split = text.split(/\s*[;|]\s*/).map((item) => item.trim()).filter(Boolean)
+  return split.length >= 2 ? split : []
+}
+
+export function getForms(record: FormIngredient): string[] {
+  const primary = toFormItems(record.forms)
+  const fallback = toFormItems(record.available_forms)
+  return [...new Set([...primary, ...fallback])]
+}
+
+export function selectIndexableFormIngredients(records: RuntimeRecord[]): FormIngredient[] {
+  const bySlug = new Map<string, FormIngredient>()
+
+  for (const record of records as FormIngredient[]) {
+    if (!getRuntimeVisibility(record).canIndex) continue
+
+    const slug = cleanFormValue(record.slug)
+    if (!slug || getForms(record).length < 2) continue
+
+    if (!bySlug.has(slug)) bySlug.set(slug, record)
+  }
+
+  return [...bySlug.values()]
+}
+
+export async function loadIndexableFormIngredients(): Promise<FormIngredient[]> {
+  const { allRecords } = await getUnifiedRuntimeRecords()
+  return selectIndexableFormIngredients(allRecords as RuntimeRecord[])
+}

--- a/tests/form-guide-publication-gate.test.ts
+++ b/tests/form-guide-publication-gate.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getForms,
+  selectIndexableFormIngredients,
+} from '../app/guides/forms/form-data'
+import type { RuntimeRecord } from '../src/types/content'
+
+describe('form guide publication gate', () => {
+  it('publishes only indexable records with at least two distinct forms', () => {
+    const records: RuntimeRecord[] = [
+      {
+        slug: 'published',
+        forms: ['capsule', 'powder'],
+        indexability_status: 'PUBLISH',
+      },
+      {
+        slug: 'noindex',
+        forms: ['capsule', 'powder'],
+        indexability_status: 'NOINDEX',
+      },
+      {
+        slug: 'hidden',
+        forms: ['capsule', 'powder'],
+        indexability_status: 'PUBLISH',
+        runtime_export_decision: 'hide',
+      },
+      {
+        slug: 'single-form',
+        forms: ['capsule'],
+        indexability_status: 'PUBLISH',
+      },
+    ]
+
+    expect(selectIndexableFormIngredients(records).map((record) => record.slug)).toEqual([
+      'published',
+    ])
+  })
+
+  it('applies publication visibility before slug deduplication', () => {
+    const records: RuntimeRecord[] = [
+      {
+        slug: 'shared',
+        name: 'Noindex version',
+        forms: ['capsule', 'powder'],
+        indexability_status: 'NOINDEX',
+      },
+      {
+        slug: 'shared',
+        name: 'Published version',
+        available_forms: 'capsule; liquid',
+        indexability_status: 'PUBLISH',
+      },
+    ]
+
+    const selected = selectIndexableFormIngredients(records)
+
+    expect(selected).toHaveLength(1)
+    expect(selected[0]?.name).toBe('Published version')
+  })
+
+  it('deduplicates forms before testing whether a comparison is meaningful', () => {
+    const repeated: RuntimeRecord = {
+      slug: 'repeated',
+      forms: ['capsule'],
+      available_forms: ['capsule'],
+      indexability_status: 'PUBLISH',
+    }
+
+    expect(getForms(repeated)).toEqual(['capsule'])
+    expect(selectIndexableFormIngredients([repeated])).toEqual([])
+  })
+
+  it('preserves object and delimiter-separated form representations', () => {
+    const objectRecord: RuntimeRecord = {
+      forms: { extract: 'standardized', powder: 'whole root' },
+    }
+    const stringRecord: RuntimeRecord = {
+      available_forms: 'capsule | liquid',
+    }
+
+    expect(getForms(objectRecord)).toEqual(['extract: standardized', 'powder: whole root'])
+    expect(getForms(stringRecord)).toEqual(['capsule', 'liquid'])
+  })
+})


### PR DESCRIPTION
## Root cause
The programmatic `/guides/forms/[slug]` route independently scanned herb and compound records and generated indexable comparison pages whenever two form values were present, without applying the canonical runtime publication policy. Hidden or NOINDEX records could therefore expose standalone form-comparison pages.

## Change
- Add one canonical form-guide data module.
- Apply `getRuntimeVisibility(record).canIndex` before form eligibility and slug deduplication.
- Consume unified runtime `allRecords` so entity type is preserved without separate herb/compound loops.
- Centralize form/text normalization while preserving arrays, objects, and delimiter-separated strings.
- Require at least two distinct forms after deduplication.
- Use the same loader for static params, metadata, and page rendering.
- Add regression coverage for PUBLISH/NOINDEX/hidden records, visibility-before-deduplication, repeated forms, and supported form representations.

## Scope
No page copy, layout, metadata wording, or source records are changed.