### PR TITLE
feat(evidence): preserve quantitative study context from citations

### DIFF
--- a/lib/__tests__/citations.quantitative-context.test.ts
+++ b/lib/__tests__/citations.quantitative-context.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { extractCitationsFromRecord } from '@/lib/citations'
+
+describe('quantitative citation context', () => {
+  it('carries effect magnitude, uncertainty, significance, and replication fields into the shared citation model', () => {
+    const [citation] = extractCitationsFromRecord({
+      sources: [{
+        title: 'Quantitative trial',
+        pmid: '12345678',
+        study_type: 'randomized controlled trial',
+        effect_size: 'SMD -0.42',
+        confidence_interval: '95% CI -0.65 to -0.19',
+        p_value: 'p=0.001',
+        absolute_difference: '4.2 points',
+        clinical_magnitude: 'small-to-moderate',
+        replication_context: 'similar direction in two independent trials',
+        statistical_consistency: 'directionally consistent',
+      }],
+    })
+
+    expect(citation).toMatchObject({
+      effectSize: 'SMD -0.42',
+      confidenceInterval: '95% CI -0.65 to -0.19',
+      statisticalSignificance: 'p=0.001',
+      absoluteDifference: '4.2 points',
+      clinicalMagnitude: 'small-to-moderate',
+      replication: 'similar direction in two independent trials',
+      statisticalConsistency: 'directionally consistent',
+    })
+  })
+
+  it('accepts numeric quantitative fields without dropping them', () => {
+    const [citation] = extractCitationsFromRecord({
+      sources: [{ title: 'Numeric source', doi: '10.1000/example', effect_size: 0.37, p_value: 0.04 }],
+    })
+
+    expect(citation.effectSize).toBe('0.37')
+    expect(citation.statisticalSignificance).toBe('0.04')
+  })
+})

--- a/lib/citations.ts
+++ b/lib/citations.ts
@@ -24,6 +24,7 @@ function firstString(src: Record<string, unknown>, keys: string[]): string | und
   for (const key of keys) {
     const value = src[key]
     if (typeof value === 'string' && value.trim()) return value.trim()
+    if (typeof value === 'number' && Number.isFinite(value)) return String(value)
   }
   return undefined
 }
@@ -83,7 +84,13 @@ function sourceObjectToCitation(src: Record<string, unknown>): Citation {
     limitation: firstString(src, ['limitation', 'limitations', 'study_limitation', 'extraction_note']),
     relationship: normalizeEvidenceRelationship(relationshipRaw),
     confidence: normalizeEvidenceConfidence(confidenceRaw),
-    statisticalConsistency: firstString(src, ['statistical_consistency', 'statisticalSignal', 'statistical_signal']),
+    statisticalConsistency: firstString(src, ['statistical_consistency', 'statisticalConsistency', 'statisticalSignal', 'statistical_signal']),
+    effectSize: firstString(src, ['effect_size', 'effectSize', 'standardized_effect', 'standardizedEffect']),
+    confidenceInterval: firstString(src, ['confidence_interval', 'confidenceInterval', 'ci', 'effect_ci']),
+    statisticalSignificance: firstString(src, ['statistical_significance', 'statisticalSignificance', 'p_value', 'pValue']),
+    absoluteDifference: firstString(src, ['absolute_difference', 'absoluteDifference', 'absolute_effect', 'absoluteEffect']),
+    clinicalMagnitude: firstString(src, ['clinical_magnitude', 'clinicalMagnitude', 'magnitude_context', 'magnitudeContext']),
+    replication: firstString(src, ['replication', 'replication_context', 'replicationContext', 'replicated']),
     extractName: firstString(src, ['extract', 'extract_name', 'branded_extract', 'preparation']),
     ingredients: stringArray(src, ['ingredients', 'ingredient_slugs', 'entities']),
     conditions: stringArray(src, ['conditions', 'outcomes', 'condition_slugs']),


### PR DESCRIPTION
Fixes a wiring gap where the shared evidence UI supported effect size, confidence interval, absolute difference, statistical significance, clinical magnitude, replication, and consistency context but citation normalization silently dropped those source fields. Adds alias-aware extraction for those fields and regression tests, without inferring values when source data does not provide them.