### PR TITLE
Backlog 893–900: research feeds and permanent Evidence Report archives (rebased)

### DIFF
--- a/app/__tests__/research-update-feeds.test.ts
+++ b/app/__tests__/research-update-feeds.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { evidenceReportEdition, evidenceReportEditions } from '@/data/editorial/evidence-report-editions'
+import { buildResearchUpdateRss } from '@/lib/research-updates'
+
+describe('research update feeds and annual evidence archives', () => {
+  it('preserves the 2026 Evidence Report permalink and pinned dataset version', () => {
+    expect(evidenceReportEdition(2026)).toMatchObject({
+      year: 2026,
+      datasetVersion: '2026.08.15',
+      permalink: '/evidence/evidence-report/2026/',
+    })
+  })
+
+  it('keeps annual report years unique and permanent-looking', () => {
+    const years = evidenceReportEditions.map(edition => edition.year)
+    expect(new Set(years).size).toBe(years.length)
+    for (const edition of evidenceReportEditions) {
+      expect(edition.permalink).toBe(`/evidence/evidence-report/${edition.year}/`)
+      expect(edition.datasetVersion).toMatch(/^\d{4}\.\d{2}\.\d{2}$/)
+    }
+  })
+
+  it('emits a valid focused RSS shell even before truthful events exist', () => {
+    const xml = buildResearchUpdateRss({
+      title: 'Research updates',
+      description: 'Recorded research updates.',
+      selfPath: '/updates/test.xml',
+      updates: [],
+    })
+    expect(xml).toContain('<rss version="2.0"')
+    expect(xml).toContain('<channel>')
+    expect(xml).toContain('https://thehippiescientist.net/updates/test.xml')
+    expect(xml).not.toContain('<item>')
+  })
+})

--- a/app/evidence/evidence-report/2026/page.tsx
+++ b/app/evidence/evidence-report/2026/page.tsx
@@ -1,0 +1,50 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import EvidenceReportClient from '../EvidenceReportClient'
+import CategoryEvidenceMixPanel from '../CategoryEvidenceMixPanel'
+import { evidenceGradeHistory } from '@/data/editorial/evidence-grade-history'
+import { evidenceReportEdition } from '@/data/editorial/evidence-report-editions'
+import { getPublicEvidenceDataset } from '@/lib/public-evidence-dataset'
+import { buildPageMetadata } from '@/src/lib/seo'
+
+const edition = evidenceReportEdition(2026)!
+
+export const metadata: Metadata = buildPageMetadata({
+  title: `${edition.title} — Archived Edition`,
+  description: `Permanent ${edition.year} edition of The Hippie Scientist Evidence Report, pinned to dataset ${edition.datasetVersion}.`,
+  path: edition.permalink,
+  openGraphType: 'article',
+})
+
+export default async function EvidenceReport2026Page() {
+  const dataset = await getPublicEvidenceDataset()
+  const versionMatches = dataset.datasetVersion === edition.datasetVersion
+
+  if (!versionMatches) {
+    return (
+      <main className='container-page space-y-6 py-10'>
+        <p className='eyebrow-label'>Permanent archive · {edition.year}</p>
+        <h1 className='text-4xl font-semibold tracking-tight text-ink'>{edition.title}</h1>
+        <div className='rounded-2xl border border-amber-900/15 bg-amber-50/70 p-6 text-sm leading-7 text-amber-950'>
+          This annual edition is pinned to dataset <strong>{edition.datasetVersion}</strong>. The active dataset is now <strong>{dataset.datasetVersion}</strong>, so this route refuses to substitute newer calculations for the historical edition. This fail-closed guard prevents a later rebuild from silently rewriting the 2026 report.
+        </div>
+        <div className='flex flex-wrap gap-3 text-sm font-bold'>
+          <Link href='/evidence/evidence-report/' className='text-brand-800 hover:underline'>Open the current report →</Link>
+          <Link href='/evidence/evidence-report/compare/' className='text-brand-800 hover:underline'>Compare annual editions →</Link>
+        </div>
+      </main>
+    )
+  }
+
+  return (
+    <>
+      <div className='container-page pt-8'>
+        <div className='rounded-xl border border-brand-900/10 bg-brand-50/60 px-4 py-3 text-sm text-muted'>
+          <strong className='text-ink'>Archived annual edition:</strong> {edition.year} · pinned to dataset {edition.datasetVersion} · published {edition.publishedAt}. <Link href='/evidence/evidence-report/compare/' className='font-bold text-brand-800 underline'>Compare years</Link>
+        </div>
+      </div>
+      <EvidenceReportClient datasetVersion={dataset.datasetVersion} citationText={dataset.citationText} metrics={dataset.metrics} changeHistory={evidenceGradeHistory} />
+      <CategoryEvidenceMixPanel dataset={dataset} />
+    </>
+  )
+}

--- a/app/evidence/evidence-report/compare/page.tsx
+++ b/app/evidence/evidence-report/compare/page.tsx
@@ -1,0 +1,46 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { evidenceReportEditions } from '@/data/editorial/evidence-report-editions'
+import { getPublicEvidenceDataset } from '@/lib/public-evidence-dataset'
+import { buildPageMetadata } from '@/src/lib/seo'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Evidence Report — Year-over-Year Comparison',
+  description: 'Compare annual State of Supplement Evidence editions and track how the underlying dataset changes over time.',
+  path: '/evidence/evidence-report/compare/',
+})
+
+export default async function EvidenceReportComparePage() {
+  const current = await getPublicEvidenceDataset()
+  const editions = [...evidenceReportEditions].sort((a, b) => b.year - a.year)
+  const latestEdition = editions[0]
+  const hasMultipleYears = new Set(editions.map(edition => edition.year)).size > 1
+
+  return (
+    <main className='container-page space-y-8 py-10'>
+      <section className='hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8'>
+        <p className='eyebrow-label'>Longitudinal original research</p>
+        <h1 className='mt-2 text-4xl font-semibold tracking-tight text-ink'>Evidence Report — year over year</h1>
+        <p className='mt-4 max-w-3xl text-lg leading-8 text-muted'>Each annual edition gets a stable permalink and a pinned dataset version. New years are added; old years are never repointed to the latest data.</p>
+      </section>
+
+      <section aria-labelledby='annual-editions'>
+        <h2 id='annual-editions' className='text-2xl font-bold text-ink'>Annual editions</h2>
+        <div className='mt-4 overflow-x-auto rounded-2xl border border-brand-900/10 bg-white'>
+          <table className='w-full min-w-[620px] text-left text-sm'>
+            <caption className='sr-only'>Annual Evidence Report editions and pinned dataset versions</caption>
+            <thead className='border-b border-brand-900/10 bg-brand-50/70 text-xs uppercase tracking-[0.08em] text-muted'><tr><th scope='col' className='px-4 py-3'>Year</th><th scope='col' className='px-4 py-3'>Dataset</th><th scope='col' className='px-4 py-3'>Published</th><th scope='col' className='px-4 py-3'>Status</th><th scope='col' className='px-4 py-3'>Report</th></tr></thead>
+            <tbody>{editions.map(edition => <tr key={edition.year} className='border-b border-brand-900/5 last:border-0'><td className='px-4 py-3 font-bold text-ink'>{edition.year}</td><td className='px-4 py-3 font-mono text-xs'>{edition.datasetVersion}</td><td className='px-4 py-3'>{edition.publishedAt}</td><td className='px-4 py-3 capitalize'>{edition.status}</td><td className='px-4 py-3'><Link href={edition.permalink} className='font-bold text-brand-800 hover:underline'>Open →</Link></td></tr>)}</tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className='grid gap-4 md:grid-cols-2'>
+        <article className='card-premium p-6'><p className='eyebrow-label'>Current dataset</p><p className='mt-2 text-2xl font-bold text-ink'>{current.datasetVersion}</p><p className='mt-2 text-sm leading-6 text-muted'>{current.metrics.ingredientCount.toLocaleString()} indexable ingredients · {current.metrics.studyCount.toLocaleString()} deduplicated structured study entities.</p></article>
+        <article className='card-premium p-6'><p className='eyebrow-label'>Comparison state</p><p className='mt-2 text-2xl font-bold text-ink'>{hasMultipleYears ? `${editions.length} annual editions` : `${latestEdition.year} baseline established`}</p><p className='mt-2 text-sm leading-6 text-muted'>{hasMultipleYears ? 'Use the stable annual editions above to compare published years without rewriting earlier results.' : '2026 is the first permanent baseline. When the 2027 edition is added, this page becomes the year-over-year comparison index without changing the 2026 URL.'}</p></article>
+      </section>
+
+      <section className='rounded-2xl border border-brand-900/10 bg-brand-50/50 p-5 text-sm leading-7 text-muted'><strong className='text-ink'>Archive rule:</strong> an annual route may render calculated report metrics only while the active dataset version matches the version pinned to that edition. If it does not match, the archive fails closed instead of substituting newer data.</section>
+    </main>
+  )
+}

--- a/app/updates/evidence-changes.xml/route.ts
+++ b/app/updates/evidence-changes.xml/route.ts
@@ -1,0 +1,12 @@
+import { buildResearchUpdateRss, getEvidenceChangeUpdates } from '@/lib/research-updates'
+
+export const dynamic = 'force-static'
+
+export function GET() {
+  return new Response(buildResearchUpdateRss({
+    title: 'The Hippie Scientist — Evidence Changes',
+    description: 'Recorded supplement evidence-grade changes from The Hippie Scientist.',
+    selfPath: '/updates/evidence-changes.xml',
+    updates: getEvidenceChangeUpdates(),
+  }), { headers: { 'Content-Type': 'application/rss+xml; charset=utf-8' } })
+}

--- a/app/updates/evidence-changes/page.tsx
+++ b/app/updates/evidence-changes/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import ResearchUpdateList from '@/components/updates/ResearchUpdateList'
+import { getEvidenceChangeUpdates } from '@/lib/research-updates'
+import { buildPageMetadata } from '@/src/lib/seo'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Recent Supplement Evidence Changes',
+  description: 'An append-only public feed of recorded supplement evidence-grade changes, including the prior grade, new grade, and reason for each change.',
+  path: '/updates/evidence-changes/',
+})
+
+export default function EvidenceChangesPage() {
+  const updates = getEvidenceChangeUpdates()
+  return (
+    <main className='container-page space-y-7 py-10'>
+      <section className='hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8'>
+        <p className='eyebrow-label'>Evidence Change Tracker</p>
+        <h1 className='mt-2 text-4xl font-semibold tracking-tight text-ink'>Recent evidence changes</h1>
+        <p className='mt-4 max-w-3xl text-lg leading-8 text-muted'>This feed records actual evidence-grade changes and why they happened. It does not infer historical upgrades or downgrades that were never recorded at the time.</p>
+        <div className='mt-5 flex flex-wrap gap-3 text-sm font-bold'>
+          <a href='/updates/evidence-changes.xml' className='rounded-full border border-brand-900/15 bg-white px-4 py-2 text-brand-800'>Follow this RSS feed</a>
+          <Link href='/updates/recently-reviewed/' className='rounded-full border border-brand-900/15 bg-white px-4 py-2 text-brand-800'>Recently reviewed</Link>
+          <Link href='/evidence/evidence-report/' className='rounded-full border border-brand-900/15 bg-white px-4 py-2 text-brand-800'>Evidence Report</Link>
+        </div>
+      </section>
+      <ResearchUpdateList updates={updates} emptyMessage='No evidence-grade changes have been recorded in the append-only public ledger yet. The tracker will populate when a real reviewed change occurs.' />
+    </main>
+  )
+}

--- a/app/updates/page.tsx
+++ b/app/updates/page.tsx
@@ -1,0 +1,40 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { buildPageMetadata } from '@/src/lib/seo'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Research Updates & Feeds',
+  description: 'Follow recently reviewed pages, evidence-grade changes, and the main Hippie Scientist research RSS feed.',
+  path: '/updates/',
+})
+
+const feeds = [
+  { title: 'Recently reviewed', body: 'Real human/editorial review events only — never deployment timestamps.', href: '/updates/recently-reviewed/', rss: '/updates/recently-reviewed.xml' },
+  { title: 'Evidence changes', body: 'Recorded grade upgrades and downgrades with the reason preserved.', href: '/updates/evidence-changes/', rss: '/updates/evidence-changes.xml' },
+  { title: 'All research publishing', body: 'The existing sitewide article and research feed.', href: '/articles/', rss: '/rss.xml' },
+] as const
+
+export default function UpdatesPage() {
+  return (
+    <main className='container-page space-y-8 py-10'>
+      <section className='hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8'>
+        <p className='eyebrow-label'>For readers, researchers & journalists</p>
+        <h1 className='mt-2 text-4xl font-semibold tracking-tight text-ink'>Follow the research without checking manually</h1>
+        <p className='mt-4 max-w-3xl text-lg leading-8 text-muted'>Subscribe only to the update stream you care about. Additional topic feeds will be added when observed demand justifies them rather than multiplying low-value feeds by default.</p>
+      </section>
+      <section className='grid gap-4 md:grid-cols-3'>
+        {feeds.map(feed => (
+          <article key={feed.title} className='card-premium p-6'>
+            <h2 className='text-xl font-bold text-ink'>{feed.title}</h2>
+            <p className='mt-3 text-sm leading-7 text-muted'>{feed.body}</p>
+            <div className='mt-5 flex flex-wrap gap-3 text-sm font-bold'>
+              <Link href={feed.href} className='text-brand-800 hover:underline'>View feed →</Link>
+              <a href={feed.rss} className='text-brand-800 hover:underline'>RSS ↗</a>
+            </div>
+          </article>
+        ))}
+      </section>
+      <p className='text-sm leading-6 text-muted'>Topic-specific RSS is intentionally demand-gated. Evidence changes already receive their own focused feed because they are a distinct research-following use case; arbitrary ingredient/topic feeds are not generated unless usage demonstrates demand.</p>
+    </main>
+  )
+}

--- a/app/updates/recently-reviewed.xml/route.ts
+++ b/app/updates/recently-reviewed.xml/route.ts
@@ -1,0 +1,12 @@
+import { buildResearchUpdateRss, getRecentlyReviewedUpdates } from '@/lib/research-updates'
+
+export const dynamic = 'force-static'
+
+export function GET() {
+  return new Response(buildResearchUpdateRss({
+    title: 'The Hippie Scientist — Recently Reviewed',
+    description: 'Real editorial and scientific review events from The Hippie Scientist.',
+    selfPath: '/updates/recently-reviewed.xml',
+    updates: getRecentlyReviewedUpdates(),
+  }), { headers: { 'Content-Type': 'application/rss+xml; charset=utf-8' } })
+}

--- a/app/updates/recently-reviewed/page.tsx
+++ b/app/updates/recently-reviewed/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import ResearchUpdateList from '@/components/updates/ResearchUpdateList'
+import { getRecentlyReviewedUpdates } from '@/lib/research-updates'
+import { buildPageMetadata } from '@/src/lib/seo'
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Recently Reviewed Research Pages',
+  description: 'A truthful, append-only feed of pages that received a real editorial or scientific review — not pages that merely rebuilt or redeployed.',
+  path: '/updates/recently-reviewed/',
+})
+
+export default function RecentlyReviewedPage() {
+  const updates = getRecentlyReviewedUpdates()
+  return (
+    <main className='container-page space-y-7 py-10'>
+      <section className='hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8'>
+        <p className='eyebrow-label'>Research updates</p>
+        <h1 className='mt-2 text-4xl font-semibold tracking-tight text-ink'>Recently reviewed</h1>
+        <p className='mt-4 max-w-3xl text-lg leading-8 text-muted'>Only real recorded review events appear here. Deployments, template edits, and build timestamps do not make a page “recently reviewed.”</p>
+        <div className='mt-5 flex flex-wrap gap-3 text-sm font-bold'>
+          <a href='/updates/recently-reviewed.xml' className='rounded-full border border-brand-900/15 bg-white px-4 py-2 text-brand-800'>Follow this RSS feed</a>
+          <Link href='/updates/evidence-changes/' className='rounded-full border border-brand-900/15 bg-white px-4 py-2 text-brand-800'>Evidence changes</Link>
+          <a href='/rss.xml' className='rounded-full border border-brand-900/15 bg-white px-4 py-2 text-brand-800'>All-site RSS</a>
+        </div>
+      </section>
+      <ResearchUpdateList updates={updates} emptyMessage='No real editorial review events have been recorded in the public ledger yet. This empty state is intentional; the site will not manufacture review dates.' />
+    </main>
+  )
+}

--- a/components/updates/ResearchUpdateList.tsx
+++ b/components/updates/ResearchUpdateList.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link'
+import type { ResearchUpdate } from '@/lib/research-updates'
+
+export default function ResearchUpdateList({ updates, emptyMessage }: { updates: ResearchUpdate[]; emptyMessage: string }) {
+  if (!updates.length) {
+    return <div className='rounded-2xl border border-brand-900/10 bg-white p-6 text-sm leading-6 text-muted'>{emptyMessage}</div>
+  }
+
+  return (
+    <ol className='space-y-4'>
+      {updates.map(update => (
+        <li key={update.id} id={update.id} className='scroll-mt-24 rounded-2xl border border-brand-900/10 bg-white p-5 shadow-sm'>
+          <div className='flex flex-wrap items-center gap-x-3 gap-y-1 text-xs font-semibold uppercase tracking-[0.08em] text-brand-700'>
+            <time dateTime={update.occurredAt}>{new Date(update.occurredAt).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC' })}</time>
+            <span>{update.kind === 'review' ? 'Editorial review' : 'Evidence grade change'}</span>
+          </div>
+          <h2 className='mt-2 text-xl font-bold text-ink'>{update.title}</h2>
+          <p className='mt-2 text-sm leading-7 text-muted'>{update.summary}</p>
+          <Link href={update.path} className='mt-3 inline-block text-sm font-bold text-brand-800 hover:underline'>Open the affected page →</Link>
+        </li>
+      ))}
+    </ol>
+  )
+}

--- a/data/editorial/evidence-report-editions.ts
+++ b/data/editorial/evidence-report-editions.ts
@@ -1,0 +1,31 @@
+export type EvidenceReportEdition = {
+  year: number
+  title: string
+  datasetVersion: string
+  publishedAt: string
+  permalink: string
+  status: 'baseline' | 'archived'
+}
+
+/**
+ * Stable annual Evidence Report registry.
+ *
+ * Never repoint an existing year to a later dataset version. Add a new year as
+ * a new entry. The year-specific route verifies its dataset version before it
+ * will render live calculations, preventing a future dataset from silently
+ * masquerading as the historical edition.
+ */
+export const evidenceReportEditions: EvidenceReportEdition[] = [
+  {
+    year: 2026,
+    title: 'State of Supplement Evidence 2026',
+    datasetVersion: '2026.08.15',
+    publishedAt: '2026-08-15',
+    permalink: '/evidence/evidence-report/2026/',
+    status: 'baseline',
+  },
+]
+
+export function evidenceReportEdition(year: number) {
+  return evidenceReportEditions.find(edition => edition.year === year)
+}

--- a/lib/research-updates.ts
+++ b/lib/research-updates.ts
@@ -1,0 +1,106 @@
+import { editorialReviewHistory } from '@/data/editorial/review-history'
+import { evidenceGradeHistory } from '@/data/editorial/evidence-grade-history'
+
+const SITE = 'https://thehippiescientist.net'
+
+export type ResearchUpdate = {
+  id: string
+  kind: 'review' | 'evidence-change'
+  title: string
+  path: string
+  occurredAt: string
+  summary: string
+  topic?: string
+}
+
+function titleFromPath(pagePath: string) {
+  const slug = pagePath.split('/').filter(Boolean).at(-1) || 'Research update'
+  return slug
+    .split('-')
+    .filter(Boolean)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+export function getRecentlyReviewedUpdates(limit = 50): ResearchUpdate[] {
+  return [...editorialReviewHistory]
+    .sort((a, b) => Date.parse(b.reviewedAt) - Date.parse(a.reviewedAt))
+    .slice(0, limit)
+    .map(review => ({
+      id: review.id,
+      kind: 'review' as const,
+      title: `${titleFromPath(review.pagePath)} reviewed`,
+      path: review.pagePath,
+      occurredAt: review.reviewedAt,
+      summary: review.summary?.trim() || `${review.kind} review recorded by ${review.reviewerName}.`,
+      topic: review.kind,
+    }))
+}
+
+export function getEvidenceChangeUpdates(limit = 50): ResearchUpdate[] {
+  return [...evidenceGradeHistory]
+    .sort((a, b) => Date.parse(b.changedAt) - Date.parse(a.changedAt))
+    .slice(0, limit)
+    .map(change => ({
+      id: change.id,
+      kind: 'evidence-change' as const,
+      title: `${change.ingredientName}: ${change.fromGrade} → ${change.toGrade}`,
+      path: change.ingredientPath,
+      occurredAt: change.changedAt,
+      summary: change.reason,
+      topic: change.quarter,
+    }))
+}
+
+function escapeXml(value: string) {
+  return value.replace(/[<>&"']/g, character => ({
+    '<': '&lt;',
+    '>': '&gt;',
+    '&': '&amp;',
+    '"': '&quot;',
+    "'": '&apos;',
+  }[character] || character))
+}
+
+function safeCdata(value: string) {
+  return value.replace(/]]>/g, ']]]]><![CDATA[>')
+}
+
+export function buildResearchUpdateRss({
+  title,
+  description,
+  selfPath,
+  updates,
+}: {
+  title: string
+  description: string
+  selfPath: string
+  updates: ResearchUpdate[]
+}) {
+  const sorted = [...updates].sort((a, b) => Date.parse(b.occurredAt) - Date.parse(a.occurredAt)).slice(0, 50)
+  const lastBuildDate = new Date(sorted[0]?.occurredAt || '2026-01-01').toUTCString()
+  const items = sorted.map(update => {
+    const url = `${SITE}${update.path}`
+    return `
+    <item>
+      <title><![CDATA[${safeCdata(update.title)}]]></title>
+      <link>${escapeXml(url)}</link>
+      <guid isPermaLink="true">${escapeXml(`${SITE}/updates/#${update.id}`)}</guid>
+      <pubDate>${new Date(update.occurredAt).toUTCString()}</pubDate>
+      <description><![CDATA[${safeCdata(update.summary)}]]></description>
+    </item>`
+  }).join('\n')
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<channel>
+  <title>${escapeXml(title)}</title>
+  <link>${SITE}/updates/</link>
+  <atom:link href="${SITE}${selfPath}" rel="self" type="application/rss+xml" />
+  <description>${escapeXml(description)}</description>
+  <language>en</language>
+  <lastBuildDate>${lastBuildDate}</lastBuildDate>${items}
+</channel>
+</rss>
+`
+}


### PR DESCRIPTION
Rebased replacement for #3171 after main advanced. Adds truthful Recently Reviewed and Evidence Changes pages/RSS from append-only ledgers, a research-feed hub, a stable annual Evidence Report edition registry, permanent 2026 archive pinned to dataset 2026.08.15, and a year-over-year edition index. Includes regression tests and does not fabricate review or grade-change events.