### PR TITLE
feat(ui): demote evidence confidence into calibration ledger

### DIFF
--- a/components/editorial/EvidenceConfidence.tsx
+++ b/components/editorial/EvidenceConfidence.tsx
@@ -17,14 +17,6 @@ const GRADE_STYLE: Record<string, string> = {
  * EvidenceConfidence — explains an evidence grade in plain English instead of
  * leaving "Moderate" unexplained. States why it isn't higher, why it isn't
  * lower, and the practical takeaway. Builds trust and calibrates expectations.
- *
- * MDX usage:
- *   <EvidenceConfidence
- *     grade="Moderate"
- *     whyNotHigher={['Most trials are small', 'Long-term data is limited', 'Outcomes vary by dose']}
- *     whyNotLower={['Multiple human trials exist', 'Effects are biologically plausible', 'Short-term safety is favorable']}
- *     practicalTakeaway="Reasonable to try for mild situational use, not a replacement for medical care."
- *   />
  */
 export function EvidenceConfidence({
   title = 'How strong is the evidence?',
@@ -40,52 +32,61 @@ export function EvidenceConfidence({
   practicalTakeaway: ReactNode
 }) {
   const gradeStyle = GRADE_STYLE[String(grade).toLowerCase()] ?? GRADE_STYLE.moderate
+
   return (
-    <section className="not-prose my-4 rounded-2xl border border-brand-900/12 bg-white p-4 shadow-[0_1px_2px_rgba(13,23,18,0.05)] dark:border-white/10 dark:bg-[var(--surface-card)]">
-      <details className="group border-0 bg-transparent p-0 shadow-none backdrop-blur-none">
-        <summary className="flex cursor-pointer flex-wrap items-center justify-between gap-3 select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40 focus-visible:rounded">
+    <section className="not-prose my-4">
+      <details className="group border-y border-[color:var(--hs-hairline-strong)] !bg-transparent !p-0 !shadow-none">
+        <summary className="flex min-h-12 cursor-pointer list-none flex-wrap items-center justify-between gap-3 py-3 select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--hs-gold)] [&::-webkit-details-marker]:hidden">
           <span className="flex flex-wrap items-center gap-3">
-            <span className="text-base font-bold tracking-tight text-ink">{title}</span>
+            <span className="text-sm font-bold uppercase tracking-[0.12em] text-[color:var(--tone-ink)]">{title}</span>
             <span className={`rounded-full border px-3 py-0.5 text-sm font-bold ${gradeStyle}`}>{grade}</span>
           </span>
-          <span aria-hidden="true" className="shrink-0 text-brand-500 transition-transform group-open:rotate-180">v</span>
+          <svg
+            className="size-4 shrink-0 text-[color:var(--hs-body)] transition-transform group-open:rotate-180"
+            viewBox="0 0 16 16"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            aria-hidden="true"
+          >
+            <path d="M4 6l4 4 4-4" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
         </summary>
-      <div className="mt-4 grid gap-4 border-t border-brand-900/10 pt-4 sm:grid-cols-2 dark:border-white/10">
-        <div>
-          <p className="text-xs font-bold uppercase tracking-wider text-muted">Why not higher</p>
-          <ul className="mt-2 space-y-1.5">
-            {whyNotHigher.map((item) => (
-              <li key={item} className="flex gap-2 text-sm leading-6 text-muted">
-                <span aria-hidden="true" className="mt-0.5">
-                  –
-                </span>
-                <span>{item}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
-        {whyNotLower && whyNotLower.length > 0 ? (
-          <div>
-            <p className="text-xs font-bold uppercase tracking-wider text-emerald-700 dark:text-emerald-300">
-              Why not lower
-            </p>
+
+        <div className="grid gap-0 border-t border-[color:var(--hs-hairline)] sm:grid-cols-2">
+          <div className="py-4 sm:pr-5">
+            <p className="text-xs font-bold uppercase tracking-wider text-[color:var(--hs-body)]">Why not higher</p>
             <ul className="mt-2 space-y-1.5">
-              {whyNotLower.map((item) => (
-                <li key={item} className="flex gap-2 text-sm leading-6 text-ink">
-                  <span aria-hidden="true" className="mt-0.5 font-bold text-emerald-600 dark:text-emerald-400">
-                    +
-                  </span>
+              {whyNotHigher.map((item) => (
+                <li key={item} className="flex gap-2 text-sm leading-6 text-[color:var(--hs-body)]">
+                  <span aria-hidden="true" className="mt-0.5 text-[color:var(--hs-gold)]">–</span>
                   <span>{item}</span>
                 </li>
               ))}
             </ul>
           </div>
-        ) : null}
-      </div>
-      <p className="mt-4 border-t border-brand-900/10 pt-3 text-sm leading-7 text-ink dark:border-white/10">
-        <span className="font-bold">Practical takeaway: </span>
-        {practicalTakeaway}
-      </p>
+
+          {whyNotLower && whyNotLower.length > 0 ? (
+            <div className="border-t border-[color:var(--hs-hairline)] py-4 sm:border-l sm:border-t-0 sm:pl-5">
+              <p className="text-xs font-bold uppercase tracking-wider text-emerald-700 dark:text-emerald-300">
+                Why not lower
+              </p>
+              <ul className="mt-2 space-y-1.5">
+                {whyNotLower.map((item) => (
+                  <li key={item} className="flex gap-2 text-sm leading-6 text-[color:var(--hs-ink)]">
+                    <span aria-hidden="true" className="mt-0.5 font-bold text-emerald-600 dark:text-emerald-400">+</span>
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </div>
+
+        <p className="border-t border-[color:var(--hs-hairline)] py-4 text-sm leading-7 text-[color:var(--hs-ink)]">
+          <span className="font-bold">Practical takeaway: </span>
+          {practicalTakeaway}
+        </p>
       </details>
     </section>
   )


### PR DESCRIPTION
Keep semantic grade/support colors while replacing the secondary Evidence Confidence card with an open calibration ledger, preserving the primary Scientific Verdict as the visual anchor.