### PR TITLE
ci: cancel stale high-frequency workflow runs

### DIFF
--- a/.github/workflows/atomic-upgrade-gate.yml
+++ b/.github/workflows/atomic-upgrade-gate.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited, ready_for_review]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/fast-ui-check.yml
+++ b/.github/workflows/fast-ui-check.yml
@@ -17,6 +17,10 @@ on:
       - '.github/workflows/fast-ui-check.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/scripts/ci/workflow-concurrency.test.mjs
+++ b/scripts/ci/workflow-concurrency.test.mjs
@@ -1,0 +1,18 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const workflows = [
+  '.github/workflows/check.yml',
+  '.github/workflows/fast-ui-check.yml',
+  '.github/workflows/atomic-upgrade-gate.yml',
+]
+
+const concurrencyContract = /\nconcurrency:\s*\n\s+group:\s*\$\{\{\s*github\.workflow\s*\}\}-\$\{\{\s*github\.ref\s*\}\}\s*\n\s+cancel-in-progress:\s*true\b/
+
+describe('high-frequency workflow concurrency', () => {
+  it.each(workflows)('%s cancels stale runs only within the same workflow/ref', (workflow) => {
+    const yaml = fs.readFileSync(path.join(process.cwd(), workflow), 'utf8')
+    expect(yaml).toMatch(concurrencyContract)
+  })
+})


### PR DESCRIPTION
Closes #3144.

## Relevant URLs
- CI/Actions infrastructure only; no user-facing route changes.

## Acceptance criteria
- Site Health Check, Fast UI Check, and Atomic upgrade gate use per-workflow/per-ref concurrency.
- Newer runs cancel obsolete runs for the same workflow/ref.
- Different PR refs remain independent.
- Existing triggers, path filters, jobs, and validation commands remain intact.

## Validation commands
- `npm test -- scripts/ci/workflow-concurrency.test.mjs`
- Existing CI workflows remain authoritative for their normal validation suites.

## Before → after metrics
- Before: 0/3 targeted high-frequency workflows declared stale-run cancellation.
- After: 3/3 declare `cancel-in-progress: true` with `${{ github.workflow }}-${{ github.ref }}` grouping.

## Generator/source-of-truth decision
- Concurrency remains defined directly in each workflow YAML; no generated workflow layer is introduced.

## Regression contract
- `scripts/ci/workflow-concurrency.test.mjs` verifies all three targeted workflows retain the same-workflow/same-ref cancellation contract.