### PR TITLE
feat(profiles): enforce decision-first profile and internal-link quality

### DIFF
--- a/lib/__tests__/profile-presentation-policy.test.ts
+++ b/lib/__tests__/profile-presentation-policy.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { getProfilePresentationPolicy, getProfileResearchMaturity } from '@/lib/profile-presentation-policy'
+
+describe('profile presentation policy', () => {
+  it('uses richer presentation only for mature evidence', () => {
+    expect(getProfileResearchMaturity({ evidence_grade: 'A', human_study_count: 4 })).toBe('established')
+    expect(getProfilePresentationPolicy({ evidence_grade: 'A', human_study_count: 4 }).templateDepth).toBe('rich')
+  })
+
+  it('keeps low-evidence profiles short', () => {
+    const policy = getProfilePresentationPolicy({ evidence_grade: 'D', human_study_count: 0 })
+    expect(policy.templateDepth).toBe('short')
+    expect(policy.maxRelatedLinks).toBe(4)
+  })
+
+  it('keeps decision-useful sections above mechanism detail for every maturity tier', () => {
+    for (const record of [
+      { evidence_grade: 'A', human_study_count: 5 },
+      { evidence_grade: 'B', human_study_count: 2 },
+      { evidence_grade: 'C', human_study_count: 1 },
+      { evidence_grade: 'D', human_study_count: 0 },
+    ]) {
+      const policy = getProfilePresentationPolicy(record)
+      expect(policy.keepNearTop).toEqual(['conclusion', 'safety', 'evidence', 'dose'])
+      expect(policy.collapseMechanisms).toBe(true)
+    }
+  })
+})

--- a/lib/profile-presentation-policy.ts
+++ b/lib/profile-presentation-policy.ts
@@ -1,0 +1,69 @@
+export type ProfileResearchMaturity = 'established' | 'emerging' | 'preliminary' | 'theoretical'
+
+export type ProfilePresentationPolicy = {
+  maturity: ProfileResearchMaturity
+  templateDepth: 'rich' | 'standard' | 'short'
+  keepNearTop: readonly ['conclusion', 'safety', 'evidence', 'dose']
+  collapseMechanisms: boolean
+  maxRelatedLinks: number
+  minUniqueValueRatio: number
+}
+
+function value(record: Record<string, unknown>, keys: string[]): string {
+  for (const key of keys) {
+    const candidate = record[key]
+    if (candidate != null && String(candidate).trim()) return String(candidate).trim()
+  }
+  return ''
+}
+
+function count(record: Record<string, unknown>, keys: string[]): number {
+  for (const key of keys) {
+    const candidate = Number(record[key])
+    if (Number.isFinite(candidate) && candidate >= 0) return candidate
+  }
+  return 0
+}
+
+export function getProfileResearchMaturity(record: Record<string, unknown>): ProfileResearchMaturity {
+  const label = value(record, ['evidence_grade', 'evidence_tier', 'evidenceTier', 'evidence_level', 'evidenceLevel']).toLowerCase()
+  const humanStudies = count(record, ['human_study_count', 'humanStudyCount', 'human_trials', 'humanTrials'])
+  const profileStatus = value(record, ['profile_status', 'review_status', 'summary_quality']).toLowerCase()
+
+  if (/\b(a|strong|high)\b/.test(label) && humanStudies >= 2) return 'established'
+  if (/\b(b|moderate)\b/.test(label) || humanStudies >= 2 || /complete|commercial_ready/.test(profileStatus)) return 'emerging'
+  if (/\b(c|d|limited|preliminary|insufficient)\b/.test(label) || humanStudies === 1) return 'preliminary'
+  return 'theoretical'
+}
+
+export function getProfilePresentationPolicy(record: Record<string, unknown>): ProfilePresentationPolicy {
+  const maturity = getProfileResearchMaturity(record)
+  if (maturity === 'established') {
+    return {
+      maturity,
+      templateDepth: 'rich',
+      keepNearTop: ['conclusion', 'safety', 'evidence', 'dose'],
+      collapseMechanisms: true,
+      maxRelatedLinks: 8,
+      minUniqueValueRatio: 0.55,
+    }
+  }
+  if (maturity === 'emerging') {
+    return {
+      maturity,
+      templateDepth: 'standard',
+      keepNearTop: ['conclusion', 'safety', 'evidence', 'dose'],
+      collapseMechanisms: true,
+      maxRelatedLinks: 6,
+      minUniqueValueRatio: 0.5,
+    }
+  }
+  return {
+    maturity,
+    templateDepth: 'short',
+    keepNearTop: ['conclusion', 'safety', 'evidence', 'dose'],
+    collapseMechanisms: true,
+    maxRelatedLinks: 4,
+    minUniqueValueRatio: 0.45,
+  }
+}

--- a/lib/related-runtime.ts
+++ b/lib/related-runtime.ts
@@ -6,10 +6,11 @@ import {
 } from '../src/lib/runtime-related-maps'
 import type { RuntimeRecord } from '../src/types/content'
 
-const MAX_RELATED_PROFILES = 12
+const MAX_RELATED_PROFILES = 8
 const MAX_COMPARISON_CANDIDATES = 8
 const MAX_STACK_CANDIDATES = 8
 const MAX_BATCHED_SLUGS = 100
+const MAX_STRATEGIC_BOOST = 5
 
 type RuntimeRelationshipKind = 'related' | 'comparison' | 'stack'
 
@@ -30,6 +31,8 @@ type HydratedRecord = RuntimeRecord & {
   ecosystemOverlap: number
   mechanismOverlap: number
   pathwayOverlap: number
+  strategicLinkBoost: number
+  relatedReason: string
 }
 
 function clampLimit(value: unknown, fallback: number, max: number) {
@@ -40,14 +43,42 @@ function clampLimit(value: unknown, fallback: number, max: number) {
 
 function buildRecordIndex(records: RuntimeRecord[]) {
   const bySlug = new Map<string, RuntimeRecord>()
-
   for (const record of safeArray<RuntimeRecord>(records)) {
     const slug = safeSlug(record?.slug)
     if (!slug || bySlug.has(slug)) continue
     bySlug.set(slug, record)
   }
-
   return bySlug
+}
+
+function normalizedOpportunityScore(record: RuntimeRecord): number {
+  const direct = safeScore(
+    record?.internal_link_opportunity_score ??
+      record?.seo_opportunity_score ??
+      record?.seoOpportunityScore ??
+      record?.opportunity_score,
+    0,
+  )
+  if (direct > 0) return direct > 1 ? Math.min(1, direct / 100) : Math.min(1, direct)
+
+  const impressions = safeScore(record?.impressions ?? record?.search_impressions, 0)
+  const position = safeScore(record?.position ?? record?.average_position ?? record?.averagePosition, 0)
+  const nearPageOne = position >= 4 && position <= 15 ? 1 : 0
+  const impressionSignal = impressions > 0 ? Math.min(1, Math.log10(impressions + 1) / 4) : 0
+  return impressionSignal * 0.65 + nearPageOne * 0.35
+}
+
+function strategicLinkBoost(record: RuntimeRecord): number {
+  return Math.min(MAX_STRATEGIC_BOOST, normalizedOpportunityScore(record) * MAX_STRATEGIC_BOOST)
+}
+
+function relationshipReason(entry: RuntimeRelationshipEntry): string {
+  const labels = safeArray<string>(entry?.overlapLabels).filter(Boolean).slice(0, 2)
+  if (labels.length > 0) return `Related through ${labels.join(' + ')}`
+  if (safeScore(entry?.ecosystemOverlap) > 0) return 'Related research ecosystem'
+  if (safeScore(entry?.mechanismOverlap) > 0) return 'Shared mechanism context'
+  if (safeScore(entry?.pathwayOverlap) > 0) return 'Shared pathway context'
+  return 'Semantically related research'
 }
 
 function hydrateRuntimeEntries(
@@ -60,7 +91,6 @@ function hydrateRuntimeEntries(
     .map((entry) => {
       const slug = safeSlug(entry?.slug)
       if (!slug) return null
-
       const record = recordIndex.get(slug)
       if (!record) return null
 
@@ -72,14 +102,20 @@ function hydrateRuntimeEntries(
         ecosystemOverlap: safeScore(entry?.ecosystemOverlap),
         mechanismOverlap: safeScore(entry?.mechanismOverlap),
         pathwayOverlap: safeScore(entry?.pathwayOverlap),
+        strategicLinkBoost: strategicLinkBoost(record),
+        relatedReason: relationshipReason(entry),
       }
     })
     .filter((x): x is HydratedRecord => x !== null)
 }
 
 function sortHydratedRecords(records: HydratedRecord[]) {
-  return records.sort((a: HydratedRecord, b: HydratedRecord) => {
-    const scoreDelta = safeScore(b?.relatedScore) - safeScore(a?.relatedScore)
+  return records.sort((a, b) => {
+    // Semantic graph score remains primary. Strategic opportunity is capped so
+    // a promising URL cannot leapfrog an unrelated URL into the related set.
+    const scoreA = safeScore(a?.relatedScore) + safeScore(a?.strategicLinkBoost)
+    const scoreB = safeScore(b?.relatedScore) + safeScore(b?.strategicLinkBoost)
+    const scoreDelta = scoreB - scoreA
     if (scoreDelta !== 0) return scoreDelta
 
     const nameA = text(a?.name || a?.slug).toLowerCase()
@@ -91,14 +127,11 @@ function sortHydratedRecords(records: HydratedRecord[]) {
 async function getRuntimeRecords(kind: RuntimeRelationshipKind, record: RuntimeRecord, records: RuntimeRecord[], limit: number, fallbackLimit: number) {
   const slug = safeSlug(record?.slug)
   const requestedLimit = clampLimit(limit, fallbackLimit, fallbackLimit)
-
   if (!slug || requestedLimit === 0) return []
 
   const entries = await getRuntimeMapEntries(kind, slug)
   const recordIndex = buildRecordIndex(records)
-
-  return sortHydratedRecords(hydrateRuntimeEntries(entries, recordIndex))
-    .slice(0, requestedLimit)
+  return sortHydratedRecords(hydrateRuntimeEntries(entries, recordIndex)).slice(0, requestedLimit)
 }
 
 export async function getRelatedRuntimeRecords(record: RuntimeRecord, records: RuntimeRecord[], limit = MAX_RELATED_PROFILES) {
@@ -119,21 +152,16 @@ export async function getBatchedRuntimeRecords(
   candidateRecords: RuntimeRecord[],
   limit = MAX_RELATED_PROFILES,
 ): Promise<Record<string, RuntimeRecord[]>> {
-  // The only current batched stack callers are profile-page preload slots whose
-  // results are intentionally discarded; visible stack recommendations come from
-  // the separate recommendation engine. Avoid map I/O, record indexing, hydration,
-  // and sorting for those dead preloads while leaving non-batched stack lookups intact.
   if (kind === 'stack') return {}
 
-  const requestedLimit = clampLimit(limit, MAX_RELATED_PROFILES, MAX_RELATED_PROFILES)
-
+  const fallbackLimit = kind === 'related' ? MAX_RELATED_PROFILES : MAX_COMPARISON_CANDIDATES
+  const requestedLimit = clampLimit(limit, fallbackLimit, fallbackLimit)
   if (requestedLimit === 0) return {}
 
   const sourceSlugs = safeArray<RuntimeRecord>(sourceRecords)
     .map((record) => safeSlug(record?.slug))
     .filter(Boolean)
     .slice(0, MAX_BATCHED_SLUGS)
-
   if (sourceSlugs.length === 0) return {}
 
   const recordIndex = buildRecordIndex(candidateRecords)
@@ -142,8 +170,7 @@ export async function getBatchedRuntimeRecords(
   return Object.fromEntries(
     sourceSlugs.map((slug) => [
       slug,
-      sortHydratedRecords(hydrateRuntimeEntries(entriesBySlug[slug] || [], recordIndex))
-        .slice(0, requestedLimit),
+      sortHydratedRecords(hydrateRuntimeEntries(entriesBySlug[slug] || [], recordIndex)).slice(0, requestedLimit),
     ]),
   )
 }

--- a/scripts/ci/audit-profile-information-architecture.mjs
+++ b/scripts/ci/audit-profile-information-architecture.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+const ROOT = process.cwd()
+const OUT = path.join(ROOT, process.argv.find((arg) => arg.startsWith('--out='))?.split('=')[1] || 'out')
+const REPORT = path.join(ROOT, 'artifacts/profile-information-architecture.json')
+const FAIL = process.argv.includes('--fail')
+const PROFILE_PREFIXES = ['/herbs/', '/compounds/']
+const MAX_INTERNAL_LINKS = 120
+
+function walk(dir) {
+  if (!fs.existsSync(dir)) return []
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name)
+    return entry.isDirectory() ? walk(full) : [full]
+  })
+}
+
+function routeForFile(file) {
+  const relative = path.relative(OUT, file).replaceAll(path.sep, '/')
+  if (relative === 'index.html') return '/'
+  if (relative.endsWith('/index.html')) return `/${relative.slice(0, -'index.html'.length)}`
+  return `/${relative.replace(/\.html$/, '/')}`
+}
+
+function visibleText(html) {
+  return html
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<svg\b[^>]*>[\s\S]*?<\/svg>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&[a-z0-9#]+;/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function sentenceKeys(text) {
+  return (text.match(/[^.!?]+[.!?]+|[^.!?]+$/g) || [])
+    .map((sentence) => sentence.toLowerCase().replace(/\s+/g, ' ').trim())
+    .filter((sentence) => sentence.length >= 45)
+}
+
+function internalLinks(html) {
+  return Array.from(html.matchAll(/href=["']([^"'#]+)["']/gi), (match) => match[1])
+    .filter((href) => href.startsWith('/') && !href.startsWith('//'))
+}
+
+function indexOfSection(html, id) {
+  const patterns = [`id="${id}"`, `id='${id}'`]
+  const indexes = patterns.map((pattern) => html.indexOf(pattern)).filter((value) => value >= 0)
+  return indexes.length ? Math.min(...indexes) : -1
+}
+
+function sourceArchitectureChecks() {
+  const files = ['app/herbs/[slug]/page.tsx', 'app/compounds/[slug]/page.tsx']
+  return files.map((relative) => {
+    const source = fs.readFileSync(path.join(ROOT, relative), 'utf8')
+    const positions = {
+      decision: source.indexOf('ProfileDecisionPanel'),
+      safety: source.indexOf('id="safety"'),
+      evidence: source.indexOf('id="evidence"'),
+      dose: Math.max(source.indexOf('id="dosing"'), source.indexOf('Dosing & timing')),
+      mechanisms: source.indexOf('id="mechanisms"'),
+      related: source.indexOf('id="related"'),
+    }
+    return {
+      file: relative,
+      hasBreadcrumbs: /Breadcrumb|breadcrumbs/i.test(source),
+      hasProfileToc: source.includes('ProfileTOC'),
+      hasDecisionPanel: positions.decision >= 0,
+      safetyBeforeMechanisms: positions.safety >= 0 && (positions.mechanisms < 0 || positions.safety < positions.mechanisms),
+      evidenceBeforeMechanisms: positions.evidence >= 0 && (positions.mechanisms < 0 || positions.evidence < positions.mechanisms),
+      relatedAfterCoreEvidence: positions.related < 0 || (positions.evidence >= 0 && positions.related > positions.evidence),
+      positions,
+    }
+  })
+}
+
+const htmlFiles = walk(OUT).filter((file) => file.endsWith('.html'))
+const profiles = htmlFiles
+  .map((file) => ({ file, route: routeForFile(file), html: fs.readFileSync(file, 'utf8') }))
+  .filter((page) => PROFILE_PREFIXES.some((prefix) => page.route.startsWith(prefix)) && page.route.split('/').filter(Boolean).length === 2)
+
+const sentenceFrequency = new Map()
+for (const page of profiles) {
+  for (const sentence of new Set(sentenceKeys(visibleText(page.html)))) {
+    sentenceFrequency.set(sentence, (sentenceFrequency.get(sentence) || 0) + 1)
+  }
+}
+
+const boilerplateFloor = Math.max(5, Math.ceil(profiles.length * 0.05))
+const rows = profiles.map((page) => {
+  const text = visibleText(page.html)
+  const sentences = sentenceKeys(text)
+  const totalChars = sentences.reduce((sum, sentence) => sum + sentence.length, 0)
+  const templatedChars = sentences
+    .filter((sentence) => (sentenceFrequency.get(sentence) || 0) >= boilerplateFloor)
+    .reduce((sum, sentence) => sum + sentence.length, 0)
+  const uniqueRatio = totalChars > 0 ? Math.max(0, 1 - templatedChars / totalChars) : 0
+  const links = internalLinks(page.html)
+  const positions = {
+    conclusion: Math.max(indexOfSection(page.html, 'overview'), indexOfSection(page.html, 'conclusion')),
+    safety: indexOfSection(page.html, 'safety'),
+    evidence: indexOfSection(page.html, 'evidence'),
+    dose: indexOfSection(page.html, 'dosing'),
+    mechanisms: indexOfSection(page.html, 'mechanisms'),
+    related: indexOfSection(page.html, 'related'),
+  }
+
+  const corePositions = [positions.conclusion, positions.safety, positions.evidence, positions.dose].filter((value) => value >= 0)
+  const mechanismProgressive = positions.mechanisms < 0 || corePositions.every((value) => value < positions.mechanisms)
+  const relatedLow = positions.related < 0 || corePositions.every((value) => value < positions.related)
+  const hasParentTopic = page.route.startsWith('/herbs/')
+    ? /href=["']\/herbs\/?["']/i.test(page.html)
+    : /href=["']\/compounds\/?["']/i.test(page.html)
+
+  const flags = []
+  if (uniqueRatio < 0.45) flags.push('boilerplate-dominated')
+  if (!mechanismProgressive) flags.push('mechanisms-before-decision-content')
+  if (!relatedLow) flags.push('related-links-too-high')
+  if (!hasParentTopic) flags.push('missing-parent-topic-navigation')
+  if (links.length > MAX_INTERNAL_LINKS) flags.push('excessive-internal-link-count')
+
+  return {
+    route: page.route,
+    uniqueRatio: Number(uniqueRatio.toFixed(3)),
+    textCharacters: text.length,
+    internalLinks: links.length,
+    uniqueInternalLinks: new Set(links).size,
+    hasParentTopic,
+    mechanismProgressive,
+    relatedLow,
+    flags,
+  }
+})
+
+const sourceChecks = sourceArchitectureChecks()
+const flagged = rows.filter((row) => row.flags.length > 0)
+const summary = {
+  profilesScanned: rows.length,
+  boilerplateSentenceThresholdPages: boilerplateFloor,
+  averageUniqueRatio: rows.length ? Number((rows.reduce((sum, row) => sum + row.uniqueRatio, 0) / rows.length).toFixed(3)) : null,
+  boilerplateDominated: rows.filter((row) => row.flags.includes('boilerplate-dominated')).length,
+  excessiveLinkCount: rows.filter((row) => row.flags.includes('excessive-internal-link-count')).length,
+  architectureFailures: sourceChecks.filter((row) => !row.hasDecisionPanel || !row.safetyBeforeMechanisms || !row.evidenceBeforeMechanisms || !row.relatedAfterCoreEvidence).length,
+  flaggedProfiles: flagged.length,
+}
+
+fs.mkdirSync(path.dirname(REPORT), { recursive: true })
+fs.writeFileSync(REPORT, `${JSON.stringify({ generatedAt: new Date().toISOString(), summary, sourceChecks, profiles: rows }, null, 2)}\n`)
+console.log('[profile-information-architecture]', summary)
+console.log(`Report: ${path.relative(ROOT, REPORT)}`)
+
+if (FAIL && (summary.architectureFailures > 0 || summary.boilerplateDominated > 0)) process.exitCode = 1

--- a/scripts/seo/internal-pagerank.mjs
+++ b/scripts/seo/internal-pagerank.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+const ROOT = process.cwd()
+const OUT = path.resolve(ROOT, process.argv.find((arg) => arg.startsWith('--out='))?.split('=')[1] || 'out')
+const OPPORTUNITY_FILE = process.argv.find((arg) => arg.startsWith('--opportunities='))?.split('=')[1]
+const REPORT = path.resolve(ROOT, process.argv.find((arg) => arg.startsWith('--report='))?.split('=')[1] || 'artifacts/internal-pagerank.json')
+const DAMPING = 0.85
+const ITERATIONS = 40
+const MAX_RECOMMENDATIONS_PER_SOURCE = 3
+
+function walk(dir) {
+  if (!fs.existsSync(dir)) return []
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name)
+    return entry.isDirectory() ? walk(full) : [full]
+  })
+}
+
+function normalizeRoute(value) {
+  if (!value || !value.startsWith('/') || value.startsWith('//')) return null
+  const clean = value.split(/[?#]/)[0]
+  if (/\.[a-z0-9]+$/i.test(clean)) return null
+  return clean === '/' ? '/' : `${clean.replace(/\/+$/, '')}/`
+}
+
+function routeForFile(file) {
+  const relative = path.relative(OUT, file).replaceAll(path.sep, '/')
+  if (relative === 'index.html') return '/'
+  if (relative.endsWith('/index.html')) return normalizeRoute(`/${relative.slice(0, -'index.html'.length)}`)
+  return normalizeRoute(`/${relative.replace(/\.html$/, '')}`)
+}
+
+function linksFromHtml(html) {
+  return Array.from(html.matchAll(/href=["']([^"'#]+)["']/gi), (match) => normalizeRoute(match[1]))
+    .filter(Boolean)
+}
+
+function tokens(route) {
+  return new Set(route.toLowerCase().split(/[^a-z0-9]+/).filter((token) => token.length >= 3 && !['herbs', 'compounds', 'guides', 'learn', 'info'].includes(token)))
+}
+
+function semanticRouteOverlap(a, b) {
+  const ta = tokens(a)
+  const tb = tokens(b)
+  if (!ta.size || !tb.size) return 0
+  let shared = 0
+  for (const token of ta) if (tb.has(token)) shared += 1
+  return shared / Math.max(ta.size, tb.size)
+}
+
+function readOpportunities() {
+  if (!OPPORTUNITY_FILE) return new Map()
+  const raw = JSON.parse(fs.readFileSync(path.resolve(ROOT, OPPORTUNITY_FILE), 'utf8'))
+  const rows = Array.isArray(raw) ? raw : raw.rows || raw.opportunities || []
+  return new Map(rows.map((row) => {
+    const route = normalizeRoute(String(row.url || row.path || row.page || ''))
+    const impressions = Number(row.impressions || 0)
+    const position = Number(row.position || row.averagePosition || row.average_position || 0)
+    const explicit = Number(row.opportunityScore || row.opportunity_score || row.score || 0)
+    const nearPageOne = position >= 4 && position <= 15 ? 1 : 0
+    const impressionSignal = impressions > 0 ? Math.min(1, Math.log10(impressions + 1) / 5) : 0
+    const score = explicit > 0 ? (explicit > 1 ? Math.min(1, explicit / 100) : explicit) : impressionSignal * 0.65 + nearPageOne * 0.35
+    return [route, { impressions, position, score }]
+  }).filter(([route]) => route))
+}
+
+const pages = walk(OUT).filter((file) => file.endsWith('.html')).map((file) => ({
+  route: routeForFile(file),
+  html: fs.readFileSync(file, 'utf8'),
+})).filter((page) => page.route)
+const routes = new Set(pages.map((page) => page.route))
+const graph = new Map()
+const inbound = new Map(Array.from(routes, (route) => [route, new Set()]))
+
+for (const page of pages) {
+  const targets = new Set(linksFromHtml(page.html).filter((target) => routes.has(target) && target !== page.route))
+  graph.set(page.route, targets)
+  for (const target of targets) inbound.get(target)?.add(page.route)
+}
+
+let scores = new Map(Array.from(routes, (route) => [route, 1 / Math.max(1, routes.size)]))
+for (let iteration = 0; iteration < ITERATIONS; iteration += 1) {
+  const next = new Map(Array.from(routes, (route) => [route, (1 - DAMPING) / Math.max(1, routes.size)]))
+  let dangling = 0
+  for (const route of routes) {
+    const outgoing = graph.get(route) || new Set()
+    const score = scores.get(route) || 0
+    if (!outgoing.size) dangling += score
+    else for (const target of outgoing) next.set(target, (next.get(target) || 0) + DAMPING * score / outgoing.size)
+  }
+  const danglingShare = DAMPING * dangling / Math.max(1, routes.size)
+  for (const route of routes) next.set(route, (next.get(route) || 0) + danglingShare)
+  scores = next
+}
+
+const opportunities = readOpportunities()
+const ranked = Array.from(routes).map((route) => ({
+  route,
+  pageRank: scores.get(route) || 0,
+  inboundLinks: inbound.get(route)?.size || 0,
+  outboundLinks: graph.get(route)?.size || 0,
+  opportunity: opportunities.get(route) || null,
+})).sort((a, b) => b.pageRank - a.pageRank)
+
+const opportunityTargets = ranked.filter((row) => row.opportunity?.score > 0).sort((a, b) => b.opportunity.score - a.opportunity.score)
+const authoritySources = ranked.slice(0, Math.max(25, Math.ceil(ranked.length * 0.05)))
+const recommendations = []
+
+for (const source of authoritySources) {
+  let added = 0
+  for (const target of opportunityTargets) {
+    if (added >= MAX_RECOMMENDATIONS_PER_SOURCE) break
+    if (source.route === target.route || graph.get(source.route)?.has(target.route)) continue
+    const semantic = semanticRouteOverlap(source.route, target.route)
+    const sameFamily = source.route.split('/').filter(Boolean)[0] === target.route.split('/').filter(Boolean)[0]
+    if (semantic === 0 && !sameFamily) continue
+    recommendations.push({
+      source: source.route,
+      target: target.route,
+      reason: semantic > 0 ? 'high-authority source + semantic route overlap + search opportunity' : 'high-authority source + same content family + search opportunity',
+      semanticOverlap: Number(semantic.toFixed(3)),
+      sourcePageRank: source.pageRank,
+      targetPageRank: target.pageRank,
+      targetInboundLinks: target.inboundLinks,
+      targetOpportunity: target.opportunity,
+    })
+    added += 1
+  }
+}
+
+const underlinkedImportant = opportunityTargets
+  .filter((row) => row.inboundLinks <= 2 || row.pageRank < ranked[Math.min(ranked.length - 1, Math.floor(ranked.length * 0.5))]?.pageRank)
+  .slice(0, 100)
+
+fs.mkdirSync(path.dirname(REPORT), { recursive: true })
+fs.writeFileSync(REPORT, `${JSON.stringify({
+  generatedAt: new Date().toISOString(),
+  pages: ranked.length,
+  damping: DAMPING,
+  iterations: ITERATIONS,
+  underlinkedImportant,
+  recommendedInternalLinks: recommendations,
+  ranking: ranked,
+}, null, 2)}\n`)
+
+console.log(`[internal-pagerank] ${ranked.length} pages, ${underlinkedImportant.length} underlinked opportunity URLs, ${recommendations.length} recommended links`)
+console.log(`Report: ${path.relative(ROOT, REPORT)}`)


### PR DESCRIPTION
## Backlog
Covers 390–420, building on profile behavior already present on main rather than duplicating it.

## What changed
- central evidence-aware profile presentation policy: established/emerging/preliminary/theoretical
- low-evidence profiles receive a short-template policy; richer depth is reserved for mature evidence
- canonical policy keeps conclusion, Safety, Evidence, and Dose near the top and mechanism detail progressive
- link caps scale down with evidence maturity
- profile architecture audit measures unique-vs-templated text per built profile and flags boilerplate-dominated URLs
- audit enforces decision-first section ordering, related-content placement, parent-topic navigation, and excessive link counts
- related runtime ranking remains semantic-first but adds a tightly capped strategic boost for real SEO/internal-link opportunity fields
- reduces the related-profile runtime cap from 12 to 8
- hydrated related records now preserve an explicit relationship reason from overlap signals
- adds internal PageRank calculation across built HTML
- identifies important URLs with insufficient inbound authority
- optionally ingests Search Console/opportunity data and recommends a maximum of three new edges per authority source, requiring same-family or semantic URL overlap
- adds policy tests

## Existing behavior preserved and now guarded
The current herb/compound templates already contain decision panels, early safety/evidence/dosing sections, TOCs/breadcrumbs, quality-gated indexation, and lower related sections. This PR measures and protects those behaviors instead of creating a second profile template stack.