### PR TITLE
Backlog 870–880: major-page accessibility regression coverage

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -19,7 +19,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: Lighthouse audit
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
@@ -43,6 +43,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Validate accessibility primitives
+        run: |
+          node scripts/ci/validate-accessibility-baseline.mjs
+          npm run test:a11y
+
       - name: Build static export
         env:
           COMMIT_HASH: ${{ github.sha }}
@@ -54,22 +59,29 @@ jobs:
       - name: Audit third-party scripts and image stability
         run: node scripts/ci/audit-third-party-performance.mjs
 
-      - name: Run Lighthouse CI
+      - name: Run Lighthouse performance and accessibility audits
         run: |
           npx serve@14 out -p 3000 &
           SERVER_PID=$!
+          trap 'kill $SERVER_PID 2>/dev/null || true' EXIT
           timeout 30 bash -c 'until curl -sf http://localhost:3000 > /dev/null; do sleep 1; done'
+
           npx @lhci/cli@0.14 collect --config=.lighthouserc.json
           npx @lhci/cli@0.14 assert --config=.lighthouserc.json
-          kill $SERVER_PID 2>/dev/null || true
+          mv .lighthouseci .lighthouseci-performance
 
-      - name: Upload performance results
+          npx @lhci/cli@0.14 collect --config=.lighthouserc.a11y.json
+          npx @lhci/cli@0.14 assert --config=.lighthouserc.a11y.json
+          mv .lighthouseci .lighthouseci-accessibility
+
+      - name: Upload performance and accessibility results
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: performance-results-${{ github.run_number }}
           path: |
-            .lighthouseci/
+            .lighthouseci-performance/
+            .lighthouseci-accessibility/
             reports/third-party-performance.json
             docs/performance/budgets-log.md
           retention-days: 30
@@ -77,10 +89,11 @@ jobs:
       - name: Add workflow summary
         if: always()
         run: |
-          echo "## Performance Governance" >> "$GITHUB_STEP_SUMMARY"
+          echo "## Performance & Accessibility Governance" >> "$GITHUB_STEP_SUMMARY"
           echo "- Lighthouse performance target: ≥ 82" >> "$GITHUB_STEP_SUMMARY"
           echo "- Hard CWV gates: LCP ≤ 2.5s, CLS ≤ 0.10, TBT ≤ 300ms" >> "$GITHUB_STEP_SUMMARY"
           echo "- Hard accessibility gate: ≥ 90" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Bundle/data budgets and third-party script policy are enforced before Lighthouse" >> "$GITHUB_STEP_SUMMARY"
-          echo "- URLs tested: /, /herbs/ashwagandha/, /compounds/l-theanine/" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Global skip-link, focus, target-size, reduced-motion, table, and form-label contracts are source-validated" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Performance URLs: /, /herbs/ashwagandha/, /compounds/l-theanine/" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Accessibility URLs: /, /goals/, /herbs/ashwagandha/, /compounds/l-theanine/, /guides/compare/, /safety-checker/, /evidence/evidence-checker/, /tools/botanical-activity-atlas/, /evidence/evidence-report/" >> "$GITHUB_STEP_SUMMARY"
           echo "- Status: ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.lighthouserc.a11y.json
+++ b/.lighthouserc.a11y.json
@@ -1,0 +1,37 @@
+{
+  "ci": {
+    "collect": {
+      "url": [
+        "http://localhost:3000/",
+        "http://localhost:3000/goals/",
+        "http://localhost:3000/herbs/ashwagandha/",
+        "http://localhost:3000/compounds/l-theanine/",
+        "http://localhost:3000/guides/compare/",
+        "http://localhost:3000/safety-checker/",
+        "http://localhost:3000/evidence/evidence-checker/",
+        "http://localhost:3000/tools/botanical-activity-atlas/",
+        "http://localhost:3000/evidence/evidence-report/"
+      ],
+      "numberOfRuns": 1,
+      "settings": {
+        "onlyCategories": ["accessibility"],
+        "chromeFlags": "--no-sandbox --disable-dev-shm-usage"
+      }
+    },
+    "assert": {
+      "assertions": {
+        "categories:accessibility": ["error", { "minScore": 0.9 }],
+        "button-name": ["error", { "minScore": 1 }],
+        "link-name": ["error", { "minScore": 1 }],
+        "image-alt": ["error", { "minScore": 1 }],
+        "label": ["error", { "minScore": 1 }],
+        "color-contrast": ["error", { "minScore": 1 }],
+        "heading-order": ["error", { "minScore": 1 }],
+        "html-has-lang": ["error", { "minScore": 1 }]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}

--- a/scripts/ci/validate-accessibility-baseline.mjs
+++ b/scripts/ci/validate-accessibility-baseline.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+import fs from 'node:fs/promises'
+
+const files = {
+  layout: 'app/layout.tsx',
+  css: 'styles/accessibility-wcag-22.css',
+  navigation: 'components/Navigation.tsx',
+  evidenceLookup: 'app/evidence/evidence-checker/EvidenceLookupClient.tsx',
+  atlas: 'src/components/atlas/BotanicalActivityAtlasClient.tsx',
+}
+
+const source = Object.fromEntries(
+  await Promise.all(Object.entries(files).map(async ([key, file]) => [key, await fs.readFile(file, 'utf8')])),
+)
+
+const contracts = [
+  ['skip navigation link', source.layout.includes("href='#main-content'") && source.layout.includes("className='skip-link'")],
+  ['focusable main landmark target', source.layout.includes("id='main-content'") && source.layout.includes('tabIndex={-1}')],
+  ['primary navigation landmark', /aria-label=['"]Primary['"]/.test(source.navigation)],
+  ['mobile navigation landmark', /aria-label=['"]Mobile primary links['"]/.test(source.navigation)],
+  ['keyboard focus-visible rule', /:focus-visible/.test(source.css)],
+  ['44px minimum interactive target', /--a11y-target-size:\s*44px/.test(source.css)],
+  ['forced-colors fallback', /@media\s*\(forced-colors:\s*active\)/.test(source.css)],
+  ['reduced-motion fallback', /@media\s*\(prefers-reduced-motion:\s*reduce\)/.test(source.css)],
+  ['accessible table region focus treatment', source.css.includes('.accessible-table-region:focus-visible')],
+  ['table caption treatment', /table caption/.test(source.css)],
+  ['evidence search input label', source.evidenceLookup.includes('htmlFor="evidence-lookup-search"')],
+  ['evidence tier filter group label', source.evidenceLookup.includes('aria-label="Filter by evidence tier"')],
+  ['atlas filter labels', source.atlas.includes("const labelClass") && source.atlas.includes('<label>')],
+]
+
+const failures = contracts.filter(([, passes]) => !passes).map(([name]) => name)
+
+if (failures.length) {
+  console.error(`Accessibility baseline failed (${failures.length}):`)
+  for (const failure of failures) console.error(`- ${failure}`)
+  process.exit(1)
+}
+
+console.log(`Accessibility baseline: ${contracts.length}/${contracts.length} contracts pass.`)


### PR DESCRIPTION
Closes #3107

## Summary
- Preserve the existing WCAG 2.2 baseline rather than duplicating it page-by-page.
- Add a deterministic source-level accessibility contract validator for skip navigation, focus-visible behavior, 44px targets, forced colors, reduced motion, table affordances, primary/mobile nav landmarks, and key tool labels.
- Add a dedicated Lighthouse accessibility configuration spanning homepage, Goals, two canonical profiles, Compare, Safety Checker, Evidence Database, Botanical Activity Atlas, and Evidence Report.
- Keep the existing 3-URL performance Lighthouse audit unchanged while running the broader accessibility-only pass against the same static build/server.
- Retain axe-core component tests as an additional pre-browser gate.

## Relevant URLs
- `/`
- `/goals/`
- `/herbs/ashwagandha/`
- `/compounds/l-theanine/`
- `/guides/compare/`
- `/safety-checker/`
- `/evidence/evidence-checker/`
- `/tools/botanical-activity-atlas/`
- `/evidence/evidence-report/`

## Acceptance criteria
- [x] Keyboard/focus/skip/reduced-motion/table/target-size contracts are machine-validated.
- [x] Major intent and differentiator page categories are included in browser accessibility audits.
- [x] Accessibility category score remains a hard ≥90 gate.
- [x] Button names, link names, image alt text, labels, contrast, heading order, and document language are explicit hard checks.
- [x] Existing performance thresholds and tested URLs remain unchanged.

## Validation commands
- `node scripts/ci/validate-accessibility-baseline.mjs`
- `npm run test:a11y`
- `npx @lhci/cli@0.14 collect --config=.lighthouserc.a11y.json`
- `npx @lhci/cli@0.14 assert --config=.lighthouserc.a11y.json`
- `npm run validate:release`

## Before → after metrics
| Metric / invariant | Before | After |
|---|---:|---:|
| Browser-audited accessibility routes | 3 | 9 |
| Major differentiator routes in a11y browser gate | 0 | 5 |
| Source-level global a11y contracts | implicit | 13 explicit checks |
| Axe component suite | present | preserved + CI-adjacent |

## Generator/source-of-truth decision
Accessibility behavior stays centralized in the existing root layout and `accessibility-wcag-22.css`. This PR validates those shared primitives and expands browser coverage instead of adding one-off page fixes.

## Regression contract
The branch is four commits behind main, but merge-base→main inspection shows no overlap with this PR's three files. The original Lighthouse performance config is untouched.

## Risk notes / justified tradeoffs
The broader accessibility pass adds browser work, so the workflow timeout increases from 25 to 30 minutes. It reuses the same build and local server to avoid a second build.