### PR TITLE
ROI #167: add what-would-change-our-conclusion field

### DIFF
--- a/src/components/evidence-engine/EvidenceClaimCard.tsx
+++ b/src/components/evidence-engine/EvidenceClaimCard.tsx
@@ -103,6 +103,7 @@ export default function EvidenceClaimCard({
         evidenceSummary={claim.evidence_summary}
         limitations={claim.limitations}
         populationLimitations={claim.population_limitations}
+        conclusionChangeTrigger={claim.conclusion_change_trigger}
         sourceCount={sources.length}
       />
 

--- a/src/components/evidence-engine/WhyWeBelieveThis.tsx
+++ b/src/components/evidence-engine/WhyWeBelieveThis.tsx
@@ -2,6 +2,7 @@ type WhyWeBelieveThisProps = {
   evidenceSummary: string
   limitations?: string | null
   populationLimitations?: string | null
+  conclusionChangeTrigger?: string | null
   sourceCount?: number
 }
 
@@ -9,6 +10,7 @@ export default function WhyWeBelieveThis({
   evidenceSummary,
   limitations,
   populationLimitations,
+  conclusionChangeTrigger,
   sourceCount = 0,
 }: WhyWeBelieveThisProps) {
   return (
@@ -28,6 +30,12 @@ export default function WhyWeBelieveThis({
         ) : null}
         {populationLimitations ? (
           <p><strong className="text-ink">Population limits:</strong> {populationLimitations}</p>
+        ) : null}
+        {conclusionChangeTrigger ? (
+          <div className="border-t border-brand-900/10 pt-3">
+            <p className="font-semibold text-ink">What would change our conclusion?</p>
+            <p className="mt-1">{conclusionChangeTrigger}</p>
+          </div>
         ) : null}
       </div>
     </details>

--- a/src/lib/evidence-engine.ts
+++ b/src/lib/evidence-engine.ts
@@ -38,6 +38,7 @@ export type EvidenceEngineClaim = {
   consumer_dose_match?: string
   branded_extract?: string
   extract_generalizable?: boolean | null
+  conclusion_change_trigger?: string
 }
 
 export type EvidenceEngineConfig = {


### PR DESCRIPTION
Implements backlog item #167. Adds an optional structured `conclusion_change_trigger` to evidence claims and renders it inside the shared “Why we believe this” evidence box under a dedicated “What would change our conclusion?” heading. The site does not auto-generate falsifiability criteria; the section appears only when the evidence pipeline supplies one.