### PR TITLE
refactor(compounds): centralize published library selection

### DIFF
--- a/app/__tests__/compound-library-canonical-listing.test.ts
+++ b/app/__tests__/compound-library-canonical-listing.test.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 
+import { selectPublishedCompounds } from '../compounds/library-selector'
 import { isRedirectedCompoundDuplicate } from '../../lib/deprecated-compound-canonicals'
 
 const root = process.cwd()
@@ -40,17 +41,26 @@ describe('compound library canonical listings', () => {
     expect(isRedirectedCompoundDuplicate('gingerol', presentSlugs)).toBe(true)
   })
 
-  it('lists only indexable canonical profiles on both library routes', () => {
+  it('selects only canonical published compounds and sorts them for the library', () => {
+    const compounds = selectPublishedCompounds([
+      { slug: 'z-published', displayName: 'Zed', indexability_status: 'PUBLISH' },
+      { slug: 'noindex', displayName: 'Noindex', indexability_status: 'NOINDEX' },
+      { slug: 'hidden', displayName: 'Hidden', indexability_status: 'PUBLISH', runtime_export_decision: 'hide' },
+      { slug: 'berberine', displayName: 'Berberine', indexability_status: 'PUBLISH' },
+      { slug: 'berberine-hcl', displayName: 'Berberine HCl', indexability_status: 'PUBLISH' },
+      { slug: 'garlic-extract', displayName: 'Garlic Extract', indexability_status: 'PUBLISH' },
+      { slug: 'a-published', displayName: 'Alpha', indexability_status: 'PUBLISH' },
+    ])
+
+    expect(compounds.map((compound) => compound.slug)).toEqual(['a-published', 'berberine', 'z-published'])
+  })
+
+  it('uses the canonical published-compound loader on both library routes', () => {
     const firstPage = read('app/compounds/page.tsx')
     const paginatedPage = read('app/compounds/page/[page]/page.tsx')
 
-    for (const source of [firstPage, paginatedPage]) {
-      expect(source).toContain('getRuntimeVisibility(compound).canIndex')
-      expect(source).not.toContain('getRuntimeVisibility(compound).canRender')
-      expect(source).toContain('isRedirectedCompoundDuplicate')
-      expect(source).toContain('presentSlugs')
-      expect(source).toContain('!isRedirectedCompoundDuplicate')
-    }
+    expect(firstPage).toContain('loadPublishedCompounds')
+    expect(paginatedPage).toContain('loadPublishedCompounds')
   })
 
   it('does not advertise an inflated fixed profile count in metadata', () => {

--- a/app/compounds/library-data.ts
+++ b/app/compounds/library-data.ts
@@ -1,0 +1,9 @@
+import type { RuntimeRecord } from '../../src/types/content'
+
+import { getAllCompounds } from '@/lib/server/runtime-data'
+import { selectPublishedCompounds } from './library-selector'
+
+export async function loadPublishedCompounds(): Promise<RuntimeRecord[]> {
+  const compounds = (await getAllCompounds()) as unknown as RuntimeRecord[]
+  return selectPublishedCompounds(compounds)
+}

--- a/app/compounds/library-selector.ts
+++ b/app/compounds/library-selector.ts
@@ -1,0 +1,28 @@
+import type { RuntimeRecord } from '../../src/types/content'
+
+import { getRuntimeVisibility } from '../../lib/runtime-visibility'
+import { formatDisplayLabel } from '@/lib/display-utils'
+import { isRedirectedCompoundDuplicate } from '@/lib/deprecated-compound-canonicals'
+
+export function getCompoundName(compound: RuntimeRecord) {
+  return (
+    formatDisplayLabel(compound.displayName) ||
+    formatDisplayLabel(compound.name) ||
+    formatDisplayLabel(compound.compoundName) ||
+    formatDisplayLabel(compound.canonicalCompoundName) ||
+    formatDisplayLabel(compound.slug)
+  )
+}
+
+export function selectPublishedCompounds(compounds: RuntimeRecord[]): RuntimeRecord[] {
+  const presentSlugs = new Set(compounds.map((compound) => String(compound.slug || '')))
+
+  return compounds
+    .filter(
+      (compound) =>
+        compound.slug &&
+        getRuntimeVisibility(compound).canIndex &&
+        !isRedirectedCompoundDuplicate(String(compound.slug), presentSlugs),
+    )
+    .sort((a, b) => getCompoundName(a).localeCompare(getCompoundName(b)))
+}

--- a/app/compounds/page.tsx
+++ b/app/compounds/page.tsx
@@ -2,13 +2,11 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { Suspense } from 'react'
 
-import { getAllCompounds } from '@/lib/server/runtime-data'
-import { getRuntimeVisibility } from '../../lib/runtime-visibility'
 import { buildPageMetadata } from '../../src/lib/seo'
 import { COMPOUNDS_PAGE_SIZE, paginateItems } from '@/lib/pagination'
 import { toLeanProfileIndexRecords } from '@/lib/profile-index-records'
-import { formatDisplayLabel } from '@/lib/display-utils'
-import { isRedirectedCompoundDuplicate } from '@/lib/deprecated-compound-canonicals'
+import { loadPublishedCompounds } from './library-data'
+import { getCompoundName } from './library-selector'
 import CompoundsIndexClient from './CompoundsIndexClient'
 import type { RuntimeRecord } from '../../src/types/content'
 import Pagination from '@/components/Pagination'
@@ -22,32 +20,8 @@ export const metadata: Metadata = buildPageMetadata({
 
 export const dynamic = 'force-static'
 
-function getCompoundName(compound: RuntimeRecord) {
-  return (
-    formatDisplayLabel(compound.displayName) ||
-    formatDisplayLabel(compound.name) ||
-    formatDisplayLabel(compound.compoundName) ||
-    formatDisplayLabel(compound.canonicalCompoundName) ||
-    formatDisplayLabel(compound.slug)
-  )
-}
-
-function loadBrowseCompounds(records: RuntimeRecord[]) {
-  const presentSlugs = new Set(records.map((compound) => String(compound.slug || '')))
-
-  return records
-    .filter(
-      (compound) =>
-        compound?.slug &&
-        getRuntimeVisibility(compound).canIndex &&
-        !isRedirectedCompoundDuplicate(String(compound.slug), presentSlugs),
-    )
-    .sort((a, b) => getCompoundName(a).localeCompare(getCompoundName(b)))
-}
-
 export default async function CompoundsPage() {
-  const raw = await getAllCompounds()
-  const allCompounds = loadBrowseCompounds(raw as unknown as RuntimeRecord[])
+  const allCompounds = await loadPublishedCompounds()
 
   const pageData = paginateItems(allCompounds, 1, COMPOUNDS_PAGE_SIZE)
   const leanCompounds = toLeanProfileIndexRecords(allCompounds)

--- a/app/compounds/page/[page]/page.tsx
+++ b/app/compounds/page/[page]/page.tsx
@@ -1,12 +1,10 @@
 import type { Metadata } from 'next'
 import { Suspense } from 'react'
-import { getAllCompounds } from '@/lib/server/runtime-data'
-import { getRuntimeVisibility } from '../../../../lib/runtime-visibility'
 import { COMPOUNDS_PAGE_SIZE, clampPositiveInt, paginateItems } from '@/lib/pagination'
 import { toLeanProfileIndexRecords } from '@/lib/profile-index-records'
-import { formatDisplayLabel } from '@/lib/display-utils'
-import { isRedirectedCompoundDuplicate } from '@/lib/deprecated-compound-canonicals'
 import Link from 'next/link'
+import { loadPublishedCompounds } from '../../library-data'
+import { getCompoundName } from '../../library-selector'
 import CompoundsIndexClient from '../../CompoundsIndexClient'
 import type { RuntimeRecord } from '../../../../src/types/content'
 import Pagination from '@/components/Pagination'
@@ -15,32 +13,8 @@ type P = {
   params: Promise<{ page: string }>
 }
 
-function getCompoundName(compound: RuntimeRecord) {
-  return (
-    formatDisplayLabel(compound.displayName) ||
-    formatDisplayLabel(compound.name) ||
-    formatDisplayLabel(compound.compoundName) ||
-    formatDisplayLabel(compound.canonicalCompoundName) ||
-    formatDisplayLabel(compound.slug)
-  )
-}
-
-async function loadBrowseCompounds(): Promise<RuntimeRecord[]> {
-  const compounds = (await getAllCompounds()) as unknown as RuntimeRecord[]
-  const presentSlugs = new Set(compounds.map((compound) => String(compound.slug || '')))
-
-  return compounds
-    .filter(
-      (compound) =>
-        compound?.slug &&
-        getRuntimeVisibility(compound).canIndex &&
-        !isRedirectedCompoundDuplicate(String(compound.slug), presentSlugs),
-    )
-    .sort((a, b) => getCompoundName(a).localeCompare(getCompoundName(b)))
-}
-
 export async function generateStaticParams() {
-  const compounds = await loadBrowseCompounds()
+  const compounds = await loadPublishedCompounds()
   const total = Math.max(1, Math.ceil(compounds.length / COMPOUNDS_PAGE_SIZE))
 
   return Array.from({ length: Math.max(total - 1, 0) }, (_, i) => ({
@@ -62,7 +36,7 @@ export async function generateMetadata({ params }: P): Promise<Metadata> {
 
 export default async function CompoundsPageN({ params }: P) {
   const n = clampPositiveInt((await params).page, 2)
-  const compounds = await loadBrowseCompounds()
+  const compounds = await loadPublishedCompounds()
   const p = paginateItems(compounds, n, COMPOUNDS_PAGE_SIZE)
   const leanCompounds = toLeanProfileIndexRecords(compounds)
   const leanPageItems = toLeanProfileIndexRecords(p.pageItems as RuntimeRecord[])


### PR DESCRIPTION
## Why
The compound directory duplicates publication gating, canonical-redirect filtering, display-name resolution, and sorting in both the first-page and paginated routes. That is the same drift pattern that previously let herb browse semantics diverge.

## Change
- Add one pure `selectPublishedCompounds` selector for publication gating, canonical dedupe, name resolution, and sorting.
- Keep `loadPublishedCompounds` in a separate server-only data module so tests can exercise selection behavior without importing `server-only` runtime data.
- Route both `/compounds` and `/compounds/page/[page]` through the same loader/selector path.
- Preserve the existing `canIndex` publication gate and canonical redirect behavior.
- Replace duplicated source-string assertions with behavioral coverage for PUBLISH/NOINDEX, hidden records, same-taxonomy aliases, cross-taxonomy aliases, and sorting.

## Integration
Replayed from fresh `main` commit `9256dd9`; subsequent main commits through `965b518` were compared and do not touch any of these five compound-library files.

## Scope
No compound data, publication policy, metadata, or detail-page behavior changes. This is consolidation plus stronger regression protection.