### PR TITLE
fix(ci): classify shared release infrastructure

### DIFF
--- a/scripts/ci/classify-release-impact.mjs
+++ b/scripts/ci/classify-release-impact.mjs
@@ -10,8 +10,9 @@ export const RELEASE_SENSITIVE_PATTERNS = [
   /^app\/(?:.+\/)?route\.[^/]+$/,
   /^app\/(?:.+\/)?(?:sitemap|robots|manifest|feed|favicon|icon\d*|apple-icon\d*|opengraph-image|twitter-image)\.[^/]+$/,
   /^app\/(?:.+\/)?generateStaticParams(?:\.[^/]+)?$/,
-  /^lib\/(?:content|data|seo|schema|routes|taxonomy)/,
+  /^(?:src\/)?lib\/(?:[^/]*-)?(?:content|data|seo|schema|routes?|taxonomy)(?:[-./]|$)/,
   /^public\/data\//,
+  /^public\/(?:_redirects|_headers)$/,
   /^next\.config\./,
   /^package(?:-lock)?\.json$/,
 ]

--- a/scripts/ci/classify-release-impact.test.mjs
+++ b/scripts/ci/classify-release-impact.test.mjs
@@ -33,7 +33,15 @@ describe('release impact classification', () => {
     'app/guides/generateStaticParams.ts',
     'app/generateStaticParams.mjs',
     'lib/seo/canonical.ts',
+    'lib/semantic-schema-graph.ts',
+    'src/lib/seo.ts',
+    'src/lib/goal-seo.ts',
+    'src/lib/schema-graph.ts',
+    'src/lib/schema-injector.ts',
+    'src/lib/runtime-data.ts',
     'public/data/herbs.json',
+    'public/_redirects',
+    'public/_headers',
     'next.config.mjs',
     'package.json',
     'package-lock.json',
@@ -46,9 +54,11 @@ describe('release impact classification', () => {
     'app/guides/example/components/DecisionTable.tsx',
     'app/lib/client-state.ts',
     'components/Header.tsx',
+    'src/lib/react-cache.ts',
     'docs/build-and-verification.md',
     'styles/globals.css',
     '.github/workflows/lighthouse.yml',
+    'public/hero-illustration.jpg',
   ])('classifies %s as standard-CI-only', (file) => {
     expect(isReleaseSensitivePath(file)).toBe(false)
   })


### PR DESCRIPTION
Fixes #3179

## Relevant URLs
N/A — CI classification only.

## Acceptance criteria
- Treat equivalent `lib/` and `src/lib/` SEO/schema/data/content/route/taxonomy infrastructure as release-sensitive.
- Treat `public/_redirects` and `public/_headers` as release-sensitive.
- Keep unrelated `src/lib` utilities and normal public media delegated.
- Preserve #3178 App Router rules.

## Validation commands
- `npm run test -- scripts/ci/classify-release-impact.test.mjs`

## Before → after metrics
- Sensitive test cases: **32 → 40**
- Delegated test cases: **7 → 9**
- Workflow classifier copies added: **0**

## Generator/source-of-truth decision
`scripts/ci/classify-release-impact.mjs` remains the single source of truth.

## Regression contract
Tests cover the central `src/lib` SEO/schema/data files plus `_redirects` and `_headers`, while keeping `src/lib/react-cache.ts` and normal public media delegated.