### PR TITLE
content: refresh Lion's Mane evidence and citations

### DIFF
--- a/content/articles/lions-mane-mushroom-benefits-mechanisms-dosage-evidence-guide.md
+++ b/content/articles/lions-mane-mushroom-benefits-mechanisms-dosage-evidence-guide.md
@@ -1,9 +1,9 @@
 ---
 slug: lions-mane-mushroom-benefits-mechanisms-dosage-evidence-guide
-title: "Lion's Mane Mushroom: Benefits, Dosage & What the Evidence Actually Shows"
-description: "Evidence-based guide to Lion's Mane for memory, focus, and cognitive health. Covers dosage (1-3g/day), NGF mechanisms, fruiting body vs mycelium, 8-week protocol, and what human trials actually found."
+title: "Lion's Mane Mushroom: Cognition, Mood, Dose & Evidence — 2026 Review"
+description: "Evidence-first 2026 review of Lion's Mane (Hericium erinaceus): small human cognition trials, newer null and mixed findings in healthy adults, product-form directness, preclinical NGF mechanisms, dosing uncertainty, and safety limits."
 date: '2026-06-08'
-updatedAt: '2026-07-05'
+updatedAt: '2026-08-15'
 author: Will
 category: Cognitive health
 evidence_grade: mixed-human-evidence
@@ -11,51 +11,54 @@ herb: "Lion's Mane"
 scientific_name: "Hericium erinaceus"
 keywords:
   - lion's mane
-  - lion's mane benefits
-  - lion's mane dosage
+  - lion's mane evidence
+  - lion's mane cognition
   - hericium erinaceus
   - nootropics
-  - cognition
+  - memory
   - nerve growth factor
   - mushrooms
 featured_image: ''
 tags:
   - lion's mane
   - hericium erinaceus
-  - nootropics
   - cognition
   - mushrooms
+  - evidence review
 profile_status: published
 sitemap_included: true
 ai_assisted: true
 references:
-  - title: "Improving effects of the mushroom Yamabushitake (Hericium erinaceus) on mild cognitive impairment: a double-blind placebo-controlled clinical trial"
-    authors: "Mori K, Inatomi S, Ouchi K, Azumi Y, Tuchida T"
-    year: "2009"
-    pmid: "18844328"
-    url: "https://pubmed.ncbi.nlm.nih.gov/18844328/"
-  - title: "Nerve growth factor-inducing activity of Hericium erinaceus in 1321N1 human astrocytoma cells"
-    authors: "Mori K, Obara Y, Hirota M, Azumi Y, Kinugasa S, Inatomi S, Nakahata N"
-    year: "2008"
-    pmid: "18758067"
-    url: "https://pubmed.ncbi.nlm.nih.gov/18758067/"
-  - title: "Hericium erinaceus: an edible mushroom with medicinal values"
-    authors: "Friedman M"
-    year: "2015"
-    pmid: "26244378"
-    url: "https://pubmed.ncbi.nlm.nih.gov/26244378/"
-  - title: "Reduction of depression and anxiety by 4 weeks Hericium erinaceus intake"
-    authors: "Nagano M, Shimizu K, Kondo R, Hayashi C, Sato D, Kitagawa K, Ohnuki K"
-    year: "2010"
-    pmid: "20834180"
-    url: "https://pubmed.ncbi.nlm.nih.gov/20834180/"
-  - title: "Neuroregenerative potential of lion's mane mushroom, Hericium erinaceus, in the treatment of peripheral nerve injury"
-    authors: "Wong KH, Naidu M, David RP, Abdulla MA, Abdullah N, Kuppusamy UR, Sabaratnam V"
-    year: "2012"
-    pmid: "23510212"
-    url: "https://pubmed.ncbi.nlm.nih.gov/23510212/"
+  - title: "Benefits, side effects, and uses of Hericium erinaceus as a supplement: a systematic review"
+    authors: "Menon A, Jalal A, Arshad Z, Nawaz FA, Kashyap R"
+    year: "2025"
+    pmid: "40959699"
+    pmcid: "PMC12434001"
+    doi: "10.3389/fnut.2025.1641246"
+    url: "https://pubmed.ncbi.nlm.nih.gov/40959699/"
+  - title: "Acute effects of a standardised extract of Hericium erinaceus on cognition and mood in healthy younger adults: a double-blind randomised placebo-controlled study"
+    authors: "Surendran G, Saye J, Mohd Jalil SB, et al."
+    year: "2025"
+    pmid: "40276537"
+    pmcid: "PMC12018234"
+    doi: "10.3389/fnut.2025.1405796"
+    url: "https://pubmed.ncbi.nlm.nih.gov/40276537/"
+  - title: "Unveiling the role of erinacines in the neuroprotective effects of Hericium erinaceus: a systematic review in preclinical models"
+    authors: "Spangenberg ET, Moneypenny A, Bozzo GG, Perreault ML"
+    year: "2025"
+    pmid: "40626304"
+    pmcid: "PMC12230622"
+    doi: "10.3389/fphar.2025.1582081"
+    url: "https://pubmed.ncbi.nlm.nih.gov/40626304/"
+  - title: "The Acute and Chronic Effects of Lion's Mane Mushroom Supplementation on Cognitive Function, Stress and Mood in Young Adults: A Double-Blind, Parallel Groups, Pilot Study"
+    authors: "Docherty S, Doughty FL, Smith EF"
+    year: "2023"
+    pmid: "38004235"
+    pmcid: "PMC10675414"
+    doi: "10.3390/nu15224842"
+    url: "https://pubmed.ncbi.nlm.nih.gov/38004235/"
   - title: "Prevention of Early Alzheimer's Disease by Erinacine A-Enriched Hericium erinaceus Mycelia Pilot Double-Blind Placebo-Controlled Study"
-    authors: "Li IC, Lee LY, Tzeng TT, Chen WP, Chen YP, Shiao YJ, Chen CC"
+    authors: "Li IC, Lee LY, Tzeng TT, et al."
     year: "2020"
     pmid: "32581767"
     url: "https://pubmed.ncbi.nlm.nih.gov/32581767/"
@@ -63,268 +66,302 @@ references:
     authors: "Saitsu Y, Nishide A, Kikushima K, Shimizu K, Ohnuki K"
     year: "2019"
     pmid: "31413233"
+    doi: "10.2220/biomedres.40.125"
     url: "https://pubmed.ncbi.nlm.nih.gov/31413233/"
-  - title: "The Acute and Chronic Effects of Lion's Mane Mushroom Supplementation on Cognitive Function, Stress and Mood in Young Adults"
-    authors: "Docherty S, Doughty FL, Smith EF"
-    year: "2023"
-    pmid: "38004235"
-    url: "https://pubmed.ncbi.nlm.nih.gov/38004235/"
   - title: "Hericium erinaceus Improves Mood and Sleep Disorders in Patients Affected by Overweight or Obesity"
-    authors: "Vigna L, Morelli F, Agnelli GM, Napolitano F, Ratto D, Occhinegro A, Di Iorio C, Savino E, Girometta C, Brandalise F, Rossi P"
+    authors: "Vigna L, Morelli F, Agnelli GM, et al."
     year: "2019"
     pmid: "31118969"
+    doi: "10.1155/2019/7861297"
     url: "https://pubmed.ncbi.nlm.nih.gov/31118969/"
-  - title: "Benefits, side effects, and uses of Hericium erinaceus as a supplement: a systematic review"
-    authors: "Menon S, Jalal Z, Arshad S, Nawaz S, Kashyap D"
-    year: "2025"
-    pmid: "40959699"
-    url: "https://pubmed.ncbi.nlm.nih.gov/40959699/"
+  - title: "Reduction of depression and anxiety by 4 weeks Hericium erinaceus intake"
+    authors: "Nagano M, Shimizu K, Kondo R, et al."
+    year: "2010"
+    pmid: "20834180"
+    doi: "10.2220/biomedres.31.231"
+    url: "https://pubmed.ncbi.nlm.nih.gov/20834180/"
+  - title: "Improving effects of the mushroom Yamabushitake (Hericium erinaceus) on mild cognitive impairment: a double-blind placebo-controlled clinical trial"
+    authors: "Mori K, Inatomi S, Ouchi K, Azumi Y, Tuchida T"
+    year: "2009"
+    pmid: "18844328"
+    url: "https://pubmed.ncbi.nlm.nih.gov/18844328/"
+  - title: "Chemistry, Nutrition, and Health-Promoting Properties of Hericium erinaceus Fruiting Bodies and Mycelia and Their Bioactive Compounds"
+    authors: "Friedman M"
+    year: "2015"
+    pmid: "26244378"
+    doi: "10.1021/acs.jafc.5b02914"
+    url: "https://pubmed.ncbi.nlm.nih.gov/26244378/"
 ---
 
-> **The bottom line:** Lion's Mane stimulates nerve growth factor (NGF), supporting brain cell health over weeks to months. Human trials show improved cognitive scores in mild cognitive impairment at 750 mg–3 g/day for 8–16 weeks — but benefits faded after stopping, suggesting ongoing use is needed. It's not a stimulant or an acute nootropic — expect subtle, cumulative effects. Evidence grade: **Moderate** for cognition in older adults with existing impairment; preliminary for mood and healthy-young-adult focus. No ADHD-specific trials exist.
-
-## At a Glance
-
-Lion's Mane (*Hericium erinaceus*) is a medicinal mushroom studied primarily for cognitive function in older adults. Its most plausible value is longer-term support through compounds (erinacines and hericenones) that stimulate nerve growth factor (NGF) signaling — a protein involved in neuron survival, maintenance, and plasticity. It is not an acute focus booster and should not be compared to stimulants.
-
-| Question | Answer |
-|---|---|
-| Best fit | Adults 50+ with mild memory complaints or mild cognitive impairment; long-term cognitive support |
-| Evidence level | Moderate for cognition in mild impairment; preliminary for mood and healthy-young-adult focus |
-| Typical dose | 1,000–3,000 mg/day of fruiting body extract or 750 mg–3 g/day depending on product form |
-| Onset | 4–8 weeks minimum; 12–16 weeks for full cognitive effects |
-| Is it a stimulant? | No — no acute energy, no jitters, nothing like caffeine or modafinil |
-| Does it work for ADHD? | No ADHD-specific trials exist. Do not substitute for prescribed ADHD medication. |
-| Main safety concern | Mushroom allergy; caution with blood thinners |
-| Cost | $15–40/month depending on extract quality and dose |
-
+> **Bottom line:** Lion's Mane has **promising but still limited and product-specific human evidence**. Small trials in older adults or people with cognitive impairment reported improvements on selected cognitive scales, while newer studies in healthy younger adults have produced isolated positive signals alongside null findings. A 2025 acute crossover trial found **no significant overall improvement in global cognition or mood** after a standardized fruiting-body extract. Mechanistic claims involving NGF, neurogenesis, and erinacines remain dominated by cell and animal research. There is no evidence-based universal dose, onset timeline, cycling schedule, or need for indefinite use.
 
 ![Lions Mane Mushroom Benefits Mechanisms Dosage Evidence Guide](/images/guides/lions-mane.jpg)
 
----
+## At a glance
 
-## What Lion's Mane Actually Feels Like
-
-Lion's Mane is one of the most subtle supplements people take. Unlike caffeine (which you definitely feel) or ashwagandha (which many notice within weeks), Lion's Mane operates almost entirely in the background. Most users who benefit don't realize it's working until they stop.
-
-**What users who benefit typically report:**
-- "I didn't notice anything dramatic, but after a month I realized I wasn't forgetting words mid-sentence anymore"
-- "My thinking feels clearer — not faster, just less foggy. Like a fog machine was turned off."
-- "I dream more vividly and remember my dreams" (commonly reported, though not formally studied in controlled trials)
-- "I stopped taking it for a week and noticed my recall got worse — that's when I realized it was actually doing something"
-
-**What it absolutely does NOT feel like:**
-- A stimulant (zero energy boost, no jitters)
-- Adderall or Ritalin (no acute focus enhancement — completely different mechanism and magnitude)
-- A psychedelic or psychoactive mushroom (zero perceptual effects — Hericium erinaceus is not a psilocybin-containing species)
-- An immediate cognitive enhancer (you won't feel sharper 30 minutes after taking it)
-
-> **The best way to know if it's working:** track a specific cognitive metric before and after 8–12 weeks. Examples: number of times you lose your train of thought in meetings, word-finding difficulty, typing speed, or a standardized cognitive test app score. Without measurement, it's very difficult to tell whether it's doing anything.
+| Question | Evidence-first answer |
+|---|---|
+| Best-supported human signal | Selected cognitive outcomes in a few small older-adult / cognitive-impairment trials |
+| Healthy-young-adult cognition | **Weak and mixed.** Two small modern trials found task-specific signals, not a broad nootropic effect |
+| Mood / stress | Preliminary; small studies, narrow populations, and inconsistent outcome patterns |
+| Mechanism | NGF/neurogenesis hypotheses are biologically interesting but substantially **preclinical** |
+| Dose | Trials used different powders, fruiting-body extracts, and erinacine-enriched mycelia; milligram amounts are not interchangeable |
+| Onset | No universal onset has been established. Trial measurement windows are not an individual-response schedule |
+| Long-term use | Not established as necessary; long-term safety and sustained benefit remain incompletely characterized |
+| ADHD | No evidence establishes Lion's Mane as an ADHD treatment or replacement for evaluated care |
 
 ---
 
-## The 8-Week Protocol: How to Actually Test Lion's Mane
+## What changed in the 2025–2026 evidence picture
 
-Lion's Mane is not something you feel on day one — or even week one. Neurotrophic mechanisms operate on the timescale of neuronal growth and synaptic remodeling, which takes weeks. Here's a structured testing protocol based on the clinical trial timelines:
+The biggest update is not a dramatic new benefit. It is a clearer reason to **lower certainty**.
 
-| Phase | Duration | Dose | What to track | What to expect |
-|---|---|---|---|---|
-| **Baseline** | Week 1–2 | 1,000 mg/day with breakfast | Establish baseline: memory, focus, sleep quality, word-finding difficulty. Write it down. | Nothing dramatic — confirm no GI side effects. Some people report vivid dreams even in week 1. |
-| **Escalate** | Week 3–4 | 2,000 mg/day, split morning + lunch | Compare to baseline. Track same metrics. | Subtle or no change for most people. This is normal — don't quit yet. |
-| **Optimize** | Week 5–6 | 2,000 mg/day maintained | Track word recall, work output, subjective clarity, reading comprehension speed | Some responders begin to notice clearer thinking and better recall. |
-| **Assess** | Week 7–8 | 2,000 mg/day maintained | Compare all metrics to baseline. Make a decision. | Responders should notice measurable improvement by now. The Mori 2009 trial showed cognitive benefits only emerged clearly after 8+ weeks. |
-| **Continue or discontinue** | Week 9+ | Continue at effective dose or stop | If no benefit: stop and reassess after 2 weeks off. Some people only notice the effect when it's gone. | The Mori 2009 trial found cognitive benefits faded within 4 weeks of discontinuation — suggesting ongoing use is needed to maintain effects. |
+A 2025 double-blind randomized crossover trial gave 18 healthy adults ages 18–35 a single **3 g dose of a 10:1 fruiting-body extract**. The investigators found **no significant effect on composite global cognition or mood** compared with placebo. One individual psychomotor task (pegboard performance) improved, illustrating why an isolated test result should not be converted into a claim of broad cognitive enhancement. The authors explicitly concluded that any acute benefit may be task- or domain-specific and that chronic studies are still needed. [PubMed 40276537](https://pubmed.ncbi.nlm.nih.gov/40276537/) · [DOI 10.3389/fnut.2025.1405796](https://doi.org/10.3389/fnut.2025.1405796)
 
-**Decision at week 8:**
-- **Clear improvement** → continue at effective dose
-- **Mild improvement** → continue only if cost is acceptable relative to benefit
-- **No improvement** → stop. Consider whether you're in the right population (Lion's Mane works best in older adults with existing cognitive complaints)
-- **Negative effects** → stop immediately
+That result complements a 2023 pilot in 41 healthy adults ages 18–45. In that study, **1.8 g/day for 28 days** produced a faster Stroop response after an acute dose and a near-threshold trend toward lower subjective stress after chronic use, but the investigators also reported null and limited negative findings and emphasized the small sample. [PubMed 38004235](https://pubmed.ncbi.nlm.nih.gov/38004235/) · [DOI 10.3390/nu15224842](https://doi.org/10.3390/nu15224842)
 
----
+A 2025 systematic review broadened the evidence map but also shows why citation counts can be misleading. It included **five randomized controlled trials**, three pilot clinical trials, a cohort, a case report, and **15 laboratory studies**. Clinical and preclinical findings were discussed together, so mechanistic volume should not be mistaken for a large human efficacy literature. [PubMed 40959699](https://pubmed.ncbi.nlm.nih.gov/40959699/) · [DOI 10.3389/fnut.2025.1641246](https://doi.org/10.3389/fnut.2025.1641246)
 
-## The Clinical Evidence: Study-by-Study
+### Updated interpretation
 
-> **Key finding:** The strongest human data is in older adults with mild cognitive impairment (MCI) or early cognitive decline. No ADHD-specific trials exist. Healthy-young-adult evidence is early and mixed. The effects are real but narrow — think "cognitive aging support," not "brain optimization."
-
-### Evidence Summary Table
-
-| Study | Population | n | Duration | Dose/Form | Primary Outcomes | Quality |
-|---|---|---|---|---|---|---|
-| Mori 2009 | Adults 50–80 with MCI | 30 | 16 weeks | 3 g/day fruiting body powder (tablets) | Cognitive function scale significantly improved during treatment; benefits faded 4 weeks after stopping | **Moderate** |
-| Saitsu 2019 | Adults 50+ with cognitive complaints | 31 | 12 weeks | 1.2 g/day fruiting body extract | Cognitive function scores ↑; effects appeared around week 8 | **Limited-moderate** |
-| Li 2020 | Early Alzheimer's disease | 49 | 49 weeks | Erinacine A-enriched mycelia (350 mg × 3/day) | MMSE, ADAS-Cog, and ADCS-ADL all improved vs. placebo; longest Lion's Mane trial to date | **Moderate** |
-| Nagano 2010 | Adults with self-reported mood complaints | 30 | 4 weeks | 2 g/day fruiting body (cookies) | Depression and anxiety scores ↓; effects specific to those with higher baseline symptoms | **Limited** |
-| Docherty 2023 | Healthy young adults (mean age ~26) | 41 | 28 days acute + chronic | 1.8 g/day fruiting body extract | Tentative signals for stress reduction and some cognitive measures; pilot-scale | **Preliminary** |
-| Vigna 2019 | Overweight/obese adults with mood/sleep complaints | 77 | 8 weeks | Fruiting body + mycelium blend | Mood and sleep improved; BDNF-related biomarkers showed favorable trends | **Limited-moderate** |
-
-### Deep Dive: The Core Trials
-
-**Mori 2009** — The foundational human trial. 30 Japanese adults aged 50–80 with mild cognitive impairment (MCI, defined as MMSE < 24 or clinical diagnosis) were randomized to 3 g/day of dried Lion's Mane fruiting body (in tablet form) or placebo for 16 weeks. This is a whole fruiting body powder, not a concentrated extract — an important distinction.
-
-The treatment group showed statistically significant improvement on a cognitive function scale (HDS-R) beginning around week 8 and peaking at week 16. Crucially, cognitive scores declined again within 4 weeks of discontinuing the supplement — suggesting that Lion's Mane supports cognitive function while it's being taken but does not produce permanent structural changes that persist after stopping.
-
-**Li 2020** — The longest, most rigorous Lion's Mane trial to date. 49 patients with early Alzheimer's disease (CDR 0.5–1) were randomized to erinacine A-enriched *Hericium erinaceus* mycelia (350 mg × 3/day = 1,050 mg/day) or placebo for 49 weeks. This is not a standard fruiting body product — it's a fermented mycelium product specifically enriched in erinacine A.
-
-Results: MMSE improved by ~1.5 points vs. decline in placebo; ADAS-Cog (cognitive subscale of Alzheimer's assessment) improved significantly; ADCS-ADL (activities of daily living) improved significantly; biomarker analyses suggested reduced oxidative stress and inflammatory markers. This trial demonstrates that the erinacine-enriched mycelium form can produce clinically meaningful effects in diagnosed Alzheimer's — but the product used is not what most consumers are buying.
-
-**Docherty 2023** — The most relevant trial for the "healthy young adult nootropic" use case that dominates Lion's Mane marketing. 41 healthy young adults (mean age ~26) took 1.8 g/day Lion's Mane fruiting body extract or placebo for 28 days, with acute cognitive testing at multiple timepoints.
-
-Results: Some tentative signals for improved stress response and aspects of cognitive performance, but the effects were inconsistent across measures and the study was not powered to detect small effects. This trial does not provide strong evidence that healthy young adults will experience meaningful cognitive enhancement from Lion's Mane — which is consistent with the mechanism (neurotrophic support matters more when cognition is already declining).
+- **Older/cognitively impaired populations:** encouraging small trials, but limited replication and product heterogeneity.
+- **Healthy younger adults:** no convincing broad cognitive-enhancement effect; some task-specific signals remain worth studying.
+- **Mood/stress:** preliminary rather than established.
+- **Mechanisms:** useful for plausibility, not a substitute for human outcomes.
+- **Retail products:** a result from one fruiting-body powder, extract, or enriched mycelium cannot be assumed to apply to another.
 
 ---
 
-<CollapsibleDetails title="How It Works — Complete Mechanism (tap to expand)" defaultOpen={false}>
+## Human cognition evidence, study by study
 
-## How It Works (Complete Mechanism)
+| Study | Population | Intervention | Duration | Main signal | Important limitation |
+|---|---|---|---|---|---|
+| Mori 2009 | 30 adults age 50–80 with mild cognitive impairment | 3 g/day dried fruiting-body powder | 16 weeks + 4-week follow-up | Higher HDS-R cognitive scores at weeks 8, 12, and 16 | Very small single-country trial; one preparation; post-stop decline does not prove lifelong use is required |
+| Saitsu 2019 | Older adults in a small randomized trial | Fruiting-body supplement | 12 weeks | MMSE improved; other cognitive tests were less clearly supportive | Small study; a single significant instrument should not be generalized to all cognitive domains |
+| Li 2020 | Small disease-specific pilot in early cognitive decline | Erinacine-A-enriched mycelia | 49 weeks | Favorable differences on several cognitive/function measures | Specialized enriched product and disease population; not evidence for ordinary retail fruiting-body products or general-wellness treatment claims |
+| Docherty 2023 | 41 healthy adults age 18–45 | 1.8 g/day fruiting-body material | 28 days | Acute Stroop-speed signal; stress trend | Pilot-scale; null and limited negative findings also occurred |
+| Surendran 2025 | 18 healthy adults age 18–35 | 3 g 10:1 fruiting-body extract | Acute crossover | Pegboard improvement only | No significant overall global cognition or mood benefit; tiny sample |
 
-*Hericium erinaceus* contains two families of bioactive compounds that drive its effects:
+### Mori 2009: positive, but much narrower than “Lion’s Mane improves memory”
 
-### Erinacines (Mycelium-Derived)
+The classic Mori trial randomized 30 Japanese adults with mild cognitive impairment. Participants received 3 g/day of dried mushroom powder or placebo for 16 weeks. Cognitive scores favored Lion's Mane at several later time points. Four weeks after stopping, scores in the intervention group declined. [PubMed 18844328](https://pubmed.ncbi.nlm.nih.gov/18844328/)
 
-Erinacines are cyathin diterpenoids found primarily in the mycelium (the underground fungal network). They are small, lipophilic molecules capable of crossing the blood-brain barrier — a critical property for any compound targeting CNS function.
+The correct conclusion is **not** that everyone needs continuous Lion's Mane or that stopping reverses a proven structural brain change. The study shows that, in one small population using one preparation, the measured cognitive advantage was not maintained at the same level after discontinuation. Replication is needed before converting that observation into a maintenance protocol.
 
-Key actions:
-- **NGF stimulation:** Erinacine A and related compounds are among the most potent known natural inducers of nerve growth factor synthesis in astrocytes. NGF is a neurotrophin that supports the survival, maintenance, and repair of cholinergic neurons in the basal forebrain — the same neurons that degenerate in Alzheimer's disease.
-- **Neuroprotection:** Erinacine A protects dopaminergic neurons in MPTP neurotoxicity models (a Parkinson's disease model) and reduces ischemic neuronal death in stroke models.
-- **Anti-inflammatory:** Erinacines reduce microglial activation and neuroinflammatory cytokine production.
+### Saitsu 2019: one cognitive scale moved more clearly than the others
 
-The Li 2020 trial, which used erinacine A-enriched mycelia, provides the strongest human evidence for this compound class. Standard fruiting body products contain much lower erinacine concentrations.
+A 12-week randomized, double-blind trial assessed MMSE, Benton visual retention, and paired-associate learning. The clearest reported difference was on MMSE rather than across every cognitive measure. [PubMed 31413233](https://pubmed.ncbi.nlm.nih.gov/31413233/) · [DOI 10.2220/biomedres.40.125](https://doi.org/10.2220/biomedres.40.125)
 
-### Hericenones (Fruiting Body-Derived)
+That is evidence for a possible cognitive signal, but it is not proof of generalized memory enhancement, dementia prevention, or a predictable 8-week onset.
 
-Hericenones are benzaldehyde derivatives found in the fruiting body (the visible mushroom). They also stimulate NGF synthesis but through a different mechanistic pathway than erinacines. Hericenones are less well-characterized in human studies because most supplemental products don't standardize for them, and their brain penetrance is less established than erinacines.
+### Disease-specific enriched-mycelium evidence is not a class effect
 
-### Beta-Glucans and Polysaccharides
+The Li 2020 pilot used **erinacine-A-enriched mycelia**, a specialized intervention that is not equivalent to ordinary culinary mushroom, generic fruiting-body powder, or unspecified “full-spectrum” retail products. Its disease-specific population also makes it inappropriate to use as support for broad wellness or nootropic claims. [PubMed 32581767](https://pubmed.ncbi.nlm.nih.gov/32581767/)
 
-Lion's Mane contains immunomodulatory beta-glucans that are shared across most medicinal mushrooms. These support innate immune function and may contribute to anti-inflammatory effects relevant to neuroinflammation-driven cognitive decline. However, beta-glucan content is a general marker of mushroom quality, not a specific indicator of Lion's Mane's unique nootropic potential.
-
-### The NGF Pathway: Why It Takes Weeks
-
-The mechanism explains the timeline. NGF doesn't produce acute cognitive enhancement — it supports neuronal health over weeks:
-
-```
-Lion's Mane compounds → Astrocyte NGF synthesis ↑ → NGF binds TrkA receptors on cholinergic neurons →
-Neuronal survival signals activated → Synaptic maintenance and plasticity supported →
-Cognitive improvements measurable after 8+ weeks
-```
-
-This is fundamentally different from stimulants (acute dopamine/norepinephrine), cholinesterase inhibitors (acute acetylcholine boost), or even adaptogens (HPA axis modulation over days to weeks). It's a structural support mechanism, not a neurotransmitter-targeted intervention.
+The useful lesson is **preparation directness**: when an evidence claim depends on an enriched mycelial product, the page should say so rather than presenting it as evidence for every Lion's Mane supplement.
 
 ---
 
-## Dosage, Product Selection, and Buying Guide
+## Healthy adults: the nootropic claim remains uncertain
 
-</CollapsibleDetails>
+Marketing often frames Lion's Mane as a general cognitive enhancer for healthy adults. Human trials do not currently justify that level of certainty.
 
-## Dosage, Product Selection, and Buying Guide
+The 2023 pilot produced a few encouraging signals but was explicitly exploratory. [PubMed 38004235](https://pubmed.ncbi.nlm.nih.gov/38004235/) The 2025 crossover study then found no significant overall acute improvement in cognition or mood despite testing a concentrated fruiting-body extract. [PubMed 40276537](https://pubmed.ncbi.nlm.nih.gov/40276537/)
 
-### Dose by Product Type
+Together, these studies support a cautious statement:
 
-| Product type | Typical dose | What to look for | Best evidence |
-|---|---|---|---|
-| **Fruiting body extract (powder/capsule)** | 1,000–3,000 mg/day | Beta-glucan content tested; fruiting body clearly stated (not "mycelium on grain") | Mori 2009 used 3 g/day whole fruiting body |
-| **Mycelium extract** | 1,000–3,000 mg/day | Erinacine standardization if claimed; avoid mycelium-on-grain without beta-glucan testing | Li 2020 used erinacine-enriched mycelia at 1,050 mg/day |
-| **Dual extract (water + alcohol)** | 500–2,000 mg/day | Both extraction methods used; beta-glucans (water) + terpenoids (alcohol) | Better absorption theoretically; limited human data specifically for dual extracts |
-| **Whole fruiting body powder** | 2,000–3,000 mg/day | Fruiting body only; no grain filler | Budget option; more variable potency |
+> Lion's Mane may affect selected cognitive tasks in some settings, but broad enhancement of attention, memory, executive function, mood, or productivity in healthy younger adults has **not** been established.
 
-### How to Read a Lion's Mane Label
-
-**Ideal label:**
-- States "fruiting body" or "mycelium" explicitly and separately (not "full spectrum" which can mean anything)
-- Lists beta-glucan content (e.g., ">25% beta-glucans")
-- Specifies extraction method (hot water extract, dual extract, etc.)
-- Third-party tested for heavy metals and contaminants
-- Specifies country of origin and cultivation method (wild-crafted vs. indoor-grown vs. substrate-grown)
-
-**Red flags:**
-- "Mycelium on grain" or "myceliated grain" — mostly starch from the grain substrate, not mushroom
-- "Polysaccharides" without beta-glucan specification — polysaccharides can include grain starch
-- "Proprietary blend" — you don't know the ratio of fruiting body to mycelium (or to grain filler)
-- "Full spectrum" without percentage breakdown
-- Extremely low price — quality Lion's Mane costs $15–40/month at effective doses
-
-### The Mycelium-on-Grain Problem
-
-Most cheap Lion's Mane products use mycelium grown on grain (typically brown rice or oats). The final product is ground up together — grain substrate + mycelium. Since the grain substrate typically constitutes 50–70% of the final weight, you're getting mostly grain starch with some mycelium. These products can still contain beneficial compounds (beta-glucans, some erinacines), but the potency per gram is dramatically lower than pure fruiting body or pure mycelium extracts.
-
-The industry is slowly moving toward requiring disclosure of grain content, but as of 2026, most labels don't make this clear. If the price seems too good to be true ($8–12 for a month's supply), it's likely mycelium-on-grain.
+That is also why this page does not promise that users should “feel it” after a particular number of days or that a lack of subjective sensation means the supplement is quietly working.
 
 ---
 
-<CollapsibleWarning title="Safety, Side Effects & Contraindications">
+## Mood, anxiety, stress, and sleep
 
-## Safety, Side Effects, and Populations
+The human evidence here is smaller and more context-dependent than the cognition marketing suggests.
 
-### General Tolerability
+A 2010 randomized study enrolled 30 women and used Lion's Mane-containing cookies for four weeks. Some complaint and mood-related measures improved, while the evidence base was too small to establish a general antidepressant or anti-anxiety effect. [PubMed 20834180](https://pubmed.ncbi.nlm.nih.gov/20834180/) · [DOI 10.2220/biomedres.31.231](https://doi.org/10.2220/biomedres.31.231)
 
-Lion's Mane is generally well tolerated. A 2025 systematic review of adverse effects found a favorable safety profile across available studies, though long-term data (>1 year) is very limited [14].
+A 2019 study in adults affected by overweight or obesity reported changes in mood/sleep measures and explored BDNF-related biomarkers. That population and intervention should not be generalized to healthy adults seeking a sleep aid. [PubMed 31118969](https://pubmed.ncbi.nlm.nih.gov/31118969/) · [DOI 10.1155/2019/7861297](https://doi.org/10.1155/2019/7861297)
 
-**Common side effects (mild and self-limiting):**
-- GI discomfort (nausea, bloating) — more common at higher doses or on empty stomach
-- Itching or mild rash — may indicate mushroom sensitivity
-- Headache — uncommon
-- Vivid dreams — commonly reported, possibly related to NGF effects on REM sleep, not studied
+The 2023 healthy-young-adult pilot reported a **trend** toward lower subjective stress after 28 days rather than a robust replicated stress effect. [PubMed 38004235](https://pubmed.ncbi.nlm.nih.gov/38004235/)
 
-### Who Should Be Cautious
+**Practical evidence boundary:** Lion's Mane should not be presented as a treatment for anxiety, depression, insomnia, or another mental-health condition. Those outcomes remain preliminary and population-specific.
 
-| Population | Guidance | Rationale |
+---
+
+## NGF, erinacines, hericenones: compelling biology, mostly preclinical evidence
+
+Lion's Mane contains chemically distinct constituents in its fruiting body and mycelium, including hericenones and erinacines. Laboratory studies have reported effects involving nerve growth factor signaling, antioxidant responses, inflammatory pathways, neurogenesis, and neuronal survival.
+
+But the mechanistic evidence needs a visible species boundary.
+
+A 2025 systematic review devoted specifically to erinacines synthesized **cellular and rodent models**. It reported neuroprotective and neurotrophic signals, including antioxidant and pro-survival pathways, but it was not a systematic review of human cognitive outcomes. [PubMed 40626304](https://pubmed.ncbi.nlm.nih.gov/40626304/) · [DOI 10.3389/fphar.2025.1582081](https://doi.org/10.3389/fphar.2025.1582081)
+
+Older chemistry and pharmacology reviews likewise describe many candidate compounds and mechanisms spanning cells, animals, and limited human studies. [PubMed 26244378](https://pubmed.ncbi.nlm.nih.gov/26244378/) · [DOI 10.1021/acs.jafc.5b02914](https://doi.org/10.1021/acs.jafc.5b02914)
+
+### What mechanism evidence can support
+
+- Biological plausibility for further study.
+- A reason to track whether fruiting-body and mycelial preparations differ.
+- Hypotheses about neurotrophic or inflammatory pathways.
+
+### What it cannot currently support
+
+- A guaranteed “NGF boost” in a person taking a retail capsule.
+- A claim that neurogenesis requires exactly 8–12 weeks before benefit appears.
+- A claim that one extract is clinically superior because it contains a mechanistically interesting constituent.
+- Disease-treatment claims based on rodent models.
+
+Mechanism should explain **why a question is worth testing**, not substitute for the test.
+
+---
+
+## Dose and timing: use trial regimens as study descriptors, not a universal prescription
+
+There is no validated personal dose that can be derived by averaging the published milligram amounts. The studies used interventions that differ in concentration, extraction, fruiting-body/mycelium source, and enrichment.
+
+| Trial context | Studied intervention | What it tells us |
 |---|---|---|
-| **Mushroom allergy** | Avoid | Cross-reactivity possible across fungal species |
-| **Pregnant or breastfeeding** | Avoid | No safety data in pregnancy or lactation |
-| **Blood thinners (warfarin, antiplatelets)** | Ask clinician | Theoretical antiplatelet activity from mushroom polysaccharides |
-| **Immunosuppressants** | Ask clinician | Beta-glucans are immunomodulatory — theoretical interaction |
-| **Severe dementia or neurological disease** | Medical oversight required | Lion's Mane is not a replacement for neurological care |
-| **Diabetes medications** | Monitor blood glucose | Some mushroom polysaccharides may modestly lower blood glucose |
+| Mori 2009 | 3 g/day dried fruiting-body powder | Describes that trial only; not equivalent to 3 g of a concentrated extract |
+| Docherty 2023 | 1.8 g/day fruiting-body material | Useful for matching that pilot; not an established optimal daily dose |
+| Surendran 2025 | 3 g acute dose of 10:1 fruiting-body extract | High concentration still did not produce a broad acute cognitive effect |
+| Li 2020 | Specialized erinacine-A-enriched mycelia | Cannot be converted directly into an equivalent dose of ordinary fruiting-body powder |
 
-### Long-Term Safety
+### What is not established
 
-The Li 2020 trial is the longest safety study at 49 weeks — no significant adverse events were observed. Beyond one year, safety is unknown. The 2025 systematic review noted the limited long-term data and recommended caution with indefinite daily use.
+- A standard “1–3 g/day” dose that fits every product.
+- A mandatory titration from 1 g to 2 g.
+- A minimum 8-week trial before deciding whether a product is useful.
+- A proven 12–16 week “full effect” point.
+- A cycling schedule.
+- A rule that continued use is required indefinitely.
 
----
-
-## Stacking Lion's Mane
-
-</CollapsibleWarning>
-
-## Stacking Lion's Mane
-
-Lion's Mane's neurotrophic mechanism is distinct from nearly all other nootropics, making it stackable with most supplements.
-
-| Stack | Protocol | Why | Best for |
-|---|---|---|---|
-| **Lion's Mane + Bacopa Monnieri** | LM 1–3 g/day + Bacopa 300–600 mg/day | Two different memory-support pathways: neurotrophic (LM) + cholinergic/serotonergic (Bacopa). Both require weeks. | Long-term memory and learning support |
-| **Lion's Mane + L-Theanine + Caffeine** | LM daily + L-theanine 200 mg + caffeine as needed | LM provides long-term structural support; L-theanine + caffeine provide acute cognitive performance | Daily productivity with long-term brain health |
-| **Lion's Mane + Ginkgo Biloba** | LM 1–3 g/day + Ginkgo 120–240 mg/day | LM: neurotrophic. Ginkgo: cerebral blood flow + antioxidant. Complementary vascular + neuronal support. | Older adults with memory + circulation concerns |
-| **Lion's Mane + Omega-3 (DHA)** | LM daily + 1–2 g DHA/day | DHA is a structural component of neuronal membranes; Lion's Mane supports NGF signaling. Structural support at two levels. | Comprehensive brain health protocol |
-
-**Avoid stacking with:** multiple untested nootropics simultaneously — you won't know what's working (or causing side effects).
+If a product is being compared with a study, the relevant question is not simply **how many milligrams?** It is **how closely does this preparation match what was tested?**
 
 ---
 
-## FAQ
+## Fruiting body vs mycelium: evidence matching matters more than slogans
 
-### Does Lion's Mane really work for memory?
-It depends on your starting point. In older adults with mild cognitive impairment, the evidence is encouraging — the Mori 2009 trial showed measurable cognitive improvement over 16 weeks. In healthy young adults, the evidence is weak — the Docherty 2023 trial found only tentative signals. Lion's Mane appears to support cognition when it's already declining, not enhance it from a healthy baseline.
+Both fruiting-body and mycelial preparations appear in the literature. They are not interchangeable merely because they come from the same species.
 
-### How long until I notice effects?
-Most trials show measurable effects at 8–16 weeks. Some users report vivid dreams within the first week. If you haven't noticed anything by 12 weeks, you're likely a non-responder or aren't in the population that benefits most (older adults with existing cognitive complaints).
+- The Mori and Saitsu cognition trials used fruiting-body preparations.
+- The Li disease-specific pilot used an erinacine-A-enriched mycelial preparation.
+- The 2025 healthy-younger-adult crossover used a standardized 10:1 fruiting-body extract.
+- Mechanistic erinacine literature is heavily preclinical and often centered on mycelial constituents.
 
-### What's the best form — fruiting body or mycelium?
-They have different evidence bases. Fruiting body is better studied for general cognitive support (Mori 2009, Saitsu 2019). Erinacine-enriched mycelium has the strongest evidence for diagnosed cognitive decline (Li 2020). Standard mycelium-on-grain products are the least supported — most of their weight is grain starch.
+A label that clearly identifies the material, extraction method, and standardized constituents is more useful for evidence matching than vague terms such as “full spectrum.” Third-party contaminant testing and transparent lot information are useful product-quality signals, but they do **not** prove efficacy.
 
-### Can I take Lion's Mane with my ADHD medication?
-No interaction studies exist. Lion's Mane has no stimulant properties and is mechanistically unrelated to ADHD medications. It's unlikely to interfere, but it's also very unlikely to augment ADHD treatment beyond what your medication already provides. Do not reduce or replace prescribed ADHD medication with Lion's Mane.
-
-### Does cooking destroy Lion's Mane compounds?
-Some degradation is likely with high heat. Erinacines and hericenones are relatively heat-stable compared to many bioactive compounds, but prolonged high-temperature cooking may reduce potency. Supplemental extracts are designed to preserve these compounds; culinary Lion's Mane is primarily a food, not a therapeutic.
+This page no longer assigns a universal “best form,” because the clinical evidence is too preparation-specific for that conclusion.
 
 ---
 
-## Related Articles
+## Safety and tolerability
+
+The available human trials are small, so absence of frequent serious events should not be read as proof of comprehensive long-term safety.
+
+The 2025 systematic review described reported side effects such as stomach discomfort, headache, and allergic reactions while also emphasizing a generally favorable profile in the available literature. [PubMed 40959699](https://pubmed.ncbi.nlm.nih.gov/40959699/)
+
+The older MCI trial reported limited gastrointestinal symptoms and did not identify a liver-safety signal in the small sample. A LiverTox review also notes the lack of a clear published Lion's Mane hepatotoxicity signal to date, while appropriately treating the human experience as limited. [PubMed 38289992](https://pubmed.ncbi.nlm.nih.gov/38289992/)
+
+### Important uncertainty
+
+Human interaction studies with anticoagulants, antiplatelet drugs, diabetes medications, immunosuppressants, psychiatric drugs, or ADHD medications are sparse or absent. Therefore, this page does **not** label those combinations as proven safe or proven harmful based only on laboratory mechanisms.
+
+For pregnancy, breastfeeding, significant medical conditions, mushroom allergy, or prescription-drug use, limited evidence is a reason for additional caution rather than a reason to infer safety.
+
+---
+
+## Combination and “stack” evidence
+
+Separate studies of Lion's Mane, Bacopa, L-theanine, caffeine, omega-3s, or Ginkgo do **not** establish that combining them is synergistic, safer, or more effective.
+
+This page therefore does not prescribe a Lion's Mane stack or assign combination doses. A combination creates a new intervention with its own questions:
+
+- Were the ingredients tested together?
+- Can any benefit be attributed to one component?
+- Do adverse effects or interactions change in combination?
+- Does the product match the preparations used in the separate trials?
+
+Where direct combination evidence is absent, the evidence grade for the **stack** should remain lower than the evidence grade of either ingredient alone.
+
+---
+
+## A better way to evaluate Lion's Mane claims
+
+Instead of following a universal 8-week protocol, use the study-design questions that determine whether a claim actually applies:
+
+1. **Population:** Was the study in healthy young adults, older adults, cognitive impairment, or another narrow group?
+2. **Preparation:** Fruiting-body powder, concentrated extract, mycelium, or enriched mycelium?
+3. **Outcome:** A global cognitive composite, one task, subjective stress, or a disease-specific scale?
+4. **Duration:** Acute, 4 weeks, 12 weeks, 16 weeks, or longer?
+5. **Replication:** Has another independent trial found the same effect?
+6. **Null findings:** Were other outcomes unchanged?
+7. **Product directness:** Does the retail product actually resemble the studied intervention?
+
+A claim becomes stronger when those dimensions align across more than one well-designed human study—not when a page simply accumulates more citations.
+
+---
+
+## Frequently asked questions
+
+### Does Lion's Mane really improve memory?
+
+There is an encouraging signal from small trials in older adults or people with cognitive impairment, including Mori 2009 and Saitsu 2019. That does not establish a broad memory-enhancement effect in healthy adults. Newer healthy-younger-adult studies are mixed and include a 2025 trial with no significant overall global cognitive benefit.
+
+### How long does Lion's Mane take to work?
+
+No universal onset has been established. Some longer trials measured differences after multiple weeks, while newer work has also tested acute effects. A trial's assessment schedule should not be converted into a promise that an individual “should feel” an effect by week 4, 8, or 12.
+
+### What dose should I take?
+
+There is no single evidence-based personal dose across products. Published studies used materially different powders, extracts, and enriched mycelial preparations. Trial regimens are most useful for judging **study-to-product match**, not as a universal prescription.
+
+### Is fruiting body better than mycelium?
+
+Not categorically. They have different constituent profiles and different study histories. Positive evidence from an erinacine-enriched mycelial product cannot be generalized to generic mycelium, just as a fruiting-body trial cannot prove every fruiting-body extract is equivalent.
+
+### Does Lion's Mane work for focus in healthy young adults?
+
+Evidence is preliminary and mixed. A 2023 pilot found task-specific signals, while a 2025 crossover RCT found no significant overall improvement in global cognition or mood after an acute concentrated fruiting-body dose. That is not strong evidence for a general-purpose nootropic effect.
+
+### Does Lion's Mane work for ADHD?
+
+No evidence establishes Lion's Mane as an ADHD treatment or as a replacement for evaluated care. Healthy-adult cognition studies should not be repackaged as ADHD evidence.
+
+### Does stopping Lion's Mane make cognition worse?
+
+One small 2009 MCI trial observed that cognitive scores declined after the intervention stopped. That does not prove withdrawal, dependence, or that everyone must continue Lion's Mane indefinitely. It simply means the measured group advantage was not maintained to the same degree in that small follow-up.
+
+### Can Lion's Mane be safely stacked with other nootropics?
+
+Direct combination evidence is sparse. Mechanistic complementarity is not the same as demonstrated combination safety or efficacy. Introduce caution rather than calling an untested stack “synergistic.”
+
+---
+
+## Evidence quality summary
+
+**Most useful evidence:**
+- Small randomized human cognition trials in older/cognitively impaired populations.
+- Newer randomized studies in healthy younger adults that help define what Lion's Mane does **not** reliably do.
+- A 2025 systematic review mapping the small clinical literature alongside extensive preclinical work.
+
+**Main limitations:**
+- Small samples.
+- Different populations.
+- Different preparations and concentrations.
+- Few independent replications of the same intervention/outcome pair.
+- Many mechanistic claims derived from cells or animals.
+- Sparse long-term safety and interaction data.
+
+**Current verdict:** **Limited-to-moderate, outcome-specific human evidence** for selected cognition contexts; **preliminary/mixed** for healthy-adult nootropic use and mood/stress; **preclinical** for many NGF/neurogenesis mechanism claims.
+
+---
+
+## Related evidence guides
 
 - [Bacopa Monnieri: Memory Evidence Guide](/articles/bacopa-monnieri/)
 - [Ginkgo Biloba: Cognition & Circulation](/articles/ginkgo-biloba/)
-- [L-Theanine: Calm Focus Guide](/articles/l-theanine/)
+- [L-Theanine: Calm Focus Evidence Review](/articles/l-theanine/)
 - [Functional Mushrooms Guide](/articles/functional-mushrooms-guide/)
 - [Mushroom Coffee Review](/articles/mushroom-coffee-benefits-review/)


### PR DESCRIPTION
## Checkpoint 1 — evidence quality refresh

### Why
The Lion's Mane guide had substantial citation volume but several conclusions went beyond what those sources establish: a prescriptive 8-week dose-escalation protocol, deterministic NGF/onset framing, claims that ongoing use is required, broad healthy-adult nootropic language, and unsupported stack/interaction certainty.

### Update
- Add the 2025 randomized placebo-controlled crossover trial in healthy younger adults (PMID 40276537; DOI 10.3389/fnut.2025.1405796), which found no significant overall global cognition or mood benefit after an acute standardized fruiting-body extract.
- Add DOI/PMCID metadata for the 2025 systematic review and the 2025 preclinical erinacine systematic review.
- Preserve positive older MCI/cognition trials, but make their small samples, population limits, product specificity, and measurement limits explicit.
- Separate human outcomes from cell/rodent NGF/neurogenesis evidence.
- Replace generic personal dosing/onset/titration claims with study-regimen/directness context.
- Remove unsupported stack protocols and treat combination evidence as a distinct evidence gap.
- Reframe safety around observed trial/review data and explicitly distinguish unstudied interactions from established interactions.
- Add direct PubMed/DOI links throughout the article so claims remain auditable in prose as well as frontmatter references.

### Scope
One article only. No runtime profile data, evidence grades, publication governance, affiliate logic, or generated JSON changed.