### PR TITLE
Backlog 11-12, 40-50: catch imperative editorial instructions, report what cannot be auto-fixed

### DIFF
--- a/lib/__tests__/editorial-leak.test.ts
+++ b/lib/__tests__/editorial-leak.test.ts
@@ -27,6 +27,26 @@ describe('findEditorialLeaks', () => {
     expect(hasEditorialLeak('It should be framed consistently with gymnema while preserving alternate-name discoverability.')).toBe(true)
   })
 
+  it('catches imperative instructions that have no subject at all', () => {
+    // Verbatim summaries of 77 profiles, 44 of them indexable. The two below
+    // are shared by 35 and 34 records respectively.
+    expect(hasEditorialLeak('Keep claims tied to source-backed preparation and safety context.')).toBe(true)
+    expect(hasEditorialLeak('Treat dosing and outcomes as review-gated unless pmid-backed human evidence is present.')).toBe(true)
+  })
+
+  it('treats internal governance jargon as pipeline copy wherever it appears', () => {
+    // Neither term means anything to a reader.
+    expect(hasEditorialLeak('Dosing is review-gated for this record.')).toBe(true)
+    expect(hasEditorialLeak('Outcomes require pmid-backed evidence.')).toBe(true)
+  })
+
+  it('does not treat ordinary sentences starting with Keep or Treat as instructions', () => {
+    // The imperative patterns are anchored on editorial nouns, so advice to a
+    // reader survives.
+    expect(hasEditorialLeak('Keep the bottle away from direct sunlight.')).toBe(false)
+    expect(hasEditorialLeak('Treat any new symptom as a reason to stop and ask a clinician.')).toBe(false)
+  })
+
   it('names the pattern that matched, for the audit trail', () => {
     expect(findEditorialLeaks('It should be framed modestly.')[0]?.name).toBe('framing-instruction')
   })

--- a/lib/editorial-leak.mjs
+++ b/lib/editorial-leak.mjs
@@ -36,6 +36,16 @@ export const EDITORIAL_INSTRUCTION_PATTERNS = [
   { pattern: /\bshould\s+be\s+(?:framed|positioned|presented|described|treated)\b/i, name: 'presentation-instruction' },
   { pattern: /\bframe\s+(?:this|it)\b/i, name: 'imperative-framing' },
   { pattern: /\bpreserv\w*\s+(?:\w+\s+){0,3}discoverability\b/i, name: 'seo-instruction' },
+  // Imperative voice: an instruction to whoever writes the page, with no
+  // subject at all. 77 records carry one of these as their entire summary —
+  // "Keep claims tied to source-backed preparation and safety context." is on
+  // 35 profiles, 44 of the 77 are indexable.
+  { pattern: /^\s*keep\s+(?:claims|language|framing|dosing|copy|wording)\b/i, name: 'imperative-keep' },
+  { pattern: /^\s*treat\s+(?:dosing|outcomes|claims|this|these)\b/i, name: 'imperative-treat' },
+  // Internal governance jargon. Neither term has any reader-facing meaning, so
+  // its presence anywhere in prose marks the sentence as pipeline copy.
+  { pattern: /\breview[- ]gated\b/i, name: 'governance-jargon' },
+  { pattern: /\bpmid[- ]backed\b/i, name: 'governance-jargon' },
 ]
 
 /**

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "data:repair-packed-citations": "node scripts/data/repair-packed-citations.mjs",
     "validate:evidence-grades": "tsx scripts/ci/validate-evidence-grade-consistency.ts",
     "data:normalize-evidence": "tsx scripts/data/normalize-evidence-grades.ts --data-dir=public/data",
+    "audit:content-integrity": "node scripts/ci/audit-content-integrity.mjs",
     "validate:editorial-leaks": "node scripts/ci/validate-editorial-leaks.mjs",
     "report:thin-pages": "npm run -s gate:content-quality && npm run -s audit:citation-density && node scripts/ci/report-thin-page-actions.mjs",
     "seo:ai-citations": "node scripts/seo/ai-citation-tracker.mjs",

--- a/public/data/compounds.json
+++ b/public/data/compounds.json
@@ -126,8 +126,8 @@
   {
     "slug": "23-epi-26-deoxyactein",
     "name": "23-epi-26-deoxyactein",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "23-epi-26-deoxyactein compound profile with evidence, safety, and practical fit.",
+    "description": "23-epi-26-deoxyactein compound profile with evidence, safety, and practical fit.",
     "effects": [],
     "primary_effects": [],
     "mechanisms": [
@@ -332,8 +332,8 @@
   {
     "slug": "acarbose",
     "name": "Acarbose",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "Acarbose compound profile with evidence, safety, and practical fit.",
+    "description": "Acarbose compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Metabolic Health",
       "Inflammation",
@@ -431,7 +431,7 @@
     "robots": "index,follow",
     "sitemap_included": true,
     "indexability_status": "PUBLISH",
-    "indexability_score": 100,
+    "indexability_score": 95,
     "indexability_reasons": [
       "effect-coverage",
       "evidence-signal",
@@ -440,7 +440,7 @@
       "mechanism-context",
       "profile-status:commercial_ready",
       "safety-context",
-      "summary-depth",
+      "summary-present",
       "summary-quality-missing"
     ],
     "meta_title": "",
@@ -579,8 +579,8 @@
   {
     "slug": "acetate",
     "name": "acetate",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence.",
+    "summary": "acetate compound profile with evidence, safety, and practical fit.",
+    "description": "acetate compound profile with evidence, safety, and practical fit.",
     "effects": [
       "glucose_AMPK"
     ],
@@ -7174,8 +7174,8 @@
   {
     "slug": "banaba-leaf-extract",
     "name": "Banaba Leaf Extract",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed.",
+    "summary": "Banaba Leaf Extract compound profile with evidence, safety, and practical fit.",
+    "description": "Banaba Leaf Extract compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Metabolic Health",
       "Oxidative Stress",
@@ -8253,8 +8253,8 @@
   {
     "slug": "bhb",
     "name": "beta- hydroxybutyrate",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "beta- hydroxybutyrate compound profile with evidence, safety, and practical fit.",
+    "description": "beta- hydroxybutyrate compound profile with evidence, safety, and practical fit.",
     "effects": [
       "HDAC AMPK"
     ],
@@ -8596,8 +8596,8 @@
   {
     "slug": "beta-ecdysterone",
     "name": "beta-ecdysterone",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "beta-ecdysterone compound profile with evidence, safety, and practical fit.",
+    "description": "beta-ecdysterone compound profile with evidence, safety, and practical fit.",
     "effects": [
       "PI3K Akt"
     ],
@@ -10624,8 +10624,8 @@
   {
     "slug": "black-seed-oil",
     "name": "Black Seed Oil",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "Black Seed Oil compound profile with evidence, safety, and practical fit.",
+    "description": "Black Seed Oil compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Oxidative Stress",
       "Metabolic Health",
@@ -10724,7 +10724,7 @@
     "robots": "index,follow",
     "sitemap_included": true,
     "indexability_status": "PUBLISH",
-    "indexability_score": 100,
+    "indexability_score": 95,
     "indexability_reasons": [
       "effect-coverage",
       "evidence-signal",
@@ -10733,7 +10733,7 @@
       "mechanism-context",
       "profile-status:commercial_ready",
       "safety-context",
-      "summary-depth",
+      "summary-present",
       "summary-quality-missing"
     ],
     "meta_title": "",
@@ -11208,8 +11208,8 @@
   {
     "slug": "boswellic-acids",
     "name": "boswellic acids",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "boswellic acids compound profile with evidence, safety, and practical fit.",
+    "description": "boswellic acids compound profile with evidence, safety, and practical fit.",
     "effects": [
       "5- LOX"
     ],
@@ -11789,8 +11789,8 @@
   {
     "slug": "butyrate",
     "name": "butyrate",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "butyrate compound profile with evidence, safety, and practical fit.",
+    "description": "butyrate compound profile with evidence, safety, and practical fit.",
     "effects": [
       "HDAC inhibition"
     ],
@@ -12669,8 +12669,8 @@
   {
     "slug": "calcium-d-glucarate",
     "name": "calcium d-glucarate",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "calcium d-glucarate compound profile with evidence, safety, and practical fit.",
+    "description": "calcium d-glucarate compound profile with evidence, safety, and practical fit.",
     "effects": [
       "beta-glucuronidase"
     ],
@@ -15590,8 +15590,8 @@
   {
     "slug": "chromium-picolinate",
     "name": "chromium picolinate",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "chromium picolinate compound profile with evidence, safety, and practical fit.",
+    "description": "chromium picolinate compound profile with evidence, safety, and practical fit.",
     "effects": [
       "insulin receptor"
     ],
@@ -15698,8 +15698,8 @@
   {
     "slug": "cimifugoside",
     "name": "Cimifugoside",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "Cimifugoside compound profile with evidence, safety, and practical fit.",
+    "description": "Cimifugoside compound profile with evidence, safety, and practical fit.",
     "effects": [],
     "primary_effects": [],
     "mechanisms": [
@@ -16516,8 +16516,8 @@
   {
     "slug": "coconut-oil",
     "name": "Coconut Oil",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human.",
+    "summary": "Coconut Oil compound profile with evidence, safety, and practical fit.",
+    "description": "Coconut Oil compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Metabolic Health",
       "Cardiovascular Health",
@@ -17819,8 +17819,8 @@
   {
     "slug": "cordycepin",
     "name": "cordycepin",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "cordycepin compound profile with evidence, safety, and practical fit.",
+    "description": "cordycepin compound profile with evidence, safety, and practical fit.",
     "effects": [
       "AMPK"
     ],
@@ -18053,8 +18053,8 @@
   {
     "slug": "cordyceps-militaris",
     "name": "cordyceps militaris",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "cordyceps militaris compound profile with evidence, safety, and practical fit.",
+    "description": "cordyceps militaris compound profile with evidence, safety, and practical fit.",
     "effects": [
       "ATP synthesis"
     ],
@@ -18142,7 +18142,7 @@
       "non-publishable-profile-status",
       "profile-status:research_only",
       "safety-context",
-      "summary-depth",
+      "summary-present",
       "summary-quality-missing"
     ],
     "meta_title": "",
@@ -21937,8 +21937,8 @@
   {
     "slug": "dim",
     "name": "diindolylmethane",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "diindolylmethane compound profile with evidence, safety, and practical fit.",
+    "description": "diindolylmethane compound profile with evidence, safety, and practical fit.",
     "effects": [
       "CYP1A1 CYP1B1"
     ],
@@ -22927,8 +22927,8 @@
   {
     "slug": "egcg-caffeine",
     "name": "EGCG + Caffeine",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "EGCG + Caffeine compound profile with evidence, safety, and practical fit.",
+    "description": "EGCG + Caffeine compound profile with evidence, safety, and practical fit.",
     "effects": [
       "stimulant_CNS",
       "glucose_AMPK"
@@ -23026,7 +23026,7 @@
     "robots": "index,follow",
     "sitemap_included": true,
     "indexability_status": "PUBLISH",
-    "indexability_score": 100,
+    "indexability_score": 95,
     "indexability_reasons": [
       "effect-coverage",
       "evidence-signal",
@@ -23035,7 +23035,7 @@
       "mechanism-context",
       "profile-status:commercial_ready",
       "safety-context",
-      "summary-depth",
+      "summary-present",
       "summary-quality-missing"
     ],
     "meta_title": "",
@@ -25271,8 +25271,8 @@
   {
     "slug": "exogenous-ketones",
     "name": "exogenous ketones",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "exogenous ketones compound profile with evidence, safety, and practical fit.",
+    "description": "exogenous ketones compound profile with evidence, safety, and practical fit.",
     "effects": [
       "BHB energy metabolism"
     ],
@@ -25950,8 +25950,8 @@
   {
     "slug": "fenugreek-extract",
     "name": "Fenugreek Extract",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "Fenugreek Extract compound profile with evidence, safety, and practical fit.",
+    "description": "Fenugreek Extract compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Metabolic Health",
       "Hormonal Health",
@@ -26048,7 +26048,7 @@
     "robots": "index,follow",
     "sitemap_included": true,
     "indexability_status": "PUBLISH",
-    "indexability_score": 100,
+    "indexability_score": 95,
     "indexability_reasons": [
       "effect-coverage",
       "evidence-signal",
@@ -26057,7 +26057,7 @@
       "mechanism-context",
       "profile-status:commercial_ready",
       "safety-context",
-      "summary-depth",
+      "summary-present",
       "summary-quality-missing"
     ],
     "meta_title": "",
@@ -26930,8 +26930,8 @@
   {
     "slug": "fos",
     "name": "Fructooligosaccharides",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "Fructooligosaccharides compound profile with evidence, safety, and practical fit.",
+    "description": "Fructooligosaccharides compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Digestive Health"
     ],
@@ -27037,8 +27037,8 @@
   {
     "slug": "fucoxanthin",
     "name": "Fucoxanthin",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "Fucoxanthin compound profile with evidence, safety, and practical fit.",
+    "description": "Fucoxanthin compound profile with evidence, safety, and practical fit.",
     "effects": [
       "UCP1",
       "fat oxidation"
@@ -27128,7 +27128,7 @@
     "robots": "index,follow",
     "sitemap_included": true,
     "indexability_status": "PUBLISH",
-    "indexability_score": 100,
+    "indexability_score": 95,
     "indexability_reasons": [
       "effect-coverage",
       "evidence-signal",
@@ -27137,7 +27137,7 @@
       "mechanism-context",
       "profile-status:commercial_ready",
       "safety-context",
-      "summary-depth",
+      "summary-present",
       "summary-quality-missing"
     ],
     "meta_title": "",
@@ -27158,8 +27158,8 @@
   {
     "slug": "fukinolic-acid",
     "name": "Fukinolic acid",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "Fukinolic acid compound profile with evidence, safety, and practical fit.",
+    "description": "Fukinolic acid compound profile with evidence, safety, and practical fit.",
     "effects": [],
     "primary_effects": [],
     "mechanisms": [
@@ -27910,8 +27910,8 @@
   {
     "slug": "garcinia-cambogia-extract",
     "name": "Garcinia Cambogia Extract",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "Garcinia Cambogia Extract compound profile with evidence, safety, and practical fit.",
+    "description": "Garcinia Cambogia Extract compound profile with evidence, safety, and practical fit.",
     "effects": [
       "ATP citrate lyase"
     ],
@@ -28786,8 +28786,8 @@
   {
     "slug": "gingerol",
     "name": "gingerol",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "gingerol compound profile with evidence, safety, and practical fit.",
+    "description": "gingerol compound profile with evidence, safety, and practical fit.",
     "effects": [
       "COX-2 PGE2"
     ],
@@ -28868,7 +28868,7 @@
     "robots": "index,follow",
     "sitemap_included": true,
     "indexability_status": "PUBLISH",
-    "indexability_score": 100,
+    "indexability_score": 90,
     "indexability_reasons": [
       "effect-present",
       "evidence-signal",
@@ -28877,7 +28877,7 @@
       "mechanism-context",
       "profile-status:commercial_ready",
       "safety-context",
-      "summary-depth",
+      "summary-present",
       "summary-quality-missing"
     ],
     "meta_title": "",
@@ -34429,8 +34429,8 @@
   {
     "slug": "icariin",
     "name": "icariin",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "icariin compound profile with evidence, safety, and practical fit.",
+    "description": "icariin compound profile with evidence, safety, and practical fit.",
     "effects": [
       "PDE5 NO"
     ],
@@ -45827,8 +45827,8 @@
   {
     "slug": "nicotinamide-riboside",
     "name": "Nicotinamide riboside",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "Nicotinamide riboside compound profile with evidence, safety, and practical fit.",
+    "description": "Nicotinamide riboside compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Mitochondrial Health",
       "Longevity",
@@ -48045,8 +48045,8 @@
   {
     "slug": "ornithine",
     "name": "ornithine",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "ornithine compound profile with evidence, safety, and practical fit.",
+    "description": "ornithine compound profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep_GABA"
     ],
@@ -50526,8 +50526,8 @@
   {
     "slug": "phosphatidic-acid",
     "name": "phosphatidic acid",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "phosphatidic acid compound profile with evidence, safety, and practical fit.",
+    "description": "phosphatidic acid compound profile with evidence, safety, and practical fit.",
     "effects": [
       "mTOR"
     ],
@@ -52028,8 +52028,8 @@
   {
     "slug": "probiotic-multistrain",
     "name": "Probiotic Multistrain",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed.",
+    "summary": "Probiotic Multistrain compound profile with evidence, safety, and practical fit.",
+    "description": "Probiotic Multistrain compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Digestive Health",
       "Immune Function"
@@ -52113,7 +52113,7 @@
     "robots": "index,follow",
     "sitemap_included": true,
     "indexability_status": "PUBLISH",
-    "indexability_score": 95,
+    "indexability_score": 100,
     "indexability_reasons": [
       "effect-coverage",
       "evidence-signal",
@@ -52122,7 +52122,7 @@
       "mechanism-context",
       "profile-status:commercial_ready",
       "safety-context",
-      "summary-present",
+      "summary-depth",
       "summary-quality-missing"
     ],
     "meta_title": "",
@@ -52517,8 +52517,8 @@
   {
     "slug": "proline",
     "name": "proline",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is.",
+    "summary": "proline compound profile with evidence, safety, and practical fit.",
+    "description": "proline compound profile with evidence, safety, and practical fit.",
     "effects": [
       "involved in collagen synthesis and connective tissue repair"
     ],
@@ -52620,8 +52620,8 @@
   {
     "slug": "propionate",
     "name": "propionate",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence.",
+    "summary": "propionate compound profile with evidence, safety, and practical fit.",
+    "description": "propionate compound profile with evidence, safety, and practical fit.",
     "effects": [
       "glucose_AMPK"
     ],
@@ -53702,8 +53702,8 @@
   {
     "slug": "putrescine",
     "name": "putrescine",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence.",
+    "summary": "putrescine compound profile with evidence, safety, and practical fit.",
+    "description": "putrescine compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Cardiovascular Health",
       "Digestive Health",
@@ -55656,8 +55656,8 @@
   {
     "slug": "saffron-extract",
     "name": "Saffron Extract",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "Saffron Extract compound profile with evidence, safety, and practical fit.",
+    "description": "Saffron Extract compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Oxidative Stress",
       "Inflammation",
@@ -55757,7 +55757,7 @@
     "robots": "index,follow",
     "sitemap_included": true,
     "indexability_status": "PUBLISH",
-    "indexability_score": 100,
+    "indexability_score": 95,
     "indexability_reasons": [
       "effect-coverage",
       "evidence-signal",
@@ -55766,7 +55766,7 @@
       "mechanism-context",
       "profile-status:commercial_ready",
       "safety-context",
-      "summary-depth",
+      "summary-present",
       "summary-quality-missing"
     ],
     "meta_title": "",
@@ -57611,8 +57611,8 @@
   {
     "slug": "serine",
     "name": "serine",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "serine compound profile with evidence, safety, and practical fit.",
+    "description": "serine compound profile with evidence, safety, and practical fit.",
     "effects": [
       "supports phosphatidylserine synthesis and neuronal membrane function"
     ],
@@ -58172,8 +58172,8 @@
   {
     "slug": "shogaol",
     "name": "shogaol",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "shogaol compound profile with evidence, safety, and practical fit.",
+    "description": "shogaol compound profile with evidence, safety, and practical fit.",
     "effects": [
       "NF-kB"
     ],
@@ -59523,8 +59523,8 @@
   {
     "slug": "spermidine",
     "name": "spermidine",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "spermidine compound profile with evidence, safety, and practical fit.",
+    "description": "spermidine compound profile with evidence, safety, and practical fit.",
     "effects": [
       "mTOR autophagy"
     ],
@@ -59638,8 +59638,8 @@
   {
     "slug": "spirulina",
     "name": "Spirulina",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "Spirulina compound profile with evidence, safety, and practical fit.",
+    "description": "Spirulina compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Oxidative Stress",
       "Metabolic Health",
@@ -59739,7 +59739,7 @@
     "robots": "index,follow",
     "sitemap_included": true,
     "indexability_status": "PUBLISH",
-    "indexability_score": 100,
+    "indexability_score": 95,
     "indexability_reasons": [
       "effect-coverage",
       "evidence-signal",
@@ -59748,7 +59748,7 @@
       "mechanism-context",
       "profile-status:commercial_ready",
       "safety-context",
-      "summary-depth",
+      "summary-present",
       "summary-quality-missing"
     ],
     "meta_title": "",
@@ -62703,8 +62703,8 @@
   {
     "slug": "turkesterone",
     "name": "turkesterone",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "turkesterone compound profile with evidence, safety, and practical fit.",
+    "description": "turkesterone compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Hormonal Health",
       "Exercise Performance"
@@ -63204,8 +63204,8 @@
   {
     "slug": "uc-ii-collagen",
     "name": "Uc Ii Collagen",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "Uc Ii Collagen compound profile with evidence, safety, and practical fit.",
+    "description": "Uc Ii Collagen compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Inflammation",
       "Immune Function"
@@ -63287,7 +63287,7 @@
     "robots": "index,follow",
     "sitemap_included": true,
     "indexability_status": "PUBLISH",
-    "indexability_score": 100,
+    "indexability_score": 95,
     "indexability_reasons": [
       "effect-coverage",
       "evidence-signal",
@@ -63296,7 +63296,7 @@
       "mechanism-context",
       "profile-status:commercial_ready",
       "safety-context",
-      "summary-depth",
+      "summary-present",
       "summary-quality-missing"
     ],
     "meta_title": "",
@@ -64449,8 +64449,8 @@
   {
     "slug": "valerian-root-extract",
     "name": "Valerian Root Extract",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "Valerian Root Extract compound profile with evidence, safety, and practical fit.",
+    "description": "Valerian Root Extract compound profile with evidence, safety, and practical fit.",
     "effects": [
       "GABA signaling"
     ],
@@ -66355,8 +66355,8 @@
   {
     "slug": "willow-bark-extract",
     "name": "Willow Bark Extract",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is.",
+    "summary": "Willow Bark Extract compound profile with evidence, safety, and practical fit.",
+    "description": "Willow Bark Extract compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Inflammation",
       "Oxidative Stress",
@@ -67455,8 +67455,8 @@
   {
     "slug": "yohimbine",
     "name": "Yohimbine",
-    "summary": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
-    "description": "Treat dosing and outcomes as review-gated unless PMID-backed human evidence is present.",
+    "summary": "Yohimbine compound profile with evidence, safety, and practical fit.",
+    "description": "Yohimbine compound profile with evidence, safety, and practical fit.",
     "effects": [
       "alpha-2 adrenergic receptor"
     ],
@@ -67548,7 +67548,7 @@
     "robots": "index,follow",
     "sitemap_included": true,
     "indexability_status": "PUBLISH",
-    "indexability_score": 100,
+    "indexability_score": 90,
     "indexability_reasons": [
       "effect-present",
       "evidence-signal",
@@ -67557,7 +67557,7 @@
       "mechanism-context",
       "profile-status:commercial_ready",
       "safety-context",
-      "summary-depth",
+      "summary-present",
       "summary-quality-missing"
     ],
     "meta_title": "",

--- a/public/data/herbs.json
+++ b/public/data/herbs.json
@@ -1399,8 +1399,8 @@
   {
     "slug": "angelica-sinensis",
     "name": "Angelica Sinensis",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Angelica Sinensis botanical profile with evidence, safety, and practical fit.",
+    "description": "Angelica Sinensis botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
       "hormonal",
@@ -3704,8 +3704,8 @@
   {
     "slug": "bayberry",
     "name": "Bayberry",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Bayberry botanical profile with evidence, safety, and practical fit.",
+    "description": "Bayberry botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory"
     ],
@@ -4548,8 +4548,8 @@
   {
     "slug": "black-tea",
     "name": "Black Tea",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Black Tea botanical profile with evidence, safety, and practical fit.",
+    "description": "Black Tea botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
       "antioxidant",
@@ -4681,8 +4681,8 @@
   {
     "slug": "blue-lotus",
     "name": "Blue Lotus",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Blue Lotus botanical profile with evidence, safety, and practical fit.",
+    "description": "Blue Lotus botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep"
     ],
@@ -4789,8 +4789,8 @@
   {
     "slug": "blueberry",
     "name": "Blueberry",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Blueberry botanical profile with evidence, safety, and practical fit.",
+    "description": "Blueberry botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
       "antioxidant",
@@ -5473,8 +5473,8 @@
   {
     "slug": "buckwheat",
     "name": "Buckwheat",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Buckwheat botanical profile with evidence, safety, and practical fit.",
+    "description": "Buckwheat botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
       "cardiovascular",
@@ -6399,8 +6399,8 @@
   {
     "slug": "eschscholzia-californica",
     "name": "California Poppy",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "California Poppy botanical profile with evidence, safety, and practical fit.",
+    "description": "California Poppy botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep"
     ],
@@ -9399,8 +9399,8 @@
   {
     "slug": "coffea-arabica",
     "name": "Coffee",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Coffee botanical profile with evidence, safety, and practical fit.",
+    "description": "Coffee botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "energy",
       "stimulant",
@@ -11086,8 +11086,8 @@
   {
     "slug": "curcumin",
     "name": "Curcumin",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Curcumin botanical profile with evidence, safety, and practical fit.",
+    "description": "Curcumin botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
       "analgesic"
@@ -11554,8 +11554,8 @@
   {
     "slug": "damiana",
     "name": "Damiana",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Damiana botanical profile with evidence, safety, and practical fit.",
+    "description": "Damiana botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "libido",
       "mood_support",
@@ -12117,8 +12117,8 @@
   {
     "slug": "dong-quai",
     "name": "Dong Quai",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Dong Quai botanical profile with evidence, safety, and practical fit.",
+    "description": "Dong Quai botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
       "hormonal",
@@ -13166,8 +13166,8 @@
   {
     "slug": "eucalyptus",
     "name": "Eucalyptus",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Eucalyptus botanical profile with evidence, safety, and practical fit.",
+    "description": "Eucalyptus botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
       "antimicrobial",
@@ -13709,8 +13709,8 @@
   {
     "slug": "feverfew",
     "name": "Feverfew",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Feverfew botanical profile with evidence, safety, and practical fit.",
+    "description": "Feverfew botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
       "analgesic"
@@ -15492,8 +15492,8 @@
   {
     "slug": "vitis-vinifera",
     "name": "Grape",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Grape botanical profile with evidence, safety, and practical fit.",
+    "description": "Grape botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antioxidant",
       "cardiovascular",
@@ -15621,8 +15621,8 @@
   {
     "slug": "grapefruit",
     "name": "Grapefruit",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Grapefruit botanical profile with evidence, safety, and practical fit.",
+    "description": "Grapefruit botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "digestive"
     ],
@@ -15864,8 +15864,8 @@
   {
     "slug": "green-tea-extract",
     "name": "Green Tea Extract",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Green Tea Extract botanical profile with evidence, safety, and practical fit.",
+    "description": "Green Tea Extract botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "metabolic"
     ],
@@ -15975,8 +15975,8 @@
   {
     "slug": "guarana",
     "name": "Guarana",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Guarana botanical profile with evidence, safety, and practical fit.",
+    "description": "Guarana botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
       "antioxidant",
@@ -17829,8 +17829,8 @@
   {
     "slug": "berberis-aristata",
     "name": "Indian Barberry",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Indian Barberry botanical profile with evidence, safety, and practical fit.",
+    "description": "Indian Barberry botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "digestive",
       "liver-protective",
@@ -18883,8 +18883,8 @@
   {
     "slug": "kudzu",
     "name": "Kudzu",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Kudzu botanical profile with evidence, safety, and practical fit.",
+    "description": "Kudzu botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
       "antioxidant",
@@ -19007,8 +19007,8 @@
   {
     "slug": "tyrosine",
     "name": "L-Tyrosine",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "L-Tyrosine botanical profile with evidence, safety, and practical fit.",
+    "description": "L-Tyrosine botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "cognitive_support",
       "dopamine_precursor",
@@ -24312,8 +24312,8 @@
   {
     "slug": "oregano",
     "name": "Oregano",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Oregano botanical profile with evidence, safety, and practical fit.",
+    "description": "Oregano botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep"
     ],
@@ -24797,8 +24797,8 @@
   {
     "slug": "parsley",
     "name": "Parsley",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Parsley botanical profile with evidence, safety, and practical fit.",
+    "description": "Parsley botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep"
     ],
@@ -25736,8 +25736,8 @@
   {
     "slug": "phosphatidylserine",
     "name": "Phosphatidylserine",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Phosphatidylserine botanical profile with evidence, safety, and practical fit.",
+    "description": "Phosphatidylserine botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "cognitive_support",
       "cortisol_reduction",
@@ -27287,8 +27287,8 @@
   {
     "slug": "quercetin",
     "name": "Quercetin",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Quercetin botanical profile with evidence, safety, and practical fit.",
+    "description": "Quercetin botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antioxidant",
       "anti_inflammatory",
@@ -27412,8 +27412,8 @@
   {
     "slug": "raspberry-leaf",
     "name": "Raspberry Leaf",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Raspberry Leaf botanical profile with evidence, safety, and practical fit.",
+    "description": "Raspberry Leaf botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory"
     ],
@@ -27891,8 +27891,8 @@
   {
     "slug": "ganoderma-lucidum",
     "name": "Reishi",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Reishi botanical profile with evidence, safety, and practical fit.",
+    "description": "Reishi botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
       "energy"
@@ -28116,8 +28116,8 @@
   {
     "slug": "resveratrol",
     "name": "Resveratrol",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Resveratrol botanical profile with evidence, safety, and practical fit.",
+    "description": "Resveratrol botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
       "antioxidant"
@@ -28490,8 +28490,8 @@
   {
     "slug": "rice-bran",
     "name": "Rice Bran",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Rice Bran botanical profile with evidence, safety, and practical fit.",
+    "description": "Rice Bran botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
       "antioxidant",
@@ -28987,8 +28987,8 @@
   {
     "slug": "rosemary",
     "name": "Rosemary",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Rosemary botanical profile with evidence, safety, and practical fit.",
+    "description": "Rosemary botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
       "antioxidant",
@@ -29247,8 +29247,8 @@
   {
     "slug": "sage",
     "name": "Sage",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Sage botanical profile with evidence, safety, and practical fit.",
+    "description": "Sage botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "cognitive_support",
       "antimicrobial",
@@ -31131,8 +31131,8 @@
   {
     "slug": "soybean",
     "name": "Soybean",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Soybean botanical profile with evidence, safety, and practical fit.",
+    "description": "Soybean botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
       "antioxidant",
@@ -32175,8 +32175,8 @@
   {
     "slug": "artemisia-dracunculus",
     "name": "Tarragon",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Tarragon botanical profile with evidence, safety, and practical fit.",
+    "description": "Tarragon botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "metabolic"
     ],
@@ -32507,8 +32507,8 @@
   {
     "slug": "thyme",
     "name": "Thyme",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Thyme botanical profile with evidence, safety, and practical fit.",
+    "description": "Thyme botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep"
     ],
@@ -33918,8 +33918,8 @@
   {
     "slug": "yarrow",
     "name": "Yarrow",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Yarrow botanical profile with evidence, safety, and practical fit.",
+    "description": "Yarrow botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
       "digestive"
@@ -34026,8 +34026,8 @@
   {
     "slug": "yerba-mate",
     "name": "Yerba Mate",
-    "summary": "Keep claims tied to source-backed preparation and safety context.",
-    "description": "Keep claims tied to source-backed preparation and safety context.",
+    "summary": "Yerba Mate botanical profile with evidence, safety, and practical fit.",
+    "description": "Yerba Mate botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
       "antioxidant",

--- a/scripts/ci/audit-content-integrity.mjs
+++ b/scripts/ci/audit-content-integrity.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+/**
+ * Content integrity report (backlog 50).
+ *
+ * One report covering the defect classes that are real but not safe to fix
+ * automatically, because each needs an editorial decision rather than a rule:
+ *
+ *  1. Instruction-voice prose that the build does NOT strip. `validate-editorial-leaks`
+ *     removes unambiguous cases ("It should be framed modestly because…").
+ *     "Bitter melon is best framed around blood-glucose research" is editorial
+ *     voice too, but it carries real meaning, so deleting it would cost content.
+ *  2. Boilerplate summaries — machine-generated filler standing in for prose.
+ *  3. Duplicate entity candidates — two slugs competing for one search intent.
+ *  4. Summaries repeated verbatim across different entities.
+ *
+ * Reporting only; this never exits non-zero. It exists so the work is visible
+ * and rankable, not to block a build on a judgement call.
+ *
+ * Usage: node scripts/ci/audit-content-integrity.mjs
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+const ROOT = process.cwd()
+const DATA_DIR = path.join(ROOT, 'public', 'data')
+const REPORTS_DIR = path.join(ROOT, 'ops', 'reports')
+const REPORT_PATH = path.join(REPORTS_DIR, 'content-integrity.json')
+
+const text = (value) => (Array.isArray(value) ? value.join(' ') : String(value ?? '')).replace(/\s+/g, ' ').trim()
+const isIndexable = (record) => String(record.indexability_status ?? '').toUpperCase() === 'PUBLISH'
+
+function load() {
+  const read = (file) => {
+    const full = path.join(DATA_DIR, file)
+    return fs.existsSync(full) ? JSON.parse(fs.readFileSync(full, 'utf8')) : []
+  }
+  return [
+    ...read('herbs.json').map((r) => ({ ...r, entityType: 'herb' })),
+    ...read('compounds.json').map((r) => ({ ...r, entityType: 'compound' })),
+  ]
+}
+
+/** Editorial voice that survives the build because stripping it would cost meaning. */
+const SOFT_INSTRUCTION_PATTERNS = [
+  { pattern: /\b(?:is|are)\s+best\s+framed\b/i, name: 'is-best-framed' },
+  { pattern: /\bconservative evidence language\b/i, name: 'evidence-language-note' },
+  { pattern: /\bconservative research profile\b/i, name: 'research-profile-template' },
+]
+
+/** Machine-written filler that stands in for a real summary. */
+const BOILERPLATE_PATTERNS = [
+  /\b(?:botanical|compound)\s+profile\s+with\s+evidence,\s+safety,\s+and\s+practical\s+fit\.?$/i,
+  /\bprofile\s+with\s+mechanism,?\s+safety,?\s+and\s+practical\s+context\b/i,
+  /^no summary available yet\.?$/i,
+]
+
+const ENTITY_SUFFIXES = [
+  '-extract', '-berry', '-root', '-powder', '-isolated', '-hcl',
+  '-standardized', '-leaf', '-seed', '-oil',
+]
+
+function tokenSet(value) {
+  return new Set(
+    text(value).toLowerCase().replace(/[^a-z0-9\s]/g, ' ').split(/\s+/).filter((w) => w.length > 3),
+  )
+}
+
+function jaccard(a, b) {
+  if (!a.size && !b.size) return 1
+  if (!a.size || !b.size) return 0
+  let intersection = 0
+  for (const item of a) if (b.has(item)) intersection += 1
+  return intersection / (a.size + b.size - intersection)
+}
+
+function main() {
+  const records = load()
+  const bySlug = new Map(records.map((r) => [r.slug, r]))
+
+  // 1. Soft instruction voice.
+  const softInstructions = []
+  for (const record of records) {
+    for (const field of ['summary', 'description']) {
+      const value = text(record[field])
+      const hit = SOFT_INSTRUCTION_PATTERNS.find(({ pattern }) => pattern.test(value))
+      if (!hit) continue
+      softInstructions.push({
+        slug: record.slug,
+        field,
+        pattern: hit.name,
+        indexable: isIndexable(record),
+        value: value.slice(0, 140),
+      })
+      break
+    }
+  }
+
+  // 2. Boilerplate summaries.
+  const boilerplate = records
+    .filter((record) => BOILERPLATE_PATTERNS.some((pattern) => pattern.test(text(record.summary))))
+    .map((record) => ({ slug: record.slug, indexable: isIndexable(record), summary: text(record.summary).slice(0, 120) }))
+
+  // 3. Duplicate entity candidates.
+  const duplicates = []
+  for (const record of records) {
+    for (const suffix of ENTITY_SUFFIXES) {
+      if (!record.slug.endsWith(suffix)) continue
+      const base = bySlug.get(record.slug.slice(0, -suffix.length))
+      if (!base) continue
+
+      const prose = jaccard(
+        tokenSet(`${base.summary} ${base.description}`),
+        tokenSet(`${record.summary} ${record.description}`),
+      )
+      const mechanisms = jaccard(tokenSet(base.mechanisms), tokenSet(record.mechanisms))
+      const effects = jaccard(tokenSet(base.effects), tokenSet(record.effects))
+
+      duplicates.push({
+        base: base.slug,
+        variant: record.slug,
+        suffix,
+        bothIndexable: isIndexable(base) && isIndexable(record),
+        overlap: Number(((prose + mechanisms + effects) / 3).toFixed(2)),
+        prose: Number(prose.toFixed(2)),
+        mechanisms: Number(mechanisms.toFixed(2)),
+        effects: Number(effects.toFixed(2)),
+        baseGrade: base.evidence_grade ?? null,
+        variantGrade: record.evidence_grade ?? null,
+        // Same words, different verdict: one of the two grades is wrong, or the
+        // two records are not actually the same thing and should not read alike.
+        contradictoryGrades: prose >= 0.9 && String(base.evidence_grade) !== String(record.evidence_grade),
+      })
+    }
+  }
+  duplicates.sort((a, b) => b.overlap - a.overlap)
+
+  // 4. Summaries repeated across entities.
+  const summaryOwners = new Map()
+  for (const record of records) {
+    const value = text(record.summary).toLowerCase()
+    if (!value || BOILERPLATE_PATTERNS.some((pattern) => pattern.test(value))) continue
+    if (!summaryOwners.has(value)) summaryOwners.set(value, [])
+    summaryOwners.get(value).push(record.slug)
+  }
+  const repeatedSummaries = [...summaryOwners.entries()]
+    .filter(([, slugs]) => slugs.length > 1)
+    .map(([value, slugs]) => ({ slugs, count: slugs.length, summary: value.slice(0, 110) }))
+    .sort((a, b) => b.count - a.count)
+
+  const indexableCount = (list) => list.filter((item) => item.indexable).length
+  const summary = {
+    profiles: records.length,
+    indexable: records.filter(isIndexable).length,
+    softInstructionVoice: { total: softInstructions.length, indexable: indexableCount(softInstructions) },
+    boilerplateSummaries: { total: boilerplate.length, indexable: indexableCount(boilerplate) },
+    duplicateCandidates: {
+      total: duplicates.length,
+      bothIndexable: duplicates.filter((d) => d.bothIndexable).length,
+      contradictoryGrades: duplicates.filter((d) => d.contradictoryGrades).length,
+    },
+    repeatedSummaries: { groups: repeatedSummaries.length, records: repeatedSummaries.reduce((n, g) => n + g.count, 0) },
+  }
+
+  fs.mkdirSync(REPORTS_DIR, { recursive: true })
+  fs.writeFileSync(
+    REPORT_PATH,
+    `${JSON.stringify({ generatedAt: new Date().toISOString(), summary, softInstructions, boilerplate, duplicates, repeatedSummaries }, null, 2)}\n`,
+  )
+
+  console.log('\nContent integrity')
+  console.log('='.repeat(72))
+  console.log(`Profiles ${summary.profiles} (${summary.indexable} indexable)\n`)
+  console.log(`Instruction voice, not auto-stripped   ${String(summary.softInstructionVoice.total).padStart(4)}  (${summary.softInstructionVoice.indexable} indexable)`)
+  console.log(`Boilerplate summaries                  ${String(summary.boilerplateSummaries.total).padStart(4)}  (${summary.boilerplateSummaries.indexable} indexable)`)
+  console.log(`Duplicate entity candidates            ${String(summary.duplicateCandidates.total).padStart(4)}  (${summary.duplicateCandidates.bothIndexable} with both pages indexable)`)
+  console.log(`  of those, contradictory grades       ${String(summary.duplicateCandidates.contradictoryGrades).padStart(4)}`)
+  console.log(`Summaries repeated across entities     ${String(summary.repeatedSummaries.groups).padStart(4)}  groups covering ${summary.repeatedSummaries.records} records`)
+
+  const worst = duplicates.filter((d) => d.bothIndexable).slice(0, 8)
+  if (worst.length) {
+    console.log('\nHighest-overlap indexable pairs:')
+    for (const d of worst) {
+      const flag = d.contradictoryGrades ? '  <- same prose, different grade' : ''
+      console.log(`  ${d.overlap.toFixed(2)}  /${d.base}/ vs /${d.variant}/  (${d.baseGrade} vs ${d.variantGrade})${flag}`)
+    }
+  }
+
+  console.log(`\nReport: ${path.relative(ROOT, REPORT_PATH)}`)
+}
+
+main()


### PR DESCRIPTION
## The leak the last pass missed

#3248 matched instruction voice *with a subject* — "It should be framed modestly because…". **77 records carry an instruction with no subject at all, as their entire summary:**

| Summary | Records |
|---|---|
| `Keep claims tied to source-backed preparation and safety context.` | 35 |
| `Treat dosing and outcomes as review-gated unless pmid-backed human evidence is present.` | 34 |
| truncated variants of the above | 8 |

**44 of those pages are indexable.**

## Changes

- Patterns now cover **imperative voice** and the two pieces of internal governance jargon with no reader-facing meaning, `review-gated` and `pmid-backed`.
- The imperative patterns are anchored on editorial nouns so ordinary advice survives — `"Keep the bottle away from direct sunlight."` is not an instruction to an author, and there's a test asserting that.
- **Summaries repeated verbatim across entities: 76 records in 5 groups → 0.**

## New: `audit:content-integrity` (backlog 50)

Reports the defect classes that are real but need an editorial decision rather than a rule, so they stay visible instead of being silently deleted:

- **35 records (24 indexable)** whose prose is editorial voice but carries real meaning — *"Bitter melon is best framed around blood-glucose and metabolic-health research"*. Deleting these would cost content, so the build leaves them alone.
- **339 boilerplate summaries, 248 indexable.** This rose from 262 because the 77 stripped records now fall back to generic filler. Filler is not an improvement on an instruction, only less embarrassing — the real fix is writing summaries or dropping the pages from the index, and that is a ~248-page decision that belongs to you.
- **30 duplicate entity candidates, 16 with both pages indexable**, scored by content overlap rather than merged automatically. `berberine` vs `berberine-hcl` share prose but are graded **A and D**; `creatine` vs `creatine-hcl` are genuinely different salts. One pair is flagged `contradictoryGrades`.

## Verification

- `vitest lib/__tests__/editorial-leak.test.ts` — 10 passed
- `validate:editorial-leaks` — 856 scanned, **0 leaks**
- `tsc --noEmit` — 45 errors, same as main
- Full suite — 38 failing files vs a 39 baseline; the only delta reproduces on main without this branch
- **Indexability unchanged at PUBLISH 445**; data diff confined to `summary`, `description` and the indexability signals that follow from them

## Note on scope

I opened this branch to do backlog 28–34 (dose units). **That data turned out to be clean** — 174 numeric dose mentions across 62 records, zero impossible values, zero inverted ranges, units already limited to g/mg/ml/IU. There was nothing to fix, so I followed the defects that the investigation actually surfaced instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Q6dk9xa1jngoNqWPmXNsR