### PR TITLE
ROI 751-756 follow-up: live research-maturity governance

### DIFF
--- a/components/ui/ProfileEvidenceLens.tsx
+++ b/components/ui/ProfileEvidenceLens.tsx
@@ -4,8 +4,8 @@ import {
   getEvidenceTier,
   hasHumanEvidence,
   hasMechanismEvidence,
-  isPreliminaryResearch,
 } from '@/lib/evidence'
+import { policyForResearchRecord } from '@/src/lib/research-maturity'
 import type { RuntimeRecord } from '../../src/types/content'
 
 type ProfileEvidenceLensProps = {
@@ -131,14 +131,22 @@ export default function ProfileEvidenceLens({
   const effects = cleanList(record.primary_effects || record.primaryEffects || record.effects, 3)
   const humanSignal = hasHumanEvidence(runtimeRecord)
   const mechanismSignal = hasMechanismEvidence(runtimeRecord) || mechanisms.length > 0
-  const preliminarySignal = isPreliminaryResearch(runtimeRecord)
+  const maturity = policyForResearchRecord(record)
   const safety = firstReadable(safetySummary || record.safetyNotes || record.safety_notes || record.safety)
   const limitation = limitations.map(formatDisplayLabel).find(Boolean)
+  const maturityDetail =
+    maturity.maturity === 'theoretical'
+      ? 'Mechanistic or unresolved evidence is kept separate from established human outcomes.'
+      : maturity.maturity === 'preliminary'
+        ? 'Early findings are not treated as established consumer benefit.'
+        : limitation || (effects.length ? `main contexts: ${effects.join(' · ')}` : undefined)
 
   return (
     <section
       className="rounded-2xl border border-brand-900/10 bg-white/80 p-4 shadow-sm dark:border-white/10 dark:bg-white/5"
       aria-labelledby="profile-evidence-lens-heading"
+      data-research-maturity={maturity.maturity}
+      data-research-visual-weight={maturity.visualWeight}
     >
       <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
         <div>
@@ -179,9 +187,9 @@ export default function ProfileEvidenceLens({
         />
         <SignalRow
           title="Research maturity"
-          value={preliminarySignal ? 'Preliminary or mixed' : 'More interpretable'}
-          detail={limitation || (effects.length ? `main contexts: ${effects.join(' · ')}` : undefined)}
-          tone={preliminarySignal ? 'caution' : 'clinical'}
+          value={maturity.label}
+          detail={maturityDetail}
+          tone={maturity.maturity === 'established' ? 'clinical' : maturity.maturity === 'theoretical' ? 'mechanism' : 'caution'}
         />
         <SignalRow
           title="Safety boundary"

--- a/components/ui/__tests__/ProfileEvidenceLens.maturity.test.tsx
+++ b/components/ui/__tests__/ProfileEvidenceLens.maturity.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import ProfileEvidenceLens from '../ProfileEvidenceLens'
+
+describe('ProfileEvidenceLens research maturity', () => {
+  it('shows theoretical research distinctly for preclinical-only records', () => {
+    const { container } = render(
+      <ProfileEvidenceLens
+        record={{
+          slug: 'example',
+          evidence_tier: 'Preclinical animal studies only',
+          mechanisms: ['receptor modulation'],
+        }}
+      />,
+    )
+
+    expect(screen.getByText('Theoretical / mechanistic research')).toBeTruthy()
+    expect(container.querySelector('[data-research-maturity="theoretical"]')).toBeTruthy()
+    expect(container.querySelector('[data-research-visual-weight="research-only"]')).toBeTruthy()
+  })
+
+  it('shows established research distinctly for strong human evidence', () => {
+    const { container } = render(
+      <ProfileEvidenceLens record={{ slug: 'example', evidence_tier: 'Strong human clinical trial evidence' }} />,
+    )
+
+    expect(screen.getByText('Established research')).toBeTruthy()
+    expect(container.querySelector('[data-research-maturity="established"]')).toBeTruthy()
+  })
+})

--- a/src/lib/__tests__/affiliate-maturity-governance.test.ts
+++ b/src/lib/__tests__/affiliate-maturity-governance.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { canRenderAffiliateLinks, getAffiliateShopLinks } from '../affiliate'
+
+describe('affiliate research-maturity governance', () => {
+  it('blocks preliminary records from affiliate purchase intent', () => {
+    const record = {
+      slug: 'example-compound',
+      displayName: 'Example Compound',
+      evidence_tier: 'Preliminary human evidence',
+      profile_status: 'complete',
+      affiliate_ready: true,
+    }
+
+    expect(canRenderAffiliateLinks(record)).toBe(false)
+    expect(getAffiliateShopLinks(record, record.displayName, 'compound')).toEqual([])
+  })
+
+  it('blocks theoretical mechanism-only records from affiliate purchase intent', () => {
+    const record = {
+      slug: 'example-mechanism-compound',
+      displayName: 'Example Mechanism Compound',
+      evidence_tier: 'Preclinical animal studies only',
+      mechanisms: ['receptor modulation'],
+      profile_status: 'complete',
+      affiliate_ready: true,
+    }
+
+    expect(canRenderAffiliateLinks(record)).toBe(false)
+  })
+
+  it('does not add a maturity restriction to sparse compact payloads without evidence fields', () => {
+    const record = {
+      slug: 'l-theanine',
+      displayName: 'L-Theanine',
+      affiliate_ready: true,
+      profile_status: 'complete',
+    }
+
+    expect(canRenderAffiliateLinks(record)).toBe(true)
+  })
+})

--- a/src/lib/__tests__/research-maturity-live.test.ts
+++ b/src/lib/__tests__/research-maturity-live.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import {
+  deriveResearchMaturity,
+  hasExplicitResearchMaturitySignal,
+  policyForResearchRecord,
+} from '../research-maturity'
+
+describe('live research maturity governance', () => {
+  it('maps strong human evidence to established research', () => {
+    expect(deriveResearchMaturity({ evidence_tier: 'Strong human clinical trial evidence' })).toBe('established')
+  })
+
+  it('maps early human evidence to preliminary research', () => {
+    expect(deriveResearchMaturity({ evidence_tier: 'Preliminary human evidence' })).toBe('preliminary')
+    expect(policyForResearchRecord({ evidence_tier: 'Preliminary human evidence' }).purchaseIntentAllowed).toBe(false)
+  })
+
+  it('maps preclinical mechanism-only records to theoretical research', () => {
+    const record = { evidence_tier: 'Preclinical animal studies only', mechanisms: ['receptor modulation'] }
+    expect(deriveResearchMaturity(record)).toBe('theoretical')
+    expect(policyForResearchRecord(record).visualWeight).toBe('research-only')
+  })
+
+  it('does not invent a maturity commerce restriction for sparse payloads with no evidence signal', () => {
+    expect(hasExplicitResearchMaturitySignal({ slug: 'sparse-payload' })).toBe(false)
+    expect(hasExplicitResearchMaturitySignal({ evidence_grade: 'D' })).toBe(true)
+  })
+})

--- a/src/lib/affiliate.ts
+++ b/src/lib/affiliate.ts
@@ -1,6 +1,10 @@
 import { isClean, list, text } from '@/lib/display-utils'
 import { getRuntimeVisibility } from '@/lib/runtime-visibility'
 import { isRestrictedIngredient, isRestrictedRecord } from './restricted-ingredients'
+import {
+  hasExplicitResearchMaturitySignal,
+  policyForResearchRecord,
+} from './research-maturity'
 import { AFFILIATE_TAGS } from '@/config/affiliate'
 
 export const AMAZON_ASSOCIATE_ID = AFFILIATE_TAGS.amazon
@@ -61,6 +65,17 @@ export function canRenderAffiliateLinks(item: any) {
   // Full profile records do not carry the compact flag. Enforce the same central
   // runtime monetization decision before profile-level sourcing CTAs are rendered.
   if (item.monetization_allowed == null && !getRuntimeVisibility(item).canMonetize) {
+    return false
+  }
+
+  // Research maturity is independent from safety. When a canonical record
+  // explicitly identifies itself as preliminary or mechanism-only, remove
+  // purchase intent even if no separate safety restriction applies.
+  if (
+    item.monetization_allowed == null &&
+    hasExplicitResearchMaturitySignal(item as Record<string, unknown>) &&
+    !policyForResearchRecord(item).purchaseIntentAllowed
+  ) {
     return false
   }
 

--- a/src/lib/research-maturity.ts
+++ b/src/lib/research-maturity.ts
@@ -1,3 +1,10 @@
+import {
+  getEvidenceTier,
+  hasHumanEvidence,
+  hasMechanismEvidence,
+} from '@/lib/evidence'
+import type { RuntimeRecord } from '../types/content'
+
 export const RESEARCH_MATURITY_LEVELS = [
   'established',
   'emerging',
@@ -51,6 +58,61 @@ export const RESEARCH_MATURITY_POLICIES: Record<ResearchMaturity, ResearchMaturi
   },
 }
 
+export function policyForResearchMaturity(level: ResearchMaturity): ResearchMaturityPolicy {
+  return RESEARCH_MATURITY_POLICIES[level]
+}
+
+/**
+ * Derives the public research-maturity indicator from the existing canonical
+ * evidence helpers rather than asking templates to invent a second grading
+ * system. Strong/moderate human evidence is established; weaker human evidence
+ * is emerging; early human/traditional evidence is preliminary; mechanism-only
+ * or unresolved evidence is theoretical.
+ */
+export function deriveResearchMaturity(
+  record: RuntimeRecord | Record<string, unknown>,
+): ResearchMaturity {
+  const runtimeRecord = record as RuntimeRecord
+  const tier = getEvidenceTier(runtimeRecord)
+  const human = hasHumanEvidence(runtimeRecord)
+  const mechanism = hasMechanismEvidence(runtimeRecord)
+
+  if ((tier === 'strong' || tier === 'moderate') && human) return 'established'
+  if ((tier === 'limited' || tier === 'mixed') && human) return 'emerging'
+  if (tier === 'preliminary' || tier === 'traditional') return 'preliminary'
+  if (!human && mechanism) return 'theoretical'
+  if (tier === 'insufficient' || tier === 'review') return 'theoretical'
+
+  return human ? 'emerging' : 'theoretical'
+}
+
+export function policyForResearchRecord(
+  record: RuntimeRecord | Record<string, unknown>,
+): ResearchMaturityPolicy & { maturity: ResearchMaturity } {
+  const maturity = deriveResearchMaturity(record)
+  return { maturity, ...policyForResearchMaturity(maturity) }
+}
+
+/**
+ * Affiliate governance should only add a maturity restriction when a record
+ * actually carries an evidence/maturity signal. This avoids turning sparse
+ * internal payloads into implicit "theoretical" judgments merely because they
+ * omit fields that exist on the canonical full record.
+ */
+export function hasExplicitResearchMaturitySignal(record: Record<string, unknown>): boolean {
+  return [
+    record.evidence_grade,
+    record.evidence_tier,
+    record.evidenceTier,
+    record.evidenceLevel,
+    record.confidenceTier,
+    record.profile_status,
+    record.review_status,
+    record.summary_quality,
+    record.source_status,
+  ].some((value) => String(value ?? '').trim().length > 0)
+}
+
 export type RelationshipKind =
   | 'outcome-supported'
   | 'exploratory-outcome'
@@ -74,10 +136,6 @@ export interface RelationshipValidationIssue {
     | 'alternative-without-outcome-evidence'
     | 'clinical-effect-without-outcome-evidence'
   message: string
-}
-
-export function policyForResearchMaturity(level: ResearchMaturity): ResearchMaturityPolicy {
-  return RESEARCH_MATURITY_POLICIES[level]
 }
 
 export function validateResearchRelationship(


### PR DESCRIPTION
Operationalizes backlog 751-756 in existing production paths.

- derives established/emerging/preliminary/theoretical maturity from the canonical evidence helpers instead of a second grading system
- exposes the canonical maturity label and visual-weight state in ProfileEvidenceLens
- makes theoretical/preliminary profiles explicitly distinct from established research
- centrally suppresses affiliate purchase intent for full records that explicitly carry preliminary/theoretical evidence signals
- preserves sparse compact payload behavior when evidence fields are intentionally absent
- adds focused regression coverage for derivation, visual indicators, and affiliate suppression