### PR TITLE
feat(report): quantify preclinical reliance by category

### DIFF
--- a/app/evidence/evidence-report/CategoryEvidenceMixPanel.tsx
+++ b/app/evidence/evidence-report/CategoryEvidenceMixPanel.tsx
@@ -1,0 +1,61 @@
+import { summarizeCategoryEvidenceMix } from '@/lib/evidence-report-insights'
+import type { PublicEvidenceDataset } from '@/lib/public-evidence-dataset'
+
+type Props = { dataset: PublicEvidenceDataset }
+
+function formatPct(value: number) {
+  return `${Math.round(value * 100)}%`
+}
+
+export default function CategoryEvidenceMixPanel({ dataset }: Props) {
+  const categories = summarizeCategoryEvidenceMix(dataset)
+  const meaningful = categories.filter(category => category.evidenceRelationships >= 3).slice(0, 12)
+
+  if (!meaningful.length) return null
+
+  return (
+    <section className="mx-auto mb-10 max-w-6xl px-4 sm:px-6 lg:px-8" aria-labelledby="category-evidence-mix-title">
+      <div className="rounded-2xl border border-brand-900/10 bg-white p-6 shadow-sm sm:p-8">
+        <p className="eyebrow-label">Human vs preclinical evidence mix</p>
+        <h2 id="category-evidence-mix-title" className="mt-2 text-2xl font-semibold text-ink">
+          Which categories currently rely most on mechanism, animal, or in-vitro evidence?
+        </h2>
+        <p className="mt-3 max-w-4xl text-sm leading-7 text-muted">
+          This compares structured study-to-ingredient relationships by evidence class. “Preclinical” here means
+          mechanistic, animal, or in-vitro evidence. A high share is a research-maturity signal, not a statement that
+          the category is ineffective or unsafe. Categories with fewer than three structured relationships are omitted
+          from this ranking to reduce tiny-sample noise.
+        </p>
+
+        <div className="mt-6 overflow-x-auto">
+          <table className="w-full min-w-[720px] border-collapse text-left text-sm">
+            <thead>
+              <tr className="border-b border-brand-900/10 text-xs uppercase tracking-wider text-muted">
+                <th className="py-3 pr-4">Category</th>
+                <th className="py-3 pr-4">Evidence relationships</th>
+                <th className="py-3 pr-4">Preclinical</th>
+                <th className="py-3 pr-4">Human</th>
+                <th className="py-3">Other / unclear</th>
+              </tr>
+            </thead>
+            <tbody>
+              {meaningful.map(category => (
+                <tr key={category.category} className="border-b border-brand-900/10 last:border-0">
+                  <td className="py-3 pr-4 font-semibold text-ink">{category.category}</td>
+                  <td className="py-3 pr-4 text-muted">{category.evidenceRelationships}</td>
+                  <td className="py-3 pr-4 text-muted">
+                    {category.preclinicalRelationships} · {formatPct(category.preclinicalShare)}
+                  </td>
+                  <td className="py-3 pr-4 text-muted">
+                    {category.humanRelationships} · {formatPct(category.humanShare)}
+                  </td>
+                  <td className="py-3 text-muted">{category.otherRelationships}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/app/evidence/evidence-report/page.tsx
+++ b/app/evidence/evidence-report/page.tsx
@@ -4,10 +4,11 @@ import { buildPageMetadata } from '@/src/lib/seo'
 import { getPublicEvidenceDataset } from '@/lib/public-evidence-dataset'
 import { evidenceGradeHistory } from '@/data/editorial/evidence-grade-history'
 import EvidenceReportClient from './EvidenceReportClient'
+import CategoryEvidenceMixPanel from './CategoryEvidenceMixPanel'
 
 export const metadata: Metadata = buildPageMetadata({
   title: 'State of Supplement Evidence 2026',
-  description: 'Original data report on evidence grades, structured source coverage, human trials, safety cautions, disagreement, and downloadable research data from The Hippie Scientist.',
+  description: 'Original data report on evidence grades, structured source coverage, human trials, preclinical reliance, safety cautions, disagreement, and downloadable research data from The Hippie Scientist.',
   path: '/evidence/evidence-report/',
   openGraphType: 'article',
 })
@@ -16,11 +17,14 @@ export default async function EvidenceReportPage() {
   const dataset = await getPublicEvidenceDataset()
 
   return (
-    <EvidenceReportClient
-      datasetVersion={dataset.datasetVersion}
-      citationText={dataset.citationText}
-      metrics={dataset.metrics}
-      changeHistory={evidenceGradeHistory}
-    />
+    <>
+      <EvidenceReportClient
+        datasetVersion={dataset.datasetVersion}
+        citationText={dataset.citationText}
+        metrics={dataset.metrics}
+        changeHistory={evidenceGradeHistory}
+      />
+      <CategoryEvidenceMixPanel dataset={dataset} />
+    </>
   )
 }

--- a/lib/__tests__/evidence-report-insights.test.ts
+++ b/lib/__tests__/evidence-report-insights.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { summarizeCategoryEvidenceMix } from '@/lib/evidence-report-insights'
+import type { PublicEvidenceDataset } from '@/lib/public-evidence-dataset'
+
+const dataset = {
+  ingredients: [
+    { slug: 'alpha', category: 'Adaptogens' },
+    { slug: 'beta', category: 'Adaptogens' },
+    { slug: 'gamma', category: 'Minerals' },
+  ],
+  studies: [
+    { evidenceClass: 'mechanistic', relationships: [{ ingredientSlug: 'alpha' }] },
+    { evidenceClass: 'animal', relationships: [{ ingredientSlug: 'beta' }] },
+    { evidenceClass: 'randomized_controlled_trial', relationships: [{ ingredientSlug: 'alpha' }] },
+    { evidenceClass: 'randomized_controlled_trial', relationships: [{ ingredientSlug: 'gamma' }] },
+    { evidenceClass: 'systematic_review', relationships: [{ ingredientSlug: 'gamma' }] },
+  ],
+} as unknown as PublicEvidenceDataset
+
+describe('summarizeCategoryEvidenceMix', () => {
+  it('separates mechanism/preclinical relationships from human evidence', () => {
+    const rows = summarizeCategoryEvidenceMix(dataset)
+    const adaptogens = rows.find(row => row.category === 'Adaptogens')
+    const minerals = rows.find(row => row.category === 'Minerals')
+
+    expect(adaptogens).toMatchObject({
+      evidenceRelationships: 3,
+      preclinicalRelationships: 2,
+      humanRelationships: 1,
+    })
+    expect(adaptogens?.preclinicalShare).toBeCloseTo(2 / 3)
+    expect(minerals).toMatchObject({
+      evidenceRelationships: 2,
+      preclinicalRelationships: 0,
+      humanRelationships: 2,
+    })
+  })
+
+  it('orders categories by preclinical share rather than raw category size', () => {
+    const rows = summarizeCategoryEvidenceMix(dataset)
+    expect(rows[0].category).toBe('Adaptogens')
+  })
+})

--- a/lib/evidence-report-insights.ts
+++ b/lib/evidence-report-insights.ts
@@ -1,0 +1,61 @@
+import type { PublicEvidenceDataset } from '@/lib/public-evidence-dataset'
+
+const PRECLINICAL_CLASSES = new Set(['mechanistic', 'animal', 'in_vitro'])
+const HUMAN_CLASSES = new Set([
+  'meta_analysis',
+  'systematic_review',
+  'randomized_controlled_trial',
+  'controlled_trial',
+  'observational',
+  'case_report',
+])
+
+export type CategoryEvidenceMix = {
+  category: string
+  evidenceRelationships: number
+  humanRelationships: number
+  preclinicalRelationships: number
+  otherRelationships: number
+  preclinicalShare: number
+  humanShare: number
+}
+
+export function summarizeCategoryEvidenceMix(dataset: PublicEvidenceDataset): CategoryEvidenceMix[] {
+  const categoryBySlug = new Map(dataset.ingredients.map(ingredient => [ingredient.slug, ingredient.category]))
+  const buckets = new Map<string, Omit<CategoryEvidenceMix, 'preclinicalShare' | 'humanShare'>>()
+
+  for (const study of dataset.studies) {
+    for (const relationship of study.relationships) {
+      const category = categoryBySlug.get(relationship.ingredientSlug) || 'Uncategorized'
+      const bucket = buckets.get(category) || {
+        category,
+        evidenceRelationships: 0,
+        humanRelationships: 0,
+        preclinicalRelationships: 0,
+        otherRelationships: 0,
+      }
+
+      bucket.evidenceRelationships += 1
+      if (PRECLINICAL_CLASSES.has(study.evidenceClass)) bucket.preclinicalRelationships += 1
+      else if (HUMAN_CLASSES.has(study.evidenceClass)) bucket.humanRelationships += 1
+      else bucket.otherRelationships += 1
+      buckets.set(category, bucket)
+    }
+  }
+
+  return [...buckets.values()]
+    .map(bucket => ({
+      ...bucket,
+      preclinicalShare: bucket.evidenceRelationships
+        ? bucket.preclinicalRelationships / bucket.evidenceRelationships
+        : 0,
+      humanShare: bucket.evidenceRelationships
+        ? bucket.humanRelationships / bucket.evidenceRelationships
+        : 0,
+    }))
+    .sort((a, b) =>
+      b.preclinicalShare - a.preclinicalShare ||
+      b.preclinicalRelationships - a.preclinicalRelationships ||
+      a.category.localeCompare(b.category),
+    )
+}


### PR DESCRIPTION
Closes the remaining State-of-Evidence category gap by computing the share of structured study-to-ingredient relationships that are mechanistic, animal, or in-vitro versus human evidence. Adds a report panel ranking sufficiently populated categories by preclinical reliance, with explicit small-sample and interpretation caveats, plus unit coverage.