### PR TITLE
ROI #146: enforce stricter disease/YMYL publication standards

### DIFF
--- a/app/__tests__/runtime-visibility.test.ts
+++ b/app/__tests__/runtime-visibility.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { getHealthContentGovernance } from '../../lib/health-content-governance'
+import {
+  getDiseaseEditorialAssessment,
+  getHealthContentGovernance,
+} from '../../lib/health-content-governance'
 import { getRuntimeVisibility } from '../../lib/runtime-visibility'
 
 // Regression coverage for the recurring string-vs-boolean sitemap_included bug:
@@ -38,7 +41,7 @@ describe('getRuntimeVisibility', () => {
     expect(visibility.canIndex).toBe(false)
   })
 
-  it('PUBLISH indexability_status takes priority', () => {
+  it('PUBLISH indexability_status takes priority for non-disease content', () => {
     const visibility = getRuntimeVisibility({
       slug: 'test-herb',
       indexability_status: 'PUBLISH',
@@ -75,7 +78,7 @@ describe('getRuntimeVisibility', () => {
     expect(visibility.canIndex).toBe(false)
   })
 
-  it('keeps explicitly disease-treatment content out of feature and commerce paths', () => {
+  it('keeps disease-treatment content out of index, feature, and commerce paths until enhanced review passes', () => {
     const visibility = getRuntimeVisibility({
       ...publishable,
       sitemap_included: true,
@@ -83,9 +86,43 @@ describe('getRuntimeVisibility', () => {
     })
 
     expect(visibility.canRender).toBe(true)
-    expect(visibility.canIndex).toBe(true)
+    expect(visibility.canIndex).toBe(false)
     expect(visibility.canFeature).toBe(false)
     expect(visibility.canMonetize).toBe(false)
+  })
+
+  it('allows indexing after disease content clears review, human-evidence, and safety gates', () => {
+    const record = {
+      ...publishable,
+      sitemap_included: true,
+      content_intent: 'disease-treatment',
+      ymyl_review_status: 'approved',
+      evidence_grade: 'B',
+      safety: 'Source-backed safety summary.',
+      contraindications: 'Source-backed contraindication context.',
+      interactions: 'Source-backed interaction context.',
+    }
+
+    expect(getDiseaseEditorialAssessment(record)).toMatchObject({
+      required: true,
+      approved: true,
+      reviewApproved: true,
+      humanEvidenceAdequate: true,
+      safetyCoverageAdequate: true,
+    })
+    expect(getRuntimeVisibility(record).canIndex).toBe(true)
+    expect(getRuntimeVisibility(record).canMonetize).toBe(false)
+  })
+
+  it('does not let a generic PUBLISH flag bypass the disease-treatment review gate', () => {
+    const visibility = getRuntimeVisibility({
+      indexability_status: 'PUBLISH',
+      content_intent: 'disease-treatment',
+      evidence_grade: 'A',
+      safety: 'Safety context.',
+      contraindications: 'Contraindication context.',
+    })
+    expect(visibility.canIndex).toBe(false)
   })
 
   it('classifies a primary disease condition without scanning secondary safety mentions', () => {

--- a/lib/health-content-governance.ts
+++ b/lib/health-content-governance.ts
@@ -1,4 +1,4 @@
-import { text } from '@/lib/display-utils'
+import { list, text } from '@/lib/display-utils'
 
 export type HealthContentIntent = 'general-wellness' | 'disease-treatment' | 'unclear'
 
@@ -6,6 +6,15 @@ export type HealthContentGovernance = {
   intent: HealthContentIntent
   source: 'explicit' | 'primary-topic' | 'default'
   diseaseTreatment: boolean
+}
+
+export type DiseaseEditorialAssessment = {
+  required: boolean
+  approved: boolean
+  reviewApproved: boolean
+  humanEvidenceAdequate: boolean
+  safetyCoverageAdequate: boolean
+  reasons: string[]
 }
 
 const DISEASE_TREATMENT_PATTERN = /\b(?:cancer|tumou?r|diabetes|prediabetes|hypertension|high blood pressure|hyperlipidemia|high cholesterol|cardiovascular disease|heart disease|coronary|stroke|arthritis|osteoarthritis|rheumatoid|depression|major depressive|bipolar|schizophrenia|alzheimer|dementia|parkinson|epilepsy|seizure|asthma|copd|chronic kidney|kidney disease|liver disease|hepatitis|cirrhosis|pcos|polycystic ovary|endometriosis|osteoporosis|infection|influenza|covid|migraine|glaucoma|macular degeneration)\b/i
@@ -32,6 +41,42 @@ function primaryTopic(record: Record<string, unknown>): string {
     record?.primary_indication,
   ]
   return fields.map(text).filter(Boolean).join(' ')
+}
+
+function hasApprovedEnhancedReview(record: Record<string, unknown>): boolean {
+  const reviewStatus = [
+    record?.ymyl_review_status,
+    record?.enhanced_review_status,
+    record?.editorial_review_status,
+  ]
+    .map(text)
+    .find(Boolean)
+
+  return /^(approved|reviewed|verified|passed|complete)$/i.test(reviewStatus || '')
+}
+
+function hasAdequateHumanEvidence(record: Record<string, unknown>): boolean {
+  const grade = text(record?.evidence_grade || record?.evidence_level || record?.evidence_tier)
+  if (/^(?:A|B)(?:\b|[+-])/i.test(grade) || /\b(?:strong|moderate)\s+human\b/i.test(grade)) return true
+
+  const humanEvidence = text(record?.human_evidence || record?.human_evidence_summary)
+  if (!humanEvidence || /\b(?:none|absent|lacking|no human|preclinical only|animal only|in[- ]vitro only)\b/i.test(humanEvidence)) {
+    return false
+  }
+
+  const humanStudyCount = Number(record?.human_study_count || record?.human_trials || record?.clinical_study_count || 0)
+  return humanStudyCount >= 2
+}
+
+function hasAdequateSafetyCoverage(record: Record<string, unknown>): boolean {
+  const sections = [
+    text(record?.safety || record?.safety_summary),
+    text(record?.contraindications),
+    text(record?.interactions),
+    ...list(record?.safety_flags),
+  ].filter((value) => value && !/^(?:unknown|none|n\/?a|not available|no data)$/i.test(value))
+
+  return sections.length >= 2
 }
 
 /**
@@ -62,4 +107,40 @@ export function getHealthContentGovernance(record: Record<string, unknown>): Hea
   }
 
   return { intent: 'unclear', source: 'default', diseaseTreatment: false }
+}
+
+/**
+ * Disease-treatment pages have a higher publication bar than ordinary wellness
+ * pages. A generic PUBLISH flag cannot bypass this assessment.
+ */
+export function getDiseaseEditorialAssessment(record: Record<string, unknown>): DiseaseEditorialAssessment {
+  const governance = getHealthContentGovernance(record)
+  if (!governance.diseaseTreatment) {
+    return {
+      required: false,
+      approved: true,
+      reviewApproved: true,
+      humanEvidenceAdequate: true,
+      safetyCoverageAdequate: true,
+      reasons: [],
+    }
+  }
+
+  const reviewApproved = hasApprovedEnhancedReview(record)
+  const humanEvidenceAdequate = hasAdequateHumanEvidence(record)
+  const safetyCoverageAdequate = hasAdequateSafetyCoverage(record)
+  const reasons: string[] = []
+
+  if (!reviewApproved) reasons.push('enhanced-editorial-review-required')
+  if (!humanEvidenceAdequate) reasons.push('direct-human-evidence-below-disease-page-threshold')
+  if (!safetyCoverageAdequate) reasons.push('safety-coverage-below-disease-page-threshold')
+
+  return {
+    required: true,
+    approved: reasons.length === 0,
+    reviewApproved,
+    humanEvidenceAdequate,
+    safetyCoverageAdequate,
+    reasons,
+  }
 }

--- a/lib/runtime-visibility.ts
+++ b/lib/runtime-visibility.ts
@@ -1,5 +1,8 @@
 import { list, text } from '@/lib/display-utils'
-import { getHealthContentGovernance } from '@/lib/health-content-governance'
+import {
+  getDiseaseEditorialAssessment,
+  getHealthContentGovernance,
+} from '@/lib/health-content-governance'
 
 const HIDDEN_VISIBILITY = {
   canRender: false,
@@ -54,9 +57,11 @@ function evaluateRuntimeVisibility(record: Record<string, unknown>) {
   const evidenceTier = text(record?.evidence_tier || record?.evidenceTier || record?.evidence_grade)
   const indexabilityStatus = getIndexabilityStatus(record)
   const healthGovernance = getHealthContentGovernance(record)
+  const diseaseEditorial = getDiseaseEditorialAssessment(record)
 
   const hidden = /^hide$/i.test(exportDecision)
   const diseaseTreatment = healthGovernance.diseaseTreatment
+  const editoriallyIndexable = diseaseEditorial.approved
 
   const weak =
     /^minimal$/i.test(profileStatus) ||
@@ -67,8 +72,8 @@ function evaluateRuntimeVisibility(record: Record<string, unknown>) {
     const publish = indexabilityStatus === 'PUBLISH'
     return {
       canRender: !hidden,
-      canIndex: !hidden && publish,
-      canFeature: !hidden && publish && !diseaseTreatment,
+      canIndex: !hidden && publish && editoriallyIndexable,
+      canFeature: !hidden && publish && editoriallyIndexable && !diseaseTreatment,
       canMonetize: !hidden && indexabilityStatus !== 'BLOCKED' && !weak && !diseaseTreatment,
     }
   }
@@ -81,8 +86,8 @@ function evaluateRuntimeVisibility(record: Record<string, unknown>) {
     const publish = sitemapIncluded && /^index/i.test(robotsField)
     return {
       canRender: !hidden,
-      canIndex: !hidden && publish,
-      canFeature: !hidden && publish && !diseaseTreatment,
+      canIndex: !hidden && publish && editoriallyIndexable,
+      canFeature: !hidden && publish && editoriallyIndexable && !diseaseTreatment,
       canMonetize: !hidden && !weak && !diseaseTreatment,
     }
   }
@@ -99,8 +104,8 @@ function evaluateRuntimeVisibility(record: Record<string, unknown>) {
 
   return {
     canRender: !hidden,
-    canIndex: !hidden && strong,
-    canFeature: !hidden && strong && !diseaseTreatment,
+    canIndex: !hidden && strong && editoriallyIndexable,
+    canFeature: !hidden && strong && editoriallyIndexable && !diseaseTreatment,
     canMonetize: !hidden && !weak && !diseaseTreatment,
   }
 }


### PR DESCRIPTION
Implements backlog item #146. Disease-treatment content now requires explicit enhanced editorial approval, adequate direct human-evidence signal, and substantive safety coverage before indexing. A generic PUBLISH flag cannot bypass the YMYL gate; disease pages remain non-commercial even after approval.