### PR TITLE
fix(deploy): prevent production starvation during rapid merges

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy to Cloudflare Pages
 on:
   workflow_run:
     workflows:
-      - CI
+      - Site Health Check
     types:
       - completed
     branches:
@@ -12,14 +12,14 @@ on:
 
 concurrency:
   group: deploy-${{ github.event.workflow_run.head_branch || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read
 
 jobs:
   deploy:
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    if: github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push')
     runs-on: ubuntu-latest
     environment: production
     env:

--- a/tests/deployment-handoff-contract.test.ts
+++ b/tests/deployment-handoff-contract.test.ts
@@ -1,0 +1,38 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+}
+
+describe('production deployment handoff contract', () => {
+  it('cancels stale Site Health PR heads but preserves the active main validation', () => {
+    const workflow = read('.github/workflows/check.yml')
+
+    expect(workflow).toContain("cancel-in-progress: ${{ github.event_name == 'pull_request' }}")
+    expect(workflow).toContain('push:')
+    expect(workflow).toContain('branches: [ main ]')
+    expect(workflow).toContain('run: npm run check:full')
+  })
+
+  it('deploys only after successful push-triggered Site Health validation', () => {
+    const workflow = read('.github/workflows/deploy.yml')
+
+    expect(workflow).toContain('- Site Health Check')
+    expect(workflow).not.toMatch(/workflows:\s*[\s\S]{0,80}?- CI\b/)
+    expect(workflow).toContain("github.event.workflow_run.conclusion == 'success'")
+    expect(workflow).toContain("github.event.workflow_run.event == 'push'")
+    expect(workflow).toContain('branches:')
+    expect(workflow).toContain('- main')
+  })
+
+  it('lets the active production deploy finish instead of canceling it for a newer head', () => {
+    const workflow = read('.github/workflows/deploy.yml')
+
+    expect(workflow).toContain('concurrency:')
+    expect(workflow).toContain('group: deploy-${{ github.event.workflow_run.head_branch || github.ref }}')
+    expect(workflow).toContain('cancel-in-progress: false')
+    expect(workflow).toContain('workflow_dispatch:')
+  })
+})


### PR DESCRIPTION
Fixes #3182

## Relevant URLs
N/A — production CI/deploy orchestration only.

## Acceptance criteria
- PR Site Health still cancels stale heads.
- Main Site Health lets the active full validation finish.
- Deploy triggers from successful push-triggered Site Health on main, not CI.
- Active production deploys are not canceled by newer validated heads.
- Manual deploy remains available.

## Validation commands
- `npm run test -- tests/deployment-handoff-contract.test.ts`
- GitHub Actions workflow parsing/dispatch on this PR.
- After merge, observe main Site Health survive a subsequent merge and then trigger Cloudflare deploy.

## Before → after metrics
- Successful main CI runs among the 20 most recent completed runs observed: **0 → no longer required for deploy**
- Production deploy gate: **CI success → Site Health success**
- Main Site Health active-run cancellation: **enabled → disabled**
- Active deploy cancellation: **enabled → disabled**

## Generator/source-of-truth decision
- Main release quality remains owned by Site Health `check:full` / `validate:release`.
- Deploy remains responsible for deploy-specific security, build-output, Cloudflare, and IndexNow checks.

## Regression contract
`tests/deployment-handoff-contract.test.ts` locks event-sensitive Site Health concurrency, Site Health-based deploy triggering, push-only successful workflow handoff, manual dispatch, and non-canceling active deploys.