### PR TITLE
feat(navigation): add Start Here research router and one-tap mobile search

### DIFF
--- a/app/start/page.tsx
+++ b/app/start/page.tsx
@@ -1,0 +1,88 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { buildPageMetadata } from '@/src/lib/seo'
+
+const TITLE = 'Start Here: Choose What You Are Researching'
+const DESCRIPTION =
+  'Choose a research path for Sleep, Stress, Anxiety, Focus, ingredient lookup, or supplement safety without entering personal medical information.'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: TITLE,
+  description: DESCRIPTION,
+  path: '/start/',
+  openGraphType: 'website',
+})
+
+const paths = [
+  {
+    label: 'Sleep',
+    href: '/guides/sleep/',
+    description: 'Compare sleep-support evidence, timing, forms, and next-day tradeoffs.',
+  },
+  {
+    label: 'Stress',
+    href: '/guides/stress/',
+    description: 'Explore stress-related evidence without treating every calming mechanism as a proven outcome.',
+  },
+  {
+    label: 'Anxiety',
+    href: '/guides/anxiety/',
+    description: 'Use stricter evidence and safety framing for anxiety-adjacent research.',
+  },
+  {
+    label: 'Focus',
+    href: '/guides/focus/',
+    description: 'Research attention, cognition, stimulant tradeoffs, and non-stimulant approaches.',
+  },
+  {
+    label: 'Ingredient lookup',
+    href: '/search/',
+    description: 'Find a herb or compound by common name, scientific context, goal, or mechanism.',
+  },
+  {
+    label: 'Safety',
+    href: '/safety-checker/',
+    description: 'Screen combinations for documented or theoretical caution flags and open the full safety profiles.',
+  },
+] as const
+
+export default function StartHerePage() {
+  return (
+    <main className='container-page mx-auto max-w-5xl space-y-8 py-10 sm:py-14'>
+      <header className='rounded-[2rem] border border-brand-900/10 bg-white/95 p-6 shadow-sm sm:p-10'>
+        <p className='eyebrow-label'>Start here</p>
+        <h1 className='mt-3 max-w-4xl text-4xl font-bold tracking-tight text-ink sm:text-5xl'>
+          What are you researching?
+        </h1>
+        <p className='mt-5 max-w-3xl text-lg leading-8 text-muted'>
+          Pick the closest research path. You do not need to describe symptoms, diagnoses, medications, or other personal health information to use this router.
+        </p>
+      </header>
+
+      <section className='grid gap-4 sm:grid-cols-2 lg:grid-cols-3' aria-label='Research starting points'>
+        {paths.map((path) => (
+          <Link
+            key={path.label}
+            href={path.href}
+            className='group rounded-[1.5rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm transition hover:-translate-y-0.5 hover:border-brand-700/25 hover:bg-brand-50/30'
+          >
+            <h2 className='text-2xl font-bold tracking-tight text-ink group-hover:text-brand-800'>{path.label}</h2>
+            <p className='mt-3 text-sm leading-7 text-muted'>{path.description}</p>
+            <span className='mt-5 inline-flex text-sm font-bold text-brand-800'>Open path →</span>
+          </Link>
+        ))}
+      </section>
+
+      <section className='rounded-2xl border border-brand-900/10 bg-brand-50/60 p-6 sm:p-8'>
+        <h2 className='text-2xl font-bold text-ink'>Not sure which path fits?</h2>
+        <p className='mt-3 max-w-3xl text-sm leading-7 text-muted'>
+          Start with ingredient search if you already have a name. Start with Safety if you are checking a combination. Otherwise choose the goal that best describes the information you want to read—not a diagnosis you want the site to make.
+        </p>
+        <div className='mt-5 flex flex-wrap gap-3'>
+          <Link href='/search/' className='button-primary'>Search ingredients</Link>
+          <Link href='/safety-checker/' className='button-secondary'>Open Safety Checker</Link>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/lib/primary-navigation.ts
+++ b/lib/primary-navigation.ts
@@ -12,8 +12,9 @@ export const primaryNavigation: PrimaryNavigationItem[] = [
     label: 'Explore',
     href: '/library',
     description: 'The complete site directory — every major content collection in one place',
-    activePrefixes: ['/library', '/search'],
+    activePrefixes: ['/library', '/search', '/start'],
     children: [
+      { label: 'Start here', href: '/start', description: 'Choose Sleep, Stress, Anxiety, Focus, ingredient lookup, or Safety' },
       { label: 'Explore everything', href: '/library', description: 'Use the master directory to see every major section of the site' },
       { label: 'All articles', href: '/articles', description: 'Research notes, evidence reviews, updates, and editorial deep dives' },
       { label: 'All guides', href: '/guides', description: 'Goal-based supplement and mental health guides' },

--- a/src/components/mobile-bottom-nav.tsx
+++ b/src/components/mobile-bottom-nav.tsx
@@ -18,13 +18,6 @@ function toCanonicalHref(href: string) {
   return href.endsWith('/') ? href : `${href}/`
 }
 
-/**
- * Mobile navigation as a corner widget rather than a docked bar.
- *
- * The bar version held a strip of the viewport on every page and every scroll
- * position. This collapses to a single button in the bottom-left corner and
- * opens the same destinations on demand, so reading space stays with the page.
- */
 export default function MobileBottomNav() {
   const pathname = usePathname() || '/'
   const [open, setOpen] = useState(false)
@@ -32,7 +25,6 @@ export default function MobileBottomNav() {
   const triggerRef = useRef<HTMLButtonElement | null>(null)
   const panelRef = useRef<HTMLDivElement | null>(null)
 
-  // Close on route change so the panel never survives a navigation.
   useEffect(() => {
     setOpen(false)
     if (panelRef.current?.contains(document.activeElement)) {
@@ -60,7 +52,6 @@ export default function MobileBottomNav() {
 
     document.addEventListener('keydown', onKeyDown)
     document.addEventListener('pointerdown', onPointerDown)
-    // Move focus into the panel so keyboard and screen-reader users land there.
     panelRef.current?.querySelector<HTMLAnchorElement>('a')?.focus()
 
     return () => {
@@ -105,21 +96,33 @@ export default function MobileBottomNav() {
         </nav>
       </div>
 
-      <button
-        ref={triggerRef}
-        type='button'
-        onClick={() => setOpen((value) => !value)}
-        aria-expanded={open}
-        aria-controls={panelId}
-        aria-label={open ? 'Close quick navigation menu' : 'Open quick navigation menu'}
-        className='pointer-events-auto inline-flex h-13 w-13 min-h-12 min-w-12 items-center justify-center rounded-full border border-[color:var(--hs-hairline-strong)] bg-[color:var(--hs-surface)] text-[color:var(--hs-ink)] shadow-[var(--hs-lift)] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--hs-gold)] focus-visible:ring-offset-2 motion-safe:active:scale-95'
-      >
-        {open ? (
-          <X aria-hidden='true' className='h-5 w-5' strokeWidth={2} />
-        ) : (
-          <Compass aria-hidden='true' className='h-5 w-5' strokeWidth={1.9} />
-        )}
-      </button>
+      <div className='flex items-center gap-2'>
+        {pathname !== '/search' && !pathname.startsWith('/search/') ? (
+          <Link
+            href='/search/'
+            aria-label='Search herbs and compounds'
+            className='pointer-events-auto inline-flex h-13 w-13 min-h-12 min-w-12 items-center justify-center rounded-full border border-[color:var(--hs-hairline-strong)] bg-[color:var(--hs-surface)] text-[color:var(--hs-ink)] shadow-[var(--hs-lift)] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--hs-gold)] focus-visible:ring-offset-2 motion-safe:active:scale-95'
+          >
+            <Search aria-hidden='true' className='h-5 w-5' strokeWidth={1.9} />
+          </Link>
+        ) : null}
+
+        <button
+          ref={triggerRef}
+          type='button'
+          onClick={() => setOpen((value) => !value)}
+          aria-expanded={open}
+          aria-controls={panelId}
+          aria-label={open ? 'Close quick navigation menu' : 'Open quick navigation menu'}
+          className='pointer-events-auto inline-flex h-13 w-13 min-h-12 min-w-12 items-center justify-center rounded-full border border-[color:var(--hs-hairline-strong)] bg-[color:var(--hs-surface)] text-[color:var(--hs-ink)] shadow-[var(--hs-lift)] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--hs-gold)] focus-visible:ring-offset-2 motion-safe:active:scale-95'
+        >
+          {open ? (
+            <X aria-hidden='true' className='h-5 w-5' strokeWidth={2} />
+          ) : (
+            <Compass aria-hidden='true' className='h-5 w-5' strokeWidth={1.9} />
+          )}
+        </button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Backlog
Covers 369–372.

## What changed
- adds a first-time `/start/` research router
- asks exactly one non-medical question: “What are you researching?”
- routes to Sleep, Stress, Anxiety, Focus, ingredient lookup, or Safety
- surfaces Start Here in the primary Explore navigation
- keeps mobile ingredient search one tap away with a fixed search action beside the compact navigation control

## Privacy guardrail
The router explicitly avoids asking for symptoms, diagnoses, medications, or other personal health information.