### PR TITLE
ROI #149: answer-first intro budget

### DIFF
--- a/src/lib/__tests__/answer-first-intro-budget.test.ts
+++ b/src/lib/__tests__/answer-first-intro-budget.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import { evaluateIntroBudget } from '@/src/lib/answer-first-intro-budget'
+
+describe('evaluateIntroBudget', () => {
+  it('passes a short setup followed by a direct answer', () => {
+    const result = evaluateIntroBudget({
+      intro: 'Magnesium forms differ in absorption, tolerability, and evidence. The useful choice depends on the outcome and form actually studied.',
+      directAnswerPresent: true,
+      directAnswerBeforeLongBody: true,
+    })
+
+    expect(result.passes).toBe(true)
+    expect(result.reasons).toEqual([])
+  })
+
+  it('flags intros that become a wall of setup copy', () => {
+    const intro = Array.from({ length: 90 }, (_, index) => `word${index}`).join(' ')
+    const result = evaluateIntroBudget({ intro, directAnswerPresent: true, directAnswerBeforeLongBody: true })
+
+    expect(result.passes).toBe(false)
+    expect(result.reasons).toContain('intro-too-long')
+  })
+
+  it('flags too many setup sentences even when the word count is low', () => {
+    const result = evaluateIntroBudget({
+      intro: 'First point. Second point. Third point. Fourth point.',
+      directAnswerPresent: true,
+      directAnswerBeforeLongBody: true,
+    })
+
+    expect(result.reasons).toContain('too-many-intro-sentences')
+  })
+
+  it('fails when the answer is missing or appears after the long body', () => {
+    const result = evaluateIntroBudget({
+      intro: 'Short intro.',
+      directAnswerPresent: false,
+      directAnswerBeforeLongBody: false,
+    })
+
+    expect(result.reasons).toEqual(expect.arrayContaining(['missing-direct-answer', 'answer-after-long-body']))
+  })
+})

--- a/src/lib/answer-first-intro-budget.ts
+++ b/src/lib/answer-first-intro-budget.ts
@@ -1,0 +1,60 @@
+export type IntroBudgetInput = {
+  intro?: string | null
+  directAnswerPresent: boolean
+  directAnswerBeforeLongBody: boolean
+  maxIntroWords?: number
+  maxIntroSentences?: number
+}
+
+export type IntroBudgetResult = {
+  passes: boolean
+  wordCount: number
+  sentenceCount: number
+  maxIntroWords: number
+  maxIntroSentences: number
+  reasons: string[]
+}
+
+export const DEFAULT_MAX_INTRO_WORDS = 80
+export const DEFAULT_MAX_INTRO_SENTENCES = 3
+
+export function countWords(value: string): number {
+  return value.trim() ? value.trim().split(/\s+/).length : 0
+}
+
+export function countSentences(value: string): number {
+  const normalized = value.replace(/\s+/g, ' ').trim()
+  if (!normalized) return 0
+  const matches = normalized.match(/[^.!?]+[.!?]+(?:["'”’)]*)|[^.!?]+$/g)
+  return matches?.filter((sentence) => sentence.trim()).length ?? 0
+}
+
+/**
+ * First-screen editorial budget for important informational pages.
+ *
+ * The setup copy should orient the reader, not delay the answer. Pages can use
+ * shorter limits, but exceeding the shared defaults should be an explicit
+ * editorial decision rather than gradual template bloat.
+ */
+export function evaluateIntroBudget(input: IntroBudgetInput): IntroBudgetResult {
+  const intro = input.intro?.trim() ?? ''
+  const wordCount = countWords(intro)
+  const sentenceCount = countSentences(intro)
+  const maxIntroWords = input.maxIntroWords ?? DEFAULT_MAX_INTRO_WORDS
+  const maxIntroSentences = input.maxIntroSentences ?? DEFAULT_MAX_INTRO_SENTENCES
+  const reasons: string[] = []
+
+  if (!input.directAnswerPresent) reasons.push('missing-direct-answer')
+  if (!input.directAnswerBeforeLongBody) reasons.push('answer-after-long-body')
+  if (wordCount > maxIntroWords) reasons.push('intro-too-long')
+  if (sentenceCount > maxIntroSentences) reasons.push('too-many-intro-sentences')
+
+  return {
+    passes: reasons.length === 0,
+    wordCount,
+    sentenceCount,
+    maxIntroWords,
+    maxIntroSentences,
+    reasons,
+  }
+}


### PR DESCRIPTION
Adds a deterministic editorial budget for pre-answer setup copy: direct answer required before the long body, with default caps of 80 words and 3 setup sentences. Regression tests cover missing answers, delayed answers, word bloat, and sentence bloat.