### PR TITLE
content: refresh Ginkgo evidence and citations

### DIFF
--- a/content/articles/ginkgo-biloba.md
+++ b/content/articles/ginkgo-biloba.md
@@ -1,19 +1,19 @@
 ---
 slug: ginkgo-biloba
-title: "Ginkgo Biloba Benefits, Dosage & Evidence: Cognition, Circulation & Aging"
-description: "Evidence-based guide to Ginkgo biloba (EGb 761) for memory, cerebral blood flow, and cognitive aging. Covers dosage (120-240mg), the GEM trial findings, safety, and what the research actually shows."
+title: "Ginkgo Biloba: Cognition, Dementia & Evidence — 2026 Review"
+description: "Evidence-first 2026 review of Ginkgo biloba: healthy-adult cognition, mild cognitive impairment, dementia, EGb 761 product directness, prevention trials, circulation claims, safety, and dosing uncertainty."
 date: '2026-06-06'
-updatedAt: '2026-07-05'
+updatedAt: '2026-08-15'
 author: Will
 category: Cognitive health
 keywords:
   - ginkgo biloba
-  - ginkgo biloba benefits
-  - ginkgo biloba dosage
+  - ginkgo evidence
   - EGb 761
-  - memory supplement
-  - cerebral blood flow
-  - dementia prevention
+  - memory
+  - cognition
+  - dementia
+  - mild cognitive impairment
   - cognitive aging
 featured_image: ''
 tags:
@@ -24,134 +24,290 @@ tags:
 profile_status: published
 ai_assisted: false
 references:
+  - title: "Ginkgo biloba for cognitive impairment and dementia"
+    authors: "Wieland LS, Ludeman E, Chi Y, et al."
+    year: "2026"
+    pmid: "41641880"
+    doi: "10.1002/14651858.CD013661.pub2"
+    url: "https://pubmed.ncbi.nlm.nih.gov/41641880/"
+  - title: "Ginkgo biloba extract EGb 761 is safe and effective in the treatment of mild dementia - a meta-analysis of patient subgroups in randomised controlled trials"
+    year: "2024"
+    pmid: "39895346"
+    doi: "10.1080/15622975.2024.2446830"
+    url: "https://pubmed.ncbi.nlm.nih.gov/39895346/"
   - title: "Ginkgo biloba for prevention of dementia: a randomized controlled trial"
     authors: "DeKosky ST, Williamson JD, Fitzpatrick AL, et al."
     year: "2008"
     pmid: "19017911"
+    pmcid: "PMC2823569"
+    doi: "10.1001/jama.2008.683"
     url: "https://pubmed.ncbi.nlm.nih.gov/19017911/"
+  - title: "Ginkgo biloba for preventing cognitive decline in older adults: a randomized trial"
+    authors: "Snitz BE, O'Meara ES, Carlson MC, et al."
+    year: "2009"
+    pmid: "20040554"
+    pmcid: "PMC2832285"
+    doi: "10.1001/jama.2009.1913"
+    url: "https://pubmed.ncbi.nlm.nih.gov/20040554/"
+  - title: "Is Ginkgo biloba a cognitive enhancer in healthy individuals? A meta-analysis"
+    authors: "Laws KR, Sweetnam H, Kondel TK"
+    year: "2012"
+    pmid: "23001963"
+    doi: "10.1002/hup.2259"
+    url: "https://pubmed.ncbi.nlm.nih.gov/23001963/"
+  - title: "Ginkgo biloba is not a smart drug: an updated systematic review of randomised clinical trials testing the nootropic effects of G. biloba extracts in healthy people"
+    authors: "Canter PH, Ernst E"
+    year: "2007"
+    pmid: "17480002"
+    doi: "10.1002/hup.843"
+    url: "https://pubmed.ncbi.nlm.nih.gov/17480002/"
   - title: "Ginkgo biloba special extract in dementia with neuropsychiatric features: a randomised, placebo-controlled, double-blind clinical trial"
     authors: "Napryeyenko O, Borzenko I"
     year: "2007"
     pmid: "17341003"
     url: "https://pubmed.ncbi.nlm.nih.gov/17341003/"
+  - title: "Efficacy and tolerability of a once daily formulation of Ginkgo biloba extract EGb 761 in Alzheimer's disease and vascular dementia: results from a randomised controlled trial"
+    year: "2012"
+    pmid: "22086747"
+    doi: "10.1055/s-0031-1291217"
+    url: "https://pubmed.ncbi.nlm.nih.gov/22086747/"
   - title: "Ginkgo biloba extract for the treatment of intermittent claudication: a meta-analysis of randomized trials"
     authors: "Pittler MH, Ernst E"
     year: "2000"
     pmid: "11014719"
     url: "https://pubmed.ncbi.nlm.nih.gov/11014719/"
-  - title: "Ginkgo biloba for cognitive impairment and dementia"
-    authors: "Birks J, Grimley Evans J"
-    year: "2009"
-    pmid: "19160216"
-    url: "https://pubmed.ncbi.nlm.nih.gov/19160216/"
 ---
 
-> **The bottom line:** Ginkgo biloba (EGb 761 extract) improves cerebral blood flow and shows modest benefits for cognitive function in dementia and age-related cognitive decline. It does **not** prevent dementia in healthy older adults — the large GEM trial showed no preventive effect. Evidence grade: **Moderate** for treating cognitive symptoms; **negative** for prevention in healthy populations.
-
-## At a Glance
-
-Ginkgo biloba is one of the oldest living tree species and one of the most prescribed botanical medicines worldwide. Standardized EGb 761 extract (24% flavone glycosides, 6% terpene lactones) is approved in Germany and France for dementia and circulatory disorders.
-
-| Question | Answer |
-|---|---|
-| Best fit | Age-related cognitive decline, vascular dementia, intermittent claudication |
-| Evidence level | Moderate for treating cognitive symptoms; does NOT prevent dementia |
-| Typical dose | 120–240 mg/day EGb 761, split into 2–3 doses |
-| Onset | 4–12 weeks for cognitive effects |
-| Key mechanism | Increases cerebral blood flow, antioxidant, mild antiplatelet |
-| Main caution | Blood thinners — theoretical bleeding risk; stop 2 weeks before surgery |
-
+> **Bottom line:** Ginkgo biloba does **not** have one evidence grade for “cognition.” In healthy people, randomized-trial meta-analysis does not show a convincing memory, attention, or executive-function benefit. In mild cognitive impairment (MCI), a 2026 Cochrane review concludes that Ginkgo probably has **little or no effect** at six months on global status, cognition, or activities of daily living. In dementia, the same review finds **low-certainty evidence of small-to-moderate benefits** on some outcomes, mostly from standardized extracts such as EGb 761. The large GEM prevention trial found no reduction in dementia incidence and no slowing of cognitive decline. Product identity, population, and outcome therefore matter more than the word “Ginkgo.”
 
 ![Ginkgo Biloba](/images/guides/ginkgo-biloba.jpg)
 
----
+## At a glance
 
-## What to Expect
-
-Ginkgo is a marathon supplement, not a sprint. It doesn't produce acute cognitive enhancement like caffeine.
-
-| Timeframe | What you might notice |
+| Question | Evidence-first answer |
 |---|---|
-| **Week 1–4** | Generally nothing noticeable. Blood flow improvements begin but aren't subjectively felt. |
-| **Week 4–12** | Modest improvements in memory, attention, and mental clarity — mainly in older adults with existing cognitive complaints. |
-| **Month 3+** | Effects stabilize. If no benefit by 12 weeks, ginkgo is unlikely to help. |
-
-> **Important reality check:** The 3,069-person GEM trial (2008) found ginkgo did NOT reduce dementia incidence in healthy older adults over 6 years. Ginkgo treats symptoms — it doesn't prevent disease. Don't take it expecting to "Alzheimer's-proof" your brain.
-
-## Dosage and Forms
-
-### Standardized extract
-
-The clinically studied form is **EGb 761** — standardized to:
-- 24% flavone glycosides
-- 6% terpene lactones (ginkgolides + bilobalide)
-
-**Dose:** 120–240 mg/day, split into 2–3 doses with meals. Start at 120 mg/day and increase after 2–3 weeks if tolerated.
-
-### Quality matters
-
-Cheap, unstandardized ginkgo products may contain ginkgolic acids — allergenic compounds that should be removed during extraction. EGb 761 limits ginkgolic acids to <5 ppm. Look for products that explicitly reference EGb 761 standardization or clearly state ginkgolic acid limits.
+| Healthy-person memory/focus | **Not supported convincingly.** Meta-analysis found effect estimates close to zero for memory, executive function, and attention |
+| Dementia prevention | **Negative.** The 3,069-person GEM trial found no reduction in dementia or Alzheimer disease incidence |
+| Cognitive decline prevention | **Negative.** GEM follow-up found no slowing of global or domain-specific decline |
+| Mild cognitive impairment | **Probably little or no six-month benefit** according to the 2026 Cochrane review |
+| Dementia symptoms | Possible small-to-moderate benefits in some six-month outcomes, but certainty is low and heterogeneity is high |
+| Best-studied preparation | EGb 761 appears frequently in dementia trials; results should not be generalized automatically to generic leaf powders/extracts |
+| Dose | Trial regimens describe studied products; there is no universal personal dose established across products/uses |
+| Onset | No universal 4–12 week onset rule has been established |
 
 ---
 
-## The Clinical Evidence
+## The 2026 evidence update changes the page's center of gravity
 
-> **Key finding:** Ginkgo shows the most consistent benefits in people who already have cognitive impairment — not in healthy people trying to prevent it.
+The most important modern source is the 2026 Cochrane review, which included **82 studies and 10,613 participants**; 72 studies with 9,783 participants contributed extractable data. Only four studies were judged low risk of bias across all assessed domains. [PubMed 41641880](https://pubmed.ncbi.nlm.nih.gov/41641880/) · [DOI 10.1002/14651858.CD013661.pub2](https://doi.org/10.1002/14651858.CD013661.pub2)
 
-| Study | Population | n | Duration | Dose | Outcome |
-|---|---|---|---|---|---|
-| GEM Trial 2008 | Healthy elderly, no cognitive impairment | 3,069 | 6 years | 240 mg/day | **No reduction in dementia incidence** |
-| GEM subgroup 2009 | MCI subgroup | ~500 | 6 years | 240 mg/day | Modest cognitive decline slowing in subgroup with MCI |
-| Napryeyenko 2007 | Alzheimer's/vascular dementia | 400 | 22 weeks | 240 mg/day | Cognitive scores ↑, caregiver burden ↓ |
-| Pittler 2000 | Intermittent claudication | Meta-analysis | — | 120–160 mg/day | Pain-free walking distance ↑ by ~33 meters |
+Its conclusions are population-specific:
 
-### The GEM Trial: what everyone should know
+- **MCI:** Ginkgo probably has little or no effect at six months on global clinical status, cognition, or activities of daily living.
+- **Dementia:** low-certainty evidence suggests possible small-to-moderate improvements in global status, cognition, and activities of daily living at around six months.
+- **Cognitive complaints without a clear diagnosis:** the evidence remains uncertain.
 
-The Ginkgo Evaluation of Memory (GEM) study was the definitive prevention trial: 3,069 cognitively healthy adults aged 75+ took 240 mg/day EGb 761 or placebo for a median of 6.1 years. **Result: no significant difference in dementia or Alzheimer's rates between groups.**
-
-This doesn't mean ginkgo is useless — it means it's not a preventive. The same trial's subgroup analysis found modest benefits in people who already had mild cognitive impairment (MCI). Think of it as a treatment, not a vaccine.
+That means a sentence such as “Ginkgo has moderate evidence for treating cognitive symptoms” is too broad. It merges different populations and different certainty levels into one claim.
 
 ---
 
-## How It Works (For the Curious)
+## Healthy adults: Ginkgo is not established as a nootropic
 
-Ginkgo's effects come from two compound classes in EGb 761 extract:
+A 2012 meta-analysis pooled randomized-trial data on healthy participants and found effect sizes that were **non-significant and close to zero** for:
 
-**1. Flavone glycosides (24%)** — potent antioxidants that scavenge free radicals and protect neuronal membranes from oxidative damage. This is the primary mechanism for neuroprotection.
+- memory,
+- executive function,
+- attention.
 
-**2. Terpene lactones (6%)** — ginkgolides and bilobalide. Ginkgolide B is a platelet-activating factor (PAF) antagonist, producing mild antiplatelet effects. Bilobalide supports mitochondrial function and has neuroprotective properties.
+The analyses included data from 1,132 participants for memory, 534 for executive function, and 910 for attention. [PubMed 23001963](https://pubmed.ncbi.nlm.nih.gov/23001963/) · [DOI 10.1002/hup.2259](https://doi.org/10.1002/hup.2259)
 
-The combined effect: increased cerebral blood flow + antioxidant protection + mild blood-thinning. This is why ginkgo helps in vascular dementia (where blood flow is compromised) more than in pure Alzheimer's pathology.
+An earlier updated systematic review reached a similar conclusion: acute studies sometimes produced isolated positive findings at particular doses/time points, but these were not consistently replicated and longer-term studies were largely negative. [PubMed 17480002](https://pubmed.ncbi.nlm.nih.gov/17480002/) · [DOI 10.1002/hup.843](https://doi.org/10.1002/hup.843)
 
----
-
-## Safety and Interactions
-
-Ginkgo is generally well tolerated. The most common side effects are mild: headache, GI upset, dizziness.
-
-**Key safety concerns:**
-
-| Concern | Guidance |
-|---|---|
-| **Bleeding risk** | Mild antiplatelet activity. Caution with warfarin, aspirin, NSAIDs, or before surgery. Stop 2 weeks pre-op. |
-| **Seizures** | Theoretical risk from ginkgotoxin in raw seeds — not in standardized extract. EGb 761 is considered safe. |
-| **Pregnancy** | Insufficient data — avoid. |
-| **SSRIs/antidepressants** | Generally compatible, but monitor for bruising/bleeding. |
+**Practical evidence boundary:** Ginkgo should not be sold conceptually as a general “brain blood-flow” enhancer that reliably improves focus or memory in healthy people.
 
 ---
 
-## Beyond Cognition: Circulation
+## GEM: prevention and cognitive decline were both negative
 
-Ginkgo's circulatory benefits extend beyond the brain:
+The Ginkgo Evaluation of Memory (GEM) trial is the strongest prevention anchor because it was large, long, randomized, double-blind, and placebo-controlled.
 
-- **Intermittent claudication:** Meta-analyses show EGb 761 increases pain-free walking distance by ~33 meters in patients with peripheral arterial disease — comparable to cilostazol but better tolerated.
-- **Tinnitus:** Mixed evidence. Some trials show modest benefit; systematic reviews are inconclusive.
-- **Altitude sickness:** Trials are negative — ginkgo does not prevent AMS.
+### Dementia incidence
+
+The trial enrolled **3,069 adults age 75 or older** with either normal cognition or MCI and followed them for a median of 6.1 years. Participants received 120 mg Ginkgo extract twice daily or placebo.
+
+Ginkgo did **not** significantly reduce:
+
+- all-cause dementia,
+- Alzheimer disease,
+- progression to dementia among the subgroup who entered with MCI.
+
+For all-cause dementia, the hazard ratio was 1.12 (95% CI 0.94–1.33). In participants with MCI, the hazard ratio for progression to dementia was 1.13 (95% CI 0.85–1.50). [PubMed 19017911](https://pubmed.ncbi.nlm.nih.gov/19017911/) · [DOI 10.1001/jama.2008.683](https://doi.org/10.1001/jama.2008.683)
+
+### Cognitive decline
+
+A subsequent GEM analysis asked whether Ginkgo slowed global or domain-specific cognitive decline even if it did not prevent dementia. It did not. No meaningful treatment effect was found on the rate of decline in memory, attention, language, executive function, or global cognition. [PubMed 20040554](https://pubmed.ncbi.nlm.nih.gov/20040554/) · [DOI 10.1001/jama.2009.1913](https://doi.org/10.1001/jama.2009.1913)
+
+The older version of this page claimed the GEM MCI subgroup showed modest slowing. That claim is removed because the large trial did not support it.
 
 ---
 
-## Related Articles
+## Dementia: possible benefit, but keep certainty and product directness visible
 
-- [Lion's Mane: Benefits, Dosage & Evidence](/articles/lions-mane-mushroom-benefits-mechanisms-dosage-evidence-guide/)
-- [Bacopa Monnieri: Memory Evidence Guide](/articles/bacopa-monnieri/)
+Dementia trials are where Ginkgo has the strongest positive clinical signal, but this evidence should not be generalized to prevention, healthy adults, or every Ginkgo product.
+
+The 2026 Cochrane review found that, at six months, low-certainty evidence suggested possible benefits in dementia on several outcomes, with substantial heterogeneity across analyses. [PubMed 41641880](https://pubmed.ncbi.nlm.nih.gov/41641880/)
+
+Individual trials using **EGb 761** have also reported favorable differences in cognition and neuropsychiatric symptoms in Alzheimer/vascular dementia populations. A 24-week randomized trial of 404 outpatients reported treatment-placebo differences on the SKT cognitive score and Neuropsychiatric Inventory in both Alzheimer and vascular dementia subgroups. [PubMed 22086747](https://pubmed.ncbi.nlm.nih.gov/22086747/) · [DOI 10.1055/s-0031-1291217](https://doi.org/10.1055/s-0031-1291217)
+
+A more recent meta-analysis of four eligible trials focused on **240 mg/day EGb 761** in patients with mild dementia and reported favorable pooled differences in cognition, global assessment, activities of daily living, and quality of life. [PubMed 39895346](https://pubmed.ncbi.nlm.nih.gov/39895346/) · [DOI 10.1080/15622975.2024.2446830](https://doi.org/10.1080/15622975.2024.2446830)
+
+### Why this does not become a consumer protocol
+
+- Dementia is a disease-treatment context, not a general-wellness claim.
+- EGb 761 is a standardized extract, not a synonym for every Ginkgo product.
+- Cochrane rates much of the dementia benefit evidence as **low certainty**.
+- A trial dose is part of the intervention description, not an individualized treatment recommendation.
+
+This site should therefore preserve the evidence while keeping disease-treatment claims behind the appropriate editorial and clinical-governance boundary.
+
+---
+
+## Mild cognitive impairment: do not blend positive individual trials with the total evidence
+
+Some individual MCI studies of Ginkgo or EGb 761 have reported favorable findings on selected cognitive or neuropsychiatric measures. That does not mean the total evidence supports a broad MCI benefit.
+
+The 2026 Cochrane review synthesizes the larger evidence base and concludes that Ginkgo **probably has little or no effect** at six months on global status, cognition, or activities of daily living in MCI. [PubMed 41641880](https://pubmed.ncbi.nlm.nih.gov/41641880/)
+
+That synthesis should outrank selective citation of one favorable small trial when the page summarizes the overall MCI evidence.
+
+---
+
+## Dose and product form: evidence matching instead of a universal range
+
+The old page prescribed **120–240 mg/day**, split into two or three doses, and suggested increasing after two to three weeks. That is more prescriptive than the evidence warrants for a general educational page.
+
+What the literature actually provides is **study-specific exposure**:
+
+- GEM: 120 mg twice daily of the study extract for prevention/cognitive-decline questions — negative outcomes.
+- Multiple dementia studies: 240 mg/day EGb 761 — some favorable symptom outcomes in disease populations.
+- Healthy-adult trials: varied standardized extracts/doses — no convincing general cognitive-enhancement effect.
+
+A milligram number only becomes meaningful when the **extract, standardization, population, outcome, and trial design** are also known.
+
+### EGb 761 is not every Ginkgo product
+
+EGb 761 is a standardized Ginkgo extract used in many clinical trials. Evidence generated with that preparation should remain attached to it. A generic leaf powder or differently manufactured extract cannot inherit EGb 761 results merely because the label says *Ginkgo biloba*.
+
+Standardization is useful for study matching; it is not evidence that a retail product will reproduce a trial result.
+
+---
+
+## Onset: no universal 4–12 week clock
+
+The old page gave a deterministic progression from “nothing noticeable” to “memory/clarity by weeks 4–12” and a plateau after three months. The evidence does not establish that consumer timeline.
+
+Trials assessed different populations and outcomes at different intervals. A study detecting a group difference after 22–26 weeks in dementia does not prove that an individual will notice a subjective effect at week four, eight, or twelve.
+
+The evidence supports saying **trial duration varies**. It does not support a universal onset schedule.
+
+---
+
+## Mechanisms: do not let cerebral-blood-flow language outrun outcomes
+
+Ginkgo constituents—particularly flavone glycosides and terpene lactones—have been studied in antioxidant, vascular, platelet-activating-factor, mitochondrial, and neuroprotective pathways.
+
+These mechanisms may help explain why standardized extracts were studied. They do **not** prove that:
+
+- a retail Ginkgo product meaningfully increases cerebral blood flow in a way that improves cognition,
+- increased blood flow is the demonstrated cause of a clinical cognitive effect,
+- vascular mechanisms make Ginkgo a predictable treatment for vascular dementia,
+- healthy users should expect greater mental clarity from “better circulation.”
+
+Human randomized outcomes should outrank plausible mechanism narratives.
+
+---
+
+## Safety: separate observed evidence from theoretical interaction lists
+
+Across many trials, Ginkgo extracts were generally tolerated similarly to placebo, but safety depends on product quality, population, comorbidities, and co-medications. The 2026 Cochrane review found probably little or no difference in overall adverse-event risk in dementia up to 12 months, with lower-certainty evidence for serious adverse events. [PubMed 41641880](https://pubmed.ncbi.nlm.nih.gov/41641880/)
+
+The old page gave a universal instruction to stop Ginkgo two weeks before surgery and described SSRI compatibility as generally acceptable. Those statements are too directive for an evidence summary without patient-specific medication/surgical context.
+
+A better boundary is:
+
+- platelet-related mechanisms and case-level concerns justify **medication/surgery review**, especially with anticoagulants or antiplatelet drugs;
+- raw Ginkgo seeds are a different exposure from standardized leaf extracts and should not be used to infer trial safety;
+- pregnancy/breastfeeding and complex polypharmacy have limited direct randomized evidence;
+- absence of a large safety signal in trials is not proof of universal compatibility.
+
+---
+
+## Intermittent claudication and circulation claims
+
+Ginkgo has also been studied for intermittent claudication/peripheral arterial disease. Older meta-analyses reported improvements in pain-free walking distance, but this is a **disease-specific vascular outcome**, not evidence that Ginkgo gives healthy people better circulation or cognitive performance.
+
+The existence of a statistically significant walking-distance change should also not be translated into statements that Ginkgo is “comparable to” a prescription drug unless a direct, adequately powered comparative trial supports that claim.
+
+This page therefore treats claudication evidence as a separate clinical research domain rather than a general reason to use Ginkgo.
+
+---
+
+## Frequently asked questions
+
+### Does Ginkgo improve memory in healthy people?
+
+Randomized-trial meta-analysis does not show a convincing benefit. Effect estimates for memory, executive function, and attention in healthy participants were close to zero. [PubMed 23001963](https://pubmed.ncbi.nlm.nih.gov/23001963/)
+
+### Does Ginkgo prevent dementia?
+
+No convincing preventive effect was found in the large GEM trial. Ginkgo did not reduce all-cause dementia or Alzheimer disease incidence over a median 6.1 years. [PubMed 19017911](https://pubmed.ncbi.nlm.nih.gov/19017911/)
+
+### Does Ginkgo slow normal cognitive aging?
+
+The GEM cognitive follow-up found no evidence that Ginkgo slowed global or domain-specific cognitive decline. [PubMed 20040554](https://pubmed.ncbi.nlm.nih.gov/20040554/)
+
+### Does Ginkgo help mild cognitive impairment?
+
+The 2026 Cochrane review concludes that Ginkgo probably has little or no effect at six months on global status, cognition, or activities of daily living in MCI. Individual positive trials do not override that overall synthesis.
+
+### Does Ginkgo help dementia symptoms?
+
+Possibly, in some contexts. The 2026 Cochrane review found low-certainty evidence of small-to-moderate benefits on some dementia outcomes, and several EGb 761 trials are positive. That evidence is disease- and preparation-specific.
+
+### What is the best Ginkgo dose?
+
+No universal personal dose is established across uses and products. Many dementia studies used 240 mg/day of EGb 761, while other trials used different schedules. A trial regimen should be treated as part of the study description rather than a personal prescription.
+
+### How long does Ginkgo take to work?
+
+There is no validated universal onset. Study durations vary substantially, and a group-level difference measured at a follow-up visit does not establish when an individual should notice an effect.
+
+---
+
+## Evidence quality summary
+
+**What is relatively clear:**
+- Ginkgo does not convincingly enhance cognition in healthy people.
+- GEM did not prevent dementia or slow cognitive decline.
+- The 2026 Cochrane synthesis does not support a meaningful six-month MCI benefit.
+
+**Where a signal remains:**
+- Some dementia trials of standardized extracts, especially EGb 761, report favorable cognition/global/ADL outcomes.
+- Cochrane characterizes those dementia benefits as low-certainty and heterogeneous.
+
+**Main limitations:**
+- Large differences in extract identity and standardization.
+- Different diagnoses and disease severity.
+- Substantial heterogeneity in dementia analyses.
+- Positive individual trials can conflict with broader syntheses.
+- Mechanistic vascular/neuroprotective claims do not establish clinical benefit by themselves.
+
+**Current verdict:** **Negative for healthy-person nootropic use and dementia prevention; probably little/no benefit for MCI at six months; possible low-certainty, product-specific symptomatic benefit in dementia.**
+
+---
+
+## Related evidence guides
+
+- [Bacopa Monnieri: Memory, Cognition & Evidence](/articles/bacopa-monnieri/)
+- [Lion's Mane: Cognition, Mood & Evidence](/articles/lions-mane-mushroom-benefits-mechanisms-dosage-evidence-guide/)
 - [How to Choose a Quality Supplement](/articles/how-to-choose-supplement-quality/)


### PR DESCRIPTION
## Checkpoint 5 — Ginkgo evidence refresh

The live Ginkgo guide was materially out of date and conflated healthy-adult cognition, MCI, dementia treatment, and dementia prevention.

### Evidence corrections
- Add the 2026 Cochrane review (PMID 41641880; DOI 10.1002/14651858.CD013661.pub2): Ginkgo probably has little/no six-month benefit for MCI, while dementia evidence suggests possible small-to-moderate benefits with low certainty and substantial heterogeneity.
- Correct the GEM MCI claim: the 3,069-person prevention trial found no reduction in progression to dementia in the MCI subgroup; the subsequent cognitive analysis found no slowing of global or domain-specific cognitive decline.
- Add the healthy-adult cognition meta-analysis showing no ascertainable benefit for memory, executive function, or attention.
- Preserve positive EGb 761 dementia trials, but bind those findings to the standardized extract and disease populations rather than generalizing them to generic Ginkgo products.

### Claim-discipline fixes
- Remove universal 120–240 mg/day prescription/escalation language and deterministic 4–12 week onset claims.
- Remove unsupported 'cerebral blood flow = cognitive benefit' causal framing.
- Remove universal two-week pre-operative stop instruction and broad SSRI-compatibility reassurance from the evidence summary.
- Keep intermittent-claudication evidence separate from healthy-person circulation/cognition claims.
- Add PubMed/DOI links throughout and expand source metadata.

### Scope
One live article only. No generated runtime JSON, canonical workbook data, publication governance, or monetization code changed.