### PR TITLE
feat(seo): enforce canonical, redirect, 404, and sitemap health

### DIFF
--- a/.github/workflows/technical-seo-monitor.yml
+++ b/.github/workflows/technical-seo-monitor.yml
@@ -1,0 +1,87 @@
+name: Technical SEO Monitor
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'app/**'
+      - 'components/**'
+      - 'lib/**'
+      - 'src/lib/**'
+      - 'public/_redirects'
+      - 'app/sitemap.ts'
+      - 'app/robots.ts'
+      - 'scripts/ci/audit-technical-seo-contract.mjs'
+      - 'scripts/monitor/production-seo-health.mjs'
+      - '.github/workflows/technical-seo-monitor.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'public/_redirects'
+      - 'app/sitemap.ts'
+      - 'app/robots.ts'
+      - 'src/lib/seo.ts'
+      - 'src/lib/site.ts'
+      - 'scripts/ci/audit-technical-seo-contract.mjs'
+      - 'scripts/monitor/production-seo-health.mjs'
+      - '.github/workflows/technical-seo-monitor.yml'
+  schedule:
+    - cron: '17 11 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: technical-seo-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  static-contract:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build static export
+        env:
+          COMMIT_HASH: ${{ github.sha }}
+        run: npm run build:deploy
+
+      - name: Audit canonical, redirect, 404, and sitemap contract
+        run: node scripts/ci/audit-technical-seo-contract.mjs
+
+      - name: Upload technical SEO report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: technical-seo-contract-${{ github.run_number }}
+          path: reports/technical-seo-contract.json
+          retention-days: 30
+
+  live-production:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+
+      - name: Verify production hostname, protocol, slash, status, and sitemap health
+        run: node scripts/monitor/production-seo-health.mjs --sample=50

--- a/scripts/ci/audit-technical-seo-contract.mjs
+++ b/scripts/ci/audit-technical-seo-contract.mjs
@@ -1,0 +1,235 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+const ROOT = process.cwd()
+const OUT = path.resolve(ROOT, process.argv.find((arg) => arg.startsWith('--out='))?.split('=')[1] || 'out')
+const REDIRECTS_FILE = path.join(ROOT, 'public/_redirects')
+const REPORT = path.join(ROOT, 'reports/technical-seo-contract.json')
+const CANONICAL_ORIGIN = 'https://thehippiescientist.net'
+const FAIL = !process.argv.includes('--warn-only')
+
+function walk(dir) {
+  if (!fs.existsSync(dir)) return []
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name)
+    return entry.isDirectory() ? walk(full) : [full]
+  })
+}
+
+function normalizePath(value) {
+  if (!value) return '/'
+  try {
+    const url = new URL(value, CANONICAL_ORIGIN)
+    const pathname = url.pathname || '/'
+    if (/\.[a-z0-9]+$/i.test(pathname)) return pathname
+    return pathname === '/' ? '/' : `${pathname.replace(/\/+$/, '')}/`
+  } catch {
+    return ''
+  }
+}
+
+function routeForFile(file) {
+  const relative = path.relative(OUT, file).replaceAll(path.sep, '/')
+  if (relative === 'index.html') return '/'
+  if (relative === '404.html') return '/404.html'
+  if (relative.endsWith('/index.html')) return normalizePath(`/${relative.slice(0, -'index.html'.length)}`)
+  return normalizePath(`/${relative.replace(/\.html$/, '')}`)
+}
+
+function canonicalFromHtml(html) {
+  return html.match(/<link\b[^>]*rel=["']canonical["'][^>]*href=["']([^"']+)["'][^>]*>/i)?.[1]
+    || html.match(/<link\b[^>]*href=["']([^"']+)["'][^>]*rel=["']canonical["'][^>]*>/i)?.[1]
+    || ''
+}
+
+function robotsNoindex(html) {
+  return /<meta\b[^>]*name=["']robots["'][^>]*content=["'][^"']*noindex/i.test(html)
+    || /<meta\b[^>]*content=["'][^"']*noindex[^"']*["'][^>]*name=["']robots["']/i.test(html)
+}
+
+function visibleText(html) {
+  return html
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&[a-z0-9#]+;/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function internalLinks(html) {
+  return Array.from(html.matchAll(/<a\b[^>]*href=["']([^"'#]+)["'][^>]*>/gi), (match) => match[1])
+    .map((href) => {
+      if (/^(mailto:|tel:|javascript:)/i.test(href)) return null
+      if (/^https?:\/\//i.test(href)) {
+        try {
+          const url = new URL(href)
+          if (url.hostname !== 'thehippiescientist.net' && url.hostname !== 'www.thehippiescientist.net') return null
+          return normalizePath(url.pathname)
+        } catch {
+          return null
+        }
+      }
+      return href.startsWith('/') ? normalizePath(href) : null
+    })
+    .filter(Boolean)
+}
+
+function parseRedirects() {
+  if (!fs.existsSync(REDIRECTS_FILE)) return []
+  return fs.readFileSync(REDIRECTS_FILE, 'utf8').split(/\r?\n/).map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'))
+    .map((line) => line.split(/\s+/))
+    .filter((parts) => parts.length >= 2)
+    .map(([from, to, status = '302']) => ({ from: normalizePath(from), to: normalizePath(to), rawTo: to, status }))
+    .filter((row) => row.from && row.to && /^30[1278]$/.test(row.status))
+}
+
+function parseSitemap() {
+  const file = path.join(OUT, 'sitemap.xml')
+  if (!fs.existsSync(file)) return { entries: [], raw: '' }
+  const raw = fs.readFileSync(file, 'utf8')
+  const entries = Array.from(raw.matchAll(/<url>([\s\S]*?)<\/url>/gi), (match) => {
+    const block = match[1]
+    return {
+      loc: block.match(/<loc>([^<]+)<\/loc>/i)?.[1]?.trim() || '',
+      lastmod: block.match(/<lastmod>([^<]+)<\/lastmod>/i)?.[1]?.trim() || '',
+    }
+  }).filter((entry) => entry.loc)
+  return { entries, raw }
+}
+
+const htmlPages = walk(OUT).filter((file) => file.endsWith('.html')).map((file) => ({
+  file,
+  route: routeForFile(file),
+  html: fs.readFileSync(file, 'utf8'),
+})).filter((page) => page.route)
+const builtRoutes = new Set(htmlPages.map((page) => page.route))
+const redirects = parseRedirects()
+const redirectMap = new Map(redirects.map((row) => [row.from, row]))
+const errors = []
+const warnings = []
+
+for (const page of htmlPages) {
+  if (page.route === '/404.html') continue
+  const canonical = canonicalFromHtml(page.html)
+  if (!canonical) {
+    errors.push({ type: 'missing-canonical', route: page.route })
+    continue
+  }
+  let canonicalUrl
+  try {
+    canonicalUrl = new URL(canonical)
+  } catch {
+    errors.push({ type: 'malformed-canonical', route: page.route, canonical })
+    continue
+  }
+  if (canonicalUrl.origin !== CANONICAL_ORIGIN) errors.push({ type: 'wrong-canonical-host', route: page.route, canonical })
+  if (canonicalUrl.protocol !== 'https:') errors.push({ type: 'non-https-canonical', route: page.route, canonical })
+  if (canonicalUrl.hostname.startsWith('www.')) errors.push({ type: 'www-canonical', route: page.route, canonical })
+  const expectedPath = normalizePath(page.route)
+  const actualPath = normalizePath(canonicalUrl.pathname)
+  if (!robotsNoindex(page.html) && actualPath !== expectedPath && !redirectMap.has(expectedPath)) {
+    errors.push({ type: 'canonical-path-mismatch', route: page.route, expectedPath, actualPath })
+  }
+}
+
+for (const redirect of redirects) {
+  const seen = new Set([redirect.from])
+  let current = redirect
+  let hops = 0
+  while (current && redirectMap.has(current.to)) {
+    hops += 1
+    if (seen.has(current.to)) {
+      errors.push({ type: 'redirect-loop', source: redirect.from, at: current.to })
+      break
+    }
+    seen.add(current.to)
+    current = redirectMap.get(current.to)
+    if (hops > 10) {
+      errors.push({ type: 'redirect-loop-or-excessive-chain', source: redirect.from })
+      break
+    }
+  }
+  if (hops > 0) errors.push({ type: 'redirect-chain', source: redirect.from, hops: hops + 1 })
+  if (redirect.to === '/' && redirect.from !== '/') warnings.push({ type: 'redirect-to-home-review-equivalence', source: redirect.from })
+}
+
+for (const page of htmlPages) {
+  if (page.route === '/404.html') continue
+  for (const target of new Set(internalLinks(page.html))) {
+    if (redirectMap.has(target)) errors.push({ type: 'internal-link-to-redirect', source: page.route, target })
+    const isStaticAsset = /\.[a-z0-9]{2,8}\/?$/i.test(target)
+    if (!builtRoutes.has(target) && !redirectMap.has(target) && !isStaticAsset) {
+      errors.push({ type: 'broken-internal-link', source: page.route, target })
+    }
+  }
+
+  const text = visibleText(page.html).toLowerCase()
+  const soft404Signals = [
+    /\bpage not found\b/,
+    /\bcontent not found\b/,
+    /\bno matching canonical profile yet\b/,
+    /\bdoes not exist\b/,
+    /\bwe couldn't find\b/,
+  ]
+  if (soft404Signals.some((pattern) => pattern.test(text)) && !robotsNoindex(page.html)) {
+    errors.push({ type: 'soft-404-content-on-indexable-route', route: page.route })
+  }
+}
+
+const sitemap = parseSitemap()
+const sitemapPaths = new Set()
+const lastmods = []
+const pageByRoute = new Map(htmlPages.map((page) => [page.route, page]))
+for (const entry of sitemap.entries) {
+  let url
+  try {
+    url = new URL(entry.loc)
+  } catch {
+    errors.push({ type: 'malformed-sitemap-url', loc: entry.loc })
+    continue
+  }
+  if (url.origin !== CANONICAL_ORIGIN) errors.push({ type: 'sitemap-wrong-host', loc: entry.loc })
+  const route = normalizePath(url.pathname)
+  if (sitemapPaths.has(route)) errors.push({ type: 'duplicate-sitemap-url', route })
+  sitemapPaths.add(route)
+  if (redirectMap.has(route)) errors.push({ type: 'redirected-url-in-sitemap', route })
+  const page = pageByRoute.get(route)
+  if (!page) {
+    errors.push({ type: 'sitemap-url-missing-from-build', route })
+  } else {
+    if (robotsNoindex(page.html)) errors.push({ type: 'noindex-url-in-sitemap', route })
+    const canonical = canonicalFromHtml(page.html)
+    if (canonical && normalizePath(new URL(canonical, CANONICAL_ORIGIN).pathname) !== route) {
+      errors.push({ type: 'noncanonical-url-in-sitemap', route, canonical })
+    }
+  }
+  if (entry.lastmod) lastmods.push(entry.lastmod)
+}
+
+if (!sitemap.entries.length) errors.push({ type: 'missing-or-empty-sitemap' })
+if (sitemap.entries.length > 10000) warnings.push({ type: 'consider-sitemap-index-split', count: sitemap.entries.length })
+if (lastmods.length >= 20) {
+  const counts = new Map()
+  for (const value of lastmods) counts.set(value, (counts.get(value) || 0) + 1)
+  const [mostCommon, frequency] = [...counts.entries()].sort((a, b) => b[1] - a[1])[0]
+  if (frequency / lastmods.length > 0.8) {
+    errors.push({ type: 'suspicious-uniform-lastmod', value: mostCommon, frequency, total: lastmods.length })
+  }
+}
+
+const summary = {
+  builtHtmlPages: htmlPages.length,
+  redirects: redirects.length,
+  sitemapUrls: sitemap.entries.length,
+  errors: errors.length,
+  warnings: warnings.length,
+}
+fs.mkdirSync(path.dirname(REPORT), { recursive: true })
+fs.writeFileSync(REPORT, `${JSON.stringify({ generatedAt: new Date().toISOString(), summary, errors, warnings }, null, 2)}\n`)
+console.log('[technical-seo-contract]', summary)
+console.log(`Report: ${path.relative(ROOT, REPORT)}`)
+if (errors.length && FAIL) process.exitCode = 1

--- a/scripts/monitor/production-seo-health.mjs
+++ b/scripts/monitor/production-seo-health.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+const CANONICAL_ORIGIN = 'https://thehippiescientist.net'
+const MAX_REDIRECTS = 6
+const SAMPLE_LIMIT = Number(process.argv.find((arg) => arg.startsWith('--sample='))?.split('=')[1] || 40)
+const errors = []
+const warnings = []
+
+async function fetchWithChain(input, options = {}) {
+  let url = input
+  const chain = []
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop += 1) {
+    const response = await fetch(url, { ...options, redirect: 'manual', headers: { 'user-agent': 'TheHippieScientist-SEO-Monitor/1.0', ...(options.headers || {}) } })
+    chain.push({ url, status: response.status, location: response.headers.get('location') || '' })
+    if (response.status < 300 || response.status >= 400 || !response.headers.get('location')) return { response, finalUrl: url, chain }
+    url = new URL(response.headers.get('location'), url).toString()
+  }
+  return { response: null, finalUrl: url, chain }
+}
+
+function canonicalFromHtml(html) {
+  return html.match(/<link\b[^>]*rel=["']canonical["'][^>]*href=["']([^"']+)["']/i)?.[1]
+    || html.match(/<link\b[^>]*href=["']([^"']+)["'][^>]*rel=["']canonical["'][^>]*>/i)?.[1]
+    || ''
+}
+
+function soft404(html) {
+  const text = html.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ').replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').toLowerCase()
+  return [/\bpage not found\b/, /\bcontent not found\b/, /\bdoes not exist\b/, /\bwe couldn't find\b/].some((pattern) => pattern.test(text))
+}
+
+async function verifyHostNormalization(url, label) {
+  const result = await fetchWithChain(url, { method: 'GET' })
+  if (!result.response) {
+    errors.push({ type: 'redirect-overflow', label, chain: result.chain })
+    return
+  }
+  const final = new URL(result.finalUrl)
+  if (final.origin !== CANONICAL_ORIGIN) errors.push({ type: 'wrong-final-origin', label, finalUrl: result.finalUrl, chain: result.chain })
+  if (result.chain.length > 3) errors.push({ type: 'host-redirect-chain-too-long', label, chain: result.chain })
+  if (result.response.status >= 400) errors.push({ type: 'host-normalization-error-status', label, status: result.response.status })
+}
+
+await verifyHostNormalization('http://thehippiescientist.net/', 'http-apex')
+await verifyHostNormalization('http://www.thehippiescientist.net/', 'http-www')
+await verifyHostNormalization('https://www.thehippiescientist.net/', 'https-www')
+
+const missingPath = `/__seo-monitor-definitely-gone-${Date.now()}/`
+const missing = await fetch(`${CANONICAL_ORIGIN}${missingPath}`, { redirect: 'manual', headers: { 'user-agent': 'TheHippieScientist-SEO-Monitor/1.0' } })
+if (missing.status !== 404 && missing.status !== 410) errors.push({ type: 'missing-content-does-not-return-404-or-410', status: missing.status, path: missingPath })
+
+const sitemapResponse = await fetch(`${CANONICAL_ORIGIN}/sitemap.xml`, { headers: { 'user-agent': 'TheHippieScientist-SEO-Monitor/1.0' } })
+if (!sitemapResponse.ok) errors.push({ type: 'live-sitemap-unavailable', status: sitemapResponse.status })
+const sitemapXml = sitemapResponse.ok ? await sitemapResponse.text() : ''
+const urls = Array.from(sitemapXml.matchAll(/<loc>([^<]+)<\/loc>/gi), (match) => match[1].trim())
+if (!urls.length) errors.push({ type: 'live-sitemap-empty' })
+
+for (const url of urls.slice(0, Math.max(1, SAMPLE_LIMIT))) {
+  let parsed
+  try {
+    parsed = new URL(url)
+  } catch {
+    errors.push({ type: 'live-sitemap-malformed-url', url })
+    continue
+  }
+  if (parsed.origin !== CANONICAL_ORIGIN) {
+    errors.push({ type: 'live-sitemap-wrong-origin', url })
+    continue
+  }
+
+  const result = await fetchWithChain(url, { method: 'GET' })
+  if (!result.response) {
+    errors.push({ type: 'live-url-redirect-overflow', url })
+    continue
+  }
+  if (result.chain.length > 1) errors.push({ type: 'redirected-url-in-live-sitemap', url, chain: result.chain })
+  if (result.response.status !== 200) {
+    errors.push({ type: 'live-sitemap-url-non-200', url, status: result.response.status })
+    continue
+  }
+  const html = await result.response.text()
+  if (soft404(html)) errors.push({ type: 'live-soft-404', url })
+  const canonical = canonicalFromHtml(html)
+  if (!canonical) errors.push({ type: 'live-missing-canonical', url })
+  else {
+    const canonicalUrl = new URL(canonical, CANONICAL_ORIGIN)
+    if (canonicalUrl.origin !== CANONICAL_ORIGIN) errors.push({ type: 'live-canonical-wrong-origin', url, canonical })
+    if (canonicalUrl.pathname !== parsed.pathname) errors.push({ type: 'live-canonical-path-mismatch', url, canonical })
+  }
+
+  if (parsed.pathname !== '/' && parsed.pathname.endsWith('/')) {
+    const withoutSlash = `${parsed.origin}${parsed.pathname.replace(/\/$/, '')}`
+    const slashResult = await fetchWithChain(withoutSlash, { method: 'GET' })
+    const finalPath = new URL(slashResult.finalUrl).pathname
+    if (finalPath !== parsed.pathname) errors.push({ type: 'trailing-slash-not-canonicalized', source: withoutSlash, final: slashResult.finalUrl })
+    if (slashResult.chain.length > 3) errors.push({ type: 'trailing-slash-chain-too-long', source: withoutSlash, chain: slashResult.chain })
+  }
+}
+
+const summary = { sampledSitemapUrls: Math.min(urls.length, SAMPLE_LIMIT), errors: errors.length, warnings: warnings.length }
+console.log(JSON.stringify({ generatedAt: new Date().toISOString(), summary, errors, warnings }, null, 2))
+if (errors.length) process.exitCode = 1

--- a/scripts/validators/validate-canonical-host.mjs
+++ b/scripts/validators/validate-canonical-host.mjs
@@ -5,10 +5,27 @@ import path from 'node:path'
 const ROOT = process.cwd()
 const siteFile = path.join(ROOT, 'src/lib/site.ts')
 const content = fs.readFileSync(siteFile, 'utf8')
+const EXPECTED = 'https://thehippiescientist.net'
 
-if (!content.includes("https://thehippiescientist.net")) {
-  console.error('[validate-canonical-host] FAIL: src/lib/site.ts must default SITE_URL to https://thehippiescientist.net')
+const siteUrlMatch = content.match(/export\s+const\s+SITE_URL\s*=\s*['"]([^'"]+)['"]/)
+if (!siteUrlMatch) {
+  console.error('[validate-canonical-host] FAIL: SITE_URL must be an explicit immutable string constant.')
   process.exit(1)
 }
 
-console.log('[validate-canonical-host] PASS: Central SITE_URL defaults to https://thehippiescientist.net.')
+if (siteUrlMatch[1] !== EXPECTED) {
+  console.error(`[validate-canonical-host] FAIL: SITE_URL must equal ${EXPECTED}, got ${siteUrlMatch[1]}.`)
+  process.exit(1)
+}
+
+if (/NEXT_PUBLIC_SITE_URL|process\.env/.test(content)) {
+  console.error('[validate-canonical-host] FAIL: canonical origin must not drift through environment configuration.')
+  process.exit(1)
+}
+
+if (/https?:\/\/www\.thehippiescientist\.net/i.test(content)) {
+  console.error('[validate-canonical-host] FAIL: www must not be emitted as the canonical origin.')
+  process.exit(1)
+}
+
+console.log(`[validate-canonical-host] PASS: immutable canonical origin is ${EXPECTED}.`)

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,6 +1,2 @@
-const configuredSiteUrl = process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, '')
-
-export const SITE_URL = configuredSiteUrl === 'https://www.thehippiescientist.net'
-  ? 'https://thehippiescientist.net'
-  : configuredSiteUrl || 'https://thehippiescientist.net'
+export const SITE_URL = 'https://thehippiescientist.net'
 export const SITE_NAME = 'The Hippie Scientist'


### PR DESCRIPTION
## Backlog
Covers 434–450, extending the crawl/robots controls already present on main.

## What changed
- makes the production canonical origin immutable at `https://thehippiescientist.net` so environment configuration cannot emit a competing hostname
- strengthens the canonical-host validator to reject www, non-HTTPS, or environment-dependent canonical origins
- audits every built HTML page for the intended canonical host/path
- detects canonical mismatches, redirect loops, and redirect chains
- fails on internal anchor links that point at redirect sources
- scans built pages for broken internal page links and soft-404 language
- warns on redirects to the homepage so deleted URLs can be reviewed for genuine destination equivalence instead of blanket home redirects
- validates sitemap URLs against the static build, canonical tags, robots noindex state, and redirect sources
- flags suspiciously uniform sitemap `lastmod` values rather than treating deployment time as content modification time
- warns when sitemap scale crosses 10,000 URLs so splitting can be considered when it is actually warranted
- adds a weekly live production monitor for apex/www, HTTP→HTTPS, trailing-slash normalization, random 404/410 behavior, sitemap availability, live status codes, soft 404s, and live canonicals
- adds a PR/push build-time technical SEO contract workflow and uploads the machine-readable audit report

## Existing behavior preserved
The current sitemap generator already excludes many noindex/redirected routes and the existing Crawl Governance workflow already validates robots/page categories. This tranche adds an independent build + live integrity layer instead of duplicating those systems.

Supersedes #3126, which was closed after `main` advanced during implementation.