### PR TITLE
ROI 766-785: Search Console routing governance

### DIFF
--- a/scripts/seo/search-governance-report.ts
+++ b/scripts/seo/search-governance-report.ts
@@ -1,0 +1,69 @@
+#!/usr/bin/env -S npx tsx
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import {
+  buildSearchGovernanceArtifact,
+  renderSearchGovernanceMarkdown,
+  type QueryIntentMap,
+  type SearchOpportunityReport,
+} from '../../src/lib/search-opportunity-governance'
+import type { MetadataExperiment } from '../../src/lib/search-intent-routing'
+
+function arg(name: string, fallback = ''): string {
+  const prefix = `--${name}=`
+  return process.argv.find((value) => value.startsWith(prefix))?.slice(prefix.length) || fallback
+}
+
+async function readJson<T>(filePath: string, fallback: T): Promise<T> {
+  if (!filePath) return fallback
+  try {
+    return JSON.parse(await fs.readFile(filePath, 'utf8')) as T
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return fallback
+    throw error
+  }
+}
+
+async function writeText(filePath: string, content: string): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true })
+  await fs.writeFile(filePath, content, 'utf8')
+}
+
+async function main(): Promise<void> {
+  const currentPath = path.resolve(arg('input', 'ops/reports/search-opportunities.json'))
+  const previousArg = arg('previous')
+  const previousPath = previousArg ? path.resolve(previousArg) : ''
+  const intentMapPath = path.resolve(arg('intent-map', 'data-sources/search-console/query-intent-map.json'))
+  const experimentsPath = path.resolve(arg('experiments', 'ops/metadata-experiments.json'))
+  const jsonPath = path.resolve(arg('out', 'ops/reports/search-governance.json'))
+  const markdownPath = path.resolve(arg('markdown', 'ops/reports/search-governance.md'))
+
+  const current = await readJson<SearchOpportunityReport>(currentPath, { pages: [], queries: [] })
+  if (!Array.isArray(current.pages) || !Array.isArray(current.queries)) {
+    throw new Error('Search opportunity input must contain `pages` and `queries` arrays. Run the existing Search Console opportunity engine first.')
+  }
+
+  const [previous, intentMap, experiments] = await Promise.all([
+    readJson<SearchOpportunityReport | undefined>(previousPath, undefined),
+    readJson<QueryIntentMap>(intentMapPath, {}),
+    readJson<MetadataExperiment[]>(experimentsPath, []),
+  ])
+
+  const report = buildSearchGovernanceArtifact({ current, previous, intentMap, experiments })
+
+  await Promise.all([
+    writeText(jsonPath, `${JSON.stringify(report, null, 2)}\n`),
+    writeText(markdownPath, renderSearchGovernanceMarkdown(report)),
+  ])
+
+  console.log(`Search governance: ${report.summary.queryCount} queries.`)
+  console.log(`Cannibalized: ${report.summary.cannibalizedQueries}; routing mismatches: ${report.summary.routingMismatches}.`)
+  console.log(`CTR rewrites eligible: ${report.summary.metadataRewriteEligible}; protected metadata: ${report.summary.metadataProtected}.`)
+  console.log(`Wrote ${path.relative(process.cwd(), jsonPath)} and ${path.relative(process.cwd(), markdownPath)}.`)
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exit(1)
+})

--- a/src/lib/__tests__/search-opportunity-governance.test.ts
+++ b/src/lib/__tests__/search-opportunity-governance.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildSearchGovernanceArtifact,
+  renderSearchGovernanceMarkdown,
+} from '../search-opportunity-governance'
+
+describe('Search Console governance report', () => {
+  it('classifies intent, flags unambiguous wrong URLs, and tracks page-set stability', () => {
+    const current = {
+      generatedAt: '2026-08-15T00:00:00.000Z',
+      pages: [],
+      queries: [
+        {
+          query: 'magnesium glycinate vs citrate',
+          clicks: 5,
+          impressions: 100,
+          position: 8,
+          pages: ['/herbs/magnesium/', '/guides/compare/magnesium-glycinate-vs-citrate/'],
+          competingPages: 2,
+        },
+        {
+          query: 'ashwagandha dosage',
+          clicks: 4,
+          impressions: 80,
+          position: 7,
+          pages: ['/herbs/ashwagandha/'],
+          competingPages: 1,
+        },
+      ],
+    }
+    const previous = {
+      pages: [],
+      queries: [
+        {
+          query: 'magnesium glycinate vs citrate',
+          clicks: 2,
+          impressions: 60,
+          position: 10,
+          pages: ['/guides/compare/magnesium-glycinate-vs-citrate/'],
+          competingPages: 1,
+        },
+      ],
+    }
+
+    const report = buildSearchGovernanceArtifact({
+      current,
+      previous,
+      intentMap: {
+        'magnesium glycinate vs citrate': '/guides/compare/magnesium-glycinate-vs-citrate/',
+        'ashwagandha dosage': '/guides/ashwagandha-dosage/',
+      },
+      generatedAt: '2026-08-15T01:00:00.000Z',
+    })
+
+    const comparison = report.queries.find((row) => row.query.startsWith('magnesium'))!
+    const dosage = report.queries.find((row) => row.query.startsWith('ashwagandha'))!
+
+    expect(comparison.intent).toBe('comparison')
+    expect(comparison.cannibalized).toBe(true)
+    expect(comparison.mismatch).toBe(false)
+    expect(comparison.pageSetStability).toBe(0.5)
+    expect(comparison.actions).toContain('differentiate-or-consolidate-competing-pages')
+    expect(comparison.actions).toContain('query-to-page-instability-after-release')
+
+    expect(dosage.intent).toBe('dose')
+    expect(dosage.mismatch).toBe(true)
+    expect(dosage.mismatchReason).toBe('single-wrong-url')
+  })
+
+  it('flags CTR underperformers but protects winning metadata experiments', () => {
+    const report = buildSearchGovernanceArtifact({
+      current: {
+        pages: [
+          { url: '/guides/sleep/magnesium-for-sleep/', impressions: 1000, clicks: 10, position: 5 },
+          { url: '/weak-page/', impressions: 1000, clicks: 10, position: 5 },
+        ],
+        queries: [],
+      },
+      experiments: [
+        {
+          id: 'exp-1',
+          url: '/guides/sleep/magnesium-for-sleep/',
+          startedAt: '2026-08-01',
+          titleBefore: 'Old title',
+          titleAfter: 'Winning title',
+          baselineCtr: 0.02,
+          resultCtr: 0.04,
+          status: 'won',
+        },
+      ],
+    })
+
+    const protectedPage = report.pages.find((row) => row.url.includes('magnesium-for-sleep'))!
+    const weakPage = report.pages.find((row) => row.url === '/weak-page/')!
+
+    expect(protectedPage.underperforming).toBe(true)
+    expect(protectedPage.preserveMetadata).toBe(true)
+    expect(protectedPage.rewriteEligible).toBe(false)
+    expect(weakPage.rewriteEligible).toBe(true)
+    expect(report.summary.metadataProtected).toBe(1)
+    expect(report.summary.metadataRewriteEligible).toBe(1)
+  })
+
+  it('renders a human-readable routing and CTR report without inventing a winner for multi-page queries', () => {
+    const report = buildSearchGovernanceArtifact({
+      current: {
+        pages: [],
+        queries: [
+          {
+            query: 'l theanine for sleep',
+            clicks: 5,
+            impressions: 100,
+            position: 9,
+            pages: ['/herbs/l-theanine/', '/guides/sleep/l-theanine-for-sleep/'],
+            competingPages: 2,
+          },
+        ],
+      },
+      intentMap: { 'l theanine for sleep': '/guides/sleep/l-theanine-for-sleep/' },
+    })
+
+    const markdown = renderSearchGovernanceMarkdown(report)
+    expect(markdown).toContain('Search Intent, Routing & CTR Governance')
+    expect(markdown).toContain('Cannibalized queries: **1**')
+    expect(markdown).toContain('without inventing a preferred-page distribution')
+  })
+})

--- a/src/lib/search-opportunity-governance.ts
+++ b/src/lib/search-opportunity-governance.ts
@@ -1,0 +1,242 @@
+import {
+  canStartMetadataRewrite,
+  classifyQueryIntent,
+  diagnoseCtr,
+  routePolicyForIntent,
+  shouldPreserveMetadata,
+  type CtrDiagnostic,
+  type MetadataExperiment,
+  type QueryIntent,
+} from './search-intent-routing'
+
+export interface SearchOpportunityPage {
+  url: string
+  clicks: number
+  impressions: number
+  position: number
+  ctr?: number
+  actions?: string[]
+}
+
+export interface SearchOpportunityQuery {
+  query: string
+  clicks: number
+  impressions: number
+  position: number
+  ctr?: number
+  competingPages?: number
+  pages?: string[]
+  priority?: number
+}
+
+export interface SearchOpportunityReport {
+  generatedAt?: string
+  pages: SearchOpportunityPage[]
+  queries: SearchOpportunityQuery[]
+}
+
+export type QueryIntentMap = Record<string, string>
+
+export interface QueryGovernanceRow {
+  query: string
+  intent: QueryIntent
+  intendedRouteFamily: string
+  pageFormat: string
+  intendedUrl: string | null
+  observedPages: string[]
+  cannibalized: boolean
+  mismatch: boolean
+  mismatchReason: 'single-wrong-url' | 'intended-url-absent' | null
+  pageSetStability: number | null
+  actions: string[]
+}
+
+export interface PageMetadataGovernanceRow extends CtrDiagnostic {
+  preserveMetadata: boolean
+  rewriteEligible: boolean
+  actions: string[]
+}
+
+export interface SearchGovernanceArtifact {
+  generatedAt: string
+  sourceGeneratedAt?: string
+  pages: PageMetadataGovernanceRow[]
+  queries: QueryGovernanceRow[]
+  summary: {
+    queryCount: number
+    cannibalizedQueries: number
+    routingMismatches: number
+    unstableQueries: number
+    ctrUnderperformers: number
+    metadataProtected: number
+    metadataRewriteEligible: number
+  }
+}
+
+function normalizePath(value: string): string {
+  if (!value) return ''
+  try {
+    const pathname = /^https?:\/\//i.test(value) ? new URL(value).pathname : value
+    const clean = pathname.split(/[?#]/)[0]
+    if (!clean) return '/'
+    return clean.endsWith('/') ? clean : `${clean}/`
+  } catch {
+    return value
+  }
+}
+
+function normalizedIntentMap(map: QueryIntentMap): Map<string, string> {
+  return new Map(
+    Object.entries(map).map(([query, url]) => [query.trim().toLowerCase(), normalizePath(url)]),
+  )
+}
+
+function pageSetStability(current: string[], previous: string[] | undefined): number | null {
+  if (!previous) return null
+  const a = new Set(current.map(normalizePath).filter(Boolean))
+  const b = new Set(previous.map(normalizePath).filter(Boolean))
+  const union = new Set([...a, ...b])
+  if (union.size === 0) return 1
+  const intersection = [...a].filter((value) => b.has(value)).length
+  return Number((intersection / union.size).toFixed(3))
+}
+
+export function buildSearchGovernanceArtifact(input: {
+  current: SearchOpportunityReport
+  previous?: SearchOpportunityReport
+  intentMap?: QueryIntentMap
+  experiments?: MetadataExperiment[]
+  generatedAt?: string
+}): SearchGovernanceArtifact {
+  const experiments = input.experiments ?? []
+  const intentMap = normalizedIntentMap(input.intentMap ?? {})
+  const previousQueries = new Map(
+    (input.previous?.queries ?? []).map((row) => [row.query.trim().toLowerCase(), row]),
+  )
+
+  const pages = input.current.pages.map((page): PageMetadataGovernanceRow => {
+    const diagnostic = diagnoseCtr({
+      url: normalizePath(page.url),
+      impressions: page.impressions,
+      clicks: page.clicks,
+      position: page.position,
+    })
+    const preserveMetadata = shouldPreserveMetadata(experiments, diagnostic.url)
+    const rewriteEligible = canStartMetadataRewrite(diagnostic, experiments)
+    const actions: string[] = []
+    if (preserveMetadata) actions.push('preserve-winning-or-running-metadata')
+    else if (rewriteEligible) actions.push('eligible-for-measured-metadata-rewrite')
+    else if (diagnostic.underperforming) actions.push('underperforming-but-not-rewrite-eligible')
+    else actions.push('preserve-current-metadata')
+
+    return { ...diagnostic, preserveMetadata, rewriteEligible, actions }
+  })
+
+  const queries = input.current.queries.map((row): QueryGovernanceRow => {
+    const queryKey = row.query.trim().toLowerCase()
+    const intent = classifyQueryIntent(row.query)
+    const routePolicy = routePolicyForIntent(intent)
+    const intendedUrl = intentMap.get(queryKey) ?? null
+    const observedPages = [...new Set((row.pages ?? []).map(normalizePath).filter(Boolean))]
+    const cannibalized = observedPages.length > 1 || (row.competingPages ?? 0) > 1
+    let mismatchReason: QueryGovernanceRow['mismatchReason'] = null
+
+    if (intendedUrl && observedPages.length === 1 && observedPages[0] !== intendedUrl) {
+      mismatchReason = 'single-wrong-url'
+    } else if (intendedUrl && observedPages.length > 0 && !observedPages.includes(intendedUrl)) {
+      mismatchReason = 'intended-url-absent'
+    }
+
+    const stability = pageSetStability(
+      observedPages,
+      previousQueries.get(queryKey)?.pages,
+    )
+    const actions: string[] = []
+    if (mismatchReason) actions.push('align-internal-links-canonical-and-content-intent')
+    if (cannibalized) actions.push('differentiate-or-consolidate-competing-pages')
+    if (stability !== null && stability < 0.7) actions.push('query-to-page-instability-after-release')
+    if (!actions.length) actions.push('preserve-current-routing')
+
+    return {
+      query: row.query,
+      intent,
+      intendedRouteFamily: routePolicy.routeFamily,
+      pageFormat: routePolicy.pageFormat,
+      intendedUrl,
+      observedPages,
+      cannibalized,
+      mismatch: mismatchReason !== null,
+      mismatchReason,
+      pageSetStability: stability,
+      actions,
+    }
+  })
+
+  return {
+    generatedAt: input.generatedAt ?? new Date().toISOString(),
+    sourceGeneratedAt: input.current.generatedAt,
+    pages,
+    queries,
+    summary: {
+      queryCount: queries.length,
+      cannibalizedQueries: queries.filter((row) => row.cannibalized).length,
+      routingMismatches: queries.filter((row) => row.mismatch).length,
+      unstableQueries: queries.filter((row) => row.pageSetStability !== null && row.pageSetStability < 0.7).length,
+      ctrUnderperformers: pages.filter((row) => row.underperforming).length,
+      metadataProtected: pages.filter((row) => row.preserveMetadata).length,
+      metadataRewriteEligible: pages.filter((row) => row.rewriteEligible).length,
+    },
+  }
+}
+
+export function renderSearchGovernanceMarkdown(report: SearchGovernanceArtifact): string {
+  const lines = [
+    '# Search Intent, Routing & CTR Governance',
+    '',
+    `Generated: ${report.generatedAt}`,
+    report.sourceGeneratedAt ? `Source Search Console report: ${report.sourceGeneratedAt}` : '',
+    '',
+    '## Summary',
+    '',
+    `- Queries evaluated: **${report.summary.queryCount}**`,
+    `- Cannibalized queries: **${report.summary.cannibalizedQueries}**`,
+    `- Intended-URL mismatches: **${report.summary.routingMismatches}**`,
+    `- Unstable query-to-page sets: **${report.summary.unstableQueries}**`,
+    `- CTR underperformers: **${report.summary.ctrUnderperformers}**`,
+    `- Protected winning/running metadata: **${report.summary.metadataProtected}**`,
+    `- Metadata rewrites eligible for a measured experiment: **${report.summary.metadataRewriteEligible}**`,
+    '',
+    '## Query routing',
+    '',
+    '| Query | Intent | Intended format | Intended URL | Observed pages | Cannibalized | Stability | Action |',
+    '|---|---|---|---|---|---|---:|---|',
+  ].filter(Boolean)
+
+  for (const row of report.queries) {
+    lines.push(
+      `| ${row.query.replace(/\|/g, '\\|')} | ${row.intent} | ${row.pageFormat.replace(/\|/g, '\\|')} | ${row.intendedUrl ?? '—'} | ${row.observedPages.join('<br>') || '—'} | ${row.cannibalized ? 'yes' : 'no'} | ${row.pageSetStability === null ? '—' : row.pageSetStability.toFixed(2)} | ${row.actions.join(', ')} |`,
+    )
+  }
+
+  lines.push(
+    '',
+    '## CTR / metadata governance',
+    '',
+    '| URL | Impressions | Position | Actual CTR | Expected CTR | Gap | Protected | Rewrite eligible |',
+    '|---|---:|---:|---:|---:|---:|---|---|',
+  )
+
+  for (const row of report.pages) {
+    lines.push(
+      `| ${row.url} | ${row.impressions.toLocaleString()} | ${row.position.toFixed(1)} | ${(row.actualCtr * 100).toFixed(2)}% | ${(row.expectedCtr * 100).toFixed(2)}% | ${(row.gap * 100).toFixed(2)} pts | ${row.preserveMetadata ? 'yes' : 'no'} | ${row.rewriteEligible ? 'yes' : 'no'} |`,
+    )
+  }
+
+  lines.push(
+    '',
+    'Routing mismatches are only asserted when the Search Console observation is unambiguous: a single wrong URL wins, or the intended URL is absent from the observed set. Multi-URL queries are flagged as cannibalized without inventing a preferred-page distribution that the source report does not contain.',
+    '',
+  )
+
+  return lines.join('\n')
+}


### PR DESCRIPTION
Post-processes the existing Search Console opportunity report with canonical query intent, intended-URL routing, cannibalization/stability checks, CTR diagnostics, and metadata experiment protection. Adds an executable report and focused tests.