### PR TITLE
Backlog 881–892: privacy-safe feedback and demand-ranked research intake

### DIFF
--- a/.github/ISSUE_TEMPLATE/research-intake.yml
+++ b/.github/ISSUE_TEMPLATE/research-intake.yml
@@ -1,0 +1,51 @@
+name: Research suggestion or correction
+description: Suggest an ingredient, comparison, missing study, or evidence correction without sharing personal health information.
+title: "Research intake: "
+labels:
+  - enhancement
+  - evidence
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve The Hippie Scientist research database. **Do not include symptoms, diagnoses, medications, lab results, or other personal health information.** This form is for public research/data requests only.
+  - type: dropdown
+    id: request_type
+    attributes:
+      label: Request type
+      options:
+        - Ingredient suggestion
+        - Comparison suggestion
+        - Missing study
+        - Scientific correction
+    validations:
+      required: true
+  - type: input
+    id: subject
+    attributes:
+      label: Ingredient, comparison, claim, or page
+      description: Use public research terms only (for example, "Ashwagandha", "magnesium vs melatonin", or a site URL).
+      placeholder: Ashwagandha
+    validations:
+      required: true
+  - type: input
+    id: source
+    attributes:
+      label: PMID, DOI, or public source URL
+      description: Strongly encouraged for missing studies and corrections. Link the primary or authoritative source when possible.
+      placeholder: PMID 12345678 or 10.xxxx/xxxxx
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Why would this improve the research resource?
+      description: Keep this about evidence, search usefulness, taxonomy, safety, or data quality. Do not describe your personal medical situation.
+      placeholder: The current profile appears to omit a 2025 randomized trial that directly studied the named ingredient and outcome.
+    validations:
+      required: true
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Public-information confirmation
+      options:
+        - label: I have not included personal health information, private records, or sensitive personal details.
+          required: true

--- a/.github/workflows/research-intake-demand-weekly.yml
+++ b/.github/workflows/research-intake-demand-weekly.yml
@@ -1,0 +1,41 @@
+name: Weekly Research Intake Demand
+
+on:
+  schedule:
+    - cron: '10 8 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  rank-demand:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Rank public research requests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/ops/rank-research-intake.mjs
+
+      - name: Upload ranked backlog
+        uses: actions/upload-artifact@v7
+        with:
+          name: research-intake-demand-${{ github.run_number }}
+          path: |
+            ops/reports/research-intake-demand.json
+            ops/reports/research-intake-demand.md
+          retention-days: 90
+
+      - name: Publish summary
+        run: cat ops/reports/research-intake-demand.md >> "$GITHUB_STEP_SUMMARY"

--- a/app/roadmap/page.tsx
+++ b/app/roadmap/page.tsx
@@ -1,0 +1,87 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { buildPageMetadata } from '@/lib/seo'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Public Research Roadmap | The Hippie Scientist',
+  description: 'See how The Hippie Scientist prioritizes evidence, safety, tools, and reader-requested research improvements — and submit a public research suggestion.',
+  path: '/roadmap/',
+})
+
+const lanes = [
+  {
+    title: 'Evidence quality',
+    status: 'Continuous',
+    body: 'Verify high-traffic claims, improve source classification, refresh citations, and strengthen outcome-specific evidence summaries before expanding weak pages.',
+  },
+  {
+    title: 'Safety and interactions',
+    status: 'Continuous',
+    body: 'Improve interaction provenance, uncertainty labels, safety completeness, and educational pairwise resources without treating missing data as proof of safety.',
+  },
+  {
+    title: 'Research tools',
+    status: 'Active',
+    body: 'Expand the Evidence Database, Safety Checker, Botanical Activity Atlas, Citation Explorer, evidence-change tracking, and downloadable original-data resources.',
+  },
+  {
+    title: 'High-demand content',
+    status: 'Demand-ranked',
+    body: 'Upgrade pages and comparisons that show measurable search demand, reader demand, or evidence gaps rather than expanding the database evenly by alphabetical order.',
+  },
+] as const
+
+const intakeHref = 'https://github.com/Razzleberrytt/hippie-scientist-site/issues/new?template=research-intake.yml'
+const openRequestsHref = 'https://github.com/Razzleberrytt/hippie-scientist-site/issues?q=is%3Aissue+is%3Aopen+label%3Aevidence+label%3Aenhancement'
+
+export default function RoadmapPage() {
+  return (
+    <main className='container-page space-y-8 py-10'>
+      <section className='hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8 lg:p-10'>
+        <p className='eyebrow-label'>Public roadmap</p>
+        <h1 className='mt-3 text-4xl font-semibold tracking-tight text-ink sm:text-5xl'>What gets improved next — and why</h1>
+        <p className='mt-5 max-w-3xl text-lg leading-8 text-muted'>
+          Work is prioritized by evidence and safety importance, measurable search demand, reader demand, expected impact, confidence, and implementation effort. Requests can influence the queue, but they do not automatically change scientific conclusions or evidence grades.
+        </p>
+        <div className='mt-6 flex flex-wrap gap-3'>
+          <a href={intakeHref} rel='noreferrer' className='rounded-full bg-brand-800 px-5 py-3 text-sm font-bold text-white transition hover:bg-brand-700'>Suggest research or a correction</a>
+          <a href={openRequestsHref} rel='noreferrer' className='rounded-full border border-brand-900/15 bg-white px-5 py-3 text-sm font-bold text-brand-800 transition hover:bg-brand-50'>See open public requests</a>
+        </div>
+      </section>
+
+      <section aria-labelledby='roadmap-lanes' className='space-y-4'>
+        <div>
+          <p className='eyebrow-label'>Current lanes</p>
+          <h2 id='roadmap-lanes' className='mt-2 text-2xl font-semibold tracking-tight text-ink'>The work streams that stay in view</h2>
+        </div>
+        <div className='grid gap-4 md:grid-cols-2'>
+          {lanes.map((lane) => (
+            <article key={lane.title} className='card-premium p-6'>
+              <div className='flex items-start justify-between gap-4'>
+                <h3 className='text-lg font-bold text-ink'>{lane.title}</h3>
+                <span className='rounded-full border border-brand-900/10 bg-brand-50 px-2.5 py-1 text-xs font-bold text-brand-800'>{lane.status}</span>
+              </div>
+              <p className='mt-3 text-sm leading-7 text-muted'>{lane.body}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className='rounded-2xl border border-brand-900/10 bg-[var(--surface-card)] p-6'>
+        <h2 className='text-xl font-bold text-ink'>How reader demand enters the queue</h2>
+        <ol className='mt-4 space-y-3 text-sm leading-6 text-muted'>
+          <li><strong className='text-ink'>1. Submit a public research request.</strong> Choose ingredient, comparison, missing study, or scientific correction.</li>
+          <li><strong className='text-ink'>2. Demand is aggregated.</strong> Public reactions and substantive discussion are counted as demand signals; duplicate requests can be consolidated.</li>
+          <li><strong className='text-ink'>3. Demand is not the only score.</strong> Safety importance, evidence availability, search opportunity, expected impact, confidence, and effort can outrank popularity.</li>
+          <li><strong className='text-ink'>4. Scientific changes still require review.</strong> A popular request never automatically rewrites a conclusion or evidence grade.</li>
+        </ol>
+      </section>
+
+      <section className='rounded-2xl border border-amber-900/15 bg-amber-50/60 p-5 text-sm leading-6 text-amber-950'>
+        <strong>Privacy:</strong> public requests are for research topics and public sources only. Do not submit symptoms, diagnoses, medication lists, medical records, or other sensitive personal health information.
+      </section>
+
+      <p className='text-sm text-muted'>Looking for the site methodology instead? <Link href='/info/methodology/' className='font-bold text-brand-800 underline'>Read how evidence and safety conclusions are built.</Link></p>
+    </main>
+  )
+}

--- a/components/ClickTracker.tsx
+++ b/components/ClickTracker.tsx
@@ -11,6 +11,7 @@ import {
 import { CONSENT_CHANGE_EVENT, getConsent } from '@/lib/consent'
 import { loadAnalytics } from '../src/lib/loadAnalytics'
 import { trackRevenueEvent } from '../src/lib/revenue-tracking'
+import ProfileFeedbackControls from '@/components/feedback/ProfileFeedbackControls'
 
 export default function ClickTracker() {
   const pathname = usePathname() || '/'
@@ -99,5 +100,5 @@ export default function ClickTracker() {
     }
   }, [])
 
-  return null
+  return <ProfileFeedbackControls />
 }

--- a/components/feedback/ProfileFeedbackControls.tsx
+++ b/components/feedback/ProfileFeedbackControls.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { canTrackAnalytics } from '@/lib/consent'
+
+const MISSING_OPTIONS = ['Evidence', 'Safety', 'Dose', 'Interactions', 'Forms', 'Comparisons'] as const
+
+type Clarity = 'yes' | 'partly' | 'no'
+type FoundAnswer = 'yes' | 'no'
+
+function profileContext(pathname: string) {
+  const match = pathname.match(/^\/(herbs|compounds)\/([^/]+)\/?$/)
+  if (!match) return null
+  return { type: match[1] === 'herbs' ? 'herb' : 'compound', slug: match[2] }
+}
+
+function emitFeedback(payload: Record<string, string>) {
+  if (!canTrackAnalytics()) return
+  try {
+    const analyticsWindow = window as Window & {
+      gtag?: (command: 'event', eventName: string, params: Record<string, string>) => void
+      plausible?: (eventName: string, options?: { props?: Record<string, string> }) => void
+    }
+    analyticsWindow.gtag?.('event', 'profile_feedback', payload)
+    analyticsWindow.plausible?.('profile_feedback', { props: payload })
+  } catch {
+    // Feedback must never interfere with reading or navigation.
+  }
+}
+
+export default function ProfileFeedbackControls() {
+  const pathname = usePathname() || '/'
+  const context = useMemo(() => profileContext(pathname), [pathname])
+  const [clarity, setClarity] = useState<Clarity | null>(null)
+  const [foundAnswer, setFoundAnswer] = useState<FoundAnswer | null>(null)
+  const [missing, setMissing] = useState<string | null>(null)
+  const [submitted, setSubmitted] = useState(false)
+
+  if (!context) return null
+
+  const record = (field: string, value: string) => {
+    emitFeedback({
+      profile_type: context.type,
+      profile_slug: context.slug,
+      feedback_field: field,
+      feedback_value: value,
+      page_path: pathname,
+    })
+  }
+
+  const chooseClarity = (value: Clarity) => {
+    setClarity(value)
+    record('clarity', value)
+  }
+
+  const chooseFoundAnswer = (value: FoundAnswer) => {
+    setFoundAnswer(value)
+    record('found_answer', value)
+  }
+
+  const chooseMissing = (value: string) => {
+    setMissing(value)
+    setSubmitted(true)
+    record('missing_information', value.toLowerCase())
+  }
+
+  return (
+    <aside
+      aria-labelledby='profile-feedback-title'
+      className='mx-auto my-8 max-w-4xl rounded-2xl border border-brand-900/10 bg-[var(--surface-card)] p-5 shadow-sm sm:p-6'
+    >
+      <div className='max-w-3xl'>
+        <p className='eyebrow-label'>Help improve this profile</p>
+        <h2 id='profile-feedback-title' className='mt-1 text-lg font-bold text-ink'>Was this evidence summary clear?</h2>
+        <div className='mt-3 flex flex-wrap gap-2' role='group' aria-label='Rate evidence-summary clarity'>
+          {(['yes', 'partly', 'no'] as const).map((value) => (
+            <button
+              key={value}
+              type='button'
+              aria-pressed={clarity === value}
+              onClick={() => chooseClarity(value)}
+              className={`min-h-11 rounded-full border px-4 py-2 text-sm font-semibold transition ${clarity === value ? 'border-brand-700 bg-brand-50 text-brand-900' : 'border-brand-900/15 bg-white text-ink hover:border-brand-700/40'}`}
+            >
+              {value === 'yes' ? 'Yes' : value === 'partly' ? 'Partly' : 'No'}
+            </button>
+          ))}
+        </div>
+
+        <h3 className='mt-5 text-sm font-bold text-ink'>Did you find what you were researching?</h3>
+        <div className='mt-2 flex flex-wrap gap-2' role='group' aria-label='Did this profile answer your research question'>
+          {(['yes', 'no'] as const).map((value) => (
+            <button
+              key={value}
+              type='button'
+              aria-pressed={foundAnswer === value}
+              onClick={() => chooseFoundAnswer(value)}
+              className={`min-h-11 rounded-full border px-4 py-2 text-sm font-semibold transition ${foundAnswer === value ? 'border-brand-700 bg-brand-50 text-brand-900' : 'border-brand-900/15 bg-white text-ink hover:border-brand-700/40'}`}
+            >
+              {value === 'yes' ? 'Yes' : 'Not yet'}
+            </button>
+          ))}
+        </div>
+
+        {(clarity === 'partly' || clarity === 'no' || foundAnswer === 'no') ? (
+          <div className='mt-5'>
+            <h3 className='text-sm font-bold text-ink'>What information was missing?</h3>
+            <p className='mt-1 text-xs leading-5 text-muted'>Choose a topic only. Please do not enter symptoms, diagnoses, medications, or other personal health information.</p>
+            <div className='mt-2 flex flex-wrap gap-2' role='group' aria-label='Missing information category'>
+              {MISSING_OPTIONS.map((option) => (
+                <button
+                  key={option}
+                  type='button'
+                  aria-pressed={missing === option}
+                  onClick={() => chooseMissing(option)}
+                  className={`min-h-11 rounded-full border px-3.5 py-2 text-sm font-semibold transition ${missing === option ? 'border-brand-700 bg-brand-50 text-brand-900' : 'border-brand-900/15 bg-white text-ink hover:border-brand-700/40'}`}
+                >
+                  {option}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : null}
+
+        {submitted ? <p className='mt-4 text-sm font-semibold text-brand-800' role='status'>Thanks — that signal helps prioritize the next profile upgrades.</p> : null}
+
+        <div className='mt-5 flex flex-wrap gap-x-4 gap-y-2 border-t border-brand-900/10 pt-4 text-sm'>
+          <Link href='/roadmap/' className='font-semibold text-brand-800 hover:underline'>See the public research roadmap →</Link>
+          <a href='https://github.com/Razzleberrytt/hippie-scientist-site/issues/new?template=research-intake.yml' className='font-semibold text-brand-800 hover:underline' rel='noreferrer'>Suggest an ingredient, comparison, study, or correction →</a>
+        </div>
+      </div>
+    </aside>
+  )
+}

--- a/scripts/ops/aggregate-profile-feedback.mjs
+++ b/scripts/ops/aggregate-profile-feedback.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+
+/**
+ * Convert exported aggregate `profile_feedback` analytics rows into a ranked
+ * content-improvement backlog. No free-text or personal health fields are
+ * accepted; only the structured dimensions emitted by ProfileFeedbackControls.
+ *
+ * Expected CSV columns (case/spacing tolerant):
+ * profile_slug, profile_type, feedback_field, feedback_value, event_count
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+const ROOT = process.cwd()
+const SOURCE_DIR = path.join(ROOT, 'data-sources', 'profile-feedback')
+const OUT_DIR = path.join(ROOT, 'ops', 'reports')
+const JSON_PATH = path.join(OUT_DIR, 'profile-feedback-backlog.json')
+const MD_PATH = path.join(OUT_DIR, 'profile-feedback-backlog.md')
+
+function parseCsv(content) {
+  const rows = []
+  let row = []
+  let field = ''
+  let quoted = false
+  for (let index = 0; index < content.length; index += 1) {
+    const char = content[index]
+    if (quoted) {
+      if (char === '"' && content[index + 1] === '"') {
+        field += '"'
+        index += 1
+      } else if (char === '"') quoted = false
+      else field += char
+    } else if (char === '"') quoted = true
+    else if (char === ',') {
+      row.push(field)
+      field = ''
+    } else if (char === '\n') {
+      row.push(field)
+      rows.push(row)
+      row = []
+      field = ''
+    } else if (char !== '\r') field += char
+  }
+  if (field || row.length) {
+    row.push(field)
+    rows.push(row)
+  }
+  return rows.filter((cells) => cells.some((cell) => String(cell).trim()))
+}
+
+function normalizeHeader(value) {
+  return String(value).trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '')
+}
+
+function number(value) {
+  const parsed = Number.parseFloat(String(value ?? '').replace(/,/g, '').trim())
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0
+}
+
+function loadRows() {
+  if (!fs.existsSync(SOURCE_DIR)) return []
+  const files = fs.readdirSync(SOURCE_DIR).filter((name) => name.toLowerCase().endsWith('.csv'))
+  return files.flatMap((name) => {
+    const parsed = parseCsv(fs.readFileSync(path.join(SOURCE_DIR, name), 'utf8'))
+    if (parsed.length < 2) return []
+    const header = parsed[0].map(normalizeHeader)
+    const indexOf = (...names) => names.map(normalizeHeader).map((candidate) => header.indexOf(candidate)).find((index) => index >= 0) ?? -1
+    const indexes = {
+      slug: indexOf('profile_slug', 'Profile slug'),
+      type: indexOf('profile_type', 'Profile type'),
+      field: indexOf('feedback_field', 'Feedback field'),
+      value: indexOf('feedback_value', 'Feedback value'),
+      count: indexOf('event_count', 'Event count', 'count'),
+    }
+    if (Object.values(indexes).some((index) => index < 0)) {
+      throw new Error(`${name} must include profile_slug, profile_type, feedback_field, feedback_value, event_count`)
+    }
+    return parsed.slice(1).map((cells) => ({
+      slug: String(cells[indexes.slug] || '').trim(),
+      type: String(cells[indexes.type] || '').trim(),
+      field: String(cells[indexes.field] || '').trim().toLowerCase(),
+      value: String(cells[indexes.value] || '').trim().toLowerCase(),
+      count: number(cells[indexes.count]),
+      sourceFile: name,
+    })).filter((row) => row.slug && row.count > 0)
+  })
+}
+
+function weight(field, value) {
+  if (field === 'clarity' && value === 'no') return 4
+  if (field === 'clarity' && value === 'partly') return 2
+  if (field === 'found_answer' && value === 'no') return 4
+  if (field === 'missing_information') return 3
+  return 0
+}
+
+function main() {
+  const rows = loadRows()
+  const grouped = new Map()
+
+  for (const row of rows) {
+    const key = `${row.type}:${row.slug}`
+    const current = grouped.get(key) || {
+      profileType: row.type,
+      profileSlug: row.slug,
+      signals: {},
+      totalResponses: 0,
+      priorityScore: 0,
+    }
+    const signalKey = `${row.field}:${row.value}`
+    current.signals[signalKey] = (current.signals[signalKey] || 0) + row.count
+    current.totalResponses += row.count
+    current.priorityScore += row.count * weight(row.field, row.value)
+    grouped.set(key, current)
+  }
+
+  const items = [...grouped.values()]
+    .filter((item) => item.priorityScore > 0)
+    .map((item) => ({
+      ...item,
+      dominantMissingCategory: Object.entries(item.signals)
+        .filter(([key]) => key.startsWith('missing_information:'))
+        .sort((a, b) => b[1] - a[1])[0]?.[0]?.split(':')[1] || null,
+    }))
+    .sort((a, b) => b.priorityScore - a.priorityScore || b.totalResponses - a.totalResponses || a.profileSlug.localeCompare(b.profileSlug))
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    sourceDirectory: path.relative(ROOT, SOURCE_DIR),
+    privacyContract: 'Structured aggregate dimensions only; no free text, symptoms, diagnoses, medications, or medical records.',
+    rowsIngested: rows.length,
+    items,
+  }
+
+  fs.mkdirSync(OUT_DIR, { recursive: true })
+  fs.writeFileSync(JSON_PATH, `${JSON.stringify(report, null, 2)}\n`)
+  fs.writeFileSync(MD_PATH, [
+    '# Profile feedback improvement backlog',
+    '',
+    `Generated: ${report.generatedAt}`,
+    '',
+    report.privacyContract,
+    '',
+    '| Rank | Priority | Profile | Responses | Dominant missing information |',
+    '| ---: | ---: | --- | ---: | --- |',
+    ...items.map((item, index) => `| ${index + 1} | ${item.priorityScore} | ${item.profileType}:${item.profileSlug} | ${item.totalResponses} | ${item.dominantMissingCategory || '—'} |`),
+    '',
+  ].join('\n'))
+
+  console.log(`[profile-feedback] rows=${rows.length} prioritizedProfiles=${items.length}`)
+}
+
+try {
+  main()
+} catch (error) {
+  console.error(`[profile-feedback] ${error.message}`)
+  process.exitCode = 1
+}

--- a/scripts/ops/rank-research-intake.mjs
+++ b/scripts/ops/rank-research-intake.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+
+/**
+ * Rank public research-intake issues by observable demand.
+ *
+ * This intentionally uses public issue engagement only: reactions, comments,
+ * and duplicate/consolidation signals. It never ingests user health data.
+ * Scientific corrections and missing-study reports receive a small review
+ * urgency bonus, but popularity never changes evidence conclusions directly.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+const OWNER = process.env.GITHUB_REPOSITORY?.split('/')[0] || 'Razzleberrytt'
+const REPO = process.env.GITHUB_REPOSITORY?.split('/')[1] || 'hippie-scientist-site'
+const TOKEN = process.env.GITHUB_TOKEN || ''
+const ROOT = process.cwd()
+const OUT_DIR = path.join(ROOT, 'ops', 'reports')
+const JSON_PATH = path.join(OUT_DIR, 'research-intake-demand.json')
+const MD_PATH = path.join(OUT_DIR, 'research-intake-demand.md')
+
+function requestType(body = '') {
+  const text = String(body)
+  const match = text.match(/### Request type\s+([^\n]+)/i)
+  return match?.[1]?.trim() || 'Unclassified'
+}
+
+function subject(body = '') {
+  const text = String(body)
+  const match = text.match(/### Ingredient, comparison, claim, or page\s+([^\n]+)/i)
+  return match?.[1]?.trim() || ''
+}
+
+function demandScore(issue) {
+  const reactions = issue.reactions || {}
+  const positiveReactions = Number(reactions['+1'] || 0)
+    + Number(reactions.heart || 0)
+    + Number(reactions.hooray || 0)
+    + Number(reactions.rocket || 0)
+    + Number(reactions.eyes || 0)
+  const comments = Number(issue.comments || 0)
+  const type = requestType(issue.body)
+  const reviewUrgency = /Scientific correction/i.test(type) ? 6 : /Missing study/i.test(type) ? 4 : 0
+  return {
+    positiveReactions,
+    comments,
+    reviewUrgency,
+    score: positiveReactions * 5 + comments * 2 + reviewUrgency,
+  }
+}
+
+async function fetchIssues() {
+  const headers = {
+    accept: 'application/vnd.github+json',
+    'x-github-api-version': '2022-11-28',
+    ...(TOKEN ? { authorization: `Bearer ${TOKEN}` } : {}),
+  }
+  const issues = []
+  for (let page = 1; page <= 10; page += 1) {
+    const url = `https://api.github.com/repos/${OWNER}/${REPO}/issues?state=open&labels=evidence,enhancement&per_page=100&page=${page}`
+    const response = await fetch(url, { headers })
+    if (!response.ok) throw new Error(`GitHub issues request failed (${response.status})`)
+    const rows = await response.json()
+    const filtered = rows.filter((row) => !row.pull_request && /^Research intake:/i.test(row.title || ''))
+    issues.push(...filtered)
+    if (rows.length < 100) break
+  }
+  return issues
+}
+
+function renderMarkdown(report) {
+  return [
+    '# Research intake — demand ranking',
+    '',
+    `Generated: ${report.generatedAt}`,
+    '',
+    'Demand score = positive public reactions × 5 + comments × 2 + a small review-urgency bonus for missing-study/correction reports. This ranks review attention; it never changes evidence grades automatically.',
+    '',
+    '| Rank | Demand | Type | Subject | Issue | Reactions | Comments |',
+    '| ---: | ---: | --- | --- | --- | ---: | ---: |',
+    ...report.items.map((item, index) => `| ${index + 1} | ${item.demandScore} | ${item.requestType} | ${item.subject || '—'} | #${item.number} | ${item.positiveReactions} | ${item.comments} |`),
+    '',
+  ].join('\n')
+}
+
+async function main() {
+  const issues = await fetchIssues()
+  const items = issues.map((issue) => {
+    const demand = demandScore(issue)
+    return {
+      number: issue.number,
+      title: issue.title,
+      url: issue.html_url,
+      requestType: requestType(issue.body),
+      subject: subject(issue.body),
+      positiveReactions: demand.positiveReactions,
+      comments: demand.comments,
+      reviewUrgency: demand.reviewUrgency,
+      demandScore: demand.score,
+      createdAt: issue.created_at,
+      updatedAt: issue.updated_at,
+    }
+  }).sort((a, b) => b.demandScore - a.demandScore || new Date(b.updatedAt) - new Date(a.updatedAt))
+
+  const report = { generatedAt: new Date().toISOString(), repository: `${OWNER}/${REPO}`, totalOpenRequests: items.length, items }
+  fs.mkdirSync(OUT_DIR, { recursive: true })
+  fs.writeFileSync(JSON_PATH, `${JSON.stringify(report, null, 2)}\n`)
+  fs.writeFileSync(MD_PATH, renderMarkdown(report))
+  console.log(`[research-intake] ranked ${items.length} open public request${items.length === 1 ? '' : 's'}`)
+}
+
+main().catch((error) => {
+  console.error(`[research-intake] ${error.message}`)
+  process.exitCode = 1
+})


### PR DESCRIPTION
Implements backlog 881–892 as one coherent reader-feedback/research-intake system.

- Adds structured profile feedback to every herb and compound profile via the global engagement layer.
- Asks whether the evidence summary was clear and whether the visitor found what they were researching.
- Missing-information feedback uses fixed categories only; no free-text health data is collected.
- Adds a public roadmap explaining evidence/safety/tool/demand prioritization.
- Adds a public GitHub issue form for ingredient suggestions, comparisons, missing studies, and scientific corrections with an explicit no-personal-health-data confirmation.
- Adds weekly demand ranking for public research requests from reactions/comments plus a small review-urgency bonus for missing-study/correction reports.
- Adds a structured analytics-export aggregator that turns profile feedback into a ranked content-improvement backlog.

Scientific conclusions/evidence grades are never changed automatically from popularity or submissions.