### PR TITLE
fix(links): exclude hidden profiles from related-link candidates

### DIFF
--- a/lib/__tests__/runtime-link-candidates.test.ts
+++ b/lib/__tests__/runtime-link-candidates.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildRenderableRuntimeRecordIndex } from '@/lib/runtime-link-candidates'
+import type { RuntimeRecord } from '@/src/types/content'
+
+describe('renderable runtime link candidate index', () => {
+  it('keeps publish and noindex records while excluding hidden candidates', () => {
+    const index = buildRenderableRuntimeRecordIndex([
+      { slug: 'published', indexability_status: 'PUBLISH' },
+      { slug: 'research-only', indexability_status: 'NOINDEX' },
+      {
+        slug: 'hidden',
+        indexability_status: 'PUBLISH',
+        runtime_export_decision: 'hide',
+      },
+    ])
+
+    expect([...index.keys()]).toEqual(['published', 'research-only'])
+  })
+
+  it('does not let an unrenderable duplicate reserve a slug ahead of a renderable record', () => {
+    const hidden: RuntimeRecord = {
+      slug: 'shared',
+      name: 'Hidden version',
+      indexability_status: 'PUBLISH',
+      runtime_export_decision: 'hide',
+    }
+    const renderable: RuntimeRecord = {
+      slug: 'shared',
+      name: 'Renderable version',
+      indexability_status: 'PUBLISH',
+    }
+
+    const index = buildRenderableRuntimeRecordIndex([hidden, renderable])
+
+    expect(index.get('shared')?.name).toBe('Renderable version')
+  })
+
+  it('ignores records without a usable slug', () => {
+    expect(
+      buildRenderableRuntimeRecordIndex([
+        { slug: '', indexability_status: 'PUBLISH' },
+        { indexability_status: 'PUBLISH' },
+      ]),
+    ).toEqual(new Map())
+  })
+})

--- a/lib/ecosystem-continuity.ts
+++ b/lib/ecosystem-continuity.ts
@@ -1,4 +1,5 @@
 import { list, text, unique } from '@/lib/display-utils'
+import { buildRenderableRuntimeRecordIndex } from '@/lib/runtime-link-candidates'
 import { safeArray, safeLower, safeScore, safeSlug } from '@/lib/search-safe'
 import { getRuntimeMapEntries } from '../src/lib/runtime-related-maps'
 import type { RuntimeRecord } from '../src/types/content'
@@ -32,13 +33,7 @@ function sortByScoreThenName(a: Record<string, unknown>, b: Record<string, unkno
 function hydrateContinuityEntries(entries: RuntimeRelationshipEntry[], records: RuntimeRecord[]) {
   if (!Array.isArray(entries) || entries.length === 0) return []
 
-  const bySlug = new Map<string, RuntimeRecord>()
-
-  for (const record of safeArray<RuntimeRecord>(records)) {
-    const slug = safeSlug(record?.slug)
-    if (!slug || bySlug.has(slug)) continue
-    bySlug.set(slug, record)
-  }
+  const bySlug = buildRenderableRuntimeRecordIndex(records)
 
   return entries
     .map((entry): RuntimeRecord | null => {

--- a/lib/related-runtime.ts
+++ b/lib/related-runtime.ts
@@ -1,4 +1,5 @@
 import { text } from '@/lib/display-utils'
+import { buildRenderableRuntimeRecordIndex } from '@/lib/runtime-link-candidates'
 import { safeArray, safeScore, safeSlug } from '@/lib/search-safe'
 import {
   getRuntimeMapEntries,
@@ -39,16 +40,6 @@ function clampLimit(value: unknown, fallback: number, max: number) {
   const parsed = safeScore(value, fallback)
   if (!Number.isFinite(parsed)) return fallback
   return Math.min(max, Math.max(0, Math.floor(parsed)))
-}
-
-function buildRecordIndex(records: RuntimeRecord[]) {
-  const bySlug = new Map<string, RuntimeRecord>()
-  for (const record of safeArray<RuntimeRecord>(records)) {
-    const slug = safeSlug(record?.slug)
-    if (!slug || bySlug.has(slug)) continue
-    bySlug.set(slug, record)
-  }
-  return bySlug
 }
 
 function normalizedOpportunityScore(record: RuntimeRecord): number {
@@ -130,7 +121,7 @@ async function getRuntimeRecords(kind: RuntimeRelationshipKind, record: RuntimeR
   if (!slug || requestedLimit === 0) return []
 
   const entries = await getRuntimeMapEntries(kind, slug)
-  const recordIndex = buildRecordIndex(records)
+  const recordIndex = buildRenderableRuntimeRecordIndex(records)
   return sortHydratedRecords(hydrateRuntimeEntries(entries, recordIndex)).slice(0, requestedLimit)
 }
 
@@ -164,7 +155,7 @@ export async function getBatchedRuntimeRecords(
     .slice(0, MAX_BATCHED_SLUGS)
   if (sourceSlugs.length === 0) return {}
 
-  const recordIndex = buildRecordIndex(candidateRecords)
+  const recordIndex = buildRenderableRuntimeRecordIndex(candidateRecords)
   const entriesBySlug = await getRuntimeMapEntriesForSlugs(kind, sourceSlugs)
 
   return Object.fromEntries(

--- a/lib/runtime-link-candidates.ts
+++ b/lib/runtime-link-candidates.ts
@@ -1,0 +1,15 @@
+import { getRuntimeVisibility } from '@/lib/runtime-visibility'
+import { safeArray, safeSlug } from '@/lib/search-safe'
+import type { RuntimeRecord } from '@/src/types/content'
+
+export function buildRenderableRuntimeRecordIndex(records: RuntimeRecord[]) {
+  const bySlug = new Map<string, RuntimeRecord>()
+
+  for (const record of safeArray<RuntimeRecord>(records)) {
+    const slug = safeSlug(record?.slug)
+    if (!slug || bySlug.has(slug) || !getRuntimeVisibility(record).canRender) continue
+    bySlug.set(slug, record)
+  }
+
+  return bySlug
+}


### PR DESCRIPTION
## Root cause
Profile pages pass raw unified `allRecords` into both the related/comparison relationship engine and ecosystem-continuity engine. Each utility independently built a slug index from every candidate record, so a hidden/unrenderable profile could be hydrated into a related, comparison, stack, or ecosystem-continuity recommendation and become a dead internal profile link.

## Change
- Add one canonical `buildRenderableRuntimeRecordIndex` helper for profile-link candidates.
- Apply the canonical `getRuntimeVisibility(record).canRender` policy before a slug can enter the candidate index.
- Reuse that helper in `related-runtime` and `ecosystem-continuity`, deleting their duplicated index-building loops.
- Preserve renderable `NOINDEX` research/archive profiles as candidates; this is a navigation/renderability rule, not an indexing-policy rule.
- Ensure an unrenderable duplicate cannot reserve a slug ahead of a later renderable record.
- Add behavior-level regression coverage for PUBLISH, NOINDEX, hidden, duplicate-slug, and missing-slug records.

## Scope
Semantic graph scores, strategic link boosts, relationship reasons, ranking order, limits, and profile rendering remain unchanged.