### PR TITLE
ci: scope heavyweight PR audits to production inputs

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -5,6 +5,27 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
+    paths:
+      - 'app/**'
+      - 'components/**'
+      - 'src/**'
+      - 'lib/**'
+      - 'public/**'
+      - 'data/**'
+      - 'content/**'
+      - 'scripts/**'
+      - 'styles/**'
+      - 'types/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.nvmrc'
+      - 'next.config.*'
+      - 'next-env.d.ts'
+      - 'tsconfig*.json'
+      - 'tailwind.config.*'
+      - 'postcss.config.*'
+      - '**/*.xlsx'
+      - '.github/workflows/build-check.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -5,6 +5,30 @@ on:
     branches: [main]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'app/**'
+      - 'components/**'
+      - 'src/**'
+      - 'lib/**'
+      - 'public/**'
+      - 'data/**'
+      - 'content/**'
+      - 'scripts/**'
+      - 'styles/**'
+      - 'types/**'
+      - 'tests/**'
+      - '**/__tests__/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.nvmrc'
+      - 'next.config.*'
+      - 'next-env.d.ts'
+      - 'tsconfig*.json'
+      - 'tailwind.config.*'
+      - 'postcss.config.*'
+      - '.lighthouserc*.json'
+      - '**/*.xlsx'
+      - '.github/workflows/lighthouse.yml'
   workflow_dispatch:
 
 concurrency:

--- a/tests/heavy-pr-workflow-scope-contract.test.ts
+++ b/tests/heavy-pr-workflow-scope-contract.test.ts
@@ -1,0 +1,49 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+}
+
+const PRODUCTION_INPUTS = [
+  "- 'app/**'",
+  "- 'components/**'",
+  "- 'src/**'",
+  "- 'lib/**'",
+  "- 'public/**'",
+  "- 'data/**'",
+  "- 'scripts/**'",
+  "- 'styles/**'",
+  "- 'package.json'",
+  "- 'package-lock.json'",
+  "- 'next.config.*'",
+  "- 'tsconfig*.json'",
+]
+
+describe('heavy pull-request workflow path scopes', () => {
+  it('keeps Build Check focused on production-build inputs', () => {
+    const workflow = read('.github/workflows/build-check.yml')
+
+    expect(workflow).toContain('pull_request:')
+    expect(workflow).toContain('paths:')
+    for (const input of PRODUCTION_INPUTS) expect(workflow).toContain(input)
+    expect(workflow).toContain("- '.github/workflows/build-check.yml'")
+    expect(workflow).not.toContain("- 'docs/**'")
+    expect(workflow).not.toContain("- '.github/workflows/**'")
+  })
+
+  it('keeps Lighthouse focused on measurable site and accessibility inputs', () => {
+    const workflow = read('.github/workflows/lighthouse.yml')
+
+    expect(workflow).toContain('push:\n    branches: [main]\n  pull_request:')
+    expect(workflow).toContain('paths:')
+    for (const input of PRODUCTION_INPUTS) expect(workflow).toContain(input)
+    expect(workflow).toContain("- 'tests/**'")
+    expect(workflow).toContain("- '**/__tests__/**'")
+    expect(workflow).toContain("- '.lighthouserc*.json'")
+    expect(workflow).toContain("- '.github/workflows/lighthouse.yml'")
+    expect(workflow).not.toContain("- 'docs/**'")
+    expect(workflow).not.toContain("- '.github/workflows/**'")
+  })
+})


### PR DESCRIPTION
Fixes #3186

## Relevant URLs
N/A — CI trigger scope only.

## Acceptance criteria
- Build Check runs on pull requests only when production-build inputs or its own workflow change.
- Lighthouse runs on pull requests only when site/performance/accessibility inputs or its own config/workflow change.
- Lighthouse push-to-main coverage remains unchanged.
- App, components, source, shared libraries, public assets/data, scripts, styles, package/config, workbook, and relevant accessibility test changes remain covered.
- Docs-only and unrelated workflow-only pull requests no longer launch these two heavyweight jobs.

## Validation commands
- `npm run test -- tests/heavy-pr-workflow-scope-contract.test.ts`
- GitHub Actions workflow parsing on this pull request.
- Nested docs-only smoke pull request to verify Build Check and Lighthouse are not dispatched.

## Before → after metrics
- Heavy PR workflows launching on docs/workflow-only changes: **2 → 0**
- Full build/Lighthouse validation removed from production-affecting PRs: **0**
- Lighthouse main-push coverage: **unchanged**

## Generator/source-of-truth decision
The two workflow YAML path filters remain the source of truth for when their specialized audits are relevant; standard CI remains the universal PR validation path.

## Regression contract
`tests/heavy-pr-workflow-scope-contract.test.ts` requires representative production inputs and each workflow's own config, forbids broad docs/workflow triggers, and locks Lighthouse main-push coverage.