### PR TITLE
feat(perf): close remaining performance-governance gaps

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -29,6 +29,8 @@ on:
       - '.lighthouserc*.json'
       - '**/*.xlsx'
       - '.github/workflows/lighthouse.yml'
+  schedule:
+    - cron: '41 10 * * 2'
   workflow_dispatch:
 
 concurrency:
@@ -72,6 +74,11 @@ jobs:
           node scripts/ci/validate-accessibility-baseline.mjs
           npm run test:a11y
 
+      - name: Audit client runtime and style surface
+        run: |
+          node scripts/ci/audit-client-runtime-size.mjs
+          node scripts/ci/audit-css-component-surface.mjs
+
       - name: Build static export
         env:
           COMMIT_HASH: ${{ github.sha }}
@@ -98,6 +105,10 @@ jobs:
           npx @lhci/cli@0.14 assert --config=.lighthouserc.a11y.json
           mv .lighthouseci .lighthouseci-accessibility
 
+      - name: Monitor production cache behavior
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        run: node scripts/monitor/production-cache-health.mjs
+
       - name: Upload performance and accessibility results
         if: always()
         uses: actions/upload-artifact@v7
@@ -107,6 +118,8 @@ jobs:
             .lighthouseci-performance/
             .lighthouseci-accessibility/
             reports/third-party-performance.json
+            reports/client-runtime-size.json
+            reports/css-component-surface.json
             docs/performance/budgets-log.md
           retention-days: 30
 
@@ -117,7 +130,9 @@ jobs:
           echo "- Lighthouse performance target: ≥ 82" >> "$GITHUB_STEP_SUMMARY"
           echo "- Hard CWV gates: LCP ≤ 2.5s, CLS ≤ 0.10, TBT ≤ 300ms" >> "$GITHUB_STEP_SUMMARY"
           echo "- Hard accessibility gate: ≥ 90" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Global skip-link, focus, target-size, reduced-motion, table, and form-label contracts are source-validated" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Client-boundary source budget: warn at 18KB, fail at 45KB" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Global CSS and likely-unused component surface is reported on every run" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Weekly production cache monitor verifies explicit cache policy and immutable Next static assets" >> "$GITHUB_STEP_SUMMARY"
           echo "- Performance URLs: /, /herbs/ashwagandha/, /compounds/l-theanine/" >> "$GITHUB_STEP_SUMMARY"
           echo "- Accessibility URLs: /, /goals/, /herbs/ashwagandha/, /compounds/l-theanine/, /guides/compare/, /safety-checker/, /evidence/evidence-checker/, /tools/botanical-activity-atlas/, /evidence/evidence-report/" >> "$GITHUB_STEP_SUMMARY"
           echo "- Status: ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/ci/audit-client-runtime-size.mjs
+++ b/scripts/ci/audit-client-runtime-size.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const reportPath = path.join(root, 'reports/client-runtime-size.json')
+const roots = ['app', 'components', 'src/components', 'lib', 'src/lib']
+const warningKb = 18
+const errorKb = 45
+
+function walk(dir) {
+  if (!fs.existsSync(dir)) return []
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name)
+    return entry.isDirectory() ? walk(full) : [full]
+  })
+}
+
+const codeFiles = roots.flatMap((dir) => walk(path.join(root, dir))).filter((file) => /\.(ts|tsx|js|jsx)$/.test(file))
+const clientModules = []
+const warnings = []
+const errors = []
+
+for (const file of codeFiles) {
+  const text = fs.readFileSync(file, 'utf8')
+  if (!/^\s*['"]use client['"]/m.test(text)) continue
+  const sizeKb = Buffer.byteLength(text) / 1024
+  const relative = path.relative(root, file).split(path.sep).join('/')
+  clientModules.push({ file: relative, sizeKb: Number(sizeKb.toFixed(1)) })
+  if (sizeKb >= errorKb) errors.push(`${relative} is ${sizeKb.toFixed(1)}KB inside a client boundary`)
+  else if (sizeKb >= warningKb) warnings.push(`${relative} is ${sizeKb.toFixed(1)}KB inside a client boundary`)
+}
+
+const layoutPath = path.join(root, 'app/layout.tsx')
+const layout = fs.existsSync(layoutPath) ? fs.readFileSync(layoutPath, 'utf8') : ''
+const globalStylesheets = [...layout.matchAll(/import\s+['"]([^'"]+\.css)['"]/g)].map((match) => match[1])
+if (globalStylesheets.length > 28) warnings.push(`app/layout.tsx imports ${globalStylesheets.length} global stylesheets`)
+
+const report = {
+  generatedAt: new Date().toISOString(),
+  budgets: { warningKb, errorKb, globalStylesheetWarning: 28 },
+  clientModules: clientModules.sort((a, b) => b.sizeKb - a.sizeKb),
+  globalStylesheets,
+  warnings,
+  errors,
+}
+fs.mkdirSync(path.dirname(reportPath), { recursive: true })
+fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`)
+console.log(`[client-runtime-size] ${clientModules.length} client modules; ${warnings.length} warnings; ${errors.length} errors`)
+if (errors.length) process.exitCode = 1

--- a/scripts/ci/audit-css-component-surface.mjs
+++ b/scripts/ci/audit-css-component-surface.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const reportPath = path.join(root, 'reports/css-component-surface.json')
+
+function walk(dir) {
+  if (!fs.existsSync(dir)) return []
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    if (entry.name === 'node_modules' || entry.name === '.next' || entry.name === 'out') return []
+    const full = path.join(dir, entry.name)
+    return entry.isDirectory() ? walk(full) : [full]
+  })
+}
+
+function relative(file) {
+  return path.relative(root, file).split(path.sep).join('/')
+}
+
+const cssFiles = walk(path.join(root, 'styles')).concat(walk(path.join(root, 'app'))).filter((file) => file.endsWith('.css'))
+const ruleMap = new Map()
+for (const file of cssFiles) {
+  const text = fs.readFileSync(file, 'utf8').replace(/\/\*[\s\S]*?\*\//g, '')
+  for (const rawRule of text.split('}')) {
+    const rule = rawRule.replace(/\s+/g, ' ').trim()
+    if (rule.length < 100) continue
+    const key = rule.toLowerCase()
+    const files = ruleMap.get(key) || []
+    files.push(relative(file))
+    ruleMap.set(key, files)
+  }
+}
+
+const duplicateRuleGroups = [...ruleMap.entries()]
+  .map(([rule, files]) => ({ rule: rule.slice(0, 180), files: [...new Set(files)] }))
+  .filter((entry) => entry.files.length > 1)
+
+const componentFiles = walk(path.join(root, 'components')).concat(walk(path.join(root, 'src/components')))
+  .filter((file) => /\.(tsx|jsx)$/.test(file))
+const codeFiles = walk(path.join(root, 'app')).concat(walk(path.join(root, 'components')), walk(path.join(root, 'src')))
+  .filter((file) => /\.(ts|tsx|js|jsx)$/.test(file))
+const corpus = codeFiles.map((file) => fs.readFileSync(file, 'utf8')).join('\n')
+const likelyUnusedComponents = []
+
+for (const file of componentFiles) {
+  const base = path.basename(file).replace(/\.(tsx|jsx)$/, '')
+  if (base.length < 3 || base === 'index') continue
+  const escaped = base.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const mentions = corpus.match(new RegExp(`\\b${escaped}\\b`, 'g')) || []
+  if (mentions.length <= 1) likelyUnusedComponents.push(relative(file))
+}
+
+const warnings = []
+if (duplicateRuleGroups.length > 20) warnings.push(`${duplicateRuleGroups.length} substantial CSS rules appear in multiple stylesheets`)
+if (likelyUnusedComponents.length) warnings.push(`${likelyUnusedComponents.length} components appear unreferenced by component name`)
+
+const report = {
+  generatedAt: new Date().toISOString(),
+  summary: {
+    cssFiles: cssFiles.length,
+    duplicateRuleGroups: duplicateRuleGroups.length,
+    componentFiles: componentFiles.length,
+    likelyUnusedComponents: likelyUnusedComponents.length,
+  },
+  duplicateRuleGroups: duplicateRuleGroups.slice(0, 250),
+  likelyUnusedComponents,
+  warnings,
+}
+
+fs.mkdirSync(path.dirname(reportPath), { recursive: true })
+fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`)
+console.log('[css-component-surface]', report.summary)

--- a/scripts/monitor/production-cache-health.mjs
+++ b/scripts/monitor/production-cache-health.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+const origin = 'https://thehippiescientist.net'
+const targets = [
+  { path: '/sitemap.xml', expectImmutable: false },
+  { path: '/robots.txt', expectImmutable: false },
+  { path: '/favicon.svg', expectImmutable: false },
+]
+const errors = []
+const observations = []
+
+for (const target of targets) {
+  const response = await fetch(`${origin}${target.path}`, {
+    headers: { 'user-agent': 'TheHippieScientist-Cache-Monitor/1.0' },
+  })
+  const cacheControl = response.headers.get('cache-control') || ''
+  const cfCacheStatus = response.headers.get('cf-cache-status') || ''
+  const age = response.headers.get('age') || ''
+  observations.push({ path: target.path, status: response.status, cacheControl, cfCacheStatus, age })
+  if (!response.ok) errors.push(`${target.path} returned ${response.status}`)
+  if (!/public|max-age|s-maxage/i.test(cacheControl)) errors.push(`${target.path} has no explicit public/cache lifetime policy`)
+}
+
+const home = await fetch(`${origin}/`, { headers: { 'user-agent': 'TheHippieScientist-Cache-Monitor/1.0' } })
+const html = await home.text()
+const assetMatches = [...html.matchAll(/(?:src|href)=["']([^"']*\/_next\/static\/[^"']+)["']/g)].map((match) => match[1])
+const asset = assetMatches[0]
+if (asset) {
+  const assetUrl = new URL(asset, origin)
+  const response = await fetch(assetUrl, { headers: { 'user-agent': 'TheHippieScientist-Cache-Monitor/1.0' } })
+  const cacheControl = response.headers.get('cache-control') || ''
+  const cfCacheStatus = response.headers.get('cf-cache-status') || ''
+  observations.push({ path: assetUrl.pathname, status: response.status, cacheControl, cfCacheStatus, age: response.headers.get('age') || '' })
+  if (!response.ok) errors.push(`${assetUrl.pathname} returned ${response.status}`)
+  if (!/immutable/i.test(cacheControl) || !/max-age=31536000/i.test(cacheControl)) {
+    errors.push(`${assetUrl.pathname} is not serving the expected one-year immutable cache policy`)
+  }
+}
+
+console.log(JSON.stringify({ generatedAt: new Date().toISOString(), observations, errors }, null, 2))
+if (errors.length) process.exitCode = 1


### PR DESCRIPTION
## Backlog
Covers 451–480 by extending performance systems already present on main.

## Existing controls reused
- Lighthouse CI already enforces performance, accessibility, LCP, CLS, and TBT budgets.
- Existing bundle/data budgets remain the source of truth for built output.
- Existing third-party/image audit already checks approved script hosts, async/defer behavior, and image dimension stability.
- Static export, responsive image loader, immutable `_next/static` and asset cache headers, and reduced-motion/accessibility controls remain unchanged.

## Missing gaps added
- source-level audit of oversized `use client` modules to catch unnecessary hydration before bundle growth reaches Lighthouse
- global stylesheet-count reporting to expose CSS sprawl
- duplicate CSS rule and likely-unused component inventory for consolidation work
- weekly production cache monitor that verifies explicit cache policy and one-year immutable Next static assets
- Lighthouse workflow now runs these audits and stores their reports
- scheduled Lighthouse run provides recurring cache/performance monitoring rather than PR-only validation

## Guardrails
Audits report likely-unused components rather than deleting them automatically. CSS duplication is reported rather than blindly rewritten. Existing Lighthouse, bundle, image, and third-party gates remain authoritative.