### PR TITLE
ci: scope full Site Health release validation

### DIFF
--- a/.github/workflows/atomic-upgrade-gate.yml
+++ b/.github/workflows/atomic-upgrade-gate.yml
@@ -50,29 +50,26 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: |
           git fetch origin "$BASE_REF" --depth=1
-          changed="$(git diff --name-only "origin/$BASE_REF"...HEAD)"
-          printf '%s\n' "$changed"
-          if printf '%s\n' "$changed" | grep -Eq '^(scripts/(data|build|pipeline|ci)/|scripts/(build|orchestrate|profile-build|generate-|create-content)|app/.+/(generateStaticParams|page\.)|lib/(content|data|seo|schema|routes|taxonomy)|public/data/|next\.config\.|package(-lock)?\.json)'; then
-            echo 'generator_changed=true' >> "$GITHUB_OUTPUT"
-          else
-            echo 'generator_changed=false' >> "$GITHUB_OUTPUT"
-          fi
+          changed_file="$RUNNER_TEMP/release-impact-files.txt"
+          git diff --name-only "origin/$BASE_REF"...HEAD > "$changed_file"
+          cat "$changed_file"
+          node scripts/ci/release-impact-classifier.mjs "$changed_file" >> "$GITHUB_OUTPUT"
 
       - name: Set up Node.js
-        if: steps.detect.outputs.generator_changed == 'true'
+        if: steps.detect.outputs.release_required == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
 
       - name: Install dependencies
-        if: steps.detect.outputs.generator_changed == 'true'
+        if: steps.detect.outputs.release_required == 'true'
         run: npm ci
 
       - name: Run complete release-quality suite
-        if: steps.detect.outputs.generator_changed == 'true'
+        if: steps.detect.outputs.release_required == 'true'
         run: npm run validate:release
 
       - name: No generator-level change
-        if: steps.detect.outputs.generator_changed != 'true'
+        if: steps.detect.outputs.release_required != 'true'
         run: echo 'No generator/structural files changed; standard CI remains authoritative.'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,6 +21,25 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Detect release-sensitive changes
+        id: detect
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo 'release_required=true' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git fetch origin "$BASE_REF" --depth=1
+          changed_file="$RUNNER_TEMP/release-impact-files.txt"
+          git diff --name-only "origin/$BASE_REF"...HEAD > "$changed_file"
+          cat "$changed_file"
+          node scripts/ci/release-impact-classifier.mjs "$changed_file" >> "$GITHUB_OUTPUT"
 
       - name: Use Node
         uses: actions/setup-node@v7
@@ -29,6 +48,7 @@ jobs:
           cache: npm
 
       - name: Cache Next.js build cache
+        if: steps.detect.outputs.release_required == 'true'
         uses: actions/cache@v6
         with:
           path: |
@@ -39,13 +59,19 @@ jobs:
             ${{ runner.os }}-nextjs-
 
       - name: Install deps
+        if: steps.detect.outputs.release_required == 'true'
         run: npm ci
 
       - name: Verify Node engine
         run: npm run check:node
 
       - name: Run full check
+        if: steps.detect.outputs.release_required == 'true'
         run: npm run check:full
+
+      - name: Delegate non-structural PR validation to standard CI
+        if: github.event_name == 'pull_request' && steps.detect.outputs.release_required != 'true'
+        run: echo 'No release-sensitive files changed; standard CI remains authoritative for this pull request.'
 
       - name: Generate Botanical Activity Atlas coverage report
         if: always()

--- a/scripts/ci/release-impact-classifier.mjs
+++ b/scripts/ci/release-impact-classifier.mjs
@@ -1,0 +1,36 @@
+import fs from 'node:fs'
+import { pathToFileURL } from 'node:url'
+
+const RELEASE_IMPACT_PATTERNS = [
+  /^scripts\/(?:data|build|pipeline|ci)\//,
+  /^scripts\/(?:build|orchestrate|profile-build|generate-|create-content)/,
+  /^app\/(?:.*\/)?page\.[^/]+$/,
+  /^app\/(?:.*\/)?route\.[^/]+$/,
+  /^app\/(?:sitemap|robots|manifest|feed)(?:\.|\/)/,
+  /^lib\/(?:content|data|seo|schema|routes|taxonomy)(?:[./]|$)/,
+  /^public\/data\//,
+  /^next\.config\./,
+  /^package(?:-lock)?\.json$/,
+]
+
+export function requiresFullRelease(paths) {
+  return paths.some((rawPath) => {
+    const filePath = String(rawPath || '').trim()
+    return filePath && RELEASE_IMPACT_PATTERNS.some((pattern) => pattern.test(filePath))
+  })
+}
+
+function readChangedPaths(filePath) {
+  const raw = filePath ? fs.readFileSync(filePath, 'utf8') : fs.readFileSync(0, 'utf8')
+  return raw.split(/\r?\n/).map((line) => line.trim()).filter(Boolean)
+}
+
+function main() {
+  const changedPaths = readChangedPaths(process.argv[2])
+  const releaseRequired = requiresFullRelease(changedPaths)
+  process.stdout.write(`release_required=${releaseRequired}\n`)
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main()
+}

--- a/scripts/ci/release-impact-classifier.test.mjs
+++ b/scripts/ci/release-impact-classifier.test.mjs
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { requiresFullRelease } from './release-impact-classifier.mjs'
+
+describe('release impact classifier', () => {
+  it.each([
+    'scripts/data/build-runtime-from-workbook.mjs',
+    'scripts/ci/validate-route-seo.mjs',
+    'scripts/build-deploy.mjs',
+    'app/page.tsx',
+    'app/herbs/[slug]/page.tsx',
+    'app/api/example/route.ts',
+    'app/sitemap.ts',
+    'lib/seo.ts',
+    'lib/schema/graph.ts',
+    'public/data/herbs.json',
+    'next.config.mjs',
+    'package.json',
+    'package-lock.json',
+  ])('treats %s as release-sensitive', (filePath) => {
+    expect(requiresFullRelease([filePath])).toBe(true)
+  })
+
+  it.each([
+    'components/Card.tsx',
+    'src/components/ProfileHero.tsx',
+    'tests/profile.test.ts',
+    'docs/build-and-verification.md',
+    '.github/workflows/check.yml',
+    'README.md',
+  ])('delegates %s to standard CI', (filePath) => {
+    expect(requiresFullRelease([filePath])).toBe(false)
+  })
+
+  it('requires full release when any changed path is release-sensitive', () => {
+    expect(requiresFullRelease(['docs/readme.md', 'app/compounds/page.tsx'])).toBe(true)
+  })
+})

--- a/tests/site-health-release-scope-contract.test.ts
+++ b/tests/site-health-release-scope-contract.test.ts
@@ -1,0 +1,35 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+}
+
+describe('release-impact workflow contract', () => {
+  it('keeps Atomic and Site Health on one shared classifier', () => {
+    const atomic = read('.github/workflows/atomic-upgrade-gate.yml')
+    const siteHealth = read('.github/workflows/check.yml')
+
+    expect(atomic).toContain('scripts/ci/release-impact-classifier.mjs')
+    expect(siteHealth).toContain('scripts/ci/release-impact-classifier.mjs')
+    expect(atomic).not.toContain("grep -Eq '^(scripts/")
+  })
+
+  it('always requires full release validation on integrated main', () => {
+    const siteHealth = read('.github/workflows/check.yml')
+
+    expect(siteHealth).toContain('if [ "$EVENT_NAME" != "pull_request" ]; then')
+    expect(siteHealth).toContain("echo 'release_required=true' >> \"$GITHUB_OUTPUT\"")
+  })
+
+  it('skips only the expensive duplicate PR work when release impact is false', () => {
+    const siteHealth = read('.github/workflows/check.yml')
+
+    expect(siteHealth).toContain("if: steps.detect.outputs.release_required == 'true'")
+    expect(siteHealth).toContain('run: npm ci')
+    expect(siteHealth).toContain('run: npm run check:full')
+    expect(siteHealth).toContain('Delegate non-structural PR validation to standard CI')
+    expect(siteHealth).toContain('Generate Botanical Activity Atlas coverage report')
+  })
+})


### PR DESCRIPTION
Superseded by merged PR #3173, which landed the shared release-impact classifier and scoped Site Health/Atomic release validation on `main`. This branch is not merged to avoid duplicating the policy.

A fresh-main follow-up is addressing classifier coverage that #3173 still misses (root `app/page.tsx`, route handlers, and route-infrastructure files such as `app/sitemap.ts`).