### PR TITLE
fix(ci): make robots route fallback explicit

### DIFF
--- a/scripts/ci/audit-page-category-robots.mjs
+++ b/scripts/ci/audit-page-category-robots.mjs
@@ -40,7 +40,9 @@ function normalizeRoute(value) {
   let pathname = value
   try {
     pathname = new URL(value, 'https://thehippiescientist.net').pathname
-  } catch {}
+  } catch {
+    pathname = value
+  }
   pathname = pathname.replace(/\/+/g, '/')
   if (!pathname.startsWith('/')) pathname = `/${pathname}`
   if (pathname !== '/' && !pathname.endsWith('/')) pathname += '/'


### PR DESCRIPTION
Closes #3133.

Replace the lint-blocking empty `catch {}` in the page-category robots audit with an explicit fallback to the original route value when URL parsing fails.

This preserves the existing normalization and robots-policy semantics while satisfying ESLint `no-empty`.