### PR TITLE
feat(explorer): add searchable citation database

### DIFF
--- a/app/learn/citation-explorer/CitationExplorerClient.tsx
+++ b/app/learn/citation-explorer/CitationExplorerClient.tsx
@@ -1,0 +1,183 @@
+'use client'
+
+import Link from 'next/link'
+import { useMemo, useState } from 'react'
+import {
+  evidenceRelationshipLabel,
+  formatEvidenceStudyClass,
+  parseSampleSize,
+  type EvidenceRelationship,
+  type EvidenceStudyClass,
+} from '@/lib/evidence-study'
+import type { PublicStudyEntity } from '@/lib/public-evidence-dataset'
+
+type Props = { studies: PublicStudyEntity[] }
+const PAGE_SIZE = 50
+
+function anchorId(studyId: string) {
+  return `study-${studyId.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`
+}
+
+function sourceUrl(study: PublicStudyEntity) {
+  if (study.url) return study.url
+  if (study.pmid) return `https://pubmed.ncbi.nlm.nih.gov/${study.pmid}/`
+  if (study.doi) return `https://doi.org/${study.doi}`
+  return ''
+}
+
+function relationTone(value: EvidenceRelationship) {
+  if (value === 'supports') return 'border-emerald-600/20 bg-emerald-50 text-emerald-800'
+  if (value === 'contradicts') return 'border-rose-600/20 bg-rose-50 text-rose-800'
+  if (value === 'mixed' || value === 'no_clear_effect') return 'border-amber-600/20 bg-amber-50 text-amber-800'
+  return 'border-brand-900/10 bg-brand-50 text-muted'
+}
+
+export default function CitationExplorerClient({ studies }: Props) {
+  const [query, setQuery] = useState('')
+  const [ingredient, setIngredient] = useState('')
+  const [condition, setCondition] = useState('')
+  const [studyClass, setStudyClass] = useState('')
+  const [year, setYear] = useState('')
+  const [grade, setGrade] = useState('')
+  const [minSample, setMinSample] = useState('')
+  const [duration, setDuration] = useState('')
+  const [safety, setSafety] = useState('')
+  const [relationship, setRelationship] = useState('')
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE)
+
+  const ingredientOptions = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const study of studies) {
+      for (const relation of study.relationships) map.set(relation.ingredientSlug, relation.ingredientName)
+    }
+    return [...map.entries()].sort((a, b) => a[1].localeCompare(b[1]))
+  }, [studies])
+  const conditionOptions = useMemo(() => [...new Set(studies.flatMap(study => study.conditions))].sort(), [studies])
+  const classOptions = useMemo(() => [...new Set(studies.map(study => study.evidenceClass))].sort(), [studies])
+  const yearOptions = useMemo(() => [...new Set(studies.map(study => String(study.year || '')).filter(Boolean))].sort((a, b) => Number(b) - Number(a)), [studies])
+  const gradeOptions = useMemo(() => [...new Set(studies.flatMap(study => study.relationships.map(item => item.evidenceGrade)))].sort(), [studies])
+
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase()
+    const minN = minSample ? Number(minSample) : 0
+    const durationNeedle = duration.trim().toLowerCase()
+
+    return studies.filter(study => {
+      if (ingredient && !study.relationships.some(item => item.ingredientSlug === ingredient)) return false
+      if (condition && !study.conditions.includes(condition)) return false
+      if (studyClass && study.evidenceClass !== studyClass) return false
+      if (year && String(study.year || '') !== year) return false
+      if (grade && !study.relationships.some(item => item.evidenceGrade === grade)) return false
+      if (relationship && !study.relationships.some(item => item.relationship === relationship)) return false
+      if (minN && (parseSampleSize(study.sampleSize) || 0) < minN) return false
+      if (durationNeedle && !String(study.duration || '').toLowerCase().includes(durationNeedle)) return false
+      if (safety === 'reported' && !study.safetyOutcome) return false
+      if (safety === 'not-reported' && study.safetyOutcome) return false
+      if (needle) {
+        const haystack = [
+          study.title,
+          study.authors,
+          study.journal,
+          study.population,
+          study.outcome,
+          study.result,
+          study.extractName,
+          study.conditions.join(' '),
+          study.relationships.map(item => `${item.ingredientName} ${item.ingredientSlug}`).join(' '),
+        ].filter(Boolean).join(' ').toLowerCase()
+        if (!haystack.includes(needle)) return false
+      }
+      return true
+    })
+  }, [studies, query, ingredient, condition, studyClass, year, grade, minSample, duration, safety, relationship])
+
+  const selectedIngredientName = ingredientOptions.find(([slug]) => slug === ingredient)?.[1]
+  const timeline = useMemo(() => {
+    if (!ingredient) return []
+    return studies
+      .filter(study => study.relationships.some(item => item.ingredientSlug === ingredient) && study.year)
+      .sort((a, b) => Number(a.year) - Number(b.year))
+  }, [studies, ingredient])
+
+  const disagreementCount = filtered.filter(study => study.relationshipSummary === 'mixed').length
+  const visible = filtered.slice(0, visibleCount)
+  const hasFilters = Boolean(query || ingredient || condition || studyClass || year || grade || minSample || duration || safety || relationship)
+
+  function changeFilter(setter: (value: string) => void, value: string) {
+    setter(value)
+    setVisibleCount(PAGE_SIZE)
+  }
+
+  function resetFilters() {
+    setQuery(''); setIngredient(''); setCondition(''); setStudyClass(''); setYear(''); setGrade('')
+    setMinSample(''); setDuration(''); setSafety(''); setRelationship(''); setVisibleCount(PAGE_SIZE)
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-[2rem] border border-brand-900/10 bg-white p-5 shadow-sm sm:p-6" aria-label="Study filters">
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+          <label className="xl:col-span-2">
+            <span className="text-xs font-bold uppercase tracking-[0.12em] text-muted">Search studies</span>
+            <input value={query} onChange={event => changeFilter(setQuery, event.target.value)} placeholder="Title, ingredient, outcome, population…" className="mt-1.5 w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2.5 text-sm text-ink outline-none focus:border-brand-700" />
+          </label>
+          <label><span className="text-xs font-bold uppercase tracking-[0.12em] text-muted">Ingredient</span><select value={ingredient} onChange={event => changeFilter(setIngredient, event.target.value)} className="mt-1.5 w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2.5 text-sm text-ink"><option value="">All ingredients</option>{ingredientOptions.map(([slug, name]) => <option key={slug} value={slug}>{name}</option>)}</select></label>
+          <label><span className="text-xs font-bold uppercase tracking-[0.12em] text-muted">Condition</span><select value={condition} onChange={event => changeFilter(setCondition, event.target.value)} className="mt-1.5 w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2.5 text-sm text-ink"><option value="">All conditions</option>{conditionOptions.map(item => <option key={item} value={item}>{item}</option>)}</select></label>
+          <label><span className="text-xs font-bold uppercase tracking-[0.12em] text-muted">Study type</span><select value={studyClass} onChange={event => changeFilter(setStudyClass, event.target.value)} className="mt-1.5 w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2.5 text-sm text-ink"><option value="">All study classes</option>{classOptions.map(item => <option key={item} value={item}>{formatEvidenceStudyClass(item as EvidenceStudyClass)}</option>)}</select></label>
+          <label><span className="text-xs font-bold uppercase tracking-[0.12em] text-muted">Publication year</span><select value={year} onChange={event => changeFilter(setYear, event.target.value)} className="mt-1.5 w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2.5 text-sm text-ink"><option value="">All years</option>{yearOptions.map(item => <option key={item} value={item}>{item}</option>)}</select></label>
+          <label><span className="text-xs font-bold uppercase tracking-[0.12em] text-muted">Evidence grade</span><select value={grade} onChange={event => changeFilter(setGrade, event.target.value)} className="mt-1.5 w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2.5 text-sm text-ink"><option value="">All grades</option>{gradeOptions.map(item => <option key={item} value={item}>{item}</option>)}</select></label>
+          <label><span className="text-xs font-bold uppercase tracking-[0.12em] text-muted">Minimum sample size</span><input value={minSample} onChange={event => changeFilter(setMinSample, event.target.value.replace(/\D/g, ''))} inputMode="numeric" placeholder="e.g. 100" className="mt-1.5 w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2.5 text-sm text-ink" /></label>
+          <label><span className="text-xs font-bold uppercase tracking-[0.12em] text-muted">Duration contains</span><input value={duration} onChange={event => changeFilter(setDuration, event.target.value)} placeholder="e.g. 8 weeks" className="mt-1.5 w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2.5 text-sm text-ink" /></label>
+          <label><span className="text-xs font-bold uppercase tracking-[0.12em] text-muted">Safety outcome</span><select value={safety} onChange={event => changeFilter(setSafety, event.target.value)} className="mt-1.5 w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2.5 text-sm text-ink"><option value="">Any safety reporting</option><option value="reported">Safety outcome recorded</option><option value="not-reported">No structured safety outcome</option></select></label>
+          <label><span className="text-xs font-bold uppercase tracking-[0.12em] text-muted">Evidence direction</span><select value={relationship} onChange={event => changeFilter(setRelationship, event.target.value)} className="mt-1.5 w-full rounded-xl border border-brand-900/15 bg-white px-3 py-2.5 text-sm text-ink"><option value="">All directions</option><option value="supports">Supporting</option><option value="mixed">Mixed</option><option value="contradicts">Contradicting</option><option value="no_clear_effect">No clear effect</option><option value="background">Background</option></select></label>
+        </div>
+        <div className="mt-4 flex flex-wrap items-center justify-between gap-3 border-t border-brand-900/10 pt-4">
+          <p className="text-sm text-muted"><strong className="text-ink">{filtered.length.toLocaleString()}</strong> studies match{disagreementCount ? <> · <strong className="text-amber-800">{disagreementCount}</strong> mixed/discordant</> : null}</p>
+          {hasFilters ? <button type="button" onClick={resetFilters} className="rounded-full border border-brand-900/15 px-4 py-2 text-xs font-bold text-ink hover:bg-brand-50">Clear filters</button> : null}
+        </div>
+      </section>
+
+      {ingredient && timeline.length > 0 ? (
+        <section className="rounded-2xl border border-brand-900/10 bg-brand-50/50 p-5 sm:p-6">
+          <p className="eyebrow-label">Research timeline</p>
+          <h2 className="mt-2 text-xl font-semibold text-ink">{selectedIngredientName}: structured publication timeline</h2>
+          <div className="mt-4 flex gap-3 overflow-x-auto pb-2">
+            {timeline.map(study => <a key={study.id} href={`#${anchorId(study.id)}`} className="min-w-[190px] rounded-xl border border-brand-900/10 bg-white p-3 text-xs hover:border-brand-700/30"><strong className="block text-brand-800">{study.year}</strong><span className="mt-1 line-clamp-3 block leading-5 text-muted">{study.title}</span></a>)}
+          </div>
+        </section>
+      ) : null}
+
+      {disagreementCount > 0 ? <section className="rounded-2xl border border-amber-700/20 bg-amber-50 p-5"><p className="text-xs font-bold uppercase tracking-[0.12em] text-amber-900">Where studies disagree</p><p className="mt-2 text-sm leading-6 text-amber-950">This result set contains study entities linked to mixed, unfavorable, or null interpretations across ingredient or outcome contexts. Those relationships remain visible instead of being averaged into one smooth score.</p></section> : null}
+
+      <section className="space-y-4" aria-live="polite">
+        {visible.length === 0 ? <div className="rounded-2xl border border-brand-900/10 bg-brand-50/50 p-6 text-sm text-muted">No structured studies match these filters.</div> : visible.map(study => {
+          const url = sourceUrl(study)
+          return (
+            <article key={study.id} id={anchorId(study.id)} className="scroll-mt-24 rounded-2xl border border-brand-900/10 bg-white p-5 shadow-sm sm:p-6">
+              <div className="flex flex-wrap items-start justify-between gap-4">
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap gap-2"><span className="rounded-full border border-brand-900/10 bg-brand-50 px-2.5 py-1 text-[10px] font-bold text-brand-800">{formatEvidenceStudyClass(study.evidenceClass)}</span><span className={`rounded-full border px-2.5 py-1 text-[10px] font-bold ${relationTone(study.relationshipSummary)}`}>{evidenceRelationshipLabel(study.relationshipSummary)}</span>{study.year ? <span className="rounded-full border border-brand-900/10 px-2.5 py-1 text-[10px] font-semibold text-muted">{study.year}</span> : null}{study.sampleSize ? <span className="rounded-full border border-brand-900/10 px-2.5 py-1 text-[10px] font-semibold text-muted">n={study.sampleSize}</span> : null}</div>
+                  <h2 className="mt-3 text-lg font-semibold leading-snug text-ink">{url ? <a href={url} target="_blank" rel="noopener noreferrer" className="hover:text-brand-700 hover:underline">{study.title}</a> : study.title}</h2>
+                  {(study.authors || study.journal) ? <p className="mt-1 text-xs leading-5 text-muted">{[study.authors, study.journal].filter(Boolean).join(' · ')}</p> : null}
+                </div>
+                <a href={`#${anchorId(study.id)}`} className="text-xs font-semibold text-brand-700 hover:underline" aria-label={`Permanent anchor for ${study.title}`}>#{study.id}</a>
+              </div>
+              <dl className="mt-5 grid gap-3 text-sm md:grid-cols-2 xl:grid-cols-4">
+                {study.population ? <div><dt className="text-[10px] font-bold uppercase tracking-[0.12em] text-muted">Population</dt><dd className="mt-1 leading-6 text-ink">{study.population}</dd></div> : null}
+                {study.dose ? <div><dt className="text-[10px] font-bold uppercase tracking-[0.12em] text-muted">Dose / form</dt><dd className="mt-1 leading-6 text-ink">{study.dose}{study.extractName ? ` · ${study.extractName}` : ''}</dd></div> : null}
+                {study.duration ? <div><dt className="text-[10px] font-bold uppercase tracking-[0.12em] text-muted">Duration</dt><dd className="mt-1 leading-6 text-ink">{study.duration}</dd></div> : null}
+                {study.outcome ? <div><dt className="text-[10px] font-bold uppercase tracking-[0.12em] text-muted">Outcome</dt><dd className="mt-1 leading-6 text-ink">{study.outcome}</dd></div> : null}
+              </dl>
+              {study.result ? <p className="mt-4 rounded-xl bg-brand-50/60 p-4 text-sm leading-7 text-ink"><strong>Result:</strong> {study.result}</p> : null}
+              {study.limitation ? <p className="mt-3 text-sm leading-7 text-muted"><strong className="text-ink">Limitation:</strong> {study.limitation}</p> : null}
+              {study.safetyOutcome ? <p className="mt-3 text-sm leading-7 text-muted"><strong className="text-ink">Safety outcome:</strong> {study.safetyOutcome}</p> : null}
+              <div className="mt-5 border-t border-brand-900/10 pt-4"><p className="text-[10px] font-bold uppercase tracking-[0.12em] text-muted">Ingredient / claim relationships</p><div className="mt-2 flex flex-wrap gap-2">{study.relationships.map((item, index) => <Link key={`${item.ingredientSlug}-${item.relationship}-${index}`} href={item.ingredientPath} className={`rounded-full border px-3 py-1.5 text-xs font-semibold hover:brightness-95 ${relationTone(item.relationship)}`}>{item.ingredientName} · {item.evidenceGrade} · {evidenceRelationshipLabel(item.relationship)}</Link>)}</div></div>
+            </article>
+          )
+        })}
+      </section>
+
+      {visibleCount < filtered.length ? <div className="flex justify-center"><button type="button" onClick={() => setVisibleCount(count => count + PAGE_SIZE)} className="rounded-full bg-brand-800 px-5 py-2.5 text-sm font-bold text-white hover:bg-brand-900">Show {Math.min(PAGE_SIZE, filtered.length - visibleCount)} more studies</button></div> : null}
+    </div>
+  )
+}

--- a/app/learn/citation-explorer/page.tsx
+++ b/app/learn/citation-explorer/page.tsx
@@ -4,10 +4,12 @@ import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
 import FaqJsonLd from '@/components/seo/FaqJsonLd'
 import { buildPageMetadata } from '../../../src/lib/seo'
+import { getPublicEvidenceDataset } from '@/lib/public-evidence-dataset'
+import CitationExplorerClient from './CitationExplorerClient'
 
-const TITLE = 'Scientific Citation Explorer: How We Read Supplement Research'
+const TITLE = 'Human Trial & Scientific Citation Explorer'
 const DESCRIPTION =
-  'Learn how The Hippie Scientist reads citations, human trials, mechanism studies, sample size, study design, dose realism, and evidence confidence before summarizing supplement research.'
+  'Search and filter the trials, reviews, observational studies, preclinical sources, doses, populations, outcomes, limitations, and evidence directions behind The Hippie Scientist research database.'
 
 export const metadata: Metadata = buildPageMetadata({
   title: TITLE,
@@ -16,50 +18,27 @@ export const metadata: Metadata = buildPageMetadata({
   openGraphType: 'article',
 })
 
-const evidenceLayers = [
-  {
-    title: 'Human outcomes first',
-    body: 'Human outcome studies usually carry more weight than mechanism-only reasoning. A pathway can explain why an idea is plausible, but it should not do all the work by itself.',
-  },
-  {
-    title: 'Dose realism matters',
-    body: 'A study is more useful when the dose, extract form, timing, and population resemble how readers might realistically encounter the ingredient.',
-  },
-  {
-    title: 'Safety changes the tone',
-    body: 'Even promising research deserves careful wording when there are interaction concerns, sedative overlap, stimulant load, liver cautions, or poor product-quality signals.',
-  },
-]
-
-const confidenceChecks = [
-  'Was the study done in humans, animals, cells, or a mixed evidence base?',
-  'Does the study measure the outcome readers care about, or only a biomarker?',
-  'Is the dose achievable with normal supplement products?',
-  'Is the population similar to the intended use case?',
-  'Do safety notes change how strongly the page should summarize the finding?',
-]
-
 const faqItems = [
   {
-    question: 'What makes a citation useful for a supplement page?',
-    answer:
-      'A useful citation directly studies a relevant outcome, uses a realistic dose and product form, clearly describes the population, and reports limitations or adverse events.',
+    question: 'What does “supports,” “mixed,” or “contradicts” mean?',
+    answer: 'Those labels describe how a structured study relationship is used for a particular ingredient or claim context. They are kept separate so conflicting evidence is visible instead of averaged away.',
   },
   {
-    question: 'Why are mechanism studies still included?',
-    answer:
-      'Mechanism studies can explain biological plausibility and help readers understand pathways. They are helpful background, but they should not be treated as proof of a real-world outcome by themselves.',
+    question: 'Does a study appearing here prove an ingredient works?',
+    answer: 'No. Study design, sample size, population, dose, formulation, outcome, limitations, replication, and disagreement with other studies all affect confidence. The explorer exposes those details rather than treating citation count as proof.',
   },
   {
-    question: 'How should mixed evidence be handled?',
-    answer:
-      'Mixed evidence should reduce certainty. A good summary explains what appears consistent, what remains uncertain, and where softer wording is more appropriate.',
+    question: 'Why are animal, cell, or mechanism studies included?',
+    answer: 'They can be useful research context and help explain plausibility, but the explorer labels them separately from direct human evidence so they are not mistaken for clinical efficacy evidence.',
   },
 ]
 
-export default function CitationExplorerPage() {
+export default async function CitationExplorerPage() {
+  const dataset = await getPublicEvidenceDataset()
+  const metrics = dataset.metrics
+
   return (
-    <div className="container-page py-10 space-y-10">
+    <div className="container-page space-y-10 py-10">
       <AuthorityJsonLd
         title={TITLE}
         description={DESCRIPTION}
@@ -73,85 +52,54 @@ export default function CitationExplorerPage() {
       />
       <FaqJsonLd items={faqItems} />
 
-      <AuthorityBreadcrumbs
-        items={[
-          { label: 'Home', href: '/' },
-          { label: 'Education', href: '/learn' },
-          { label: 'Citation Explorer' },
-        ]}
-      />
+      <AuthorityBreadcrumbs items={[{ label: 'Home', href: '/' }, { label: 'Education', href: '/learn' }, { label: 'Citation Explorer' }]} />
 
       <section className="rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8 lg:p-10">
-        <p className="eyebrow-label">Evidence verification</p>
-        <h1 className="mt-3 max-w-4xl text-4xl font-bold tracking-tight text-ink sm:text-5xl">
-          Scientific citation explorer for supplement research.
-        </h1>
+        <p className="eyebrow-label">Public study database · v{dataset.datasetVersion}</p>
+        <h1 className="mt-3 max-w-4xl text-4xl font-bold tracking-tight text-ink sm:text-5xl">Search the evidence behind the ingredient profiles.</h1>
         <p className="mt-5 max-w-3xl text-lg leading-8 text-muted">
-          This page explains how citations are read before a research summary becomes confident or cautious.
-          The goal is to separate human outcome evidence, mechanism background, dose realism, safety context,
-          and marketing language so readers can understand the evidence layer behind the page.
+          Explore the structured studies attached to currently indexable ingredient profiles, including study class,
+          sample size, dose, duration, population, outcome, limitations, safety reporting, and whether a source
+          supports, complicates, or contradicts a claim context.
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
-          <Link href="/info/methodology/" className="chip-readable hover:bg-white transition">Editorial methodology</Link>
-          <Link href="/learn/efficacy-model/" className="chip-readable hover:bg-white transition">Efficacy modeler</Link>
-          <Link href="/learn/explorer/" className="chip-readable hover:bg-white transition">Pathway explorer</Link>
+          <Link href="/info/editorial-policy/" className="chip-readable transition hover:bg-white">Evidence rules</Link>
+          <Link href="/evidence/evidence-report/" className="chip-readable transition hover:bg-white">State of Supplement Evidence 2026</Link>
+          <a href="/evidence/evidence-report/dataset.csv" className="chip-readable transition hover:bg-white" download>Download CSV</a>
+          <a href="/evidence/evidence-report/dataset.json" className="chip-readable transition hover:bg-white" download>Download JSON</a>
         </div>
       </section>
 
-      <section className="grid gap-5 lg:grid-cols-3">
-        {evidenceLayers.map((layer) => (
-          <article key={layer.title} className="card-premium p-6">
-            <p className="eyebrow-label">Evidence layer</p>
-            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">{layer.title}</h2>
-            <p className="mt-3 text-sm leading-7 text-muted">{layer.body}</p>
-          </article>
-        ))}
+      <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4" aria-label="Citation Explorer coverage">
+        <div className="card-premium p-5"><p className="eyebrow-label">Structured studies</p><p className="mt-2 text-3xl font-bold text-ink">{metrics.studyCount.toLocaleString()}</p></div>
+        <div className="card-premium p-5"><p className="eyebrow-label">Human evidence sources</p><p className="mt-2 text-3xl font-bold text-ink">{metrics.humanStudyCount.toLocaleString()}</p></div>
+        <div className="card-premium p-5"><p className="eyebrow-label">Human trials</p><p className="mt-2 text-3xl font-bold text-ink">{metrics.humanTrialCount.toLocaleString()}</p></div>
+        <div className="card-premium p-5"><p className="eyebrow-label">Mixed/discordant entities</p><p className="mt-2 text-3xl font-bold text-ink">{metrics.disagreementStudyCount.toLocaleString()}</p></div>
       </section>
 
-      <section className="rounded-[2rem] border border-brand-900/10 bg-brand-50/60 p-6 shadow-sm sm:p-8">
-        <div className="max-w-3xl space-y-3">
-          <p className="eyebrow-label">Citation quality checklist</p>
-          <h2 className="text-3xl font-semibold tracking-tight text-ink">Five questions before reading a citation too strongly</h2>
-          <p className="text-sm leading-7 text-muted">
-            A citation can be real and still be easy to over-read. These checks keep the wording on the site
-            proportional to the actual evidence.
-          </p>
-        </div>
-        <ol className="mt-6 grid gap-3 md:grid-cols-2">
-          {confidenceChecks.map((check, index) => (
-            <li key={check} className="rounded-2xl border border-brand-900/10 bg-white/80 p-4 text-sm leading-6 text-muted">
-              <span className="mr-2 font-bold text-brand-800">{index + 1}.</span>{check}
-            </li>
-          ))}
-        </ol>
+      <section className="rounded-2xl border border-brand-900/10 bg-brand-50/60 p-5 text-sm leading-7 text-muted">
+        <strong className="text-ink">Scope note:</strong> This explorer is generated from currently indexable runtime
+        records. A missing study is not evidence that no study exists, and missing structured safety data is not a
+        declaration of safety. <Link href="/info/corrections/" className="font-semibold text-brand-700 hover:underline">Submit a correction or missing study →</Link>
       </section>
 
-      <section className="card-premium p-6 sm:p-8">
-        <p className="eyebrow-label">How this supports page quality</p>
-        <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
-          Better citation reading makes better educational pages.
-        </h2>
-        <p className="mt-3 max-w-3xl text-sm leading-7 text-muted">
-          Search traffic is only useful if the page earns trust after the click. The citation workflow keeps
-          high-intent pages from sounding like product copy: stronger phrases need stronger evidence layers,
-          and uncertain findings should be labeled as uncertain.
+      <CitationExplorerClient studies={dataset.studies} />
+
+      <section className="rounded-[2rem] border border-brand-900/10 bg-white p-6 shadow-sm sm:p-8">
+        <p className="eyebrow-label">Dataset citation</p>
+        <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">Cite this evidence dataset</h2>
+        <p className="mt-3 max-w-4xl rounded-xl bg-brand-50/60 p-4 font-mono text-xs leading-6 text-ink">{dataset.citationText}</p>
+        <p className="mt-3 text-sm leading-7 text-muted">
+          Stable study IDs prefer PMID, then DOI, then source URL, then a normalized title fallback. Ingredient
+          relationships are represented separately from study identity so the same paper can be interpreted in more
+          than one ingredient or outcome context without duplicating the paper itself.
         </p>
-        <div className="mt-5 flex flex-wrap gap-3">
-          <Link href="/learn/product-quality/" className="chip-readable hover:bg-white transition">Product-quality guide</Link>
-          <Link href="/learn/interactions/" className="chip-readable hover:bg-white transition">Interaction framework</Link>
-          <Link href="/evidence/evidence-checker/" className="chip-readable hover:bg-white transition">Evidence checker</Link>
-        </div>
       </section>
 
       <section className="rounded-2xl border border-brand-900/10 bg-white/90 p-6 shadow-sm">
         <h2 className="text-2xl font-semibold tracking-tight text-ink">FAQ</h2>
         <div className="mt-4 grid gap-4">
-          {faqItems.map((item) => (
-            <article key={item.question} className="rounded-2xl border border-brand-900/10 bg-brand-50/40 p-4">
-              <h3 className="font-bold text-ink">{item.question}</h3>
-              <p className="mt-2 text-sm leading-7 text-muted">{item.answer}</p>
-            </article>
-          ))}
+          {faqItems.map(item => <article key={item.question} className="rounded-2xl border border-brand-900/10 bg-brand-50/40 p-4"><h3 className="font-bold text-ink">{item.question}</h3><p className="mt-2 text-sm leading-7 text-muted">{item.answer}</p></article>)}
         </div>
       </section>
     </div>


### PR DESCRIPTION
Turns Citation Explorer into a real study database backed by the normalized dataset. Adds filters for ingredient, condition, study class, year, evidence grade, sample size, duration, safety outcome, and evidence direction; stable study anchors and source links; ingredient relationships; disagreement surfacing; and an ingredient-level publication timeline.