### PR TITLE
feat(data): migrate legacy evidence grades at production boundary

### DIFF
--- a/components/EvidenceMeter.tsx
+++ b/components/EvidenceMeter.tsx
@@ -18,6 +18,7 @@ export default function EvidenceMeter({
   defaultOpen = false,
 }: Props) {
   const ariaLabel = `Evidence strength: ${data.label}${context ? ` ${context}` : ''}. Score ${data.score} out of 100.`
+  const gradeLabel = data.grade ? `Grade ${data.grade}` : 'No universal grade'
 
   if (compact) {
     return (
@@ -51,9 +52,9 @@ export default function EvidenceMeter({
 
         <span
           className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-semibold ${data.bgColorClass} ${data.textColorClass} ${data.borderColorClass}`}
-          aria-label={`Evidence grade: ${data.grade} — ${data.label}`}
+          aria-label={`${gradeLabel} — ${data.label}`}
         >
-          {data.grade} · {data.label}
+          {gradeLabel} · {data.label}
         </span>
       </div>
 

--- a/components/EvidenceMeterDetail.tsx
+++ b/components/EvidenceMeterDetail.tsx
@@ -6,6 +6,8 @@ type Props = {
 }
 
 export default function EvidenceMeterDetail({ data }: Props) {
+  const gradeLabel = data.grade ? `Grade ${data.grade}` : 'No universal grade'
+
   return (
     <div className="mt-3 space-y-3 text-sm">
       <p className="leading-6 text-muted">{data.explanation}</p>
@@ -37,9 +39,9 @@ export default function EvidenceMeterDetail({ data }: Props) {
 
         <span
           className="inline-flex items-center rounded-full border border-brand-900/10 bg-white/80 px-2.5 py-1 text-xs font-semibold text-muted dark:border-white/10 dark:bg-white/5"
-          aria-label={`Evidence grade: ${data.grade}`}
+          aria-label={`Evidence grade: ${data.grade ?? 'not universally assigned'}`}
         >
-          Grade {data.grade}
+          {gradeLabel}
         </span>
       </div>
 

--- a/components/ui/EvidenceScoreBadge.tsx
+++ b/components/ui/EvidenceScoreBadge.tsx
@@ -1,7 +1,7 @@
 import { getEvidenceLetterGrade, type EvidenceLetterGrade } from '@/lib/evidence'
 import type { RuntimeRecord } from '@/src/types/content'
 
-const GRADE_CONFIG: Record<EvidenceLetterGrade, {
+type GradePresentation = {
   badge: string
   label: string
   meaning: string
@@ -10,7 +10,9 @@ const GRADE_CONFIG: Record<EvidenceLetterGrade, {
   border: string
   ringColor: string
   solid: string
-}> = {
+}
+
+const GRADE_CONFIG: Record<EvidenceLetterGrade, GradePresentation> = {
   A: {
     badge: 'A',
     label: 'A',
@@ -63,6 +65,23 @@ const GRADE_CONFIG: Record<EvidenceLetterGrade, {
   },
 }
 
+const UNASSIGNED_CONFIG: GradePresentation = {
+  badge: '–',
+  label: 'Not assigned',
+  meaning: 'No universal evidence grade is assigned. Evidence may vary by outcome or require review.',
+  bg: 'bg-slate-50 dark:bg-slate-300/10',
+  text: 'text-slate-700 dark:text-slate-100',
+  border: 'border-slate-200 dark:border-slate-200/20',
+  ringColor: 'ring-slate-200/30',
+  solid: 'bg-slate-500',
+}
+
+const OUTCOME_SPECIFIC_CONFIG: GradePresentation = {
+  ...UNASSIGNED_CONFIG,
+  label: 'Outcome-specific',
+  meaning: 'No single universal evidence grade applies because evidence strength differs by outcome.',
+}
+
 const GRADE_MEANING_SHORT: Record<EvidenceLetterGrade, string> = {
   A: 'Strong',
   B: 'Moderate',
@@ -71,9 +90,6 @@ const GRADE_MEANING_SHORT: Record<EvidenceLetterGrade, string> = {
   'Avoid/Insufficient': 'Avoid / Insufficient',
 }
 
-// Dark-mode-aware text color for the circle variant's label — the static
-// --color-evidence-* tokens don't have dark overrides and read low-contrast
-// against dark surfaces, so this uses adaptive Tailwind utilities instead.
 const GRADE_TEXT_ADAPTIVE: Record<EvidenceLetterGrade, string> = {
   A: 'text-emerald-800 dark:text-emerald-100',
   B: 'text-blue-800 dark:text-blue-100',
@@ -84,7 +100,7 @@ const GRADE_TEXT_ADAPTIVE: Record<EvidenceLetterGrade, string> = {
 
 type EvidenceScoreBadgeProps = {
   record?: Record<string, unknown>
-  grade?: EvidenceLetterGrade
+  grade?: EvidenceLetterGrade | null
   size?: 'sm' | 'md' | 'circle'
   showLabel?: boolean
   className?: string
@@ -97,8 +113,22 @@ export default function EvidenceScoreBadge({
   showLabel = true,
   className = '',
 }: EvidenceScoreBadgeProps) {
-  const canonicalGrade = grade ?? (record ? getEvidenceLetterGrade(record as RuntimeRecord) : 'C')
-  const config = GRADE_CONFIG[canonicalGrade]
+  const canonicalGrade = grade !== undefined
+    ? grade
+    : record
+      ? getEvidenceLetterGrade(record as RuntimeRecord)
+      : null
+  const outcomeSpecific = String(record?.evidence_grade_status ?? '').toLowerCase() === 'outcome-dependent'
+  const config = canonicalGrade
+    ? GRADE_CONFIG[canonicalGrade]
+    : outcomeSpecific
+      ? OUTCOME_SPECIFIC_CONFIG
+      : UNASSIGNED_CONFIG
+  const shortLabel = canonicalGrade ? GRADE_MEANING_SHORT[canonicalGrade] : config.label
+  const adaptiveText = canonicalGrade ? GRADE_TEXT_ADAPTIVE[canonicalGrade] : config.text
+  const ariaLabel = canonicalGrade
+    ? `Evidence grade ${canonicalGrade}: ${config.meaning}`
+    : `Evidence grade not assigned: ${config.meaning}`
 
   if (size === 'circle') {
     return (
@@ -113,8 +143,8 @@ export default function EvidenceScoreBadge({
           {config.badge}
         </span>
         {showLabel && (
-          <span aria-label={`Evidence grade ${canonicalGrade}: ${config.meaning}`} className={`text-sm font-semibold ${GRADE_TEXT_ADAPTIVE[canonicalGrade]}`}>
-            {GRADE_MEANING_SHORT[canonicalGrade]}
+          <span aria-label={ariaLabel} className={`text-sm font-semibold ${adaptiveText}`}>
+            {shortLabel}
           </span>
         )}
       </span>
@@ -129,14 +159,14 @@ export default function EvidenceScoreBadge({
   return (
     <span
       title={config.meaning}
-      aria-label={`Evidence grade ${canonicalGrade}: ${config.meaning}`}
+      aria-label={ariaLabel}
       className={`inline-flex items-center rounded-full border font-bold tracking-wide ${config.bg} ${config.text} ${config.border} ${sizeClasses} ${className}`}
     >
-      <span className={size === 'sm' ? 'text-[0.8rem]' : 'text-sm'}>{config.label}</span>
-      {showLabel && canonicalGrade !== 'Avoid/Insufficient' && (
+      <span className={size === 'sm' ? 'text-[0.8rem]' : 'text-sm'}>{canonicalGrade ? config.label : config.badge}</span>
+      {showLabel && (canonicalGrade !== 'Avoid/Insufficient' || !canonicalGrade) && (
         <span className="font-semibold">
           {' '}
-          {GRADE_MEANING_SHORT[canonicalGrade]}
+          {shortLabel}
         </span>
       )}
     </span>

--- a/lib/evidence-grade-core.js
+++ b/lib/evidence-grade-core.js
@@ -1,0 +1,206 @@
+/**
+ * Runtime-agnostic evidence-grade normalization core.
+ *
+ * This file is plain ESM on purpose: Next/TypeScript code and Node `.mjs` data
+ * pipelines both import this exact implementation. Keep legacy parsing here so
+ * build scripts, migrations, validators, and UI cannot grow competing rules.
+ */
+
+export const CANONICAL_EVIDENCE_GRADES = Object.freeze([
+  'A',
+  'B',
+  'C',
+  'D',
+  'Avoid/Insufficient',
+])
+
+export const BAND_LABEL = Object.freeze({
+  strong: 'Strong evidence',
+  moderate: 'Moderate evidence',
+  limited: 'Limited evidence',
+  preliminary: 'Preliminary evidence',
+  insufficient: 'Insufficient evidence',
+})
+
+export const CANONICAL_GRADE_LABEL = Object.freeze({
+  A: 'Grade A: Strong Evidence',
+  B: 'Grade B: Moderate Evidence',
+  C: 'Grade C: Limited Evidence',
+  D: 'Grade D: Preliminary / Theoretical Evidence',
+  'Avoid/Insufficient': 'Avoid / Insufficient Evidence',
+})
+
+export const LETTER_LABEL = Object.freeze({
+  A: CANONICAL_GRADE_LABEL.A,
+  B: CANONICAL_GRADE_LABEL.B,
+  C: CANONICAL_GRADE_LABEL.C,
+  D: CANONICAL_GRADE_LABEL.D,
+})
+
+const GRADE_FOR_BAND = Object.freeze({
+  strong: 'A',
+  moderate: 'B',
+  limited: 'C',
+  preliminary: 'D',
+  insufficient: 'Avoid/Insufficient',
+})
+
+const BAND_FOR_GRADE = Object.freeze({
+  A: 'strong',
+  B: 'moderate',
+  C: 'limited',
+  D: 'preliminary',
+  'Avoid/Insufficient': 'insufficient',
+})
+
+const BARE_LETTER_RE = /^([a-d])\s*[+-]?$/i
+const LEGACY_FAIL_RE = /^f\s*[+-]?$/i
+const OUTCOME_DEPENDENT_RE = /\b[a-df]\s*[+-]?\s+for\s+\w+.*;\s*[a-df]\s*[+-]?\s+for\s+/i
+const INSUFFICIENT_RE = /\b(insufficient|no evidence|none|avoid|blocked|contraindicat(?:ed|ion)?)\b/i
+const NO_HUMAN_RE = /\b(no\s+human(?:\s+(?:trial|trials|evidence|data|stud(?:y|ies)))?|without\s+human(?:\s+(?:trial|trials|evidence|data|stud(?:y|ies)))?)\b/i
+const PRECLINICAL_SIGNAL_RE = /\b(preclinical|animal(?:\s+stud(?:y|ies))?|in\s*vitro|cell(?:ular)?\s+(?:study|studies)|theoretical)\b/i
+const MECHANISTIC_RE = /\bmechanistic(?:\s+evidence)?\b/i
+const HUMAN_CLINICAL_RE = /\b(human|clinical|rct|randomi[sz]ed|controlled\s+trial|meta[- ]analysis|systematic\s+review)\b/i
+const MIXED_RE = /\b(mixed|inconsistent|conflict(?:ing)?|equivocal)\b/i
+
+const STRONG_RE = /\b(moderate[- ]to[- ]strong|strong|robust|high[- ]quality|well[- ]established)\b/i
+const MODERATE_RE = /\b(limited[- ]to[- ]moderate|moderate)\b/i
+const LIMITED_RE = /\b(limited|low[- ]moderate|emerging)\b/i
+const PRELIMINARY_RE = /\b(preliminary|pilot|early|weak|low)\b/i
+
+const EMPTY = Object.freeze({
+  grade: null,
+  letter: null,
+  band: null,
+  label: 'Evidence grade not assigned',
+  raw: '',
+  canonical: false,
+  outcomeDependent: false,
+})
+
+export function isCanonicalEvidenceGrade(value) {
+  return CANONICAL_EVIDENCE_GRADES.includes(value)
+}
+
+export function bandFromCanonicalGrade(grade) {
+  return BAND_FOR_GRADE[grade] ?? null
+}
+
+/**
+ * Conservative phrase classifier.
+ *
+ * Disqualifying language is checked before positive adjectives. This prevents
+ * strings such as "strong mechanistic evidence; no human trials" from being
+ * upgraded merely because the word "strong" appears first. A preclinical or
+ * mechanistic mention caps the grade only when the phrase has no human/clinical
+ * study signal; mixed evidence containing both human and animal work is not
+ * downgraded simply because the animal work is mentioned.
+ */
+function bandFromPhrase(value) {
+  if (INSUFFICIENT_RE.test(value)) return 'insufficient'
+  if (NO_HUMAN_RE.test(value)) return 'preliminary'
+
+  const hasHumanClinicalSignal = HUMAN_CLINICAL_RE.test(value)
+  if ((PRECLINICAL_SIGNAL_RE.test(value) || MECHANISTIC_RE.test(value)) && !hasHumanClinicalSignal) {
+    return 'preliminary'
+  }
+
+  if (MIXED_RE.test(value)) return 'limited'
+  if (STRONG_RE.test(value)) return 'strong'
+  if (MODERATE_RE.test(value)) return 'moderate'
+  if (LIMITED_RE.test(value)) return 'limited'
+  if (PRELIMINARY_RE.test(value)) return 'preliminary'
+  return null
+}
+
+function normalizedFromGrade(grade, raw, canonical, sourceLabel) {
+  const label = sourceLabel && sourceLabel !== grade
+    ? `${CANONICAL_GRADE_LABEL[grade]} — ${sourceLabel}`
+    : CANONICAL_GRADE_LABEL[grade]
+
+  return {
+    grade,
+    letter: grade === 'Avoid/Insufficient' ? null : grade,
+    band: BAND_FOR_GRADE[grade],
+    label,
+    raw,
+    canonical,
+    outcomeDependent: false,
+  }
+}
+
+export function normalizeEvidenceGrade(raw) {
+  const value = String(raw ?? '').trim()
+  if (!value) return { ...EMPTY }
+
+  if (OUTCOME_DEPENDENT_RE.test(value)) {
+    return {
+      grade: null,
+      letter: null,
+      band: null,
+      label: value,
+      raw: value,
+      canonical: false,
+      outcomeDependent: true,
+    }
+  }
+
+  if (isCanonicalEvidenceGrade(value)) {
+    return normalizedFromGrade(value, value, true)
+  }
+
+  if (/^avoid\s*\/\s*insufficient$/i.test(value)) {
+    return normalizedFromGrade('Avoid/Insufficient', value, false)
+  }
+
+  const bare = BARE_LETTER_RE.exec(value)
+  if (bare) {
+    return normalizedFromGrade(bare[1].toUpperCase(), value, false)
+  }
+
+  if (LEGACY_FAIL_RE.test(value)) {
+    return normalizedFromGrade('Avoid/Insufficient', value, false)
+  }
+
+  const band = bandFromPhrase(value)
+  if (band) {
+    const grade = GRADE_FOR_BAND[band]
+    return normalizedFromGrade(grade, value, false, value)
+  }
+
+  return { ...EMPTY, raw: value, label: value }
+}
+
+export function canonicalGradeFromEvidenceTier(tier) {
+  const value = String(tier ?? '').trim()
+  if (!value) return null
+  const band = bandFromPhrase(value)
+  return band ? GRADE_FOR_BAND[band] : null
+}
+
+export function bandFromEvidenceTier(tier) {
+  const grade = canonicalGradeFromEvidenceTier(tier)
+  return grade ? BAND_FOR_GRADE[grade] : null
+}
+
+export const BAND_ORDER = Object.freeze([
+  'insufficient',
+  'preliminary',
+  'limited',
+  'moderate',
+  'strong',
+])
+
+export function gradeTierDistance(gradeBand, tierBand) {
+  if (!gradeBand || !tierBand) return null
+  return Math.abs(BAND_ORDER.indexOf(gradeBand) - BAND_ORDER.indexOf(tierBand))
+}
+
+/**
+ * Persisted-data helper: returns the canonical enum value or null. It never
+ * falls back to evidence tier because migrations should expose missing/unknown
+ * grade data rather than silently synthesize it from another field.
+ */
+export function canonicalizePersistedEvidenceGrade(raw) {
+  return normalizeEvidenceGrade(raw).grade
+}

--- a/lib/evidence-grade.ts
+++ b/lib/evidence-grade.ts
@@ -1,236 +1,77 @@
 /**
- * Canonical evidence-grade contract.
+ * Typed facade for the runtime-agnostic evidence-grade normalization core.
  *
- * The workbook historically accepted free-text values such as `a`, `B+`,
- * `moderate-high`, `Strong drug evidence`, and `F`. Those legacy values are
- * still accepted at the ingestion boundary, but they must collapse into one
- * canonical public/data contract:
- *
- *   A | B | C | D | Avoid/Insufficient
- *
- * Unknown or outcome-dependent values intentionally normalize to `null`; a
- * caller must not invent a grade when the source does not support one.
+ * The implementation lives in `evidence-grade-core.js` so browser/Next code,
+ * TypeScript, Node build scripts, migrations, and CI all execute the exact same
+ * normalization rules.
  */
 
-export const CANONICAL_EVIDENCE_GRADES = ['A', 'B', 'C', 'D', 'Avoid/Insufficient'] as const
+import {
+  BAND_LABEL as CORE_BAND_LABEL,
+  BAND_ORDER as CORE_BAND_ORDER,
+  CANONICAL_EVIDENCE_GRADES as CORE_CANONICAL_EVIDENCE_GRADES,
+  CANONICAL_GRADE_LABEL as CORE_CANONICAL_GRADE_LABEL,
+  LETTER_LABEL as CORE_LETTER_LABEL,
+  bandFromCanonicalGrade as bandFromCanonicalGradeCore,
+  bandFromEvidenceTier as bandFromEvidenceTierCore,
+  canonicalGradeFromEvidenceTier as canonicalGradeFromEvidenceTierCore,
+  canonicalizePersistedEvidenceGrade as canonicalizePersistedEvidenceGradeCore,
+  gradeTierDistance as gradeTierDistanceCore,
+  isCanonicalEvidenceGrade as isCanonicalEvidenceGradeCore,
+  normalizeEvidenceGrade as normalizeEvidenceGradeCore,
+} from './evidence-grade-core.js'
+
+export const CANONICAL_EVIDENCE_GRADES = CORE_CANONICAL_EVIDENCE_GRADES as readonly [
+  'A',
+  'B',
+  'C',
+  'D',
+  'Avoid/Insufficient',
+]
 
 export type CanonicalEvidenceGrade = (typeof CANONICAL_EVIDENCE_GRADES)[number]
 export type EvidenceLetter = Exclude<CanonicalEvidenceGrade, 'Avoid/Insufficient'>
 export type EvidenceBand = 'strong' | 'moderate' | 'limited' | 'preliminary' | 'insufficient'
 
 export type NormalizedEvidenceGrade = {
-  /** Canonical grade, or null when no honest single grade can be assigned. */
   grade: CanonicalEvidenceGrade | null
-  /** Single-letter badge value. Avoid/Insufficient intentionally has no letter. */
   letter: EvidenceLetter | null
-  /** Coarse semantic band used for comparisons and presentation. */
   band: EvidenceBand | null
-  /** Human-readable label for display. */
   label: string
-  /** Original source value preserved for audit/migration reporting. */
   raw: string
-  /** True only when the source already equals one canonical enum value. */
   canonical: boolean
-  /** True when the source grades different outcomes differently. */
   outcomeDependent: boolean
 }
 
-const BAND_LABEL: Record<EvidenceBand, string> = {
-  strong: 'Strong evidence',
-  moderate: 'Moderate evidence',
-  limited: 'Limited evidence',
-  preliminary: 'Preliminary evidence',
-  insufficient: 'Insufficient evidence',
-}
-
-export const CANONICAL_GRADE_LABEL: Record<CanonicalEvidenceGrade, string> = {
-  A: 'Grade A: Strong Evidence',
-  B: 'Grade B: Moderate Evidence',
-  C: 'Grade C: Limited Evidence',
-  D: 'Grade D: Preliminary / Theoretical Evidence',
-  'Avoid/Insufficient': 'Avoid / Insufficient Evidence',
-}
-
-/** Compatibility export for components that render only letter-grade badges. */
-export const LETTER_LABEL: Record<EvidenceLetter, string> = {
-  A: CANONICAL_GRADE_LABEL.A,
-  B: CANONICAL_GRADE_LABEL.B,
-  C: CANONICAL_GRADE_LABEL.C,
-  D: CANONICAL_GRADE_LABEL.D,
-}
-
-const GRADE_FOR_BAND: Record<EvidenceBand, CanonicalEvidenceGrade> = {
-  strong: 'A',
-  moderate: 'B',
-  limited: 'C',
-  preliminary: 'D',
-  insufficient: 'Avoid/Insufficient',
-}
-
-const BAND_FOR_GRADE: Record<CanonicalEvidenceGrade, EvidenceBand> = {
-  A: 'strong',
-  B: 'moderate',
-  C: 'limited',
-  D: 'preliminary',
-  'Avoid/Insufficient': 'insufficient',
-}
-
-/** A bare legacy letter grade, optionally with a +/- modifier. */
-const BARE_LETTER_RE = /^([a-d])\s*[+-]?$/i
-const LEGACY_FAIL_RE = /^f\s*[+-]?$/i
-
-/**
- * Values that grade different outcomes differently. Picking one grade from
- * these would misrepresent the record, so they remain explicitly unassigned.
- */
-const OUTCOME_DEPENDENT_RE = /\b[a-df]\s*[+-]?\s+for\s+\w+.*;\s*[a-df]\s*[+-]?\s+for\s+/i
-
-/**
- * Legacy phrase mappings, ordered from strongest/specific to weakest. Ambiguous
- * language resolves conservatively; explicit insufficiency/avoidance is never
- * collapsed into D because the canonical model reserves its own state for it.
- */
-const PHRASE_BANDS: [RegExp, EvidenceBand][] = [
-  [/\b(moderate[- ]to[- ]strong|strong|robust|high[- ]quality|well[- ]established)\b/i, 'strong'],
-  [/\b(limited[- ]to[- ]moderate|moderate)\b/i, 'moderate'],
-  [/\b(mixed|inconsistent|limited|low[- ]moderate|emerging)\b/i, 'limited'],
-  [/\b(preliminary|pilot|early|weak|mechanistic|theoretical|preclinical|no human|low)\b/i, 'preliminary'],
-  [/\b(insufficient|no evidence|none|avoid|blocked|contraindicated)\b/i, 'insufficient'],
-]
-
-const EMPTY: NormalizedEvidenceGrade = {
-  grade: null,
-  letter: null,
-  band: null,
-  label: 'Evidence grade not assigned',
-  raw: '',
-  canonical: false,
-  outcomeDependent: false,
-}
+export const BAND_LABEL = CORE_BAND_LABEL as Readonly<Record<EvidenceBand, string>>
+export const BAND_ORDER = CORE_BAND_ORDER as readonly EvidenceBand[]
+export const CANONICAL_GRADE_LABEL = CORE_CANONICAL_GRADE_LABEL as Readonly<Record<CanonicalEvidenceGrade, string>>
+export const LETTER_LABEL = CORE_LETTER_LABEL as Readonly<Record<EvidenceLetter, string>>
 
 export function isCanonicalEvidenceGrade(value: unknown): value is CanonicalEvidenceGrade {
-  return CANONICAL_EVIDENCE_GRADES.includes(value as CanonicalEvidenceGrade)
+  return isCanonicalEvidenceGradeCore(value)
 }
 
 export function bandFromCanonicalGrade(grade: CanonicalEvidenceGrade): EvidenceBand {
-  return BAND_FOR_GRADE[grade]
+  return bandFromCanonicalGradeCore(grade) as EvidenceBand
 }
 
-function bandFromPhrase(value: string): EvidenceBand | null {
-  for (const [pattern, band] of PHRASE_BANDS) {
-    if (pattern.test(value)) return band
-  }
-  return null
-}
-
-function normalizedFromGrade(
-  grade: CanonicalEvidenceGrade,
-  raw: string,
-  canonical: boolean,
-  sourceLabel?: string,
-): NormalizedEvidenceGrade {
-  const label = sourceLabel && sourceLabel !== grade
-    ? `${CANONICAL_GRADE_LABEL[grade]} — ${sourceLabel}`
-    : CANONICAL_GRADE_LABEL[grade]
-
-  return {
-    grade,
-    letter: grade === 'Avoid/Insufficient' ? null : grade,
-    band: BAND_FOR_GRADE[grade],
-    label,
-    raw,
-    canonical,
-    outcomeDependent: false,
-  }
-}
-
-/**
- * Normalize any raw evidence-grade value to the canonical enum.
- *
- * Legacy values are accepted only at this boundary so migration and rendering
- * can share one deterministic interpretation. Unrecognized values return null.
- */
 export function normalizeEvidenceGrade(raw: unknown): NormalizedEvidenceGrade {
-  const value = String(raw ?? '').trim()
-  if (!value) return EMPTY
-
-  if (OUTCOME_DEPENDENT_RE.test(value)) {
-    return {
-      grade: null,
-      letter: null,
-      band: null,
-      label: value,
-      raw: value,
-      canonical: false,
-      outcomeDependent: true,
-    }
-  }
-
-  if (isCanonicalEvidenceGrade(value)) {
-    return normalizedFromGrade(value, value, true)
-  }
-
-  if (/^avoid\s*\/\s*insufficient$/i.test(value)) {
-    return normalizedFromGrade('Avoid/Insufficient', value, false)
-  }
-
-  const bare = BARE_LETTER_RE.exec(value)
-  if (bare) {
-    const grade = bare[1].toUpperCase() as EvidenceLetter
-    return normalizedFromGrade(grade, value, false)
-  }
-
-  // F was a legacy pseudo-grade. Preserve the meaning while removing F from
-  // the canonical model entirely.
-  if (LEGACY_FAIL_RE.test(value)) {
-    return normalizedFromGrade('Avoid/Insufficient', value, false)
-  }
-
-  const band = bandFromPhrase(value)
-  if (band) {
-    const grade = GRADE_FOR_BAND[band]
-    return normalizedFromGrade(grade, value, false, value)
-  }
-
-  return { ...EMPTY, raw: value, label: value }
+  return normalizeEvidenceGradeCore(raw) as NormalizedEvidenceGrade
 }
 
-/**
- * Map a legacy evidence-tier phrase onto the canonical grade contract. This is
- * an adapter for older records; new persisted grade fields should already be
- * canonical rather than storing these presentation labels.
- */
+export function canonicalizePersistedEvidenceGrade(raw: unknown): CanonicalEvidenceGrade | null {
+  return canonicalizePersistedEvidenceGradeCore(raw) as CanonicalEvidenceGrade | null
+}
+
 export function canonicalGradeFromEvidenceTier(tier: unknown): CanonicalEvidenceGrade | null {
-  const value = String(tier ?? '').toLowerCase().trim()
-  if (!value) return null
-  if (/\b(insufficient|no evidence|none|avoid|blocked|contraindicat)/.test(value)) return 'Avoid/Insufficient'
-  if (value.includes('strong')) return 'A'
-  if (value.includes('moderate')) return 'B'
-  if (value.includes('limited') || value.includes('contextual') || value.includes('mixed')) return 'C'
-  if (
-    value.includes('mechanistic') ||
-    value.includes('preclinical') ||
-    value.includes('preliminary') ||
-    value.includes('traditional') ||
-    value.includes('theoretical') ||
-    value.includes('early')
-  ) {
-    return 'D'
-  }
-  return null
+  return canonicalGradeFromEvidenceTierCore(tier) as CanonicalEvidenceGrade | null
 }
 
 export function bandFromEvidenceTier(tier: unknown): EvidenceBand | null {
-  const grade = canonicalGradeFromEvidenceTier(tier)
-  return grade ? BAND_FOR_GRADE[grade] : null
+  return bandFromEvidenceTierCore(tier) as EvidenceBand | null
 }
 
-const BAND_ORDER: EvidenceBand[] = ['insufficient', 'preliminary', 'limited', 'moderate', 'strong']
-
-/** How far apart two evidence signals sit, in semantic bands. */
 export function gradeTierDistance(gradeBand: EvidenceBand | null, tierBand: EvidenceBand | null): number | null {
-  if (!gradeBand || !tierBand) return null
-  return Math.abs(BAND_ORDER.indexOf(gradeBand) - BAND_ORDER.indexOf(tierBand))
+  return gradeTierDistanceCore(gradeBand, tierBand)
 }
-
-export { BAND_LABEL, BAND_ORDER }

--- a/lib/evidence-strength.ts
+++ b/lib/evidence-strength.ts
@@ -23,7 +23,8 @@ export type EvidenceStrengthData = {
   tier: EvidenceStrengthTier
   /** Human-readable label e.g. "Strong Human Evidence" */
   label: string
-  grade: EvidenceLetterGrade
+  /** Null when the evidence is outcome-dependent or no honest universal grade exists. */
+  grade: EvidenceLetterGrade | null
   humanEvidence: boolean
   mechanismEvidence: boolean
   /** One-line confidence explanation shown in expanded detail */
@@ -126,9 +127,11 @@ export function getEvidenceStrengthData(record: RuntimeRecord): EvidenceStrength
   if (!humanEvidence && !mechanismEvidence) {
     downgradeReasons.push('No published mechanism or clinical evidence on file.')
   }
+  if (!grade) {
+    downgradeReasons.push('No universal evidence grade is assigned; evidence may vary by outcome.')
+  }
 
   let score = TIER_SCORES[tier]
-  // Small boosts for corroborating signals without changing the tier
   if (mechanismEvidence && tier === 'limited') score = Math.min(score + 5, 55)
   if (humanEvidence && tier === 'moderate') score = Math.min(score + 5, 78)
 

--- a/lib/evidence.ts
+++ b/lib/evidence.ts
@@ -57,20 +57,26 @@ function evidenceText(record: RuntimeRecord): string {
     .toLowerCase()
 }
 
+function hasHumanClinicalSignal(value: string): boolean {
+  return /\b(human|clinical|trial|rct|randomi[sz]ed|meta[- ]analysis|systematic\s+review)\b/.test(value)
+}
+
+function explicitlyExcludesHumanEvidence(value: string): boolean {
+  return /\b(no\s+human(?:\s+(?:trial|trials|evidence|data|stud(?:y|ies)))?|without\s+human(?:\s+(?:trial|trials|evidence|data|stud(?:y|ies)))?|preclinical\s+only|animal(?:\s+stud(?:y|ies))?\s+only|in\s*vitro\s+only|theoretical\s+only)\b/.test(value)
+}
+
+function hasPreclinicalSignal(value: string): boolean {
+  return /\b(preclinical|animal|in\s*vitro|cell(?:ular)?|theoretical|mechanistic)\b/.test(value)
+}
+
 export function hasHumanEvidence(record: RuntimeRecord): boolean {
   const evidence = evidenceText(record)
 
-  if (/\b(no|none|theoretical|traditional|preclinical|in\s*vitro|animal)\b/.test(evidence)) {
-    return false
-  }
+  if (explicitlyExcludesHumanEvidence(evidence)) return false
+  if (hasHumanClinicalSignal(evidence)) return true
+  if (hasPreclinicalSignal(evidence) || /\b(traditional|ethnobotanical)\b/.test(evidence)) return false
 
-  if (
-    /\b(human|clinical|trial|rct|randomi[sz]ed|meta|systematic|strong|high|moderate|grade\s*[ab]|tier\s*[ab])\b/.test(
-      evidence,
-    )
-  ) {
-    return true
-  }
+  if (/\b(strong|high|moderate|grade\s*[ab]|tier\s*[ab])\b/.test(evidence)) return true
 
   const sourceCount = Number(record?.sourceCount ?? record?.source_count ?? record?.sources_count)
   return (
@@ -86,6 +92,9 @@ export function hasMechanismEvidence(record: RuntimeRecord): boolean {
 
 export function isPreliminaryResearch(record: RuntimeRecord): boolean {
   const evidence = evidenceText(record)
+  if (hasHumanClinicalSignal(evidence) && !explicitlyExcludesHumanEvidence(evidence)) {
+    return /\b(preliminary|emerging|limited|low|weak|partial|draft|grade\s*[cd]|tier\s*[cd])\b/.test(evidence)
+  }
 
   return /\b(preliminary|emerging|limited|low|weak|partial|draft|none|preclinical|animal|in\s*vitro|theoretical|grade\s*[cd]|tier\s*[cd])\b/.test(
     evidence,
@@ -93,11 +102,33 @@ export function isPreliminaryResearch(record: RuntimeRecord): boolean {
 }
 
 export function getEvidenceTier(record: RuntimeRecord): EvidenceTier {
+  const universalGradeStatus = text(readPath(record, ['evidence_grade_status'])).toLowerCase()
+  if (universalGradeStatus === 'outcome-dependent') return 'mixed'
+  if (universalGradeStatus === 'unassigned') return 'review'
+
+  const normalized = normalizeEvidenceGrade(record?.evidence_grade)
+  if (normalized.raw) {
+    if (normalized.outcomeDependent) return 'mixed'
+    if (normalized.grade) {
+      const tierByGrade: Record<CanonicalEvidenceGrade, EvidenceTier> = {
+        A: 'strong',
+        B: 'moderate',
+        C: 'limited',
+        D: 'preliminary',
+        'Avoid/Insufficient': 'insufficient',
+      }
+      return tierByGrade[normalized.grade]
+    }
+    return 'review'
+  }
+
   const evidence = evidenceText(record)
 
   if (/\b(needs? review|unknown|tbd|draft|placeholder|profile pending)\b/.test(evidence)) return 'review'
   if (/\b(none|no evidence|insufficient|minimal|not established)\b/.test(evidence)) return 'insufficient'
   if (/\b(mixed|conflict|inconsistent|equivocal)\b/.test(evidence)) return 'mixed'
+  if (explicitlyExcludesHumanEvidence(evidence)) return 'preliminary'
+  if (hasPreclinicalSignal(evidence) && !hasHumanClinicalSignal(evidence)) return 'preliminary'
   if (/\b(strong|high|robust|grade\s*a|tier\s*a)\b/.test(evidence)) return 'strong'
   if (/\b(moderate|medium|grade\s*b|tier\s*b)\b/.test(evidence)) return 'moderate'
   if (/\b(traditional|ethnobotanical|historical)\b/.test(evidence)) return 'traditional'
@@ -139,22 +170,30 @@ export function getEvidenceColor(record: RuntimeRecord): EvidenceColor {
   return colors[getEvidenceTier(record)]
 }
 
-/**
- * Compatibility name retained for UI callers. The value now comes from the
- * single canonical evidence-grade contract and may be Avoid/Insufficient.
- */
+/** Canonical persisted evidence grade. Null means no honest universal grade exists. */
 export type EvidenceLetterGrade = CanonicalEvidenceGrade
 
 /**
- * Resolve a record to the canonical evidence-grade enum.
+ * Resolve a record to a canonical universal evidence grade.
  *
- * Explicit grade data wins, but all legacy parsing is delegated to
- * `normalizeEvidenceGrade` so this file cannot drift into a second grading
- * system. Legacy evidence-tier text is only a fallback adapter.
+ * Explicit grade data wins. If an explicit value exists but cannot honestly be
+ * represented by one canonical grade, return null rather than silently deriving
+ * a different grade from evidence_tier. A migration marker also prevents an
+ * outcome-dependent grade that was intentionally removed from being recreated.
+ * Legacy evidence-tier text remains a fallback only when no explicit grade or
+ * no-universal-grade marker is present.
  */
-export function getEvidenceLetterGrade(record: RuntimeRecord): EvidenceLetterGrade {
+export function getEvidenceLetterGrade(record: RuntimeRecord): EvidenceLetterGrade | null {
+  const universalGradeStatus = text(readPath(record, ['evidence_grade_status'])).toLowerCase()
+  if (universalGradeStatus === 'outcome-dependent' || universalGradeStatus === 'unassigned') {
+    return null
+  }
+
   const normalized = normalizeEvidenceGrade(record?.evidence_grade)
-  if (normalized.grade && !normalized.outcomeDependent) return normalized.grade
+  if (normalized.raw) {
+    if (normalized.grade && !normalized.outcomeDependent) return normalized.grade
+    return null
+  }
 
   const evidenceTierField = record?.evidence_tier || record?.evidenceTier
   const gradeFromTier = canonicalGradeFromEvidenceTier(evidenceTierField)

--- a/scripts/build-deploy.mjs
+++ b/scripts/build-deploy.mjs
@@ -15,22 +15,23 @@
  * 2. build-blog (blog post generation)
  * 3. build-articles (long-form article generation)
  * 4. build-runtime-from-workbook (data extraction)
- * 5. build-related-runtime-maps (relationship maps)
- * 6. build-runtime-summary-indexes (search indexes)
- * 7. build-route-manifest (route discovery)
- * 8. build-internal-link-engine (semantic internal links)
- * 9. build-sitemap-manifest (SEO sitemap source manifest)
- * 10. build-export-batches (batch optimization)
- * 11. build-semantic-snapshots (snapshot generation)
- * 12. build-production (next build)
- * 13. repair-broken-canonicals (replace deprecated canonical aliases in exported HTML)
- * 14. inject-content-depth-support (add route-aware supporting copy for low text/HTML pages)
- * 15. validate-structured-data-regressions (report known Semrush schema failures)
- * 16. apply-redirect-overrides (prepend exact audit-cleanup redirects)
- * 17. write-static-sitemap (physical out/sitemap.xml for Cloudflare Pages)
- * 18. validate-sitemap-static (prove /sitemap.xml is real XML, not HTML)
- * 19. repair-static-blog-h1s (legacy static blog heading repair)
- * 20. build-pagefind (static search index)
+ * 5. normalize-evidence-grades (canonical evidence-grade migration + gate)
+ * 6. build-related-runtime-maps (relationship maps)
+ * 7. build-runtime-summary-indexes (search indexes)
+ * 8. build-route-manifest (route discovery)
+ * 9. build-internal-link-engine (semantic internal links)
+ * 10. build-sitemap-manifest (SEO sitemap source manifest)
+ * 11. build-export-batches (batch optimization)
+ * 12. build-semantic-snapshots (snapshot generation)
+ * 13. build-production (next build)
+ * 14. repair-broken-canonicals (replace deprecated canonical aliases in exported HTML)
+ * 15. inject-content-depth-support (add route-aware supporting copy for low text/HTML pages)
+ * 16. validate-structured-data-regressions (report known Semrush schema failures)
+ * 17. apply-redirect-overrides (prepend exact audit-cleanup redirects)
+ * 18. write-static-sitemap (physical out/sitemap.xml for Cloudflare Pages)
+ * 19. validate-sitemap-static (prove /sitemap.xml is real XML, not HTML)
+ * 20. repair-static-blog-h1s (legacy static blog heading repair)
+ * 21. build-pagefind (static search index)
  *
  * Time estimate: cold builds are dominated by Next static export and Pagefind;
  * warm builds skip cacheable generation steps when inputs and outputs match.
@@ -84,6 +85,19 @@ const steps = [
     cmd: 'node --trace-uncaught --enable-source-maps scripts/data/build-runtime-from-workbook.mjs --out public/data',
     inputs: ['data/**/*.xlsx', 'data/**/*.json', 'data-sources/**/*.xlsx', 'scripts/data/**/*.mjs'],
     outputs: ['public/data/**/*'],
+  },
+  {
+    name: 'normalize-evidence-grades',
+    cmd: 'node scripts/data/normalize-evidence-grades.mjs --data-dir=public/data --write --strict',
+    inputs: [
+      'public/data/herbs.json',
+      'public/data/compounds.json',
+      'public/data/claims.json',
+      'lib/evidence-grade-core.js',
+      'scripts/data/normalize-evidence-grades.mjs',
+    ],
+    outputs: ['public/data/herbs.json', 'public/data/compounds.json', 'public/data/claims.json'],
+    cacheable: false,
   },
   {
     name: 'build-related-runtime-maps',

--- a/scripts/data/__tests__/normalize-evidence-grades.test.mjs
+++ b/scripts/data/__tests__/normalize-evidence-grades.test.mjs
@@ -1,0 +1,89 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  migrateEvidenceGradeArray,
+  migrateEvidenceGradeRecord,
+  normalizeEvidenceGradeFiles,
+} from '../normalize-evidence-grades.mjs'
+
+describe('evidence-grade migration boundary', () => {
+  it('rewrites known legacy variants to the canonical enum', () => {
+    expect(migrateEvidenceGradeRecord({ evidence_grade: 'b+' }).record.evidence_grade).toBe('B')
+    expect(migrateEvidenceGradeRecord({ evidence_grade: 'F' }).record.evidence_grade).toBe('Avoid/Insufficient')
+    expect(migrateEvidenceGradeRecord({ evidence_grade: 'preclinical evidence' }).record.evidence_grade).toBe('D')
+  })
+
+  it('leaves already-canonical values byte-stable', () => {
+    const original = { slug: 'x', evidence_grade: 'A' }
+    const result = migrateEvidenceGradeRecord(original)
+    expect(result.record).toBe(original)
+    expect(result.changed).toBe(false)
+    expect(result.status).toBe('canonical')
+  })
+
+  it('removes a misleading universal grade and leaves an outcome-dependent marker', () => {
+    const result = migrateEvidenceGradeRecord({ slug: 'x', evidence_grade: 'B for PCOS; D for core goals' })
+    expect(result.record).toEqual({ slug: 'x', evidence_grade_status: 'outcome-dependent' })
+    expect(result.status).toBe('outcome-dependent-universal-grade-removed')
+  })
+
+  it('never guesses an unmappable value', () => {
+    const original = { slug: 'x', evidence_grade: 'banana-scale' }
+    const result = migrateEvidenceGradeRecord(original)
+    expect(result.record).toBe(original)
+    expect(result.status).toBe('unmappable')
+    expect(result.canonical).toBeNull()
+  })
+
+  it('reports migrations and unknowns with record identity', () => {
+    const result = migrateEvidenceGradeArray([
+      { slug: 'one', evidence_grade: 'c-' },
+      { slug: 'two', evidence_grade: 'mystery' },
+      { slug: 'three', evidence_grade: 'D' },
+    ])
+
+    expect(result.output[0].evidence_grade).toBe('C')
+    expect(result.findings).toEqual([
+      { index: 0, slug: 'one', status: 'migrated', raw: 'c-', canonical: 'C' },
+      { index: 1, slug: 'two', status: 'unmappable', raw: 'mystery', canonical: null },
+    ])
+  })
+
+  it('normalizes every denormalized runtime surface emitted by the workbook builder', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'evidence-grade-migration-'))
+    const files = [
+      'herbs.json',
+      'compounds.json',
+      'featured-herbs.json',
+      'featured-compounds.json',
+      'herb-index.json',
+      'compound-index.json',
+      'claims.json',
+    ]
+
+    try {
+      for (const filename of files) {
+        fs.writeFileSync(
+          path.join(dir, filename),
+          `${JSON.stringify([{ slug: filename, evidence_grade: 'b+' }], null, 2)}\n`,
+          'utf8',
+        )
+      }
+
+      const report = normalizeEvidenceGradeFiles({ dataDir: dir, write: true, strict: true })
+      expect(report.files.filter((file) => file.exists)).toHaveLength(files.length)
+      expect(report.totals.unmappable).toBe(0)
+
+      for (const filename of files) {
+        const [record] = JSON.parse(fs.readFileSync(path.join(dir, filename), 'utf8'))
+        expect(record.evidence_grade, filename).toBe('B')
+      }
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/scripts/data/normalize-evidence-grades.mjs
+++ b/scripts/data/normalize-evidence-grades.mjs
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+
+/**
+ * Normalize generated evidence_grade fields to the canonical persisted enum.
+ *
+ * This is a migration boundary, not a scientific grading engine. It only
+ * converts legacy representations whose meaning is already explicit. Values
+ * that grade different outcomes differently are removed from the universal
+ * grade field (and reported) rather than flattened into a misleading verdict.
+ * Unknown non-empty values are never guessed; --strict makes them fatal.
+ *
+ * The runtime builder emits several denormalized copies of herb/compound
+ * records in one pass. Every copy that can carry `evidence_grade` is migrated
+ * here so a profile cannot be canonical while a featured/search index still
+ * exposes the legacy value.
+ *
+ * Usage:
+ *   node scripts/data/normalize-evidence-grades.mjs --data-dir=public/data
+ *   node scripts/data/normalize-evidence-grades.mjs --data-dir=public/data --write --strict
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import {
+  CANONICAL_EVIDENCE_GRADES,
+  normalizeEvidenceGrade,
+} from '../../lib/evidence-grade-core.js'
+
+const DEFAULT_FILES = [
+  'herbs.json',
+  'compounds.json',
+  'featured-herbs.json',
+  'featured-compounds.json',
+  'herb-index.json',
+  'compound-index.json',
+  'claims.json',
+]
+
+function parseArgs(argv) {
+  const args = { dataDir: 'public/data', write: false, strict: false }
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === '--write') args.write = true
+    else if (arg === '--strict') args.strict = true
+    else if (arg === '--data-dir') {
+      args.dataDir = argv[i + 1] || ''
+      i += 1
+    } else if (arg.startsWith('--data-dir=')) {
+      args.dataDir = arg.slice('--data-dir='.length)
+    }
+  }
+  if (!args.dataDir.trim()) throw new Error('[evidence-grade] missing --data-dir value')
+  return args
+}
+
+function stableJson(value) {
+  return `${JSON.stringify(value, null, 2)}\n`
+}
+
+export function migrateEvidenceGradeRecord(record) {
+  if (!record || typeof record !== 'object' || Array.isArray(record)) {
+    return { record, status: 'not-a-record', changed: false, raw: '', canonical: null }
+  }
+
+  const normalized = normalizeEvidenceGrade(record.evidence_grade)
+
+  if (!normalized.raw) {
+    return { record, status: 'missing', changed: false, raw: '', canonical: null }
+  }
+
+  if (normalized.outcomeDependent) {
+    const next = { ...record, evidence_grade_status: 'outcome-dependent' }
+    delete next.evidence_grade
+    return {
+      record: next,
+      status: 'outcome-dependent-universal-grade-removed',
+      changed: true,
+      raw: normalized.raw,
+      canonical: null,
+    }
+  }
+
+  if (!normalized.grade) {
+    return {
+      record,
+      status: 'unmappable',
+      changed: false,
+      raw: normalized.raw,
+      canonical: null,
+    }
+  }
+
+  if (normalized.canonical) {
+    return {
+      record,
+      status: 'canonical',
+      changed: false,
+      raw: normalized.raw,
+      canonical: normalized.grade,
+    }
+  }
+
+  return {
+    record: { ...record, evidence_grade: normalized.grade },
+    status: 'migrated',
+    changed: true,
+    raw: normalized.raw,
+    canonical: normalized.grade,
+  }
+}
+
+export function migrateEvidenceGradeArray(records) {
+  if (!Array.isArray(records)) throw new Error('[evidence-grade] expected a JSON array')
+
+  const findings = []
+  const output = records.map((record, index) => {
+    const result = migrateEvidenceGradeRecord(record)
+    if (result.status !== 'canonical' && result.status !== 'missing' && result.status !== 'not-a-record') {
+      findings.push({
+        index,
+        slug: String(record?.slug ?? record?.target_slug ?? record?.id ?? ''),
+        status: result.status,
+        raw: result.raw,
+        canonical: result.canonical,
+      })
+    }
+    return result.record
+  })
+
+  return { output, findings }
+}
+
+function summarize(findings) {
+  const counts = {}
+  for (const finding of findings) counts[finding.status] = (counts[finding.status] ?? 0) + 1
+  return counts
+}
+
+export function normalizeEvidenceGradeFiles({ dataDir, write = false, strict = false, files = DEFAULT_FILES }) {
+  const absoluteDataDir = path.resolve(dataDir)
+  const report = {
+    canonicalEnum: [...CANONICAL_EVIDENCE_GRADES],
+    dataDir: absoluteDataDir,
+    write,
+    files: [],
+    totals: { scanned: 0, changed: 0, unmappable: 0, outcomeDependent: 0 },
+    findings: [],
+  }
+
+  for (const filename of files) {
+    const file = path.join(absoluteDataDir, filename)
+    if (!fs.existsSync(file)) {
+      report.files.push({ filename, exists: false, records: 0, changed: 0 })
+      continue
+    }
+
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf8'))
+    if (!Array.isArray(parsed)) throw new Error(`[evidence-grade] ${file} must contain a JSON array`)
+
+    const { output, findings } = migrateEvidenceGradeArray(parsed)
+    const changed = findings.filter((finding) => finding.status !== 'unmappable').length
+    const unmappable = findings.filter((finding) => finding.status === 'unmappable').length
+    const outcomeDependent = findings.filter((finding) => finding.status === 'outcome-dependent-universal-grade-removed').length
+
+    report.totals.scanned += parsed.length
+    report.totals.changed += changed
+    report.totals.unmappable += unmappable
+    report.totals.outcomeDependent += outcomeDependent
+    report.findings.push(...findings.map((finding) => ({ filename, ...finding })))
+    report.files.push({ filename, exists: true, records: parsed.length, changed, unmappable, outcomeDependent })
+
+    if (write && changed > 0) fs.writeFileSync(file, stableJson(output), 'utf8')
+  }
+
+  report.issueCounts = summarize(report.findings)
+
+  if (strict && report.totals.unmappable > 0) {
+    const preview = report.findings
+      .filter((finding) => finding.status === 'unmappable')
+      .slice(0, 20)
+      .map((finding) => `${finding.filename}[${finding.index}] ${finding.slug || '(no id)'}: ${JSON.stringify(finding.raw)}`)
+      .join('\n')
+    throw new Error(
+      `[evidence-grade] ${report.totals.unmappable} unmappable evidence_grade value(s) remain after migration.\n${preview}`,
+    )
+  }
+
+  return report
+}
+
+export function main(argv = process.argv) {
+  const args = parseArgs(argv)
+  const report = normalizeEvidenceGradeFiles(args)
+
+  console.log('\nCanonical evidence-grade migration')
+  console.log('='.repeat(60))
+  console.log(`Enum:              ${report.canonicalEnum.join(' | ')}`)
+  console.log(`Records scanned:   ${report.totals.scanned}`)
+  console.log(`Values migrated:   ${report.totals.changed}`)
+  console.log(`Outcome-dependent: ${report.totals.outcomeDependent}`)
+  console.log(`Unmappable:        ${report.totals.unmappable}`)
+  console.log(`Mode:              ${args.write ? 'WRITE' : 'DRY RUN'}`)
+  for (const file of report.files) {
+    console.log(`  ${file.filename.padEnd(24)} records=${String(file.records).padStart(4)} changed=${String(file.changed).padStart(4)} unmappable=${String(file.unmappable ?? 0).padStart(3)}`)
+  }
+
+  return report
+}
+
+const isDirectRun = process.argv[1]
+  ? import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+  : false
+
+if (isDirectRun) {
+  try {
+    main()
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  }
+}

--- a/src/lib/__tests__/evidence-grade.test.ts
+++ b/src/lib/__tests__/evidence-grade.test.ts
@@ -41,6 +41,24 @@ describe('canonical evidence grade contract', () => {
     expect(normalizeEvidenceGrade('Insufficient evidence').grade).toBe('Avoid/Insufficient')
   })
 
+  it('caps positive adjectives when the same phrase says evidence is preclinical-only or lacks humans', () => {
+    expect(normalizeEvidenceGrade('Strong mechanistic evidence; no human trials').grade).toBe('D')
+    expect(normalizeEvidenceGrade('Robust preclinical evidence in animals').grade).toBe('D')
+    expect(canonicalGradeFromEvidenceTier('Strong mechanistic evidence; no human trials')).toBe('D')
+  })
+
+  it('does not downgrade explicit human clinical evidence merely because preclinical work is also mentioned', () => {
+    expect(normalizeEvidenceGrade('Strong human clinical evidence').grade).toBe('A')
+    expect(normalizeEvidenceGrade('Strong mechanistic and human clinical evidence').grade).toBe('A')
+    expect(normalizeEvidenceGrade('Strong human clinical and animal studies').grade).toBe('A')
+    expect(canonicalGradeFromEvidenceTier('Strong clinical evidence plus preclinical studies')).toBe('A')
+  })
+
+  it('treats inconsistent or conflicting wording conservatively', () => {
+    expect(normalizeEvidenceGrade('Strong but inconsistent evidence').grade).toBe('C')
+    expect(canonicalGradeFromEvidenceTier('Moderate evidence with conflicting findings')).toBe('C')
+  })
+
   it('does not flatten outcome-dependent grades into one verdict', () => {
     const normalized = normalizeEvidenceGrade('B for PCOS; D for core goals')
     expect(normalized.grade).toBeNull()

--- a/src/lib/__tests__/evidence.test.ts
+++ b/src/lib/__tests__/evidence.test.ts
@@ -24,6 +24,15 @@ describe('hasHumanEvidence', () => {
     expect(hasHumanEvidence(record({ evidence_tier: 'Strong human clinical trial evidence' }))).toBe(true)
   })
 
+  it('does not erase human evidence merely because animal or preclinical work is also mentioned', () => {
+    expect(hasHumanEvidence(record({ evidence_tier: 'Strong human clinical evidence plus animal studies' }))).toBe(true)
+    expect(hasHumanEvidence(record({ evidence_tier: 'Human trials supported by preclinical mechanism data' }))).toBe(true)
+  })
+
+  it('still respects explicit no-human language even when positive adjectives are present', () => {
+    expect(hasHumanEvidence(record({ evidence_tier: 'Strong mechanistic evidence; no human trials' }))).toBe(false)
+  })
+
   it('falls back to source count when text is ambiguous', () => {
     expect(hasHumanEvidence(record({ summary_quality: 'reviewed', sourceCount: 6 }))).toBe(true)
     expect(hasHumanEvidence(record({ summary_quality: 'reviewed', sourceCount: 2 }))).toBe(false)
@@ -45,12 +54,16 @@ describe('hasMechanismEvidence', () => {
 })
 
 describe('isPreliminaryResearch', () => {
-  it('is true for preliminary/emerging/animal language', () => {
+  it('is true for preliminary/emerging/animal-only language', () => {
     expect(isPreliminaryResearch(record({ evidence_tier: 'Preliminary animal studies' }))).toBe(true)
   })
 
   it('is false for strong evidence language', () => {
     expect(isPreliminaryResearch(record({ evidence_tier: 'Strong evidence' }))).toBe(false)
+  })
+
+  it('does not become preliminary solely because a strong human record also mentions animal work', () => {
+    expect(isPreliminaryResearch(record({ evidence_tier: 'Strong human clinical evidence plus animal studies' }))).toBe(false)
   })
 })
 
@@ -79,6 +92,15 @@ describe('getEvidenceTier', () => {
     expect(getEvidenceTier(record({ evidence_tier: 'Traditional / historical use only' }))).toBe('traditional')
   })
 
+  it('lets the canonical explicit grade outrank contradictory legacy tier wording', () => {
+    expect(getEvidenceTier(record({ evidence_grade: 'D', evidence_tier: 'Strong mechanistic evidence; no human trials' }))).toBe('preliminary')
+    expect(getEvidenceTier(record({ evidence_grade: 'A', evidence_tier: 'Strong human clinical evidence plus animal studies' }))).toBe('strong')
+  })
+
+  it('treats an outcome-dependent universal grade as mixed instead of inventing one tier', () => {
+    expect(getEvidenceTier(record({ evidence_grade_status: 'outcome-dependent', evidence_tier: 'Strong evidence' }))).toBe('mixed')
+  })
+
   it('falls back to "limited" when nothing else is known', () => {
     expect(getEvidenceTier(record())).toBe('limited')
   })
@@ -102,12 +124,42 @@ describe('getEvidenceLetterGrade', () => {
     expect(getEvidenceLetterGrade(record({ evidence_grade: 'b+' }))).toBe('B')
   })
 
-  it('derives the grade from evidence_tier vocabulary when no letter grade is present', () => {
+  it('derives the grade from evidence_tier vocabulary when no grade is present', () => {
     expect(getEvidenceLetterGrade(record({ evidence_tier: 'Strong evidence' }))).toBe('A')
     expect(getEvidenceLetterGrade(record({ evidence_tier: 'Traditional use' }))).toBe('D')
   })
 
-  it('falls back to the tier map derived from getEvidenceTier', () => {
+  it('does not flatten an explicit outcome-dependent grade through the tier fallback', () => {
+    expect(
+      getEvidenceLetterGrade(
+        record({
+          evidence_grade: 'B for PCOS; D for core goals',
+          evidence_tier: 'Moderate evidence',
+        }),
+      ),
+    ).toBeNull()
+  })
+
+  it('honors the migration marker when an outcome-dependent universal grade was removed', () => {
+    expect(
+      getEvidenceLetterGrade(
+        record({
+          evidence_grade_status: 'outcome-dependent',
+          evidence_tier: 'Strong evidence',
+        }),
+      ),
+    ).toBeNull()
+  })
+
+  it('does not hide an explicit unmappable grade by inferring another grade', () => {
+    expect(
+      getEvidenceLetterGrade(
+        record({ evidence_grade: 'mystery-scale', evidence_tier: 'Strong evidence' }),
+      ),
+    ).toBeNull()
+  })
+
+  it('falls back to the tier map derived from getEvidenceTier when no grade signal exists', () => {
     expect(getEvidenceLetterGrade(record())).toBe('C')
   })
 })


### PR DESCRIPTION
Closes #3067

Supersedes #3003 with a clean one-commit branch based on current `main` so unrelated parallel-agent history is not part of the merge surface.

## Summary
- Shares one evidence-grade normalization core between TypeScript runtime code and Node data scripts.
- Canonical enum: `A | B | C | D | Avoid/Insufficient`.
- Migrates known legacy grades immediately after workbook extraction and before downstream indexes/routes/sitemaps/search/build.
- Covers herb/compound profiles, featured copies, index copies, and claims.
- Production uses `--write --strict`; unknown non-empty grade strings fail rather than being guessed.
- Outcome-dependent grades are explicitly marked and cannot be silently flattened into a universal grade.
- Preclinical/no-human wording caps positive legacy language, while records with explicit human clinical evidence are not downgraded merely for also mentioning animal/in-vitro work.
- UI renders unassigned/outcome-specific grades honestly instead of defaulting to C or displaying `Grade null`.

## Relevant URLs
- `/herbs/[slug]/`
- `/compounds/[slug]/`
- `/herbs/`
- `/compounds/`
- No URL inventory expansion intended.

## Acceptance criteria
- Public/runtime universal grades are limited to the five canonical enum values.
- Lowercase grades, +/- modifiers, and legacy `F` migrate deterministically.
- Unmappable non-empty grades abort the strict production migration.
- Outcome-dependent grades remain outcome-specific and are not reconstructed from `evidence_tier`.
- `Strong mechanistic evidence; no human trials` cannot resolve to A/B.
- Explicit human clinical evidence is not erased merely because animal/preclinical work is also mentioned.
- Profile, featured, and index copies normalize consistently.
- Evidence badge/meter surfaces handle a missing universal grade explicitly.

## Validation commands
- `npm test -- src/lib/__tests__/evidence-grade.test.ts src/lib/__tests__/evidence.test.ts scripts/data/__tests__/normalize-evidence-grades.test.mjs`
- `npm run typecheck`
- `node scripts/data/normalize-evidence-grades.mjs --data-dir=public/data --write --strict`
- `npm run build:deploy`
- Repository Atomic upgrade gate / release-quality checks.

## Before → after metrics
- Persisted/public grade vocabulary: overlapping legacy free text → exactly **5 canonical values**.
- Independent runtime/data grade parsers: **2 → 1 shared core**.
- Generated grade-bearing surfaces normalized at publication boundary: **0 → 6 profile/featured/index surfaces**, plus claims when present.
- Unknown grade behavior: **propagated/permissive → fatal strict gate**.
- Outcome-dependent fallback: **could be flattened → explicitly unassigned/outcome-specific**.

## Generator/source-of-truth decision
The workbook remains the live source of truth. This fixes the generator/publication boundary rather than hand-editing generated profiles. `data/canonical/` remains staged until parity is proven.

## Regression contract
- Unit tests lock the five-value enum, legacy mappings, conservative language precedence, human+preclinical coexistence, and outcome-dependent behavior.
- Resolver tests prevent explicit unknown/outcome-dependent grades from falling through to another taxonomy.
- Temp-directory integration tests verify every denormalized runtime grade surface is normalized consistently.
- `--strict` remains production-critical so future unknown grades block deployment.
