### PR TITLE
fix(deploy): bound active production job runtime

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     environment: production
     env:
       STATIC_OUTPUT_DIR: out

--- a/tests/deployment-handoff-contract.test.ts
+++ b/tests/deployment-handoff-contract.test.ts
@@ -26,12 +26,13 @@ describe('production deployment handoff contract', () => {
     expect(workflow).toContain('ref: ${{ github.sha }}')
   })
 
-  it('lets an active production deploy finish instead of canceling it for a newer head', () => {
+  it('lets an active production deploy finish but bounds how long it can monopolize the deploy group', () => {
     const workflow = read('.github/workflows/deploy.yml')
 
     expect(workflow).toContain('concurrency:')
     expect(workflow).toContain('group: deploy-${{ github.ref }}')
     expect(workflow).toContain('cancel-in-progress: false')
+    expect(workflow).toContain('timeout-minutes: 60')
   })
 
   it('validates tests, canonical data, source-of-truth, types, lint, build, and output before publishing', () => {


### PR DESCRIPTION
Fixes #3234

## Relevant URLs
N/A — production deployment orchestration only.

## Acceptance criteria
- Add an explicit 60-minute timeout to the production deploy job.
- Keep direct `main` push/manual triggers unchanged.
- Keep `cancel-in-progress: false` unchanged so active publishes finish.
- Keep newest pending deploy behavior unchanged.

## Validation commands
- `npm run test -- tests/deployment-handoff-contract.test.ts`
- GitHub Actions workflow parsing/dispatch on this PR.

## Before → after metrics
- Maximum active deploy job runtime before platform intervention: **platform default → 60 minutes**
- Production deploy cancellation behavior: **unchanged**
- Validation/deploy commands: **unchanged**

## Generator/source-of-truth decision
The production deploy workflow remains the authoritative deployment contract; this change only bounds its runtime.

## Regression contract
`tests/deployment-handoff-contract.test.ts` now requires `timeout-minutes: 60` alongside the non-canceling deploy concurrency contract.