### PR TITLE
fix(affiliate): reject invalid curated-product review timestamps

### DIFF
--- a/src/lib/__tests__/curated-product-review-recency.test.ts
+++ b/src/lib/__tests__/curated-product-review-recency.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { CURATED_PRODUCT_STALE_REVIEW_DAYS } from '@/data/curatedProducts'
+import { assessCuratedProductReadiness, getReviewRecencyState } from '../curatedProducts'
+
+const NOW = new Date('2026-08-15T12:00:00.000Z')
+
+function productWithReviewedAt(reviewedAt: string) {
+  return {
+    entityType: 'herb',
+    entitySlug: 'test-herb',
+    productId: 'test-product',
+    productTitle: 'Test Product',
+    amazonUrl: 'https://www.amazon.com/dp/B000000001',
+    active: true,
+    featured: false,
+    sortOrder: 1,
+    confidenceTierRequired: 'low',
+    researchStatus: 'approved',
+    reviewedAt,
+    affiliateDisclosure: 'Affiliate disclosure',
+    rationaleShort: 'Short rationale',
+    rationaleLong: 'Long rationale',
+    bestFor: ['testing'],
+  } as any
+}
+
+const pageContext = {
+  entityType: 'herb' as const,
+  entitySlug: 'test-herb',
+  confidence: 'low' as const,
+  sourceCount: 1,
+}
+
+function isoDaysBefore(days: number) {
+  return new Date(NOW.getTime() - days * 24 * 60 * 60 * 1000).toISOString()
+}
+
+describe('curated product review recency', () => {
+  it('keeps a current review fresh', () => {
+    expect(getReviewRecencyState(productWithReviewedAt(NOW.toISOString()), NOW)).toBe('fresh')
+  })
+
+  it('keeps the configured grace window distinct from expired reviews', () => {
+    expect(CURATED_PRODUCT_STALE_REVIEW_DAYS).toBeGreaterThan(0)
+    const graceReview = productWithReviewedAt(isoDaysBefore(CURATED_PRODUCT_STALE_REVIEW_DAYS + 5))
+    expect(getReviewRecencyState(graceReview, NOW)).toBe('stale_grace')
+
+    const expiredReview = productWithReviewedAt(isoDaysBefore(CURATED_PRODUCT_STALE_REVIEW_DAYS + 31))
+    expect(getReviewRecencyState(expiredReview, NOW)).toBe('stale_expired')
+  })
+
+  it('treats malformed review timestamps as invalid and non-renderable', () => {
+    const product = productWithReviewedAt('not-a-date')
+    expect(getReviewRecencyState(product, NOW)).toBe('missing_reviewed_at')
+
+    const readiness = assessCuratedProductReadiness({ product, pageContext, now: NOW })
+    expect(readiness.renderEligible).toBe(false)
+    expect(readiness.failureReasons).toContain('missing_reviewed_at')
+    expect(readiness.requiresManualReview).toBe(true)
+  })
+
+  it('rejects materially future-dated approvals with an explicit failure reason', () => {
+    const future = new Date(NOW.getTime() + 60 * 60 * 1000).toISOString()
+    const product = productWithReviewedAt(future)
+    expect(getReviewRecencyState(product, NOW)).toBe('future_reviewed_at')
+
+    const readiness = assessCuratedProductReadiness({ product, pageContext, now: NOW })
+    expect(readiness.renderEligible).toBe(false)
+    expect(readiness.failureReasons).toContain('future_reviewed_at')
+    expect(readiness.requiresManualReview).toBe(true)
+  })
+
+  it('allows only a small clock-skew tolerance', () => {
+    const fourMinutesAhead = new Date(NOW.getTime() + 4 * 60 * 1000).toISOString()
+    expect(getReviewRecencyState(productWithReviewedAt(fourMinutesAhead), NOW)).toBe('fresh')
+  })
+})

--- a/src/lib/curatedProducts.ts
+++ b/src/lib/curatedProducts.ts
@@ -59,8 +59,14 @@ function parseDate(value: string): Date | null {
 }
 
 const REVIEW_GRACE_PERIOD_DAYS = 30
+const MAX_FUTURE_REVIEW_SKEW_DAYS = 5 / (24 * 60)
 
-export type ReviewRecencyState = 'fresh' | 'stale_grace' | 'stale_expired' | 'missing_reviewed_at'
+export type ReviewRecencyState =
+  | 'fresh'
+  | 'stale_grace'
+  | 'stale_expired'
+  | 'missing_reviewed_at'
+  | 'future_reviewed_at'
 
 function getReviewAgeDays(
   product: CuratedProductRecommendation,
@@ -77,9 +83,10 @@ export function getReviewRecencyState(
   product: CuratedProductRecommendation,
   now: Date = new Date(),
 ): ReviewRecencyState {
-  if (!CURATED_PRODUCT_STALE_REVIEW_DAYS || CURATED_PRODUCT_STALE_REVIEW_DAYS <= 0) return 'fresh'
   const elapsedDays = getReviewAgeDays(product, now)
   if (elapsedDays === null) return 'missing_reviewed_at'
+  if (elapsedDays < -MAX_FUTURE_REVIEW_SKEW_DAYS) return 'future_reviewed_at'
+  if (!CURATED_PRODUCT_STALE_REVIEW_DAYS || CURATED_PRODUCT_STALE_REVIEW_DAYS <= 0) return 'fresh'
   if (elapsedDays <= CURATED_PRODUCT_STALE_REVIEW_DAYS) return 'fresh'
   if (elapsedDays <= CURATED_PRODUCT_STALE_REVIEW_DAYS + REVIEW_GRACE_PERIOD_DAYS)
     return 'stale_grace'
@@ -119,6 +126,7 @@ export type CuratedProductReadinessFailureReason =
   | 'missing_rationale'
   | 'missing_research_status'
   | 'missing_reviewed_at'
+  | 'future_reviewed_at'
   | 'inactive'
   | 'entity_page_mismatch'
   | 'confidence_tier_not_met'
@@ -177,7 +185,9 @@ export function assessCuratedProductReadiness(params: {
   if (!disclosurePresent) failureReasons.push('missing_disclosure')
   if (!rationalePresent) failureReasons.push('missing_rationale')
   if (!researchedReviewedStatusPresent) failureReasons.push('missing_research_status')
-  if (!reviewedAtPresent) failureReasons.push('missing_reviewed_at')
+  if (!reviewedAtPresent || reviewRecencyState === 'missing_reviewed_at')
+    failureReasons.push('missing_reviewed_at')
+  if (reviewRecencyState === 'future_reviewed_at') failureReasons.push('future_reviewed_at')
   if (!product.active) failureReasons.push('inactive')
   if (
     product.entityType !== pageContext.entityType ||
@@ -209,7 +219,8 @@ export function assessCuratedProductReadiness(params: {
     staleWithinGracePeriod ||
     genericLinkDetected ||
     malformedUrlDetected ||
-    reviewRecencyState === 'missing_reviewed_at'
+    reviewRecencyState === 'missing_reviewed_at' ||
+    reviewRecencyState === 'future_reviewed_at'
 
   return {
     entitySlug: product.entitySlug,


### PR DESCRIPTION
Closed without merge after deeper architecture audit.

The timestamp bug is real inside `src/lib/curatedProducts.ts`, but that module is explicitly quarantined in `tsconfig.json` and `scripts/ci/validate-quarantine-imports.mjs`; its canonical dataset `src/data/curatedProducts.ts` was deleted during legacy cleanup months ago, and no active package script invokes the old curated-affiliate reports/verifier. Adding a behavior test would re-activate a dead dependency and fail on the missing dataset.

The correct next action is removal of this orphaned legacy subsystem rather than restoring stale affiliate recommendations.