### PR TITLE
ROI #142: expand energy and fatigue goal hub

### DIFF
--- a/data/goal-content-growth.ts
+++ b/data/goal-content-growth.ts
@@ -41,4 +41,44 @@ export const growthGoalContentBySlug: Record<string, GoalContentExtension> = {
       'Keep mechanistic findings separate from demonstrated human outcomes throughout the decision path.',
     ],
   },
+  energy: {
+    faqItems: [
+      {
+        question: 'How should fatigue and energy supplements be compared?',
+        answer:
+          'Separate immediate alertness, exercise performance, fatigue outcomes, and longer-term metabolic or mitochondrial markers. They are different intents and should not be collapsed into one generic “energy” claim.',
+      },
+      {
+        question: 'Does feeling stimulating mean an ingredient has stronger fatigue evidence?',
+        answer:
+          'No. Subjective stimulation and clinically measured fatigue are different outcomes. Compare the endpoint used in human studies, the duration, and the population before treating a faster sensation as stronger evidence.',
+      },
+      {
+        question: 'Why does timing matter for energy-oriented products?',
+        answer:
+          'Timing can affect tolerability, sleep, and how an intervention is evaluated. Use the canonical timing record when it exists rather than inferring a schedule from stimulant or mechanism labels.',
+      },
+      {
+        question: 'What should I check before comparing two energy options?',
+        answer:
+          'Compare human evidence, the exact fatigue or performance endpoint, studied dose, formulation, interaction burden, and whether the expected time course matches the outcome being researched.',
+      },
+    ],
+    dosingNotes: [
+      { compound: 'Caffeine', note: 'Use the canonical timing and dose record; do not let “more stimulating” substitute for a better evidence fit.' },
+      { compound: 'Rhodiola', note: 'Match any dose discussion to the studied extract and fatigue/stress population.' },
+      { compound: 'CoQ10', note: 'Keep formulation and population differences visible when interpreting dose or absorption information.' },
+    ],
+    evidenceRows: [
+      { compound: 'Caffeine', evidence: 'See canonical profile', humanData: 'Alertness and performance outcomes', limitation: 'Alertness is not the same endpoint as chronic fatigue' },
+      { compound: 'Rhodiola', evidence: 'See canonical profile', humanData: 'Fatigue/stress outcomes', limitation: 'Study populations and extracts vary' },
+      { compound: 'CoQ10', evidence: 'See canonical profile', humanData: 'Population-specific human outcomes', limitation: 'Do not generalize mitochondrial mechanisms into universal energy benefit' },
+      { compound: 'Panax Ginseng', evidence: 'See canonical profile', humanData: 'Fatigue and vitality research', limitation: 'Extract and population differences matter' },
+    ],
+    safetyBullets: [
+      'Keep wakefulness, exercise performance, fatigue, and metabolic outcomes separate.',
+      'Check sleep disruption, cardiovascular context, and interaction data before treating stimulation as a benefit.',
+      'Use explicit human outcomes rather than mechanism language to rank energy-oriented options.',
+    ],
+  },
 }


### PR DESCRIPTION
Adds structured energy/fatigue intent depth that separates wakefulness, performance, fatigue, and metabolic endpoints while routing dose, timing, and safety decisions back to canonical records.