### PR TITLE
ROI #151: preserve caveats in extractable summaries

### DIFF
--- a/src/lib/__tests__/citation-ready-caveats.test.ts
+++ b/src/lib/__tests__/citation-ready-caveats.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { buildCitationReadySummary } from '../article-citation-metadata'
+
+describe('citation-ready caveat preservation', () => {
+  it('keeps an authored caveat even when it appears after the first four authored sentences', () => {
+    const summary = buildCitationReadySummary({
+      description: 'Sentence one states the conclusion. Sentence two adds context. Sentence three adds dose context. Sentence four adds duration context.',
+      keyTakeaways: [
+        'The evidence is limited by small studies and a specific population.',
+      ],
+      sourceCount: 8,
+      evidenceGrade: 'B',
+    })
+
+    expect(summary).toContain('The evidence is limited by small studies and a specific population.')
+    expect(summary).not.toContain('Sentence four adds duration context.')
+  })
+
+  it('does not invent a caveat when authored metadata does not contain one', () => {
+    const summary = buildCitationReadySummary({
+      description: 'Sentence one states the conclusion. Sentence two adds context.',
+      keyTakeaways: ['Sentence three adds formulation context.'],
+    })
+
+    expect(summary).toBe('Sentence one states the conclusion. Sentence two adds context. Sentence three adds formulation context.')
+  })
+})

--- a/src/lib/article-citation-metadata.ts
+++ b/src/lib/article-citation-metadata.ts
@@ -25,6 +25,8 @@ export type CitationReadySummaryInput = {
   evidenceGrade?: string | null
 }
 
+const CAVEAT_PATTERN = /\b(?:limit(?:ation|ed|s)?|uncertain(?:ty)?|mixed|inconsistent|small|short[- ]term|preliminary|exploratory|not established|not proven|does not establish|cannot establish|unknown|unclear|lack(?:s|ing)?|sparse|indirect|heterogeneous|specific extract|specific population)\b/i
+
 function isRelatedArticle(
   article: ArticleRelationshipRecord | undefined,
   currentSlug: string
@@ -92,10 +94,21 @@ function uniqueSentences(values: string[]): string[] {
   return unique
 }
 
+function preserveAuthoredCaveat(selected: string[], authoredSentences: string[]): string[] {
+  const caveat = authoredSentences.find((sentence) => CAVEAT_PATTERN.test(sentence))
+  if (!caveat || selected.includes(caveat)) return selected
+
+  if (selected.length < 4) return [...selected, caveat]
+  return [...selected.slice(0, 3), caveat]
+}
+
 /**
  * Build a 2–4 sentence extractive summary from authored article metadata.
  * Scientific claims come only from the authored description/takeaways; any
  * fallback sentence describes verifiable page metadata rather than efficacy.
+ * When authored metadata contains a recognizable limitation/caveat sentence,
+ * keep one in the extract so answer engines cannot lift a conclusion while
+ * silently dropping its qualification.
  */
 export function buildCitationReadySummary({
   description,
@@ -108,7 +121,7 @@ export function buildCitationReadySummary({
     ...keyTakeaways.map(cleanSentence),
   ])
 
-  const selected = authoredSentences.slice(0, 4)
+  let selected = preserveAuthoredCaveat(authoredSentences.slice(0, 4), authoredSentences)
 
   if (selected.length < 2) {
     if (sourceCount > 0 && evidenceGrade) {


### PR DESCRIPTION
Implements backlog item #151. Citation-ready summaries now detect authored limitation/caveat language and guarantee that one caveat survives the 2–4 sentence extraction window. The system never invents a caveat; it only preserves one already present in authored description/takeaways. Added regression coverage for caveats appearing after the first four authored sentences.