### PR TITLE
ROI #163: add per-study limitations beneath evidence rows

### DIFF
--- a/src/components/evidence-engine/EvidenceSourceList.tsx
+++ b/src/components/evidence-engine/EvidenceSourceList.tsx
@@ -39,6 +39,11 @@ export default function EvidenceSourceList({ sources }: EvidenceSourceListProps)
                     {source.title || source.citation_label}
                   </a>
                   <span className="mt-1 block text-xs text-muted">{source.year || 'Year not recorded'}</span>
+                  {source.limitation ? (
+                    <span className="mt-2 block text-xs leading-5 text-amber-900">
+                      <strong>Limitation:</strong> {source.limitation}
+                    </span>
+                  ) : null}
                   {source.source_note ? (
                     <span className="mt-1 block text-xs leading-5 text-muted">{source.source_note}</span>
                   ) : null}

--- a/src/lib/evidence-engine.ts
+++ b/src/lib/evidence-engine.ts
@@ -65,6 +65,7 @@ export type EvidenceEngineSource = {
   population?: string
   outcome?: string
   result?: string
+  limitation?: string
   published: boolean
 }
 


### PR DESCRIPTION
Implements backlog item #163. Adds an optional structured `limitation` field to evidence-engine study rows and renders it directly beneath the study title as a dedicated one-sentence limitation. Generic source notes remain separate.