### PR TITLE
ci: share release-impact classifier and skip duplicate PR release runs

### DIFF
--- a/.github/workflows/atomic-upgrade-gate.yml
+++ b/.github/workflows/atomic-upgrade-gate.yml
@@ -44,35 +44,31 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Detect generator/structural changes
-        id: detect
+      - name: Classify release impact
+        id: impact
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
           git fetch origin "$BASE_REF" --depth=1
           changed="$(git diff --name-only "origin/$BASE_REF"...HEAD)"
           printf '%s\n' "$changed"
-          if printf '%s\n' "$changed" | grep -Eq '^(scripts/(data|build|pipeline|ci)/|scripts/(build|orchestrate|profile-build|generate-|create-content)|app/.+/(generateStaticParams|page\.)|lib/(content|data|seo|schema|routes|taxonomy)|public/data/|next\.config\.|package(-lock)?\.json)'; then
-            echo 'generator_changed=true' >> "$GITHUB_OUTPUT"
-          else
-            echo 'generator_changed=false' >> "$GITHUB_OUTPUT"
-          fi
+          printf '%s\n' "$changed" | node scripts/ci/classify-release-impact.mjs --github-output="$GITHUB_OUTPUT"
 
       - name: Set up Node.js
-        if: steps.detect.outputs.generator_changed == 'true'
+        if: steps.impact.outputs.release_sensitive == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
 
       - name: Install dependencies
-        if: steps.detect.outputs.generator_changed == 'true'
+        if: steps.impact.outputs.release_sensitive == 'true'
         run: npm ci
 
       - name: Run complete release-quality suite
-        if: steps.detect.outputs.generator_changed == 'true'
+        if: steps.impact.outputs.release_sensitive == 'true'
         run: npm run validate:release
 
-      - name: No generator-level change
-        if: steps.detect.outputs.generator_changed != 'true'
-        run: echo 'No generator/structural files changed; standard CI remains authoritative.'
+      - name: No release-sensitive change
+        if: steps.impact.outputs.release_sensitive != 'true'
+        run: echo 'No release-sensitive/structural files changed; standard CI remains authoritative.'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,14 +21,29 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Classify release impact
+        id: impact
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git fetch origin "$BASE_REF" --depth=1
+          changed="$(git diff --name-only "origin/$BASE_REF"...HEAD)"
+          printf '%s\n' "$changed"
+          printf '%s\n' "$changed" | node scripts/ci/classify-release-impact.mjs --github-output="$GITHUB_OUTPUT"
 
       - name: Use Node
+        if: github.event_name != 'pull_request' || steps.impact.outputs.release_sensitive == 'true'
         uses: actions/setup-node@v7
         with:
           node-version-file: .nvmrc
           cache: npm
 
       - name: Cache Next.js build cache
+        if: github.event_name != 'pull_request' || steps.impact.outputs.release_sensitive == 'true'
         uses: actions/cache@v6
         with:
           path: |
@@ -39,13 +54,20 @@ jobs:
             ${{ runner.os }}-nextjs-
 
       - name: Install deps
+        if: github.event_name != 'pull_request' || steps.impact.outputs.release_sensitive == 'true'
         run: npm ci
 
       - name: Verify Node engine
+        if: github.event_name != 'pull_request' || steps.impact.outputs.release_sensitive == 'true'
         run: npm run check:node
 
       - name: Run full check
+        if: github.event_name != 'pull_request' || steps.impact.outputs.release_sensitive == 'true'
         run: npm run check:full
+
+      - name: Delegate non-structural PR validation to standard CI
+        if: github.event_name == 'pull_request' && steps.impact.outputs.release_sensitive != 'true'
+        run: echo 'No release-sensitive files changed; standard CI remains authoritative for this PR.'
 
       - name: Generate Botanical Activity Atlas coverage report
         if: always()

--- a/scripts/ci/classify-release-impact.mjs
+++ b/scripts/ci/classify-release-impact.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+export const RELEASE_SENSITIVE_PATTERNS = [
+  /^scripts\/(?:data|build|pipeline|ci)\//,
+  /^scripts\/(?:build|orchestrate|profile-build|generate-|create-content)/,
+  /^app\/.+\/(?:generateStaticParams|page\.)/,
+  /^lib\/(?:content|data|seo|schema|routes|taxonomy)/,
+  /^public\/data\//,
+  /^next\.config\./,
+  /^package(?:-lock)?\.json$/,
+]
+
+export function isReleaseSensitivePath(file) {
+  const normalized = String(file || '').trim().replaceAll('\\', '/')
+  return Boolean(normalized) && RELEASE_SENSITIVE_PATTERNS.some((pattern) => pattern.test(normalized))
+}
+
+export function classifyReleaseImpact(files) {
+  const normalizedFiles = Array.from(new Set(
+    files.map((file) => String(file || '').trim().replaceAll('\\', '/')).filter(Boolean),
+  ))
+  const sensitiveFiles = normalizedFiles.filter(isReleaseSensitivePath)
+  return {
+    releaseSensitive: sensitiveFiles.length > 0,
+    sensitiveFiles,
+    files: normalizedFiles,
+  }
+}
+
+function main() {
+  const args = process.argv.slice(2)
+  const outputArg = args.find((arg) => arg.startsWith('--github-output='))
+  const fileArgs = args.filter((arg) => !arg.startsWith('--github-output='))
+  const input = fileArgs.length ? fileArgs : fs.readFileSync(0, 'utf8').split(/\r?\n/)
+  const result = classifyReleaseImpact(input)
+
+  for (const file of result.sensitiveFiles) console.log(`[release-impact] sensitive: ${file}`)
+  console.log(`[release-impact] release_sensitive=${result.releaseSensitive}`)
+
+  if (outputArg) {
+    const outputPath = outputArg.slice('--github-output='.length)
+    if (!outputPath) throw new Error('--github-output requires a file path')
+    fs.appendFileSync(outputPath, `release_sensitive=${result.releaseSensitive}\n`)
+  }
+}
+
+const entry = process.argv[1] ? pathToFileURL(path.resolve(process.argv[1])).href : ''
+if (entry && import.meta.url === entry) main()

--- a/scripts/ci/classify-release-impact.test.mjs
+++ b/scripts/ci/classify-release-impact.test.mjs
@@ -1,0 +1,55 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { classifyReleaseImpact, isReleaseSensitivePath } from './classify-release-impact.mjs'
+
+describe('release impact classification', () => {
+  it.each([
+    'scripts/data/build-runtime-from-workbook.mjs',
+    'scripts/ci/validate-route-seo.mjs',
+    'scripts/build-deploy.mjs',
+    'app/guides/example/page.tsx',
+    'lib/seo/canonical.ts',
+    'public/data/herbs.json',
+    'next.config.mjs',
+    'package.json',
+    'package-lock.json',
+  ])('classifies %s as release-sensitive', (file) => {
+    expect(isReleaseSensitivePath(file)).toBe(true)
+  })
+
+  it.each([
+    'components/Header.tsx',
+    'docs/build-and-verification.md',
+    'styles/globals.css',
+    '.github/workflows/lighthouse.yml',
+  ])('classifies %s as standard-CI-only', (file) => {
+    expect(isReleaseSensitivePath(file)).toBe(false)
+  })
+
+  it('normalizes, deduplicates, and reports the sensitive subset', () => {
+    expect(classifyReleaseImpact([
+      ' components/Header.tsx ',
+      'public\\data\\herbs.json',
+      'public/data/herbs.json',
+      '',
+    ])).toEqual({
+      releaseSensitive: true,
+      sensitiveFiles: ['public/data/herbs.json'],
+      files: ['components/Header.tsx', 'public/data/herbs.json'],
+    })
+  })
+})
+
+describe('workflow release-impact contract', () => {
+  const classifierCommand = 'node scripts/ci/classify-release-impact.mjs --github-output="$GITHUB_OUTPUT"'
+
+  it.each([
+    '.github/workflows/check.yml',
+    '.github/workflows/atomic-upgrade-gate.yml',
+  ])('%s consumes the shared classifier', (workflow) => {
+    const yaml = fs.readFileSync(path.join(process.cwd(), workflow), 'utf8')
+    expect(yaml).toContain(classifierCommand)
+    expect(yaml).toContain('steps.impact.outputs.release_sensitive')
+  })
+})


### PR DESCRIPTION
Closes #3167

## Relevant URLs
- CI/Actions infrastructure only; no public route changes.

## Acceptance criteria
- Site Health Check remains present on pull requests.
- Pushes to `main` still run `npm run check:full` / `validate:release`.
- Release-sensitive PRs still run the full Site Health release suite.
- Non-structural PRs skip setup/cache/install/full-release work in Site Health and explicitly delegate code validation to standard CI.
- Botanical Activity Atlas coverage/report upload still runs on every Site Health execution.
- Atomic Upgrade Gate and Site Health consume one shared release-impact classifier.
- Classifier and workflow-consumption behavior have focused regression coverage.

## Validation commands
- `npx vitest run scripts/ci/classify-release-impact.test.mjs scripts/ci/workflow-concurrency.test.mjs`
- Existing Site Health, Atomic Upgrade Gate, and standard CI runs remain authoritative for workflow integration.

## Before → after metrics
- Before: non-structural PRs could run the full release-quality suite in Site Health in addition to standard CI; release-impact classification existed only as an inline regex in Atomic Gate.
- After: one shared classifier feeds both workflows; non-structural Site Health PR runs execute checkout/classification + Atlas reporting rather than a second dependency install/full release suite.
- Main pushes and release-sensitive PRs retain full release validation.

## Generator/source-of-truth decision
- `scripts/ci/classify-release-impact.mjs` is the single source of truth for release-sensitive file classification. Workflow YAML only obtains changed files and consumes the classifier output.

## Regression contract
- `scripts/ci/classify-release-impact.test.mjs` verifies representative sensitive/non-sensitive paths, normalization/deduplication, and that both workflows consume the same classifier/output contract.