### PR TITLE
ROI #164: link study titles directly to PubMed or DOI

### DIFF
--- a/src/components/evidence-engine/EvidenceSourceList.tsx
+++ b/src/components/evidence-engine/EvidenceSourceList.tsx
@@ -1,3 +1,4 @@
+import { getEvidenceSourceUrl } from '../../lib/evidence-source-metrics'
 import type { EvidenceEngineSource } from '../../lib/evidence-engine'
 
 type EvidenceSourceListProps = {
@@ -31,7 +32,7 @@ export default function EvidenceSourceList({ sources }: EvidenceSourceListProps)
               <tr key={source.source_id} className="align-top">
                 <td className="px-3 py-3">
                   <a
-                    href={source.url}
+                    href={getEvidenceSourceUrl(source)}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="font-semibold text-brand-800 hover:text-brand-700 hover:underline"

--- a/src/lib/__tests__/evidence-source-metrics.test.ts
+++ b/src/lib/__tests__/evidence-source-metrics.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   countHumanTrials,
+  getEvidenceSourceUrl,
   getHumanParticipantMetric,
   isHumanTrialSource,
 } from '../evidence-source-metrics'
@@ -64,5 +65,13 @@ describe('evidence source metrics', () => {
       humanTrials: 2,
       complete: false,
     })
+  })
+
+  it('prefers PubMed, then DOI, then the stored URL', () => {
+    expect(getEvidenceSourceUrl({ pubmed_id: '12345678', doi: '10.1000/test', url: 'https://example.com' }))
+      .toBe('https://pubmed.ncbi.nlm.nih.gov/12345678/')
+    expect(getEvidenceSourceUrl({ doi: 'https://doi.org/10.1000/test', url: 'https://example.com' }))
+      .toBe('https://doi.org/10.1000/test')
+    expect(getEvidenceSourceUrl({ url: 'https://example.com' })).toBe('https://example.com')
   })
 })

--- a/src/lib/evidence-engine.ts
+++ b/src/lib/evidence-engine.ts
@@ -58,6 +58,8 @@ export type EvidenceEngineSource = {
   title: string
   year: number | string
   url: string
+  pubmed_id?: string
+  doi?: string
   source_note?: string
   sample_size?: number | null
   dose?: string

--- a/src/lib/evidence-source-metrics.ts
+++ b/src/lib/evidence-source-metrics.ts
@@ -33,3 +33,20 @@ export function getHumanParticipantMetric(sources: EvidenceEngineSource[]): Huma
     complete: withSampleSize.length === humanTrials.length,
   }
 }
+
+export function getEvidenceSourceUrl(source: Pick<EvidenceEngineSource, 'pubmed_id' | 'doi' | 'url'>): string {
+  const pmid = source.pubmed_id?.trim()
+  if (pmid && /^\d+$/.test(pmid)) {
+    return `https://pubmed.ncbi.nlm.nih.gov/${pmid}/`
+  }
+
+  const doi = source.doi
+    ?.trim()
+    .replace(/^https?:\/\/(?:dx\.)?doi\.org\//i, '')
+    .replace(/^doi:\s*/i, '')
+  if (doi) {
+    return `https://doi.org/${doi}`
+  }
+
+  return source.url
+}


### PR DESCRIPTION
Implements backlog item #164. Evidence-engine sources now support PMID and DOI identifiers. Study-title links prefer PubMed when a valid PMID exists, otherwise DOI, otherwise the stored source URL. DOI normalization handles existing doi.org/doi: prefixes. Added regression coverage for link precedence.