### PR TITLE
feat(content): add canonical typed publication boundary

### DIFF
--- a/src/lib/__tests__/canonical-content.test.ts
+++ b/src/lib/__tests__/canonical-content.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { parseCanonicalPublicationRecord, requireCanonicalPublicationRecord } from '../canonical-content'
+import type { RuntimeRecord } from '../../types/content'
+
+describe('canonical publication content boundary', () => {
+  it('normalizes legacy aliases into one typed publication shape', () => {
+    const record: RuntimeRecord = {
+      slug: 'ashwagandha',
+      name: 'Ashwagandha',
+      scientific_name: 'Withania somnifera',
+      synonyms: 'Indian ginseng|winter cherry',
+      evidence_grade: 'B+',
+      primary_effects: ['stress', 'sleep'],
+      mechanisms: 'HPA-axis modulation; GABAergic signaling',
+      contraindications: 'pregnancy|thyroid medication review',
+      interactions: ['sedatives'],
+      dose: '300–600 mg/day standardized extract',
+      preparation: 'root extract',
+      profile_status: 'complete',
+      summary_quality: 'strong',
+    }
+
+    const result = parseCanonicalPublicationRecord(record, 'herb')
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    expect(result.value).toMatchObject({
+      id: 'herb:ashwagandha',
+      slug: 'ashwagandha',
+      entityType: 'herb',
+      name: 'Ashwagandha',
+      scientificName: 'Withania somnifera',
+      evidence: { grade: 'B' },
+      dosing: {
+        studiedDose: '300–600 mg/day standardized extract',
+        preparation: 'root extract',
+      },
+    })
+    expect(result.value.aliases).toEqual(expect.arrayContaining(['Indian ginseng', 'winter cherry', 'Withania somnifera']))
+    expect(result.value.outcomes).toEqual(['stress', 'sleep'])
+    expect(result.value.mechanisms).toEqual(['HPA-axis modulation', 'GABAergic signaling'])
+    expect(result.value.safety.contraindications).toEqual(['pregnancy', 'thyroid medication review'])
+  })
+
+  it('fails closed before rendering malformed canonical slugs', () => {
+    const result = parseCanonicalPublicationRecord({ slug: 'Bad Slug', name: 'Bad record' }, 'compound')
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.issues).toEqual(expect.arrayContaining([
+      expect.objectContaining({ field: 'slug', code: 'invalid' }),
+    ]))
+  })
+
+  it('requires a usable display name', () => {
+    const result = parseCanonicalPublicationRecord({ slug: 'unnamed-record', name: '' }, 'herb')
+    // The canonical boundary may use the slug as the final human-readable fallback,
+    // but it must still return a stable non-empty name rather than undefined.
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.value.name).toBe('unnamed-record')
+  })
+
+  it('throws an auditable validation message when callers require a malformed record', () => {
+    expect(() => requireCanonicalPublicationRecord({ slug: '***' }, 'compound')).toThrow(/slug:/i)
+  })
+})

--- a/src/lib/canonical-content.ts
+++ b/src/lib/canonical-content.ts
@@ -1,0 +1,162 @@
+import { getEvidenceLetterGrade } from '../../lib/evidence'
+import { getRuntimeVisibility } from '../../lib/runtime-visibility'
+import type { RuntimeRecord } from '../types/content'
+
+export type CanonicalEntityType = 'herb' | 'compound'
+export type CanonicalEvidenceGrade = 'A' | 'B' | 'C' | 'D' | 'Avoid/Insufficient'
+
+export type CanonicalPublicationRecord = {
+  id: string
+  slug: string
+  entityType: CanonicalEntityType
+  name: string
+  scientificName?: string
+  aliases: string[]
+  summary: string
+  outcomes: string[]
+  mechanisms: string[]
+  evidence: {
+    grade: CanonicalEvidenceGrade
+    confidence?: string
+    summary?: string
+  }
+  safety: {
+    summary?: string
+    cautions: string[]
+    contraindications: string[]
+    interactions: string[]
+  }
+  dosing: {
+    studiedDose?: string
+    preparation?: string
+    onset?: string
+    duration?: string
+  }
+  visibility: {
+    canRender: boolean
+    canIndex: boolean
+    canFeature: boolean
+    canMonetize: boolean
+  }
+}
+
+export type CanonicalContentIssue = {
+  field: string
+  code: 'missing' | 'invalid'
+  message: string
+}
+
+export type CanonicalContentResult =
+  | { ok: true; value: CanonicalPublicationRecord; issues: [] }
+  | { ok: false; value: null; issues: CanonicalContentIssue[] }
+
+function firstString(record: RuntimeRecord, keys: string[]): string {
+  for (const key of keys) {
+    const value = record[key]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  return ''
+}
+
+function strings(value: unknown): string[] {
+  const raw = Array.isArray(value) ? value : typeof value === 'string' ? value.split(/[|;,]/) : []
+  return [...new Set(raw.map(item => String(item).trim()).filter(Boolean))]
+}
+
+function stringsFrom(record: RuntimeRecord, keys: string[]): string[] {
+  return [...new Set(keys.flatMap(key => strings(record[key])))]
+}
+
+function canonicalGrade(record: RuntimeRecord): CanonicalEvidenceGrade {
+  const grade = getEvidenceLetterGrade(record)
+  if (grade === 'A' || grade === 'B' || grade === 'C' || grade === 'D' || grade === 'Avoid/Insufficient') return grade
+  return 'Avoid/Insufficient'
+}
+
+function resolveName(record: RuntimeRecord, entityType: CanonicalEntityType): string {
+  if (entityType === 'herb') {
+    return firstString(record, ['displayName', 'name', 'commonName', 'common', 'nameNorm', 'slug'])
+  }
+  return firstString(record, ['displayName', 'name', 'canonicalCompoundName', 'compoundName', 'slug'])
+}
+
+function resolveScientificName(record: RuntimeRecord): string {
+  return firstString(record, ['scientific_name', 'scientificName', 'scientificname', 'latin_name', 'latinName', 'botanical_name'])
+}
+
+function resolveAliases(record: RuntimeRecord, name: string, scientificName: string): string[] {
+  return [...new Set([
+    ...stringsFrom(record, ['aliases', 'synonyms', 'common_names', 'commonnames', 'historical_names']),
+    firstString(record, ['commonName', 'common']),
+    scientificName,
+  ].map(item => String(item || '').trim()).filter(item => item && item !== name))]
+}
+
+export function parseCanonicalPublicationRecord(
+  record: RuntimeRecord,
+  entityType: CanonicalEntityType,
+): CanonicalContentResult {
+  const issues: CanonicalContentIssue[] = []
+  const slug = typeof record?.slug === 'string' ? record.slug.trim() : ''
+  if (!slug) issues.push({ field: 'slug', code: 'missing', message: 'Canonical publication records require a slug.' })
+  else if (!/^[a-z0-9][a-z0-9-]*$/.test(slug)) {
+    issues.push({ field: 'slug', code: 'invalid', message: `Invalid canonical slug: ${slug}` })
+  }
+
+  const name = resolveName(record, entityType)
+  if (!name) issues.push({ field: 'name', code: 'missing', message: 'Canonical publication records require a display name.' })
+  if (issues.length) return { ok: false, value: null, issues }
+
+  const scientificName = resolveScientificName(record)
+  const visibility = getRuntimeVisibility(record)
+  const summary = firstString(record, ['summary', 'description', 'evidence_summary'])
+  const safetySummary = firstString(record, ['safetyNotes', 'safety_notes', 'safety', 'safety_summary'])
+
+  return {
+    ok: true,
+    issues: [],
+    value: {
+      id: firstString(record, ['canonical_id', 'canonicalId', 'id']) || `${entityType}:${slug}`,
+      slug,
+      entityType,
+      name,
+      scientificName: scientificName || undefined,
+      aliases: resolveAliases(record, name, scientificName),
+      summary,
+      outcomes: stringsFrom(record, ['primary_effects', 'effects', 'clinical_outcomes', 'outcomes']),
+      mechanisms: stringsFrom(record, ['mechanisms', 'primary_mechanisms', 'pathways']),
+      evidence: {
+        grade: canonicalGrade(record),
+        confidence: firstString(record, ['evidence_confidence', 'confidence']) || undefined,
+        summary: firstString(record, ['evidence_summary', 'evidence_rationale']) || undefined,
+      },
+      safety: {
+        summary: safetySummary || undefined,
+        cautions: stringsFrom(record, ['cautions', 'warnings', 'safety_flags']),
+        contraindications: stringsFrom(record, ['contraindications', 'avoid_if', 'avoidIf']),
+        interactions: stringsFrom(record, ['interactions', 'drugInteractions', 'interactionNotes']),
+      },
+      dosing: {
+        studiedDose: firstString(record, ['studied_dose', 'dose', 'dosage', 'dosing', 'minimum_effective_dose']) || undefined,
+        preparation: firstString(record, ['preparation', 'preparationsText', 'extract', 'extract_name']) || undefined,
+        onset: firstString(record, ['time_to_effect', 'onset', 'timeline']) || undefined,
+        duration: firstString(record, ['duration', 'study_duration']) || undefined,
+      },
+      visibility: {
+        canRender: visibility.canRender,
+        canIndex: visibility.canIndex,
+        canFeature: visibility.canFeature,
+        canMonetize: visibility.canMonetize,
+      },
+    },
+  }
+}
+
+export function requireCanonicalPublicationRecord(
+  record: RuntimeRecord,
+  entityType: CanonicalEntityType,
+): CanonicalPublicationRecord {
+  const parsed = parseCanonicalPublicationRecord(record, entityType)
+  if (parsed.ok) return parsed.value
+  throw new Error(parsed.issues.map(issue => `${issue.field}: ${issue.message}`).join('; '))
+}

--- a/src/lib/canonical-runtime-data.ts
+++ b/src/lib/canonical-runtime-data.ts
@@ -1,0 +1,55 @@
+import { cache } from './react-cache'
+import {
+  getCompoundBySlug,
+  getCompounds,
+  getHerbBySlug,
+  getHerbs,
+} from './runtime-data'
+import {
+  parseCanonicalPublicationRecord,
+  type CanonicalEntityType,
+  type CanonicalPublicationRecord,
+} from './canonical-content'
+import type { RuntimeRecord } from '../types/content'
+
+function canonicalize(
+  record: RuntimeRecord | null,
+  entityType: CanonicalEntityType,
+): CanonicalPublicationRecord | null {
+  if (!record) return null
+  const parsed = parseCanonicalPublicationRecord(record, entityType)
+  return parsed.ok ? parsed.value : null
+}
+
+function canonicalizeMany(
+  records: RuntimeRecord[],
+  entityType: CanonicalEntityType,
+): CanonicalPublicationRecord[] {
+  return records.flatMap(record => {
+    const parsed = parseCanonicalPublicationRecord(record, entityType)
+    return parsed.ok ? [parsed.value] : []
+  })
+}
+
+/**
+ * Typed publication boundary for React/page consumers.
+ *
+ * Raw runtime loaders intentionally remain available to data-pipeline code,
+ * but new public-facing components should prefer these getters so legacy field
+ * aliases are normalized and malformed records fail closed before rendering.
+ */
+export const getCanonicalHerbs = cache(async (): Promise<CanonicalPublicationRecord[]> =>
+  canonicalizeMany(await getHerbs(), 'herb'),
+)
+
+export const getCanonicalCompounds = cache(async (): Promise<CanonicalPublicationRecord[]> =>
+  canonicalizeMany(await getCompounds(), 'compound'),
+)
+
+export async function getCanonicalHerbBySlug(slug: string): Promise<CanonicalPublicationRecord | null> {
+  return canonicalize(await getHerbBySlug(slug), 'herb')
+}
+
+export async function getCanonicalCompoundBySlug(slug: string): Promise<CanonicalPublicationRecord | null> {
+  return canonicalize(await getCompoundBySlug(slug), 'compound')
+}


### PR DESCRIPTION
Implements the first high-ROI slice of backlog 622–624 without a risky repo-wide migration. Adds one canonical typed publication record for herb/compound public content, normalizes legacy display/scientific names, aliases, outcomes, mechanisms, canonical evidence grade, safety, contraindications/interactions, studied-dose/preparation/onset/duration, and runtime visibility at a single boundary; exposes validated canonical list/detail getters for React/page consumers while leaving raw loaders available to pipeline code; malformed slugs fail closed before rendering. Includes contract tests for legacy alias normalization, canonical grade handling, safety/dose normalization, stable IDs, and malformed-record rejection.