### PR TITLE
feat(data): publish normalized evidence dataset foundation

### DIFF
--- a/app/evidence/evidence-report/changelog/page.tsx
+++ b/app/evidence/evidence-report/changelog/page.tsx
@@ -1,0 +1,44 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { buildPageMetadata } from '@/src/lib/seo'
+import { evidenceDatasetChangelog } from '@/data/research/evidence-dataset-changelog'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Evidence Dataset Changelog',
+  description: 'Version history for The Hippie Scientist public research dataset and Evidence Report.',
+  path: '/evidence/evidence-report/changelog/',
+  openGraphType: 'article',
+})
+
+export default function EvidenceDatasetChangelogPage() {
+  return (
+    <main className="container-page mx-auto max-w-4xl space-y-8 py-10">
+      <section className="hero-shell rounded-[2rem] border p-6 sm:p-8">
+        <p className="eyebrow-label">Version history</p>
+        <h1 className="heading-premium mt-3">Evidence dataset changelog</h1>
+        <p className="text-reading mt-4 max-w-3xl">
+          Public releases are versioned so researchers, writers, and readers can identify which dataset structure
+          and evidence state they referenced. Evidence-grade changes live in a separate append-only change tracker.
+        </p>
+        <div className="mt-5 flex flex-wrap gap-3">
+          <Link href="/evidence/evidence-report/" className="chip-readable">Evidence Report</Link>
+          <a href="/evidence/evidence-report/dataset.csv" download className="chip-readable">CSV</a>
+          <a href="/evidence/evidence-report/dataset.json" download className="chip-readable">JSON</a>
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        {evidenceDatasetChangelog.map(release => (
+          <article key={release.version} className="card-premium p-6">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <h2 className="text-xl font-semibold text-ink">Version {release.version}</h2>
+              <time dateTime={release.date} className="text-sm text-muted">{release.date}</time>
+            </div>
+            <p className="mt-2 text-xs font-semibold uppercase tracking-[0.12em] text-brand-700">Schema v{release.schemaVersion}</p>
+            <p className="mt-3 text-sm leading-7 text-muted">{release.summary}</p>
+          </article>
+        ))}
+      </section>
+    </main>
+  )
+}

--- a/app/evidence/evidence-report/changes/page.tsx
+++ b/app/evidence/evidence-report/changes/page.tsx
@@ -1,0 +1,74 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { buildPageMetadata } from '@/src/lib/seo'
+import { evidenceGradeHistory } from '@/data/editorial/evidence-grade-history'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Evidence Change Tracker',
+  description: 'Quarterly public history of evidence-grade upgrades, downgrades, and conclusion-changing research recorded by The Hippie Scientist.',
+  path: '/evidence/evidence-report/changes/',
+  openGraphType: 'article',
+})
+
+export default function EvidenceChangeTrackerPage() {
+  const events = [...evidenceGradeHistory].sort((a, b) => Date.parse(b.changedAt) - Date.parse(a.changedAt))
+  const quarters = [...new Set(events.map(event => event.quarter))]
+
+  return (
+    <main className="container-page mx-auto max-w-5xl space-y-10 py-10">
+      <section className="hero-shell rounded-[2rem] border p-6 sm:p-8 lg:p-10">
+        <p className="eyebrow-label">Original research monitoring</p>
+        <h1 className="heading-premium mt-3">Evidence Change Tracker</h1>
+        <p className="text-reading mt-4 max-w-3xl">
+          A public, append-only record of evidence-grade changes. Each event records what moved, when it moved,
+          why the conclusion changed, and the triggering source IDs when they are available.
+        </p>
+        <div className="mt-5 flex flex-wrap gap-3">
+          <Link href="/evidence/evidence-report/" className="chip-readable">State of Supplement Evidence 2026</Link>
+          <Link href="/learn/citation-explorer/" className="chip-readable">Citation Explorer</Link>
+        </div>
+      </section>
+
+      <section className="grid gap-4 sm:grid-cols-3">
+        <div className="card-premium p-5"><p className="eyebrow-label">Recorded changes</p><p className="mt-2 text-3xl font-bold text-ink">{events.length}</p></div>
+        <div className="card-premium p-5"><p className="eyebrow-label">Evidence upgrades</p><p className="mt-2 text-3xl font-bold text-ink">{events.filter(event => ['A','B'].includes(event.toGrade) && !['A','B'].includes(event.fromGrade)).length}</p></div>
+        <div className="card-premium p-5"><p className="eyebrow-label">Evidence downgrades</p><p className="mt-2 text-3xl font-bold text-ink">{events.filter(event => ['C','D','Avoid/Insufficient'].includes(event.toGrade) && ['A','B'].includes(event.fromGrade)).length}</p></div>
+      </section>
+
+      {events.length === 0 ? (
+        <section className="rounded-2xl border border-brand-900/10 bg-brand-50/60 p-6 text-sm leading-7 text-muted">
+          The append-only tracker is live, but no historical grade-change events have been recorded under this
+          provenance system yet. The site will not backfill invented C→B or B→A histories from the current
+          database snapshot. The first real reviewed change becomes the first public event.
+        </section>
+      ) : quarters.map(quarter => (
+        <section key={quarter} className="space-y-4">
+          <h2 className="text-2xl font-semibold text-ink">{quarter}</h2>
+          {events.filter(event => event.quarter === quarter).map(event => (
+            <article key={event.id} id={event.id} className="card-premium p-6">
+              <div className="flex flex-wrap items-center gap-2 text-xs text-muted">
+                <time dateTime={event.changedAt}>{event.changedAt}</time>
+                <span aria-hidden="true">•</span>
+                <Link href={event.ingredientPath} className="font-semibold text-brand-700 hover:underline">{event.ingredientName}</Link>
+              </div>
+              <h3 className="mt-3 text-xl font-semibold text-ink">{event.fromGrade} → {event.toGrade}</h3>
+              <p className="mt-3 text-sm leading-7 text-muted">{event.reason}</p>
+              {event.sourceIds?.length ? (
+                <p className="mt-3 text-xs text-muted"><strong className="text-ink">Triggering sources:</strong> {event.sourceIds.join(', ')}</p>
+              ) : null}
+            </article>
+          ))}
+        </section>
+      ))}
+
+      <section className="rounded-2xl border border-brand-900/10 bg-white p-6 shadow-sm">
+        <h2 className="text-xl font-semibold text-ink">Quarterly report model</h2>
+        <p className="mt-3 text-sm leading-7 text-muted">
+          Quarterly editions are generated from this ledger: records whose rating changed, upgrades,
+          downgrades, and claims whose conclusion changed. New sources that do not change a grade remain
+          discoverable in the Citation Explorer rather than being mislabeled as a grade-change event.
+        </p>
+      </section>
+    </main>
+  )
+}

--- a/app/evidence/evidence-report/dataset.csv/route.ts
+++ b/app/evidence/evidence-report/dataset.csv/route.ts
@@ -1,0 +1,17 @@
+import {
+  getPublicEvidenceDataset,
+  publicEvidenceDatasetToCsv,
+} from '@/lib/public-evidence-dataset'
+
+export const dynamic = 'force-static'
+
+export async function GET() {
+  const dataset = await getPublicEvidenceDataset()
+  return new Response(publicEvidenceDatasetToCsv(dataset), {
+    headers: {
+      'content-type': 'text/csv; charset=utf-8',
+      'content-disposition': `attachment; filename="hippie-scientist-evidence-${dataset.datasetVersion}.csv"`,
+      'cache-control': 'public, max-age=3600',
+    },
+  })
+}

--- a/app/evidence/evidence-report/dataset.json/route.ts
+++ b/app/evidence/evidence-report/dataset.json/route.ts
@@ -1,0 +1,14 @@
+import { getPublicEvidenceDataset } from '@/lib/public-evidence-dataset'
+
+export const dynamic = 'force-static'
+
+export async function GET() {
+  const dataset = await getPublicEvidenceDataset()
+  return new Response(`${JSON.stringify(dataset, null, 2)}\n`, {
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'content-disposition': `attachment; filename="hippie-scientist-evidence-${dataset.datasetVersion}.json"`,
+      'cache-control': 'public, max-age=3600',
+    },
+  })
+}

--- a/data/editorial/evidence-grade-history.ts
+++ b/data/editorial/evidence-grade-history.ts
@@ -1,0 +1,24 @@
+export type EvidenceGradeChange = {
+  id: string
+  ingredientSlug: string
+  ingredientName: string
+  ingredientPath: string
+  changedAt: string
+  quarter: string
+  fromGrade: string
+  toGrade: string
+  reason: string
+  sourceIds?: string[]
+}
+
+/**
+ * Append-only public evidence-grade change ledger.
+ *
+ * New grade changes should be added as new events with a reason and, when
+ * available, the study/source IDs that changed the conclusion. Historical
+ * events should not be rewritten merely to simplify the current narrative.
+ *
+ * The initial empty state is deliberate: do not fabricate historical C→B or
+ * B→A events that were not actually recorded at the time of review.
+ */
+export const evidenceGradeHistory: EvidenceGradeChange[] = []

--- a/data/research/evidence-dataset-changelog.ts
+++ b/data/research/evidence-dataset-changelog.ts
@@ -1,0 +1,15 @@
+export type EvidenceDatasetRelease = {
+  version: string
+  date: string
+  summary: string
+  schemaVersion: number
+}
+
+export const evidenceDatasetChangelog: EvidenceDatasetRelease[] = [
+  {
+    version: '2026.08.15',
+    date: '2026-08-15',
+    schemaVersion: 1,
+    summary: 'Initial normalized public dataset release with stable study IDs, study classes, ingredient relationships, evidence direction labels, study-level metadata, aggregate report metrics, and CSV/JSON exports.',
+  },
+]

--- a/lib/__tests__/public-evidence-dataset.test.ts
+++ b/lib/__tests__/public-evidence-dataset.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildPublicEvidenceDatasetFromRecords,
+  publicEvidenceDatasetToCsv,
+} from '@/lib/public-evidence-dataset'
+import type { RuntimeRecord } from '@/src/types/content'
+
+function record(overrides: Partial<RuntimeRecord>): RuntimeRecord {
+  return {
+    slug: 'example',
+    name: 'Example',
+    indexability_status: 'PUBLISH',
+    evidence_grade: 'B',
+    summary_quality: 'strong',
+    profile_status: 'complete',
+    ...overrides,
+  } as RuntimeRecord
+}
+
+describe('public evidence dataset', () => {
+  it('deduplicates a PMID into one study entity while preserving ingredient relationships', () => {
+    const dataset = buildPublicEvidenceDatasetFromRecords([
+      {
+        type: 'herb',
+        record: record({
+          slug: 'alpha',
+          name: 'Alpha',
+          sources: [{
+            title: 'Shared human trial',
+            pmid: '12345678',
+            study_type: 'randomized controlled trial',
+            n: 120,
+            relationship: 'supports',
+            outcome: 'Stress score',
+          }],
+        }),
+      },
+      {
+        type: 'compound',
+        record: record({
+          slug: 'beta',
+          name: 'Beta',
+          evidence_grade: 'C',
+          sources: [{
+            title: 'Shared human trial',
+            pmid: '12345678',
+            study_type: 'randomized controlled trial',
+            n: 120,
+            relationship: 'contradicts',
+            outcome: 'Stress score',
+          }],
+        }),
+      },
+    ])
+
+    expect(dataset.studies).toHaveLength(1)
+    expect(dataset.studies[0].id).toBe('pmid:12345678')
+    expect(dataset.studies[0].relationships).toHaveLength(2)
+    expect(dataset.studies[0].relationshipSummary).toBe('mixed')
+    expect(dataset.metrics.disagreementStudyCount).toBe(1)
+    expect(dataset.metrics.humanTrialCount).toBe(1)
+  })
+
+  it('excludes non-indexable records from the public dataset', () => {
+    const dataset = buildPublicEvidenceDatasetFromRecords([
+      { type: 'herb', record: record({ slug: 'public', indexability_status: 'PUBLISH' }) },
+      { type: 'herb', record: record({ slug: 'private', indexability_status: 'NOINDEX' }) },
+    ])
+
+    expect(dataset.ingredients.map(item => item.slug)).toEqual(['public'])
+  })
+
+  it('keeps explicit safety cautions and canonical grades in aggregate metrics', () => {
+    const dataset = buildPublicEvidenceDatasetFromRecords([
+      { type: 'herb', record: record({ slug: 'a', evidence_grade: 'A', contraindications: ['Pregnancy'] }) },
+      { type: 'compound', record: record({ slug: 'd', evidence_grade: 'D' }) },
+    ])
+
+    expect(dataset.metrics.strongOrModerateIngredients).toBe(1)
+    expect(dataset.metrics.preliminaryOrInsufficientIngredients).toBe(1)
+    expect(dataset.metrics.ingredientsWithSafetyCautions).toBe(1)
+  })
+
+  it('exports structured study relationships to CSV without losing stable IDs', () => {
+    const dataset = buildPublicEvidenceDatasetFromRecords([
+      {
+        type: 'herb',
+        record: record({
+          slug: 'alpha',
+          name: 'Alpha',
+          sources: [{ title: 'Trial, with comma', doi: '10.1000/example', relationship: 'supports' }],
+        }),
+      },
+    ])
+
+    const csv = publicEvidenceDatasetToCsv(dataset)
+    expect(csv).toContain('study_id,title')
+    expect(csv).toContain('doi:10.1000/example')
+    expect(csv).toContain('"Trial, with comma"')
+    expect(csv).toContain('alpha')
+  })
+})

--- a/lib/public-evidence-dataset.ts
+++ b/lib/public-evidence-dataset.ts
@@ -1,0 +1,476 @@
+import { extractCitationsFromRecord } from '@/lib/citations'
+import { getEvidenceLetterGrade } from '@/lib/evidence'
+import {
+  evidenceStudyId,
+  isHumanEvidenceClass,
+  isHumanTrialClass,
+  normalizeEvidenceConfidence,
+  normalizeEvidenceRelationship,
+  normalizeEvidenceStudyClass,
+  parseSampleSize,
+  summarizeEvidenceStudies,
+  type EvidenceConfidence,
+  type EvidenceRelationship,
+  type EvidenceStudyClass,
+  type EvidenceStudyRecord,
+} from '@/lib/evidence-study'
+import { getRuntimeVisibility } from '@/lib/runtime-visibility'
+import {
+  getCompoundBySlug,
+  getCompounds,
+  getHerbBySlug,
+  getHerbs,
+} from '@/src/lib/runtime-data'
+import type { RuntimeRecord } from '@/src/types/content'
+
+export const PUBLIC_EVIDENCE_DATASET_VERSION = '2026.08.15'
+export const PUBLIC_EVIDENCE_DATASET_TITLE = 'The Hippie Scientist Public Evidence Dataset 2026'
+
+export type PublicEvidenceIngredient = {
+  slug: string
+  name: string
+  type: 'herb' | 'compound'
+  path: string
+  evidenceGrade: string
+  category: string
+  safetyCaution: boolean
+}
+
+export type PublicStudyRelationship = {
+  ingredientSlug: string
+  ingredientName: string
+  ingredientType: 'herb' | 'compound'
+  ingredientPath: string
+  evidenceGrade: string
+  relationship: EvidenceRelationship
+  outcome?: string
+}
+
+export type PublicStudyEntity = {
+  id: string
+  title: string
+  authors?: string
+  journal?: string
+  year?: number | string
+  pmid?: string
+  doi?: string
+  url?: string
+  studyType?: string
+  evidenceClass: EvidenceStudyClass
+  sampleSize?: number | string
+  dose?: string
+  duration?: string
+  population?: string
+  outcome?: string
+  result?: string
+  limitation?: string
+  confidence: EvidenceConfidence
+  statisticalConsistency?: string
+  extractName?: string
+  conditions: string[]
+  safetyOutcome?: string
+  relationships: PublicStudyRelationship[]
+  relationshipSummary: EvidenceRelationship
+}
+
+export type EvidenceCategorySummary = {
+  category: string
+  totalIngredients: number
+  strongOrModerate: number
+  preliminaryOrInsufficient: number
+  humanStudies: number
+  humanTrials: number
+}
+
+export type PublicEvidenceReportMetrics = {
+  ingredientCount: number
+  studyCount: number
+  humanStudyCount: number
+  humanTrialCount: number
+  approximateParticipants: number
+  participantCountCoverage: number
+  strongOrModerateIngredients: number
+  preliminaryOrInsufficientIngredients: number
+  ingredientsWithSafetyCautions: number
+  explicitlyFlaggedClaimOverreach: number
+  supportingRelationships: number
+  mixedRelationships: number
+  contradictingRelationships: number
+  noClearEffectRelationships: number
+  disagreementStudyCount: number
+  gradeDistribution: Array<{ grade: string; count: number; pct: number }>
+  categories: EvidenceCategorySummary[]
+}
+
+export type PublicEvidenceDataset = {
+  schemaVersion: 1
+  datasetVersion: string
+  title: string
+  generatedFrom: 'current indexable runtime records'
+  methodologyPath: '/info/editorial-policy/'
+  citationExplorerPath: '/learn/citation-explorer/'
+  citationText: string
+  ingredients: PublicEvidenceIngredient[]
+  studies: PublicStudyEntity[]
+  metrics: PublicEvidenceReportMetrics
+}
+
+type EntityRecord = {
+  record: RuntimeRecord
+  type: 'herb' | 'compound'
+}
+
+function cleanString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function cleanList(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map(item => cleanString(item)).filter(Boolean)
+  const text = cleanString(value)
+  if (!text) return []
+  return text.split(/[|;,]/).map(item => item.trim()).filter(Boolean)
+}
+
+function canIndexRecord(record: RuntimeRecord): boolean {
+  try {
+    return Boolean(record.slug && getRuntimeVisibility(record).canIndex)
+  } catch {
+    return false
+  }
+}
+
+function entityName(record: RuntimeRecord): string {
+  return (
+    cleanString(record.displayName) ||
+    cleanString(record.name) ||
+    cleanString(record.common) ||
+    cleanString(record.scientific) ||
+    cleanString(record.slug)
+  )
+}
+
+function entityCategory(record: RuntimeRecord): string {
+  return cleanString(record.category_label || record.category || record.class || record.compoundClass) || 'Uncategorized'
+}
+
+function hasSafetyCaution(record: RuntimeRecord): boolean {
+  const text = [
+    ...cleanList(record.safety_flags),
+    ...cleanList(record.safetyNotes),
+    ...cleanList(record.safety_notes),
+    ...cleanList(record.contraindications),
+    ...cleanList(record.interactions),
+    cleanString(record.safetyLevel),
+    cleanString(record.safety_level),
+  ].join(' ').toLowerCase()
+
+  return /\b(avoid|contraindicat|caution|interaction|pregnan|breastfeed|liver|kidney|bleed|sedat|stimul|risk|toxic|monitor)\b/.test(text)
+}
+
+function hasExplicitClaimOverreachFlag(record: RuntimeRecord): boolean {
+  const fields = [
+    record.claim_overreach,
+    record.claimOverreach,
+    record.evidence_language_violation,
+    record.evidenceLanguageViolation,
+    record.marketing_claim_exceeds_evidence,
+    record.marketingClaimExceedsEvidence,
+  ]
+  return fields.some(value => value === true || /^(true|yes|flagged|overreach)$/i.test(cleanString(value)))
+}
+
+function aggregateRelationship(relationships: PublicStudyRelationship[]): EvidenceRelationship {
+  const values = new Set(relationships.map(item => item.relationship))
+  if (values.has('supports') && (values.has('contradicts') || values.has('no_clear_effect'))) return 'mixed'
+  if (values.has('contradicts') && values.has('mixed')) return 'mixed'
+  if (values.has('mixed')) return 'mixed'
+  if (values.has('contradicts')) return 'contradicts'
+  if (values.has('supports')) return 'supports'
+  if (values.has('no_clear_effect')) return 'no_clear_effect'
+  return 'background'
+}
+
+function toStudyRecord(study: PublicStudyEntity): EvidenceStudyRecord {
+  return {
+    id: study.id,
+    title: study.title,
+    authors: study.authors,
+    journal: study.journal,
+    year: study.year,
+    pmid: study.pmid,
+    doi: study.doi,
+    url: study.url,
+    studyType: study.studyType,
+    evidenceClass: study.evidenceClass,
+    sampleSize: study.sampleSize,
+    dose: study.dose,
+    duration: study.duration,
+    population: study.population,
+    outcome: study.outcome,
+    result: study.result,
+    limitation: study.limitation,
+    relationship: study.relationshipSummary,
+    confidence: study.confidence,
+    statisticalConsistency: study.statisticalConsistency,
+    extractName: study.extractName,
+    conditions: study.conditions,
+    safetyOutcome: study.safetyOutcome,
+  }
+}
+
+function mergeStudyField<T>(current: T | undefined, incoming: T | undefined): T | undefined {
+  if (current !== undefined && current !== null && String(current).trim() !== '') return current
+  return incoming
+}
+
+export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]): PublicEvidenceDataset {
+  const ingredients: PublicEvidenceIngredient[] = []
+  const studiesById = new Map<string, PublicStudyEntity>()
+  const gradeCounts = new Map<string, number>()
+  const categoryMap = new Map<string, EvidenceCategorySummary>()
+  let explicitlyFlaggedClaimOverreach = 0
+
+  for (const { record, type } of entities) {
+    if (!canIndexRecord(record)) continue
+
+    const name = entityName(record)
+    const evidenceGrade = getEvidenceLetterGrade(record)
+    const category = entityCategory(record)
+    const safetyCaution = hasSafetyCaution(record)
+    const path = `/${type === 'herb' ? 'herbs' : 'compounds'}/${record.slug}/`
+
+    ingredients.push({ slug: record.slug, name, type, path, evidenceGrade, category, safetyCaution })
+    gradeCounts.set(evidenceGrade, (gradeCounts.get(evidenceGrade) || 0) + 1)
+    if (hasExplicitClaimOverreachFlag(record)) explicitlyFlaggedClaimOverreach += 1
+
+    const categorySummary = categoryMap.get(category) || {
+      category,
+      totalIngredients: 0,
+      strongOrModerate: 0,
+      preliminaryOrInsufficient: 0,
+      humanStudies: 0,
+      humanTrials: 0,
+    }
+    categorySummary.totalIngredients += 1
+    if (evidenceGrade === 'A' || evidenceGrade === 'B') categorySummary.strongOrModerate += 1
+    if (evidenceGrade === 'C' || evidenceGrade === 'D' || evidenceGrade === 'Avoid/Insufficient') {
+      categorySummary.preliminaryOrInsufficient += 1
+    }
+
+    const citations = extractCitationsFromRecord(record)
+    for (const citation of citations) {
+      const evidenceClass = citation.evidenceClass || normalizeEvidenceStudyClass(citation.studyType)
+      const relationship = normalizeEvidenceRelationship(citation.relationship)
+      const id = citation.id || evidenceStudyId(citation)
+      const conditions = [...new Set([...(citation.conditions || [])].map(item => item.trim()).filter(Boolean))]
+      const relationshipRecord: PublicStudyRelationship = {
+        ingredientSlug: record.slug,
+        ingredientName: name,
+        ingredientType: type,
+        ingredientPath: path,
+        evidenceGrade,
+        relationship,
+        outcome: citation.outcome,
+      }
+
+      const existing = studiesById.get(id)
+      if (!existing) {
+        studiesById.set(id, {
+          id,
+          title: citation.title || id,
+          authors: citation.authors,
+          journal: citation.journal,
+          year: citation.year,
+          pmid: citation.pmid,
+          doi: citation.doi,
+          url: citation.url,
+          studyType: citation.studyType,
+          evidenceClass,
+          sampleSize: citation.sampleSize,
+          dose: citation.dose,
+          duration: citation.duration,
+          population: citation.population,
+          outcome: citation.outcome,
+          result: citation.result,
+          limitation: citation.limitation,
+          confidence: normalizeEvidenceConfidence(citation.confidence),
+          statisticalConsistency: citation.statisticalConsistency,
+          extractName: citation.extractName,
+          conditions,
+          safetyOutcome: citation.safetyOutcome,
+          relationships: [relationshipRecord],
+          relationshipSummary: relationship,
+        })
+      } else {
+        existing.authors = mergeStudyField(existing.authors, citation.authors)
+        existing.journal = mergeStudyField(existing.journal, citation.journal)
+        existing.year = mergeStudyField(existing.year, citation.year)
+        existing.pmid = mergeStudyField(existing.pmid, citation.pmid)
+        existing.doi = mergeStudyField(existing.doi, citation.doi)
+        existing.url = mergeStudyField(existing.url, citation.url)
+        existing.studyType = mergeStudyField(existing.studyType, citation.studyType)
+        existing.sampleSize = mergeStudyField(existing.sampleSize, citation.sampleSize)
+        existing.dose = mergeStudyField(existing.dose, citation.dose)
+        existing.duration = mergeStudyField(existing.duration, citation.duration)
+        existing.population = mergeStudyField(existing.population, citation.population)
+        existing.outcome = mergeStudyField(existing.outcome, citation.outcome)
+        existing.result = mergeStudyField(existing.result, citation.result)
+        existing.limitation = mergeStudyField(existing.limitation, citation.limitation)
+        existing.statisticalConsistency = mergeStudyField(existing.statisticalConsistency, citation.statisticalConsistency)
+        existing.extractName = mergeStudyField(existing.extractName, citation.extractName)
+        existing.safetyOutcome = mergeStudyField(existing.safetyOutcome, citation.safetyOutcome)
+        existing.conditions = [...new Set([...existing.conditions, ...conditions])]
+        if (!existing.relationships.some(item =>
+          item.ingredientSlug === relationshipRecord.ingredientSlug &&
+          item.relationship === relationshipRecord.relationship &&
+          item.outcome === relationshipRecord.outcome,
+        )) {
+          existing.relationships.push(relationshipRecord)
+        }
+        existing.relationshipSummary = aggregateRelationship(existing.relationships)
+      }
+
+      if (isHumanEvidenceClass(evidenceClass)) categorySummary.humanStudies += 1
+      if (isHumanTrialClass(evidenceClass)) categorySummary.humanTrials += 1
+    }
+
+    categoryMap.set(category, categorySummary)
+  }
+
+  const studies = [...studiesById.values()].sort((a, b) => {
+    const yearDiff = Number(b.year || 0) - Number(a.year || 0)
+    if (yearDiff !== 0) return yearDiff
+    return a.title.localeCompare(b.title)
+  })
+  const studyMetrics = summarizeEvidenceStudies(studies.map(toStudyRecord))
+
+  let supportingRelationships = 0
+  let mixedRelationships = 0
+  let contradictingRelationships = 0
+  let noClearEffectRelationships = 0
+  for (const study of studies) {
+    for (const relationship of study.relationships) {
+      if (relationship.relationship === 'supports') supportingRelationships += 1
+      else if (relationship.relationship === 'mixed') mixedRelationships += 1
+      else if (relationship.relationship === 'contradicts') contradictingRelationships += 1
+      else if (relationship.relationship === 'no_clear_effect') noClearEffectRelationships += 1
+    }
+  }
+
+  const gradeOrder = ['A', 'B', 'C', 'D', 'Avoid/Insufficient']
+  const gradeDistribution = gradeOrder.map(grade => {
+    const count = gradeCounts.get(grade) || 0
+    return {
+      grade,
+      count,
+      pct: ingredients.length ? (count / ingredients.length) * 100 : 0,
+    }
+  })
+
+  const categories = [...categoryMap.values()]
+    .sort((a, b) => {
+      const aRate = a.totalIngredients ? a.strongOrModerate / a.totalIngredients : 0
+      const bRate = b.totalIngredients ? b.strongOrModerate / b.totalIngredients : 0
+      return bRate - aRate || b.humanTrials - a.humanTrials || a.category.localeCompare(b.category)
+    })
+
+  const metrics: PublicEvidenceReportMetrics = {
+    ingredientCount: ingredients.length,
+    studyCount: studies.length,
+    humanStudyCount: studyMetrics.humanStudies,
+    humanTrialCount: studyMetrics.humanTrials,
+    approximateParticipants: studyMetrics.approximateParticipants,
+    participantCountCoverage: studyMetrics.studiesWithParticipantCounts,
+    strongOrModerateIngredients: ingredients.filter(item => item.evidenceGrade === 'A' || item.evidenceGrade === 'B').length,
+    preliminaryOrInsufficientIngredients: ingredients.filter(item => item.evidenceGrade === 'C' || item.evidenceGrade === 'D' || item.evidenceGrade === 'Avoid/Insufficient').length,
+    ingredientsWithSafetyCautions: ingredients.filter(item => item.safetyCaution).length,
+    explicitlyFlaggedClaimOverreach,
+    supportingRelationships,
+    mixedRelationships,
+    contradictingRelationships,
+    noClearEffectRelationships,
+    disagreementStudyCount: studies.filter(study => study.relationshipSummary === 'mixed').length,
+    gradeDistribution,
+    categories,
+  }
+
+  return {
+    schemaVersion: 1,
+    datasetVersion: PUBLIC_EVIDENCE_DATASET_VERSION,
+    title: PUBLIC_EVIDENCE_DATASET_TITLE,
+    generatedFrom: 'current indexable runtime records',
+    methodologyPath: '/info/editorial-policy/',
+    citationExplorerPath: '/learn/citation-explorer/',
+    citationText: `The Hippie Scientist. ${PUBLIC_EVIDENCE_DATASET_TITLE}. Version ${PUBLIC_EVIDENCE_DATASET_VERSION}. https://thehippiescientist.net/evidence/evidence-report/`,
+    ingredients: ingredients.sort((a, b) => a.name.localeCompare(b.name)),
+    studies,
+    metrics,
+  }
+}
+
+async function hydrateIndexableRecords(summary: RuntimeRecord[], type: 'herb' | 'compound'): Promise<EntityRecord[]> {
+  const indexable = summary.filter(canIndexRecord)
+  const hydrated: EntityRecord[] = []
+  const chunkSize = 32
+
+  for (let index = 0; index < indexable.length; index += chunkSize) {
+    const chunk = indexable.slice(index, index + chunkSize)
+    const detailed = await Promise.all(chunk.map(record =>
+      type === 'herb' ? getHerbBySlug(record.slug) : getCompoundBySlug(record.slug),
+    ))
+    for (let offset = 0; offset < chunk.length; offset += 1) {
+      const record = detailed[offset] || chunk[offset]
+      if (record && canIndexRecord(record)) hydrated.push({ record, type })
+    }
+  }
+
+  return hydrated
+}
+
+export async function getPublicEvidenceDataset(): Promise<PublicEvidenceDataset> {
+  const [herbs, compounds] = await Promise.all([getHerbs(), getCompounds()])
+  const [herbRecords, compoundRecords] = await Promise.all([
+    hydrateIndexableRecords(herbs, 'herb'),
+    hydrateIndexableRecords(compounds, 'compound'),
+  ])
+  return buildPublicEvidenceDatasetFromRecords([...herbRecords, ...compoundRecords])
+}
+
+function csvEscape(value: unknown): string {
+  const text = value == null ? '' : String(value)
+  return /[",\n\r]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text
+}
+
+export function publicEvidenceDatasetToCsv(dataset: PublicEvidenceDataset): string {
+  const headers = [
+    'study_id', 'title', 'authors', 'journal', 'year', 'pmid', 'doi', 'study_class', 'sample_size',
+    'dose', 'duration', 'population', 'outcome', 'result', 'limitation', 'relationship_summary',
+    'conditions', 'safety_outcome', 'ingredient_slugs', 'ingredient_names', 'ingredient_grades',
+  ]
+
+  const rows = dataset.studies.map(study => [
+    study.id,
+    study.title,
+    study.authors,
+    study.journal,
+    study.year,
+    study.pmid,
+    study.doi,
+    study.evidenceClass,
+    parseSampleSize(study.sampleSize) ?? study.sampleSize,
+    study.dose,
+    study.duration,
+    study.population,
+    study.outcome,
+    study.result,
+    study.limitation,
+    study.relationshipSummary,
+    study.conditions.join('|'),
+    study.safetyOutcome,
+    study.relationships.map(item => item.ingredientSlug).join('|'),
+    study.relationships.map(item => item.ingredientName).join('|'),
+    study.relationships.map(item => item.evidenceGrade).join('|'),
+  ].map(csvEscape).join(','))
+
+  return `${headers.join(',')}\n${rows.join('\n')}\n`
+}


### PR DESCRIPTION
Adds the reusable public research-data layer: stable study entities, ingredient relationships, directional evidence labels, aggregate report metrics, versioned CSV/JSON exports, an append-only grade-change ledger, public changelog/change-tracker pages, and regression coverage. Public rows are restricted to indexable runtime records and visibility checks fail closed.