### PR TITLE
feat(quality): add build-to-build production regression gate

### DIFF
--- a/.github/workflows/production-content-lint.yml
+++ b/.github/workflows/production-content-lint.yml
@@ -13,6 +13,7 @@ concurrency:
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   production-content-lint:
@@ -39,7 +40,40 @@ jobs:
       - name: Run production content lint
         run: node scripts/ci/production-content-lint.mjs
 
-      - name: Upload production content quality report
+      - name: Snapshot built production quality
+        run: node scripts/ci/build-production-quality-snapshot.mjs
+
+      - name: Download latest successful main quality baseline
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          mkdir -p .quality-baseline
+          run_id="$(gh run list --workflow 'Production Content Lint' --branch main --status success --limit 1 --json databaseId --jq '.[0].databaseId // empty')"
+          if [ -z "$run_id" ]; then
+            echo 'No successful main baseline run exists yet; this PR will bootstrap comparison coverage.'
+            exit 0
+          fi
+          if ! gh run download "$run_id" --name production-quality-baseline --dir .quality-baseline; then
+            echo 'Latest successful main run predates the baseline artifact; comparison will bootstrap after the next main run.'
+          fi
+
+      - name: Compare against latest main production snapshot
+        env:
+          PULL_REQUEST_BODY: ${{ github.event.pull_request.body }}
+          REQUIRE_QUALITY_CHANGE_EXPLANATION: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+        run: node scripts/ci/compare-production-quality-snapshot.mjs
+
+      - name: Publish main production quality baseline
+        if: github.event_name == 'push' && success()
+        uses: actions/upload-artifact@v7
+        with:
+          name: production-quality-baseline
+          path: public/data/reports/production-quality-snapshot.json
+          retention-days: 90
+
+      - name: Upload production content quality reports
         if: always() && hashFiles('public/data/reports/production-content-lint.*') != ''
         uses: actions/upload-artifact@v7
         with:
@@ -47,4 +81,8 @@ jobs:
           path: |
             public/data/reports/production-content-lint.json
             public/data/reports/production-content-lint.md
+            public/data/reports/production-quality-snapshot.json
+            public/data/reports/production-quality-regression.json
+            public/data/reports/production-quality-regression.md
+          if-no-files-found: ignore
           retention-days: 30

--- a/docs/production-content-lint.md
+++ b/docs/production-content-lint.md
@@ -27,4 +27,32 @@ Outputs:
 
 The command requires built HTML in `out/`. If it is missing, the lint fails instead of silently auditing an incomplete representation.
 
+## Build-to-build regression snapshot
+
+The Production Content Lint workflow also snapshots the built site with:
+
+```bash
+node scripts/ci/build-production-quality-snapshot.mjs
+```
+
+The snapshot records the actual built route inventory, title, first H1, canonical URL, indexability state, unique internal links, evidence-grade distribution, and structured source counts. Successful `main` runs publish the snapshot as a 90-day workflow artifact named `production-quality-baseline`.
+
+Pull requests download the latest successful `main` baseline and compare it with:
+
+```bash
+node scripts/ci/compare-production-quality-snapshot.mjs
+```
+
+The comparison always reports title changes, indexability changes, lost internal links, evidence-grade distribution changes, page-count drift, and structured citation/source decreases. Small editorial changes remain informational. Material/systemic changes require an explanation rather than failing merely because they are large.
+
+For an intentional major change, add a substantive entry to the pull request body:
+
+```text
+Quality change explanation: Consolidated obsolete alias routes into canonical profiles; the page-count drop is intentional and redirects were validated.
+```
+
+The workflow fails a pull request when a material regression/change crosses the configured thresholds and no explanation of at least 20 characters is supplied. This makes large automated changes auditable without treating every legitimate refactor as an error.
+
+The first successful `main` run after this feature lands bootstraps the baseline artifact. Until that baseline exists, comparison exits successfully with an explicit bootstrap message rather than pretending a comparison occurred.
+
 Do not weaken a dedicated validator to make this aggregate gate pass. Fix the underlying content, template, route, data contract, or validator input. If a rule truly needs to change, change the canonical validator first so every caller remains consistent.

--- a/scripts/ci/build-production-quality-snapshot.mjs
+++ b/scripts/ci/build-production-quality-snapshot.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const outDir = path.join(root, 'out')
+const outputArg = process.argv.indexOf('--output')
+const outputPath = path.resolve(root, outputArg >= 0 && process.argv[outputArg + 1]
+  ? process.argv[outputArg + 1]
+  : 'public/data/reports/production-quality-snapshot.json')
+
+function decode(value) {
+  return String(value || '')
+    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => String.fromCodePoint(Number.parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number.parseInt(n, 10)))
+    .replace(/&amp;/gi, '&').replace(/&quot;/gi, '"').replace(/&#39;|&apos;/gi, "'")
+    .replace(/&lt;/gi, '<').replace(/&gt;/gi, '>')
+}
+
+function text(value) {
+  return decode(String(value || '').replace(/<[^>]+>/g, ' ')).replace(/\s+/g, ' ').trim()
+}
+
+function attr(tag, name) {
+  const match = String(tag || '').match(new RegExp(`\\b${name}=["']([^"']*)["']`, 'i'))
+  return match ? decode(match[1]).trim() : ''
+}
+
+function routeFromFile(file) {
+  const rel = path.relative(outDir, file).replace(/\\/g, '/')
+  if (rel === 'index.html') return '/'
+  return `/${rel.replace(/\/index\.html$/, '').replace(/\.html$/, '')}`.replace(/\/+/g, '/')
+}
+
+function walkHtml(dir) {
+  const files = []
+  const walk = current => {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      if (entry.name === '_next') continue
+      const full = path.join(current, entry.name)
+      if (entry.isDirectory()) walk(full)
+      else if (entry.isFile() && entry.name.endsWith('.html')) files.push(full)
+    }
+  }
+  if (fs.existsSync(dir)) walk(dir)
+  return files
+}
+
+function normalizeInternalHref(raw) {
+  const href = String(raw || '').trim()
+  if (!href || href.startsWith('#') || /^(mailto:|tel:|javascript:|data:)/i.test(href)) return ''
+  try {
+    const url = new URL(href, 'https://thehippiescientist.net')
+    if (url.hostname !== 'thehippiescientist.net' && url.hostname !== 'www.thehippiescientist.net') return ''
+    return `${url.pathname}${url.search}` || '/'
+  } catch {
+    return ''
+  }
+}
+
+function buildRouteSnapshot() {
+  const routes = {}
+  for (const file of walkHtml(outDir)) {
+    const route = routeFromFile(file)
+    if (route === '/404' || route === '/500') continue
+    const html = fs.readFileSync(file, 'utf8')
+    const title = text((html.match(/<title[^>]*>([\s\S]*?)<\/title>/i) || [])[1])
+    const h1 = text((html.match(/<h1\b[^>]*>([\s\S]*?)<\/h1>/i) || [])[1])
+    const canonicalTag = (html.match(/<link\b[^>]*rel=["']canonical["'][^>]*>/i) || [])[0] ||
+      (html.match(/<link\b[^>]*href=["'][^"']+["'][^>]*rel=["']canonical["'][^>]*>/i) || [])[0] || ''
+    const canonical = attr(canonicalTag, 'href')
+    const robotsTag = (html.match(/<meta\b[^>]*name=["']robots["'][^>]*>/i) || [])[0] ||
+      (html.match(/<meta\b[^>]*content=["'][^"']+["'][^>]*name=["']robots["'][^>]*>/i) || [])[0] || ''
+    const robots = attr(robotsTag, 'content').toLowerCase()
+    const links = [...html.matchAll(/<a\b[^>]*href=["']([^"']+)["'][^>]*>/gi)]
+      .map(match => normalizeInternalHref(match[1]))
+      .filter(Boolean)
+    routes[route] = {
+      title,
+      h1,
+      canonical,
+      indexable: !/\bnoindex\b/.test(robots),
+      internalLinks: [...new Set(links)].sort(),
+    }
+  }
+  return routes
+}
+
+function readJson(rel) {
+  const file = path.join(root, rel)
+  if (!fs.existsSync(file)) return []
+  try { return JSON.parse(fs.readFileSync(file, 'utf8')) } catch { return [] }
+}
+
+function recordsFrom(value) {
+  if (Array.isArray(value)) return value
+  if (Array.isArray(value?.records)) return value.records
+  if (Array.isArray(value?.items)) return value.items
+  return []
+}
+
+function evidenceGrade(record) {
+  const value = record?.evidence_grade ?? record?.evidenceGrade ?? record?.evidence_tier ?? record?.evidenceTier ?? ''
+  const raw = String(value || '').trim()
+  const upper = raw.toUpperCase()
+  if (/^A\b/.test(upper)) return 'A'
+  if (/^B\b/.test(upper)) return 'B'
+  if (/^C\b/.test(upper)) return 'C'
+  if (/^D\b/.test(upper)) return 'D'
+  if (/AVOID|INSUFFICIENT/.test(upper)) return 'Avoid/Insufficient'
+  return raw || 'Unclassified'
+}
+
+function buildEvidenceSnapshot() {
+  const fullRecords = [
+    ...recordsFrom(readJson('public/data/herbs.json')),
+    ...recordsFrom(readJson('public/data/compounds.json')),
+  ]
+  const summaries = [
+    ...recordsFrom(readJson('public/data/herbs-summary.json')),
+    ...recordsFrom(readJson('public/data/compounds-summary.json')),
+  ]
+  const gradeDistribution = {}
+  for (const record of fullRecords) {
+    const grade = evidenceGrade(record)
+    gradeDistribution[grade] = (gradeDistribution[grade] || 0) + 1
+  }
+  const sourceCounts = {}
+  for (const record of summaries) {
+    const slug = String(record?.slug || '').trim()
+    if (!slug) continue
+    const explicit = Number(record?.source_count ?? record?.citation_count)
+    const pmids = Array.isArray(record?.pubmed_ids) ? record.pubmed_ids.length : 0
+    sourceCounts[slug] = Number.isFinite(explicit) ? explicit : pmids
+  }
+  return {
+    recordCount: fullRecords.length,
+    gradeDistribution,
+    totalSources: Object.values(sourceCounts).reduce((sum, value) => sum + Number(value || 0), 0),
+    sourceCounts,
+  }
+}
+
+function main() {
+  if (!fs.existsSync(outDir)) {
+    console.error('[quality-snapshot] built output is required in out/.')
+    process.exit(2)
+  }
+  const routes = buildRouteSnapshot()
+  const snapshot = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    routes,
+    totals: {
+      pages: Object.keys(routes).length,
+      indexablePages: Object.values(routes).filter(route => route.indexable).length,
+      internalLinks: Object.values(routes).reduce((sum, route) => sum + route.internalLinks.length, 0),
+    },
+    evidence: buildEvidenceSnapshot(),
+  }
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true })
+  fs.writeFileSync(outputPath, `${JSON.stringify(snapshot, null, 2)}\n`)
+  console.log(`[quality-snapshot] wrote ${outputPath} with ${snapshot.totals.pages} built pages.`)
+}
+
+main()

--- a/scripts/ci/compare-production-quality-snapshot.mjs
+++ b/scripts/ci/compare-production-quality-snapshot.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const args = process.argv.slice(2)
+const valueFor = flag => {
+  const index = args.indexOf(flag)
+  return index >= 0 ? args[index + 1] : ''
+}
+const currentPath = path.resolve(root, valueFor('--current') || 'public/data/reports/production-quality-snapshot.json')
+const baselinePath = path.resolve(root, valueFor('--baseline') || '.quality-baseline/production-quality-snapshot.json')
+const reportPath = path.resolve(root, valueFor('--report') || 'public/data/reports/production-quality-regression.json')
+
+function read(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'))
+}
+
+function pctChange(current, baseline) {
+  if (!baseline) return current ? 100 : 0
+  return ((current - baseline) / baseline) * 100
+}
+
+function changedRoutes(current, baseline, selector) {
+  const changes = []
+  for (const [route, currentRow] of Object.entries(current.routes || {})) {
+    const baseRow = baseline.routes?.[route]
+    if (!baseRow) continue
+    const before = selector(baseRow)
+    const after = selector(currentRow)
+    if (JSON.stringify(before) !== JSON.stringify(after)) changes.push({ route, before, after })
+  }
+  return changes
+}
+
+function lostLinks(current, baseline) {
+  const losses = []
+  for (const [route, baseRow] of Object.entries(baseline.routes || {})) {
+    const currentRow = current.routes?.[route]
+    if (!currentRow) continue
+    const currentLinks = new Set(currentRow.internalLinks || [])
+    for (const href of baseRow.internalLinks || []) {
+      if (!currentLinks.has(href)) losses.push({ route, href })
+    }
+  }
+  return losses
+}
+
+function evidenceGradeChanges(current, baseline) {
+  const grades = new Set([
+    ...Object.keys(current.evidence?.gradeDistribution || {}),
+    ...Object.keys(baseline.evidence?.gradeDistribution || {}),
+  ])
+  return [...grades].map(grade => {
+    const before = Number(baseline.evidence?.gradeDistribution?.[grade] || 0)
+    const after = Number(current.evidence?.gradeDistribution?.[grade] || 0)
+    return { grade, before, after, delta: after - before }
+  }).filter(row => row.delta !== 0)
+}
+
+function citationLosses(current, baseline) {
+  const losses = []
+  for (const [slug, beforeRaw] of Object.entries(baseline.evidence?.sourceCounts || {})) {
+    if (!(slug in (current.evidence?.sourceCounts || {}))) continue
+    const before = Number(beforeRaw || 0)
+    const after = Number(current.evidence.sourceCounts[slug] || 0)
+    if (after < before) losses.push({ slug, before, after, delta: after - before })
+  }
+  return losses.sort((a, b) => a.delta - b.delta || a.slug.localeCompare(b.slug))
+}
+
+function explanation() {
+  const explicit = String(process.env.QUALITY_CHANGE_EXPLANATION || '').trim()
+  if (explicit.length >= 20) return explicit
+  const body = String(process.env.PULL_REQUEST_BODY || '')
+  const match = body.match(/(?:^|\n)\s*Quality change explanation\s*:\s*([\s\S]+?)(?=\n\s*[A-Z][^\n]{0,60}:|$)/i)
+  return String(match?.[1] || '').trim()
+}
+
+function markdown(report) {
+  const m = report.metrics
+  const lines = [
+    '## Production build regression summary',
+    '',
+    `Status: **${report.passed ? 'PASS' : 'FAIL'}**`,
+    '',
+    `- Pages: ${m.pageCount.before} → ${m.pageCount.after} (${m.pageCount.delta >= 0 ? '+' : ''}${m.pageCount.delta})`,
+    `- Indexable pages: ${m.indexableCount.before} → ${m.indexableCount.after} (${m.indexableCount.delta >= 0 ? '+' : ''}${m.indexableCount.delta})`,
+    `- Internal link edges: ${m.internalLinkCount.before} → ${m.internalLinkCount.after} (${m.internalLinkCount.delta >= 0 ? '+' : ''}${m.internalLinkCount.delta})`,
+    `- Structured source count: ${m.sourceCount.before} → ${m.sourceCount.after} (${m.sourceCount.delta >= 0 ? '+' : ''}${m.sourceCount.delta})`,
+    `- Title changes: ${report.changes.titles.length}`,
+    `- Indexability changes: ${report.changes.indexability.length}`,
+    `- Lost internal links: ${report.changes.lostInternalLinks.length}`,
+    `- Entity source-count decreases: ${report.changes.citationLosses.length}`,
+    `- Evidence-grade buckets changed: ${report.changes.evidenceGrades.length}`,
+  ]
+  if (report.majorChanges.length) {
+    lines.push('', '### Major changes requiring explanation')
+    for (const item of report.majorChanges) lines.push(`- ${item}`)
+    lines.push('', report.explanation ? `Explanation: ${report.explanation}` : '❌ Missing `Quality change explanation:` in the PR body (or `QUALITY_CHANGE_EXPLANATION`).')
+  }
+  return `${lines.join('\n')}\n`
+}
+
+function main() {
+  if (!fs.existsSync(currentPath)) {
+    console.error(`[quality-regression] missing current snapshot: ${currentPath}`)
+    process.exit(2)
+  }
+  if (!fs.existsSync(baselinePath)) {
+    console.log('[quality-regression] no baseline snapshot available; bootstrap run will publish the current snapshot for future comparisons.')
+    process.exit(0)
+  }
+
+  const current = read(currentPath)
+  const baseline = read(baselinePath)
+  const pageBefore = Number(baseline.totals?.pages || 0)
+  const pageAfter = Number(current.totals?.pages || 0)
+  const indexBefore = Number(baseline.totals?.indexablePages || 0)
+  const indexAfter = Number(current.totals?.indexablePages || 0)
+  const linksBefore = Number(baseline.totals?.internalLinks || 0)
+  const linksAfter = Number(current.totals?.internalLinks || 0)
+  const sourcesBefore = Number(baseline.evidence?.totalSources || 0)
+  const sourcesAfter = Number(current.evidence?.totalSources || 0)
+
+  const titles = changedRoutes(current, baseline, row => row.title)
+  const indexability = changedRoutes(current, baseline, row => row.indexable)
+  const lostInternalLinks = lostLinks(current, baseline)
+  const citationLossRows = citationLosses(current, baseline)
+  const evidenceGrades = evidenceGradeChanges(current, baseline)
+
+  const majorChanges = []
+  const pageDelta = pageAfter - pageBefore
+  const pagePct = pctChange(pageAfter, pageBefore)
+  if (Math.abs(pageDelta) >= 25 || Math.abs(pagePct) >= 5) {
+    majorChanges.push(`Built page count changed ${pageDelta >= 0 ? '+' : ''}${pageDelta} (${pagePct.toFixed(1)}%).`)
+  }
+  const indexDelta = indexAfter - indexBefore
+  const indexPct = pctChange(indexAfter, indexBefore)
+  if (Math.abs(indexDelta) >= 10 || Math.abs(indexPct) >= 2) {
+    majorChanges.push(`Indexable page count changed ${indexDelta >= 0 ? '+' : ''}${indexDelta} (${indexPct.toFixed(1)}%).`)
+  }
+  if (titles.length >= Math.max(20, Math.ceil(pageBefore * 0.05))) {
+    majorChanges.push(`${titles.length} existing routes changed title.`)
+  }
+  if (indexability.length >= Math.max(10, Math.ceil(pageBefore * 0.02))) {
+    majorChanges.push(`${indexability.length} existing routes changed indexability.`)
+  }
+  if (lostInternalLinks.length >= Math.max(25, Math.ceil(Math.max(linksBefore, 1) * 0.05))) {
+    majorChanges.push(`${lostInternalLinks.length} previously present internal-link edges were removed.`)
+  }
+  const sourceDelta = sourcesAfter - sourcesBefore
+  if (sourceDelta < 0) majorChanges.push(`Aggregate structured source count decreased by ${Math.abs(sourceDelta)}.`)
+  if (citationLossRows.length >= 10) majorChanges.push(`${citationLossRows.length} existing entities lost structured sources.`)
+  const recordCount = Math.max(1, Number(baseline.evidence?.recordCount || 0))
+  for (const row of evidenceGrades) {
+    if (Math.abs(row.delta) >= Math.max(20, Math.ceil(recordCount * 0.05))) {
+      majorChanges.push(`Evidence grade ${row.grade} changed by ${row.delta >= 0 ? '+' : ''}${row.delta} records.`)
+    }
+  }
+
+  const why = explanation()
+  const explanationRequired = majorChanges.length > 0 && process.env.REQUIRE_QUALITY_CHANGE_EXPLANATION !== 'false'
+  const passed = !explanationRequired || why.length >= 20
+  const report = {
+    generatedAt: new Date().toISOString(),
+    contract: 'production-quality-regression/v1',
+    passed,
+    baselineGeneratedAt: baseline.generatedAt,
+    currentGeneratedAt: current.generatedAt,
+    explanation: why,
+    metrics: {
+      pageCount: { before: pageBefore, after: pageAfter, delta: pageDelta },
+      indexableCount: { before: indexBefore, after: indexAfter, delta: indexDelta },
+      internalLinkCount: { before: linksBefore, after: linksAfter, delta: linksAfter - linksBefore },
+      sourceCount: { before: sourcesBefore, after: sourcesAfter, delta: sourceDelta },
+    },
+    changes: { titles, indexability, lostInternalLinks, citationLosses: citationLossRows, evidenceGrades },
+    majorChanges,
+  }
+  fs.mkdirSync(path.dirname(reportPath), { recursive: true })
+  fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`)
+  const md = markdown(report)
+  const mdPath = reportPath.replace(/\.json$/i, '.md')
+  fs.writeFileSync(mdPath, md)
+  if (process.env.GITHUB_STEP_SUMMARY) fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n${md}\n`)
+  console.log(md)
+  if (!passed) process.exit(1)
+}
+
+main()


### PR DESCRIPTION
Implements backlog 613–621 on top of the consolidated production-content lint. Snapshots the actual built HTML route inventory (titles, H1s, canonicals, indexability, internal-link edges) plus evidence-grade distribution and structured source counts; publishes successful main snapshots as a durable baseline artifact; compares PR builds against the latest successful main snapshot; reports page-count growth/drop, evidence-grade shifts, citation/source decreases, lost internal links, title changes, and indexability changes; and requires a substantive `Quality change explanation:` only when changes cross material/systemic thresholds. The first main run bootstraps the baseline explicitly rather than faking a comparison.