### PR TITLE
feat(email): implement backlog 341-350 contextual lead magnets

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,6 +11,7 @@ import MobileBottomNav from '../src/components/mobile-bottom-nav'
 import ScrollToTopButton from '../src/components/ScrollToTopButton'
 import ClickTracker from '@/components/ClickTracker'
 import CommercialIntentBridge from '@/components/CommercialIntentBridge'
+import ContextualLeadMagnet from '@/components/ContextualLeadMagnet'
 import EmailReturnAttribution from '@/components/EmailReturnAttribution'
 import ConsentBanner from '../src/components/ConsentBanner'
 import CitationDrawerLazy from '@/components/education/CitationDrawerLazy'
@@ -143,6 +144,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             >
               <GlobalTOC />
               {children}
+              <ContextualLeadMagnet />
             </main>
             <Footer />
             <MobileBottomNav />

--- a/app/lead-magnets/[slug]/page.tsx
+++ b/app/lead-magnets/[slug]/page.tsx
@@ -1,0 +1,80 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { LEAD_MAGNETS, getLeadMagnet } from '@/lib/lead-magnets'
+import { buildPageMetadata } from '@/lib/seo'
+
+interface PageProps { params: Promise<{ slug: string }> }
+
+export const dynamicParams = false
+
+export function generateStaticParams() {
+  return Object.values(LEAD_MAGNETS).map((offer) => ({ slug: offer.slug }))
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params
+  const offer = getLeadMagnet(slug)
+  if (!offer) return {}
+  return buildPageMetadata({
+    title: offer.title,
+    description: offer.description,
+    path: `/lead-magnets/${offer.slug}`,
+  })
+}
+
+export default async function LeadMagnetResourcePage({ params }: PageProps) {
+  const { slug } = await params
+  const offer = getLeadMagnet(slug)
+  if (!offer) notFound()
+
+  return (
+    <main className='mx-auto max-w-5xl space-y-8 px-4 py-8 sm:py-10'>
+      <nav aria-label='Breadcrumb' className='text-sm text-muted'>
+        <Link href='/' className='font-semibold text-indigo-800 hover:underline'>Home</Link>
+        <span aria-hidden='true' className='mx-2'>/</span>
+        <Link href='/lead-magnets/' className='font-semibold text-indigo-800 hover:underline'>Free resources</Link>
+      </nav>
+
+      <section className='rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8'>
+        <p className='eyebrow-label'>{offer.eyebrow}</p>
+        <h1 className='mt-2 text-3xl font-bold tracking-tight text-ink sm:text-5xl'>{offer.title}</h1>
+        <p className='mt-4 max-w-4xl text-base leading-7 text-muted sm:text-lg'>{offer.description}</p>
+        <ul className='mt-5 grid gap-2 sm:grid-cols-3'>
+          {offer.bullets.map((bullet) => <li key={bullet} className='rounded-xl border border-brand-900/10 bg-brand-50/60 p-3 text-sm font-semibold leading-5 text-ink'>{bullet}</li>)}
+        </ul>
+        {offer.downloadHref ? (
+          <a href={offer.downloadHref} className='mt-6 inline-flex rounded-full bg-indigo-950 px-5 py-3 text-sm font-bold text-white hover:bg-indigo-900'>
+            {offer.downloadLabel || 'Download resource'} ↓
+          </a>
+        ) : null}
+      </section>
+
+      <section className='grid gap-5'>
+        {offer.sections.map((section, index) => (
+          <article key={section.title} className='rounded-2xl border border-brand-900/10 bg-white p-5 shadow-sm sm:p-6'>
+            <div className='flex gap-4'>
+              <span className='flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-indigo-950 text-sm font-bold text-white'>{index + 1}</span>
+              <div>
+                <h2 className='text-xl font-bold text-ink'>{section.title}</h2>
+                <ul className='mt-3 space-y-2 text-sm leading-6 text-muted'>
+                  {section.items.map((item) => <li key={item} className='flex gap-2'><span aria-hidden='true' className='mt-0.5 text-emerald-700'>✓</span><span>{item}</span></li>)}
+                </ul>
+              </div>
+            </div>
+          </article>
+        ))}
+      </section>
+
+      <section className='rounded-2xl border border-sky-900/15 bg-sky-50/60 p-5 text-sm leading-6 text-sky-950'>
+        <strong>Use this as a research framework, not a treatment plan.</strong> The resource helps organize evidence, product-quality, and safety questions. It does not determine whether a supplement is appropriate for a specific person.
+      </section>
+
+      <section className='flex flex-wrap gap-3 text-sm font-semibold'>
+        <Link href='/evidence/' className='text-indigo-800 hover:underline'>Explore the evidence database →</Link>
+        <Link href='/safety-checker/' className='text-indigo-800 hover:underline'>Open the Safety Checker →</Link>
+        <Link href='/learn/product-quality/' className='text-indigo-800 hover:underline'>Review product-quality criteria →</Link>
+      </section>
+    </main>
+  )
+}

--- a/app/lead-magnets/page.tsx
+++ b/app/lead-magnets/page.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { LEAD_MAGNETS } from '@/lib/lead-magnets'
+import { buildPageMetadata } from '@/lib/seo'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Free Supplement Research Resources',
+  description: 'Free evidence, sleep, stress, focus, label-reading, interaction, and supplement-buying research checklists from The Hippie Scientist.',
+  path: '/lead-magnets/',
+})
+
+export default function LeadMagnetsPage() {
+  const resources = Object.values(LEAD_MAGNETS)
+  return (
+    <main className='mx-auto max-w-6xl space-y-8 px-4 py-8 sm:py-10'>
+      <section className='rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8'>
+        <p className='eyebrow-label'>Free research resources</p>
+        <h1 className='mt-2 text-3xl font-bold tracking-tight text-ink sm:text-5xl'>Choose the checklist that matches what you are researching</h1>
+        <p className='mt-4 max-w-4xl text-base leading-7 text-muted sm:text-lg'>Instead of one generic download on every page, these resources are matched to sleep, stress, focus, safety, label reading, evidence literacy, and buying decisions.</p>
+      </section>
+
+      <section className='grid gap-4 md:grid-cols-2 lg:grid-cols-3'>
+        {resources.map((resource) => (
+          <article key={resource.slug} className='flex flex-col rounded-2xl border border-brand-900/10 bg-white p-5 shadow-sm'>
+            <p className='text-xs font-bold uppercase tracking-wide text-indigo-800'>{resource.eyebrow}</p>
+            <h2 className='mt-2 text-xl font-bold text-ink'>{resource.title}</h2>
+            <p className='mt-2 flex-1 text-sm leading-6 text-muted'>{resource.description}</p>
+            <Link href={`/lead-magnets/${resource.slug}/`} className='mt-4 font-bold text-indigo-800 hover:underline'>Open resource →</Link>
+          </article>
+        ))}
+      </section>
+    </main>
+  )
+}

--- a/components/ContextualLeadMagnet.tsx
+++ b/components/ContextualLeadMagnet.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import EmailCapture from '@/components/articles/EmailCapture'
+import { getContextualLeadMagnet, shouldShowContextualLeadMagnet } from '@/lib/lead-magnets'
+
+export default function ContextualLeadMagnet() {
+  const pathname = usePathname() || '/'
+  if (!shouldShowContextualLeadMagnet(pathname)) return null
+
+  const offer = getContextualLeadMagnet(pathname)
+  const resourceUrl = offer.downloadHref || `/lead-magnets/${offer.slug}/`
+
+  return (
+    <section className='container-page pb-4 pt-2' aria-label={`Free resource: ${offer.shortTitle}`}>
+      <EmailCapture
+        title={offer.title}
+        description={offer.description}
+        ctaLabel={`Email me the ${offer.shortTitle}`}
+        magnet={offer.slug}
+        resourceUrl={resourceUrl}
+        resourceLabel={offer.downloadLabel || `Open the ${offer.shortTitle}`}
+        eyebrow={offer.eyebrow}
+        placement='contextual-global'
+        disclaimer='Research education only. We ask for your email to deliver the resource and research updates; we do not ask for diagnoses, medications, or other health details here.'
+      />
+    </section>
+  )
+}

--- a/components/articles/EmailCapture.tsx
+++ b/components/articles/EmailCapture.tsx
@@ -1,8 +1,10 @@
 'use client'
 
-import { FormEvent, useId, useState } from 'react'
+import { FormEvent, useEffect, useId, useRef, useState } from 'react'
 import Link from 'next/link'
 import { trackEmailSignup } from '@/lib/analytics'
+import { CONSENT_CHANGE_EVENT, getConsent } from '@/lib/consent'
+import { trackLeadMagnetFunnelEvent } from '@/lib/lead-magnet-analytics'
 import TurnstileWidget, { turnstileEnabled } from '@/components/security/TurnstileWidget'
 
 type EmailCaptureProps = {
@@ -10,16 +12,32 @@ type EmailCaptureProps = {
   description: string
   ctaLabel: string
   magnet: string
+  resourceUrl?: string
+  resourceLabel?: string
+  eyebrow?: string
+  placement?: string
+  disclaimer?: string
 }
 
 type SubmitState = 'idle' | 'loading' | 'success' | 'error'
 
-const CHECKLIST_URL = '/lead-magnets/adhd-supplement-starter-checklist/'
+const DEFAULT_RESOURCE_URL = '/lead-magnets/adhd-supplement-starter-checklist/'
 
-export default function EmailCapture({ title, description, ctaLabel, magnet }: EmailCaptureProps) {
+export default function EmailCapture({
+  title,
+  description,
+  ctaLabel,
+  magnet,
+  resourceUrl = DEFAULT_RESOURCE_URL,
+  resourceLabel = 'Open your resource',
+  eyebrow = 'Free research resource',
+  placement = 'article-inline',
+  disclaimer = 'Educational content only. This resource does not replace individualized medical or medication guidance.',
+}: EmailCaptureProps) {
   const titleId = useId()
   const emailId = useId()
   const firstNameId = useId()
+  const impressionTracked = useRef(false)
   const [email, setEmail] = useState('')
   const [firstName, setFirstName] = useState('')
   const [confirmEmail, setConfirmEmail] = useState('')
@@ -27,6 +45,22 @@ export default function EmailCapture({ title, description, ctaLabel, magnet }: E
   const [turnstileResetKey, setTurnstileResetKey] = useState(0)
   const [state, setState] = useState<SubmitState>('idle')
   const [message, setMessage] = useState('')
+
+  useEffect(() => {
+    const trackImpression = () => {
+      if (impressionTracked.current || getConsent() !== 'granted') return
+      impressionTracked.current = true
+      trackLeadMagnetFunnelEvent('lead_magnet_impression', {
+        slug: magnet,
+        sourcePath: window.location.pathname,
+        placement,
+      })
+    }
+
+    trackImpression()
+    window.addEventListener(CONSENT_CHANGE_EVENT, trackImpression)
+    return () => window.removeEventListener(CONSENT_CHANGE_EVENT, trackImpression)
+  }, [magnet, placement])
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
@@ -39,6 +73,11 @@ export default function EmailCapture({ title, description, ctaLabel, magnet }: E
 
     setState('loading')
     setMessage('')
+    trackLeadMagnetFunnelEvent('lead_magnet_signup_attempt', {
+      slug: magnet,
+      sourcePath: window.location.pathname,
+      placement,
+    })
 
     try {
       const response = await fetch('/api/subscribe', {
@@ -59,9 +98,14 @@ export default function EmailCapture({ title, description, ctaLabel, magnet }: E
       }
 
       setState('success')
-      setMessage('You are subscribed. Open the checklist below.')
+      setMessage('You are subscribed. Your resource is ready below.')
       setTurnstileResetKey((value) => value + 1)
-      trackEmailSignup({ source: `article-${magnet}` })
+      trackEmailSignup({ source: `lead-magnet-${magnet}` })
+      trackLeadMagnetFunnelEvent('lead_magnet_signup_success', {
+        slug: magnet,
+        sourcePath: window.location.pathname,
+        placement,
+      })
     } catch (error) {
       setState('error')
       setMessage(error instanceof Error ? error.message : 'Could not subscribe this email right now.')
@@ -73,17 +117,17 @@ export default function EmailCapture({ title, description, ctaLabel, magnet }: E
   const statusClassName = state === 'error' ? 'text-sm leading-6 text-red-700' : 'text-sm leading-6 text-muted'
 
   return (
-    <aside className="my-10 rounded-3xl border border-brand-900/10 bg-brand-50/70 p-5 shadow-sm sm:p-7" aria-labelledby={titleId}>
+    <aside className="my-10 rounded-3xl border border-brand-900/10 bg-brand-50/70 p-5 shadow-sm sm:p-7" aria-labelledby={titleId} data-lead-magnet={magnet}>
       <div className="space-y-3">
-        <p className="eyebrow-label">Free printable checklist</p>
+        <p className="eyebrow-label">{eyebrow}</p>
         <h2 id={titleId} className="font-display text-2xl font-semibold tracking-tight text-ink sm:text-3xl">
           {title}
         </h2>
         <p className="max-w-2xl text-base leading-7 text-muted">{description}</p>
         <p className="text-sm leading-6 text-muted">
           Want to review it first?{' '}
-          <Link className="font-semibold text-brand-800 underline decoration-brand-700/35 underline-offset-4 hover:text-brand-900" href={CHECKLIST_URL}>
-            Preview and print the checklist
+          <Link className="font-semibold text-brand-800 underline decoration-brand-700/35 underline-offset-4 hover:text-brand-900" href={resourceUrl}>
+            Preview the resource
           </Link>
           .
         </p>
@@ -92,8 +136,8 @@ export default function EmailCapture({ title, description, ctaLabel, magnet }: E
       {state === 'success' ? (
         <div className="mt-6 rounded-2xl border border-brand-900/10 bg-white p-4 text-sm leading-6 text-muted">
           <p className="font-semibold text-ink">{message}</p>
-          <a className="mt-3 inline-flex rounded-full bg-brand-700 px-5 py-3 text-sm font-bold text-white transition hover:bg-brand-800" href={CHECKLIST_URL}>
-            Open the ADHD checklist
+          <a className="mt-3 inline-flex rounded-full bg-brand-700 px-5 py-3 text-sm font-bold text-white transition hover:bg-brand-800" href={resourceUrl}>
+            {resourceLabel}
           </a>
         </div>
       ) : (
@@ -127,7 +171,6 @@ export default function EmailCapture({ title, description, ctaLabel, magnet }: E
             />
           </div>
 
-          {/* Honeypot field to catch spam bots */}
           <div style={{ display: 'none' }} aria-hidden="true">
             <label htmlFor="confirmEmail">Do not fill this field if you are a human</label>
             <input
@@ -151,15 +194,8 @@ export default function EmailCapture({ title, description, ctaLabel, magnet }: E
             {isLoading ? 'Sending…' : ctaLabel}
           </button>
 
-          {message ? (
-            <p className={statusClassName} role="status">
-              {message}
-            </p>
-          ) : null}
-
-          <p className="text-xs leading-5 text-muted">
-            Educational content only. No supplement checklist replaces medical care or prescribed ADHD treatment.
-          </p>
+          {message ? <p className={statusClassName} role="status">{message}</p> : null}
+          <p className="text-xs leading-5 text-muted">{disclaimer}</p>
         </form>
       )}
     </aside>

--- a/public/lead-magnets/questions-to-ask-before-buying-supplements.pdf
+++ b/public/lead-magnets/questions-to-ask-before-buying-supplements.pdf
@@ -1,0 +1,72 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<</F1 2 0 R/F2 3 0 R/F3 4 0 R>>
+endobj
+2 0 obj
+<</BaseFont/Helvetica/Encoding/WinAnsiEncoding/Name/F1/Subtype/Type1/Type/Font>>
+endobj
+3 0 obj
+<</BaseFont/Helvetica-Bold/Encoding/WinAnsiEncoding/Name/F2/Subtype/Type1/Type/Font>>
+endobj
+4 0 obj
+<</BaseFont/Helvetica-Oblique/Encoding/WinAnsiEncoding/Name/F3/Subtype/Type1/Type/Font>>
+endobj
+5 0 obj
+<</Contents 10 0 R/MediaBox[0 0 612 792]/Parent 9 0 R/Resources<</Font 1 0 R/ProcSet[/PDF/Text]>>/Rotate 0/Trans<<>>/Type/Page>>
+endobj
+6 0 obj
+<</Contents 11 0 R/MediaBox[0 0 612 792]/Parent 9 0 R/Resources<</Font 1 0 R/ProcSet[/PDF/Text]>>/Rotate 0/Trans<<>>/Type/Page>>
+endobj
+7 0 obj
+<</Contents 12 0 R/MediaBox[0 0 612 792]/Parent 9 0 R/Resources<</Font 1 0 R/ProcSet[/PDF/Text]>>/Rotate 0/Trans<<>>/Type/Page>>
+endobj
+8 0 obj
+<</PageMode/UseNone/Pages 9 0 R/Type/Catalog>>
+endobj
+9 0 obj
+<</Count 3/Kids[5 0 R 6 0 R 7 0 R]/Type/Pages>>
+endobj
+10 0 obj
+<</Filter[/ASCII85Decode/FlateDecode]/Length 3062>>
+stream
+GapPd0a]HT&Hl\,Q0Q3=(JGQ*GMq,US\bJQ=h]rtS_Yi^^_Q(0*I/La;cPAj9")CeB9[Y#\/Td2iAF)W.aRI*](Jj]0B"0IC)2k]>UTkDXW*:cCJ/(/D=jSa^rfP'2Lf99n_+.TNG_Jl=rtJ^d\4('5#DtmdC_Nh<V#=puQ9iaaR>@YF2F5:FUbd?MWO)X"dgMgTNkr>b[Ulk\B"C)=>>7q8J%]]sRK-H q87oeJ<GAJl>hg#$WgG:Uu4N7N*W~>endstream
+endobj
+12 0 obj
+<</Filter[/ASCII85Decode/FlateDecode]/Length 1256>>
+stream
+GapQh0E1<FaM(CbBp'1Mf*"C*G-XtzN6vg>NrA;6EGn(2dueU$%AZ%KA9-^[Jn<4k+X5ZA3I=n8Jjh;;?Mx%8u3n#INe>L-9Ka2{mjNureu/u^]K\ESw0X6$kgY,;G*IaBqdSAMFg^($~>endstream
+endobj
+11 0 obj
+<</Filter[/ASCII85Decode/FlateDecode]/Length 2223>>
+stream
+GapQh0E1<Fam,Pa\b(e7crP`bGh8jiMDMELZ?jCe`Qh-m=aO>K.3E>7(</qc`I0p8$%IF0VITwpQ(h%L]?V-MC>cT;S-g:0^X+*diRFp>[,bA&#<j%%56Fa6"aJDnBBl4p<pGbSH9'&omdd:lIlT`;KH3I=8^*SDu?knAE@t<^@f1Hm(Wm/bV0d^?!u8B2iwC)TS@\UK$D-llY+xj5>epstream
+endobj
+xref
+0 13
+0000000000 65535 f 
+0000000073 00000 n 
+0000000121 00000 n 
+0000000228 00000 n 
+0000000339 00000 n 
+0000000453 00000 n 
+0000000585 00000 n 
+0000000717 00000 n 
+0000000849 00000 n 
+0000000917 00000 n 
+0000000982 00000 n 
+0000004141 00000 n 
+0000006441 00000 n 
+trailer
+<</ID [<d53fb7d63d8d194fa967ec4845c11c91><d53fb7d63d8d194fa967ec4845c11c91>]
+/Info 13 0 R
+/Root 8 0 R
+/Size 13>>
+startxref
+7774
+%%EOF
+13 0 obj
+<</Author (anonymous) /CreationDate (D:20260816024605-00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20260816024605-00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+/Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj

--- a/scripts/analytics/build-lead-magnet-report.mjs
+++ b/scripts/analytics/build-lead-magnet-report.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const inputPath = process.argv[2] || path.join(root, 'ops', 'analytics', 'lead-magnet-events.json')
+const outputPath = process.argv[3] || path.join(root, 'reports', 'lead-magnet-conversion.json')
+
+const raw = fs.existsSync(inputPath) ? JSON.parse(fs.readFileSync(inputPath, 'utf8')) : []
+const events = Array.isArray(raw) ? raw : Array.isArray(raw.events) ? raw.events : []
+const byOffer = new Map()
+
+for (const event of events) {
+  const name = String(event.name || event.event || '')
+  if (!['lead_magnet_impression', 'lead_magnet_signup_attempt', 'lead_magnet_signup_success'].includes(name)) continue
+  const payload = event.payload || event
+  const slug = String(payload.lead_magnet_slug || payload.slug || '').trim()
+  if (!slug) continue
+  const row = byOffer.get(slug) || { slug, impressions: 0, attempts: 0, successes: 0, placements: {}, sourcePaths: {} }
+  if (name === 'lead_magnet_impression') row.impressions += 1
+  if (name === 'lead_magnet_signup_attempt') row.attempts += 1
+  if (name === 'lead_magnet_signup_success') row.successes += 1
+  const placement = String(payload.placement || 'unknown')
+  const sourcePath = String(payload.source_path || 'unknown')
+  row.placements[placement] = (row.placements[placement] || 0) + 1
+  row.sourcePaths[sourcePath] = (row.sourcePaths[sourcePath] || 0) + 1
+  byOffer.set(slug, row)
+}
+
+const offers = Array.from(byOffer.values()).map((row) => ({
+  ...row,
+  submitRate: row.impressions ? row.attempts / row.impressions : null,
+  confirmedSuccessRate: row.impressions ? row.successes / row.impressions : null,
+  completionRateAfterSubmit: row.attempts ? row.successes / row.attempts : null,
+})).sort((a, b) => (b.confirmedSuccessRate ?? -1) - (a.confirmedSuccessRate ?? -1) || b.impressions - a.impressions)
+
+const report = {
+  generatedAt: new Date().toISOString(),
+  inputPath,
+  definitions: {
+    submitRate: 'signup attempts / qualified offer impressions',
+    confirmedSuccessRate: 'successful subscribe responses / qualified offer impressions',
+    completionRateAfterSubmit: 'successful subscribe responses / signup attempts',
+  },
+  offers,
+}
+
+fs.mkdirSync(path.dirname(outputPath), { recursive: true })
+fs.writeFileSync(outputPath, `${JSON.stringify(report, null, 2)}\n`)
+console.log(`Wrote lead magnet conversion report for ${offers.length} offer(s) to ${outputPath}`)

--- a/src/lib/__tests__/lead-magnets.test.ts
+++ b/src/lib/__tests__/lead-magnets.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import {
+  LEAD_MAGNETS,
+  getContextualLeadMagnet,
+  getLeadMagnet,
+  shouldShowContextualLeadMagnet,
+} from '../lead-magnets'
+
+describe('contextual lead magnets', () => {
+  it('routes sleep research to the sleep-specific offer', () => {
+    expect(getContextualLeadMagnet('/guides/sleep/best-supplements-for-sleep/').slug).toBe('sleep-supplement-evidence-guide')
+    expect(getContextualLeadMagnet('/herbs/melatonin/').slug).toBe('sleep-supplement-evidence-guide')
+  })
+
+  it('routes stress and anxiety research to the stress-specific offer', () => {
+    expect(getContextualLeadMagnet('/guides/anxiety/').slug).toBe('anxiety-stress-evidence-cheat-sheet')
+    expect(getContextualLeadMagnet('/herbs/ashwagandha/').slug).toBe('anxiety-stress-evidence-cheat-sheet')
+  })
+
+  it('routes focus and nootropic research to the focus-specific offer', () => {
+    expect(getContextualLeadMagnet('/guides/focus/').slug).toBe('focus-supplement-evidence-cheat-sheet')
+    expect(getContextualLeadMagnet('/compounds/l-theanine/').slug).toBe('focus-supplement-evidence-cheat-sheet')
+  })
+
+  it('routes safety and interaction research to the interaction checklist', () => {
+    expect(getContextualLeadMagnet('/safety-checker/').slug).toBe('supplement-interaction-checklist')
+    expect(getContextualLeadMagnet('/safety-checker/interactions/st-johns-wort-antidepressants/').slug).toBe('supplement-interaction-checklist')
+  })
+
+  it('routes commercial comparison and buying research to the buying-questions PDF', () => {
+    expect(getContextualLeadMagnet('/learn/product-quality/').slug).toBe('questions-before-buying-supplements')
+    expect(getContextualLeadMagnet('/guides/compare/magnesium-vs-melatonin/').slug).toBe('questions-before-buying-supplements')
+  })
+
+  it('uses the label-reading guide for generic ingredient profiles', () => {
+    expect(getContextualLeadMagnet('/herbs/elderberry/').slug).toBe('supplement-label-reading-guide')
+    expect(getContextualLeadMagnet('/compounds/quercetin/').slug).toBe('supplement-label-reading-guide')
+  })
+
+  it('uses the evidence starter kit as the default offer', () => {
+    expect(getContextualLeadMagnet('/about/').slug).toBe('supplement-evidence-starter-kit')
+  })
+
+  it('suppresses the contextual capture on resource and policy pages', () => {
+    expect(shouldShowContextualLeadMagnet('/lead-magnets/sleep-supplement-evidence-guide/')).toBe(false)
+    expect(shouldShowContextualLeadMagnet('/privacy/')).toBe(false)
+    expect(shouldShowContextualLeadMagnet('/terms/')).toBe(false)
+    expect(shouldShowContextualLeadMagnet('/herbs/ashwagandha/')).toBe(true)
+  })
+
+  it('keeps every registered resource addressable by its stable slug', () => {
+    const offers = Object.values(LEAD_MAGNETS)
+    expect(new Set(offers.map((offer) => offer.slug)).size).toBe(offers.length)
+    for (const offer of offers) expect(getLeadMagnet(offer.slug)).toBe(offer)
+  })
+
+  it('ships the buying checklist as a real PDF asset', () => {
+    const offer = LEAD_MAGNETS['questions-before-buying-supplements']
+    expect(offer.downloadHref).toBe('/lead-magnets/questions-to-ask-before-buying-supplements.pdf')
+    expect(offer.downloadHref).toMatch(/\.pdf$/)
+  })
+})

--- a/src/lib/lead-magnet-analytics.ts
+++ b/src/lib/lead-magnet-analytics.ts
@@ -1,0 +1,23 @@
+'use client'
+
+import { canTrackAnalytics } from '@/lib/consent'
+
+export type LeadMagnetFunnelEvent = 'lead_magnet_impression' | 'lead_magnet_signup_attempt' | 'lead_magnet_signup_success'
+
+export interface LeadMagnetAnalyticsInput {
+  slug: string
+  sourcePath: string
+  placement: string
+}
+
+export function trackLeadMagnetFunnelEvent(eventName: LeadMagnetFunnelEvent, input: LeadMagnetAnalyticsInput) {
+  if (typeof window === 'undefined' || !canTrackAnalytics()) return
+  const payload = {
+    lead_magnet_slug: input.slug,
+    source_path: input.sourcePath,
+    placement: input.placement,
+  }
+  window.dataLayer = window.dataLayer || []
+  window.dataLayer.push({ event: eventName, ...payload })
+  window.gtag?.('event', eventName, payload)
+}

--- a/src/lib/lead-magnets.ts
+++ b/src/lib/lead-magnets.ts
@@ -1,0 +1,151 @@
+export type LeadMagnetSlug =
+  | 'supplement-evidence-starter-kit'
+  | 'sleep-supplement-evidence-guide'
+  | 'anxiety-stress-evidence-cheat-sheet'
+  | 'focus-supplement-evidence-cheat-sheet'
+  | 'supplement-label-reading-guide'
+  | 'supplement-interaction-checklist'
+  | 'questions-before-buying-supplements'
+
+export interface LeadMagnetSection {
+  title: string
+  items: string[]
+}
+
+export interface LeadMagnet {
+  slug: LeadMagnetSlug
+  title: string
+  shortTitle: string
+  eyebrow: string
+  description: string
+  bullets: string[]
+  sections: LeadMagnetSection[]
+  downloadHref?: string
+  downloadLabel?: string
+}
+
+export const LEAD_MAGNETS: Record<LeadMagnetSlug, LeadMagnet> = {
+  'supplement-evidence-starter-kit': {
+    slug: 'supplement-evidence-starter-kit',
+    title: 'Supplement Evidence Starter Kit',
+    shortTitle: 'Evidence Starter Kit',
+    eyebrow: 'Free evidence toolkit',
+    description: 'A fast system for checking whether a supplement claim is backed by relevant human evidence, whether the dose and form match the research, and what uncertainty is still hiding underneath the headline.',
+    bullets: ['A five-minute evidence filter', 'Study-type and dose/form checkpoints', 'A safety and product-quality handoff'],
+    sections: [
+      { title: 'The five-minute evidence filter', items: ['Name the exact outcome instead of asking whether a supplement “works.”', 'Look for human evidence that directly studies that outcome.', 'Check whether the study form, extract, dose, duration, and population resemble the real question.', 'Separate a mechanism from a demonstrated outcome.', 'Keep limitations beside the conclusion instead of burying them.'] },
+      { title: 'Evidence strength checkpoints', items: ['Meta-analyses and systematic reviews can synthesize a body of research, but their quality depends on the included studies.', 'Randomized controlled trials can provide stronger causal evidence than observational studies for many efficacy questions.', 'Animal and in-vitro findings are useful for mechanism discovery but should not be presented as proven human benefits.', 'One positive trial is not the same as replicated evidence.'] },
+      { title: 'Before a buying decision', items: ['Confirm the current product matches the studied form when that matters.', 'Check dose transparency, third-party testing, and COA availability.', 'Review safety and medication interactions separately from efficacy.'] },
+    ],
+  },
+  'sleep-supplement-evidence-guide': {
+    slug: 'sleep-supplement-evidence-guide',
+    title: 'Sleep Supplement Evidence Guide',
+    shortTitle: 'Sleep Evidence Guide',
+    eyebrow: 'Sleep research cheat sheet',
+    description: 'A compact guide for separating sleep onset, sleep maintenance, relaxation, next-day effects, and evidence quality before comparing supplements.',
+    bullets: ['Separate sleep outcomes before comparing ingredients', 'Track dose, timing, duration, and next-day effects', 'Avoid treating sedation as proof of better sleep'],
+    sections: [
+      { title: 'Define the sleep outcome', items: ['Sleep onset: how long it takes to fall asleep.', 'Sleep maintenance: awakenings and time awake during the night.', 'Total sleep time and sleep efficiency are different outcomes.', 'Subjective sleep quality may improve even when objective sleep measures change little.', 'Next-day alertness and adverse effects belong in the same decision.'] },
+      { title: 'Evidence questions', items: ['Was the study randomized and controlled?', 'Was insomnia actually present in the study population?', 'How long was the trial?', 'Was the dose and form similar to what is sold?', 'Were benefits consistent across trials or concentrated in one study?'] },
+      { title: 'Safety handoff', items: ['Check additive sedation when combining several calming products.', 'Medication interactions and alcohol/CNS depressants require separate review.', 'Do not interpret “natural” as evidence of low risk.'] },
+    ],
+  },
+  'anxiety-stress-evidence-cheat-sheet': {
+    slug: 'anxiety-stress-evidence-cheat-sheet',
+    title: 'Anxiety & Stress Evidence Cheat Sheet',
+    shortTitle: 'Stress Evidence Cheat Sheet',
+    eyebrow: 'Stress research cheat sheet',
+    description: 'A practical way to distinguish stress outcomes, anxiety symptom scales, acute calming, chronic trials, and the limits of adaptogen-style claims.',
+    bullets: ['Separate stress from anxiety outcomes', 'Check scale, duration, population, and extract', 'Keep serotonergic and sedative cautions visible'],
+    sections: [
+      { title: 'Do not collapse every outcome into “calm”', items: ['Perceived stress scores are not identical to anxiety-disorder outcomes.', 'Acute calming and multi-week stress adaptation answer different questions.', 'Mood, sleep, and fatigue improvements can influence stress scores without proving a direct anxiolytic effect.'] },
+      { title: 'What to extract from a trial', items: ['Population and baseline symptom severity', 'Validated scale used', 'Extract/form and dose', 'Duration and dropout rate', 'Magnitude and consistency of the effect', 'Adverse events and medication exclusions'] },
+      { title: 'Safety handoff', items: ['Check serotonergic overlap where relevant.', 'Check additive sedation rather than assuming two calming agents are automatically complementary.', 'Use medication-specific review for prescriptions rather than a generic supplement list.'] },
+    ],
+  },
+  'focus-supplement-evidence-cheat-sheet': {
+    slug: 'focus-supplement-evidence-cheat-sheet',
+    title: 'Focus Supplement Evidence Cheat Sheet',
+    shortTitle: 'Focus Evidence Cheat Sheet',
+    eyebrow: 'Focus research cheat sheet',
+    description: 'A quick framework for separating attention, memory, reaction time, fatigue, wakefulness, and subjective focus so nootropic claims are compared on the outcome actually studied.',
+    bullets: ['Separate attention from memory and wakefulness', 'Distinguish stimulant effects from cognition evidence', 'Check baseline caffeine use, sleep, dose, and testing'],
+    sections: [
+      { title: 'Name the cognitive endpoint', items: ['Sustained attention', 'Working memory', 'Recall / learning', 'Reaction time', 'Executive function', 'Subjective focus or mental fatigue'] },
+      { title: 'Context that can change the result', items: ['Sleep deprivation versus well-rested participants', 'Baseline caffeine or stimulant exposure', 'Single-dose versus chronic use', 'Healthy participants versus diagnosed populations', 'Practice effects and multiple cognitive tests'] },
+      { title: 'Avoid the mechanism trap', items: ['A neurotransmitter or pathway effect is not a demonstrated improvement in attention.', 'Feeling stimulated is not the same as improved cognitive performance.', 'A statistically significant test result should still be judged by magnitude, replication, and relevance.'] },
+    ],
+  },
+  'supplement-label-reading-guide': {
+    slug: 'supplement-label-reading-guide',
+    title: 'Supplement Label-Reading Guide',
+    shortTitle: 'Label-Reading Guide',
+    eyebrow: 'Product-quality field guide',
+    description: 'A label-by-label checklist for dose transparency, standardized extracts, active-marker percentages, elemental mineral amounts, proprietary blends, and testing claims.',
+    bullets: ['Decode serving size and active dose', 'Spot form/extract mismatches', 'Know what “lab tested” does and does not prove'],
+    sections: [
+      { title: 'Start with the active amount', items: ['Read serving size before reading the front-label claim.', 'Find the amount of each active ingredient per serving.', 'For minerals, distinguish compound weight from elemental mineral amount when relevant.', 'A proprietary blend can prevent a meaningful studied-dose comparison.'] },
+      { title: 'Form and standardization', items: ['Identify the salt, extract, strain, or preparation when the evidence is form-specific.', 'Marker percentages describe composition; a higher percentage is not automatically better.', 'Do not assume evidence from one branded extract transfers to every generic product.'] },
+      { title: 'Testing language', items: ['“Third-party tested” is more useful when the lab, scope, or batch result is verifiable.', 'A COA should be current and tied to the product or batch when possible.', 'Relevant contaminant testing depends on the ingredient and manufacturing process.'] },
+    ],
+  },
+  'supplement-interaction-checklist': {
+    slug: 'supplement-interaction-checklist',
+    title: 'Supplement Interaction Checklist',
+    shortTitle: 'Interaction Checklist',
+    eyebrow: 'Safety research checklist',
+    description: 'A non-diagnostic checklist for researching ingredient-to-ingredient and supplement-to-medication interaction signals without turning missing data into “safe.”',
+    bullets: ['Documented vs theoretical interaction checkpoints', 'PK vs PD mechanism prompts', 'A rule for incomplete safety data'],
+    sections: [
+      { title: 'Classify the interaction question', items: ['Documented clinical interaction', 'Structured safety warning or class effect', 'Theoretical additive risk from mechanism', 'Unknown because relevant data is missing'] },
+      { title: 'Ask how the interaction could happen', items: ['Pharmacokinetic: absorption, metabolism, transport, or clearance changes exposure.', 'Pharmacodynamic: two agents push the same physiological effect, such as sedation or bleeding.', 'Mixed interactions can involve both pathways.'] },
+      { title: 'Screen common overlap categories', items: ['Sedation / CNS depression', 'Stimulation / cardiovascular load', 'Serotonergic effects', 'Bleeding / platelet effects', 'Blood-pressure effects', 'Drug-metabolism induction or inhibition', 'Liver cautions', 'Pregnancy / breastfeeding evidence gaps'] },
+    ],
+  },
+  'questions-before-buying-supplements': {
+    slug: 'questions-before-buying-supplements',
+    title: 'Questions to Ask Before Buying Supplements',
+    shortTitle: 'Buying Questions PDF',
+    eyebrow: 'Printable buying checklist',
+    description: 'A printable decision worksheet covering evidence fit, studied form, label transparency, product verification, safety boundaries, and reasons to skip a product.',
+    bullets: ['Six pre-purchase question groups', 'Two-product comparison worksheet', 'Evidence, safety, and quality kept separate'],
+    sections: [
+      { title: 'Before spending money', items: ['Does the ingredient have direct human evidence for the outcome I care about?', 'Does the product match the form and dose studied?', 'Is the label transparent enough to compare with the research?', 'Is testing and formulation information verifiable?', 'What safety or medication-interaction questions still need review?', 'What evidence or quality failure would make me skip it?'] },
+      { title: 'Use the worksheet side by side', items: ['Compare form, active amount, standardization, testing, COA status, formulation verification, safety cautions, and evidence context.', 'Treat a blank field as a data gap, not a positive score.', 'Never let a retailer link or commission raise either an evidence grade or a product-quality score.'] },
+    ],
+    downloadHref: '/lead-magnets/questions-to-ask-before-buying-supplements.pdf',
+    downloadLabel: 'Download the printable PDF',
+  },
+}
+
+const sleepTerms = ['sleep', 'melatonin', 'valerian', 'chamomile']
+const stressTerms = ['anxiety', 'stress', 'ashwagandha', 'rhodiola', 'saffron']
+const focusTerms = ['focus', 'cognition', 'adhd', 'nootropic', 'l-theanine', 'caffeine', 'bacopa', 'lion-s-mane', 'lions-mane', 'citicoline', 'alpha-gpc']
+
+function containsAny(path: string, terms: string[]) {
+  return terms.some((term) => path.includes(term))
+}
+
+export function getLeadMagnet(slug: string) {
+  return LEAD_MAGNETS[slug as LeadMagnetSlug]
+}
+
+export function getContextualLeadMagnet(pathname: string): LeadMagnet {
+  const path = pathname.toLowerCase()
+  if (path.includes('/safety-checker') || path.includes('interaction')) return LEAD_MAGNETS['supplement-interaction-checklist']
+  if (path.includes('/learn/product-quality') || path.includes('/buy-guide') || path.includes('/guides/best') || path.includes('/compare/')) return LEAD_MAGNETS['questions-before-buying-supplements']
+  if (containsAny(path, sleepTerms)) return LEAD_MAGNETS['sleep-supplement-evidence-guide']
+  if (containsAny(path, stressTerms)) return LEAD_MAGNETS['anxiety-stress-evidence-cheat-sheet']
+  if (containsAny(path, focusTerms)) return LEAD_MAGNETS['focus-supplement-evidence-cheat-sheet']
+  if (path.startsWith('/herbs/') || path.startsWith('/compounds/')) return LEAD_MAGNETS['supplement-label-reading-guide']
+  return LEAD_MAGNETS['supplement-evidence-starter-kit']
+}
+
+export function shouldShowContextualLeadMagnet(pathname: string) {
+  const path = pathname.toLowerCase()
+  if (path.startsWith('/lead-magnets/')) return false
+  if (path.startsWith('/api/')) return false
+  if (path.includes('/privacy') || path.includes('/terms') || path.includes('/corrections')) return false
+  return true
+}


### PR DESCRIPTION
Implements backlog 341–350 as one contextual lead-magnet system.

Coverage:
- upgrades the generic opt-in into a structured Supplement Evidence Starter Kit
- adds Sleep Supplement Evidence Guide
- adds Anxiety & Stress Evidence Cheat Sheet
- adds Focus Supplement Evidence Cheat Sheet
- adds Supplement Label-Reading Guide
- adds Supplement Interaction Checklist
- adds a real printable 3-page “Questions to Ask Before Buying Supplements” PDF plus web resource
- central lead-magnet registry and reusable statically generated resource template
- global contextual offer selection by page intent instead of showing the same generic opt-in everywhere
- dedicated free-resource library
- `/api/subscribe` success is used as the confirmed conversion event; impressions and attempts are tracked separately
- consent-aware per-offer funnel telemetry: impression → signup attempt → confirmed signup success
- report generator measures submit rate, confirmed opt-in conversion rate, and post-submit completion by offer, placement, and source page
- capture form preserves honeypot + Turnstile protection and explicitly avoids requesting diagnosis/medication/other health details
- contextual routing regression tests