### PR TITLE
fix(seo): fail closed on unreadable sitemap route policy

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -271,7 +271,8 @@ function checkRouteFileEligibility(normalizedRoute: string): boolean {
       }
     }
   } catch {
-    // Safe fallback: treat as eligible when the file exists but can't be read.
+    // Publication/crawler policy must fail closed when source policy cannot be verified.
+    return false;
   }
 
   return true;

--- a/tests/sitemap-source-policy-fail-closed.test.ts
+++ b/tests/sitemap-source-policy-fail-closed.test.ts
@@ -1,0 +1,29 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const sitemapSource = fs.readFileSync(path.join(process.cwd(), 'app/sitemap.ts'), 'utf8')
+
+describe('sitemap route source policy', () => {
+  it('fails closed when a non-dynamic route source cannot be read', () => {
+    const eligibilityStart = sitemapSource.indexOf('function checkRouteFileEligibility')
+    const manifestStart = sitemapSource.indexOf('function isAllowedRouteManifestEntry')
+    const eligibilitySource = sitemapSource.slice(eligibilityStart, manifestStart)
+
+    expect(eligibilityStart).toBeGreaterThanOrEqual(0)
+    expect(manifestStart).toBeGreaterThan(eligibilityStart)
+    expect(eligibilitySource).toContain("const content = readFileSync(servedFile, 'utf8')")
+    expect(eligibilitySource).toMatch(/catch\s*\{[\s\S]*?return false;[\s\S]*?\}/)
+    expect(eligibilitySource).not.toContain("treat as eligible when the file exists but can't be read")
+  })
+
+  it('keeps dynamic catch-all source checks delegated to runtime indexability gating', () => {
+    const eligibilityStart = sitemapSource.indexOf('function checkRouteFileEligibility')
+    const manifestStart = sitemapSource.indexOf('function isAllowedRouteManifestEntry')
+    const eligibilitySource = sitemapSource.slice(eligibilityStart, manifestStart)
+
+    expect(eligibilitySource).toContain("if (/\\[[^\\]]+\\]/.test(servedFile))")
+    expect(eligibilitySource).toContain('return true;')
+    expect(eligibilitySource).toContain('shouldIndexRoute()')
+  })
+})


### PR DESCRIPTION
Fixes #3240

## Relevant URLs
`/sitemap.xml` and all URLs emitted by the sitemap.

## Acceptance criteria
- Non-dynamic route source-read failures are treated as ineligible for sitemap publication.
- Existing dynamic catch-all behavior remains delegated to runtime `shouldIndexRoute()` gating.
- Missing route files remain ineligible.

## Validation commands
- `npm run test -- tests/sitemap-source-policy-fail-closed.test.ts`
- Existing sitemap/build validation in CI.

## Before → after metrics
- Unreadable static route source policy: **eligible → excluded**
- Dynamic catch-all behavior changed: **0 routes**
- Production source diff: **+2 / -1 lines**

## Generator/source-of-truth decision
The sitemap remains generated from canonical runtime/publication inputs; this change only makes its final source-policy verification fail closed when robots/canonical metadata cannot be inspected.

## Regression contract
`tests/sitemap-source-policy-fail-closed.test.ts` locks the fail-closed catch and separately protects the intentional dynamic catch-all delegation.