### PR TITLE
ROI #571–590: content decay and PubMed review intake loop

### DIFF
--- a/.github/workflows/research-maintenance.yml
+++ b/.github/workflows/research-maintenance.yml
@@ -1,0 +1,81 @@
+name: Research Maintenance
+
+on:
+  schedule:
+    - cron: '47 12 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  maintenance:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+
+      - name: Rank content decay and recovery opportunity
+        run: node scripts/maintenance/build-content-decay-report.mjs
+
+      - name: Build update issue payloads
+        run: node scripts/maintenance/build-decay-issue-payloads.mjs
+
+      - name: Create missing content-decay issues
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/maintenance/create-decay-issues.mjs
+
+      - name: Query PubMed into a review queue
+        env:
+          NCBI_EMAIL: ${{ secrets.NCBI_EMAIL }}
+          NCBI_API_KEY: ${{ secrets.NCBI_API_KEY }}
+          NCBI_TOOL: hippie_scientist_research
+          PUBMED_RELDATE_DAYS: '35'
+          PUBMED_RESULTS_PER_ENTITY: '15'
+        run: node scripts/research/pubmed-ingest.mjs
+
+      - name: Upload research maintenance artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: research-maintenance-${{ github.run_number }}
+          path: |
+            reports/content-decay.json
+            reports/content-decay-issues.json
+            artifacts/research-intake/pubmed-review-queue.json
+          if-no-files-found: warn
+          retention-days: 90
+
+      - name: Summarize
+        if: always()
+        run: |
+          echo '## Research maintenance' >> "$GITHUB_STEP_SUMMARY"
+          if [ -f reports/content-decay.json ]; then
+            node - <<'NODE' >> "$GITHUB_STEP_SUMMARY"
+          const fs = require('fs')
+          const r = JSON.parse(fs.readFileSync('reports/content-decay.json', 'utf8'))
+          console.log(`- URLs ranked for decay: ${r.pageCount}`)
+          console.log(`- Urgent updates: ${r.urgent}`)
+          console.log(`- High-priority updates: ${r.high}`)
+          NODE
+          fi
+          if [ -f artifacts/research-intake/pubmed-review-queue.json ]; then
+            node - <<'NODE' >> "$GITHUB_STEP_SUMMARY"
+          const fs = require('fs')
+          const r = JSON.parse(fs.readFileSync('artifacts/research-intake/pubmed-review-queue.json', 'utf8'))
+          console.log(`- PubMed intake status: ${r.status}`)
+          if (r.studyCount != null) console.log(`- New undecided study/entity matches: ${r.studyCount}`)
+          if (r.likelyGradeImpact != null) console.log(`- Likely grade-impact reviews: ${r.likelyGradeImpact}`)
+          if (r.safetyStudies != null) console.log(`- Safety-signal studies: ${r.safetyStudies}`)
+          if (r.reason) console.log(`- Note: ${r.reason}`)
+          NODE
+          fi
+          echo '- PubMed discovery never changes evidence grades or public conclusions automatically.' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/research-maintenance.yml
+++ b/.github/workflows/research-maintenance.yml
@@ -22,17 +22,6 @@ jobs:
         with:
           node-version-file: .nvmrc
 
-      - name: Rank content decay and recovery opportunity
-        run: node scripts/maintenance/build-content-decay-report.mjs
-
-      - name: Build update issue payloads
-        run: node scripts/maintenance/build-decay-issue-payloads.mjs
-
-      - name: Create missing content-decay issues
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: node scripts/maintenance/create-decay-issues.mjs
-
       - name: Query PubMed into a review queue
         env:
           NCBI_EMAIL: ${{ secrets.NCBI_EMAIL }}
@@ -42,6 +31,20 @@ jobs:
           PUBMED_RESULTS_PER_ENTITY: '15'
         run: node scripts/research/pubmed-ingest.mjs
 
+      - name: Feed high-impact research signals into decay scoring
+        run: node scripts/maintenance/enrich-decay-with-research-intake.mjs
+
+      - name: Rank content decay and recovery opportunity
+        run: node scripts/maintenance/build-content-decay-report.mjs artifacts/maintenance/content-decay-signals-enriched.json
+
+      - name: Build update issue payloads
+        run: node scripts/maintenance/build-decay-issue-payloads.mjs
+
+      - name: Create missing content-decay issues
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/maintenance/create-decay-issues.mjs
+
       - name: Upload research maintenance artifacts
         if: always()
         uses: actions/upload-artifact@v7
@@ -50,6 +53,7 @@ jobs:
           path: |
             reports/content-decay.json
             reports/content-decay-issues.json
+            artifacts/maintenance/content-decay-signals-enriched.json
             artifacts/research-intake/pubmed-review-queue.json
           if-no-files-found: warn
           retention-days: 90

--- a/data/maintenance/content-decay-signals.json
+++ b/data/maintenance/content-decay-signals.json
@@ -1,0 +1,5 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": null,
+  "rows": []
+}

--- a/data/research/pubmed-priorities.json
+++ b/data/research/pubmed-priorities.json
@@ -1,0 +1,12 @@
+[
+  { "entityId": "herb:ashwagandha", "slug": "ashwagandha", "displayName": "Ashwagandha", "terms": ["ashwagandha", "Withania somnifera"], "priorityWeight": 10 },
+  { "entityId": "compound:magnesium", "slug": "magnesium", "displayName": "Magnesium", "terms": ["magnesium supplementation", "magnesium supplement"], "priorityWeight": 10 },
+  { "entityId": "compound:melatonin", "slug": "melatonin", "displayName": "Melatonin", "terms": ["melatonin supplementation", "melatonin"], "priorityWeight": 10 },
+  { "entityId": "compound:l-theanine", "slug": "l-theanine", "displayName": "L-Theanine", "terms": ["L-theanine", "theanine"], "priorityWeight": 10 },
+  { "entityId": "compound:creatine", "slug": "creatine", "displayName": "Creatine", "terms": ["creatine supplementation", "creatine monohydrate"], "priorityWeight": 9 },
+  { "entityId": "compound:berberine", "slug": "berberine", "displayName": "Berberine", "terms": ["berberine"], "priorityWeight": 9 },
+  { "entityId": "herb:rhodiola-rosea", "slug": "rhodiola-rosea", "displayName": "Rhodiola rosea", "terms": ["Rhodiola rosea", "rhodiola"], "priorityWeight": 8 },
+  { "entityId": "compound:saffron", "slug": "saffron", "displayName": "Saffron", "terms": ["saffron supplementation", "Crocus sativus"], "priorityWeight": 8 },
+  { "entityId": "herb:lions-mane", "slug": "lions-mane", "displayName": "Lion's Mane", "terms": ["Hericium erinaceus", "lion's mane"], "priorityWeight": 8 },
+  { "entityId": "herb:bacopa-monnieri", "slug": "bacopa-monnieri", "displayName": "Bacopa monnieri", "terms": ["Bacopa monnieri", "bacopa"], "priorityWeight": 8 }
+]

--- a/scripts/maintenance/build-content-decay-report.mjs
+++ b/scripts/maintenance/build-content-decay-report.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * Rank content decay by scientific freshness + organic/revenue recovery value.
+ * Input is a joined signal export so Search Console, product, citation and
+ * research-intake data can all contribute without hard-coupling this script to
+ * one provider.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const inputPath = path.resolve(process.argv[2] || 'data/maintenance/content-decay-signals.json')
+const outPath = path.resolve(process.env.CONTENT_DECAY_REPORT || 'reports/content-decay.json')
+
+function readJson(file, fallback) {
+  try { return JSON.parse(fs.readFileSync(file, 'utf8')) } catch { return fallback }
+}
+function n(value, fallback = 0) {
+  const valueNumber = Number(value)
+  return Number.isFinite(valueNumber) ? valueNumber : fallback
+}
+function clamp(value, min = 0, max = 100) { return Math.max(min, Math.min(max, value)) }
+function normalizeUrl(value) {
+  try {
+    const url = new URL(String(value), 'https://thehippiescientist.net')
+    if (url.hostname !== 'thehippiescientist.net') return ''
+    const pathname = url.pathname.replace(/\/+/g, '/')
+    return pathname === '/' || pathname.endsWith('/') ? pathname : `${pathname}/`
+  } catch { return '' }
+}
+function scoreRow(raw) {
+  const url = normalizeUrl(raw.url)
+  const newResearch = clamp(n(raw.newResearchCount) * 8, 0, 24)
+  const evidenceAge = clamp(n(raw.daysSinceEvidenceSearch) / 365 * 12, 0, 18)
+  const citationAge = clamp(Math.max(0, n(raw.avgCitationAgeDays) - 730) / 365 * 6, 0, 15)
+
+  const currentPosition = n(raw.positionCurrent, 100)
+  const previousPosition = n(raw.positionPrevious, currentPosition)
+  const rankLoss = clamp(Math.max(0, currentPosition - previousPosition) * 2.5, 0, 25)
+
+  const currentClicks = n(raw.clicks28)
+  const previousClicks = n(raw.clicksPrevious28, currentClicks)
+  const clickLossPct = previousClicks > 0 ? Math.max(0, (previousClicks - currentClicks) / previousClicks) : 0
+  const clickLoss = clamp(clickLossPct * 18, 0, 18)
+
+  const impressions = n(raw.impressions28)
+  const nearPageOne = currentPosition >= 4 && currentPosition <= 20 ? 1 : currentPosition > 20 && currentPosition <= 40 ? 0.5 : 0.2
+  const organicRecovery = clamp(Math.log10(Math.max(1, impressions)) * 5 * nearPageOne, 0, 20)
+  const revenueRecovery = clamp(Math.log10(Math.max(1, n(raw.revenue28) + 1)) * 5, 0, 10)
+  const productChange = raw.productChanged === true ? 10 : 0
+  const priorityBoost = clamp(n(raw.priorityBoost), 0, 10)
+
+  const decayScore = clamp(
+    newResearch + evidenceAge + citationAge + rankLoss + clickLoss + productChange,
+    0,
+    100,
+  )
+  const recoveryValue = clamp(organicRecovery + revenueRecovery + priorityBoost, 0, 40)
+  const updatePriority = Number(clamp(decayScore * 0.7 + recoveryValue * 0.75, 0, 100).toFixed(1))
+
+  const reasons = []
+  if (n(raw.newResearchCount) > 0) reasons.push(`${n(raw.newResearchCount)} new research signal(s)`)
+  if (n(raw.daysSinceEvidenceSearch) >= 365) reasons.push(`${Math.round(n(raw.daysSinceEvidenceSearch))} days since evidence search`)
+  if (n(raw.avgCitationAgeDays) >= 1095) reasons.push(`older citation set (~${Math.round(n(raw.avgCitationAgeDays) / 365)} years average)`)
+  if (currentPosition - previousPosition >= 2) reasons.push(`average position fell ${Number((currentPosition - previousPosition).toFixed(1))}`)
+  if (clickLossPct >= 0.2) reasons.push(`clicks down ${Math.round(clickLossPct * 100)}% vs prior 28 days`)
+  if (raw.productChanged === true) reasons.push('linked/reviewed product information changed')
+  if (!reasons.length) reasons.push('routine decay review')
+
+  return {
+    url,
+    updatePriority,
+    decayScore: Number(decayScore.toFixed(1)),
+    recoveryValue: Number(recoveryValue.toFixed(1)),
+    reasons,
+    gsc: {
+      impressions28: impressions,
+      clicks28: currentClicks,
+      clicksPrevious28: previousClicks,
+      positionCurrent: currentPosition,
+      positionPrevious: previousPosition,
+      ctrCurrent: n(raw.ctrCurrent),
+      ctrPrevious: n(raw.ctrPrevious),
+    },
+    revenue28: n(raw.revenue28),
+    newResearchCount: n(raw.newResearchCount),
+    daysSinceEvidenceSearch: n(raw.daysSinceEvidenceSearch),
+    avgCitationAgeDays: n(raw.avgCitationAgeDays),
+    productChanged: raw.productChanged === true,
+    queryOpportunities: Array.isArray(raw.queryOpportunities)
+      ? raw.queryOpportunities
+          .map((q) => ({ query: String(q.query || '').trim(), impressions: n(q.impressions), position: n(q.position), ctr: n(q.ctr) }))
+          .filter((q) => q.query)
+          .sort((a, b) => b.impressions - a.impressions)
+          .slice(0, 10)
+      : [],
+  }
+}
+
+const input = readJson(inputPath, { rows: [] })
+if (!Array.isArray(input.rows)) throw new Error('content decay input must contain rows[]')
+const rows = input.rows.map(scoreRow).filter((row) => row.url).sort((a, b) => b.updatePriority - a.updatePriority)
+const report = {
+  generatedAt: new Date().toISOString(),
+  sourceGeneratedAt: input.generatedAt || null,
+  pageCount: rows.length,
+  urgent: rows.filter((row) => row.updatePriority >= 70).length,
+  high: rows.filter((row) => row.updatePriority >= 50 && row.updatePriority < 70).length,
+  methodology: {
+    decaySignals: ['new research', 'time since evidence search', 'citation age', 'ranking loss', 'click loss', 'product change'],
+    recoverySignals: ['Search Console impressions', 'near-page-one position', 'revenue', 'explicit priority boost'],
+    priorityFormula: '0.70 × decayScore + 0.75 × recoveryValue, capped at 100',
+  },
+  pages: rows,
+}
+fs.mkdirSync(path.dirname(outPath), { recursive: true })
+fs.writeFileSync(outPath, `${JSON.stringify(report, null, 2)}\n`)
+console.log(`[content-decay] ranked ${rows.length} URLs; urgent=${report.urgent}, high=${report.high}`)
+if (rows[0]) console.log(`[content-decay] next update: ${rows[0].url} (${rows[0].updatePriority}) — ${rows[0].reasons.join('; ')}`)
+console.log(`[content-decay] report: ${path.relative(root, outPath)}`)

--- a/scripts/maintenance/build-decay-issue-payloads.mjs
+++ b/scripts/maintenance/build-decay-issue-payloads.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+import crypto from 'node:crypto'
+
+const root = process.cwd()
+const reportPath = path.resolve(process.argv[2] || 'reports/content-decay.json')
+const outputPath = path.resolve(process.env.CONTENT_DECAY_ISSUES || 'reports/content-decay-issues.json')
+const threshold = Number(process.env.CONTENT_DECAY_ISSUE_THRESHOLD || 50)
+const limit = Math.max(1, Number(process.env.CONTENT_DECAY_ISSUE_LIMIT || 10))
+
+if (!fs.existsSync(reportPath)) {
+  console.log(`[decay-issues] SKIP: ${path.relative(root, reportPath)} not found`)
+  process.exit(0)
+}
+const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'))
+const pages = Array.isArray(report.pages) ? report.pages : []
+
+function marker(url) {
+  return `content-decay:${crypto.createHash('sha1').update(url).digest('hex').slice(0, 12)}`
+}
+function fmtPct(value) {
+  const n = Number(value)
+  return Number.isFinite(n) ? `${(n * 100).toFixed(1)}%` : 'n/a'
+}
+
+const issues = pages
+  .filter((page) => Number(page.updatePriority) >= threshold)
+  .slice(0, limit)
+  .map((page) => {
+    const id = marker(page.url)
+    const queries = Array.isArray(page.queryOpportunities) && page.queryOpportunities.length
+      ? page.queryOpportunities.map((q) => `| ${q.query} | ${q.impressions} | ${q.position.toFixed?.(1) ?? q.position} | ${fmtPct(q.ctr)} |`).join('\n')
+      : '| _No query opportunities supplied_ | — | — | — |'
+    const body = `<!-- ${id} -->
+## Why this page needs updating
+
+**URL:** https://thehippiescientist.net${page.url}\n**Update priority:** ${page.updatePriority}/100  \n**Decay score:** ${page.decayScore}/100  \n**Recovery value:** ${page.recoveryValue}/40
+
+${page.reasons.map((reason) => `- ${reason}`).join('\n')}
+
+## Search Console context
+
+- Impressions, last 28d: ${page.gsc.impressions28}
+- Clicks, last 28d: ${page.gsc.clicks28}
+- Clicks, prior 28d: ${page.gsc.clicksPrevious28}
+- Average position: ${page.gsc.positionCurrent} (prior ${page.gsc.positionPrevious})
+- CTR: ${fmtPct(page.gsc.ctrCurrent)} (prior ${fmtPct(page.gsc.ctrPrevious)})
+- Revenue, last 28d: ${page.revenue28}
+
+## Query opportunities
+
+| Query | Impressions | Position | CTR |
+|---|---:|---:|---:|
+${queries}
+
+## Scientific/content freshness
+
+- New research signals: ${page.newResearchCount}
+- Days since evidence search: ${page.daysSinceEvidenceSearch}
+- Average citation age: ${Math.round(page.avgCitationAgeDays)} days
+- Product information changed: ${page.productChanged ? 'yes' : 'no'}
+
+## Acceptance criteria
+
+- [ ] Re-run the evidence/source search where freshness or new-research signals justify it.
+- [ ] Verify the page's major claims and citations against current canonical data.
+- [ ] Address the highest-value query opportunities without changing the page's search intent.
+- [ ] Re-check product/formulation information if product-change signals are present.
+- [ ] Run production-content lint and the relevant build/test suite.
+- [ ] Record what changed and the before/after metrics in the PR.
+`
+    return {
+      marker: id,
+      url: page.url,
+      title: `[Content decay] Update ${page.url} (priority ${page.updatePriority})`,
+      body,
+      labels: ['content-decay', 'seo', 'research-update'],
+      priority: page.updatePriority,
+    }
+  })
+
+fs.mkdirSync(path.dirname(outputPath), { recursive: true })
+fs.writeFileSync(outputPath, `${JSON.stringify({ generatedAt: new Date().toISOString(), threshold, issues }, null, 2)}\n`)
+console.log(`[decay-issues] generated ${issues.length} issue payload(s) at threshold ${threshold}`)

--- a/scripts/maintenance/create-decay-issues.mjs
+++ b/scripts/maintenance/create-decay-issues.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * Create missing content-decay issues from generated payloads. Existing open
+ * issues are deduplicated by a stable HTML marker embedded in the issue body.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const payloadPath = path.resolve(process.argv[2] || 'reports/content-decay-issues.json')
+const token = (process.env.GITHUB_TOKEN || '').trim()
+const repository = (process.env.GITHUB_REPOSITORY || '').trim()
+
+if (!fs.existsSync(payloadPath)) {
+  console.log(`[create-decay-issues] SKIP: ${path.relative(root, payloadPath)} not found`)
+  process.exit(0)
+}
+const payload = JSON.parse(fs.readFileSync(payloadPath, 'utf8'))
+const issues = Array.isArray(payload.issues) ? payload.issues : []
+if (!issues.length) {
+  console.log('[create-decay-issues] no qualifying issue payloads')
+  process.exit(0)
+}
+if (!token || !repository.includes('/')) {
+  console.log('[create-decay-issues] SKIP: GITHUB_TOKEN / GITHUB_REPOSITORY not configured')
+  process.exit(0)
+}
+
+const api = `https://api.github.com/repos/${repository}`
+const headers = {
+  Authorization: `Bearer ${token}`,
+  Accept: 'application/vnd.github+json',
+  'X-GitHub-Api-Version': '2022-11-28',
+  'User-Agent': 'hippie-scientist-content-decay',
+}
+async function request(url, options = {}) {
+  const response = await fetch(url, { ...options, headers: { ...headers, ...(options.headers || {}) } })
+  if (!response.ok) throw new Error(`GitHub HTTP ${response.status}: ${(await response.text()).slice(0, 500)}`)
+  return response.status === 204 ? null : response.json()
+}
+
+const existing = []
+for (let page = 1; page <= 5; page += 1) {
+  const batch = await request(`${api}/issues?state=open&per_page=100&page=${page}`)
+  existing.push(...batch)
+  if (batch.length < 100) break
+}
+
+let created = 0
+let skipped = 0
+for (const issue of issues) {
+  if (existing.some((open) => String(open.body || '').includes(`<!-- ${issue.marker} -->`))) {
+    skipped += 1
+    continue
+  }
+  const createdIssue = await request(`${api}/issues`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title: issue.title, body: issue.body }),
+  })
+  existing.push(createdIssue)
+  created += 1
+  console.log(`[create-decay-issues] created #${createdIssue.number}: ${issue.url}`)
+}
+console.log(`[create-decay-issues] created=${created}; already-open=${skipped}`)

--- a/scripts/maintenance/enrich-decay-with-research-intake.mjs
+++ b/scripts/maintenance/enrich-decay-with-research-intake.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const basePath = path.resolve(process.argv[2] || 'data/maintenance/content-decay-signals.json')
+const queuePath = path.resolve(process.argv[3] || 'artifacts/research-intake/pubmed-review-queue.json')
+const outputPath = path.resolve(process.env.ENRICHED_DECAY_SIGNALS || 'artifacts/maintenance/content-decay-signals-enriched.json')
+const impactThreshold = Number(process.env.RESEARCH_DECAY_IMPACT_THRESHOLD || 50)
+
+function readJson(file, fallback) {
+  try { return JSON.parse(fs.readFileSync(file, 'utf8')) } catch { return fallback }
+}
+function normalizeUrl(value) {
+  try {
+    const url = new URL(String(value), 'https://thehippiescientist.net')
+    const pathname = url.pathname.replace(/\/+/g, '/')
+    return pathname === '/' || pathname.endsWith('/') ? pathname : `${pathname}/`
+  } catch { return '' }
+}
+function pageUrlForStudy(study) {
+  const prefix = String(study.entityId || '').split(':')[0]
+  const collection = prefix === 'herb' ? 'herbs' : prefix === 'compound' ? 'compounds' : ''
+  return collection && study.ingredientSlug ? `/${collection}/${study.ingredientSlug}/` : ''
+}
+
+const base = readJson(basePath, { schemaVersion: 1, rows: [] })
+if (!Array.isArray(base.rows)) throw new Error('base decay signals must contain rows[]')
+const queue = readJson(queuePath, { studies: [] })
+const studies = Array.isArray(queue.studies) ? queue.studies : []
+
+const rows = base.rows.map((row) => ({ ...row, url: normalizeUrl(row.url), researchSignals: Array.isArray(row.researchSignals) ? row.researchSignals : [] }))
+const byUrl = new Map(rows.filter((row) => row.url).map((row) => [row.url, row]))
+
+for (const study of studies) {
+  if (Number(study.likelyGradeImpactScore || 0) < impactThreshold) continue
+  const url = pageUrlForStudy(study)
+  if (!url) continue
+  let row = byUrl.get(url)
+  if (!row) {
+    row = {
+      url,
+      impressions28: 0,
+      clicks28: 0,
+      clicksPrevious28: 0,
+      positionCurrent: 100,
+      positionPrevious: 100,
+      ctrCurrent: 0,
+      ctrPrevious: 0,
+      revenue28: 0,
+      daysSinceEvidenceSearch: 0,
+      avgCitationAgeDays: 0,
+      productChanged: false,
+      newResearchCount: 0,
+      priorityBoost: 0,
+      queryOpportunities: [],
+      researchSignals: [],
+    }
+    rows.push(row)
+    byUrl.set(url, row)
+  }
+  row.newResearchCount = Number(row.newResearchCount || 0) + 1
+  row.priorityBoost = Math.max(Number(row.priorityBoost || 0), study.safetySignal ? 8 : study.likelyGradeImpactScore >= 75 ? 6 : 3)
+  row.researchSignals.push({
+    queueId: study.queueId,
+    pmid: study.pmid,
+    studyClass: study.studyClass,
+    likelyGradeImpactScore: study.likelyGradeImpactScore,
+    safetySignal: Boolean(study.safetySignal),
+    title: study.title,
+  })
+}
+
+const output = {
+  schemaVersion: 1,
+  generatedAt: new Date().toISOString(),
+  baseGeneratedAt: base.generatedAt || null,
+  pubmedQueueGeneratedAt: queue.generatedAt || null,
+  researchImpactThreshold: impactThreshold,
+  rows,
+}
+fs.mkdirSync(path.dirname(outputPath), { recursive: true })
+fs.writeFileSync(outputPath, `${JSON.stringify(output, null, 2)}\n`)
+const affected = rows.filter((row) => row.researchSignals.length).length
+console.log(`[decay-research] enriched ${affected} page(s) with high-impact PubMed intake signals`)
+console.log(`[decay-research] output: ${path.relative(root, outputPath)}`)

--- a/scripts/research/pubmed-ingest.mjs
+++ b/scripts/research/pubmed-ingest.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+/**
+ * Discover recent PubMed records for priority canonical entities and place them
+ * in a review queue. This script never mutates evidence grades or public claims.
+ *
+ * NCBI E-utilities policy: include tool + email on every request. Requests are
+ * intentionally throttled below 3/second even when an API key is configured.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const prioritiesPath = path.resolve(process.argv[2] || 'data/research/pubmed-priorities.json')
+const decisionsPath = path.resolve(process.env.RESEARCH_DECISIONS || 'data/research/review-decisions.jsonl')
+const outputPath = path.resolve(process.env.PUBMED_REVIEW_QUEUE || 'artifacts/research-intake/pubmed-review-queue.json')
+const email = (process.env.NCBI_EMAIL || '').trim()
+const apiKey = (process.env.NCBI_API_KEY || '').trim()
+const toolName = (process.env.NCBI_TOOL || 'hippie_scientist_research').trim().replace(/\s+/g, '_')
+const relativeDays = Math.max(1, Number(process.env.PUBMED_RELDATE_DAYS || 35))
+const perEntity = Math.min(50, Math.max(1, Number(process.env.PUBMED_RESULTS_PER_ENTITY || 15)))
+const base = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils'
+
+function readJson(file, fallback) {
+  try { return JSON.parse(fs.readFileSync(file, 'utf8')) } catch { return fallback }
+}
+function readDecisions(file) {
+  if (!fs.existsSync(file)) return []
+  return fs.readFileSync(file, 'utf8').split(/\r?\n/).filter(Boolean).flatMap((line) => {
+    try { return [JSON.parse(line)] } catch { return [] }
+  })
+}
+function writeJson(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true })
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`)
+}
+function sleep(ms) { return new Promise((resolve) => setTimeout(resolve, ms)) }
+function decode(value) {
+  return String(value || '')
+    .replaceAll('&quot;', '"').replaceAll('&#39;', "'").replaceAll('&amp;', '&')
+    .replaceAll('&lt;', '<').replaceAll('&gt;', '>')
+    .replace(/<[^>]+>/g, '')
+    .trim()
+}
+function skipped(reason) {
+  writeJson(outputPath, { generatedAt: new Date().toISOString(), status: 'skipped', reason, studies: [] })
+  console.log(`[pubmed-ingest] SKIP: ${reason}`)
+  process.exit(0)
+}
+if (!email || !email.includes('@')) skipped('NCBI_EMAIL must be configured with a valid contact email before querying E-utilities')
+
+const commonParams = { tool: toolName, email, ...(apiKey ? { api_key: apiKey } : {}) }
+let lastRequestAt = 0
+async function requestJson(endpoint, params) {
+  const elapsed = Date.now() - lastRequestAt
+  if (elapsed < 375) await sleep(375 - elapsed)
+  const query = new URLSearchParams({ ...commonParams, ...params })
+  const response = await fetch(`${base}/${endpoint}?${query}`, { headers: { Accept: 'application/json' } })
+  lastRequestAt = Date.now()
+  if (!response.ok) throw new Error(`${endpoint} HTTP ${response.status}: ${(await response.text()).slice(0, 300)}`)
+  return response.json()
+}
+
+function publicationClass(pubTypes, title) {
+  const types = (Array.isArray(pubTypes) ? pubTypes : []).map((value) => String(value).toLowerCase())
+  const text = `${types.join(' ')} ${title}`.toLowerCase()
+  if (/meta-analysis/.test(text)) return 'meta-analysis'
+  if (/systematic review/.test(text)) return 'systematic-review'
+  if (/randomized controlled trial|randomised controlled trial/.test(text)) return 'RCT'
+  if (/controlled clinical trial|clinical trial/.test(text)) return 'controlled-trial'
+  if (/observational study|cohort|case-control|cross-sectional/.test(text)) return 'observational'
+  if (/case report/.test(text)) return 'case-report'
+  if (/review/.test(text)) return 'narrative-review'
+  return 'unclassified'
+}
+function safetySignal(title) {
+  return /safety|adverse|toxicity|toxic|hepat|liver injury|interaction|contraindicat|pregnan|terat|bleed|arrhythm|withdrawal|dependence/i.test(title)
+}
+function gradeChangeScore(studyClass, safety, priorityWeight, title) {
+  const classScore = {
+    'meta-analysis': 68,
+    'systematic-review': 62,
+    RCT: 54,
+    'controlled-trial': 42,
+    observational: 30,
+    'case-report': 22,
+    'narrative-review': 18,
+    unclassified: 12,
+  }[studyClass] || 10
+  const safetyBoost = safety ? 18 : 0
+  const languageBoost = /primary outcome|significant|no effect|ineffective|harm|adverse|safety|efficacy/i.test(title) ? 5 : 0
+  return Math.min(100, classScore + safetyBoost + Math.max(0, Number(priorityWeight || 0)) + languageBoost)
+}
+function doiFrom(summary) {
+  const ids = Array.isArray(summary.articleids) ? summary.articleids : []
+  const hit = ids.find((item) => String(item?.idtype || '').toLowerCase() === 'doi')
+  return hit?.value || null
+}
+function authorsFrom(summary) {
+  return Array.isArray(summary.authors) ? summary.authors.map((author) => author?.name).filter(Boolean).slice(0, 20) : []
+}
+
+const priorities = readJson(prioritiesPath, [])
+if (!Array.isArray(priorities) || !priorities.length) skipped('no PubMed priority entities configured')
+const decisions = readDecisions(decisionsPath)
+const decided = new Map(decisions.map((item) => [`${item.entityId}:${item.pmid}`, item]))
+const queue = new Map()
+const searches = []
+
+for (const entity of priorities) {
+  const terms = (Array.isArray(entity.terms) ? entity.terms : []).map((term) => `"${String(term).replaceAll('"', '')}"[Title/Abstract]`)
+  if (!terms.length || !entity.entityId || !entity.slug) continue
+  const term = `(${terms.join(' OR ')})`
+  const search = await requestJson('esearch.fcgi', {
+    db: 'pubmed',
+    term,
+    retmode: 'json',
+    retmax: String(perEntity),
+    sort: 'pub_date',
+    datetype: 'edat',
+    reldate: String(relativeDays),
+  })
+  const ids = search?.esearchresult?.idlist || []
+  searches.push({ entityId: entity.entityId, slug: entity.slug, query: term, returnedPmids: ids.length })
+  if (!ids.length) continue
+
+  const summaries = await requestJson('esummary.fcgi', {
+    db: 'pubmed',
+    id: ids.join(','),
+    retmode: 'json',
+  })
+
+  for (const pmid of ids) {
+    const summary = summaries?.result?.[pmid]
+    if (!summary) continue
+    const decisionKey = `${entity.entityId}:${pmid}`
+    if (decided.has(decisionKey)) continue
+    const title = decode(summary.title)
+    const studyClass = publicationClass(summary.pubtype, title)
+    const safety = safetySignal(title)
+    const candidate = {
+      queueId: `pubmed:${entity.entityId}:${pmid}`,
+      entityId: entity.entityId,
+      ingredientSlug: entity.slug,
+      ingredientName: entity.displayName || entity.slug,
+      pmid: String(pmid),
+      doi: doiFrom(summary),
+      title,
+      authors: authorsFrom(summary),
+      journal: decode(summary.fulljournalname || summary.source),
+      publicationDate: summary.pubdate || null,
+      epubDate: summary.epubdate || null,
+      publicationTypes: Array.isArray(summary.pubtype) ? summary.pubtype : [],
+      studyClass,
+      safetySignal: safety,
+      likelyGradeImpactScore: gradeChangeScore(studyClass, safety, entity.priorityWeight, title),
+      priorityWeight: Number(entity.priorityWeight || 0),
+      pubmedUrl: `https://pubmed.ncbi.nlm.nih.gov/${pmid}/`,
+      discoveredAt: new Date().toISOString(),
+      status: 'needs-review',
+      automationDecision: 'none — reviewer must inspect the paper before any evidence grade or public conclusion changes',
+    }
+    const existing = queue.get(candidate.queueId)
+    if (!existing || candidate.likelyGradeImpactScore > existing.likelyGradeImpactScore) queue.set(candidate.queueId, candidate)
+  }
+}
+
+const studies = [...queue.values()].sort((a, b) => b.likelyGradeImpactScore - a.likelyGradeImpactScore || String(b.publicationDate).localeCompare(String(a.publicationDate)))
+const report = {
+  generatedAt: new Date().toISOString(),
+  status: 'review-required',
+  source: 'NCBI PubMed ESearch + ESummary',
+  windowDays: relativeDays,
+  entityCount: priorities.length,
+  searchSummary: searches,
+  studyCount: studies.length,
+  likelyGradeImpact: studies.filter((study) => study.likelyGradeImpactScore >= 70).length,
+  safetyStudies: studies.filter((study) => study.safetySignal).length,
+  policy: 'Discovery metadata is not evidence adjudication. No public claims, grades, doses, or safety conclusions may change until a reviewer accepts/rejects the study with provenance.',
+  studies,
+}
+writeJson(outputPath, report)
+console.log(`[pubmed-ingest] queued ${studies.length} undecided study/entity matches; likely-grade-impact=${report.likelyGradeImpact}; safety=${report.safetyStudies}`)
+if (studies[0]) console.log(`[pubmed-ingest] top review: ${studies[0].ingredientName} · ${studies[0].studyClass} · PMID ${studies[0].pmid} · impact ${studies[0].likelyGradeImpactScore}`)
+console.log(`[pubmed-ingest] review queue: ${path.relative(root, outputPath)}`)

--- a/scripts/research/review-study.mjs
+++ b/scripts/research/review-study.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+import crypto from 'node:crypto'
+
+const root = process.cwd()
+const [action, identifier] = process.argv.slice(2).filter((arg) => !arg.startsWith('--'))
+const queuePath = path.resolve(process.argv.find((arg) => arg.startsWith('--queue='))?.slice(8) || 'artifacts/research-intake/pubmed-review-queue.json')
+const decisionsPath = path.resolve(process.argv.find((arg) => arg.startsWith('--decisions='))?.slice(12) || 'data/research/review-decisions.jsonl')
+const entityArg = process.argv.find((arg) => arg.startsWith('--entity='))?.slice(9)
+const reason = process.argv.find((arg) => arg.startsWith('--reason='))?.slice(9) || ''
+const reviewer = process.env.GITHUB_ACTOR || process.env.USER || process.env.USERNAME || 'local-reviewer'
+
+if (!['accept', 'reject'].includes(action) || !identifier) {
+  console.error('Usage: node scripts/research/review-study.mjs <accept|reject> <queueId|PMID> [--entity=entityId] [--reason="..."] [--queue=path]')
+  process.exit(1)
+}
+if (!fs.existsSync(queuePath)) {
+  console.error(`[review-study] queue not found: ${queuePath}`)
+  process.exit(1)
+}
+
+const queue = JSON.parse(fs.readFileSync(queuePath, 'utf8'))
+const studies = Array.isArray(queue.studies) ? queue.studies : []
+const matches = studies.filter((study) => {
+  if (identifier === study.queueId) return true
+  if (String(identifier) === String(study.pmid) && (!entityArg || entityArg === study.entityId)) return true
+  return false
+})
+if (!matches.length) {
+  console.error(`[review-study] no matching study for ${identifier}${entityArg ? ` / ${entityArg}` : ''}`)
+  process.exit(1)
+}
+if (matches.length > 1) {
+  console.error(`[review-study] PMID ${identifier} matches multiple entities; pass --entity=<entityId> or the full queueId`)
+  process.exit(1)
+}
+const study = matches[0]
+
+let prior = []
+if (fs.existsSync(decisionsPath)) {
+  prior = fs.readFileSync(decisionsPath, 'utf8').split(/\r?\n/).filter(Boolean).flatMap((line) => {
+    try { return [JSON.parse(line)] } catch { return [] }
+  })
+}
+const existing = prior.find((item) => item.queueId === study.queueId && item.supersededBy == null)
+if (existing) {
+  console.error(`[review-study] active decision already exists for ${study.queueId}: ${existing.decision} at ${existing.decidedAt}`)
+  process.exit(1)
+}
+
+const decidedAt = new Date().toISOString()
+const record = {
+  provenanceId: `decision:${crypto.createHash('sha256').update(`${study.queueId}:${action}:${decidedAt}:${reviewer}`).digest('hex').slice(0, 16)}`,
+  queueId: study.queueId,
+  entityId: study.entityId,
+  ingredientSlug: study.ingredientSlug,
+  pmid: study.pmid,
+  doi: study.doi || null,
+  title: study.title,
+  studyClass: study.studyClass,
+  safetySignal: Boolean(study.safetySignal),
+  likelyGradeImpactScore: study.likelyGradeImpactScore,
+  decision: action === 'accept' ? 'accepted-for-editorial-review' : 'rejected-from-review-queue',
+  decisionMeaning: action === 'accept'
+    ? 'This study may now be used by an editor/researcher in evidence adjudication; acceptance does not automatically change a grade or conclusion.'
+    : 'This study/entity match was rejected from the intake queue; rejection does not delete the discovery provenance.',
+  reason: reason || null,
+  reviewer,
+  decidedAt,
+  sourceQueueGeneratedAt: queue.generatedAt || null,
+  sourceSystem: queue.source || 'PubMed review queue',
+  supersededBy: null,
+}
+
+fs.mkdirSync(path.dirname(decisionsPath), { recursive: true })
+fs.appendFileSync(decisionsPath, `${JSON.stringify(record)}\n`)
+console.log(`[review-study] ${record.decision}: ${study.queueId}`)
+console.log(`[review-study] provenance: ${record.provenanceId}`)
+console.log('[review-study] no evidence grade or public conclusion was changed automatically')


### PR DESCRIPTION
Implements the freshness/research-ingestion tranche as a closed maintenance loop while keeping scientific judgment review-gated.

- scores content decay upward when important new research appears, rankings/clicks fall, citations age, or product information changes
- ranks updates by combined decay severity and expected organic/revenue recovery value
- carries Search Console metrics and query opportunities into every generated update issue payload
- creates deduplicated GitHub content-decay issues automatically using stable body markers
- defines canonical priority ingredient entities/synonyms for PubMed matching
- queries NCBI PubMed ESearch + ESummary on a throttled weekly cadence with required tool/email identification and optional API key
- detects and labels meta-analyses, systematic reviews, RCTs, controlled trials, observational studies, case reports, reviews, and safety-signal papers
- scores studies by likely evidence-grade impact and canonical ingredient priority
- feeds high-impact PubMed discoveries back into the corresponding page's decay/update score
- places every discovered paper into a review queue rather than mutating conclusions
- adds one-command accept/reject review decisions with append-only provenance, reviewer, reason, PMID/DOI, source queue timestamp, and explicit semantics
- accepted studies are only accepted for editorial adjudication; acceptance never automatically changes evidence grades, doses, safety conclusions, or public copy
- schedules the full loop weekly and uploads the review/decay artifacts

NCBI credentials are conservative: without NCBI_EMAIL, PubMed intake writes an explicit skipped queue and the rest of the decay system still runs.