### PR TITLE
ROI #157: surface population limitations

### DIFF
--- a/src/components/evidence-engine/EvidenceClaimCard.tsx
+++ b/src/components/evidence-engine/EvidenceClaimCard.tsx
@@ -91,6 +91,12 @@ export default function EvidenceClaimCard({
           <dt className="font-semibold text-ink">Limitations</dt>
           <dd className="text-[#36483e] dark:text-[var(--text-muted)]">{claim.limitations}</dd>
         </div>
+        {claim.population_limitations ? (
+          <div>
+            <dt className="font-semibold text-ink">Population limits</dt>
+            <dd className="text-[#36483e] dark:text-[var(--text-muted)]">{claim.population_limitations}</dd>
+          </div>
+        ) : null}
         <div className="grid gap-3 sm:grid-cols-2">
           <div className="rounded-xl bg-brand-50/80 p-3 ring-1 ring-brand-900/8 dark:bg-[var(--surface-subtle)]">
             <dt className="font-semibold text-ink">Best fit</dt>

--- a/src/lib/evidence-engine.ts
+++ b/src/lib/evidence-engine.ts
@@ -34,6 +34,7 @@ export type EvidenceEngineClaim = {
   control?: string
   design_insight?: string
   finding_consistency?: string
+  population_limitations?: string
 }
 
 export type EvidenceEngineConfig = {


### PR DESCRIPTION
Implements backlog item #157. Adds an optional structured `population_limitations` field to evidence-engine claims and renders it as a dedicated “Population limits” row directly beside the claim’s evidence summary and limitations. Missing population data remains hidden rather than inferred.