### PR TITLE
fix(seo): detect canonical host redirects that lose paths

### DIFF
--- a/.github/workflows/technical-seo-monitor.yml
+++ b/.github/workflows/technical-seo-monitor.yml
@@ -12,7 +12,7 @@ on:
       - 'app/sitemap.ts'
       - 'app/robots.ts'
       - 'scripts/ci/audit-technical-seo-contract.mjs'
-      - 'scripts/monitor/production-seo-health.mjs'
+      - 'scripts/monitor/production-seo-health*.mjs'
       - '.github/workflows/technical-seo-monitor.yml'
   push:
     branches: [main]
@@ -23,7 +23,7 @@ on:
       - 'src/lib/seo.ts'
       - 'src/lib/site.ts'
       - 'scripts/ci/audit-technical-seo-contract.mjs'
-      - 'scripts/monitor/production-seo-health.mjs'
+      - 'scripts/monitor/production-seo-health*.mjs'
       - '.github/workflows/technical-seo-monitor.yml'
   schedule:
     - cron: '17 11 * * 1'

--- a/scripts/monitor/production-seo-health-lib.mjs
+++ b/scripts/monitor/production-seo-health-lib.mjs
@@ -1,0 +1,35 @@
+export const CANONICAL_ORIGIN = 'https://thehippiescientist.net'
+
+export function evaluateHostNormalization({ inputUrl, result, label, canonicalOrigin = CANONICAL_ORIGIN }) {
+  const errors = []
+
+  if (!result?.response) {
+    errors.push({ type: 'redirect-overflow', label, chain: result?.chain || [] })
+    return errors
+  }
+
+  const requested = new URL(inputUrl)
+  const final = new URL(result.finalUrl)
+
+  if (final.origin !== canonicalOrigin) {
+    errors.push({ type: 'wrong-final-origin', label, finalUrl: result.finalUrl, chain: result.chain })
+  }
+  if (final.pathname !== requested.pathname) {
+    errors.push({
+      type: 'host-redirect-path-mismatch',
+      label,
+      expectedPath: requested.pathname,
+      finalPath: final.pathname,
+      finalUrl: result.finalUrl,
+      chain: result.chain,
+    })
+  }
+  if (result.chain.length > 3) {
+    errors.push({ type: 'host-redirect-chain-too-long', label, chain: result.chain })
+  }
+  if (result.response.status >= 400) {
+    errors.push({ type: 'host-normalization-error-status', label, status: result.response.status })
+  }
+
+  return errors
+}

--- a/scripts/monitor/production-seo-health.mjs
+++ b/scripts/monitor/production-seo-health.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
-const CANONICAL_ORIGIN = 'https://thehippiescientist.net'
+import { CANONICAL_ORIGIN, evaluateHostNormalization } from './production-seo-health-lib.mjs'
+
 const MAX_REDIRECTS = 6
 const SAMPLE_LIMIT = Number(process.argv.find((arg) => arg.startsWith('--sample='))?.split('=')[1] || 40)
 const errors = []
@@ -31,19 +32,13 @@ function soft404(html) {
 
 async function verifyHostNormalization(url, label) {
   const result = await fetchWithChain(url, { method: 'GET' })
-  if (!result.response) {
-    errors.push({ type: 'redirect-overflow', label, chain: result.chain })
-    return
-  }
-  const final = new URL(result.finalUrl)
-  if (final.origin !== CANONICAL_ORIGIN) errors.push({ type: 'wrong-final-origin', label, finalUrl: result.finalUrl, chain: result.chain })
-  if (result.chain.length > 3) errors.push({ type: 'host-redirect-chain-too-long', label, chain: result.chain })
-  if (result.response.status >= 400) errors.push({ type: 'host-normalization-error-status', label, status: result.response.status })
+  errors.push(...evaluateHostNormalization({ inputUrl: url, result, label }))
 }
 
-await verifyHostNormalization('http://thehippiescientist.net/', 'http-apex')
-await verifyHostNormalization('http://www.thehippiescientist.net/', 'http-www')
-await verifyHostNormalization('https://www.thehippiescientist.net/', 'https-www')
+const hostNormalizationPath = '/goals/'
+await verifyHostNormalization(`http://thehippiescientist.net${hostNormalizationPath}`, 'http-apex')
+await verifyHostNormalization(`http://www.thehippiescientist.net${hostNormalizationPath}`, 'http-www')
+await verifyHostNormalization(`https://www.thehippiescientist.net${hostNormalizationPath}`, 'https-www')
 
 const missingPath = `/__seo-monitor-definitely-gone-${Date.now()}/`
 const missing = await fetch(`${CANONICAL_ORIGIN}${missingPath}`, { redirect: 'manual', headers: { 'user-agent': 'TheHippieScientist-SEO-Monitor/1.0' } })

--- a/scripts/monitor/production-seo-health.test.mjs
+++ b/scripts/monitor/production-seo-health.test.mjs
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { evaluateHostNormalization } from './production-seo-health-lib.mjs'
+
+function result(finalUrl, chain = []) {
+  return { response: { status: 200 }, finalUrl, chain }
+}
+
+describe('production SEO host normalization', () => {
+  it('rejects canonical-host redirects that collapse the requested pathname', () => {
+    const errors = evaluateHostNormalization({
+      inputUrl: 'https://www.thehippiescientist.net/goals/',
+      label: 'https-www',
+      result: result('https://thehippiescientist.net/', [
+        { url: 'https://www.thehippiescientist.net/goals/', status: 301, location: 'https://thehippiescientist.net/' },
+        { url: 'https://thehippiescientist.net/', status: 200, location: '' },
+      ]),
+    })
+
+    expect(errors).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: 'host-redirect-path-mismatch',
+        expectedPath: '/goals/',
+        finalPath: '/',
+      }),
+    ]))
+  })
+
+  it('accepts canonical-host normalization that preserves the requested pathname', () => {
+    const errors = evaluateHostNormalization({
+      inputUrl: 'http://www.thehippiescientist.net/goals/',
+      label: 'http-www',
+      result: result('https://thehippiescientist.net/goals/', [
+        { url: 'http://www.thehippiescientist.net/goals/', status: 301, location: 'https://thehippiescientist.net/goals/' },
+        { url: 'https://thehippiescientist.net/goals/', status: 200, location: '' },
+      ]),
+    })
+
+    expect(errors).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #3168

## Relevant URLs
- `https://www.thehippiescientist.net/goals/`
- `https://thehippiescientist.net/goals/`

## Acceptance criteria
- Host normalization compares the final pathname with the requested pathname.
- The live production monitor probes a non-root route so path collapse is observable.
- Correct HTTP/WWW normalization that preserves `/goals/` passes.
- `/goals/` collapsing to `/` reports `host-redirect-path-mismatch`.
- The monitor's helper/test files remain inside the Technical SEO Monitor path trigger.
- This PR detects the account-level redirect defect; it does not pretend `_redirects` can repair a Cloudflare domain-level redirect.

## Validation commands
- `npx vitest run scripts/monitor/production-seo-health.test.mjs`
- `node scripts/monitor/production-seo-health.mjs --sample=1` is expected to report the currently-live WWW path-collapse until the Cloudflare edge redirect is corrected.

## Before → after metrics
- Before: 0 non-root host-normalization probes; path preservation was not asserted.
- After: 3 host-normalization probes exercise `/goals/`; path preservation is explicitly asserted; 2 focused regression cases cover bad and good redirects.

## Generator/source-of-truth decision
- No generated artifact changes. The live production monitor remains the source of truth for observed edge behavior; pure verdict logic lives in `scripts/monitor/production-seo-health-lib.mjs` for deterministic testing.

## Regression contract
- `scripts/monitor/production-seo-health.test.mjs` fails if a host redirect that collapses `/goals/` to `/` is treated as healthy, and verifies a path-preserving canonical redirect remains valid.