### PR TITLE
content: refresh Bacopa evidence and citations

### DIFF
--- a/content/articles/bacopa-monnieri.md
+++ b/content/articles/bacopa-monnieri.md
@@ -1,18 +1,17 @@
 ---
 slug: bacopa-monnieri
-title: "Bacopa Monnieri: Memory, Focus & Cognitive Benefits — Evidence Guide"
-description: "Evidence-based guide to Bacopa monnieri (Brahmi) for memory, learning, and cognitive function. Covers dosage (300-600mg bacosides), mechanisms, timeline, and what clinical trials actually found."
+title: "Bacopa Monnieri: Memory, Cognition & Evidence — 2026 Review"
+description: "Evidence-first 2026 review of Bacopa monnieri (Brahmi), including older memory trials, a 2026 network meta-analysis, a 2025 null-primary-outcome RCT, cognitive-domain limits, product directness, safety, and dosing uncertainty."
 date: '2026-06-06'
-updatedAt: '2026-07-05'
+updatedAt: '2026-08-15'
 author: Will
 category: Cognitive health
 keywords:
   - bacopa monnieri
-  - bacopa benefits
-  - bacopa dosage
+  - bacopa evidence
   - brahmi
-  - memory supplement
-  - nootropic
+  - memory
+  - cognition
   - cognitive enhancement
   - bacosides
 featured_image: ''
@@ -20,131 +19,277 @@ tags:
   - bacopa
   - memory
   - cognition
-  - nootropic
   - evidence review
 profile_status: published
 ai_assisted: false
 references:
-  - title: "The chronic effects of an extract of Bacopa monniera (Brahmi) on cognitive function in healthy human subjects"
-    authors: "Stough C, Lloyd J, Clarke J, Downey LA, Hutchison CW, Rodgers T, Nathan PJ"
-    year: "2001"
-    pmid: "11498727"
-    url: "https://pubmed.ncbi.nlm.nih.gov/11498727/"
-  - title: "Chronic effects of Brahmi (Bacopa monnieri) on human memory"
-    authors: "Roodenrys S, Booth D, Bulzomi S, Phipps A, Micallef C, Smoker J"
-    year: "2002"
-    pmid: "12093601"
-    url: "https://pubmed.ncbi.nlm.nih.gov/12093601/"
+  - title: "Comparative effects of Bacopa monnieri and Ginkgo biloba on cognitive functions: A systematic review and network meta-analysis"
+    authors: "Tiemtad P, Ingkaninan K, Temkitthawon P, et al."
+    year: "2026"
+    pmid: "41678913"
+    doi: "10.1016/j.phymed.2026.157915"
+    url: "https://pubmed.ncbi.nlm.nih.gov/41678913/"
+  - title: "The Effects of a Bacopa monnieri Extract (Bacumen) on Cognition, Stress, and Fatigue in Healthy Adults: A Randomized, Double-Blind, Placebo-Controlled Trial"
+    authors: "Lopresti AL, Smith SJ"
+    year: "2025"
+    pmid: "41091332"
+    doi: "10.1007/s40261-025-01492-1"
+    url: "https://pubmed.ncbi.nlm.nih.gov/41091332/"
+  - title: "Evaluating the effects of Bacopa monnieri on cognitive performance and sleep quality of patients with mild cognitive impairment: A triple-blinded, randomized, placebo-controlled trial"
+    authors: "Delfan M, Kordestani-Moghaddam P, Gholami M, Kazemi K, Mohammadi R"
+    year: "2024"
+    pmid: "38538390"
+    doi: "10.1016/j.explore.2024.02.008"
+    url: "https://pubmed.ncbi.nlm.nih.gov/38538390/"
+  - title: "Dietary Supplement Ingredients for Optimizing Cognitive Performance Among Healthy Adults: A Systematic Review"
+    year: "2021"
+    pmid: "34370563"
+    url: "https://pubmed.ncbi.nlm.nih.gov/34370563/"
   - title: "The cognitive-enhancing effects of Bacopa monnieri: a systematic review of randomized, controlled human clinical trials"
     authors: "Pase MP, Kean J, Sarris J, Neale C, Scholey AB, Stough C"
     year: "2012"
     pmid: "22747190"
+    doi: "10.1089/acm.2011.0367"
     url: "https://pubmed.ncbi.nlm.nih.gov/22747190/"
   - title: "Effects of a standardized Bacopa monnieri extract on cognitive performance, anxiety, and depression in the elderly: a randomized, double-blind, placebo-controlled trial"
     authors: "Calabrese C, Gregory WL, Leo M, Kraemer D, Bone K, Oken B"
     year: "2008"
     pmid: "18611150"
+    doi: "10.1089/acm.2008.0018"
     url: "https://pubmed.ncbi.nlm.nih.gov/18611150/"
+  - title: "Chronic effects of Brahmi (Bacopa monnieri) on human memory"
+    authors: "Roodenrys S, Booth D, Bulzomi S, Phipps A, Micallef C, Smoker J"
+    year: "2002"
+    pmid: "12093601"
+    doi: "10.1016/S0893-133X(01)00419-5"
+    url: "https://pubmed.ncbi.nlm.nih.gov/12093601/"
+  - title: "The chronic effects of an extract of Bacopa monniera (Brahmi) on cognitive function in healthy human subjects"
+    authors: "Stough C, Lloyd J, Clarke J, Downey LA, Hutchison CW, Rodgers T, Nathan PJ"
+    year: "2001"
+    pmid: "11498727"
+    doi: "10.1007/s002130100815"
+    url: "https://pubmed.ncbi.nlm.nih.gov/11498727/"
 ---
 
-> **The bottom line:** Bacopa monnieri (Brahmi) is an Ayurvedic herb that improves memory formation and recall — but it's one of the slowest nootropics. Clinical trials show cognitive benefits at 300–600 mg/day after 8–12 weeks of consistent use. Its distinctive mechanism (enhancing dendritic branching) means it builds cognitive infrastructure rather than providing acute enhancement. Evidence grade: **Moderate** for memory and learning in both older adults and healthy populations.
-
-## At a Glance
-
-| Question | Answer |
-|---|---|
-| Best fit | Long-term memory support; learning and retention; older adults with mild memory complaints; students during academic semesters |
-| Evidence level | Moderate for memory and learning in multiple populations |
-| Typical dose | 300–600 mg/day of extract standardized to 50% bacosides |
-| Onset | 8–12 weeks — this is NOT a fast nootropic |
-| Key mechanism | Enhances dendritic branching (synaptic growth); modulates acetylcholine and serotonin |
-| Main side effects | GI upset (nausea, cramping) — take with a meal containing fat; fatigue/sedation in first 1–2 weeks |
-| Better for acute focus? | Try [L-theanine + caffeine](/articles/l-theanine/) |
-
+> **Bottom line:** Bacopa monnieri has a real human research signal for **some memory outcomes**, but the evidence is more selective and less predictable than “Bacopa improves cognition after 8–12 weeks.” Older randomized trials and a 2012 review favored memory free recall or retention on some tests. A 2026 network meta-analysis again found favorable memory signals, yet a 2025 randomized trial found **no significant benefit on its primary verbal-learning, attention, or working-memory outcomes**. Extracts, doses, populations, and cognitive tests differ substantially, so there is no evidence-based universal dose, onset, cycling schedule, or guarantee of broad cognitive enhancement.
 
 ![Bacopa Monnieri](/images/guides/bacopa-monnieri.jpg)
 
----
+## At a glance
 
-## What to Expect: The Slowest Nootropic
-
-Bacopa is not for people who want to feel different today. Its mechanism — enhancing the physical growth of neuronal connections — operates on a structural timescale, not a neurochemical one.
-
-| Timeframe | What you might notice | What's happening |
-|---|---|---|
-| **Week 1–2** | GI side effects are common — nausea, cramping, loose stool. Fatigue is reported by some users, especially in week 1. Take with a fatty meal. | Your body is adapting to bacosides. GI effects are transient for most people. |
-| **Week 4–6** | Subtle improvements in learning speed — you may notice you're retaining new information more easily. | Dendritic branching is beginning. Synaptic surface area is increasing. |
-| **Week 8–12** | **This is where trials show measurable results.** Significant improvements in memory retention, new information processing, and recall speed. Verbal learning is often the most improved domain. | Dendritic spine density in the hippocampus has measurably increased. Cholinergic tone has improved. |
-| **Month 3+** | Effects stabilize. Bacopa doesn't keep improving memory indefinitely — you reach a new, higher baseline. | Structural changes plateau. Maintenance dosing preserves the gains. |
-
-> **If you need focus today:** bacopa is the wrong tool. It builds cognitive infrastructure over months, not hours. For same-day performance: L-theanine + caffeine. For long-term cognitive investment: bacopa.
+| Question | Evidence-first answer |
+|---|---|
+| Strongest human signal | Selected memory retention/free-recall outcomes in multiple older trials and recent evidence synthesis |
+| Attention / processing speed | Less consistent; several trials and reviews show null results in these domains |
+| Healthy-adult evidence | Mixed rather than uniformly positive |
+| Older / MCI evidence | Some favorable domain-specific findings, but population and study-quality limits matter |
+| Onset | Many classic trials measured outcomes after ~12 weeks, but that does not establish a universal personal onset |
+| Dose | Trial regimens vary by extract and standardization; milligram amounts are not interchangeable across products |
+| Mechanism | Bacosides have plausible cholinergic, antioxidant, and neuroplasticity mechanisms, but structural-neuron claims are substantially preclinical |
+| Safety | Gastrointestinal complaints are among the more consistently reported issues; long-term and interaction evidence is less complete |
 
 ---
 
-## The Clinical Evidence
+## What changed in the 2025–2026 evidence picture
 
-| Study | Population | n | Duration | Dose | Key finding |
-|---|---|---|---|---|---|
-| Stough 2001 | Healthy adults (mean age ~25) | 46 | 12 weeks | 300 mg bacosides/day | Significant improvements in verbal learning, memory consolidation, and speed of information processing vs. placebo |
-| Roodenrys 2002 | Healthy older adults (40–65) | 76 | 12 weeks | 300 mg/day | Improved retention of new information; effects specific to memory (not attention or baseline speed) |
-| Pase 2012 | Systematic review | 6 RCTs pooled | 12+ weeks | 300–450 mg/day | Consistent signal for memory and learning; limited evidence for attention or executive function |
-| Calabrese 2008 | Healthy older adults (mean age ~62) | 54 | 12 weeks | 300 mg/day | Improved delayed recall and Stroop task performance; reduced anxiety and depression scores as secondary outcomes |
+The newest evidence makes Bacopa more interesting **and** harder to summarize with a single headline.
 
-The evidence consistently shows memory benefits in both young and older populations, but the effects are specific to memory encoding and recall — not general cognitive enhancement. Bacopa doesn't make you smarter; it helps you retain what you learn.
+A 2026 network meta-analysis included **29 randomized trials and 2,107 healthy adults** comparing Bacopa/Brahmi and Ginkgo interventions across cognitive domains. Higher-dose Bacopa networks ranked strongly for working and short-term memory, and lower-dose Bacopa also showed a delayed-memory signal. But sustained attention, selective attention, and processing speed were not significantly improved. The authors also emphasized that the network lacked many direct head-to-head comparisons, which weakens certainty around treatment rankings. [PubMed 41678913](https://pubmed.ncbi.nlm.nih.gov/41678913/) · [DOI 10.1016/j.phymed.2026.157915](https://doi.org/10.1016/j.phymed.2026.157915)
 
----
+That favorable synthesis needs to be read alongside a 2025 randomized double-blind placebo-controlled trial of **Bacumen**, a branded Bacopa extract. The trial randomized 101 adults ages 40–70 with self-reported memory and attention problems. After 12 weeks, there were **no significant between-group differences** in the primary outcomes of verbal learning, attention, or working memory. Secondary stress-reactivity and fatigue outcomes favored Bacopa, while adverse reactions were reported more often in the Bacopa group, mainly digestive complaints and headaches. [PubMed 41091332](https://pubmed.ncbi.nlm.nih.gov/41091332/) · [DOI 10.1007/s40261-025-01492-1](https://doi.org/10.1007/s40261-025-01492-1)
 
-## How It Works
+### The correct synthesis
 
-Bacopa's effects come from **bacosides** — steroidal saponins that work through three interconnected mechanisms:
-
-### 1. Dendritic Branching Enhancement (Unique Mechanism)
-
-Bacosides increase the expression of proteins involved in dendritic arborization — the physical branching of neurons that increases the surface area available for synaptic connections. More dendritic branches = more potential synapses = greater capacity for information storage. This is a structural change that takes weeks to develop, which explains the slow onset.
-
-### 2. Cholinergic Modulation
-
-Bacosides modulate acetylcholinesterase activity and may increase cholinergic tone — the neurotransmitter system most directly involved in memory encoding. This mechanism is shared with some Alzheimer's drugs (donepezil) but bacopa's effect is milder and more modulatory.
-
-### 3. Serotonergic Effects
-
-Bacopa has mild serotonergic activity, which may explain the mood-calming secondary effect some users report. The Calabrese 2008 trial found reductions in anxiety and depression scores alongside cognitive improvements — suggesting bacopa addresses both cognitive and affective dimensions of mental performance.
+- Bacopa has a **credible memory signal**, especially across some retention/free-recall outcomes.
+- It does **not** consistently improve every cognitive domain.
+- A positive meta-analysis does not erase a well-designed null-primary-outcome RCT.
+- Branded extracts and differently standardized Bacopa products should not be treated as interchangeable.
+- Dose rankings from a network meta-analysis are research findings, not a personal dosing prescription.
 
 ---
 
-## Dosage and Practical Protocol
+## Older human evidence: why Bacopa earned its reputation
 
-**Standard dose:** 300–600 mg/day of extract standardized to 50% bacosides.
+### 2001 Stough trial
 
-**Critical detail:** Bacosides are fat-soluble. Take bacopa with a meal containing some fat (eggs, avocado, olive oil, nuts) — absorption on an empty stomach is significantly reduced. This is not a minor optimization; it's the difference between the compound reaching your brain or being excreted.
+A double-blind placebo-controlled study tested a Bacopa extract in healthy adults over 12 weeks. The study reported improvements in visual information-processing speed, learning rate, memory consolidation, and state anxiety, with the clearest effects at the later assessment. [PubMed 11498727](https://pubmed.ncbi.nlm.nih.gov/11498727/) · [DOI 10.1007/s002130100815](https://doi.org/10.1007/s002130100815)
 
-**Split dosing:** 150–300 mg twice daily with meals may reduce GI side effects and provide more consistent blood levels.
+This is supportive evidence, but it was one extract in one relatively small study. The existence of an erratum related to dosage reporting is another reason to avoid converting a trial into a universal consumer protocol.
 
-**Cycling:** Not necessary for tolerance (bacosides don't act on receptors that downregulate), but some users cycle to maintain perceived effect (e.g., 12 weeks on, 2–4 weeks off).
+### 2002 Roodenrys trial
 
----
+Seventy-six adults ages 40–65 were randomized to Bacopa or placebo. Bacopa improved **retention of newly acquired information**, while learning rate, attention, short-term verbal/visual memory, pre-existing knowledge retrieval, everyday-memory questionnaires, and anxiety were not significantly improved. [PubMed 12093601](https://pubmed.ncbi.nlm.nih.gov/12093601/) · [DOI 10.1016/S0893-133X(01)00419-5](https://doi.org/10.1016/S0893-133X(01)00419-5)
 
-## Safety
+That pattern is much more precise than saying Bacopa broadly improves “focus and cognition.”
 
-Bacopa is generally well tolerated. The most common side effects are GI — nausea, cramping, loose stool — especially at higher doses or on an empty stomach. Some users report fatigue/sedation in the first week, which typically resolves. Bacopa may slow heart rate slightly. Caution with: bradycardia, hypotension, thyroid medication (one animal study suggested possible T4 elevation). Avoid in pregnancy.
+### 2008 older-adult trial
 
----
+A randomized trial in older adults reported favorable findings on selected memory/Stroop outcomes, while other measures did not change. Stomach upset was among reported adverse events. [PubMed 18611150](https://pubmed.ncbi.nlm.nih.gov/18611150/) · [DOI 10.1089/acm.2008.0018](https://doi.org/10.1089/acm.2008.0018)
 
-## FAQ
-
-### Why does bacopa take so long to work?
-Because it works by growing new neural connections (dendritic branching), not by modulating existing neurotransmitters. Structural changes take weeks.
-
-### Is bacopa like a stimulant?
-No — if anything, it can be mildly sedating in the first week. It's the opposite of a stimulant in both mechanism and subjective effect.
-
-### Can I stack bacopa with Lion's Mane?
-Yes — they work through different mechanisms (dendritic branching vs. NGF stimulation) and are complementary for long-term cognitive support. Both require weeks to show effects.
+Again, the pattern is domain-specific, not a global cognitive upgrade.
 
 ---
 
-## Related Articles
+## What the 2012 systematic review actually found
 
-- [Lion's Mane: Benefits, Dosage & Evidence](/articles/lions-mane-mushroom-benefits-mechanisms-dosage-evidence-guide/)
-- [L-Theanine: Calm Focus Guide](/articles/l-theanine/)
+The frequently cited 2012 systematic review included **six randomized controlled trials**, all using chronic supplementation for about 12 weeks. Across the studies, Bacopa improved **9 of 17 tests in the memory free-recall domain**. The authors found little evidence for enhancement in other cognitive domains and described the nootropic literature as still early. [PubMed 22747190](https://pubmed.ncbi.nlm.nih.gov/22747190/) · [DOI 10.1089/acm.2011.0367](https://doi.org/10.1089/acm.2011.0367)
+
+This remains a useful framing even after the 2026 network meta-analysis:
+
+> **Memory is the most defensible cognitive domain for Bacopa. Broad attention, executive-function, processing-speed, or “makes you smarter” claims require substantially more caution.**
+
+A broader 2021 systematic review of supplement ingredients marketed for cognitive performance also concluded that overall certainty across this market was low enough to make strong consumer recommendations difficult. [PubMed 34370563](https://pubmed.ncbi.nlm.nih.gov/34370563/)
+
+---
+
+## Mild cognitive impairment evidence: mixed and not generalizable to everyone
+
+A 2024 triple-blind randomized trial enrolled 62 people with mild cognitive impairment and compared a Bacopa extract with placebo for two months. Some attention, verbal-fluency, and later overall-score findings favored Bacopa, while many comparisons were not significant and **overall sleep quality did not improve**. [PubMed 38538390](https://pubmed.ncbi.nlm.nih.gov/38538390/) · [DOI 10.1016/j.explore.2024.02.008](https://doi.org/10.1016/j.explore.2024.02.008)
+
+This study is useful for understanding a specific population. It should **not** be converted into a claim that Bacopa prevents dementia, treats cognitive disease, or will improve memory in a healthy young adult.
+
+Earlier reviews of Bacopa in Alzheimer-related cognitive impairment have also highlighted small samples, heterogeneous interventions, and high risk of bias. Disease-specific evidence therefore belongs in a limitation box, not in general-wellness marketing.
+
+---
+
+## Does Bacopa take exactly 8–12 weeks to work?
+
+No universal onset has been established.
+
+Many classic Bacopa cognition trials assessed outcomes after approximately 12 weeks, which is why “8–12 weeks” appears so often in supplement content. But **a study measurement schedule is not the same thing as a validated biological onset curve**.
+
+The evidence supports saying:
+
+- Bacopa has generally been studied as a **chronic**, not same-day, intervention in the classic cognition literature.
+- Some trials measured favorable differences after several weeks.
+- The literature does not establish that every responder will notice a benefit by a particular week.
+- It also does not prove that “dendritic branching begins at week 4” or that users reach a stable higher baseline after month three.
+
+Those more precise timing claims require direct human evidence that is not currently available.
+
+---
+
+## Mechanism: plausible biology is not a human timeline
+
+Bacopa contains bacosides and other compounds studied for effects on cholinergic signaling, oxidative stress, inflammation, neuroplasticity, and neuronal morphology.
+
+### What mechanism evidence can reasonably support
+
+- Bacopa has biologically plausible pathways relevant to learning and memory.
+- Multiple mechanisms may contribute rather than one single “memory pathway.”
+- Standardization and extract composition may matter when comparing products with trials.
+
+### What it does not prove
+
+- That a person's hippocampal dendritic spine density measurably increases after 8 weeks of a retail Bacopa supplement.
+- That a structural brain change is the demonstrated reason a specific human trial improved.
+- That Bacopa works like, or should be compared mechanistically with, prescription cognitive drugs.
+- That a mechanistic effect establishes treatment for a neurological condition.
+
+Mechanism is strongest when used to explain **plausibility and uncertainty**, not to manufacture a precise consumer timeline.
+
+---
+
+## Dose and product directness
+
+There is no single Bacopa milligram amount that can be treated as universally equivalent across studies.
+
+The older 2012 review included trials using several extracts, commonly in the few-hundred-milligram-per-day range. The 2026 network meta-analysis grouped studies into dose bands, but those categories include different preparations and are designed for comparative evidence synthesis—not individualized dosing. The 2025 Bacumen trial used a specific branded extract at 300 mg/day and should remain labeled as a **Bacumen-specific result**. [PubMed 41091332](https://pubmed.ncbi.nlm.nih.gov/41091332/)
+
+When comparing a product with research, look for:
+
+1. the exact extract or preparation,
+2. standardized constituent information,
+3. whether the study used that preparation or merely the same plant species,
+4. duration and population,
+5. which cognitive outcome actually changed.
+
+This page does not prescribe a universal 300–600 mg range, split-dosing schedule, fatty-meal rule, or cycling schedule because those claims are not established strongly enough across human trials.
+
+---
+
+## Safety and tolerability
+
+Across human Bacopa trials, **gastrointestinal complaints** are among the more consistent adverse effects. In the 2025 Bacumen trial, self-reported adverse reactions were more frequent with Bacopa, primarily digestive complaints and headaches, although no serious adverse reactions were reported. [PubMed 41091332](https://pubmed.ncbi.nlm.nih.gov/41091332/)
+
+Older trials also reported stomach upset in some participants. [PubMed 18611150](https://pubmed.ncbi.nlm.nih.gov/18611150/)
+
+Human evidence is much thinner for many specific interaction claims. This page therefore does not present bradycardia, thyroid-drug interaction, hypotension, pregnancy effects, or sedation timelines as established clinical outcomes based only on animal data, mechanism, or anecdote.
+
+Limited evidence should be described as **limited**, especially when prescription medications, pregnancy, or significant medical conditions are involved.
+
+---
+
+## Bacopa and “stacks”
+
+Separate evidence for Bacopa, Lion's Mane, L-theanine, caffeine, or other ingredients does not automatically establish that a combination is synergistic or safer.
+
+The old version of this page called Bacopa + Lion's Mane “complementary” based on different proposed mechanisms. That is mechanistic reasoning, not direct combination evidence.
+
+A combination claim should answer:
+
+- Was the exact combination tested in humans?
+- Was it randomized against the individual components?
+- Did the combination improve the same outcome more than either ingredient alone?
+- Were adverse effects and interactions measured?
+
+Without those data, the combination evidence grade should remain below the evidence grade of the individual ingredients.
+
+---
+
+## Frequently asked questions
+
+### Does Bacopa improve memory?
+
+There is a meaningful human signal for selected memory outcomes, especially retention/free recall, but not every trial or cognitive measure is positive. The 2026 network meta-analysis is favorable for some memory domains; the 2025 Bacumen RCT found no benefit on its primary cognitive outcomes.
+
+### Does Bacopa improve focus or attention?
+
+Evidence is less consistent than for memory. Several older trials and reviews found little or no attention benefit, and the 2026 network meta-analysis did not find significant improvements in sustained or selective attention.
+
+### How long does Bacopa take to work?
+
+Classic cognition studies usually evaluated chronic supplementation over weeks, often around 12 weeks. That does not establish a universal onset or prove that everyone should continue until a particular week before judging benefit.
+
+### What is the best Bacopa dose?
+
+No universal personal dose is established across preparations. Different extracts and standardizations cannot be compared by milligrams alone. Trial dose is best treated as part of the study description, not as a prescription.
+
+### Is Bacopa a stimulant?
+
+Bacopa is not supported as an acute stimulant-like cognitive enhancer. Most cognition evidence comes from chronic supplementation studies.
+
+### Is Bacopa proven for mild cognitive impairment or dementia?
+
+No. Some disease-adjacent studies report favorable outcomes, but the evidence is heterogeneous and limited. These studies should not be converted into disease-treatment or prevention claims.
+
+### Can Bacopa be stacked with Lion's Mane?
+
+Direct combination evidence is insufficient to claim synergy. Separate mechanisms do not demonstrate that the combination works better or is safer than either ingredient alone.
+
+---
+
+## Evidence quality summary
+
+**What raises confidence:**
+- Multiple randomized human trials.
+- Repeated memory-domain signals across older studies.
+- A 2026 network meta-analysis with 29 RCTs and more than 2,000 participants.
+
+**What lowers confidence:**
+- Different extracts and standardizations.
+- Different cognitive tests and outcome definitions.
+- Positive effects concentrated in some memory domains rather than broad cognition.
+- A recent well-designed trial with null primary cognitive outcomes.
+- Limited direct comparisons in the network meta-analysis.
+- Sparse evidence for universal dose, onset, cycling, or combination protocols.
+
+**Current verdict:** **Moderate but domain-specific evidence for selected memory outcomes; mixed/limited evidence for broad cognitive enhancement, attention, stress, and other uses.**
+
+---
+
+## Related evidence guides
+
+- [Lion's Mane: Cognition, Mood & Evidence](/articles/lions-mane-mushroom-benefits-mechanisms-dosage-evidence-guide/)
+- [L-Theanine: Calm Focus Evidence Review](/articles/l-theanine/)
 - [Ginkgo Biloba: Cognition & Circulation](/articles/ginkgo-biloba/)


### PR DESCRIPTION
## Checkpoint 3 — Bacopa evidence refresh

The existing Bacopa article overstated certainty around broad cognition, exact onset, universal dosing, mechanism-driven timelines, cycling, and stacking. This checkpoint updates the live page to match the current human evidence.

### Evidence updates
- Add the 2026 network meta-analysis (PMID 41678913; DOI 10.1016/j.phymed.2026.157915): favorable signals in selected memory domains, but not sustained/selective attention or processing speed; direct-comparison limitations remain.
- Add the 2025 randomized Bacumen trial (PMID 41091332; DOI 10.1007/s40261-025-01492-1): no significant benefit on the primary verbal-learning, attention, or working-memory outcomes; secondary stress/fatigue signals and more self-reported GI/headache reactions are preserved.
- Add the 2024 MCI trial (PMID 38538390; DOI 10.1016/j.explore.2024.02.008) with its mixed cognitive-domain findings and null sleep-quality result.
- Preserve the older 2001/2002/2008 RCTs and 2012 systematic review, but describe what actually improved and what did not.
- Add DOI metadata and direct PubMed/DOI links throughout.

### Claim-discipline fixes
- Replace “Bacopa improves memory/cognition” certainty with domain-specific, mixed evidence.
- Remove universal 300–600 mg/day prescription language, split dosing, cycling, and deterministic 8–12 week onset claims.
- Remove unsupported human claims that dendritic branching starts on a fixed schedule or that maintenance dosing preserves a higher cognitive baseline.
- Reframe mechanisms as plausibility rather than a demonstrated human timeline.
- Remove unsupported Bacopa + Lion's Mane synergy/stack guidance.
- Limit safety language to observed human evidence and explicitly identify interaction gaps.

### Scope
One live article only. No generated runtime JSON, canonical workbook rows, evidence grade automation, publication governance, or monetization logic changed.