### PR TITLE
ROI #145: separate general wellness from disease-treatment content

### DIFF
--- a/app/__tests__/runtime-visibility.test.ts
+++ b/app/__tests__/runtime-visibility.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { getHealthContentGovernance } from '../../lib/health-content-governance'
 import { getRuntimeVisibility } from '../../lib/runtime-visibility'
 
 // Regression coverage for the recurring string-vs-boolean sitemap_included bug:
@@ -72,6 +73,36 @@ describe('getRuntimeVisibility', () => {
     })
     expect(visibility.canRender).toBe(false)
     expect(visibility.canIndex).toBe(false)
+  })
+
+  it('keeps explicitly disease-treatment content out of feature and commerce paths', () => {
+    const visibility = getRuntimeVisibility({
+      ...publishable,
+      sitemap_included: true,
+      content_intent: 'disease-treatment',
+    })
+
+    expect(visibility.canRender).toBe(true)
+    expect(visibility.canIndex).toBe(true)
+    expect(visibility.canFeature).toBe(false)
+    expect(visibility.canMonetize).toBe(false)
+  })
+
+  it('classifies a primary disease condition without scanning secondary safety mentions', () => {
+    expect(getHealthContentGovernance({ primary_condition: 'type 2 diabetes' })).toMatchObject({
+      intent: 'disease-treatment',
+      diseaseTreatment: true,
+      source: 'primary-topic',
+    })
+
+    expect(getHealthContentGovernance({
+      primary_outcome: 'stress',
+      safety: 'Use caution in people with diabetes.',
+    })).toMatchObject({
+      intent: 'general-wellness',
+      diseaseTreatment: false,
+      source: 'primary-topic',
+    })
   })
 
   it('fails closed if evaluating a malformed record throws', () => {

--- a/lib/health-content-governance.ts
+++ b/lib/health-content-governance.ts
@@ -1,0 +1,65 @@
+import { text } from '@/lib/display-utils'
+
+export type HealthContentIntent = 'general-wellness' | 'disease-treatment' | 'unclear'
+
+export type HealthContentGovernance = {
+  intent: HealthContentIntent
+  source: 'explicit' | 'primary-topic' | 'default'
+  diseaseTreatment: boolean
+}
+
+const DISEASE_TREATMENT_PATTERN = /\b(?:cancer|tumou?r|diabetes|prediabetes|hypertension|high blood pressure|hyperlipidemia|high cholesterol|cardiovascular disease|heart disease|coronary|stroke|arthritis|osteoarthritis|rheumatoid|depression|major depressive|bipolar|schizophrenia|alzheimer|dementia|parkinson|epilepsy|seizure|asthma|copd|chronic kidney|kidney disease|liver disease|hepatitis|cirrhosis|pcos|polycystic ovary|endometriosis|osteoporosis|infection|influenza|covid|migraine|glaucoma|macular degeneration)\b/i
+
+const WELLNESS_PATTERN = /\b(?:wellness|general wellness|sleep support|stress|relaxation|focus|attention|energy|exercise|recovery|healthy aging|longevity research|cognition|memory|mood support|digestive support)\b/i
+
+function normalizeIntent(value: unknown): HealthContentIntent | null {
+  const candidate = text(value).toLowerCase().replace(/[_\s]+/g, '-')
+  if (/^(disease-treatment|medical-treatment|disease|clinical-treatment|ymyl)$/.test(candidate)) {
+    return 'disease-treatment'
+  }
+  if (/^(general-wellness|wellness|general|education|research-reference)$/.test(candidate)) {
+    return 'general-wellness'
+  }
+  return null
+}
+
+function primaryTopic(record: Record<string, unknown>): string {
+  const fields = [
+    record?.primary_condition,
+    record?.primary_outcome,
+    record?.condition,
+    record?.indication,
+    record?.primary_indication,
+  ]
+  return fields.map(text).filter(Boolean).join(' ')
+}
+
+/**
+ * Classify the page's primary health intent without scanning every secondary
+ * mention on the record. This deliberately avoids turning an ingredient page
+ * into disease-treatment content merely because a safety field happens to name
+ * a disease or medication-sensitive population.
+ */
+export function getHealthContentGovernance(record: Record<string, unknown>): HealthContentGovernance {
+  const explicitFields = [record?.content_intent, record?.medical_intent, record?.health_intent]
+  for (const value of explicitFields) {
+    const explicit = normalizeIntent(value)
+    if (explicit) {
+      return {
+        intent: explicit,
+        source: 'explicit',
+        diseaseTreatment: explicit === 'disease-treatment',
+      }
+    }
+  }
+
+  const topic = primaryTopic(record)
+  if (topic && DISEASE_TREATMENT_PATTERN.test(topic)) {
+    return { intent: 'disease-treatment', source: 'primary-topic', diseaseTreatment: true }
+  }
+  if (topic && WELLNESS_PATTERN.test(topic)) {
+    return { intent: 'general-wellness', source: 'primary-topic', diseaseTreatment: false }
+  }
+
+  return { intent: 'unclear', source: 'default', diseaseTreatment: false }
+}

--- a/lib/runtime-visibility.ts
+++ b/lib/runtime-visibility.ts
@@ -1,4 +1,5 @@
 import { list, text } from '@/lib/display-utils'
+import { getHealthContentGovernance } from '@/lib/health-content-governance'
 
 const HIDDEN_VISIBILITY = {
   canRender: false,
@@ -52,8 +53,10 @@ function evaluateRuntimeVisibility(record: Record<string, unknown>) {
   const summaryQuality = text(record?.summary_quality)
   const evidenceTier = text(record?.evidence_tier || record?.evidenceTier || record?.evidence_grade)
   const indexabilityStatus = getIndexabilityStatus(record)
+  const healthGovernance = getHealthContentGovernance(record)
 
   const hidden = /^hide$/i.test(exportDecision)
+  const diseaseTreatment = healthGovernance.diseaseTreatment
 
   const weak =
     /^minimal$/i.test(profileStatus) ||
@@ -65,8 +68,8 @@ function evaluateRuntimeVisibility(record: Record<string, unknown>) {
     return {
       canRender: !hidden,
       canIndex: !hidden && publish,
-      canFeature: !hidden && publish,
-      canMonetize: !hidden && indexabilityStatus !== 'BLOCKED' && !weak,
+      canFeature: !hidden && publish && !diseaseTreatment,
+      canMonetize: !hidden && indexabilityStatus !== 'BLOCKED' && !weak && !diseaseTreatment,
     }
   }
 
@@ -79,8 +82,8 @@ function evaluateRuntimeVisibility(record: Record<string, unknown>) {
     return {
       canRender: !hidden,
       canIndex: !hidden && publish,
-      canFeature: !hidden && publish,
-      canMonetize: !hidden && !weak,
+      canFeature: !hidden && publish && !diseaseTreatment,
+      canMonetize: !hidden && !weak && !diseaseTreatment,
     }
   }
 
@@ -97,8 +100,8 @@ function evaluateRuntimeVisibility(record: Record<string, unknown>) {
   return {
     canRender: !hidden,
     canIndex: !hidden && strong,
-    canFeature: !hidden && strong,
-    canMonetize: !hidden && !weak,
+    canFeature: !hidden && strong && !diseaseTreatment,
+    canMonetize: !hidden && !weak && !diseaseTreatment,
   }
 }
 


### PR DESCRIPTION
Implements backlog item #145 with a central health-content governance classifier. Disease-treatment intent is derived only from explicit intent fields or the primary condition/outcome, not secondary safety mentions. Runtime visibility now keeps disease-treatment pages out of featuring and affiliate monetization paths while preserving existing render/index rules.