### PR TITLE
ROI 675-690: strengthen answer-engine structure and public attribution

### DIFF
--- a/app/info/content-licensing/page.tsx
+++ b/app/info/content-licensing/page.tsx
@@ -1,0 +1,105 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
+import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
+import { buildPageMetadata } from '../../../src/lib/seo'
+
+const TITLE = 'Content Licensing & Attribution Policy | The Hippie Scientist'
+const DESCRIPTION = 'How to attribute The Hippie Scientist, reuse structured research data responsibly, and distinguish site-created summaries from third-party studies and publications.'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: TITLE,
+  description: DESCRIPTION,
+  path: '/info/content-licensing/',
+  openGraphType: 'article',
+})
+
+export default function ContentLicensingPage() {
+  return (
+    <div className="container-page space-y-10 py-10">
+      <AuthorityJsonLd
+        title={TITLE}
+        description={DESCRIPTION}
+        url="https://thehippiescientist.net/info/content-licensing/"
+        type="Article"
+        breadcrumbs={[
+          { name: 'Home', url: 'https://thehippiescientist.net/' },
+          { name: 'Info', url: 'https://thehippiescientist.net/info/' },
+          { name: 'Content licensing & attribution', url: 'https://thehippiescientist.net/info/content-licensing/' },
+        ]}
+      />
+
+      <AuthorityBreadcrumbs items={[
+        { label: 'Home', href: '/' },
+        { label: 'Info', href: '/info/' },
+        { label: 'Content licensing & attribution' },
+      ]} />
+
+      <header id="attribution-policy" className="scroll-mt-24 hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8 lg:p-10">
+        <p className="eyebrow-label">Attribution policy</p>
+        <h1 className="mt-3 max-w-4xl text-4xl font-semibold tracking-tight text-ink sm:text-5xl">
+          Cite the original research—and attribute our synthesis when you reuse it.
+        </h1>
+        <p className="mt-5 max-w-3xl text-lg leading-8 text-muted">
+          The Hippie Scientist organizes and synthesizes evidence. The underlying studies remain the work of their original authors and publishers. This page explains how to distinguish those layers when quoting, summarizing, linking, or using our structured data.
+        </p>
+      </header>
+
+      <section id="preferred-attribution" className="scroll-mt-24 grid gap-5 md:grid-cols-2">
+        <article className="card-premium p-6">
+          <p className="eyebrow-label">Site synthesis</p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">When you use our derived summary</h2>
+          <p className="mt-3 text-sm leading-7 text-muted">
+            Attribute <strong>The Hippie Scientist</strong> and link to the canonical page where the finding appears. Keep evidence grades, limitations, safety caveats, and review context attached when they materially affect the conclusion.
+          </p>
+        </article>
+        <article className="card-premium p-6">
+          <p className="eyebrow-label">Underlying study</p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">When you discuss a paper</h2>
+          <p className="mt-3 text-sm leading-7 text-muted">
+            Cite the original paper using its PMID, DOI, journal citation, or publisher record when available. A Hippie Scientist page is not a substitute for crediting the researchers who produced the underlying study.
+          </p>
+        </article>
+      </section>
+
+      <section id="structured-data" className="scroll-mt-24 rounded-[2rem] border border-brand-900/10 bg-brand-50/60 p-6 shadow-sm sm:p-8">
+        <p className="eyebrow-label">Machine-readable research data</p>
+        <h2 className="mt-2 text-3xl font-semibold tracking-tight text-ink">Structured data is a companion to the canonical page</h2>
+        <div className="mt-4 max-w-4xl space-y-4 text-sm leading-7 text-muted sm:text-base">
+          <p>
+            Public machine-readable artifacts are provided to make entity identity, evidence relationships, citations, safety context, and provenance easier to understand. When an artifact supplies a canonical HTML page, use that human-readable page as the primary public citation target.
+          </p>
+          <p>
+            Structured records may contain identifiers and bibliographic metadata originating from third-party sources. Their presence in our dataset does not transfer ownership of third-party publications, abstracts, figures, or other protected material.
+          </p>
+          <p>
+            The public AI entity manifest is available at <a className="font-semibold text-brand-700 underline" href="/data/ai-entities/manifest.json">/data/ai-entities/manifest.json</a>.
+          </p>
+        </div>
+      </section>
+
+      <section id="reuse-boundaries" className="scroll-mt-24 card-premium p-6 sm:p-8">
+        <p className="eyebrow-label">Reuse boundaries</p>
+        <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink">What this policy does—and does not—grant</h2>
+        <ul className="mt-5 list-disc space-y-3 pl-5 text-sm leading-7 text-muted sm:text-base">
+          <li>Normal linking, citation, quotation, and factual reference remain subject to applicable law and the rights of any third-party source.</li>
+          <li>This page does not grant a blanket open-source or Creative Commons license to all site text, graphics, datasets, or third-party material.</li>
+          <li>Do not remove attribution, provenance, evidence limitations, or source identifiers in a way that makes a derived conclusion look like original primary research.</li>
+          <li>For bulk republication, commercial syndication, or reuse beyond what applicable law already permits, request permission first.</li>
+        </ul>
+      </section>
+
+      <section id="contact" className="scroll-mt-24 rounded-2xl border border-brand-900/10 bg-white p-6 shadow-sm dark:border-white/10 dark:bg-zinc-950">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Questions about attribution or reuse?</h2>
+        <p className="mt-3 max-w-3xl text-sm leading-7 text-muted sm:text-base">
+          Use the contact page for permission requests, corrections, or questions about how to cite a specific dataset or research summary.
+        </p>
+        <div className="mt-5 flex flex-wrap gap-3">
+          <Link href="/info/contact/" className="chip-readable hover:bg-white transition">Contact</Link>
+          <Link href="/info/methodology/" className="chip-readable hover:bg-white transition">Methodology</Link>
+          <Link href="/info/disclaimer/" className="chip-readable hover:bg-white transition">Disclaimer</Link>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -9,11 +9,20 @@ export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
       userAgent: '*',
-      // Keep the generated runtime-data surface private from crawlers while
-      // explicitly exposing the public AI entity graph advertised in llms.txt.
-      // Robots matching uses the most-specific path rule, so this allow safely
-      // overrides the broader /data/ disallow only for /data/ai-entities/.
-      allow: ['/', '/data/ai-entities/'],
+      // Public search and answer engines are intentionally allowed to crawl the
+      // canonical HTML site. Most runtime data stays private, but the small set
+      // of machine-readable research artifacts below is explicitly crawlable so
+      // entity/claim provenance can be resolved back to human-readable pages.
+      // Robots matching uses the most-specific path rule, so these allows safely
+      // override the broader /data/ disallow only for approved public datasets.
+      allow: [
+        '/',
+        '/llms.txt',
+        '/data/ai-entities/',
+        '/data/ingredients/',
+        '/data/claim-knowledge-graph.json',
+        '/data/research-relationship-graph.json',
+      ],
       disallow: [
         '/api/',
         '/analytics',

--- a/components/seo/AnswerEngineTable.tsx
+++ b/components/seo/AnswerEngineTable.tsx
@@ -1,0 +1,67 @@
+import type { ReactNode } from 'react'
+
+export type AnswerEngineColumn<Row> = {
+  key: string
+  header: string
+  render: (row: Row) => ReactNode
+}
+
+type AnswerEngineTableProps<Row> = {
+  id: string
+  caption: string
+  columns: AnswerEngineColumn<Row>[]
+  rows: Row[]
+  rowKey: (row: Row, index: number) => string
+  definition?: string
+}
+
+/**
+ * Semantic table primitive for compact, extractable research facts.
+ * Requires a caption and explicit column headers instead of visual-only grids.
+ */
+export default function AnswerEngineTable<Row>({
+  id,
+  caption,
+  columns,
+  rows,
+  rowKey,
+  definition,
+}: AnswerEngineTableProps<Row>) {
+  return (
+    <section id={id} className="scroll-mt-24 space-y-3" data-answer-engine-table="true">
+      {definition ? <p className="text-sm leading-6 text-muted"><strong>Definition:</strong> {definition}</p> : null}
+      <div className="overflow-x-auto rounded-xl border border-brand-900/10 dark:border-white/10">
+        <table className="w-full border-collapse text-left text-sm">
+          <caption className="p-3 text-left font-semibold text-ink">{caption}</caption>
+          <thead>
+            <tr>
+              {columns.map((column) => (
+                <th key={column.key} scope="col" className="border-t border-brand-900/10 px-3 py-2 font-semibold text-ink dark:border-white/10">
+                  {column.header}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, index) => (
+              <tr key={rowKey(row, index)}>
+                {columns.map((column, columnIndex) => (
+                  columnIndex === 0 ? (
+                    <th key={column.key} scope="row" className="border-t border-brand-900/10 px-3 py-2 font-medium text-ink dark:border-white/10">
+                      {column.render(row)}
+                    </th>
+                  ) : (
+                    <td key={column.key} className="border-t border-brand-900/10 px-3 py-2 text-muted dark:border-white/10">
+                      {column.render(row)}
+                    </td>
+                  )
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <a href={`#${id}`} className="sr-only">Permanent link to this table</a>
+    </section>
+  )
+}

--- a/components/seo/CitationReadySummary.tsx
+++ b/components/seo/CitationReadySummary.tsx
@@ -2,6 +2,11 @@ import Link from 'next/link'
 
 import { citationReadySentenceCount, toCitationReadySummary } from '@/src/lib/citation-ready-summary'
 
+export type CitationSourceLink = {
+  label: string
+  href: string
+}
+
 type CitationReadySummaryProps = {
   answer: string
   bestFor?: string[]
@@ -9,6 +14,23 @@ type CitationReadySummaryProps = {
   safetyNote?: string
   notClaiming?: string
   referencesHref?: string
+  /** Stable deep-link ID. Prefer a claim ID when the summary represents one canonical claim. */
+  id?: string
+  entityName?: string
+  definition?: string
+  limitation?: string
+  sources?: CitationSourceLink[]
+  publishedAt?: string
+  reviewedAt?: string
+  authorName?: string
+  editorName?: string
+}
+
+function dateLabel(value: string) {
+  const date = new Date(value)
+  return Number.isNaN(date.getTime())
+    ? value
+    : new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC' }).format(date)
 }
 
 export default function CitationReadySummary({
@@ -18,25 +40,41 @@ export default function CitationReadySummary({
   safetyNote,
   notClaiming,
   referencesHref,
+  id = 'quick-answer',
+  entityName,
+  definition,
+  limitation,
+  sources = [],
+  publishedAt,
+  reviewedAt,
+  authorName,
+  editorName,
 }: CitationReadySummaryProps) {
   const citationReadyAnswer = toCitationReadySummary(answer)
   const sentenceCount = citationReadySentenceCount(answer)
+  const limitationText = limitation || notClaiming
+  const headingId = `${id}-heading`
 
   return (
     <section
-      aria-label="Citation-ready summary"
+      id={id}
+      aria-labelledby={headingId}
+      data-answer-engine-summary="true"
       data-citation-summary-sentences={sentenceCount}
-      className="max-w-4xl rounded-2xl border border-brand-900/10 bg-white p-5 shadow-sm dark:border-white/10 dark:bg-zinc-950"
+      className="scroll-mt-24 max-w-4xl rounded-2xl border border-brand-900/10 bg-white p-5 shadow-sm dark:border-white/10 dark:bg-zinc-950"
     >
       <div className="space-y-4">
         <div className="space-y-2">
-          <p className="eyebrow-label">Quick answer</p>
-          <p className="text-base leading-7 text-ink">{citationReadyAnswer}</p>
+          <h2 id={headingId} className="eyebrow-label">
+            {entityName ? `${entityName}: quick answer` : 'Quick answer'}
+          </h2>
+          {definition ? <p className="text-sm leading-6 text-muted"><strong>Definition:</strong> {definition}</p> : null}
+          <p data-claim="true" className="text-base leading-7 text-ink">{citationReadyAnswer}</p>
         </div>
 
         {bestFor.length > 0 ? (
           <div>
-            <h2 className="text-base font-semibold text-ink">Best fit</h2>
+            <h3 className="text-base font-semibold text-ink">Best fit</h3>
             <ul className="mt-2 list-disc space-y-1 pl-5 text-sm leading-6 text-muted">
               {bestFor.map((item) => (
                 <li key={item}>{item}</li>
@@ -47,30 +85,56 @@ export default function CitationReadySummary({
 
         <dl className="grid gap-3 text-sm leading-6 sm:grid-cols-2">
           {evidenceLevel ? (
-            <div>
-              <dt className="font-semibold text-ink">Evidence level</dt>
+            <div data-evidence="true">
+              <dt className="font-semibold text-ink">Evidence</dt>
               <dd className="text-muted">{evidenceLevel}</dd>
             </div>
           ) : null}
           {safetyNote ? (
             <div>
-              <dt className="font-semibold text-ink">Safety note</dt>
+              <dt className="font-semibold text-ink">Safety context</dt>
               <dd className="text-muted">{safetyNote}</dd>
             </div>
           ) : null}
-          {notClaiming ? (
-            <div className="sm:col-span-2">
-              <dt className="font-semibold text-ink">What this page is not claiming</dt>
-              <dd className="text-muted">{notClaiming}</dd>
+          {limitationText ? (
+            <div data-limitation="true" className="sm:col-span-2">
+              <dt className="font-semibold text-ink">Limitation</dt>
+              <dd className="text-muted">{limitationText}</dd>
             </div>
           ) : null}
         </dl>
 
+        {sources.length > 0 ? (
+          <div data-nearby-citations="true" className="border-t border-brand-900/10 pt-3 dark:border-white/10">
+            <h3 className="text-sm font-semibold text-ink">Sources for this finding</h3>
+            <ul className="mt-2 space-y-1 text-sm leading-6 text-muted">
+              {sources.map((source) => (
+                <li key={`${source.href}-${source.label}`}>
+                  <a href={source.href} rel="cite" className="font-medium text-brand-700 underline decoration-dotted underline-offset-4 hover:text-brand-900">
+                    {source.label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+
+        {(publishedAt || reviewedAt || authorName || editorName) ? (
+          <dl data-research-metadata="true" className="grid gap-x-5 gap-y-1 border-t border-brand-900/10 pt-3 text-xs leading-5 text-muted sm:grid-cols-2 dark:border-white/10">
+            {authorName ? <div><dt className="inline font-semibold text-ink">Author: </dt><dd className="inline">{authorName}</dd></div> : null}
+            {editorName ? <div><dt className="inline font-semibold text-ink">Editor: </dt><dd className="inline">{editorName}</dd></div> : null}
+            {publishedAt ? <div><dt className="inline font-semibold text-ink">Published: </dt><dd className="inline"><time dateTime={publishedAt}>{dateLabel(publishedAt)}</time></dd></div> : null}
+            {reviewedAt ? <div><dt className="inline font-semibold text-ink">Evidence reviewed: </dt><dd className="inline"><time dateTime={reviewedAt}>{dateLabel(reviewedAt)}</time></dd></div> : null}
+          </dl>
+        ) : null}
+
         {referencesHref ? (
-          <Link href={referencesHref} className="inline-flex text-sm font-semibold text-brand-700 underline hover:text-brand-900">
-            Jump to references
+          <Link href={referencesHref} rel="cite" className="inline-flex text-sm font-semibold text-brand-700 underline hover:text-brand-900">
+            See the full references and source context
           </Link>
         ) : null}
+
+        <a href={`#${id}`} className="sr-only">Permanent link to this finding</a>
       </div>
     </section>
   )

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -13,6 +13,7 @@ Robots: https://thehippiescientist.net/robots.txt
 - Evidence methodology: https://thehippiescientist.net/info/methodology/
 - Corrections and contact: https://thehippiescientist.net/info/contact/
 - Editorial disclaimer: https://thehippiescientist.net/info/disclaimer/
+- Content licensing and attribution: https://thehippiescientist.net/info/content-licensing/
 
 ## What this site is useful for
 
@@ -41,6 +42,7 @@ Use canonical, public, indexable URLs. Prefer the most specific page that answer
 - Methodology: https://thehippiescientist.net/info/methodology/
 - Dosing principles: https://thehippiescientist.net/info/dosing/
 - Disclaimer: https://thehippiescientist.net/info/disclaimer/
+- Content licensing and attribution: https://thehippiescientist.net/info/content-licensing/
 
 ### Topic hubs
 
@@ -103,17 +105,21 @@ When citing this site:
 5. Do not cite internal tools, draft routes, preview routes, or operational reports as user-facing sources.
 6. Use visible references, quick-answer blocks, comparison tables, and safety notes as the primary extractable passages.
 7. Use JSON-LD entity artifacts only to resolve identity, relationships, and claim provenance back to the canonical HTML page.
+8. When reusing a Hippie Scientist synthesis, preserve material limitations and follow the attribution policy at /info/content-licensing/.
+9. Stable section anchors are preferred when linking to a specific finding; do not invent fragment identifiers that are not present on the page.
 
 ## Content signals to prioritize
 
-- Quick-answer sections
+- Quick-answer sections with claim → evidence → limitation structure
 - Evidence summaries
+- Nearby source links and visible reference sections
 - Safety cautions
 - Dosing and timing context
-- Comparison tables
-- References sections
+- Semantic comparison/evidence tables with captions and headers
+- Concise definitions for specialized scientific terms
 - Methodology and editorial notes
-- Last-reviewed or date-modified signals where present
+- Publication, evidence-review, author, and editor signals where present
+- Stable section or finding anchors for deep links
 
 ## Crawl notes
 

--- a/scripts/ci/audit-answer-engine-structure.mjs
+++ b/scripts/ci/audit-answer-engine-structure.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import path from 'node:path'
+
+const ROOT = process.cwd()
+const STRICT = process.argv.includes('--strict')
+const PAGE_ROOTS = [
+  path.join(ROOT, 'app', 'guides', 'compare'),
+  path.join(ROOT, 'app', 'guides'),
+]
+
+const REQUIRED_PUBLIC_RESEARCH_ALLOWS = [
+  '/data/ai-entities/',
+  '/data/ingredients/',
+  '/data/claim-knowledge-graph.json',
+  '/data/research-relationship-graph.json',
+]
+
+function walk(dir) {
+  if (!existsSync(dir)) return []
+  return readdirSync(dir).flatMap((name) => {
+    const full = path.join(dir, name)
+    const stat = statSync(full)
+    if (stat.isDirectory()) return walk(full)
+    return /page\.(tsx|ts|jsx|js)$/.test(name) ? [full] : []
+  })
+}
+
+function routeFor(file) {
+  return `/${path.relative(path.join(ROOT, 'app'), path.dirname(file)).replaceAll(path.sep, '/')}/`.replace(/\/+/g, '/')
+}
+
+function auditPage(file) {
+  const source = readFileSync(file, 'utf8')
+  const route = routeFor(file)
+  const issues = []
+  const usesSummary = /CitationReadySummary/.test(source)
+  const hasQuickAnswer = usesSummary || /quick answer/i.test(source)
+  const hasEvidence = usesSummary || /evidence/i.test(source)
+  const hasLimitation = usesSummary || /limitation|not claiming|uncertain|caveat/i.test(source)
+  const hasReferences = /referencesHref|CompareCitations|References|citation/i.test(source)
+  const hasStableAnchor = usesSummary || /\bid=["'`{]/.test(source)
+
+  if (!hasQuickAnswer) issues.push('no direct-answer signal near the top-level page source')
+  if (!hasEvidence) issues.push('no evidence signal')
+  if (!hasLimitation) issues.push('no limitation/caveat signal')
+  if (!hasReferences) issues.push('no visible/linked citation signal')
+  if (!hasStableAnchor) issues.push('no stable section/finding anchor signal')
+
+  if (/FaqJsonLd|FAQPage/.test(source) && !hasQuickAnswer) {
+    issues.push('FAQ/schema present without a direct-answer structure; avoid FAQ-first answer-engine optimization')
+  }
+
+  return { route, file: path.relative(ROOT, file), issues }
+}
+
+function auditDiscovery() {
+  const issues = []
+  const llms = existsSync(path.join(ROOT, 'public', 'llms.txt'))
+    ? readFileSync(path.join(ROOT, 'public', 'llms.txt'), 'utf8')
+    : ''
+  const robots = existsSync(path.join(ROOT, 'app', 'robots.ts'))
+    ? readFileSync(path.join(ROOT, 'app', 'robots.ts'), 'utf8')
+    : ''
+  const licensing = path.join(ROOT, 'app', 'info', 'content-licensing', 'page.tsx')
+
+  if (!/data\/ai-entities\/manifest\.json/.test(llms)) issues.push('llms.txt does not expose the public entity dataset manifest')
+  if (!/content-licensing/.test(llms)) issues.push('llms.txt does not expose the attribution/licensing policy')
+  if (!existsSync(licensing)) issues.push('content licensing/attribution policy page is missing')
+  if (!/userAgent:\s*['"]\*['"]/.test(robots)) issues.push('robots policy does not intentionally allow the general public crawler class')
+  if (!/['"]\/data\/['"]/.test(robots)) issues.push('robots policy no longer protects the broad private /data/ surface')
+
+  for (const allowedPath of REQUIRED_PUBLIC_RESEARCH_ALLOWS) {
+    if (!robots.includes(`'${allowedPath}'`) && !robots.includes(`"${allowedPath}"`)) {
+      issues.push(`robots policy does not explicitly allow approved public research artifact: ${allowedPath}`)
+    }
+  }
+
+  return issues
+}
+
+const uniqueFiles = [...new Set(PAGE_ROOTS.flatMap(walk))]
+const pageResults = uniqueFiles.map(auditPage)
+const problemPages = pageResults.filter((row) => row.issues.length)
+const discoveryIssues = auditDiscovery()
+
+console.log('\nAnswer-engine structure audit')
+console.log('='.repeat(72))
+console.log(`Pages scanned       ${pageResults.length}`)
+console.log(`Pages with gaps     ${problemPages.length}`)
+console.log(`Discovery gaps      ${discoveryIssues.length}`)
+console.log('')
+
+for (const row of problemPages.slice(0, 100)) {
+  console.log(`${row.route} (${row.file})`)
+  for (const issue of row.issues) console.log(`  - ${issue}`)
+}
+
+if (discoveryIssues.length) {
+  console.log('\nPublic discovery')
+  for (const issue of discoveryIssues) console.log(`  - ${issue}`)
+}
+
+if (STRICT && (problemPages.length || discoveryIssues.length)) {
+  process.exit(1)
+}
+
+if (!problemPages.length && !discoveryIssues.length) {
+  console.log('PASS: direct-answer structure, citation discovery, attribution, and crawler intent are present.')
+} else {
+  console.log('\nAdvisory by default. Use --strict only after the high-value page set has been fully migrated.')
+}


### PR DESCRIPTION
Superseded by the current merged AI-search architecture, principally #3355, #3361, #3363, and #3367. Those changes reimplemented the still-useful deltas on current main: stable answer anchors, claim/evidence/limitation semantics, semantic tables, attribution/reuse policy, profile-wide extraction markers, dataset provenance, and one canonical AI-search orchestrator. Closing this stale/conflicted branch prevents older overlapping implementations from being merged back into the repository.