### PR TITLE
ROI #150: guarantee 2–4 sentence citation-ready article summaries

### DIFF
--- a/app/articles/[slug]/page.tsx
+++ b/app/articles/[slug]/page.tsx
@@ -7,7 +7,11 @@ import ArticleMdx from '@/components/articles/ArticleMdx'
 import JsonLd from '@/components/seo/JsonLd'
 import ContentCards from '@/components/content/ContentCards'
 import WhatEvidenceShows from '@/src/components/evidence/WhatEvidenceShows'
-import { normalizeCitationMetadata, resolveRelatedArticles } from '@/src/lib/article-citation-metadata'
+import {
+  buildCitationReadySummary,
+  normalizeCitationMetadata,
+  resolveRelatedArticles,
+} from '@/src/lib/article-citation-metadata'
 import { SITE_URL, buildPageMetadata, compactMetaTitle } from '../../../src/lib/seo'
 
 const articlePages = [...allArticleMonographs, ...allBlogPosts]
@@ -41,6 +45,12 @@ export default async function ArticleMonographPage({ params }: PageProps) {
 
   const relatedPages = resolveRelatedArticles(page, articlePages)
   const { keyTakeaways, citationQuestions, canonicalConcepts } = normalizeCitationMetadata(page)
+  const citationReadySummary = buildCitationReadySummary({
+    description: page.description,
+    keyTakeaways,
+    sourceCount: page.references.length,
+    evidenceGrade: page.evidenceGrade,
+  })
 
   const author = 'author' in page ? page.author : undefined
   const reviewedBy = 'reviewedBy' in page && page.reviewedBy ? page.reviewedBy : undefined
@@ -56,6 +66,7 @@ export default async function ArticleMonographPage({ params }: PageProps) {
     '@type': 'Article',
     headline: page.title,
     description: page.description,
+    abstract: citationReadySummary,
     dateModified: page.lastUpdated,
     datePublished: page.date ?? page.lastUpdated,
     mainEntityOfPage: `${SITE_URL}/articles/${page.slug}/`,
@@ -138,10 +149,9 @@ export default async function ArticleMonographPage({ params }: PageProps) {
         <div className="mt-5 max-w-4xl">
           <WhatEvidenceShows
             id={`article-evidence-${page.slug}`}
-            summary={page.description}
+            summary={citationReadySummary}
             evidenceGrade={page.evidenceGrade}
             sourceCount={page.references.length}
-            keyPoints={keyTakeaways}
           />
         </div>
 

--- a/src/components/evidence/WhatEvidenceShows.tsx
+++ b/src/components/evidence/WhatEvidenceShows.tsx
@@ -35,7 +35,13 @@ export default function WhatEvidenceShows({
       <h2 id={`${id}-title`} className="mt-3 text-xl font-semibold tracking-tight text-ink">
         Direct answer
       </h2>
-      <p className="mt-2 text-base leading-7 text-[color:var(--hs-body)]">{summary}</p>
+      <p
+        className="mt-2 text-base leading-7 text-[color:var(--hs-body)]"
+        data-citation-ready-summary="true"
+        itemProp="abstract"
+      >
+        {summary}
+      </p>
 
       {visiblePoints.length > 0 ? (
         <ul className="mt-4 space-y-2 text-sm leading-6 text-[color:var(--hs-body)]">

--- a/src/lib/__tests__/article-citation-metadata.test.ts
+++ b/src/lib/__tests__/article-citation-metadata.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  buildCitationReadySummary,
   normalizeCitationMetadata,
   resolveRelatedArticles,
 } from '../article-citation-metadata'
@@ -18,6 +19,55 @@ function page(
     relatedSlugs,
   }
 }
+
+function sentenceCount(value: string) {
+  return value
+    .split(/(?<=[.!?])\s+(?=[A-Z0-9“"'])/)
+    .map((sentence) => sentence.trim())
+    .filter(Boolean).length
+}
+
+describe('buildCitationReadySummary', () => {
+  it('keeps authored summaries between two and four sentences', () => {
+    const summary = buildCitationReadySummary({
+      description: 'The first authored sentence states the direct conclusion.',
+      keyTakeaways: [
+        'The second authored sentence preserves an important qualification.',
+        'The third authored sentence adds population context.',
+        'The fourth authored sentence adds formulation context.',
+        'A fifth sentence should not appear in the concise summary.',
+      ],
+      sourceCount: 12,
+      evidenceGrade: 'B',
+    })
+
+    expect(sentenceCount(summary)).toBe(4)
+    expect(summary).not.toContain('A fifth sentence')
+  })
+
+  it('adds only verifiable page metadata when one authored sentence is available', () => {
+    const summary = buildCitationReadySummary({
+      description: 'The authored description supplies the scientific conclusion.',
+      sourceCount: 7,
+      evidenceGrade: 'B',
+    })
+
+    expect(sentenceCount(summary)).toBe(2)
+    expect(summary).toContain('7 cited sources')
+    expect(summary).toContain('overall evidence as B')
+  })
+
+  it('deduplicates identical authored sentences', () => {
+    const summary = buildCitationReadySummary({
+      description: 'Keep this conclusion.',
+      keyTakeaways: ['Keep this conclusion.', 'Preserve this limitation.'],
+      sourceCount: 3,
+    })
+
+    expect(summary.match(/Keep this conclusion\./g)).toHaveLength(1)
+    expect(sentenceCount(summary)).toBe(2)
+  })
+})
 
 describe('resolveRelatedArticles', () => {
   const articles = [

--- a/src/lib/article-citation-metadata.ts
+++ b/src/lib/article-citation-metadata.ts
@@ -18,6 +18,13 @@ export type ArticleCitationMetadata = {
   canonicalConcepts?: string[]
 }
 
+export type CitationReadySummaryInput = {
+  description: string
+  keyTakeaways?: string[]
+  sourceCount?: number
+  evidenceGrade?: string | null
+}
+
 function isRelatedArticle(
   article: ArticleRelationshipRecord | undefined,
   currentSlug: string
@@ -51,6 +58,79 @@ function categoryFallbacks(
   return rotated.filter(
     (article) => article.slug !== current.slug && !excludedSlugs.has(article.slug)
   )
+}
+
+function cleanSentence(value: string): string {
+  const cleaned = value.replace(/\s+/g, ' ').trim()
+  if (!cleaned) return ''
+  return /[.!?]$/.test(cleaned) ? cleaned : `${cleaned}.`
+}
+
+function splitSentences(value: string): string[] {
+  const cleaned = value.replace(/\s+/g, ' ').trim()
+  if (!cleaned) return []
+
+  return cleaned
+    .split(/(?<=[.!?])\s+(?=[A-Z0-9“"'])/)
+    .map(cleanSentence)
+    .filter(Boolean)
+}
+
+function uniqueSentences(values: string[]): string[] {
+  const seen = new Set<string>()
+  const unique: string[] = []
+
+  for (const value of values) {
+    const sentence = cleanSentence(value)
+    if (!sentence) continue
+    const key = sentence.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+    unique.push(sentence)
+  }
+
+  return unique
+}
+
+/**
+ * Build a 2–4 sentence extractive summary from authored article metadata.
+ * Scientific claims come only from the authored description/takeaways; any
+ * fallback sentence describes verifiable page metadata rather than efficacy.
+ */
+export function buildCitationReadySummary({
+  description,
+  keyTakeaways = [],
+  sourceCount = 0,
+  evidenceGrade,
+}: CitationReadySummaryInput): string {
+  const authoredSentences = uniqueSentences([
+    ...splitSentences(description),
+    ...keyTakeaways.map(cleanSentence),
+  ])
+
+  const selected = authoredSentences.slice(0, 4)
+
+  if (selected.length < 2) {
+    if (sourceCount > 0 && evidenceGrade) {
+      selected.push(
+        `The page labels the overall evidence as ${evidenceGrade} and links ${sourceCount} cited source${sourceCount === 1 ? '' : 's'} for verification.`
+      )
+    } else if (sourceCount > 0) {
+      selected.push(
+        `The page links ${sourceCount} cited source${sourceCount === 1 ? '' : 's'} for verification.`
+      )
+    } else if (evidenceGrade) {
+      selected.push(`The page labels the overall evidence as ${evidenceGrade} and presents the detailed evidence below.`)
+    } else {
+      selected.push('The detailed evidence and limitations are presented below.')
+    }
+  }
+
+  if (selected.length < 2) {
+    selected.push('The full article provides the supporting context and source details.')
+  }
+
+  return selected.slice(0, 4).join(' ')
 }
 
 export function resolveRelatedArticles(


### PR DESCRIPTION
Implements backlog item #150. Adds a deterministic summary builder that composes 2–4 sentences from authored descriptions and takeaways, using only verifiable page metadata as fallback when a second sentence is needed. Article heroes now render that summary, expose it with `data-citation-ready-summary`/`itemProp="abstract"`, and include it as Article JSON-LD `abstract`. Tests enforce sentence count, metadata-only fallback, and deduplication.