### PR TITLE
Clear current no-empty lint blockers in Node scripts

### DIFF
--- a/scripts/ci/audit-static-crawl-surface.mjs
+++ b/scripts/ci/audit-static-crawl-surface.mjs
@@ -20,7 +20,11 @@ if (!fs.existsSync(outDir)) {
 
 function normalizeRoute(input) {
   let value = input || '/'
-  try { value = new URL(value, 'https://thehippiescientist.net').pathname } catch {}
+  try {
+    value = new URL(value, 'https://thehippiescientist.net').pathname
+  } catch {
+    // Keep the original route-like value when URL parsing fails.
+  }
   value = value.replace(/\/+/g, '/')
   if (!value.startsWith('/')) value = `/${value}`
   if (value !== '/' && !value.endsWith('/')) value += '/'
@@ -58,7 +62,9 @@ function links(html) {
       const url = new URL(href, 'https://thehippiescientist.net')
       if (url.hostname !== 'thehippiescientist.net') continue
       values.push(normalizeRoute(url.pathname))
-    } catch {}
+    } catch {
+      // Ignore malformed hrefs; only valid internal links are crawl-audit candidates.
+    }
   }
   return [...new Set(values)]
 }

--- a/scripts/ci/no-empty-catch.test.mjs
+++ b/scripts/ci/no-empty-catch.test.mjs
@@ -1,0 +1,34 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const root = path.join(process.cwd(), 'scripts')
+const scriptExtensions = new Set(['.js', '.mjs', '.cjs', '.ts', '.tsx'])
+const emptyCatch = /catch\s*\{\s*\}/g
+
+function walk(dir) {
+  const files = []
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      if (path.relative(root, full).split(path.sep)[0] === 'dev') continue
+      files.push(...walk(full))
+      continue
+    }
+    if (entry.isFile() && scriptExtensions.has(path.extname(entry.name))) files.push(full)
+  }
+  return files
+}
+
+describe('non-dev script empty catches', () => {
+  it('keeps literal empty catch blocks out of scripts governed by ESLint no-empty', () => {
+    const offenders = []
+    for (const file of walk(root)) {
+      const source = fs.readFileSync(file, 'utf8')
+      if (emptyCatch.test(source)) offenders.push(path.relative(process.cwd(), file).split(path.sep).join('/'))
+      emptyCatch.lastIndex = 0
+    }
+
+    expect(offenders).toEqual([])
+  })
+})

--- a/scripts/distribution/publish-research-trend.mjs
+++ b/scripts/distribution/publish-research-trend.mjs
@@ -33,7 +33,11 @@ for (const field of listFields) {
 }
 
 let destination = { schemaVersion: 1, reports: [] }
-try { destination = JSON.parse(fs.readFileSync(destinationPath, 'utf8')) } catch {}
+try {
+  destination = JSON.parse(fs.readFileSync(destinationPath, 'utf8'))
+} catch {
+  // Missing or malformed prior review state intentionally starts from an empty history.
+}
 if (!Array.isArray(destination.reports)) destination.reports = []
 
 const publicReport = {

--- a/scripts/ops/analytics-export-utils.mjs
+++ b/scripts/ops/analytics-export-utils.mjs
@@ -68,7 +68,9 @@ export function normalizePagePath(value) {
   let path = String(value).trim()
   try {
     if (/^https?:\/\//i.test(path)) path = new URL(path).pathname
-  } catch {}
+  } catch {
+    // Keep malformed absolute-looking values for the path cleanup below.
+  }
   path = path.split(/[?#]/)[0]
   if (!path.startsWith('/')) path = `/${path}`
   if (path !== '/' && !path.endsWith('/')) path += '/'

--- a/scripts/ops/navigation-click-report.mjs
+++ b/scripts/ops/navigation-click-report.mjs
@@ -42,7 +42,9 @@ function normalizeDestination(value) {
   if (!value) return null
   try {
     if (/^https?:\/\//i.test(value)) value = new URL(value).pathname
-  } catch {}
+  } catch {
+    // Keep malformed absolute-looking values for the path cleanup below.
+  }
   const clean = String(value).split(/[?#]/)[0].trim()
   if (!clean.startsWith('/')) return null
   if (clean === '/') return '/'

--- a/scripts/ops/next-highest-roi-task.mjs
+++ b/scripts/ops/next-highest-roi-task.mjs
@@ -37,7 +37,9 @@ function normalizeUrl(value) {
   if (!value) return null;
   try {
     if (/^https?:\/\//i.test(value)) value = new URL(value).pathname;
-  } catch {}
+  } catch {
+    // Keep malformed absolute-looking values for the path cleanup below.
+  }
   const clean = String(value).split(/[?#]/)[0];
   if (!clean.startsWith('/')) return `/${clean}`;
   return clean;

--- a/scripts/outreach/fetch-ahrefs-backlinks.mjs
+++ b/scripts/outreach/fetch-ahrefs-backlinks.mjs
@@ -100,7 +100,11 @@ for (const link of backlinks) {
 }
 
 let previous = { domains: {} }
-try { previous = JSON.parse(fs.readFileSync(statePath, 'utf8')) } catch {}
+try {
+  previous = JSON.parse(fs.readFileSync(statePath, 'utf8'))
+} catch {
+  // Missing or malformed prior snapshot intentionally behaves like no previous domains.
+}
 const previousDomains = new Set(Object.keys(previous?.domains || {}))
 const newReferringDomains = [...current.values()]
   .filter((row) => !previousDomains.has(row.domain))


### PR DESCRIPTION
## Bug

Several current Node scripts contain literal empty catch blocks while the repository inherits ESLint `no-empty: error` outside the explicit `scripts/dev/**` override.

## Relevant URLs
- CI/lint infrastructure and supporting Node scripts only; no public route behavior changes.

## Acceptance criteria
- Remove literal empty catch blocks from the confirmed non-dev scripts governed by ESLint `no-empty`.
- Preserve each existing fallback/ignore behavior rather than tightening error semantics.
- Leave the intentional `scripts/dev/**` empty-catch allowance untouched.
- Add a regression scan across normal script extensions that excludes `scripts/dev/**`.

## Validation commands
- `npx vitest run scripts/ci/no-empty-catch.test.mjs`
- `npx eslint scripts/ci/audit-static-crawl-surface.mjs scripts/ops/analytics-export-utils.mjs scripts/distribution/publish-research-trend.mjs scripts/ops/navigation-click-report.mjs scripts/outreach/fetch-ahrefs-backlinks.mjs scripts/ops/next-highest-roi-task.mjs scripts/ci/no-empty-catch.test.mjs --max-warnings=0`

## Before → after metrics
- Before: 7 literal empty catches across 6 non-dev scripts were governed by ESLint `no-empty: error`.
- After: 0 literal empty catches remain in those scripts; the regression test scans the full non-dev scripts tree.

## Generator/source-of-truth decision
- No generated artifacts are changed. ESLint remains the lint source of truth; the regression test mirrors its intentional `scripts/dev/**` exception for this specific failure class.

## Regression contract
- `scripts/ci/no-empty-catch.test.mjs` recursively scans normal script extensions and fails if a literal empty catch appears outside `scripts/dev/**`.