### PR TITLE
fix(claims): remove unsupported rhodiola-ashwagandha stack reassurance

### DIFF
--- a/app/guides/compare/rhodiola-vs-ashwagandha/page.tsx
+++ b/app/guides/compare/rhodiola-vs-ashwagandha/page.tsx
@@ -84,7 +84,7 @@ export default function RhodiolaVsAshwagandhaComparePage() {
         bestFor={[
           'Rhodiola: mental fatigue, burnout-adjacent exhaustion, and stress resilience without sedation.',
           'Ashwagandha: steady stress support, evening settling, and situations where calm matters more than activation.',
-          'Together: rhodiola in the morning for output, ashwagandha at night for wind-down — a common, well-tolerated pairing.',
+          'Combination evidence: the cited references evaluate these ingredients separately; this page does not establish that combining them is safer or more effective than using either alone.',
         ]}
         evidenceLevel="Human trials support rhodiola for stress-related fatigue and ashwagandha for perceived stress and anxiety, though effect sizes are modest and study quality varies."
         safetyNote="Rhodiola can feel overstimulating for some people and is best avoided late in the day. Ashwagandha may affect thyroid hormone levels and should be reviewed with a clinician during pregnancy or with thyroid or autoimmune conditions."
@@ -156,7 +156,7 @@ export default function RhodiolaVsAshwagandhaComparePage() {
 
       <section className="card-premium p-6 space-y-4 max-w-4xl mb-8">
         <h2 className="text-2xl font-semibold tracking-tight text-ink">How to choose</h2>
-        <p className="text-sm leading-7 text-muted">Ask yourself: am I wired or tired? If you feel anxious, overstimulated, and cannot wind down at night — ashwagandha (calming). If you feel exhausted, unmotivated, and burned out — rhodiola (stimulating). If both: ashwagandha at night, rhodiola in the morning — this is a common and well-tolerated stack. Start with one for 2-4 weeks before adding the other. Do not expect acute effects — adaptogens work cumulatively. If you feel nothing after 4 weeks, the adaptogen is likely not a fit for your stress pattern.</p>
+        <p className="text-sm leading-7 text-muted">Use the ingredient-specific evidence to decide whether fatigue-oriented or calming/stress-oriented context is more relevant to the comparison. If both patterns are present, do not infer from this page that combining rhodiola and ashwagandha is appropriate: the cited references do not establish the safety or benefit of the pair as a stack. Combination decisions need separate interaction, medication, and individual-risk review rather than a morning/night rule inferred from the ingredients’ separate profiles.</p>
         <div className="flex flex-wrap gap-3">
           <Link href="/info/dosing/" className="chip-readable text-xs font-bold">Review dosing basics</Link>
           <Link href="/safety-checker/" className="chip-readable text-xs font-bold">Check safety context</Link>

--- a/scripts/ci/validate-claim-discipline.mjs
+++ b/scripts/ci/validate-claim-discipline.mjs
@@ -56,6 +56,10 @@ const GUIDE_RISK_PATTERNS = [
     name: 'combination safety reassurance',
   },
   {
+    re: /\bcommon(?:ly)?\b[^.\n]{0,60}\bwell[- ]tolerated\b[^.\n]{0,30}\b(?:pair(?:ing)?|stack|combination)\b/i,
+    name: 'unsupported combination reassurance',
+  },
+  {
     re: /\bworks?\s+(?:within|in)\s+\d+(?:\s*[–-]\s*\d+)?\s*(?:minutes?|hours?|days?|weeks?)\b/i,
     name: 'efficacy timing certainty',
   },

--- a/tests/rhodiola-ashwagandha-claim-discipline.test.ts
+++ b/tests/rhodiola-ashwagandha-claim-discipline.test.ts
@@ -1,0 +1,27 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+}
+
+describe('rhodiola vs ashwagandha combination claims', () => {
+  it('does not present the pair as a common well-tolerated stack without combination evidence', () => {
+    const page = read('app/guides/compare/rhodiola-vs-ashwagandha/page.tsx')
+
+    expect(page).not.toMatch(
+      /\bcommon(?:ly)?\b[^.\n]{0,60}\bwell[- ]tolerated\b[^.\n]{0,30}\b(?:pair(?:ing)?|stack|combination)\b/i,
+    )
+    expect(page).toContain(
+      'the cited references do not establish the safety or benefit of the pair as a stack',
+    )
+  })
+
+  it('keeps the guide risk scanner aware of unsupported combination reassurance', () => {
+    const validator = read('scripts/ci/validate-claim-discipline.mjs')
+
+    expect(validator).toContain("name: 'unsupported combination reassurance'")
+    expect(validator).toContain('well[- ]tolerated')
+  })
+})


### PR DESCRIPTION
## Root cause
The live Rhodiola vs Ashwagandha comparison described the combination as a common, well-tolerated pairing/stack and suggested a morning/night stacking pattern, but the references on that page evaluate the ingredients separately rather than establishing combination safety or benefit. The claim-discipline scanner also lacked a pattern for this specific form of reassurance.

## Change
- Replace the two unsupported combination claims with an explicit boundary between ingredient-specific evidence and combination evidence.
- Remove the inferred morning/night stacking instruction from the decision copy.
- Add a guide-risk pattern for `common ... well-tolerated ... pairing/stack/combination` language.
- Add a focused regression test that prevents this priority comparison from reintroducing the reassurance and verifies the scanner retains the new pattern.

## Scope
Ingredient-specific comparison positioning, citations, metadata, layout, affiliate components, and source references are unchanged.