### PR TITLE
ci: cancel stale specialized audit runs

### DIFF
--- a/.github/workflows/ai-entity-enrichment-check.yml
+++ b/.github/workflows/ai-entity-enrichment-check.yml
@@ -12,6 +12,10 @@ on:
       - '.github/workflows/ai-entity-enrichment-check.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/botanical-atlas-coverage.yml
+++ b/.github/workflows/botanical-atlas-coverage.yml
@@ -21,6 +21,10 @@ on:
       - '.github/workflows/botanical-atlas-coverage.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/related-botanicals-audit.yml
+++ b/.github/workflows/related-botanicals-audit.yml
@@ -21,6 +21,10 @@ on:
       - 'scripts/audit-related-botanicals.ts'
       - 'scripts/rank-related-comparisons.ts'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/research-distribution.yml
+++ b/.github/workflows/research-distribution.yml
@@ -13,6 +13,10 @@ on:
       - 'app/evidence/research-trends/**'
       - '.github/workflows/research-distribution.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/schema-media-governance.yml
+++ b/.github/workflows/schema-media-governance.yml
@@ -27,6 +27,10 @@ on:
       - '.github/workflows/schema-media-governance.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/tests/workflow-concurrency-contract.test.ts
+++ b/tests/workflow-concurrency-contract.test.ts
@@ -6,6 +6,11 @@ const WORKFLOWS = [
   '.github/workflows/check.yml',
   '.github/workflows/fast-ui-check.yml',
   '.github/workflows/atomic-upgrade-gate.yml',
+  '.github/workflows/schema-media-governance.yml',
+  '.github/workflows/related-botanicals-audit.yml',
+  '.github/workflows/ai-entity-enrichment-check.yml',
+  '.github/workflows/botanical-atlas-coverage.yml',
+  '.github/workflows/research-distribution.yml',
 ]
 
 function read(relativePath: string) {

--- a/tests/workflow-concurrency-contract.test.ts
+++ b/tests/workflow-concurrency-contract.test.ts
@@ -17,12 +17,12 @@ function read(relativePath: string) {
   return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
 }
 
-describe('high-frequency workflow concurrency contract', () => {
+describe('covered workflow concurrency contract', () => {
   it.each(WORKFLOWS)('%s cancels stale runs for the same workflow/ref', (relativePath) => {
     const source = read(relativePath)
 
     expect(source).toContain('concurrency:')
-    expect(source).toContain('group: ${{ github.workflow }}-${{ github.ref }}')
+    expect(source.match(/group: \$\{\{ github\.workflow \}\}-\$\{\{ github\.ref \}\}/g)).toHaveLength(1)
     expect(source.match(/cancel-in-progress:\s*true/g)).toHaveLength(1)
     expect(source).not.toContain('cancel-in-progress: false')
   })


### PR DESCRIPTION
Fixes #3158

## Relevant URLs
- N/A — CI/audit orchestration only; no production route behavior changes.

## Acceptance criteria
- Schema & Media Governance, Related Botanicals, AI Entity Enrichment, Botanical Atlas Coverage, and Research Distribution define per-workflow/per-ref concurrency.
- `cancel-in-progress: true` cancels obsolete runs for older heads on the same ref.
- Different PR refs remain independent.
- Existing triggers, path filters, commands, artifacts, timeouts, and validation coverage remain unchanged.
- The shared workflow concurrency contract covers all eight currently identified uncapped/high-frequency workflows.

## Validation commands
- `npm run test -- tests/workflow-concurrency-contract.test.ts`
- GitHub Actions workflow syntax/dispatch validation on this PR.
- Live synchronize-event cancellation check on a specialized workflow.

## Before → after metrics
- Specialized PR workflows in scope lacking stale-run cancellation: **5 → 0**
- Workflows covered by the shared cancellation regression contract: **3 → 8**
- Expensive specialized workflows protected (full build/runtime build/typecheck class): **0/3 → 3/3**
- Validation or audit steps removed: **0**

## Generator/source-of-truth decision
- No generated runtime/content data changes.
- Concurrency remains declared directly in each workflow YAML.
- `tests/workflow-concurrency-contract.test.ts` is the regression contract ensuring the selected workflows retain the policy.

## Regression contract
- All eight listed workflows must declare `group: ${{ github.workflow }}-${{ github.ref }}` and exactly one `cancel-in-progress: true`.
- No workflow may silently flip cancellation off without an explicit contract change.
- Workflow commands, triggers, and path scopes remain independently editable.

## Integration
Built from `c6450f9`. Current `main` advanced during implementation; this patch only touches the five named workflow files plus the existing concurrency contract test.