### PR TITLE
Backlog 816: schedule weekly content-integrity checks

### DIFF
--- a/.github/workflows/content-integrity-weekly.yml
+++ b/.github/workflows/content-integrity-weekly.yml
@@ -1,0 +1,64 @@
+name: Weekly Content Integrity
+
+on:
+  schedule:
+    # Tuesdays at 06:20 UTC. Staggered from the Monday link crawl.
+    - cron: '20 6 * * 2'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  content-integrity:
+    name: Content integrity audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Audit content structure
+        run: npm run audit:content
+
+      - name: Enforce publication quality gate
+        run: npm run gate:content-quality
+
+      - name: Audit citation density
+        run: npm run audit:citation-density
+
+      - name: Detect leaked pipeline/editorial text
+        run: npm run audit:leaked-text
+
+      - name: Upload generated audit reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: weekly-content-integrity-${{ github.run_number }}
+          path: |
+            ops/reports/**
+            reports/**
+          retention-days: 30
+          if-no-files-found: ignore
+
+      - name: Workflow summary
+        if: always()
+        run: |
+          {
+            echo "## Weekly Content Integrity"
+            echo "- Content structure: npm run audit:content"
+            echo "- Publication quality: npm run gate:content-quality"
+            echo "- Citation density: npm run audit:citation-density"
+            echo "- Production text leaks: npm run audit:leaked-text"
+            echo "- Status: ${{ job.status }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/ops/backlog-816-weekly-content-integrity.md
+++ b/docs/ops/backlog-816-weekly-content-integrity.md
@@ -1,0 +1,14 @@
+# Backlog 816 — Weekly content-integrity checks
+
+Status: implemented.
+
+The `Weekly Content Integrity` GitHub Actions workflow runs every Tuesday at 06:20 UTC and can also be dispatched manually.
+
+It reuses the repository's canonical audits rather than creating another validation stack:
+
+- `npm run audit:content`
+- `npm run gate:content-quality`
+- `npm run audit:citation-density`
+- `npm run audit:leaked-text`
+
+Generated audit artifacts are retained for 30 days. Any failing audit fails the workflow so content regressions become visible without waiting for a production deployment.


### PR DESCRIPTION
Implements backlog item 816 as an independently mergeable maintenance unit.

- Adds a Tuesday weekly content-integrity workflow.
- Reuses existing canonical content, quality-gate, citation-density, and leaked-text audits.
- Uploads generated reports for 30 days.
- Fails the scheduled job when an integrity audit fails.

No content-generation behavior changes.