### PR TITLE
ROI #155: show approximate participant totals when supportable

### DIFF
--- a/src/components/evidence-engine/EvidenceClaimCard.tsx
+++ b/src/components/evidence-engine/EvidenceClaimCard.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 import EvidenceSafetyNotes from './EvidenceSafetyNotes'
 import EvidenceSourceList from './EvidenceSourceList'
 import TrialDesignInsight from '@/components/education/TrialDesignInsight'
-import { countHumanTrials } from '../../lib/evidence-source-metrics'
+import { countHumanTrials, getHumanParticipantMetric } from '../../lib/evidence-source-metrics'
 import {
   formatEvidenceLabel,
   getConfidenceDisplay,
@@ -28,6 +28,7 @@ export default function EvidenceClaimCard({
 }: EvidenceClaimCardProps) {
   const confidence = getConfidenceDisplay(claim.confidence_tier)
   const humanTrialCount = countHumanTrials(sources)
+  const participantMetric = getHumanParticipantMetric(sources)
   const evidenceSignals = [
     claim.design_type
       ? { label: 'Evidence type', value: formatEvidenceLabel(claim.design_type) }
@@ -35,9 +36,14 @@ export default function EvidenceClaimCard({
     humanTrialCount > 0
       ? { label: 'Human trials', value: String(humanTrialCount) }
       : null,
-    claim.sample_size && claim.sample_size > 0
-      ? { label: 'Participants', value: `N=${claim.sample_size.toLocaleString()}` }
-      : null,
+    participantMetric
+      ? {
+          label: participantMetric.complete ? 'Approx participants' : 'Known participants',
+          value: `N≈${participantMetric.total.toLocaleString()}`,
+        }
+      : claim.sample_size && claim.sample_size > 0
+        ? { label: 'Participants', value: `N=${claim.sample_size.toLocaleString()}` }
+        : null,
     sources.length > 0
       ? { label: 'Cited sources', value: String(sources.length) }
       : null,

--- a/src/lib/__tests__/evidence-source-metrics.test.ts
+++ b/src/lib/__tests__/evidence-source-metrics.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, it } from 'vitest'
-import { countHumanTrials, isHumanTrialSource } from '../evidence-source-metrics'
+import {
+  countHumanTrials,
+  getHumanParticipantMetric,
+  isHumanTrialSource,
+} from '../evidence-source-metrics'
 import type { EvidenceEngineSource } from '../evidence-engine'
 
-function source(source_type: string, source_id: string): EvidenceEngineSource {
+function source(
+  source_type: string,
+  source_id: string,
+  sample_size?: number
+): EvidenceEngineSource {
   return {
     source_id,
     claim_id: 'claim-1',
@@ -11,6 +19,7 @@ function source(source_type: string, source_id: string): EvidenceEngineSource {
     title: source_id,
     year: 2026,
     url: 'https://example.com',
+    sample_size,
     published: true,
   }
 }
@@ -30,5 +39,30 @@ describe('evidence source metrics', () => {
   it('does not infer a human trial from generic human evidence wording', () => {
     expect(isHumanTrialSource(source('human evidence', 'human'))).toBe(false)
     expect(isHumanTrialSource(source('meta-analysis', 'meta'))).toBe(false)
+  })
+
+  it('returns a complete approximate total when every human trial has N metadata', () => {
+    expect(getHumanParticipantMetric([
+      source('RCT', 'one', 120),
+      source('clinical trial', 'two', 80),
+      source('systematic review', 'review'),
+    ])).toEqual({
+      total: 200,
+      trialsWithSampleSize: 2,
+      humanTrials: 2,
+      complete: true,
+    })
+  })
+
+  it('marks participant totals partial when a human trial is missing N metadata', () => {
+    expect(getHumanParticipantMetric([
+      source('RCT', 'one', 120),
+      source('controlled trial', 'two'),
+    ])).toEqual({
+      total: 120,
+      trialsWithSampleSize: 1,
+      humanTrials: 2,
+      complete: false,
+    })
   })
 })

--- a/src/lib/evidence-engine.ts
+++ b/src/lib/evidence-engine.ts
@@ -54,6 +54,7 @@ export type EvidenceEngineSource = {
   year: number | string
   url: string
   source_note?: string
+  sample_size?: number | null
   published: boolean
 }
 

--- a/src/lib/evidence-source-metrics.ts
+++ b/src/lib/evidence-source-metrics.ts
@@ -2,10 +2,34 @@ import type { EvidenceEngineSource } from './evidence-engine'
 
 const HUMAN_TRIAL_TYPE = /\b(?:rct|randomi[sz]ed(?: controlled)? trial|clinical trial|controlled trial|human trial|crossover trial|cross-over trial)\b/i
 
+export type HumanParticipantMetric = {
+  total: number
+  trialsWithSampleSize: number
+  humanTrials: number
+  complete: boolean
+}
+
 export function isHumanTrialSource(source: Pick<EvidenceEngineSource, 'source_type'>): boolean {
   return HUMAN_TRIAL_TYPE.test(source.source_type.trim())
 }
 
 export function countHumanTrials(sources: EvidenceEngineSource[]): number {
   return sources.filter(isHumanTrialSource).length
+}
+
+export function getHumanParticipantMetric(sources: EvidenceEngineSource[]): HumanParticipantMetric | null {
+  const humanTrials = sources.filter(isHumanTrialSource)
+  if (humanTrials.length === 0) return null
+
+  const withSampleSize = humanTrials.filter(
+    (source) => typeof source.sample_size === 'number' && Number.isFinite(source.sample_size) && source.sample_size > 0
+  )
+  if (withSampleSize.length === 0) return null
+
+  return {
+    total: withSampleSize.reduce((sum, source) => sum + (source.sample_size as number), 0),
+    trialsWithSampleSize: withSampleSize.length,
+    humanTrials: humanTrials.length,
+    complete: withSampleSize.length === humanTrials.length,
+  }
 }


### PR DESCRIPTION
Implements backlog item #155. Evidence sources can now carry source-level sample sizes; the shared claim renderer aggregates N across explicitly identified human trials. If every human trial has sample-size metadata it shows an approximate participant total; if only some do, it labels the number “Known participants” rather than implying completeness. Added regression tests for complete and partial totals.