### PR TITLE
feat(ui): turn related botanicals into research ledger

### DIFF
--- a/components/RelatedBotanicalsTracked.tsx
+++ b/components/RelatedBotanicalsTracked.tsx
@@ -46,47 +46,54 @@ export default function RelatedBotanicalsTracked({ sourceSlug, matches }: Props)
 
   return (
     <section
-      className="space-y-4 rounded-2xl border border-brand-900/10 bg-white/80 p-4 sm:p-5"
+      className="border-y border-[color:var(--hs-hairline-strong)] py-5"
       aria-labelledby="related-botanicals-heading"
     >
       <div className="space-y-1">
-        <p id="related-botanicals-heading" className="text-xs font-bold uppercase tracking-wider text-brand-700">
+        <p id="related-botanicals-heading" className="eyebrow-label">
           Related botanicals
         </p>
-        <p className="text-sm leading-6 text-muted">
+        <p className="max-w-3xl text-sm leading-6 text-[color:var(--hs-body)]">
           Ranked from shared effects and chemistry. These are research-navigation links, not treatment recommendations.
         </p>
       </div>
 
-      <div className="grid gap-3 md:grid-cols-3">
+      <div className="mt-4 divide-y divide-[color:var(--hs-hairline)] border-t border-[color:var(--hs-hairline)]">
         {matches.map((match, index) => (
           <article
             key={match.slug}
-            className="rounded-2xl border border-brand-900/10 bg-[var(--surface-card)] p-4 transition hover:border-brand-600/30 hover:bg-brand-50/40"
+            className="grid gap-3 py-5 sm:grid-cols-[3rem_minmax(0,1fr)_auto] sm:items-start sm:gap-4"
           >
-            <div className="space-y-1">
-              <h3 className="font-bold text-ink">{match.name}</h3>
-              {match.scientificName ? <p className="text-xs italic text-muted">{match.scientificName}</p> : null}
+            <span className="font-display text-sm tabular-nums text-[color:var(--hs-gold)]" aria-hidden="true">
+              {String(index + 1).padStart(2, '0')}
+            </span>
+
+            <div className="min-w-0">
+              <div>
+                <h3 className="font-bold text-[color:var(--hs-ink)]">{match.name}</h3>
+                {match.scientificName ? (
+                  <p className="mt-0.5 text-xs italic text-[color:var(--hs-body)]">{match.scientificName}</p>
+                ) : null}
+              </div>
+
+              {match.reasons.length > 0 ? (
+                <dl className="mt-3 space-y-1.5 text-xs leading-5 text-[color:var(--hs-body)]">
+                  {match.reasons.map((reason) => (
+                    <div key={`${match.slug}:${reason.type}`} className="grid gap-0.5 sm:grid-cols-[8rem_minmax(0,1fr)] sm:gap-3">
+                      <dt className="font-semibold text-[color:var(--hs-ink)]">{reason.label}</dt>
+                      <dd>{reason.values.slice(0, 3).join(', ')}</dd>
+                    </div>
+                  ))}
+                </dl>
+              ) : null}
             </div>
 
-            {match.reasons.length > 0 ? (
-              <div className="mt-3 space-y-2">
-                <p className="text-[10px] font-bold uppercase tracking-wider text-muted">Why related</p>
-                {match.reasons.map((reason) => (
-                  <div key={`${match.slug}:${reason.type}`} className="text-xs leading-5 text-muted">
-                    <span className="font-semibold text-ink">{reason.label}:</span>{' '}
-                    {reason.values.slice(0, 3).join(', ')}
-                  </div>
-                ))}
-              </div>
-            ) : null}
-
-            <div className="mt-4 flex flex-wrap gap-2">
+            <div className="flex flex-wrap gap-x-4 gap-y-2 sm:justify-end">
               <Link
                 href={`/herbs/${match.slug}/`}
                 prefetch={false}
                 onClick={() => trackRelatedBotanicalClick(sourceSlug, trackingItems[index])}
-                className="inline-flex min-h-10 items-center rounded-full bg-brand-800 px-3.5 text-xs font-bold text-white transition hover:bg-brand-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2"
+                className="inline-flex min-h-10 items-center text-xs font-bold text-[color:var(--tone-ink)] underline decoration-[color:var(--hs-hairline-strong)] underline-offset-4 transition hover:decoration-[color:var(--hs-gold)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--hs-gold)] focus-visible:ring-offset-2"
               >
                 Explore profile →
               </Link>
@@ -95,7 +102,7 @@ export default function RelatedBotanicalsTracked({ sourceSlug, matches }: Props)
                   href={match.compareHref}
                   prefetch={false}
                   onClick={() => trackRelatedBotanicalCompare(sourceSlug, trackingItems[index], match.compareHref!)}
-                  className="inline-flex min-h-10 items-center rounded-full border border-brand-900/15 px-3.5 text-xs font-bold text-brand-800 transition hover:bg-brand-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2"
+                  className="inline-flex min-h-10 items-center text-xs font-bold text-[color:var(--hs-body)] underline-offset-4 transition hover:text-[color:var(--tone-ink)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--hs-gold)] focus-visible:ring-offset-2"
                 >
                   Compare ↔
                 </Link>


### PR DESCRIPTION
Replace the nested Related Botanicals card grid with a ranked research-navigation ledger while preserving all matching data, impression tracking, profile-click tracking, and compare tracking behavior.