### PR TITLE
ROI #153: surface explicit evidence type beside claims

### DIFF
--- a/src/components/evidence-engine/EvidenceClaimCard.tsx
+++ b/src/components/evidence-engine/EvidenceClaimCard.tsx
@@ -3,6 +3,7 @@ import EvidenceSafetyNotes from './EvidenceSafetyNotes'
 import EvidenceSourceList from './EvidenceSourceList'
 import TrialDesignInsight from '@/components/education/TrialDesignInsight'
 import {
+  formatEvidenceLabel,
   getConfidenceDisplay,
   type EvidenceEngineClaim,
   type EvidenceEngineSafetyNote,
@@ -25,7 +26,10 @@ export default function EvidenceClaimCard({
   sources,
 }: EvidenceClaimCardProps) {
   const confidence = getConfidenceDisplay(claim.confidence_tier)
-  const numericSignals = [
+  const evidenceSignals = [
+    claim.design_type
+      ? { label: 'Evidence type', value: formatEvidenceLabel(claim.design_type) }
+      : null,
     claim.sample_size && claim.sample_size > 0
       ? { label: 'Participants', value: `N=${claim.sample_size.toLocaleString()}` }
       : null,
@@ -53,9 +57,9 @@ export default function EvidenceClaimCard({
 
       <p className="mt-4 text-sm font-semibold leading-6 text-ink">{claim.claim_statement}</p>
 
-      {numericSignals.length > 0 ? (
-        <dl className="mt-3 flex flex-wrap gap-2" aria-label="Numeric evidence details">
-          {numericSignals.map((signal) => (
+      {evidenceSignals.length > 0 ? (
+        <dl className="mt-3 flex flex-wrap gap-2" aria-label="Evidence details">
+          {evidenceSignals.map((signal) => (
             <div key={signal.label} className="rounded-lg border border-brand-900/10 bg-brand-50/60 px-3 py-2">
               <dt className="text-[0.65rem] font-bold uppercase tracking-[0.1em] text-muted">{signal.label}</dt>
               <dd className="mt-0.5 text-sm font-semibold text-ink">{signal.value}</dd>


### PR DESCRIPTION
Implements backlog item #153 in the shared evidence claim renderer. When structured `design_type` exists, the claim card now labels the evidence type directly beside the claim and numeric evidence details, reducing reliance on vague prose like “studies suggest.” Missing design metadata remains hidden rather than inferred.