### PR TITLE
fix(compare): gate runtime comparison sides on publication visibility

### DIFF
--- a/src/components/comparison/RuntimeEvidenceComparison.tsx
+++ b/src/components/comparison/RuntimeEvidenceComparison.tsx
@@ -1,18 +1,18 @@
 import Link from 'next/link'
+import { notFound } from 'next/navigation'
 
 import ComparisonTable from '@/components/ComparisonTable'
 import Disclaimer from '@/src/components/Disclaimer'
+import {
+  firstComparisonField,
+  resolveRuntimeComparisonSide,
+  type ResolvedRuntimeComparisonSide,
+  type RuntimeComparisonSideConfig,
+} from '@/src/lib/runtime-comparison-resolution'
 import { getUnifiedRuntimeRecords } from '@/src/lib/runtime-record-index'
+import type { RuntimeRecord } from '@/src/types/content'
 
-type RuntimeIngredient = Record<string, unknown> & {
-  slug?: string
-  name?: string
-}
-
-type SideConfig = {
-  label: string
-  candidates: string[]
-}
+type SideConfig = RuntimeComparisonSideConfig
 
 type Props = {
   title: string
@@ -22,53 +22,7 @@ type Props = {
   goal?: string
 }
 
-type ResolvedSide = {
-  label: string
-  record: RuntimeIngredient | null
-  href: string | null
-}
-
-function clean(value: unknown): string {
-  if (typeof value !== 'string') return ''
-  return value.replace(/\s+/g, ' ').trim()
-}
-
-function toText(value: unknown): string {
-  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return clean(String(value))
-  if (Array.isArray(value)) return value.map(toText).filter(Boolean).join('; ')
-  if (value && typeof value === 'object') {
-    return Object.entries(value as Record<string, unknown>)
-      .map(([key, nested]) => {
-        const text = toText(nested)
-        return text ? `${key.replace(/[_-]+/g, ' ')}: ${text}` : ''
-      })
-      .filter(Boolean)
-      .join('; ')
-  }
-  return ''
-}
-
-function firstField(record: RuntimeIngredient | null, keys: string[]): string {
-  if (!record) return 'Not available in the canonical record.'
-  for (const key of keys) {
-    const value = toText(record[key])
-    if (value) return value
-  }
-  return 'Not available in the canonical record.'
-}
-
-async function resolveSide(config: SideConfig): Promise<ResolvedSide> {
-  const { herbs, compounds } = await getUnifiedRuntimeRecords()
-  const candidates = new Set(config.candidates)
-
-  const herb = (herbs as RuntimeIngredient[]).find((record) => candidates.has(clean(record.slug)))
-  if (herb) return { label: config.label, record: herb, href: `/herbs/${clean(herb.slug)}/` }
-
-  const compound = (compounds as RuntimeIngredient[]).find((record) => candidates.has(clean(record.slug)))
-  if (compound) return { label: config.label, record: compound, href: `/compounds/${clean(compound.slug)}/` }
-
-  return { label: config.label, record: null, href: null }
-}
+type ResolvedSide = ResolvedRuntimeComparisonSide
 
 function choiceChecks(side: ResolvedSide): string[] {
   if (!side.record) {
@@ -83,56 +37,62 @@ function choiceChecks(side: ResolvedSide): string[] {
 }
 
 export default async function RuntimeEvidenceComparison({ title, summary, left, right, goal }: Props) {
-  const [leftSide, rightSide] = await Promise.all([resolveSide(left), resolveSide(right)])
+  const { herbs, compounds } = await getUnifiedRuntimeRecords()
+  const runtimeHerbs = herbs as RuntimeRecord[]
+  const runtimeCompounds = compounds as RuntimeRecord[]
+  const leftSide = resolveRuntimeComparisonSide(left, runtimeHerbs, runtimeCompounds)
+  const rightSide = resolveRuntimeComparisonSide(right, runtimeHerbs, runtimeCompounds)
+
+  if (!leftSide.record || !rightSide.record) notFound()
 
   const rows = [
     {
       label: 'Evidence strength',
       values: [
-        firstField(leftSide.record, ['evidence_grade', 'evidence_level', 'evidence_summary']),
-        firstField(rightSide.record, ['evidence_grade', 'evidence_level', 'evidence_summary']),
+        firstComparisonField(leftSide.record, ['evidence_grade', 'evidence_level', 'evidence_summary']),
+        firstComparisonField(rightSide.record, ['evidence_grade', 'evidence_level', 'evidence_summary']),
       ],
     },
     {
       label: 'Human evidence',
       values: [
-        firstField(leftSide.record, ['human_evidence', 'evidence_summary']),
-        firstField(rightSide.record, ['human_evidence', 'evidence_summary']),
+        firstComparisonField(leftSide.record, ['human_evidence', 'evidence_summary']),
+        firstComparisonField(rightSide.record, ['human_evidence', 'evidence_summary']),
       ],
     },
     {
       label: 'Studied dose / dose context',
       values: [
-        firstField(leftSide.record, ['typical_dosage', 'dosage', 'dose']),
-        firstField(rightSide.record, ['typical_dosage', 'dosage', 'dose']),
+        firstComparisonField(leftSide.record, ['typical_dosage', 'dosage', 'dose']),
+        firstComparisonField(rightSide.record, ['typical_dosage', 'dosage', 'dose']),
       ],
     },
     {
       label: 'Forms / preparation',
       values: [
-        firstField(leftSide.record, ['forms', 'available_forms', 'bioavailability_notes']),
-        firstField(rightSide.record, ['forms', 'available_forms', 'bioavailability_notes']),
+        firstComparisonField(leftSide.record, ['forms', 'available_forms', 'bioavailability_notes']),
+        firstComparisonField(rightSide.record, ['forms', 'available_forms', 'bioavailability_notes']),
       ],
     },
     {
       label: 'Safety',
       values: [
-        firstField(leftSide.record, ['safety', 'contraindications', 'side_effects']),
-        firstField(rightSide.record, ['safety', 'contraindications', 'side_effects']),
+        firstComparisonField(leftSide.record, ['safety', 'contraindications', 'side_effects']),
+        firstComparisonField(rightSide.record, ['safety', 'contraindications', 'side_effects']),
       ],
     },
     {
       label: 'Interactions',
       values: [
-        firstField(leftSide.record, ['interactions']),
-        firstField(rightSide.record, ['interactions']),
+        firstComparisonField(leftSide.record, ['interactions']),
+        firstComparisonField(rightSide.record, ['interactions']),
       ],
     },
     {
       label: 'Mechanism context',
       values: [
-        firstField(leftSide.record, ['mechanism', 'mechanisms']),
-        firstField(rightSide.record, ['mechanism', 'mechanisms']),
+        firstComparisonField(leftSide.record, ['mechanism', 'mechanisms']),
+        firstComparisonField(rightSide.record, ['mechanism', 'mechanisms']),
       ],
     },
   ]
@@ -192,7 +152,7 @@ export default async function RuntimeEvidenceComparison({ title, summary, left, 
           <article key={side.label} className="card-premium space-y-3 p-5">
             <h2 className="text-xl font-semibold text-ink">{side.label}</h2>
             <p className="text-sm leading-6 text-muted">
-              {side.record ? firstField(side.record, ['summary', 'short_description', 'description']) : 'A canonical record could not be resolved for this side of the comparison.'}
+              {firstComparisonField(side.record, ['summary', 'short_description', 'description'])}
             </p>
             {side.href ? <Link href={side.href} className="font-semibold text-brand-700 hover:underline">Read the full profile →</Link> : null}
           </article>

--- a/src/lib/runtime-comparison-resolution.ts
+++ b/src/lib/runtime-comparison-resolution.ts
@@ -1,0 +1,84 @@
+import { getRuntimeVisibility } from '@/lib/runtime-visibility'
+import type { RuntimeRecord } from '@/src/types/content'
+
+export type RuntimeComparisonIngredient = RuntimeRecord
+
+export type RuntimeComparisonSideConfig = {
+  label: string
+  candidates: string[]
+}
+
+export type ResolvedRuntimeComparisonSide = {
+  label: string
+  record: RuntimeComparisonIngredient | null
+  href: string | null
+}
+
+export function cleanComparisonValue(value: unknown): string {
+  if (typeof value !== 'string') return ''
+  return value.replace(/\s+/g, ' ').trim()
+}
+
+export function comparisonValueToText(value: unknown): string {
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return cleanComparisonValue(String(value))
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(comparisonValueToText).filter(Boolean).join('; ')
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.entries(value as Record<string, unknown>)
+      .map(([key, nested]) => {
+        const text = comparisonValueToText(nested)
+        return text ? `${key.replace(/[_-]+/g, ' ')}: ${text}` : ''
+      })
+      .filter(Boolean)
+      .join('; ')
+  }
+
+  return ''
+}
+
+export function firstComparisonField(
+  record: RuntimeComparisonIngredient | null,
+  keys: string[],
+): string {
+  if (!record) return 'Not available in the canonical record.'
+
+  for (const key of keys) {
+    const value = comparisonValueToText(record[key])
+    if (value) return value
+  }
+
+  return 'Not available in the canonical record.'
+}
+
+export function resolveRuntimeComparisonSide(
+  config: RuntimeComparisonSideConfig,
+  herbs: RuntimeRecord[],
+  compounds: RuntimeRecord[],
+): ResolvedRuntimeComparisonSide {
+  const candidates = new Set(config.candidates.map(cleanComparisonValue).filter(Boolean))
+
+  const herb = herbs.find((record) => {
+    const slug = cleanComparisonValue(record.slug)
+    return candidates.has(slug) && getRuntimeVisibility(record).canIndex
+  })
+  if (herb) {
+    const slug = cleanComparisonValue(herb.slug)
+    return { label: config.label, record: herb, href: `/herbs/${slug}/` }
+  }
+
+  const compound = compounds.find((record) => {
+    const slug = cleanComparisonValue(record.slug)
+    return candidates.has(slug) && getRuntimeVisibility(record).canIndex
+  })
+  if (compound) {
+    const slug = cleanComparisonValue(compound.slug)
+    return { label: config.label, record: compound, href: `/compounds/${slug}/` }
+  }
+
+  return { label: config.label, record: null, href: null }
+}

--- a/tests/runtime-comparison-publication-gate.test.ts
+++ b/tests/runtime-comparison-publication-gate.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  comparisonValueToText,
+  firstComparisonField,
+  resolveRuntimeComparisonSide,
+} from '../src/lib/runtime-comparison-resolution'
+import type { RuntimeRecord } from '../src/types/content'
+
+describe('runtime comparison publication gate', () => {
+  it('skips unpublished aliases and resolves a later publishable candidate', () => {
+    const herbs: RuntimeRecord[] = [
+      {
+        slug: 'first-alias',
+        name: 'Unpublished alias',
+        indexability_status: 'NOINDEX',
+      },
+      {
+        slug: 'second-alias',
+        name: 'Published alias',
+        indexability_status: 'PUBLISH',
+      },
+    ]
+
+    const resolved = resolveRuntimeComparisonSide(
+      { label: 'Example', candidates: ['first-alias', 'second-alias'] },
+      herbs,
+      [],
+    )
+
+    expect(resolved.record?.slug).toBe('second-alias')
+    expect(resolved.href).toBe('/herbs/second-alias/')
+  })
+
+  it('does not expose hidden records and can fall through to a publishable compound', () => {
+    const herbs: RuntimeRecord[] = [
+      {
+        slug: 'shared-candidate',
+        name: 'Hidden herb',
+        indexability_status: 'PUBLISH',
+        runtime_export_decision: 'hide',
+      },
+    ]
+    const compounds: RuntimeRecord[] = [
+      {
+        slug: 'shared-candidate',
+        name: 'Published compound',
+        indexability_status: 'PUBLISH',
+      },
+    ]
+
+    const resolved = resolveRuntimeComparisonSide(
+      { label: 'Example', candidates: ['shared-candidate'] },
+      herbs,
+      compounds,
+    )
+
+    expect(resolved.record?.name).toBe('Published compound')
+    expect(resolved.href).toBe('/compounds/shared-candidate/')
+  })
+
+  it('returns no side when every candidate is unpublished', () => {
+    const records: RuntimeRecord[] = [
+      { slug: 'noindex', indexability_status: 'NOINDEX' },
+      { slug: 'hidden', indexability_status: 'PUBLISH', runtime_export_decision: 'hide' },
+    ]
+
+    expect(
+      resolveRuntimeComparisonSide(
+        { label: 'Example', candidates: ['noindex', 'hidden'] },
+        records,
+        [],
+      ),
+    ).toEqual({ label: 'Example', record: null, href: null })
+  })
+
+  it('preserves structured comparison field rendering after consolidation', () => {
+    const record: RuntimeRecord = {
+      safety: {
+        common: ['GI upset', 'headache'],
+        note: 'Dose dependent',
+      },
+    }
+
+    expect(comparisonValueToText(record.safety)).toBe(
+      'common: GI upset; headache; note: Dose dependent',
+    )
+    expect(firstComparisonField(record, ['missing', 'safety'])).toBe(
+      'common: GI upset; headache; note: Dose dependent',
+    )
+  })
+})


### PR DESCRIPTION
## Root cause
The canonical runtime comparison renderer resolved candidate herbs/compounds directly from raw runtime records without applying the repository's publication policy. Hidden or NOINDEX records could therefore populate an indexable comparison page and receive a profile link. The component also loaded the full runtime dataset separately for each side.

## Change
- Add one canonical runtime-comparison resolution helper.
- Require `getRuntimeVisibility(record).canIndex` before a candidate can resolve.
- Preserve herb-first lookup and fall through to later aliases / compounds when an earlier candidate is unpublished.
- Load unified runtime data once per comparison instead of once per side.
- Return a 404 when either side lacks a publishable canonical record instead of rendering a one-sided comparison shell.
- Centralize comparison value normalization/structured rendering and first-field selection.
- Add regression coverage for NOINDEX aliases, hidden records, compound fallback, fully unpublished candidate sets, and structured field rendering.

## Scope
Comparison copy, table dimensions, decision checks, source data, and individual static comparison route metadata are unchanged.