### PR TITLE
ROI 636-654: build evidence-aware research relationship graph

### DIFF
--- a/scripts/data/build-research-relationship-graph.mjs
+++ b/scripts/data/build-research-relationship-graph.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { buildResearchRelationshipGraph } from './research-graph-lib.mjs'
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const PUBLIC_DATA = path.join(ROOT, 'public', 'data')
+const REPORTS = path.join(ROOT, 'ops', 'reports')
+const OUTPUT_JSON = path.join(PUBLIC_DATA, 'research-relationship-graph.json')
+const OUTPUT_MD = path.join(REPORTS, 'research-relationship-graph.md')
+
+function readJson(filePath, fallback) {
+  if (!existsSync(filePath)) return fallback
+  try {
+    return JSON.parse(readFileSync(filePath, 'utf8'))
+  } catch {
+    return fallback
+  }
+}
+
+function readFirstJson(paths, fallback) {
+  for (const filePath of paths) {
+    const value = readJson(filePath, undefined)
+    if (value !== undefined && (!Array.isArray(value) || value.length > 0)) return value
+  }
+  return fallback
+}
+
+function readJsonl(filePath) {
+  if (!existsSync(filePath)) return []
+  return readFileSync(filePath, 'utf8')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .flatMap((line) => {
+      try {
+        return [JSON.parse(line)]
+      } catch {
+        return []
+      }
+    })
+}
+
+function renderMarkdown(graph) {
+  const counts = Object.entries(graph.summary.edgeCounts).sort((a, b) => b[1] - a[1])
+  const lines = [
+    '# Research relationship graph',
+    '',
+    `Generated ${graph.generatedAt}.`,
+    '',
+    `- Nodes: **${graph.summary.nodes}**`,
+    `- Edges: **${graph.summary.edges}**`,
+    `- Differentiated comparison opportunities: **${graph.summary.comparisonOpportunities}**`,
+    `- Isolated entities: **${graph.summary.isolatedEntities}**`,
+    `- Suspiciously over-connected entities: **${graph.summary.overConnectedEntities}**`,
+    '',
+    '## Relationship coverage',
+    '',
+    '| Relationship | Edges |',
+    '| --- | ---: |',
+    ...counts.map(([rel, count]) => `| ${rel} | ${count} |`),
+    '',
+    '## Highest-moat comparison opportunities',
+    '',
+    '| Pair | Score | Differentiators |',
+    '| --- | ---: | --- |',
+    ...graph.comparisonOpportunities.slice(0, 50).map((row) => `| ${row.pair.map((item) => item.label).join(' vs ')} | ${row.moatScore} | ${row.types.join(', ')} |`),
+    '',
+    '## Guardrail',
+    '',
+    graph.semantics.pathway_associated_outcome,
+    '',
+  ]
+  return `${lines.join('\n')}\n`
+}
+
+const herbs = readFirstJson([
+  path.join(PUBLIC_DATA, 'summary-indexes', 'herbs-summary.json'),
+  path.join(PUBLIC_DATA, 'herbs-summary.json'),
+  path.join(PUBLIC_DATA, 'herbs.json'),
+], [])
+const compounds = readFirstJson([
+  path.join(PUBLIC_DATA, 'summary-indexes', 'compounds-summary.json'),
+  path.join(PUBLIC_DATA, 'compounds-summary.json'),
+  path.join(PUBLIC_DATA, 'compounds.json'),
+], [])
+const herbCompoundMap = readJson(path.join(PUBLIC_DATA, 'herb-compound-map.json'), [])
+const claims = readJsonl(path.join(ROOT, 'data', 'canonical', 'claims', 'claims.jsonl'))
+
+const graph = buildResearchRelationshipGraph({ herbs, compounds, herbCompoundMap, claims })
+mkdirSync(PUBLIC_DATA, { recursive: true })
+mkdirSync(REPORTS, { recursive: true })
+writeFileSync(OUTPUT_JSON, `${JSON.stringify(graph, null, 2)}\n`)
+writeFileSync(OUTPUT_MD, renderMarkdown(graph))
+
+console.log('\nResearch relationship graph')
+console.log('='.repeat(64))
+console.log(`Nodes                  ${graph.summary.nodes}`)
+console.log(`Edges                  ${graph.summary.edges}`)
+console.log(`Comparison candidates  ${graph.summary.comparisonOpportunities}`)
+console.log(`Isolated               ${graph.summary.isolatedEntities}`)
+console.log(`Over-connected         ${graph.summary.overConnectedEntities}`)
+console.log('Output                 public/data/research-relationship-graph.json')
+console.log('Report                 ops/reports/research-relationship-graph.md')

--- a/scripts/data/build-research-relationship-graph.mjs
+++ b/scripts/data/build-research-relationship-graph.mjs
@@ -4,6 +4,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { buildResearchRelationshipGraph } from './research-graph-lib.mjs'
+import { remapResearchGraphToStableSubstanceIds } from './research-graph-identity.mjs'
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
 const PUBLIC_DATA = path.join(ROOT, 'public', 'data')
@@ -56,6 +57,11 @@ function renderMarkdown(graph) {
     `- Isolated entities: **${graph.summary.isolatedEntities}**`,
     `- Suspiciously over-connected entities: **${graph.summary.overConnectedEntities}**`,
     '',
+    '## Identity contract',
+    '',
+    `- Public substance IDs: **${graph.identityContract?.publicSubstanceIds || 'legacy'}**`,
+    `- Legacy claim join IDs: **${graph.identityContract?.legacyClaimJoinIds || 'n/a'}**`,
+    '',
     '## Relationship coverage',
     '',
     '| Relationship | Edges |',
@@ -89,7 +95,8 @@ const compounds = readFirstJson([
 const herbCompoundMap = readJson(path.join(PUBLIC_DATA, 'herb-compound-map.json'), [])
 const claims = readJsonl(path.join(ROOT, 'data', 'canonical', 'claims', 'claims.jsonl'))
 
-const graph = buildResearchRelationshipGraph({ herbs, compounds, herbCompoundMap, claims })
+const derivedGraph = buildResearchRelationshipGraph({ herbs, compounds, herbCompoundMap, claims })
+const graph = remapResearchGraphToStableSubstanceIds(derivedGraph, { herbs, compounds })
 mkdirSync(PUBLIC_DATA, { recursive: true })
 mkdirSync(REPORTS, { recursive: true })
 writeFileSync(OUTPUT_JSON, `${JSON.stringify(graph, null, 2)}\n`)
@@ -102,5 +109,6 @@ console.log(`Edges                  ${graph.summary.edges}`)
 console.log(`Comparison candidates  ${graph.summary.comparisonOpportunities}`)
 console.log(`Isolated               ${graph.summary.isolatedEntities}`)
 console.log(`Over-connected         ${graph.summary.overConnectedEntities}`)
+console.log('Identity               stable evidence-graph substance IDs')
 console.log('Output                 public/data/research-relationship-graph.json')
 console.log('Report                 ops/reports/research-relationship-graph.md')

--- a/scripts/data/canonical/__tests__/research-graph-identity.test.mjs
+++ b/scripts/data/canonical/__tests__/research-graph-identity.test.mjs
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildStableEntityId } from '../../../config/evidence-graph/identity-rules.mjs'
+import { buildStableEntityId } from '../../../../config/evidence-graph/identity-rules.mjs'
 import { entityId } from '../ids.mjs'
 import { buildResearchRelationshipGraph } from '../../research-graph-lib.mjs'
 import { remapResearchGraphToStableSubstanceIds } from '../../research-graph-identity.mjs'

--- a/scripts/data/canonical/__tests__/research-graph-identity.test.mjs
+++ b/scripts/data/canonical/__tests__/research-graph-identity.test.mjs
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { buildStableEntityId } from '../../../config/evidence-graph/identity-rules.mjs'
+import { entityId } from '../ids.mjs'
+import { buildResearchRelationshipGraph } from '../../research-graph-lib.mjs'
+import { remapResearchGraphToStableSubstanceIds } from '../../research-graph-identity.mjs'
+
+describe('research graph identity compatibility', () => {
+  it('keeps legacy claim joins but emits stable evidence-graph substance IDs', () => {
+    const herbs = [{ slug: 'herb-a', name: 'Herb A' }]
+    const compounds = [{ slug: 'compound-x', name: 'Compound X' }]
+    const legacyHerbId = entityId('herb', 'herb-a')
+    const legacyCompoundId = entityId('compound', 'compound-x')
+    const stableHerbId = buildStableEntityId('herb', 'herb-a')
+    const stableCompoundId = buildStableEntityId('compound', 'compound-x')
+
+    const derived = buildResearchRelationshipGraph({
+      herbs,
+      compounds,
+      herbCompoundMap: [{ herb_slug: 'herb-a', compound_slug: 'compound-x' }],
+      claims: [{
+        id: 'clm_test',
+        subject_id: legacyHerbId,
+        predicate: 'supports_outcome',
+        object_literal: 'sleep',
+        qualifiers: { direction: '+' },
+      }],
+    })
+    const graph = remapResearchGraphToStableSubstanceIds(derived, { herbs, compounds })
+
+    const herbNode = graph.nodes.find((node) => node.id === stableHerbId)
+    const compoundNode = graph.nodes.find((node) => node.id === stableCompoundId)
+    expect(herbNode?.legacyCanonicalId).toBe(legacyHerbId)
+    expect(compoundNode?.legacyCanonicalId).toBe(legacyCompoundId)
+    expect(graph.nodes.some((node) => node.id === legacyHerbId)).toBe(false)
+    expect(graph.edges.some((edge) => edge.from === stableHerbId && edge.rel === 'studied_for_outcome')).toBe(true)
+    expect(graph.indexes.compoundsByBotanical[stableHerbId]).toContain(stableCompoundId)
+    expect(graph.identityContract.publicSubstanceIds).toBe('<entityType>:<canonical-slug>')
+  })
+})

--- a/scripts/data/canonical/__tests__/research-graph.test.mjs
+++ b/scripts/data/canonical/__tests__/research-graph.test.mjs
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import { entityId } from '../ids.mjs'
+import { buildResearchRelationshipGraph } from '../../research-graph-lib.mjs'
+
+describe('research relationship graph', () => {
+  it('derives study, pathway, outcome, botanical-compound and comparison relationships conservatively', () => {
+    const herbA = entityId('herb', 'herb-a')
+    const herbB = entityId('herb', 'herb-b')
+    const compound = entityId('compound', 'compound-x')
+    const pathway = entityId('mechanism', 'pathway-x')
+    const outcome = entityId('effect', 'sleep')
+    const study = entityId('study', 'study-1')
+
+    const graph = buildResearchRelationshipGraph({
+      herbs: [
+        { slug: 'herb-a', name: 'Herb A', evidence_grade: 'A' },
+        { slug: 'herb-b', name: 'Herb B', evidence_grade: 'C' },
+      ],
+      compounds: [{ slug: 'compound-x', name: 'Compound X', evidence_grade: 'B' }],
+      herbCompoundMap: [
+        { herb_slug: 'herb-a', compound_slug: 'compound-x', herb: 'Herb A', compound: 'Compound X' },
+        { herb_slug: 'herb-b', compound_slug: 'compound-x', herb: 'Herb B', compound: 'Compound X' },
+      ],
+      claims: [
+        {
+          id: 'clm_mechanism',
+          subject_id: herbA,
+          predicate: 'affects_mechanism',
+          object_id: pathway,
+          qualifiers: { study_id: study },
+          source_ids: ['src_1'],
+          evidence_level: 'human_rct',
+        },
+        {
+          id: 'clm_outcome',
+          subject_id: herbA,
+          predicate: 'supports_outcome',
+          object_id: outcome,
+          qualifiers: { study_id: study, direction: '+' },
+          source_ids: ['src_1'],
+          evidence_level: 'human_rct',
+        },
+      ],
+    })
+
+    const relationships = new Set(graph.edges.map((edge) => edge.rel))
+    expect(relationships).toContain('contains_compound')
+    expect(relationships).toContain('affects_pathway')
+    expect(relationships).toContain('studied_for_outcome')
+    expect(relationships).toContain('study_investigates_ingredient')
+    expect(relationships).toContain('study_reports_outcome')
+    expect(relationships).toContain('pathway_associated_outcome')
+
+    const pathwayOutcome = graph.edges.find((edge) => edge.rel === 'pathway_associated_outcome')
+    expect(pathwayOutcome?.from).toBe(pathway)
+    expect(pathwayOutcome?.to).toBe(outcome)
+    expect(pathwayOutcome?.caveat).toMatch(/not a causal/i)
+
+    expect(graph.indexes.compoundsByBotanical[herbA]).toContain(compound)
+    expect(graph.indexes.botanicalsByCompound[compound]).toEqual(expect.arrayContaining([herbA, herbB]))
+
+    const sharedCompoundComparison = graph.comparisonOpportunities.find((row) =>
+      row.pair.some((item) => item.slug === 'herb-a') && row.pair.some((item) => item.slug === 'herb-b')
+    )
+    expect(sharedCompoundComparison?.types).toContain('shared_active_compounds')
+  })
+
+  it('does not invent pathway-to-outcome causality across unrelated studies', () => {
+    const subject = entityId('compound', 'compound-y')
+    const pathway = entityId('mechanism', 'pathway-y')
+    const outcome = entityId('effect', 'focus')
+
+    const graph = buildResearchRelationshipGraph({
+      compounds: [{ slug: 'compound-y', name: 'Compound Y' }],
+      claims: [
+        { id: 'clm_a', subject_id: subject, predicate: 'affects_mechanism', object_id: pathway, qualifiers: { study_id: entityId('study', 'a') } },
+        { id: 'clm_b', subject_id: subject, predicate: 'supports_outcome', object_id: outcome, qualifiers: { study_id: entityId('study', 'b') } },
+      ],
+    })
+
+    expect(graph.edges.some((edge) => edge.rel === 'pathway_associated_outcome')).toBe(false)
+  })
+})

--- a/scripts/data/research-graph-identity.mjs
+++ b/scripts/data/research-graph-identity.mjs
@@ -1,0 +1,112 @@
+import { buildStableEntityId } from '../../config/evidence-graph/identity-rules.mjs'
+import { edgeId, entityId } from './canonical/ids.mjs'
+
+function clean(value) {
+  return String(value ?? '').trim()
+}
+
+function buildSubstanceIdMap({ herbs = [], compounds = [] } = {}) {
+  const map = new Map()
+  const metadata = new Map()
+
+  const add = (record, kind) => {
+    const slug = clean(record?.slug)
+    if (!slug) return
+    const legacyId = entityId(kind, slug)
+    const stableId = buildStableEntityId(kind, slug)
+    map.set(legacyId, stableId)
+    metadata.set(stableId, { legacyCanonicalId: legacyId, canonicalSlug: slug })
+  }
+
+  herbs.forEach((record) => add(record, 'herb'))
+  compounds.forEach((record) => add(record, 'compound'))
+  return { map, metadata }
+}
+
+function remapId(value, map) {
+  return map.get(value) || value
+}
+
+function remapIdArray(values, map) {
+  return Array.isArray(values) ? values.map((value) => remapId(value, map)) : values
+}
+
+function remapDictionaryKeysAndValues(dictionary, map) {
+  const output = {}
+  for (const [key, values] of Object.entries(dictionary || {})) {
+    output[remapId(key, map)] = remapIdArray(values, map)
+  }
+  return output
+}
+
+/**
+ * The canonical claim store still uses deterministic `ent_*` subject IDs while
+ * the newer evidence-graph identity foundation exposes human-stable substance
+ * IDs such as `herb:ashwagandha` and `compound:magnesium`.
+ *
+ * Relationship derivation intentionally happens against the legacy IDs first so
+ * existing claims continue to join exactly as they do today. This boundary
+ * remap then exposes one public substance identity system while retaining the
+ * legacy canonical ID as provenance on each remapped substance node.
+ */
+export function remapResearchGraphToStableSubstanceIds(graph, runtime = {}) {
+  const { map, metadata } = buildSubstanceIdMap(runtime)
+  if (!map.size) return graph
+
+  const nodes = (graph.nodes || []).map((node) => {
+    const stableId = remapId(node.id, map)
+    const identity = metadata.get(stableId)
+    return {
+      ...node,
+      id: stableId,
+      ...(identity ? identity : {}),
+    }
+  })
+
+  const edges = (graph.edges || []).map((edge) => {
+    const from = remapId(edge.from, map)
+    const to = remapId(edge.to, map)
+    return {
+      ...edge,
+      id: edgeId({ from_id: from, rel_type: edge.rel, to_id: to }),
+      from,
+      to,
+    }
+  })
+
+  const relatedContent = {}
+  for (const [key, rows] of Object.entries(graph.indexes?.relatedContent || {})) {
+    relatedContent[remapId(key, map)] = (rows || []).map((row) => ({
+      ...row,
+      id: remapId(row.id, map),
+    }))
+  }
+
+  const comparisonOpportunities = (graph.comparisonOpportunities || []).map((row) => ({
+    ...row,
+    pair: (row.pair || []).map((item) => ({ ...item, id: remapId(item.id, map) })),
+    shared: remapIdArray(row.shared, map),
+  }))
+
+  return {
+    ...graph,
+    identityContract: {
+      publicSubstanceIds: '<entityType>:<canonical-slug>',
+      legacyClaimJoinIds: 'ent_<type>_<hash>',
+      note: 'Legacy ent_* IDs remain only as compatibility provenance for canonical claim joins.',
+    },
+    nodes,
+    edges,
+    indexes: {
+      ...(graph.indexes || {}),
+      botanicalsByCompound: remapDictionaryKeysAndValues(graph.indexes?.botanicalsByCompound, map),
+      compoundsByBotanical: remapDictionaryKeysAndValues(graph.indexes?.compoundsByBotanical, map),
+      relatedContent,
+    },
+    diagnostics: {
+      isolated: (graph.diagnostics?.isolated || []).map((row) => ({ ...row, id: remapId(row.id, map) })),
+      overConnected: (graph.diagnostics?.overConnected || []).map((row) => ({ ...row, id: remapId(row.id, map) })),
+    },
+    comparisonOpportunities,
+  }
+}

--- a/scripts/data/research-graph-lib.mjs
+++ b/scripts/data/research-graph-lib.mjs
@@ -1,0 +1,400 @@
+import { edgeId, entityId } from './canonical/ids.mjs'
+
+function clean(value) {
+  return String(value ?? '').replace(/\s+/g, ' ').trim()
+}
+
+function slugify(value) {
+  return clean(value)
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+function asArray(value) {
+  if (Array.isArray(value)) return value.filter(Boolean)
+  if (value == null || value === '') return []
+  return [value]
+}
+
+function canonicalGrade(value) {
+  const text = clean(value).toUpperCase()
+  if (/^A(?:\b|[+-])/.test(text)) return 'A'
+  if (/^B(?:\b|[+-])/.test(text)) return 'B'
+  if (/^C(?:\b|[+-])/.test(text)) return 'C'
+  if (/^D(?:\b|[+-])/.test(text)) return 'D'
+  if (/AVOID|INSUFFICIENT/.test(text)) return 'Avoid/Insufficient'
+  return ''
+}
+
+function addNode(nodes, node) {
+  if (!node?.id) return
+  const existing = nodes.get(node.id)
+  nodes.set(node.id, existing ? { ...node, ...existing, ...node } : node)
+}
+
+function addEdge(edges, edge) {
+  if (!edge?.from || !edge?.to || !edge?.rel) return
+  const id = edge.id || edgeId({ from_id: edge.from, rel_type: edge.rel, to_id: edge.to })
+  const existing = edges.get(id)
+  if (!existing) {
+    edges.set(id, { id, sourceClaimIds: [], sourceIds: [], ...edge })
+    return
+  }
+  edges.set(id, {
+    ...existing,
+    ...edge,
+    sourceClaimIds: [...new Set([...(existing.sourceClaimIds || []), ...(edge.sourceClaimIds || [])])],
+    sourceIds: [...new Set([...(existing.sourceIds || []), ...(edge.sourceIds || [])])],
+  })
+}
+
+function runtimeEntityNode(record, kind) {
+  const slug = clean(record?.slug)
+  if (!slug) return null
+  return {
+    id: entityId(kind, slug),
+    kind,
+    slug,
+    label: clean(record?.displayName || record?.name || record?.compoundName || slug),
+    evidenceGrade: canonicalGrade(record?.evidence_grade || record?.evidenceGrade || record?.evidence_tier),
+    safetyFlags: asArray(record?.safety_flags || record?.safetyFlags || record?.contraindications).map(clean).filter(Boolean),
+  }
+}
+
+function claimStudyId(claim) {
+  return clean(claim?.qualifiers?.study_id || claim?.qualifiers?.studyId)
+}
+
+function claimDirection(claim) {
+  return clean(claim?.qualifiers?.direction)
+}
+
+function claimNodeKind(predicate) {
+  if (predicate === 'affects_mechanism') return 'pathway'
+  if (predicate === 'supports_outcome' || predicate === 'targets_condition') return 'outcome'
+  if (predicate === 'has_safety_warning' || predicate === 'contraindicated_in') return 'safety'
+  return 'entity'
+}
+
+function objectNodeForClaim(claim) {
+  if (claim?.object_id) {
+    return {
+      id: clean(claim.object_id),
+      kind: claimNodeKind(claim.predicate),
+      label: clean(claim?.qualifiers?.object_label || claim?.qualifiers?.label || claim.object_id),
+    }
+  }
+
+  const literal = typeof claim?.object_literal === 'string' ? clean(claim.object_literal) : ''
+  if (!literal) return null
+  const kind = claimNodeKind(claim.predicate)
+  return {
+    id: entityId(kind === 'pathway' ? 'mechanism' : kind === 'outcome' ? 'effect' : 'safety_issue', slugify(literal)),
+    kind,
+    slug: slugify(literal),
+    label: literal,
+  }
+}
+
+function relationForClaim(predicate) {
+  if (predicate === 'affects_mechanism') return 'affects_pathway'
+  if (predicate === 'supports_outcome') return 'studied_for_outcome'
+  if (predicate === 'targets_condition') return 'targets_outcome'
+  if (predicate === 'has_safety_warning') return 'has_safety_issue'
+  if (predicate === 'contraindicated_in') return 'contraindicated_in'
+  if (predicate === 'interacts_with') return 'interacts_with'
+  if (predicate === 'contains') return 'contains_compound'
+  return ''
+}
+
+function pairKey(a, b) {
+  return [a, b].sort().join('|')
+}
+
+function buildComparisonOpportunities({ nodes, edges }) {
+  const opportunities = new Map()
+  const entityNodes = [...nodes.values()].filter((node) => node.kind === 'herb' || node.kind === 'compound')
+  const byId = new Map(entityNodes.map((node) => [node.id, node]))
+  const compoundsByHerb = new Map()
+  const pathwaysByEntity = new Map()
+  const outcomesByEntity = new Map()
+  const safetyByEntity = new Map()
+
+  const addIndex = (map, key, value) => {
+    if (!key || !value) return
+    map.set(key, new Set([...(map.get(key) || []), value]))
+  }
+
+  for (const edge of edges.values()) {
+    if (edge.rel === 'contains_compound') addIndex(compoundsByHerb, edge.from, edge.to)
+    if (edge.rel === 'affects_pathway') addIndex(pathwaysByEntity, edge.from, edge.to)
+    if (edge.rel === 'studied_for_outcome' || edge.rel === 'targets_outcome') addIndex(outcomesByEntity, edge.from, edge.to)
+    if (edge.rel === 'has_safety_issue' || edge.rel === 'contraindicated_in') addIndex(safetyByEntity, edge.from, edge.to)
+  }
+
+  function addOpportunity(aId, bId, type, rationale, shared = []) {
+    if (aId === bId || !byId.has(aId) || !byId.has(bId)) return
+    const key = pairKey(aId, bId)
+    const a = byId.get(aId)
+    const b = byId.get(bId)
+    const current = opportunities.get(key) || {
+      pair: [a, b].sort((x, y) => x.slug.localeCompare(y.slug)).map((node) => ({ id: node.id, slug: node.slug, label: node.label, kind: node.kind, evidenceGrade: node.evidenceGrade })),
+      types: [],
+      rationales: [],
+      shared: [],
+      moatScore: 0,
+    }
+    if (!current.types.includes(type)) current.types.push(type)
+    if (!current.rationales.includes(rationale)) current.rationales.push(rationale)
+    current.shared = [...new Set([...current.shared, ...shared])]
+    current.moatScore = Math.min(100, current.moatScore + ({
+      shared_active_compounds: 30,
+      similar_mechanism_different_evidence: 25,
+      same_goal_different_mechanism: 30,
+      same_mechanism_different_safety: 35,
+    }[type] || 10))
+    opportunities.set(key, current)
+  }
+
+  const herbs = entityNodes.filter((node) => node.kind === 'herb')
+  for (let i = 0; i < herbs.length; i += 1) {
+    for (let j = i + 1; j < herbs.length; j += 1) {
+      const a = herbs[i]
+      const b = herbs[j]
+      const sharedCompounds = [...(compoundsByHerb.get(a.id) || [])].filter((id) => compoundsByHerb.get(b.id)?.has(id))
+      if (sharedCompounds.length >= 1) {
+        addOpportunity(a.id, b.id, 'shared_active_compounds', `${a.label} and ${b.label} share ${sharedCompounds.length} mapped active compound${sharedCompounds.length === 1 ? '' : 's'}.`, sharedCompounds)
+      }
+    }
+  }
+
+  for (let i = 0; i < entityNodes.length; i += 1) {
+    for (let j = i + 1; j < entityNodes.length; j += 1) {
+      const a = entityNodes[i]
+      const b = entityNodes[j]
+      const aPathways = pathwaysByEntity.get(a.id) || new Set()
+      const bPathways = pathwaysByEntity.get(b.id) || new Set()
+      const sharedPathways = [...aPathways].filter((id) => bPathways.has(id))
+      const aOutcomes = outcomesByEntity.get(a.id) || new Set()
+      const bOutcomes = outcomesByEntity.get(b.id) || new Set()
+      const sharedOutcomes = [...aOutcomes].filter((id) => bOutcomes.has(id))
+
+      if (sharedPathways.length && a.evidenceGrade && b.evidenceGrade && a.evidenceGrade !== b.evidenceGrade) {
+        addOpportunity(a.id, b.id, 'similar_mechanism_different_evidence', `${a.label} and ${b.label} share a mechanism/pathway signal but have different evidence grades (${a.evidenceGrade} vs ${b.evidenceGrade}).`, sharedPathways)
+      }
+
+      if (sharedOutcomes.length && aPathways.size && bPathways.size && sharedPathways.length === 0) {
+        addOpportunity(a.id, b.id, 'same_goal_different_mechanism', `${a.label} and ${b.label} are studied for the same outcome through different mapped mechanisms.`, sharedOutcomes)
+      }
+
+      if (sharedPathways.length) {
+        const aSafety = safetyByEntity.get(a.id) || new Set()
+        const bSafety = safetyByEntity.get(b.id) || new Set()
+        const safetyDifference = [...aSafety].some((id) => !bSafety.has(id)) || [...bSafety].some((id) => !aSafety.has(id))
+        if (safetyDifference) {
+          addOpportunity(a.id, b.id, 'same_mechanism_different_safety', `${a.label} and ${b.label} share a mapped mechanism but have different safety-warning relationships.`, sharedPathways)
+        }
+      }
+    }
+  }
+
+  return [...opportunities.values()]
+    .sort((a, b) => b.moatScore - a.moatScore || a.pair[0].slug.localeCompare(b.pair[0].slug))
+}
+
+function buildIndexes(nodes, edges) {
+  const botanicalsByCompound = {}
+  const compoundsByBotanical = {}
+  const recommendations = {}
+  const degree = new Map()
+
+  for (const edge of edges.values()) {
+    degree.set(edge.from, (degree.get(edge.from) || 0) + 1)
+    degree.set(edge.to, (degree.get(edge.to) || 0) + 1)
+    if (edge.rel === 'contains_compound') {
+      compoundsByBotanical[edge.from] = [...new Set([...(compoundsByBotanical[edge.from] || []), edge.to])]
+      botanicalsByCompound[edge.to] = [...new Set([...(botanicalsByCompound[edge.to] || []), edge.from])]
+    }
+  }
+
+  const weights = {
+    contains_compound: 5,
+    studied_for_outcome: 4,
+    affects_pathway: 3,
+    pathway_associated_outcome: 3,
+    study_investigates_ingredient: 2,
+    study_reports_outcome: 2,
+    has_safety_issue: 2,
+  }
+
+  for (const node of nodes.values()) {
+    const candidates = new Map()
+    for (const edge of edges.values()) {
+      if (edge.from !== node.id && edge.to !== node.id) continue
+      const other = edge.from === node.id ? edge.to : edge.from
+      if (!nodes.has(other)) continue
+      candidates.set(other, (candidates.get(other) || 0) + (weights[edge.rel] || 1))
+    }
+    recommendations[node.id] = [...candidates.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 12)
+      .map(([id, score]) => ({ id, score, label: nodes.get(id)?.label || id, kind: nodes.get(id)?.kind || 'entity' }))
+  }
+
+  const isolated = [...nodes.values()].filter((node) => !degree.get(node.id)).map((node) => ({ id: node.id, kind: node.kind, slug: node.slug, label: node.label }))
+  const overConnected = [...degree.entries()]
+    .filter(([, count]) => count >= 50)
+    .sort((a, b) => b[1] - a[1])
+    .map(([id, count]) => ({ id, degree: count, label: nodes.get(id)?.label || id, kind: nodes.get(id)?.kind || 'entity' }))
+
+  return { botanicalsByCompound, compoundsByBotanical, recommendations, isolated, overConnected }
+}
+
+export function buildResearchRelationshipGraph({ herbs = [], compounds = [], herbCompoundMap = [], claims = [] } = {}) {
+  const nodes = new Map()
+  const edges = new Map()
+
+  for (const row of herbs) {
+    const node = runtimeEntityNode(row, 'herb')
+    if (node) addNode(nodes, node)
+  }
+  for (const row of compounds) {
+    const node = runtimeEntityNode(row, 'compound')
+    if (node) addNode(nodes, node)
+  }
+
+  for (const relation of herbCompoundMap) {
+    const herbSlug = clean(relation?.herb_slug || relation?.herbSlug)
+    const compoundSlug = clean(relation?.compound_slug || relation?.compoundSlug)
+    if (!herbSlug || !compoundSlug) continue
+    const herbId = entityId('herb', herbSlug)
+    const compoundId = entityId('compound', compoundSlug)
+    if (!nodes.has(herbId)) addNode(nodes, { id: herbId, kind: 'herb', slug: herbSlug, label: clean(relation?.herb || herbSlug) })
+    if (!nodes.has(compoundId)) addNode(nodes, { id: compoundId, kind: 'compound', slug: compoundSlug, label: clean(relation?.compound || compoundSlug) })
+    addEdge(edges, {
+      from: herbId,
+      to: compoundId,
+      rel: 'contains_compound',
+      origin: 'runtime_relationship',
+      evidence: 'mapped botanical constituent relationship',
+    })
+  }
+
+  const claimsByStudySubject = new Map()
+  for (const claim of claims) {
+    const subjectId = clean(claim?.subject_id)
+    if (!subjectId) continue
+    const subjectKnown = nodes.get(subjectId)
+    if (!subjectKnown) {
+      addNode(nodes, { id: subjectId, kind: subjectId.startsWith('ent_herb_') ? 'herb' : subjectId.startsWith('ent_compound_') ? 'compound' : 'entity', label: subjectId })
+    }
+
+    const objectNode = objectNodeForClaim(claim)
+    if (objectNode) addNode(nodes, objectNode)
+    const relation = relationForClaim(claim?.predicate)
+    if (relation && objectNode) {
+      addEdge(edges, {
+        from: subjectId,
+        to: objectNode.id,
+        rel: relation,
+        origin: 'claim',
+        evidenceLevel: clean(claim?.evidence_level),
+        direction: claimDirection(claim),
+        sourceClaimIds: [clean(claim?.id)].filter(Boolean),
+        sourceIds: asArray(claim?.source_ids).map(clean).filter(Boolean),
+      })
+    }
+
+    const studyId = claimStudyId(claim)
+    if (studyId) {
+      addNode(nodes, { id: studyId, kind: 'study', label: studyId })
+      addEdge(edges, {
+        from: studyId,
+        to: subjectId,
+        rel: 'study_investigates_ingredient',
+        origin: 'claim_qualifier',
+        evidenceLevel: clean(claim?.evidence_level),
+        sourceClaimIds: [clean(claim?.id)].filter(Boolean),
+        sourceIds: asArray(claim?.source_ids).map(clean).filter(Boolean),
+      })
+      if (objectNode && (claim?.predicate === 'supports_outcome' || claim?.predicate === 'targets_condition')) {
+        addEdge(edges, {
+          from: studyId,
+          to: objectNode.id,
+          rel: 'study_reports_outcome',
+          origin: 'claim_qualifier',
+          evidenceLevel: clean(claim?.evidence_level),
+          direction: claimDirection(claim),
+          sourceClaimIds: [clean(claim?.id)].filter(Boolean),
+          sourceIds: asArray(claim?.source_ids).map(clean).filter(Boolean),
+        })
+      }
+
+      const groupKey = `${studyId}|${subjectId}`
+      claimsByStudySubject.set(groupKey, [...(claimsByStudySubject.get(groupKey) || []), { claim, objectNode }])
+    }
+  }
+
+  // A pathway→outcome edge is deliberately emitted only when the same study ID
+  // and same ingredient connect a mechanism claim and an outcome claim. The
+  // relationship is associative, not causal, so mechanisms never masquerade as
+  // proven benefits.
+  for (const rows of claimsByStudySubject.values()) {
+    const pathways = rows.filter(({ claim, objectNode }) => claim?.predicate === 'affects_mechanism' && objectNode)
+    const outcomes = rows.filter(({ claim, objectNode }) => (claim?.predicate === 'supports_outcome' || claim?.predicate === 'targets_condition') && objectNode)
+    for (const pathway of pathways) {
+      for (const outcome of outcomes) {
+        addEdge(edges, {
+          from: pathway.objectNode.id,
+          to: outcome.objectNode.id,
+          rel: 'pathway_associated_outcome',
+          origin: 'same_study_association',
+          sourceClaimIds: [clean(pathway.claim?.id), clean(outcome.claim?.id)].filter(Boolean),
+          sourceIds: [...new Set([
+            ...asArray(pathway.claim?.source_ids).map(clean),
+            ...asArray(outcome.claim?.source_ids).map(clean),
+          ].filter(Boolean))],
+          caveat: 'Association inferred from claims sharing the same study and ingredient; not a causal clinical-effect claim.',
+        })
+      }
+    }
+  }
+
+  const comparisonOpportunities = buildComparisonOpportunities({ nodes, edges })
+  const indexes = buildIndexes(nodes, edges)
+
+  const edgeCounts = {}
+  for (const edge of edges.values()) edgeCounts[edge.rel] = (edgeCounts[edge.rel] || 0) + 1
+
+  return {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    semantics: {
+      pathway_associated_outcome: 'Same-study association only; does not assert that the pathway causes the outcome.',
+      study_investigates_ingredient: 'Derived from claim.qualifiers.study_id.',
+      study_reports_outcome: 'Derived from an outcome claim carrying claim.qualifiers.study_id.',
+    },
+    summary: {
+      nodes: nodes.size,
+      edges: edges.size,
+      edgeCounts,
+      comparisonOpportunities: comparisonOpportunities.length,
+      isolatedEntities: indexes.isolated.length,
+      overConnectedEntities: indexes.overConnected.length,
+    },
+    nodes: [...nodes.values()].sort((a, b) => a.id.localeCompare(b.id)),
+    edges: [...edges.values()].sort((a, b) => a.id.localeCompare(b.id)),
+    indexes: {
+      botanicalsByCompound: indexes.botanicalsByCompound,
+      compoundsByBotanical: indexes.compoundsByBotanical,
+      relatedContent: indexes.recommendations,
+    },
+    diagnostics: {
+      isolated: indexes.isolated,
+      overConnected: indexes.overConnected,
+    },
+    comparisonOpportunities,
+  }
+}


### PR DESCRIPTION
Fixes #3104

## Relevant URLs
- `public/data/research-relationship-graph.json`
- `ops/reports/research-relationship-graph.md`
- Future graph-driven ingredient/Atlas/comparison research views

## Acceptance criteria
- Build herb→compound, ingredient→pathway/outcome, study→ingredient/outcome, safety, and comparison relationships.
- Use the repository evidence-graph identity foundation (`herb:<slug>` / `compound:<slug>`) for public substance nodes.
- Preserve legacy canonical `ent_*` IDs only as compatibility provenance for existing claim joins.
- Generate graph-driven related-content indexes and isolated/over-connected diagnostics.
- Generate differentiated comparison opportunities from shared compounds, mechanism, outcome, evidence, and safety relationships.
- Never infer causal clinical benefit from mechanism-only evidence.

## Validation commands
- `npm test -- scripts/data/canonical/__tests__/research-graph.test.mjs scripts/data/canonical/__tests__/research-graph-identity.test.mjs`
- `node scripts/data/build-research-relationship-graph.mjs`
- `npm run check`

## Before → after metrics
- New evidence-aware research graph artifacts: 0 → 1 public graph + 1 human-readable report.
- Explicit new relationship families: 0 → 8+ derived types.
- Graph diagnostics: none → isolated and suspicious-overconnection reporting.
- Differentiated graph comparison classes: 0 → 4.
- Public substance identity systems introduced by this PR: 0; it reuses the existing evidence-graph identity foundation.

## Generator/source-of-truth decision
Canonical claims/study IDs, the existing herb-compound runtime map, and the evidence-graph identity foundation remain source data. Relationship derivation first joins legacy claim IDs exactly as stored, then a boundary remap exposes the repository's stable public substance IDs. This PR does not invent replacement scientific facts or a competing identity registry.

## Regression contract
A pathway→outcome relationship may only be emitted as a noncausal association when mechanism and outcome claims share the same study ID and ingredient. Unrelated studies must never be joined into an implied clinical effect. Public herb/compound nodes must use `herb:<slug>` / `compound:<slug>` IDs, while any legacy `ent_*` ID is provenance only, and graph derivation must remain deterministic from source relationships.