### PR TITLE
fix(deploy): deploy directly from main pushes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,17 +1,13 @@
 name: Deploy to Cloudflare Pages
 
 on:
-  workflow_run:
-    workflows:
-      - Site Health Check
-    types:
-      - completed
+  push:
     branches:
       - main
   workflow_dispatch:
 
 concurrency:
-  group: deploy-${{ github.event.workflow_run.head_branch || github.ref }}
+  group: deploy-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:
@@ -19,19 +15,18 @@ permissions:
 
 jobs:
   deploy:
-    if: github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push')
     runs-on: ubuntu-latest
     environment: production
     env:
       STATIC_OUTPUT_DIR: out
       DEPLOY_MODE: cloudflare-direct
-      DEPLOY_BRANCH: ${{ github.event.workflow_run.head_branch || github.ref_name }}
-      DEPLOY_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+      DEPLOY_BRANCH: ${{ github.ref_name }}
+      DEPLOY_SHA: ${{ github.sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ github.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -67,6 +62,12 @@ jobs:
 
       - name: Audit high-severity dependencies
         run: npm run audit:high
+
+      - name: Run test suite
+        run: npm run test
+
+      - name: Validate canonical data pipeline
+        run: npm run data:ci
 
       - name: Validate workbook source
         run: npm run validate:workbook-source

--- a/tests/deployment-handoff-contract.test.ts
+++ b/tests/deployment-handoff-contract.test.ts
@@ -7,32 +7,49 @@ function read(relativePath: string) {
 }
 
 describe('production deployment handoff contract', () => {
-  it('cancels stale Site Health PR heads but preserves the active main validation', () => {
-    const workflow = read('.github/workflows/check.yml')
-
-    expect(workflow).toContain("cancel-in-progress: ${{ github.event_name == 'pull_request' }}")
-    expect(workflow).toContain('push:')
-    expect(workflow).toContain('branches: [ main ]')
-    expect(workflow).toContain('run: npm run check:full')
-  })
-
-  it('deploys only after successful push-triggered Site Health validation', () => {
+  it('deploys directly from main pushes without depending on another workflow finishing', () => {
     const workflow = read('.github/workflows/deploy.yml')
 
-    expect(workflow).toContain('- Site Health Check')
-    expect(workflow).not.toMatch(/workflows:\s*[\s\S]{0,80}?- CI\b/)
-    expect(workflow).toContain("github.event.workflow_run.conclusion == 'success'")
-    expect(workflow).toContain("github.event.workflow_run.event == 'push'")
+    expect(workflow).toContain('push:')
     expect(workflow).toContain('branches:')
     expect(workflow).toContain('- main')
+    expect(workflow).toContain('workflow_dispatch:')
+    expect(workflow).not.toContain('workflow_run:')
+    expect(workflow).not.toContain('github.event.workflow_run')
   })
 
-  it('lets the active production deploy finish instead of canceling it for a newer head', () => {
+  it('pins production deployment to the triggering push SHA and branch', () => {
+    const workflow = read('.github/workflows/deploy.yml')
+
+    expect(workflow).toContain('DEPLOY_BRANCH: ${{ github.ref_name }}')
+    expect(workflow).toContain('DEPLOY_SHA: ${{ github.sha }}')
+    expect(workflow).toContain('ref: ${{ github.sha }}')
+  })
+
+  it('lets an active production deploy finish instead of canceling it for a newer head', () => {
     const workflow = read('.github/workflows/deploy.yml')
 
     expect(workflow).toContain('concurrency:')
-    expect(workflow).toContain('group: deploy-${{ github.event.workflow_run.head_branch || github.ref }}')
+    expect(workflow).toContain('group: deploy-${{ github.ref }}')
     expect(workflow).toContain('cancel-in-progress: false')
-    expect(workflow).toContain('workflow_dispatch:')
+  })
+
+  it('validates tests, canonical data, source-of-truth, types, lint, build, and output before publishing', () => {
+    const workflow = read('.github/workflows/deploy.yml')
+
+    for (const command of [
+      'npm run test',
+      'npm run data:ci',
+      'npm run validate:workbook-source',
+      'npm run validate:static-export',
+      'npm run lint',
+      'npm run typecheck',
+      'npm run guard:source-of-truth',
+      'npm run build:deploy',
+      'npm run verify:output',
+      'npm run audit:affiliate-tag-production',
+    ]) {
+      expect(workflow).toContain(command)
+    }
   })
 })


### PR DESCRIPTION
Fixes #3190

## Relevant URLs
N/A — production deployment orchestration only.

## Acceptance criteria
- Cloudflare deploy triggers directly on pushes to `main` plus manual dispatch.
- No upstream `workflow_run` success is required.
- Deploy pins checkout, branch, and commit metadata to the triggering push.
- Active deploys are not canceled by newer pushes.
- Deploy independently runs tests, canonical data CI, source-of-truth checks, lint/typecheck, production build verification, affiliate safety, and Cloudflare preflight.

## Validation commands
- `npm run test -- tests/deployment-handoff-contract.test.ts`
- GitHub Actions workflow parsing/dispatch on this PR.
- After merge, verify a `Deploy to Cloudflare Pages` run is created directly for the merge SHA.

## Before → after metrics
- Upstream workflow dependencies required before a deploy run can exist: **1 → 0**
- Latest-main deploy candidate preserved under upstream pending-run churn: **not guaranteed → guaranteed by direct push trigger**
- Independent deploy validation: **build/security checks → build/security + tests + canonical data CI**

## Generator/source-of-truth decision
Deployment becomes self-contained: committed `main` is the source revision, while workbook/canonical-data and build guards validate that revision before publishing.

## Regression contract
`tests/deployment-handoff-contract.test.ts` forbids `workflow_run`, requires direct `main` push/manual triggers, SHA pinning, non-canceling active deploys, and the independent validation commands.