### PR TITLE
ROI #136: goal to ingredient to comparison funnels

### DIFF
--- a/src/components/goals/GoalHubSections.tsx
+++ b/src/components/goals/GoalHubSections.tsx
@@ -1,10 +1,11 @@
 import Link from 'next/link'
 import type { GoalHubLink } from '../../lib/goal-hub-links'
+import { getGoalIngredientCandidates } from '../../lib/goal-hub-links'
+import { getSlugEntityTypeMap } from '../../lib/runtime-data'
 
 type GoalHubSectionsProps = {
   goalSlug: string
   stack: GoalHubLink | null
-  ingredients: GoalHubLink[]
   compares: GoalHubLink[]
   seoEntry: GoalHubLink | null
 }
@@ -14,13 +15,25 @@ function toCanonicalHref(href: string) {
   return href.endsWith('/') ? href : `${href}/`
 }
 
-export default function GoalHubSections({
+export default async function GoalHubSections({
   goalSlug,
   stack,
-  ingredients,
   compares,
   seoEntry,
 }: GoalHubSectionsProps) {
+  const entityTypeMap = await getSlugEntityTypeMap()
+  const ingredients = getGoalIngredientCandidates(goalSlug)
+    .map((candidate) => {
+      const entityType = entityTypeMap[candidate.slug]
+      if (!entityType) return null
+      return {
+        label: candidate.label,
+        href: `/${entityType === 'herb' ? 'herbs' : 'compounds'}/${candidate.slug}/`,
+        note: candidate.note,
+      } satisfies GoalHubLink
+    })
+    .filter((link): link is GoalHubLink => Boolean(link))
+
   const hasLinks = stack || ingredients.length > 0 || compares.length > 0 || seoEntry
   if (!hasLinks) return null
 

--- a/src/components/goals/GoalHubSections.tsx
+++ b/src/components/goals/GoalHubSections.tsx
@@ -4,6 +4,7 @@ import type { GoalHubLink } from '../../lib/goal-hub-links'
 type GoalHubSectionsProps = {
   goalSlug: string
   stack: GoalHubLink | null
+  ingredients: GoalHubLink[]
   compares: GoalHubLink[]
   seoEntry: GoalHubLink | null
 }
@@ -16,36 +17,48 @@ function toCanonicalHref(href: string) {
 export default function GoalHubSections({
   goalSlug,
   stack,
+  ingredients,
   compares,
   seoEntry,
 }: GoalHubSectionsProps) {
-  const hasLinks = stack || compares.length > 0 || seoEntry
+  const hasLinks = stack || ingredients.length > 0 || compares.length > 0 || seoEntry
   if (!hasLinks) return null
 
   return (
     <section className='card-premium space-y-6 p-5 sm:p-8'>
       <div>
-        <p className='eyebrow-label'>Explore next</p>
-        <h2 className='mt-2 text-xl font-semibold text-ink'>Stacks and comparisons</h2>
+        <p className='eyebrow-label'>Decision path</p>
+        <h2 className='mt-2 text-xl font-semibold text-ink'>Goal → ingredient → comparison</h2>
         <p className='mt-2 text-sm leading-6 text-muted'>
-          Continue from this goal into pre-built stacks and head-to-head comparisons — educational context only.
+          Start with the outcome you are researching, inspect the strongest-fit ingredient profiles, then compare realistic alternatives head to head.
         </p>
       </div>
 
-      {stack ? (
-        <div className='rounded-2xl border border-brand-900/10 bg-white/70 p-5 dark:border-white/10 dark:bg-white/5'>
-          <p className='text-[10px] font-bold uppercase tracking-wider text-brand-700 dark:text-brand-200'>Stack</p>
-          <Link href={toCanonicalHref(stack.href)} className='mt-2 block text-base font-semibold text-brand-800 hover:underline dark:text-brand-100'>
-            {stack.label} →
-          </Link>
-          {stack.note ? <p className='mt-2 text-sm text-muted'>{stack.note}</p> : null}
+      {ingredients.length > 0 ? (
+        <div>
+          <p className='mb-3 text-[10px] font-bold uppercase tracking-wider text-brand-700 dark:text-brand-200'>
+            1 · Inspect ingredient evidence
+          </p>
+          <ul className='grid gap-3 sm:grid-cols-2 lg:grid-cols-3'>
+            {ingredients.map((link) => (
+              <li key={link.href}>
+                <Link
+                  href={toCanonicalHref(link.href)}
+                  className='block h-full rounded-2xl border border-brand-900/10 bg-white/70 p-4 transition hover:border-brand-700/20 hover:bg-white hover:shadow-sm dark:border-white/10 dark:bg-white/5 dark:hover:bg-white/10'
+                >
+                  <span className='font-semibold text-brand-800 dark:text-brand-100'>{link.label} →</span>
+                  {link.note ? <span className='mt-2 block text-xs leading-relaxed text-muted'>{link.note}</span> : null}
+                </Link>
+              </li>
+            ))}
+          </ul>
         </div>
       ) : null}
 
       {compares.length > 0 ? (
         <div>
           <p className='mb-3 text-[10px] font-bold uppercase tracking-wider text-brand-700 dark:text-brand-200'>
-            Head-to-head compares
+            2 · Compare realistic alternatives
           </p>
           <ul className='grid gap-3 sm:grid-cols-2'>
             {compares.map((link) => (
@@ -64,6 +77,16 @@ export default function GoalHubSections({
               </li>
             ))}
           </ul>
+        </div>
+      ) : null}
+
+      {stack ? (
+        <div className='rounded-2xl border border-brand-900/10 bg-white/70 p-5 dark:border-white/10 dark:bg-white/5'>
+          <p className='text-[10px] font-bold uppercase tracking-wider text-brand-700 dark:text-brand-200'>3 · Broader goal context</p>
+          <Link href={toCanonicalHref(stack.href)} className='mt-2 block text-base font-semibold text-brand-800 hover:underline dark:text-brand-100'>
+            {stack.label} →
+          </Link>
+          {stack.note ? <p className='mt-2 text-sm text-muted'>{stack.note}</p> : null}
         </div>
       ) : null}
 

--- a/src/lib/goal-hub-links.ts
+++ b/src/lib/goal-hub-links.ts
@@ -6,6 +6,12 @@ export type GoalHubLink = {
   note?: string
 }
 
+export type GoalIngredientCandidate = {
+  slug: string
+  label: string
+  note: string
+}
+
 const GOAL_STACK_ROUTES: Record<string, string> = {
   sleep: '/guides/sleep/',
   stress: '/guides/anxiety/',
@@ -15,6 +21,51 @@ const GOAL_STACK_ROUTES: Record<string, string> = {
   pain: '/guides/best/supplements-for-joint-support/',
   inflammation: '/guides/best/supplements-for-joint-support/',
   energy: '/guides/focus/',
+}
+
+const GOAL_INGREDIENT_CANDIDATES: Record<string, GoalIngredientCandidate[]> = {
+  sleep: [
+    { slug: 'melatonin', label: 'Melatonin', note: 'Circadian timing and sleep-onset evidence.' },
+    { slug: 'magnesium', label: 'Magnesium', note: 'Mineral status, relaxation, and sleep-quality context.' },
+    { slug: 'l-theanine', label: 'L-Theanine', note: 'Calm-focus and pre-sleep relaxation evidence.' },
+    { slug: 'valerian', label: 'Valerian', note: 'Traditional sleep aid with mixed human evidence.' },
+  ],
+  stress: [
+    { slug: 'ashwagandha', label: 'Ashwagandha', note: 'Stress and cortisol-related human trial evidence.' },
+    { slug: 'rhodiola', label: 'Rhodiola', note: 'Stress-related fatigue and resilience context.' },
+    { slug: 'l-theanine', label: 'L-Theanine', note: 'Acute stress and calm-focus context.' },
+  ],
+  anxiety: [
+    { slug: 'l-theanine', label: 'L-Theanine', note: 'Acute stress and anxious-tension research context.' },
+    { slug: 'ashwagandha', label: 'Ashwagandha', note: 'Longer-duration stress and anxiety-scale evidence.' },
+    { slug: 'kava', label: 'Kava', note: 'Anxiety evidence with materially higher safety scrutiny.' },
+  ],
+  focus: [
+    { slug: 'caffeine', label: 'Caffeine', note: 'Fast alertness and vigilance evidence.' },
+    { slug: 'l-theanine', label: 'L-Theanine', note: 'Calmer attention, often researched with caffeine.' },
+    { slug: 'bacopa', label: 'Bacopa', note: 'Longer-term memory and learning context.' },
+    { slug: 'rhodiola', label: 'Rhodiola', note: 'Fatigue-sensitive cognitive performance context.' },
+  ],
+  cognition: [
+    { slug: 'bacopa', label: 'Bacopa', note: 'Memory and learning evidence over longer durations.' },
+    { slug: 'lions-mane', label: 'Lion’s Mane', note: 'Emerging cognition and nerve-signaling research.' },
+    { slug: 'citicoline', label: 'Citicoline', note: 'Choline-related cognition and attention context.' },
+  ],
+  energy: [
+    { slug: 'caffeine', label: 'Caffeine', note: 'Immediate wakefulness and performance evidence.' },
+    { slug: 'rhodiola', label: 'Rhodiola', note: 'Fatigue and stress-resilience research.' },
+    { slug: 'coq10', label: 'CoQ10', note: 'Mitochondrial and fatigue-related evidence context.' },
+  ],
+  pain: [
+    { slug: 'curcumin', label: 'Curcumin', note: 'Joint-discomfort and inflammatory outcome evidence.' },
+    { slug: 'boswellia', label: 'Boswellia', note: 'Joint pain and function evidence.' },
+    { slug: 'magnesium', label: 'Magnesium', note: 'Context-dependent evidence for specific pain patterns.' },
+  ],
+  inflammation: [
+    { slug: 'curcumin', label: 'Curcumin', note: 'Human inflammatory-marker and joint evidence.' },
+    { slug: 'boswellia', label: 'Boswellia', note: 'Inflammation-adjacent joint outcome evidence.' },
+    { slug: 'omega-3', label: 'Omega-3', note: 'EPA/DHA evidence across inflammatory contexts.' },
+  ],
 }
 
 const GOAL_COMPARE_SLUGS: Record<string, string[]> = {
@@ -108,6 +159,10 @@ export function getGoalStackLink(goalSlug: string): GoalHubLink | null {
     href,
     note: 'Evidence-first guide context for this goal.',
   }
+}
+
+export function getGoalIngredientCandidates(goalSlug: string, limit = 4): GoalIngredientCandidate[] {
+  return (GOAL_INGREDIENT_CANDIDATES[goalSlug] ?? []).slice(0, limit)
 }
 
 export function getGoalCompareLinks(goalSlug: string, limit = 4): GoalHubLink[] {


### PR DESCRIPTION
Turns goal hubs into an explicit decision funnel: goal context → canonical ingredient profiles → head-to-head comparisons → broader guide context. Ingredient links resolve through the runtime slug/entity map so herb/compound routes cannot be guessed incorrectly.