### PR TITLE
fix(metadata): exclude hidden profiles from runtime metadata cache

### DIFF
--- a/src/lib/runtime-metadata-cache.ts
+++ b/src/lib/runtime-metadata-cache.ts
@@ -1,4 +1,5 @@
 import { cache } from './react-cache'
+import { getRuntimeVisibility } from '../../lib/runtime-visibility'
 import { getCompoundSummaryIndex, getHerbSummaryIndex } from './runtime-summary-indexes'
 import type { RuntimeRecord } from '../types/content'
 
@@ -58,7 +59,7 @@ function optimizeMetadataRecord(record: RuntimeRecord, type: 'herb' | 'compound'
   } as RuntimeRecord
 }
 
-function buildSlugMap(records: RuntimeRecord[], type: 'herb' | 'compound') {
+export function buildRenderableMetadataMap(records: RuntimeRecord[], type: 'herb' | 'compound') {
   const bySlug = new Map<string, RuntimeRecord>()
 
   for (const record of records) {
@@ -66,7 +67,7 @@ function buildSlugMap(records: RuntimeRecord[], type: 'herb' | 'compound') {
       ? record.slug
       : ''
 
-    if (!slug || bySlug.has(slug)) continue
+    if (!slug || bySlug.has(slug) || !getRuntimeVisibility(record).canRender) continue
 
     bySlug.set(slug, optimizeMetadataRecord(record, type))
   }
@@ -76,12 +77,12 @@ function buildSlugMap(records: RuntimeRecord[], type: 'herb' | 'compound') {
 
 export const getHerbMetadataMap = cache(async () => {
   const records = await getHerbSummaryIndex()
-  return buildSlugMap(records, 'herb')
+  return buildRenderableMetadataMap(records, 'herb')
 })
 
 export const getCompoundMetadataMap = cache(async () => {
   const records = await getCompoundSummaryIndex()
-  return buildSlugMap(records, 'compound')
+  return buildRenderableMetadataMap(records, 'compound')
 })
 
 export async function getHerbMetadataRecord(slug: string): Promise<RuntimeRecord | null> {

--- a/tests/runtime-metadata-cache-visibility.test.ts
+++ b/tests/runtime-metadata-cache-visibility.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildRenderableMetadataMap } from '../src/lib/runtime-metadata-cache'
+import type { RuntimeRecord } from '../src/types/content'
+
+describe('runtime metadata cache visibility', () => {
+  it('keeps publish and noindex profiles while excluding hidden records', () => {
+    const map = buildRenderableMetadataMap(
+      [
+        { slug: 'published', name: 'Published', indexability_status: 'PUBLISH' },
+        { slug: 'research-only', name: 'Research Only', indexability_status: 'NOINDEX' },
+        {
+          slug: 'hidden',
+          name: 'Hidden',
+          indexability_status: 'PUBLISH',
+          runtime_export_decision: 'hide',
+        },
+      ],
+      'herb',
+    )
+
+    expect([...map.keys()]).toEqual(['published', 'research-only'])
+    expect(map.get('published')?.meta_title).toBe('Published Benefits, Dosage & Safety')
+  })
+
+  it('does not let a hidden duplicate reserve a slug ahead of a renderable record', () => {
+    const records: RuntimeRecord[] = [
+      {
+        slug: 'shared',
+        name: 'Hidden version',
+        indexability_status: 'PUBLISH',
+        runtime_export_decision: 'hide',
+      },
+      {
+        slug: 'shared',
+        name: 'Renderable version',
+        indexability_status: 'PUBLISH',
+      },
+    ]
+
+    const map = buildRenderableMetadataMap(records, 'compound')
+
+    expect(map.get('shared')?.name).toBe('Renderable version')
+    expect(map.get('shared')?.meta_title).toBe('Renderable version: Effects, Dose & Safety')
+  })
+
+  it('ignores records without a usable slug', () => {
+    expect(
+      buildRenderableMetadataMap(
+        [
+          { slug: '', name: 'Empty', indexability_status: 'PUBLISH' },
+          { name: 'Missing', indexability_status: 'PUBLISH' },
+        ],
+        'herb',
+      ),
+    ).toEqual(new Map())
+  })
+})


### PR DESCRIPTION
## Root cause
Herb and compound static params/profile loaders use the canonical runtime visibility policy, but `runtime-metadata-cache` indexed every summary record with a slug. A hidden/unrenderable profile could therefore resolve normal profile metadata before the page correctly terminates as not found.

## Change
- Gate metadata-map insertion on `getRuntimeVisibility(record).canRender`.
- Preserve renderable `NOINDEX` research/archive profiles; this is a renderability boundary, not an indexing-policy change.
- Apply visibility before duplicate-slug reservation so a hidden record cannot block a later renderable record.
- Export the small map builder for behavior-level regression coverage.
- Add tests for PUBLISH, NOINDEX, hidden, duplicate-slug, missing-slug, and preserved metadata optimization behavior.

## Scope
No metadata templates, title/description limits, canonical logic, route indexing rules, profile rendering, or runtime source data are changed.