### PR TITLE
Backlog 819: automate weekly Search Console opportunity reports

### DIFF
--- a/.github/workflows/search-console-opportunities-weekly.yml
+++ b/.github/workflows/search-console-opportunities-weekly.yml
@@ -1,0 +1,72 @@
+name: Weekly Search Console Opportunities
+
+on:
+  schedule:
+    # Fridays at 07:20 UTC.
+    - cron: '20 7 * * 5'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  search-opportunities:
+    name: Pull Search Console data and rank opportunities
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      GSC_SERVICE_ACCOUNT_JSON: ${{ secrets.GSC_SERVICE_ACCOUNT_JSON }}
+      GSC_SITE_URL: ${{ vars.GSC_SITE_URL || 'sc-domain:thehippiescientist.net' }}
+      GSC_LOOKBACK_DAYS: '28'
+      GSC_LAG_DAYS: '3'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Require Search Console credentials
+        run: |
+          if [ -z "$GSC_SERVICE_ACCOUNT_JSON" ]; then
+            echo "::error::Missing repository secret GSC_SERVICE_ACCOUNT_JSON. Add a Search Console service-account JSON key whose client email has read access to the property."
+            exit 1
+          fi
+
+      - name: Fetch finalized Search Console performance
+        run: node scripts/seo/fetch-search-console.mjs
+
+      - name: Rank search opportunities
+        run: npm run seo:opportunities
+
+      - name: Upload opportunity report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: weekly-search-opportunities-${{ github.run_number }}
+          path: |
+            ops/reports/search-opportunities.json
+            ops/reports/search-opportunities.md
+            data-sources/search-console/fetch-metadata.json
+          retention-days: 60
+          if-no-files-found: ignore
+
+      - name: Publish report to workflow summary
+        if: always()
+        run: |
+          echo "## Weekly Search Console Opportunities" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Property: $GSC_SITE_URL" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Window: 28 finalized days, ending 3 days before the run" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f ops/reports/search-opportunities.md ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            cat ops/reports/search-opportunities.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- Report was not generated; inspect the failed step above." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/scripts/seo/fetch-search-console.mjs
+++ b/scripts/seo/fetch-search-console.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+/**
+ * Pull finalized Google Search Console performance data for the opportunity engine.
+ *
+ * Required environment:
+ *   GSC_SERVICE_ACCOUNT_JSON  Service-account key JSON (raw JSON or base64-encoded JSON)
+ * Optional:
+ *   GSC_SITE_URL              Search Console property; defaults to sc-domain:thehippiescientist.net
+ *   GSC_LOOKBACK_DAYS         Rolling window; defaults to 28
+ *   GSC_LAG_DAYS              Finalization lag; defaults to 3
+ *
+ * The service-account email must be granted read access to the Search Console property.
+ */
+
+import { createSign } from 'node:crypto'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const OUTPUT_DIR = path.join(ROOT, 'data-sources', 'search-console')
+const TOKEN_URL = 'https://oauth2.googleapis.com/token'
+const SCOPE = 'https://www.googleapis.com/auth/webmasters.readonly'
+const ROW_LIMIT = 25_000
+const MAX_ROWS = 50_000
+
+function decodeServiceAccount(raw) {
+  if (!raw?.trim()) throw new Error('GSC_SERVICE_ACCOUNT_JSON is required')
+  const trimmed = raw.trim()
+  const candidates = [trimmed]
+  try {
+    candidates.push(Buffer.from(trimmed, 'base64').toString('utf8'))
+  } catch {
+    // Raw JSON remains the primary parse path.
+  }
+  for (const candidate of candidates) {
+    try {
+      const parsed = JSON.parse(candidate)
+      if (parsed?.client_email && parsed?.private_key) return parsed
+    } catch {
+      // Try the next representation.
+    }
+  }
+  throw new Error('GSC_SERVICE_ACCOUNT_JSON must be raw or base64-encoded service-account JSON')
+}
+
+function base64url(value) {
+  return Buffer.from(value).toString('base64url')
+}
+
+function createAssertion(credentials, now = Math.floor(Date.now() / 1000)) {
+  const header = { alg: 'RS256', typ: 'JWT' }
+  if (credentials.private_key_id) header.kid = credentials.private_key_id
+  const claims = {
+    iss: credentials.client_email,
+    scope: SCOPE,
+    aud: TOKEN_URL,
+    iat: now,
+    exp: now + 3600,
+  }
+  const unsigned = `${base64url(JSON.stringify(header))}.${base64url(JSON.stringify(claims))}`
+  const signer = createSign('RSA-SHA256')
+  signer.update(unsigned)
+  signer.end()
+  const signature = signer.sign(credentials.private_key).toString('base64url')
+  return `${unsigned}.${signature}`
+}
+
+async function getAccessToken(credentials) {
+  const body = new URLSearchParams({
+    grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+    assertion: createAssertion(credentials),
+  })
+  const response = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body,
+  })
+  const payload = await response.json().catch(() => ({}))
+  if (!response.ok || !payload.access_token) {
+    throw new Error(`Google OAuth token request failed (${response.status}): ${payload.error_description || payload.error || 'unknown error'}`)
+  }
+  return payload.access_token
+}
+
+function isoDate(date) {
+  return date.toISOString().slice(0, 10)
+}
+
+function dateRange({ lookbackDays, lagDays }) {
+  const end = new Date()
+  end.setUTCHours(12, 0, 0, 0)
+  end.setUTCDate(end.getUTCDate() - lagDays)
+  const start = new Date(end)
+  start.setUTCDate(start.getUTCDate() - (lookbackDays - 1))
+  return { startDate: isoDate(start), endDate: isoDate(end) }
+}
+
+async function querySearchAnalytics({ accessToken, siteUrl, dimensions, startDate, endDate }) {
+  const rows = []
+  const endpoint = `https://www.googleapis.com/webmasters/v3/sites/${encodeURIComponent(siteUrl)}/searchAnalytics/query`
+
+  for (let startRow = 0; startRow < MAX_ROWS; startRow += ROW_LIMIT) {
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${accessToken}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        startDate,
+        endDate,
+        dimensions,
+        type: 'web',
+        dataState: 'final',
+        rowLimit: ROW_LIMIT,
+        startRow,
+      }),
+    })
+    const payload = await response.json().catch(() => ({}))
+    if (!response.ok) {
+      throw new Error(`Search Console query failed (${response.status}): ${payload.error?.message || 'unknown error'}`)
+    }
+    const pageRows = Array.isArray(payload.rows) ? payload.rows : []
+    rows.push(...pageRows)
+    if (pageRows.length < ROW_LIMIT) break
+  }
+
+  return rows
+}
+
+function csvEscape(value) {
+  const text = String(value ?? '')
+  if (!/[",\r\n]/.test(text)) return text
+  return `"${text.replaceAll('"', '""')}"`
+}
+
+function rowsToCsv(rows, dimensions) {
+  const headers = [
+    ...dimensions.map((dimension) => dimension === 'query' ? 'Query' : dimension === 'page' ? 'Page' : dimension),
+    'Clicks',
+    'Impressions',
+    'CTR',
+    'Position',
+  ]
+  const lines = [headers.map(csvEscape).join(',')]
+  for (const row of rows) {
+    const values = [
+      ...(row.keys || []),
+      Number(row.clicks || 0),
+      Number(row.impressions || 0),
+      `${(Number(row.ctr || 0) * 100).toFixed(4)}%`,
+      Number(row.position || 0).toFixed(4),
+    ]
+    lines.push(values.map(csvEscape).join(','))
+  }
+  return `${lines.join('\n')}\n`
+}
+
+function positiveInteger(value, fallback) {
+  const parsed = Number.parseInt(String(value ?? ''), 10)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback
+}
+
+async function main() {
+  const credentials = decodeServiceAccount(process.env.GSC_SERVICE_ACCOUNT_JSON)
+  const siteUrl = process.env.GSC_SITE_URL?.trim() || 'sc-domain:thehippiescientist.net'
+  const lookbackDays = positiveInteger(process.env.GSC_LOOKBACK_DAYS, 28)
+  const lagDays = positiveInteger(process.env.GSC_LAG_DAYS, 3)
+  const { startDate, endDate } = dateRange({ lookbackDays, lagDays })
+  const accessToken = await getAccessToken(credentials)
+
+  const datasets = [
+    { filename: 'Queries.csv', dimensions: ['query'] },
+    { filename: 'Pages.csv', dimensions: ['page'] },
+    { filename: 'queries-by-page.csv', dimensions: ['query', 'page'] },
+  ]
+
+  mkdirSync(OUTPUT_DIR, { recursive: true })
+  const summary = []
+  for (const dataset of datasets) {
+    const rows = await querySearchAnalytics({ accessToken, siteUrl, dimensions: dataset.dimensions, startDate, endDate })
+    writeFileSync(path.join(OUTPUT_DIR, dataset.filename), rowsToCsv(rows, dataset.dimensions))
+    summary.push(`${dataset.filename}=${rows.length}`)
+  }
+
+  writeFileSync(
+    path.join(OUTPUT_DIR, 'fetch-metadata.json'),
+    `${JSON.stringify({ siteUrl, startDate, endDate, lookbackDays, lagDays, fetchedAt: new Date().toISOString() }, null, 2)}\n`,
+  )
+  console.log(`[search-console] ${siteUrl} ${startDate}..${endDate} ${summary.join(' ')}`)
+}
+
+main().catch((error) => {
+  console.error(`[search-console] ${error.message}`)
+  process.exitCode = 1
+})


### PR DESCRIPTION
Implements backlog item 819 end to end.

- Adds Search Console API ingestion using the existing Node runtime (no new dependency).
- Pulls finalized web-search data for query, page, and query+page dimensions.
- Writes the exact CSV shape consumed by the existing search-opportunity engine.
- Schedules a Friday weekly run and uploads the JSON/Markdown opportunity reports.
- Fails loudly if `GSC_SERVICE_ACCOUNT_JSON` is not configured instead of silently producing an empty report.
- `GSC_SITE_URL` may be supplied as a repository variable; default is the domain property.

Security: the service-account key is read only from GitHub Actions secrets and is never written to disk or artifacts.