### PR TITLE
ROI #158: state trial-dose relevance to consumer products

### DIFF
--- a/src/components/evidence-engine/EvidenceClaimCard.tsx
+++ b/src/components/evidence-engine/EvidenceClaimCard.tsx
@@ -53,6 +53,9 @@ export default function EvidenceClaimCard({
     claim.finding_consistency
       ? { label: 'Consistency', value: formatEvidenceLabel(claim.finding_consistency) }
       : null,
+    claim.consumer_dose_match
+      ? { label: 'Dose vs products', value: formatEvidenceLabel(claim.consumer_dose_match) }
+      : null,
   ].filter((signal): signal is { label: string; value: string } => signal !== null)
 
   return (

--- a/src/lib/evidence-engine.ts
+++ b/src/lib/evidence-engine.ts
@@ -35,6 +35,7 @@ export type EvidenceEngineClaim = {
   design_insight?: string
   finding_consistency?: string
   population_limitations?: string
+  consumer_dose_match?: string
 }
 
 export type EvidenceEngineConfig = {


### PR DESCRIPTION
Implements backlog item #158. Adds an optional structured `consumer_dose_match` field to evidence-engine claims and surfaces it beside the claim as “Dose vs products.” The site does not infer dose comparability from prose; the label appears only when the evidence pipeline explicitly supplies it.