### PR TITLE
fix(explorer): keep pathway visibility fail-closed

### DIFF
--- a/app/learn/explorer/page.tsx
+++ b/app/learn/explorer/page.tsx
@@ -130,24 +130,15 @@ function compactExplorerPayload(records: ExplorerSourceRecord[]): ExplorerPayloa
     .filter((record): record is ExplorerPayloadRecord => Boolean(record))
 }
 
+function isRenderableExplorerRecord(record: ExplorerSourceRecord) {
+  return getRuntimeVisibility(record).canRender
+}
+
 export default async function PathwayExplorerPage() {
   const [rawHerbs, rawCompounds] = await Promise.all([getHerbs(), getCompounds()])
 
-  const herbs = compactExplorerPayload(rawHerbs.filter((h: Record<string, unknown>) => {
-    try {
-      return getRuntimeVisibility(h).canRender
-    } catch {
-      return true
-    }
-  }))
-
-  const compounds = compactExplorerPayload(rawCompounds.filter((c: Record<string, unknown>) => {
-    try {
-      return getRuntimeVisibility(c).canRender
-    } catch {
-      return true
-    }
-  }))
+  const herbs = compactExplorerPayload(rawHerbs.filter(isRenderableExplorerRecord))
+  const compounds = compactExplorerPayload(rawCompounds.filter(isRenderableExplorerRecord))
 
   return (
     <div className='mx-auto max-w-6xl space-y-10 px-4 py-8 sm:py-10'>

--- a/tests/pathway-explorer-visibility-contract.test.ts
+++ b/tests/pathway-explorer-visibility-contract.test.ts
@@ -1,0 +1,24 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+}
+
+describe('pathway explorer visibility contract', () => {
+  it('uses one fail-closed renderability predicate for herbs and compounds', () => {
+    const page = read('app/learn/explorer/page.tsx')
+
+    expect(page).toContain('function isRenderableExplorerRecord(record: ExplorerSourceRecord)')
+    expect(page).toContain('return getRuntimeVisibility(record).canRender')
+    expect(page).toContain('rawHerbs.filter(isRenderableExplorerRecord)')
+    expect(page).toContain('rawCompounds.filter(isRenderableExplorerRecord)')
+  })
+
+  it('does not locally override runtime visibility failures with a fail-open fallback', () => {
+    const page = read('app/learn/explorer/page.tsx')
+
+    expect(page).not.toMatch(/getRuntimeVisibility\([^)]*\)[\s\S]{0,120}catch[\s\S]{0,80}return true/)
+  })
+})


### PR DESCRIPTION
## Root cause
The pathway explorer duplicated herb and compound visibility filters, and both wrapped the canonical `getRuntimeVisibility(...).canRender` decision in `try/catch` blocks that returned `true` on error. That overrode the central helper's fail-closed behavior and could admit malformed/hidden records into the mechanism explorer.

## Change
- Replace both duplicated filters with one local `isRenderableExplorerRecord` predicate.
- Preserve `canRender` semantics and all existing payload compaction.
- Remove both fail-open exception fallbacks.
- Add a focused regression guard requiring herb and compound lists to share the predicate and preventing local `catch → true` overrides.

## Scope
No pathway copy, client behavior, metadata, compact payload fields, or runtime source data are changed.