### PR TITLE
ROI #591–600: production content invariant gate

### DIFF
--- a/.github/workflows/production-content-invariants.yml
+++ b/.github/workflows/production-content-invariants.yml
@@ -1,0 +1,119 @@
+name: Production Content Invariants
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'data/**'
+      - 'data-sources/**'
+      - 'public/data/**'
+      - 'content/**'
+      - 'app/**'
+      - 'components/**'
+      - 'lib/**'
+      - 'src/**'
+      - 'scripts/data/**'
+      - 'scripts/lib/production-content-invariants.mjs'
+      - 'scripts/ci/*production*'
+      - '.github/workflows/production-content-invariants.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'data/**'
+      - 'data-sources/**'
+      - 'public/data/**'
+      - 'content/**'
+      - 'app/**'
+      - 'components/**'
+      - 'lib/**'
+      - 'src/**'
+      - 'scripts/data/**'
+      - 'scripts/lib/production-content-invariants.mjs'
+      - 'scripts/ci/*production*'
+      - '.github/workflows/production-content-invariants.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: production-content-invariants-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  invariants:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Exercise every invariant with deterministic fixtures
+        run: node scripts/ci/test-production-content-invariants.mjs
+
+      - name: Build canonical runtime data
+        run: node --trace-uncaught --enable-source-maps scripts/data/build-runtime-from-workbook.mjs --out public/data
+
+      - name: Scrub internal language and demote unsafe profiles
+        run: node scripts/data/enforce-production-content-invariants.mjs --data-dir=public/data
+
+      - name: Validate the post-enforcement profile corpus
+        run: node scripts/ci/validate-production-content-invariants.mjs --data-dir=public/data
+
+      - name: Build downstream runtime maps
+        run: |
+          node scripts/data/build-related-runtime-maps.mjs --data-dir=public/data
+          node scripts/data/build-runtime-summary-indexes.mjs --data-dir=public/data
+          node scripts/data/build-route-manifest.mjs --data-dir=public/data
+          node scripts/data/build-internal-link-engine.mjs --data-dir=public/data
+          node scripts/data/build-sitemap-manifest.mjs --data-dir=public/data
+          node scripts/data/build-export-batches.mjs --data-dir=public/data
+          node scripts/data/build-semantic-snapshots.mjs --data-dir=public/data
+          node scripts/data/build-search-index.mjs --data-dir=public/data
+
+      - name: Build production static HTML from governed data
+        run: node scripts/build-production.mjs
+
+      - name: Prove placeholders and dev language are absent from visible HTML
+        run: node scripts/ci/audit-production-visible-language.mjs
+
+      - name: Verify profile robots after invariant demotions
+        run: node scripts/ci/audit-profile-robots.mjs
+
+      - name: Upload invariant reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: production-content-invariants-${{ github.run_number }}
+          path: |
+            reports/production-invariant-enforcement.json
+            reports/production-content-invariants.json
+            reports/production-visible-language.json
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Summary
+        if: always()
+        run: |
+          echo '## Production content invariants' >> "$GITHUB_STEP_SUMMARY"
+          echo '- A-grade criteria, human-source, safety-source, dose-source, citation resolution, placeholders, canonical duplicates, scientific names and internal-development language are covered.' >> "$GITHUB_STEP_SUMMARY"
+          if [ -f reports/production-invariant-enforcement.json ]; then
+            node - <<'NODE' >> "$GITHUB_STEP_SUMMARY"
+          const fs = require('fs')
+          const r = JSON.parse(fs.readFileSync('reports/production-invariant-enforcement.json', 'utf8'))
+          console.log(`- Profiles scanned: ${r.scannedProfiles}`)
+          console.log(`- Profiles scrubbed: ${r.scrubbedProfiles}`)
+          console.log(`- Profiles demoted to NEEDS_REVIEW/noindex: ${r.demotedProfiles}`)
+          NODE
+          fi
+          echo '- Invalid profiles remain research-accessible but cannot stay indexable.' >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/build-production.mjs
+++ b/scripts/build-production.mjs
@@ -19,6 +19,21 @@ for (const dir of [outPath, nextPath]) {
 }
 
 try {
+  // Publication invariants are deployment-critical. The workbook/runtime build
+  // may preserve weak records for internal research, but immediately before
+  // Next renders production HTML we scrub internal language and force any
+  // invariant-breaking public profile to NEEDS_REVIEW/noindex. If demotions
+  // occur, derived route/search/sitemap data is rebuilt from the governed state.
+  console.log('[build] Enforcing production content invariants...')
+  execSync('node scripts/data/enforce-production-content-invariants.mjs --data-dir=public/data --refresh-derived', {
+    stdio: 'inherit',
+    env: process.env,
+  })
+  execSync('node scripts/ci/validate-production-content-invariants.mjs --data-dir=public/data', {
+    stdio: 'inherit',
+    env: process.env,
+  })
+
   if (fs.existsSync(pagesPath)) {
     console.log('[build] Temporarily moving src/pages to avoid Next.js routing conflicts...')
     fs.renameSync(pagesPath, tempPagesPath)
@@ -29,6 +44,15 @@ try {
   execSync('npx next build', {
     stdio: 'inherit',
     env: { ...process.env, NODE_OPTIONS: '--max-old-space-size=4096', NEXT_TELEMETRY_DISABLED: '1' },
+  })
+
+  // The source-data gate proves structured invariants. This second gate proves
+  // the user/crawler-visible HTML did not reintroduce placeholders, version
+  // labels, debug strings or other internal-development language in templates.
+  console.log('[build] Auditing production-visible language...')
+  execSync('node scripts/ci/audit-production-visible-language.mjs', {
+    stdio: 'inherit',
+    env: process.env,
   })
 } catch (error) {
   // Next.js 15 static export on Windows occasionally throws an ENOENT when it tries to

--- a/scripts/ci/audit-production-visible-language.mjs
+++ b/scripts/ci/audit-production-visible-language.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const outDir = path.join(root, 'out')
+const reportPath = path.join(root, 'reports/production-visible-language.json')
+if (!fs.existsSync(outDir)) {
+  console.error('[production-visible-language] missing out/ — run a production build first')
+  process.exit(1)
+}
+
+const forbidden = [
+  ['pubmed-metadata-placeholder', /(?:metadata extraction (?:is )?required|still require(?:s)? pubmed metadata extraction|minimal citation row added from existing workbook)/i],
+  ['editorial-todo', /\b(?:editorial|internal) todo\b/i],
+  ['debug-language', /\b(?:debug string|migration comment|placeholder citation)\b/i],
+  ['internal-version-prefix', /(?:^|[\s>])v\d+(?:\.\d+)*\s*:\s*[A-Z]/],
+  ['object-leak', /\[object Object\]/i],
+  ['lorem-ipsum', /\blorem ipsum\b/i],
+  ['duplicated-evidence-word', /\bevidence\s+evidence\b/i],
+]
+
+function walk(dir) {
+  const files = []
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory() && entry.name !== '_next' && entry.name !== 'pagefind') files.push(...walk(full))
+    else if (entry.isFile() && entry.name.endsWith('.html')) files.push(full)
+  }
+  return files
+}
+function routeFromFile(file) {
+  let rel = path.relative(outDir, file).split(path.sep).join('/')
+  if (rel === 'index.html') return '/'
+  rel = rel.replace(/\/index\.html$/, '/').replace(/\.html$/, '/')
+  return `/${rel}`.replace(/\/+/g, '/')
+}
+function visibleText(html) {
+  return html
+    .replace(/<script\b[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style\b[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<svg\b[\s\S]*?<\/svg>/gi, ' ')
+    .replace(/<!--([\s\S]*?)-->/g, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&(?:nbsp|amp|quot|#39|lt|gt);/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+const findings = []
+let pages = 0
+for (const file of walk(outDir)) {
+  pages += 1
+  const route = routeFromFile(file)
+  const body = visibleText(fs.readFileSync(file, 'utf8'))
+  for (const [code, pattern] of forbidden) {
+    const match = pattern.exec(body)
+    if (!match) continue
+    const start = Math.max(0, match.index - 80)
+    const end = Math.min(body.length, match.index + match[0].length + 120)
+    findings.push({ route, code, excerpt: body.slice(start, end) })
+  }
+}
+
+const report = { generatedAt: new Date().toISOString(), pagesScanned: pages, findings, forbiddenCodes: forbidden.map(([code]) => code) }
+fs.mkdirSync(path.dirname(reportPath), { recursive: true })
+fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`)
+console.log(`[production-visible-language] scanned ${pages} HTML pages; findings=${findings.length}`)
+console.log(`[production-visible-language] report: ${path.relative(root, reportPath)}`)
+if (findings.length) {
+  console.error(`\n[production-visible-language] FAILED — ${findings.length} production-visible leak(s)`)
+  findings.slice(0, 100).forEach((finding) => console.error(`[production-visible-language] ${finding.route} · ${finding.code} · ${finding.excerpt}`))
+  process.exit(1)
+}
+console.log('[production-visible-language] PASS')

--- a/scripts/ci/test-production-content-invariants.mjs
+++ b/scripts/ci/test-production-content-invariants.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict'
+import { evaluateCorpus, evaluateRecord, PRODUCTION_INVARIANT_CODES } from '../lib/production-content-invariants.mjs'
+
+const base = {
+  slug: 'fixture',
+  indexability_status: 'PUBLISH',
+  sitemap_included: true,
+  governance: { indexingAllowed: true },
+  evidence_grade: 'B',
+  evidence_tier: 'Moderate Evidence',
+  evidence_design_match: 'direct human outcomes',
+  evidence_risk_of_bias: 'acceptable',
+  evidence_consistency: 'replicated',
+  scientific_name: 'Withania somnifera',
+  safety: '',
+  dosage: '',
+  sources: [
+    { id: 'human', title: 'Randomized controlled trial in adults', url: 'https://pubmed.ncbi.nlm.nih.gov/12345678/', citation: 'RCT; 120 adults; 300 mg/day', studyType: 'RCT' },
+    { id: 'safety', title: 'Safety and tolerability in adults', url: 'https://pubmed.ncbi.nlm.nih.gov/23456789/', citation: 'Safety; 300 mg/day; adverse events monitored' },
+  ],
+  claimMap: [],
+}
+
+function codes(record, kind = 'herb') {
+  return new Set(evaluateRecord(record, kind).map((finding) => finding.code))
+}
+
+// #592 A-grade pages must have a mature, replicated human evidence basis plus
+// the structured design/risk/consistency rationale published by methodology.
+const aGrade = structuredClone(base)
+aGrade.evidence_grade = 'A'
+aGrade.evidence_tier = 'Strong Human Evidence'
+aGrade.sources = [base.sources[0]]
+assert(codes(aGrade).has('A_GRADE_CRITERIA'))
+
+// #593 human claims require sources that are themselves classifiable as human evidence.
+const human = structuredClone(base)
+human.sources = [{ id: 'mechanism', title: 'Cell signaling experiment', url: 'https://example.org/paper' }]
+human.claimMap = [{ id: 'c1', claim: 'A randomized human trial improved stress', evidenceLevel: 'human_rct', sourceRefIds: ['mechanism'] }]
+assert(codes(human).has('HUMAN_CLAIM_WITHOUT_HUMAN_SOURCE'))
+
+// #594 safety claims require safety evidence, not an arbitrary efficacy paper.
+const safety = structuredClone(base)
+safety.sources = [base.sources[0]]
+safety.claimMap = [{ id: 'c2', claim: 'Avoid during pregnancy because of a safety concern', sourceRefIds: ['human'] }]
+assert(codes(safety).has('SAFETY_CLAIM_WITHOUT_SAFETY_SOURCE'))
+
+// #595 numeric dose statements must trace to a dose-bearing source.
+const dose = structuredClone(base)
+dose.sources = [{ id: 'human', title: 'Randomized controlled trial in adults', url: 'https://pubmed.ncbi.nlm.nih.gov/12345678/', citation: 'Human trial' }]
+dose.dosage = 'Take 300 mg/day for 8 weeks.'
+assert(codes(dose).has('DOSE_STATEMENT_WITHOUT_DOSE_SOURCE'))
+
+// #596 source references and citation destinations must resolve inside the
+// record graph and use structurally valid destinations.
+const missingRef = structuredClone(base)
+missingRef.claimMap = [{ id: 'c3', claim: 'Human RCT evidence exists', evidenceLevel: 'human_rct', sourceRefIds: ['missing'] }]
+assert(codes(missingRef).has('UNRESOLVED_CITATION_REFERENCE'))
+const invalidUrl = structuredClone(base)
+invalidUrl.sources[0].url = 'https://pubmed.ncbi.nlm.nih.gov/not-a-pmid/'
+assert(codes(invalidUrl).has('INVALID_CITATION_DESTINATION'))
+
+// #597 placeholders are forbidden.
+const placeholder = structuredClone(base)
+placeholder.sources[0].title = 'Minimal citation row added from existing workbook PMID; title still requires PubMed metadata extraction.'
+assert(codes(placeholder).has('PRODUCTION_PLACEHOLDER'))
+
+// #598 duplicate canonical entities are a corpus-level failure.
+const duplicateA = structuredClone(base)
+duplicateA.slug = 'duplicate'
+duplicateA.canonical_id = 'entity:shared'
+const duplicateB = structuredClone(base)
+duplicateB.slug = 'duplicate-2'
+duplicateB.canonical_id = 'entity:shared'
+assert(evaluateCorpus([{ kind: 'herb', record: duplicateA }, { kind: 'herb', record: duplicateB }]).some((finding) => finding.code === 'DUPLICATE_CANONICAL_ENTITY'))
+
+// #599 scientific names get a conservative structural sanity check.
+const malformed = structuredClone(base)
+malformed.scientific_name = 'TODO plant 12345'
+assert(codes(malformed).has('MALFORMED_SCIENTIFIC_NAME'))
+
+// #600 version/debug language is not a public scientific claim.
+const internal = structuredClone(base)
+internal.claimMap = [{ id: 'c4', claim: 'v9.8: internal claim wording', sourceRefIds: ['human'] }]
+assert(codes(internal).has('INTERNAL_DEVELOPMENT_LANGUAGE'))
+
+const exercised = new Set([
+  'A_GRADE_CRITERIA',
+  'HUMAN_CLAIM_WITHOUT_HUMAN_SOURCE',
+  'SAFETY_CLAIM_WITHOUT_SAFETY_SOURCE',
+  'DOSE_STATEMENT_WITHOUT_DOSE_SOURCE',
+  'UNRESOLVED_CITATION_REFERENCE',
+  'INVALID_CITATION_DESTINATION',
+  'PRODUCTION_PLACEHOLDER',
+  'DUPLICATE_CANONICAL_ENTITY',
+  'MALFORMED_SCIENTIFIC_NAME',
+  'INTERNAL_DEVELOPMENT_LANGUAGE',
+])
+assert.deepEqual([...exercised].sort(), [...PRODUCTION_INVARIANT_CODES].sort())
+console.log(`[production-invariant-tests] PASS — exercised all ${PRODUCTION_INVARIANT_CODES.length} invariant codes`)

--- a/scripts/ci/validate-production-content-invariants.mjs
+++ b/scripts/ci/validate-production-content-invariants.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+import { evaluateCorpus, recordIsPublished } from '../lib/production-content-invariants.mjs'
+
+const root = process.cwd()
+const dataDir = path.resolve(root, process.argv.find((arg) => arg.startsWith('--data-dir='))?.slice(11) || 'public/data')
+const reportPath = path.join(root, 'reports/production-content-invariants.json')
+
+function readJson(file) {
+  try { return JSON.parse(fs.readFileSync(file, 'utf8')) } catch { return {} }
+}
+function detailDir(kind) {
+  const plural = path.join(dataDir, kind === 'herb' ? 'herbs-detail' : 'compounds-detail')
+  const singular = path.join(dataDir, kind === 'herb' ? 'herb-detail' : 'compound-detail')
+  return fs.existsSync(plural) ? plural : singular
+}
+function entriesFor(kind) {
+  const dir = detailDir(kind)
+  if (!fs.existsSync(dir)) return []
+  return fs.readdirSync(dir).filter((name) => name.endsWith('.json')).sort().map((name) => ({ kind, record: readJson(path.join(dir, name)) }))
+}
+
+const entries = [...entriesFor('herb'), ...entriesFor('compound')]
+const issues = evaluateCorpus(entries)
+const publishedKeys = new Set(entries.filter(({ record }) => recordIsPublished(record)).map(({ kind, record }) => `${kind}:${record.slug}`))
+
+const alwaysBlocking = new Set([
+  'UNRESOLVED_CITATION_REFERENCE',
+  'INVALID_CITATION_DESTINATION',
+  'PRODUCTION_PLACEHOLDER',
+  'DUPLICATE_CANONICAL_ENTITY',
+  'MALFORMED_SCIENTIFIC_NAME',
+  'INTERNAL_DEVELOPMENT_LANGUAGE',
+])
+const publicationBlocking = new Set([
+  'A_GRADE_CRITERIA',
+  'HUMAN_CLAIM_WITHOUT_HUMAN_SOURCE',
+  'SAFETY_CLAIM_WITHOUT_SAFETY_SOURCE',
+  'DOSE_STATEMENT_WITHOUT_DOSE_SOURCE',
+])
+
+const blocking = issues.filter((finding) => {
+  if (!finding.blocking) return false
+  if (alwaysBlocking.has(finding.code)) return true
+  return publicationBlocking.has(finding.code) && publishedKeys.has(`${finding.kind}:${finding.slug}`)
+})
+const counts = {}
+for (const finding of issues) counts[finding.code] = (counts[finding.code] || 0) + 1
+
+const report = {
+  generatedAt: new Date().toISOString(),
+  profilesScanned: entries.length,
+  publishedProfiles: publishedKeys.size,
+  findings: issues.length,
+  blockingFindings: blocking.length,
+  counts,
+  blocking,
+  policy: {
+    publishedClaims: 'A-grade, human-evidence, safety and dose claims must be backed by the required evidence class before indexation.',
+    corpusIntegrity: 'Broken source references, malformed citation destinations, placeholders, duplicate canonical IDs, malformed scientific names and internal-development language are forbidden in the generated profile corpus.',
+  },
+}
+fs.mkdirSync(path.dirname(reportPath), { recursive: true })
+fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`)
+
+console.log(`[production-content-invariants] profiles=${report.profilesScanned}; published=${report.publishedProfiles}; findings=${report.findings}; blocking=${report.blockingFindings}`)
+for (const [code, count] of Object.entries(counts).sort((a, b) => b[1] - a[1])) console.log(`[production-content-invariants] ${code}: ${count}`)
+console.log(`[production-content-invariants] report: ${path.relative(root, reportPath)}`)
+
+if (blocking.length) {
+  console.error(`\n[production-content-invariants] FAILED — ${blocking.length} blocking invariant violation(s)`) 
+  for (const finding of blocking.slice(0, 80)) console.error(`[production-content-invariants] ${finding.url || `${finding.kind}:${finding.slug}`} · ${finding.code} · ${finding.detail}`)
+  process.exit(1)
+}
+console.log('[production-content-invariants] PASS')

--- a/scripts/data/enforce-production-content-invariants.mjs
+++ b/scripts/data/enforce-production-content-invariants.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import fs from 'node:fs'
 import path from 'node:path'
+import { execSync } from 'node:child_process'
 import {
   demoteFromIndex,
   evaluateCorpus,
@@ -11,6 +12,7 @@ import {
 
 const root = process.cwd()
 const dataDir = path.resolve(root, process.argv.find((arg) => arg.startsWith('--data-dir='))?.slice(11) || 'public/data')
+const refreshDerived = process.argv.includes('--refresh-derived')
 const reportPath = path.join(root, 'reports/production-invariant-enforcement.json')
 
 function readJson(file, fallback) {
@@ -30,8 +32,12 @@ function listDetails(kind) {
   if (!fs.existsSync(dir)) return []
   return fs.readdirSync(dir).filter((name) => name.endsWith('.json')).sort().map((name) => ({ kind, name, file: path.join(dir, name), record: readJson(path.join(dir, name), {}) }))
 }
+function run(command) {
+  execSync(command, { cwd: root, stdio: 'inherit', env: process.env })
+}
 
 const entries = [...listDetails('herb'), ...listDetails('compound')]
+const originalByFile = new Map(entries.map((entry) => [entry.file, entry.record]))
 const scrubbedEntries = entries.map((entry) => ({ ...entry, record: scrubInternalLanguage(entry.record) }))
 
 // Duplicate canonical IDs are a corpus-level invariant, so calculate them once
@@ -63,7 +69,7 @@ for (const entry of scrubbedEntries) {
       details: blocking.map((finding) => finding.detail),
     })
   }
-  if (JSON.stringify(record) !== JSON.stringify(entries.find((original) => original.file === entry.file)?.record)) scrubbed.push(`${entry.kind}:${record.slug}`)
+  if (JSON.stringify(record) !== JSON.stringify(originalByFile.get(entry.file))) scrubbed.push(`${entry.kind}:${record.slug}`)
   writeJson(entry.file, record)
   finalByKindSlug.set(`${entry.kind}:${record.slug}`, record)
 }
@@ -98,8 +104,26 @@ const report = {
   scrubbedProfiles: new Set(scrubbed).size,
   demotedProfiles: demotions.length,
   demotions,
+  refreshedDerivedData: false,
   policy: 'Invariant-breaking records remain available to the research system but are forced to noindex/NEEDS_REVIEW before route, sitemap and search manifests are generated.',
 }
+
+// The deploy pipeline normally builds derived maps before Next.js. When this
+// enforcement is invoked from the final production-build step, a demotion would
+// otherwise leave those maps stale. Refresh them only when a demotion happened.
+if (refreshDerived && demotions.length) {
+  console.log(`[production-invariants] refreshing derived route/search/sitemap data after ${demotions.length} demotion(s)`)
+  run('node scripts/data/build-related-runtime-maps.mjs --data-dir=public/data')
+  run('node scripts/data/build-runtime-summary-indexes.mjs --data-dir=public/data')
+  run('node scripts/data/build-route-manifest.mjs --data-dir=public/data')
+  run('node scripts/data/build-internal-link-engine.mjs --data-dir=public/data')
+  run('node scripts/data/build-sitemap-manifest.mjs --data-dir=public/data')
+  run('node scripts/data/build-export-batches.mjs --data-dir=public/data')
+  run('node scripts/data/build-semantic-snapshots.mjs --data-dir=public/data')
+  run('node scripts/data/build-search-index.mjs --data-dir=public/data')
+  report.refreshedDerivedData = true
+}
+
 writeJson(reportPath, report)
 console.log(`[production-invariants] scanned ${report.scannedProfiles}; scrubbed=${report.scrubbedProfiles}; demoted=${report.demotedProfiles}`)
 if (demotions.length) console.log(`[production-invariants] first demotion: ${demotions[0].url} — ${demotions[0].codes.join(', ')}`)

--- a/scripts/data/enforce-production-content-invariants.mjs
+++ b/scripts/data/enforce-production-content-invariants.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+import {
+  demoteFromIndex,
+  evaluateCorpus,
+  evaluateRecord,
+  recordIsPublished,
+  scrubInternalLanguage,
+} from '../lib/production-content-invariants.mjs'
+
+const root = process.cwd()
+const dataDir = path.resolve(root, process.argv.find((arg) => arg.startsWith('--data-dir='))?.slice(11) || 'public/data')
+const reportPath = path.join(root, 'reports/production-invariant-enforcement.json')
+
+function readJson(file, fallback) {
+  try { return JSON.parse(fs.readFileSync(file, 'utf8')) } catch { return fallback }
+}
+function writeJson(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true })
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`)
+}
+function detailDir(kind) {
+  const plural = path.join(dataDir, kind === 'herb' ? 'herbs-detail' : 'compounds-detail')
+  const singular = path.join(dataDir, kind === 'herb' ? 'herb-detail' : 'compound-detail')
+  return fs.existsSync(plural) ? plural : singular
+}
+function listDetails(kind) {
+  const dir = detailDir(kind)
+  if (!fs.existsSync(dir)) return []
+  return fs.readdirSync(dir).filter((name) => name.endsWith('.json')).sort().map((name) => ({ kind, name, file: path.join(dir, name), record: readJson(path.join(dir, name), {}) }))
+}
+
+const entries = [...listDetails('herb'), ...listDetails('compound')]
+const scrubbedEntries = entries.map((entry) => ({ ...entry, record: scrubInternalLanguage(entry.record) }))
+
+// Duplicate canonical IDs are a corpus-level invariant, so calculate them once
+// and attribute them to the affected record before deciding publication status.
+const corpusIssues = evaluateCorpus(scrubbedEntries)
+const corpusByKey = new Map()
+for (const finding of corpusIssues) {
+  const key = `${finding.kind}:${finding.slug}`
+  if (!corpusByKey.has(key)) corpusByKey.set(key, [])
+  corpusByKey.get(key).push(finding)
+}
+
+const demotions = []
+const scrubbed = []
+const finalByKindSlug = new Map()
+for (const entry of scrubbedEntries) {
+  const key = `${entry.kind}:${entry.record.slug || ''}`
+  let record = entry.record
+  const wasPublished = recordIsPublished(record)
+  const issues = corpusByKey.get(key) || evaluateRecord(record, entry.kind)
+  const blocking = issues.filter((finding) => finding.blocking)
+  if (wasPublished && blocking.length) {
+    record = demoteFromIndex(record, new Set(blocking.map((finding) => finding.code)))
+    demotions.push({
+      kind: entry.kind,
+      slug: record.slug,
+      url: `/${entry.kind === 'herb' ? 'herbs' : 'compounds'}/${record.slug}/`,
+      codes: [...new Set(blocking.map((finding) => finding.code))],
+      details: blocking.map((finding) => finding.detail),
+    })
+  }
+  if (JSON.stringify(record) !== JSON.stringify(entries.find((original) => original.file === entry.file)?.record)) scrubbed.push(`${entry.kind}:${record.slug}`)
+  writeJson(entry.file, record)
+  finalByKindSlug.set(`${entry.kind}:${record.slug}`, record)
+}
+
+// Keep collection-level route/indexability records synchronized with detail
+// governance so sitemap/search builders cannot accidentally republish a profile
+// that the detail-level invariant gate demoted.
+for (const [kind, fileName] of [['herb', 'herbs.json'], ['compound', 'compounds.json']]) {
+  const file = path.join(dataDir, fileName)
+  const rows = readJson(file, [])
+  if (!Array.isArray(rows)) continue
+  let changed = false
+  const nextRows = rows.map((raw) => {
+    const row = scrubInternalLanguage(raw)
+    const detail = finalByKindSlug.get(`${kind}:${row.slug || ''}`)
+    let next = row
+    if (detail && !recordIsPublished(detail) && recordIsPublished(row)) {
+      const reasons = (detail.indexability_reasons || []).filter((reason) => String(reason).startsWith('production-invariant:'))
+      next = demoteFromIndex(row, new Set(reasons.map((reason) => String(reason).slice('production-invariant:'.length).toUpperCase())))
+      next.indexability_reasons = [...new Set([...(next.indexability_reasons || []), ...reasons])]
+      changed = true
+    }
+    if (JSON.stringify(next) !== JSON.stringify(raw)) changed = true
+    return next
+  })
+  if (changed) writeJson(file, nextRows)
+}
+
+const report = {
+  generatedAt: new Date().toISOString(),
+  scannedProfiles: entries.length,
+  scrubbedProfiles: new Set(scrubbed).size,
+  demotedProfiles: demotions.length,
+  demotions,
+  policy: 'Invariant-breaking records remain available to the research system but are forced to noindex/NEEDS_REVIEW before route, sitemap and search manifests are generated.',
+}
+writeJson(reportPath, report)
+console.log(`[production-invariants] scanned ${report.scannedProfiles}; scrubbed=${report.scrubbedProfiles}; demoted=${report.demotedProfiles}`)
+if (demotions.length) console.log(`[production-invariants] first demotion: ${demotions[0].url} — ${demotions[0].codes.join(', ')}`)
+console.log(`[production-invariants] report: ${path.relative(root, reportPath)}`)

--- a/scripts/lib/production-content-invariants.mjs
+++ b/scripts/lib/production-content-invariants.mjs
@@ -1,0 +1,289 @@
+const INTERNAL_VERSION_PREFIX = /^\s*v\d+(?:\.\d+)*\s*:\s*/i
+
+const PLACEHOLDER_PATTERNS = [
+  /metadata extraction (?:is )?required/i,
+  /still require(?:s)? pubmed metadata extraction/i,
+  /minimal citation row added from existing workbook/i,
+  /\blorem ipsum\b/i,
+  /\b(?:editorial|internal) todo\b/i,
+  /\bdebug string\b/i,
+  /\bmigration comment\b/i,
+  /\bplaceholder citation\b/i,
+  /\[object Object\]/i,
+]
+
+const HUMAN_SOURCE_RE = /\b(?:human|randomi[sz]ed|rct|clinical trial|controlled trial|meta-analysis|systematic review|cohort|observational|participants?|patients?|adults?|subjects?)\b/i
+const SAFETY_SOURCE_RE = /\b(?:safety|adverse|tolerab|toxic|hepat|liver injury|interaction|contraindicat|pregnan|breastfeed|bleed|arrhythm|withdrawal|dependence|side effects?)\b/i
+const DOSE_SOURCE_RE = /(?:\b\d+(?:\.\d+)?\s*(?:mg|g|mcg|µg|ug|ml|iu)\b|\b(?:dose|dosage|daily|per day|\/day|twice daily|once daily)\b)/i
+const HUMAN_CLAIM_RE = /\b(?:human|randomi[sz]ed|rct|clinical trial|meta-analysis|systematic review|participants?|patients?|adults?)\b/i
+const SAFETY_CLAIM_RE = /\b(?:safe|safety|adverse|side effect|interaction|contraindicat|avoid|pregnan|breastfeed|liver|bleed|sedat|toxicity)\b/i
+const DOSE_CLAIM_RE = /\b\d+(?:\.\d+)?\s*(?:mg|g|mcg|µg|ug|ml|iu)(?:\s*\/\s*(?:day|d))?\b/i
+
+export const PRODUCTION_INVARIANT_CODES = [
+  'A_GRADE_CRITERIA',
+  'HUMAN_CLAIM_WITHOUT_HUMAN_SOURCE',
+  'SAFETY_CLAIM_WITHOUT_SAFETY_SOURCE',
+  'DOSE_STATEMENT_WITHOUT_DOSE_SOURCE',
+  'UNRESOLVED_CITATION_REFERENCE',
+  'INVALID_CITATION_DESTINATION',
+  'PRODUCTION_PLACEHOLDER',
+  'DUPLICATE_CANONICAL_ENTITY',
+  'MALFORMED_SCIENTIFIC_NAME',
+  'INTERNAL_DEVELOPMENT_LANGUAGE',
+]
+
+function text(value) {
+  if (value == null) return ''
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  if (Array.isArray(value)) return value.map(text).join(' ')
+  if (typeof value === 'object') return Object.values(value).map(text).join(' ')
+  return ''
+}
+
+function isPublished(record) {
+  if (record?.governance && typeof record.governance.indexingAllowed === 'boolean') {
+    return record.governance.indexingAllowed
+  }
+  return String(record?.indexability_status || '').toUpperCase() === 'PUBLISH' || record?.sitemap_included === true
+}
+
+function sourceId(source) {
+  return String(source?.id || source?.sourceId || source?.source_id || '').trim()
+}
+
+function sourceText(source) {
+  return [source?.title, source?.citation, source?.note, source?.studyType, source?.study_type, source?.design, source?.publicationType, source?.publication_type]
+    .map((value) => String(value || ''))
+    .join(' ')
+}
+
+function sourceUrls(source) {
+  const values = [source?.url, source?.doi ? `https://doi.org/${source.doi}` : '', source?.pmid ? `https://pubmed.ncbi.nlm.nih.gov/${source.pmid}/` : '']
+  return values
+    .flatMap((value) => String(value || '').split(/\s*\|\s*/))
+    .map((value) => value.trim())
+    .filter(Boolean)
+}
+
+function validCitationDestination(value) {
+  let url
+  try { url = new URL(value) } catch { return false }
+  if (!['http:', 'https:'].includes(url.protocol)) return false
+  if (!url.hostname) return false
+  if (/pubmed\.ncbi\.nlm\.nih\.gov$/i.test(url.hostname)) {
+    return /^\/\d+\/?$/.test(url.pathname)
+  }
+  if (/doi\.org$/i.test(url.hostname)) {
+    return /^\/10\.\d{4,9}\/.+/.test(url.pathname)
+  }
+  return true
+}
+
+function claimRefs(claim) {
+  const refs = claim?.sourceRefIds || claim?.sourceIds || claim?.source_ids || claim?.sources || []
+  return (Array.isArray(refs) ? refs : [refs]).map((value) => typeof value === 'string' ? value.trim() : sourceId(value)).filter(Boolean)
+}
+
+function claimText(claim) {
+  return [claim?.claim, claim?.notes, claim?.predicate, claim?.evidenceLevel, claim?.evidence_level, claim?.qualifiers].map(text).join(' ')
+}
+
+function hasPlaceholder(value) {
+  const string = text(value)
+  return PLACEHOLDER_PATTERNS.some((pattern) => pattern.test(string))
+}
+
+function hasInternalVersion(value) {
+  if (typeof value === 'string') return INTERNAL_VERSION_PREFIX.test(value)
+  if (Array.isArray(value)) return value.some(hasInternalVersion)
+  if (value && typeof value === 'object') return Object.values(value).some(hasInternalVersion)
+  return false
+}
+
+function scientificNames(record) {
+  return [record?.scientific_name, record?.scientificName, record?.latin_name, record?.latinName, record?.botanical_name, record?.botanicalName]
+    .map((value) => String(value || '').trim())
+    .filter(Boolean)
+}
+
+function isObviouslyMalformedScientificName(value) {
+  if (!value || value.length > 160) return true
+  if (/https?:|www\.|\d{3,}|\b(?:todo|unknown|n\/a|none|placeholder|tbd)\b/i.test(value)) return true
+  if (!/^[A-Z][\p{L}-]+(?:\s+(?:×\s+)?[a-z][\p{L}.-]+)(?:\s+(?:(?:subsp|ssp|var|f)\.)\s+[a-z][\p{L}.-]+)?(?:\s+[A-Z][\p{L}.'&()-]+.*)?$/u.test(value)) return true
+  return false
+}
+
+function canonicalId(record, kind) {
+  const explicit = record?.canonical_id || record?.canonicalId || record?.entity_id || record?.entityId
+  if (explicit) return String(explicit).trim().toLowerCase()
+  const slug = String(record?.slug || '').trim().toLowerCase()
+  return slug ? `${kind}:${slug}` : ''
+}
+
+function issue(code, record, kind, detail, blocking = true) {
+  return {
+    code,
+    blocking,
+    kind,
+    slug: String(record?.slug || ''),
+    url: record?.slug ? `/${kind === 'herb' ? 'herbs' : 'compounds'}/${record.slug}/` : '',
+    detail,
+  }
+}
+
+export function evaluateRecord(record, kind = 'herb') {
+  const issues = []
+  const sources = Array.isArray(record?.sources) ? record.sources : []
+  const claims = Array.isArray(record?.claimMap) ? record.claimMap : []
+  const byId = new Map(sources.map((source) => [sourceId(source), source]).filter(([id]) => id))
+  const published = isPublished(record)
+
+  for (const source of sources) {
+    for (const url of sourceUrls(source)) {
+      if (!validCitationDestination(url)) {
+        issues.push(issue('INVALID_CITATION_DESTINATION', record, kind, `Invalid citation URL: ${url}`))
+      }
+    }
+    if (hasPlaceholder(source)) {
+      issues.push(issue('PRODUCTION_PLACEHOLDER', record, kind, `Citation ${sourceId(source) || '(unidentified)'} contains placeholder/editorial metadata text`))
+    }
+  }
+
+  for (const claim of claims) {
+    const refs = claimRefs(claim)
+    const resolvedSources = refs.map((ref) => byId.get(ref)).filter(Boolean)
+    for (const ref of refs) {
+      if (!byId.has(ref)) issues.push(issue('UNRESOLVED_CITATION_REFERENCE', record, kind, `Claim ${claim?.id || ''} references missing source ${ref}`))
+    }
+    const cText = claimText(claim)
+    const humanClaim = /human/i.test(String(claim?.evidenceLevel || claim?.evidence_level || '')) || HUMAN_CLAIM_RE.test(cText)
+    const safetyClaim = SAFETY_CLAIM_RE.test(cText)
+    const doseClaim = DOSE_CLAIM_RE.test(cText) || Boolean(claim?.qualifiers?.dose_or_duration)
+    if (humanClaim && !resolvedSources.some((source) => HUMAN_SOURCE_RE.test(sourceText(source)))) {
+      issues.push(issue('HUMAN_CLAIM_WITHOUT_HUMAN_SOURCE', record, kind, `Human-evidence claim ${claim?.id || ''} lacks a human-classified source`))
+    }
+    if (safetyClaim && !resolvedSources.some((source) => SAFETY_SOURCE_RE.test(sourceText(source)))) {
+      issues.push(issue('SAFETY_CLAIM_WITHOUT_SAFETY_SOURCE', record, kind, `Safety claim ${claim?.id || ''} lacks a safety source`))
+    }
+    if (doseClaim && !resolvedSources.some((source) => DOSE_SOURCE_RE.test(sourceText(source)))) {
+      issues.push(issue('DOSE_STATEMENT_WITHOUT_DOSE_SOURCE', record, kind, `Dose claim ${claim?.id || ''} lacks a dose-bearing source`))
+    }
+  }
+
+  const dosage = String(record?.dosage || record?.typical_dosage || '').trim()
+  if (DOSE_CLAIM_RE.test(dosage)) {
+    const claimDoseBacked = claims.some((claim) => {
+      const cText = claimText(claim)
+      if (!(DOSE_CLAIM_RE.test(cText) || claim?.qualifiers?.dose_or_duration)) return false
+      return claimRefs(claim).some((ref) => {
+        const source = byId.get(ref)
+        return source && DOSE_SOURCE_RE.test(sourceText(source))
+      })
+    })
+    const sourceDoseBacked = sources.some((source) => DOSE_SOURCE_RE.test(sourceText(source)))
+    if (!claimDoseBacked && !sourceDoseBacked) {
+      issues.push(issue('DOSE_STATEMENT_WITHOUT_DOSE_SOURCE', record, kind, 'Profile dose statement has no dose-bearing source'))
+    }
+  }
+
+  const safetyText = text([record?.safety, record?.contraindications, record?.interactions, record?.side_effects])
+  if (published && SAFETY_CLAIM_RE.test(safetyText) && !sources.some((source) => SAFETY_SOURCE_RE.test(sourceText(source)))) {
+    issues.push(issue('SAFETY_CLAIM_WITHOUT_SAFETY_SOURCE', record, kind, 'Published safety section has no safety-classified source'))
+  }
+
+  const grade = String(record?.evidence_grade || '').trim().toUpperCase()
+  if (published && grade === 'A') {
+    const humanSources = sources.filter((source) => HUMAN_SOURCE_RE.test(sourceText(source)))
+    const rubric = [record?.evidence_design_match, record?.evidence_risk_of_bias, record?.evidence_consistency]
+    const tier = String(record?.evidence_tier || '')
+    const failures = []
+    if (humanSources.length < 2) failures.push(`only ${humanSources.length} human-classified source(s)`)
+    if (rubric.some((value) => !String(value || '').trim())) failures.push('design/risk-of-bias/consistency rationale incomplete')
+    if (tier && !/strong|robust|high[- ]quality|well[- ]established/i.test(tier)) failures.push(`tier is not strong (${tier})`)
+    if (failures.length) issues.push(issue('A_GRADE_CRITERIA', record, kind, failures.join('; ')))
+  }
+
+  for (const scientificName of scientificNames(record)) {
+    if (isObviouslyMalformedScientificName(scientificName)) {
+      issues.push(issue('MALFORMED_SCIENTIFIC_NAME', record, kind, `Malformed scientific name: ${scientificName}`))
+    }
+  }
+
+  if (hasPlaceholder([record?.summary, record?.description, record?.safety, record?.dosage, record?.typical_dosage])) {
+    issues.push(issue('PRODUCTION_PLACEHOLDER', record, kind, 'Public profile fields contain placeholder/editorial language'))
+  }
+  if (hasInternalVersion(record?.claimMap)) {
+    issues.push(issue('INTERNAL_DEVELOPMENT_LANGUAGE', record, kind, 'Claim text contains internal version prefixes'))
+  }
+
+  return issues
+}
+
+export function evaluateCorpus(entries) {
+  const issues = []
+  const seenCanonical = new Map()
+  for (const entry of entries) {
+    const { record, kind } = entry
+    issues.push(...evaluateRecord(record, kind))
+    const id = canonicalId(record, kind)
+    if (!id) continue
+    const prior = seenCanonical.get(id)
+    if (prior) {
+      issues.push(issue('DUPLICATE_CANONICAL_ENTITY', record, kind, `Canonical entity ${id} duplicates ${prior.kind}:${prior.record.slug}`))
+    } else {
+      seenCanonical.set(id, entry)
+    }
+  }
+  return issues
+}
+
+function scrubString(value, context = {}) {
+  let result = String(value || '')
+  result = result.replace(INTERNAL_VERSION_PREFIX, '')
+  if (/minimal citation row added from existing workbook pmid|still require(?:s)? pubmed metadata extraction/i.test(result)) {
+    const pmid = context.pmid || result.match(/PMID\s*(\d+)/i)?.[1]
+    return pmid ? `PubMed record (PMID ${pmid})` : 'PubMed record'
+  }
+  result = result
+    .replace(/metadata extraction (?:is )?required/gi, 'bibliographic metadata pending review')
+    .replace(/\b(?:editorial|internal) todo\b:?/gi, '')
+    .replace(/\bdebug string\b:?/gi, '')
+    .replace(/\bmigration comment\b:?/gi, '')
+    .replace(/\bplaceholder citation\b:?/gi, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim()
+  return result
+}
+
+export function scrubInternalLanguage(value, context = {}) {
+  if (typeof value === 'string') return scrubString(value, context)
+  if (Array.isArray(value)) return value.map((item) => scrubInternalLanguage(item, context))
+  if (!value || typeof value !== 'object') return value
+  const next = {}
+  const childContext = { ...context, pmid: value.pmid || context.pmid }
+  for (const [key, child] of Object.entries(value)) next[key] = scrubInternalLanguage(child, childContext)
+  return next
+}
+
+export function demoteFromIndex(record, codes) {
+  const next = { ...record }
+  next.indexability_status = 'NEEDS_REVIEW'
+  next.robots = 'noindex,follow'
+  next.sitemap_included = false
+  next.profile_status = next.profile_status === 'published' ? 'needs_review' : (next.profile_status || 'needs_review')
+  const reasons = new Set(Array.isArray(next.indexability_reasons) ? next.indexability_reasons : [])
+  for (const code of codes) reasons.add(`production-invariant:${code.toLowerCase()}`)
+  next.indexability_reasons = [...reasons]
+  next.governance = {
+    ...(next.governance || {}),
+    indexingAllowed: false,
+    requiresHumanReview: true,
+    reason: `Production invariant review required: ${[...codes].join(', ')}`,
+  }
+  return next
+}
+
+export function recordIsPublished(record) {
+  return isPublished(record)
+}


### PR DESCRIPTION
Implements backlog items 591–600 with deterministic invariant tests, generated-data enforcement, publication demotion for failing profiles, citation/source integrity checks, scientific-name sanity checks, placeholder/internal-language cleanup, and a final built-HTML audit. The production build now runs the invariant enforcer and validator before static generation and refreshes derived route/search/sitemap data when a profile is demoted. Reports are written under reports/production-*.json.