### PR TITLE
fix: make page-category robots fallback lint-safe

### DIFF
--- a/scripts/ci/audit-page-category-robots.mjs
+++ b/scripts/ci/audit-page-category-robots.mjs
@@ -40,7 +40,9 @@ function normalizeRoute(value) {
   let pathname = value
   try {
     pathname = new URL(value, 'https://thehippiescientist.net').pathname
-  } catch {}
+  } catch {
+    pathname = String(value)
+  }
   pathname = pathname.replace(/\/+/g, '/')
   if (!pathname.startsWith('/')) pathname = `/${pathname}`
   if (pathname !== '/' && !pathname.endsWith('/')) pathname += '/'


### PR DESCRIPTION
Fixes #3133

## Relevant URLs
- Repository CI lint
- `scripts/ci/audit-page-category-robots.mjs`

## Acceptance criteria
- Preserve route normalization and robots audit semantics.
- Remove the ESLint `no-empty` violation.
- Use explicit fallback behavior for malformed URL input.
- Do not change crawl policy.

## Validation commands
- `npm run lint`
- `node scripts/ci/audit-page-category-robots.mjs` after a production build
- `npm run check`

## Before → after metrics
- `no-empty` lint errors in this file: 1 → 0.
- Robots policy changes: 0 → 0.

## Generator/source-of-truth decision
The existing robots audit remains the source of truth. This patch only makes its URL parse fallback explicit; no generator or policy layer is added.

## Regression contract
Malformed URL-like values must fall back to their string form and continue through the same route normalization logic without suppressing errors through an empty catch block.