### PR TITLE
fix(search): restore interaction-backed filter

### DIFF
--- a/scripts/data/build-search-index.mjs
+++ b/scripts/data/build-search-index.mjs
@@ -138,6 +138,25 @@ function readJson(file) {
   return JSON.parse(fs.readFileSync(path.join(DATA_DIR, file), 'utf8'))
 }
 
+export function interactionSlugsFromEdges(edges) {
+  if (!edges || typeof edges !== 'object' || Array.isArray(edges)) return new Set()
+  return new Set(
+    Object.entries(edges)
+      .filter(([slug, relationships]) => slug.trim() && Array.isArray(relationships) && relationships.length > 0)
+      .map(([slug]) => slug.trim()),
+  )
+}
+
+function loadInteractionSlugs() {
+  try {
+    return interactionSlugsFromEdges(readJson('interaction_edges.json'))
+  } catch {
+    return new Set()
+  }
+}
+
+const INTERACTION_SLUGS = loadInteractionSlugs()
+
 function mergeSearchRecords(summaryFile, coreFile) {
   const summaries = readJson(summaryFile)
   const coreBySlug = new Map(readJson(coreFile).map(record => [record.slug, record]))
@@ -190,7 +209,7 @@ function buildHerbDocs() {
         evidenceGrade: normalizeEvidence(item.evidenceLevel || item.confidence),
         safety: normalizeSafety({ safetyNotes: item.safetyNotes || item.safety, contraindications, interactions, isEducation: false }),
         safetyFlags: {
-          hasInteractions: interactions.length > 0,
+          hasInteractions: INTERACTION_SLUGS.has(slug) || interactions.length > 0,
           hasContraindications: contraindications.length > 0,
         },
         tags: effects.slice(0, 4),
@@ -236,7 +255,7 @@ function buildCompoundDocs() {
         evidenceGrade: normalizeEvidence(item.evidenceLevel),
         safety: normalizeSafety({ safetyNotes: item.safetyNotes || item.safety, contraindications, interactions, isEducation: false }),
         safetyFlags: {
-          hasInteractions: interactions.length > 0,
+          hasInteractions: INTERACTION_SLUGS.has(slug) || interactions.length > 0,
           hasContraindications: contraindications.length > 0,
         },
         tags: effects.slice(0, 4),

--- a/scripts/data/build-search-index.test.mjs
+++ b/scripts/data/build-search-index.test.mjs
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { GOAL_KEYWORDS, PATHWAY_KEYWORDS, matchFacets } from './build-search-index.mjs'
+import {
+  GOAL_KEYWORDS,
+  PATHWAY_KEYWORDS,
+  interactionSlugsFromEdges,
+  matchFacets,
+} from './build-search-index.mjs'
 
 describe('matchFacets', () => {
   it('does not match a keyword glued as a prefix inside an unrelated word', () => {
@@ -34,5 +39,22 @@ describe('matchFacets', () => {
     // frontmatter-derived goals, so it relies entirely on this facet match
     // to appear under the Inflammation search filter.
     expect(matchFacets('what is neuroinflammation', GOAL_KEYWORDS)).toContain('inflammation')
+  })
+})
+
+describe('interactionSlugsFromEdges', () => {
+  it('derives searchable interaction flags from non-empty graph adjacency lists', () => {
+    const slugs = interactionSlugsFromEdges({
+      caffeine: [{ partner_slug: 'l-theanine' }],
+      ashwagandha: [],
+      '  magnesium  ': [{ partner_slug: 'zinc' }],
+    })
+
+    expect([...slugs].sort()).toEqual(['caffeine', 'magnesium'])
+  })
+
+  it('fails closed for malformed graph payloads', () => {
+    expect([...interactionSlugsFromEdges(null)]).toEqual([])
+    expect([...interactionSlugsFromEdges([])]).toEqual([])
   })
 })


### PR DESCRIPTION
Fix the global search `Has interactions` facet so it reflects the canonical interaction graph instead of relying only on mostly-empty flat profile interaction arrays.

- derive interaction-bearing slugs from `public/data/interaction_edges.json`,
- preserve flat interaction arrays as a fallback,
- keep educational records interaction-free,
- add regression coverage for non-empty, empty, trimmed, and malformed graph entries.

The production deploy pipeline regenerates `search-index.json` before the Next.js build, so this changes the deployed search index on the next build without hand-editing generated JSON.

Related: #2339