### PR TITLE
feat(editorial): expose correction path beside review metadata

### DIFF
--- a/src/components/editorial/LastUpdatedBadge.tsx
+++ b/src/components/editorial/LastUpdatedBadge.tsx
@@ -3,6 +3,7 @@ type LastUpdatedBadgeProps = {
   label?: string
   className?: string
   citationCount?: number
+  showCorrectionLink?: boolean
 }
 
 function formatReviewDate(value: string | null | undefined): string | null {
@@ -21,26 +22,40 @@ export default function LastUpdatedBadge({
   label = 'Last reviewed',
   className = '',
   citationCount,
+  showCorrectionLink = true,
 }: LastUpdatedBadgeProps) {
   const formatted = formatReviewDate(date)
   if (!formatted) return null
   const sourceLabel = citationCount === 1 ? 'source cited' : 'sources cited'
 
   return (
-    <p
-      aria-label={`${label}: ${formatted}${citationCount ? `. ${citationCount} ${sourceLabel}.` : ''}`}
-      className={`inline-flex items-center gap-2 rounded-full border border-brand-900/10 bg-white/80 px-3 py-1 text-xs font-semibold text-muted ${className}`}
+    <span
+      aria-label={`${label}: ${formatted}${citationCount ? `. ${citationCount} ${sourceLabel}.` : ''}${showCorrectionLink ? ' Report a correction.' : ''}`}
+      className={`inline-flex flex-wrap items-center gap-2 rounded-full border border-brand-900/10 bg-white/80 px-3 py-1 text-xs font-semibold text-muted ${className}`}
     >
-      <span className='h-1.5 w-1.5 rounded-full bg-[var(--color-evidence-strong)]' aria-hidden='true' />
-      <span>
-        {label}: <time dateTime={date || undefined}>{formatted}</time>
-        {citationCount !== undefined && citationCount > 0 ? (
-          <>
-            <span className='mx-1.5 text-muted/30'>•</span>
-            <span>{citationCount} {sourceLabel}</span>
-          </>
-        ) : null}
+      <span className="inline-flex items-center gap-2">
+        <span className='h-1.5 w-1.5 rounded-full bg-[var(--color-evidence-strong)]' aria-hidden='true' />
+        <span>
+          {label}: <time dateTime={date || undefined}>{formatted}</time>
+          {citationCount !== undefined && citationCount > 0 ? (
+            <>
+              <span className='mx-1.5 text-muted/30'>•</span>
+              <span>{citationCount} {sourceLabel}</span>
+            </>
+          ) : null}
+        </span>
       </span>
-    </p>
+      {showCorrectionLink ? (
+        <>
+          <span aria-hidden="true" className="text-muted/30">•</span>
+          <a
+            href="/info/corrections/"
+            className="text-brand-700 underline-offset-2 hover:underline dark:text-brand-100"
+          >
+            Report a correction
+          </a>
+        </>
+      ) : null}
+    </span>
   )
 }

--- a/src/components/editorial/__tests__/LastUpdatedBadge.test.tsx
+++ b/src/components/editorial/__tests__/LastUpdatedBadge.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import LastUpdatedBadge from '../LastUpdatedBadge'
+
+describe('LastUpdatedBadge', () => {
+  it('renders a correction link beside a real review date by default', () => {
+    render(<LastUpdatedBadge date="2026-08-15" citationCount={12} />)
+
+    expect(screen.getByText(/Last reviewed:/)).toBeTruthy()
+    expect(screen.getByText(/12 sources cited/)).toBeTruthy()
+    expect(screen.getByRole('link', { name: 'Report a correction' })).toHaveAttribute('href', '/info/corrections/')
+  })
+
+  it('allows contexts to suppress the correction link explicitly', () => {
+    render(<LastUpdatedBadge date="2026-08-15" showCorrectionLink={false} />)
+    expect(screen.queryByRole('link', { name: 'Report a correction' })).toBeNull()
+  })
+
+  it('does not render review UI when no real review date exists', () => {
+    const { container } = render(<LastUpdatedBadge date="" />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})


### PR DESCRIPTION
Makes the correction mechanism visible anywhere truthful review metadata is shown. Adds a default “Report a correction” link to the shared LastUpdatedBadge while preserving an opt-out for contexts that should suppress it. The component still renders nothing when no valid review date exists, so this does not create fake review events. Includes regression coverage.