### PR TITLE
ROI #154: show human trial counts when structured

### DIFF
--- a/src/components/evidence-engine/EvidenceClaimCard.tsx
+++ b/src/components/evidence-engine/EvidenceClaimCard.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import EvidenceSafetyNotes from './EvidenceSafetyNotes'
 import EvidenceSourceList from './EvidenceSourceList'
 import TrialDesignInsight from '@/components/education/TrialDesignInsight'
+import { countHumanTrials } from '../../lib/evidence-source-metrics'
 import {
   formatEvidenceLabel,
   getConfidenceDisplay,
@@ -26,9 +27,13 @@ export default function EvidenceClaimCard({
   sources,
 }: EvidenceClaimCardProps) {
   const confidence = getConfidenceDisplay(claim.confidence_tier)
+  const humanTrialCount = countHumanTrials(sources)
   const evidenceSignals = [
     claim.design_type
       ? { label: 'Evidence type', value: formatEvidenceLabel(claim.design_type) }
+      : null,
+    humanTrialCount > 0
+      ? { label: 'Human trials', value: String(humanTrialCount) }
       : null,
     claim.sample_size && claim.sample_size > 0
       ? { label: 'Participants', value: `N=${claim.sample_size.toLocaleString()}` }

--- a/src/lib/__tests__/evidence-source-metrics.test.ts
+++ b/src/lib/__tests__/evidence-source-metrics.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { countHumanTrials, isHumanTrialSource } from '../evidence-source-metrics'
+import type { EvidenceEngineSource } from '../evidence-engine'
+
+function source(source_type: string, source_id: string): EvidenceEngineSource {
+  return {
+    source_id,
+    claim_id: 'claim-1',
+    citation_label: source_id,
+    source_type,
+    title: source_id,
+    year: 2026,
+    url: 'https://example.com',
+    published: true,
+  }
+}
+
+describe('evidence source metrics', () => {
+  it('counts only explicit human trial source types', () => {
+    const sources = [
+      source('RCT', 'rct'),
+      source('randomized controlled trial', 'randomized'),
+      source('systematic review', 'review'),
+      source('animal study', 'animal'),
+    ]
+
+    expect(countHumanTrials(sources)).toBe(2)
+  })
+
+  it('does not infer a human trial from generic human evidence wording', () => {
+    expect(isHumanTrialSource(source('human evidence', 'human'))).toBe(false)
+    expect(isHumanTrialSource(source('meta-analysis', 'meta'))).toBe(false)
+  })
+})

--- a/src/lib/evidence-source-metrics.ts
+++ b/src/lib/evidence-source-metrics.ts
@@ -1,0 +1,11 @@
+import type { EvidenceEngineSource } from './evidence-engine'
+
+const HUMAN_TRIAL_TYPE = /\b(?:rct|randomi[sz]ed(?: controlled)? trial|clinical trial|controlled trial|human trial|crossover trial|cross-over trial)\b/i
+
+export function isHumanTrialSource(source: Pick<EvidenceEngineSource, 'source_type'>): boolean {
+  return HUMAN_TRIAL_TYPE.test(source.source_type.trim())
+}
+
+export function countHumanTrials(sources: EvidenceEngineSource[]): number {
+  return sources.filter(isHumanTrialSource).length
+}


### PR DESCRIPTION
Implements backlog item #154. Adds a conservative source-type classifier that counts only explicit human trial types (RCT/randomized/clinical/controlled/crossover trial) and surfaces the human-trial count beside major claims. Reviews, meta-analyses, generic “human evidence,” and preclinical sources are deliberately not counted as trials. Added regression tests.