### PR TITLE
fix(ci): expand release-impact path coverage

### DIFF
--- a/scripts/ci/classify-release-impact.mjs
+++ b/scripts/ci/classify-release-impact.mjs
@@ -6,7 +6,10 @@ import { pathToFileURL } from 'node:url'
 export const RELEASE_SENSITIVE_PATTERNS = [
   /^scripts\/(?:data|build|pipeline|ci)\//,
   /^scripts\/(?:build|orchestrate|profile-build|generate-|create-content)/,
-  /^app\/.+\/(?:generateStaticParams|page\.)/,
+  /^app\/(?:.*\/)?(?:page|layout|template|default|error|global-error|not-found|loading)\.[^/]+$/,
+  /^app\/(?:.*\/)?route\.[^/]+$/,
+  /^app\/(?:.*\/)?generateStaticParams(?:[./]|$)/,
+  /^app\/(?:.*\/)?(?:sitemap|robots|manifest|feed|favicon|icon|apple-icon|opengraph-image|twitter-image)(?:[./]|$)/,
   /^lib\/(?:content|data|seo|schema|routes|taxonomy)/,
   /^public\/data\//,
   /^next\.config\./,

--- a/scripts/ci/classify-release-impact.mjs
+++ b/scripts/ci/classify-release-impact.mjs
@@ -10,8 +10,9 @@ export const RELEASE_SENSITIVE_PATTERNS = [
   /^app\/(?:.*\/)?route\.[^/]+$/,
   /^app\/(?:.*\/)?generateStaticParams(?:[./]|$)/,
   /^app\/(?:.*\/)?(?:sitemap|robots|manifest|feed|favicon|icon|apple-icon|opengraph-image|twitter-image)(?:[./]|$)/,
-  /^lib\/(?:content|data|seo|schema|routes|taxonomy)/,
+  /^(?:src\/)?lib\/(?:[^/]*-)?(?:content|data|seo|schema|routes?|taxonomy)(?:[-./]|$)/,
   /^public\/data\//,
+  /^public\/(?:_redirects|_headers)$/,
   /^next\.config\./,
   /^package(?:-lock)?\.json$/,
 ]

--- a/scripts/ci/classify-release-impact.test.mjs
+++ b/scripts/ci/classify-release-impact.test.mjs
@@ -8,7 +8,20 @@ describe('release impact classification', () => {
     'scripts/data/build-runtime-from-workbook.mjs',
     'scripts/ci/validate-route-seo.mjs',
     'scripts/build-deploy.mjs',
+    'app/page.tsx',
+    'app/layout.tsx',
     'app/guides/example/page.tsx',
+    'app/guides/example/layout.tsx',
+    'app/guides/example/loading.tsx',
+    'app/guides/example/error.tsx',
+    'app/guides/example/not-found.tsx',
+    'app/api/revalidate/route.ts',
+    'app/guides/example/generateStaticParams.ts',
+    'app/sitemap.ts',
+    'app/robots.ts',
+    'app/manifest.ts',
+    'app/icon.png',
+    'app/guides/opengraph-image.tsx',
     'lib/seo/canonical.ts',
     'public/data/herbs.json',
     'next.config.mjs',
@@ -19,6 +32,7 @@ describe('release impact classification', () => {
   })
 
   it.each([
+    'app/herbs/HerbsIndexClient.tsx',
     'components/Header.tsx',
     'docs/build-and-verification.md',
     'styles/globals.css',

--- a/scripts/ci/classify-release-impact.test.mjs
+++ b/scripts/ci/classify-release-impact.test.mjs
@@ -23,7 +23,15 @@ describe('release impact classification', () => {
     'app/icon.png',
     'app/guides/opengraph-image.tsx',
     'lib/seo/canonical.ts',
+    'lib/semantic-schema-graph.ts',
+    'src/lib/seo.ts',
+    'src/lib/goal-seo.ts',
+    'src/lib/schema-graph.ts',
+    'src/lib/schema-injector.ts',
+    'src/lib/runtime-data.ts',
     'public/data/herbs.json',
+    'public/_redirects',
+    'public/_headers',
     'next.config.mjs',
     'package.json',
     'package-lock.json',
@@ -34,9 +42,11 @@ describe('release impact classification', () => {
   it.each([
     'app/herbs/HerbsIndexClient.tsx',
     'components/Header.tsx',
+    'src/lib/affiliate-copy.ts',
     'docs/build-and-verification.md',
     'styles/globals.css',
     '.github/workflows/lighthouse.yml',
+    'public/hero-illustration.jpg',
   ])('classifies %s as standard-CI-only', (file) => {
     expect(isReleaseSensitivePath(file)).toBe(false)
   })


### PR DESCRIPTION
Superseded in part by merged #3178, which landed stronger App Router route-entry/handler/metadata coverage on `main`. This conflicting branch is closed rather than overwriting that work.

A fresh-main follow-up will preserve #3178 and add only the remaining uncovered release-sensitive classes: shared `src/lib` SEO/schema/data infrastructure plus deployed `public/_redirects` and `public/_headers`.