### PR TITLE
fix(media): reject future-dated review approvals

### DIFF
--- a/scripts/media/promote-reviewed-research-graphics.mjs
+++ b/scripts/media/promote-reviewed-research-graphics.mjs
@@ -9,6 +9,7 @@ const reviewPath = path.join(root, 'data/media/research-graphic-reviews.json')
 const publicDir = path.join(root, 'public/media/research')
 const publicManifestPath = path.join(publicDir, 'manifest.json')
 const checkOnly = process.argv.includes('--check')
+const MAX_FUTURE_REVIEW_SKEW_MS = 5 * 60 * 1000
 
 function readJson(file, fallback) {
   try { return JSON.parse(fs.readFileSync(file, 'utf8')) } catch { return fallback }
@@ -28,10 +29,15 @@ function normalizedReview(review) {
   }
 }
 
+function hasValidReviewTimestamp(reviewedAt) {
+  const reviewedAtMs = Date.parse(reviewedAt)
+  return Number.isFinite(reviewedAtMs) && reviewedAtMs <= Date.now() + MAX_FUTURE_REVIEW_SKEW_MS
+}
+
 function isApproved(review) {
   if (!review || review.status !== 'approved') return false
   if (!review.reviewer || !review.reviewedAt) return false
-  if (Number.isNaN(Date.parse(review.reviewedAt))) return false
+  if (!hasValidReviewTimestamp(review.reviewedAt)) return false
   return review.evidenceVerified && review.attributionVerified && review.destinationVerified && review.visualVerified
 }
 

--- a/tests/research-graphic-review-timestamp-contract.test.ts
+++ b/tests/research-graphic-review-timestamp-contract.test.ts
@@ -1,0 +1,23 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const source = fs.readFileSync(
+  path.join(process.cwd(), 'scripts/media/promote-reviewed-research-graphics.mjs'),
+  'utf8',
+)
+
+describe('research graphic review timestamp contract', () => {
+  it('rejects approval timestamps beyond a small future clock-skew allowance', () => {
+    expect(source).toContain('const MAX_FUTURE_REVIEW_SKEW_MS = 5 * 60 * 1000')
+    expect(source).toContain('function hasValidReviewTimestamp(reviewedAt)')
+    expect(source).toContain('reviewedAtMs <= Date.now() + MAX_FUTURE_REVIEW_SKEW_MS')
+    expect(source).toContain('if (!hasValidReviewTimestamp(review.reviewedAt)) return false')
+  })
+
+  it('keeps all four review verification flags required for promotion', () => {
+    expect(source).toContain(
+      'return review.evidenceVerified && review.attributionVerified && review.destinationVerified && review.visualVerified',
+    )
+  })
+})


### PR DESCRIPTION
Fixes #3249

## Relevant URLs
Public research graphics promoted under `/media/research/*`.

## Acceptance criteria
- Reject human review timestamps more than five minutes in the future.
- Preserve approved status, reviewer identity, and all four verification requirements.
- Keep current promotion/output behavior unchanged for valid reviews.

## Validation commands
- `npm run test -- tests/research-graphic-review-timestamp-contract.test.ts`
- Schema & Media Governance workflow.

## Before → after metrics
- Parseable future review timestamps accepted: **yes → no**
- Verification flags removed: **0**
- Production source diff: **+7 / -1 lines**

## Generator/source-of-truth decision
The human review registry remains the source of truth for promotion; this change only validates its approval timestamp before public publication.

## Regression contract
`tests/research-graphic-review-timestamp-contract.test.ts` requires the five-minute skew bound and preserves all four verification flags.