### PR TITLE
ROI #150: 2-4 sentence citation-ready summaries

### DIFF
--- a/components/seo/CitationReadySummary.tsx
+++ b/components/seo/CitationReadySummary.tsx
@@ -1,5 +1,7 @@
 import Link from 'next/link'
 
+import { citationReadySentenceCount, toCitationReadySummary } from '@/src/lib/citation-ready-summary'
+
 type CitationReadySummaryProps = {
   answer: string
   bestFor?: string[]
@@ -17,15 +19,19 @@ export default function CitationReadySummary({
   notClaiming,
   referencesHref,
 }: CitationReadySummaryProps) {
+  const citationReadyAnswer = toCitationReadySummary(answer)
+  const sentenceCount = citationReadySentenceCount(answer)
+
   return (
     <section
       aria-label="Citation-ready summary"
+      data-citation-summary-sentences={sentenceCount}
       className="max-w-4xl rounded-2xl border border-brand-900/10 bg-white p-5 shadow-sm dark:border-white/10 dark:bg-zinc-950"
     >
       <div className="space-y-4">
         <div className="space-y-2">
           <p className="eyebrow-label">Quick answer</p>
-          <p className="text-base leading-7 text-ink">{answer}</p>
+          <p className="text-base leading-7 text-ink">{citationReadyAnswer}</p>
         </div>
 
         {bestFor.length > 0 ? (

--- a/src/lib/__tests__/citation-ready-summary.test.ts
+++ b/src/lib/__tests__/citation-ready-summary.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { citationReadySentenceCount, toCitationReadySummary } from '@/src/lib/citation-ready-summary'
+
+describe('toCitationReadySummary', () => {
+  it('preserves summaries already within the 2-4 sentence window', () => {
+    const answer = 'The evidence is moderate for this outcome. Trials are short and formulation-specific.'
+    expect(toCitationReadySummary(answer)).toBe(answer)
+    expect(citationReadySentenceCount(answer)).toBe(2)
+  })
+
+  it('adds neutral context to a one-sentence answer without inventing evidence', () => {
+    const answer = 'Human evidence is limited.'
+    const summary = toCitationReadySummary(answer)
+
+    expect(citationReadySentenceCount(summary)).toBe(2)
+    expect(summary).toContain('evidence limitations and safety context')
+  })
+
+  it('folds long answers into four sentences without dropping later caveats', () => {
+    const answer = 'One. Two. Three. Four. Five includes a safety caveat. Six includes a population caveat.'
+    const summary = toCitationReadySummary(answer)
+
+    expect(citationReadySentenceCount(summary)).toBe(4)
+    expect(summary).toContain('Five includes a safety caveat')
+    expect(summary).toContain('Six includes a population caveat')
+  })
+})

--- a/src/lib/citation-ready-summary.ts
+++ b/src/lib/citation-ready-summary.ts
@@ -1,0 +1,45 @@
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim()
+}
+
+function splitSentences(value: string): string[] {
+  const normalized = normalizeWhitespace(value)
+  if (!normalized) return []
+
+  return (
+    normalized.match(/[^.!?]+(?:[.!?]+["'”’)]*|$)/g)?.map((sentence) => sentence.trim()).filter(Boolean) ?? []
+  )
+}
+
+function stripTerminalPunctuation(value: string): string {
+  return value.replace(/[.!?]+["'”’)]*$/g, '').trim()
+}
+
+/**
+ * Keep citation-ready answers within a 2–4 sentence extraction window.
+ *
+ * - 2–4 sentences: preserve exactly.
+ * - 1 sentence: add a neutral instruction to keep evidence limits/safety attached.
+ * - >4 sentences: preserve the first three sentences and fold all remaining
+ *   context into a semicolon-delimited fourth sentence instead of deleting it.
+ */
+export function toCitationReadySummary(answer: string): string {
+  const sentences = splitSentences(answer)
+  if (!sentences.length) return ''
+  if (sentences.length === 1) {
+    return `${sentences[0]} Interpret this conclusion alongside the evidence limitations and safety context below.`
+  }
+  if (sentences.length <= 4) return sentences.join(' ')
+
+  const tail = sentences
+    .slice(3)
+    .map(stripTerminalPunctuation)
+    .filter(Boolean)
+    .join('; ')
+
+  return `${sentences.slice(0, 3).join(' ')} ${tail}.`
+}
+
+export function citationReadySentenceCount(answer: string): number {
+  return splitSentences(toCitationReadySummary(answer)).length
+}


### PR DESCRIPTION
Enforces a 2–4 sentence extraction window inside the shared CitationReadySummary component. Existing 2–4 sentence answers remain unchanged; one-sentence answers receive only neutral evidence/safety context; longer answers preserve later caveats by folding them into a fourth sentence instead of deleting them.