### PR TITLE
feat(revenue): implement backlog 317-340 affiliate and product ops

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,7 @@ import Footer from '../src/components/Footer'
 import MobileBottomNav from '../src/components/mobile-bottom-nav'
 import ScrollToTopButton from '../src/components/ScrollToTopButton'
 import ClickTracker from '@/components/ClickTracker'
+import CommercialIntentBridge from '@/components/CommercialIntentBridge'
 import EmailReturnAttribution from '@/components/EmailReturnAttribution'
 import ConsentBanner from '../src/components/ConsentBanner'
 import CitationDrawerLazy from '@/components/education/CitationDrawerLazy'
@@ -133,6 +134,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
               <Navigation />
             </header>
             <Breadcrumbs />
+            <CommercialIntentBridge />
             <main
               id='main-content'
               data-pagefind-body

--- a/app/learn/product-quality/page.tsx
+++ b/app/learn/product-quality/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { getHerbs, getCompounds } from '../../../src/lib/runtime-data'
 import { getRuntimeVisibility } from '../../../lib/runtime-visibility'
 import BuyGuideClient from '../../../src/components/sourcing/BuyGuideClient'
+import ProductQualityExperimentLayout from '../../../src/components/sourcing/ProductQualityExperimentLayout'
 import BuyingQualityPrimer from '@/components/guides/BuyingQualityPrimer'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import { isRestrictedRecord } from '../../../src/lib/restricted-ingredients'
@@ -47,6 +48,13 @@ export default async function ProductQualityPage() {
     !isRestrictedRecord(compound) && getRuntimeVisibility(compound).canRender,
   )
 
+  const buyGuide = (
+    <BuyGuideClient
+      herbs={herbs.map((herb) => toBuyingToolRecord(herb, 'herb'))}
+      compounds={compounds.map((compound) => toBuyingToolRecord(compound, 'compound'))}
+    />
+  )
+
   return (
     <div className='mx-auto max-w-6xl space-y-8 px-4 py-8 sm:py-10'>
       <AuthorityJsonLd
@@ -58,55 +66,26 @@ export default async function ProductQualityPage() {
 
       <section className='space-y-4 rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8'>
         <p className='eyebrow-label'>Product quality before purchase</p>
-        <h1 className='mt-2 text-3xl font-bold tracking-tight text-ink sm:text-5xl'>
-          How to judge supplement quality before you buy
-        </h1>
+        <h1 className='mt-2 text-3xl font-bold tracking-tight text-ink sm:text-5xl'>How to judge supplement quality before you buy</h1>
         <p className='mt-4 max-w-3xl text-base leading-7 text-muted sm:text-lg'>
-          Use this checklist after you have narrowed your goal, compared evidence, and checked safety.
-          Product quality is where standardized extracts, transparent labels, heavy-metal testing,
-          certificates of analysis, and dose clarity determine whether a specific product is worth considering.
+          Use this checklist after you have narrowed your goal, compared evidence, and checked safety. Product quality is where standardized extracts, transparent labels, heavy-metal testing, certificates of analysis, and dose clarity determine whether a specific product is worth considering.
         </p>
       </section>
 
       <section className='grid gap-6 md:grid-cols-3'>
-        <div className='space-y-2 rounded-2xl border border-brand-900/10 bg-white p-5 shadow-sm'>
-          <div className='flex h-8 w-8 items-center justify-center rounded-lg bg-emerald-50 text-sm font-bold text-emerald-800'>1</div>
-          <h2 className='text-sm font-bold text-slate-800'>Verify standardization</h2>
-          <p className='text-xs leading-relaxed text-slate-500'>Prefer labels that name the extract form and marker compounds when those details matter to the cited evidence.</p>
-        </div>
-        <div className='space-y-2 rounded-2xl border border-brand-900/10 bg-white p-5 shadow-sm'>
-          <div className='flex h-8 w-8 items-center justify-center rounded-lg bg-emerald-50 text-sm font-bold text-emerald-800'>2</div>
-          <h2 className='text-sm font-bold text-slate-800'>Look for third-party testing</h2>
-          <p className='text-xs leading-relaxed text-slate-500'>Certificates of analysis and independent testing are strongest when the scope, batch, and tested contaminants are actually documented.</p>
-        </div>
-        <div className='space-y-2 rounded-2xl border border-brand-900/10 bg-white p-5 shadow-sm'>
-          <div className='flex h-8 w-8 items-center justify-center rounded-lg bg-emerald-50 text-sm font-bold text-emerald-800'>3</div>
-          <h2 className='text-sm font-bold text-slate-800'>Avoid hidden-dose blends</h2>
-          <p className='text-xs leading-relaxed text-slate-500'>Proprietary blends can obscure individual amounts and make studied-dose, interaction, and stacking comparisons harder.</p>
-        </div>
+        <div className='space-y-2 rounded-2xl border border-brand-900/10 bg-white p-5 shadow-sm'><div className='flex h-8 w-8 items-center justify-center rounded-lg bg-emerald-50 text-sm font-bold text-emerald-800'>1</div><h2 className='text-sm font-bold text-slate-800'>Verify standardization</h2><p className='text-xs leading-relaxed text-slate-500'>Prefer labels that name the extract form and marker compounds when those details matter to the cited evidence.</p></div>
+        <div className='space-y-2 rounded-2xl border border-brand-900/10 bg-white p-5 shadow-sm'><div className='flex h-8 w-8 items-center justify-center rounded-lg bg-emerald-50 text-sm font-bold text-emerald-800'>2</div><h2 className='text-sm font-bold text-slate-800'>Look for third-party testing</h2><p className='text-xs leading-relaxed text-slate-500'>Certificates of analysis and independent testing are strongest when the scope, batch, and tested contaminants are actually documented.</p></div>
+        <div className='space-y-2 rounded-2xl border border-brand-900/10 bg-white p-5 shadow-sm'><div className='flex h-8 w-8 items-center justify-center rounded-lg bg-emerald-50 text-sm font-bold text-emerald-800'>3</div><h2 className='text-sm font-bold text-slate-800'>Avoid hidden-dose blends</h2><p className='text-xs leading-relaxed text-slate-500'>Proprietary blends can obscure individual amounts and make studied-dose, interaction, and stacking comparisons harder.</p></div>
       </section>
 
       <section className='rounded-3xl border border-brand-900/10 bg-white/90 p-5 shadow-sm'>
-        <div className='max-w-3xl space-y-2'>
-          <p className='eyebrow-label'>Use this page after intent is clear</p>
-          <h2 className='text-2xl font-bold tracking-tight text-ink'>Start with the goal, then judge product quality</h2>
-          <p className='text-sm leading-6 text-muted'>A clean certificate of analysis does not make the wrong supplement useful. Pick the goal page first, then use this checklist to compare form, dose transparency, third-party testing, and safety context.</p>
-        </div>
-        <div className='mt-5 grid gap-3 md:grid-cols-3'>
-          {qualityStartingPoints.map((item) => (
-            <Link key={item.href} href={item.href} className='rounded-2xl border border-brand-900/10 bg-brand-50/50 p-4 transition hover:border-brand-300 hover:bg-white'>
-              <h3 className='text-sm font-bold text-ink'>{item.title}</h3>
-              <p className='mt-2 text-xs leading-5 text-muted'>{item.body}</p>
-            </Link>
-          ))}
-        </div>
+        <div className='max-w-3xl space-y-2'><p className='eyebrow-label'>Use this page after intent is clear</p><h2 className='text-2xl font-bold tracking-tight text-ink'>Start with the goal, then judge product quality</h2><p className='text-sm leading-6 text-muted'>A clean certificate of analysis does not make the wrong supplement useful. Pick the goal page first, then use this checklist to compare form, dose transparency, third-party testing, and safety context.</p></div>
+        <div className='mt-5 grid gap-3 md:grid-cols-3'>{qualityStartingPoints.map((item) => <Link key={item.href} href={item.href} className='rounded-2xl border border-brand-900/10 bg-brand-50/50 p-4 transition hover:border-brand-300 hover:bg-white'><h3 className='text-sm font-bold text-ink'>{item.title}</h3><p className='mt-2 text-xs leading-5 text-muted'>{item.body}</p></Link>)}</div>
       </section>
 
-      <BuyingQualityPrimer />
-
-      <BuyGuideClient
-        herbs={herbs.map((herb) => toBuyingToolRecord(herb, 'herb'))}
-        compounds={compounds.map((compound) => toBuyingToolRecord(compound, 'compound'))}
+      <ProductQualityExperimentLayout
+        evidenceContent={<BuyingQualityPrimer />}
+        commerceContent={buyGuide}
       />
 
       <section className='rounded-2xl border border-amber-900/15 bg-amber-50/70 p-5 text-xs leading-relaxed text-amber-950'>

--- a/components/AffiliateProductCard.tsx
+++ b/components/AffiliateProductCard.tsx
@@ -1,10 +1,19 @@
 'use client'
 
 import Image from 'next/image'
+import { useEffect, useState } from 'react'
 import { isOptimizableRemoteImage } from '../src/lib/image-hosts'
-import { getOutboundLinkRel, resolveRegionalUrl, type RegionalUrlMap } from '../src/lib/platforms'
+import {
+  getOutboundLinkRel,
+  inferPlatformRegionFromLocale,
+  resolveRegionalUrl,
+  resolveRetailerLinks,
+  type RegionalUrlMap,
+  type RetailerLink,
+} from '../src/lib/platforms'
 import { trackRevenueEvent } from '../src/lib/revenue-tracking'
 import { affiliateRationaleForDisplay } from '../src/lib/affiliate-copy'
+import { evaluateProductLifecycle, type ProductLifecycleMetadata } from '../src/lib/product-lifecycle'
 
 export type AffiliateProduct = {
   asin?: string
@@ -22,10 +31,13 @@ export type AffiliateProduct = {
   url?: string
   link?: string
   regionalUrls?: RegionalUrlMap
+  retailerLinks?: RetailerLink[]
   preferredRegion?: string | null
   trackingLocation?: string
   trackingProductSlug?: string
   trackingSlot?: string
+  selectionCriteria?: string[]
+  lifecycle?: ProductLifecycleMetadata
 }
 
 type AffiliateProductCardProps = {
@@ -34,53 +46,54 @@ type AffiliateProductCardProps = {
 }
 
 export default function AffiliateProductCard({ product, compact = false }: AffiliateProductCardProps) {
+  const [browserRegion, setBrowserRegion] = useState<string | null>(product.preferredRegion ?? null)
+
+  useEffect(() => {
+    if (product.preferredRegion) return
+    setBrowserRegion(inferPlatformRegionFromLocale(navigator.language))
+  }, [product.preferredRegion])
+
   const title = product.title || product.name || 'Supplement option'
   const imageUrl = product.imageUrl || product.image
   const rationale = affiliateRationaleForDisplay(title, product.rationale || product.notes)
   const rawUrl = product.affiliateUrl || product.url || product.link
   const resolvedUrl = rawUrl
-    ? resolveRegionalUrl({
-        defaultUrl: rawUrl,
-        regionalUrls: product.regionalUrls,
-        preferredRegion: product.preferredRegion,
-      })
+    ? resolveRegionalUrl({ defaultUrl: rawUrl, regionalUrls: product.regionalUrls, preferredRegion: browserRegion })
     : ''
-  const isValidUrl = typeof resolvedUrl === 'string' && (resolvedUrl.startsWith('http://') || resolvedUrl.startsWith('https://'))
+  const lifecycle = product.lifecycle ? evaluateProductLifecycle(product.lifecycle) : null
+  const lifecycleBlocked = lifecycle?.action === 'block'
+  const isValidUrl = !lifecycleBlocked && typeof resolvedUrl === 'string' && /^https?:\/\//i.test(resolvedUrl)
   const affiliateUrl = isValidUrl ? resolvedUrl : ''
-  const ctaLabel = product.ctaLabel || 'Check current price'
+  const ctaLabel = product.ctaLabel || 'View product details'
   const trackingLocation = product.trackingLocation || 'recommendation-section'
+  const retailerLinks = resolveRetailerLinks(product.retailerLinks, browserRegion)
 
   return (
     <article className={`flex h-full flex-col overflow-hidden rounded-2xl border border-brand-900/10 bg-white/80 shadow-sm dark:border-white/10 dark:bg-white/5 ${compact ? 'p-4' : 'p-5'}`}>
       {imageUrl && isOptimizableRemoteImage(imageUrl) ? (
         <div className='mb-4 aspect-[4/3] overflow-hidden rounded-xl border border-brand-900/10 bg-brand-50 p-3 dark:border-white/10 dark:bg-white/5'>
-          <Image
-            src={imageUrl}
-            alt={title}
-            width={400}
-            height={300}
-            sizes="(max-width: 767px) 272px, (max-width: 1024px) 33vw, 320px"
-            quality={78}
-            decoding="async"
-            className="h-full w-full object-contain"
-          />
+          <Image src={imageUrl} alt={title} width={400} height={300} sizes="(max-width: 767px) 272px, (max-width: 1024px) 33vw, 320px" quality={78} decoding="async" className="h-full w-full object-contain" />
         </div>
       ) : null}
 
       <div className='flex flex-1 flex-col'>
         <div>
-          {product.brand ? (
-            <p className='text-xs font-bold uppercase tracking-[0.16em] text-brand-700 dark:text-brand-200'>{product.brand}</p>
-          ) : null}
+          {product.brand ? <p className='text-xs font-bold uppercase tracking-[0.16em] text-brand-700 dark:text-brand-200'>{product.brand}</p> : null}
           <h3 className='mt-2 text-base font-semibold leading-6 text-ink'>{title}</h3>
           <p className='mt-3 text-sm leading-6 text-muted'>{rationale}</p>
         </div>
 
-        {(product.price || product.rating) ? (
-          <p className='mt-4 text-xs font-semibold text-muted'>
-            {[product.price, product.rating ? `${product.rating.toFixed(1)} rating` : ''].filter(Boolean).join(' / ')}
-          </p>
+        {(product.price || product.rating) ? <p className='mt-4 text-xs font-semibold text-muted'>{[product.price, product.rating ? `${product.rating.toFixed(1)} rating` : ''].filter(Boolean).join(' / ')}</p> : null}
+
+        {product.selectionCriteria?.length ? (
+          <div className='mt-4 rounded-xl border border-brand-900/10 bg-brand-50/50 p-3'>
+            <p className='text-[10px] font-bold uppercase tracking-wider text-muted'>Selection criteria</p>
+            <ul className='mt-2 space-y-1 text-xs leading-5 text-muted'>{product.selectionCriteria.slice(0, 4).map((criterion) => <li key={criterion}>• {criterion}</li>)}</ul>
+          </div>
         ) : null}
+
+        {lifecycle?.action === 'review' ? <p className='mt-3 rounded-lg bg-amber-50 px-3 py-2 text-xs leading-5 text-amber-900'>Product verification needs refresh: {lifecycle.reasons.join(' ')}</p> : null}
+        {lifecycleBlocked ? <p className='mt-3 rounded-lg bg-rose-50 px-3 py-2 text-xs leading-5 text-rose-900'>Recommendation suppressed: {lifecycle?.reasons.join(' ')}</p> : null}
 
         {isValidUrl ? (
           <a
@@ -93,6 +106,7 @@ export default function AffiliateProductCard({ product, compact = false }: Affil
             data-product-slot={product.trackingSlot || undefined}
             data-product-asin={product.asin || undefined}
             data-tracking-location={trackingLocation}
+            data-retailer={(() => { try { return new URL(affiliateUrl).hostname.replace(/^www\./, '') } catch { return '' } })()}
             onClick={() => trackRevenueEvent({
               kind: 'recommendation_click',
               location: trackingLocation,
@@ -108,9 +122,30 @@ export default function AffiliateProductCard({ product, compact = false }: Affil
           </a>
         ) : (
           <span className='mt-5 inline-flex min-h-11 w-full cursor-not-allowed items-center justify-center rounded-full border border-brand-900/10 bg-brand-50 px-4 py-2.5 text-sm font-bold text-muted dark:border-white/10 dark:bg-white/5'>
-            Product Unavailable
+            {lifecycleBlocked ? 'Product recommendation paused' : 'Product unavailable'}
           </span>
         )}
+
+        {retailerLinks.length ? (
+          <div className='mt-3 flex flex-wrap gap-2' aria-label={`Other retailers for ${title}`}>
+            {retailerLinks.slice(0, 3).map((retailer) => (
+              <a
+                key={`${retailer.retailer}:${retailer.resolvedUrl}`}
+                href={retailer.resolvedUrl}
+                target='_blank'
+                rel={getOutboundLinkRel(true)}
+                data-revenue-tracked='true'
+                data-ingredient={product.trackingProductSlug || undefined}
+                data-tracking-location={`${trackingLocation}-retailer-diversification`}
+                data-retailer={retailer.retailer}
+                onClick={() => trackRevenueEvent({ kind: 'affiliate_click', location: `${trackingLocation}-retailer-diversification`, label: `${title} — ${retailer.retailer}`, target: retailer.resolvedUrl, productSlug: product.trackingProductSlug, retailer: retailer.retailer })}
+                className='rounded-full border border-brand-900/10 px-3 py-1.5 text-xs font-semibold text-indigo-800 hover:bg-brand-50'
+              >
+                {retailer.label || retailer.retailer}
+              </a>
+            ))}
+          </div>
+        ) : null}
       </div>
     </article>
   )

--- a/components/ClickTracker.tsx
+++ b/components/ClickTracker.tsx
@@ -12,6 +12,33 @@ import { CONSENT_CHANGE_EVENT, getConsent } from '@/lib/consent'
 import { loadAnalytics } from '../src/lib/loadAnalytics'
 import { trackRevenueEvent } from '../src/lib/revenue-tracking'
 
+function isAffiliateLink(link: HTMLAnchorElement) {
+  const href = link.getAttribute('href') || ''
+  return href.includes('amazon.com') || href.includes('amzn.to') || Boolean(link.getAttribute('rel')?.includes('sponsored'))
+}
+
+function affiliateMetadata(link: HTMLAnchorElement) {
+  const href = link.getAttribute('href') || ''
+  const currentPath = window.location.pathname
+  const ingredient =
+    link.dataset.ingredient ||
+    link.dataset.slug ||
+    link.dataset.item ||
+    (currentPath.startsWith('/herbs/') || currentPath.startsWith('/compounds/') ? currentPath.split('/')[2] : '')
+  return {
+    href,
+    ingredient,
+    label: link.innerText.trim() || link.getAttribute('aria-label') || ingredient || 'Affiliate CTA',
+    location: link.dataset.trackingLocation || 'document-capture',
+    productSlot: link.dataset.productSlot || undefined,
+    productAsin: link.dataset.productAsin || undefined,
+    modulePosition: link.dataset.modulePosition || link.closest<HTMLElement>('[data-module-position]')?.dataset.modulePosition,
+    ctaVariant: link.dataset.ctaVariant || undefined,
+    experimentVariant: link.dataset.experimentVariant || undefined,
+    retailer: link.dataset.retailer || undefined,
+  }
+}
+
 export default function ClickTracker() {
   const pathname = usePathname() || '/'
   const lastTrackedGuidePath = useRef<string | null>(null)
@@ -22,9 +49,6 @@ export default function ClickTracker() {
 
     const trackCurrentGuide = () => {
       if (getConsent() !== 'granted' || lastTrackedGuidePath.current === guide.pagePath) return
-
-      // loadAnalytics creates the gtag queue synchronously before its network script
-      // arrives, so the first consented view is not lost.
       loadAnalytics()
       trackGuideView(guide)
       lastTrackedGuidePath.current = guide.pagePath
@@ -36,9 +60,70 @@ export default function ClickTracker() {
   }, [pathname])
 
   useEffect(() => {
-    const handleDocumentClick = (e: MouseEvent) => {
-      const target = e.target as HTMLElement
-      const link = target.closest('a')
+    const seenImpressions = new WeakSet<HTMLAnchorElement>()
+    const visibleAffiliateLinks = new Map<HTMLAnchorElement, boolean>()
+
+    const trackGenericImpression = (link: HTMLAnchorElement) => {
+      if (seenImpressions.has(link) || getConsent() !== 'granted') return
+      if (link.closest('[data-revenue-impression-tracker="true"]')) return
+      const meta = affiliateMetadata(link)
+      seenImpressions.add(link)
+      trackRevenueEvent({
+        kind: 'recommendation_impression',
+        location: meta.location,
+        label: meta.label,
+        target: meta.href,
+        productSlug: meta.ingredient || undefined,
+        productSlot: meta.productSlot,
+        productAsin: meta.productAsin,
+        modulePosition: meta.modulePosition,
+        ctaVariant: meta.ctaVariant,
+        experimentVariant: meta.experimentVariant,
+        retailer: meta.retailer,
+      })
+    }
+
+    const observer = typeof IntersectionObserver === 'undefined'
+      ? null
+      : new IntersectionObserver((entries) => {
+          for (const entry of entries) {
+            const link = entry.target as HTMLAnchorElement
+            const qualified = Boolean(entry.isIntersecting && entry.intersectionRatio >= 0.5)
+            visibleAffiliateLinks.set(link, qualified)
+            if (qualified) trackGenericImpression(link)
+          }
+        }, { threshold: [0, 0.5, 1] })
+
+    const observeAffiliateLinks = (root: ParentNode = document) => {
+      if (!observer) return
+      root.querySelectorAll<HTMLAnchorElement>('a').forEach((link) => {
+        if (!isAffiliateLink(link) || link.dataset.affiliateObserverAttached === 'true') return
+        link.dataset.affiliateObserverAttached = 'true'
+        observer.observe(link)
+      })
+    }
+
+    observeAffiliateLinks()
+    const mutationObserver = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        for (const node of Array.from(mutation.addedNodes)) {
+          if (node instanceof HTMLElement) observeAffiliateLinks(node)
+        }
+      }
+    })
+    mutationObserver.observe(document.body, { childList: true, subtree: true })
+
+    const handleConsentChange = () => {
+      if (getConsent() !== 'granted') return
+      for (const [link, visible] of visibleAffiliateLinks.entries()) {
+        if (visible) trackGenericImpression(link)
+      }
+    }
+    window.addEventListener(CONSENT_CHANGE_EVENT, handleConsentChange)
+
+    const handleDocumentClick = (event: MouseEvent) => {
+      const target = event.target as HTMLElement
+      const link = target.closest<HTMLAnchorElement>('a')
       if (!link) return
 
       const href = link.getAttribute('href') || ''
@@ -55,46 +140,33 @@ export default function ClickTracker() {
       }
 
       const leadMagnetMatch = href.match(/^\/lead-magnets\/([^/?#]+)/)
-
       if (leadMagnetMatch && consentGranted) {
-        trackLeadMagnetClick({
-          slug: leadMagnetMatch[1],
-          sourcePath: window.location.pathname,
-        })
+        trackLeadMagnetClick({ slug: leadMagnetMatch[1], sourcePath: window.location.pathname })
       }
 
-      const isAffiliate =
-        href.includes('amazon.com') ||
-        href.includes('amzn.to') ||
-        link.getAttribute('rel')?.includes('sponsored')
-
-      // Recommendation components emit their own richer event after this capture phase.
-      // Skip them here so a single click never becomes two analytics conversions.
-      if (!isAffiliate || link.dataset.revenueTracked === 'true' || !consentGranted) return
-
-      const cta = link.innerText.trim() || 'CTA'
-      const currentPath = window.location.pathname
-      const ingredient =
-        link.dataset.ingredient ||
-        link.dataset.slug ||
-        link.dataset.item ||
-        (currentPath.startsWith('/herbs/') || currentPath.startsWith('/compounds/')
-          ? currentPath.split('/')[2]
-          : '')
-
+      if (!isAffiliateLink(link) || link.dataset.revenueTracked === 'true' || !consentGranted) return
+      const meta = affiliateMetadata(link)
       trackRevenueEvent({
         kind: 'affiliate_click',
-        location: link.dataset.trackingLocation || 'document-capture',
-        label: cta || ingredient || 'unknown',
-        target: href,
-        productSlug: ingredient || undefined,
-        productSlot: link.dataset.productSlot || undefined,
-        productAsin: link.dataset.productAsin || undefined,
+        location: meta.location,
+        label: meta.label,
+        target: meta.href,
+        productSlug: meta.ingredient || undefined,
+        productSlot: meta.productSlot,
+        productAsin: meta.productAsin,
+        modulePosition: meta.modulePosition,
+        ctaVariant: meta.ctaVariant,
+        experimentVariant: meta.experimentVariant,
+        retailer: meta.retailer,
       })
     }
 
     document.addEventListener('click', handleDocumentClick, { capture: true })
     return () => {
+      observer?.disconnect()
+      mutationObserver.disconnect()
+      visibleAffiliateLinks.clear()
+      window.removeEventListener(CONSENT_CHANGE_EVENT, handleConsentChange)
       document.removeEventListener('click', handleDocumentClick, { capture: true })
     }
   }, [])

--- a/components/CommercialIntentBridge.tsx
+++ b/components/CommercialIntentBridge.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+import { usePathname } from 'next/navigation'
+import { trackRevenueEvent } from '@/lib/revenue-tracking'
+
+export default function CommercialIntentBridge() {
+  const pathname = usePathname() || '/'
+  const [active, setActive] = useState(false)
+
+  useEffect(() => {
+    if (!/^\/(herbs|compounds)\/[^/]+/.test(pathname)) {
+      setActive(false)
+      return
+    }
+    const params = new URLSearchParams(window.location.search)
+    const queryClass = params.get('query_class')?.toLowerCase()
+    const intent = params.get('intent')?.toLowerCase()
+    setActive(queryClass === 'commercial' || queryClass === 'comparison' || intent === 'buy' || intent === 'compare')
+  }, [pathname])
+
+  if (!active) return null
+  const slug = pathname.split('/')[2] || ''
+
+  return (
+    <aside className='border-y border-brand-900/10 bg-brand-50/70' aria-label='Commercial research next steps'>
+      <div className='mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-3 px-4 py-3'>
+        <p className='text-sm text-ink'><strong>Researching a purchase?</strong> Keep the evidence page intact, then move to comparison or product-quality criteria.</p>
+        <div className='flex flex-wrap gap-3 text-sm font-bold'>
+          <Link href={`/guides/compare/?from=${encodeURIComponent(slug)}`} onClick={() => trackRevenueEvent({ kind: 'cta_click', location: 'commercial-intent-bridge', label: 'Compare options', productSlug: slug })} className='text-indigo-800 hover:underline'>Compare options →</Link>
+          <Link href={`/learn/product-quality/?ingredient=${encodeURIComponent(slug)}`} onClick={() => trackRevenueEvent({ kind: 'cta_click', location: 'commercial-intent-bridge', label: 'Product quality', productSlug: slug })} className='text-indigo-800 hover:underline'>Product-quality checklist →</Link>
+        </div>
+      </div>
+    </aside>
+  )
+}

--- a/components/ProductComparisonTable.tsx
+++ b/components/ProductComparisonTable.tsx
@@ -1,0 +1,32 @@
+import { evaluateProductLifecycle, type ProductLifecycleMetadata } from '@/lib/product-lifecycle'
+
+export interface ReliableProductComparisonRow {
+  key: string
+  product: string
+  form: string
+  activeAmount: string
+  testing: string
+  priceContext?: string
+  lifecycle: ProductLifecycleMetadata & { lastVerifiedAt: string }
+}
+
+export default function ProductComparisonTable({ rows }: { rows: ReliableProductComparisonRow[] }) {
+  const reliableRows = rows.filter((row) => evaluateProductLifecycle(row.lifecycle).action === 'allow')
+  if (reliableRows.length < 2) return null
+
+  return (
+    <section className='space-y-3' aria-labelledby='verified-product-comparison-heading'>
+      <div>
+        <p className='eyebrow-label'>Verified product comparison</p>
+        <h2 id='verified-product-comparison-heading' className='mt-1 text-xl font-bold text-ink'>Compare maintained product data</h2>
+        <p className='mt-2 text-sm leading-6 text-muted'>Rows appear only while their formulation metadata is inside the verification window and still matches the reviewed form. Price context is descriptive and never affects evidence or product-quality scoring.</p>
+      </div>
+      <div className='overflow-x-auto rounded-2xl border border-brand-900/10 bg-white shadow-sm'>
+        <table className='min-w-[760px] w-full border-collapse text-left text-sm'>
+          <thead className='bg-brand-50/80 text-xs uppercase tracking-wide text-muted'><tr><th className='p-4'>Product</th><th className='p-4'>Form</th><th className='p-4'>Active amount</th><th className='p-4'>Testing / verification</th><th className='p-4'>Price context</th><th className='p-4'>Verified</th></tr></thead>
+          <tbody>{reliableRows.map((row) => <tr key={row.key} className='border-t border-brand-900/10 align-top'><td className='p-4 font-bold text-ink'>{row.product}</td><td className='p-4 text-muted'>{row.form}</td><td className='p-4 text-muted'>{row.activeAmount}</td><td className='p-4 text-muted'>{row.testing}</td><td className='p-4 text-muted'>{row.priceContext || 'Not compared'}</td><td className='p-4 text-muted'>{row.lifecycle.lastVerifiedAt}</td></tr>)}</tbody>
+        </table>
+      </div>
+    </section>
+  )
+}

--- a/components/RecommendationSection.tsx
+++ b/components/RecommendationSection.tsx
@@ -3,6 +3,7 @@ import AffiliateProductCard, { type AffiliateProduct } from './AffiliateProductC
 import RevenueImpressionTracker from './RevenueImpressionTracker'
 import WhyWeRecommend from '../src/components/monetization/WhyWeRecommend'
 import HorizontalCardRail from './ui/HorizontalCardRail'
+import { shouldSuppressProductRecommendation } from '../src/lib/product-lifecycle'
 
 export type RecommendationSlot = 'budget' | 'overall' | 'premium'
 
@@ -31,11 +32,10 @@ function isUsableOutboundUrl(value: unknown): value is string {
 }
 
 function hasUsableProductUrl(product: RecommendationProduct): boolean {
-  if (isUsableOutboundUrl(product.affiliateUrl) || isUsableOutboundUrl(product.url) || isUsableOutboundUrl(product.link)) {
-    return true
-  }
-
-  return Object.values(product.regionalUrls ?? {}).some(isUsableOutboundUrl)
+  if (product.lifecycle && shouldSuppressProductRecommendation(product.lifecycle)) return false
+  if (isUsableOutboundUrl(product.affiliateUrl) || isUsableOutboundUrl(product.url) || isUsableOutboundUrl(product.link)) return true
+  if (Object.values(product.regionalUrls ?? {}).some(isUsableOutboundUrl)) return true
+  return product.retailerLinks?.some((retailer) => isUsableOutboundUrl(retailer.url) || Object.values(retailer.regionalUrls ?? {}).some(isUsableOutboundUrl)) ?? false
 }
 
 export default function RecommendationSection({
@@ -52,9 +52,7 @@ export default function RecommendationSection({
   const availableProducts = products.filter(hasUsableProductUrl)
   if (availableProducts.length === 0) return null
 
-  const ordered = ['budget', 'overall', 'premium'].flatMap((slot) =>
-    availableProducts.filter((product) => product.slot === slot)
-  )
+  const ordered = ['budget', 'overall', 'premium'].flatMap((slot) => availableProducts.filter((product) => product.slot === slot))
 
   return (
     <section className='card-premium p-4 sm:p-5'>
@@ -70,6 +68,11 @@ export default function RecommendationSection({
           const productTitle = product.title || product.name || `${slotLabels[product.slot]} option`
           const productSlug = product.trackingProductSlug ?? trackingProductSlug
           const productLocation = product.trackingLocation ?? trackingLocation
+          const selectionCriteria = product.selectionCriteria?.length
+            ? product.selectionCriteria
+            : product.rationale || product.notes
+              ? [product.rationale || product.notes || '']
+              : []
 
           return (
             <RevenueImpressionTracker
@@ -85,6 +88,7 @@ export default function RecommendationSection({
               <AffiliateProductCard
                 product={{
                   ...product,
+                  selectionCriteria,
                   preferredRegion: product.preferredRegion ?? preferredRegion,
                   trackingLocation: productLocation,
                   trackingProductSlug: productSlug,

--- a/scripts/analytics/build-revenue-funnel-report.mjs
+++ b/scripts/analytics/build-revenue-funnel-report.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const inputPath = process.argv[2] || path.join(root, 'ops', 'analytics', 'revenue-funnel-input.json')
+const outputPath = process.argv[3] || path.join(root, 'reports', 'revenue-funnel-report.json')
+
+const readJson = (file) => fs.existsSync(file) ? JSON.parse(fs.readFileSync(file, 'utf8')) : {}
+const input = readJson(inputPath)
+const events = Array.isArray(input) ? input : Array.isArray(input.events) ? input.events : []
+const pageMetrics = Array.isArray(input.pageMetrics) ? input.pageMetrics : []
+
+const bucket = () => ({ impressions: 0, clicks: 0, revenueUsd: 0, emailSignups: 0, organicVisitors: 0 })
+const add = (map, key, field, value = 1) => {
+  if (!key) key = 'unknown'
+  const current = map.get(key) || bucket()
+  current[field] = (current[field] || 0) + value
+  map.set(key, current)
+}
+
+const maps = {
+  page: new Map(),
+  modulePosition: new Map(),
+  ingredient: new Map(),
+  landingQueryClass: new Map(),
+  routeFamily: new Map(),
+  contentCluster: new Map(),
+  country: new Map(),
+  experiment: new Map(),
+  ctaVariant: new Map(),
+}
+
+for (const event of events) {
+  const isImpression = event.kind === 'recommendation_impression'
+  const isClick = event.kind === 'affiliate_click' || event.kind === 'recommendation_click'
+  const isSignup = event.kind === 'email_signup_success'
+  const revenue = event.kind === 'revenue_attributed' ? Number(event.valueUsd || 0) : 0
+  const targets = [
+    [maps.page, event.pagePath],
+    [maps.modulePosition, event.modulePosition],
+    [maps.ingredient, event.productSlug],
+    [maps.landingQueryClass, event.landingQueryClass],
+    [maps.routeFamily, event.routeFamily],
+    [maps.contentCluster, event.contentCluster],
+    [maps.country, event.countryCode],
+    [maps.experiment, event.experimentVariant],
+    [maps.ctaVariant, event.ctaVariant],
+  ]
+  for (const [map, key] of targets) {
+    if (isImpression) add(map, key, 'impressions')
+    if (isClick) add(map, key, 'clicks')
+    if (isSignup) add(map, key, 'emailSignups')
+    if (revenue) add(map, key, 'revenueUsd', revenue)
+  }
+}
+
+for (const metric of pageMetrics) {
+  const pagePath = metric.pagePath || 'unknown'
+  const organicVisitors = Number(metric.organicVisitors || 0)
+  const emailSignups = Number(metric.emailSignups || 0)
+  const revenueUsd = Number(metric.revenueUsd || 0)
+  add(maps.page, pagePath, 'organicVisitors', organicVisitors)
+  add(maps.page, pagePath, 'emailSignups', emailSignups)
+  add(maps.page, pagePath, 'revenueUsd', revenueUsd)
+  if (metric.contentCluster) {
+    add(maps.contentCluster, metric.contentCluster, 'organicVisitors', organicVisitors)
+    add(maps.contentCluster, metric.contentCluster, 'emailSignups', emailSignups)
+    add(maps.contentCluster, metric.contentCluster, 'revenueUsd', revenueUsd)
+  }
+  if (metric.countryCode) {
+    add(maps.country, metric.countryCode, 'organicVisitors', organicVisitors)
+    add(maps.country, metric.countryCode, 'emailSignups', emailSignups)
+    add(maps.country, metric.countryCode, 'revenueUsd', revenueUsd)
+  }
+}
+
+const finalize = (map) => Array.from(map.entries()).map(([key, value]) => ({
+  key,
+  ...value,
+  affiliateCtr: value.impressions ? value.clicks / value.impressions : null,
+  revenuePer1000OrganicVisitors: value.organicVisitors ? (value.revenueUsd / value.organicVisitors) * 1000 : null,
+  emailSignupRate: value.organicVisitors ? value.emailSignups / value.organicVisitors : null,
+})).sort((a, b) => b.revenueUsd - a.revenueUsd || b.clicks - a.clicks || a.key.localeCompare(b.key))
+
+const report = {
+  generatedAt: new Date().toISOString(),
+  inputPath,
+  definitions: {
+    affiliateCtr: 'affiliate/recommendation clicks divided by qualified affiliate/recommendation impressions',
+    revenuePer1000OrganicVisitors: 'attributed revenue / organic visitors × 1,000; requires pageMetrics from analytics export',
+    emailSignupRate: 'successful email signups / organic visitors; requires successful-signup events or pageMetrics',
+    country: 'Use analytics-provider country dimension when available; client events do not infer physical location from locale.',
+  },
+  byPage: finalize(maps.page),
+  byModulePosition: finalize(maps.modulePosition),
+  byIngredient: finalize(maps.ingredient),
+  byLandingQueryClass: finalize(maps.landingQueryClass),
+  byRouteFamily: finalize(maps.routeFamily),
+  byContentCluster: finalize(maps.contentCluster),
+  byCountry: finalize(maps.country),
+  byExperiment: finalize(maps.experiment),
+  byCtaVariant: finalize(maps.ctaVariant),
+}
+
+fs.mkdirSync(path.dirname(outputPath), { recursive: true })
+fs.writeFileSync(outputPath, `${JSON.stringify(report, null, 2)}\n`)
+console.log(`Wrote revenue funnel report to ${outputPath}`)

--- a/scripts/commerce/audit-product-freshness.mjs
+++ b/scripts/commerce/audit-product-freshness.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const currentPath = process.argv[2] || path.join(root, 'ops', 'product-monitor', 'current.json')
+const baselinePath = process.argv[3] || path.join(root, 'ops', 'product-monitor', 'reviewed-baseline.json')
+const outputPath = process.argv[4] || path.join(root, 'reports', 'product-freshness.json')
+const staleDays = Number(process.env.PRODUCT_STALE_DAYS || 90)
+const dayMs = 86400000
+
+const read = (file) => fs.existsSync(file) ? JSON.parse(fs.readFileSync(file, 'utf8')) : { products: [] }
+const current = read(currentPath)
+const baseline = read(baselinePath)
+const baselineByKey = new Map((baseline.products || []).map((product) => [product.key, product]))
+const now = Date.now()
+
+const products = (current.products || []).map((product) => {
+  const reviewed = baselineByKey.get(product.key) || {}
+  const reasons = []
+  let status = 'active'
+  const checkedAt = Date.parse(product.checkedAt || '')
+  const ageDays = Number.isFinite(checkedAt) ? Math.floor(Math.max(0, now - checkedAt) / dayMs) : null
+
+  if (ageDays === null || ageDays > staleDays) {
+    status = 'stale'
+    reasons.push(ageDays === null ? 'No valid last-check date.' : `Last check is ${ageDays} days old.`)
+  }
+
+  if (product.available === false || [404, 410].includes(Number(product.httpStatus)) || /discontinued|no longer available/i.test(String(product.availabilityText || ''))) {
+    status = 'discontinued'
+    reasons.push('Current monitor indicates the product is no longer available.')
+  }
+
+  const fingerprintChanged = reviewed.formulationFingerprint && product.formulationFingerprint && reviewed.formulationFingerprint !== product.formulationFingerprint
+  const evidenceFormChanged = reviewed.evidenceForm && product.currentForm && String(reviewed.evidenceForm).trim().toLowerCase() !== String(product.currentForm).trim().toLowerCase()
+  if (fingerprintChanged || evidenceFormChanged) {
+    status = 'formulation-changed'
+    reasons.push(fingerprintChanged ? 'Formulation fingerprint differs from the reviewed baseline.' : 'Current form differs from the evidence form recorded at review.')
+  }
+
+  return {
+    key: product.key,
+    title: product.title,
+    url: product.url,
+    status,
+    ageDays,
+    reasons,
+    action: status === 'discontinued' || status === 'formulation-changed' ? 'pause' : status === 'stale' ? 'review' : 'allow',
+  }
+})
+
+const counts = products.reduce((acc, product) => {
+  acc[product.status] = (acc[product.status] || 0) + 1
+  return acc
+}, {})
+
+fs.mkdirSync(path.dirname(outputPath), { recursive: true })
+fs.writeFileSync(outputPath, `${JSON.stringify({ generatedAt: new Date().toISOString(), staleDays, counts, products }, null, 2)}\n`)
+console.log(`Wrote product freshness report to ${outputPath}`)
+
+if (products.some((product) => product.action === 'pause')) process.exitCode = 1

--- a/src/components/sourcing/BuyGuideClient.tsx
+++ b/src/components/sourcing/BuyGuideClient.tsx
@@ -1,11 +1,12 @@
 'use client'
 
-import { useState, useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
 import { AFFILIATE_TAGS } from '@/config/affiliate'
 import { canRenderAffiliateLinks, ensureAmazonAffiliateTag } from '../../lib/affiliate'
 import { trackRevenueEvent } from '../../lib/revenue-tracking'
 import { scoreProductQuality, type ProductQualityScore } from '@/lib/product-quality-score'
+import { commerceCtaLabel, getCommerceExperimentAssignments, type CommerceExperimentAssignments } from '@/lib/commerce-experiments'
 
 interface GuideItem {
   slug: string
@@ -28,7 +29,12 @@ interface BuyGuideClientProps {
   compounds: any[]
 }
 
-const DEFAULT_VISIBLE_ITEMS = 12
+const DEFAULT_EXPERIMENTS: CommerceExperimentAssignments = {
+  moduleDensity: 'multiple',
+  placement: 'post-evidence',
+  ctaVariant: 'view-details',
+  experimentVariant: 'density:multiple|placement:post-evidence|cta:view-details',
+}
 
 const bandLabel: Record<ProductQualityScore['band'], string> = {
   'strong-label-quality': 'Strong label quality',
@@ -39,6 +45,11 @@ const bandLabel: Record<ProductQualityScore['band'], string> = {
 
 export default function BuyGuideClient({ herbs, compounds }: BuyGuideClientProps) {
   const [searchQuery, setSearchQuery] = useState('')
+  const [experiments, setExperiments] = useState<CommerceExperimentAssignments>(DEFAULT_EXPERIMENTS)
+
+  useEffect(() => {
+    setExperiments(getCommerceExperimentAssignments())
+  }, [])
 
   const allItems = useMemo(() => {
     const combined = [
@@ -127,17 +138,19 @@ export default function BuyGuideClient({ herbs, compounds }: BuyGuideClientProps
   }, [herbs, compounds])
 
   const filteredItems = useMemo(() => {
-    if (!searchQuery) return allItems.slice(0, DEFAULT_VISIBLE_ITEMS)
+    if (!searchQuery) return allItems.slice(0, experiments.moduleDensity === 'single' ? 1 : 3)
     const query = searchQuery.toLowerCase()
     return allItems.filter(item =>
       item.name.toLowerCase().includes(query) ||
       item.slug.toLowerCase().includes(query) ||
       Boolean(item.standardization && String(item.standardization).toLowerCase().includes(query))
     )
-  }, [searchQuery, allItems])
+  }, [searchQuery, allItems, experiments.moduleDensity])
+
+  const ctaLabel = commerceCtaLabel(experiments.ctaVariant)
 
   return (
-    <div className='space-y-8'>
+    <div className='space-y-8' data-module-position={experiments.placement}>
       <div className='rounded-3xl border border-brand-900/10 bg-white/90 p-5 shadow-sm space-y-4'>
         <div className='max-w-3xl space-y-2'>
           <p className='eyebrow-label'>Product-quality layer</p>
@@ -147,7 +160,7 @@ export default function BuyGuideClient({ herbs, compounds }: BuyGuideClientProps
         </div>
       </div>
 
-      {!searchQuery && allItems.length > DEFAULT_VISIBLE_ITEMS ? <p className='text-xs text-slate-500'>Showing {DEFAULT_VISIBLE_ITEMS} common sourcing checklists. Search by ingredient name to inspect the full library.</p> : null}
+      {!searchQuery && allItems.length > filteredItems.length ? <p className='text-xs text-slate-500'>Showing {filteredItems.length} sourcing option{filteredItems.length === 1 ? '' : 's'} in this session. Search by ingredient name to inspect the full library.</p> : null}
 
       <div className='grid gap-6 sm:grid-cols-2 lg:grid-cols-3'>
         {filteredItems.length === 0 ? (
@@ -181,7 +194,30 @@ export default function BuyGuideClient({ herbs, compounds }: BuyGuideClientProps
             </div>
 
             <div className='mt-5 pt-3 border-t border-slate-100 space-y-3'>
-              <a href={item.affiliateUrl} target='_blank' rel='nofollow sponsored noopener noreferrer' onClick={() => trackRevenueEvent({ kind: 'affiliate_click', location: 'product-quality-buy-guide', label: item.name, target: item.affiliateUrl, productSlug: item.slug })} className='flex w-full items-center justify-between rounded-2xl bg-emerald-600 hover:bg-emerald-700 text-white font-bold text-xs py-3 px-4 transition-all shadow-sm'><span>Sourcing options on Amazon</span><span aria-hidden='true'>↗</span></a>
+              <a
+                href={item.affiliateUrl}
+                target='_blank'
+                rel='nofollow sponsored noopener noreferrer'
+                data-revenue-tracked='true'
+                data-ingredient={item.slug}
+                data-module-position={experiments.placement}
+                data-cta-variant={experiments.ctaVariant}
+                data-experiment-variant={experiments.experimentVariant}
+                data-tracking-location='product-quality-buy-guide'
+                onClick={() => trackRevenueEvent({
+                  kind: 'affiliate_click',
+                  location: 'product-quality-buy-guide',
+                  label: item.name,
+                  target: item.affiliateUrl,
+                  productSlug: item.slug,
+                  modulePosition: experiments.placement,
+                  ctaVariant: experiments.ctaVariant,
+                  experimentVariant: experiments.experimentVariant,
+                })}
+                className='flex w-full items-center justify-between rounded-2xl bg-emerald-600 hover:bg-emerald-700 text-white font-bold text-xs py-3 px-4 transition-all shadow-sm'
+              >
+                <span>{ctaLabel}</span><span aria-hidden='true'>↗</span>
+              </a>
               <p className='text-[9px] text-center text-slate-400 leading-normal'>Affiliate link · Commission never affects evidence or product-quality scoring</p>
             </div>
           </div>

--- a/src/components/sourcing/ProductQualityExperimentLayout.tsx
+++ b/src/components/sourcing/ProductQualityExperimentLayout.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { useEffect, useState, type ReactNode } from 'react'
+import { allowedCommercePlacement, getCommerceExperimentAssignments, type CommercePlacement } from '@/lib/commerce-experiments'
+
+export default function ProductQualityExperimentLayout({
+  evidenceContent,
+  commerceContent,
+}: {
+  evidenceContent: ReactNode
+  commerceContent: ReactNode
+}) {
+  const [placement, setPlacement] = useState<CommercePlacement>('post-evidence')
+
+  useEffect(() => {
+    const assignments = getCommerceExperimentAssignments()
+    setPlacement(allowedCommercePlacement('buy-guide', assignments.placement))
+  }, [])
+
+  if (placement === 'top-commercial-section') {
+    return <>{commerceContent}{evidenceContent}</>
+  }
+
+  return <>{evidenceContent}{commerceContent}</>
+}

--- a/src/lib/__tests__/commerce-experiments.test.ts
+++ b/src/lib/__tests__/commerce-experiments.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { allowedCommercePlacement, commerceCtaLabel, shouldShowCommerceForIntent } from '../commerce-experiments'
+
+describe('commerce experiment guardrails', () => {
+  it('never moves affiliate modules ahead of evidence on research-oriented route families', () => {
+    expect(allowedCommercePlacement('herb-profile', 'top-commercial-section')).toBe('post-evidence')
+    expect(allowedCommercePlacement('compound-profile', 'top-commercial-section')).toBe('post-evidence')
+    expect(allowedCommercePlacement('comparison', 'top-commercial-section')).toBe('post-evidence')
+    expect(allowedCommercePlacement('best-supplements', 'top-commercial-section')).toBe('post-evidence')
+  })
+
+  it('allows the placement experiment only on the dedicated buying guide', () => {
+    expect(allowedCommercePlacement('buy-guide', 'top-commercial-section')).toBe('top-commercial-section')
+  })
+
+  it('limits commerce-heavy treatment to commercial route families', () => {
+    expect(shouldShowCommerceForIntent('buy-guide')).toBe(true)
+    expect(shouldShowCommerceForIntent('comparison')).toBe(true)
+    expect(shouldShowCommerceForIntent('best-supplements')).toBe(true)
+    expect(shouldShowCommerceForIntent('herb-profile')).toBe(false)
+  })
+
+  it('uses informative CTA language instead of a generic price-only prompt', () => {
+    expect(commerceCtaLabel('view-details')).toBe('View product details')
+    expect(commerceCtaLabel('compare-options')).toBe('Compare current sourcing options')
+  })
+})

--- a/src/lib/__tests__/product-lifecycle.test.ts
+++ b/src/lib/__tests__/product-lifecycle.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { evaluateProductLifecycle, shouldSuppressProductRecommendation } from '../product-lifecycle'
+
+describe('product lifecycle recommendation gates', () => {
+  const now = new Date('2026-08-15T12:00:00Z')
+
+  it('allows recently verified products', () => {
+    expect(evaluateProductLifecycle({ status: 'active', lastVerifiedAt: '2026-08-01' }, now)).toMatchObject({ status: 'active', action: 'allow' })
+  })
+
+  it('flags old verification for review instead of pretending the product disappeared', () => {
+    expect(evaluateProductLifecycle({ status: 'active', lastVerifiedAt: '2026-01-01' }, now, 90)).toMatchObject({ status: 'stale', action: 'review' })
+  })
+
+  it('blocks discontinued products', () => {
+    expect(shouldSuppressProductRecommendation({ discontinued: true })).toBe(true)
+  })
+
+  it('blocks formulation changes', () => {
+    expect(evaluateProductLifecycle({ reviewedFormulationFingerprint: 'old', currentFormulationFingerprint: 'new' }, now)).toMatchObject({ status: 'formulation-changed', action: 'block' })
+  })
+
+  it('blocks a product form that no longer matches the reviewed evidence form', () => {
+    expect(evaluateProductLifecycle({ reviewedEvidenceForm: 'KSM-66 extract', currentProductForm: 'generic root powder' }, now)).toMatchObject({ status: 'formulation-changed', action: 'block' })
+  })
+})

--- a/src/lib/__tests__/revenue-tracking.test.ts
+++ b/src/lib/__tests__/revenue-tracking.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildRevenueEvent,
+  classifyLandingQueryClass,
+  classifyRevenueContentCluster,
   classifyRevenueRoute,
+  classifyRevenueVisitorSource,
   getRevenueDeviceType,
   getRevenueScrollDepth,
   getRevenueTargetHost,
@@ -16,6 +19,8 @@ describe('revenue tracking', () => {
     expect(normalizeRevenueEventKind('affiliate_click')).toBe('affiliate_click')
     expect(normalizeRevenueEventKind('cta_click')).toBe('cta_click')
     expect(normalizeRevenueEventKind('email_signup_attempt')).toBe('email_signup_attempt')
+    expect(normalizeRevenueEventKind('email_signup_success')).toBe('email_signup_success')
+    expect(normalizeRevenueEventKind('revenue_attributed')).toBe('revenue_attributed')
     expect(normalizeRevenueEventKind('other')).toBe('cta_click')
   })
 
@@ -28,6 +33,14 @@ describe('revenue tracking', () => {
     expect(classifyRevenueRoute('/learn/product-quality/')).toBe('buy-guide')
     expect(classifyRevenueRoute('/buy-guide/')).toBe('buy-guide')
     expect(classifyRevenueRoute('/guides/other/alkaloids-on-amazon/')).toBe('guide')
+  })
+
+  it('classifies source and landing intent without storing raw search terms', () => {
+    expect(classifyRevenueVisitorSource('?utm_medium=email', '', 'thehippiescientist.net')).toBe('email')
+    expect(classifyRevenueVisitorSource('', 'https://www.google.com/search?q=private-term', 'thehippiescientist.net')).toBe('organic')
+    expect(classifyLandingQueryClass('/guides/compare/magnesium-vs-melatonin/')).toEqual({ value: 'comparison', source: 'route-inferred' })
+    expect(classifyLandingQueryClass('/herbs/ashwagandha/', '?query_class=commercial')).toEqual({ value: 'commercial', source: 'explicit' })
+    expect(classifyRevenueContentCluster('/guides/sleep/best-supplements-for-sleep/')).toBe('sleep')
   })
 
   it('derives device, scroll, host, and profile context without personal data', () => {
@@ -48,9 +61,14 @@ describe('revenue tracking', () => {
         target: 'https://www.amazon.com/product',
         productSlot: 'overall',
         productAsin: 'B000000000',
+        modulePosition: 'post-evidence',
+        ctaVariant: 'compare-options',
+        experimentVariant: 'density:single|placement:post-evidence|cta:compare-options',
       },
       {
         pagePath: '/compounds/magnesium-glycinate/?source=guide',
+        landingPath: '/guides/compare/magnesium-vs-melatonin/',
+        landingReferrer: 'https://www.google.com/search?q=hidden',
         viewportWidth: 390,
         viewportHeight: 800,
         scrollY: 500,
@@ -69,6 +87,10 @@ describe('revenue tracking', () => {
       productSlug: 'magnesium-glycinate',
       productSlot: 'overall',
       productAsin: 'B000000000',
+      modulePosition: 'post-evidence',
+      ctaVariant: 'compare-options',
+      visitorSource: 'organic',
+      landingQueryClass: 'comparison',
       deviceType: 'mobile',
       scrollDepth: '50-74',
     })
@@ -77,33 +99,10 @@ describe('revenue tracking', () => {
 
   it('uses the same dimensions for recommendation impressions and clicks', () => {
     const impression = buildRevenueEvent(
-      {
-        kind: 'recommendation_impression',
-        location: 'compare-recommendation',
-        label: 'Magnesium glycinate',
-        productSlug: 'magnesium',
-        productSlot: 'overall',
-        productAsin: 'B000000000',
-      },
-      {
-        pagePath: '/guides/compare/magnesium-vs-melatonin/',
-        viewportWidth: 1440,
-        viewportHeight: 900,
-        scrollY: 1200,
-        documentHeight: 3000,
-      },
+      { kind: 'recommendation_impression', location: 'compare-recommendation', label: 'Magnesium glycinate', productSlug: 'magnesium', productSlot: 'overall', productAsin: 'B000000000' },
+      { pagePath: '/guides/compare/magnesium-vs-melatonin/', viewportWidth: 1440, viewportHeight: 900, scrollY: 1200, documentHeight: 3000 },
     )
 
-    expect(impression).toMatchObject({
-      kind: 'recommendation_impression',
-      location: 'compare-recommendation',
-      label: 'Magnesium glycinate',
-      routeFamily: 'comparison',
-      productSlug: 'magnesium',
-      productSlot: 'overall',
-      productAsin: 'B000000000',
-      deviceType: 'desktop',
-      scrollDepth: '50-74',
-    })
+    expect(impression).toMatchObject({ kind: 'recommendation_impression', location: 'compare-recommendation', label: 'Magnesium glycinate', routeFamily: 'comparison', productSlug: 'magnesium', productSlot: 'overall', productAsin: 'B000000000', deviceType: 'desktop', scrollDepth: '50-74' })
   })
 })

--- a/src/lib/commerce-experiments.ts
+++ b/src/lib/commerce-experiments.ts
@@ -1,0 +1,54 @@
+import type { RevenueRouteFamily } from '@/lib/revenue-tracking'
+
+export type CommerceModuleDensity = 'single' | 'multiple'
+export type CommercePlacement = 'top-commercial-section' | 'post-evidence'
+export type CommerceCtaVariant = 'view-details' | 'compare-options'
+
+export interface CommerceExperimentAssignments {
+  moduleDensity: CommerceModuleDensity
+  placement: CommercePlacement
+  ctaVariant: CommerceCtaVariant
+  experimentVariant: string
+}
+
+const SESSION_KEY = 'ths_commerce_experiments_v1'
+
+const assignmentsFromSeed = (seed: number): CommerceExperimentAssignments => {
+  const moduleDensity: CommerceModuleDensity = seed % 2 === 0 ? 'single' : 'multiple'
+  const placement: CommercePlacement = Math.floor(seed / 2) % 2 === 0 ? 'top-commercial-section' : 'post-evidence'
+  const ctaVariant: CommerceCtaVariant = Math.floor(seed / 4) % 2 === 0 ? 'view-details' : 'compare-options'
+  return {
+    moduleDensity,
+    placement,
+    ctaVariant,
+    experimentVariant: `density:${moduleDensity}|placement:${placement}|cta:${ctaVariant}`,
+  }
+}
+
+export function getCommerceExperimentAssignments(): CommerceExperimentAssignments {
+  if (typeof window === 'undefined') return assignmentsFromSeed(0)
+  try {
+    const existing = window.sessionStorage.getItem(SESSION_KEY)
+    if (existing) return JSON.parse(existing) as CommerceExperimentAssignments
+    const seed = Math.floor(Math.random() * 100000)
+    const assignments = assignmentsFromSeed(seed)
+    window.sessionStorage.setItem(SESSION_KEY, JSON.stringify(assignments))
+    return assignments
+  } catch {
+    return assignmentsFromSeed(0)
+  }
+}
+
+export function allowedCommercePlacement(routeFamily: RevenueRouteFamily, assigned: CommercePlacement): CommercePlacement {
+  // Evidence-led and research routes never move affiliate modules ahead of evidence.
+  if (routeFamily !== 'buy-guide') return 'post-evidence'
+  return assigned
+}
+
+export function shouldShowCommerceForIntent(routeFamily: RevenueRouteFamily) {
+  return routeFamily === 'comparison' || routeFamily === 'best-supplements' || routeFamily === 'buy-guide'
+}
+
+export function commerceCtaLabel(variant: CommerceCtaVariant) {
+  return variant === 'compare-options' ? 'Compare current sourcing options' : 'View product details'
+}

--- a/src/lib/platforms.ts
+++ b/src/lib/platforms.ts
@@ -1,7 +1,7 @@
-export const PLATFORM_REGIONS = ['US', 'UK', 'CA'] as const
+export const PLATFORM_REGIONS = ['US', 'UK', 'CA', 'AU'] as const
 export type PlatformRegion = (typeof PLATFORM_REGIONS)[number]
 
-export type CommercePlatform = 'amazon'
+export type CommercePlatform = 'amazon' | 'manufacturer' | 'iherb' | 'other'
 
 export type PlatformRegionConfig = {
   region: PlatformRegion
@@ -13,6 +13,13 @@ export type PlatformRegionConfig = {
 
 export type RegionalUrlMap = Partial<Record<PlatformRegion, string>>
 
+export type RetailerLink = {
+  retailer: string
+  label?: string
+  url: string
+  regionalUrls?: RegionalUrlMap
+}
+
 export type ResolveRegionalUrlInput = {
   defaultUrl: string
   regionalUrls?: RegionalUrlMap
@@ -22,45 +29,29 @@ export type ResolveRegionalUrlInput = {
 export const DEFAULT_PLATFORM_REGION: PlatformRegion = 'US'
 
 export const PLATFORM_REGION_CONFIG: Record<PlatformRegion, PlatformRegionConfig> = {
-  US: {
-    region: 'US',
-    countryCode: 'US',
-    label: 'United States',
-    amazonHost: 'www.amazon.com',
-    currencyCode: 'USD',
-  },
-  UK: {
-    region: 'UK',
-    countryCode: 'GB',
-    label: 'United Kingdom',
-    amazonHost: 'www.amazon.co.uk',
-    currencyCode: 'GBP',
-  },
-  CA: {
-    region: 'CA',
-    countryCode: 'CA',
-    label: 'Canada',
-    amazonHost: 'www.amazon.ca',
-    currencyCode: 'CAD',
-  },
+  US: { region: 'US', countryCode: 'US', label: 'United States', amazonHost: 'www.amazon.com', currencyCode: 'USD' },
+  UK: { region: 'UK', countryCode: 'GB', label: 'United Kingdom', amazonHost: 'www.amazon.co.uk', currencyCode: 'GBP' },
+  CA: { region: 'CA', countryCode: 'CA', label: 'Canada', amazonHost: 'www.amazon.ca', currencyCode: 'CAD' },
+  AU: { region: 'AU', countryCode: 'AU', label: 'Australia', amazonHost: 'www.amazon.com.au', currencyCode: 'AUD' },
 }
 
 const REGION_ALIASES: Record<string, PlatformRegion> = {
-  US: 'US',
-  USA: 'US',
-  'UNITED STATES': 'US',
-  UK: 'UK',
-  GB: 'UK',
-  'UNITED KINGDOM': 'UK',
-  CA: 'CA',
-  CANADA: 'CA',
+  US: 'US', USA: 'US', 'UNITED STATES': 'US',
+  UK: 'UK', GB: 'UK', 'UNITED KINGDOM': 'UK',
+  CA: 'CA', CANADA: 'CA',
+  AU: 'AU', AUSTRALIA: 'AU',
 }
 
 export function normalizePlatformRegion(region?: string | null): PlatformRegion {
   if (!region) return DEFAULT_PLATFORM_REGION
-
   const normalized = region.trim().toUpperCase()
   return REGION_ALIASES[normalized] ?? DEFAULT_PLATFORM_REGION
+}
+
+export function inferPlatformRegionFromLocale(locale?: string | null): PlatformRegion {
+  const value = String(locale || '').toUpperCase()
+  const region = value.match(/[-_]([A-Z]{2})\b/)?.[1]
+  return normalizePlatformRegion(region)
 }
 
 export function getPlatformRegionConfig(region?: string | null): PlatformRegionConfig {
@@ -74,4 +65,11 @@ export function getOutboundLinkRel(isSponsored = true) {
 export function resolveRegionalUrl({ defaultUrl, regionalUrls, preferredRegion }: ResolveRegionalUrlInput): string {
   const region = normalizePlatformRegion(preferredRegion)
   return regionalUrls?.[region] ?? regionalUrls?.[DEFAULT_PLATFORM_REGION] ?? defaultUrl
+}
+
+export function resolveRetailerLinks(links: RetailerLink[] | undefined, preferredRegion?: string | null) {
+  if (!links?.length) return []
+  return links
+    .map((link) => ({ ...link, resolvedUrl: resolveRegionalUrl({ defaultUrl: link.url, regionalUrls: link.regionalUrls, preferredRegion }) }))
+    .filter((link) => /^https?:\/\//i.test(link.resolvedUrl))
 }

--- a/src/lib/product-lifecycle.ts
+++ b/src/lib/product-lifecycle.ts
@@ -1,0 +1,69 @@
+export type ProductLifecycleStatus = 'active' | 'stale' | 'discontinued' | 'formulation-changed' | 'unverified'
+
+export interface ProductLifecycleMetadata {
+  status?: ProductLifecycleStatus
+  lastVerifiedAt?: string
+  reviewedFormulationFingerprint?: string
+  currentFormulationFingerprint?: string
+  reviewedEvidenceForm?: string
+  currentProductForm?: string
+  discontinued?: boolean
+}
+
+export interface ProductLifecycleDecision {
+  status: ProductLifecycleStatus
+  action: 'allow' | 'review' | 'block'
+  reasons: string[]
+}
+
+const DAY_MS = 86_400_000
+
+function parseTime(value?: string) {
+  if (!value) return Number.NaN
+  return Date.parse(value)
+}
+
+export function evaluateProductLifecycle(
+  product: ProductLifecycleMetadata,
+  now = new Date(),
+  staleAfterDays = 90,
+): ProductLifecycleDecision {
+  const reasons: string[] = []
+
+  if (product.discontinued || product.status === 'discontinued') {
+    return { status: 'discontinued', action: 'block', reasons: ['Product is marked discontinued.'] }
+  }
+
+  const formulationChanged = Boolean(
+    product.status === 'formulation-changed' ||
+    (product.reviewedFormulationFingerprint && product.currentFormulationFingerprint && product.reviewedFormulationFingerprint !== product.currentFormulationFingerprint) ||
+    (product.reviewedEvidenceForm && product.currentProductForm && product.reviewedEvidenceForm.trim().toLowerCase() !== product.currentProductForm.trim().toLowerCase()),
+  )
+  if (formulationChanged) {
+    return {
+      status: 'formulation-changed',
+      action: 'block',
+      reasons: ['Current formulation no longer matches the reviewed formulation/evidence form.'],
+    }
+  }
+
+  const verifiedAt = parseTime(product.lastVerifiedAt)
+  if (Number.isFinite(verifiedAt)) {
+    const ageDays = Math.max(0, (now.getTime() - verifiedAt) / DAY_MS)
+    if (ageDays > staleAfterDays || product.status === 'stale') {
+      reasons.push(`Product verification is ${Math.floor(ageDays)} days old.`)
+      return { status: 'stale', action: 'review', reasons }
+    }
+    return { status: product.status === 'active' ? 'active' : 'active', action: 'allow', reasons: ['Product metadata is within the verification window.'] }
+  }
+
+  return {
+    status: product.status ?? 'unverified',
+    action: product.status === 'active' ? 'review' : 'review',
+    reasons: ['No current product-verification date is recorded.'],
+  }
+}
+
+export function shouldSuppressProductRecommendation(product: ProductLifecycleMetadata) {
+  return evaluateProductLifecycle(product).action === 'block'
+}

--- a/src/lib/revenue-tracking.ts
+++ b/src/lib/revenue-tracking.ts
@@ -7,6 +7,8 @@ export type RevenueEventKind =
   | 'affiliate_click'
   | 'cta_click'
   | 'email_signup_attempt'
+  | 'email_signup_success'
+  | 'revenue_attributed'
 
 export type RevenueRouteFamily =
   | 'home'
@@ -24,6 +26,8 @@ export type RevenueRouteFamily =
 
 export type RevenueDeviceType = 'mobile' | 'tablet' | 'desktop' | 'unknown'
 export type RevenueScrollDepth = '0-24' | '25-49' | '50-74' | '75-99' | '100' | 'unknown'
+export type RevenueVisitorSource = 'organic' | 'paid-search' | 'email' | 'social' | 'referral' | 'direct' | 'internal' | 'unknown'
+export type RevenueLandingQueryClass = 'commercial' | 'comparison' | 'safety' | 'dose' | 'timing' | 'mechanism' | 'research' | 'informational' | 'unknown'
 
 export type RevenueEventInput = {
   kind: string
@@ -33,14 +37,25 @@ export type RevenueEventInput = {
   productSlug?: string
   productSlot?: string
   productAsin?: string
+  modulePosition?: string
+  ctaVariant?: string
+  experimentVariant?: string
+  retailer?: string
+  valueUsd?: number
 }
 
 export type RevenueEventContext = {
   pagePath?: string
+  pageSearch?: string
+  referrer?: string
+  landingPath?: string
+  landingSearch?: string
+  landingReferrer?: string
   viewportWidth?: number
   viewportHeight?: number
   scrollY?: number
   documentHeight?: number
+  countryCode?: string
 }
 
 export type RevenueEvent = {
@@ -51,13 +66,25 @@ export type RevenueEvent = {
   targetHost: string
   pagePath: string
   routeFamily: RevenueRouteFamily
+  contentCluster: string
   productSlug: string
   productSlot: string
   productAsin: string
+  modulePosition: string
+  ctaVariant: string
+  experimentVariant: string
+  retailer: string
+  visitorSource: RevenueVisitorSource
+  landingQueryClass: RevenueLandingQueryClass
+  landingQueryClassSource: 'explicit' | 'route-inferred'
+  countryCode: string
+  valueUsd: number
   deviceType: RevenueDeviceType
   scrollDepth: RevenueScrollDepth
   occurredAt: string
 }
+
+const LANDING_SESSION_KEY = 'ths_revenue_landing_v1'
 
 function canSendAnalytics(): boolean {
   return canTrackAnalytics()
@@ -69,10 +96,10 @@ export function normalizeRevenueEventKind(kind: string): RevenueEventKind {
     kind === 'recommendation_click' ||
     kind === 'affiliate_click' ||
     kind === 'cta_click' ||
-    kind === 'email_signup_attempt'
-  ) {
-    return kind
-  }
+    kind === 'email_signup_attempt' ||
+    kind === 'email_signup_success' ||
+    kind === 'revenue_attributed'
+  ) return kind
   return 'cta_click'
 }
 
@@ -89,30 +116,26 @@ export function classifyRevenueRoute(pathname: string): RevenueRouteFamily {
   if (path.startsWith('/herbs/')) return 'herb-profile'
   if (path.startsWith('/compounds/')) return 'compound-profile'
   if (path.startsWith('/compare/') || path.includes('/compare/')) return 'comparison'
-  if (path.includes('/best-supplements-for-') || path.startsWith('/best-for/')) return 'best-supplements'
+  if (path.includes('/best-supplements-for-') || path.startsWith('/best-for/') || path.startsWith('/guides/best/')) return 'best-supplements'
   if (path.startsWith('/top/')) return 'top-list'
   if (path.startsWith('/goals/')) return 'goal'
   if (path.startsWith('/stacks/')) return 'stack'
-  if (
-    path === '/buy-guide' ||
-    path.startsWith('/buy-guide/') ||
-    path === '/learn/product-quality' ||
-    path.startsWith('/learn/product-quality/')
-  ) return 'buy-guide'
+  if (path === '/buy-guide' || path.startsWith('/buy-guide/') || path === '/learn/product-quality' || path.startsWith('/learn/product-quality/')) return 'buy-guide'
   if (path.startsWith('/guides/')) return 'guide'
   return 'other'
+}
+
+export function classifyRevenueContentCluster(pathname: string): string {
+  const path = normalizeRevenuePagePath(pathname).toLowerCase()
+  const clusters = ['sleep', 'anxiety', 'stress', 'focus', 'cognition', 'adhd', 'metabolic', 'energy', 'safety', 'evidence', 'magnesium', 'ashwagandha', 'melatonin', 'l-theanine', 'creatine', 'berberine']
+  return clusters.find((cluster) => path.includes(`/${cluster}`) || path.includes(`${cluster}-`)) ?? 'general'
 }
 
 export function inferRevenueProductSlug(pathname: string): string {
   const path = normalizeRevenuePagePath(pathname)
   const match = path.match(/^\/(?:herbs|compounds)\/([^/]+)/)
   if (!match) return ''
-
-  try {
-    return decodeURIComponent(match[1])
-  } catch {
-    return match[1]
-  }
+  try { return decodeURIComponent(match[1]) } catch { return match[1] }
 }
 
 export function getRevenueDeviceType(viewportWidth: number | undefined): RevenueDeviceType {
@@ -126,10 +149,8 @@ export function getRevenueScrollDepth(context: RevenueEventContext): RevenueScro
   const viewportHeight = context.viewportHeight ?? 0
   const documentHeight = context.documentHeight ?? 0
   if (viewportHeight <= 0 || documentHeight <= 0) return 'unknown'
-
   const viewedBottom = Math.max(0, context.scrollY ?? 0) + viewportHeight
   const percentage = Math.min(100, Math.max(0, (viewedBottom / documentHeight) * 100))
-
   if (percentage >= 99) return '100'
   if (percentage >= 75) return '75-99'
   if (percentage >= 50) return '50-74'
@@ -139,28 +160,92 @@ export function getRevenueScrollDepth(context: RevenueEventContext): RevenueScro
 
 export function getRevenueTargetHost(target: string | undefined): string {
   if (!target) return ''
+  try { return new URL(target).hostname.replace(/^www\./, '') } catch { return '' }
+}
 
+function safeUrlSearch(search: string | undefined) {
+  try { return new URLSearchParams((search ?? '').replace(/^\?/, '')) } catch { return new URLSearchParams() }
+}
+
+export function classifyRevenueVisitorSource(search: string | undefined, referrer: string | undefined, currentHost = ''): RevenueVisitorSource {
+  const params = safeUrlSearch(search)
+  const medium = (params.get('utm_medium') ?? '').toLowerCase()
+  const source = (params.get('utm_source') ?? '').toLowerCase()
+  if (/cpc|ppc|paid|sem/.test(medium)) return 'paid-search'
+  if (/email|newsletter/.test(medium) || /email|newsletter/.test(source)) return 'email'
+  if (/social/.test(medium) || /facebook|instagram|tiktok|youtube|reddit|x\.com|twitter/.test(source)) return 'social'
+  if (!referrer) return 'direct'
   try {
-    return new URL(target).hostname.replace(/^www\./, '')
+    const host = new URL(referrer).hostname.replace(/^www\./, '')
+    if (currentHost && host === currentHost.replace(/^www\./, '')) return 'internal'
+    if (/google\.|bing\.|duckduckgo\.|yahoo\.|brave\.|ecosia\./.test(host)) return 'organic'
+    if (/facebook\.|instagram\.|tiktok\.|youtube\.|reddit\.|x\.com|twitter\./.test(host)) return 'social'
+    return 'referral'
   } catch {
-    return ''
+    return 'unknown'
   }
+}
+
+function inferQueryClassFromPath(pathname: string): RevenueLandingQueryClass {
+  const path = normalizeRevenuePagePath(pathname).toLowerCase()
+  if (path.includes('/compare/') || /-vs-/.test(path)) return 'comparison'
+  if (path.includes('/safety') || path.includes('interaction')) return 'safety'
+  if (path.includes('dosage') || path.includes('/dose')) return 'dose'
+  if (path.includes('best-time') || path.includes('morning-or-night') || path.includes('timing')) return 'timing'
+  if (path.includes('mechanism') || path.includes('pathway')) return 'mechanism'
+  if (path.includes('evidence') || path.includes('research') || path.includes('atlas')) return 'research'
+  if (path.includes('/best') || path.includes('/buy') || path.includes('product-quality')) return 'commercial'
+  return 'informational'
+}
+
+export function classifyLandingQueryClass(pathname: string, search?: string): { value: RevenueLandingQueryClass; source: 'explicit' | 'route-inferred' } {
+  const explicit = safeUrlSearch(search).get('query_class')?.toLowerCase()
+  const allowed: RevenueLandingQueryClass[] = ['commercial', 'comparison', 'safety', 'dose', 'timing', 'mechanism', 'research', 'informational', 'unknown']
+  if (explicit && allowed.includes(explicit as RevenueLandingQueryClass)) return { value: explicit as RevenueLandingQueryClass, source: 'explicit' }
+  return { value: inferQueryClassFromPath(pathname), source: 'route-inferred' }
+}
+
+function readLandingContext(): Pick<RevenueEventContext, 'landingPath' | 'landingSearch' | 'landingReferrer'> {
+  if (typeof window === 'undefined') return {}
+  const fallback = { landingPath: window.location.pathname, landingSearch: window.location.search, landingReferrer: document.referrer }
+  try {
+    const existing = window.sessionStorage.getItem(LANDING_SESSION_KEY)
+    if (existing) return JSON.parse(existing)
+    window.sessionStorage.setItem(LANDING_SESSION_KEY, JSON.stringify(fallback))
+  } catch {
+    // Session attribution is best-effort and never blocks tracking.
+  }
+  return fallback
 }
 
 export function buildRevenueEvent(input: RevenueEventInput, context: RevenueEventContext = {}): RevenueEvent {
   const pagePath = normalizeRevenuePagePath(context.pagePath ?? '')
+  const landingPath = context.landingPath || pagePath
+  const landingSearch = context.landingSearch || context.pageSearch || ''
+  const landingClass = classifyLandingQueryClass(landingPath, landingSearch)
+  const targetHost = getRevenueTargetHost(input.target)
 
   return {
     kind: normalizeRevenueEventKind(input.kind),
     location: input.location,
     label: input.label,
     target: input.target || '',
-    targetHost: getRevenueTargetHost(input.target),
+    targetHost,
     pagePath,
     routeFamily: classifyRevenueRoute(pagePath),
+    contentCluster: classifyRevenueContentCluster(pagePath),
     productSlug: input.productSlug || inferRevenueProductSlug(pagePath),
     productSlot: input.productSlot || '',
     productAsin: input.productAsin || '',
+    modulePosition: input.modulePosition || getRevenueScrollDepth(context),
+    ctaVariant: input.ctaVariant || '',
+    experimentVariant: input.experimentVariant || '',
+    retailer: input.retailer || targetHost || '',
+    visitorSource: classifyRevenueVisitorSource(landingSearch, context.landingReferrer ?? context.referrer, typeof window !== 'undefined' ? window.location.hostname : ''),
+    landingQueryClass: landingClass.value,
+    landingQueryClassSource: landingClass.source,
+    countryCode: (context.countryCode || '').toUpperCase().slice(0, 2),
+    valueUsd: Number.isFinite(input.valueUsd) ? Number(input.valueUsd) : 0,
     deviceType: getRevenueDeviceType(context.viewportWidth),
     scrollDepth: getRevenueScrollDepth(context),
     occurredAt: new Date().toISOString(),
@@ -169,82 +254,57 @@ export function buildRevenueEvent(input: RevenueEventInput, context: RevenueEven
 
 export function getBrowserRevenueContext(): RevenueEventContext {
   if (typeof window === 'undefined' || typeof document === 'undefined') return {}
-
   const documentElementHeight = document.documentElement?.scrollHeight ?? 0
   const bodyHeight = document.body?.scrollHeight ?? 0
-
+  const landing = readLandingContext()
   return {
     pagePath: window.location.pathname,
+    pageSearch: window.location.search,
+    referrer: document.referrer,
+    ...landing,
     viewportWidth: window.innerWidth,
     viewportHeight: window.innerHeight,
     scrollY: window.scrollY,
     documentHeight: Math.max(documentElementHeight, bodyHeight),
+    countryCode: document.documentElement.dataset.countryCode || '',
   }
 }
 
 export function trackAffiliateClick(productName: string) {
-  trackRevenueEvent({
-    kind: 'affiliate_click',
-    location: 'legacy-affiliate-click',
-    label: productName,
-  })
+  trackRevenueEvent({ kind: 'affiliate_click', location: 'legacy-affiliate-click', label: productName })
 }
 
 export function trackEmailCapture(source: string) {
   if (typeof window !== 'undefined' && window.gtag && canSendAnalytics()) {
-    window.gtag('event', 'email_signup', {
-      signup_source: source,
-      value: 1,
-    })
+    window.gtag('event', 'email_signup', { signup_source: source, value: 1 })
   }
 }
 
 export function trackProfileView(profileName: string, profileType: string) {
   if (typeof window !== 'undefined' && window.gtag && canSendAnalytics()) {
-    window.gtag('event', 'profile_view', {
-      profile_name: profileName,
-      profile_type: profileType,
-    })
+    window.gtag('event', 'profile_view', { profile_name: profileName, profile_type: profileType })
   }
 }
 
 export function trackRecommendationImpression(sourceProduct: string, recommendedProducts: string[]) {
-  trackRevenueEvent({
-    kind: 'recommendation_impression',
-    location: 'legacy-recommendation-impression',
-    label: recommendedProducts.join(',') || sourceProduct,
-    productSlug: sourceProduct,
-  })
+  trackRevenueEvent({ kind: 'recommendation_impression', location: 'legacy-recommendation-impression', label: recommendedProducts.join(',') || sourceProduct, productSlug: sourceProduct })
 }
 
 export function trackStackView(stackName: string, products: string[]) {
   if (typeof window !== 'undefined' && window.gtag && canSendAnalytics()) {
-    window.gtag('event', 'stack_view', {
-      stack_name: stackName,
-      product_count: products.length,
-      products: products.join(','),
-    })
+    window.gtag('event', 'stack_view', { stack_name: stackName, product_count: products.length, products: products.join(',') })
   }
 }
 
 export function trackRevenueEvent(input: RevenueEventInput) {
   if (typeof window === 'undefined') return
-
   const event = buildRevenueEvent(input, getBrowserRevenueContext())
   window.dispatchEvent(new CustomEvent('ths:revenue-event', { detail: event }))
-
   if (!canSendAnalytics()) return
 
   const newsletter = getNewsletterAttribution()
   window.dataLayer = window.dataLayer || []
-  window.dataLayer.push({
-    ...event,
-    newsletterAttributed: newsletter.newsletterAttributed,
-    newsletterCampaign: newsletter.campaign,
-    newsletterContent: newsletter.content,
-    subscriberAgeDays: newsletter.subscriberAgeDays,
-    firstEmailReturnAgeDays: newsletter.firstEmailReturnAgeDays,
-  })
+  window.dataLayer.push({ ...event, newsletterAttributed: newsletter.newsletterAttributed, newsletterCampaign: newsletter.campaign, newsletterContent: newsletter.content, subscriberAgeDays: newsletter.subscriberAgeDays, firstEmailReturnAgeDays: newsletter.firstEmailReturnAgeDays })
 
   if (window.gtag) {
     window.gtag('event', event.kind, {
@@ -254,9 +314,19 @@ export function trackRevenueEvent(input: RevenueEventInput) {
       target_host: event.targetHost || undefined,
       page_path: event.pagePath || undefined,
       route_family: event.routeFamily,
+      content_cluster: event.contentCluster,
       product_slug: event.productSlug || undefined,
       product_slot: event.productSlot || undefined,
       product_asin: event.productAsin || undefined,
+      module_position: event.modulePosition || undefined,
+      cta_variant: event.ctaVariant || undefined,
+      experiment_variant: event.experimentVariant || undefined,
+      retailer: event.retailer || undefined,
+      visitor_source: event.visitorSource,
+      landing_query_class: event.landingQueryClass,
+      landing_query_class_source: event.landingQueryClassSource,
+      country_code: event.countryCode || undefined,
+      value_usd: event.valueUsd || undefined,
       device_type: event.deviceType,
       scroll_depth: event.scrollDepth,
       newsletter_attributed: newsletter.newsletterAttributed,


### PR DESCRIPTION
Implements backlog 317–340 as one revenue/product-operations layer.

Analytics and experiments:
- qualified affiliate/recommendation impression denominators plus click capture
- page, route family, content cluster, ingredient, slot, module position, CTA variant, experiment cohort, retailer, landing-intent class, acquisition source, device, and scroll dimensions
- first-session landing context without storing raw search terms
- reports for CTR by page/module/ingredient/intent, revenue by URL/cluster/country, revenue per 1,000 organic visitors, email signup rate, and comparison-vs-profile conversion
- low-clutter 1-vs-3 affiliate-module experiment
- informative CTA test and buy-guide-only placement experiment; evidence-led routes remain post-evidence
- explicit commercial-intent bridge while research users remain undisturbed

Product operations:
- active/stale/discontinued/formulation-changed/unverified lifecycle model
- suppression of discontinued or formulation-mismatched recommendations
- freshness audit against reviewed formulation baselines
- product-selection criteria adjacent to affiliate links
- verification-gated product comparison table
- retailer diversification and verified US/UK/CA/AU routing

Conflict resolution note: rebased on current main and preserved the newer navigation-click telemetry in ClickTracker while adding the affiliate impression/click funnel.