### PR TITLE
ROI 701-710 follow-up: executable competitor content-gap reporting

### DIFF
--- a/scripts/seo/competitor-content-gap-report.ts
+++ b/scripts/seo/competitor-content-gap-report.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env -S npx tsx
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import {
+  buildCompetitorGapArtifact,
+  renderCompetitorGapMarkdown,
+  type CompetitorCoverageDataset,
+  type RouteManifestEntry,
+} from '../../src/lib/competitor-gap-reporting'
+
+function arg(name: string, fallback: string): string {
+  const prefix = `--${name}=`
+  return process.argv.find((value) => value.startsWith(prefix))?.slice(prefix.length) || fallback
+}
+
+async function readJson<T>(filePath: string): Promise<T> {
+  const raw = await fs.readFile(filePath, 'utf8')
+  return JSON.parse(raw) as T
+}
+
+async function writeText(filePath: string, content: string): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true })
+  await fs.writeFile(filePath, content, 'utf8')
+}
+
+function validateDataset(dataset: CompetitorCoverageDataset): void {
+  if (!dataset || !Array.isArray(dataset.topics)) {
+    throw new Error('Competitor coverage input must be a JSON object with a `topics` array.')
+  }
+
+  const invalid = dataset.topics.find((row) => !row?.topic || !row?.publisher)
+  if (invalid) {
+    throw new Error('Every competitor topic observation must include both `topic` and `publisher`.')
+  }
+}
+
+async function main(): Promise<void> {
+  const routeManifestPath = path.resolve(
+    arg('routes', 'public/data/runtime-manifests/route-manifest.json'),
+  )
+  const competitorInputPath = path.resolve(
+    arg('input', 'data-sources/seo/competitor-topic-coverage.json'),
+  )
+  const jsonOutPath = path.resolve(
+    arg('out', 'reports/seo/competitor-content-gap.json'),
+  )
+  const markdownOutPath = path.resolve(
+    arg('markdown', 'reports/seo/competitor-content-gap.md'),
+  )
+
+  const [routes, competitorDataset] = await Promise.all([
+    readJson<RouteManifestEntry[]>(routeManifestPath),
+    readJson<CompetitorCoverageDataset>(competitorInputPath),
+  ])
+  validateDataset(competitorDataset)
+
+  const report = buildCompetitorGapArtifact(routes, competitorDataset)
+  const markdown = renderCompetitorGapMarkdown(report)
+
+  await Promise.all([
+    writeText(jsonOutPath, `${JSON.stringify(report, null, 2)}\n`),
+    writeText(markdownOutPath, markdown),
+  ])
+
+  const missingCore = report.publisherCoverage.filter((row) => !row.present).map((row) => row.publisher)
+  console.log(`Competitor gap report: ${report.decisionCounts.pursue} pursue, ${report.decisionCounts.protect} protect, ${report.decisionCounts['avoid-generic-head-term']} avoid generic.`)
+  console.log(`Wrote ${path.relative(process.cwd(), jsonOutPath)} and ${path.relative(process.cwd(), markdownOutPath)}.`)
+  if (missingCore.length) {
+    console.warn(`Coverage warning: missing publisher observations for ${missingCore.join(', ')}.`)
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exit(1)
+})

--- a/src/lib/__tests__/competitor-gap-reporting.test.ts
+++ b/src/lib/__tests__/competitor-gap-reporting.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildCompetitorGapArtifact,
+  renderCompetitorGapMarkdown,
+  siteTopicsFromRouteManifest,
+  summarizePublisherCoverage,
+} from '../competitor-gap-reporting'
+
+describe('competitor gap reporting', () => {
+  it('turns indexed route-manifest entries into comparable topics and capabilities', () => {
+    const topics = siteTopicsFromRouteManifest([
+      {
+        route: '/guides/compare/magnesium-glycinate-vs-citrate',
+        canonical_url: 'https://thehippiescientist.net/guides/compare/magnesium-glycinate-vs-citrate/',
+      },
+      {
+        route: '/tools/botanical-activity-atlas',
+        canonical_url: 'https://thehippiescientist.net/tools/botanical-activity-atlas/',
+      },
+    ])
+
+    expect(topics[0]).toMatchObject({
+      topic: 'compare magnesium glycinate vs citrate',
+      intent: 'comparison',
+    })
+    expect(topics[0].capabilities).toContain('comparison')
+    expect(topics[1].capabilities).toContain('interactive-tool')
+  })
+
+  it('always reports coverage status for the three core publishers', () => {
+    const coverage = summarizePublisherCoverage([
+      { topic: 'ashwagandha', publisher: 'Examine' },
+      { topic: 'ashwagandha', publisher: 'Healthline' },
+      { topic: 'ashwagandha', publisher: 'Independent Evidence Lab' },
+    ])
+
+    expect(coverage.find((row) => row.publisher === 'Examine')).toMatchObject({ present: true, topicCount: 1 })
+    expect(coverage.find((row) => row.publisher === 'NIH/NCCIH')).toMatchObject({ present: false, topicCount: 0 })
+    expect(coverage.find((row) => row.publisher === 'Healthline')).toMatchObject({ present: true, topicCount: 1 })
+  })
+
+  it('builds pursue/protect/avoid decisions and renders an incomplete-coverage warning', () => {
+    const report = buildCompetitorGapArtifact(
+      [
+        {
+          route: '/herbs/ashwagandha',
+          canonical_url: 'https://thehippiescientist.net/herbs/ashwagandha/',
+        },
+      ],
+      {
+        topics: [
+          { topic: 'ashwagandha', publisher: 'Examine', authorityTier: 'evidence-specialist' },
+          {
+            topic: 'what is magnesium',
+            publisher: 'NIH/NCCIH',
+            intent: 'generic-definition',
+            authorityTier: 'medical-authority',
+          },
+          {
+            topic: 'ashwagandha morning or night',
+            publisher: 'Examine',
+            intent: 'long-tail-decision',
+          },
+        ],
+      },
+      '2026-08-15T00:00:00.000Z',
+    )
+
+    expect(report.decisionCounts.protect).toBe(1)
+    expect(report.decisionCounts.pursue).toBe(1)
+    expect(report.decisionCounts['avoid-generic-head-term']).toBe(1)
+
+    const markdown = renderCompetitorGapMarkdown(report)
+    expect(markdown).toContain('Coverage warning')
+    expect(markdown).toContain('Healthline')
+    expect(markdown).toContain('Pursue: differentiated gaps')
+    expect(markdown).toContain('Avoid: generic medical head terms')
+  })
+})

--- a/src/lib/__tests__/competitor-gap-reporting.test.ts
+++ b/src/lib/__tests__/competitor-gap-reporting.test.ts
@@ -20,10 +20,11 @@ describe('competitor gap reporting', () => {
     ])
 
     expect(topics[0]).toMatchObject({
-      topic: 'compare magnesium glycinate vs citrate',
+      topic: 'magnesium glycinate vs citrate',
       intent: 'comparison',
     })
     expect(topics[0].capabilities).toContain('comparison')
+    expect(topics[1]).toMatchObject({ topic: 'botanical activity atlas', intent: 'interactive-tool' })
     expect(topics[1].capabilities).toContain('interactive-tool')
   })
 

--- a/src/lib/competitor-gap-reporting.ts
+++ b/src/lib/competitor-gap-reporting.ts
@@ -35,7 +35,7 @@ export interface CompetitorGapReportArtifact {
   gaps: CompetitorGap[]
 }
 
-const STRIP_ROUTE_PREFIXES = new Set([
+const STRIP_ROUTE_SEGMENTS = new Set([
   'herbs',
   'compounds',
   'guides',
@@ -56,7 +56,7 @@ function humanizeSlug(value: string): string {
 
 function routeTopic(route: string, metaTitle?: string): string {
   const segments = route.split(/[?#]/)[0].split('/').filter(Boolean)
-  const useful = segments.filter((segment, index) => index !== 0 || !STRIP_ROUTE_PREFIXES.has(segment))
+  const useful = segments.filter((segment) => !STRIP_ROUTE_SEGMENTS.has(segment))
   const slugTopic = humanizeSlug(useful.join(' '))
   if (slugTopic) return slugTopic
 

--- a/src/lib/competitor-gap-reporting.ts
+++ b/src/lib/competitor-gap-reporting.ts
@@ -1,0 +1,201 @@
+import {
+  CORE_COMPETITOR_PUBLISHERS,
+  buildCompetitorContentGapReport,
+  type CompetitorGap,
+  type GapIntent,
+  type SiteTopic,
+  type TopicCoverage,
+} from './competitor-content-gap'
+
+export interface RouteManifestEntry {
+  route: string
+  type?: string
+  meta_title?: string
+  canonical_url?: string
+}
+
+export interface CompetitorCoverageDataset {
+  generatedAt?: string
+  methodology?: string
+  topics: TopicCoverage[]
+}
+
+export interface PublisherCoverageSummary {
+  publisher: string
+  topicCount: number
+  present: boolean
+}
+
+export interface CompetitorGapReportArtifact {
+  generatedAt: string
+  indexedTopicCount: number
+  competitorTopicCount: number
+  publisherCoverage: PublisherCoverageSummary[]
+  decisionCounts: Record<CompetitorGap['decision'], number>
+  gaps: CompetitorGap[]
+}
+
+const STRIP_ROUTE_PREFIXES = new Set([
+  'herbs',
+  'compounds',
+  'guides',
+  'compare',
+  'safety',
+  'interactions',
+  'tools',
+  'evidence',
+  'learn',
+])
+
+function humanizeSlug(value: string): string {
+  return decodeURIComponent(value)
+    .replace(/[-_]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function routeTopic(route: string, metaTitle?: string): string {
+  const segments = route.split(/[?#]/)[0].split('/').filter(Boolean)
+  const useful = segments.filter((segment, index) => index !== 0 || !STRIP_ROUTE_PREFIXES.has(segment))
+  const slugTopic = humanizeSlug(useful.join(' '))
+  if (slugTopic) return slugTopic
+
+  return String(metaTitle || '')
+    .replace(/\s*[|—-]\s*The Hippie Scientist.*$/i, '')
+    .trim()
+}
+
+function routeIntent(route: string): GapIntent | undefined {
+  const value = route.toLowerCase()
+  if (value.includes('/compare/') || value === '/compare') return 'comparison'
+  if (value.includes('/safety') || value.includes('/interaction')) return 'interaction-research'
+  if (value.includes('/tools/')) return 'interactive-tool'
+  if (value.includes('/evidence')) return 'evidence-synthesis'
+  if (/\b(?:dose|dosage)\b/.test(value)) return 'long-tail-decision'
+  return undefined
+}
+
+function routeCapabilities(route: string): NonNullable<SiteTopic['capabilities']> {
+  const value = route.toLowerCase()
+  const capabilities: NonNullable<SiteTopic['capabilities']> = []
+  if (value.includes('/compare/') || value === '/compare') capabilities.push('comparison')
+  if (value.includes('/tools/')) capabilities.push('interactive-tool')
+  if (value.includes('/evidence')) capabilities.push('structured-data', 'evidence-synthesis')
+  if (value.includes('/safety') || value.includes('/interaction')) capabilities.push('source-level-safety')
+  return capabilities
+}
+
+export function siteTopicsFromRouteManifest(routes: RouteManifestEntry[]): SiteTopic[] {
+  return routes
+    .filter((entry) => Boolean(entry?.route))
+    .map((entry) => ({
+      topic: routeTopic(entry.route, entry.meta_title),
+      url: entry.canonical_url || entry.route,
+      intent: routeIntent(entry.route),
+      capabilities: routeCapabilities(entry.route),
+    }))
+    .filter((entry) => Boolean(entry.topic))
+}
+
+export function summarizePublisherCoverage(topics: TopicCoverage[]): PublisherCoverageSummary[] {
+  const counts = new Map<string, number>()
+  for (const topic of topics) {
+    const publisher = String(topic.publisher || '').trim()
+    if (!publisher) continue
+    counts.set(publisher, (counts.get(publisher) || 0) + 1)
+  }
+
+  const orderedPublishers = [
+    ...CORE_COMPETITOR_PUBLISHERS,
+    ...[...counts.keys()].filter((publisher) => !CORE_COMPETITOR_PUBLISHERS.includes(publisher as never)).sort(),
+  ]
+
+  return [...new Set(orderedPublishers)].map((publisher) => ({
+    publisher,
+    topicCount: counts.get(publisher) || 0,
+    present: counts.has(publisher),
+  }))
+}
+
+export function buildCompetitorGapArtifact(
+  routes: RouteManifestEntry[],
+  competitorDataset: CompetitorCoverageDataset,
+  generatedAt = new Date().toISOString(),
+): CompetitorGapReportArtifact {
+  const siteTopics = siteTopicsFromRouteManifest(routes)
+  const competitorTopics = competitorDataset.topics || []
+  const gaps = buildCompetitorContentGapReport(siteTopics, competitorTopics)
+
+  const decisionCounts: CompetitorGapReportArtifact['decisionCounts'] = {
+    pursue: 0,
+    protect: 0,
+    'avoid-generic-head-term': 0,
+  }
+  for (const gap of gaps) decisionCounts[gap.decision] += 1
+
+  return {
+    generatedAt,
+    indexedTopicCount: siteTopics.length,
+    competitorTopicCount: competitorTopics.length,
+    publisherCoverage: summarizePublisherCoverage(competitorTopics),
+    decisionCounts,
+    gaps,
+  }
+}
+
+function markdownRows(gaps: CompetitorGap[]): string {
+  if (!gaps.length) return '_None._'
+  return gaps
+    .map((gap) => {
+      const publishers = gap.competitorPublishers.join(', ') || '—'
+      const site = gap.siteUrls.join(', ') || 'Gap'
+      return `| ${gap.topic.replace(/\|/g, '\\|')} | ${gap.intent} | ${gap.distinctivenessScore} | ${publishers} | ${site} |`
+    })
+    .join('\n')
+}
+
+export function renderCompetitorGapMarkdown(report: CompetitorGapReportArtifact): string {
+  const missingCore = report.publisherCoverage
+    .filter((row) => CORE_COMPETITOR_PUBLISHERS.includes(row.publisher as never) && !row.present)
+    .map((row) => row.publisher)
+
+  const sections: Array<[string, CompetitorGap['decision']]> = [
+    ['Pursue: differentiated gaps', 'pursue'],
+    ['Protect: topics already covered', 'protect'],
+    ['Avoid: generic medical head terms', 'avoid-generic-head-term'],
+  ]
+
+  return [
+    '# Competitor Content Gap Report',
+    '',
+    `Generated: ${report.generatedAt}`,
+    '',
+    `Indexed topics analyzed: **${report.indexedTopicCount}**  `,
+    `Competitor topic observations: **${report.competitorTopicCount}**  `,
+    `Decisions: **${report.decisionCounts.pursue} pursue**, **${report.decisionCounts.protect} protect**, **${report.decisionCounts['avoid-generic-head-term']} avoid generic**`,
+    '',
+    '## Publisher coverage',
+    '',
+    ...report.publisherCoverage.map((row) => `- ${row.publisher}: ${row.topicCount} topic observation${row.topicCount === 1 ? '' : 's'}`),
+    '',
+    missingCore.length
+      ? `> Coverage warning: the input dataset is missing ${missingCore.join(', ')}. Treat this report as incomplete until those publishers are sampled.`
+      : '> Core comparison coverage includes Examine, NIH/NCCIH, and Healthline.',
+    '',
+    ...sections.flatMap(([heading, decision]) => {
+      const rows = report.gaps.filter((gap) => gap.decision === decision)
+      return [
+        `## ${heading}`,
+        '',
+        '| Topic | Intent | Distinctiveness | Competitors | Hippie Scientist |',
+        '|---|---|---:|---|---|',
+        markdownRows(rows),
+        '',
+      ]
+    }),
+    '## Interpretation rule',
+    '',
+    'Prefer long-tail decisions, form/extract questions, evidence comparisons, mechanism-vs-human-evidence questions, careful interaction research, structured data, comparisons, interactive tools, and evidence synthesis. Do not create me-too generic definitions merely because an authoritative medical publisher ranks for them.',
+    '',
+  ].join('\n')
+}


### PR DESCRIPTION
Superseded by #3089 after main advanced before merge. The rebased replacement was merged successfully.