### PR TITLE
ROI #134: gate cost-per-studied-dose comparisons on canonical data

### DIFF
--- a/src/components/comparison/RuntimeEvidenceComparison.tsx
+++ b/src/components/comparison/RuntimeEvidenceComparison.tsx
@@ -5,6 +5,7 @@ import ComparisonTable from '@/components/ComparisonTable'
 import Disclaimer from '@/src/components/Disclaimer'
 import {
   firstComparisonField,
+  optionalComparisonField,
   resolveRuntimeComparisonSide,
   type ResolvedRuntimeComparisonSide,
   type RuntimeComparisonSideConfig,
@@ -115,6 +116,17 @@ export default async function RuntimeEvidenceComparison({ title, summary, left, 
   if (!leftSide.record || !rightSide.record) notFound()
 
   const verdict = quickVerdict(leftSide, rightSide)
+  const leftStudiedDoseCost = optionalComparisonField(leftSide.record, [
+    'cost_per_studied_dose',
+    'cost_per_effective_dose',
+    'studied_dose_cost',
+  ])
+  const rightStudiedDoseCost = optionalComparisonField(rightSide.record, [
+    'cost_per_studied_dose',
+    'cost_per_effective_dose',
+    'studied_dose_cost',
+  ])
+
   const rows = [
     {
       label: 'Evidence strength',
@@ -166,6 +178,16 @@ export default async function RuntimeEvidenceComparison({ title, summary, left, 
       ],
     },
   ]
+
+  if (leftStudiedDoseCost || rightStudiedDoseCost) {
+    rows.splice(4, 0, {
+      label: 'Cost per studied dose',
+      values: [
+        leftStudiedDoseCost || 'Not available in the canonical record.',
+        rightStudiedDoseCost || 'Not available in the canonical record.',
+      ],
+    })
+  }
 
   return (
     <main className="container-page space-y-8 py-10">
@@ -228,6 +250,11 @@ export default async function RuntimeEvidenceComparison({ title, summary, left, 
           headers={['Dimension', leftSide.label, rightSide.label]}
           rows={rows}
         />
+        {(leftStudiedDoseCost || rightStudiedDoseCost) ? (
+          <p className="mt-3 text-xs leading-5 text-muted">
+            Cost-per-studied-dose is shown only when an explicit canonical cost field is present. It is intentionally omitted when reliable maintained product-cost data is unavailable.
+          </p>
+        ) : null}
       </section>
 
       <section className="grid max-w-5xl gap-4 sm:grid-cols-2">

--- a/src/lib/runtime-comparison-resolution.ts
+++ b/src/lib/runtime-comparison-resolution.ts
@@ -41,18 +41,25 @@ export function comparisonValueToText(value: unknown): string {
   return ''
 }
 
-export function firstComparisonField(
+export function optionalComparisonField(
   record: RuntimeComparisonIngredient | null,
   keys: string[],
 ): string {
-  if (!record) return 'Not available in the canonical record.'
+  if (!record) return ''
 
   for (const key of keys) {
     const value = comparisonValueToText(record[key])
     if (value) return value
   }
 
-  return 'Not available in the canonical record.'
+  return ''
+}
+
+export function firstComparisonField(
+  record: RuntimeComparisonIngredient | null,
+  keys: string[],
+): string {
+  return optionalComparisonField(record, keys) || 'Not available in the canonical record.'
 }
 
 export function resolveRuntimeComparisonSide(


### PR DESCRIPTION
Implements backlog item #134. The shared comparison renderer now supports cost-per-studied-dose rows only when an explicit canonical cost field exists; otherwise the cost dimension is omitted entirely. Adds a reusable optional-field resolver so missing data is not confused with real comparison data.