### PR TITLE
fix(maintenance): preserve content-decay issue labels

### DIFF
--- a/scripts/maintenance/build-decay-issue-payloads.mjs
+++ b/scripts/maintenance/build-decay-issue-payloads.mjs
@@ -75,7 +75,7 @@ ${queries}
       url: page.url,
       title: `[Content decay] Update ${page.url} (priority ${page.updatePriority})`,
       body,
-      labels: ['content-decay', 'seo', 'research-update'],
+      labels: ['maintenance', 'seo', 'evidence'],
       priority: page.updatePriority,
     }
   })

--- a/scripts/maintenance/create-decay-issues.mjs
+++ b/scripts/maintenance/create-decay-issues.mjs
@@ -53,10 +53,13 @@ for (const issue of issues) {
     skipped += 1
     continue
   }
+  const labels = Array.isArray(issue.labels)
+    ? issue.labels.map((label) => String(label).trim()).filter(Boolean)
+    : []
   const createdIssue = await request(`${api}/issues`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ title: issue.title, body: issue.body }),
+    body: JSON.stringify({ title: issue.title, body: issue.body, labels }),
   })
   existing.push(createdIssue)
   created += 1


### PR DESCRIPTION
Fix the content-decay issue automation contract.

- Replace non-existent generated labels with existing repository labels: `maintenance`, `seo`, and `evidence`.
- Pass generated labels through to the GitHub Issues API instead of silently dropping them.
- Keep deduplication and issue body behavior unchanged.

This restores the intended triage metadata without introducing labels that would make GitHub return a validation error.