### PR TITLE
feat(email): build evidence digest retention and attribution loop

### DIFF
--- a/app/evidence/evidence-digest/2026-08-evidence-literacy/page.tsx
+++ b/app/evidence/evidence-digest/2026-08-evidence-literacy/page.tsx
@@ -1,0 +1,89 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { getEvidenceDigestEdition } from '@/content/evidenceDigest'
+import { buildPageMetadata, SITE_URL } from '@/src/lib/seo'
+import { SafetyDisclaimerBox } from '@/components/monetization/SafetyDisclaimerBox'
+
+const SLUG = '2026-08-evidence-literacy'
+const edition = getEvidenceDigestEdition(SLUG)
+
+if (!edition) throw new Error(`Missing evidence digest edition: ${SLUG}`)
+
+const PATH = `/evidence/evidence-digest/${SLUG}/`
+const SHARE_SUBJECT = encodeURIComponent(edition.title)
+const SHARE_BODY = encodeURIComponent(`Worth reading: ${edition.title}\n\n${SITE_URL}${PATH}`)
+
+export const metadata: Metadata = {
+  ...buildPageMetadata({
+    title: edition.title,
+    description: edition.description,
+    path: PATH,
+    openGraphType: 'article',
+  }),
+  robots: {
+    index: edition.indexable && edition.editorialStatus === 'verified',
+    follow: true,
+  },
+}
+
+export default function EvidenceLiteracyDigestEditionPage() {
+  return (
+    <article className='container-page mx-auto max-w-4xl space-y-8 py-10'>
+      <nav aria-label='Breadcrumb' className='flex flex-wrap gap-2 text-sm font-semibold text-brand-800'>
+        <Link href='/'>Home</Link>
+        <span aria-hidden='true'>/</span>
+        <Link href='/evidence/evidence-digest/'>Evidence Digest</Link>
+        <span aria-hidden='true'>/</span>
+        <span aria-current='page'>Evidence literacy</span>
+      </nav>
+
+      <header className='rounded-[2rem] border border-brand-900/10 bg-white/95 p-6 shadow-sm sm:p-9'>
+        <p className='eyebrow-label'>Biweekly Evidence Digest</p>
+        <h1 className='mt-3 text-4xl font-bold tracking-tight text-ink sm:text-5xl'>{edition.title}</h1>
+        <p className='mt-5 max-w-3xl text-lg leading-8 text-muted'>{edition.description}</p>
+        <div className='mt-5 flex flex-wrap gap-3 text-xs font-semibold text-muted'>
+          <span>Published {edition.publishedAt}</span>
+          <span aria-hidden='true'>•</span>
+          <span>Editorial status: {edition.editorialStatus}</span>
+        </div>
+      </header>
+
+      {edition.sections.map((section) => (
+        <section key={section.heading} className='rounded-2xl border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8'>
+          <h2 className='text-2xl font-bold tracking-tight text-ink'>{section.heading}</h2>
+          <div className='mt-4 space-y-4 text-base leading-8 text-muted'>
+            {section.body.map((paragraph) => <p key={paragraph}>{paragraph}</p>)}
+          </div>
+          {section.href && section.linkLabel ? (
+            <Link href={section.href} className='mt-5 inline-flex font-semibold text-brand-800 hover:underline'>
+              {section.linkLabel} →
+            </Link>
+          ) : null}
+        </section>
+      ))}
+
+      <section className='rounded-2xl border border-emerald-900/15 bg-emerald-50/65 p-6 sm:p-8'>
+        <h2 className='text-2xl font-bold text-ink'>Useful? Forward it.</h2>
+        <p className='mt-3 text-sm leading-7 text-muted'>
+          The easiest growth loop for the digest is a useful issue sent to one person who would genuinely benefit from the same research workflow.
+        </p>
+        <div className='mt-5 flex flex-wrap gap-3'>
+          <a
+            href={`mailto:?subject=${SHARE_SUBJECT}&body=${SHARE_BODY}`}
+            className='inline-flex min-h-11 items-center rounded-full bg-brand-950 px-5 py-2.5 text-sm font-bold text-white hover:bg-brand-900'
+          >
+            Forward this digest
+          </a>
+          <Link
+            href='/info/newsletter/'
+            className='inline-flex min-h-11 items-center rounded-full border border-brand-900/10 bg-white px-5 py-2.5 text-sm font-bold text-ink hover:bg-brand-50'
+          >
+            Get future editions
+          </Link>
+        </div>
+      </section>
+
+      <SafetyDisclaimerBox />
+    </article>
+  )
+}

--- a/app/evidence/evidence-digest/page.tsx
+++ b/app/evidence/evidence-digest/page.tsx
@@ -2,11 +2,12 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 
 import { SafetyDisclaimerBox } from '@/components/monetization/SafetyDisclaimerBox'
+import { evidenceDigestEditions, evidenceDigestProgram } from '@/content/evidenceDigest'
 
 export const metadata: Metadata = {
   title: 'Evidence Digest — Source Verification in Progress',
   description:
-    'The Evidence Digest is being rebuilt around source-verified human research. Previous study cards have been withdrawn while citations, interventions, outcomes, and evidence labels are re-audited.',
+    'The Evidence Digest is being rebuilt around source-verified human research. Verified editorial editions remain available while study-level cards are re-audited.',
   alternates: { canonical: '/evidence/evidence-digest/' },
   robots: {
     index: false,
@@ -37,6 +38,10 @@ const VERIFIED_ROUTES = [
   },
 ]
 
+const verifiedEditions = evidenceDigestEditions.filter(
+  (edition) => edition.editorialStatus === 'verified' && edition.indexable,
+)
+
 export default function EvidenceDigestPage() {
   return (
     <div className='container-page mx-auto max-w-4xl space-y-8 py-10'>
@@ -46,18 +51,42 @@ export default function EvidenceDigestPage() {
           Evidence Digest
         </h1>
         <p className='mt-4 max-w-3xl text-base leading-7 text-muted'>
-          The previous digest feed has been withdrawn while its study identifiers, intervention details, outcome summaries, and evidence labels are re-audited against the underlying publications.
+          Study-level digest cards remain withdrawn while their identifiers, interventions, outcomes, and evidence labels are re-audited against the underlying publications.
         </p>
         <p className='mt-3 max-w-3xl text-sm leading-6 text-muted'>
-          We would rather temporarily show fewer research updates than leave a citation attached to the wrong paper or present a study design more confidently than the source supports.
+          Verified editorial editions can still publish on the {evidenceDigestProgram.cadence} cadence when they do not depend on unresolved study-level claims. The quality gate is intentionally stricter than the publishing schedule.
         </p>
         <p className='mt-5 text-xs font-semibold uppercase tracking-[0.14em] text-brand-700'>
-          Review status: source verification in progress · Updated August 12, 2026
+          Review status: source verification in progress · Updated August 15, 2026
         </p>
       </header>
 
+      {verifiedEditions.length > 0 ? (
+        <section className='space-y-4' aria-labelledby='verified-digest-editions'>
+          <div>
+            <p className='eyebrow-label'>Verified editions</p>
+            <h2 id='verified-digest-editions' className='mt-2 text-2xl font-bold tracking-tight text-ink'>
+              Publish only what clears the evidence gate
+            </h2>
+            <p className='mt-2 text-sm leading-6 text-muted'>{evidenceDigestProgram.retentionPromise}</p>
+          </div>
+          {verifiedEditions.map((edition) => (
+            <Link
+              key={edition.slug}
+              href={`/evidence/evidence-digest/${edition.slug}/`}
+              className='block rounded-2xl border border-brand-900/10 bg-white/90 p-5 shadow-sm transition hover:border-brand-700/25 hover:bg-brand-50/30'
+            >
+              <p className='text-xs font-bold uppercase tracking-[0.14em] text-brand-700'>{edition.publishedAt}</p>
+              <h3 className='mt-2 text-xl font-bold text-ink'>{edition.title}</h3>
+              <p className='mt-2 text-sm leading-6 text-muted'>{edition.description}</p>
+              <span className='mt-4 inline-flex text-sm font-semibold text-brand-800'>Read edition →</span>
+            </Link>
+          ))}
+        </section>
+      ) : null}
+
       <section className='rounded-2xl border border-amber-900/15 bg-amber-50/55 p-5 sm:p-6'>
-        <h2 className='text-xl font-bold text-ink'>What is being checked</h2>
+        <h2 className='text-xl font-bold text-ink'>What is being checked before study updates return</h2>
         <ul className='mt-4 list-disc space-y-2 pl-5 text-sm leading-6 text-muted'>
           <li>Every PMID or DOI must resolve to the study described on the card.</li>
           <li>Ingredient form, dose, duration, population, comparator, and sample size must match the publication.</li>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,7 @@ import Footer from '../src/components/Footer'
 import MobileBottomNav from '../src/components/mobile-bottom-nav'
 import ScrollToTopButton from '../src/components/ScrollToTopButton'
 import ClickTracker from '@/components/ClickTracker'
+import EmailReturnAttribution from '@/components/EmailReturnAttribution'
 import ConsentBanner from '../src/components/ConsentBanner'
 import CitationDrawerLazy from '@/components/education/CitationDrawerLazy'
 import GlobalTOC from '@/components/content/GlobalTOC'
@@ -145,6 +146,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             <ScrollToTopButton />
             <CitationDrawerLazy />
             <ClickTracker />
+            <EmailReturnAttribution />
             <ConsentBanner />
           </div>
         </DarkModeProvider>

--- a/components/EmailReturnAttribution.tsx
+++ b/components/EmailReturnAttribution.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { captureEmailReturn } from '@/lib/email-attribution'
+import { trackEmailReturn } from '@/lib/analytics'
+
+export default function EmailReturnAttribution() {
+  const trackedUrlRef = useRef('')
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const currentUrl = window.location.href
+    if (trackedUrlRef.current === currentUrl) return
+
+    const attribution = captureEmailReturn(new URL(currentUrl))
+    if (!attribution) return
+
+    trackedUrlRef.current = currentUrl
+    trackEmailReturn({
+      campaign: attribution.campaign,
+      content: attribution.content,
+      pagePath: window.location.pathname,
+    })
+  })
+
+  return null
+}

--- a/content/__tests__/evidenceDigest.test.ts
+++ b/content/__tests__/evidenceDigest.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { evidenceDigestEditions, evidenceDigestProgram } from '@/content/evidenceDigest'
+
+describe('evidence digest program', () => {
+  it('uses a retention-oriented weekly or biweekly cadence', () => {
+    expect(['weekly', 'biweekly']).toContain(evidenceDigestProgram.cadence)
+    expect(evidenceDigestProgram.retentionPromise.length).toBeGreaterThan(80)
+  })
+
+  it('never makes a reviewing edition indexable', () => {
+    for (const edition of evidenceDigestEditions) {
+      if (edition.editorialStatus !== 'verified') {
+        expect(edition.indexable).toBe(false)
+      }
+    }
+  })
+
+  it('gives indexable editions meaningful sections and deeper destinations', () => {
+    for (const edition of evidenceDigestEditions.filter((item) => item.indexable)) {
+      expect(edition.editorialStatus).toBe('verified')
+      expect(edition.sections.length).toBeGreaterThanOrEqual(3)
+      expect(edition.sections.some((section) => Boolean(section.href))).toBe(true)
+    }
+  })
+})

--- a/content/evidenceDigest.ts
+++ b/content/evidenceDigest.ts
@@ -1,0 +1,83 @@
+export type EvidenceDigestCadence = 'weekly' | 'biweekly'
+
+export type EvidenceDigestEdition = {
+  slug: string
+  title: string
+  description: string
+  publishedAt: string
+  editorialStatus: 'verified' | 'reviewing'
+  indexable: boolean
+  sections: readonly {
+    heading: string
+    body: readonly string[]
+    href?: string
+    linkLabel?: string
+  }[]
+}
+
+export const evidenceDigestProgram = {
+  cadence: 'biweekly' as EvidenceDigestCadence,
+  retentionPromise:
+    'Every edition should save the reader time by explaining one evidence or safety decision clearly, linking to the underlying site resources, and keeping uncertainty visible.',
+  publicationRules: [
+    'Only verified editorial editions may be indexable.',
+    'A digest containing unverified study-level claims must remain noindex until source review is complete.',
+    'Every edition needs at least one practical takeaway and at least one deeper research destination.',
+    'Email and web editions must share one canonical content object rather than being rewritten independently.',
+    'Digest links use campaign attribution but never place an email address or other subscriber identifier in the URL.',
+  ] as const,
+} as const
+
+export const evidenceDigestEditions: readonly EvidenceDigestEdition[] = [
+  {
+    slug: '2026-08-evidence-literacy',
+    title: 'Evidence Digest: Four Checks Before You Trust a Supplement Claim',
+    description:
+      'A practical evidence-literacy edition covering study type, ingredient form, dose relevance, and safety context without relying on unverified study cards.',
+    publishedAt: '2026-08-15',
+    editorialStatus: 'verified',
+    indexable: true,
+    sections: [
+      {
+        heading: '1. Ask what kind of evidence you are looking at',
+        body: [
+          'A mechanism, an animal experiment, an observational association, a randomized trial, and a systematic review answer different questions. Treating them as interchangeable is one of the fastest ways to overstate a supplement claim.',
+          'Start by identifying the evidence class. Then make the conclusion no stronger than that class and the broader body of evidence can support.',
+        ],
+        href: '/learn/evidence-levels/',
+        linkLabel: 'Review evidence levels',
+      },
+      {
+        heading: '2. Check whether the product resembles what was studied',
+        body: [
+          'The ingredient name alone is not enough. Form, extract standardization, elemental amount, active-marker percentage, and serving size can determine whether a retail product meaningfully resembles the intervention used in research.',
+          'This matters most when findings come from a specific extract or formulation that should not be generalized to every product using the same common ingredient name.',
+        ],
+        href: '/learn/product-quality/',
+        linkLabel: 'Read the product-quality guide',
+      },
+      {
+        heading: '3. Put the studied dose beside the claim',
+        body: [
+          'A useful evidence summary should distinguish a standardized medical dose from doses that happened to be studied in trials. It should also make the preparation or extract explicit when dose interpretation depends on it.',
+          'If a consumer product delivers a very different amount or form, the research result may be less transferable even when the ingredient name matches.',
+        ],
+        href: '/info/dosing/',
+        linkLabel: 'Review dosing basics',
+      },
+      {
+        heading: '4. Treat safety as a separate question from efficacy',
+        body: [
+          'Strong evidence that something has an effect does not prove that it is appropriate for every person. Weak evidence of benefit does not automatically mean a substance is dangerous either.',
+          'Use interaction, contraindication, sedation, stimulation, pregnancy, and medication context as a separate safety layer. When the dataset has no documented interaction, that should not be rewritten as proof that no interaction exists.',
+        ],
+        href: '/safety-checker/',
+        linkLabel: 'Open the Safety Checker',
+      },
+    ],
+  },
+]
+
+export function getEvidenceDigestEdition(slug: string): EvidenceDigestEdition | undefined {
+  return evidenceDigestEditions.find((edition) => edition.slug === slug)
+}

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -7,6 +7,7 @@ type Gtag = (
   eventName:
     | 'affiliate_click'
     | 'atlas_callout_click'
+    | 'email_return'
     | 'email_signup'
     | 'experiment_conversion'
     | 'experiment_impression'
@@ -78,6 +79,18 @@ export function trackEmailSignup(params: { source: string; pagePath?: string }):
   }
 }
 
+export function trackEmailReturn(params: { campaign: string; content: string; pagePath?: string }): void {
+  try {
+    getGtag()?.('event', 'email_return', {
+      email_campaign: params.campaign,
+      email_content: params.content,
+      page_path: getCurrentPagePath(params.pagePath),
+    })
+  } catch {
+    // Analytics must never block navigation.
+  }
+}
+
 export function trackExperimentImpression(params: ExperimentAnalyticsParams): void {
   try {
     getGtag()?.('event', 'experiment_impression', {
@@ -125,8 +138,6 @@ export function trackAtlasCalloutClick(params: AtlasCalloutClickParams): void {
   try {
     if (!getGtag()) return
 
-    // dataLayer entries are consumed by tag managers, so they are only written
-    // once the same consent gate that guards gtag has passed.
     const analyticsWindow = window as Window & { dataLayer?: Array<Record<string, unknown>> }
     analyticsWindow.dataLayer = analyticsWindow.dataLayer || []
     analyticsWindow.dataLayer.push({

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { canTrackAnalytics } from '@/lib/consent'
+import { markNewsletterSignup } from '@/lib/email-attribution'
 
 type Gtag = (
   command: 'event',
@@ -67,8 +68,12 @@ export function trackAffiliateClick(params: { itemName: string; program: string;
 
 export function trackEmailSignup(params: { source: string; pagePath?: string }): void {
   try {
+    const gtag = getGtag()
+    if (!gtag) return
+
+    markNewsletterSignup()
     const pagePath = getCurrentPagePath(params.pagePath)
-    getGtag()?.('event', 'email_signup', {
+    gtag('event', 'email_signup', {
       source: params.source,
       signup_source: params.source,
       page_path: pagePath,

--- a/lib/email-attribution.ts
+++ b/lib/email-attribution.ts
@@ -1,0 +1,71 @@
+'use client'
+
+const SIGNUP_AT_KEY = 'ths:newsletter:signup-at:v1'
+const FIRST_EMAIL_RETURN_AT_KEY = 'ths:newsletter:first-return-at:v1'
+const CAMPAIGN_KEY = 'ths:newsletter:last-campaign:v1'
+const CONTENT_KEY = 'ths:newsletter:last-content:v1'
+
+export type NewsletterAttribution = {
+  newsletterAttributed: boolean
+  campaign: string
+  content: string
+  subscriberAgeDays: number | null
+  firstEmailReturnAgeDays: number | null
+}
+
+function safeRead(key: string): string {
+  if (typeof window === 'undefined') return ''
+  try {
+    return window.localStorage.getItem(key) || ''
+  } catch {
+    return ''
+  }
+}
+
+function safeWrite(key: string, value: string): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(key, value)
+  } catch {
+    // Attribution storage must never block navigation or signup.
+  }
+}
+
+function ageDays(timestamp: string): number | null {
+  const parsed = Date.parse(timestamp)
+  if (!Number.isFinite(parsed)) return null
+  return Math.max(0, Math.floor((Date.now() - parsed) / 86_400_000))
+}
+
+export function markNewsletterSignup(now = new Date()): void {
+  if (!safeRead(SIGNUP_AT_KEY)) safeWrite(SIGNUP_AT_KEY, now.toISOString())
+}
+
+export function captureEmailReturn(url: URL, now = new Date()): { campaign: string; content: string } | null {
+  const medium = url.searchParams.get('utm_medium')?.toLowerCase().trim()
+  if (medium !== 'email') return null
+
+  const campaign = url.searchParams.get('utm_campaign')?.trim() || 'unknown-email-campaign'
+  const content = url.searchParams.get('utm_content')?.trim() || 'unknown-email-content'
+
+  if (!safeRead(FIRST_EMAIL_RETURN_AT_KEY)) safeWrite(FIRST_EMAIL_RETURN_AT_KEY, now.toISOString())
+  safeWrite(CAMPAIGN_KEY, campaign)
+  safeWrite(CONTENT_KEY, content)
+
+  return { campaign, content }
+}
+
+export function getNewsletterAttribution(): NewsletterAttribution {
+  const signupAt = safeRead(SIGNUP_AT_KEY)
+  const firstReturnAt = safeRead(FIRST_EMAIL_RETURN_AT_KEY)
+  const campaign = safeRead(CAMPAIGN_KEY)
+  const content = safeRead(CONTENT_KEY)
+
+  return {
+    newsletterAttributed: Boolean(signupAt || firstReturnAt || campaign),
+    campaign,
+    content,
+    subscriberAgeDays: signupAt ? ageDays(signupAt) : null,
+    firstEmailReturnAgeDays: firstReturnAt ? ageDays(firstReturnAt) : null,
+  }
+}

--- a/src/lib/revenue-tracking.ts
+++ b/src/lib/revenue-tracking.ts
@@ -1,4 +1,5 @@
 import { canTrackAnalytics } from '@/lib/consent'
+import { getNewsletterAttribution } from '@/lib/email-attribution'
 
 export type RevenueEventKind =
   | 'recommendation_impression'
@@ -234,8 +235,16 @@ export function trackRevenueEvent(input: RevenueEventInput) {
 
   if (!canSendAnalytics()) return
 
+  const newsletter = getNewsletterAttribution()
   window.dataLayer = window.dataLayer || []
-  window.dataLayer.push(event)
+  window.dataLayer.push({
+    ...event,
+    newsletterAttributed: newsletter.newsletterAttributed,
+    newsletterCampaign: newsletter.campaign,
+    newsletterContent: newsletter.content,
+    subscriberAgeDays: newsletter.subscriberAgeDays,
+    firstEmailReturnAgeDays: newsletter.firstEmailReturnAgeDays,
+  })
 
   if (window.gtag) {
     window.gtag('event', event.kind, {
@@ -250,6 +259,11 @@ export function trackRevenueEvent(input: RevenueEventInput) {
       product_asin: event.productAsin || undefined,
       device_type: event.deviceType,
       scroll_depth: event.scrollDepth,
+      newsletter_attributed: newsletter.newsletterAttributed,
+      newsletter_campaign: newsletter.campaign || undefined,
+      newsletter_content: newsletter.content || undefined,
+      subscriber_age_days: newsletter.subscriberAgeDays ?? undefined,
+      first_email_return_age_days: newsletter.firstEmailReturnAgeDays ?? undefined,
     })
   }
 }


### PR DESCRIPTION
## Backlog
Covers 363–368.

## What changed
- defines a biweekly Evidence Digest publishing/retention contract
- keeps reviewing/unverified study editions non-indexable by rule
- publishes a verified evidence-literacy edition as indexable web content
- adds a forward-this-digest sharing prompt
- surfaces verified editions from the existing digest hold page without lifting the study-level verification hold
- adds consent-gated `email_return` analytics for UTM-tagged email landings
- records anonymous signup/first-return timestamps locally (no email identity)
- attaches newsletter campaign/content and subscriber-age dimensions to downstream monetization events for aggregate LTV/cohort analysis
- adds digest quality-gate tests

## Privacy / evidence guardrails
- no email address is placed in URLs, local attribution keys, or analytics dimensions
- subscriber value is tracked as aggregate anonymous cohort context
- the existing unverified study-card hold remains in place