### PR TITLE
ROI #170: separate factual and template update dates

### DIFF
--- a/app/articles/[slug]/page.tsx
+++ b/app/articles/[slug]/page.tsx
@@ -57,6 +57,8 @@ export default async function ArticleMonographPage({ params }: PageProps) {
   const reviewerCredential =
     'reviewerCredential' in page && page.reviewerCredential ? page.reviewerCredential : undefined
   const lastReviewed = 'lastReviewed' in page && page.lastReviewed ? page.lastReviewed : undefined
+  const factualUpdated = page.factualUpdated || page.lastUpdated
+  const templateUpdated = page.templateUpdated || undefined
   const reviewerLabel = reviewedBy
     ? `${reviewedBy}${reviewerCredential ? `, ${reviewerCredential}` : ''}`
     : undefined
@@ -67,8 +69,8 @@ export default async function ArticleMonographPage({ params }: PageProps) {
     headline: page.title,
     description: page.description,
     abstract: citationReadySummary,
-    dateModified: page.lastUpdated,
-    datePublished: page.date ?? page.lastUpdated,
+    dateModified: factualUpdated,
+    datePublished: page.date ?? factualUpdated,
     mainEntityOfPage: `${SITE_URL}/articles/${page.slug}/`,
     image: `${SITE_URL}/og-default.jpg`,
     keywords: page.tags,
@@ -135,9 +137,19 @@ export default async function ArticleMonographPage({ params }: PageProps) {
           {page.evidenceGrade ? (
             <span className="identity-kicker">Evidence {page.evidenceGrade}</span>
           ) : null}
-          <time dateTime={page.lastUpdated} className="identity-meta">
-            Updated {page.lastUpdated}
-          </time>
+          {factualUpdated ? (
+            <time dateTime={factualUpdated} className="identity-meta">
+              Factual update {factualUpdated}
+            </time>
+          ) : null}
+          {templateUpdated ? (
+            <>
+              <span aria-hidden="true" className="identity-meta">·</span>
+              <time dateTime={templateUpdated} className="identity-meta">
+                Template revision {templateUpdated}
+              </time>
+            </>
+          ) : null}
           <span aria-hidden="true" className="identity-meta">·</span>
           <span className="identity-meta">
             {typeof page.readingTime === 'number' ? `${page.readingTime} min read` : page.readingTime}

--- a/content-collections.ts
+++ b/content-collections.ts
@@ -29,6 +29,8 @@ const citationPageSchema = z.object({
   date: z.string().regex(isoDatePattern).optional(),
   lastUpdated: z.string().regex(isoDatePattern).optional(),
   updatedAt: z.string().regex(isoDatePattern).optional(),
+  factualUpdated: z.string().regex(isoDatePattern).optional(),
+  templateUpdated: z.string().regex(isoDatePattern).optional(),
   category: z.string().min(1),
   tags: z.array(z.string()).default([]),
   readingTime: z.union([z.string().min(1), z.number().int().positive()]).optional(),
@@ -64,13 +66,16 @@ const articleMonographs = defineCollection({
       typeof document.readingTime === 'number'
         ? `${document.readingTime} min read`
         : document.readingTime || `${estimatedMinutes} min read`
-    const lastUpdated = document.lastUpdated ?? document.updatedAt ?? document.date ?? ''
+    const factualUpdated = document.factualUpdated ?? document.lastUpdated ?? document.updatedAt ?? document.date ?? ''
+    const templateUpdated = document.templateUpdated ?? ''
     const evidenceGrade = document.evidenceGrade ?? document.evidence_grade ?? ''
 
     return {
       ...document,
       readingTime,
-      lastUpdated,
+      lastUpdated: factualUpdated,
+      factualUpdated,
+      templateUpdated,
       evidenceGrade,
       body,
       url: `/articles/${document.slug}`,
@@ -95,13 +100,16 @@ const conceptPages = defineCollection({
       typeof document.readingTime === 'number'
         ? `${document.readingTime} min read`
         : document.readingTime || `${estimatedMinutes} min read`
-    const lastUpdated = document.lastUpdated ?? document.updatedAt ?? document.date ?? ''
+    const factualUpdated = document.factualUpdated ?? document.lastUpdated ?? document.updatedAt ?? document.date ?? ''
+    const templateUpdated = document.templateUpdated ?? ''
     const evidenceGrade = document.evidenceGrade ?? document.evidence_grade ?? ''
 
     return {
       ...document,
       readingTime,
-      lastUpdated,
+      lastUpdated: factualUpdated,
+      factualUpdated,
+      templateUpdated,
       evidenceGrade,
       body,
       url: `/learn/${document.slug}`,
@@ -135,6 +143,8 @@ const blogPosts = defineCollection({
       ...document,
       description: document.excerpt,
       lastUpdated: document.date ?? '',
+      factualUpdated: document.date ?? '',
+      templateUpdated: '',
       category: 'Field Notes',
       readingTime: `${estimatedMinutes} min read`,
       evidenceGrade: '',
@@ -159,6 +169,8 @@ const compoundMdxPages = defineCollection({
     metaDescription: z.string().min(1),
     keywords: z.array(z.string()).default([]),
     lastUpdated: z.string().regex(isoDatePattern),
+    factualUpdated: z.string().regex(isoDatePattern).optional(),
+    templateUpdated: z.string().regex(isoDatePattern).optional(),
     evidenceGrade: z.string().min(1),
     readingTime: z.union([z.string().min(1), z.number().int().positive()]).default(6),
     references: z.array(articleReferenceSchema).default([]),
@@ -170,11 +182,15 @@ const compoundMdxPages = defineCollection({
       typeof document.readingTime === 'number'
         ? `${document.readingTime} min read`
         : document.readingTime
+    const factualUpdated = document.factualUpdated ?? document.lastUpdated
 
     return {
       ...document,
       description: document.metaDescription,
       readingTime,
+      lastUpdated: factualUpdated,
+      factualUpdated,
+      templateUpdated: document.templateUpdated ?? '',
       body,
       url: `/compounds/${document.slug}`,
     }


### PR DESCRIPTION
Adds distinct factual-update and template-revision dates to the shared content model. Existing date fields remain backward-compatible, structured-data dateModified follows the factual date, and article headers show template revisions only when explicitly recorded.