### PR TITLE
ROI #166: add expandable why-we-believe-this evidence box

### DIFF
--- a/src/components/evidence-engine/EvidenceClaimCard.tsx
+++ b/src/components/evidence-engine/EvidenceClaimCard.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import EvidenceSafetyNotes from './EvidenceSafetyNotes'
 import EvidenceSourceList from './EvidenceSourceList'
+import WhyWeBelieveThis from './WhyWeBelieveThis'
 import TrialDesignInsight from '@/components/education/TrialDesignInsight'
 import { countHumanTrials, getHumanParticipantMetric } from '../../lib/evidence-source-metrics'
 import {
@@ -98,21 +99,14 @@ export default function EvidenceClaimCard({
         </div>
       ) : null}
 
-      <dl className="mt-4 space-y-3 text-sm leading-6">
-        <div>
-          <dt className="font-semibold text-ink">Evidence summary</dt>
-          <dd className="text-[#36483e] dark:text-[var(--text-muted)]">{claim.evidence_summary}</dd>
-        </div>
-        <div>
-          <dt className="font-semibold text-ink">Limitations</dt>
-          <dd className="text-[#36483e] dark:text-[var(--text-muted)]">{claim.limitations}</dd>
-        </div>
-        {claim.population_limitations ? (
-          <div>
-            <dt className="font-semibold text-ink">Population limits</dt>
-            <dd className="text-[#36483e] dark:text-[var(--text-muted)]">{claim.population_limitations}</dd>
-          </div>
-        ) : null}
+      <WhyWeBelieveThis
+        evidenceSummary={claim.evidence_summary}
+        limitations={claim.limitations}
+        populationLimitations={claim.population_limitations}
+        sourceCount={sources.length}
+      />
+
+      <dl className="mt-4 text-sm leading-6">
         <div className="grid gap-3 sm:grid-cols-2">
           <div className="rounded-xl bg-brand-50/80 p-3 ring-1 ring-brand-900/8 dark:bg-[var(--surface-subtle)]">
             <dt className="font-semibold text-ink">Best fit</dt>

--- a/src/components/evidence-engine/WhyWeBelieveThis.tsx
+++ b/src/components/evidence-engine/WhyWeBelieveThis.tsx
@@ -1,0 +1,35 @@
+type WhyWeBelieveThisProps = {
+  evidenceSummary: string
+  limitations?: string | null
+  populationLimitations?: string | null
+  sourceCount?: number
+}
+
+export default function WhyWeBelieveThis({
+  evidenceSummary,
+  limitations,
+  populationLimitations,
+  sourceCount = 0,
+}: WhyWeBelieveThisProps) {
+  return (
+    <details open className="mt-4 rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+      <summary className="cursor-pointer font-semibold text-ink">
+        Why we believe this
+        {sourceCount > 0 ? (
+          <span className="ml-2 text-xs font-normal text-muted">
+            {sourceCount} cited source{sourceCount === 1 ? '' : 's'}
+          </span>
+        ) : null}
+      </summary>
+      <div className="mt-3 space-y-3 text-sm leading-6 text-[#36483e] dark:text-[var(--text-muted)]">
+        <p>{evidenceSummary}</p>
+        {limitations ? (
+          <p><strong className="text-ink">Limitations:</strong> {limitations}</p>
+        ) : null}
+        {populationLimitations ? (
+          <p><strong className="text-ink">Population limits:</strong> {populationLimitations}</p>
+        ) : null}
+      </div>
+    </details>
+  )
+}


### PR DESCRIPTION
Implements backlog item #166. Adds a reusable no-JavaScript `WhyWeBelieveThis` details component and integrates it into the shared evidence claim renderer. It consolidates evidence summary, limitations, population limits, and cited-source count into one expandable box that is open by default, while removing the duplicated legacy rows.