### PR TITLE
feat(schema): enforce truthful structured-data policy

### DIFF
--- a/components/seo/SchemaGraphScript.tsx
+++ b/components/seo/SchemaGraphScript.tsx
@@ -60,8 +60,6 @@ export function normalizeProfileEntitySemantics(
     if (record['@id'] === artifact.entityId) {
       return {
         ...record,
-        // Schema.org `Substance` covers matter of biological origin. Avoid the
-        // non-canonical `MedicalSubstance` label previously emitted for herbs.
         '@type': 'Substance',
       }
     }
@@ -80,9 +78,6 @@ export function normalizeProfileEntitySemantics(
     if (mainEntityId === artifact.entityId && aboutType === 'MedicalTherapy') {
       return {
         ...record,
-        // The profile page is about the canonical herb entity, not a treatment
-        // intervention. Point `about` to the same Substance node used by
-        // `mainEntity` so the graph has one consistent identity.
         about: { '@id': artifact.entityId },
       }
     }
@@ -132,11 +127,7 @@ export function normalizePlaceholderPublicationDates(
     const types = Array.isArray(record['@type']) ? record['@type'] : [record['@type']]
 
     const isEntryArticle = id.endsWith('#webpage') && types.includes('Article')
-    if (
-      isEntryArticle &&
-      record.datePublished === LEGACY_PLACEHOLDER_PUBLICATION_DATE &&
-      !record.dateModified
-    ) {
+    if (isEntryArticle && record.datePublished === LEGACY_PLACEHOLDER_PUBLICATION_DATE) {
       const { datePublished: _datePublished, ...rest } = record
       return rest
     }

--- a/components/seo/__tests__/SchemaGraphPublicationDate.test.ts
+++ b/components/seo/__tests__/SchemaGraphPublicationDate.test.ts
@@ -20,7 +20,7 @@ describe('SEO entry schema publication dates', () => {
     expect(article.datePublished).toBeUndefined()
   })
 
-  it('preserves explicit publication dates when modification metadata is present', () => {
+  it('removes the legacy placeholder even when a real modification date exists', () => {
     const graph = {
       '@context': 'https://schema.org',
       '@graph': [
@@ -36,6 +36,26 @@ describe('SEO entry schema publication dates', () => {
     const normalized = normalizePlaceholderPublicationDates(graph)
     const article = (normalized['@graph'] as Record<string, unknown>[])[0]
 
-    expect(article.datePublished).toBe('2026-01-01')
+    expect(article.datePublished).toBeUndefined()
+    expect(article.dateModified).toBe('2026-08-14')
+  })
+
+  it('preserves a non-placeholder publication date', () => {
+    const graph = {
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': 'Article',
+          '@id': 'https://thehippiescientist.net/guides/example/#webpage',
+          datePublished: '2026-07-10',
+          dateModified: '2026-08-14',
+        },
+      ],
+    }
+
+    const normalized = normalizePlaceholderPublicationDates(graph)
+    const article = (normalized['@graph'] as Record<string, unknown>[])[0]
+
+    expect(article.datePublished).toBe('2026-07-10')
   })
 })

--- a/scripts/ci/audit-schema-policy.mjs
+++ b/scripts/ci/audit-schema-policy.mjs
@@ -10,8 +10,23 @@ if (!fs.existsSync(outDir)) {
   process.exit(1)
 }
 
-const bannedTypes = new Set(['Physician', 'MedicalOrganization', 'MedicalClinic', 'Hospital'])
-const recognized = new Set(['Organization', 'Person', 'BreadcrumbList', 'Article', 'BlogPosting', 'Dataset', 'ImageObject', 'FAQPage', 'MedicalWebPage', 'WebPage', 'WebSite'])
+const bannedTypes = new Set([
+  'Physician',
+  'MedicalOrganization',
+  'MedicalClinic',
+  'Hospital',
+  'Pharmacy',
+  'Dentist',
+  'DiagnosticLab',
+  'MedicalBusiness',
+])
+const recognized = new Set([
+  'Organization', 'Person', 'BreadcrumbList', 'Article', 'BlogPosting', 'Dataset',
+  'ImageObject', 'FAQPage', 'MedicalWebPage', 'WebPage', 'WebSite', 'ProfilePage',
+  'CollectionPage', 'ItemList', 'ListItem', 'Question', 'Answer', 'Substance',
+  'ChemicalSubstance', 'DefinedTerm', 'Offer', 'Product', 'SoftwareApplication',
+])
+const legacyPlaceholderDates = new Set(['2026-01-01'])
 const errors = []
 const warnings = []
 const typeCounts = {}
@@ -51,9 +66,18 @@ function typesOf(node) {
 
 function dateCheck(node, route, key) {
   if (!node[key]) return
+  if (legacyPlaceholderDates.has(String(node[key]))) {
+    errors.push(`${route}: ${key} uses legacy placeholder date ${node[key]}`)
+    return
+  }
   const parsed = new Date(node[key])
   if (Number.isNaN(parsed.getTime())) errors.push(`${route}: ${key} is not a valid date (${node[key]})`)
   else if (parsed.getTime() > Date.now() + 24 * 60 * 60 * 1000) errors.push(`${route}: ${key} is in the future (${node[key]})`)
+}
+
+function nameOfReference(value) {
+  if (!value || typeof value !== 'object') return ''
+  return String(value.name || value['@id'] || '')
 }
 
 function validateNode(node, route) {
@@ -65,9 +89,10 @@ function validateNode(node, route) {
 
   if (types.includes('Person')) {
     if (!node.name) errors.push(`${route}: Person schema is missing name`)
-    if (node.medicalSpecialty || node.hasCredential || /doctor|physician|clinician/i.test(String(node.jobTitle || ''))) {
+    if (node.medicalSpecialty || node.hasCredential || /doctor|physician|clinician|pharmacist|dietitian/i.test(String(node.jobTitle || ''))) {
       errors.push(`${route}: Person schema contains medical credential/specialty claims requiring explicit editorial verification`)
     }
+    if (node.worksFor && !nameOfReference(node.worksFor)) errors.push(`${route}: Person worksFor relationship is incomplete`)
   }
 
   if (types.includes('Organization')) {
@@ -82,11 +107,13 @@ function validateNode(node, route) {
     if (!node.headline) errors.push(`${route}: Article/BlogPosting is missing headline`)
     dateCheck(node, route, 'datePublished')
     dateCheck(node, route, 'dateModified')
+    if (node.reviewedBy && !node.dateReviewed) errors.push(`${route}: reviewedBy is present without a truthful dateReviewed event`)
+    dateCheck(node, route, 'dateReviewed')
   }
 
   if (types.includes('Dataset')) {
     if (!node.name || !node.description || !node.url) errors.push(`${route}: Dataset requires name, description and stable url`)
-    if (!node.distribution) warnings.push(`${route}: Dataset has no downloadable distribution metadata`)
+    if (!node.distribution && !node.encodingFormat) warnings.push(`${route}: Dataset has no distribution or encoding metadata`)
     dateCheck(node, route, 'datePublished')
     dateCheck(node, route, 'dateModified')
   }
@@ -115,7 +142,7 @@ for (const file of walk(outDir)) {
   }
 }
 
-for (const required of ['Organization', 'Person', 'BreadcrumbList', 'Article']) {
+for (const required of ['Organization', 'Person', 'BreadcrumbList', 'Article', 'Dataset']) {
   if (!typeCounts[required]) warnings.push(`no ${required} schema observed in built output`)
 }
 


### PR DESCRIPTION
## Backlog
Covers 481–497 by hardening the schema stack already present on main.

## Existing coverage reused
- Organization, Person, BreadcrumbList, Article/BlogPosting, Dataset, ImageObject, FAQPage, and WebPage/MedicalWebPage schemas already exist.
- JSON-LD parsing and schema policy audits already run post-build.
- The author page already publishes a truthful Person → Organization relationship and explicitly disclaims medical/academic credentials.
- Evidence profile JSON-LD already removes unsupported review claims and exposes structured Dataset companions.

## Changes
- removes the legacy `2026-01-01` placeholder publication date unconditionally, even when a real modification date exists
- expands schema-policy bans for clinical/credential entity types the site must not imply (`Physician`, `MedicalClinic`, `MedicalOrganization`, `Hospital`, `Pharmacy`, `Dentist`, `DiagnosticLab`, `MedicalBusiness`)
- fails on legacy placeholder dates reaching built JSON-LD
- fails when `reviewedBy` is present without a real `dateReviewed`
- validates reviewer dates and Person `worksFor` relationships
- strengthens Dataset metadata requirements while allowing encoding metadata for machine-readable entity datasets
- expands recognized schema vocabulary so the policy report distinguishes legitimate graph nodes from unexpected types
- updates tests so placeholder publication dates can never survive merely because `dateModified` is present

## Guardrails
No credential, medical-specialty, or patient-audience claims are added. Existing FAQ schema remains content-driven rather than manufactured solely for markup.