### PR TITLE
ROI 655-674: add claim knowledge graph and ingredient JSON endpoints

### DIFF
--- a/docs/data/ingredient-json-endpoints.md
+++ b/docs/data/ingredient-json-endpoints.md
@@ -1,0 +1,67 @@
+# Machine-readable ingredient evidence endpoints
+
+The Hippie Scientist publishes structured companion JSON for ingredient profiles so search, research, and answer systems can consume the same claim/source relationships that power editorial work without treating JSON as a replacement for the human-readable page.
+
+## Canonical relationship
+
+Human-readable ingredient profiles remain the canonical destinations:
+
+- `/herbs/<slug>/`
+- `/compounds/<slug>/`
+
+Structured companions are generated at:
+
+- `/data/ingredients/<slug>.json`
+- `/data/claim-knowledge-graph.json`
+- `/data/claim-page-dependencies.json`
+
+Every ingredient JSON document includes its canonical human page in `entity.canonicalPage`.
+
+## Stable identifiers
+
+The data uses the repository's deterministic canonical IDs:
+
+- entity IDs: `ent_<type>_<hash>`
+- claim IDs: `clm_<hash>`
+- source IDs: `src_<hash>`
+
+A claim also carries a `revision` hash. Ingredient endpoints carry a `claimsRevision` hash, and the aggregate graph carries an `integrityHash`. These hashes make scientific changes observable without changing stable identities.
+
+## Claim semantics
+
+Each claim exposes structured subject, predicate, object, evidence class, confidence, review state, affected pages, source identifiers, and—when explicitly curated—a `publicStatement`.
+
+Free-form migration/editorial notes are **not** promoted into public claim wording. `publicStatement` remains null unless an explicit `public_statement`, `publicStatement`, or `claim_text` qualifier exists.
+
+Source direction is conservative:
+
+- `supportingSourceIds` only when the claim direction explicitly indicates support/benefit.
+- `contradictingSourceIds` only when the direction explicitly indicates contradiction/no effect/harm.
+- `mixedSourceIds` for explicitly mixed/inconsistent findings.
+- `contextSourceIds` when direction is not explicit enough to classify.
+
+No missing classification is interpreted as supporting evidence.
+
+## Review dates
+
+`updatedAt` and `lastReviewedAt` are intentionally separate. An ordinary data/template update is not called an editorial review. `lastReviewedAt` is populated only from an explicit review timestamp or, for an approved canonical claim, its approved update timestamp.
+
+## Citations
+
+Referenced source records include stable source IDs and the strongest available external identifier (PMID, DOI, then URL). Raw migration citation strings are not emitted, which prevents internal metadata/TODO language from leaking into the public structured dataset.
+
+## Attribution
+
+When reusing a derived Hippie Scientist summary or structured conclusion, attribute **The Hippie Scientist** and link to the endpoint's `entity.canonicalPage`. When discussing an underlying study, retain and cite its original PMID/DOI whenever available.
+
+This attribution guidance does not replace the site's published content-licensing terms and does not grant rights to third-party publications or study text.
+
+## Generation
+
+Run:
+
+```bash
+node scripts/data/build-claim-knowledge-endpoints.mjs
+```
+
+Generation fails if the same stable claim ID appears with conflicting payloads. This prevents two divergent versions of one scientific claim from being serialized into separate pages or machine-readable artifacts.

--- a/docs/data/ingredient-json-endpoints.md
+++ b/docs/data/ingredient-json-endpoints.md
@@ -19,11 +19,14 @@ Every ingredient JSON document includes its canonical human page in `entity.cano
 
 ## Stable identifiers
 
-The data uses the repository's deterministic canonical IDs:
+Public substance identities follow the repository's evidence-graph identity foundation:
 
-- entity IDs: `ent_<type>_<hash>`
+- herb IDs: `herb:<canonical-slug>`
+- compound IDs: `compound:<canonical-slug>`
 - claim IDs: `clm_<hash>`
 - source IDs: `src_<hash>`
+
+The canonical claim store still contains deterministic legacy `ent_<type>_<hash>` subject IDs. When one is required to trace a public endpoint back to the existing claim store, it is preserved explicitly as `legacyCanonicalId` / `legacyCanonicalSubjectId`; it is not presented as a second public substance identity system.
 
 A claim also carries a `revision` hash. Ingredient endpoints carry a `claimsRevision` hash, and the aggregate graph carries an `integrityHash`. These hashes make scientific changes observable without changing stable identities.
 

--- a/scripts/data/build-claim-knowledge-endpoints.mjs
+++ b/scripts/data/build-claim-knowledge-endpoints.mjs
@@ -5,6 +5,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { contentHash, stableStringify } from './canonical/ids.mjs'
 import { buildClaimKnowledgeBase } from './claim-knowledge-lib.mjs'
+import { remapClaimKnowledgeToStableSubstanceIds } from './claim-knowledge-identity.mjs'
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
 const PUBLIC_DATA = path.join(ROOT, 'public', 'data')
@@ -70,6 +71,11 @@ function renderMarkdown(knowledge) {
     `- Orphan claims not attached to a public herb/compound profile: **${knowledge.summary.orphanClaims}**`,
     `- Integrity hash: \`${knowledge.integrityHash}\``,
     '',
+    '## Identity contract',
+    '',
+    `- Public substance IDs: **${knowledge.identityContract?.publicSubstanceIds || 'legacy'}**`,
+    `- Legacy claim join IDs: **${knowledge.identityContract?.legacyClaimJoinIds || 'n/a'}**`,
+    '',
     '## Contract',
     '',
     '- Stable claim IDs are the identity key; duplicate IDs with conflicting payloads fail generation.',
@@ -105,7 +111,8 @@ const claims = readJsonl(path.join(ROOT, 'data', 'canonical', 'claims', 'claims.
 const sources = readJsonl(path.join(ROOT, 'data', 'canonical', 'sources', 'sources.jsonl'))
 
 assertUniqueClaims(claims)
-const knowledge = buildClaimKnowledgeBase({ herbs, compounds, claims, sources })
+const derivedKnowledge = buildClaimKnowledgeBase({ herbs, compounds, claims, sources })
+const knowledge = remapClaimKnowledgeToStableSubstanceIds(derivedKnowledge, { herbs, compounds })
 
 mkdirSync(PUBLIC_DATA, { recursive: true })
 mkdirSync(REPORT_DIR, { recursive: true })
@@ -119,6 +126,7 @@ for (const endpoint of knowledge.endpoints) {
 const aggregate = {
   version: knowledge.version,
   generatedAt: knowledge.generatedAt,
+  identityContract: knowledge.identityContract,
   summary: knowledge.summary,
   claims: knowledge.claims,
   dependencies: knowledge.dependencies,
@@ -138,6 +146,7 @@ console.log(`Claims        ${knowledge.summary.claims}`)
 console.log(`Endpoints     ${knowledge.summary.endpoints}`)
 console.log(`Orphan claims ${knowledge.summary.orphanClaims}`)
 console.log(`Integrity     ${knowledge.integrityHash.slice(0, 16)}…`)
+console.log('Identity      stable evidence-graph substance IDs')
 console.log('Aggregate     public/data/claim-knowledge-graph.json')
 console.log('Dependencies  public/data/claim-page-dependencies.json')
 console.log('Endpoints     public/data/ingredients/<slug>.json')

--- a/scripts/data/build-claim-knowledge-endpoints.mjs
+++ b/scripts/data/build-claim-knowledge-endpoints.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { contentHash, stableStringify } from './canonical/ids.mjs'
+import { buildClaimKnowledgeBase } from './claim-knowledge-lib.mjs'
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const PUBLIC_DATA = path.join(ROOT, 'public', 'data')
+const ENDPOINT_DIR = path.join(PUBLIC_DATA, 'ingredients')
+const REPORT_DIR = path.join(ROOT, 'ops', 'reports')
+
+function readJson(filePath, fallback) {
+  if (!existsSync(filePath)) return fallback
+  try {
+    return JSON.parse(readFileSync(filePath, 'utf8'))
+  } catch {
+    return fallback
+  }
+}
+
+function readFirstJson(paths, fallback) {
+  for (const filePath of paths) {
+    const value = readJson(filePath, undefined)
+    if (value !== undefined && (!Array.isArray(value) || value.length > 0)) return value
+  }
+  return fallback
+}
+
+function readJsonl(filePath) {
+  if (!existsSync(filePath)) return []
+  const rows = []
+  for (const [index, line] of readFileSync(filePath, 'utf8').split(/\r?\n/).entries()) {
+    const text = line.trim()
+    if (!text) continue
+    try {
+      rows.push(JSON.parse(text))
+    } catch (error) {
+      throw new Error(`Invalid JSONL at ${path.relative(ROOT, filePath)}:${index + 1}: ${error.message}`)
+    }
+  }
+  return rows
+}
+
+function assertUniqueClaims(claims) {
+  const seen = new Map()
+  for (const claim of claims) {
+    const id = String(claim?.id || '').trim()
+    if (!id) continue
+    const fingerprint = contentHash(stableStringify(claim))
+    const prior = seen.get(id)
+    if (prior && prior !== fingerprint) {
+      throw new Error(`Claim ID ${id} appears with conflicting payloads; refusing to generate drift-prone endpoints.`)
+    }
+    seen.set(id, fingerprint)
+  }
+}
+
+function renderMarkdown(knowledge) {
+  const lines = [
+    '# Claim knowledge endpoint report',
+    '',
+    `Generated ${knowledge.generatedAt}.`,
+    '',
+    `- Runtime profiles represented: **${knowledge.summary.profiles}**`,
+    `- Canonical claims attached: **${knowledge.summary.claims}**`,
+    `- Machine-readable ingredient endpoints: **${knowledge.summary.endpoints}**`,
+    `- Canonical source records available: **${knowledge.summary.sourceRecords}**`,
+    `- Orphan claims not attached to a public herb/compound profile: **${knowledge.summary.orphanClaims}**`,
+    `- Integrity hash: \`${knowledge.integrityHash}\``,
+    '',
+    '## Contract',
+    '',
+    '- Stable claim IDs are the identity key; duplicate IDs with conflicting payloads fail generation.',
+    '- `supportingSourceIds`, `contradictingSourceIds`, and `mixedSourceIds` are populated only when claim direction explicitly supports that classification.',
+    '- A claim `updated_at` is not called a review date unless the claim is approved or carries an explicit review timestamp.',
+    '- Migration/editorial notes are never exported as public claim wording unless an explicit `public_statement`/`claim_text` qualifier exists.',
+    '- Human-readable ingredient pages remain the canonical destinations; JSON files are structured companion data.',
+    '',
+  ]
+
+  if (knowledge.diagnostics.orphanClaims.length) {
+    lines.push('## Orphan claims requiring mapping review', '')
+    for (const row of knowledge.diagnostics.orphanClaims.slice(0, 100)) {
+      lines.push(`- \`${row.claimId}\` → \`${row.subjectId}\`: ${row.reason}`)
+    }
+    lines.push('')
+  }
+
+  return `${lines.join('\n')}\n`
+}
+
+const herbs = readFirstJson([
+  path.join(PUBLIC_DATA, 'summary-indexes', 'herbs-summary.json'),
+  path.join(PUBLIC_DATA, 'herbs-summary.json'),
+  path.join(PUBLIC_DATA, 'herbs.json'),
+], [])
+const compounds = readFirstJson([
+  path.join(PUBLIC_DATA, 'summary-indexes', 'compounds-summary.json'),
+  path.join(PUBLIC_DATA, 'compounds-summary.json'),
+  path.join(PUBLIC_DATA, 'compounds.json'),
+], [])
+const claims = readJsonl(path.join(ROOT, 'data', 'canonical', 'claims', 'claims.jsonl'))
+const sources = readJsonl(path.join(ROOT, 'data', 'canonical', 'sources', 'sources.jsonl'))
+
+assertUniqueClaims(claims)
+const knowledge = buildClaimKnowledgeBase({ herbs, compounds, claims, sources })
+
+mkdirSync(PUBLIC_DATA, { recursive: true })
+mkdirSync(REPORT_DIR, { recursive: true })
+rmSync(ENDPOINT_DIR, { recursive: true, force: true })
+mkdirSync(ENDPOINT_DIR, { recursive: true })
+
+for (const endpoint of knowledge.endpoints) {
+  writeFileSync(path.join(ENDPOINT_DIR, `${endpoint.entity.slug}.json`), `${JSON.stringify(endpoint, null, 2)}\n`)
+}
+
+const aggregate = {
+  version: knowledge.version,
+  generatedAt: knowledge.generatedAt,
+  summary: knowledge.summary,
+  claims: knowledge.claims,
+  dependencies: knowledge.dependencies,
+  endpointIndex: knowledge.endpointIndex,
+  diagnostics: knowledge.diagnostics,
+  integrityHash: knowledge.integrityHash,
+}
+
+writeFileSync(path.join(PUBLIC_DATA, 'claim-knowledge-graph.json'), `${JSON.stringify(aggregate, null, 2)}\n`)
+writeFileSync(path.join(PUBLIC_DATA, 'claim-page-dependencies.json'), `${JSON.stringify(knowledge.dependencies, null, 2)}\n`)
+writeFileSync(path.join(REPORT_DIR, 'claim-knowledge-endpoints.md'), renderMarkdown(knowledge))
+
+console.log('\nClaim knowledge endpoints')
+console.log('='.repeat(64))
+console.log(`Profiles      ${knowledge.summary.profiles}`)
+console.log(`Claims        ${knowledge.summary.claims}`)
+console.log(`Endpoints     ${knowledge.summary.endpoints}`)
+console.log(`Orphan claims ${knowledge.summary.orphanClaims}`)
+console.log(`Integrity     ${knowledge.integrityHash.slice(0, 16)}…`)
+console.log('Aggregate     public/data/claim-knowledge-graph.json')
+console.log('Dependencies  public/data/claim-page-dependencies.json')
+console.log('Endpoints     public/data/ingredients/<slug>.json')

--- a/scripts/data/canonical/__tests__/claim-knowledge-identity.test.mjs
+++ b/scripts/data/canonical/__tests__/claim-knowledge-identity.test.mjs
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { buildStableEntityId } from '../../../../config/evidence-graph/identity-rules.mjs'
+import { entityId } from '../ids.mjs'
+import { buildClaimKnowledgeBase } from '../../claim-knowledge-lib.mjs'
+import { remapClaimKnowledgeToStableSubstanceIds } from '../../claim-knowledge-identity.mjs'
+
+describe('claim knowledge identity compatibility', () => {
+  it('joins legacy canonical claims while exposing stable public substance IDs', () => {
+    const herbs = [{ slug: 'ashwagandha', name: 'Ashwagandha', evidence_grade: 'B' }]
+    const legacySubjectId = entityId('herb', 'ashwagandha')
+    const stableSubjectId = buildStableEntityId('herb', 'ashwagandha')
+
+    const derived = buildClaimKnowledgeBase({
+      herbs,
+      claims: [{
+        id: 'clm_identitytest',
+        subject_id: legacySubjectId,
+        predicate: 'supports_outcome',
+        object_literal: 'stress',
+        qualifiers: { direction: '+' },
+        source_ids: [],
+        evidence_level: 'human_rct',
+        review_status: 'pending',
+      }],
+    })
+    const knowledge = remapClaimKnowledgeToStableSubstanceIds(derived, { herbs })
+
+    const endpoint = knowledge.endpoints[0]
+    expect(endpoint.entity.id).toBe(stableSubjectId)
+    expect(endpoint.entity.legacyCanonicalId).toBe(legacySubjectId)
+    expect(endpoint.claims[0].subjectId).toBe(stableSubjectId)
+    expect(endpoint.claims[0].legacyCanonicalSubjectId).toBe(legacySubjectId)
+    expect(knowledge.dependencies.clm_identitytest.subjectId).toBe(stableSubjectId)
+    expect(knowledge.endpointIndex[stableSubjectId]).toBe('/data/ingredients/ashwagandha.json')
+    expect(knowledge.identityContract.publicSubstanceIds).toBe('<entityType>:<canonical-slug>')
+  })
+})

--- a/scripts/data/canonical/__tests__/claim-knowledge.test.mjs
+++ b/scripts/data/canonical/__tests__/claim-knowledge.test.mjs
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import { entityId } from '../ids.mjs'
+import { buildClaimKnowledgeBase } from '../../claim-knowledge-lib.mjs'
+
+describe('claim knowledge base', () => {
+  it('attaches stable claims, sources, review truthfulness, and affected pages', () => {
+    const subjectId = entityId('herb', 'ashwagandha')
+    const knowledge = buildClaimKnowledgeBase({
+      herbs: [{
+        slug: 'ashwagandha',
+        name: 'Ashwagandha',
+        evidence_grade: 'B',
+        safety_flags: ['pregnancy-caution'],
+      }],
+      claims: [{
+        id: 'clm_123456789abc',
+        subject_id: subjectId,
+        predicate: 'supports_outcome',
+        object_literal: 'stress',
+        qualifiers: {
+          direction: 'positive',
+          study_id: entityId('study', 'stress-rct'),
+          public_statement: 'Human trials report a stress-reduction signal in studied ashwagandha preparations.',
+        },
+        source_ids: ['src_123456789abc'],
+        evidence_level: 'human_rct',
+        confidence: 0.8,
+        review_status: 'approved',
+        updated_at: '2026-08-15T12:00:00.000Z',
+      }],
+      sources: [{
+        id: 'src_123456789abc',
+        pmid: '12345678',
+        title: 'Example RCT',
+        author_or_label: 'Example A',
+        journal: 'Example Journal',
+        year: 2026,
+        url: 'https://pubmed.ncbi.nlm.nih.gov/12345678/',
+        review_status: 'approved',
+      }],
+    })
+
+    expect(knowledge.summary.claims).toBe(1)
+    const endpoint = knowledge.endpoints[0]
+    expect(endpoint.entity.id).toBe(subjectId)
+    expect(endpoint.entity.canonicalPage).toBe('/herbs/ashwagandha/')
+    expect(endpoint.evidence.profileGrade).toBe('B')
+    expect(endpoint.safetyFlags).toContain('pregnancy-caution')
+    expect(endpoint.claims[0].supportingSourceIds).toEqual(['src_123456789abc'])
+    expect(endpoint.claims[0].contradictingSourceIds).toEqual([])
+    expect(endpoint.claims[0].lastReviewedAt).toBe('2026-08-15T12:00:00.000Z')
+    expect(endpoint.claims[0].affectedPages).toEqual(['/herbs/ashwagandha/'])
+    expect(endpoint.citations[0].identifier).toEqual({ type: 'pmid', value: '12345678' })
+    expect(knowledge.dependencies['clm_123456789abc'].affectedPages).toEqual(['/herbs/ashwagandha/'])
+  })
+
+  it('does not call an ordinary update a review when the claim is still pending', () => {
+    const subjectId = entityId('compound', 'compound-a')
+    const knowledge = buildClaimKnowledgeBase({
+      compounds: [{ slug: 'compound-a', name: 'Compound A', evidence_grade: 'C' }],
+      claims: [{
+        id: 'clm_pending00001',
+        subject_id: subjectId,
+        predicate: 'supports_outcome',
+        object_literal: 'focus',
+        qualifiers: { direction: 'mixed' },
+        source_ids: ['src_context0001'],
+        evidence_level: 'human_obs',
+        confidence: 0.5,
+        review_status: 'pending',
+        updated_at: '2026-08-15T12:00:00.000Z',
+      }],
+      sources: [{ id: 'src_context0001', doi: '10.1000/example', title: 'Example' }],
+    })
+
+    const claim = knowledge.endpoints[0].claims[0]
+    expect(claim.lastReviewedAt).toBeNull()
+    expect(claim.mixedSourceIds).toEqual(['src_context0001'])
+    expect(claim.publicStatement).toBeNull()
+  })
+
+  it('never exposes free-form migration notes as public claim wording', () => {
+    const subjectId = entityId('herb', 'herb-a')
+    const knowledge = buildClaimKnowledgeBase({
+      herbs: [{ slug: 'herb-a', name: 'Herb A' }],
+      claims: [{
+        id: 'clm_notes000001',
+        subject_id: subjectId,
+        predicate: 'supports_outcome',
+        object_literal: 'sleep',
+        notes: 'study_count=2; needs_validation; migration note',
+        qualifiers: {},
+        source_ids: [],
+        evidence_level: 'none',
+        review_status: 'pending',
+      }],
+    })
+
+    expect(knowledge.endpoints[0].claims[0].publicStatement).toBeNull()
+  })
+})

--- a/scripts/data/claim-knowledge-identity.mjs
+++ b/scripts/data/claim-knowledge-identity.mjs
@@ -1,0 +1,97 @@
+import { buildStableEntityId } from '../../config/evidence-graph/identity-rules.mjs'
+import { contentHash, entityId, stableStringify } from './canonical/ids.mjs'
+
+function clean(value) {
+  return String(value ?? '').trim()
+}
+
+function buildIdentityMap({ herbs = [], compounds = [] } = {}) {
+  const map = new Map()
+  const add = (record, kind) => {
+    const slug = clean(record?.slug)
+    if (!slug) return
+    map.set(entityId(kind, slug), buildStableEntityId(kind, slug))
+  }
+  herbs.forEach((record) => add(record, 'herb'))
+  compounds.forEach((record) => add(record, 'compound'))
+  return map
+}
+
+function remap(value, map) {
+  return map.get(value) || value
+}
+
+function remapClaim(claim, map) {
+  const legacyCanonicalSubjectId = claim.subjectId
+  const subjectId = remap(legacyCanonicalSubjectId, map)
+  return {
+    ...claim,
+    subjectId,
+    ...(subjectId !== legacyCanonicalSubjectId ? { legacyCanonicalSubjectId } : {}),
+  }
+}
+
+/**
+ * Canonical claims still reference legacy deterministic `ent_*` subject IDs.
+ * Public structured endpoints use the newer evidence-graph identity contract
+ * (`herb:<slug>` / `compound:<slug>`), while preserving legacy IDs only for
+ * provenance and backwards-compatible claim-store joins.
+ */
+export function remapClaimKnowledgeToStableSubstanceIds(knowledge, runtime = {}) {
+  const map = buildIdentityMap(runtime)
+  if (!map.size) return knowledge
+
+  const claims = Object.fromEntries(
+    Object.entries(knowledge.claims || {}).map(([claimId, claim]) => [claimId, remapClaim(claim, map)]),
+  )
+
+  const dependencies = Object.fromEntries(
+    Object.entries(knowledge.dependencies || {}).map(([claimId, dependency]) => {
+      const legacyCanonicalSubjectId = dependency.subjectId
+      const subjectId = remap(legacyCanonicalSubjectId, map)
+      return [claimId, {
+        ...dependency,
+        subjectId,
+        ...(subjectId !== legacyCanonicalSubjectId ? { legacyCanonicalSubjectId } : {}),
+      }]
+    }),
+  )
+
+  const endpoints = (knowledge.endpoints || []).map((endpoint) => {
+    const legacyCanonicalId = endpoint.entity.id
+    const stableId = remap(legacyCanonicalId, map)
+    const endpointClaims = (endpoint.claims || []).map((claim) => remapClaim(claim, map))
+    return {
+      ...endpoint,
+      entity: {
+        ...endpoint.entity,
+        id: stableId,
+        ...(stableId !== legacyCanonicalId ? { legacyCanonicalId } : {}),
+      },
+      claims: endpointClaims,
+    }
+  })
+
+  const endpointIndex = Object.fromEntries(
+    endpoints.map((endpoint) => [endpoint.entity.id, `/data/ingredients/${endpoint.entity.slug}.json`]),
+  )
+
+  const integrityHash = contentHash(stableStringify({
+    claims: Object.values(claims).map((claim) => [claim.claimId, claim.revision, claim.subjectId]),
+    endpoints: endpoints.map((endpoint) => [endpoint.entity.id, endpoint.claimsRevision]),
+  }))
+
+  return {
+    ...knowledge,
+    identityContract: {
+      publicSubstanceIds: '<entityType>:<canonical-slug>',
+      legacyClaimJoinIds: 'ent_<type>_<hash>',
+      note: 'Legacy ent_* IDs are retained only as provenance/claim-store compatibility identifiers.',
+    },
+    claims,
+    dependencies,
+    endpointIndex,
+    endpoints,
+    integrityHash,
+  }
+}

--- a/scripts/data/claim-knowledge-lib.mjs
+++ b/scripts/data/claim-knowledge-lib.mjs
@@ -23,8 +23,8 @@ function canonicalGrade(value) {
 function normalizeDirection(value) {
   const text = clean(value).toLowerCase()
   if (!text) return 'unknown'
-  if (/^(\+|positive|benefit|beneficial|supports?|improved?|increase(?:d)?|reduced?|decrease(?:d)?)\b/.test(text)) return 'supporting'
-  if (/^(\-|negative|contradict|no benefit|no effect|null|worse|harm)\b/.test(text)) return 'contradicting'
+  if (text === '+' || /^(positive|benefit|beneficial|supports?|improved?|increase(?:d)?|reduced?|decrease(?:d)?)\b/.test(text)) return 'supporting'
+  if (text === '-' || /^(negative|contradict|no benefit|no effect|null|worse|harm)\b/.test(text)) return 'contradicting'
   if (/\b(mixed|inconsistent|equivocal|heterogeneous|conflict)\b/.test(text)) return 'mixed'
   return 'unknown'
 }

--- a/scripts/data/claim-knowledge-lib.mjs
+++ b/scripts/data/claim-knowledge-lib.mjs
@@ -1,0 +1,268 @@
+import { contentHash, entityId, stableStringify } from './canonical/ids.mjs'
+
+function clean(value) {
+  return String(value ?? '').replace(/\s+/g, ' ').trim()
+}
+
+function asArray(value) {
+  if (Array.isArray(value)) return value.filter(Boolean)
+  if (value == null || value === '') return []
+  return [value]
+}
+
+function canonicalGrade(value) {
+  const text = clean(value).toUpperCase()
+  if (/^A(?:\b|[+-])/.test(text)) return 'A'
+  if (/^B(?:\b|[+-])/.test(text)) return 'B'
+  if (/^C(?:\b|[+-])/.test(text)) return 'C'
+  if (/^D(?:\b|[+-])/.test(text)) return 'D'
+  if (/AVOID|INSUFFICIENT/.test(text)) return 'Avoid/Insufficient'
+  return ''
+}
+
+function normalizeDirection(value) {
+  const text = clean(value).toLowerCase()
+  if (!text) return 'unknown'
+  if (/^(\+|positive|benefit|beneficial|supports?|improved?|increase(?:d)?|reduced?|decrease(?:d)?)\b/.test(text)) return 'supporting'
+  if (/^(\-|negative|contradict|no benefit|no effect|null|worse|harm)\b/.test(text)) return 'contradicting'
+  if (/\b(mixed|inconsistent|equivocal|heterogeneous|conflict)\b/.test(text)) return 'mixed'
+  return 'unknown'
+}
+
+function sourceIdentifier(source) {
+  const pmid = clean(source?.pmid).replace(/^PMID:\s*/i, '')
+  const doi = clean(source?.doi).replace(/^https?:\/\/(?:dx\.)?doi\.org\//i, '').replace(/^doi:\s*/i, '')
+  if (pmid) return { type: 'pmid', value: pmid }
+  if (doi) return { type: 'doi', value: doi }
+  const url = clean(source?.url)
+  if (url) return { type: 'url', value: url }
+  return null
+}
+
+function sourceForPublic(source) {
+  if (!source) return null
+  const identifier = sourceIdentifier(source)
+  return {
+    id: clean(source.id),
+    identifier,
+    title: clean(source.title),
+    authors: clean(source.author_or_label || source.authors),
+    journal: clean(source.journal),
+    year: source.year ?? null,
+    url: clean(source.url),
+    reviewStatus: clean(source.review_status),
+    metadataComplete: Boolean(clean(source.title) && (clean(source.pmid) || clean(source.doi) || clean(source.url))),
+  }
+}
+
+function publicRoute(kind, slug) {
+  return `/${kind === 'herb' ? 'herbs' : 'compounds'}/${slug}/`
+}
+
+function profileEntity(record, kind) {
+  const slug = clean(record?.slug)
+  if (!slug) return null
+  const id = entityId(kind, slug)
+  return {
+    id,
+    slug,
+    kind,
+    name: clean(record?.displayName || record?.name || record?.compoundName || slug),
+    route: publicRoute(kind, slug),
+    evidenceGrade: canonicalGrade(record?.evidence_grade || record?.evidenceGrade || record?.evidence_tier),
+    safetyFlags: asArray(record?.safety_flags || record?.safetyFlags || record?.contraindications).map(clean).filter(Boolean),
+    profileReviewStatus: clean(record?.review_status || record?.profile_status),
+    profileReviewedAt: clean(record?.last_evidence_search_date || record?.lastReviewedAt || record?.last_reviewed_at) || null,
+  }
+}
+
+function objectDescriptor(claim) {
+  if (claim?.object_id) return { type: 'entity', id: clean(claim.object_id) }
+  if (claim?.object_literal !== undefined) return { type: 'literal', value: claim.object_literal }
+  return null
+}
+
+function lastReviewedAt(claim) {
+  const explicit = clean(claim?.last_reviewed_at || claim?.qualifiers?.last_reviewed_at || claim?.qualifiers?.reviewed_at)
+  if (explicit) return explicit
+  // An ordinary updated_at is not automatically an editorial review. Only use
+  // it as review time when the canonical claim is explicitly approved.
+  if (clean(claim?.review_status).toLowerCase() === 'approved') return clean(claim?.updated_at) || null
+  return null
+}
+
+function publicStatement(claim) {
+  // Do not expose migration/editorial notes as public claim copy. A public
+  // statement must be explicitly curated into the claim qualifiers.
+  return clean(claim?.qualifiers?.public_statement || claim?.qualifiers?.publicStatement || claim?.qualifiers?.claim_text)
+}
+
+function claimRevision(claim) {
+  return contentHash({
+    id: claim?.id,
+    subject_id: claim?.subject_id,
+    predicate: claim?.predicate,
+    object_id: claim?.object_id,
+    object_literal: claim?.object_literal,
+    qualifiers: claim?.qualifiers,
+    source_ids: claim?.source_ids,
+    evidence_level: claim?.evidence_level,
+    confidence: claim?.confidence,
+    review_status: claim?.review_status,
+    updated_at: claim?.updated_at,
+  }).slice(0, 16)
+}
+
+function evidenceBucket(claim) {
+  const direction = normalizeDirection(claim?.qualifiers?.direction)
+  if (direction !== 'unknown') return direction
+  return 'context'
+}
+
+function buildClaimObject(claim, profile, sourceIndex) {
+  const bucket = evidenceBucket(claim)
+  const sourceIds = [...new Set(asArray(claim?.source_ids).map(clean).filter(Boolean))]
+  const sources = sourceIds.map((id) => sourceIndex.get(id)).filter(Boolean).map(sourceForPublic).filter(Boolean)
+  const supportingSourceIds = bucket === 'supporting' ? sourceIds : []
+  const contradictingSourceIds = bucket === 'contradicting' ? sourceIds : []
+  const mixedSourceIds = bucket === 'mixed' ? sourceIds : []
+  const contextSourceIds = bucket === 'context' ? sourceIds : []
+  const reviewedAt = lastReviewedAt(claim)
+  const statement = publicStatement(claim)
+
+  return {
+    claimId: clean(claim?.id),
+    revision: claimRevision(claim),
+    subjectId: clean(claim?.subject_id),
+    predicate: clean(claim?.predicate),
+    object: objectDescriptor(claim),
+    publicStatement: statement || null,
+    claimEvidenceClass: clean(claim?.evidence_level) || 'none',
+    evidenceGrade: profile.evidenceGrade || null,
+    evidenceGradeScope: profile.evidenceGrade ? 'subject_profile' : null,
+    confidence: typeof claim?.confidence === 'number' ? claim.confidence : null,
+    direction: normalizeDirection(claim?.qualifiers?.direction),
+    supportingSourceIds,
+    contradictingSourceIds,
+    mixedSourceIds,
+    contextSourceIds,
+    citationIds: sourceIds,
+    citations: sources,
+    reviewStatus: clean(claim?.review_status) || 'pending',
+    lastReviewedAt: reviewedAt,
+    affectedPages: [profile.route],
+    studyId: clean(claim?.qualifiers?.study_id) || null,
+    updatedAt: clean(claim?.updated_at) || null,
+  }
+}
+
+function driftFingerprint(claimObject) {
+  return contentHash({
+    predicate: claimObject.predicate,
+    object: claimObject.object,
+    publicStatement: claimObject.publicStatement,
+    claimEvidenceClass: claimObject.claimEvidenceClass,
+    evidenceGrade: claimObject.evidenceGrade,
+    direction: claimObject.direction,
+    citationIds: claimObject.citationIds,
+  }).slice(0, 16)
+}
+
+export function buildClaimKnowledgeBase({ herbs = [], compounds = [], claims = [], sources = [] } = {}) {
+  const profiles = new Map()
+  for (const record of herbs) {
+    const profile = profileEntity(record, 'herb')
+    if (profile) profiles.set(profile.id, profile)
+  }
+  for (const record of compounds) {
+    const profile = profileEntity(record, 'compound')
+    if (profile) profiles.set(profile.id, profile)
+  }
+
+  const sourceIndex = new Map(sources.map((source) => [clean(source?.id), source]).filter(([id]) => id))
+  const claimsById = new Map()
+  const claimsByEntity = new Map()
+  const dependencies = {}
+  const orphanClaims = []
+
+  for (const claim of claims) {
+    const claimId = clean(claim?.id)
+    const subjectId = clean(claim?.subject_id)
+    if (!claimId || !subjectId) continue
+    const profile = profiles.get(subjectId)
+    if (!profile) {
+      orphanClaims.push({ claimId, subjectId, reason: 'subject is not a public herb/compound profile in the current runtime index' })
+      continue
+    }
+
+    const claimObject = buildClaimObject(claim, profile, sourceIndex)
+    claimObject.driftFingerprint = driftFingerprint(claimObject)
+    claimsById.set(claimId, claimObject)
+    claimsByEntity.set(subjectId, [...(claimsByEntity.get(subjectId) || []), claimObject])
+    dependencies[claimId] = {
+      revision: claimObject.revision,
+      affectedPages: claimObject.affectedPages,
+      subjectId,
+    }
+  }
+
+  const endpoints = []
+  for (const profile of profiles.values()) {
+    const entityClaims = (claimsByEntity.get(profile.id) || []).sort((a, b) => a.claimId.localeCompare(b.claimId))
+    const sourceIds = [...new Set(entityClaims.flatMap((claim) => claim.citationIds))]
+    const sourceRows = sourceIds.map((id) => sourceIndex.get(id)).filter(Boolean).map(sourceForPublic).filter(Boolean)
+    const claimsRevision = contentHash(entityClaims.map((claim) => [claim.claimId, claim.revision])).slice(0, 16)
+    const lastReviewedDates = entityClaims.map((claim) => claim.lastReviewedAt).filter(Boolean).sort()
+
+    endpoints.push({
+      schemaVersion: 1,
+      entity: {
+        id: profile.id,
+        type: profile.kind,
+        slug: profile.slug,
+        name: profile.name,
+        canonicalPage: profile.route,
+      },
+      evidence: {
+        profileGrade: profile.evidenceGrade || null,
+        profileReviewStatus: profile.profileReviewStatus || null,
+        profileReviewedAt: profile.profileReviewedAt,
+        latestClaimReviewAt: lastReviewedDates.at(-1) || null,
+      },
+      safetyFlags: profile.safetyFlags,
+      claimsRevision,
+      claims: entityClaims,
+      citations: sourceRows,
+      attribution: {
+        name: 'The Hippie Scientist',
+        canonicalPage: profile.route,
+        note: 'Attribute derived summaries to The Hippie Scientist and retain original PMID/DOI identifiers when citing underlying studies.',
+      },
+    })
+  }
+
+  const endpointIndex = Object.fromEntries(endpoints.map((endpoint) => [endpoint.entity.id, `/data/ingredients/${endpoint.entity.slug}.json`]))
+
+  return {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    summary: {
+      profiles: profiles.size,
+      claims: claimsById.size,
+      orphanClaims: orphanClaims.length,
+      sourceRecords: sourceIndex.size,
+      endpoints: endpoints.length,
+    },
+    claims: Object.fromEntries([...claimsById.entries()].sort(([a], [b]) => a.localeCompare(b))),
+    dependencies,
+    endpointIndex,
+    endpoints,
+    diagnostics: {
+      orphanClaims,
+    },
+    integrityHash: contentHash(stableStringify({
+      claims: [...claimsById.values()].map((claim) => [claim.claimId, claim.revision]),
+      endpoints: endpoints.map((endpoint) => [endpoint.entity.id, endpoint.claimsRevision]),
+    })),
+  }
+}


### PR DESCRIPTION
Fixes #3106

## Relevant URLs
- `/data/ingredients/<slug>.json`
- `/data/claim-knowledge-graph.json`
- `/data/claim-page-dependencies.json`
- Canonical herb/compound profile pages referenced by each endpoint

## Acceptance criteria
- Preserve stable claim identities and detectable claim revisions.
- Use the repository evidence-graph identity foundation (`herb:<slug>` / `compound:<slug>`) for public substance IDs.
- Preserve legacy canonical `ent_*` subject IDs only as explicit provenance/claim-store compatibility fields.
- Attach source IDs, evidence class/confidence, truthful review state/date, study IDs, safety flags, and affected-page dependencies.
- Separate supporting, contradicting, mixed, and context sources conservatively.
- Fail generation on conflicting payloads for one stable claim ID.
- Never promote migration/editorial notes into public claim wording.
- Keep human-readable profile pages canonical.

## Validation commands
- `npm test -- scripts/data/canonical/__tests__/claim-knowledge.test.mjs scripts/data/canonical/__tests__/claim-knowledge-identity.test.mjs`
- `node scripts/data/build-claim-knowledge-endpoints.mjs`
- `npm run check`

## Before → after metrics
- Claim→affected-page dependency artifact: 0 → 1.
- Per-ingredient structured evidence endpoints: 0 → one per runtime herb/compound profile.
- Explicit evidence-direction buckets: unclassified links → supporting / contradicting / mixed / context.
- Stable revision/integrity hashes: 0 → claim, endpoint, and aggregate hashes.
- Competing public substance identity systems introduced: 0; the endpoint layer reuses the existing evidence-graph identity foundation.

## Generator/source-of-truth decision
Canonical claims and sources remain the scientific source of truth, and the evidence-graph identity foundation remains the public substance identity source of truth. Endpoint generation joins the legacy `ent_*` claim subjects first, then remaps herb/compound identities at the public boundary; it does not auto-change scientific conclusions.

## Regression contract
One stable claim ID cannot resolve to conflicting payloads. Build/update timestamps must not masquerade as editorial review dates. Missing direction must never be interpreted as support, literal `+`/`-` directions must classify correctly, and free-form internal notes must remain non-public. Public entity IDs must use `herb:<slug>` / `compound:<slug>` while legacy `ent_*` values remain provenance only.