### PR TITLE
feat(ui): simplify evidence snapshot into signal ledger

### DIFF
--- a/components/ui/EvidenceSnapshotPanel.tsx
+++ b/components/ui/EvidenceSnapshotPanel.tsx
@@ -17,9 +17,18 @@ type Props = {
 }
 
 function fieldToneClasses(tone: EvidenceSnapshotField['tone']) {
-  if (tone === 'caution') return 'border-amber-900/15 bg-amber-50/70'
-  if (tone === 'best-fit') return 'border-emerald-900/15 bg-emerald-50/70'
-  return 'border-brand-900/10 bg-white/90'
+  if (tone === 'caution') return 'border-l-amber-500 bg-amber-50/35 dark:bg-amber-950/12'
+  if (tone === 'best-fit') return 'border-l-emerald-600 bg-emerald-50/30 dark:bg-emerald-950/10'
+  return 'border-l-transparent'
+}
+
+function SnapshotField({ field }: { field: EvidenceSnapshotField }) {
+  return (
+    <article className={`border-l-2 px-3 py-2.5 ${fieldToneClasses(field.tone)}`}>
+      <h3 className="text-[0.66rem] font-bold uppercase tracking-[0.14em] text-[color:var(--hs-body)]">{field.label}</h3>
+      <p className="mt-1 text-sm leading-5 text-[color:var(--hs-body)]">{field.value}</p>
+    </article>
+  )
 }
 
 export default function EvidenceSnapshotPanel({
@@ -28,7 +37,7 @@ export default function EvidenceSnapshotPanel({
   badge,
   fields,
   className,
-  columnsClassName = 'grid gap-2 sm:grid-cols-2 lg:grid-cols-1',
+  columnsClassName = 'grid sm:grid-cols-2 lg:grid-cols-1',
   footer,
 }: Props) {
   const visibleFields = fields.filter(field => field?.label && field?.value)
@@ -37,44 +46,50 @@ export default function EvidenceSnapshotPanel({
   if (visibleFields.length === 0) return null
 
   return (
-    <aside className={className || 'rounded-[0.9rem] border border-brand-900/10 bg-white/95 p-3 shadow-sm'}>
-      <div className="flex items-start justify-between gap-2 border-b border-brand-900/10 pb-2">
+    <aside className={className || 'rounded-[0.9rem] border border-[color:var(--hs-hairline-strong)] bg-[color:var(--hs-surface)] p-3 shadow-[var(--hs-lift)]'}>
+      <div className="flex items-start justify-between gap-2 border-b border-[color:var(--hs-hairline)] pb-3">
         <div>
           <p className="eyebrow-label">Evidence snapshot</p>
-          <h2 className="mt-0.5 text-base font-semibold tracking-tight text-ink">{title}</h2>
-          <p className="mt-0.5 text-xs leading-5 text-muted">{subtitle}</p>
+          <h2 className="mt-1 text-base font-semibold tracking-tight text-[color:var(--hs-ink)]">{title}</h2>
+          <p className="mt-1 text-xs leading-5 text-[color:var(--hs-body)]">{subtitle}</p>
         </div>
         {badge ? (
-          <span className="rounded-full bg-emerald-700/10 px-2 py-0.5 text-[10px] font-bold uppercase tracking-[0.14em] text-emerald-900">
+          <span className="rounded-full border border-[color:var(--hs-hairline)] bg-[color:var(--hs-surface-2)] px-2 py-0.5 text-[10px] font-bold uppercase tracking-[0.14em] text-[color:var(--tone-ink)]">
             {badge}
           </span>
         ) : null}
       </div>
 
-      <div className={`mt-3 ${columnsClassName}`}>
+      <div className={`mt-2 divide-y divide-[color:var(--hs-hairline)] ${columnsClassName}`}>
         {primaryFields.map((field) => (
-          <article key={field.label} className={`rounded-[0.7rem] border p-2.5 ${fieldToneClasses(field.tone)}`}>
-            <h3 className="text-[0.66rem] font-bold uppercase tracking-[0.14em] text-muted">{field.label}</h3>
-            <p className="mt-1 text-sm leading-5 text-muted">{field.value}</p>
-          </article>
+          <SnapshotField key={field.label} field={field} />
         ))}
       </div>
 
       {secondaryFields.length > 0 ? (
-        <details className="mt-2 rounded-[0.7rem] border border-brand-900/10 bg-white/70 p-2.5 shadow-none">
-          <summary className="text-xs font-bold uppercase tracking-[0.14em] text-brand-800">More context</summary>
-          <div className="mt-2 grid gap-2">
+        <details className="group mt-2 border-t border-[color:var(--hs-hairline)] !bg-transparent !p-0 !shadow-none">
+          <summary className="flex min-h-11 cursor-pointer list-none items-center justify-between py-2.5 text-[10px] font-bold uppercase tracking-[0.14em] text-[color:var(--tone-ink)] [&::-webkit-details-marker]:hidden">
+            More context
+            <svg
+              className="size-3.5 text-[color:var(--hs-body)] transition-transform group-open:rotate-180"
+              viewBox="0 0 16 16"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              aria-hidden="true"
+            >
+              <path d="M4 6l4 4 4-4" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </summary>
+          <div className="divide-y divide-[color:var(--hs-hairline)] border-t border-[color:var(--hs-hairline)]">
             {secondaryFields.map((field) => (
-              <article key={field.label} className={`rounded-[0.65rem] border p-2.5 ${fieldToneClasses(field.tone)}`}>
-                <h3 className="text-[0.66rem] font-bold uppercase tracking-[0.14em] text-muted">{field.label}</h3>
-                <p className="mt-1 text-sm leading-5 text-muted">{field.value}</p>
-              </article>
+              <SnapshotField key={field.label} field={field} />
             ))}
           </div>
         </details>
       ) : null}
 
-      {footer ? <div className="mt-3 border-t border-brand-900/10 pt-2">{footer}</div> : null}
+      {footer ? <div className="mt-3 border-t border-[color:var(--hs-hairline)] pt-3">{footer}</div> : null}
     </aside>
   )
 }


### PR DESCRIPTION
Keep the Evidence Snapshot as a contained scan-first decision surface while replacing its nested mini-cards and nested context card with compact ledger rows and semantic caution/best-fit rails.