### PR TITLE
ROI #156: surface finding consistency beside claims

### DIFF
--- a/src/components/evidence-engine/EvidenceClaimCard.tsx
+++ b/src/components/evidence-engine/EvidenceClaimCard.tsx
@@ -50,6 +50,9 @@ export default function EvidenceClaimCard({
     claim.duration
       ? { label: 'Duration', value: claim.duration }
       : null,
+    claim.finding_consistency
+      ? { label: 'Consistency', value: formatEvidenceLabel(claim.finding_consistency) }
+      : null,
   ].filter((signal): signal is { label: string; value: string } => signal !== null)
 
   return (

--- a/src/lib/evidence-engine.ts
+++ b/src/lib/evidence-engine.ts
@@ -33,6 +33,7 @@ export type EvidenceEngineClaim = {
   blinding?: string
   control?: string
   design_insight?: string
+  finding_consistency?: string
 }
 
 export type EvidenceEngineConfig = {


### PR DESCRIPTION
Implements backlog item #156. Adds an optional structured `finding_consistency` field to evidence-engine claims and surfaces it directly beside the claim when present. Missing consistency data remains hidden rather than inferred from prose.