### PR TITLE
ROI #159: label branded extracts studied in trials

### DIFF
--- a/src/components/evidence-engine/EvidenceClaimCard.tsx
+++ b/src/components/evidence-engine/EvidenceClaimCard.tsx
@@ -56,6 +56,9 @@ export default function EvidenceClaimCard({
     claim.consumer_dose_match
       ? { label: 'Dose vs products', value: formatEvidenceLabel(claim.consumer_dose_match) }
       : null,
+    claim.branded_extract
+      ? { label: 'Studied extract', value: claim.branded_extract }
+      : null,
   ].filter((signal): signal is { label: string; value: string } => signal !== null)
 
   return (

--- a/src/lib/evidence-engine.ts
+++ b/src/lib/evidence-engine.ts
@@ -36,6 +36,7 @@ export type EvidenceEngineClaim = {
   finding_consistency?: string
   population_limitations?: string
   consumer_dose_match?: string
+  branded_extract?: string
 }
 
 export type EvidenceEngineConfig = {


### PR DESCRIPTION
Implements backlog item #159. Adds an optional structured `branded_extract` field to evidence-engine claims and surfaces it beside the major claim as “Studied extract.” The label appears only when the pipeline explicitly identifies a branded/specific extract.