### PR TITLE
fix(dosing): keep record visibility fail-closed

### DIFF
--- a/app/info/dosing/page.tsx
+++ b/app/info/dosing/page.tsx
@@ -14,26 +14,15 @@ export const metadata: Metadata = buildPageMetadata({
   path: '/info/dosing/',
 })
 
+function isRenderableDosingRecord(record: RuntimeRecord) {
+  return !isRestrictedRecord(record) && getRuntimeVisibility(record).canRender
+}
+
 export default async function DosingPage() {
   const [rawHerbs, rawCompounds] = await Promise.all([getHerbs(), getCompounds()])
 
-  const herbs: RuntimeRecord[] = rawHerbs.filter((h: RuntimeRecord) => {
-    if (isRestrictedRecord(h)) return false
-    try {
-      return getRuntimeVisibility(h).canRender
-    } catch {
-      return true
-    }
-  })
-
-  const compounds: RuntimeRecord[] = rawCompounds.filter((c: RuntimeRecord) => {
-    if (isRestrictedRecord(c)) return false
-    try {
-      return getRuntimeVisibility(c).canRender
-    } catch {
-      return true
-    }
-  })
+  const herbs: RuntimeRecord[] = rawHerbs.filter(isRenderableDosingRecord)
+  const compounds: RuntimeRecord[] = rawCompounds.filter(isRenderableDosingRecord)
 
   return (
     <div className='mx-auto max-w-6xl space-y-8 px-4 py-8 sm:py-10'>

--- a/tests/dosing-visibility-contract.test.ts
+++ b/tests/dosing-visibility-contract.test.ts
@@ -1,0 +1,24 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+}
+
+describe('dosing tool visibility contract', () => {
+  it('uses one fail-closed eligibility predicate for herbs and compounds', () => {
+    const page = read('app/info/dosing/page.tsx')
+
+    expect(page).toContain('function isRenderableDosingRecord(record: RuntimeRecord)')
+    expect(page).toContain('!isRestrictedRecord(record) && getRuntimeVisibility(record).canRender')
+    expect(page).toContain('rawHerbs.filter(isRenderableDosingRecord)')
+    expect(page).toContain('rawCompounds.filter(isRenderableDosingRecord)')
+  })
+
+  it('does not locally override runtime visibility errors with a fail-open fallback', () => {
+    const page = read('app/info/dosing/page.tsx')
+
+    expect(page).not.toMatch(/getRuntimeVisibility\([^)]*\)[\s\S]{0,120}catch[\s\S]{0,80}return true/)
+  })
+})


### PR DESCRIPTION
## Root cause
The dosing tool duplicated herb and compound eligibility logic, and both copies wrapped the canonical `getRuntimeVisibility(...).canRender` decision in `try/catch` blocks that returned `true` on error. That contradicted the central helper's fail-closed policy in a health-adjacent dose-math tool.

## Change
- Replace the two duplicated filters with one local `isRenderableDosingRecord` predicate.
- Preserve restricted-record exclusion and `canRender` semantics.
- Remove both fail-open exception fallbacks.
- Add a focused regression guard requiring both herb and compound lists to use the shared predicate and preventing local `catch → true` visibility overrides.

## Scope
No dosage math, copy, payload fields, metadata, or runtime source data are changed.