### PR TITLE
feat(commerce): implement backlog 296-316 evidence-first buying framework

### DIFF
--- a/app/guides/best/methodology/page.tsx
+++ b/app/guides/best/methodology/page.tsx
@@ -1,0 +1,45 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import BuyingQualityPrimer from '@/components/guides/BuyingQualityPrimer'
+import { BEST_GUIDE_INCLUSION_CRITERIA } from '@/lib/best-guide-framework'
+import { buildPageMetadata } from '@/lib/seo'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'How We Rank “Best Supplement” Guides',
+  description: 'The evidence-first ranking, exclusion, safety, product-quality, and affiliate-separation rules used for Hippie Scientist best-supplement guides.',
+  path: '/guides/best/methodology',
+})
+
+export default function BestGuideMethodologyPage() {
+  return (
+    <main className='mx-auto max-w-5xl space-y-8 px-4 py-8 sm:py-10'>
+      <section className='rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8'>
+        <p className='eyebrow-label'>Ranking methodology</p>
+        <h1 className='mt-2 text-3xl font-bold tracking-tight text-ink sm:text-5xl'>“Best” starts with the evidence, not the product carousel</h1>
+        <p className='mt-4 max-w-4xl text-base leading-7 text-muted sm:text-lg'>Best-of guides rank ingredient options first. Commercial products are a separate downstream choice after evidence, limitations, studied form, dose context, and safety are visible.</p>
+      </section>
+
+      <section className='rounded-2xl border border-brand-900/10 bg-white p-5 shadow-sm'>
+        <h2 className='text-2xl font-bold text-ink'>Inclusion criteria</h2>
+        <ol className='mt-4 space-y-3'>
+          {BEST_GUIDE_INCLUSION_CRITERIA.map((criterion, index) => <li key={criterion} className='flex gap-3 rounded-xl bg-brand-50/50 p-3 text-sm leading-6 text-muted'><span className='flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-indigo-950 text-xs font-bold text-white'>{index + 1}</span><span>{criterion}</span></li>)}
+        </ol>
+      </section>
+
+      <section className='grid gap-4 md:grid-cols-3'>
+        <article className='rounded-2xl border border-emerald-900/15 bg-emerald-50 p-5'><p className='text-xs font-bold uppercase tracking-wide text-emerald-900'>Best evidence</p><p className='mt-2 text-sm leading-6 text-emerald-950'>The ingredient with the strongest outcome-relevant human evidence among options that pass the inclusion gate. This is not a product brand ranking.</p></article>
+        <article className='rounded-2xl border border-sky-900/15 bg-sky-50 p-5'><p className='text-xs font-bold uppercase tracking-wide text-sky-900'>Best safety fit</p><p className='mt-2 text-sm leading-6 text-sky-950'>A comparison category based on the structured safety profile among eligible options. It is not a claim that one ingredient is personally safest for every reader.</p></article>
+        <article className='rounded-2xl border border-amber-900/15 bg-amber-50 p-5'><p className='text-xs font-bold uppercase tracking-wide text-amber-900'>Most uncertain</p><p className='mt-2 text-sm leading-6 text-amber-950'>An eligible or popular option with weaker, more indirect, sparse, or less replicated evidence so readers can see uncertainty rather than having it averaged away.</p></article>
+      </section>
+
+      <section className='grid gap-4 md:grid-cols-2'>
+        <article className='rounded-2xl border border-brand-900/10 bg-white p-5 shadow-sm'><h2 className='text-xl font-bold text-ink'>Not recommended / insufficient evidence</h2><p className='mt-2 text-sm leading-6 text-muted'>Popular supplements are not silently dropped when the evidence fails the threshold. They remain visible with the reason they did not qualify—such as mechanism-only evidence, no relevant human trials, unsuitable population evidence, or an unfavorable safety boundary.</p></article>
+        <article className='rounded-2xl border border-brand-900/10 bg-white p-5 shadow-sm'><h2 className='text-xl font-bold text-ink'>Prescription drugs are out of scope</h2><p className='mt-2 text-sm leading-6 text-muted'>Prescription medicines can be discussed as clinical context, but the ranking engine rejects them as consumer supplement candidates. A supplement list is not allowed to imply that a prescription treatment and a retail supplement are interchangeable shopping choices.</p></article>
+      </section>
+
+      <BuyingQualityPrimer />
+
+      <section className='rounded-2xl border border-brand-900/10 bg-brand-50/60 p-5'><h2 className='text-xl font-bold text-ink'>Required page order</h2><p className='mt-2 text-sm leading-6 text-muted'>Direct answer → ingredient evidence table → inclusion/exclusion rationale → safety and studied-form context → product-quality criteria → optional commercial product examples. Affiliate modules never come before the evidence needed to understand why an ingredient belongs on the page.</p><Link href='/guides/best/' className='mt-4 inline-flex font-bold text-indigo-800 hover:underline'>Browse best-supplement guides →</Link></section>
+    </main>
+  )
+}

--- a/app/learn/product-quality/page.tsx
+++ b/app/learn/product-quality/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { getHerbs, getCompounds } from '../../../src/lib/runtime-data'
 import { getRuntimeVisibility } from '../../../lib/runtime-visibility'
 import BuyGuideClient from '../../../src/components/sourcing/BuyGuideClient'
+import BuyingQualityPrimer from '@/components/guides/BuyingQualityPrimer'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import { isRestrictedRecord } from '../../../src/lib/restricted-ingredients'
 import { toBuyingToolRecord } from '../../../src/lib/tool-page-payloads'
@@ -38,23 +39,13 @@ const qualityStartingPoints = [
 export default async function ProductQualityPage() {
   const [rawHerbs, rawCompounds] = await Promise.all([getHerbs(), getCompounds()])
 
-  const herbs: RuntimeRecord[] = rawHerbs.filter((herb: RuntimeRecord) => {
-    if (isRestrictedRecord(herb)) return false
-    try {
-      return getRuntimeVisibility(herb).canRender
-    } catch {
-      return true
-    }
-  })
+  const herbs: RuntimeRecord[] = rawHerbs.filter((herb: RuntimeRecord) =>
+    !isRestrictedRecord(herb) && getRuntimeVisibility(herb).canRender,
+  )
 
-  const compounds: RuntimeRecord[] = rawCompounds.filter((compound: RuntimeRecord) => {
-    if (isRestrictedRecord(compound)) return false
-    try {
-      return getRuntimeVisibility(compound).canRender
-    } catch {
-      return true
-    }
-  })
+  const compounds: RuntimeRecord[] = rawCompounds.filter((compound: RuntimeRecord) =>
+    !isRestrictedRecord(compound) && getRuntimeVisibility(compound).canRender,
+  )
 
   return (
     <div className='mx-auto max-w-6xl space-y-8 px-4 py-8 sm:py-10'>
@@ -73,7 +64,7 @@ export default async function ProductQualityPage() {
         <p className='mt-4 max-w-3xl text-base leading-7 text-muted sm:text-lg'>
           Use this checklist after you have narrowed your goal, compared evidence, and checked safety.
           Product quality is where standardized extracts, transparent labels, heavy-metal testing,
-          certificates of analysis, and dose clarity determine whether a supplement is worth considering.
+          certificates of analysis, and dose clarity determine whether a specific product is worth considering.
         </p>
       </section>
 
@@ -81,23 +72,17 @@ export default async function ProductQualityPage() {
         <div className='space-y-2 rounded-2xl border border-brand-900/10 bg-white p-5 shadow-sm'>
           <div className='flex h-8 w-8 items-center justify-center rounded-lg bg-emerald-50 text-sm font-bold text-emerald-800'>1</div>
           <h2 className='text-sm font-bold text-slate-800'>Verify standardization</h2>
-          <p className='text-xs leading-relaxed text-slate-500'>
-            Prefer labels that name the extract form and marker compounds, not vague root, leaf, or proprietary blend language.
-          </p>
+          <p className='text-xs leading-relaxed text-slate-500'>Prefer labels that name the extract form and marker compounds when those details matter to the cited evidence.</p>
         </div>
         <div className='space-y-2 rounded-2xl border border-brand-900/10 bg-white p-5 shadow-sm'>
           <div className='flex h-8 w-8 items-center justify-center rounded-lg bg-emerald-50 text-sm font-bold text-emerald-800'>2</div>
           <h2 className='text-sm font-bold text-slate-800'>Look for third-party testing</h2>
-          <p className='text-xs leading-relaxed text-slate-500'>
-            Certificates of analysis and independent testing are strongest when they cover identity, heavy metals, microbes, and solvent residues.
-          </p>
+          <p className='text-xs leading-relaxed text-slate-500'>Certificates of analysis and independent testing are strongest when the scope, batch, and tested contaminants are actually documented.</p>
         </div>
         <div className='space-y-2 rounded-2xl border border-brand-900/10 bg-white p-5 shadow-sm'>
           <div className='flex h-8 w-8 items-center justify-center rounded-lg bg-emerald-50 text-sm font-bold text-emerald-800'>3</div>
           <h2 className='text-sm font-bold text-slate-800'>Avoid hidden-dose blends</h2>
-          <p className='text-xs leading-relaxed text-slate-500'>
-            Proprietary blends can hide under-dosed or over-stacked formulas. Favor transparent products with clear ingredient amounts.
-          </p>
+          <p className='text-xs leading-relaxed text-slate-500'>Proprietary blends can obscure individual amounts and make studied-dose, interaction, and stacking comparisons harder.</p>
         </div>
       </section>
 
@@ -105,17 +90,11 @@ export default async function ProductQualityPage() {
         <div className='max-w-3xl space-y-2'>
           <p className='eyebrow-label'>Use this page after intent is clear</p>
           <h2 className='text-2xl font-bold tracking-tight text-ink'>Start with the goal, then judge product quality</h2>
-          <p className='text-sm leading-6 text-muted'>
-            A clean certificate of analysis does not make the wrong supplement useful. Pick the goal page first, then use this checklist to compare form, dose transparency, third-party testing, and safety context.
-          </p>
+          <p className='text-sm leading-6 text-muted'>A clean certificate of analysis does not make the wrong supplement useful. Pick the goal page first, then use this checklist to compare form, dose transparency, third-party testing, and safety context.</p>
         </div>
         <div className='mt-5 grid gap-3 md:grid-cols-3'>
           {qualityStartingPoints.map((item) => (
-            <Link
-              key={item.href}
-              href={item.href}
-              className='rounded-2xl border border-brand-900/10 bg-brand-50/50 p-4 transition hover:border-brand-300 hover:bg-white'
-            >
+            <Link key={item.href} href={item.href} className='rounded-2xl border border-brand-900/10 bg-brand-50/50 p-4 transition hover:border-brand-300 hover:bg-white'>
               <h3 className='text-sm font-bold text-ink'>{item.title}</h3>
               <p className='mt-2 text-xs leading-5 text-muted'>{item.body}</p>
             </Link>
@@ -123,20 +102,7 @@ export default async function ProductQualityPage() {
         </div>
       </section>
 
-      <section className='rounded-2xl border border-amber-900/15 bg-amber-50/70 p-5 text-sm leading-7 text-amber-950'>
-        <p className='font-bold'>Tobacco replacement note:</p>
-        <p className='mt-1'>
-          Product quality is especially important when a product is used to replace a dependence-forming habit.
-          For dipping tobacco, compare regulated cessation aids, tobacco-free nicotine pouches, and non-nicotine
-          oral substitutes before assuming a pouch is healthy.
-        </p>
-        <Link
-          href='/guides/other/healthy-dipping-tobacco-alternatives/'
-          className='mt-3 inline-flex text-sm font-semibold text-amber-900 hover:underline'
-        >
-          Read the dipping tobacco alternatives guide -&gt;
-        </Link>
-      </section>
+      <BuyingQualityPrimer />
 
       <BuyGuideClient
         herbs={herbs.map((herb) => toBuyingToolRecord(herb, 'herb'))}
@@ -145,11 +111,7 @@ export default async function ProductQualityPage() {
 
       <section className='rounded-2xl border border-amber-900/15 bg-amber-50/70 p-5 text-xs leading-relaxed text-amber-950'>
         <p className='font-bold'>Disclosure and safety note:</p>
-        <p className='mt-1'>
-          Product-quality guidance may include affiliate links that support the site at no additional cost to you.
-          Evidence ratings, safety warnings, and editorial framing should remain independent of commission.
-          This page is educational and does not replace clinician guidance.
-        </p>
+        <p className='mt-1'>Product-quality guidance may include affiliate links that support the site at no additional cost to you. Evidence ratings, safety warnings, and product-quality scores remain independent of commission. Missing testing or formulation data is treated as unverified, not as a positive quality signal. This page is educational and does not replace clinician guidance.</p>
       </section>
     </div>
   )

--- a/scripts/audit/best-guide-commerce-order.mjs
+++ b/scripts/audit/best-guide-commerce-order.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const bestRoot = path.join(root, 'app', 'guides')
+const files = []
+
+function walk(dir) {
+  if (!fs.existsSync(dir)) return
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) walk(full)
+    else if (entry.isFile() && /page\.(tsx|jsx)$/.test(entry.name) && full.includes(`${path.sep}best`)) files.push(full)
+  }
+}
+
+walk(bestRoot)
+
+const evidenceMarkers = [
+  /evidence table/i,
+  /evidence comparison/i,
+  /what .* evidence/i,
+  /human evidence/i,
+  /evidence strength/i,
+  /directness before ranking/i,
+  /<table\b/i,
+]
+const commerceMarkers = [
+  /affiliate/i,
+  /amazon\.com/i,
+  /BuyGuideClient/,
+  /AffiliateProduct/,
+  /ProductComparison/,
+]
+
+const findings = []
+for (const file of files) {
+  const source = fs.readFileSync(file, 'utf8')
+  const returnIndex = source.indexOf('return (')
+  if (returnIndex < 0) continue
+  const body = source.slice(returnIndex)
+  const evidencePositions = evidenceMarkers.map((pattern) => body.search(pattern)).filter((index) => index >= 0)
+  const commercePositions = commerceMarkers.map((pattern) => body.search(pattern)).filter((index) => index >= 0)
+  if (!commercePositions.length) continue
+
+  const firstCommerce = Math.min(...commercePositions)
+  const firstEvidence = evidencePositions.length ? Math.min(...evidencePositions) : -1
+  if (firstEvidence < 0 || firstCommerce < firstEvidence) {
+    findings.push({
+      file: path.relative(root, file),
+      issue: firstEvidence < 0 ? 'commercial module/affiliate marker present without a detectable evidence section' : 'commercial marker appears before the first detectable evidence section',
+    })
+  }
+}
+
+const report = {
+  generatedAt: new Date().toISOString(),
+  scannedBestGuidePages: files.length,
+  findings,
+  policy: 'Best-guide pages with commerce must present evidence before commercial modules. This audit is conservative and requires manual review for flagged layouts.',
+}
+
+const reportPath = path.join(root, 'reports', 'best-guide-commerce-order.json')
+fs.mkdirSync(path.dirname(reportPath), { recursive: true })
+fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`)
+console.log(`Scanned ${files.length} best-guide pages; ${findings.length} ordering finding(s).`)
+console.log(`Report: ${reportPath}`)
+
+if (findings.length) {
+  console.error('Best-guide evidence-before-commerce audit found pages requiring review.')
+  process.exitCode = 1
+}

--- a/src/components/guides/BuyingQualityPrimer.tsx
+++ b/src/components/guides/BuyingQualityPrimer.tsx
@@ -1,0 +1,66 @@
+interface BuyingQualityPrimerProps {
+  ingredientName?: string
+  isMineral?: boolean
+}
+
+const topics = [
+  {
+    title: 'Standardized extracts',
+    body: 'For botanicals, an extract name or standardization can matter because a trial may have studied a defined preparation rather than generic plant powder. Do not assume evidence transfers automatically to every extract.',
+  },
+  {
+    title: 'Clinically studied forms',
+    body: 'Match the form on the label to the form used in the relevant human evidence when the form changes absorption, composition, or active-constituent exposure.',
+  },
+  {
+    title: 'Active marker percentages',
+    body: 'Marker percentages help identify what an extract contains and make batches easier to compare. A higher percentage is not automatically more effective or safer.',
+  },
+  {
+    title: 'Elemental mineral amounts',
+    body: 'Mineral labels can list the weight of a compound and the smaller elemental amount the body actually receives. Compare products using the elemental amount when that is the relevant dose metric.',
+  },
+  {
+    title: 'Proprietary blends',
+    body: 'A proprietary blend can hide the amount of each ingredient. That makes it harder to compare a product with studied doses and harder to reason about stacking or safety.',
+  },
+  {
+    title: 'COAs and third-party testing',
+    body: 'A useful certificate of analysis should be tied to the product or batch and should show what was actually tested. “Lab tested” without an accessible scope or result is a weaker quality signal.',
+  },
+  {
+    title: 'Contaminant risk',
+    body: 'Relevant testing can include heavy metals, microbes, residual solvents, pesticides, or other contaminants depending on the ingredient and manufacturing process.',
+  },
+  {
+    title: 'Adulteration risk',
+    body: 'Identity testing matters most in categories with substitution, undeclared drug ingredients, or economically motivated adulteration. Product-quality scoring should reward documented controls rather than marketing language.',
+  },
+]
+
+export default function BuyingQualityPrimer({ ingredientName = 'this supplement', isMineral = false }: BuyingQualityPrimerProps) {
+  return (
+    <section className='space-y-5 rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8' aria-labelledby='buying-quality-primer-heading'>
+      <div>
+        <p className='eyebrow-label'>What to look for when buying {ingredientName}</p>
+        <h2 id='buying-quality-primer-heading' className='mt-2 text-2xl font-bold tracking-tight text-ink'>Product quality is a separate question from efficacy</h2>
+        <p className='mt-3 max-w-4xl text-sm leading-6 text-muted'>A well-made product can contain an ingredient with weak evidence, and an evidence-supported ingredient can be sold in a poor-quality product. The Hippie Scientist keeps those judgments separate.</p>
+      </div>
+
+      <div className='grid gap-3 md:grid-cols-2'>
+        {topics.filter((topic) => isMineral || topic.title !== 'Elemental mineral amounts').map((topic) => (
+          <article key={topic.title} className='rounded-2xl border border-brand-900/10 bg-brand-50/45 p-4'>
+            <h3 className='font-bold text-ink'>{topic.title}</h3>
+            <p className='mt-2 text-sm leading-6 text-muted'>{topic.body}</p>
+          </article>
+        ))}
+      </div>
+
+      <div className='grid gap-3 sm:grid-cols-3'>
+        <div className='rounded-xl border border-emerald-900/15 bg-emerald-50 p-4'><p className='text-xs font-bold uppercase tracking-wide text-emerald-900'>Evidence score</p><p className='mt-2 text-sm leading-6 text-emerald-950'>Based on research for the ingredient/outcome. Product testing and retailer economics do not raise it.</p></div>
+        <div className='rounded-xl border border-sky-900/15 bg-sky-50 p-4'><p className='text-xs font-bold uppercase tracking-wide text-sky-900'>Product-quality score</p><p className='mt-2 text-sm leading-6 text-sky-950'>Based on label transparency, form, testing, COA, contamination/adulteration controls, and formulation verification.</p></div>
+        <div className='rounded-xl border border-amber-900/15 bg-amber-50 p-4'><p className='text-xs font-bold uppercase tracking-wide text-amber-900'>Affiliate economics</p><p className='mt-2 text-sm leading-6 text-amber-950'>Commission may affect whether a retailer link exists. It is not an input to either evidence or product-quality scoring.</p></div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/sourcing/BuyGuideClient.tsx
+++ b/src/components/sourcing/BuyGuideClient.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { AFFILIATE_TAGS } from '@/config/affiliate'
 import { canRenderAffiliateLinks, ensureAmazonAffiliateTag } from '../../lib/affiliate'
 import { trackRevenueEvent } from '../../lib/revenue-tracking'
+import { scoreProductQuality, type ProductQualityScore } from '@/lib/product-quality-score'
 
 interface GuideItem {
   slug: string
@@ -14,7 +15,11 @@ interface GuideItem {
   affiliateUrl: string
   affiliateLabel: string
   standardization?: string
+  studiedForm?: string
+  activeMarker?: string
+  elementalAmount?: string
   bestFor?: string
+  quality: ProductQualityScore
 }
 
 interface BuyGuideClientProps {
@@ -24,21 +29,23 @@ interface BuyGuideClientProps {
 
 const DEFAULT_VISIBLE_ITEMS = 12
 
+const bandLabel: Record<ProductQualityScore['band'], string> = {
+  'strong-label-quality': 'Strong label quality',
+  'adequate-label-quality': 'Adequate label quality',
+  'limited-quality-data': 'Limited quality data',
+  'poor-transparency': 'Poor transparency',
+}
+
 export default function BuyGuideClient({ herbs, compounds }: BuyGuideClientProps) {
   const [searchQuery, setSearchQuery] = useState('')
 
-  // Map and combine datasets
   const allItems = useMemo(() => {
     const combined = [
       ...herbs.map(item => ({ ...item, type: 'herb' as const })),
       ...compounds.map(item => ({ ...item, type: 'compound' as const })),
-    ].filter(item => {
-      // Compliance gate: product-quality pages must not monetize or promote workbook-governed restricted records.
-      return canRenderAffiliateLinks(item)
-    })
+    ].filter(item => canRenderAffiliateLinks(item))
 
     return combined.map(item => {
-      // Resolve buying criteria
       let criteria: string[] = []
       if (Array.isArray(item.buying_criteria)) {
         criteria = item.buying_criteria.filter((c: any) => typeof c === 'string' && c.trim())
@@ -50,26 +57,20 @@ export default function BuyGuideClient({ herbs, compounds }: BuyGuideClientProps
           : String(item.buyingCriteria).split(/[;,\n]+/).map((s: string) => s.trim()).filter(Boolean)
       }
 
-      // Default criteria if empty
       if (criteria.length === 0) {
-        if (item.type === 'herb') {
-          criteria = [
-            'Third-party testing for heavy metals and solvent residues',
-            'Standardized to active marker compounds (e.g. extracts over raw root powder)',
-            'Certified organic or sustainably wildcrafted sourcing'
-          ]
-        } else {
-          criteria = [
-            'USP or pharmaceutical grade purity (98%+ minimum)',
-            'Third-party tested COA (Certificate of Analysis) available',
-            'Free from synthetic flow agents and common allergen fillers'
-          ]
-        }
+        criteria = item.type === 'herb'
+          ? [
+              'Third-party testing for heavy metals and solvent residues',
+              'Standardized extract or clearly identified botanical form',
+              'Transparent active amount and serving size',
+            ]
+          : [
+              'Third-party purity or identity testing',
+              'COA (Certificate of Analysis) when available',
+              'Transparent active amount and serving size',
+            ]
       }
 
-      // Resolve affiliate URL. Any Amazon URL that reaches the UI is normalized
-      // through the central associate-tag helper so direct product links cannot
-      // silently bypass attribution when source data omitted or changed the tag.
       let affiliateUrl = ''
       const direct = item.amazon_affiliate_url || item.amazonAffiliateUrl
       if (direct && String(direct).includes('amazon.com/dp/')) {
@@ -85,8 +86,26 @@ export default function BuyGuideClient({ herbs, compounds }: BuyGuideClientProps
         }
       }
 
-      const affiliateLabel = item.affiliate_label || item.affiliateLabel || `Find Verified ${item.displayName || item.name} on Amazon`
+      const affiliateLabel = item.affiliate_label || item.affiliateLabel || `Find ${item.displayName || item.name} sourcing options`
       const standardization = item.standardization || item.standardized_extract || item.active_compounds
+      const studiedForm = item.studied_form || item.studiedForm
+      const activeMarker = item.active_marker || item.activeMarker
+      const elementalAmount = item.elemental_amount || item.elementalAmount
+      const criteriaText = criteria.join(' ').toLowerCase()
+
+      const quality = scoreProductQuality({
+        transparentActiveDose: /dose|amount|serving/.test(criteriaText),
+        studiedFormDisclosed: Boolean(studiedForm || standardization),
+        standardizedExtractOrForm: Boolean(standardization),
+        activeMarkerDeclared: Boolean(activeMarker),
+        elementalAmountDeclared: elementalAmount ? true : undefined,
+        thirdPartyTesting: item.third_party_testing === true || /third[- ]party|independent test/.test(criteriaText),
+        coaAvailable: item.coa_available === true || /certificate of analysis|\bcoa\b/.test(criteriaText),
+        contaminantTesting: item.contaminant_testing === true || /heavy metal|microb|solvent|pesticide|contaminant/.test(criteriaText),
+        adulterationControls: item.adulteration_controls === true || /identity test|adulteration/.test(criteriaText),
+        proprietaryBlend: item.proprietary_blend === true,
+        currentFormulationVerified: item.formulation_verified === true,
+      })
 
       return {
         slug: item.slug,
@@ -96,135 +115,74 @@ export default function BuyGuideClient({ herbs, compounds }: BuyGuideClientProps
         affiliateUrl,
         affiliateLabel,
         standardization,
-        bestFor: item.best_for || item.bestFor || item.primary_effects
+        studiedForm,
+        activeMarker,
+        elementalAmount,
+        bestFor: item.best_for || item.bestFor || item.primary_effects,
+        quality,
       } as GuideItem
     })
   }, [herbs, compounds])
 
-  // Filter items by search query
   const filteredItems = useMemo(() => {
     if (!searchQuery) return allItems.slice(0, DEFAULT_VISIBLE_ITEMS)
+    const query = searchQuery.toLowerCase()
     return allItems.filter(item =>
-      item.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      item.slug.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      (item.standardization && item.standardization.toLowerCase().includes(searchQuery.toLowerCase()))
+      item.name.toLowerCase().includes(query) ||
+      item.slug.toLowerCase().includes(query) ||
+      Boolean(item.standardization?.toLowerCase().includes(query))
     )
   }, [searchQuery, allItems])
 
   return (
     <div className='space-y-8'>
-      {/* Sourcing Search bar */}
       <div className='rounded-3xl border border-brand-900/10 bg-white/90 p-5 shadow-sm space-y-4'>
-        <div className='max-w-xl space-y-2'>
-          <h2 className='text-lg font-bold text-slate-800'>Search Sourcing Checklists</h2>
-          <p className='text-xs text-slate-500'>
-            Filter the guide to verify active standardized markers and quality controls before completing your purchase.
-          </p>
-          <input
-            type='text'
-            value={searchQuery}
-            onChange={e => setSearchQuery(e.target.value)}
-            placeholder='Search ingredient name (e.g. Ashwagandha, L-Theanine)...'
-            className='w-full rounded-2xl border border-slate-200 px-4 py-3 text-sm focus:border-emerald-500 focus:outline-none'
-          />
+        <div className='max-w-3xl space-y-2'>
+          <p className='eyebrow-label'>Product-quality layer</p>
+          <h2 className='text-lg font-bold text-slate-800'>Search sourcing checklists</h2>
+          <p className='text-xs leading-5 text-slate-500'>Quality scores describe label/form/testing transparency only. They do not change an ingredient’s evidence grade, and affiliate commission is not a scoring input.</p>
+          <input type='text' value={searchQuery} onChange={e => setSearchQuery(e.target.value)} placeholder='Search ingredient name (e.g. Ashwagandha, L-Theanine)...' className='w-full rounded-2xl border border-slate-200 px-4 py-3 text-sm focus:border-emerald-500 focus:outline-none' />
         </div>
       </div>
 
-      {/* Grid of Sourcing Cards */}
-      {!searchQuery && allItems.length > DEFAULT_VISIBLE_ITEMS ? (
-        <p className='text-xs text-slate-500'>
-          Showing {DEFAULT_VISIBLE_ITEMS} common sourcing checklists to keep the page scannable. Search by ingredient name to inspect the full library.
-        </p>
-      ) : null}
+      {!searchQuery && allItems.length > DEFAULT_VISIBLE_ITEMS ? <p className='text-xs text-slate-500'>Showing {DEFAULT_VISIBLE_ITEMS} common sourcing checklists. Search by ingredient name to inspect the full library.</p> : null}
+
       <div className='grid gap-6 sm:grid-cols-2 lg:grid-cols-3'>
         {filteredItems.length === 0 ? (
-          <div className='col-span-full py-16 text-center text-slate-400 text-sm border border-dashed border-slate-200 rounded-[2rem] bg-white/50'>
-            No sourcing checklists match your search.
-          </div>
-        ) : (
-          filteredItems.map(item => (
-            <div
-              key={item.slug}
-              className='flex flex-col justify-between rounded-3xl border border-brand-900/10 bg-white p-5 hover:shadow-md transition-shadow'
-            >
-              <div className='space-y-4'>
-                {/* Header */}
-                <div>
-                  <div className='flex items-start justify-between gap-2'>
-                    <Link
-                      href={item.type === 'herb' ? `/herbs/${item.slug}` : `/compounds/${item.slug}`}
-                      className='text-base font-bold text-slate-800 hover:text-emerald-700 hover:underline leading-snug'
-                    >
-                      {item.name}
-                    </Link>
-                    <span className='rounded-full bg-slate-100 px-2 py-0.5 text-[9px] uppercase font-bold text-slate-500 shrink-0'>
-                      {item.type}
-                    </span>
-                  </div>
-                  {item.standardization && (
-                    <p className='mt-1 text-[11px] text-emerald-800 font-semibold'>
-                      Standardized to: {item.standardization}
-                    </p>
-                  )}
+          <div className='col-span-full py-16 text-center text-slate-400 text-sm border border-dashed border-slate-200 rounded-[2rem] bg-white/50'>No sourcing checklists match your search.</div>
+        ) : filteredItems.map(item => (
+          <div key={item.slug} className='flex flex-col justify-between rounded-3xl border border-brand-900/10 bg-white p-5 hover:shadow-md transition-shadow'>
+            <div className='space-y-4'>
+              <div>
+                <div className='flex items-start justify-between gap-2'>
+                  <Link href={item.type === 'herb' ? `/herbs/${item.slug}` : `/compounds/${item.slug}`} className='text-base font-bold text-slate-800 hover:text-emerald-700 hover:underline leading-snug'>{item.name}</Link>
+                  <span className='rounded-full bg-slate-100 px-2 py-0.5 text-[9px] uppercase font-bold text-slate-500 shrink-0'>{item.type}</span>
                 </div>
-
-                {/* Checklist */}
-                <div className='border-t border-slate-100 pt-3 space-y-2.5'>
-                  <span className='text-[10px] font-bold uppercase tracking-wider text-slate-400'>
-                    Quality Checklist
-                  </span>
-                  <ul className='space-y-2'>
-                    {item.criteria.slice(0, 3).map((itemCriteria, idx) => (
-                      <li key={idx} className='flex items-start gap-2 text-xs leading-relaxed text-slate-600'>
-                        <svg
-                          className='mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-600'
-                          fill='none'
-                          viewBox='0 0 24 24'
-                          strokeWidth={3}
-                          stroke='currentColor'
-                        >
-                          <path strokeLinecap='round' strokeLinejoin='round' d='M4.5 12.75l6 6 9-13.5' />
-                        </svg>
-                        <span>{itemCriteria}</span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
+                {item.standardization ? <p className='mt-1 text-[11px] text-emerald-800 font-semibold'>Standardization/form: {item.standardization}</p> : null}
+                {item.studiedForm ? <p className='mt-1 text-[11px] text-slate-500'>Studied form recorded: {item.studiedForm}</p> : null}
+                {item.activeMarker ? <p className='mt-1 text-[11px] text-slate-500'>Active marker: {item.activeMarker}</p> : null}
+                {item.elementalAmount ? <p className='mt-1 text-[11px] text-slate-500'>Elemental amount: {item.elementalAmount}</p> : null}
               </div>
 
-              {/* Action and Disclaimer */}
-              <div className='mt-5 pt-3 border-t border-slate-100 space-y-3'>
-                <a
-                  href={item.affiliateUrl}
-                  target='_blank'
-                  rel='nofollow sponsored noopener noreferrer'
-                  onClick={() => trackRevenueEvent({
-                    kind: 'affiliate_click',
-                    location: 'product-quality-buy-guide',
-                    label: item.name,
-                    target: item.affiliateUrl,
-                    productSlug: item.slug,
-                  })}
-                  className='flex w-full items-center justify-between rounded-2xl bg-emerald-600 hover:bg-emerald-700 text-white font-bold text-xs py-3 px-4 transition-all shadow-sm'
-                >
-                  <span>Sourcing Options on Amazon</span>
-                  <svg
-                    className='h-3.5 w-3.5 shrink-0'
-                    fill='none'
-                    viewBox='0 0 24 24'
-                    strokeWidth={2.5}
-                    stroke='currentColor'
-                  >
-                    <path strokeLinecap='round' strokeLinejoin='round' d='M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25' />
-                  </svg>
-                </a>
-                <p className='text-[9px] text-center text-slate-400 leading-normal'>
-                  Affiliate Link · Earns commission
-                </p>
+              <div className='rounded-xl border border-sky-900/10 bg-sky-50/70 p-3'>
+                <div className='flex items-center justify-between gap-3'><span className='text-[10px] font-bold uppercase tracking-wider text-sky-900'>Product-quality score</span><strong className='text-sm text-sky-950'>{item.quality.score}/100</strong></div>
+                <p className='mt-1 text-xs font-semibold text-sky-950'>{bandLabel[item.quality.band]}</p>
+                <p className='mt-1 text-[10px] leading-4 text-sky-900'>Independent of efficacy evidence and affiliate payout.</p>
+              </div>
+
+              <div className='border-t border-slate-100 pt-3 space-y-2.5'>
+                <span className='text-[10px] font-bold uppercase tracking-wider text-slate-400'>Quality checklist</span>
+                <ul className='space-y-2'>{item.criteria.slice(0, 4).map((criterion, idx) => <li key={`${criterion}-${idx}`} className='flex items-start gap-2 text-xs leading-relaxed text-slate-600'><span aria-hidden='true' className='mt-0.5 text-emerald-600'>✓</span><span>{criterion}</span></li>)}</ul>
+                {item.quality.cautions.length ? <p className='text-[10px] leading-4 text-amber-800'>Data gaps: {item.quality.cautions.slice(0, 2).join(' · ')}</p> : null}
               </div>
             </div>
-          ))
-        )}
+
+            <div className='mt-5 pt-3 border-t border-slate-100 space-y-3'>
+              <a href={item.affiliateUrl} target='_blank' rel='nofollow sponsored noopener noreferrer' onClick={() => trackRevenueEvent({ kind: 'affiliate_click', location: 'product-quality-buy-guide', label: item.name, target: item.affiliateUrl, productSlug: item.slug })} className='flex w-full items-center justify-between rounded-2xl bg-emerald-600 hover:bg-emerald-700 text-white font-bold text-xs py-3 px-4 transition-all shadow-sm'><span>Sourcing options on Amazon</span><span aria-hidden='true'>↗</span></a>
+              <p className='text-[9px] text-center text-slate-400 leading-normal'>Affiliate link · Commission never affects evidence or product-quality scoring</p>
+            </div>
+          </div>
+        ))}
       </div>
     </div>
   )

--- a/src/components/sourcing/BuyGuideClient.tsx
+++ b/src/components/sourcing/BuyGuideClient.tsx
@@ -18,6 +18,7 @@ interface GuideItem {
   studiedForm?: string
   activeMarker?: string
   elementalAmount?: string
+  activeDose?: string
   bestFor?: string
   quality: ProductQualityScore
 }
@@ -60,14 +61,14 @@ export default function BuyGuideClient({ herbs, compounds }: BuyGuideClientProps
       if (criteria.length === 0) {
         criteria = item.type === 'herb'
           ? [
-              'Third-party testing for heavy metals and solvent residues',
-              'Standardized extract or clearly identified botanical form',
-              'Transparent active amount and serving size',
+              'Look for third-party testing for heavy metals and solvent residues',
+              'Prefer a standardized extract or clearly identified botanical form when relevant',
+              'Confirm the active amount and serving size on the current label',
             ]
           : [
-              'Third-party purity or identity testing',
-              'COA (Certificate of Analysis) when available',
-              'Transparent active amount and serving size',
+              'Look for third-party purity or identity testing',
+              'Check whether a COA (Certificate of Analysis) is available',
+              'Confirm the active amount and serving size on the current label',
             ]
       }
 
@@ -91,18 +92,18 @@ export default function BuyGuideClient({ herbs, compounds }: BuyGuideClientProps
       const studiedForm = item.studied_form || item.studiedForm
       const activeMarker = item.active_marker || item.activeMarker
       const elementalAmount = item.elemental_amount || item.elementalAmount
-      const criteriaText = criteria.join(' ').toLowerCase()
+      const activeDose = item.active_dose || item.activeDose
 
       const quality = scoreProductQuality({
-        transparentActiveDose: /dose|amount|serving/.test(criteriaText),
-        studiedFormDisclosed: Boolean(studiedForm || standardization),
+        transparentActiveDose: item.transparent_active_dose === true || Boolean(activeDose),
+        studiedFormDisclosed: Boolean(studiedForm),
         standardizedExtractOrForm: Boolean(standardization),
         activeMarkerDeclared: Boolean(activeMarker),
         elementalAmountDeclared: elementalAmount ? true : undefined,
-        thirdPartyTesting: item.third_party_testing === true || /third[- ]party|independent test/.test(criteriaText),
-        coaAvailable: item.coa_available === true || /certificate of analysis|\bcoa\b/.test(criteriaText),
-        contaminantTesting: item.contaminant_testing === true || /heavy metal|microb|solvent|pesticide|contaminant/.test(criteriaText),
-        adulterationControls: item.adulteration_controls === true || /identity test|adulteration/.test(criteriaText),
+        thirdPartyTesting: item.third_party_testing === true,
+        coaAvailable: item.coa_available === true,
+        contaminantTesting: item.contaminant_testing === true,
+        adulterationControls: item.adulteration_controls === true,
         proprietaryBlend: item.proprietary_blend === true,
         currentFormulationVerified: item.formulation_verified === true,
       })
@@ -118,6 +119,7 @@ export default function BuyGuideClient({ herbs, compounds }: BuyGuideClientProps
         studiedForm,
         activeMarker,
         elementalAmount,
+        activeDose,
         bestFor: item.best_for || item.bestFor || item.primary_effects,
         quality,
       } as GuideItem
@@ -130,7 +132,7 @@ export default function BuyGuideClient({ herbs, compounds }: BuyGuideClientProps
     return allItems.filter(item =>
       item.name.toLowerCase().includes(query) ||
       item.slug.toLowerCase().includes(query) ||
-      Boolean(item.standardization?.toLowerCase().includes(query))
+      Boolean(item.standardization && String(item.standardization).toLowerCase().includes(query))
     )
   }, [searchQuery, allItems])
 
@@ -140,7 +142,7 @@ export default function BuyGuideClient({ herbs, compounds }: BuyGuideClientProps
         <div className='max-w-3xl space-y-2'>
           <p className='eyebrow-label'>Product-quality layer</p>
           <h2 className='text-lg font-bold text-slate-800'>Search sourcing checklists</h2>
-          <p className='text-xs leading-5 text-slate-500'>Quality scores describe label/form/testing transparency only. They do not change an ingredient’s evidence grade, and affiliate commission is not a scoring input.</p>
+          <p className='text-xs leading-5 text-slate-500'>Quality scores reward only structured product/form/testing facts actually recorded in the dataset. Checklist advice is guidance, not proof. Scores do not change an ingredient’s evidence grade, and affiliate commission is not a scoring input.</p>
           <input type='text' value={searchQuery} onChange={e => setSearchQuery(e.target.value)} placeholder='Search ingredient name (e.g. Ashwagandha, L-Theanine)...' className='w-full rounded-2xl border border-slate-200 px-4 py-3 text-sm focus:border-emerald-500 focus:outline-none' />
         </div>
       </div>
@@ -162,18 +164,19 @@ export default function BuyGuideClient({ herbs, compounds }: BuyGuideClientProps
                 {item.studiedForm ? <p className='mt-1 text-[11px] text-slate-500'>Studied form recorded: {item.studiedForm}</p> : null}
                 {item.activeMarker ? <p className='mt-1 text-[11px] text-slate-500'>Active marker: {item.activeMarker}</p> : null}
                 {item.elementalAmount ? <p className='mt-1 text-[11px] text-slate-500'>Elemental amount: {item.elementalAmount}</p> : null}
+                {item.activeDose ? <p className='mt-1 text-[11px] text-slate-500'>Active dose/serving: {item.activeDose}</p> : null}
               </div>
 
               <div className='rounded-xl border border-sky-900/10 bg-sky-50/70 p-3'>
-                <div className='flex items-center justify-between gap-3'><span className='text-[10px] font-bold uppercase tracking-wider text-sky-900'>Product-quality score</span><strong className='text-sm text-sky-950'>{item.quality.score}/100</strong></div>
+                <div className='flex items-center justify-between gap-3'><span className='text-[10px] font-bold uppercase tracking-wider text-sky-900'>Product-quality data score</span><strong className='text-sm text-sky-950'>{item.quality.score}/100</strong></div>
                 <p className='mt-1 text-xs font-semibold text-sky-950'>{bandLabel[item.quality.band]}</p>
-                <p className='mt-1 text-[10px] leading-4 text-sky-900'>Independent of efficacy evidence and affiliate payout.</p>
+                <p className='mt-1 text-[10px] leading-4 text-sky-900'>Measures recorded label/form/testing transparency only. It is not an efficacy score.</p>
               </div>
 
               <div className='border-t border-slate-100 pt-3 space-y-2.5'>
-                <span className='text-[10px] font-bold uppercase tracking-wider text-slate-400'>Quality checklist</span>
+                <span className='text-[10px] font-bold uppercase tracking-wider text-slate-400'>What to verify before buying</span>
                 <ul className='space-y-2'>{item.criteria.slice(0, 4).map((criterion, idx) => <li key={`${criterion}-${idx}`} className='flex items-start gap-2 text-xs leading-relaxed text-slate-600'><span aria-hidden='true' className='mt-0.5 text-emerald-600'>✓</span><span>{criterion}</span></li>)}</ul>
-                {item.quality.cautions.length ? <p className='text-[10px] leading-4 text-amber-800'>Data gaps: {item.quality.cautions.slice(0, 2).join(' · ')}</p> : null}
+                {item.quality.cautions.length ? <p className='text-[10px] leading-4 text-amber-800'>Unverified / missing structured data: {item.quality.cautions.slice(0, 3).join(' · ')}</p> : null}
               </div>
             </div>
 

--- a/src/lib/__tests__/best-guide-commerce-separation.test.ts
+++ b/src/lib/__tests__/best-guide-commerce-separation.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getBestGuideBuckets,
+  rankBestGuideIngredients,
+  validateBestGuideCandidates,
+  type BestGuideCandidate,
+} from '../best-guide-framework'
+import { scoreProductQuality, type ProductQualitySignals } from '../product-quality-score'
+
+const candidate = (overrides: Partial<BestGuideCandidate>): BestGuideCandidate => ({
+  slug: 'example',
+  name: 'Example',
+  type: 'supplement',
+  evidenceGrade: 'B',
+  outcomeHumanStudyCount: 3,
+  outcomeEvidenceDirectness: 'direct',
+  safetyCompleteness: 'complete',
+  cautionCount: 1,
+  disposition: 'included',
+  rationale: 'Direct human evidence.',
+  ...overrides,
+})
+
+const quality: ProductQualitySignals = {
+  transparentActiveDose: true,
+  studiedFormDisclosed: true,
+  standardizedExtractOrForm: true,
+  activeMarkerDeclared: true,
+  thirdPartyTesting: true,
+  coaAvailable: true,
+  contaminantTesting: true,
+  adulterationControls: true,
+  proprietaryBlend: false,
+  currentFormulationVerified: true,
+}
+
+describe('best-guide evidence and commerce separation', () => {
+  it('ranks ingredient evidence without prescription drugs, mechanism-only candidates, or insufficient evidence', () => {
+    const ranked = rankBestGuideIngredients([
+      candidate({ slug: 'strong', name: 'Strong', evidenceGrade: 'A', outcomeHumanStudyCount: 5 }),
+      candidate({ slug: 'rx', name: 'Prescription', type: 'prescription-drug', evidenceGrade: 'A' }),
+      candidate({ slug: 'mechanism', name: 'Mechanism only', outcomeEvidenceDirectness: 'mechanistic-only' }),
+      candidate({ slug: 'insufficient', name: 'Insufficient', evidenceGrade: 'Avoid/Insufficient', disposition: 'insufficient-evidence' }),
+    ])
+
+    expect(ranked.map((item) => item.slug)).toEqual(['strong'])
+  })
+
+  it('rejects prescription drugs and mechanism-only evidence from included rankings', () => {
+    expect(() => validateBestGuideCandidates([candidate({ type: 'prescription-drug' })])).toThrow(/prescription drugs/i)
+    expect(() => validateBestGuideCandidates([candidate({ outcomeEvidenceDirectness: 'mechanistic-only' })])).toThrow(/mechanism-only/i)
+  })
+
+  it('keeps insufficient and safety-excluded options visible in separate buckets', () => {
+    const buckets = getBestGuideBuckets([
+      candidate({ slug: 'included' }),
+      candidate({ slug: 'weak', evidenceGrade: 'Avoid/Insufficient', disposition: 'insufficient-evidence' }),
+      candidate({ slug: 'safety', disposition: 'excluded-safety' }),
+    ])
+    expect(buckets.insufficient.map((item) => item.slug)).toEqual(['weak'])
+    expect(buckets.excludedForSafety.map((item) => item.slug)).toEqual(['safety'])
+  })
+
+  it('does not let affiliate payout or evidence grade influence product quality', () => {
+    const baseline = scoreProductQuality(quality)
+    const commerciallyDecorated = scoreProductQuality({ ...quality, affiliatePayout: 999, evidenceGrade: 'A' } as ProductQualitySignals & { affiliatePayout: number; evidenceGrade: string })
+    expect(commerciallyDecorated).toEqual(baseline)
+  })
+
+  it('penalizes hidden-dose proprietary blends independently of efficacy', () => {
+    const transparent = scoreProductQuality(quality)
+    const hidden = scoreProductQuality({ ...quality, proprietaryBlend: true, transparentActiveDose: false })
+    expect(hidden.score).toBeLessThan(transparent.score)
+    expect(hidden.cautions.join(' ')).toMatch(/proprietary blend/i)
+  })
+})

--- a/src/lib/best-guide-framework.ts
+++ b/src/lib/best-guide-framework.ts
@@ -1,0 +1,86 @@
+import type { CanonicalEvidenceGrade } from '../../lib/evidence-grade'
+
+export type BestGuideCandidateType = 'supplement' | 'food-derived-nutrient' | 'prescription-drug'
+export type BestGuideDisposition = 'included' | 'insufficient-evidence' | 'excluded-safety' | 'out-of-scope'
+
+export interface BestGuideCandidate {
+  slug: string
+  name: string
+  type: BestGuideCandidateType
+  evidenceGrade: CanonicalEvidenceGrade
+  outcomeHumanStudyCount: number
+  outcomeEvidenceDirectness: 'direct' | 'indirect' | 'mechanistic-only'
+  safetyCompleteness: 'complete' | 'partial' | 'unknown'
+  cautionCount: number
+  disposition: BestGuideDisposition
+  rationale: string
+  popularOptionReason?: string
+}
+
+export const BEST_GUIDE_INCLUSION_CRITERIA = [
+  'The option must be a supplement or food-derived nutrient, not a prescription drug presented as a consumer alternative.',
+  'The relevant outcome must have direct or clearly bounded indirect human evidence; mechanism alone cannot qualify an option as “best.”',
+  'Evidence and safety must be described before any product or retailer module appears.',
+  'Studied form, extract, dose, population, and duration must be called out when they materially limit generalization.',
+  'Popular options with insufficient evidence stay visible in a not-recommended / insufficient-evidence section rather than disappearing.',
+] as const
+
+const gradeRank: Record<CanonicalEvidenceGrade, number> = {
+  A: 5,
+  B: 4,
+  C: 3,
+  D: 2,
+  'Avoid/Insufficient': 1,
+}
+
+export function rankBestGuideIngredients(candidates: BestGuideCandidate[]) {
+  return candidates
+    .filter((candidate) => candidate.type !== 'prescription-drug')
+    .filter((candidate) => candidate.disposition === 'included')
+    .filter((candidate) => candidate.outcomeEvidenceDirectness !== 'mechanistic-only')
+    .slice()
+    .sort((a, b) => {
+      const gradeDelta = gradeRank[b.evidenceGrade] - gradeRank[a.evidenceGrade]
+      if (gradeDelta) return gradeDelta
+      const directnessDelta = Number(b.outcomeEvidenceDirectness === 'direct') - Number(a.outcomeEvidenceDirectness === 'direct')
+      if (directnessDelta) return directnessDelta
+      const studyDelta = b.outcomeHumanStudyCount - a.outcomeHumanStudyCount
+      if (studyDelta) return studyDelta
+      return a.name.localeCompare(b.name)
+    })
+}
+
+export function getBestGuideBuckets(candidates: BestGuideCandidate[]) {
+  const ranked = rankBestGuideIngredients(candidates)
+  const safetyEligible = ranked
+    .filter((candidate) => candidate.safetyCompleteness === 'complete')
+    .slice()
+    .sort((a, b) => a.cautionCount - b.cautionCount || gradeRank[b.evidenceGrade] - gradeRank[a.evidenceGrade])
+
+  return {
+    ranked,
+    bestEvidence: ranked[0] ?? null,
+    bestSafetyFit: safetyEligible[0] ?? null,
+    mostUncertain: ranked.slice().sort((a, b) => gradeRank[a.evidenceGrade] - gradeRank[b.evidenceGrade] || a.outcomeHumanStudyCount - b.outcomeHumanStudyCount)[0] ?? null,
+    insufficient: candidates.filter((candidate) => candidate.disposition === 'insufficient-evidence' || candidate.evidenceGrade === 'Avoid/Insufficient'),
+    excludedForSafety: candidates.filter((candidate) => candidate.disposition === 'excluded-safety'),
+    outOfScope: candidates.filter((candidate) => candidate.type === 'prescription-drug' || candidate.disposition === 'out-of-scope'),
+  }
+}
+
+export function assertBestGuideCandidate(candidate: BestGuideCandidate) {
+  if (candidate.type === 'prescription-drug' && candidate.disposition === 'included') {
+    throw new Error(`${candidate.name}: prescription drugs cannot be ranked as consumer supplement choices`)
+  }
+  if (candidate.outcomeEvidenceDirectness === 'mechanistic-only' && candidate.disposition === 'included') {
+    throw new Error(`${candidate.name}: mechanism-only evidence cannot qualify for an evidence-ranked best guide`)
+  }
+  if (candidate.evidenceGrade === 'Avoid/Insufficient' && candidate.disposition === 'included') {
+    throw new Error(`${candidate.name}: Avoid/Insufficient evidence cannot be included in the ranked recommendation set`)
+  }
+}
+
+export function validateBestGuideCandidates(candidates: BestGuideCandidate[]) {
+  for (const candidate of candidates) assertBestGuideCandidate(candidate)
+  return true
+}

--- a/src/lib/product-quality-score.ts
+++ b/src/lib/product-quality-score.ts
@@ -1,0 +1,80 @@
+export interface ProductQualitySignals {
+  transparentActiveDose: boolean
+  studiedFormDisclosed: boolean
+  standardizedExtractOrForm: boolean
+  activeMarkerDeclared: boolean
+  elementalAmountDeclared?: boolean
+  thirdPartyTesting: boolean
+  coaAvailable: boolean
+  contaminantTesting: boolean
+  adulterationControls: boolean
+  proprietaryBlend: boolean
+  currentFormulationVerified: boolean
+}
+
+export interface ProductQualityScore {
+  score: number
+  band: 'strong-label-quality' | 'adequate-label-quality' | 'limited-quality-data' | 'poor-transparency'
+  positives: string[]
+  cautions: string[]
+}
+
+const positiveSignals: Array<[keyof ProductQualitySignals, number, string]> = [
+  ['transparentActiveDose', 15, 'Active dose is disclosed'],
+  ['studiedFormDisclosed', 12, 'Form is identified clearly enough to compare with research'],
+  ['standardizedExtractOrForm', 10, 'Standardized extract or defined form is disclosed'],
+  ['activeMarkerDeclared', 8, 'Active-marker percentage or amount is disclosed'],
+  ['thirdPartyTesting', 15, 'Independent/third-party testing is reported'],
+  ['coaAvailable', 12, 'Certificate of analysis is available'],
+  ['contaminantTesting', 10, 'Contaminant testing is reported'],
+  ['adulterationControls', 8, 'Identity/adulteration controls are reported'],
+  ['currentFormulationVerified', 10, 'Current formulation has been verified'],
+]
+
+export function scoreProductQuality(signals: ProductQualitySignals): ProductQualityScore {
+  let score = 0
+  const positives: string[] = []
+  const cautions: string[] = []
+
+  for (const [key, weight, description] of positiveSignals) {
+    if (signals[key] === true) {
+      score += weight
+      positives.push(description)
+    }
+  }
+
+  if (signals.elementalAmountDeclared === true) {
+    score += 10
+    positives.push('Elemental mineral amount is disclosed')
+  }
+  if (signals.elementalAmountDeclared === false) cautions.push('Elemental mineral amount is not clearly disclosed')
+
+  if (signals.proprietaryBlend) {
+    score -= 20
+    cautions.push('Proprietary blend obscures individual ingredient amounts')
+  }
+  if (!signals.transparentActiveDose) cautions.push('Active amount per serving is unclear')
+  if (!signals.thirdPartyTesting) cautions.push('Independent testing is not documented')
+  if (!signals.coaAvailable) cautions.push('No accessible certificate of analysis is documented')
+  if (!signals.currentFormulationVerified) cautions.push('Current formulation has not been verified')
+
+  score = Math.max(0, Math.min(100, score))
+  const band = score >= 80
+    ? 'strong-label-quality'
+    : score >= 60
+      ? 'adequate-label-quality'
+      : score >= 35
+        ? 'limited-quality-data'
+        : 'poor-transparency'
+
+  return { score, band, positives, cautions }
+}
+
+/**
+ * Deliberately narrow API: efficacy evidence, affiliate payout, commission rate,
+ * revenue, CTR, and retailer identity are not accepted inputs. Product quality
+ * must describe the product itself rather than its commercial value to the site.
+ */
+export function productQualityInputsDoNotIncludeCommerceOrEfficacy(): true {
+  return true
+}

--- a/src/lib/tool-page-payloads.ts
+++ b/src/lib/tool-page-payloads.ts
@@ -98,6 +98,7 @@ export function toBuyingToolRecord(record: RuntimeRecord, type: ToolKind) {
   const studiedForm = firstText(record, ['studied_form', 'studiedForm', 'clinically_studied_form', 'clinicallyStudiedForm', 'extract_type', 'extractType'])
   const activeMarker = firstText(record, ['active_marker', 'activeMarker', 'marker_compound', 'markerCompound', 'standardized_to', 'standardizedTo'])
   const elementalAmount = firstText(record, ['elemental_amount', 'elementalAmount', 'elemental_mg', 'elementalMg'])
+  const activeDose = firstText(record, ['active_dose', 'activeDose', 'dose_per_serving', 'dosePerServing', 'serving_amount', 'servingAmount'])
 
   return {
     ...baseToolRecord(record, type),
@@ -111,6 +112,8 @@ export function toBuyingToolRecord(record: RuntimeRecord, type: ToolKind) {
     studied_form: studiedForm,
     active_marker: activeMarker,
     elemental_amount: elementalAmount,
+    active_dose: activeDose,
+    transparent_active_dose: firstBoolean(record, ['transparent_active_dose', 'transparentActiveDose']),
     third_party_testing: firstBoolean(record, ['third_party_testing', 'thirdPartyTesting', 'independent_testing', 'independentTesting']),
     coa_available: firstBoolean(record, ['coa_available', 'coaAvailable', 'certificate_of_analysis', 'certificateOfAnalysis']),
     contaminant_testing: firstBoolean(record, ['contaminant_testing', 'contaminantTesting', 'heavy_metal_testing', 'heavyMetalTesting']),

--- a/src/lib/tool-page-payloads.ts
+++ b/src/lib/tool-page-payloads.ts
@@ -17,6 +17,23 @@ function firstText(record: RuntimeRecord, keys: string[]): string | undefined {
   return undefined
 }
 
+function booleanValue(value: unknown): boolean | undefined {
+  if (typeof value === 'boolean') return value
+  if (typeof value !== 'string') return undefined
+  const normalized = value.trim().toLowerCase()
+  if (['yes', 'true', '1', 'available', 'verified', 'tested'].includes(normalized)) return true
+  if (['no', 'false', '0', 'unavailable', 'not verified', 'not tested'].includes(normalized)) return false
+  return undefined
+}
+
+function firstBoolean(record: RuntimeRecord, keys: string[]): boolean | undefined {
+  for (const key of keys) {
+    const value = booleanValue(record[key])
+    if (value !== undefined) return value
+  }
+  return undefined
+}
+
 function textList(value: unknown): string[] | undefined {
   const list = Array.isArray(value)
     ? value
@@ -77,6 +94,11 @@ export function toDosingToolRecord(record: RuntimeRecord, type: ToolKind) {
 }
 
 export function toBuyingToolRecord(record: RuntimeRecord, type: ToolKind) {
+  const standardization = firstText(record, ['standardization', 'standardized_extract', 'active_compounds'])
+  const studiedForm = firstText(record, ['studied_form', 'studiedForm', 'clinically_studied_form', 'clinicallyStudiedForm', 'extract_type', 'extractType'])
+  const activeMarker = firstText(record, ['active_marker', 'activeMarker', 'marker_compound', 'markerCompound', 'standardized_to', 'standardizedTo'])
+  const elementalAmount = firstText(record, ['elemental_amount', 'elementalAmount', 'elemental_mg', 'elementalMg'])
+
   return {
     ...baseToolRecord(record, type),
     monetization_allowed: getRuntimeVisibility(record).canMonetize,
@@ -85,7 +107,16 @@ export function toBuyingToolRecord(record: RuntimeRecord, type: ToolKind) {
     affiliate_url: firstText(record, ['affiliate_url', 'affiliateUrl']),
     affiliate_query: firstText(record, ['affiliate_query', 'affiliateQuery']),
     affiliate_label: firstText(record, ['affiliate_label', 'affiliateLabel']),
-    standardization: firstText(record, ['standardization', 'standardized_extract', 'active_compounds']),
+    standardization,
+    studied_form: studiedForm,
+    active_marker: activeMarker,
+    elemental_amount: elementalAmount,
+    third_party_testing: firstBoolean(record, ['third_party_testing', 'thirdPartyTesting', 'independent_testing', 'independentTesting']),
+    coa_available: firstBoolean(record, ['coa_available', 'coaAvailable', 'certificate_of_analysis', 'certificateOfAnalysis']),
+    contaminant_testing: firstBoolean(record, ['contaminant_testing', 'contaminantTesting', 'heavy_metal_testing', 'heavyMetalTesting']),
+    adulteration_controls: firstBoolean(record, ['adulteration_controls', 'adulterationControls', 'identity_testing', 'identityTesting']),
+    proprietary_blend: firstBoolean(record, ['proprietary_blend', 'proprietaryBlend']),
+    formulation_verified: firstBoolean(record, ['formulation_verified', 'formulationVerified', 'current_formulation_verified', 'currentFormulationVerified']),
     best_for: firstText(record, ['best_for', 'bestFor']) || textList(record.primary_effects)?.join('; '),
   }
 }


### PR DESCRIPTION
Implements backlog 296–316 with a hard separation between ingredient efficacy, product quality, and affiliate economics.

Coverage:
- evidence-first best-guide candidate model and inclusion/exclusion validation
- explicit insufficient-evidence, safety-excluded, and out-of-scope buckets
- prescription drugs cannot enter consumer supplement rankings
- best-evidence / best-safety-fit / most-uncertain categories
- public best-guide methodology with required evidence-before-commerce order
- reusable buying-quality education: standardized extracts, clinically studied forms, active marker %, elemental amounts, proprietary blends, COAs, third-party testing, contaminant risk, and adulteration risk
- independent product-quality scoring framework based only on observed label/form/testing/formulation fields
- product-quality score cannot accept efficacy grade, affiliate payout, revenue, CTR, or retailer identity as inputs
- product-quality UI treats missing verification as a data gap and never infers quality from generic checklist advice
- affiliate disclosure explicitly states commission cannot alter evidence or quality scoring
- removes fail-open visibility behavior from the product-quality page
- regression tests for evidence/commerce separation
- audit script to flag best-guide layouts that place commercial markers before detectable evidence