### PR TITLE
Backlog 881–892: privacy-safe feedback, research roadmap, and suggestion demand

### DIFF
--- a/app/info/research-roadmap/ResearchSuggestionPanel.tsx
+++ b/app/info/research-roadmap/ResearchSuggestionPanel.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import Link from 'next/link'
-import { FormEvent, useState } from 'react'
+import { useState } from 'react'
+import type { FormEvent } from 'react'
 import { trackResearchSuggestion, type ResearchSuggestionParams } from '@/lib/analytics'
 
 type SuggestionType = ResearchSuggestionParams['suggestionType']

--- a/app/info/research-roadmap/ResearchSuggestionPanel.tsx
+++ b/app/info/research-roadmap/ResearchSuggestionPanel.tsx
@@ -1,0 +1,153 @@
+'use client'
+
+import Link from 'next/link'
+import { FormEvent, useState } from 'react'
+import { trackResearchSuggestion, type ResearchSuggestionParams } from '@/lib/analytics'
+
+type SuggestionType = ResearchSuggestionParams['suggestionType']
+
+const TERM_PATTERN = /^[A-Za-z0-9][A-Za-z0-9 .+'’()/-]{1,59}$/
+const PMID_PATTERN = /^\d{6,9}$/
+const DOI_PATTERN = /^10\.\d{4,9}\/[A-Za-z0-9._;()/:+-]+$/i
+
+function normalizeTerm(value: string) {
+  return value.trim().replace(/\s+/g, ' ')
+}
+
+export default function ResearchSuggestionPanel() {
+  const [type, setType] = useState<SuggestionType>('ingredient')
+  const [first, setFirst] = useState('')
+  const [second, setSecond] = useState('')
+  const [status, setStatus] = useState('')
+
+  const reset = () => {
+    setFirst('')
+    setSecond('')
+  }
+
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setStatus('')
+
+    const a = normalizeTerm(first)
+    const b = normalizeTerm(second)
+    let value = ''
+
+    if (type === 'ingredient') {
+      if (!TERM_PATTERN.test(a)) {
+        setStatus('Enter one ingredient or compound name (2–60 characters).')
+        return
+      }
+      value = a.toLowerCase()
+    } else if (type === 'comparison') {
+      if (!TERM_PATTERN.test(a) || !TERM_PATTERN.test(b)) {
+        setStatus('Enter two ingredient or compound names (2–60 characters each).')
+        return
+      }
+      const pair = [a.toLowerCase(), b.toLowerCase()].sort()
+      if (pair[0] === pair[1]) {
+        setStatus('Choose two different ingredients or compounds.')
+        return
+      }
+      value = pair.join(' vs ')
+    } else {
+      const identifier = a.replace(/^https?:\/\/(?:dx\.)?doi\.org\//i, '').replace(/^pmid\s*:?\s*/i, '')
+      if (!PMID_PATTERN.test(identifier) && !DOI_PATTERN.test(identifier)) {
+        setStatus('Enter a PMID (6–9 digits) or DOI beginning with 10.')
+        return
+      }
+      value = identifier.toLowerCase()
+    }
+
+    const recorded = trackResearchSuggestion({ suggestionType: type, suggestionValue: value, pagePath: '/info/research-roadmap/' })
+    if (recorded) {
+      setStatus('Thanks — suggestion recorded for demand ranking.')
+      reset()
+    } else {
+      setStatus('Analytics consent is off, so this was not recorded. You can send the research suggestion by email instead.')
+    }
+  }
+
+  return (
+    <section aria-labelledby="research-suggestion-title" className="card-premium p-6 sm:p-8">
+      <p className="eyebrow-label">Shape the backlog</p>
+      <h2 id="research-suggestion-title" className="mt-2 text-2xl font-semibold text-ink">Suggest research</h2>
+      <p className="mt-3 max-w-3xl text-sm leading-7 text-muted">
+        Submit topic names only. Do not enter symptoms, diagnoses, medications you take, or other personal medical information. Detailed corrections belong in the public correction workflow.
+      </p>
+
+      <div className="mt-5 flex flex-wrap gap-2" role="group" aria-label="Research suggestion type">
+        {([
+          ['ingredient', 'Ingredient'],
+          ['comparison', 'Comparison'],
+          ['missing_study', 'Missing study'],
+        ] as const).map(([value, label]) => (
+          <button
+            key={value}
+            type="button"
+            aria-pressed={type === value}
+            onClick={() => { setType(value); reset(); setStatus('') }}
+            className={`min-h-11 rounded-full border px-4 py-2 text-sm font-semibold transition ${
+              type === value ? 'border-brand-700/40 bg-brand-50 text-brand-900' : 'border-brand-900/15 bg-white text-ink hover:bg-brand-50/60'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      <form className="mt-5 max-w-2xl space-y-4" onSubmit={submit}>
+        <div>
+          <label htmlFor="research-suggestion-a" className="text-sm font-bold text-ink">
+            {type === 'missing_study' ? 'PMID or DOI' : type === 'comparison' ? 'First ingredient or compound' : 'Ingredient or compound name'}
+          </label>
+          <input
+            id="research-suggestion-a"
+            value={first}
+            onChange={(event) => setFirst(event.target.value)}
+            maxLength={type === 'missing_study' ? 100 : 60}
+            placeholder={type === 'missing_study' ? 'e.g. 39123456 or 10.1000/example' : 'e.g. Ashwagandha'}
+            className="mt-2 w-full rounded-xl border border-brand-900/15 bg-white px-4 py-3 text-sm text-ink"
+          />
+        </div>
+
+        {type === 'comparison' ? (
+          <div>
+            <label htmlFor="research-suggestion-b" className="text-sm font-bold text-ink">Second ingredient or compound</label>
+            <input
+              id="research-suggestion-b"
+              value={second}
+              onChange={(event) => setSecond(event.target.value)}
+              maxLength={60}
+              placeholder="e.g. Magnesium"
+              className="mt-2 w-full rounded-xl border border-brand-900/15 bg-white px-4 py-3 text-sm text-ink"
+            />
+          </div>
+        ) : null}
+
+        <div className="flex flex-wrap items-center gap-3">
+          <button type="submit" className="min-h-11 rounded-full bg-brand-800 px-5 py-2.5 text-sm font-bold text-white hover:bg-brand-900">
+            Add to demand signal
+          </button>
+          <a
+            href="mailto:randolphwillie77@gmail.com?subject=Hippie%20Scientist%20research%20suggestion"
+            className="text-sm font-semibold text-brand-800 underline-offset-4 hover:underline"
+          >
+            Email instead
+          </a>
+        </div>
+        {status ? <p role="status" className="text-sm leading-6 text-muted">{status}</p> : null}
+      </form>
+
+      <div className="mt-6 border-t border-brand-900/10 pt-5">
+        <h3 className="text-base font-bold text-ink">Found an error or missing context?</h3>
+        <p className="mt-2 text-sm leading-6 text-muted">
+          Use the correction workflow for a specific claim, citation, dose, safety statement, or study interpretation so the evidence can be reviewed and, when material, added to the public correction history.
+        </p>
+        <Link href="/info/corrections/" className="mt-3 inline-flex text-sm font-semibold text-brand-800 underline-offset-4 hover:underline">
+          Submit a correction or missing study →
+        </Link>
+      </div>
+    </section>
+  )
+}

--- a/app/info/research-roadmap/page.tsx
+++ b/app/info/research-roadmap/page.tsx
@@ -1,0 +1,103 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { buildPageMetadata } from '@/src/lib/seo'
+import ResearchSuggestionPanel from './ResearchSuggestionPanel'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Research Roadmap & Topic Suggestions | The Hippie Scientist',
+  description: 'See what The Hippie Scientist is improving next and suggest ingredients, comparisons, missing studies, or scientific corrections without sharing personal health information.',
+  path: '/info/research-roadmap/',
+  openGraphType: 'article',
+})
+
+const roadmap = [
+  {
+    status: 'Now',
+    title: 'Verified high-traffic profiles',
+    body: 'Raise evidence, citation, dose, safety, and claim-level verification on pages already receiving meaningful search demand.',
+    href: '/evidence/evidence-report/',
+    linkLabel: 'Evidence Report',
+  },
+  {
+    status: 'Now',
+    title: 'Safety Checker depth',
+    body: 'Improve interaction provenance, uncertainty labels, and source-backed educational explanations for combinations people actually check.',
+    href: '/safety-checker/',
+    linkLabel: 'Safety Checker',
+  },
+  {
+    status: 'Next',
+    title: 'Evidence Database & trial exploration',
+    body: 'Make structured human evidence easier to filter, verify, compare, and connect back to specific claims and outcomes.',
+    href: '/evidence/evidence-checker/',
+    linkLabel: 'Evidence Database',
+  },
+  {
+    status: 'Next',
+    title: 'High-demand comparisons',
+    body: 'Expand only comparisons with distinct search intent, adequate evidence on both sides, and a useful decision framework.',
+    href: '/guides/compare/',
+    linkLabel: 'Comparison center',
+  },
+  {
+    status: 'Later',
+    title: 'Botanical relationship tools',
+    body: 'Deepen the Atlas and knowledge graph around botanicals, compounds, mechanisms, outcomes, studies, and safety without presenting mechanisms as proven benefits.',
+    href: '/tools/botanical-activity-atlas/',
+    linkLabel: 'Botanical Activity Atlas',
+  },
+  {
+    status: 'Ongoing',
+    title: 'Corrections & new evidence',
+    body: 'Review material corrections, missing primary studies, evidence-grade changes, and safety updates as the literature changes.',
+    href: '/info/corrections/',
+    linkLabel: 'Correction history',
+  },
+]
+
+export default function ResearchRoadmapPage() {
+  return (
+    <main className="container-page mx-auto max-w-5xl space-y-10 py-10">
+      <section className="hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8 lg:p-10">
+        <p className="eyebrow-label">Public roadmap</p>
+        <h1 className="mt-3 max-w-4xl text-4xl font-semibold tracking-tight text-ink sm:text-5xl">What gets researched next should follow evidence and demand.</h1>
+        <p className="mt-5 max-w-3xl text-lg leading-8 text-muted">
+          This roadmap shows the major research/database priorities. Reader suggestions are one input alongside search demand, evidence gaps, safety importance, revenue opportunity, backlink potential, page quality, confidence, and implementation effort.
+        </p>
+        <div className="mt-6 flex flex-wrap gap-3">
+          <Link href="/info/methodology/" className="chip-readable hover:bg-white transition">Methodology</Link>
+          <Link href="/info/corrections/" className="chip-readable hover:bg-white transition">Corrections</Link>
+          <Link href="/evidence/evidence-report/" className="chip-readable hover:bg-white transition">Evidence Report</Link>
+        </div>
+      </section>
+
+      <section aria-labelledby="roadmap-title" className="space-y-5">
+        <div>
+          <p className="eyebrow-label">Priority lanes</p>
+          <h2 id="roadmap-title" className="mt-2 text-3xl font-semibold tracking-tight text-ink">Major research/database work</h2>
+        </div>
+        <div className="grid gap-5 md:grid-cols-2">
+          {roadmap.map((item) => (
+            <article key={item.title} className="card-premium p-6">
+              <span className="inline-flex rounded-full border border-brand-900/10 bg-brand-50 px-3 py-1 text-xs font-bold uppercase tracking-wider text-brand-800">{item.status}</span>
+              <h3 className="mt-3 text-xl font-semibold text-ink">{item.title}</h3>
+              <p className="mt-2 text-sm leading-7 text-muted">{item.body}</p>
+              <Link href={item.href} className="mt-4 inline-flex text-sm font-semibold text-brand-800 underline-offset-4 hover:underline">
+                {item.linkLabel} →
+              </Link>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <ResearchSuggestionPanel />
+
+      <section className="rounded-2xl border border-brand-900/10 bg-brand-50/50 p-6 sm:p-8">
+        <h2 className="text-2xl font-semibold text-ink">How suggestions are prioritized</h2>
+        <p className="mt-3 max-w-3xl text-sm leading-7 text-muted">
+          Repeated suggestions create a demand signal, not an automatic publishing order. A topic still needs adequate evidence, a useful search or research intent, acceptable safety framing, and enough unique value to justify an indexable page or tool upgrade.
+        </p>
+      </section>
+    </main>
+  )
+}

--- a/components/AuthorCredentials.tsx
+++ b/components/AuthorCredentials.tsx
@@ -1,25 +1,29 @@
 import Link from 'next/link'
+import ProfileFeedback from '@/components/profile/ProfileFeedback'
 
 export default function AuthorCredentials() {
   return (
-    <section className="border-y border-brand-700/15 py-5">
-      <div className="relative flex flex-col gap-2 pl-4 before:absolute before:inset-y-0 before:left-0 before:w-[3px] before:rounded-full before:bg-brand-700/30 sm:flex-row sm:items-center sm:justify-between dark:before:bg-[var(--accent-teal)]/40">
-        <div>
-          <h3 className="text-xs font-bold uppercase tracking-[0.16em] text-brand-700">
-            Editorial Review
-          </h3>
-          <p className="mt-1 text-xs leading-5 text-muted">
-            Checked against primary sources, cited evidence, and contraindication language before publication.
-            Evidence claims, safety language, and affiliate modules are reviewed independently. Not personal medical advice.
-          </p>
+    <div className="space-y-5">
+      <section className="border-y border-brand-700/15 py-5">
+        <div className="relative flex flex-col gap-2 pl-4 before:absolute before:inset-y-0 before:left-0 before:w-[3px] before:rounded-full before:bg-brand-700/30 sm:flex-row sm:items-center sm:justify-between dark:before:bg-[var(--accent-teal)]/40">
+          <div>
+            <h3 className="text-xs font-bold uppercase tracking-[0.16em] text-brand-700">
+              Editorial Review
+            </h3>
+            <p className="mt-1 text-xs leading-5 text-muted">
+              Checked against primary sources, cited evidence, and contraindication language before publication.
+              Evidence claims, safety language, and affiliate modules are reviewed independently. Not personal medical advice.
+            </p>
+          </div>
+          <Link
+            href="/info/about/"
+            className="shrink-0 self-start text-xs font-bold text-brand-800 transition hover:text-brand-700 hover:underline sm:self-center"
+          >
+            Editorial Standards &rarr;
+          </Link>
         </div>
-        <Link
-          href="/info/about/"
-          className="shrink-0 self-start text-xs font-bold text-brand-800 transition hover:text-brand-700 hover:underline sm:self-center"
-        >
-          Editorial Standards &rarr;
-        </Link>
-      </div>
-    </section>
+      </section>
+      <ProfileFeedback />
+    </div>
   )
 }

--- a/components/editorial/ProfileDecisionPanel.tsx
+++ b/components/editorial/ProfileDecisionPanel.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import type { ProfileDecision } from '@/lib/profile-decision'
 import ScientificVerdictCard from '@/components/editorial/ScientificVerdictCard'
 import EvidenceConfidence from '@/components/editorial/EvidenceConfidence'
+import ProfileFeedback from '@/components/profile/ProfileFeedback'
 
 /**
  * ProfileDecisionPanel — the shared decision surface for every herb and
@@ -10,8 +11,9 @@ import EvidenceConfidence from '@/components/editorial/EvidenceConfidence'
  *
  * - When the slug has a curated verdict (config/profile-verdicts.ts), it opens
  *   with a full ScientificVerdictCard.
- * - Always shows an intent-based "Continue reading" nav derived from the
- *   record's own data — replacing generic related-link dumps with routing.
+ * - Shows intent-based "Continue reading" navigation derived from the record.
+ * - Always exposes the same privacy-safe research feedback controls so profile
+ *   quality can be improved from observed reader friction instead of guesses.
  *
  * Static-safe server component; theme-aware. Data comes from
  * `buildProfileDecision(record, kind)`.
@@ -24,7 +26,11 @@ export function ProfileDecisionPanel({
   name: string
 }) {
   const { verdict, continueReading } = decision
-  if (!verdict && continueReading.length === 0) return null
+  const hasRouting = Boolean(
+    verdict?.primaryGuide ||
+    (verdict?.comparisons && verdict.comparisons.length > 0) ||
+    continueReading.length > 0,
+  )
 
   return (
     <div className="space-y-4">
@@ -53,7 +59,7 @@ export function ProfileDecisionPanel({
         />
       ) : null}
 
-      {verdict?.primaryGuide || (verdict?.comparisons && verdict.comparisons.length > 0) || continueReading.length > 0 ? (
+      {hasRouting ? (
         <section
           aria-label="Where to go next"
           className="not-prose rounded-2xl border border-brand-900/12 bg-brand-50/40 p-4 dark:border-white/10 dark:bg-[var(--surface-subtle)]"
@@ -64,62 +70,64 @@ export function ProfileDecisionPanel({
               <span aria-hidden="true" className="shrink-0 text-brand-500 transition-transform group-open:rotate-180">v</span>
             </summary>
             <div className="mt-3 border-t border-brand-900/10 pt-3 dark:border-white/10">
-          {verdict?.primaryGuide ? (
-            <p className="text-sm leading-6">
-              <span className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700 dark:text-emerald-300">Start here</span>{' '}
-              <span className="text-muted">— new to this? Begin with </span>
-              <Link
-                href={verdict.primaryGuide.href}
-                className="font-bold text-brand-800 hover:underline dark:text-[var(--text-primary)]"
-              >
-                {verdict.primaryGuide.label}
-              </Link>
-            </p>
-          ) : null}
+              {verdict?.primaryGuide ? (
+                <p className="text-sm leading-6">
+                  <span className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700 dark:text-emerald-300">Start here</span>{' '}
+                  <span className="text-muted">— new to this? Begin with </span>
+                  <Link
+                    href={verdict.primaryGuide.href}
+                    className="font-bold text-brand-800 hover:underline dark:text-[var(--text-primary)]"
+                  >
+                    {verdict.primaryGuide.label}
+                  </Link>
+                </p>
+              ) : null}
 
-          {verdict?.comparisons && verdict.comparisons.length > 0 ? (
-            <div className={verdict?.primaryGuide ? 'mt-3 border-t border-brand-900/10 pt-3 dark:border-white/10' : ''}>
-              <p className="text-xs font-bold uppercase tracking-[0.14em] text-amber-700 dark:text-amber-300">
-                Compare before choosing
-              </p>
-              <ul className="mt-2 space-y-1.5">
-                {verdict.comparisons.map((c) => (
-                  <li key={c.href} className="text-sm leading-6">
-                    <Link
-                      href={c.href}
-                      className="font-bold text-brand-800 hover:underline dark:text-[var(--text-primary)]"
-                    >
-                      {c.label}
-                    </Link>
-                    <span className="text-muted"> — if {c.when}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ) : null}
+              {verdict?.comparisons && verdict.comparisons.length > 0 ? (
+                <div className={verdict?.primaryGuide ? 'mt-3 border-t border-brand-900/10 pt-3 dark:border-white/10' : ''}>
+                  <p className="text-xs font-bold uppercase tracking-[0.14em] text-amber-700 dark:text-amber-300">
+                    Compare before choosing
+                  </p>
+                  <ul className="mt-2 space-y-1.5">
+                    {verdict.comparisons.map((c) => (
+                      <li key={c.href} className="text-sm leading-6">
+                        <Link
+                          href={c.href}
+                          className="font-bold text-brand-800 hover:underline dark:text-[var(--text-primary)]"
+                        >
+                          {c.label}
+                        </Link>
+                        <span className="text-muted"> — if {c.when}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
 
-          {continueReading.length > 0 ? (
-            <div className={verdict?.primaryGuide || (verdict?.comparisons && verdict.comparisons.length > 0) ? 'mt-3 border-t border-brand-900/10 pt-3 dark:border-white/10' : ''}>
-              <p className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700">Continue reading</p>
-              <ul className="mt-2 space-y-1.5">
-                {continueReading.map((path) => (
-                  <li key={path.href} className="text-sm leading-6">
-                    <span className="text-muted">If you want {path.ifYouWant} → </span>
-                    <Link
-                      href={path.href}
-                      className="font-bold text-brand-800 hover:underline dark:text-[var(--text-primary)]"
-                    >
-                      {path.goTo}
-                    </Link>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ) : null}
+              {continueReading.length > 0 ? (
+                <div className={verdict?.primaryGuide || (verdict?.comparisons && verdict.comparisons.length > 0) ? 'mt-3 border-t border-brand-900/10 pt-3 dark:border-white/10' : ''}>
+                  <p className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700">Continue reading</p>
+                  <ul className="mt-2 space-y-1.5">
+                    {continueReading.map((path) => (
+                      <li key={path.href} className="text-sm leading-6">
+                        <span className="text-muted">If you want {path.ifYouWant} → </span>
+                        <Link
+                          href={path.href}
+                          className="font-bold text-brand-800 hover:underline dark:text-[var(--text-primary)]"
+                        >
+                          {path.goTo}
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
             </div>
           </details>
         </section>
       ) : null}
+
+      <ProfileFeedback />
     </div>
   )
 }

--- a/components/editorial/ProfileDecisionPanel.tsx
+++ b/components/editorial/ProfileDecisionPanel.tsx
@@ -2,7 +2,6 @@ import Link from 'next/link'
 import type { ProfileDecision } from '@/lib/profile-decision'
 import ScientificVerdictCard from '@/components/editorial/ScientificVerdictCard'
 import EvidenceConfidence from '@/components/editorial/EvidenceConfidence'
-import ProfileFeedback from '@/components/profile/ProfileFeedback'
 
 /**
  * ProfileDecisionPanel — the shared decision surface for every herb and
@@ -11,9 +10,8 @@ import ProfileFeedback from '@/components/profile/ProfileFeedback'
  *
  * - When the slug has a curated verdict (config/profile-verdicts.ts), it opens
  *   with a full ScientificVerdictCard.
- * - Shows intent-based "Continue reading" navigation derived from the record.
- * - Always exposes the same privacy-safe research feedback controls so profile
- *   quality can be improved from observed reader friction instead of guesses.
+ * - Always shows an intent-based "Continue reading" nav derived from the
+ *   record's own data — replacing generic related-link dumps with routing.
  *
  * Static-safe server component; theme-aware. Data comes from
  * `buildProfileDecision(record, kind)`.
@@ -26,11 +24,7 @@ export function ProfileDecisionPanel({
   name: string
 }) {
   const { verdict, continueReading } = decision
-  const hasRouting = Boolean(
-    verdict?.primaryGuide ||
-    (verdict?.comparisons && verdict.comparisons.length > 0) ||
-    continueReading.length > 0,
-  )
+  if (!verdict && continueReading.length === 0) return null
 
   return (
     <div className="space-y-4">
@@ -59,7 +53,7 @@ export function ProfileDecisionPanel({
         />
       ) : null}
 
-      {hasRouting ? (
+      {verdict?.primaryGuide || (verdict?.comparisons && verdict.comparisons.length > 0) || continueReading.length > 0 ? (
         <section
           aria-label="Where to go next"
           className="not-prose rounded-2xl border border-brand-900/12 bg-brand-50/40 p-4 dark:border-white/10 dark:bg-[var(--surface-subtle)]"
@@ -70,64 +64,62 @@ export function ProfileDecisionPanel({
               <span aria-hidden="true" className="shrink-0 text-brand-500 transition-transform group-open:rotate-180">v</span>
             </summary>
             <div className="mt-3 border-t border-brand-900/10 pt-3 dark:border-white/10">
-              {verdict?.primaryGuide ? (
-                <p className="text-sm leading-6">
-                  <span className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700 dark:text-emerald-300">Start here</span>{' '}
-                  <span className="text-muted">— new to this? Begin with </span>
-                  <Link
-                    href={verdict.primaryGuide.href}
-                    className="font-bold text-brand-800 hover:underline dark:text-[var(--text-primary)]"
-                  >
-                    {verdict.primaryGuide.label}
-                  </Link>
-                </p>
-              ) : null}
+          {verdict?.primaryGuide ? (
+            <p className="text-sm leading-6">
+              <span className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700 dark:text-emerald-300">Start here</span>{' '}
+              <span className="text-muted">— new to this? Begin with </span>
+              <Link
+                href={verdict.primaryGuide.href}
+                className="font-bold text-brand-800 hover:underline dark:text-[var(--text-primary)]"
+              >
+                {verdict.primaryGuide.label}
+              </Link>
+            </p>
+          ) : null}
 
-              {verdict?.comparisons && verdict.comparisons.length > 0 ? (
-                <div className={verdict?.primaryGuide ? 'mt-3 border-t border-brand-900/10 pt-3 dark:border-white/10' : ''}>
-                  <p className="text-xs font-bold uppercase tracking-[0.14em] text-amber-700 dark:text-amber-300">
-                    Compare before choosing
-                  </p>
-                  <ul className="mt-2 space-y-1.5">
-                    {verdict.comparisons.map((c) => (
-                      <li key={c.href} className="text-sm leading-6">
-                        <Link
-                          href={c.href}
-                          className="font-bold text-brand-800 hover:underline dark:text-[var(--text-primary)]"
-                        >
-                          {c.label}
-                        </Link>
-                        <span className="text-muted"> — if {c.when}</span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              ) : null}
+          {verdict?.comparisons && verdict.comparisons.length > 0 ? (
+            <div className={verdict?.primaryGuide ? 'mt-3 border-t border-brand-900/10 pt-3 dark:border-white/10' : ''}>
+              <p className="text-xs font-bold uppercase tracking-[0.14em] text-amber-700 dark:text-amber-300">
+                Compare before choosing
+              </p>
+              <ul className="mt-2 space-y-1.5">
+                {verdict.comparisons.map((c) => (
+                  <li key={c.href} className="text-sm leading-6">
+                    <Link
+                      href={c.href}
+                      className="font-bold text-brand-800 hover:underline dark:text-[var(--text-primary)]"
+                    >
+                      {c.label}
+                    </Link>
+                    <span className="text-muted"> — if {c.when}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
 
-              {continueReading.length > 0 ? (
-                <div className={verdict?.primaryGuide || (verdict?.comparisons && verdict.comparisons.length > 0) ? 'mt-3 border-t border-brand-900/10 pt-3 dark:border-white/10' : ''}>
-                  <p className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700">Continue reading</p>
-                  <ul className="mt-2 space-y-1.5">
-                    {continueReading.map((path) => (
-                      <li key={path.href} className="text-sm leading-6">
-                        <span className="text-muted">If you want {path.ifYouWant} → </span>
-                        <Link
-                          href={path.href}
-                          className="font-bold text-brand-800 hover:underline dark:text-[var(--text-primary)]"
-                        >
-                          {path.goTo}
-                        </Link>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              ) : null}
+          {continueReading.length > 0 ? (
+            <div className={verdict?.primaryGuide || (verdict?.comparisons && verdict.comparisons.length > 0) ? 'mt-3 border-t border-brand-900/10 pt-3 dark:border-white/10' : ''}>
+              <p className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700">Continue reading</p>
+              <ul className="mt-2 space-y-1.5">
+                {continueReading.map((path) => (
+                  <li key={path.href} className="text-sm leading-6">
+                    <span className="text-muted">If you want {path.ifYouWant} → </span>
+                    <Link
+                      href={path.href}
+                      className="font-bold text-brand-800 hover:underline dark:text-[var(--text-primary)]"
+                    >
+                      {path.goTo}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
             </div>
           </details>
         </section>
       ) : null}
-
-      <ProfileFeedback />
     </div>
   )
 }

--- a/components/profile/ProfileFeedback.tsx
+++ b/components/profile/ProfileFeedback.tsx
@@ -56,6 +56,7 @@ export default function ProfileFeedback() {
   const [found, setFound] = useState<YesNo | null>(null)
   const [missing, setMissing] = useState<MissingCategory | null>(null)
   const [recorded, setRecorded] = useState(false)
+  const isCanonicalProfile = /^\/(?:herbs|compounds)\/[^/]+\/?$/.test(pathname)
 
   const submit = (question: ProfileFeedbackParams['question'], answer: ProfileFeedbackParams['answer']) => {
     const didRecord = trackProfileFeedback({ question, answer, pagePath: pathname })
@@ -72,6 +73,8 @@ export default function ProfileFeedback() {
     setMissing(value)
     submit('missing_information', value)
   }
+
+  if (!isCanonicalProfile) return null
 
   return (
     <section aria-labelledby="profile-feedback-title" className="not-prose rounded-2xl border border-brand-900/10 bg-white/80 p-5 shadow-sm dark:bg-[var(--surface-card)]">

--- a/components/profile/ProfileFeedback.tsx
+++ b/components/profile/ProfileFeedback.tsx
@@ -1,0 +1,128 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { useState } from 'react'
+import { trackProfileFeedback, type ProfileFeedbackParams } from '@/lib/analytics'
+
+type YesNoQuestion = 'evidence_clarity' | 'research_found'
+type YesNo = 'yes' | 'no'
+type MissingCategory = Extract<ProfileFeedbackParams['answer'],
+  'evidence_studies' | 'dose_form' | 'safety_interactions' | 'timing_practical' | 'comparison' | 'other'
+>
+
+const missingCategories: Array<{ value: MissingCategory; label: string }> = [
+  { value: 'evidence_studies', label: 'Evidence / studies' },
+  { value: 'dose_form', label: 'Dose / form' },
+  { value: 'safety_interactions', label: 'Safety / interactions' },
+  { value: 'timing_practical', label: 'Timing / practical use' },
+  { value: 'comparison', label: 'Comparison' },
+  { value: 'other', label: 'Something else' },
+]
+
+function ChoiceButtons({
+  question,
+  value,
+  onChoose,
+}: {
+  question: YesNoQuestion
+  value: YesNo | null
+  onChoose: (question: YesNoQuestion, answer: YesNo) => void
+}) {
+  return (
+    <div className="flex flex-wrap gap-2" role="group" aria-label={question === 'evidence_clarity' ? 'Evidence summary clarity' : 'Research task completion'}>
+      {(['yes', 'no'] as const).map((answer) => (
+        <button
+          key={answer}
+          type="button"
+          aria-pressed={value === answer}
+          onClick={() => onChoose(question, answer)}
+          className={`min-h-10 rounded-full border px-4 py-2 text-sm font-semibold transition ${
+            value === answer
+              ? 'border-brand-700/40 bg-brand-50 text-brand-900'
+              : 'border-brand-900/15 bg-white text-ink hover:bg-brand-50/60'
+          }`}
+        >
+          {answer === 'yes' ? 'Yes' : 'No'}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+export default function ProfileFeedback() {
+  const pathname = usePathname() || '/'
+  const [clarity, setClarity] = useState<YesNo | null>(null)
+  const [found, setFound] = useState<YesNo | null>(null)
+  const [missing, setMissing] = useState<MissingCategory | null>(null)
+  const [recorded, setRecorded] = useState(false)
+
+  const submit = (question: ProfileFeedbackParams['question'], answer: ProfileFeedbackParams['answer']) => {
+    const didRecord = trackProfileFeedback({ question, answer, pagePath: pathname })
+    setRecorded((current) => current || didRecord)
+  }
+
+  const chooseYesNo = (question: YesNoQuestion, answer: YesNo) => {
+    if (question === 'evidence_clarity') setClarity(answer)
+    else setFound(answer)
+    submit(question, answer)
+  }
+
+  const chooseMissing = (value: MissingCategory) => {
+    setMissing(value)
+    submit('missing_information', value)
+  }
+
+  return (
+    <section aria-labelledby="profile-feedback-title" className="not-prose rounded-2xl border border-brand-900/10 bg-white/80 p-5 shadow-sm dark:bg-[var(--surface-card)]">
+      <div className="max-w-2xl">
+        <p className="eyebrow-label">Help improve this profile</p>
+        <h2 id="profile-feedback-title" className="mt-2 text-xl font-semibold text-ink">Was this useful for your research?</h2>
+        <p className="mt-2 text-sm leading-6 text-muted">
+          These controls record only the page and the structured choice you make when analytics consent is enabled. Please don’t include personal medical information in research requests.
+        </p>
+      </div>
+
+      <div className="mt-5 grid gap-5 md:grid-cols-2">
+        <div className="space-y-2">
+          <p className="text-sm font-bold text-ink">Was this evidence summary clear?</p>
+          <ChoiceButtons question="evidence_clarity" value={clarity} onChoose={chooseYesNo} />
+        </div>
+        <div className="space-y-2">
+          <p className="text-sm font-bold text-ink">Did you find what you were researching?</p>
+          <ChoiceButtons question="research_found" value={found} onChoose={chooseYesNo} />
+        </div>
+      </div>
+
+      {found === 'no' ? (
+        <div className="mt-5 border-t border-brand-900/10 pt-4">
+          <p className="text-sm font-bold text-ink">What information was missing?</p>
+          <div className="mt-2 flex flex-wrap gap-2" role="group" aria-label="Missing information category">
+            {missingCategories.map((category) => (
+              <button
+                key={category.value}
+                type="button"
+                aria-pressed={missing === category.value}
+                onClick={() => chooseMissing(category.value)}
+                className={`min-h-10 rounded-full border px-3.5 py-2 text-sm font-semibold transition ${
+                  missing === category.value
+                    ? 'border-brand-700/40 bg-brand-50 text-brand-900'
+                    : 'border-brand-900/15 bg-white text-ink hover:bg-brand-50/60'
+                }`}
+              >
+                {category.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      <div className="mt-5 flex flex-wrap items-center gap-3 text-sm">
+        {recorded ? <span role="status" className="font-semibold text-brand-800">Thanks — feedback recorded.</span> : null}
+        <Link href="/info/research-roadmap/" className="font-semibold text-brand-800 underline-offset-4 hover:underline">
+          Suggest an ingredient, comparison, or study →
+        </Link>
+      </div>
+    </section>
+  )
+}

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -14,7 +14,9 @@ type Gtag = (
     | 'experiment_impression'
     | 'guide_view'
     | 'lead_magnet_click'
-    | 'navigation_click',
+    | 'navigation_click'
+    | 'profile_feedback'
+    | 'research_suggestion',
   params: Record<string, string | number | boolean | undefined>,
 ) => void
 
@@ -36,6 +38,18 @@ export type NavigationClickParams = {
   destination: string
   sourcePath?: string
   location: 'desktop-primary' | 'mobile-primary'
+}
+
+export type ProfileFeedbackParams = {
+  question: 'evidence_clarity' | 'research_found' | 'missing_information'
+  answer: 'yes' | 'no' | 'evidence_studies' | 'dose_form' | 'safety_interactions' | 'timing_practical' | 'comparison' | 'other'
+  pagePath?: string
+}
+
+export type ResearchSuggestionParams = {
+  suggestionType: 'ingredient' | 'comparison' | 'missing_study'
+  suggestionValue: string
+  pagePath?: string
 }
 
 function getGtag(): Gtag | null {
@@ -151,6 +165,36 @@ export function trackNavigationClick(params: NavigationClickParams): void {
     })
   } catch {
     // Analytics must never block navigation.
+  }
+}
+
+export function trackProfileFeedback(params: ProfileFeedbackParams): boolean {
+  try {
+    const gtag = getGtag()
+    if (!gtag) return false
+    gtag('event', 'profile_feedback', {
+      feedback_question: params.question,
+      feedback_answer: params.answer,
+      page_path: getCurrentPagePath(params.pagePath),
+    })
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function trackResearchSuggestion(params: ResearchSuggestionParams): boolean {
+  try {
+    const gtag = getGtag()
+    if (!gtag) return false
+    gtag('event', 'research_suggestion', {
+      suggestion_type: params.suggestionType,
+      suggestion_value: params.suggestionValue,
+      page_path: getCurrentPagePath(params.pagePath),
+    })
+    return true
+  } catch {
+    return false
   }
 }
 

--- a/scripts/ops/analytics-export-utils.mjs
+++ b/scripts/ops/analytics-export-utils.mjs
@@ -1,0 +1,76 @@
+import fs from 'node:fs/promises'
+
+export function parseCsv(text) {
+  const rows = []
+  let row = []
+  let field = ''
+  let quoted = false
+
+  for (let i = 0; i < text.length; i += 1) {
+    const char = text[i]
+    if (char === '"') {
+      if (quoted && text[i + 1] === '"') {
+        field += '"'
+        i += 1
+      } else quoted = !quoted
+    } else if (char === ',' && !quoted) {
+      row.push(field)
+      field = ''
+    } else if ((char === '\n' || char === '\r') && !quoted) {
+      if (char === '\r' && text[i + 1] === '\n') i += 1
+      row.push(field)
+      field = ''
+      if (row.some((value) => value.trim())) rows.push(row)
+      row = []
+    } else field += char
+  }
+
+  if (field || row.length) {
+    row.push(field)
+    rows.push(row)
+  }
+  if (rows.length < 2) return []
+
+  const headers = rows[0].map((value) => value.trim())
+  return rows.slice(1).map((values) => Object.fromEntries(headers.map((header, index) => [header, values[index] ?? ''])))
+}
+
+export async function readAnalyticsExport(file) {
+  try {
+    const text = await fs.readFile(file, 'utf8')
+    if (file.toLowerCase().endsWith('.csv')) return { rows: parseCsv(text), metadata: {} }
+    const parsed = JSON.parse(text)
+    if (Array.isArray(parsed)) return { rows: parsed, metadata: {} }
+    return {
+      rows: Array.isArray(parsed.events) ? parsed.events : Array.isArray(parsed.rows) ? parsed.rows : [],
+      metadata: parsed,
+    }
+  } catch (error) {
+    if (error?.code === 'ENOENT') return { rows: [], metadata: { missingInput: true } }
+    throw error
+  }
+}
+
+export function first(record, keys) {
+  for (const key of keys) {
+    if (record?.[key] !== undefined && record?.[key] !== null && record?.[key] !== '') return record[key]
+  }
+  return undefined
+}
+
+export function eventCount(record) {
+  const value = Number(first(record, ['event_count', 'eventCount', 'count', 'clicks']) ?? 1)
+  return Number.isFinite(value) && value > 0 ? value : 1
+}
+
+export function normalizePagePath(value) {
+  if (!value) return null
+  let path = String(value).trim()
+  try {
+    if (/^https?:\/\//i.test(path)) path = new URL(path).pathname
+  } catch {}
+  path = path.split(/[?#]/)[0]
+  if (!path.startsWith('/')) path = `/${path}`
+  if (path !== '/' && !path.endsWith('/')) path += '/'
+  return path
+}

--- a/scripts/ops/feedback-improvement-backlog.mjs
+++ b/scripts/ops/feedback-improvement-backlog.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { eventCount, first, normalizePagePath, readAnalyticsExport } from './analytics-export-utils.mjs'
+
+const DEFAULT_INPUT = 'data-sources/analytics/profile-feedback.json'
+const DEFAULT_OUTPUT = 'ops/reports/feedback-improvement-backlog.json'
+
+function normalizeRow(row) {
+  const eventName = String(first(row, ['event_name', 'eventName', 'event']) ?? 'profile_feedback')
+  if (eventName && eventName !== 'profile_feedback') return null
+  const pagePath = normalizePagePath(first(row, ['page_path', 'pagePath', 'source_path']))
+  const question = String(first(row, ['feedback_question', 'question']) ?? '')
+  const answer = String(first(row, ['feedback_answer', 'answer']) ?? '')
+  if (!pagePath || !question || !answer) return null
+  return { pagePath, question, answer, count: eventCount(row) }
+}
+
+export function buildFeedbackBacklog(rows, metadata = {}) {
+  const pages = new Map()
+  const normalized = rows.map(normalizeRow).filter(Boolean)
+
+  for (const row of normalized) {
+    const current = pages.get(row.pagePath) ?? {
+      pagePath: row.pagePath,
+      clarityYes: 0,
+      clarityNo: 0,
+      foundYes: 0,
+      foundNo: 0,
+      missing: {},
+    }
+    if (row.question === 'evidence_clarity' && row.answer === 'yes') current.clarityYes += row.count
+    if (row.question === 'evidence_clarity' && row.answer === 'no') current.clarityNo += row.count
+    if (row.question === 'research_found' && row.answer === 'yes') current.foundYes += row.count
+    if (row.question === 'research_found' && row.answer === 'no') current.foundNo += row.count
+    if (row.question === 'missing_information') current.missing[row.answer] = (current.missing[row.answer] ?? 0) + row.count
+    pages.set(row.pagePath, current)
+  }
+
+  const backlog = [...pages.values()].map((page) => {
+    const clarityTotal = page.clarityYes + page.clarityNo
+    const foundTotal = page.foundYes + page.foundNo
+    const missingTotal = Object.values(page.missing).reduce((sum, value) => sum + value, 0)
+    const score = page.clarityNo * 3 + page.foundNo * 4 + missingTotal * 2
+    const topMissing = Object.entries(page.missing)
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+      .map(([category, count]) => ({ category, count }))
+
+    return {
+      ...page,
+      clarityNegativeRate: clarityTotal ? Number((page.clarityNo / clarityTotal).toFixed(4)) : null,
+      researchFailureRate: foundTotal ? Number((page.foundNo / foundTotal).toFixed(4)) : null,
+      missingTotal,
+      improvementScore: score,
+      topMissing,
+      suggestedAction: topMissing[0]
+        ? `Improve ${topMissing[0].category.replaceAll('_', ' ')} coverage, then remeasure.`
+        : page.foundNo > 0
+          ? 'Inspect the page against its landing-query intent and add the missing decision answer.'
+          : page.clarityNo > 0
+            ? 'Rewrite the evidence summary for clarity without weakening caveats.'
+            : 'No negative signal yet.',
+    }
+  }).filter((page) => page.improvementScore > 0)
+    .sort((a, b) => b.improvementScore - a.improvementScore || b.foundNo - a.foundNo || a.pagePath.localeCompare(b.pagePath))
+
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    sourcePeriod: metadata.sourcePeriod ?? metadata.source_period ?? null,
+    privacyModel: 'Only structured page-level feedback categories are expected. Free-text health information is not part of this event schema.',
+    feedbackEvents: normalized.reduce((sum, row) => sum + row.count, 0),
+    candidateCount: backlog.length,
+    nextImprovement: backlog[0] ?? null,
+    backlog,
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2)
+  const arg = (name, fallback) => {
+    const index = args.indexOf(name)
+    return index >= 0 ? args[index + 1] ?? fallback : fallback
+  }
+  const input = arg('--input', DEFAULT_INPUT)
+  const output = arg('--output', DEFAULT_OUTPUT)
+  const { rows, metadata } = await readAnalyticsExport(input)
+  const report = buildFeedbackBacklog(rows, metadata)
+  await fs.mkdir(path.dirname(output), { recursive: true })
+  await fs.writeFile(output, `${JSON.stringify(report, null, 2)}\n`)
+  console.log(`Feedback backlog: ${report.candidateCount} page candidates from ${report.feedbackEvents} structured feedback events → ${output}`)
+  if (metadata.missingInput) console.log(`No feedback export found at ${input}; wrote an empty, non-failing baseline.`)
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack : error)
+  process.exitCode = 1
+})

--- a/scripts/ops/research-suggestion-demand-report.mjs
+++ b/scripts/ops/research-suggestion-demand-report.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { eventCount, first, readAnalyticsExport } from './analytics-export-utils.mjs'
+
+const DEFAULT_INPUT = 'data-sources/analytics/research-suggestions.json'
+const DEFAULT_OUTPUT = 'ops/reports/research-suggestion-demand.json'
+const ALLOWED_TYPES = new Set(['ingredient', 'comparison', 'missing_study'])
+
+function normalizeValue(type, value) {
+  const clean = String(value ?? '').trim().toLowerCase().replace(/\s+/g, ' ')
+  if (!clean) return null
+  if (type === 'comparison') {
+    const parts = clean.split(/\s+vs\s+/i).map((part) => part.trim()).filter(Boolean)
+    return parts.length === 2 ? parts.sort().join(' vs ') : clean
+  }
+  return clean
+}
+
+function normalizeRow(row) {
+  const eventName = String(first(row, ['event_name', 'eventName', 'event']) ?? 'research_suggestion')
+  if (eventName && eventName !== 'research_suggestion') return null
+  const type = String(first(row, ['suggestion_type', 'suggestionType', 'type']) ?? '')
+  if (!ALLOWED_TYPES.has(type)) return null
+  const value = normalizeValue(type, first(row, ['suggestion_value', 'suggestionValue', 'value']))
+  if (!value) return null
+  return { type, value, count: eventCount(row) }
+}
+
+export function buildSuggestionDemandReport(rows, metadata = {}) {
+  const normalized = rows.map(normalizeRow).filter(Boolean)
+  const aggregate = new Map()
+
+  for (const row of normalized) {
+    const key = `${row.type}\u0000${row.value}`
+    const current = aggregate.get(key) ?? { suggestionType: row.type, suggestionValue: row.value, demandCount: 0 }
+    current.demandCount += row.count
+    aggregate.set(key, current)
+  }
+
+  const ranked = [...aggregate.values()]
+    .map((item) => ({
+      ...item,
+      demandScore: item.demandCount,
+      queueInstruction: item.suggestionType === 'missing_study'
+        ? `Review study identifier ${item.suggestionValue} for canonical entity/outcome matching before changing any conclusion.`
+        : `Evaluate “${item.suggestionValue}” against search demand, evidence availability, safety requirements, uniqueness, and ROI before publication.`,
+    }))
+    .sort((a, b) => b.demandScore - a.demandScore || a.suggestionType.localeCompare(b.suggestionType) || a.suggestionValue.localeCompare(b.suggestionValue))
+
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    sourcePeriod: metadata.sourcePeriod ?? metadata.source_period ?? null,
+    policy: 'Demand ranks suggestions within this reader-suggestion signal only. It does not bypass evidence, safety, usefulness, or ROI gates.',
+    totalSuggestionEvents: normalized.reduce((sum, row) => sum + row.count, 0),
+    uniqueSuggestions: ranked.length,
+    topSuggestion: ranked[0] ?? null,
+    suggestions: ranked,
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2)
+  const arg = (name, fallback) => {
+    const index = args.indexOf(name)
+    return index >= 0 ? args[index + 1] ?? fallback : fallback
+  }
+  const input = arg('--input', DEFAULT_INPUT)
+  const output = arg('--output', DEFAULT_OUTPUT)
+  const { rows, metadata } = await readAnalyticsExport(input)
+  const report = buildSuggestionDemandReport(rows, metadata)
+  await fs.mkdir(path.dirname(output), { recursive: true })
+  await fs.writeFile(output, `${JSON.stringify(report, null, 2)}\n`)
+  console.log(`Research suggestion demand: ${report.uniqueSuggestions} unique suggestions from ${report.totalSuggestionEvents} events → ${output}`)
+  if (metadata.missingInput) console.log(`No suggestion export found at ${input}; wrote an empty, non-failing baseline.`)
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack : error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
Closes #3131

## Summary
- Add one privacy-safe feedback surface to the shared profile footer used by canonical herb and compound profiles.
- Ask “Was this evidence summary clear?”, “Did you find what you were researching?”, and, only after a negative answer, a predefined missing-information category.
- Add consent-gated `profile_feedback` and `research_suggestion` analytics events.
- Publish `/info/research-roadmap/` with transparent Now / Next / Later / Ongoing research lanes.
- Let readers suggest an ingredient, a comparison, or a missing study; missing studies accept PMID/DOI identifiers.
- Keep detailed corrections in the existing public correction/contact workflow.
- Add analytics-export parsers plus ranked feedback-improvement and research-suggestion demand reports.

## Relevant URLs
- `/herbs/[slug]/`
- `/compounds/[slug]/`
- `/info/research-roadmap/`
- `/info/corrections/`

## Acceptance criteria
- [x] Both canonical profile families expose the same end-of-profile feedback controls through a shared component.
- [x] No free-text profile feedback field exists.
- [x] Missing-information choices are predefined non-medical categories.
- [x] Events are consent-gated through the existing analytics gate.
- [x] Public roadmap exposes ingredient, comparison, missing-study, and correction pathways.
- [x] Missing-study demand accepts PMID/DOI identifiers rather than narratives.
- [x] Feedback exports produce a ranked improvement backlog.
- [x] Suggestion exports aggregate normalized suggestions by observed demand.

## Validation commands
- `node scripts/ops/feedback-improvement-backlog.mjs`
- `node scripts/ops/research-suggestion-demand-report.mjs`
- `npm run validate:code`
- `npm run validate:release`

## Before → after metrics
| Metric / invariant | Before | After |
|---|---:|---:|
| Canonical profile families with feedback controls | 0 | 2 |
| Free-text profile health-feedback fields | 0 | 0 |
| Structured feedback questions | 0 | 3 |
| Public research roadmap | absent | present |
| Demand-ranked suggestion report | absent | present |
| Demand-ranked feedback improvement report | absent | present |

## Generator/source-of-truth decision
The feedback UI is attached once through the shared `AuthorCredentials` footer and self-limits to canonical `/herbs/:slug` and `/compounds/:slug` routes. The two operational reports share one analytics-export parser. Detailed scientific corrections reuse the existing corrections system rather than creating a competing workflow.

## Regression contract
The branch is behind an extremely active main, but merge-base→main inspection shows no overlap with the eight changed files in this PR. Feedback events contain only page paths, enum choices, short research-topic names, comparison pairs, or PMID/DOI identifiers; there is no open personal-health text field.

## Risk notes / justified tradeoffs
Suggestions submitted with analytics consent disabled are not falsely reported as recorded; the UI explicitly offers email fallback. Reader demand remains only one ranking signal and cannot bypass evidence, safety, uniqueness, or ROI gates.