### PR TITLE
test: align affiliate governance coverage with live API

### DIFF
--- a/src/lib/__tests__/affiliate-governance.test.ts
+++ b/src/lib/__tests__/affiliate-governance.test.ts
@@ -3,7 +3,6 @@ import {
   canRenderAffiliateLinks,
   canShowAffiliateModule,
   getAffiliateShopLinks,
-  getGovernedCompoundSearchLinks,
 } from '../affiliate'
 import { getGoal } from '@/data/goals'
 import { goalContainsRestrictedIngredient, isRestrictedRecord } from '../restricted-ingredients'
@@ -28,7 +27,6 @@ describe('affiliate governance gates', () => {
     expect(canRenderAffiliateLinks(record)).toBe(false)
     expect(canShowAffiliateModule(record)).toBe(false)
     expect(getAffiliateShopLinks(record, record.displayName, 'compound')).toEqual([])
-    expect(getGovernedCompoundSearchLinks(record, record.displayName)).toEqual([])
   })
 
   it('blocks Amazon links for workbook doNotPromote records with string flags', () => {
@@ -88,7 +86,7 @@ describe('affiliate governance gates', () => {
     expect(links[0]?.url).toContain('tag=')
   })
 
-  it('blocks sourcing/search Amazon and affiliate cards for additional restricted (kratom, ibogaine, ketamine, 5-MeO-DMT, fadogia)', () => {
+  it('blocks sourcing Amazon links for additional restricted (kratom, ibogaine, ketamine, 5-MeO-DMT, fadogia)', () => {
     const kratomRec = { ...baseAffiliateRecord, slug: 'kratom', displayName: 'Kratom' }
     const iboRec = { ...baseAffiliateRecord, slug: 'ibogaine', displayName: 'Ibogaine' }
     const ketRec = { ...baseAffiliateRecord, slug: 'ketamine', displayName: 'Ketamine' }
@@ -99,7 +97,6 @@ describe('affiliate governance gates', () => {
       expect(isRestrictedRecord(rec)).toBe(true)
       expect(canRenderAffiliateLinks(rec)).toBe(false)
       expect(getAffiliateShopLinks(rec, rec.displayName, 'compound')).toEqual([])
-      expect(getGovernedCompoundSearchLinks(rec, rec.displayName)).toEqual([])
     })
   })
 


### PR DESCRIPTION
## Validation finding
After removing four zero-consumer affiliate search wrappers, the governance test still imported/called one of those deleted wrappers. Production code had no consumer, but the stale test contract would fail CI.

## Change
- Remove the deleted wrapper from the test import.
- Remove assertions against the obsolete wrapper.
- Keep governance coverage on the live canonical paths: `canRenderAffiliateLinks`, `canShowAffiliateModule`, and `getAffiliateShopLinks`.
- Rename the restricted-case test so its description matches what it actually exercises.

## Scope
Test-only follow-up: 1 addition, 4 deletions. No production behavior changes.