### PR TITLE
ROI #149: remove delayed redundant article intros

### DIFF
--- a/app/articles/[slug]/page.tsx
+++ b/app/articles/[slug]/page.tsx
@@ -145,8 +145,6 @@ export default async function ArticleMonographPage({ params }: PageProps) {
           />
         </div>
 
-        <p className="text-reading mt-4 max-w-3xl">{page.description}</p>
-
         <div className="mt-6 flex flex-wrap items-center gap-x-3 gap-y-2 border-t border-[color:var(--hs-hairline)] pt-4 text-xs text-[color:var(--hs-body)]">
           {author ? (
             <span>


### PR DESCRIPTION
Implements backlog item #149. After moving the direct evidence answer into the hero, the shared article renderer now removes the duplicated generic description paragraph that delayed the byline and research metadata. The result is a shorter, answer-first first screen.