### PR TITLE
fix(interactions): stop linking hidden partner profiles

### DIFF
--- a/src/lib/runtime-data.ts
+++ b/src/lib/runtime-data.ts
@@ -276,12 +276,29 @@ export const getEntityRiskTags = cache(async () => {
   return readJsonFile('entity_risk_tags.json') as Promise<RiskTagsBySlug>
 })
 
+export function buildRenderableSlugEntityTypeMap(
+  herbs: RuntimeRecord[],
+  compounds: RuntimeRecord[],
+): SlugEntityTypeMap {
+  const map: SlugEntityTypeMap = {}
+
+  for (const herb of herbs) {
+    const slug = typeof herb.slug === 'string' ? herb.slug : ''
+    if (slug && getRuntimeVisibility(herb).canRender) map[slug] = 'herb'
+  }
+
+  for (const compound of compounds) {
+    const slug = typeof compound.slug === 'string' ? compound.slug : ''
+    if (slug && getRuntimeVisibility(compound).canRender) map[slug] = 'compound'
+  }
+
+  return map
+}
+
 // Resolves which route (/herbs/[slug] vs /compounds/[slug]) a given partner
-// slug belongs to, so interaction-edge links never point at the wrong path.
+// slug belongs to. Only renderable records receive a route so interaction
+// warnings cannot link to a profile that intentionally resolves to 404.
 export const getSlugEntityTypeMap = cache(async (): Promise<SlugEntityTypeMap> => {
   const { herbs, compounds } = await getUnifiedRuntimeRecords()
-  const map: SlugEntityTypeMap = {}
-  for (const h of herbs) map[h.slug] = 'herb'
-  for (const c of compounds) map[c.slug] = 'compound'
-  return map
+  return buildRenderableSlugEntityTypeMap(herbs as RuntimeRecord[], compounds as RuntimeRecord[])
 })

--- a/tests/interaction-route-map-visibility.test.ts
+++ b/tests/interaction-route-map-visibility.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildRenderableSlugEntityTypeMap } from '../src/lib/runtime-data'
+import type { RuntimeRecord } from '../src/types/content'
+
+describe('interaction partner route map visibility', () => {
+  it('keeps renderable publish and noindex profiles linkable while excluding hidden records', () => {
+    const herbs: RuntimeRecord[] = [
+      { slug: 'published-herb', indexability_status: 'PUBLISH' },
+      { slug: 'research-herb', indexability_status: 'NOINDEX' },
+      {
+        slug: 'hidden-herb',
+        indexability_status: 'PUBLISH',
+        runtime_export_decision: 'hide',
+      },
+    ]
+    const compounds: RuntimeRecord[] = [
+      { slug: 'published-compound', indexability_status: 'PUBLISH' },
+      { slug: 'research-compound', indexability_status: 'NOINDEX' },
+      {
+        slug: 'hidden-compound',
+        indexability_status: 'PUBLISH',
+        runtime_export_decision: 'hide',
+      },
+    ]
+
+    expect(buildRenderableSlugEntityTypeMap(herbs, compounds)).toEqual({
+      'published-herb': 'herb',
+      'research-herb': 'herb',
+      'published-compound': 'compound',
+      'research-compound': 'compound',
+    })
+  })
+
+  it('does not create route entries for records without a valid slug', () => {
+    expect(
+      buildRenderableSlugEntityTypeMap(
+        [{ slug: '', indexability_status: 'PUBLISH' }],
+        [{ indexability_status: 'PUBLISH' }],
+      ),
+    ).toEqual({})
+  })
+})


### PR DESCRIPTION
## Root cause
`getSlugEntityTypeMap()` added every runtime herb and compound slug to the interaction partner route map. `InteractionWarnings` treats presence in that map as permission to render a clickable profile link, so an interaction edge targeting a hidden/unrenderable record could link users to a profile that correctly resolves to 404.

## Change
- Add one shared `buildRenderableSlugEntityTypeMap` helper.
- Include only records where the canonical `getRuntimeVisibility(record).canRender` policy allows the profile to render.
- Preserve renderable `NOINDEX` research/archive profiles as linkable; this is a renderability fix, not an indexing-policy change.
- Ignore records without a usable slug.
- Make the cached runtime map delegate to the shared builder.
- Add behavior-level regression coverage for PUBLISH, NOINDEX, hidden, and missing-slug records.

## Scope
Interaction warnings, severity/certainty logic, edge data, partner labels, and safety content remain unchanged. Hidden partners still appear as warning text; they simply no longer become dead profile links.