### PR TITLE
Backlog 830–838: atomic upgrade governance and generator release gate

### DIFF
--- a/.github/ISSUE_TEMPLATE/roi-upgrade.yml
+++ b/.github/ISSUE_TEMPLATE/roi-upgrade.yml
@@ -1,0 +1,97 @@
+name: Atomic ROI upgrade
+description: One independently mergeable improvement selected from the Content Command Center queue.
+title: "[ROI] "
+labels: ["roi-upgrade"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Keep this issue atomic. Prefer a generator/source-of-truth fix when many generated pages share the same defect. The change is done only when the acceptance criteria pass and before/after evidence shows no regression.
+
+  - type: input
+    id: queue_task
+    attributes:
+      label: Queue task ID
+      description: Stable backlog/queue identifier selected by the Next Highest ROI Task generator.
+      placeholder: "821"
+    validations:
+      required: true
+
+  - type: textarea
+    id: urls
+    attributes:
+      label: Relevant URLs
+      description: One URL per line. Use N/A only for repository-wide infrastructure with no user-facing URL.
+      placeholder: |
+        /herbs/ashwagandha/
+        /compare/ashwagandha-vs-l-theanine/
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem and expected impact
+      description: State the measurable defect/opportunity and why fixing it is worth doing now.
+    validations:
+      required: true
+
+  - type: textarea
+    id: generator
+    attributes:
+      label: Generator/source-of-truth approach
+      description: Identify the upstream generator, canonical data field, reusable component, or shared rule to change. Explain why page-by-page patching is unnecessary; if it truly is necessary, explain why.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Use objective, testable completion criteria.
+      placeholder: |
+        - [ ] All affected canonical records render the corrected field.
+        - [ ] No indexability or citation regressions are introduced.
+    validations:
+      required: true
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation commands
+      description: Exact commands that must pass before merge. Structural/generator changes should include the full release suite.
+      placeholder: |
+        npm run validate:code
+        npm run validate:release
+    validations:
+      required: true
+
+  - type: textarea
+    id: before_metrics
+    attributes:
+      label: Before metrics / baseline
+      description: Record the relevant pre-change state, counts, scores, screenshots, or regression snapshot reference.
+    validations:
+      required: true
+
+  - type: textarea
+    id: after_metrics
+    attributes:
+      label: Expected after metrics
+      description: Define what must improve or remain unchanged after the implementation.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: atomicity
+    attributes:
+      label: Merge contract
+      options:
+        - label: This issue represents one independently useful, independently mergeable improvement.
+          required: true
+        - label: I will prefer a generator/source-of-truth fix over patching generated pages individually.
+          required: true
+        - label: I will rerun the complete release-quality suite after a generator/structural change.
+          required: true
+        - label: I will not merge if regression checks are worse than baseline without an explicit, justified tradeoff.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,45 @@
-## Summary
+## Atomic upgrade
+
+Closes #
+
+### Summary
 
 - 
 
-## Verification
+### Relevant URLs
+
+- 
+
+### Acceptance criteria
+
+- [ ] 
+
+### Validation commands
 
 - [ ] `npm run lint`
 - [ ] `npm run check`
+- [ ] `npm run validate:release` for generator, route, schema, sitemap, or structural changes
 - [ ] no package-lock drift
 - [ ] no unexpected `public/data` diffs
 - [ ] no generated file corruption
 - [ ] static export compatible
 
-## Risk Notes
+### Before → after metrics
 
-- 
+| Metric / invariant | Before | After |
+|---|---:|---:|
+|  |  |  |
+
+### Generator/source-of-truth decision
+
+- [ ] The fix is at the generator/canonical-source/shared-component level where the defect is systemic, **or** this PR explains why an isolated page-level patch is correct.
+
+### Regression contract
+
+- [ ] The change is independently useful and independently mergeable.
+- [ ] Relevant regression baseline/snapshot comparison is unchanged or improved.
+- [ ] Any intentional regression/tradeoff is explicitly documented below and is outweighed by a measured improvement.
+
+### Risk notes / justified tradeoffs
+
+- None.

--- a/.github/workflows/atomic-upgrade-gate.yml
+++ b/.github/workflows/atomic-upgrade-gate.yml
@@ -1,0 +1,74 @@
+name: Atomic upgrade gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  atomic-contract:
+    name: Atomic issue and measurement contract
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR contract
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          node <<'NODE'
+          const body = process.env.PR_BODY || '';
+          const failures = [];
+          if (!/(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#\d+/i.test(body)) failures.push('link one atomic GitHub issue with Closes/Fixes/Resolves #N');
+          for (const heading of ['Relevant URLs', 'Acceptance criteria', 'Validation commands', 'Before → after metrics', 'Generator/source-of-truth decision', 'Regression contract']) {
+            if (!body.toLowerCase().includes(heading.toLowerCase())) failures.push(`include the “${heading}” section from the PR template`);
+          }
+          if (failures.length) {
+            console.error('Atomic upgrade contract failed:\n- ' + failures.join('\n- '));
+            process.exit(1);
+          }
+          console.log('Atomic upgrade contract present.');
+          NODE
+
+  generator-release-quality:
+    name: Full release suite for generator changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect generator/structural changes
+        id: detect
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git fetch origin "$BASE_REF" --depth=1
+          changed="$(git diff --name-only "origin/$BASE_REF"...HEAD)"
+          printf '%s\n' "$changed"
+          if printf '%s\n' "$changed" | grep -Eq '^(scripts/(data|build|pipeline|ci)/|scripts/(build|orchestrate|profile-build|generate-|create-content)|app/.+/(generateStaticParams|page\.)|lib/(content|data|seo|schema|routes|taxonomy)|public/data/|next\.config\.|package(-lock)?\.json)'; then
+            echo 'generator_changed=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'generator_changed=false' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Node.js
+        if: steps.detect.outputs.generator_changed == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        if: steps.detect.outputs.generator_changed == 'true'
+        run: npm ci
+
+      - name: Run complete release-quality suite
+        if: steps.detect.outputs.generator_changed == 'true'
+        run: npm run validate:release
+
+      - name: No generator-level change
+        if: steps.detect.outputs.generator_changed != 'true'
+        run: echo 'No generator/structural files changed; standard CI remains authoritative.'


### PR DESCRIPTION
Closes #3038

## Summary
- Add a dedicated atomic ROI upgrade issue form.
- Strengthen the PR template around measurable completion and regression safety.
- Escalate generator/structural changes to the complete release-quality suite.

## Relevant URLs
- N/A — repository development governance only.

## Acceptance criteria
- [x] ROI issue form captures task ID, URLs, acceptance criteria, validation commands, before/after metrics, and generator/source-of-truth reasoning.
- [x] PR template requires independent mergeability and regression evidence.
- [x] Generator/structural changes trigger `npm run validate:release`.

## Validation commands
- [x] Review `.github/ISSUE_TEMPLATE/roi-upgrade.yml` schema.
- [x] Review `.github/workflows/atomic-upgrade-gate.yml` changed-file detector and release command.
- [x] Confirm `npm run validate:release` is the repo-documented full structural/pre-merge path.

## Before → after metrics
| Metric / invariant | Before | After |
|---|---:|---:|
| Required atomic issue fields | 0 standardized | 8 required field groups + 4 merge-contract checks |
| Generator-specific release escalation | not dedicated | automatic PR detector + full release suite |
| PR baseline/regression contract | absent | explicit |

## Generator/source-of-truth decision
This is implemented once in GitHub governance templates/workflows rather than repeated in individual agent prompts or page patches.

## Regression contract
The change is independently mergeable, does not modify production content/runtime output, and only adds governance/validation constraints. Existing generic PR checks remain represented in the expanded template.

## Risk notes / justified tradeoffs
The atomic-contract job will require future PRs using this workflow to link a GitHub issue and include the structured PR sections. That friction is intentional and directly implements backlog 830–838.