### PR TITLE
ROI 731-744 follow-up: interaction certainty, provenance and live safety UI

### DIFF
--- a/lib/interaction-risk.ts
+++ b/lib/interaction-risk.ts
@@ -1,30 +1,23 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import type { InteractionEdge, RiskTag } from '@/src/types/interactions'
+import type { SafetyCertainty } from '@/src/lib/safety-governance'
 
 const dataDir = path.join(process.cwd(), 'public', 'data')
 
-interface EdgeEntry {
-  partner_slug: string
-  partner_name: string
-  risk_mechanism: string
-  severity: string
-  weight: number
-  claim_language: string
-  notes: string
-}
-
-interface TagEntry {
-  risk_mechanism: string
-  pair_behavior: string
-  matched_text: string
-  confidence: string
-}
+type EdgeEntry = InteractionEdge
+type TagEntry = RiskTag
 
 export interface MechanismRisk {
   mechanism: string
   label: string
   severity: string
+  certainties: SafetyCertainty[]
   partnerCount: number
+  provenanceCoverage: {
+    withProvenance: number
+    total: number
+  }
   topPartners: { slug: string; name: string }[]
 }
 
@@ -61,6 +54,11 @@ function tags(): Record<string, TagEntry[]> {
   return tagCache!
 }
 
+function certainty(edge: EdgeEntry): SafetyCertainty {
+  // Legacy interaction files were generated from shared mechanisms only.
+  return edge.certainty || 'theoretical'
+}
+
 export function getAdditiveRisks(slug: string): MechanismRisk[] {
   const slugTags = tags()[slug] ?? []
   const slugEdges = edges()[slug] ?? []
@@ -75,11 +73,18 @@ export function getAdditiveRisks(slug: string): MechanismRisk[] {
     const mechEdges = slugEdges
       .filter(e => e.risk_mechanism === mech)
       .sort((a, b) => b.weight - a.weight)
+    const withProvenance = mechEdges.filter((edge) => (edge.provenance?.source_ids?.length || 0) > 0).length
+
     risks.push({
       mechanism: mech,
       label: LABELS[mech]?.label ?? mech,
       severity: LABELS[mech]?.severity ?? 'moderate',
+      certainties: [...new Set(mechEdges.map(certainty))],
       partnerCount: mechEdges.length,
+      provenanceCoverage: {
+        withProvenance,
+        total: mechEdges.length,
+      },
       topPartners: mechEdges.slice(0, 5).map(e => ({ slug: e.partner_slug, name: e.partner_name })),
     })
   }

--- a/scripts/data/build-interaction-data.mjs
+++ b/scripts/data/build-interaction-data.mjs
@@ -25,6 +25,15 @@ const PLAIN = { serotonergic:'serotonergic activity', anticoagulant:'effects on 
   cns_sedation:'sedation / CNS depression', blood_glucose:'blood-sugar lowering', blood_pressure:'blood-pressure effects' };
 
 const splitFlags = v => (v == null ? [] : String(v).split(/[;,]/).map(s => s.trim()).filter(Boolean));
+const workbookSourceId = slug => `workbook:Entity_Master:${slug}:contraindications_or_flags`;
+const tagProvenance = slug => ({
+  source_ids: [workbookSourceId(slug)],
+  note: 'Derived from the canonical contraindications_or_flags source field. This provenance identifies the source data field, not an independently verified clinical interaction study.',
+});
+const edgeProvenance = (sourceSlug, targetSlug) => ({
+  source_ids: [workbookSourceId(sourceSlug), workbookSourceId(targetSlug)],
+  note: 'Pairwise flag is inferred from two source-backed contraindication fields sharing a mechanism. It is a theoretical additive-risk screen unless pair-specific evidence is reviewed separately.',
+});
 
 export function deriveInteractionData(rows) {
   const tagSet = new Set();        // dedupe on full tuple, like pandas drop_duplicates
@@ -43,8 +52,17 @@ export function deriveInteractionData(rows) {
           const key = [slug, mech, beh, phrase].join('\u0001');
           if (!tagSet.has(key)) {
             tagSet.add(key);
-            tags.push({ entity_slug: slug, entity_name: name, risk_mechanism: mech,
-                        pair_behavior: beh, matched_text: phrase, confidence: 'high' });
+            tags.push({
+              entity_slug: slug,
+              entity_name: name,
+              risk_mechanism: mech,
+              pair_behavior: beh,
+              matched_text: phrase,
+              // Pattern-match confidence is distinct from interaction certainty.
+              confidence: 'high',
+              certainty: 'theoretical',
+              provenance: tagProvenance(slug),
+            });
           }
           if (ADDITIVE.has(mech)) {
             if (!entMech.has(slug)) entMech.set(slug, new Set());
@@ -70,9 +88,24 @@ export function deriveInteractionData(rows) {
         const claim = `Both ${nameBySlug.get(s)} and ${nameBySlug.get(t)} are flagged for ${PLAIN[mech]}. `
           + `Combining them may have an additive effect. This is a mechanistic caution, not a verified `
           + `interaction — consult a clinician before stacking.`;
-        edges.push({ source_slug: s, target_slug: t, source_name: nameBySlug.get(s), target_name: nameBySlug.get(t),
-          relationship_type: 'additive_risk', risk_mechanism: mech, severity: sev,
-          weight_or_strength: wt, confidence: 'high', claim_language: claim, notes: note });
+        edges.push({
+          source_slug: s,
+          target_slug: t,
+          source_name: nameBySlug.get(s),
+          target_name: nameBySlug.get(t),
+          relationship_type: 'additive_risk',
+          risk_mechanism: mech,
+          severity: sev,
+          weight_or_strength: wt,
+          // Confidence describes deterministic keyword extraction. Certainty describes the pairwise claim.
+          confidence: 'high',
+          certainty: 'theoretical',
+          risk_class: 'general',
+          provenance: edgeProvenance(s, t),
+          unsupervised_use_inappropriate: false,
+          claim_language: claim,
+          notes: note,
+        });
       }
   }
   edges.sort((a, b) => a.source_slug.localeCompare(b.source_slug)
@@ -81,13 +114,41 @@ export function deriveInteractionData(rows) {
   // slug-keyed lookups for O(1) detail-page access (each edge indexed under both ends)
   const edgesBySlug = {}, tagsBySlug = {};
   for (const e of edges) {
-    (edgesBySlug[e.source_slug] ??= []).push({ partner_slug: e.target_slug, partner_name: e.target_name,
-      risk_mechanism: e.risk_mechanism, severity: e.severity, weight: e.weight_or_strength, claim_language: e.claim_language, notes: e.notes });
-    (edgesBySlug[e.target_slug] ??= []).push({ partner_slug: e.source_slug, partner_name: e.source_name,
-      risk_mechanism: e.risk_mechanism, severity: e.severity, weight: e.weight_or_strength, claim_language: e.claim_language, notes: e.notes });
+    (edgesBySlug[e.source_slug] ??= []).push({
+      partner_slug: e.target_slug,
+      partner_name: e.target_name,
+      risk_mechanism: e.risk_mechanism,
+      severity: e.severity,
+      weight: e.weight_or_strength,
+      certainty: e.certainty,
+      risk_class: e.risk_class,
+      provenance: e.provenance,
+      unsupervised_use_inappropriate: e.unsupervised_use_inappropriate,
+      claim_language: e.claim_language,
+      notes: e.notes,
+    });
+    (edgesBySlug[e.target_slug] ??= []).push({
+      partner_slug: e.source_slug,
+      partner_name: e.source_name,
+      risk_mechanism: e.risk_mechanism,
+      severity: e.severity,
+      weight: e.weight_or_strength,
+      certainty: e.certainty,
+      risk_class: e.risk_class,
+      provenance: e.provenance,
+      unsupervised_use_inappropriate: e.unsupervised_use_inappropriate,
+      claim_language: e.claim_language,
+      notes: e.notes,
+    });
   }
-  for (const tg of tags) (tagsBySlug[tg.entity_slug] ??= []).push({ risk_mechanism: tg.risk_mechanism,
-    pair_behavior: tg.pair_behavior, matched_text: tg.matched_text, confidence: tg.confidence });
+  for (const tg of tags) (tagsBySlug[tg.entity_slug] ??= []).push({
+    risk_mechanism: tg.risk_mechanism,
+    pair_behavior: tg.pair_behavior,
+    matched_text: tg.matched_text,
+    confidence: tg.confidence,
+    certainty: tg.certainty,
+    provenance: tg.provenance,
+  });
 
   return { edges, tags, edgesBySlug, tagsBySlug };
 }
@@ -97,10 +158,17 @@ export function validate({ edges, tags }) {
   // expected to grow as that field is enriched (see docs/LOOP_NOTES.md) — do
   // not hard-fail the data:build pipeline on count drift. Structural
   // correctness of the derivation itself is covered by
-  // build-interaction-data.test.mjs; the invariant enforced here is that
-  // every edge carries a claim, not a specific count.
+  // build-interaction-data.test.mjs.
   const errors = [];
   if (edges.some(e => !e.claim_language)) errors.push('empty claim_language present');
+  if (edges.some(e => !e.certainty)) errors.push('interaction edge missing certainty');
+  if (edges.some(e => !Array.isArray(e.provenance?.source_ids) || e.provenance.source_ids.length < 2)) {
+    errors.push('interaction edge missing pair provenance');
+  }
+  if (tags.some(t => !t.certainty)) errors.push('risk tag missing certainty');
+  if (tags.some(t => !Array.isArray(t.provenance?.source_ids) || t.provenance.source_ids.length < 1)) {
+    errors.push('risk tag missing provenance');
+  }
   const byMech = {};
   for (const e of edges) byMech[e.risk_mechanism] = (byMech[e.risk_mechanism] || 0) + 1;
   if (errors.length) { errors.forEach(e => console.error('VALIDATION FAIL:', e)); process.exit(1); }

--- a/scripts/data/build-interaction-data.test.mjs
+++ b/scripts/data/build-interaction-data.test.mjs
@@ -14,7 +14,7 @@ describe('deriveInteractionData', () => {
     expect(data.tagsBySlug).toEqual({})
   })
 
-  it('tags an additive mechanism (e.g. serotonergic) from matching keyword text', () => {
+  it('tags an additive mechanism with separate extraction confidence, interaction certainty, and provenance', () => {
     const data = deriveInteractionData([
       { slug: 'herb-a', name: 'Herb A', contraindications_or_flags: 'May interact with SSRIs' },
     ])
@@ -25,7 +25,11 @@ describe('deriveInteractionData', () => {
       risk_mechanism: 'serotonergic',
       pair_behavior: 'additive',
       confidence: 'high',
+      certainty: 'theoretical',
     })
+    expect(data.tags[0].provenance.source_ids).toEqual([
+      'workbook:Entity_Master:herb-a:contraindications_or_flags',
+    ])
   })
 
   it('tags a non-additive mechanism (e.g. renal) as single_only and excludes it from edge generation', () => {
@@ -56,7 +60,7 @@ describe('deriveInteractionData', () => {
     expect(data.tags.map((t) => t.risk_mechanism).sort()).toEqual(['renal', 'serotonergic'])
   })
 
-  it('creates a bidirectional additive-risk edge between two entities sharing the same mechanism', () => {
+  it('creates a bidirectional additive-risk edge with severity, certainty, and pair provenance', () => {
     const data = deriveInteractionData([
       { slug: 'herb-a', name: 'Herb A', contraindications_or_flags: 'interacts with SSRIs' },
       { slug: 'herb-b', name: 'Herb B', contraindications_or_flags: 'serotonin syndrome risk' },
@@ -69,11 +73,20 @@ describe('deriveInteractionData', () => {
     expect(edge.risk_mechanism).toBe('serotonergic')
     expect(edge.severity).toBe('severe')
     expect(edge.weight_or_strength).toBe(90)
+    expect(edge.certainty).toBe('theoretical')
+    expect(edge.risk_class).toBe('general')
+    expect(edge.provenance.source_ids).toEqual([
+      'workbook:Entity_Master:herb-a:contraindications_or_flags',
+      'workbook:Entity_Master:herb-b:contraindications_or_flags',
+    ])
     expect(edge.claim_language).toContain('Herb A')
     expect(edge.claim_language).toContain('Herb B')
 
     expect(data.edgesBySlug['herb-a']).toHaveLength(1)
-    expect(data.edgesBySlug['herb-a'][0].partner_slug).toBe('herb-b')
+    expect(data.edgesBySlug['herb-a'][0]).toMatchObject({
+      partner_slug: 'herb-b',
+      certainty: 'theoretical',
+    })
     expect(data.edgesBySlug['herb-b']).toHaveLength(1)
     expect(data.edgesBySlug['herb-b'][0].partner_slug).toBe('herb-a')
   })

--- a/src/components/InteractionWarnings.tsx
+++ b/src/components/InteractionWarnings.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { ChevronDown, Leaf, ShieldAlert } from 'lucide-react'
 import type { InteractionEdge, SlugEntityTypeMap, InteractionSeverity } from '@/src/types/interactions'
+import type { SafetyCertainty } from '@/src/lib/safety-governance'
 import { canonicalProfileHref } from '@/lib/canonical-profile-href'
 
 const MECHANISM_LABELS: Record<string, string> = {
@@ -32,9 +33,22 @@ const SEVERITY_CONFIG: Record<InteractionSeverity, { label: string; accent: stri
   },
 }
 
+const CERTAINTY_LABELS: Record<SafetyCertainty, string> = {
+  known: 'Known',
+  probable: 'Probable',
+  theoretical: 'Theoretical',
+  unknown: 'Unknown',
+}
+
 interface InteractionWarningsProps {
   edges: InteractionEdge[]
   slugTypeMap: SlugEntityTypeMap
+}
+
+function edgeCertainty(edge: InteractionEdge): SafetyCertainty {
+  // Legacy generated files predate the explicit field. Their pairings were
+  // mechanism-derived, so theoretical is the truthful backward-compatible default.
+  return edge.certainty || 'theoretical'
 }
 
 export function InteractionWarnings({ edges, slugTypeMap }: InteractionWarningsProps) {
@@ -53,7 +67,7 @@ export function InteractionWarnings({ edges, slugTypeMap }: InteractionWarningsP
         <p className='editorial-eyebrow'>Evidence-based safety</p>
         <h2 className='editorial-display mt-2 text-[2rem] sm:text-[2.7rem]'>Caution when combined</h2>
         <p className='mt-3 text-sm leading-7 text-[#526159] dark:text-[var(--text-secondary)] sm:text-base'>
-          These pairings share a flagged risk mechanism. They are additive-effect cautions derived from contraindication data, not confirmed clinical interactions. Consult a clinician before combining.
+          Severity and certainty are shown separately. A high-priority caution can still be theoretical: these pairings are screened from shared contraindication mechanisms and are not automatically documented clinical interactions. Provenance identifies the source fields that produced each flag; it does not upgrade the certainty of the pairwise claim.
         </p>
       </div>
 
@@ -91,15 +105,31 @@ export function InteractionWarnings({ edges, slugTypeMap }: InteractionWarningsP
                   {byMechanism.map(({ mechanism, edges: mechanismEdges }) => {
                     const visibleEdges = mechanismEdges.slice(0, MAX_VISIBLE_PARTNERS_PER_MECHANISM)
                     const hiddenCount = mechanismEdges.length - visibleEdges.length
+                    const certainties = [...new Set(mechanismEdges.map(edgeCertainty))]
+                    const provenanceCount = mechanismEdges.filter((edge) => (edge.provenance?.source_ids?.length || 0) > 0).length
 
                     return (
                       <div key={mechanism} className='space-y-3'>
-                        <span className={`inline-flex rounded-full border px-3 py-1 text-[0.68rem] font-extrabold uppercase tracking-[0.12em] ${config.badge}`}>
-                          {MECHANISM_LABELS[mechanism] ?? mechanism}
-                        </span>
+                        <div className='flex flex-wrap items-center gap-2'>
+                          <span className={`inline-flex rounded-full border px-3 py-1 text-[0.68rem] font-extrabold uppercase tracking-[0.12em] ${config.badge}`}>
+                            {MECHANISM_LABELS[mechanism] ?? mechanism}
+                          </span>
+                          {certainties.map((certainty) => (
+                            <span
+                              key={certainty}
+                              className='inline-flex rounded-full border border-brand-900/10 bg-white/80 px-2.5 py-1 text-[0.66rem] font-bold text-[#526159] dark:border-white/10 dark:bg-white/5 dark:text-[var(--text-secondary)]'
+                            >
+                              Certainty: {CERTAINTY_LABELS[certainty]}
+                            </span>
+                          ))}
+                        </div>
+                        <p className='text-[11px] leading-5 text-[#647168] dark:text-[var(--text-muted)]'>
+                          Data provenance recorded for {provenanceCount} of {mechanismEdges.length} pairing{mechanismEdges.length === 1 ? '' : 's'} in this mechanism group.
+                        </p>
                         <ul className='flex flex-wrap gap-2'>
                           {visibleEdges.map((edge) => {
                             const partnerType = slugTypeMap[edge.partner_slug]
+                            const certainty = edgeCertainty(edge)
                             // interaction_edges.json carries raw workbook slugs, so a
                             // partner can be a slug that only exists to be 301'd. Resolve
                             // to the canonical URL rather than linking into a redirect.
@@ -114,11 +144,13 @@ export function InteractionWarnings({ edges, slugTypeMap }: InteractionWarningsP
                               <>
                                 <Leaf className='h-3.5 w-3.5 shrink-0 text-[#315f50]' aria-hidden='true' strokeWidth={1.8} />
                                 <span>{edge.partner_name}</span>
+                                <span className='sr-only'> — {CERTAINTY_LABELS[certainty]} interaction certainty</span>
                               </>
                             )
+                            const title = `${edge.claim_language} Certainty: ${CERTAINTY_LABELS[certainty]}.`
 
                             return (
-                              <li key={`${edge.partner_slug}-${edge.risk_mechanism}`} title={edge.claim_language}>
+                              <li key={`${edge.partner_slug}-${edge.risk_mechanism}`} title={title}>
                                 {partnerHref ? (
                                   <Link href={partnerHref} className='interaction-chip inline-flex items-center gap-1.5 rounded-full px-3 py-2 text-xs font-bold transition'>
                                     {content}

--- a/src/lib/__tests__/interaction-risk.test.ts
+++ b/src/lib/__tests__/interaction-risk.test.ts
@@ -2,8 +2,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const edgesFixture = {
   'herb-a': [
-    { partner_slug: 'herb-b', partner_name: 'Herb B', risk_mechanism: 'serotonergic', severity: 'severe', weight: 90, claim_language: '', notes: '' },
-    { partner_slug: 'herb-c', partner_name: 'Herb C', risk_mechanism: 'serotonergic', severity: 'severe', weight: 40, claim_language: '', notes: '' },
+    {
+      partner_slug: 'herb-b', partner_name: 'Herb B', risk_mechanism: 'serotonergic', severity: 'severe', weight: 90,
+      certainty: 'theoretical', provenance: { source_ids: ['workbook:a', 'workbook:b'] }, claim_language: '', notes: '',
+    },
+    {
+      partner_slug: 'herb-c', partner_name: 'Herb C', risk_mechanism: 'serotonergic', severity: 'severe', weight: 40,
+      certainty: 'probable', provenance: { source_ids: ['PMID:123', 'PMID:456'], reviewed_at: '2026-08-15' }, claim_language: '', notes: '',
+    },
+    // Deliberately legacy-shaped to verify the truthful theoretical fallback.
     { partner_slug: 'herb-d', partner_name: 'Herb D', risk_mechanism: 'cns_sedation', severity: 'moderate', weight: 70, claim_language: '', notes: '' },
   ],
 }
@@ -57,6 +64,19 @@ describe('interaction-risk', () => {
 
     expect(serotonergic.topPartners.map(p => p.slug)).toEqual(['herb-b', 'herb-c'])
     expect(serotonergic.partnerCount).toBe(2)
+  })
+
+  it('keeps certainty separate from severity and reports provenance coverage', async () => {
+    const { getAdditiveRisks } = await import('../../../lib/interaction-risk')
+    const risks = getAdditiveRisks('herb-a')
+    const serotonergic = risks.find(r => r.mechanism === 'serotonergic')!
+    const sedation = risks.find(r => r.mechanism === 'cns_sedation')!
+
+    expect(serotonergic.severity).toBe('severe')
+    expect(serotonergic.certainties).toEqual(['theoretical', 'probable'])
+    expect(serotonergic.provenanceCoverage).toEqual({ withProvenance: 2, total: 2 })
+    expect(sedation.certainties).toEqual(['theoretical'])
+    expect(sedation.provenanceCoverage).toEqual({ withProvenance: 0, total: 1 })
   })
 
   it('returns an empty array when no additive tags exist for the slug', async () => {

--- a/src/types/interactions.ts
+++ b/src/types/interactions.ts
@@ -2,6 +2,8 @@
 // Mirrors the shape emitted by scripts/data/build-interaction-data.mjs
 // into public/data/interaction_edges.json and entity_risk_tags.json.
 
+import type { SafetyCertainty, SafetyRiskClass } from '../lib/safety-governance'
+
 export type InteractionSeverity = 'severe' | 'moderate' | 'caution'
 export type RiskMechanism =
   | 'serotonergic'
@@ -16,6 +18,12 @@ export type RiskMechanism =
   | 'allergy'
   | 'thyroid'
 
+export interface InteractionProvenance {
+  source_ids: string[]
+  reviewed_at?: string
+  note?: string
+}
+
 export interface InteractionEdge {
   partner_slug: string
   partner_name: string
@@ -24,6 +32,12 @@ export interface InteractionEdge {
   weight: number
   claim_language: string
   notes: string
+  /** Separate from severity: how certain the interaction claim itself is. */
+  certainty?: SafetyCertainty
+  /** Risk class drives review/suppression policy without changing certainty. */
+  risk_class?: SafetyRiskClass
+  provenance?: InteractionProvenance
+  unsupervised_use_inappropriate?: boolean
 }
 
 export interface RiskTag {
@@ -31,6 +45,8 @@ export interface RiskTag {
   pair_behavior: 'additive' | 'single_only'
   matched_text: string
   confidence: 'high' | 'inferred'
+  certainty?: SafetyCertainty
+  provenance?: InteractionProvenance
 }
 
 export type InteractionEdgesBySlug = Record<string, InteractionEdge[]>


### PR DESCRIPTION
Closes the remaining 731-744 safety implementation gap in the existing interaction pipeline.

- keeps interaction severity separate from certainty
- generator now emits explicit `theoretical` certainty for mechanism-derived pairings instead of letting keyword-match confidence masquerade as clinical certainty
- records provenance back to each canonical contraindication field used to derive a flag
- preserves truthful backward compatibility for legacy generated data by treating mechanism-only pairings as theoretical
- interaction UI now explains severity vs certainty, displays certainty labels, and reports provenance coverage
- `lib/interaction-risk.ts` consumes the canonical interaction types rather than duplicating edge/tag shapes
- validation fails generated data that drops certainty or provenance
- regression tests cover certainty/provenance generation, propagation, and legacy fallback