### PR TITLE
fix(atlas): restore typecheck for relationship contract

### DIFF
--- a/src/lib/__tests__/botanical-atlas-data.test.ts
+++ b/src/lib/__tests__/botanical-atlas-data.test.ts
@@ -87,14 +87,24 @@ describe('Botanical Activity Atlas runtime fallbacks', () => {
       record({ herb_slug: 'ashwagandha', compound: 'Noise', relationship: 'compared_with' }),
     ])
 
-    expect(mapped.get('ashwagandha')).toEqual(['Withanolides', 'Withaferin A'])
+    expect(mapped.get('ashwagandha')).toEqual([
+      { compound: 'Withanolides', relationship: 'contains_compound' },
+      { compound: 'Withaferin A', relationship: 'contains_compound' },
+    ])
   })
 
   it('merges canonical mapped compounds without duplicates and infers chemistry classes', () => {
     const atlasRecord = toAtlasRecord(record({ slug: 'ashwagandha', effects: ['calming'], active_constituents: ['Withaferin A'] }))
-    const enriched = enrichAtlasRecordWithMappedCompounds(atlasRecord, ['withaferin a', 'Withanolides'])
+    const enriched = enrichAtlasRecordWithMappedCompounds(atlasRecord, [
+      { compound: 'withaferin a', relationship: 'contains_compound' },
+      { compound: 'Withanolides', relationship: 'contains_compound' },
+    ])
 
     expect(enriched.compounds).toEqual(['withaferin a', 'Withanolides'])
     expect(enriched.compoundClasses).toContain('Withanolides')
+    expect(enriched.sourceRelationships).toEqual([
+      'Test Herb contains_compound withaferin a',
+      'Test Herb contains_compound Withanolides',
+    ])
   })
 })


### PR DESCRIPTION
Closes #3113.

The Botanical Atlas runtime now preserves canonical herb-compound relationship provenance as `{ compound, relationship }` objects, but two regression tests still used the old `string[]` contract.

This fix:
- updates the canonical-map expectation to the current relationship-object shape,
- passes relationship objects into Atlas enrichment,
- asserts `sourceRelationships` provenance,
- leaves the production contract and types unchanged.

This directly addresses the TypeScript release failure reported in #3113.