### PR TITLE
feat(evidence): surface default citation-ready evidence snapshot

### DIFF
--- a/components/ui/ShowMeTheStudies.tsx
+++ b/components/ui/ShowMeTheStudies.tsx
@@ -298,6 +298,14 @@ export default function ShowMeTheStudies({
   const participantLabel = metrics.studiesWithParticipantCounts > 0
     ? `~${metrics.approximateParticipants.toLocaleString()} participants across ${metrics.studiesWithParticipantCounts} human sources with reported N`
     : 'Participant totals not consistently reported'
+  const namedExtracts = [...new Set(studies.map(study => study.extractName).filter((value): value is string => Boolean(value)))]
+  const evidenceSnapshot = conclusion || [
+    `This table contains ${metrics.totalStudies} structured source${metrics.totalStudies === 1 ? '' : 's'}, including ${metrics.humanTrials} human trial${metrics.humanTrials === 1 ? '' : 's'}.`,
+    metrics.studiesWithParticipantCounts > 0
+      ? `Across ${metrics.studiesWithParticipantCounts} human source${metrics.studiesWithParticipantCounts === 1 ? '' : 's'} with a reported sample size, the approximate participant total is ${metrics.approximateParticipants.toLocaleString()}; overlapping publications may include some of the same people.`
+      : 'A reliable participant total cannot be calculated because sample size is not consistently structured in the cited sources.',
+    `The structured direction is ${evidenceConsistencyLabel(metrics.consistency).toLowerCase()}: ${metrics.supportive} supporting, ${metrics.mixed} mixed, ${metrics.contradicting} contradicting, and ${metrics.noClearEffect} no-clear-effect source relationships.`,
+  ].join(' ')
 
   return (
     <details className="group/studies overflow-hidden rounded-2xl border-2 border-brand-900/10 bg-[var(--surface-card)] p-0 shadow-none backdrop-blur-none dark:border-white/10">
@@ -341,28 +349,28 @@ export default function ShowMeTheStudies({
         </div>
       ) : null}
 
-      {(conclusion || evidenceGrade || confidence || whatWouldChangeConclusion) ? (
-        <div className="grid gap-3 border-t border-brand-900/10 bg-white/80 p-4 md:grid-cols-2 dark:border-white/10 dark:bg-white/5">
-          <div className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
-            <p className="text-[10px] font-bold uppercase tracking-[0.12em] text-brand-700">Why we believe this</p>
-            {conclusion ? <p className="mt-2 text-sm leading-6 text-ink">{conclusion}</p> : null}
-            <p className="mt-2 text-xs leading-5 text-muted">
-              {metrics.supportive} supporting · {metrics.mixed} mixed · {metrics.contradicting} contradicting · {metrics.noClearEffect} no-clear-effect sources.
+      <div className="grid gap-3 border-t border-brand-900/10 bg-white/80 p-4 md:grid-cols-2 dark:border-white/10 dark:bg-white/5">
+        <div className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+          <p className="text-[10px] font-bold uppercase tracking-[0.12em] text-brand-700">What the evidence actually shows</p>
+          <p className="mt-2 text-sm leading-6 text-ink">{evidenceSnapshot}</p>
+          {namedExtracts.length > 0 ? (
+            <p className="mt-2 text-xs leading-5 text-amber-900 dark:text-amber-100">
+              <strong>Form limitation:</strong> Some findings concern named preparations ({namedExtracts.slice(0, 3).join(', ')}{namedExtracts.length > 3 ? ', …' : ''}); those results should not automatically be generalized to every product sold under the ingredient name.
             </p>
-            {(evidenceGrade || confidence) ? (
-              <p className="mt-2 text-xs font-semibold text-ink">
-                {evidenceGrade ? `Evidence grade: ${evidenceGrade}` : ''}{evidenceGrade && confidence ? ' · ' : ''}{confidence ? `Confidence: ${confidence}` : ''}
-              </p>
-            ) : null}
-          </div>
-          <div className="rounded-xl border border-brand-900/10 bg-white p-4 dark:bg-white/5">
-            <p className="text-[10px] font-bold uppercase tracking-[0.12em] text-brand-700">What would change our conclusion?</p>
-            <p className="mt-2 text-sm leading-6 text-muted">
-              {whatWouldChangeConclusion || 'Larger, well-controlled human trials using comparable populations, doses, preparations, and clinically meaningful outcomes could materially strengthen or weaken this conclusion.'}
-            </p>
-          </div>
+          ) : null}
+          <p className="mt-2 text-xs font-semibold text-ink">
+            {evidenceGrade ? `Evidence grade: ${evidenceGrade}` : 'Evidence grade: see the profile-level grade above'}
+            {' · '}
+            {confidence ? `Confidence: ${confidence}` : 'Confidence: not separately assigned'}
+          </p>
         </div>
-      ) : null}
+        <div className="rounded-xl border border-brand-900/10 bg-white p-4 dark:bg-white/5">
+          <p className="text-[10px] font-bold uppercase tracking-[0.12em] text-brand-700">What would change our conclusion?</p>
+          <p className="mt-2 text-sm leading-6 text-muted">
+            {whatWouldChangeConclusion || 'Larger, well-controlled human trials using comparable populations, doses, preparations, and clinically meaningful outcomes could materially strengthen or weaken this conclusion. Replication in a different population or a high-quality synthesis resolving current disagreement could also materially change confidence.'}
+          </p>
+        </div>
+      </div>
 
       <div className="overflow-x-auto border-t border-brand-900/10 dark:border-white/10">
         <table className="w-full min-w-[1600px] border-collapse text-left text-sm">

--- a/components/ui/__tests__/ShowMeTheStudies.snapshot.test.tsx
+++ b/components/ui/__tests__/ShowMeTheStudies.snapshot.test.tsx
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import ShowMeTheStudies from '../ShowMeTheStudies'
+
+const citations = [
+  {
+    title: 'Trial one',
+    pmid: '12345678',
+    studyType: 'randomized controlled trial',
+    evidenceClass: 'randomized_controlled_trial' as const,
+    sampleSize: 120,
+    relationship: 'supports' as const,
+    extractName: 'Standardized extract A',
+  },
+  {
+    title: 'Trial two',
+    pmid: '23456789',
+    studyType: 'randomized controlled trial',
+    evidenceClass: 'randomized_controlled_trial' as const,
+    sampleSize: 80,
+    relationship: 'contradicts' as const,
+  },
+]
+
+describe('ShowMeTheStudies default evidence snapshot', () => {
+  it('renders a citation-ready evidence summary even when callers pass only citations', () => {
+    render(<ShowMeTheStudies citations={citations} />)
+
+    expect(screen.getByText('What the evidence actually shows')).toBeTruthy()
+    expect(screen.getByText(/2 human trials/i)).toBeTruthy()
+    expect(screen.getByText(/approximate participant total is 200/i)).toBeTruthy()
+    expect(screen.getByText(/1 supporting, 0 mixed, 1 contradicting/i)).toBeTruthy()
+    expect(screen.getByText(/Confidence: not separately assigned/i)).toBeTruthy()
+  })
+
+  it('warns against generalizing named-extract findings to every product', () => {
+    render(<ShowMeTheStudies citations={citations} />)
+    expect(screen.getByText(/should not automatically be generalized to every product/i)).toBeTruthy()
+  })
+
+  it('always states what evidence could change the conclusion', () => {
+    render(<ShowMeTheStudies citations={citations} />)
+    expect(screen.getByText('What would change our conclusion?')).toBeTruthy()
+    expect(screen.getByText(/larger, well-controlled human trials/i)).toBeTruthy()
+  })
+})


### PR DESCRIPTION
Makes the shared study component publish a concise evidence snapshot even when profile callers only provide citations. The snapshot states study/trial counts, reported participant context, directional agreement/disagreement, confidence status, named-extract generalization caveats, and what new evidence could change the conclusion. Preserves the newer study-class filters and quantitative-context fields already on main.