### PR TITLE
ci: cancel stale high-frequency validation runs

### DIFF
--- a/.github/workflows/atomic-upgrade-gate.yml
+++ b/.github/workflows/atomic-upgrade-gate.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited, ready_for_review]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/fast-ui-check.yml
+++ b/.github/workflows/fast-ui-check.yml
@@ -17,6 +17,10 @@ on:
       - '.github/workflows/fast-ui-check.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/tests/workflow-concurrency-contract.test.ts
+++ b/tests/workflow-concurrency-contract.test.ts
@@ -18,6 +18,7 @@ describe('high-frequency workflow concurrency contract', () => {
 
     expect(source).toContain('concurrency:')
     expect(source).toContain('group: ${{ github.workflow }}-${{ github.ref }}')
-    expect(source).toContain('cancel-in-progress: true')
+    expect(source.match(/cancel-in-progress:\s*true/g)).toHaveLength(1)
+    expect(source).not.toContain('cancel-in-progress: false')
   })
 })

--- a/tests/workflow-concurrency-contract.test.ts
+++ b/tests/workflow-concurrency-contract.test.ts
@@ -1,0 +1,23 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const WORKFLOWS = [
+  '.github/workflows/check.yml',
+  '.github/workflows/fast-ui-check.yml',
+  '.github/workflows/atomic-upgrade-gate.yml',
+]
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+}
+
+describe('high-frequency workflow concurrency contract', () => {
+  it.each(WORKFLOWS)('%s cancels stale runs for the same workflow/ref', (relativePath) => {
+    const source = read(relativePath)
+
+    expect(source).toContain('concurrency:')
+    expect(source).toContain('group: ${{ github.workflow }}-${{ github.ref }}')
+    expect(source).toContain('cancel-in-progress: true')
+  })
+})


### PR DESCRIPTION
Fixes #3144

## Relevant URLs
- N/A — CI orchestration only; no production route behavior changes.

## Acceptance criteria
- Site Health Check, Fast UI Check, and Atomic Upgrade Gate define per-workflow/per-ref concurrency.
- `cancel-in-progress: true` cancels obsolete runs when a newer event arrives for the same ref.
- Different PR refs remain independent because the concurrency key includes `github.ref`.
- No validation command, trigger, path filter, timeout, or quality gate is removed.
- A regression contract prevents stale-run cancellation from disappearing from these workflows.

## Validation commands
- `npm run test -- tests/workflow-concurrency-contract.test.ts`
- GitHub Actions workflow syntax/dispatch validation on this PR.
- Standard CI remains authoritative for repository-wide validation.

## Before → after metrics
- High-frequency workflows lacking stale-run cancellation: **3 → 0**
- High-frequency workflows with `cancel-in-progress: true`: **0/3 → 3/3**
- Maximum simultaneously relevant run generations per workflow/ref: **unbounded stale queue → latest generation only**
- Validation steps removed: **0**

## Generator/source-of-truth decision
- No generated data or production source changes.
- Concurrency policy remains declared directly in each workflow YAML.
- The contract test only verifies that the three high-frequency workflows keep their per-ref cancellation policy.

## Regression contract
- `tests/workflow-concurrency-contract.test.ts` requires all three workflows to contain `concurrency`, the `${{ github.workflow }}-${{ github.ref }}` group, and `cancel-in-progress: true`.
- Future workflow edits may change commands or triggers independently, but cannot silently restore unbounded stale runs without updating the contract deliberately.

## Integration
Built from `22e8250`; current `main` through `3adf0a1` was compared and does not touch these three workflow files or the new contract test.