### PR TITLE
ROI #481–510: schema truthfulness and research graphics pipeline

### DIFF
--- a/.github/workflows/schema-media-governance.yml
+++ b/.github/workflows/schema-media-governance.yml
@@ -1,0 +1,66 @@
+name: Schema and Media Governance
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'app/**'
+      - 'components/**'
+      - 'lib/**'
+      - 'public/data/**'
+      - 'data/evidence/**'
+      - 'scripts/ci/audit-schema-policy.mjs'
+      - 'scripts/ci/audit-structured-data.mjs'
+      - 'scripts/media/**'
+      - '.github/workflows/schema-media-governance.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'app/**'
+      - 'components/**'
+      - 'lib/**'
+      - 'public/data/**'
+      - 'data/evidence/**'
+      - 'scripts/ci/audit-schema-policy.mjs'
+      - 'scripts/ci/audit-structured-data.mjs'
+      - 'scripts/media/**'
+      - '.github/workflows/schema-media-governance.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  schema-and-media:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - name: Build static export
+        env:
+          COMMIT_HASH: ${{ github.sha }}
+        run: npm run build:deploy
+      - name: Existing structured-data completeness audit
+        env:
+          FULL_HTML_AUDIT: '1'
+        run: node scripts/ci/audit-structured-data.mjs
+      - name: Enforce schema safety and truthfulness policy
+        run: node scripts/ci/audit-schema-policy.mjs
+      - name: Generate review-only research graphics
+        run: node scripts/media/build-research-graphics.mjs
+      - name: Upload reports and graphics for review
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: schema-media-${{ github.run_number }}
+          path: |
+            reports/schema-policy.json
+            ops/reports/structured-data-completeness.json
+            artifacts/research-graphics/
+          retention-days: 30

--- a/lib/structured-data.ts
+++ b/lib/structured-data.ts
@@ -1,65 +1,97 @@
+const SITE_URL = 'https://thehippiescientist.net'
+const AUTHOR_URL = `${SITE_URL}/info/author/`
+
+function toIsoDate(value: unknown): string | undefined {
+  if (typeof value !== 'string' || !value.trim()) return undefined
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString()
+}
+
+export function buildOrganizationSchema() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    '@id': `${SITE_URL}/#organization`,
+    name: 'The Hippie Scientist',
+    url: SITE_URL,
+    logo: {
+      '@type': 'ImageObject',
+      url: `${SITE_URL}/logo.svg`,
+    },
+  }
+}
+
+export function buildPersonSchema() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    '@id': `${AUTHOR_URL}#person`,
+    name: 'Willie B. Randolph III',
+    url: AUTHOR_URL,
+    affiliation: { '@id': `${SITE_URL}/#organization` },
+  }
+}
+
 export function buildMedicalWebPageSchema(entity: Record<string, unknown>, type: 'herb' | 'compound') {
-  const url = `https://thehippiescientist.net/${type === 'herb' ? 'herbs' : 'compounds'}/${entity.slug}/`
+  const url = `${SITE_URL}/${type === 'herb' ? 'herbs' : 'compounds'}/${entity.slug}/`
   const description = entity.description || entity.summary || `${entity.name} profile – mechanisms, safety, evidence level, and practical context.`
 
   return {
     '@context': 'https://schema.org',
     '@type': 'MedicalWebPage',
     name: entity.name,
-    description: description,
-    url: url,
+    description,
+    url,
     mainEntityOfPage: url,
-    medicalAudience: {
-      '@type': 'MedicalAudience',
-      audienceType: 'Patient'
-    },
+    // This is an educational research page, not a clinical service. Avoid
+    // MedicalAudience/Patient and profession-bearing schema that could imply a
+    // clinical relationship or credential the site does not claim.
     about: {
-      '@type': type === 'herb' ? 'Drug' : 'ChemicalSubstance',
+      '@type': 'Substance',
       name: entity.name,
-      description: description
+      description,
     },
-    publisher: {
-      '@type': 'Organization',
-      name: 'The Hippie Scientist',
-      url: 'https://thehippiescientist.net',
-      logo: {
-        '@type': 'ImageObject',
-        url: 'https://thehippiescientist.net/logo.svg'
-      }
-    }
+    author: { '@id': `${AUTHOR_URL}#person` },
+    publisher: { '@id': `${SITE_URL}/#organization` },
   }
 }
 
 export function buildArticleSchema(post: Record<string, unknown>) {
-  const url = `https://thehippiescientist.net/articles/${post.slug}/`
-  const datePublished = post.date ? new Date(post.date as string).toISOString() : new Date().toISOString()
-  const rawModified = post.lastModified || post.updated || post.date
-  const dateModified = rawModified
-    ? new Date(rawModified as string).toISOString()
-    : datePublished
+  const url = `${SITE_URL}/articles/${post.slug}/`
+  const datePublished = toIsoDate(post.date || post.datePublished)
+  const dateModified = toIsoDate(post.lastModified || post.updated || post.dateModified || post.date || post.datePublished)
 
   return {
     '@context': 'https://schema.org',
     '@type': 'Article',
     headline: post.title,
     description: post.excerpt || post.description || post.summary || '',
-    datePublished: datePublished,
-    dateModified: dateModified,
+    ...(datePublished ? { datePublished } : {}),
+    ...(dateModified ? { dateModified } : {}),
     mainEntityOfPage: url,
-    url: url,
-    author: {
-      '@type': 'Person',
-      name: 'Willie B. Randolph III',
-      url: 'https://thehippiescientist.net/info/author/'
-    },
-    publisher: {
-      '@type': 'Organization',
-      name: 'The Hippie Scientist',
-      logo: {
-        '@type': 'ImageObject',
-        url: 'https://thehippiescientist.net/logo.svg'
-      }
-    }
+    url,
+    author: { '@id': `${AUTHOR_URL}#person` },
+    publisher: { '@id': `${SITE_URL}/#organization` },
+    ...(post.image ? { image: post.image } : {}),
+  }
+}
+
+export function buildDatasetSchema(dataset: Record<string, unknown>) {
+  const url = String(dataset.url || '')
+  const datePublished = toIsoDate(dataset.datePublished)
+  const dateModified = toIsoDate(dataset.dateModified)
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Dataset',
+    name: dataset.name,
+    description: dataset.description,
+    url,
+    ...(datePublished ? { datePublished } : {}),
+    ...(dateModified ? { dateModified } : {}),
+    creator: { '@id': `${SITE_URL}/#organization` },
+    publisher: { '@id': `${SITE_URL}/#organization` },
+    ...(dataset.license ? { license: dataset.license } : {}),
+    ...(dataset.distribution ? { distribution: dataset.distribution } : {}),
   }
 }
 
@@ -71,8 +103,8 @@ export function buildBreadcrumbSchema(items: { name: string; url: string }[]) {
       '@type': 'ListItem',
       position: i + 1,
       name: item.name,
-      item: item.url.endsWith('/') || item.url.includes('?') || item.url.includes('#') ? item.url : `${item.url}/`
-    }))
+      item: item.url.endsWith('/') || item.url.includes('?') || item.url.includes('#') ? item.url : `${item.url}/`,
+    })),
   }
 }
 
@@ -85,8 +117,8 @@ export function buildFAQSchema(faqs: { question: string; answer: string }[]) {
       name: faq.question,
       acceptedAnswer: {
         '@type': 'Answer',
-        text: faq.answer
-      }
-    }))
+        text: faq.answer,
+      },
+    })),
   }
 }

--- a/scripts/ci/audit-schema-policy.mjs
+++ b/scripts/ci/audit-schema-policy.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const outDir = path.join(root, 'out')
+const reportPath = path.join(root, 'reports/schema-policy.json')
+if (!fs.existsSync(outDir)) {
+  console.error('[schema-policy] missing out/ — run a production build first')
+  process.exit(1)
+}
+
+const bannedTypes = new Set(['Physician', 'MedicalOrganization', 'MedicalClinic', 'Hospital'])
+const recognized = new Set(['Organization', 'Person', 'BreadcrumbList', 'Article', 'BlogPosting', 'Dataset', 'ImageObject', 'FAQPage', 'MedicalWebPage', 'WebPage', 'WebSite'])
+const errors = []
+const warnings = []
+const typeCounts = {}
+let jsonLdBlocks = 0
+
+function walk(dir) {
+  const files = []
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory() && entry.name !== '_next') files.push(...walk(full))
+    else if (entry.isFile() && entry.name.endsWith('.html')) files.push(full)
+  }
+  return files
+}
+
+function routeFromFile(file) {
+  const rel = path.relative(outDir, file).split(path.sep).join('/')
+  if (rel === 'index.html') return '/'
+  return `/${rel.replace(/\/index\.html$/, '').replace(/\.html$/, '')}`
+}
+
+function nodes(value, out = []) {
+  if (!value || typeof value !== 'object') return out
+  if (Array.isArray(value)) {
+    value.forEach((item) => nodes(item, out))
+    return out
+  }
+  out.push(value)
+  Object.values(value).forEach((item) => nodes(item, out))
+  return out
+}
+
+function typesOf(node) {
+  const raw = node?.['@type']
+  return Array.isArray(raw) ? raw.map(String) : raw ? [String(raw)] : []
+}
+
+function dateCheck(node, route, key) {
+  if (!node[key]) return
+  const parsed = new Date(node[key])
+  if (Number.isNaN(parsed.getTime())) errors.push(`${route}: ${key} is not a valid date (${node[key]})`)
+  else if (parsed.getTime() > Date.now() + 24 * 60 * 60 * 1000) errors.push(`${route}: ${key} is in the future (${node[key]})`)
+}
+
+function validateNode(node, route) {
+  const types = typesOf(node)
+  for (const type of types) {
+    typeCounts[type] = (typeCounts[type] || 0) + 1
+    if (bannedTypes.has(type)) errors.push(`${route}: banned credential/clinical schema type ${type}`)
+  }
+
+  if (types.includes('Person')) {
+    if (!node.name) errors.push(`${route}: Person schema is missing name`)
+    if (node.medicalSpecialty || node.hasCredential || /doctor|physician|clinician/i.test(String(node.jobTitle || ''))) {
+      errors.push(`${route}: Person schema contains medical credential/specialty claims requiring explicit editorial verification`)
+    }
+  }
+
+  if (types.includes('Organization')) {
+    if (!node.name || !node.url) errors.push(`${route}: Organization schema requires name and url`)
+  }
+
+  if (types.includes('BreadcrumbList')) {
+    if (!Array.isArray(node.itemListElement) || !node.itemListElement.length) errors.push(`${route}: BreadcrumbList has no items`)
+  }
+
+  if (types.includes('Article') || types.includes('BlogPosting')) {
+    if (!node.headline) errors.push(`${route}: Article/BlogPosting is missing headline`)
+    dateCheck(node, route, 'datePublished')
+    dateCheck(node, route, 'dateModified')
+  }
+
+  if (types.includes('Dataset')) {
+    if (!node.name || !node.description || !node.url) errors.push(`${route}: Dataset requires name, description and stable url`)
+    if (!node.distribution) warnings.push(`${route}: Dataset has no downloadable distribution metadata`)
+    dateCheck(node, route, 'datePublished')
+    dateCheck(node, route, 'dateModified')
+  }
+
+  if (types.includes('FAQPage') && !Array.isArray(node.mainEntity)) errors.push(`${route}: FAQPage must contain visible FAQ entities`)
+  if (types.includes('ImageObject') && !node.url && !node.contentUrl) warnings.push(`${route}: ImageObject has no url/contentUrl`)
+
+  if (node.medicalAudience?.audienceType === 'Patient') {
+    errors.push(`${route}: patient-targeted medicalAudience is not allowed for general educational pages`)
+  }
+}
+
+for (const file of walk(outDir)) {
+  const route = routeFromFile(file)
+  const html = fs.readFileSync(file, 'utf8')
+  const blocks = [...html.matchAll(/<script[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi)]
+  for (const match of blocks) {
+    jsonLdBlocks += 1
+    let parsed
+    try { parsed = JSON.parse(match[1]) }
+    catch (error) {
+      errors.push(`${route}: malformed JSON-LD (${error.message})`)
+      continue
+    }
+    nodes(parsed).forEach((node) => validateNode(node, route))
+  }
+}
+
+for (const required of ['Organization', 'Person', 'BreadcrumbList', 'Article']) {
+  if (!typeCounts[required]) warnings.push(`no ${required} schema observed in built output`)
+}
+
+const unknownTypes = Object.keys(typeCounts).filter((type) => !recognized.has(type)).sort()
+const report = {
+  generatedAt: new Date().toISOString(),
+  jsonLdBlocks,
+  typeCounts,
+  unknownTypes,
+  warningCount: warnings.length,
+  warnings: warnings.slice(0, 200),
+  errors,
+}
+fs.mkdirSync(path.dirname(reportPath), { recursive: true })
+fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`)
+
+console.log(`[schema-policy] parsed ${jsonLdBlocks} JSON-LD blocks`)
+console.log(`[schema-policy] types: ${Object.entries(typeCounts).sort(([a],[b]) => a.localeCompare(b)).map(([k,v]) => `${k}=${v}`).join(', ')}`)
+console.log(`[schema-policy] warnings: ${warnings.length}`)
+console.log('[schema-policy] report: reports/schema-policy.json')
+
+if (errors.length) {
+  console.error(`\n[schema-policy] ${errors.length} blocking problem(s):`)
+  errors.slice(0, 100).forEach((error) => console.error(`[schema-policy]   ${error}`))
+  process.exit(1)
+}
+console.log('[schema-policy] OK: JSON-LD is parseable and complies with schema safety policy')

--- a/scripts/media/build-research-graphics.mjs
+++ b/scripts/media/build-research-graphics.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+/**
+ * Generates deterministic, data-backed social cards and evidence charts for
+ * manual editorial review. Outputs live under artifacts/ rather than public/
+ * so generated claims cannot ship without a human promotion step.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const root = process.cwd()
+const outputDir = path.join(root, 'artifacts/research-graphics')
+const siteUrl = 'https://thehippiescientist.net'
+const prioritySlugs = ['ashwagandha', 'magnesium', 'melatonin', 'l-theanine', 'creatine', 'berberine']
+const comparisonPairs = [
+  ['ashwagandha', 'magnesium'],
+  ['melatonin', 'l-theanine'],
+  ['caffeine', 'l-theanine'],
+]
+
+function readJson(file, fallback = []) {
+  try { return JSON.parse(fs.readFileSync(file, 'utf8')) } catch { return fallback }
+}
+
+function esc(value) {
+  return String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+}
+
+function nameOf(record) {
+  return String(record?.displayName || record?.name || record?.slug || '').trim()
+}
+
+function gradeOf(record) {
+  const raw = String(record?.evidence_grade || record?.evidenceGrade || record?.evidence_tier || record?.evidenceTier || '').trim()
+  const normalized = raw.toUpperCase()
+  if (/^A(?:\b|[-+])/.test(normalized) || /STRONG/.test(normalized)) return 'A'
+  if (/^B(?:\b|[-+])/.test(normalized) || /MODERATE/.test(normalized)) return 'B'
+  if (/^C(?:\b|[-+])/.test(normalized) || /LIMITED|PRELIM/.test(normalized)) return 'C'
+  if (/^D(?:\b|[-+])/.test(normalized) || /INSUFFICIENT|THEORETICAL/.test(normalized)) return 'D'
+  return 'Unrated'
+}
+
+function recordUrl(record, collection) {
+  return `${siteUrl}/${collection}/${record.slug}/`
+}
+
+function cardSvg({ eyebrow, title, subtitle, grade, sourceUrl, footer = 'Evidence-first supplement research' }) {
+  const gradeMarkup = grade && grade !== 'Unrated'
+    ? `<rect x="875" y="80" width="235" height="150" rx="36" fill="#143f28"/><text x="992" y="142" text-anchor="middle" font-family="Arial, sans-serif" font-size="30" font-weight="700" fill="#cfe9d6">EVIDENCE</text><text x="992" y="205" text-anchor="middle" font-family="Arial, sans-serif" font-size="74" font-weight="800" fill="#ffffff">${esc(grade)}</text>`
+    : ''
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="${esc(title)}">
+  <defs><linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#ffffff"/><stop offset="1" stop-color="#e7f2e9"/></linearGradient></defs>
+  <rect width="1200" height="630" fill="url(#bg)"/><rect x="44" y="44" width="1112" height="542" rx="34" fill="#ffffff" fill-opacity=".72" stroke="#143f28" stroke-opacity=".12"/>
+  <text x="88" y="115" font-family="Arial, sans-serif" font-size="24" letter-spacing="4" font-weight="700" fill="#52715e">${esc(eyebrow.toUpperCase())}</text>
+  ${gradeMarkup}
+  <foreignObject x="88" y="155" width="760" height="245"><div xmlns="http://www.w3.org/1999/xhtml" style="font-family:Arial,sans-serif;font-size:66px;line-height:1.02;font-weight:800;color:#102018;letter-spacing:-2px">${esc(title)}</div></foreignObject>
+  <foreignObject x="88" y="405" width="970" height="82"><div xmlns="http://www.w3.org/1999/xhtml" style="font-family:Arial,sans-serif;font-size:29px;line-height:1.25;color:#486152">${esc(subtitle)}</div></foreignObject>
+  <text x="88" y="535" font-family="Arial, sans-serif" font-size="21" font-weight="700" fill="#143f28">THE HIPPIE SCIENTIST</text>
+  <text x="1110" y="535" text-anchor="end" font-family="Arial, sans-serif" font-size="18" fill="#61766a">${esc(footer)}</text>
+  <metadata>${esc(JSON.stringify({ sourceUrl, attribution: 'The Hippie Scientist' }))}</metadata>
+</svg>`
+}
+
+function chartSvg(items) {
+  const score = { A: 4, B: 3, C: 2, D: 1, Unrated: 0 }
+  const bars = items.map((item, index) => {
+    const x = 105 + index * 165
+    const value = score[item.grade] || 0
+    const height = value * 82
+    const y = 480 - height
+    return `<rect x="${x}" y="${y}" width="105" height="${height}" rx="16" fill="#2f7d4a"/><text x="${x + 52}" y="${Math.max(105, y - 14)}" text-anchor="middle" font-family="Arial" font-size="34" font-weight="800" fill="#143f28">${esc(item.grade)}</text><foreignObject x="${x - 20}" y="495" width="145" height="72"><div xmlns="http://www.w3.org/1999/xhtml" style="font:700 20px Arial;text-align:center;color:#2c4436">${esc(item.name)}</div></foreignObject>`
+  }).join('')
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Priority supplement evidence grades"><rect width="1200" height="630" fill="#f4f8f4"/><text x="70" y="70" font-family="Arial" font-size="25" letter-spacing="4" font-weight="700" fill="#52715e">THE HIPPIE SCIENTIST · EVIDENCE SNAPSHOT</text><text x="70" y="125" font-family="Arial" font-size="46" font-weight="800" fill="#102018">Evidence grades for priority research profiles</text><line x1="70" y1="480" x2="1130" y2="480" stroke="#9eb4a5" stroke-width="2"/>${bars}<text x="1130" y="600" text-anchor="end" font-family="Arial" font-size="17" fill="#64786b">Source: thehippiescientist.net · generated for editorial review</text></svg>`
+}
+
+async function writeGraphic(baseName, svg, metadata, sharp) {
+  const svgPath = path.join(outputDir, `${baseName}.svg`)
+  const pngPath = path.join(outputDir, `${baseName}.png`)
+  fs.writeFileSync(svgPath, svg)
+  let pngGenerated = false
+  if (sharp) {
+    await sharp(Buffer.from(svg)).png({ compressionLevel: 9 }).toFile(pngPath)
+    pngGenerated = true
+  }
+  return {
+    ...metadata,
+    svg: path.relative(root, svgPath).split(path.sep).join('/'),
+    png: pngGenerated ? path.relative(root, pngPath).split(path.sep).join('/') : null,
+    approvedForPublicUse: false,
+    embedHtml: `<a href="${metadata.sourceUrl}"><img src="${metadata.publicSvgUrl}" alt="${esc(metadata.alt)}"><\/a><p>Source: <a href="${metadata.sourceUrl}">The Hippie Scientist</a></p>`,
+  }
+}
+
+fs.mkdirSync(outputDir, { recursive: true })
+let sharp = null
+try { sharp = require('sharp') } catch { console.warn('[research-graphics] sharp unavailable; SVGs will still be generated') }
+
+const herbs = readJson(path.join(root, 'public/data/herbs.json'))
+const compounds = readJson(path.join(root, 'public/data/compounds.json'))
+const all = [
+  ...herbs.map((r) => ({ ...r, __collection: 'herbs' })),
+  ...compounds.map((r) => ({ ...r, __collection: 'compounds' })),
+]
+const bySlug = new Map(all.map((record) => [String(record.slug || '').toLowerCase(), record]))
+const manifest = []
+
+for (const slug of prioritySlugs) {
+  const record = bySlug.get(slug)
+  if (!record) continue
+  const name = nameOf(record)
+  const grade = gradeOf(record)
+  const sourceUrl = recordUrl(record, record.__collection)
+  const baseName = `ingredient-${slug}`
+  const svg = cardSvg({ eyebrow: 'Evidence profile', title: name, subtitle: 'Human evidence, safety context, studied forms, and source-linked limitations.', grade, sourceUrl })
+  manifest.push(await writeGraphic(baseName, svg, {
+    kind: 'ingredient-card', entitySlug: slug, evidenceGrade: grade, sourceUrl,
+    alt: `${name} evidence profile — ${grade === 'Unrated' ? 'evidence under review' : `grade ${grade}`}`,
+    publicSvgUrl: `${siteUrl}/media/research/${baseName}.svg`,
+  }, sharp))
+}
+
+for (const [aSlug, bSlug] of comparisonPairs) {
+  const a = bySlug.get(aSlug), b = bySlug.get(bSlug)
+  if (!a || !b) continue
+  const sourceUrl = `${siteUrl}/guides/compare/${aSlug}-vs-${bSlug}/`
+  const baseName = `comparison-${aSlug}-vs-${bSlug}`
+  const svg = cardSvg({
+    eyebrow: 'Evidence comparison',
+    title: `${nameOf(a)} vs ${nameOf(b)}`,
+    subtitle: `Evidence: ${nameOf(a)} ${gradeOf(a)} · ${nameOf(b)} ${gradeOf(b)}. Compare evidence, safety, form, and dose context.`,
+    sourceUrl,
+  })
+  manifest.push(await writeGraphic(baseName, svg, {
+    kind: 'comparison-card', entitySlugs: [aSlug, bSlug], sourceUrl,
+    alt: `${nameOf(a)} versus ${nameOf(b)} evidence comparison`,
+    publicSvgUrl: `${siteUrl}/media/research/${baseName}.svg`,
+  }, sharp))
+}
+
+const changed = readJson(path.join(root, 'data/evidence/evidence-changes.json'), [])
+for (const change of Array.isArray(changed) ? changed.slice(0, 20) : []) {
+  if (!change?.slug || !change?.from || !change?.to) continue
+  const record = bySlug.get(String(change.slug).toLowerCase())
+  const name = nameOf(record || change)
+  const sourceUrl = record ? recordUrl(record, record.__collection) : `${siteUrl}/search/?q=${encodeURIComponent(name)}`
+  const baseName = `evidence-changed-${change.slug}`
+  const svg = cardSvg({ eyebrow: 'Evidence changed', title: `${name}: ${change.from} → ${change.to}`, subtitle: change.reason || 'The evidence rating changed after review of the underlying research.', grade: change.to, sourceUrl })
+  manifest.push(await writeGraphic(baseName, svg, {
+    kind: 'evidence-change-card', entitySlug: change.slug, sourceUrl,
+    alt: `${name} evidence grade changed from ${change.from} to ${change.to}`,
+    publicSvgUrl: `${siteUrl}/media/research/${baseName}.svg`,
+  }, sharp))
+}
+
+const chartItems = prioritySlugs.map((slug) => bySlug.get(slug)).filter(Boolean).map((r) => ({ name: nameOf(r), grade: gradeOf(r), sourceUrl: recordUrl(r, r.__collection) }))
+if (chartItems.length) {
+  const baseName = 'priority-evidence-grades'
+  manifest.push(await writeGraphic(baseName, chartSvg(chartItems), {
+    kind: 'evidence-chart', sourceUrl: `${siteUrl}/evidence/`, alt: 'Evidence grades for priority supplement profiles',
+    publicSvgUrl: `${siteUrl}/media/research/${baseName}.svg`, data: chartItems,
+  }, sharp))
+}
+
+const review = {
+  generatedAt: new Date().toISOString(),
+  policy: 'Generated graphics are review artifacts. Do not copy into public/media/research until evidence, labels, attribution, and destination URLs are manually verified.',
+  graphics: manifest,
+}
+fs.writeFileSync(path.join(outputDir, 'manifest.json'), `${JSON.stringify(review, null, 2)}\n`)
+fs.writeFileSync(path.join(outputDir, 'REVIEW_REQUIRED.md'), `# Research graphics review required\n\nGenerated: ${review.generatedAt}\n\nBefore publication, verify every evidence grade, label, source URL, comparison statement, image alt text, and attribution. Approved files can then be promoted to \`public/media/research/\`.\n`)
+console.log(`[research-graphics] generated ${manifest.length} review-gated graphics in ${path.relative(root, outputDir)}`)

--- a/src/lib/__tests__/structured-data.test.ts
+++ b/src/lib/__tests__/structured-data.test.ts
@@ -4,50 +4,64 @@ import {
   buildArticleSchema,
   buildBreadcrumbSchema,
   buildFAQSchema,
+  buildOrganizationSchema,
+  buildPersonSchema,
+  buildDatasetSchema,
 } from '../../../lib/structured-data'
 
-describe('buildMedicalWebPageSchema', () => {
-  it('builds a MedicalWebPage schema with a herb-specific "about.@type" and canonical URL', () => {
-    const schema = buildMedicalWebPageSchema({ slug: 'ashwagandha', name: 'Ashwagandha', summary: 'An adaptogen.' }, 'herb')
+describe('structured identities', () => {
+  it('connects the author to the site without claiming a medical profession', () => {
+    const org = buildOrganizationSchema()
+    const person = buildPersonSchema()
+    expect(org['@type']).toBe('Organization')
+    expect(person['@type']).toBe('Person')
+    expect(person.affiliation).toEqual({ '@id': 'https://thehippiescientist.net/#organization' })
+    expect(person).not.toHaveProperty('jobTitle')
+  })
+})
 
+describe('buildMedicalWebPageSchema', () => {
+  it('builds an educational MedicalWebPage without patient/clinical-role claims', () => {
+    const schema = buildMedicalWebPageSchema({ slug: 'ashwagandha', name: 'Ashwagandha', summary: 'An adaptogen.' }, 'herb')
     expect(schema['@type']).toBe('MedicalWebPage')
     expect(schema.url).toBe('https://thehippiescientist.net/herbs/ashwagandha/')
     expect(schema.mainEntityOfPage).toBe(schema.url)
-    expect((schema.about as Record<string, unknown>)['@type']).toBe('Drug')
-  })
-
-  it('uses ChemicalSubstance as the "about.@type" for compounds', () => {
-    const schema = buildMedicalWebPageSchema({ slug: 'curcumin', name: 'Curcumin' }, 'compound')
-
-    expect(schema.url).toBe('https://thehippiescientist.net/compounds/curcumin/')
-    expect((schema.about as Record<string, unknown>)['@type']).toBe('ChemicalSubstance')
-  })
-
-  it('falls back to a generated description when none is provided', () => {
-    const schema = buildMedicalWebPageSchema({ slug: 'bare', name: 'Bare Herb' }, 'herb')
-    expect(schema.description).toMatch(/^Bare Herb profile/)
+    expect((schema.about as Record<string, unknown>)['@type']).toBe('Substance')
+    expect(schema).not.toHaveProperty('medicalAudience')
   })
 })
 
 describe('buildArticleSchema', () => {
-  it('formats datePublished/dateModified as ISO strings, falling back to the publish date', () => {
+  it('formats real dates and falls modified back to the supplied publish date', () => {
     const schema = buildArticleSchema({ slug: 'my-post', title: 'My Post', date: '2024-01-15' })
-
     expect(schema.datePublished).toBe(new Date('2024-01-15').toISOString())
     expect(schema.dateModified).toBe(schema.datePublished)
     expect(schema.url).toBe('https://thehippiescientist.net/articles/my-post/')
   })
 
-  it('prefers lastModified over the publish date when present', () => {
-    const schema = buildArticleSchema({
-      slug: 'my-post',
-      title: 'My Post',
-      date: '2024-01-15',
-      lastModified: '2024-06-01',
-    })
+  it('does not invent a publication date when source data has none', () => {
+    const schema = buildArticleSchema({ slug: 'undated', title: 'Undated' })
+    expect(schema).not.toHaveProperty('datePublished')
+    expect(schema).not.toHaveProperty('dateModified')
+  })
 
+  it('prefers lastModified over the publish date when present', () => {
+    const schema = buildArticleSchema({ slug: 'my-post', title: 'My Post', date: '2024-01-15', lastModified: '2024-06-01' })
     expect(schema.dateModified).toBe(new Date('2024-06-01').toISOString())
-    expect(schema.dateModified).not.toBe(schema.datePublished)
+  })
+})
+
+describe('buildDatasetSchema', () => {
+  it('connects genuine datasets to the organization and preserves distribution metadata', () => {
+    const schema = buildDatasetSchema({
+      name: 'Evidence dataset',
+      description: 'Aggregated evidence data.',
+      url: 'https://thehippiescientist.net/evidence/data/',
+      distribution: [{ '@type': 'DataDownload', encodingFormat: 'text/csv', contentUrl: 'https://thehippiescientist.net/data/evidence.csv' }],
+    })
+    expect(schema['@type']).toBe('Dataset')
+    expect(schema.creator).toEqual({ '@id': 'https://thehippiescientist.net/#organization' })
+    expect(schema.distribution).toHaveLength(1)
   })
 })
 
@@ -57,29 +71,20 @@ describe('buildBreadcrumbSchema', () => {
       { name: 'Home', url: 'https://thehippiescientist.net' },
       { name: 'Herbs', url: 'https://thehippiescientist.net/herbs' },
     ])
-
     expect(schema.itemListElement[0].position).toBe(1)
     expect(schema.itemListElement[0].item).toBe('https://thehippiescientist.net/')
     expect(schema.itemListElement[1].position).toBe(2)
-    expect(schema.itemListElement[1].item).toBe('https://thehippiescientist.net/herbs/')
-  })
-
-  it('does not double up a trailing slash that is already present', () => {
-    const schema = buildBreadcrumbSchema([{ name: 'Home', url: 'https://thehippiescientist.net/' }])
-    expect(schema.itemListElement[0].item).toBe('https://thehippiescientist.net/')
   })
 })
 
 describe('buildFAQSchema', () => {
-  it('builds a FAQPage schema with one mainEntity Question per FAQ', () => {
+  it('builds a FAQPage only from supplied visible FAQ content', () => {
     const schema = buildFAQSchema([
       { question: 'Is it safe?', answer: 'Consult a clinician.' },
       { question: 'Does it work?', answer: 'Evidence is mixed.' },
     ])
-
     expect(schema['@type']).toBe('FAQPage')
     expect(schema.mainEntity).toHaveLength(2)
-    expect(schema.mainEntity[0].name).toBe('Is it safe?')
     expect(schema.mainEntity[0].acceptedAnswer.text).toBe('Consult a clinician.')
   })
 })


### PR DESCRIPTION
Implements the structured-data/media tranche for backlog #481–510 with a single governed source of truth.

- centralizes Organization and Person identities and links author → site organization without medical credential claims
- removes patient-audience / Drug typing from the generic profile schema while preserving the existing educational MedicalWebPage contract
- stops inventing Article publication dates when source data is undated
- adds Dataset schema support for genuine downloadable datasets
- adds a full-output JSON-LD policy audit that fails malformed JSON, future/invalid dates, prohibited credential/clinical schema, and invalid core objects
- retains the existing structured-data completeness audit and runs both in CI
- adds deterministic ingredient, comparison, evidence-change, and evidence-chart generation from structured data
- generates SVG plus PNG when Sharp is available, embeds attribution/source metadata, alt text, and reusable embed HTML
- keeps generated graphics out of public/ by default and marks every artifact unapproved until manual editorial review, preventing data-driven graphics from silently shipping

This is intentionally a review-gated media pipeline rather than auto-publishing scientific claims into social cards.