### PR TITLE
ROI #146: stricter YMYL editorial gate

### DIFF
--- a/src/lib/__tests__/ymyl-editorial-gate.test.ts
+++ b/src/lib/__tests__/ymyl-editorial-gate.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+
+import { evaluateYmylEditorialGate } from '@/src/lib/ymyl-editorial-gate'
+
+describe('evaluateYmylEditorialGate', () => {
+  it('keeps the baseline lightweight for ordinary wellness content', () => {
+    const result = evaluateYmylEditorialGate({
+      title: 'Everyday stress research',
+      hasDirectAnswer: true,
+    })
+
+    expect(result).toMatchObject({ ymyl: false, canPublish: true })
+    expect(result.required).toEqual(['direct-answer'])
+  })
+
+  it('blocks disease education that lacks safety and evidence context', () => {
+    const result = evaluateYmylEditorialGate({
+      title: 'Berberine evidence in type 2 diabetes',
+      hasDirectAnswer: true,
+      primarySourceCount: 2,
+      hasEvidenceLimitations: true,
+      hasSafetySection: false,
+      hasMedicationContext: false,
+      hasEditorialReview: true,
+    })
+
+    expect(result.purpose).toBe('disease-education')
+    expect(result.canPublish).toBe(false)
+    expect(result.missing).toEqual(expect.arrayContaining(['safety-section', 'medication-context']))
+  })
+
+  it('requires a higher source count and treatment boundary for disease-treatment intent', () => {
+    const result = evaluateYmylEditorialGate({
+      title: 'Can supplements treat ADHD?',
+      hasDirectAnswer: true,
+      primarySourceCount: 2,
+      hasEvidenceLimitations: true,
+      hasSafetySection: true,
+      hasMedicationContext: true,
+      hasTreatmentBoundary: false,
+      hasEditorialReview: true,
+    })
+
+    expect(result.purpose).toBe('disease-treatment')
+    expect(result.canPublish).toBe(false)
+    expect(result.missing).toEqual(expect.arrayContaining(['primary-sources', 'treatment-boundary']))
+  })
+
+  it('passes disease-treatment content only after every stricter requirement is met', () => {
+    const result = evaluateYmylEditorialGate({
+      title: 'Can supplements treat ADHD?',
+      hasDirectAnswer: true,
+      primarySourceCount: 3,
+      hasEvidenceLimitations: true,
+      hasSafetySection: true,
+      hasMedicationContext: true,
+      hasTreatmentBoundary: true,
+      hasEditorialReview: true,
+    })
+
+    expect(result).toMatchObject({ purpose: 'disease-treatment', ymyl: true, canPublish: true })
+    expect(result.missing).toEqual([])
+  })
+})

--- a/src/lib/ymyl-editorial-gate.ts
+++ b/src/lib/ymyl-editorial-gate.ts
@@ -1,0 +1,101 @@
+import {
+  classifyHealthContentPurpose,
+  type HealthContentPurpose,
+  type HealthContentPurposeInput,
+} from '@/src/lib/health-content-purpose'
+
+export type EditorialReadinessInput = HealthContentPurposeInput & {
+  primarySourceCount?: number
+  hasEvidenceLimitations?: boolean
+  hasSafetySection?: boolean
+  hasMedicationContext?: boolean
+  hasTreatmentBoundary?: boolean
+  hasEditorialReview?: boolean
+  hasDirectAnswer?: boolean
+}
+
+export type EditorialRequirement =
+  | 'direct-answer'
+  | 'primary-sources'
+  | 'evidence-limitations'
+  | 'safety-section'
+  | 'medication-context'
+  | 'treatment-boundary'
+  | 'editorial-review'
+
+export type EditorialReadinessResult = {
+  purpose: HealthContentPurpose
+  ymyl: boolean
+  required: EditorialRequirement[]
+  missing: EditorialRequirement[]
+  canPublish: boolean
+}
+
+const BASE_REQUIREMENTS: EditorialRequirement[] = ['direct-answer']
+const DISEASE_EDUCATION_REQUIREMENTS: EditorialRequirement[] = [
+  'direct-answer',
+  'primary-sources',
+  'evidence-limitations',
+  'safety-section',
+  'medication-context',
+  'editorial-review',
+]
+const DISEASE_TREATMENT_REQUIREMENTS: EditorialRequirement[] = [
+  ...DISEASE_EDUCATION_REQUIREMENTS,
+  'treatment-boundary',
+]
+
+function requirementsFor(purpose: HealthContentPurpose): EditorialRequirement[] {
+  if (purpose === 'disease-treatment') return DISEASE_TREATMENT_REQUIREMENTS
+  if (purpose === 'disease-education') return DISEASE_EDUCATION_REQUIREMENTS
+  return BASE_REQUIREMENTS
+}
+
+function requirementMet(
+  requirement: EditorialRequirement,
+  input: EditorialReadinessInput,
+  purpose: HealthContentPurpose,
+): boolean {
+  switch (requirement) {
+    case 'direct-answer':
+      return input.hasDirectAnswer === true
+    case 'primary-sources':
+      return (input.primarySourceCount ?? 0) >= (purpose === 'disease-treatment' ? 3 : 2)
+    case 'evidence-limitations':
+      return input.hasEvidenceLimitations === true
+    case 'safety-section':
+      return input.hasSafetySection === true
+    case 'medication-context':
+      return input.hasMedicationContext === true
+    case 'treatment-boundary':
+      return input.hasTreatmentBoundary === true
+    case 'editorial-review':
+      return input.hasEditorialReview === true
+  }
+}
+
+/**
+ * Publication-readiness gate for health content.
+ *
+ * Disease-related pages must clear a materially higher evidence and safety bar
+ * than ordinary wellness/symptom pages. This gate does not imply medical review;
+ * `hasEditorialReview` means a real editorial review event occurred. Qualified
+ * external review, where used, is tracked separately.
+ */
+export function evaluateYmylEditorialGate(
+  input: EditorialReadinessInput,
+): EditorialReadinessResult {
+  const classification = classifyHealthContentPurpose(input)
+  const required = requirementsFor(classification.purpose)
+  const missing = required.filter(
+    (requirement) => !requirementMet(requirement, input, classification.purpose),
+  )
+
+  return {
+    purpose: classification.purpose,
+    ymyl: classification.ymyl,
+    required,
+    missing,
+    canPublish: missing.length === 0,
+  }
+}


### PR DESCRIPTION
Adds a publication-readiness gate that consumes the canonical health-content classification. Disease education requires stronger sourcing, limitations, safety, medication context, and an editorial review; disease-treatment intent also requires a treatment-boundary statement and a higher primary-source count.