### PR TITLE
fix: align Botanical Atlas tests with typed relationship contract

### DIFF
--- a/src/lib/__tests__/botanical-atlas-data.test.ts
+++ b/src/lib/__tests__/botanical-atlas-data.test.ts
@@ -87,12 +87,18 @@ describe('Botanical Activity Atlas runtime fallbacks', () => {
       record({ herb_slug: 'ashwagandha', compound: 'Noise', relationship: 'compared_with' }),
     ])
 
-    expect(mapped.get('ashwagandha')).toEqual(['Withanolides', 'Withaferin A'])
+    expect(mapped.get('ashwagandha')).toEqual([
+      { compound: 'Withanolides', relationship: 'contains_compound' },
+      { compound: 'Withaferin A', relationship: 'contains_compound' },
+    ])
   })
 
   it('merges canonical mapped compounds without duplicates and infers chemistry classes', () => {
     const atlasRecord = toAtlasRecord(record({ slug: 'ashwagandha', effects: ['calming'], active_constituents: ['Withaferin A'] }))
-    const enriched = enrichAtlasRecordWithMappedCompounds(atlasRecord, ['withaferin a', 'Withanolides'])
+    const enriched = enrichAtlasRecordWithMappedCompounds(atlasRecord, [
+      { compound: 'withaferin a', relationship: 'contains_compound' },
+      { compound: 'Withanolides', relationship: 'contains_compound' },
+    ])
 
     expect(enriched.compounds).toEqual(['withaferin a', 'Withanolides'])
     expect(enriched.compoundClasses).toContain('Withanolides')


### PR DESCRIPTION
Fixes #3112

## Relevant URLs
- Repository test suite / Site Health workflow
- `src/lib/__tests__/botanical-atlas-data.test.ts`

## Acceptance criteria
- Align stale test fixtures with the production `AtlasCompoundRelationship[]` contract.
- Do not change runtime Botanical Activity Atlas behavior.
- Remove the two TypeScript errors currently blocking repository-wide validation.

## Validation commands
- `npm run typecheck`
- `npm test -- src/lib/__tests__/botanical-atlas-data.test.ts`
- `npm run check`

## Before → after metrics
- Typed Atlas test contract mismatches: 2 → 0.
- Production files changed: 0 → 0.

## Generator/source-of-truth decision
Production `src/lib/botanical-atlas-data.ts` is already the source of truth. This PR changes tests only; it does not introduce or alter a generator.

## Regression contract
The tests must use `{ compound, relationship }` records anywhere `AtlasCompoundRelationship[]` is required so future typecheck cannot silently regress to the retired string-array contract.