### PR TITLE
content: refresh Valerian evidence and citations

### DIFF
--- a/content/articles/valerian-root.md
+++ b/content/articles/valerian-root.md
@@ -1,153 +1,304 @@
 ---
 slug: valerian-root
-title: "Valerian Root for Sleep: Benefits, Dosage & What the Evidence Shows"
-description: "Evidence-based guide to valerian root for sleep and anxiety. Covers dosage (300-600mg), GABA mechanisms, sleep latency RCTs, drug interactions, and how it compares to melatonin and magnesium."
+title: "Valerian Root for Sleep: What the Evidence Shows — 2026 Review"
+description: "Evidence-first 2026 review of valerian root for sleep and insomnia: the 2024 umbrella review, older meta-analyses and trials, subjective-versus-objective outcomes, mechanism limits, CYP interaction evidence, dosing uncertainty, and safety."
 date: '2026-06-06'
-updatedAt: '2026-07-05'
+updatedAt: '2026-08-15'
 author: Will
 category: Anxiety & Sleep
 keywords:
   - valerian root
   - valerian for sleep
-  - valerian root benefits
-  - valerian dosage
-  - natural sleep aid
-  - GABA
+  - valerian evidence
+  - insomnia
+  - sleep quality
   - valerenic acid
-  - insomnia supplement
+  - GABA
 featured_image: ''
 tags:
   - valerian
   - sleep
-  - anxiety
+  - insomnia
   - evidence review
 profile_status: published
 ai_assisted: false
 references:
+  - title: "Does valerian work for insomnia? An umbrella review of the evidence"
+    authors: "Valente V, Machado D, Jorge S, Drake CL, Marques DR"
+    year: "2024"
+    pmid: "38359657"
+    doi: "10.1016/j.euroneuro.2024.01.008"
+    url: "https://pubmed.ncbi.nlm.nih.gov/38359657/"
+  - title: "Valerian Root in Treating Sleep Problems and Associated Disorders-A Systematic Review and Meta-Analysis"
+    year: "2020"
+    pmid: "33086877"
+    pmcid: "PMC7585905"
+    doi: "10.1177/2515690X20967323"
+    url: "https://pubmed.ncbi.nlm.nih.gov/33086877/"
+  - title: "Herbal medicine for insomnia: A systematic review and meta-analysis"
+    year: "2015"
+    pmid: "25644982"
+    doi: "10.1016/j.smrv.2014.12.003"
+    url: "https://pubmed.ncbi.nlm.nih.gov/25644982/"
+  - title: "Effectiveness of Valerian on insomnia: a meta-analysis of randomized placebo-controlled trials"
+    authors: "Fernández-San-Martín MI, Masa-Font R, Palacios-Soler L, et al."
+    year: "2010"
+    pmid: "20347389"
+    doi: "10.1016/j.sleep.2009.12.009"
+    url: "https://pubmed.ncbi.nlm.nih.gov/20347389/"
+  - title: "A systematic review of valerian as a sleep aid: safe but not effective"
+    year: "2007"
+    pmid: "17517355"
+    doi: "10.1016/j.smrv.2007.03.002"
+    url: "https://pubmed.ncbi.nlm.nih.gov/17517355/"
   - title: "Valerian for sleep: a systematic review and meta-analysis"
     authors: "Bent S, Padula A, Moore D, Patterson M, Mehling W"
     year: "2006"
     pmid: "17145239"
+    pmcid: "PMC4394901"
+    doi: "10.1016/j.amjmed.2006.02.026"
     url: "https://pubmed.ncbi.nlm.nih.gov/17145239/"
-  - title: "Effectiveness of Valerian on insomnia: a meta-analysis of randomized placebo-controlled trials"
-    authors: "Fernández-San-Martín MI, Masa-Font R, Palacios-Soler L, Sancho-Gómez P, Calbó-Caldentey C, Flores-Mateo G"
-    year: "2010"
-    pmid: "20347389"
-    url: "https://pubmed.ncbi.nlm.nih.gov/20347389/"
-  - title: "Critical evaluation of the effect of valerian extract on sleep structure and sleep quality"
-    authors: "Donath F, Quispe S, Diefenbach K, Maurer A, Fietze I, Roots I"
-    year: "2000"
-    pmid: "10761819"
-    url: "https://pubmed.ncbi.nlm.nih.gov/10761819/"
+  - title: "Multiple night-time doses of valerian (Valeriana officinalis) had minimal effects on CYP3A4 activity and no effect on CYP2D6 activity in healthy volunteers"
+    year: "2004"
+    pmid: "15328251"
+    doi: "10.1124/dmd.104.001164"
+    url: "https://pubmed.ncbi.nlm.nih.gov/15328251/"
   - title: "Efficacy and tolerability of valerian extract LI 156 compared with oxazepam in the treatment of non-organic insomnia--a randomized, double-blind, comparative clinical study"
     authors: "Ziegler G, Ploch M, Miettinen-Baumann A, Collet W"
     year: "2002"
     pmid: "12568976"
     url: "https://pubmed.ncbi.nlm.nih.gov/12568976/"
+  - title: "Critical evaluation of the effect of valerian extract on sleep structure and sleep quality"
+    authors: "Donath F, Quispe S, Diefenbach K, Maurer A, Fietze I, Roots I"
+    year: "2000"
+    pmid: "10761819"
+    url: "https://pubmed.ncbi.nlm.nih.gov/10761819/"
 ---
 
-> **The bottom line:** Valerian root (*Valeriana officinalis*) is a traditional sedative herb that enhances GABA signaling. Meta-analyses show modest but significant improvements in sleep latency — typically reducing the time to fall asleep by 8–15 minutes. It's not a knockout sleep aid — effects are subtle and build over 2–4 weeks of consistent nightly use. Evidence grade: **Mixed-moderate** for sleep; preliminary for anxiety.
-
-## At a Glance
-
-| Question | Answer |
-|---|---|
-| Best fit | Mild sleep-onset difficulty; anxiety-related sleep disruption; people who prefer herbal options and don't need strong sedation |
-| Evidence level | Mixed-moderate — meta-analyses show small but significant sleep improvements; high heterogeneity between studies |
-| Typical dose | 300–600 mg of dried root extract (standardized to 0.8% valerenic acid), 30–60 min before bed |
-| Onset | Subtle effects night 1; full effects over 2–4 weeks of consistent use |
-| Is it like a sleeping pill? | No — much milder. Won't override severe insomnia, caffeine, or acute stress. |
-| Main concern | CYP3A4 inhibition — can interact with ~50% of prescription drugs |
-| Better for circadian issues? | Try melatonin |
-| Better for muscle tension? | Try [magnesium glycinate](/articles/magnesium-glycinate/) |
-
+> **Bottom line:** Valerian root has **weak and inconsistent evidence for insomnia**. A 2024 umbrella review of systematic reviews found **no demonstrated efficacy for treating insomnia**, although some older studies and reviews suggest possible improvement in **subjective sleep quality**. Objective and quantitative sleep outcomes have not shown a reliable benefit. The evidence does not establish a universal dose, a predictable 30–60 minute onset, an 8–15 minute reduction in sleep latency, a 2–4 week “build,” or a need to cycle the herb. Valerian also should not be framed as a major CYP3A4 interaction risk: a controlled human study found only minimal CYP3A4 effects and no CYP2D6 effect at typical studied exposure.
 
 ![Valerian Root](/images/guides/valerian-root.jpg)
 
----
+## At a glance
 
-## What to Expect
-
-| Timeframe | What you might notice |
+| Question | Evidence-first answer |
 |---|---|
-| **Night 1** | Some people feel mildly drowsy 30–60 min after taking. The smell is strong (earthy, "dirty socks") — normal and not a sign of spoilage. |
-| **Week 1–2** | Sleep latency may shorten by 5–15 minutes on average. No "knockout" effect — you still need to wind down. |
-| **Week 2–4** | Sleep quality consolidates. Valerian's GABAergic effects appear to build modestly with regular use rather than causing tolerance. |
-| **Month 1+** | Effects stabilize. Consider cycling (nights you need it vs. every night) if effects seem to diminish. |
-
-> **If valerian does nothing after 2 weeks:** it may not be right for you. Some people are valerian non-responders. Consider [magnesium glycinate](/articles/magnesium-glycinate/) (for muscle tension/deficiency), [melatonin](/articles/melatonin/) (for circadian misalignment), or a [magnesium + L-theanine stack](/articles/magnesium-l-theanine-sleep-stack/).
-
----
-
-## The Clinical Evidence
-
-| Study | Design | Finding |
-|---|---|---|
-| Bent 2006 | Meta-analysis (16 studies) | Modest improvement in subjective sleep quality; high heterogeneity — studies ranged from clearly positive to null |
-| Fernández-San-Martín 2010 | Meta-analysis | Small but significant reduction in sleep latency (~8–9 min on average) |
-| Donath 2000 | RCT, n=16, polysomnography | Increased slow-wave sleep and reduced Stage 1 sleep — improved sleep architecture, not just subjective perception |
-| Ziegler 2002 | RCT, n=202 | 600 mg/day valerian comparable to 10 mg oxazepam (benzodiazepine) for sleep quality at 6 weeks — but without morning hangover or dependence |
-
-The evidence is consistently modest. Valerian is not a replacement for prescription hypnotics. Its appropriate role: first-line, low-risk option for mild sleep complaints where a subtle nudge toward sleep is sufficient.
+| Insomnia treatment | **Not supported convincingly.** The 2024 umbrella review found no evidence of efficacy for insomnia treatment |
+| Subjective sleep quality | Possible signal in some older studies/reviews, but publication bias and heterogeneity reduce confidence |
+| Objective sleep measures | No reliable demonstrated benefit across the evidence base |
+| Best dose | Not established across extracts/preparations |
+| Onset | No validated universal same-night or 2–4 week onset schedule |
+| Anxiety | Insufficient direct evidence to treat valerian as an established anxiolytic |
+| CYP3A4 / CYP2D6 | Human pharmacokinetic evidence does **not** support a large clinically important interaction effect at typical studied doses |
+| Sedative combinations | Direct combination safety is limited; additive sedation remains a practical reason for caution |
 
 ---
 
-## How It Works
+## The 2024 umbrella review changes how valerian should be described
 
-Valerian's key compound, **valerenic acid**, enhances GABA signaling through two mechanisms:
-1. Inhibits GABA transaminase — the enzyme that breaks down GABA — increasing available GABA
-2. Binds to GABA-A receptors at a site distinct from benzodiazepines, producing mild agonism
+The most useful current synthesis is a 2024 umbrella review that evaluated systematic reviews of valerian for sleep disturbances and insomnia. It identified eight eligible reviews and concluded that the evidence base is weak, heterogeneous, and methodologically limited. [PubMed 38359657](https://pubmed.ncbi.nlm.nih.gov/38359657/) · [DOI 10.1016/j.euroneuro.2024.01.008](https://doi.org/10.1016/j.euroneuro.2024.01.008)
 
-The net effect: more GABA available + enhanced receptor sensitivity = mild sedation. Unlike benzodiazepines, valerenic acid's partial, indirect mechanism does not appear to produce receptor downregulation or dependence at therapeutic doses over 4–6 weeks.
+Its central conclusions were:
+
+- no demonstrated efficacy for **treating insomnia**,
+- possible improvement in **subjective sleep quality**,
+- no demonstrated effectiveness on quantitative or objective sleep measurements,
+- generally favorable safety reporting in the studied literature,
+- a need for better randomized trials because existing studies and reviews are heterogeneous and often low quality.
+
+That evidence hierarchy should outrank older supplement summaries that turn one favorable endpoint into a precise bedtime protocol.
 
 ---
 
-## Safety and the CYP3A4 Problem
+## Why the older literature looked more positive
 
-Valerian is generally well tolerated. The most common side effects: morning grogginess (dose-dependent), vivid dreams, mild GI upset.
+### 2006 systematic review: a subjective signal with publication-bias concerns
 
-**Critical interaction:** Valerian inhibits **CYP3A4**, the liver enzyme that metabolizes approximately 50% of prescription drugs. This is the most clinically important valerian interaction and is widely underappreciated.
+A 2006 systematic review included 16 eligible studies with 1,093 participants. Six studies reported a dichotomous “sleep quality improved or not” outcome, and the pooled result favored valerian. But the authors also found substantial methodological problems, major differences in products/doses/durations, and evidence of **publication bias** in the positive summary measure. [PubMed 17145239](https://pubmed.ncbi.nlm.nih.gov/17145239/) · [DOI 10.1016/j.amjmed.2006.02.026](https://doi.org/10.1016/j.amjmed.2006.02.026)
 
-| Drug class at risk | Examples |
+The safe conclusion is “possible subjective sleep-quality signal,” not “valerian reliably shortens sleep latency by 8–15 minutes.”
+
+### 2007 review: the more rigorous studies were mostly negative
+
+A systematic review focused on preparation type and study quality found that most controlled trials showed no significant difference between valerian and placebo, and the newer/more methodologically rigorous studies available at the time were negative. The authors concluded that the evidence supported relative short-term safety better than clinical efficacy. [PubMed 17517355](https://pubmed.ncbi.nlm.nih.gov/17517355/) · [DOI 10.1016/j.smrv.2007.03.002](https://doi.org/10.1016/j.smrv.2007.03.002)
+
+### 2015 herbal-insomnia review: no significant clinical efficacy signal
+
+A broader systematic review and meta-analysis of herbal medicines for insomnia included 14 randomized trials involving 1,602 participants. For the evaluated herbal monopreparations—including valerian—the review found no statistically significant difference versus placebo or active control across the assessed clinical efficacy measures. [PubMed 25644982](https://pubmed.ncbi.nlm.nih.gov/25644982/) · [DOI 10.1016/j.smrv.2014.12.003](https://doi.org/10.1016/j.smrv.2014.12.003)
+
+### 2020 update: heterogeneity still dominates
+
+The 2020 systematic review/meta-analysis again emphasized inconsistent outcomes across preparations and studies. It is useful for mapping what has been studied, but it did not resolve the fundamental directness and heterogeneity problems that the 2024 umbrella review later highlighted. [PubMed 33086877](https://pubmed.ncbi.nlm.nih.gov/33086877/) · [DOI 10.1177/2515690X20967323](https://doi.org/10.1177/2515690X20967323)
+
+---
+
+## The oxazepam comparison does not prove equivalence to a benzodiazepine
+
+A 2002 randomized double-blind comparative study enrolled 202 outpatients with non-organic insomnia and compared **600 mg/day valerian extract LI 156** with **10 mg/day oxazepam** for six weeks. Both groups improved on questionnaire-based sleep-quality measures, and the investigators described the treatments as comparably efficacious. [PubMed 12568976](https://pubmed.ncbi.nlm.nih.gov/12568976/)
+
+That trial is frequently turned into the claim “valerian works as well as a benzodiazepine without dependence or morning hangover.” The evidence does not justify that leap:
+
+- it was an **active-comparator** trial, not evidence that valerian beats placebo,
+- improvement in both groups does not establish broad pharmacologic equivalence,
+- one specific extract/dose does not establish a class effect for all valerian products,
+- six weeks does not establish long-term dependence or withdrawal risk,
+- the trial does not justify substituting valerian for a prescribed medication.
+
+The study belongs in the evidence map, but not as a headline efficacy claim.
+
+---
+
+## Objective sleep architecture: interesting small studies, not a class-wide effect
+
+Small polysomnography studies have reported changes in sleep architecture after particular valerian preparations. The Donath study, for example, is frequently cited for slow-wave-sleep findings. [PubMed 10761819](https://pubmed.ncbi.nlm.nih.gov/10761819/)
+
+These studies can support **hypothesis-level evidence about specific preparations**, but the 2024 umbrella review found that objective/quantitative efficacy has not been established across the overall evidence base. A small positive physiology study should not overrule the broader systematic evidence.
+
+---
+
+## Dose and timing: trial regimens are not a universal bedtime prescription
+
+The previous version of this page prescribed **300–600 mg**, standardized to a specific valerenic-acid percentage, **30–60 minutes before bed**, and suggested effects build over **2–4 weeks**.
+
+The evidence does not establish those rules across valerian preparations.
+
+Valerian trials differ in:
+
+- extract and manufacturing method,
+- dose,
+- standardization,
+- single-dose versus repeated-dose exposure,
+- participant diagnosis,
+- subjective versus objective outcome measures,
+- treatment duration.
+
+A dose used in one trial describes that intervention. It does not prove the same milligram amount, timing, or onset applies to another extract or person.
+
+### What is not established
+
+- a universal 300–600 mg sleep dose,
+- a universal 30–60 minute onset,
+- a reliable 8–15 minute reduction in sleep latency,
+- a 2–4 week biological “build,”
+- a validated cycling schedule,
+- a rule that lack of effect after two weeks predicts non-response.
+
+---
+
+## Mechanism: GABA plausibility does not prove insomnia efficacy
+
+Valerian and valerenic-acid-related constituents have been studied in GABA-related and other neurochemical pathways. This makes a calming/sedative hypothesis biologically plausible.
+
+But mechanism cannot establish:
+
+- that a given retail extract meaningfully increases brain GABA in a person,
+- that GABA-related activity explains a clinical sleep benefit,
+- that valerian acts like a benzodiazepine but without benzodiazepine risks,
+- that receptor downregulation or dependence does not occur with long-term use,
+- a predictable time-to-effect.
+
+The correct hierarchy is **human outcome evidence first, mechanism second**.
+
+---
+
+## The CYP3A4 claim was overstated
+
+The old page called CYP3A4 inhibition valerian's “critical interaction,” stated that it could affect about half of prescription drugs, and recommended checking every prescription for CYP3A4 metabolism.
+
+A controlled human pharmacokinetic study does not support that level of concern. Twelve healthy volunteers received valerian nightly for 14 days and were tested with probe substrates for CYP2D6 and CYP3A4. Valerian had **no significant effect on CYP2D6**, and while alprazolam peak concentration increased modestly, the major pharmacokinetic parameters did not change significantly. The authors concluded that typical doses were unlikely to cause clinically significant CYP2D6- or CYP3A4-mediated interactions. [PubMed 15328251](https://pubmed.ncbi.nlm.nih.gov/15328251/) · [DOI 10.1124/dmd.104.001164](https://doi.org/10.1124/dmd.104.001164)
+
+That does **not** mean valerian has no interaction potential. It means a broad “CYP3A4 problem” should not be presented as established human clinical fact.
+
+### More defensible safety boundaries
+
+- Combining valerian with alcohol, prescription sedatives, or other CNS-depressant products may increase sedation; direct combination evidence is limited, so caution is appropriate.
+- Product composition varies substantially across herbal extracts.
+- Pregnancy/breastfeeding and long-term nightly use have limited direct safety evidence.
+- Medication-specific decisions should be based on the actual drug/product and clinician/pharmacist review rather than a blanket CYP3A4 rule.
+
+---
+
+## Valerian plus melatonin: mechanism difference does not prove compatibility or synergy
+
+The old FAQ said valerian and melatonin are compatible because they “work through completely different mechanisms.” That is not an adequate safety or efficacy argument.
+
+Different mechanisms do not establish:
+
+- that the combination is more effective,
+- that sedation or next-day effects will not increase,
+- that a specific valerian extract and melatonin dose were tested together,
+- that long-term combination use is safe.
+
+If two interventions have only separate evidence bases, the combination should be labeled **insufficiently studied**, not automatically compatible or synergistic.
+
+---
+
+## Valerian versus melatonin and magnesium
+
+These are not interchangeable “sleep aids.” Their evidence questions differ.
+
+| Option | More defensible evidence framing |
 |---|---|
-| Statins | Atorvastatin, simvastatin |
-| Benzodiazepines, alcohol, CNS depressants | Additive sedation — avoid combining |
-| Calcium channel blockers | Amlodipine, nifedipine |
-| SSRIs | Sertraline, fluoxetine |
-| Immunosuppressants | Cyclosporine, tacrolimus |
+| **Valerian** | Weak/inconclusive insomnia efficacy; possible subjective sleep-quality signal |
+| **Melatonin** | Stronger direct rationale for circadian timing/delayed sleep phase and jet lag; generic adult-insomnia effects are modest/variable |
+| **Magnesium** | Limited/low-certainty sleep evidence; newer bisglycinate RCT found a small insomnia-symptom effect |
+| **L-theanine** | Limited sleep evidence; better described as an arousal/calm compound than a direct hypnotic |
 
-**If you take any prescription medication, check whether it's metabolized by CYP3A4 before adding valerian.** Stop 2 weeks before surgery. Avoid in pregnancy and children under 3.
-
----
-
-## Valerian vs. Alternatives
-
-| | Valerian | Melatonin | Magnesium | L-Theanine |
-|---|---|---|---|---|
-| **Best for** | Sleep onset, mild sedation | Circadian timing | Muscle tension, deficiency | Racing thoughts |
-| **Strength** | Mild-moderate | Mild | Mild-moderate | Mild |
-| **Onset** | 30–60 min | 30–60 min | Hours to weeks | 30–40 min |
-| **Tolerance** | Unlikely (4–6 weeks data) | None | None | None |
-| **Drug interactions** | CYP3A4 — significant | Few | Few (antibiotics, bisphosphonates) | None significant |
+This comparison should guide the *question being asked*, not function as a recommendation to self-treat chronic insomnia with a supplement ladder.
 
 ---
 
-## FAQ
+## Frequently asked questions
 
-### Why does valerian smell so bad?
-Valerenic acid and related compounds produce the characteristic "dirty socks" odor. It's normal and actually indicates the active compounds are present. If valerian doesn't smell, it may have degraded.
+### Does valerian actually work for insomnia?
 
-### Can I take valerian with melatonin?
-Yes — they work through completely different mechanisms (GABA enhancement vs. circadian signaling) and are compatible. Start with one to assess individual effect before combining.
+The current highest-level synthesis says **no demonstrated insomnia-treatment efficacy**. Some older studies/reviews report subjective sleep-quality improvement, but objective and quantitative benefits have not been reliably demonstrated. [PubMed 38359657](https://pubmed.ncbi.nlm.nih.gov/38359657/)
 
-### Is valerian addictive?
-Available data suggests low dependence potential at therapeutic doses over 4–6 weeks. The partial, indirect GABAergic mechanism does not produce the receptor downregulation that drives benzodiazepine dependence. However, long-term safety data (>3 months) is limited.
+### Does valerian reduce the time it takes to fall asleep?
+
+The literature is inconsistent and does not support a universal “8–15 minutes faster” estimate for users. Products, trial designs, populations, and outcome definitions vary substantially.
+
+### How long does valerian take to work?
+
+There is no validated universal onset. Some trials evaluated acute exposure and others repeated use; a fixed 30–60 minute or 2–4 week timeline is not established.
+
+### What dose should I take?
+
+This review does not prescribe a universal dose. Trial regimens are preparation-specific and should not be converted into personal dosing without considering the actual extract, other medications, and the reason for use.
+
+### Is valerian as effective as oxazepam?
+
+One six-week active-comparator study reported similar questionnaire improvement with a specific 600 mg/day valerian extract and 10 mg/day oxazepam. That study does not establish general equivalence to benzodiazepines or justify replacing prescribed treatment. [PubMed 12568976](https://pubmed.ncbi.nlm.nih.gov/12568976/)
+
+### Does valerian cause major CYP3A4 drug interactions?
+
+A controlled human study found only minimal CYP3A4 effects and no CYP2D6 effect after 14 days, concluding that clinically significant interactions through those pathways were unlikely at typical studied exposure. Medication-specific review is still prudent because supplements and drugs vary. [PubMed 15328251](https://pubmed.ncbi.nlm.nih.gov/15328251/)
+
+### Can valerian be combined with melatonin?
+
+Direct combination evidence is insufficient to declare the pair universally safe, synergistic, or more effective. Different mechanisms alone do not answer a combination-safety question.
 
 ---
 
-## Related Articles
+## Evidence quality summary
+
+**What raises confidence:**
+- Multiple decades of human trials and systematic reviews.
+- Reasonably consistent short-term tolerability reporting in much of the literature.
+
+**What lowers confidence:**
+- Major variation in extract identity, dose, duration, and outcome measurement.
+- Many small or methodologically weak trials.
+- Publication-bias concerns in older positive meta-analysis results.
+- Subjective improvement signals not consistently matched by objective sleep outcomes.
+- Modern umbrella-level synthesis does not support valerian as an insomnia treatment.
+
+**Current verdict:** **Insufficient/inconclusive for treating insomnia; possible low-certainty subjective sleep-quality signal; no established universal dose, onset, cycling protocol, or major CYP3A4 interaction rule.**
+
+---
+
+## Related evidence guides
 
 - [Magnesium Glycinate for Sleep](/articles/magnesium-glycinate/)
 - [Magnesium + L-Theanine Sleep Stack](/articles/magnesium-l-theanine-sleep-stack/)
-- [Kava for Anxiety & Sleep](/articles/kava/)
 - [Passionflower for Anxiety](/articles/passionflower/)


### PR DESCRIPTION
## Checkpoint 6 — Valerian evidence refresh

The live Valerian guide substantially overstated both efficacy and interaction certainty. This checkpoint rebuilds the page around the current evidence hierarchy.

### Evidence updates
- Add the 2024 umbrella review (PMID 38359657; DOI 10.1016/j.euroneuro.2024.01.008): no demonstrated efficacy for treating insomnia, possible subjective sleep-quality signal, and no reliable quantitative/objective benefit.
- Add the 2020, 2015, 2007, and 2006 systematic-review evidence to show why older positive summaries are heterogeneous and vulnerable to publication/methodological bias.
- Preserve the 2002 valerian-vs-oxazepam active-comparator study, but stop treating one questionnaire-based comparison as proof of benzodiazepine equivalence or long-term dependence safety.
- Add the controlled human CYP study (PMID 15328251; DOI 10.1124/dmd.104.001164), which found no CYP2D6 effect and only minimal CYP3A4 effects at the studied exposure.

### Claim-discipline fixes
- Remove the universal 300–600 mg / 30–60 minute bedtime protocol.
- Remove the claimed 8–15 minute sleep-latency reduction and deterministic 2–4 week build/onset schedule.
- Remove cycling/non-responder rules unsupported by controlled evidence.
- Reframe GABA mechanisms as plausibility rather than demonstrated clinical causality.
- Correct the previous 'critical CYP3A4 interaction affecting ~50% of prescriptions' framing.
- Remove automatic valerian + melatonin compatibility/synergy claims.
- Separate subjective sleep-quality signals from objective insomnia-treatment efficacy.

### Scope
One live article only. No generated runtime JSON, canonical workbook rows, publication governance, monetization, or sleep-cluster engine logic changed.