### PR TITLE
ROI #121: caffeine vs caffeine + L-theanine

### DIFF
--- a/app/guides/compare/caffeine-vs-caffeine-l-theanine/page.tsx
+++ b/app/guides/compare/caffeine-vs-caffeine-l-theanine/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next'
+
+import RuntimeEvidenceComparison from '@/src/components/comparison/RuntimeEvidenceComparison'
+import { buildPageMetadata } from '@/src/lib/seo'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Caffeine vs Caffeine + L-Theanine: Evidence & Safety',
+  description: 'Compare caffeine alone with the L-theanine add-on evidence relevant to caffeine + L-theanine, using canonical dose and safety context.',
+  path: '/guides/compare/caffeine-vs-caffeine-l-theanine/',
+})
+
+export default function CaffeineVsCaffeineLTheaninePage() {
+  return (
+    <RuntimeEvidenceComparison
+      title="Caffeine vs Caffeine + L-Theanine"
+      summary="This comparison treats caffeine as the shared base and uses the L-theanine record to show what changes when L-theanine is the add-on. The right column is component evidence, not a claim that every caffeine + L-theanine ratio has been clinically tested."
+      goal="Focus decisions where the question is caffeine alone versus adding L-theanine, without generalizing beyond studied doses or formulations"
+      left={{ label: 'Caffeine Alone', candidates: ['caffeine'] }}
+      right={{ label: 'L-Theanine Add-On Evidence', candidates: ['l-theanine', 'theanine'] }}
+    />
+  )
+}


### PR DESCRIPTION
Implements backlog item #121. The comparison explicitly treats caffeine as the shared base and the right side as L-theanine add-on evidence, avoiding the false claim that every caffeine/theanine ratio has direct trial support.