### PR TITLE
fix(explorer): keep runtime visibility fail-closed

### DIFF
--- a/app/learn/explorer/page.tsx
+++ b/app/learn/explorer/page.tsx
@@ -130,24 +130,15 @@ function compactExplorerPayload(records: ExplorerSourceRecord[]): ExplorerPayloa
     .filter((record): record is ExplorerPayloadRecord => Boolean(record))
 }
 
+function isRenderableExplorerRecord(record: ExplorerSourceRecord) {
+  return getRuntimeVisibility(record).canRender
+}
+
 export default async function PathwayExplorerPage() {
   const [rawHerbs, rawCompounds] = await Promise.all([getHerbs(), getCompounds()])
 
-  const herbs = compactExplorerPayload(rawHerbs.filter((h: Record<string, unknown>) => {
-    try {
-      return getRuntimeVisibility(h).canRender
-    } catch {
-      return true
-    }
-  }))
-
-  const compounds = compactExplorerPayload(rawCompounds.filter((c: Record<string, unknown>) => {
-    try {
-      return getRuntimeVisibility(c).canRender
-    } catch {
-      return true
-    }
-  }))
+  const herbs = compactExplorerPayload(rawHerbs.filter(isRenderableExplorerRecord))
+  const compounds = compactExplorerPayload(rawCompounds.filter(isRenderableExplorerRecord))
 
   return (
     <div className='mx-auto max-w-6xl space-y-10 px-4 py-8 sm:py-10'>

--- a/tests/pathway-explorer-visibility-contract.test.ts
+++ b/tests/pathway-explorer-visibility-contract.test.ts
@@ -1,0 +1,24 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+}
+
+describe('pathway explorer visibility contract', () => {
+  it('uses one fail-closed eligibility predicate for herbs and compounds', () => {
+    const page = read('app/learn/explorer/page.tsx')
+
+    expect(page).toContain('function isRenderableExplorerRecord(record: ExplorerSourceRecord)')
+    expect(page).toContain('return getRuntimeVisibility(record).canRender')
+    expect(page).toContain('rawHerbs.filter(isRenderableExplorerRecord)')
+    expect(page).toContain('rawCompounds.filter(isRenderableExplorerRecord)')
+  })
+
+  it('does not locally override runtime visibility errors with a fail-open fallback', () => {
+    const page = read('app/learn/explorer/page.tsx')
+
+    expect(page).not.toMatch(/getRuntimeVisibility\([^)]*\)[\s\S]{0,120}catch[\s\S]{0,80}return true/)
+  })
+})


### PR DESCRIPTION
Superseded by parallel merged work on `main`. The current main branch now contains the same `isRenderableExplorerRecord` fail-closed predicate and `tests/pathway-explorer-visibility-contract.test.ts` regression contract, so merging this branch would only duplicate an already-resolved fix.

Issue #3065 is resolved by the merged main implementation.