### PR TITLE
feat(ui): flatten profile evidence meter into strip

### DIFF
--- a/components/ui/EvidenceMeter.tsx
+++ b/components/ui/EvidenceMeter.tsx
@@ -44,26 +44,31 @@ export default function EvidenceMeter({ level = 'moderate' }: { level?: string }
     : (level.charAt(0).toUpperCase() + level.slice(1))
 
   return (
-    <div className="space-y-3 rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm dark:border-white/10 dark:bg-white/5">
+    <section className="space-y-3 border-y border-[color:var(--hs-hairline-strong)] py-4">
       <div className="flex flex-col items-start gap-3 text-xs sm:flex-row sm:justify-between sm:gap-4">
         <div className="space-y-1.5">
-          <div className="text-[10px] font-bold uppercase tracking-wider text-muted">
-            Evidence Strength
-          </div>
-          <p className="max-w-md text-xs leading-relaxed text-muted">
+          <div className="eyebrow-label">Evidence Strength</div>
+          <p className="max-w-md text-xs leading-relaxed text-[color:var(--hs-body)]">
             Confidence estimate based on the design quality and consistency of published clinical trials.
           </p>
         </div>
-        <span className="shrink-0 whitespace-nowrap rounded-full bg-brand-50 px-2.5 py-1 text-[11px] font-semibold text-brand-800 dark:bg-white/10 dark:text-brand-100">
+        <span className="shrink-0 whitespace-nowrap rounded-full border border-[color:var(--hs-hairline)] bg-[color:var(--hs-surface-2)] px-2.5 py-1 text-[11px] font-semibold text-[color:var(--tone-ink)]">
           {displayLevel}
         </span>
       </div>
 
-      <div className="h-2 overflow-hidden rounded-full bg-neutral-100 dark:bg-white/10">
+      <div
+        className="h-2 overflow-hidden rounded-full bg-neutral-100 dark:bg-white/10"
+        role="meter"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={normalized.includes('strong') ? 100 : normalized.includes('moderate') ? 75 : normalized.includes('limited') || normalized.includes('mixed') ? 50 : normalized.includes('preliminary') ? 33 : normalized.includes('traditional') ? 25 : 10}
+        aria-label={`Evidence strength: ${displayLevel}`}
+      >
         <div
           className={`h-full rounded-full transition-all duration-700 ${tones[normalized] || tones.moderate} ${widths[normalized] || widths.moderate}`}
         />
       </div>
-    </div>
+    </section>
   )
 }


### PR DESCRIPTION
Replace the simple compound-profile EvidenceMeter card with an editorial evidence strip while preserving the level mapping and adding explicit meter accessibility semantics.