### PR TITLE
ROI #169: record source-review dates in claim UI

### DIFF
--- a/src/components/evidence-engine/EvidenceClaimCard.tsx
+++ b/src/components/evidence-engine/EvidenceClaimCard.tsx
@@ -60,6 +60,9 @@ export default function EvidenceClaimCard({
     claim.branded_extract
       ? { label: 'Studied extract', value: claim.branded_extract }
       : null,
+    claim.evidence_search_date
+      ? { label: 'Evidence searched', value: claim.evidence_search_date }
+      : null,
   ].filter((signal): signal is { label: string; value: string } => signal !== null)
 
   const showExtractWarning = Boolean(

--- a/src/lib/evidence-engine.ts
+++ b/src/lib/evidence-engine.ts
@@ -39,6 +39,7 @@ export type EvidenceEngineClaim = {
   branded_extract?: string
   extract_generalizable?: boolean | null
   conclusion_change_trigger?: string
+  evidence_search_date?: string
 }
 
 export type EvidenceEngineConfig = {


### PR DESCRIPTION
Adds an optional date field to the shared claim model and displays it when present.