### PR TITLE
ci: cancel stale specialized audit runs

### DIFF
--- a/.github/workflows/ai-entity-enrichment-check.yml
+++ b/.github/workflows/ai-entity-enrichment-check.yml
@@ -12,6 +12,10 @@ on:
       - '.github/workflows/ai-entity-enrichment-check.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/botanical-atlas-coverage.yml
+++ b/.github/workflows/botanical-atlas-coverage.yml
@@ -21,6 +21,10 @@ on:
       - '.github/workflows/botanical-atlas-coverage.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/related-botanicals-audit.yml
+++ b/.github/workflows/related-botanicals-audit.yml
@@ -21,6 +21,10 @@ on:
       - 'scripts/audit-related-botanicals.ts'
       - 'scripts/rank-related-comparisons.ts'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/research-distribution.yml
+++ b/.github/workflows/research-distribution.yml
@@ -13,6 +13,10 @@ on:
       - 'app/evidence/research-trends/**'
       - '.github/workflows/research-distribution.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/schema-media-governance.yml
+++ b/.github/workflows/schema-media-governance.yml
@@ -27,6 +27,10 @@ on:
       - '.github/workflows/schema-media-governance.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/scripts/ci/workflow-concurrency.test.mjs
+++ b/scripts/ci/workflow-concurrency.test.mjs
@@ -6,6 +6,11 @@ const workflows = [
   '.github/workflows/check.yml',
   '.github/workflows/fast-ui-check.yml',
   '.github/workflows/atomic-upgrade-gate.yml',
+  '.github/workflows/schema-media-governance.yml',
+  '.github/workflows/related-botanicals-audit.yml',
+  '.github/workflows/ai-entity-enrichment-check.yml',
+  '.github/workflows/botanical-atlas-coverage.yml',
+  '.github/workflows/research-distribution.yml',
 ]
 
 const concurrencyContract = /\nconcurrency:\s*\n\s+group:\s*\$\{\{\s*github\.workflow\s*\}\}-\$\{\{\s*github\.ref\s*\}\}\s*\n\s+cancel-in-progress:\s*true\b/


### PR DESCRIPTION
Closes #3158

## Relevant URLs
- CI/Actions infrastructure only; no public route or content changes.

## Acceptance criteria
- Schema and Media Governance, Related Botanicals Quality Audit, AI Entity Enrichment Check, Botanical Activity Atlas Coverage, and Research Distribution use per-workflow/per-ref concurrency.
- Newer runs cancel obsolete runs for the same workflow/ref.
- Different PR refs remain independent.
- Existing triggers, path filters, commands, timeouts, permissions, artifacts, and validation coverage remain unchanged.
- The existing concurrency regression contract covers all eight targeted workflows.

## Validation commands
- `npm test -- scripts/ci/workflow-concurrency.test.mjs`
- Existing workflow checks remain authoritative for their normal validation suites.

## Before → after metrics
- Before: 3 targeted workflows were protected by the shared stale-run cancellation contract; 5 specified specialized workflows were not.
- After: 8/8 targeted workflows declare `cancel-in-progress: true` with `${{ github.workflow }}-${{ github.ref }}` grouping.
- Diff audit: 6 files changed, 25 additions, 0 deletions.

## Generator/source-of-truth decision
- Workflow YAML remains the direct source of truth; no generated workflow layer is introduced.

## Regression contract
- `scripts/ci/workflow-concurrency.test.mjs` now verifies all eight targeted workflows retain the same-workflow/same-ref cancellation contract.