### PR TITLE
feat(data): add normalized research dataset and explorer

### DIFF
--- a/app/evidence/evidence-report/EvidenceReportClient.tsx
+++ b/app/evidence/evidence-report/EvidenceReportClient.tsx
@@ -1,145 +1,251 @@
 'use client'
 
-import { useEffect, useState } from 'react'
 import Link from 'next/link'
+import type { EvidenceGradeChange } from '@/data/editorial/evidence-grade-history'
+import type { PublicEvidenceReportMetrics } from '@/lib/public-evidence-dataset'
 
-type GradeRow = {
-  label: string
-  count: number
-  pct: number
+type Props = {
+  datasetVersion: string
+  citationText: string
+  metrics: PublicEvidenceReportMetrics
+  changeHistory: EvidenceGradeChange[]
 }
 
-type EvidenceReportClientProps = {
-  profileCount: number
-  gradedCount: number
-  gradeData: GradeRow[]
+function pct(numerator: number, denominator: number) {
+  return denominator > 0 ? (numerator / denominator) * 100 : 0
 }
 
 function formatPct(value: number) {
   if (!Number.isFinite(value)) return '0%'
-  if (value >= 10) return `${Math.round(value)}%`
-  return `${value.toFixed(1)}%`
+  return value >= 10 ? `${Math.round(value)}%` : `${value.toFixed(1)}%`
 }
 
-export default function EvidenceReportClient({ profileCount, gradedCount, gradeData }: EvidenceReportClientProps) {
-  const [animated, setAnimated] = useState(false)
-  const unclassifiedCount = Math.max(0, profileCount - gradedCount)
+function escapeXml(value: string) {
+  return value.replace(/[<>&"']/g, character => ({
+    '<': '&lt;',
+    '>': '&gt;',
+    '&': '&amp;',
+    '"': '&quot;',
+    "'": '&apos;',
+  }[character] || character))
+}
 
-  useEffect(() => {
-    const timer = window.setTimeout(() => setAnimated(true), 200)
-    return () => window.clearTimeout(timer)
-  }, [])
+function buildGradeChartSvg(metrics: PublicEvidenceReportMetrics, datasetVersion: string) {
+  const width = 1000
+  const left = 180
+  const barWidth = 650
+  const rowHeight = 76
+  const height = 130 + metrics.gradeDistribution.length * rowHeight
+  const rows = metrics.gradeDistribution.map((item, index) => {
+    const y = 90 + index * rowHeight
+    const widthValue = Math.max(0, Math.min(barWidth, (item.pct / 100) * barWidth))
+    return `
+      <text x="30" y="${y + 25}" font-family="Arial, sans-serif" font-size="22" font-weight="700" fill="#292431">${escapeXml(item.grade)}</text>
+      <rect x="${left}" y="${y}" width="${barWidth}" height="34" rx="17" fill="#eee8f4" />
+      <rect x="${left}" y="${y}" width="${widthValue}" height="34" rx="17" fill="#63558f" />
+      <text x="${left + barWidth + 24}" y="${y + 25}" font-family="Arial, sans-serif" font-size="20" fill="#514a59">${item.count} · ${formatPct(item.pct)}</text>`
+  }).join('')
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+    <rect width="100%" height="100%" fill="#fffdf9" />
+    <text x="30" y="42" font-family="Arial, sans-serif" font-size="28" font-weight="700" fill="#292431">State of Supplement Evidence 2026</text>
+    <text x="30" y="68" font-family="Arial, sans-serif" font-size="15" fill="#6b6471">Evidence-grade distribution · The Hippie Scientist · dataset ${escapeXml(datasetVersion)}</text>
+    ${rows}
+    <text x="30" y="${height - 22}" font-family="Arial, sans-serif" font-size="13" fill="#6b6471">thehippiescientist.net/evidence/evidence-report/</text>
+  </svg>`
+}
+
+export default function EvidenceReportClient({ datasetVersion, citationText, metrics, changeHistory }: Props) {
+  const strongModeratePct = pct(metrics.strongOrModerateIngredients, metrics.ingredientCount)
+  const preliminaryPct = pct(metrics.preliminaryOrInsufficientIngredients, metrics.ingredientCount)
+  const safetyPct = pct(metrics.ingredientsWithSafetyCautions, metrics.ingredientCount)
+  const sortedChanges = [...changeHistory].sort((a, b) => Date.parse(b.changedAt) - Date.parse(a.changedAt))
+  const quarters = [...new Set(sortedChanges.map(item => item.quarter))]
+
+  function downloadGradeChart() {
+    const svg = buildGradeChartSvg(metrics, datasetVersion)
+    const blob = new Blob([svg], { type: 'image/svg+xml;charset=utf-8' })
+    const href = URL.createObjectURL(blob)
+    const anchor = document.createElement('a')
+    anchor.href = href
+    anchor.download = `state-of-supplement-evidence-${datasetVersion}.svg`
+    document.body.appendChild(anchor)
+    anchor.click()
+    anchor.remove()
+    URL.revokeObjectURL(href)
+  }
 
   return (
-    <div className="mx-auto max-w-5xl px-4 py-10 sm:px-6 lg:px-8">
-      <div className="space-y-10">
-        <section className="space-y-4">
-          <p className="eyebrow-label">Generated from current runtime data</p>
-          <h1 className="font-display text-4xl font-bold tracking-tight text-ink sm:text-5xl">
-            Supplement Evidence Report
-          </h1>
-          <p className="max-w-3xl text-lg leading-8 text-muted">
-            This report summarizes the evidence-grade labels attached to the {profileCount} herb and compound reference records that are currently renderable in the site runtime. It is a profile-level distribution, not a count or grading of individual studies.
-          </p>
-        </section>
+    <main className="mx-auto max-w-6xl space-y-10 px-4 py-10 sm:px-6 lg:px-8">
+      <section className="rounded-[2rem] border border-brand-900/10 bg-white p-6 shadow-sm sm:p-8 lg:p-10">
+        <p className="eyebrow-label">Original data report · dataset v{datasetVersion}</p>
+        <h1 className="mt-3 font-display text-4xl font-bold tracking-tight text-ink sm:text-5xl">State of Supplement Evidence 2026</h1>
+        <p className="mt-5 max-w-4xl text-lg leading-8 text-muted">
+          A build-time analysis of the currently indexable Hippie Scientist research library: evidence grades,
+          structured studies, human trials, reported participant counts, safety cautions, and explicit disagreement
+          between supporting and unfavorable/null evidence relationships.
+        </p>
+        <div className="mt-6 flex flex-wrap gap-3">
+          <a href="/evidence/evidence-report/dataset.csv" download className="rounded-full bg-brand-800 px-5 py-2.5 text-sm font-bold text-white hover:bg-brand-900">Download CSV</a>
+          <a href="/evidence/evidence-report/dataset.json" download className="rounded-full border border-brand-900/15 px-5 py-2.5 text-sm font-semibold text-ink hover:bg-brand-50">Download JSON</a>
+          <button type="button" onClick={downloadGradeChart} className="rounded-full border border-brand-900/15 px-5 py-2.5 text-sm font-semibold text-ink hover:bg-brand-50">Download chart SVG</button>
+          <Link href="/learn/citation-explorer/" className="rounded-full border border-brand-900/15 px-5 py-2.5 text-sm font-semibold text-ink hover:bg-brand-50">Explore studies</Link>
+        </div>
+      </section>
 
-        <section className="grid gap-4 sm:grid-cols-3" aria-label="Evidence report summary">
-          <div className="rounded-2xl border border-brand-900/10 bg-white p-5 shadow-sm">
-            <p className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700">Renderable records</p>
-            <p className="mt-2 text-3xl font-bold text-ink">{profileCount}</p>
-          </div>
-          <div className="rounded-2xl border border-brand-900/10 bg-white p-5 shadow-sm">
-            <p className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700">Explicit grade</p>
-            <p className="mt-2 text-3xl font-bold text-ink">{gradedCount}</p>
-          </div>
-          <div className="rounded-2xl border border-brand-900/10 bg-white p-5 shadow-sm">
-            <p className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700">Unclassified</p>
-            <p className="mt-2 text-3xl font-bold text-ink">{unclassifiedCount}</p>
-          </div>
-        </section>
+      <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4" aria-label="Evidence report key findings">
+        <div className="card-premium p-5">
+          <p className="eyebrow-label">Strong / moderate</p>
+          <p className="mt-2 text-3xl font-bold text-ink">{formatPct(strongModeratePct)}</p>
+          <p className="mt-2 text-xs leading-5 text-muted">{metrics.strongOrModerateIngredients} of {metrics.ingredientCount} indexable ingredients are currently A or B.</p>
+        </div>
+        <div className="card-premium p-5">
+          <p className="eyebrow-label">Preliminary / insufficient</p>
+          <p className="mt-2 text-3xl font-bold text-ink">{formatPct(preliminaryPct)}</p>
+          <p className="mt-2 text-xs leading-5 text-muted">C, D, or Avoid/Insufficient profiles remain visibly separate from stronger evidence.</p>
+        </div>
+        <div className="card-premium p-5">
+          <p className="eyebrow-label">Meaningful safety cautions</p>
+          <p className="mt-2 text-3xl font-bold text-ink">{formatPct(safetyPct)}</p>
+          <p className="mt-2 text-xs leading-5 text-muted">{metrics.ingredientsWithSafetyCautions} profiles contain structured caution signals; this is a screening statistic, not a risk rate.</p>
+        </div>
+        <div className="card-premium p-5">
+          <p className="eyebrow-label">Human trials indexed</p>
+          <p className="mt-2 text-3xl font-bold text-ink">{metrics.humanTrialCount.toLocaleString()}</p>
+          <p className="mt-2 text-xs leading-5 text-muted">Across {metrics.studyCount.toLocaleString()} deduplicated structured study entities.</p>
+        </div>
+      </section>
 
-        <section className="rounded-2xl border border-brand-900/10 bg-white p-6 shadow-sm sm:p-8">
-          <div className="max-w-3xl">
-            <h2 className="text-xl font-semibold text-ink">Evidence-label distribution</h2>
-            <p className="mt-2 text-sm leading-6 text-muted">
-              Percentages below are calculated at build time from the current renderable runtime records. They can change when profiles are added, removed, re-reviewed, or reclassified.
-            </p>
-          </div>
+      <section className="grid gap-4 md:grid-cols-3" aria-label="Study coverage">
+        <div className="rounded-2xl border border-brand-900/10 bg-white p-5 shadow-sm">
+          <p className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700">Human evidence sources</p>
+          <p className="mt-2 text-3xl font-bold text-ink">{metrics.humanStudyCount.toLocaleString()}</p>
+        </div>
+        <div className="rounded-2xl border border-brand-900/10 bg-white p-5 shadow-sm">
+          <p className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700">Reported participants</p>
+          <p className="mt-2 text-3xl font-bold text-ink">~{metrics.approximateParticipants.toLocaleString()}</p>
+          <p className="mt-1 text-xs text-muted">Only sources with a structured, parseable N are included; not a unique-person count across overlapping studies.</p>
+        </div>
+        <div className="rounded-2xl border border-brand-900/10 bg-white p-5 shadow-sm">
+          <p className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700">Disagreement surfaced</p>
+          <p className="mt-2 text-3xl font-bold text-ink">{metrics.disagreementStudyCount.toLocaleString()}</p>
+          <p className="mt-1 text-xs text-muted">Study entities linked to mixed directional evidence contexts instead of being averaged away.</p>
+        </div>
+      </section>
 
-          {gradeData.length > 0 ? (
-            <div className="mt-7 space-y-5">
-              {gradeData.map((item) => (
-                <div key={item.label}>
-                  <div className="mb-2 flex flex-wrap items-baseline justify-between gap-3 text-sm">
-                    <div className="flex items-baseline gap-3">
-                      <span className="inline-flex min-w-8 justify-center rounded-full bg-brand-50 px-2 py-1 text-xs font-bold text-brand-800">
-                        {item.label}
-                      </span>
-                      <span className="font-semibold text-ink">{item.count} records</span>
-                    </div>
-                    <span className="text-muted">{formatPct(item.pct)}</span>
-                  </div>
-                  <div className="h-3 w-full overflow-hidden rounded-full bg-brand-50" aria-hidden="true">
-                    <div
-                      className="h-full rounded-full bg-brand-700 transition-all duration-700 ease-out"
-                      style={{ width: animated ? `${Math.max(0, Math.min(100, item.pct))}%` : '0%' }}
-                    />
-                  </div>
-                </div>
+      <section className="rounded-2xl border border-brand-900/10 bg-white p-6 shadow-sm sm:p-8">
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <p className="eyebrow-label">Evidence distribution</p>
+            <h2 className="mt-2 text-2xl font-semibold text-ink">How the indexable library is graded</h2>
+          </div>
+          <button type="button" onClick={downloadGradeChart} className="text-sm font-semibold text-brand-700 hover:underline">Download reusable SVG →</button>
+        </div>
+        <div className="mt-7 space-y-5">
+          {metrics.gradeDistribution.map(item => (
+            <div key={item.grade}>
+              <div className="mb-2 flex items-baseline justify-between gap-3 text-sm">
+                <span className="font-semibold text-ink">{item.grade} · {item.count} profiles</span>
+                <span className="text-muted">{formatPct(item.pct)}</span>
+              </div>
+              <div className="h-3 overflow-hidden rounded-full bg-brand-50">
+                <div className="h-full rounded-full bg-brand-700" style={{ width: `${Math.max(0, Math.min(100, item.pct))}%` }} />
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-2xl border border-brand-900/10 bg-white p-6 shadow-sm sm:p-8">
+        <p className="eyebrow-label">Category comparison</p>
+        <h2 className="mt-2 text-2xl font-semibold text-ink">Where the current library has stronger human-evidence coverage</h2>
+        <p className="mt-3 max-w-4xl text-sm leading-7 text-muted">
+          Categories are ranked by the share of indexable ingredients currently graded A/B, then by structured human-trial coverage. Category names come from the canonical runtime records; small categories can be volatile.
+        </p>
+        <div className="mt-6 overflow-x-auto">
+          <table className="w-full min-w-[760px] border-collapse text-left text-sm">
+            <thead><tr className="border-b border-brand-900/10 text-xs uppercase tracking-wider text-muted"><th className="py-3 pr-4">Category</th><th className="py-3 pr-4">Ingredients</th><th className="py-3 pr-4">A/B</th><th className="py-3 pr-4">Preliminary/insufficient</th><th className="py-3 pr-4">Human sources</th><th className="py-3">Human trials</th></tr></thead>
+            <tbody>
+              {metrics.categories.slice(0, 20).map(category => (
+                <tr key={category.category} className="border-b border-brand-900/10 last:border-0">
+                  <td className="py-3 pr-4 font-semibold text-ink">{category.category}</td>
+                  <td className="py-3 pr-4 text-muted">{category.totalIngredients}</td>
+                  <td className="py-3 pr-4 text-muted">{category.strongOrModerate}</td>
+                  <td className="py-3 pr-4 text-muted">{category.preliminaryOrInsufficient}</td>
+                  <td className="py-3 pr-4 text-muted">{category.humanStudies}</td>
+                  <td className="py-3 text-muted">{category.humanTrials}</td>
+                </tr>
               ))}
-            </div>
-          ) : (
-            <p className="mt-6 rounded-xl border border-brand-900/10 bg-brand-50/40 p-4 text-sm text-muted">
-              No evidence-grade labels are available in the current runtime data.
-            </p>
-          )}
-        </section>
+            </tbody>
+          </table>
+        </div>
+      </section>
 
-        <section className="rounded-2xl border border-brand-900/10 bg-brand-50/50 p-6 sm:p-8">
-          <h2 className="text-xl font-semibold text-ink">How to interpret this report</h2>
-          <div className="mt-4 grid gap-5 sm:grid-cols-2">
-            <div>
-              <h3 className="font-semibold text-ink">A profile grade is not a study count</h3>
-              <p className="mt-2 text-sm leading-6 text-muted">
-                A record’s evidence grade summarizes editorial confidence for that profile. It does not mean every claim or outcome on the page has the same evidence strength.
-              </p>
-            </div>
-            <div>
-              <h3 className="font-semibold text-ink">Distribution is not a product recommendation</h3>
-              <p className="mt-2 text-sm leading-6 text-muted">
-                A higher evidence grade does not establish that an ingredient is appropriate, safe, effective for every goal, or equivalent across products and formulations.
-              </p>
-            </div>
-            <div>
-              <h3 className="font-semibold text-ink">Unclassified does not mean ineffective</h3>
-              <p className="mt-2 text-sm leading-6 text-muted">
-                It means the current runtime record does not expose an explicit evidence-grade label. The underlying page may still contain research context that needs structured review.
-              </p>
-            </div>
-            <div>
-              <h3 className="font-semibold text-ink">The data is regenerated with the site</h3>
-              <p className="mt-2 text-sm leading-6 text-muted">
-                This page no longer relies on manually maintained percentages, fixed study totals, or hand-picked category winners that can drift away from the current library.
-              </p>
-            </div>
-          </div>
-        </section>
-
-        <section className="rounded-2xl border border-brand-900/10 bg-white p-6 shadow-sm sm:p-8">
-          <h2 className="text-xl font-semibold text-ink">Go deeper</h2>
-          <p className="mt-2 max-w-3xl text-sm leading-6 text-muted">
-            Use the methodology and individual profile citations to understand why a specific grade was assigned. Evidence quality, directness, consistency, precision, safety, formulation, and applicability still need claim-level interpretation.
+      <section className="grid gap-5 lg:grid-cols-2">
+        <article className="rounded-2xl border border-brand-900/10 bg-brand-50/50 p-6 sm:p-8">
+          <p className="eyebrow-label">Claim-discipline signal</p>
+          <h2 className="mt-2 text-2xl font-semibold text-ink">Explicitly flagged claim overreach</h2>
+          <p className="mt-3 text-4xl font-bold text-ink">{metrics.explicitlyFlaggedClaimOverreach.toLocaleString()}</p>
+          <p className="mt-3 text-sm leading-7 text-muted">
+            This number counts only records carrying an explicit structured overreach/evidence-language violation flag. It does not infer that every unflagged marketing claim is valid, and it intentionally avoids manufacturing a more dramatic statistic from weak heuristics.
           </p>
-          <div className="mt-5 flex flex-wrap gap-3">
-            <Link href="/info/methodology/" className="rounded-full bg-brand-800 px-5 py-2.5 text-sm font-semibold text-white hover:bg-brand-900">
-              Read methodology
-            </Link>
-            <Link href="/evidence/evidence-checker/" className="rounded-full border border-brand-900/15 px-5 py-2.5 text-sm font-semibold text-ink hover:border-brand-700/30 hover:bg-brand-50">
-              Open evidence lookup
-            </Link>
+        </article>
+        <article className="rounded-2xl border border-brand-900/10 bg-brand-50/50 p-6 sm:p-8">
+          <p className="eyebrow-label">Directional evidence relationships</p>
+          <h2 className="mt-2 text-2xl font-semibold text-ink">Support is not the only thing retained</h2>
+          <div className="mt-5 grid grid-cols-2 gap-3 text-sm">
+            <p><strong className="text-ink">{metrics.supportingRelationships}</strong><br /><span className="text-muted">supporting</span></p>
+            <p><strong className="text-ink">{metrics.mixedRelationships}</strong><br /><span className="text-muted">mixed</span></p>
+            <p><strong className="text-ink">{metrics.contradictingRelationships}</strong><br /><span className="text-muted">contradicting</span></p>
+            <p><strong className="text-ink">{metrics.noClearEffectRelationships}</strong><br /><span className="text-muted">no clear effect</span></p>
           </div>
-        </section>
-      </div>
-    </div>
+          <Link href="/learn/citation-explorer/?relationship=contradicts" className="mt-5 inline-flex text-sm font-semibold text-brand-700 hover:underline">Explore study relationships →</Link>
+        </article>
+      </section>
+
+      <section className="rounded-2xl border border-brand-900/10 bg-white p-6 shadow-sm sm:p-8">
+        <p className="eyebrow-label">Evidence Change Tracker</p>
+        <h2 className="mt-2 text-2xl font-semibold text-ink">What changed the conclusion?</h2>
+        <p className="mt-3 max-w-4xl text-sm leading-7 text-muted">
+          Grade changes are recorded as append-only events with the old grade, new grade, date, reason, and source IDs when available. The tracker starts from recorded events rather than inventing historical upgrades from today’s database state.
+        </p>
+        {sortedChanges.length === 0 ? (
+          <div className="mt-5 rounded-xl border border-brand-900/10 bg-brand-50/50 p-5 text-sm leading-7 text-muted">
+            No historical grade-change events have been entered in the new public ledger yet. Future C→B, B→A, downgrades, and conclusion-changing research can be published here and grouped into quarterly evidence-change reports.
+          </div>
+        ) : (
+          <div className="mt-6 space-y-6">
+            {quarters.map(quarter => (
+              <div key={quarter}>
+                <h3 className="text-lg font-semibold text-ink">{quarter}</h3>
+                <div className="mt-3 space-y-3">
+                  {sortedChanges.filter(item => item.quarter === quarter).map(change => (
+                    <article key={change.id} className="rounded-xl border border-brand-900/10 p-4">
+                      <div className="flex flex-wrap items-center gap-2 text-xs text-muted"><time dateTime={change.changedAt}>{change.changedAt}</time><span>•</span><Link href={change.ingredientPath} className="font-semibold text-brand-700 hover:underline">{change.ingredientName}</Link></div>
+                      <p className="mt-2 text-sm font-bold text-ink">{change.fromGrade} → {change.toGrade}</p>
+                      <p className="mt-2 text-sm leading-6 text-muted">{change.reason}</p>
+                    </article>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="rounded-[2rem] border border-brand-900/10 bg-white p-6 shadow-sm sm:p-8">
+        <p className="eyebrow-label">Cite / reuse</p>
+        <h2 className="mt-2 text-2xl font-semibold text-ink">Stable dataset citation</h2>
+        <p className="mt-3 rounded-xl bg-brand-50/60 p-4 font-mono text-xs leading-6 text-ink">{citationText}</p>
+        <p className="mt-4 max-w-4xl text-sm leading-7 text-muted">
+          Downloaded data includes stable study IDs, source identifiers, study class, reported sample size, dose, duration, population, outcome, limitation, safety outcome, ingredient relationships, evidence grades, and directional support labels where structured data exists.
+        </p>
+        <div className="mt-5 flex flex-wrap gap-4 text-sm font-semibold">
+          <Link href="/info/editorial-policy/" className="text-brand-700 hover:underline">Methodology &amp; inclusion rules →</Link>
+          <Link href="/info/corrections/" className="text-brand-700 hover:underline">Submit a correction →</Link>
+          <Link href="/learn/citation-explorer/" className="text-brand-700 hover:underline">Search the studies →</Link>
+        </div>
+      </section>
+    </main>
   )
 }

--- a/app/evidence/evidence-report/changelog/page.tsx
+++ b/app/evidence/evidence-report/changelog/page.tsx
@@ -1,0 +1,44 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { buildPageMetadata } from '@/src/lib/seo'
+import { evidenceDatasetChangelog } from '@/data/research/evidence-dataset-changelog'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Evidence Dataset Changelog',
+  description: 'Version history for The Hippie Scientist public supplement evidence dataset and Evidence Report.',
+  path: '/evidence/evidence-report/changelog/',
+  openGraphType: 'article',
+})
+
+export default function EvidenceDatasetChangelogPage() {
+  return (
+    <main className="container-page mx-auto max-w-4xl space-y-8 py-10">
+      <section className="hero-shell rounded-[2rem] border p-6 sm:p-8">
+        <p className="eyebrow-label">Version history</p>
+        <h1 className="heading-premium mt-3">Evidence dataset changelog</h1>
+        <p className="text-reading mt-4 max-w-3xl">
+          Public releases are versioned so researchers, writers, and readers can identify which dataset structure
+          and evidence state they referenced. Evidence-grade changes live in a separate append-only change tracker.
+        </p>
+        <div className="mt-5 flex flex-wrap gap-3">
+          <Link href="/evidence/evidence-report/" className="chip-readable">Evidence Report</Link>
+          <a href="/evidence/evidence-report/dataset.csv" download className="chip-readable">CSV</a>
+          <a href="/evidence/evidence-report/dataset.json" download className="chip-readable">JSON</a>
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        {evidenceDatasetChangelog.map(release => (
+          <article key={release.version} className="card-premium p-6">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <h2 className="text-xl font-semibold text-ink">Version {release.version}</h2>
+              <time dateTime={release.date} className="text-sm text-muted">{release.date}</time>
+            </div>
+            <p className="mt-2 text-xs font-semibold uppercase tracking-[0.12em] text-brand-700">Schema v{release.schemaVersion}</p>
+            <p className="mt-3 text-sm leading-7 text-muted">{release.summary}</p>
+          </article>
+        ))}
+      </section>
+    </main>
+  )
+}

--- a/app/evidence/evidence-report/changes/page.tsx
+++ b/app/evidence/evidence-report/changes/page.tsx
@@ -1,0 +1,74 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { buildPageMetadata } from '@/src/lib/seo'
+import { evidenceGradeHistory } from '@/data/editorial/evidence-grade-history'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Evidence Change Tracker',
+  description: 'Quarterly public history of supplement evidence-grade upgrades, downgrades, and conclusion-changing research recorded by The Hippie Scientist.',
+  path: '/evidence/evidence-report/changes/',
+  openGraphType: 'article',
+})
+
+export default function EvidenceChangeTrackerPage() {
+  const events = [...evidenceGradeHistory].sort((a, b) => Date.parse(b.changedAt) - Date.parse(a.changedAt))
+  const quarters = [...new Set(events.map(event => event.quarter))]
+
+  return (
+    <main className="container-page mx-auto max-w-5xl space-y-10 py-10">
+      <section className="hero-shell rounded-[2rem] border p-6 sm:p-8 lg:p-10">
+        <p className="eyebrow-label">Original research monitoring</p>
+        <h1 className="heading-premium mt-3">Evidence Change Tracker</h1>
+        <p className="text-reading mt-4 max-w-3xl">
+          A public, append-only record of evidence-grade changes. Each event records what moved, when it moved,
+          why the conclusion changed, and the triggering source IDs when they are available.
+        </p>
+        <div className="mt-5 flex flex-wrap gap-3">
+          <Link href="/evidence/evidence-report/" className="chip-readable">State of Supplement Evidence 2026</Link>
+          <Link href="/learn/citation-explorer/" className="chip-readable">Human Trial Explorer</Link>
+        </div>
+      </section>
+
+      <section className="grid gap-4 sm:grid-cols-3">
+        <div className="card-premium p-5"><p className="eyebrow-label">Recorded changes</p><p className="mt-2 text-3xl font-bold text-ink">{events.length}</p></div>
+        <div className="card-premium p-5"><p className="eyebrow-label">Evidence upgrades</p><p className="mt-2 text-3xl font-bold text-ink">{events.filter(event => ['A','B'].includes(event.toGrade) && !['A','B'].includes(event.fromGrade)).length}</p></div>
+        <div className="card-premium p-5"><p className="eyebrow-label">Evidence downgrades</p><p className="mt-2 text-3xl font-bold text-ink">{events.filter(event => ['C','D','Avoid/Insufficient'].includes(event.toGrade) && ['A','B'].includes(event.fromGrade)).length}</p></div>
+      </section>
+
+      {events.length === 0 ? (
+        <section className="rounded-2xl border border-brand-900/10 bg-brand-50/60 p-6 text-sm leading-7 text-muted">
+          The append-only tracker is live, but no historical grade-change events have been recorded under this
+          new provenance system yet. The site will not backfill invented C→B or B→A histories from the current
+          database snapshot. The first real reviewed change becomes the first public event.
+        </section>
+      ) : quarters.map(quarter => (
+        <section key={quarter} className="space-y-4">
+          <h2 className="text-2xl font-semibold text-ink">{quarter}</h2>
+          {events.filter(event => event.quarter === quarter).map(event => (
+            <article key={event.id} id={event.id} className="card-premium p-6">
+              <div className="flex flex-wrap items-center gap-2 text-xs text-muted">
+                <time dateTime={event.changedAt}>{event.changedAt}</time>
+                <span aria-hidden="true">•</span>
+                <Link href={event.ingredientPath} className="font-semibold text-brand-700 hover:underline">{event.ingredientName}</Link>
+              </div>
+              <h3 className="mt-3 text-xl font-semibold text-ink">{event.fromGrade} → {event.toGrade}</h3>
+              <p className="mt-3 text-sm leading-7 text-muted">{event.reason}</p>
+              {event.sourceIds?.length ? (
+                <p className="mt-3 text-xs text-muted"><strong className="text-ink">Triggering sources:</strong> {event.sourceIds.join(', ')}</p>
+              ) : null}
+            </article>
+          ))}
+        </section>
+      ))}
+
+      <section className="rounded-2xl border border-brand-900/10 bg-white p-6 shadow-sm">
+        <h2 className="text-xl font-semibold text-ink">Quarterly report model</h2>
+        <p className="mt-3 text-sm leading-7 text-muted">
+          Quarterly editions are generated from this ledger: supplements whose rating changed, new upgrades,
+          downgrades, and claims whose conclusion changed. New human trials that do not change a grade remain
+          discoverable in the Citation Explorer rather than being mislabeled as a grade-change event.
+        </p>
+      </section>
+    </main>
+  )
+}

--- a/app/evidence/evidence-report/dataset.csv/route.ts
+++ b/app/evidence/evidence-report/dataset.csv/route.ts
@@ -3,6 +3,8 @@ import {
   publicEvidenceDatasetToCsv,
 } from '@/lib/public-evidence-dataset'
 
+export const dynamic = 'force-static'
+
 export async function GET() {
   const dataset = await getPublicEvidenceDataset()
   return new Response(publicEvidenceDatasetToCsv(dataset), {

--- a/app/evidence/evidence-report/dataset.csv/route.ts
+++ b/app/evidence/evidence-report/dataset.csv/route.ts
@@ -1,0 +1,15 @@
+import {
+  getPublicEvidenceDataset,
+  publicEvidenceDatasetToCsv,
+} from '@/lib/public-evidence-dataset'
+
+export async function GET() {
+  const dataset = await getPublicEvidenceDataset()
+  return new Response(publicEvidenceDatasetToCsv(dataset), {
+    headers: {
+      'content-type': 'text/csv; charset=utf-8',
+      'content-disposition': `attachment; filename="hippie-scientist-evidence-${dataset.datasetVersion}.csv"`,
+      'cache-control': 'public, max-age=3600',
+    },
+  })
+}

--- a/app/evidence/evidence-report/dataset.json/route.ts
+++ b/app/evidence/evidence-report/dataset.json/route.ts
@@ -1,0 +1,12 @@
+import { getPublicEvidenceDataset } from '@/lib/public-evidence-dataset'
+
+export async function GET() {
+  const dataset = await getPublicEvidenceDataset()
+  return new Response(`${JSON.stringify(dataset, null, 2)}\n`, {
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'content-disposition': `attachment; filename="hippie-scientist-evidence-${dataset.datasetVersion}.json"`,
+      'cache-control': 'public, max-age=3600',
+    },
+  })
+}

--- a/app/evidence/evidence-report/dataset.json/route.ts
+++ b/app/evidence/evidence-report/dataset.json/route.ts
@@ -1,5 +1,7 @@
 import { getPublicEvidenceDataset } from '@/lib/public-evidence-dataset'
 
+export const dynamic = 'force-static'
+
 export async function GET() {
   const dataset = await getPublicEvidenceDataset()
   return new Response(`${JSON.stringify(dataset, null, 2)}\n`, {

--- a/app/evidence/evidence-report/page.tsx
+++ b/app/evidence/evidence-report/page.tsx
@@ -1,68 +1,26 @@
 import type { Metadata } from 'next'
 
 import { buildPageMetadata } from '@/src/lib/seo'
-import { getHerbs, getCompounds } from '@/src/lib/runtime-data'
-import { getRuntimeVisibility } from '@/lib/runtime-visibility'
-import type { RuntimeRecord } from '@/src/types/content'
+import { getPublicEvidenceDataset } from '@/lib/public-evidence-dataset'
+import { evidenceGradeHistory } from '@/data/editorial/evidence-grade-history'
 import EvidenceReportClient from './EvidenceReportClient'
 
 export const metadata: Metadata = buildPageMetadata({
-  title: 'Supplement Evidence Report',
-  description: 'Current evidence-label distribution across renderable herb and compound reference records in The Hippie Scientist research library.',
+  title: 'State of Supplement Evidence 2026',
+  description: 'Original data report on evidence grades, human-study coverage, human trials, safety cautions, disagreement, and downloadable structured supplement evidence from The Hippie Scientist.',
   path: '/evidence/evidence-report/',
   openGraphType: 'article',
 })
 
-function evidenceLabel(record: RuntimeRecord): string {
-  const grade = String(record.evidence_grade || '').trim()
-  if (grade) return grade
-  return 'Unclassified'
-}
-
 export default async function EvidenceReportPage() {
-  const [herbs, compounds] = await Promise.all([getHerbs(), getCompounds()])
-  const records = ([...herbs, ...compounds] as RuntimeRecord[]).filter((record) => {
-    try {
-      return getRuntimeVisibility(record).canRender
-    } catch {
-      return false
-    }
-  })
-
-  const counts = new Map<string, number>()
-  for (const record of records) {
-    const label = evidenceLabel(record)
-    counts.set(label, (counts.get(label) || 0) + 1)
-  }
-
-  const preferredOrder = ['A', 'B', 'C', 'D', 'Traditional', 'Unclassified']
-  const labels = Array.from(counts.keys()).sort((a, b) => {
-    const aIndex = preferredOrder.indexOf(a)
-    const bIndex = preferredOrder.indexOf(b)
-    if (aIndex !== -1 || bIndex !== -1) {
-      if (aIndex === -1) return 1
-      if (bIndex === -1) return -1
-      return aIndex - bIndex
-    }
-    return a.localeCompare(b)
-  })
-
-  const gradeData = labels.map((label) => {
-    const count = counts.get(label) || 0
-    return {
-      label,
-      count,
-      pct: records.length > 0 ? (count / records.length) * 100 : 0,
-    }
-  })
-
-  const gradedCount = records.length - (counts.get('Unclassified') || 0)
+  const dataset = await getPublicEvidenceDataset()
 
   return (
     <EvidenceReportClient
-      profileCount={records.length}
-      gradedCount={gradedCount}
-      gradeData={gradeData}
+      datasetVersion={dataset.datasetVersion}
+      citationText={dataset.citationText}
+      metrics={dataset.metrics}
+      changeHistory={evidenceGradeHistory}
     />
   )
 }

--- a/app/learn/citation-explorer/CitationExplorerClient.tsx
+++ b/app/learn/citation-explorer/CitationExplorerClient.tsx
@@ -1,0 +1,274 @@
+'use client'
+
+import Link from 'next/link'
+import { useMemo, useState } from 'react'
+import {
+  evidenceRelationshipLabel,
+  formatEvidenceStudyClass,
+  parseSampleSize,
+  type EvidenceRelationship,
+  type EvidenceStudyClass,
+} from '@/lib/evidence-study'
+import type { PublicStudyEntity } from '@/lib/public-evidence-dataset'
+
+type Props = {
+  studies: PublicStudyEntity[]
+}
+
+const PAGE_SIZE = 50
+
+function anchorId(studyId: string) {
+  return `study-${studyId.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`
+}
+
+function sourceUrl(study: PublicStudyEntity) {
+  if (study.url) return study.url
+  if (study.pmid) return `https://pubmed.ncbi.nlm.nih.gov/${study.pmid}/`
+  if (study.doi) return `https://doi.org/${study.doi}`
+  return ''
+}
+
+function relationTone(value: EvidenceRelationship) {
+  if (value === 'supports') return 'border-emerald-600/20 bg-emerald-50 text-emerald-800'
+  if (value === 'contradicts') return 'border-rose-600/20 bg-rose-50 text-rose-800'
+  if (value === 'mixed' || value === 'no_clear_effect') return 'border-amber-600/20 bg-amber-50 text-amber-800'
+  return 'border-brand-900/10 bg-brand-50 text-muted'
+}
+
+function relationshipMatches(study: PublicStudyEntity, filter: string) {
+  if (!filter) return true
+  return study.relationships.some(item => item.relationship === filter)
+}
+
+export default function CitationExplorerClient({ studies }: Props) {
+  const [query, setQuery] = useState('')
+  const [ingredient, setIngredient] = useState('')
+  const [condition, setCondition] = useState('')
+  const [studyClass, setStudyClass] = useState('')
+  const [year, setYear] = useState('')
+  const [grade, setGrade] = useState('')
+  const [minSample, setMinSample] = useState('')
+  const [duration, setDuration] = useState('')
+  const [safety, setSafety] = useState('')
+  const [relationship, setRelationship] = useState('')
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE)
+
+  const ingredientOptions = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const study of studies) {
+      for (const relation of study.relationships) map.set(relation.ingredientSlug, relation.ingredientName)
+    }
+    return [...map.entries()].sort((a, b) => a[1].localeCompare(b[1]))
+  }, [studies])
+
+  const conditionOptions = useMemo(() => [...new Set(studies.flatMap(study => study.conditions))].sort(), [studies])
+  const classOptions = useMemo(() => [...new Set(studies.map(study => study.evidenceClass))].sort(), [studies])
+  const yearOptions = useMemo(() => [...new Set(studies.map(study => String(study.year || '')).filter(Boolean))].sort((a, b) => Number(b) - Number(a)), [studies])
+  const gradeOptions = useMemo(() => [...new Set(studies.flatMap(study => study.relationships.map(item => item.evidenceGrade)))].sort(), [studies])
+
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase()
+    const minN = minSample ? Number(minSample) : 0
+    const durationNeedle = duration.trim().toLowerCase()
+
+    return studies.filter(study => {
+      if (ingredient && !study.relationships.some(item => item.ingredientSlug === ingredient)) return false
+      if (condition && !study.conditions.includes(condition)) return false
+      if (studyClass && study.evidenceClass !== studyClass) return false
+      if (year && String(study.year || '') !== year) return false
+      if (grade && !study.relationships.some(item => item.evidenceGrade === grade)) return false
+      if (!relationshipMatches(study, relationship)) return false
+      if (minN && (parseSampleSize(study.sampleSize) || 0) < minN) return false
+      if (durationNeedle && !String(study.duration || '').toLowerCase().includes(durationNeedle)) return false
+      if (safety === 'reported' && !study.safetyOutcome) return false
+      if (safety === 'not-reported' && study.safetyOutcome) return false
+      if (needle) {
+        const haystack = [
+          study.title,
+          study.authors,
+          study.journal,
+          study.population,
+          study.outcome,
+          study.result,
+          study.extractName,
+          study.conditions.join(' '),
+          study.relationships.map(item => `${item.ingredientName} ${item.ingredientSlug}`).join(' '),
+        ].filter(Boolean).join(' ').toLowerCase()
+        if (!haystack.includes(needle)) return false
+      }
+      return true
+    })
+  }, [studies, query, ingredient, condition, studyClass, year, grade, minSample, duration, safety, relationship])
+
+  const disagreementCount = filtered.filter(study => study.relationshipSummary === 'mixed').length
+  const visible = filtered.slice(0, visibleCount)
+  const hasFilters = Boolean(query || ingredient || condition || studyClass || year || grade || minSample || duration || safety || relationship)
+
+  function resetFilters() {
+    setQuery('')
+    setIngredient('')
+    setCondition('')
+    setStudyClass('')
+    setYear('')
+    setGrade('')
+    setMinSample('')
+    setDuration('')
+    setSafety('')
+    setRelationship('')
+    setVisibleCount(PAGE_SIZE)
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-[2rem] border border-brand-900/10 bg-white p-5 shadow-sm sm:p-6" aria-label="Study filters">
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+          <label className="xl:col-span-2">
+            <span className="text-xs font-bold uppercase tracking-[0.12em] text-muted">Search studies</span>
+            <input
+              value={query}
+              onChange={event => { setQuery(event.target.value); setVisibleCount(PAGE_SIZE) }}
+              placeholder="Title, ingredient, outcome, population…"
+              className="mt-1.5 w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2.5 text-sm text-ink outline-none focus:border-brand-700"
+            />
+          </label>
+          <label>
+            <span className="text-xs font-bold uppercase tracking-[0.12em] text-muted">Ingredient</span>
+            <select value={ingredient} onChange={event => { setIngredient(event.target.value); setVisibleCount(PAGE_SIZE) }} className="mt-1.5 w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2.5 text-sm text-ink">
+              <option value="">All ingredients</option>
+              {ingredientOptions.map(([slug, name]) => <option key={slug} value={slug}>{name}</option>)}
+            </select>
+          </label>
+          <label>
+            <span className="text-xs font-bold uppercase tracking-[0.12em] text-muted">Condition</span>
+            <select value={condition} onChange={event => { setCondition(event.target.value); setVisibleCount(PAGE_SIZE) }} className="mt-1.5 w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2.5 text-sm text-ink">
+              <option value="">All conditions</option>
+              {conditionOptions.map(item => <option key={item} value={item}>{item}</option>)}
+            </select>
+          </label>
+          <label>
+            <span className="text-xs font-bold uppercase tracking-[0.12em] text-muted">Trial / study type</span>
+            <select value={studyClass} onChange={event => { setStudyClass(event.target.value); setVisibleCount(PAGE_SIZE) }} className="mt-1.5 w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2.5 text-sm text-ink">
+              <option value="">All study classes</option>
+              {classOptions.map(item => <option key={item} value={item}>{formatEvidenceStudyClass(item as EvidenceStudyClass)}</option>)}
+            </select>
+          </label>
+          <label>
+            <span className="text-xs font-bold uppercase tracking-[0.12em] text-muted">Publication year</span>
+            <select value={year} onChange={event => { setYear(event.target.value); setVisibleCount(PAGE_SIZE) }} className="mt-1.5 w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2.5 text-sm text-ink">
+              <option value="">All years</option>
+              {yearOptions.map(item => <option key={item} value={item}>{item}</option>)}
+            </select>
+          </label>
+          <label>
+            <span className="text-xs font-bold uppercase tracking-[0.12em] text-muted">Evidence grade</span>
+            <select value={grade} onChange={event => { setGrade(event.target.value); setVisibleCount(PAGE_SIZE) }} className="mt-1.5 w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2.5 text-sm text-ink">
+              <option value="">All grades</option>
+              {gradeOptions.map(item => <option key={item} value={item}>{item}</option>)}
+            </select>
+          </label>
+          <label>
+            <span className="text-xs font-bold uppercase tracking-[0.12em] text-muted">Minimum sample size</span>
+            <input value={minSample} onChange={event => { setMinSample(event.target.value.replace(/\D/g, '')); setVisibleCount(PAGE_SIZE) }} inputMode="numeric" placeholder="e.g. 100" className="mt-1.5 w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2.5 text-sm text-ink" />
+          </label>
+          <label>
+            <span className="text-xs font-bold uppercase tracking-[0.12em] text-muted">Duration contains</span>
+            <input value={duration} onChange={event => { setDuration(event.target.value); setVisibleCount(PAGE_SIZE) }} placeholder="e.g. 8 weeks" className="mt-1.5 w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2.5 text-sm text-ink" />
+          </label>
+          <label>
+            <span className="text-xs font-bold uppercase tracking-[0.12em] text-muted">Safety outcome</span>
+            <select value={safety} onChange={event => { setSafety(event.target.value); setVisibleCount(PAGE_SIZE) }} className="mt-1.5 w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2.5 text-sm text-ink">
+              <option value="">Any safety reporting</option>
+              <option value="reported">Safety outcome recorded</option>
+              <option value="not-reported">No structured safety outcome</option>
+            </select>
+          </label>
+          <label>
+            <span className="text-xs font-bold uppercase tracking-[0.12em] text-muted">Evidence direction</span>
+            <select value={relationship} onChange={event => { setRelationship(event.target.value); setVisibleCount(PAGE_SIZE) }} className="mt-1.5 w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2.5 text-sm text-ink">
+              <option value="">All directions</option>
+              <option value="supports">Supporting</option>
+              <option value="mixed">Mixed</option>
+              <option value="contradicts">Contradicting</option>
+              <option value="no_clear_effect">No clear effect</option>
+              <option value="background">Background</option>
+            </select>
+          </label>
+        </div>
+
+        <div className="mt-4 flex flex-wrap items-center justify-between gap-3 border-t border-brand-900/10 pt-4">
+          <p className="text-sm text-muted">
+            <strong className="text-ink">{filtered.length.toLocaleString()}</strong> studies match
+            {disagreementCount ? <> · <strong className="text-amber-800">{disagreementCount}</strong> have mixed/discordant relationships</> : null}
+          </p>
+          {hasFilters ? <button type="button" onClick={resetFilters} className="rounded-full border border-brand-900/15 px-4 py-2 text-xs font-bold text-ink hover:bg-brand-50">Clear filters</button> : null}
+        </div>
+      </section>
+
+      {disagreementCount > 0 ? (
+        <section className="rounded-2xl border border-amber-700/20 bg-amber-50 p-5">
+          <p className="text-xs font-bold uppercase tracking-[0.12em] text-amber-900">Where studies disagree</p>
+          <p className="mt-2 text-sm leading-6 text-amber-950">
+            This filtered set contains studies linked to both supportive and unfavorable/null interpretations across ingredient or outcome contexts. The explorer keeps those relationships visible rather than averaging them into one smooth score.
+          </p>
+        </section>
+      ) : null}
+
+      <section className="space-y-4" aria-live="polite">
+        {visible.length === 0 ? (
+          <div className="rounded-2xl border border-brand-900/10 bg-brand-50/50 p-6 text-sm text-muted">No structured studies match these filters.</div>
+        ) : visible.map(study => {
+          const url = sourceUrl(study)
+          return (
+            <article key={study.id} id={anchorId(study.id)} className="scroll-mt-24 rounded-2xl border border-brand-900/10 bg-white p-5 shadow-sm sm:p-6">
+              <div className="flex flex-wrap items-start justify-between gap-4">
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap gap-2">
+                    <span className="rounded-full border border-brand-900/10 bg-brand-50 px-2.5 py-1 text-[10px] font-bold text-brand-800">{formatEvidenceStudyClass(study.evidenceClass)}</span>
+                    <span className={`rounded-full border px-2.5 py-1 text-[10px] font-bold ${relationTone(study.relationshipSummary)}`}>{evidenceRelationshipLabel(study.relationshipSummary)}</span>
+                    {study.year ? <span className="rounded-full border border-brand-900/10 px-2.5 py-1 text-[10px] font-semibold text-muted">{study.year}</span> : null}
+                    {study.sampleSize ? <span className="rounded-full border border-brand-900/10 px-2.5 py-1 text-[10px] font-semibold text-muted">n={study.sampleSize}</span> : null}
+                  </div>
+                  <h2 className="mt-3 text-lg font-semibold leading-snug text-ink">
+                    {url ? <a href={url} target="_blank" rel="noopener noreferrer" className="hover:text-brand-700 hover:underline">{study.title}</a> : study.title}
+                  </h2>
+                  {(study.authors || study.journal) ? <p className="mt-1 text-xs leading-5 text-muted">{[study.authors, study.journal].filter(Boolean).join(' · ')}</p> : null}
+                </div>
+                <a href={`#${anchorId(study.id)}`} className="text-xs font-semibold text-brand-700 hover:underline" aria-label={`Copyable anchor for ${study.title}`}>#{study.id}</a>
+              </div>
+
+              <dl className="mt-5 grid gap-3 text-sm md:grid-cols-2 xl:grid-cols-4">
+                {study.population ? <div><dt className="text-[10px] font-bold uppercase tracking-[0.12em] text-muted">Population</dt><dd className="mt-1 leading-6 text-ink">{study.population}</dd></div> : null}
+                {study.dose ? <div><dt className="text-[10px] font-bold uppercase tracking-[0.12em] text-muted">Dose / form</dt><dd className="mt-1 leading-6 text-ink">{study.dose}{study.extractName ? ` · ${study.extractName}` : ''}</dd></div> : null}
+                {study.duration ? <div><dt className="text-[10px] font-bold uppercase tracking-[0.12em] text-muted">Duration</dt><dd className="mt-1 leading-6 text-ink">{study.duration}</dd></div> : null}
+                {study.outcome ? <div><dt className="text-[10px] font-bold uppercase tracking-[0.12em] text-muted">Outcome</dt><dd className="mt-1 leading-6 text-ink">{study.outcome}</dd></div> : null}
+              </dl>
+
+              {study.result ? <p className="mt-4 rounded-xl bg-brand-50/60 p-4 text-sm leading-7 text-ink"><strong>Result:</strong> {study.result}</p> : null}
+              {study.limitation ? <p className="mt-3 text-sm leading-7 text-muted"><strong className="text-ink">Limitation:</strong> {study.limitation}</p> : null}
+              {study.safetyOutcome ? <p className="mt-3 text-sm leading-7 text-muted"><strong className="text-ink">Safety outcome:</strong> {study.safetyOutcome}</p> : null}
+
+              <div className="mt-5 border-t border-brand-900/10 pt-4">
+                <p className="text-[10px] font-bold uppercase tracking-[0.12em] text-muted">Ingredients / claim relationships</p>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {study.relationships.map((item, index) => (
+                    <Link key={`${item.ingredientSlug}-${item.relationship}-${index}`} href={item.ingredientPath} className={`rounded-full border px-3 py-1.5 text-xs font-semibold hover:brightness-95 ${relationTone(item.relationship)}`}>
+                      {item.ingredientName} · {item.evidenceGrade} · {evidenceRelationshipLabel(item.relationship)}
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            </article>
+          )
+        })}
+      </section>
+
+      {visibleCount < filtered.length ? (
+        <div className="flex justify-center">
+          <button type="button" onClick={() => setVisibleCount(count => count + PAGE_SIZE)} className="rounded-full bg-brand-800 px-5 py-2.5 text-sm font-bold text-white hover:bg-brand-900">
+            Show {Math.min(PAGE_SIZE, filtered.length - visibleCount)} more studies
+          </button>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/app/learn/citation-explorer/page.tsx
+++ b/app/learn/citation-explorer/page.tsx
@@ -4,10 +4,12 @@ import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
 import FaqJsonLd from '@/components/seo/FaqJsonLd'
 import { buildPageMetadata } from '../../../src/lib/seo'
+import { getPublicEvidenceDataset } from '@/lib/public-evidence-dataset'
+import CitationExplorerClient from './CitationExplorerClient'
 
-const TITLE = 'Scientific Citation Explorer: How We Read Supplement Research'
+const TITLE = 'Human Trial & Scientific Citation Explorer'
 const DESCRIPTION =
-  'Learn how The Hippie Scientist reads citations, human trials, mechanism studies, sample size, study design, dose realism, and evidence confidence before summarizing supplement research.'
+  'Search and filter the human trials, reviews, observational studies, preclinical sources, doses, populations, outcomes, limitations, and evidence directions behind The Hippie Scientist research database.'
 
 export const metadata: Metadata = buildPageMetadata({
   title: TITLE,
@@ -16,50 +18,30 @@ export const metadata: Metadata = buildPageMetadata({
   openGraphType: 'article',
 })
 
-const evidenceLayers = [
-  {
-    title: 'Human outcomes first',
-    body: 'Human outcome studies usually carry more weight than mechanism-only reasoning. A pathway can explain why an idea is plausible, but it should not do all the work by itself.',
-  },
-  {
-    title: 'Dose realism matters',
-    body: 'A study is more useful when the dose, extract form, timing, and population resemble how readers might realistically encounter the ingredient.',
-  },
-  {
-    title: 'Safety changes the tone',
-    body: 'Even promising research deserves careful wording when there are interaction concerns, sedative overlap, stimulant load, liver cautions, or poor product-quality signals.',
-  },
-]
-
-const confidenceChecks = [
-  'Was the study done in humans, animals, cells, or a mixed evidence base?',
-  'Does the study measure the outcome readers care about, or only a biomarker?',
-  'Is the dose achievable with normal supplement products?',
-  'Is the population similar to the intended use case?',
-  'Do safety notes change how strongly the page should summarize the finding?',
-]
-
 const faqItems = [
   {
-    question: 'What makes a citation useful for a supplement page?',
+    question: 'What does “supports,” “mixed,” or “contradicts” mean?',
     answer:
-      'A useful citation directly studies a relevant outcome, uses a realistic dose and product form, clearly describes the population, and reports limitations or adverse events.',
+      'Those labels describe how a structured study relationship is used for a particular ingredient or claim context. They are kept separate so conflicting evidence is visible instead of averaged away.',
   },
   {
-    question: 'Why are mechanism studies still included?',
+    question: 'Does a study appearing here prove a supplement works?',
     answer:
-      'Mechanism studies can explain biological plausibility and help readers understand pathways. They are helpful background, but they should not be treated as proof of a real-world outcome by themselves.',
+      'No. Study design, sample size, population, dose, formulation, outcome, limitations, replication, and disagreement with other studies all affect confidence. The explorer exposes those details rather than treating citation count as proof.',
   },
   {
-    question: 'How should mixed evidence be handled?',
+    question: 'Why are animal, cell, or mechanism studies included?',
     answer:
-      'Mixed evidence should reduce certainty. A good summary explains what appears consistent, what remains uncertain, and where softer wording is more appropriate.',
+      'They can be useful research context and help explain plausibility, but the explorer labels them separately from direct human evidence so they are not mistaken for clinical efficacy evidence.',
   },
 ]
 
-export default function CitationExplorerPage() {
+export default async function CitationExplorerPage() {
+  const dataset = await getPublicEvidenceDataset()
+  const metrics = dataset.metrics
+
   return (
-    <div className="container-page py-10 space-y-10">
+    <div className="container-page space-y-10 py-10">
       <AuthorityJsonLd
         title={TITLE}
         description={DESCRIPTION}
@@ -82,71 +64,67 @@ export default function CitationExplorerPage() {
       />
 
       <section className="rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8 lg:p-10">
-        <p className="eyebrow-label">Evidence verification</p>
+        <p className="eyebrow-label">Public study database · v{dataset.datasetVersion}</p>
         <h1 className="mt-3 max-w-4xl text-4xl font-bold tracking-tight text-ink sm:text-5xl">
-          Scientific citation explorer for supplement research.
+          Search the evidence behind the ingredient profiles.
         </h1>
         <p className="mt-5 max-w-3xl text-lg leading-8 text-muted">
-          This page explains how citations are read before a research summary becomes confident or cautious.
-          The goal is to separate human outcome evidence, mechanism background, dose realism, safety context,
-          and marketing language so readers can understand the evidence layer behind the page.
+          This is no longer just an explanation page. It is a structured explorer of the studies attached to
+          currently indexable ingredient profiles, including study class, sample size, dose, duration,
+          population, outcome, limitations, safety reporting, and whether a source supports, complicates, or
+          contradicts a claim context.
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
-          <Link href="/info/methodology/" className="chip-readable hover:bg-white transition">Editorial methodology</Link>
-          <Link href="/learn/efficacy-model/" className="chip-readable hover:bg-white transition">Efficacy modeler</Link>
-          <Link href="/learn/explorer/" className="chip-readable hover:bg-white transition">Pathway explorer</Link>
+          <Link href="/info/editorial-policy/" className="chip-readable transition hover:bg-white">Evidence rules</Link>
+          <Link href="/evidence/evidence-report/" className="chip-readable transition hover:bg-white">State of Supplement Evidence 2026</Link>
+          <a href="/evidence/evidence-report/dataset.csv" className="chip-readable transition hover:bg-white" download>Download CSV</a>
+          <a href="/evidence/evidence-report/dataset.json" className="chip-readable transition hover:bg-white" download>Download JSON</a>
         </div>
       </section>
 
-      <section className="grid gap-5 lg:grid-cols-3">
-        {evidenceLayers.map((layer) => (
-          <article key={layer.title} className="card-premium p-6">
-            <p className="eyebrow-label">Evidence layer</p>
-            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">{layer.title}</h2>
-            <p className="mt-3 text-sm leading-7 text-muted">{layer.body}</p>
-          </article>
-        ))}
-      </section>
-
-      <section className="rounded-[2rem] border border-brand-900/10 bg-brand-50/60 p-6 shadow-sm sm:p-8">
-        <div className="max-w-3xl space-y-3">
-          <p className="eyebrow-label">Citation quality checklist</p>
-          <h2 className="text-3xl font-semibold tracking-tight text-ink">Five questions before reading a citation too strongly</h2>
-          <p className="text-sm leading-7 text-muted">
-            A citation can be real and still be easy to over-read. These checks keep the wording on the site
-            proportional to the actual evidence.
-          </p>
+      <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4" aria-label="Citation Explorer coverage">
+        <div className="card-premium p-5">
+          <p className="eyebrow-label">Structured studies</p>
+          <p className="mt-2 text-3xl font-bold text-ink">{metrics.studyCount.toLocaleString()}</p>
         </div>
-        <ol className="mt-6 grid gap-3 md:grid-cols-2">
-          {confidenceChecks.map((check, index) => (
-            <li key={check} className="rounded-2xl border border-brand-900/10 bg-white/80 p-4 text-sm leading-6 text-muted">
-              <span className="mr-2 font-bold text-brand-800">{index + 1}.</span>{check}
-            </li>
-          ))}
-        </ol>
+        <div className="card-premium p-5">
+          <p className="eyebrow-label">Human evidence sources</p>
+          <p className="mt-2 text-3xl font-bold text-ink">{metrics.humanStudyCount.toLocaleString()}</p>
+        </div>
+        <div className="card-premium p-5">
+          <p className="eyebrow-label">Human trials</p>
+          <p className="mt-2 text-3xl font-bold text-ink">{metrics.humanTrialCount.toLocaleString()}</p>
+        </div>
+        <div className="card-premium p-5">
+          <p className="eyebrow-label">Mixed/discordant study entities</p>
+          <p className="mt-2 text-3xl font-bold text-ink">{metrics.disagreementStudyCount.toLocaleString()}</p>
+        </div>
       </section>
 
-      <section className="card-premium p-6 sm:p-8">
-        <p className="eyebrow-label">How this supports page quality</p>
-        <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
-          Better citation reading makes better educational pages.
-        </h2>
-        <p className="mt-3 max-w-3xl text-sm leading-7 text-muted">
-          Search traffic is only useful if the page earns trust after the click. The citation workflow keeps
-          high-intent pages from sounding like product copy: stronger phrases need stronger evidence layers,
-          and uncertain findings should be labeled as uncertain.
+      <section className="rounded-2xl border border-brand-900/10 bg-brand-50/60 p-5 text-sm leading-7 text-muted">
+        <strong className="text-ink">Scope note:</strong> This explorer is generated from currently indexable runtime
+        records. A missing study is not evidence that no study exists, and missing structured safety data is not a
+        declaration of safety. Use the correction pathway to flag a missing or misclassified source.
+        <Link href="/info/corrections/" className="ml-1 font-semibold text-brand-700 hover:underline">Submit a correction →</Link>
+      </section>
+
+      <CitationExplorerClient studies={dataset.studies} />
+
+      <section className="rounded-[2rem] border border-brand-900/10 bg-white p-6 shadow-sm sm:p-8">
+        <p className="eyebrow-label">Dataset citation</p>
+        <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">Cite this evidence dataset</h2>
+        <p className="mt-3 max-w-4xl rounded-xl bg-brand-50/60 p-4 font-mono text-xs leading-6 text-ink">{dataset.citationText}</p>
+        <p className="mt-3 text-sm leading-7 text-muted">
+          Stable study IDs prefer PMID, then DOI, then source URL, then a normalized title fallback. Ingredient
+          relationships are represented separately from study identity so the same paper can support one context
+          while remaining mixed or background evidence in another.
         </p>
-        <div className="mt-5 flex flex-wrap gap-3">
-          <Link href="/learn/product-quality/" className="chip-readable hover:bg-white transition">Product-quality guide</Link>
-          <Link href="/learn/interactions/" className="chip-readable hover:bg-white transition">Interaction framework</Link>
-          <Link href="/evidence/evidence-checker/" className="chip-readable hover:bg-white transition">Evidence checker</Link>
-        </div>
       </section>
 
       <section className="rounded-2xl border border-brand-900/10 bg-white/90 p-6 shadow-sm">
         <h2 className="text-2xl font-semibold tracking-tight text-ink">FAQ</h2>
         <div className="mt-4 grid gap-4">
-          {faqItems.map((item) => (
+          {faqItems.map(item => (
             <article key={item.question} className="rounded-2xl border border-brand-900/10 bg-brand-50/40 p-4">
               <h3 className="font-bold text-ink">{item.question}</h3>
               <p className="mt-2 text-sm leading-7 text-muted">{item.answer}</p>

--- a/components/ui/ShowMeTheStudies.tsx
+++ b/components/ui/ShowMeTheStudies.tsx
@@ -230,6 +230,14 @@ export default function ShowMeTheStudies({
   const participantLabel = metrics.studiesWithParticipantCounts > 0
     ? `~${metrics.approximateParticipants.toLocaleString()} participants across ${metrics.studiesWithParticipantCounts} human sources with reported N`
     : 'Participant totals not consistently reported'
+  const namedExtracts = [...new Set(studies.map(study => study.extractName).filter((value): value is string => Boolean(value)))]
+  const evidenceSnapshot = conclusion || [
+    `This evidence table contains ${metrics.totalStudies} structured source${metrics.totalStudies === 1 ? '' : 's'}, including ${metrics.humanTrials} human trial${metrics.humanTrials === 1 ? '' : 's'}.`,
+    metrics.studiesWithParticipantCounts > 0
+      ? `Across ${metrics.studiesWithParticipantCounts} human source${metrics.studiesWithParticipantCounts === 1 ? '' : 's'} with a reported sample size, the approximate participant total is ${metrics.approximateParticipants.toLocaleString()}; overlapping publications may include some of the same people.`
+      : 'A reliable total participant count cannot be calculated because sample size is not consistently structured in the cited sources.',
+    `The structured evidence direction is ${evidenceConsistencyLabel(metrics.consistency).toLowerCase()}: ${metrics.supportive} supporting, ${metrics.mixed} mixed, ${metrics.contradicting} contradicting, and ${metrics.noClearEffect} no-clear-effect source${metrics.totalStudies === 1 ? '' : 's'}.`,
+  ].join(' ')
 
   return (
     <details className="group/studies overflow-hidden rounded-2xl border-2 border-brand-900/10 bg-[var(--surface-card)] p-0 shadow-none backdrop-blur-none dark:border-white/10">
@@ -243,28 +251,28 @@ export default function ShowMeTheStudies({
         <span aria-hidden="true" className="shrink-0 text-brand-500 transition-transform group-open/studies:rotate-180">v</span>
       </summary>
 
-      {(conclusion || evidenceGrade || confidence || whatWouldChangeConclusion) ? (
-        <div className="grid gap-3 border-t border-brand-900/10 bg-white/80 p-4 md:grid-cols-2 dark:border-white/10 dark:bg-white/5">
-          <div className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
-            <p className="text-[10px] font-bold uppercase tracking-[0.12em] text-brand-700">Why we believe this</p>
-            {conclusion ? <p className="mt-2 text-sm leading-6 text-ink">{conclusion}</p> : null}
-            <p className="mt-2 text-xs leading-5 text-muted">
-              {metrics.supportive} supporting · {metrics.mixed} mixed · {metrics.contradicting} contradicting · {metrics.noClearEffect} no-clear-effect sources.
+      <div className="grid gap-3 border-t border-brand-900/10 bg-white/80 p-4 md:grid-cols-2 dark:border-white/10 dark:bg-white/5">
+        <div className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+          <p className="text-[10px] font-bold uppercase tracking-[0.12em] text-brand-700">What the evidence actually shows</p>
+          <p className="mt-2 text-sm leading-6 text-ink">{evidenceSnapshot}</p>
+          {namedExtracts.length > 0 ? (
+            <p className="mt-2 text-xs leading-5 text-amber-900">
+              <strong>Form limitation:</strong> Some findings concern named preparations ({namedExtracts.slice(0, 3).join(', ')}{namedExtracts.length > 3 ? ', …' : ''}); those results should not automatically be generalized to every product sold under the ingredient name.
             </p>
-            {(evidenceGrade || confidence) ? (
-              <p className="mt-2 text-xs font-semibold text-ink">
-                {evidenceGrade ? `Evidence grade: ${evidenceGrade}` : ''}{evidenceGrade && confidence ? ' · ' : ''}{confidence ? `Confidence: ${confidence}` : ''}
-              </p>
-            ) : null}
-          </div>
-          <div className="rounded-xl border border-brand-900/10 bg-white p-4 dark:bg-white/5">
-            <p className="text-[10px] font-bold uppercase tracking-[0.12em] text-brand-700">What would change our conclusion?</p>
-            <p className="mt-2 text-sm leading-6 text-muted">
-              {whatWouldChangeConclusion || 'Larger, well-controlled human trials using comparable populations, doses, preparations, and clinically meaningful outcomes could materially strengthen or weaken this conclusion.'}
-            </p>
-          </div>
+          ) : null}
+          <p className="mt-2 text-xs font-semibold text-ink">
+            {evidenceGrade ? `Evidence grade: ${evidenceGrade}` : 'Evidence grade: use the profile grade shown above'}
+            {' · '}
+            {confidence ? `Confidence: ${confidence}` : 'Confidence: not separately assigned'}
+          </p>
         </div>
-      ) : null}
+        <div className="rounded-xl border border-brand-900/10 bg-white p-4 dark:bg-white/5">
+          <p className="text-[10px] font-bold uppercase tracking-[0.12em] text-brand-700">What would change our conclusion?</p>
+          <p className="mt-2 text-sm leading-6 text-muted">
+            {whatWouldChangeConclusion || 'Larger, well-controlled human trials using comparable populations, doses, preparations, and clinically meaningful outcomes could materially strengthen or weaken this conclusion. A replicated result in a different population or a high-quality synthesis resolving current disagreement would also materially change confidence.'}
+          </p>
+        </div>
+      </div>
 
       <div className="overflow-x-auto border-t border-brand-900/10 dark:border-white/10">
         <table className="w-full min-w-[1500px] border-collapse text-left text-sm">

--- a/components/ui/ShowMeTheStudies.tsx
+++ b/components/ui/ShowMeTheStudies.tsx
@@ -1,7 +1,12 @@
+'use client'
+
+import { useMemo, useState } from 'react'
 import {
   evidenceConsistencyLabel,
   evidenceRelationshipLabel,
   evidenceSourceUrl,
+  evidenceStudyClassDefinition,
+  filterEvidenceStudiesByClass,
   formatEvidenceStudyClass,
   normalizeEvidenceStudyClass,
   summarizeEvidenceStudies,
@@ -32,6 +37,12 @@ export interface Citation {
   relationship?: EvidenceRelationship
   confidence?: EvidenceConfidence
   statisticalConsistency?: string
+  effectSize?: string
+  confidenceInterval?: string
+  statisticalSignificance?: string
+  absoluteDifference?: string
+  clinicalMagnitude?: string
+  replication?: string
   extractName?: string
   ingredients?: string[]
   conditions?: string[]
@@ -61,6 +72,8 @@ const STUDY_CLASS_ORDER: EvidenceStudyClass[] = [
 ]
 const VISIBLE_ROWS = 6
 
+type StudyClassFilter = 'all' | EvidenceStudyClass
+
 function normalizedStudy(citation: Citation): EvidenceStudyRecord {
   const evidenceClass = citation.evidenceClass || normalizeEvidenceStudyClass(citation.studyType)
   return {
@@ -84,6 +97,12 @@ function normalizedStudy(citation: Citation): EvidenceStudyRecord {
     relationship: citation.relationship || 'background',
     confidence: citation.confidence || 'unknown',
     statisticalConsistency: citation.statisticalConsistency,
+    effectSize: citation.effectSize,
+    confidenceInterval: citation.confidenceInterval,
+    statisticalSignificance: citation.statisticalSignificance,
+    absoluteDifference: citation.absoluteDifference,
+    clinicalMagnitude: citation.clinicalMagnitude,
+    replication: citation.replication,
     extractName: citation.extractName,
     ingredients: citation.ingredients,
     conditions: citation.conditions,
@@ -148,8 +167,36 @@ function previewText(study: EvidenceStudyRecord) {
     study.duration && `Duration: ${study.duration}`,
     study.outcome && `Outcome: ${study.outcome}`,
     study.result && `Result: ${study.result}`,
+    study.effectSize && `Effect size: ${study.effectSize}`,
+    study.confidenceInterval && `CI: ${study.confidenceInterval}`,
+    study.clinicalMagnitude && `Magnitude: ${study.clinicalMagnitude}`,
+    study.replication && `Replication: ${study.replication}`,
     study.limitation && `Limitation: ${study.limitation}`,
   ].filter(Boolean).join(' • ')
+}
+
+function QuantitativeContext({ study }: { study: EvidenceStudyRecord }) {
+  const rows = [
+    study.effectSize && ['Effect size', study.effectSize],
+    study.confidenceInterval && ['Confidence interval', study.confidenceInterval],
+    study.absoluteDifference && ['Absolute difference', study.absoluteDifference],
+    study.statisticalSignificance && ['Statistical significance', study.statisticalSignificance],
+    study.clinicalMagnitude && ['Magnitude', study.clinicalMagnitude],
+    study.replication && ['Replication', study.replication],
+  ].filter((row): row is [string, string] => Boolean(row))
+
+  if (!rows.length) return null
+
+  return (
+    <dl className="mt-2 space-y-1 border-t border-brand-900/10 pt-2 text-[10px] leading-4 text-muted dark:border-white/10">
+      {rows.map(([label, value]) => (
+        <div key={label} className="flex gap-1.5">
+          <dt className="font-semibold text-ink">{label}:</dt>
+          <dd>{value}</dd>
+        </div>
+      ))}
+    </dl>
+  )
 }
 
 function StudyRow({ study, index }: { study: EvidenceStudyRecord; index: number }) {
@@ -186,7 +233,12 @@ function StudyRow({ study, index }: { study: EvidenceStudyRecord; index: number 
           <p className="mt-2 text-[11px] leading-5 text-muted"><strong>Limitation:</strong> {study.limitation}</p>
         ) : null}
       </td>
-      <td className="min-w-[170px] px-3 py-3 align-top sm:px-4"><StudyTypeBadge study={study} /></td>
+      <td className="min-w-[190px] px-3 py-3 align-top sm:px-4">
+        <StudyTypeBadge study={study} />
+        <p className="mt-2 max-w-[250px] text-[10px] leading-4 text-muted">
+          {evidenceStudyClassDefinition(study.evidenceClass).plainEnglish}
+        </p>
+      </td>
       <td className="whitespace-nowrap px-3 py-3 align-top text-[12px] text-muted sm:px-4">
         {study.sampleSize ? `n=${study.sampleSize}` : '—'}
       </td>
@@ -194,9 +246,10 @@ function StudyRow({ study, index }: { study: EvidenceStudyRecord; index: number 
       <td className="min-w-[130px] px-3 py-3 align-top text-[12px] leading-5 text-muted sm:px-4">{study.duration || '—'}</td>
       <td className="min-w-[190px] px-3 py-3 align-top text-[12px] leading-5 text-muted sm:px-4">{study.population || '—'}</td>
       <td className="min-w-[180px] px-3 py-3 align-top text-[12px] leading-5 text-muted sm:px-4">{study.outcome || '—'}</td>
-      <td className="min-w-[200px] px-3 py-3 align-top text-[12px] leading-5 text-muted sm:px-4">
+      <td className="min-w-[240px] px-3 py-3 align-top text-[12px] leading-5 text-muted sm:px-4">
         {study.result || '—'}
         {study.statisticalConsistency ? <p className="mt-1 text-[10px] text-muted">{study.statisticalConsistency}</p> : null}
+        <QuantitativeContext study={study} />
       </td>
       <td className="px-3 py-3 text-right align-top sm:px-4">
         {sourceUrl ? (
@@ -221,23 +274,30 @@ export default function ShowMeTheStudies({
   confidence,
   whatWouldChangeConclusion,
 }: Props) {
+  const [activeClass, setActiveClass] = useState<StudyClassFilter>('all')
+
+  const studies = useMemo(
+    () => (citations || []).map(normalizedStudy).sort(sortByStudyType),
+    [citations],
+  )
+  const metrics = useMemo(() => summarizeEvidenceStudies(studies), [studies])
+  const classCounts = useMemo(() => {
+    const counts = new Map<EvidenceStudyClass, number>()
+    for (const study of studies) counts.set(study.evidenceClass, (counts.get(study.evidenceClass) || 0) + 1)
+    return counts
+  }, [studies])
+  const availableClasses = STUDY_CLASS_ORDER.filter((studyClass) => classCounts.has(studyClass))
+  const filteredStudies = activeClass === 'all'
+    ? studies
+    : filterEvidenceStudiesByClass(studies, [activeClass])
+  const visible = filteredStudies.slice(0, VISIBLE_ROWS)
+  const overflow = filteredStudies.slice(VISIBLE_ROWS)
+
   if (!citations || citations.length === 0) return null
 
-  const studies = citations.map(normalizedStudy).sort(sortByStudyType)
-  const metrics = summarizeEvidenceStudies(studies)
-  const visible = studies.slice(0, VISIBLE_ROWS)
-  const overflow = studies.slice(VISIBLE_ROWS)
   const participantLabel = metrics.studiesWithParticipantCounts > 0
     ? `~${metrics.approximateParticipants.toLocaleString()} participants across ${metrics.studiesWithParticipantCounts} human sources with reported N`
     : 'Participant totals not consistently reported'
-  const namedExtracts = [...new Set(studies.map(study => study.extractName).filter((value): value is string => Boolean(value)))]
-  const evidenceSnapshot = conclusion || [
-    `This evidence table contains ${metrics.totalStudies} structured source${metrics.totalStudies === 1 ? '' : 's'}, including ${metrics.humanTrials} human trial${metrics.humanTrials === 1 ? '' : 's'}.`,
-    metrics.studiesWithParticipantCounts > 0
-      ? `Across ${metrics.studiesWithParticipantCounts} human source${metrics.studiesWithParticipantCounts === 1 ? '' : 's'} with a reported sample size, the approximate participant total is ${metrics.approximateParticipants.toLocaleString()}; overlapping publications may include some of the same people.`
-      : 'A reliable total participant count cannot be calculated because sample size is not consistently structured in the cited sources.',
-    `The structured evidence direction is ${evidenceConsistencyLabel(metrics.consistency).toLowerCase()}: ${metrics.supportive} supporting, ${metrics.mixed} mixed, ${metrics.contradicting} contradicting, and ${metrics.noClearEffect} no-clear-effect source${metrics.totalStudies === 1 ? '' : 's'}.`,
-  ].join(' ')
 
   return (
     <details className="group/studies overflow-hidden rounded-2xl border-2 border-brand-900/10 bg-[var(--surface-card)] p-0 shadow-none backdrop-blur-none dark:border-white/10">
@@ -251,31 +311,61 @@ export default function ShowMeTheStudies({
         <span aria-hidden="true" className="shrink-0 text-brand-500 transition-transform group-open/studies:rotate-180">v</span>
       </summary>
 
-      <div className="grid gap-3 border-t border-brand-900/10 bg-white/80 p-4 md:grid-cols-2 dark:border-white/10 dark:bg-white/5">
-        <div className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
-          <p className="text-[10px] font-bold uppercase tracking-[0.12em] text-brand-700">What the evidence actually shows</p>
-          <p className="mt-2 text-sm leading-6 text-ink">{evidenceSnapshot}</p>
-          {namedExtracts.length > 0 ? (
-            <p className="mt-2 text-xs leading-5 text-amber-900">
-              <strong>Form limitation:</strong> Some findings concern named preparations ({namedExtracts.slice(0, 3).join(', ')}{namedExtracts.length > 3 ? ', …' : ''}); those results should not automatically be generalized to every product sold under the ingredient name.
+      {availableClasses.length > 1 ? (
+        <div className="border-t border-brand-900/10 bg-white/70 px-4 py-3 dark:border-white/10 dark:bg-white/5">
+          <p className="text-[10px] font-bold uppercase tracking-[0.12em] text-muted">Filter by study class</p>
+          <div className="mt-2 flex flex-wrap gap-2" role="group" aria-label="Filter evidence by study class">
+            <button
+              type="button"
+              aria-pressed={activeClass === 'all'}
+              onClick={() => setActiveClass('all')}
+              className="rounded-full border border-brand-900/15 px-3 py-1 text-xs font-semibold text-ink aria-pressed:bg-brand-700 aria-pressed:text-white dark:border-white/15"
+            >
+              All ({studies.length})
+            </button>
+            {availableClasses.map((studyClass) => (
+              <button
+                key={studyClass}
+                type="button"
+                aria-pressed={activeClass === studyClass}
+                onClick={() => setActiveClass(studyClass)}
+                className="rounded-full border border-brand-900/15 px-3 py-1 text-xs font-semibold text-ink aria-pressed:bg-brand-700 aria-pressed:text-white dark:border-white/15"
+              >
+                {formatEvidenceStudyClass(studyClass)} ({classCounts.get(studyClass)})
+              </button>
+            ))}
+          </div>
+          <p className="mt-2 text-[11px] text-muted" aria-live="polite">
+            Showing {filteredStudies.length} of {studies.length} studies.
+          </p>
+        </div>
+      ) : null}
+
+      {(conclusion || evidenceGrade || confidence || whatWouldChangeConclusion) ? (
+        <div className="grid gap-3 border-t border-brand-900/10 bg-white/80 p-4 md:grid-cols-2 dark:border-white/10 dark:bg-white/5">
+          <div className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+            <p className="text-[10px] font-bold uppercase tracking-[0.12em] text-brand-700">Why we believe this</p>
+            {conclusion ? <p className="mt-2 text-sm leading-6 text-ink">{conclusion}</p> : null}
+            <p className="mt-2 text-xs leading-5 text-muted">
+              {metrics.supportive} supporting · {metrics.mixed} mixed · {metrics.contradicting} contradicting · {metrics.noClearEffect} no-clear-effect sources.
             </p>
-          ) : null}
-          <p className="mt-2 text-xs font-semibold text-ink">
-            {evidenceGrade ? `Evidence grade: ${evidenceGrade}` : 'Evidence grade: use the profile grade shown above'}
-            {' · '}
-            {confidence ? `Confidence: ${confidence}` : 'Confidence: not separately assigned'}
-          </p>
+            {(evidenceGrade || confidence) ? (
+              <p className="mt-2 text-xs font-semibold text-ink">
+                {evidenceGrade ? `Evidence grade: ${evidenceGrade}` : ''}{evidenceGrade && confidence ? ' · ' : ''}{confidence ? `Confidence: ${confidence}` : ''}
+              </p>
+            ) : null}
+          </div>
+          <div className="rounded-xl border border-brand-900/10 bg-white p-4 dark:bg-white/5">
+            <p className="text-[10px] font-bold uppercase tracking-[0.12em] text-brand-700">What would change our conclusion?</p>
+            <p className="mt-2 text-sm leading-6 text-muted">
+              {whatWouldChangeConclusion || 'Larger, well-controlled human trials using comparable populations, doses, preparations, and clinically meaningful outcomes could materially strengthen or weaken this conclusion.'}
+            </p>
+          </div>
         </div>
-        <div className="rounded-xl border border-brand-900/10 bg-white p-4 dark:bg-white/5">
-          <p className="text-[10px] font-bold uppercase tracking-[0.12em] text-brand-700">What would change our conclusion?</p>
-          <p className="mt-2 text-sm leading-6 text-muted">
-            {whatWouldChangeConclusion || 'Larger, well-controlled human trials using comparable populations, doses, preparations, and clinically meaningful outcomes could materially strengthen or weaken this conclusion. A replicated result in a different population or a high-quality synthesis resolving current disagreement would also materially change confidence.'}
-          </p>
-        </div>
-      </div>
+      ) : null}
 
       <div className="overflow-x-auto border-t border-brand-900/10 dark:border-white/10">
-        <table className="w-full min-w-[1500px] border-collapse text-left text-sm">
+        <table className="w-full min-w-[1600px] border-collapse text-left text-sm">
           <thead>
             <tr className="bg-[var(--surface-card)] text-[10px] font-bold uppercase tracking-wider text-muted">
               <th className="px-3 py-2 sm:px-4">Study</th>
@@ -285,7 +375,7 @@ export default function ShowMeTheStudies({
               <th className="px-3 py-2 sm:px-4">Duration</th>
               <th className="px-3 py-2 sm:px-4">Population</th>
               <th className="px-3 py-2 sm:px-4">Outcome</th>
-              <th className="px-3 py-2 sm:px-4">Result</th>
+              <th className="px-3 py-2 sm:px-4">Result &amp; magnitude</th>
               <th className="px-3 py-2 text-right sm:px-4">Source</th>
             </tr>
           </thead>
@@ -302,7 +392,7 @@ export default function ShowMeTheStudies({
             Show {overflow.length} more stud{overflow.length === 1 ? 'y' : 'ies'}
           </summary>
           <div className="overflow-x-auto">
-            <table className="w-full min-w-[1500px] border-collapse text-left text-sm">
+            <table className="w-full min-w-[1600px] border-collapse text-left text-sm">
               <tbody>
                 {overflow.map((study, index) => <StudyRow key={citationKey(study, index)} study={study} index={index} />)}
               </tbody>

--- a/data/editorial/evidence-grade-history.ts
+++ b/data/editorial/evidence-grade-history.ts
@@ -1,0 +1,24 @@
+export type EvidenceGradeChange = {
+  id: string
+  ingredientSlug: string
+  ingredientName: string
+  ingredientPath: string
+  changedAt: string
+  quarter: string
+  fromGrade: string
+  toGrade: string
+  reason: string
+  sourceIds?: string[]
+}
+
+/**
+ * Append-only public evidence-grade change ledger.
+ *
+ * New grade changes should be added as new events with a reason and, when
+ * available, the study/source IDs that changed the conclusion. Historical
+ * events should not be rewritten merely to simplify the current narrative.
+ *
+ * The initial empty state is deliberate: do not fabricate historical C→B or
+ * B→A events that were not actually recorded at the time of review.
+ */
+export const evidenceGradeHistory: EvidenceGradeChange[] = []

--- a/data/research/evidence-dataset-changelog.ts
+++ b/data/research/evidence-dataset-changelog.ts
@@ -1,0 +1,15 @@
+export type EvidenceDatasetRelease = {
+  version: string
+  date: string
+  summary: string
+  schemaVersion: number
+}
+
+export const evidenceDatasetChangelog: EvidenceDatasetRelease[] = [
+  {
+    version: '2026.08.15',
+    date: '2026-08-15',
+    schemaVersion: 1,
+    summary: 'Initial normalized public dataset release with stable study IDs, study classes, ingredient relationships, evidence direction labels, study-level metadata, aggregate report metrics, and CSV/JSON exports.',
+  },
+]

--- a/lib/__tests__/public-evidence-dataset.test.ts
+++ b/lib/__tests__/public-evidence-dataset.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildPublicEvidenceDatasetFromRecords,
+  publicEvidenceDatasetToCsv,
+} from '@/lib/public-evidence-dataset'
+import type { RuntimeRecord } from '@/src/types/content'
+
+function record(overrides: Partial<RuntimeRecord>): RuntimeRecord {
+  return {
+    slug: 'example',
+    name: 'Example',
+    indexability_status: 'PUBLISH',
+    evidence_grade: 'B',
+    summary_quality: 'strong',
+    profile_status: 'complete',
+    ...overrides,
+  } as RuntimeRecord
+}
+
+describe('public evidence dataset', () => {
+  it('deduplicates a PMID into one study entity while preserving ingredient relationships', () => {
+    const dataset = buildPublicEvidenceDatasetFromRecords([
+      {
+        type: 'herb',
+        record: record({
+          slug: 'alpha',
+          name: 'Alpha',
+          sources: [{
+            title: 'Shared human trial',
+            pmid: '12345678',
+            study_type: 'randomized controlled trial',
+            n: 120,
+            relationship: 'supports',
+            outcome: 'Stress score',
+          }],
+        }),
+      },
+      {
+        type: 'compound',
+        record: record({
+          slug: 'beta',
+          name: 'Beta',
+          evidence_grade: 'C',
+          sources: [{
+            title: 'Shared human trial',
+            pmid: '12345678',
+            study_type: 'randomized controlled trial',
+            n: 120,
+            relationship: 'contradicts',
+            outcome: 'Stress score',
+          }],
+        }),
+      },
+    ])
+
+    expect(dataset.studies).toHaveLength(1)
+    expect(dataset.studies[0].id).toBe('pmid:12345678')
+    expect(dataset.studies[0].relationships).toHaveLength(2)
+    expect(dataset.studies[0].relationshipSummary).toBe('mixed')
+    expect(dataset.metrics.disagreementStudyCount).toBe(1)
+    expect(dataset.metrics.humanTrialCount).toBe(1)
+  })
+
+  it('excludes non-indexable records from the public dataset', () => {
+    const dataset = buildPublicEvidenceDatasetFromRecords([
+      { type: 'herb', record: record({ slug: 'public', indexability_status: 'PUBLISH' }) },
+      { type: 'herb', record: record({ slug: 'private', indexability_status: 'NOINDEX' }) },
+    ])
+
+    expect(dataset.ingredients.map(item => item.slug)).toEqual(['public'])
+  })
+
+  it('keeps explicit safety cautions and canonical grades in aggregate metrics', () => {
+    const dataset = buildPublicEvidenceDatasetFromRecords([
+      { type: 'herb', record: record({ slug: 'a', evidence_grade: 'A', contraindications: ['Pregnancy'] }) },
+      { type: 'compound', record: record({ slug: 'd', evidence_grade: 'D' }) },
+    ])
+
+    expect(dataset.metrics.strongOrModerateIngredients).toBe(1)
+    expect(dataset.metrics.preliminaryOrInsufficientIngredients).toBe(1)
+    expect(dataset.metrics.ingredientsWithSafetyCautions).toBe(1)
+  })
+
+  it('exports structured study relationships to CSV without losing stable IDs', () => {
+    const dataset = buildPublicEvidenceDatasetFromRecords([
+      {
+        type: 'herb',
+        record: record({
+          slug: 'alpha',
+          name: 'Alpha',
+          sources: [{ title: 'Trial, with comma', doi: '10.1000/example', relationship: 'supports' }],
+        }),
+      },
+    ])
+
+    const csv = publicEvidenceDatasetToCsv(dataset)
+    expect(csv).toContain('study_id,title')
+    expect(csv).toContain('doi:10.1000/example')
+    expect(csv).toContain('"Trial, with comma"')
+    expect(csv).toContain('alpha')
+  })
+})

--- a/lib/evidence-study.ts
+++ b/lib/evidence-study.ts
@@ -41,10 +41,92 @@ export type EvidenceStudyRecord = {
   relationship: EvidenceRelationship
   confidence: EvidenceConfidence
   statisticalConsistency?: string
+  effectSize?: string
+  confidenceInterval?: string
+  statisticalSignificance?: string
+  absoluteDifference?: string
+  clinicalMagnitude?: string
+  replication?: string
   extractName?: string
   ingredients?: string[]
   conditions?: string[]
   safetyOutcome?: string
+}
+
+export type EvidenceStudyClassDefinition = {
+  label: string
+  hierarchyRank: number
+  plainEnglish: string
+  humanEvidence: boolean
+}
+
+export const EVIDENCE_STUDY_CLASS_DEFINITIONS: Record<EvidenceStudyClass, EvidenceStudyClassDefinition> = {
+  meta_analysis: {
+    label: 'Meta-analysis',
+    hierarchyRank: 11,
+    plainEnglish: 'Statistically combines results from multiple eligible studies; confidence still depends on the quality, consistency, and directness of those studies.',
+    humanEvidence: true,
+  },
+  systematic_review: {
+    label: 'Systematic review',
+    hierarchyRank: 10,
+    plainEnglish: 'Uses a predefined method to find and evaluate relevant studies, but may or may not pool their results statistically.',
+    humanEvidence: true,
+  },
+  randomized_controlled_trial: {
+    label: 'Randomized controlled trial',
+    hierarchyRank: 9,
+    plainEnglish: 'Randomly assigns participants to interventions or controls, reducing many sources of bias when the trial is conducted well.',
+    humanEvidence: true,
+  },
+  controlled_trial: {
+    label: 'Controlled trial',
+    hierarchyRank: 8,
+    plainEnglish: 'Compares an intervention with a control group but may lack random assignment or other safeguards of a strong randomized trial.',
+    humanEvidence: true,
+  },
+  observational: {
+    label: 'Observational research',
+    hierarchyRank: 7,
+    plainEnglish: 'Observes real-world associations without assigning treatment, so confounding can limit causal conclusions.',
+    humanEvidence: true,
+  },
+  narrative_review: {
+    label: 'Narrative review',
+    hierarchyRank: 6,
+    plainEnglish: 'Summarizes selected literature without the full prespecified search and selection methods of a systematic review.',
+    humanEvidence: false,
+  },
+  case_report: {
+    label: 'Case report',
+    hierarchyRank: 5,
+    plainEnglish: 'Describes one person or a very small series and can identify signals, but cannot establish typical effects or causality.',
+    humanEvidence: true,
+  },
+  mechanistic: {
+    label: 'Mechanistic research',
+    hierarchyRank: 4,
+    plainEnglish: 'Studies biological pathways or mechanisms. It can explain plausibility but does not by itself establish a clinical benefit.',
+    humanEvidence: false,
+  },
+  animal: {
+    label: 'Animal research',
+    hierarchyRank: 3,
+    plainEnglish: 'Tests effects in non-human animals. Useful for hypotheses and safety signals, but results may not translate to people.',
+    humanEvidence: false,
+  },
+  in_vitro: {
+    label: 'In-vitro research',
+    hierarchyRank: 2,
+    plainEnglish: 'Studies cells, tissues, or biochemical systems outside a living person. It is preclinical evidence, not proof of a human outcome.',
+    humanEvidence: false,
+  },
+  other: {
+    label: 'Other / unclear',
+    hierarchyRank: 1,
+    plainEnglish: 'The study design is not yet classified clearly enough to infer its place in the evidence hierarchy.',
+    humanEvidence: false,
+  },
 }
 
 const HUMAN_CLASSES = new Set<EvidenceStudyClass>([
@@ -88,20 +170,25 @@ export function normalizeEvidenceStudyClass(value: unknown): EvidenceStudyClass 
 }
 
 export function formatEvidenceStudyClass(value: EvidenceStudyClass): string {
-  const labels: Record<EvidenceStudyClass, string> = {
-    meta_analysis: 'Meta-analysis',
-    systematic_review: 'Systematic review',
-    randomized_controlled_trial: 'Randomized controlled trial',
-    controlled_trial: 'Controlled trial',
-    observational: 'Observational research',
-    case_report: 'Case report',
-    animal: 'Animal research',
-    in_vitro: 'In-vitro research',
-    mechanistic: 'Mechanistic research',
-    narrative_review: 'Narrative review',
-    other: 'Other / unclear',
-  }
-  return labels[value]
+  return EVIDENCE_STUDY_CLASS_DEFINITIONS[value].label
+}
+
+export function evidenceStudyClassDefinition(value: EvidenceStudyClass): EvidenceStudyClassDefinition {
+  return EVIDENCE_STUDY_CLASS_DEFINITIONS[value]
+}
+
+export function rankEvidenceStudyClasses(classes: EvidenceStudyClass[]): EvidenceStudyClass[] {
+  return [...classes].sort(
+    (a, b) => EVIDENCE_STUDY_CLASS_DEFINITIONS[b].hierarchyRank - EVIDENCE_STUDY_CLASS_DEFINITIONS[a].hierarchyRank,
+  )
+}
+
+export function filterEvidenceStudiesByClass<T extends { evidenceClass: EvidenceStudyClass }>(
+  studies: T[],
+  allowed: EvidenceStudyClass[] | Set<EvidenceStudyClass>,
+): T[] {
+  const wanted = allowed instanceof Set ? allowed : new Set(allowed)
+  return studies.filter((study) => wanted.has(study.evidenceClass))
 }
 
 export function normalizeEvidenceRelationship(value: unknown): EvidenceRelationship {
@@ -179,6 +266,77 @@ export function evidenceRelationshipLabel(value: EvidenceRelationship): string {
     background: 'Background',
   }
   return labels[value]
+}
+
+export type EvidenceEffectContext = Pick<
+  EvidenceStudyRecord,
+  | 'effectSize'
+  | 'confidenceInterval'
+  | 'statisticalSignificance'
+  | 'absoluteDifference'
+  | 'clinicalMagnitude'
+  | 'duration'
+  | 'population'
+  | 'replication'
+>
+
+export type EvidenceEffectContextIssue = {
+  code:
+    | 'p-value-without-effect-size'
+    | 'p-value-without-magnitude-context'
+    | 'effect-size-without-uncertainty'
+    | 'missing-duration-context'
+    | 'missing-population-context'
+    | 'missing-replication-context'
+  message: string
+}
+
+export function validateEvidenceEffectContext(context: EvidenceEffectContext): EvidenceEffectContextIssue[] {
+  const issues: EvidenceEffectContextIssue[] = []
+
+  if (context.statisticalSignificance && !context.effectSize && !context.absoluteDifference) {
+    issues.push({
+      code: 'p-value-without-effect-size',
+      message: 'Statistical significance must not stand alone; include an effect size or absolute difference when the source reports one.',
+    })
+  }
+
+  if (context.statisticalSignificance && !context.clinicalMagnitude) {
+    issues.push({
+      code: 'p-value-without-magnitude-context',
+      message: 'Statistical significance should be accompanied by clinically meaningful magnitude context.',
+    })
+  }
+
+  if (context.effectSize && !context.confidenceInterval) {
+    issues.push({
+      code: 'effect-size-without-uncertainty',
+      message: 'Effect sizes should include a confidence interval when the source reports one.',
+    })
+  }
+
+  if (!context.duration) {
+    issues.push({
+      code: 'missing-duration-context',
+      message: 'Study duration is required to distinguish acute, short-term, and sustained findings.',
+    })
+  }
+
+  if (!context.population) {
+    issues.push({
+      code: 'missing-population-context',
+      message: 'Studied population is required so findings are not generalized beyond the participants actually studied.',
+    })
+  }
+
+  if (!context.replication) {
+    issues.push({
+      code: 'missing-replication-context',
+      message: 'Replication context is required to distinguish one-off findings from repeatedly observed results.',
+    })
+  }
+
+  return issues
 }
 
 export type EvidenceStudyMetrics = {

--- a/lib/public-evidence-dataset.ts
+++ b/lib/public-evidence-dataset.ts
@@ -1,0 +1,468 @@
+import { extractCitationsFromRecord } from '@/lib/citations'
+import { getEvidenceLetterGrade } from '@/lib/evidence'
+import {
+  evidenceStudyId,
+  isHumanEvidenceClass,
+  isHumanTrialClass,
+  normalizeEvidenceConfidence,
+  normalizeEvidenceRelationship,
+  normalizeEvidenceStudyClass,
+  parseSampleSize,
+  summarizeEvidenceStudies,
+  type EvidenceConfidence,
+  type EvidenceRelationship,
+  type EvidenceStudyClass,
+  type EvidenceStudyRecord,
+} from '@/lib/evidence-study'
+import { getRuntimeVisibility } from '@/lib/runtime-visibility'
+import {
+  getCompoundBySlug,
+  getCompounds,
+  getHerbBySlug,
+  getHerbs,
+} from '@/src/lib/runtime-data'
+import type { RuntimeRecord } from '@/src/types/content'
+
+export const PUBLIC_EVIDENCE_DATASET_VERSION = '2026.08.15'
+export const PUBLIC_EVIDENCE_DATASET_TITLE = 'The Hippie Scientist Public Evidence Dataset 2026'
+
+export type PublicEvidenceIngredient = {
+  slug: string
+  name: string
+  type: 'herb' | 'compound'
+  path: string
+  evidenceGrade: string
+  category: string
+  safetyCaution: boolean
+}
+
+export type PublicStudyRelationship = {
+  ingredientSlug: string
+  ingredientName: string
+  ingredientType: 'herb' | 'compound'
+  ingredientPath: string
+  evidenceGrade: string
+  relationship: EvidenceRelationship
+  outcome?: string
+}
+
+export type PublicStudyEntity = {
+  id: string
+  title: string
+  authors?: string
+  journal?: string
+  year?: number | string
+  pmid?: string
+  doi?: string
+  url?: string
+  studyType?: string
+  evidenceClass: EvidenceStudyClass
+  sampleSize?: number | string
+  dose?: string
+  duration?: string
+  population?: string
+  outcome?: string
+  result?: string
+  limitation?: string
+  confidence: EvidenceConfidence
+  statisticalConsistency?: string
+  extractName?: string
+  conditions: string[]
+  safetyOutcome?: string
+  relationships: PublicStudyRelationship[]
+  relationshipSummary: EvidenceRelationship
+}
+
+export type EvidenceCategorySummary = {
+  category: string
+  totalIngredients: number
+  strongOrModerate: number
+  preliminaryOrInsufficient: number
+  humanStudies: number
+  humanTrials: number
+}
+
+export type PublicEvidenceReportMetrics = {
+  ingredientCount: number
+  studyCount: number
+  humanStudyCount: number
+  humanTrialCount: number
+  approximateParticipants: number
+  participantCountCoverage: number
+  strongOrModerateIngredients: number
+  preliminaryOrInsufficientIngredients: number
+  ingredientsWithSafetyCautions: number
+  explicitlyFlaggedClaimOverreach: number
+  supportingRelationships: number
+  mixedRelationships: number
+  contradictingRelationships: number
+  noClearEffectRelationships: number
+  disagreementStudyCount: number
+  gradeDistribution: Array<{ grade: string; count: number; pct: number }>
+  categories: EvidenceCategorySummary[]
+}
+
+export type PublicEvidenceDataset = {
+  schemaVersion: 1
+  datasetVersion: string
+  title: string
+  generatedFrom: 'current indexable runtime records'
+  methodologyPath: '/info/editorial-policy/'
+  citationExplorerPath: '/learn/citation-explorer/'
+  citationText: string
+  ingredients: PublicEvidenceIngredient[]
+  studies: PublicStudyEntity[]
+  metrics: PublicEvidenceReportMetrics
+}
+
+type EntityRecord = {
+  record: RuntimeRecord
+  type: 'herb' | 'compound'
+}
+
+function cleanString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function cleanList(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map(item => cleanString(item)).filter(Boolean)
+  const text = cleanString(value)
+  if (!text) return []
+  return text.split(/[|;,]/).map(item => item.trim()).filter(Boolean)
+}
+
+function entityName(record: RuntimeRecord): string {
+  return (
+    cleanString(record.displayName) ||
+    cleanString(record.name) ||
+    cleanString(record.common) ||
+    cleanString(record.scientific) ||
+    cleanString(record.slug)
+  )
+}
+
+function entityCategory(record: RuntimeRecord): string {
+  return cleanString(record.category_label || record.category || record.class || record.compoundClass) || 'Uncategorized'
+}
+
+function hasSafetyCaution(record: RuntimeRecord): boolean {
+  const text = [
+    ...cleanList(record.safety_flags),
+    ...cleanList(record.safetyNotes),
+    ...cleanList(record.safety_notes),
+    ...cleanList(record.contraindications),
+    ...cleanList(record.interactions),
+    cleanString(record.safetyLevel),
+    cleanString(record.safety_level),
+  ].join(' ').toLowerCase()
+
+  return /\b(avoid|contraindicat|caution|interaction|pregnan|breastfeed|liver|kidney|bleed|sedat|stimul|risk|toxic|monitor)\b/.test(text)
+}
+
+function hasExplicitClaimOverreachFlag(record: RuntimeRecord): boolean {
+  const fields = [
+    record.claim_overreach,
+    record.claimOverreach,
+    record.evidence_language_violation,
+    record.evidenceLanguageViolation,
+    record.marketing_claim_exceeds_evidence,
+    record.marketingClaimExceedsEvidence,
+  ]
+  return fields.some(value => value === true || /^(true|yes|flagged|overreach)$/i.test(cleanString(value)))
+}
+
+function aggregateRelationship(relationships: PublicStudyRelationship[]): EvidenceRelationship {
+  const values = new Set(relationships.map(item => item.relationship))
+  if (values.has('supports') && (values.has('contradicts') || values.has('no_clear_effect'))) return 'mixed'
+  if (values.has('contradicts') && values.has('mixed')) return 'mixed'
+  if (values.has('mixed')) return 'mixed'
+  if (values.has('contradicts')) return 'contradicts'
+  if (values.has('supports')) return 'supports'
+  if (values.has('no_clear_effect')) return 'no_clear_effect'
+  return 'background'
+}
+
+function toStudyRecord(study: PublicStudyEntity): EvidenceStudyRecord {
+  return {
+    id: study.id,
+    title: study.title,
+    authors: study.authors,
+    journal: study.journal,
+    year: study.year,
+    pmid: study.pmid,
+    doi: study.doi,
+    url: study.url,
+    studyType: study.studyType,
+    evidenceClass: study.evidenceClass,
+    sampleSize: study.sampleSize,
+    dose: study.dose,
+    duration: study.duration,
+    population: study.population,
+    outcome: study.outcome,
+    result: study.result,
+    limitation: study.limitation,
+    relationship: study.relationshipSummary,
+    confidence: study.confidence,
+    statisticalConsistency: study.statisticalConsistency,
+    extractName: study.extractName,
+    conditions: study.conditions,
+    safetyOutcome: study.safetyOutcome,
+  }
+}
+
+function mergeStudyField<T>(current: T | undefined, incoming: T | undefined): T | undefined {
+  if (current !== undefined && current !== null && current !== '') return current
+  return incoming
+}
+
+export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]): PublicEvidenceDataset {
+  const ingredients: PublicEvidenceIngredient[] = []
+  const studiesById = new Map<string, PublicStudyEntity>()
+  const gradeCounts = new Map<string, number>()
+  const categoryMap = new Map<string, EvidenceCategorySummary>()
+  let explicitlyFlaggedClaimOverreach = 0
+
+  for (const { record, type } of entities) {
+    if (!record.slug || !getRuntimeVisibility(record).canIndex) continue
+
+    const name = entityName(record)
+    const evidenceGrade = getEvidenceLetterGrade(record)
+    const category = entityCategory(record)
+    const safetyCaution = hasSafetyCaution(record)
+    const path = `/${type === 'herb' ? 'herbs' : 'compounds'}/${record.slug}/`
+
+    ingredients.push({ slug: record.slug, name, type, path, evidenceGrade, category, safetyCaution })
+    gradeCounts.set(evidenceGrade, (gradeCounts.get(evidenceGrade) || 0) + 1)
+    if (hasExplicitClaimOverreachFlag(record)) explicitlyFlaggedClaimOverreach += 1
+
+    const categorySummary = categoryMap.get(category) || {
+      category,
+      totalIngredients: 0,
+      strongOrModerate: 0,
+      preliminaryOrInsufficient: 0,
+      humanStudies: 0,
+      humanTrials: 0,
+    }
+    categorySummary.totalIngredients += 1
+    if (evidenceGrade === 'A' || evidenceGrade === 'B') categorySummary.strongOrModerate += 1
+    if (evidenceGrade === 'C' || evidenceGrade === 'D' || evidenceGrade === 'Avoid/Insufficient') {
+      categorySummary.preliminaryOrInsufficient += 1
+    }
+
+    const citations = extractCitationsFromRecord(record)
+    for (const citation of citations) {
+      const evidenceClass = citation.evidenceClass || normalizeEvidenceStudyClass(citation.studyType)
+      const relationship = normalizeEvidenceRelationship(citation.relationship)
+      const id = citation.id || evidenceStudyId(citation)
+      const conditions = [...new Set([...(citation.conditions || [])].map(item => item.trim()).filter(Boolean))]
+      const relationshipRecord: PublicStudyRelationship = {
+        ingredientSlug: record.slug,
+        ingredientName: name,
+        ingredientType: type,
+        ingredientPath: path,
+        evidenceGrade,
+        relationship,
+        outcome: citation.outcome,
+      }
+
+      const existing = studiesById.get(id)
+      if (!existing) {
+        studiesById.set(id, {
+          id,
+          title: citation.title || id,
+          authors: citation.authors,
+          journal: citation.journal,
+          year: citation.year,
+          pmid: citation.pmid,
+          doi: citation.doi,
+          url: citation.url,
+          studyType: citation.studyType,
+          evidenceClass,
+          sampleSize: citation.sampleSize,
+          dose: citation.dose,
+          duration: citation.duration,
+          population: citation.population,
+          outcome: citation.outcome,
+          result: citation.result,
+          limitation: citation.limitation,
+          confidence: normalizeEvidenceConfidence(citation.confidence),
+          statisticalConsistency: citation.statisticalConsistency,
+          extractName: citation.extractName,
+          conditions,
+          safetyOutcome: citation.safetyOutcome,
+          relationships: [relationshipRecord],
+          relationshipSummary: relationship,
+        })
+      } else {
+        existing.authors = mergeStudyField(existing.authors, citation.authors)
+        existing.journal = mergeStudyField(existing.journal, citation.journal)
+        existing.year = mergeStudyField(existing.year, citation.year)
+        existing.pmid = mergeStudyField(existing.pmid, citation.pmid)
+        existing.doi = mergeStudyField(existing.doi, citation.doi)
+        existing.url = mergeStudyField(existing.url, citation.url)
+        existing.studyType = mergeStudyField(existing.studyType, citation.studyType)
+        existing.sampleSize = mergeStudyField(existing.sampleSize, citation.sampleSize)
+        existing.dose = mergeStudyField(existing.dose, citation.dose)
+        existing.duration = mergeStudyField(existing.duration, citation.duration)
+        existing.population = mergeStudyField(existing.population, citation.population)
+        existing.outcome = mergeStudyField(existing.outcome, citation.outcome)
+        existing.result = mergeStudyField(existing.result, citation.result)
+        existing.limitation = mergeStudyField(existing.limitation, citation.limitation)
+        existing.statisticalConsistency = mergeStudyField(existing.statisticalConsistency, citation.statisticalConsistency)
+        existing.extractName = mergeStudyField(existing.extractName, citation.extractName)
+        existing.safetyOutcome = mergeStudyField(existing.safetyOutcome, citation.safetyOutcome)
+        existing.conditions = [...new Set([...existing.conditions, ...conditions])]
+        if (!existing.relationships.some(item =>
+          item.ingredientSlug === relationshipRecord.ingredientSlug &&
+          item.relationship === relationshipRecord.relationship &&
+          item.outcome === relationshipRecord.outcome,
+        )) {
+          existing.relationships.push(relationshipRecord)
+        }
+        existing.relationshipSummary = aggregateRelationship(existing.relationships)
+      }
+
+      if (isHumanEvidenceClass(evidenceClass)) categorySummary.humanStudies += 1
+      if (isHumanTrialClass(evidenceClass)) categorySummary.humanTrials += 1
+    }
+
+    categoryMap.set(category, categorySummary)
+  }
+
+  const studies = [...studiesById.values()].sort((a, b) => {
+    const yearDiff = Number(b.year || 0) - Number(a.year || 0)
+    if (yearDiff !== 0) return yearDiff
+    return a.title.localeCompare(b.title)
+  })
+  const studyMetrics = summarizeEvidenceStudies(studies.map(toStudyRecord))
+
+  let supportingRelationships = 0
+  let mixedRelationships = 0
+  let contradictingRelationships = 0
+  let noClearEffectRelationships = 0
+  for (const study of studies) {
+    for (const relationship of study.relationships) {
+      if (relationship.relationship === 'supports') supportingRelationships += 1
+      else if (relationship.relationship === 'mixed') mixedRelationships += 1
+      else if (relationship.relationship === 'contradicts') contradictingRelationships += 1
+      else if (relationship.relationship === 'no_clear_effect') noClearEffectRelationships += 1
+    }
+  }
+
+  const gradeOrder = ['A', 'B', 'C', 'D', 'Avoid/Insufficient']
+  const gradeDistribution = gradeOrder.map(grade => {
+    const count = gradeCounts.get(grade) || 0
+    return {
+      grade,
+      count,
+      pct: ingredients.length ? (count / ingredients.length) * 100 : 0,
+    }
+  })
+
+  const categories = [...categoryMap.values()]
+    .sort((a, b) => {
+      const aRate = a.totalIngredients ? a.strongOrModerate / a.totalIngredients : 0
+      const bRate = b.totalIngredients ? b.strongOrModerate / b.totalIngredients : 0
+      return bRate - aRate || b.humanTrials - a.humanTrials || a.category.localeCompare(b.category)
+    })
+
+  const metrics: PublicEvidenceReportMetrics = {
+    ingredientCount: ingredients.length,
+    studyCount: studies.length,
+    humanStudyCount: studyMetrics.humanStudies,
+    humanTrialCount: studyMetrics.humanTrials,
+    approximateParticipants: studyMetrics.approximateParticipants,
+    participantCountCoverage: studyMetrics.studiesWithParticipantCounts,
+    strongOrModerateIngredients: ingredients.filter(item => item.evidenceGrade === 'A' || item.evidenceGrade === 'B').length,
+    preliminaryOrInsufficientIngredients: ingredients.filter(item => item.evidenceGrade === 'C' || item.evidenceGrade === 'D' || item.evidenceGrade === 'Avoid/Insufficient').length,
+    ingredientsWithSafetyCautions: ingredients.filter(item => item.safetyCaution).length,
+    explicitlyFlaggedClaimOverreach,
+    supportingRelationships,
+    mixedRelationships,
+    contradictingRelationships,
+    noClearEffectRelationships,
+    disagreementStudyCount: studies.filter(study => study.relationshipSummary === 'mixed').length,
+    gradeDistribution,
+    categories,
+  }
+
+  return {
+    schemaVersion: 1,
+    datasetVersion: PUBLIC_EVIDENCE_DATASET_VERSION,
+    title: PUBLIC_EVIDENCE_DATASET_TITLE,
+    generatedFrom: 'current indexable runtime records',
+    methodologyPath: '/info/editorial-policy/',
+    citationExplorerPath: '/learn/citation-explorer/',
+    citationText: `The Hippie Scientist. ${PUBLIC_EVIDENCE_DATASET_TITLE}. Version ${PUBLIC_EVIDENCE_DATASET_VERSION}. https://thehippiescientist.net/evidence/evidence-report/`,
+    ingredients: ingredients.sort((a, b) => a.name.localeCompare(b.name)),
+    studies,
+    metrics,
+  }
+}
+
+async function hydrateIndexableRecords(summary: RuntimeRecord[], type: 'herb' | 'compound'): Promise<EntityRecord[]> {
+  const indexable = summary.filter(record => record.slug && getRuntimeVisibility(record).canIndex)
+  const hydrated: EntityRecord[] = []
+  const chunkSize = 32
+
+  for (let index = 0; index < indexable.length; index += chunkSize) {
+    const chunk = indexable.slice(index, index + chunkSize)
+    const detailed = await Promise.all(chunk.map(record =>
+      type === 'herb' ? getHerbBySlug(record.slug) : getCompoundBySlug(record.slug),
+    ))
+    for (let offset = 0; offset < chunk.length; offset += 1) {
+      const record = detailed[offset] || chunk[offset]
+      if (record && getRuntimeVisibility(record).canIndex) hydrated.push({ record, type })
+    }
+  }
+
+  return hydrated
+}
+
+export async function getPublicEvidenceDataset(): Promise<PublicEvidenceDataset> {
+  const [herbs, compounds] = await Promise.all([getHerbs(), getCompounds()])
+  const [herbRecords, compoundRecords] = await Promise.all([
+    hydrateIndexableRecords(herbs, 'herb'),
+    hydrateIndexableRecords(compounds, 'compound'),
+  ])
+  return buildPublicEvidenceDatasetFromRecords([...herbRecords, ...compoundRecords])
+}
+
+function csvEscape(value: unknown): string {
+  const text = value == null ? '' : String(value)
+  return /[",\n\r]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text
+}
+
+export function publicEvidenceDatasetToCsv(dataset: PublicEvidenceDataset): string {
+  const headers = [
+    'study_id', 'title', 'authors', 'journal', 'year', 'pmid', 'doi', 'study_class', 'sample_size',
+    'dose', 'duration', 'population', 'outcome', 'result', 'limitation', 'relationship_summary',
+    'conditions', 'safety_outcome', 'ingredient_slugs', 'ingredient_names', 'ingredient_grades',
+  ]
+
+  const rows = dataset.studies.map(study => [
+    study.id,
+    study.title,
+    study.authors,
+    study.journal,
+    study.year,
+    study.pmid,
+    study.doi,
+    study.evidenceClass,
+    parseSampleSize(study.sampleSize) ?? study.sampleSize,
+    study.dose,
+    study.duration,
+    study.population,
+    study.outcome,
+    study.result,
+    study.limitation,
+    study.relationshipSummary,
+    study.conditions.join('|'),
+    study.safetyOutcome,
+    study.relationships.map(item => item.ingredientSlug).join('|'),
+    study.relationships.map(item => item.ingredientName).join('|'),
+    study.relationships.map(item => item.evidenceGrade).join('|'),
+  ].map(csvEscape).join(','))
+
+  return `${headers.join(',')}\n${rows.join('\n')}\n`
+}


### PR DESCRIPTION
Superseded by smaller fresh-main PRs so the research-data foundation, report UI, and explorer UI can merge independently without overwriting newer concurrent mainline evidence work.