### PR TITLE
ROI #162: add full evidence-table study fields

### DIFF
--- a/src/components/evidence-engine/EvidenceSourceList.tsx
+++ b/src/components/evidence-engine/EvidenceSourceList.tsx
@@ -13,13 +13,17 @@ export default function EvidenceSourceList({ sources }: EvidenceSourceListProps)
         Claim-specific evidence
       </p>
       <div className="mt-2 overflow-x-auto rounded-xl border border-brand-900/10">
-        <table className="w-full min-w-[640px] border-collapse text-left text-sm leading-6">
+        <table className="w-full min-w-[1120px] border-collapse text-left text-sm leading-6">
           <thead className="bg-brand-50/70 text-xs uppercase tracking-[0.08em] text-muted">
             <tr>
               <th scope="col" className="px-3 py-2 font-bold">Study</th>
               <th scope="col" className="px-3 py-2 font-bold">Design</th>
               <th scope="col" className="px-3 py-2 font-bold">N</th>
-              <th scope="col" className="px-3 py-2 font-bold">Year</th>
+              <th scope="col" className="px-3 py-2 font-bold">Dose</th>
+              <th scope="col" className="px-3 py-2 font-bold">Duration</th>
+              <th scope="col" className="px-3 py-2 font-bold">Population</th>
+              <th scope="col" className="px-3 py-2 font-bold">Outcome</th>
+              <th scope="col" className="px-3 py-2 font-bold">Result</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-brand-900/10 bg-white/70 dark:bg-white/5">
@@ -34,6 +38,7 @@ export default function EvidenceSourceList({ sources }: EvidenceSourceListProps)
                   >
                     {source.title || source.citation_label}
                   </a>
+                  <span className="mt-1 block text-xs text-muted">{source.year || 'Year not recorded'}</span>
                   {source.source_note ? (
                     <span className="mt-1 block text-xs leading-5 text-muted">{source.source_note}</span>
                   ) : null}
@@ -44,7 +49,11 @@ export default function EvidenceSourceList({ sources }: EvidenceSourceListProps)
                     ? source.sample_size.toLocaleString()
                     : '—'}
                 </td>
-                <td className="px-3 py-3 text-muted">{source.year || '—'}</td>
+                <td className="px-3 py-3 text-muted">{source.dose || '—'}</td>
+                <td className="px-3 py-3 text-muted">{source.duration || '—'}</td>
+                <td className="px-3 py-3 text-muted">{source.population || '—'}</td>
+                <td className="px-3 py-3 text-muted">{source.outcome || '—'}</td>
+                <td className="px-3 py-3 text-muted">{source.result || '—'}</td>
               </tr>
             ))}
           </tbody>

--- a/src/lib/evidence-engine.ts
+++ b/src/lib/evidence-engine.ts
@@ -60,6 +60,11 @@ export type EvidenceEngineSource = {
   url: string
   source_note?: string
   sample_size?: number | null
+  dose?: string
+  duration?: string
+  population?: string
+  outcome?: string
+  result?: string
   published: boolean
 }
 


### PR DESCRIPTION
Implements backlog item #162. Extends evidence-engine source rows with Dose, Duration, Population, Outcome, and Result fields and expands the shared evidence table to the complete Study / Design / N / Dose / Duration / Population / Outcome / Result contract. Missing values render as em dashes instead of being inferred.