### PR TITLE
fix(compare): keep dynamic visibility fail-closed

### DIFF
--- a/app/guides/compare/dynamic/page.tsx
+++ b/app/guides/compare/dynamic/page.tsx
@@ -43,13 +43,7 @@ function comparisonPayload(record: Record<string, unknown>) {
 
 function renderableComparisonItems(records: Record<string, unknown>[]) {
   return records
-    .filter((record) => {
-      try {
-        return getRuntimeVisibility(record).canRender
-      } catch {
-        return true
-      }
-    })
+    .filter((record) => getRuntimeVisibility(record).canRender)
     .map(comparisonPayload)
     .filter((record) => record.slug && record.name)
 }

--- a/tests/dynamic-compare-visibility-contract.test.ts
+++ b/tests/dynamic-compare-visibility-contract.test.ts
@@ -1,0 +1,24 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+}
+
+describe('dynamic comparison visibility contract', () => {
+  it('delegates fail-closed behavior to the canonical runtime visibility helper', () => {
+    const page = read('app/guides/compare/dynamic/page.tsx')
+
+    expect(page).toContain('.filter((record) => getRuntimeVisibility(record).canRender)')
+    expect(page).not.toMatch(/getRuntimeVisibility\(record\)[\s\S]{0,120}catch[\s\S]{0,80}return true/)
+  })
+
+  it('keeps the interactive comparison page intentionally noindex', () => {
+    const page = read('app/guides/compare/dynamic/page.tsx')
+
+    expect(page).toContain('robots: { index: false, follow: true }')
+    expect(page).toContain('.canRender')
+    expect(page).not.toContain('.canIndex')
+  })
+})


### PR DESCRIPTION
## Root cause
The dynamic comparison page wrapped the canonical `getRuntimeVisibility(record).canRender` policy in a local `try/catch` that returned `true` on error. The visibility helper itself already fails closed, so this caller duplicated governance and encoded the opposite fallback.

## Change
- Remove the fail-open caller wrapper.
- Continue using `canRender`, not `canIndex`, because this interactive comparison page is intentionally `noindex` and may legitimately expose renderable research/archive records.
- Add a focused regression guard that requires direct delegation to the canonical helper and preserves the page's `noindex + canRender` contract.

## Scope
No comparison payload fields, UI, metadata, runtime source data, or eligibility semantics beyond error fallback are changed.