### PR TITLE
feat(media): gate public research graphics on recorded human review

### DIFF
--- a/.github/workflows/schema-media-governance.yml
+++ b/.github/workflows/schema-media-governance.yml
@@ -9,6 +9,7 @@ on:
       - 'lib/**'
       - 'public/data/**'
       - 'data/evidence/**'
+      - 'data/media/**'
       - 'scripts/ci/audit-schema-policy.mjs'
       - 'scripts/ci/audit-structured-data.mjs'
       - 'scripts/media/**'
@@ -21,6 +22,7 @@ on:
       - 'lib/**'
       - 'public/data/**'
       - 'data/evidence/**'
+      - 'data/media/**'
       - 'scripts/ci/audit-schema-policy.mjs'
       - 'scripts/ci/audit-structured-data.mjs'
       - 'scripts/media/**'
@@ -58,6 +60,8 @@ jobs:
         run: node scripts/ci/audit-schema-policy.mjs
       - name: Generate review-only research graphics
         run: node scripts/media/build-research-graphics.mjs
+      - name: Validate graphic promotion registry
+        run: node scripts/media/promote-reviewed-research-graphics.mjs --check
       - name: Upload reports and graphics for review
         if: always()
         uses: actions/upload-artifact@v7

--- a/data/media/research-graphic-reviews.json
+++ b/data/media/research-graphic-reviews.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "reviews": []
+}

--- a/docs/media/research-graphic-review.md
+++ b/docs/media/research-graphic-review.md
@@ -1,0 +1,30 @@
+# Research graphic review and promotion
+
+Generated share cards and charts are **review artifacts**, not public assets. `scripts/media/build-research-graphics.mjs` writes candidate SVG/PNG files to `artifacts/research-graphics/` from structured site data. That generator covers ingredient cards, comparison cards, evidence-change cards, and evidence charts.
+
+A graphic may move into `public/media/research/` only after a human reviewer records an approval in `data/media/research-graphic-reviews.json` and verifies all four gates:
+
+- `evidenceVerified`: every displayed grade, change, comparison label, and numeric/data statement matches the current canonical evidence data.
+- `attributionVerified`: The Hippie Scientist attribution and any required source attribution are present and accurate.
+- `destinationVerified`: the card points to the correct canonical human-readable page.
+- `visualVerified`: the rendered graphic has been visually inspected for clipping, legibility, misleading emphasis, and missing caveats.
+
+Example review record:
+
+```json
+{
+  "graphic": "ingredient-ashwagandha.png",
+  "reviewer": "Human reviewer name",
+  "reviewedAt": "2026-08-15",
+  "status": "approved",
+  "evidenceVerified": true,
+  "attributionVerified": true,
+  "destinationVerified": true,
+  "visualVerified": true,
+  "note": "Verified against the current public profile and evidence data."
+}
+```
+
+Run `node scripts/media/promote-reviewed-research-graphics.mjs --check` to validate the registry without copying files. Run it without `--check` only when intentionally promoting approved assets. The resulting public manifest preserves reviewer/date provenance beside the PNG/SVG paths and source URL.
+
+Do not create an approval record merely to satisfy CI. A missing approval means the graphic remains an internal review artifact, which is the intended safe default.

--- a/scripts/media/promote-reviewed-research-graphics.mjs
+++ b/scripts/media/promote-reviewed-research-graphics.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const artifactDir = path.join(root, 'artifacts/research-graphics')
+const artifactManifestPath = path.join(artifactDir, 'manifest.json')
+const reviewPath = path.join(root, 'data/media/research-graphic-reviews.json')
+const publicDir = path.join(root, 'public/media/research')
+const publicManifestPath = path.join(publicDir, 'manifest.json')
+const checkOnly = process.argv.includes('--check')
+
+function readJson(file, fallback) {
+  try { return JSON.parse(fs.readFileSync(file, 'utf8')) } catch { return fallback }
+}
+
+function normalizedReview(review) {
+  return {
+    graphic: String(review?.graphic || '').trim(),
+    reviewer: String(review?.reviewer || '').trim(),
+    reviewedAt: String(review?.reviewedAt || '').trim(),
+    status: String(review?.status || '').trim().toLowerCase(),
+    evidenceVerified: review?.evidenceVerified === true,
+    attributionVerified: review?.attributionVerified === true,
+    destinationVerified: review?.destinationVerified === true,
+    visualVerified: review?.visualVerified === true,
+    note: String(review?.note || '').trim(),
+  }
+}
+
+function isApproved(review) {
+  if (!review || review.status !== 'approved') return false
+  if (!review.reviewer || !review.reviewedAt) return false
+  if (Number.isNaN(Date.parse(review.reviewedAt))) return false
+  return review.evidenceVerified && review.attributionVerified && review.destinationVerified && review.visualVerified
+}
+
+const artifactManifest = readJson(artifactManifestPath, null)
+if (!artifactManifest?.graphics || !Array.isArray(artifactManifest.graphics)) {
+  console.error('[media-promotion] missing artifacts/research-graphics/manifest.json — generate review artifacts first')
+  process.exit(1)
+}
+
+const reviewRegistry = readJson(reviewPath, { version: 1, reviews: [] })
+const reviews = new Map((reviewRegistry.reviews || []).map((entry) => {
+  const review = normalizedReview(entry)
+  return [review.graphic, review]
+}))
+
+const errors = []
+const eligible = []
+for (const graphic of artifactManifest.graphics) {
+  const svg = graphic.svg ? path.basename(graphic.svg) : ''
+  const png = graphic.png ? path.basename(graphic.png) : ''
+  const review = reviews.get(svg) || reviews.get(png)
+  if (!review) continue
+  if (!isApproved(review)) {
+    errors.push(`${svg || png}: review record exists but is not fully approved`)
+    continue
+  }
+  if (!graphic.sourceUrl || !graphic.alt) {
+    errors.push(`${svg || png}: generated manifest lacks sourceUrl or alt text`)
+    continue
+  }
+  eligible.push({ graphic, review, svg, png })
+}
+
+for (const [name, review] of reviews) {
+  if (!artifactManifest.graphics.some((graphic) => [graphic.svg && path.basename(graphic.svg), graphic.png && path.basename(graphic.png)].includes(name))) {
+    errors.push(`${name}: approved/reviewed registry entry does not match a current generated graphic`)
+  }
+  if (review.status === 'approved' && !isApproved(review)) errors.push(`${name}: approved review is missing one or more verification fields`)
+}
+
+if (errors.length) {
+  console.error(`[media-promotion] ${errors.length} blocking review/promotion problem(s)`)
+  errors.forEach((error) => console.error(`- ${error}`))
+  process.exit(1)
+}
+
+console.log(`[media-promotion] ${eligible.length} graphics eligible for public promotion`)
+if (checkOnly) process.exit(0)
+
+fs.mkdirSync(publicDir, { recursive: true })
+const published = []
+for (const { graphic, review, svg, png } of eligible) {
+  for (const filename of [svg, png].filter(Boolean)) {
+    const source = path.join(artifactDir, filename)
+    if (!fs.existsSync(source)) {
+      console.error(`[media-promotion] approved source missing: ${filename}`)
+      process.exit(1)
+    }
+    fs.copyFileSync(source, path.join(publicDir, filename))
+  }
+  published.push({
+    kind: graphic.kind,
+    sourceUrl: graphic.sourceUrl,
+    alt: graphic.alt,
+    evidenceGrade: graphic.evidenceGrade || null,
+    svg: svg ? `/media/research/${svg}` : null,
+    png: png ? `/media/research/${png}` : null,
+    reviewedBy: review.reviewer,
+    reviewedAt: review.reviewedAt,
+    reviewNote: review.note || null,
+  })
+}
+
+fs.writeFileSync(publicManifestPath, `${JSON.stringify({ version: 1, generatedAt: new Date().toISOString(), graphics: published }, null, 2)}\n`)
+console.log(`[media-promotion] published ${published.length} human-reviewed graphics to public/media/research`)


### PR DESCRIPTION
## Backlog
Covers the remaining implementation gap in 498–510.

## Existing system reused
The repo already generates data-backed ingredient cards with evidence grades, comparison share cards, evidence-change cards, evidence charts, SVG/PNG outputs, alt text, attribution metadata, and embed HTML into review-only CI artifacts. The public infographics library already supports downloads, source links, attribution-preserving embed code, and responsible-sharing guidance.

## What changed
- adds a versioned human-review registry for generated graphics
- adds a promotion command that refuses to copy generated SVG/PNG assets into `public/media/research/` unless a named human reviewer, review date, and four explicit checks are recorded
- requires evidence, attribution, destination URL, and rendered-visual verification before promotion
- preserves reviewer/date provenance in the public graphic manifest
- rejects stale review entries that no longer match a generated graphic
- adds `--check` mode so CI can validate the review registry without publishing anything
- integrates that validation into existing Schema and Media Governance
- documents the review/promotion contract and explicitly warns against adding approvals merely to satisfy CI

## Safety / editorial guardrail
No generated graphic is marked approved or promoted by this PR. Public promotion remains intentionally blocked until an actual human visual/evidence review occurs.